### PR TITLE
types: Allow []byte as orderby type

### DIFF
--- a/plan/plans/orderby.go
+++ b/plan/plans/orderby.go
@@ -158,13 +158,7 @@ func (r *OrderByDefaultPlan) Do(ctx context.Context, f plan.RowIterFunc) error {
 			}
 
 			if val != nil {
-				var ordered bool
-				val, ordered, err1 = types.IsOrderedType(val)
-				if err1 != nil {
-					return false, err1
-				}
-
-				if !ordered {
+				if !types.IsOrderedType(val) {
 					return false, errors.Errorf("cannot order by %v (type %T)", val, val)
 				}
 			}

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -295,13 +295,12 @@ func collateDesc(a, b []interface{}) int {
 // whether the type of y can be used by order by.
 func IsOrderedType(v interface{}) (r bool) {
 	switch v.(type) {
-	case float32, float64,
-		int, int8, int16, int32, int64,
+	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
-		string, mysql.Decimal, []byte, mysql.Time, mysql.Duration:
+		float32, float64, string, []byte,
+		mysql.Decimal, mysql.Time, mysql.Duration:
 		return true
 	}
-
 	return false
 }
 

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -298,7 +298,7 @@ func IsOrderedType(v interface{}) (y interface{}, r bool, err error) {
 	case float32, float64,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
-		string, mysql.Decimal:
+		string, mysql.Decimal, []byte:
 		return v, true, nil
 	case mysql.Time, mysql.Duration:
 		return x, true, nil

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -293,18 +293,16 @@ func collateDesc(a, b []interface{}) int {
 
 // IsOrderedType returns a boolean
 // whether the type of y can be used by order by.
-func IsOrderedType(v interface{}) (y interface{}, r bool, err error) {
-	switch x := v.(type) {
+func IsOrderedType(v interface{}) (r bool) {
+	switch v.(type) {
 	case float32, float64,
 		int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
-		string, mysql.Decimal, []byte:
-		return v, true, nil
-	case mysql.Time, mysql.Duration:
-		return x, true, nil
+		string, mysql.Decimal, []byte, mysql.Time, mysql.Duration:
+		return true
 	}
 
-	return v, false, nil
+	return false
 }
 
 // Clone copies a interface to another interface.

--- a/util/types/etc_test.go
+++ b/util/types/etc_test.go
@@ -218,6 +218,10 @@ func (s *testTypeEtcSuite) TestIsOrderedType(c *C) {
 	_, r, err = IsOrderedType(mysql.Duration{Duration: time.Duration(0), Fsp: 0})
 	c.Assert(err, IsNil)
 	c.Assert(r, IsTrue)
+
+	_, r, err = IsOrderedType([]byte{1})
+	c.Assert(err, IsNil)
+	c.Assert(r, IsTrue)
 }
 
 func (s *testTypeEtcSuite) TestMaxFloat(c *C) {

--- a/util/types/etc_test.go
+++ b/util/types/etc_test.go
@@ -205,22 +205,17 @@ func (s *testTypeEtcSuite) TestCoerce(c *C) {
 }
 
 func (s *testTypeEtcSuite) TestIsOrderedType(c *C) {
-	_, r, err := IsOrderedType(1)
-	c.Assert(err, IsNil)
+	r := IsOrderedType(1)
 	c.Assert(r, IsTrue)
-	_, r, err = IsOrderedType(-1)
-	c.Assert(err, IsNil)
+	r = IsOrderedType(-1)
 	c.Assert(r, IsTrue)
-	_, r, err = IsOrderedType(uint(1))
-	c.Assert(err, IsNil)
+	r = IsOrderedType(uint(1))
 	c.Assert(r, IsTrue)
 
-	_, r, err = IsOrderedType(mysql.Duration{Duration: time.Duration(0), Fsp: 0})
-	c.Assert(err, IsNil)
+	r = IsOrderedType(mysql.Duration{Duration: time.Duration(0), Fsp: 0})
 	c.Assert(r, IsTrue)
 
-	_, r, err = IsOrderedType([]byte{1})
-	c.Assert(err, IsNil)
+	r = IsOrderedType([]byte{1})
 	c.Assert(r, IsTrue)
 }
 


### PR DESCRIPTION
Orderby []byte is already supported by types.Compare.
With this pr we can run most of functions in phpMyAdmin.