### PR TITLE
support hexadecimal literal type

### DIFF
--- a/expression/expressions/binop.go
+++ b/expression/expressions/binop.go
@@ -678,6 +678,8 @@ func (o *BinaryOperation) coerceArithmetic(a interface{}) (interface{}, error) {
 			return nil, err
 		}
 		return f, err
+	case mysql.Hex:
+		return x.ToNumber(), nil
 	default:
 		return x, nil
 	}

--- a/expression/expressions/binop_test.go
+++ b/expression/expressions/binop_test.go
@@ -397,6 +397,7 @@ func (s *testBinOpSuite) TestNumericOp(c *C) {
 		{uint64(1), opcode.Plus, 1, 2},
 		{uint64(1), opcode.Plus, uint64(1), 2},
 		{1, opcode.Plus, []byte("1"), 2},
+		{1, opcode.Plus, mysql.Hex{Value: 1}, 2},
 
 		// minus
 		{1, opcode.Minus, 1, 0},

--- a/expression/expressions/unary.go
+++ b/expression/expressions/unary.go
@@ -198,6 +198,8 @@ func (u *UnaryOperation) Eval(ctx context.Context, args map[interface{}]interfac
 			return x, nil
 		case []byte:
 			return x, nil
+		case mysql.Hex:
+			return x, nil
 		default:
 			return types.UndOp(a, op)
 		}
@@ -245,6 +247,8 @@ func (u *UnaryOperation) Eval(ctx context.Context, args map[interface{}]interfac
 		case []byte:
 			f, err := types.StrToFloat(string(x))
 			return -f, err
+		case mysql.Hex:
+			return -x.ToNumber(), nil
 		default:
 			return types.UndOp(a, op)
 		}

--- a/expression/expressions/unary_test.go
+++ b/expression/expressions/unary_test.go
@@ -39,6 +39,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 		{1, opcode.Not, int64(0)},
 		{0, opcode.Not, int64(1)},
 		{nil, opcode.Not, nil},
+		{mysql.Hex{Value: 0}, opcode.Not, int64(1)},
 
 		// test BitNeg.
 		{nil, opcode.BitNeg, nil},
@@ -53,6 +54,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 		{uint64(1), opcode.Plus, uint64(1)},
 		{"1.0", opcode.Plus, "1.0"},
 		{[]byte("1.0"), opcode.Plus, []byte("1.0")},
+		{mysql.Hex{Value: 1}, opcode.Plus, mysql.Hex{Value: 1}},
 
 		// test Minus.
 		{nil, opcode.Minus, nil},
@@ -67,6 +69,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 		{uint64(1), opcode.Minus, -int64(1)},
 		{"1.0", opcode.Minus, -1.0},
 		{[]byte("1.0"), opcode.Minus, -1.0},
+		{mysql.Hex{Value: 1}, opcode.Minus, -1.0},
 	}
 
 	for _, t := range tbl {

--- a/mysqldef/decimal.go
+++ b/mysqldef/decimal.go
@@ -159,6 +159,8 @@ func ConvertToDecimal(value interface{}) (Decimal, error) {
 		return ParseDecimal(v)
 	case Decimal:
 		return v, nil
+	case Hex:
+		return NewDecimalFromInt(int64(v.Value), 0), nil
 	default:
 		return Decimal{}, fmt.Errorf("can't convert %v to decimal", value)
 	}

--- a/mysqldef/hex.go
+++ b/mysqldef/hex.go
@@ -1,0 +1,85 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysqldef
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+)
+
+// Hex is for mysql hexadecimal literal type.
+type Hex struct {
+	// Value holds numeric value for hexadecimal literal.
+	Value int64
+}
+
+// String implements fmt.Stringer interface.
+func (h Hex) String() string {
+	s := fmt.Sprintf("%X", h.Value)
+	if len(s)%2 != 0 {
+		return "0x0" + s
+	}
+
+	return "0x" + s
+}
+
+// ToNumber changes hexadecimal type to float64 for numeric operation.
+// MySQL treats hexadecimal literal as double type.
+func (h Hex) ToNumber() float64 {
+	return float64(h.Value)
+}
+
+// ToString returns the string representation for hexadecimal literal.
+func (h Hex) ToString() string {
+	s := fmt.Sprintf("%x", h.Value)
+	if len(s)%2 != 0 {
+		s = "0" + s
+	}
+
+	// should never error.
+	b, _ := hex.DecodeString(s)
+	return string(b)
+}
+
+// ParseHex parses hexadecimal literal string.
+// The string format can be X'val', x'val' or 0xval.
+// val must in (0...9, a...z, A...Z).
+func ParseHex(s string) (Hex, error) {
+	if len(s) == 0 {
+		return Hex{}, errors.Errorf("invalid empty string for parsing hexadecimal literal")
+	}
+
+	if s[0] == 'x' || s[0] == 'X' {
+		// format is x'val' or X'val'
+		s = strings.Trim(s[1:], "'")
+		if len(s)%2 != 0 {
+			return Hex{}, errors.Errorf("invalid hexadecimal format, must even numbers, but %d", len(s))
+		}
+		s = "0x" + s
+	} else if !strings.HasPrefix(s, "0x") {
+		// here means format is not x'val', X'val' or 0xval.
+		return Hex{}, errors.Errorf("invalid hexadecimal format %s", s)
+	}
+
+	n, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return Hex{}, errors.Trace(err)
+	}
+
+	return Hex{Value: n}, nil
+}

