### PR TITLE
parser: Fix bug in parse database()

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1849,7 +1849,7 @@ FunctionNameConflict:
 	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT"
 
 FunctionCallConflict:
-	FunctionNameConflict '(' ExpressionList ')' 
+	FunctionNameConflict '(' ExpressionListOpt ')' 
 	{
 		x := yylex.(*lexer)
 		var err error

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -264,6 +264,8 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		{"SELECT CONVERT('111', SIGNED);", true},
 
+		{"SELECT DATABASE();", true},
+
 		// For delete statement
 		{"DELETE t1, t2 FROM t1 INNER JOIN t2 INNER JOIN t3 WHERE t1.id=t2.id AND t2.id=t3.id;", true},
 		{"DELETE FROM t1, t2 USING t1 INNER JOIN t2 INNER JOIN t3 WHERE t1.id=t2.id AND t2.id=t3.id;", true},


### PR DESCRIPTION
The args list is empty. But ExpressionList need at least one arg.