### PR TITLE
parser/parser.y: S/R conflicts 1->0.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -493,6 +493,8 @@ import (
 %precedence '('
 %precedence lowerThanQuick
 %precedence quick
+%precedence lowerThanComma
+%precedence ','
 
 %start	Start
 
@@ -1047,7 +1049,7 @@ CreateSpecificationList:
  *      )
  *******************************************************************/
 CreateTableStmt:
-	"CREATE" "TABLE" IfNotExists TableIdent '(' TableElementListOpt ')' TableOptListOpt CommaOpt
+	"CREATE" "TABLE" IfNotExists TableIdent '(' TableElementListOpt ')' TableOptListOpt
 	{
 		tes := $6.([]interface {})
 		var columnDefs []*coldef.ColumnDef
@@ -2841,7 +2843,7 @@ TableOptListOpt:
 	{
 		$$ = []*coldef.TableOpt{}
 	}
-|	TableOptList
+|	TableOptList %prec lowerThanComma
 
 TableOptList:
 	TableOpt


### PR DESCRIPTION
```
state 696 // alter tableKwd after charsetKwd after [$end]

  484 TableOptListOpt: TableOptList .  [$end, ',', ';']
  486 TableOptList: TableOptList . TableOpt
  487 TableOptList: TableOptList . ',' TableOpt
   99 DefaultKwdOpt: .  [character, charsetKwd, collation]

    $end           reduce using rule 484 (TableOptListOpt)
    ','            shift, and goto state 699
    ';'            reduce using rule 484 (TableOptListOpt)
    autoIncrement  shift, and goto state 695
    character      reduce using rule 99 (DefaultKwdOpt)
    charsetKwd     reduce using rule 99 (DefaultKwdOpt)
    collation      reduce using rule 99 (DefaultKwdOpt)
    defaultKwd     shift, and goto state 654
    engine         shift, and goto state 693

    DefaultKwdOpt  goto state 694
    TableOpt       goto state 698

    conflict on ',', shift, and goto state 699, reduce using rule 484
```

```bash
(15:02) jnml@r550:~/src/github.com/cznic/tidb/parser$ goyacc -o /dev/null -cr parser.y
Parse table entries: 124933 of 382547, x 16 bits == 249866 bytes
(15:02) jnml@r550:~/src/github.com/cznic/tidb/parser$ 
```

WARNING: This PR removes the `CommaOpt` item in the `CreateTableStmt` production. Looking at [MySQL docs](http://dev.mysql.com/doc/refman/5.1/en/create-table.html), I believe it should not be accepted in this part of the grammar. However, if I'm mistaken, then you should not merge this PR and please let me know why `CommaOpt` is there - as the proper solution would have to be different (if it then exists at all).