--- a/mysqldef/hex_test.go
+++ b/mysqldef/hex_test.go
@@ -1,0 +1,66 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mysqldef
+
+import (
+	"strconv"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testHexSuite{})
+
+type testHexSuite struct {
+}
+
+func (s *testHexSuite) TestHex(c *C) {
+	tbl := []struct {
+		Input  string
+		Expect int64
+		Err    bool
+	}{
+		{"x'1'", 0, true},
+		{"x'01'", 1, false},
+		{"X'01'", 1, false},
+		{"0x1", 1, false},
+		{"0x-1", 0, true},
+		{"0X11", 0, true},
+		{"x'01+'", 1, true},
+		{"0x123", 0x123, false},
+		{"0x10", 0x10, false},
+		{"", 0, true},
+	}
+
+	for _, t := range tbl {
+		h, err := ParseHex(t.Input)
+		if t.Err {
+			c.Assert(err, NotNil)
+			continue
+		}
+
+		c.Assert(err, IsNil)
+		c.Assert(h.ToNumber(), Equals, float64(t.Expect))
+		s := h.String()
+		n, err := strconv.ParseInt(s, 0, 64)
+		c.Assert(err, IsNil)
+		c.Assert(n, Equals, t.Expect)
+	}
+
+	h, err := ParseHex("0x4D7953514C")
+	c.Assert(err, IsNil)
+	c.Assert(h.ToString(), Equals, "MySQL")
+
+	h.Value = 1
+	c.Assert(h.ToString(), Equals, "\x01")
+}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -60,6 +60,7 @@ import (
 	/*yy:token "%c"     */	identifier      "identifier"
 	/*yy:token "%d"     */	intLit          "integer literal"
 	/*yy:token "\"%c\"" */	stringLit       "string literal"
+	/*yy:token "%x"     */	hexLit          "hexadecimal literal"
 
 
 	abs		"ABS"
@@ -1708,6 +1709,7 @@ Literal:
 |	floatLit
 |	intLit
 |	stringLit
+|	hexLit
 
 Operand:
 	Literal

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -299,6 +299,11 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		// For binary operator
 		{"SELECT binary 'a';", true},
+
+		// For hexadecimal
+		{"SELECT x'0a', X'11', 0x11", true},
+		{"select x'0xaa'", false},
+		{"select 0X11", false},
 	}
 
 	for _, t := range table {

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/expressions"
 	"github.com/pingcap/tidb/stmt"
+	mysql "github.com/pingcap/tidb/mysqldef"
 )
 
 type lexer struct {
@@ -907,11 +908,11 @@ func (l *lexer) float(lval *yySymType) int {
 // https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html
 func (l *lexer) hex(lval *yySymType) int {
 	s := string(l.val)
-	// convert x'12' to general 0x12
-	s = strings.Replace(s, "'", "", -1)
-	if s[0] != '0' {
-		s = "0" + s
+	h, err := mysql.ParseHex(s)
+	if err != nil {
+		l.errf("hexadecimal literal: %v", err)
+		return int(unicode.ReplacementChar)
 	}
-	lval.item = s 
-	return stringLit
+	lval.item = h
+	return hexLit
 }

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -668,6 +668,16 @@ func (s *testSessionSuite) TestIndex(c *C) {
 	match(c, rows[0], 1)
 }
 
+func (s *testSessionSuite) TestHexadecimal(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+
+	r := mustExecSQL(c, se, `select 0x01 + 1, x'4D7953514C' = "MySQL"`)
+	row, err := r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, 2, 1)
+}
+
 func newSession(c *C, store kv.Storage, dbName string) Session {
 	se, err := CreateSession(store)
 	c.Assert(err, IsNil)

--- a/util/types/compare.go
+++ b/util/types/compare.go
@@ -183,6 +183,8 @@ func Compare(a, b interface{}) (int, error) {
 			return CompareInteger(x, y), nil
 		case string:
 			return compareFloatString(float64(x), y)
+		case mysql.Hex:
+			return CompareFloat64(float64(x), y.ToNumber()), nil
 		}
 	case uint64:
 		switch y := b.(type) {
@@ -192,6 +194,8 @@ func Compare(a, b interface{}) (int, error) {
 			return -CompareInteger(y, x), nil
 		case string:
 			return compareFloatString(float64(x), y)
+		case mysql.Hex:
+			return CompareFloat64(float64(x), y.ToNumber()), nil
 		}
 	case mysql.Decimal:
 		switch y := b.(type) {
@@ -226,6 +230,8 @@ func Compare(a, b interface{}) (int, error) {
 		case mysql.Duration:
 			n, err := y.CompareString(x)
 			return -n, err
+		case mysql.Hex:
+			return CompareString(x, y.ToString()), nil
 		}
 	case mysql.Time:
 		switch y := b.(type) {
@@ -240,6 +246,15 @@ func Compare(a, b interface{}) (int, error) {
 			return x.Compare(y), nil
 		case string:
 			return x.CompareString(y)
+		}
+	case mysql.Hex:
+		switch y := b.(type) {
+		case int64:
+			return CompareFloat64(x.ToNumber(), float64(y)), nil
+		case uint64:
+			return CompareFloat64(x.ToNumber(), float64(y)), nil
+		case string:
+			return CompareString(x.ToString(), y), nil
 		}
 	}
 

--- a/util/types/compare_test.go
+++ b/util/types/compare_test.go
@@ -126,6 +126,12 @@ func (s *testCompareSuite) TestCompare(c *C) {
 		{[]interface{}{1, 2, 3}, []interface{}{1, 2, 3}, 0},
 		{[]interface{}{1, 3, 3}, []interface{}{1, 2, 3}, 1},
 		{[]interface{}{1, 2, 3}, []interface{}{2, 2, 3}, -1},
+
+		{mysql.Hex{Value: 1}, 1, 0},
+		{mysql.Hex{Value: 0x4D7953514C}, "MySQL", 0},
+		{mysql.Hex{Value: 0}, uint64(10), -1},
+		{mysql.Hex{Value: 1}, float64(0), 1},
+		{mysql.Hex{Value: 1}, mysql.NewDecimalFromInt(1, 0), 0},
 	}
 
 	for _, t := range cmpTbl {

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -298,7 +298,7 @@ func IsOrderedType(v interface{}) (r bool) {
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, string, []byte,
-		mysql.Decimal, mysql.Time, mysql.Duration:
+		mysql.Decimal, mysql.Time, mysql.Duration, mysql.Hex:
 		return true
 	}
 	return false
@@ -333,6 +333,8 @@ func Clone(from interface{}) (interface{}, error) {
 	case mysql.Duration:
 		return x, nil
 	case mysql.Decimal:
+		return x, nil
+	case mysql.Hex:
 		return x, nil
 	default:
 		log.Error(reflect.TypeOf(from))
@@ -406,12 +408,16 @@ func Coerce(a, b interface{}) (x, y interface{}) {
 			x = float64(v)
 		case uint64:
 			x = float64(v)
+		case mysql.Hex:
+			x = v.ToNumber()
 		}
 		switch v := y.(type) {
 		case int64:
 			y = float64(v)
 		case uint64:
 			y = float64(v)
+		case mysql.Hex:
+			y = v.ToNumber()
 		}
 	}
 	return

--- a/util/types/etc_test.go
+++ b/util/types/etc_test.go
@@ -149,6 +149,7 @@ func (s *testTypeEtcSuite) TestClone(c *C) {
 	checkClone(c, mysql.Decimal{}, true)
 	checkClone(c, mysql.Time{Time: time.Now(), Type: 1, Fsp: 3}, true)
 	checkClone(c, make(map[int]string), false)
+	checkClone(c, mysql.Hex{Value: 1}, true)
 }
 
 func checkCoerce(c *C, a, b interface{}) {


### PR DESCRIPTION
see https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html

hex type can be used as a float for numeric operation and as a binary string for comparison with string type.  