### PR TITLE
expressions: operator supports []byte type

### DIFF
--- a/expression/expressions/binop.go
+++ b/expression/expressions/binop.go
@@ -662,6 +662,13 @@ func (o *BinaryOperation) coerceArithmetic(a interface{}) (interface{}, error) {
 	case mysql.Duration:
 		// TODO: if duration has no precision, return int64
 		return x.ToNumber(), nil
+	case []byte:
+		// []byte is the same as string, converted to float for arithmetic operator.
+		f, err := types.StrToFloat(string(x))
+		if err != nil {
+			return nil, err
+		}
+		return f, err
 	default:
 		return x, nil
 	}

--- a/expression/expressions/binop_test.go
+++ b/expression/expressions/binop_test.go
@@ -395,6 +395,7 @@ func (s *testBinOpSuite) TestNumericOp(c *C) {
 		{1, opcode.Plus, mysql.NewDecimalFromInt(1, 0), 2},
 		{uint64(1), opcode.Plus, 1, 2},
 		{uint64(1), opcode.Plus, uint64(1), 2},
+		{1, opcode.Plus, []byte("1"), 2},
 
 		// minus
 		{1, opcode.Minus, 1, 0},
@@ -404,6 +405,7 @@ func (s *testBinOpSuite) TestNumericOp(c *C) {
 		{uint64(1), opcode.Minus, 1, 0},
 		{uint64(1), opcode.Minus, uint64(1), 0},
 		{mysql.NewDecimalFromInt(1, 0), opcode.Minus, 1, 0},
+		{"1", opcode.Minus, []byte("1"), 0},
 
 		// mul
 		{1, opcode.Mul, 1, 1},
@@ -507,6 +509,11 @@ func (s *testBinOpSuite) TestNumericOp(c *C) {
 	c.Assert(err, NotNil)
 
 	expr.L = Value{"abc"}
+	expr.R = Value{1}
+	_, err = expr.evalArithmeticOp(nil, nil)
+	c.Assert(err, NotNil)
+
+	expr.L = Value{[]byte("abc")}
 	expr.R = Value{1}
 	_, err = expr.evalArithmeticOp(nil, nil)
 	c.Assert(err, NotNil)

--- a/expression/expressions/unary.go
+++ b/expression/expressions/unary.go
@@ -192,6 +192,8 @@ func (u *UnaryOperation) Eval(ctx context.Context, args map[interface{}]interfac
 			return x, nil
 		case mysql.Decimal:
 			return x, nil
+		case []byte:
+			return x, nil
 		default:
 			return types.UndOp(a, op)
 		}
@@ -236,6 +238,9 @@ func (u *UnaryOperation) Eval(ctx context.Context, args map[interface{}]interfac
 		case mysql.Decimal:
 			f, _ := x.Float64()
 			return mysql.NewDecimalFromFloat(-f), nil
+		case []byte:
+			f, err := types.StrToFloat(string(x))
+			return -f, err
 		default:
 			return types.UndOp(a, op)
 		}

--- a/expression/expressions/unary_test.go
+++ b/expression/expressions/unary_test.go
@@ -59,6 +59,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 		{uint32(1), opcode.Plus, uint32(1)},
 		{uint64(1), opcode.Plus, uint64(1)},
 		{"1.0", opcode.Plus, "1.0"},
+		{[]byte("1.0"), opcode.Plus, []byte("1.0")},
 
 		// test Minus.
 		{nil, opcode.Minus, nil},
@@ -75,6 +76,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 		{uint32(1), opcode.Minus, -int64(1)},
 		{uint64(1), opcode.Minus, -int64(1)},
 		{"1.0", opcode.Minus, -1.0},
+		{[]byte("1.0"), opcode.Minus, -1.0},
 	}
 
 	for _, t := range tbl {
@@ -85,7 +87,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 
 		result, err := exprc.Eval(nil, nil)
 		c.Assert(err, IsNil)
-		c.Assert(result, Equals, t.result)
+		c.Assert(result, DeepEquals, t.result)
 	}
 
 	tbl = []struct {


### PR DESCRIPTION
Support expression like:

```
select 1 + cast("123" as binary);
```