### PR TITLE
parser/parser.y: S/R conflicts 3->2.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -491,6 +491,8 @@ import (
 
 %precedence lowerThanLeftParen
 %precedence '('
+%precedence lowerThanQuick
+%precedence quick
 
 %start	Start
 
@@ -2115,6 +2117,7 @@ TableIdentList:
 	}
 
 QuickOptional:
+	%prec lowerThanQuick
 	{
 		$$ = false
 	}


### PR DESCRIPTION
```
state 627 // deleteKwd [',']

  102 DeleteFromStmt: deleteKwd LowPriorityOptional . QuickOptional IgnoreOptional from TableIdent WhereClauseOptional OrderByOptional LimitClause
  103 DeleteFromStmt: deleteKwd LowPriorityOptional . QuickOptional IgnoreOptional TableIdentList from TableRefs WhereClauseOptional
  104 DeleteFromStmt: deleteKwd LowPriorityOptional . QuickOptional IgnoreOptional from TableIdentList using TableRefs WhereClauseOptional
  336 QuickOptional: .  [',', after, autoIncrement, begin, bitType, boolType, booleanType, calcFoundRows, charsetKwd, columns, commit, dateType, datetimeType, deallocate, do, end, engine, engines, execute, first, from, full, global, identifier, ignore, local, mode, names, now, offset, password, prepare, quick, rollback, session, signed, start, substring, tables, textType, timeType, timestampType, transaction, truncate, unknown, value, warnings, yearType]

    ','            reduce using rule 336 (QuickOptional)
    after          reduce using rule 336 (QuickOptional)
    autoIncrement  reduce using rule 336 (QuickOptional)
    begin          reduce using rule 336 (QuickOptional)
    bitType        reduce using rule 336 (QuickOptional)
    boolType       reduce using rule 336 (QuickOptional)
    booleanType    reduce using rule 336 (QuickOptional)
    calcFoundRows  reduce using rule 336 (QuickOptional)
    charsetKwd     reduce using rule 336 (QuickOptional)
    columns        reduce using rule 336 (QuickOptional)
    commit         reduce using rule 336 (QuickOptional)
    dateType       reduce using rule 336 (QuickOptional)
    datetimeType   reduce using rule 336 (QuickOptional)
    deallocate     reduce using rule 336 (QuickOptional)
    do             reduce using rule 336 (QuickOptional)
    end            reduce using rule 336 (QuickOptional)
    engine         reduce using rule 336 (QuickOptional)
    engines        reduce using rule 336 (QuickOptional)
    execute        reduce using rule 336 (QuickOptional)
    first          reduce using rule 336 (QuickOptional)
    from           reduce using rule 336 (QuickOptional)
    full           reduce using rule 336 (QuickOptional)
    global         reduce using rule 336 (QuickOptional)
    identifier     reduce using rule 336 (QuickOptional)
    ignore         reduce using rule 336 (QuickOptional)
    local          reduce using rule 336 (QuickOptional)
    mode           reduce using rule 336 (QuickOptional)
    names          reduce using rule 336 (QuickOptional)
    now            reduce using rule 336 (QuickOptional)
    offset         reduce using rule 336 (QuickOptional)
    password       reduce using rule 336 (QuickOptional)
    prepare        reduce using rule 336 (QuickOptional)
    quick          shift, and goto state 629
    rollback       reduce using rule 336 (QuickOptional)
    session        reduce using rule 336 (QuickOptional)
    signed         reduce using rule 336 (QuickOptional)
    start          reduce using rule 336 (QuickOptional)
    substring      reduce using rule 336 (QuickOptional)
    tables         reduce using rule 336 (QuickOptional)
    textType       reduce using rule 336 (QuickOptional)
    timeType       reduce using rule 336 (QuickOptional)
    timestampType  reduce using rule 336 (QuickOptional)
    transaction    reduce using rule 336 (QuickOptional)
    truncate       reduce using rule 336 (QuickOptional)
    unknown        reduce using rule 336 (QuickOptional)
    value          reduce using rule 336 (QuickOptional)
    warnings       reduce using rule 336 (QuickOptional)
    yearType       reduce using rule 336 (QuickOptional)

    QuickOptional  goto state 628

    conflict on quick, shift, and goto state 629, reduce using rule 336
```

```bash
(12:37) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 125151 of 382470, x 16 bits == 250302 bytes
conflicts: 2 shift/reduce
(12:37) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```