### PR TITLE
parser/parser.y: Remove ConstraintOpts superfluous production. S/R conflicts 18->11.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -863,10 +863,6 @@ ConstraintOpts:
 	{
 		$$ = []*coldef.ConstraintOpt{}
 	}
-|	ConstraintOpt
-	{
-		$$ = []*coldef.ConstraintOpt{$1.(*coldef.ConstraintOpt)} 
-	}
 |	ConstraintOpts ConstraintOpt
 	{
 		if $2 != nil {


### PR DESCRIPTION
```
state 759 // create tableKwd after '(' after bigIntType [$end]

   38 ColumnDef: ColumnName Type . ConstraintOpts
   74 ConstraintOpts: .  [$end, ')', ',', ';', after, autoIncrement, defaultKwd, first, not, null, on, primary, unique]

    $end           reduce using rule 74 (ConstraintOpts)
    ')'            reduce using rule 74 (ConstraintOpts)
    ','            reduce using rule 74 (ConstraintOpts)
    ';'            reduce using rule 74 (ConstraintOpts)
    after          reduce using rule 74 (ConstraintOpts)
    autoIncrement  shift, and goto state 841
    defaultKwd     shift, and goto state 844
    first          reduce using rule 74 (ConstraintOpts)
    not            shift, and goto state 839
    null           shift, and goto state 840
    on             shift, and goto state 845
    primary        shift, and goto state 842
    unique         shift, and goto state 843

    Constraint      goto state 846
    ConstraintOpt   goto state 847
    ConstraintOpts  goto state 838

    conflict on autoIncrement, shift, and goto state 841, reduce using rule 74
    conflict on defaultKwd, shift, and goto state 844, reduce using rule 74
    conflict on not, shift, and goto state 839, reduce using rule 74 // not: assoc %right, prec 16
    conflict on null, shift, and goto state 840, reduce using rule 74
    conflict on on, shift, and goto state 845, reduce using rule 74
    conflict on primary, shift, and goto state 842, reduce using rule 74
    conflict on unique, shift, and goto state 843, reduce using rule 74
```

```bash
(14:09) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 124004 of 376243, x 16 bits == 248008 bytes
conflicts: 11 shift/reduce
(14:09) jnml@r550:~/src/github.com/cznic/tidb/parser$
```