### PR TITLE
parser/parser.y: S/R conflicts 25->24.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -274,10 +274,11 @@ import (
 	CharsetName		"Charset Name"
 	CollationName		"Collation Name"
 	ColumnDef		"table column definition"
+	ColumnKeywordOpt	"Column keyword or empty"
 	ColumnName		"column name"
 	ColumnNameList		"column name list"
 	ColumnNameListOpt	"column name list opt"
-	ColumnKeywordOpt	"Column keyword or empty"
+	ColumnOptColumnName	"optional COLUMN and column name"
 	ColumnSetValue		"insert statement set value by column name"
 	ColumnSetValueList	"insert statement set value by column name list"
 	CommaOpt		"optional comma"
@@ -531,11 +532,11 @@ AlterSpecification:
 			Constraint: constraint,
 		}
 	}
-|	"DROP" ColumnKeywordOpt ColumnName
+|	"DROP" ColumnOptColumnName
 	{
 		$$ = &ddl.AlterSpecification{
 			Action: ddl.AlterDropColumn,
-			Name: $3.(string),
+			Name: $2.(string),
 		}
 	}
 |	"DROP" "PRIMARY" "KEY"
@@ -559,6 +560,15 @@ AlterSpecification:
 
 KeyOrIndex:
 	"KEY"|"INDEX"
+
+ColumnOptColumnName:
+	"COLUMN"
+|	"COLUMN" "COLUMN"
+|	"COLUMN" identifier
+	{
+		$$ = $2
+	}
+|	identifier
 
 ColumnKeywordOpt:
 	{}


### PR DESCRIPTION
```
state 861 // alter tableKwd autoIncrement drop

    7 AlterSpecification: drop . ColumnKeywordOpt ColumnName
    8 AlterSpecification: drop . primary key
    9 AlterSpecification: drop . KeyOrIndex IndexName
   10 AlterSpecification: drop . foreign key Symbol
   13 ColumnKeywordOpt: .  [autoIncrement, begin, bitType, boolType, booleanType, charsetKwd, column, columns, dateType, datetimeType, engine, full, global, identifier, local, mode, names, now, offset, password, quick, rollback, session, substring, tables, textType, timeType, timestampType, transaction, truncate, value, warnings, yearType]

    autoIncrement  reduce using rule 13 (ColumnKeywordOpt)
    begin          reduce using rule 13 (ColumnKeywordOpt)
    bitType        reduce using rule 13 (ColumnKeywordOpt)
    boolType       reduce using rule 13 (ColumnKeywordOpt)
    booleanType    reduce using rule 13 (ColumnKeywordOpt)
    charsetKwd     reduce using rule 13 (ColumnKeywordOpt)
    column         shift, and goto state 869
    columns        reduce using rule 13 (ColumnKeywordOpt)
    dateType       reduce using rule 13 (ColumnKeywordOpt)
    datetimeType   reduce using rule 13 (ColumnKeywordOpt)
    engine         reduce using rule 13 (ColumnKeywordOpt)
    foreign        shift, and goto state 866
    full           reduce using rule 13 (ColumnKeywordOpt)
    global         reduce using rule 13 (ColumnKeywordOpt)
    identifier     reduce using rule 13 (ColumnKeywordOpt)
    index          shift, and goto state 868
    key            shift, and goto state 867
    local          reduce using rule 13 (ColumnKeywordOpt)
    mode           reduce using rule 13 (ColumnKeywordOpt)
    names          reduce using rule 13 (ColumnKeywordOpt)
    now            reduce using rule 13 (ColumnKeywordOpt)
    offset         reduce using rule 13 (ColumnKeywordOpt)
    password       reduce using rule 13 (ColumnKeywordOpt)
    primary        shift, and goto state 864
    quick          reduce using rule 13 (ColumnKeywordOpt)
    rollback       reduce using rule 13 (ColumnKeywordOpt)
    session        reduce using rule 13 (ColumnKeywordOpt)
    substring      reduce using rule 13 (ColumnKeywordOpt)
    tables         reduce using rule 13 (ColumnKeywordOpt)
    textType       reduce using rule 13 (ColumnKeywordOpt)
    timeType       reduce using rule 13 (ColumnKeywordOpt)
    timestampType  reduce using rule 13 (ColumnKeywordOpt)
    transaction    reduce using rule 13 (ColumnKeywordOpt)
    truncate       reduce using rule 13 (ColumnKeywordOpt)
    value          reduce using rule 13 (ColumnKeywordOpt)
    warnings       reduce using rule 13 (ColumnKeywordOpt)
    yearType       reduce using rule 13 (ColumnKeywordOpt)

    ColumnKeywordOpt  goto state 863
    KeyOrIndex        goto state 865

    conflict on column, shift, and goto state 869, reduce using rule 13
```