### PR TITLE
parser: Add mode into UnReservedKeyword list

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1511,7 +1511,7 @@ UnReservedKeyword:
 	"AUTO_INCREMENT" | "BEGIN" | "BIT" | "BOOL" | "BOOLEAN" | "CHARSET" | "COLUMN" | "COLUMNS" | "DATE" | "DATETIME"
 |	"ENGINE" | "FULL" | "LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" | "QUICK" | "ROLLBACK" | "SESSION" | "GLOBAL" 
 |	"TABLES"| "TEXT" | "TIME" | "TIMESTAMP" | "TRANSACTION" | "TRUNCATE" | "VALUE" | "WARNINGS" | "YEAR" | "NOW"
-|	"SUBSTRING"
+|	"SUBSTRING" | "MODE"
 
 
 /************************************************************************************

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -268,6 +268,9 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		// For time fsp
 		{"CREATE TABLE t( c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2) );", true},
+
+		// For unreserved keywords
+		{"SELECT id, user_id, repo_id, mode FROM access WHERE repo_id=1 AND mode>=1;", true},
 	}
 
 	for _, t := range table {

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -507,7 +507,8 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 {lock}			return lock
 {low_priority}		return lowPriority
 {mod}			return mod
-{mode}			return mode
+{mode}			lval.item = string(l.val)
+			return mode
 {names}			lval.item = string(l.val)
 			return names
 {not}			return not


### PR DESCRIPTION
"mode" can be used as an identifier.
See: https://dev.mysql.com/doc/refman/5.7/en/keywords.html

@Unknwon The following bug is caused by parser. This pr will fix it.
SELECT id, user_id, repo_id, mode FROM access WHERE repo_id=? AND mode>=?
, error: line 1 column 77 near "mode"
Is > a invalid operator?