### PR TITLE
*: fix duplicated table name when join

### DIFF
--- a/rset/rsets/join.go
+++ b/rset/rsets/join.go
@@ -72,7 +72,7 @@ type JoinRset struct {
 	Type  JoinType
 	On    expression.Expression
 
-	tableNames map[string]bool
+	tableNames map[string]struct{}
 }
 
 func (r *JoinRset) String() string {
@@ -168,7 +168,7 @@ func (r *JoinRset) checkTableDuplicate(t *TableSource, tr *TableRset) error {
 		if ok {
 			return errors.Errorf("%s: duplicate name %s", r, t.Name)
 		}
-		r.tableNames[t.Name] = true
+		r.tableNames[t.Name] = struct{}{}
 		return nil
 	}
 
@@ -178,7 +178,7 @@ func (r *JoinRset) checkTableDuplicate(t *TableSource, tr *TableRset) error {
 	if ok {
 		return errors.Errorf("%s: duplicate name %s", r, identName)
 	}
-	r.tableNames[identName] = true
+	r.tableNames[identName] = struct{}{}
 
 	qualifiedName := tr.Schema + "." + tr.Name
 	// we should check qualifed name too, e,g select * form t1 join test.t1
@@ -187,7 +187,7 @@ func (r *JoinRset) checkTableDuplicate(t *TableSource, tr *TableRset) error {
 		if ok {
 			return errors.Errorf("%s: duplicate name %s", r, identName)
 		}
-		r.tableNames[qualifiedName] = true
+		r.tableNames[qualifiedName] = struct{}{}
 	}
 
 	return nil
@@ -251,7 +251,7 @@ func (r *JoinRset) buildSourcePlan(ctx context.Context, t *TableSource) (plan.Pl
 
 // Plan gets JoinPlan.
 func (r *JoinRset) Plan(ctx context.Context) (plan.Plan, error) {
-	r.tableNames = make(map[string]bool)
+	r.tableNames = make(map[string]struct{})
 	p := &plans.JoinPlan{}
 	if err := r.buildJoinPlan(ctx, p, r); err != nil {
 		return nil, errors.Trace(err)

--- a/rset/rsets/join.go
+++ b/rset/rsets/join.go
@@ -180,14 +180,14 @@ func (r *JoinRset) checkTableDuplicate(t *TableSource, tr *TableRset) error {
 	}
 	r.tableNames[identName] = true
 
-	qualifedName := tr.Schema + "." + tr.Name
+	qualifiedName := tr.Schema + "." + tr.Name
 	// we should check qualifed name too, e,g select * form t1 join test.t1
-	if identName != qualifedName {
-		_, ok = r.tableNames[qualifedName]
+	if identName != qualifiedName {
+		_, ok = r.tableNames[qualifiedName]
 		if ok {
-			return errors.Errorf("%s: duplicate name %s", r, t.String())
+			return errors.Errorf("%s: duplicate name %s", r, identName)
 		}
-		r.tableNames[qualifedName] = true
+		r.tableNames[qualifiedName] = true
 	}
 
 	return nil

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -673,6 +673,26 @@ func (s *testSessionSuite) TestExpression(c *C) {
 	match(c, row, 1, -1, 0, 0)
 }
 
+func (s *testSessionSuite) TestSelect(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+
+	mustExecSQL(c, se, "create table if not exists t (c1 int, c2 int)")
+	mustExecSQL(c, se, "create table if not exists t1 (c1 int, c2 int)")
+
+	_, err := se.Execute("select * from t as a join t as a")
+	c.Assert(err, NotNil)
+
+	_, err = se.Execute("select * from t join t1 as t")
+	c.Assert(err, NotNil)
+
+	_, err = se.Execute("select * from t join test.t")
+	c.Assert(err, NotNil)
+
+	_, err = se.Execute("select * from t as a join (select 1) as a")
+	c.Assert(err, IsNil)
+}
+
 func newSession(c *C, store kv.Storage, dbName string) Session {
 	se, err := CreateSession(store)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Check duplicated join table name, following queries are all invalid. 
```
select * from t1 join t1;
select * from t1 join t2 as t1;
select * from t1 join test.t1;
```

