### PR TITLE
parser/parser.y: S/R conflicts 9->4.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -487,6 +487,9 @@ import (
 %left 	'~' neg
 %right 	not
 
+%precedence lowerThanLeftParen
+%precedence '('
+
 %start	Start
 
 %%
@@ -1538,7 +1541,7 @@ UnReservedKeyword:
 |	"VALUE" | "WARNINGS" | "YEAR" | "NOW" |	"MODE"
 
 NotKeywordToken:
-	"SQL_CALC_FOUND_ROWS" | "SUBSTRING"
+	"SQL_CALC_FOUND_ROWS" | "SUBSTRING" %prec lowerThanLeftParen
 
 /************************************************************************************
  *


### PR DESCRIPTION
```
state 125 // do substring

  224 NotKeywordToken: substring .  [$end, '%', '&', '(', ')', '*', '+', ',', '-', '.', '/', ';', '<', '>', '^', '|', '}', and, andand, as, asc, between, cross, desc, div, elseKwd, end, eq, forKwd, from, full, ge, group, having, identifier, in, inner, is, join, le, left, like, limit, lock, lsh, mod, neq, neqSynonym, not, on, or, order, oror, regexp, right, rlike, rsh, then, union, using, when, where, xor]
  284 Function: substring . '(' Expression ',' Expression ')'
  285 Function: substring . '(' Expression from Expression ')'
  286 Function: substring . '(' Expression ',' Expression ',' Expression ')'
  287 Function: substring . '(' Expression from Expression forKwd Expression ')'

    $end        reduce using rule 224 (NotKeywordToken)
    '%'         reduce using rule 224 (NotKeywordToken)
    '&'         reduce using rule 224 (NotKeywordToken)
    '('         shift, and goto state 272
    ')'         reduce using rule 224 (NotKeywordToken)
    '*'         reduce using rule 224 (NotKeywordToken)
    '+'         reduce using rule 224 (NotKeywordToken)
    ','         reduce using rule 224 (NotKeywordToken)
    '-'         reduce using rule 224 (NotKeywordToken)
    '.'         reduce using rule 224 (NotKeywordToken)
    '/'         reduce using rule 224 (NotKeywordToken)
    ';'         reduce using rule 224 (NotKeywordToken)
    '<'         reduce using rule 224 (NotKeywordToken)
    '>'         reduce using rule 224 (NotKeywordToken)
    '^'         reduce using rule 224 (NotKeywordToken)
    '|'         reduce using rule 224 (NotKeywordToken)
    '}'         reduce using rule 224 (NotKeywordToken)
    and         reduce using rule 224 (NotKeywordToken)
    andand      reduce using rule 224 (NotKeywordToken)
    as          reduce using rule 224 (NotKeywordToken)
    asc         reduce using rule 224 (NotKeywordToken)
    between     reduce using rule 224 (NotKeywordToken)
    cross       reduce using rule 224 (NotKeywordToken)
    desc        reduce using rule 224 (NotKeywordToken)
    div         reduce using rule 224 (NotKeywordToken)
    elseKwd     reduce using rule 224 (NotKeywordToken)
    end         reduce using rule 224 (NotKeywordToken)
    eq          reduce using rule 224 (NotKeywordToken)
    forKwd      reduce using rule 224 (NotKeywordToken)
    from        reduce using rule 224 (NotKeywordToken)
    full        reduce using rule 224 (NotKeywordToken)
    ge          reduce using rule 224 (NotKeywordToken)
    group       reduce using rule 224 (NotKeywordToken)
    having      reduce using rule 224 (NotKeywordToken)
    identifier  reduce using rule 224 (NotKeywordToken)
    in          reduce using rule 224 (NotKeywordToken)
    inner       reduce using rule 224 (NotKeywordToken)
    is          reduce using rule 224 (NotKeywordToken)
    join        reduce using rule 224 (NotKeywordToken)
    le          reduce using rule 224 (NotKeywordToken)
    left        reduce using rule 224 (NotKeywordToken)
    like        reduce using rule 224 (NotKeywordToken)
    limit       reduce using rule 224 (NotKeywordToken)
    lock        reduce using rule 224 (NotKeywordToken)
    lsh         reduce using rule 224 (NotKeywordToken)
    mod         reduce using rule 224 (NotKeywordToken)
    neq         reduce using rule 224 (NotKeywordToken)
    neqSynonym  reduce using rule 224 (NotKeywordToken)
    not         reduce using rule 224 (NotKeywordToken)
    on          reduce using rule 224 (NotKeywordToken)
    or          reduce using rule 224 (NotKeywordToken)
    order       reduce using rule 224 (NotKeywordToken)
    oror        reduce using rule 224 (NotKeywordToken)
    regexp      reduce using rule 224 (NotKeywordToken)
    right       reduce using rule 224 (NotKeywordToken)
    rlike       reduce using rule 224 (NotKeywordToken)
    rsh         reduce using rule 224 (NotKeywordToken)
    then        reduce using rule 224 (NotKeywordToken)
    union       reduce using rule 224 (NotKeywordToken)
    using       reduce using rule 224 (NotKeywordToken)
    when        reduce using rule 224 (NotKeywordToken)
    where       reduce using rule 224 (NotKeywordToken)
    xor         reduce using rule 224 (NotKeywordToken)
    conflict on '(', shift, and goto state 272, reduce using rule 224
```

```bash
(10:24) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 123807 of 377235, x 16 bits == 247614 bytes
conflicts: 4 shift/reduce
(10:24) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```