### PR TITLE
remove the dependence between tables and table

### DIFF
--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/table"
+	// import table implementation to init table.TableFromMeta
 	_ "github.com/pingcap/tidb/table/tables"
 )
 

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/table"
+	_ "github.com/pingcap/tidb/table/tables"
 )
 
 // InfoSchema is the interface used to retrieve the schema information.

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/pingcap/tidb/mysqldef"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
-	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -37,8 +35,6 @@ type testSuite struct {
 }
 
 func (*testSuite) TestT(c *C) {
-	table.TableFromMeta = tables.TableFromMeta
-
 	driver := localstore.Driver{Driver: goleveldb.MemoryDriver{}}
 	store, err := driver.Open("memory")
 	c.Assert(err, IsNil)

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -570,3 +570,7 @@ func (t *Table) IterRecords(ctx context.Context, startKey string, cols []*column
 func (t *Table) AllocAutoID() (int64, error) {
 	return t.alloc.Alloc(t.ID)
 }
+
+func init() {
+	table.TableFromMeta = TableFromMeta
+}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -25,8 +25,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
-	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 )
 
 func TestT(t *testing.T) {
@@ -41,7 +39,6 @@ type testSuite struct {
 }
 
 func (ts *testSuite) SetUpSuite(c *C) {
-	table.TableFromMeta = tables.TableFromMeta
 	driver := localstore.Driver{Driver: goleveldb.MemoryDriver{}}
 	store, err := driver.Open("memory")
 	c.Check(err, IsNil)

--- a/tidb.go
+++ b/tidb.go
@@ -37,8 +37,6 @@ import (
 	"github.com/pingcap/tidb/store/localstore/boltdb"
 	"github.com/pingcap/tidb/store/localstore/engine"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
-	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 )
 
 // Engine prefix name
@@ -258,8 +256,6 @@ func init() {
 	RegisterLocalStore("memory", goleveldb.MemoryDriver{})
 	RegisterLocalStore("goleveldb", goleveldb.Driver{})
 	RegisterLocalStore("boltdb", boltdb.Driver{})
-
-	table.TableFromMeta = tables.TableFromMeta
 
 	// start pprof handlers
 	if Debug {


### PR DESCRIPTION
As tables is the implement of table. So tables like the drivers, while
table like database/sql. while drivers need to regiester in the init.