### PR TITLE
parser/parser.y: S/R conflicts 11->10.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -465,6 +465,9 @@ import (
 
 %token	tableRefPriority
 
+%precedence lowerThanCalcFoundRows
+%precedence calcFoundRows
+
 %left   join inner cross left right full
 /* A dummy token to force the priority of TableRef production in a join. */
 %left   tableRefPriority
@@ -2417,6 +2420,7 @@ SelectStmtOpts:
 	}
 
 SelectStmtCalcFoundRows:
+	%prec lowerThanCalcFoundRows
 	{
 		$$ = false
 	}


### PR DESCRIPTION
```
state 453 // selectKwd ['!']

  385 SelectStmtOpts: SelectStmtDistinct . SelectStmtCalcFoundRows
  386 SelectStmtCalcFoundRows: .  ['!', '(', '*', '+', '-', '~', after, autoIncrement, begin, bitType, boolType, booleanType, calcFoundRows, caseKwd, cast, charsetKwd, columns, commit, convert, database, dateType, datetimeType, deallocate, defaultKwd, do, end, engine, engines, execute, falseKwd, first, floatLit, full, global, identifier, ifKwd, imaginaryLit, intLit, left, local, mode, names, not, now, null, offset, password, placeholder, prepare, quick, rollback, row, schema, session, signed, start, stringLit, substring, sysVar, tables, textType, timeType, timestampType, transaction, trueKwd, truncate, unknown, userVar, value, values, warnings, yearType]

    '!'            reduce using rule 386 (SelectStmtCalcFoundRows)
    '('            reduce using rule 386 (SelectStmtCalcFoundRows)
    '*'            reduce using rule 386 (SelectStmtCalcFoundRows)
    '+'            reduce using rule 386 (SelectStmtCalcFoundRows)
    '-'            reduce using rule 386 (SelectStmtCalcFoundRows)
    '~'            reduce using rule 386 (SelectStmtCalcFoundRows)
    after          reduce using rule 386 (SelectStmtCalcFoundRows)
    autoIncrement  reduce using rule 386 (SelectStmtCalcFoundRows)
    begin          reduce using rule 386 (SelectStmtCalcFoundRows)
    bitType        reduce using rule 386 (SelectStmtCalcFoundRows)
    boolType       reduce using rule 386 (SelectStmtCalcFoundRows)
    booleanType    reduce using rule 386 (SelectStmtCalcFoundRows)
    calcFoundRows  shift, and goto state 455
    caseKwd        reduce using rule 386 (SelectStmtCalcFoundRows)
    cast           reduce using rule 386 (SelectStmtCalcFoundRows)
    charsetKwd     reduce using rule 386 (SelectStmtCalcFoundRows)
    columns        reduce using rule 386 (SelectStmtCalcFoundRows)
    commit         reduce using rule 386 (SelectStmtCalcFoundRows)
    convert        reduce using rule 386 (SelectStmtCalcFoundRows)
    database       reduce using rule 386 (SelectStmtCalcFoundRows)
    dateType       reduce using rule 386 (SelectStmtCalcFoundRows)
    datetimeType   reduce using rule 386 (SelectStmtCalcFoundRows)
    deallocate     reduce using rule 386 (SelectStmtCalcFoundRows)
    defaultKwd     reduce using rule 386 (SelectStmtCalcFoundRows)
    do             reduce using rule 386 (SelectStmtCalcFoundRows)
    end            reduce using rule 386 (SelectStmtCalcFoundRows)
    engine         reduce using rule 386 (SelectStmtCalcFoundRows)
    engines        reduce using rule 386 (SelectStmtCalcFoundRows)
    execute        reduce using rule 386 (SelectStmtCalcFoundRows)
    falseKwd       reduce using rule 386 (SelectStmtCalcFoundRows)
    first          reduce using rule 386 (SelectStmtCalcFoundRows)
    floatLit       reduce using rule 386 (SelectStmtCalcFoundRows)
    full           reduce using rule 386 (SelectStmtCalcFoundRows)
    global         reduce using rule 386 (SelectStmtCalcFoundRows)
    identifier     reduce using rule 386 (SelectStmtCalcFoundRows)
    ifKwd          reduce using rule 386 (SelectStmtCalcFoundRows)
    imaginaryLit   reduce using rule 386 (SelectStmtCalcFoundRows)
    intLit         reduce using rule 386 (SelectStmtCalcFoundRows)
    left           reduce using rule 386 (SelectStmtCalcFoundRows)
    local          reduce using rule 386 (SelectStmtCalcFoundRows)
    mode           reduce using rule 386 (SelectStmtCalcFoundRows)
    names          reduce using rule 386 (SelectStmtCalcFoundRows)
    not            reduce using rule 386 (SelectStmtCalcFoundRows)
    now            reduce using rule 386 (SelectStmtCalcFoundRows)
    null           reduce using rule 386 (SelectStmtCalcFoundRows)
    offset         reduce using rule 386 (SelectStmtCalcFoundRows)
    password       reduce using rule 386 (SelectStmtCalcFoundRows)
    placeholder    reduce using rule 386 (SelectStmtCalcFoundRows)
    prepare        reduce using rule 386 (SelectStmtCalcFoundRows)
    quick          reduce using rule 386 (SelectStmtCalcFoundRows)
    rollback       reduce using rule 386 (SelectStmtCalcFoundRows)
    row            reduce using rule 386 (SelectStmtCalcFoundRows)
    schema         reduce using rule 386 (SelectStmtCalcFoundRows)
    session        reduce using rule 386 (SelectStmtCalcFoundRows)
    signed         reduce using rule 386 (SelectStmtCalcFoundRows)
    start          reduce using rule 386 (SelectStmtCalcFoundRows)
    stringLit      reduce using rule 386 (SelectStmtCalcFoundRows)
    substring      reduce using rule 386 (SelectStmtCalcFoundRows)
    sysVar         reduce using rule 386 (SelectStmtCalcFoundRows)
    tables         reduce using rule 386 (SelectStmtCalcFoundRows)
    textType       reduce using rule 386 (SelectStmtCalcFoundRows)
    timeType       reduce using rule 386 (SelectStmtCalcFoundRows)
    timestampType  reduce using rule 386 (SelectStmtCalcFoundRows)
    transaction    reduce using rule 386 (SelectStmtCalcFoundRows)
    trueKwd        reduce using rule 386 (SelectStmtCalcFoundRows)
    truncate       reduce using rule 386 (SelectStmtCalcFoundRows)
    unknown        reduce using rule 386 (SelectStmtCalcFoundRows)
    userVar        reduce using rule 386 (SelectStmtCalcFoundRows)
    value          reduce using rule 386 (SelectStmtCalcFoundRows)
    values         reduce using rule 386 (SelectStmtCalcFoundRows)
    warnings       reduce using rule 386 (SelectStmtCalcFoundRows)
    yearType       reduce using rule 386 (SelectStmtCalcFoundRows)

    SelectStmtCalcFoundRows  goto state 454

    conflict on calcFoundRows, shift, and goto state 455, reduce using rule 386
```

```bash
(14:46) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 124004 of 377154, x 16 bits == 248008 bytes
conflicts: 10 shift/reduce
(14:46) jnml@r550:~/src/github.com/cznic/tidb/parser$
```