### PR TITLE
localstore: fix concurrent txn commit panic

### DIFF
--- a/store/localstore/kv_test.go
+++ b/store/localstore/kv_test.go
@@ -465,11 +465,13 @@ func (s *testKVSuite) TestConditionIfEqual(c *C) {
 	for i := 0; i < cnt; i++ {
 		go func() {
 			defer wg.Done()
-			mtxn, merr := s.s.Begin()
-			c.Assert(merr, IsNil)
-			mtxn.Set(b, []byte("newValue"))
-			merr = mtxn.Commit()
-			if merr == nil {
+			// Use txn1/err1 instead of txn/err is
+			// to pass `go tool vet -shadow` check.
+			txn1, err1 := s.s.Begin()
+			c.Assert(err1, IsNil)
+			txn1.Set(b, []byte("newValue"))
+			err1 = txn1.Commit()
+			if err1 == nil {
 				atomic.AddInt64(&success, 1)
 			}
 		}()

--- a/store/localstore/kv_test.go
+++ b/store/localstore/kv_test.go
@@ -465,11 +465,11 @@ func (s *testKVSuite) TestConditionIfEqual(c *C) {
 	for i := 0; i < cnt; i++ {
 		go func() {
 			defer wg.Done()
-			txn, err := s.s.Begin()
+			mtxn, merr := s.s.Begin()
 			c.Assert(err, IsNil)
-			txn.Set(b, []byte("newValue"))
-			err = txn.Commit()
-			if err == nil {
+			mtxn.Set(b, []byte("newValue"))
+			merr = mtxn.Commit()
+			if merr == nil {
 				atomic.AddInt64(&success, 1)
 			}
 		}()

--- a/store/localstore/kv_test.go
+++ b/store/localstore/kv_test.go
@@ -465,7 +465,7 @@ func (s *testKVSuite) TestConditionIfEqual(c *C) {
 	for i := 0; i < cnt; i++ {
 		go func() {
 			defer wg.Done()
-			txn, err = s.s.Begin()
+			txn, err := s.s.Begin()
 			c.Assert(err, IsNil)
 			txn.Set(b, []byte("newValue"))
 			err = txn.Commit()

--- a/store/localstore/kv_test.go
+++ b/store/localstore/kv_test.go
@@ -466,7 +466,7 @@ func (s *testKVSuite) TestConditionIfEqual(c *C) {
 		go func() {
 			defer wg.Done()
 			mtxn, merr := s.s.Begin()
-			c.Assert(err, IsNil)
+			c.Assert(merr, IsNil)
 			mtxn.Set(b, []byte("newValue"))
 			merr = mtxn.Commit()
 			if merr == nil {


### PR DESCRIPTION
following Begin may overwrite previous Begin txn, use temporary variables. 