### PR TITLE
parser/parser.y: S/R conflicts 4->3.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1683,7 +1683,7 @@ Operand:
 	{
 		$$ = &expressions.PExpr{Expr: expressions.Expr($2)}
 	}
-|	"DEFAULT"
+|	"DEFAULT" %prec lowerThanLeftParen
 	{
 		$$ = &expressions.Default{}
 	}


### PR DESCRIPTION
```
state 136 // parseExpression defaultKwd

  255 Operand: defaultKwd .  [$end, '%', '&', '(', ')', '*', '+', ',', '-', '/', ';', '<', '>', '^', '|', '}', and, andand, as, asc, between, cross, desc, div, elseKwd, end, eq, forKwd, from, full, ge, group, having, identifier, in, inner, is, join, le, left, like, limit, lock, lsh, mod, neq, neqSynonym, not, on, or, order, oror, regexp, right, rlike, rsh, then, union, using, when, where, xor]
  256 Operand: defaultKwd . '(' ColumnName ')'

    $end        reduce using rule 255 (Operand)
    '%'         reduce using rule 255 (Operand)
    '&'         reduce using rule 255 (Operand)
    '('         shift, and goto state 262
    ')'         reduce using rule 255 (Operand)
    '*'         reduce using rule 255 (Operand)
    '+'         reduce using rule 255 (Operand)
    ','         reduce using rule 255 (Operand)
    '-'         reduce using rule 255 (Operand)
    '/'         reduce using rule 255 (Operand)
    ';'         reduce using rule 255 (Operand)
    '<'         reduce using rule 255 (Operand)
    '>'         reduce using rule 255 (Operand)
    '^'         reduce using rule 255 (Operand)
    '|'         reduce using rule 255 (Operand)
    '}'         reduce using rule 255 (Operand)
    and         reduce using rule 255 (Operand)
    andand      reduce using rule 255 (Operand)
    as          reduce using rule 255 (Operand)
    asc         reduce using rule 255 (Operand)
    between     reduce using rule 255 (Operand)
    cross       reduce using rule 255 (Operand)
    desc        reduce using rule 255 (Operand)
    div         reduce using rule 255 (Operand)
    elseKwd     reduce using rule 255 (Operand)
    end         reduce using rule 255 (Operand)
    eq          reduce using rule 255 (Operand)
    forKwd      reduce using rule 255 (Operand)
    from        reduce using rule 255 (Operand)
    full        reduce using rule 255 (Operand)
    ge          reduce using rule 255 (Operand)
    group       reduce using rule 255 (Operand)
    having      reduce using rule 255 (Operand)
    identifier  reduce using rule 255 (Operand)
    in          reduce using rule 255 (Operand)
    inner       reduce using rule 255 (Operand)
    is          reduce using rule 255 (Operand)
    join        reduce using rule 255 (Operand)
    le          reduce using rule 255 (Operand)
    left        reduce using rule 255 (Operand)
    like        reduce using rule 255 (Operand)
    limit       reduce using rule 255 (Operand)
    lock        reduce using rule 255 (Operand)
    lsh         reduce using rule 255 (Operand)
    mod         reduce using rule 255 (Operand)
    neq         reduce using rule 255 (Operand)
    neqSynonym  reduce using rule 255 (Operand)
    not         reduce using rule 255 (Operand)
    on          reduce using rule 255 (Operand)
    or          reduce using rule 255 (Operand)
    order       reduce using rule 255 (Operand)
    oror        reduce using rule 255 (Operand)
    regexp      reduce using rule 255 (Operand)
    right       reduce using rule 255 (Operand)
    rlike       reduce using rule 255 (Operand)
    rsh         reduce using rule 255 (Operand)
    then        reduce using rule 255 (Operand)
    union       reduce using rule 255 (Operand)
    using       reduce using rule 255 (Operand)
    when        reduce using rule 255 (Operand)
    where       reduce using rule 255 (Operand)
    xor         reduce using rule 255 (Operand)
    conflict on '(', shift, and goto state 262, reduce using rule 255 // '(': assoc %precedence, prec 21
```

```bash
(11:49) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 125151 of 381555, x 16 bits == 250302 bytes
conflicts: 3 shift/reduce
(11:50) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```