### PR TITLE
types: Fix convert TypeBit error

### DIFF
--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -355,12 +355,14 @@ func Convert(val interface{}, target *FieldType) (v interface{}, err error) { //
 		default:
 			return invConv(val, tp)
 		}
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeBit:
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		unsigned := mysql.HasUnsignedFlag(target.Flag)
 		if unsigned {
 			return convertToUint(val, target)
 		}
 		return convertToInt(val, target)
+	case mysql.TypeBit:
+		return convertToUint(val, target)
 	case mysql.TypeDecimal, mysql.TypeNewDecimal:
 		x, err := ToDecimal(val)
 		if err != nil {

--- a/util/types/convert_test.go
+++ b/util/types/convert_test.go
@@ -166,6 +166,12 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, uint64(100))
 
+	// For TypeBit
+	ft = NewFieldType(mysql.TypeBit)
+	v, err = Convert("100", ft)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, uint64(100))
+
 	// For TypeNewDecimal
 	ft = NewFieldType(mysql.TypeNewDecimal)
 	ft.Decimal = 5


### PR DESCRIPTION
Pass goxorm test

The bit type does not have UnSignedFlag, but should treated as unsigned.
create table t1 (c1 BIT, c2 INT UNSIGNED);
mysql> desc t1;
+-------+------------------+------+-----+---------+-------+
| Field | Type             | Null | Key | Default | Extra |
+-------+------------------+------+-----+---------+-------+
| c1    | bit(1)           | YES  |     | NULL    |       |
| c2    | int(10) unsigned | YES  |     | NULL    |       |
+-------+------------------+------+-----+---------+-------+
2 rows in set (0.00 sec)