### PR TITLE
parser/parser.y: S/R conflicts 2->1.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2103,10 +2103,7 @@ TableIdent:
 	}
 
 TableIdentList:
-	{
-		$$ = []table.Ident{}
-	}
-|	TableIdent
+	TableIdent
 	{
 		tbl := []table.Ident{$1.(table.Ident)}
 		$$ = tbl


### PR DESCRIPTION
```
state 630 // deleteKwd [',']

  102 DeleteFromStmt: deleteKwd LowPriorityOptional QuickOptional IgnoreOptional . from TableIdent WhereClauseOptional OrderByOptional LimitClause
  103 DeleteFromStmt: deleteKwd LowPriorityOptional QuickOptional IgnoreOptional . TableIdentList from TableRefs WhereClauseOptional
  104 DeleteFromStmt: deleteKwd LowPriorityOptional QuickOptional IgnoreOptional . from TableIdentList using TableRefs WhereClauseOptional
  333 TableIdentList: .  [',', from]

    ','            reduce using rule 333 (TableIdentList)
    after          shift, and goto state 60
    autoIncrement  shift, and goto state 59
    begin          shift, and goto state 61
    bitType        shift, and goto state 62
    boolType       shift, and goto state 63
    booleanType    shift, and goto state 64
    calcFoundRows  shift, and goto state 101
    charsetKwd     shift, and goto state 65
    columns        shift, and goto state 66
    commit         shift, and goto state 67
    dateType       shift, and goto state 68
    datetimeType   shift, and goto state 69
    deallocate     shift, and goto state 70
    do             shift, and goto state 71
    end            shift, and goto state 72
    engine         shift, and goto state 73
    engines        shift, and goto state 74
    execute        shift, and goto state 75
    first          shift, and goto state 76
    from           shift, and goto state 631
    full           shift, and goto state 77
    global         shift, and goto state 88
    identifier     shift, and goto state 56
    local          shift, and goto state 78
    mode           shift, and goto state 100
    names          shift, and goto state 79
    now            shift, and goto state 99
    offset         shift, and goto state 80
    password       shift, and goto state 81
    prepare        shift, and goto state 82
    quick          shift, and goto state 83
    rollback       shift, and goto state 84
    session        shift, and goto state 85
    signed         shift, and goto state 86
    start          shift, and goto state 87
    substring      shift, and goto state 102
    tables         shift, and goto state 89
    textType       shift, and goto state 90
    timeType       shift, and goto state 91
    timestampType  shift, and goto state 92
    transaction    shift, and goto state 93
    truncate       shift, and goto state 94
    unknown        shift, and goto state 95
    value          shift, and goto state 96
    warnings       shift, and goto state 97
    yearType       shift, and goto state 98

    Identifier         goto state 108
    NotKeywordToken    goto state 58
    TableIdent         goto state 616
    TableIdentList     goto state 632
    UnReservedKeyword  goto state 57

    conflict on from, shift, and goto state 631, reduce using rule 333
```

```bash
(13:54) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 125176 of 382470, x 16 bits == 250352 bytes
conflicts: 1 shift/reduce
(13:56) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```