### PR TITLE
tools: use go1.5 for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: go
 
 go:
   - 1.4.2
-  - tip
+  - 1.5


### PR DESCRIPTION
tip version is not stable, use go1.5 instead