### PR TITLE
tidb: Convert bool type prepared statement args to int8

### DIFF
--- a/session.go
+++ b/session.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/db"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/types"
 )
 
 // Session context
@@ -150,7 +151,14 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 func checkArgs(args ...interface{}) error {
 	for i, v := range args {
 		switch v.(type) {
-		case nil, bool, float32, float64, string,
+		case bool:
+			// We do not handle bool as int8 in tidb.
+			vv, err := types.ToBool(v)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			args[i] = vv
+		case nil, float32, float64, string,
 			int8, int16, int32, int64, int,
 			uint8, uint16, uint32, uint64, uint,
 			[]byte, time.Duration, time.Time:

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -392,6 +392,16 @@ func (s *testSessionSuite) TestPrimaryKeyAutoincrement(c *C) {
 	row, err = rs.FirstRow()
 	c.Assert(err, IsNil)
 	match(c, row, id, "abc", 1)
+	// Check for pass bool param to tidb prepared statement
+	mustExecSQL(c, se, "drop table if exists t")
+	mustExecSQL(c, se, "create table t (id tiny)")
+	mustExecSQL(c, se, "insert t values (?)", true)
+	rs = mustExecSQL(c, se, "select * from t")
+	c.Assert(rs, NotNil)
+	row, err = rs.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, int8(1))
+
 	mustExecSQL(c, se, s.dropDBSQL)
 }
 


### PR DESCRIPTION
We handle bool as int8 in tidb.