### PR TITLE
driver: check argument types

### DIFF
--- a/session.go
+++ b/session.go
@@ -266,9 +266,9 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 	return prepareStmt(s, sql)
 }
 
-// checkArgs make sure all the arguments's type is known and can be handled.
+// checkArgs makes sure all the arguments' types are known and can be handled.
 // integer types are converted to int64 and uint64, time.Time is converted to mysql.Time.
-// time.Duration. is converted to mysql.Duration, other known types is leaved as it is.
+// time.Duration is converted to mysql.Duration, other known types are leaved as it is.
 func checkArgs(args ...interface{}) error {
 	for i, v := range args {
 		switch x := v.(type) {

--- a/session.go
+++ b/session.go
@@ -266,6 +266,9 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 	return prepareStmt(s, sql)
 }
 
+// checkArgs make sure all the arguments's type is known and can be handled.
+// integer types are converted to int64 and uint64, time.Time is converted to mysql.Time.
+// time.Duration. is converted to mysql.Duration, other known types is leaved as it is.
 func checkArgs(args ...interface{}) error {
 	for i, v := range args {
 		switch x := v.(type) {

--- a/session.go
+++ b/session.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/stmt"
 	"github.com/pingcap/tidb/stmt/stmts"
 	"github.com/pingcap/tidb/util/errors2"
-	"github.com/pingcap/tidb/util/types"
 )
 
 // Session context
@@ -269,18 +268,40 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 
 func checkArgs(args ...interface{}) error {
 	for i, v := range args {
-		switch v.(type) {
+		switch x := v.(type) {
 		case bool:
-			// We do not handle bool as int8 in tidb.
-			vv, err := types.ToBool(v)
-			if err != nil {
-				return errors.Trace(err)
+			if x {
+				args[i] = int64(1)
+			} else {
+				args[i] = int64(0)
 			}
-			args[i] = vv
-		case nil, float32, float64, string,
-			int8, int16, int32, int64, int,
-			uint8, uint16, uint32, uint64, uint,
-			[]byte, time.Duration, time.Time:
+		case int8:
+			args[i] = int64(x)
+		case int16:
+			args[i] = int64(x)
+		case int32:
+			args[i] = int64(x)
+		case int:
+			args[i] = int64(x)
+		case uint8:
+			args[i] = uint64(x)
+		case uint16:
+			args[i] = uint64(x)
+		case uint32:
+			args[i] = uint64(x)
+		case uint:
+			args[i] = uint64(x)
+		case int64:
+		case uint64:
+		case float32:
+		case float64:
+		case string:
+		case []byte:
+		case time.Duration:
+			args[i] = mysql.Duration{Duration: x}
+		case time.Time:
+			args[i] = mysql.Time{Time: x, Type: mysql.TypeDatetime}
+		case nil:
 		default:
 			return errors.Errorf("cannot use arg[%d] (type %T):unsupported type", i, v)
 		}

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
@@ -276,6 +277,19 @@ func (s *testMainSuite) TestDeletePanic(c *C) {
 	c.Assert(rs.Next(), IsFalse)
 	c.Assert(rs.Next(), IsFalse)
 	c.Assert(rs.Close(), IsNil)
+}
+
+// Testcase for arg type.
+func (s *testMainSuite) TestCheckArgs(c *C) {
+	db, err := sql.Open("tidb", "memory://test/test")
+	defer db.Close()
+	c.Assert(err, IsNil)
+	mustExec(c, db, "create table if not exists t (c datetime)")
+	mustExec(c, db, "insert t values (?)", time.Now())
+	mustExec(c, db, "drop table t")
+	checkArgs(nil, true, false, int8(1), int16(1), int32(1), int64(1), 1,
+		uint8(1), uint16(1), uint32(1), uint64(1), uint(1), float32(1), float64(1),
+		"abc", []byte("abc"), time.Now(), time.Hour, time.Local)
 }
 
 func sessionExec(c *C, se Session, sql string) ([]rset.Recordset, error) {


### PR DESCRIPTION
We use mysql.Time internally and time.Time type has not been handled, so when user pass in time.Time type, TiDB returns error.
Since we reduced integer types to only 'int', 'int64', 'uint64' recently, all other integer types needs to be converted to int64 or uint64.

Fixes #95