### PR TITLE
parser/parser.y: Remove FieldOpts superfluous production. (S/R conflicts 24->18)

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3177,10 +3177,6 @@ FieldOpts:
 	{
 		$$ = []*field.Opt{}
 	}
-|	FieldOpt
-	{
-		$$ = []*field.Opt{$1.(*field.Opt)}    
-	}
 |	FieldOpts FieldOpt
 	{
 		$$ = append($1.([]*field.Opt), $2.(*field.Opt)) 


### PR DESCRIPTION
```
state 837 // create tableKwd after '(' after bigIntType [$end]

  496 NumericType: IntegerType OptFieldLen . FieldOpts
  542 FieldOpts: .  [$end, ')', ',', ';', after, autoIncrement, defaultKwd, first, not, null, on, primary, unique, unsigned, zerofill]

    $end           reduce using rule 542 (FieldOpts)
    ')'            reduce using rule 542 (FieldOpts)
    ','            reduce using rule 542 (FieldOpts)
    ';'            reduce using rule 542 (FieldOpts)
    after          reduce using rule 542 (FieldOpts)
    autoIncrement  reduce using rule 542 (FieldOpts)
    defaultKwd     reduce using rule 542 (FieldOpts)
    first          reduce using rule 542 (FieldOpts)
    not            reduce using rule 542 (FieldOpts)
    null           reduce using rule 542 (FieldOpts)
    on             reduce using rule 542 (FieldOpts)
    primary        reduce using rule 542 (FieldOpts)
    unique         reduce using rule 542 (FieldOpts)
    unsigned       shift, and goto state 831
    zerofill       shift, and goto state 832

    FieldOpt   goto state 833
    FieldOpts  goto state 838

    conflict on unsigned, shift, and goto state 831, reduce using rule 542
    conflict on zerofill, shift, and goto state 832, reduce using rule 542
```

```bash
(13:14) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 124041 of 376656, x 16 bits == 248082 bytes
conflicts: 18 shift/reduce
(13:14) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```