### PR TITLE
dev row constructor

### DIFF
--- a/expression/expressions/between.go
+++ b/expression/expressions/between.go
@@ -20,6 +20,7 @@ package expressions
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/opcode"
@@ -75,19 +76,23 @@ func (b *Between) String() string {
 
 // Eval implements the Expression Eval interface.
 func (b *Between) Eval(ctx context.Context, args map[interface{}]interface{}) (interface{}, error) {
+	if err := CheckAllOneColumns(b.Expr, b.Left, b.Right); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	v, err := b.Expr.Eval(ctx, args)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	lv, err := b.Left.Eval(ctx, args)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	rv, err := b.Right.Eval(ctx, args)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	var l, r expression.Expression
@@ -148,19 +153,23 @@ func (b *Between) convert() expression.Expression {
 //	a between 10 and 15 -> a >= 10 && a <= 15
 //	a not between 10 and 15 -> a < 10 || b > 15
 func NewBetween(expr, lo, hi expression.Expression, not bool) (expression.Expression, error) {
+	if err := CheckAllOneColumns(expr, lo, hi); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	e, err := staticExpr(expr)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	l, err := staticExpr(lo)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	h, err := staticExpr(hi)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	b := &Between{Expr: e, Left: l, Right: h, Not: not}

--- a/expression/expressions/between_test.go
+++ b/expression/expressions/between_test.go
@@ -93,4 +93,23 @@ func (s *testBetweenSuite) TestBetween(c *C) {
 		_, err = b.Eval(nil, nil)
 		c.Assert(err, NotNil)
 	}
+
+	tableError = []struct {
+		Expr  expression.Expression
+		Left  expression.Expression
+		Right expression.Expression
+	}{
+		{newTestRow(1, 2), f(false), f(false)},
+		{f(false), newTestRow(1, 2), f(false)},
+		{f(false), f(false), newTestRow(1, 2)},
+	}
+
+	for _, t := range tableError {
+		_, err := NewBetween(t.Expr, t.Left, t.Right, false)
+		c.Assert(err, NotNil)
+		b := Between{Expr: t.Expr, Left: t.Left, Right: t.Right, Not: false}
+
+		_, err = b.Eval(nil, nil)
+		c.Assert(err, NotNil)
+	}
 }

--- a/expression/expressions/binop.go
+++ b/expression/expressions/binop.go
@@ -147,6 +147,20 @@ func (o *BinaryOperation) Eval(ctx context.Context, args map[interface{}]interfa
 		}
 	}()
 
+	// all operands must have same column.
+	if err := hasSameColumn(o.L, o.R); err != nil {
+		return nil, o.traceErr(err)
+	}
+
+	// row constructor only supports comparison operation.
+	switch o.Op {
+	case opcode.LT, opcode.LE, opcode.GE, opcode.GT, opcode.EQ, opcode.NE:
+	default:
+		if err := CheckOneColumn(o.L); err != nil {
+			return nil, o.traceErr(err)
+		}
+	}
+
 	switch o.Op {
 	case opcode.AndAnd, opcode.OrOr, opcode.LogicXor:
 		return o.evalLogicOp(ctx, args)

--- a/expression/expressions/binop_test.go
+++ b/expression/expressions/binop_test.go
@@ -526,4 +526,19 @@ func (s *testBinOpSuite) TestNumericOp(c *C) {
 	expr.Op = 0
 	_, err = expr.Eval(nil, nil)
 	c.Assert(err, NotNil)
+
+	expr.L = newTestRow(1, 2)
+	expr.R = Value{nil}
+	expr.Op = opcode.Plus
+
+	_, err = expr.Eval(nil, nil)
+	c.Assert(err, NotNil)
+
+	expr.Op = opcode.LE
+	_, err = expr.Eval(nil, nil)
+	c.Assert(err, NotNil)
+
+	expr.R = newTestRow(1, 2)
+	expr.Op = opcode.Plus
+	c.Assert(err, NotNil)
 }

--- a/expression/expressions/helper.go
+++ b/expression/expressions/helper.go
@@ -222,6 +222,10 @@ func mentionedAggregateFuncs(e expression.Expression, m *[]expression.Expression
 		mentionedAggregateFuncs(x.Expr, m)
 		mentionedAggregateFuncs(x.Left, m)
 		mentionedAggregateFuncs(x.Right, m)
+	case *Row:
+		for _, expr := range x.Values {
+			mentionedAggregateFuncs(expr, m)
+		}
 	default:
 		log.Errorf("Unknown Expression: %T", e)
 	}
@@ -306,6 +310,10 @@ func mentionedColumns(e expression.Expression, m map[string]bool, names *[]strin
 		mentionedColumns(x.Expr, m, names)
 		mentionedColumns(x.Left, m, names)
 		mentionedColumns(x.Right, m, names)
+	case *Row:
+		for _, expr := range x.Values {
+			mentionedColumns(expr, m, names)
+		}
 	default:
 		log.Errorf("Unknown Expression: %T", e)
 	}

--- a/expression/expressions/helper_test.go
+++ b/expression/expressions/helper_test.go
@@ -40,6 +40,7 @@ func (s *testHelperSuite) TestContainAggFunc(c *C) {
 		{&WhenClause{Expr: v, Result: v}, false},
 		{&IsTruth{Expr: v}, false},
 		{&Between{Expr: v, Left: v, Right: v}, false},
+		{&Row{Values: []expression.Expression{v, v}}, false},
 	}
 
 	for _, t := range tbl {
@@ -71,6 +72,7 @@ func (s *testHelperSuite) TestMentionedColumns(c *C) {
 		{&WhenClause{Expr: v, Result: v}, 0},
 		{&IsTruth{Expr: v}, 0},
 		{&Between{Expr: v, Left: v, Right: v}, 0},
+		{&Row{Values: []expression.Expression{v, v}}, 0},
 	}
 
 	for _, t := range tbl {

--- a/expression/expressions/isnull.go
+++ b/expression/expressions/isnull.go
@@ -58,10 +58,10 @@ func (is *IsNull) String() string {
 
 // Eval implements the Expression Eval interface.
 func (is *IsNull) Eval(ctx context.Context, args map[interface{}]interface{}) (v interface{}, err error) {
-	Val, err := is.Expr.Eval(ctx, args)
+	val, err := is.Expr.Eval(ctx, args)
 	if err != nil {
 		return
 	}
 
-	return Val == nil != is.Not, nil
+	return val == nil != is.Not, nil
 }

--- a/expression/expressions/isnull.go
+++ b/expression/expressions/isnull.go
@@ -16,6 +16,7 @@ package expressions
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 )
@@ -58,6 +59,10 @@ func (is *IsNull) String() string {
 
 // Eval implements the Expression Eval interface.
 func (is *IsNull) Eval(ctx context.Context, args map[interface{}]interface{}) (v interface{}, err error) {
+	if err := CheckOneColumn(is.Expr); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	val, err := is.Expr.Eval(ctx, args)
 	if err != nil {
 		return

--- a/expression/expressions/isnull.go
+++ b/expression/expressions/isnull.go
@@ -68,5 +68,5 @@ func (is *IsNull) Eval(ctx context.Context, args map[interface{}]interface{}) (v
 		return
 	}
 
-	return val == nil != is.Not, nil
+	return (val == nil) != is.Not, nil
 }

--- a/expression/expressions/isnull_test.go
+++ b/expression/expressions/isnull_test.go
@@ -14,6 +14,8 @@
 package expressions
 
 import (
+	"errors"
+
 	. "github.com/pingcap/check"
 )
 
@@ -50,4 +52,19 @@ func (t *testIsNullSuite) TestIsNull(c *C) {
 
 	str = e2.String()
 	c.Assert(len(str), Greater, 0)
+
+	// check error
+	expr := mockExpr{}
+	expr.err = errors.New("must error")
+	e.Expr = expr
+
+	_, err = e.Clone()
+	c.Assert(err, NotNil)
+
+	_, err = e.Eval(nil, nil)
+	c.Assert(err, NotNil)
+
+	e.Expr = newTestRow(1, 2)
+	_, err = e.Eval(nil, nil)
+	c.Assert(err, NotNil)
 }

--- a/expression/expressions/istruth.go
+++ b/expression/expressions/istruth.go
@@ -16,6 +16,7 @@ package expressions
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/util/types"
@@ -67,6 +68,10 @@ func (is *IsTruth) String() string {
 
 // Eval implements the Expression Eval interface.
 func (is *IsTruth) Eval(ctx context.Context, args map[interface{}]interface{}) (v interface{}, err error) {
+	if err := CheckOneColumn(is.Expr); err != nil {
+		return nil, errors.Trace(err)
+	}
+
 	val, err := is.Expr.Eval(ctx, args)
 	if err != nil {
 		return

--- a/expression/expressions/istruth_test.go
+++ b/expression/expressions/istruth_test.go
@@ -56,4 +56,9 @@ func (t *testIsTruthSuite) TestIsTruth(c *C) {
 	vvv, err := e2.Eval(nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(vvv, IsTrue)
+
+	// check error
+	e.Expr = newTestRow(1, 2)
+	_, err = e.Eval(nil, nil)
+	c.Assert(err, NotNil)
 }

--- a/expression/expressions/row.go
+++ b/expression/expressions/row.go
@@ -1,0 +1,80 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expressions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/expression"
+)
+
+var errOperandColumns = errors.Errorf("Operand should contain 1 column(s)")
+
+// Row is the expression for row constructor.
+// See https://dev.mysql.com/doc/refman/5.7/en/row-subqueries.html
+type Row struct {
+	Values []expression.Expression
+}
+
+// Clone implements the Expression Clone interface.
+func (r *Row) Clone() (expression.Expression, error) {
+	values := make([]expression.Expression, len(r.Values))
+	var err error
+	for i, expr := range r.Values {
+		values[i], err = expr.Clone()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return &Row{Values: values}, nil
+}
+
+// IsStatic implements the Expression IsStatic interface.
+func (r *Row) IsStatic() bool {
+	for _, e := range r.Values {
+		if !e.IsStatic() {
+			return false
+		}
+	}
+
+	return true
+}
+
+// String implements the Expression String interface.
+func (r *Row) String() string {
+	ss := make([]string, len(r.Values))
+	for i := range ss {
+		ss[i] = r.Values[i].String()
+	}
+
+	return fmt.Sprintf("ROW(%s)", strings.Join(ss, ", "))
+}
+
+// Eval implements the Expression Eval interface.
+func (r *Row) Eval(ctx context.Context, args map[interface{}]interface{}) (interface{}, error) {
+	row := make([]interface{}, len(r.Values))
+	var err error
+	for i, expr := range r.Values {
+		row[i], err = expr.Eval(ctx, args)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	return row, nil
+}

--- a/expression/expressions/row.go
+++ b/expression/expressions/row.go
@@ -22,8 +22,6 @@ import (
 	"github.com/pingcap/tidb/expression"
 )
 
-var errOperandColumns = errors.Errorf("Operand should contain 1 column(s)")
-
 // Row is the expression for row constructor.
 // See https://dev.mysql.com/doc/refman/5.7/en/row-subqueries.html
 type Row struct {

--- a/expression/expressions/row_test.go
+++ b/expression/expressions/row_test.go
@@ -1,0 +1,51 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expressions
+
+import (
+	"errors"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/expression"
+)
+
+var _ = Suite(&testRowSuite{})
+
+type testRowSuite struct {
+}
+
+func (s *testRowSuite) TestRow(c *C) {
+	r := Row{Values: []expression.Expression{Value{1}, Value{2}}}
+	c.Assert(r.IsStatic(), IsTrue)
+
+	_, err := r.Clone()
+	c.Assert(err, IsNil)
+
+	c.Assert(r.String(), Equals, "ROW(1, 2)")
+
+	_, err = r.Eval(nil, nil)
+	c.Assert(err, IsNil)
+
+	expr := mockExpr{}
+	expr.isStatic = false
+	expr.err = errors.New("must error")
+	r = Row{Values: []expression.Expression{Value{1}, expr}}
+	c.Assert(r.IsStatic(), IsFalse)
+
+	_, err = r.Clone()
+	c.Assert(err, NotNil)
+
+	_, err = r.Eval(nil, nil)
+	c.Assert(err, NotNil)
+}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -164,6 +164,7 @@ import (
 	right		"RIGHT"
 	rlike		"RLIKE"
 	rollback	"ROLLBACK"
+	row 		"ROW"
 	rsh		">>"
 	runeType	"rune"
 	schema		"SCHEMA"
@@ -1699,6 +1700,17 @@ Operand:
 		l.ParamList = append(l.ParamList, pm)
 		$$ = pm
 	}
+|	"ROW" '(' Expression ',' ExpressionList ')'
+	{
+		values := append([]expression.Expression{$3.(expression.Expression)}, $5.([]expression.Expression)...)
+		$$ = &expressions.Row{Values: values}
+	}
+|	'(' Expression ',' ExpressionList ')'
+	{
+		values := append([]expression.Expression{$2.(expression.Expression)}, $4.([]expression.Expression)...)
+		$$ = &expressions.Row{Values: values}
+	}
+
 
 OrderBy:
 	"ORDER" "BY" OrderByList

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -268,6 +268,13 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		// For time fsp
 		{"CREATE TABLE t( c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2) );", true},
+
+		// For row
+		{"select row(1)", false},
+		{"select row(1, 1,)", false},
+		{"select (1, 1,)", false},
+		{"select row(1, 1) > row(1, 1), row(1, 1, 1) > row(1, 1, 1)", true},
+		{"Select (1, 1) > (1, 1)", true},
 	}
 
 	for _, t := range table {

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -311,6 +311,7 @@ regexp		{r}{e}{g}{e}{x}{p}
 right		{r}{i}{g}{h}{t}
 rlike		{r}{l}{i}{k}{e}
 rollback	{r}{o}{l}{l}{b}{a}{c}{k}
+row 		{r}{o}{w}
 schema		{s}{c}{h}{e}{m}{a}
 schemas		{s}{c}{h}{e}{m}{a}{s}
 select		{s}{e}{l}{e}{c}{t}
@@ -557,6 +558,7 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 {right}			return right
 {rollback}		lval.item = string(l.val)
 			return rollback
+{row}			return row
 {schema}		return schema
 {schemas}		return schemas
 {session}		lval.item = string(l.val)

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -558,7 +558,8 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 {right}			return right
 {rollback}		lval.item = string(l.val)
 			return rollback
-{row}			return row
+{row}			lval.item = string(l.val)
+			return row
 {schema}		return schema
 {schemas}		return schemas
 {session}		lval.item = string(l.val)


### PR DESCRIPTION
base support row constructor like `select row(1, 1) > row(1,1)`

row constructor now only supports in comparison operation.

TODO in other PRs:
+ add more checks in other expressions for Row constructor. 
+ check row constructor in select list, group by, order by, having, e,g `select row(1, 1)` is not allowed. 
+ support row constructor with sub select. 