### PR TITLE
parser/parser.y: S/R conflicts 10->9.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -471,6 +471,7 @@ import (
 %left   join inner cross left right full
 /* A dummy token to force the priority of TableRef production in a join. */
 %left   tableRefPriority
+%precedence on
 %left 	oror or
 %left 	xor
 %left 	andand and


### PR DESCRIPTION
```
state 510 // deleteKwd from after join after

  365 JoinTable: TableRef . CrossOpt TableRef  // assoc %left, prec 4
  365 JoinTable: TableRef CrossOpt TableRef .  [$end, ')', ',', ';', '}', cross, forKwd, full, group, having, inner, join, left, limit, lock, on, order, right, union, where]  // assoc %left, prec 4
  366 JoinTable: TableRef . CrossOpt TableRef on Expression
  366 JoinTable: TableRef CrossOpt TableRef . on Expression
  367 JoinTable: TableRef . JoinType OuterOpt join TableRef on Expression

    $end    reduce using rule 365 (JoinTable)
    ')'     reduce using rule 365 (JoinTable)
    ','     reduce using rule 365 (JoinTable)
    ';'     reduce using rule 365 (JoinTable)
    '}'     reduce using rule 365 (JoinTable)
    cross   reduce using rule 365 (JoinTable)
    forKwd  reduce using rule 365 (JoinTable)
    full    reduce using rule 365 (JoinTable)
    group   reduce using rule 365 (JoinTable)
    having  reduce using rule 365 (JoinTable)
    inner   reduce using rule 365 (JoinTable)
    join    reduce using rule 365 (JoinTable)
    left    reduce using rule 365 (JoinTable)
    limit   reduce using rule 365 (JoinTable)
    lock    reduce using rule 365 (JoinTable)
    on      shift, and goto state 511
    order   reduce using rule 365 (JoinTable)
    right   reduce using rule 365 (JoinTable)
    union   reduce using rule 365 (JoinTable)
    where   reduce using rule 365 (JoinTable)

    CrossOpt  goto state 494
    JoinType  goto state 495

    conflict on on, shift, and goto state 511, reduce using rule 365
```

```bash
jnml@4670:~/src/github.com/cznic/tidb/parser$ goyacc -cr -o /dev/null parser.y
Parse table entries: 124004 of 377154, x 16 bits == 248008 bytes
conflicts: 9 shift/reduce
jnml@4670:~/src/github.com/cznic/tidb/parser$ 
```