### PR TITLE
first MVCC support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.4.2
   - 1.5
 
 before_script: go get github.com/golang/lint/golint

--- a/kv/index_iter.go
+++ b/kv/index_iter.go
@@ -190,15 +190,15 @@ func (c *kvIndex) Delete(txn Transaction, indexedValues []interface{}, h int64) 
 }
 
 func hasPrefix(prefix []byte) FnKeyCmp {
-	return func(k []byte) bool {
-		return bytes.HasPrefix(k, prefix)
+	return func(k Key) bool {
+		return bytes.HasPrefix([]byte(k), prefix)
 	}
 }
 
 // Drop removes the KV index from store.
 func (c *kvIndex) Drop(txn Transaction) error {
 	prefix := []byte(c.prefix)
-	it, err := txn.Seek(prefix, hasPrefix(prefix))
+	it, err := txn.Seek(Key(prefix), hasPrefix(prefix))
 	if err != nil {
 		return err
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -39,16 +39,17 @@ func (k EncodedKey) Cmp(another EncodedKey) int {
 	return bytes.Compare(k, another)
 }
 
+// Next returns the next key in byte-order
 func (k EncodedKey) Next() EncodedKey {
 	return EncodedKey(bytes.Join([][]byte{k, Key{0}}, nil))
 }
 
-// VersionProvider
+// VersionProvider provides increasing IDs.
 type VersionProvider interface {
 	GetCurrentVer() (Version, error)
 }
 
-// Version
+// Version is the wrapper of KV's version.
 type Version struct {
 	Ver uint64
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -13,6 +13,46 @@
 
 package kv
 
+import "bytes"
+
+// EncodedKey represents encoded key in low-level storage engine.
+type EncodedKey []byte
+
+// Key represents high-level Key type
+type Key []byte
+
+// Next returns the next key in byte-order
+func (k Key) Next() Key {
+	// add \x0 to the end of key
+	return append(append([]byte(nil), []byte(k)...), 0)
+}
+
+// Cmp returns the comparison result of two key, if A > B returns 1, A = B
+// returns 0, if A < B returns -1.
+func (k Key) Cmp(another Key) int {
+	return bytes.Compare(k, another)
+}
+
+// Cmp returns the comparison result of two key, if A > B returns 1, A = B
+// returns 0, if A < B returns -1.
+func (k EncodedKey) Cmp(another EncodedKey) int {
+	return bytes.Compare(k, another)
+}
+
+func (k EncodedKey) Next() EncodedKey {
+	return EncodedKey(bytes.Join([][]byte{k, Key{0}}, nil))
+}
+
+// VersionProvider
+type VersionProvider interface {
+	GetCurrentVer() (Version, error)
+}
+
+// Version
+type Version struct {
+	Ver uint64
+}
+
 // DecodeFn is a function that decode data after fetch from store.
 type DecodeFn func(raw interface{}) (interface{}, error)
 
@@ -23,15 +63,15 @@ type EncodeFn func(raw interface{}) (interface{}, error)
 // This is not thread safe.
 type Transaction interface {
 	// Get gets the value for key k from KV store.
-	Get(k []byte) ([]byte, error)
+	Get(k Key) ([]byte, error)
 	// Set sets the value for key k as v into KV store.
-	Set(k []byte, v []byte) error
+	Set(k Key, v []byte) error
 	// Seek searches for the entry with key k in KV store.
-	Seek(k []byte, fnKeyCmp func(key []byte) bool) (Iterator, error)
+	Seek(k Key, fnKeyCmp func(key Key) bool) (Iterator, error)
 	// Inc increases the value for key k in KV store by step.
-	Inc(k []byte, step int64) (int64, error)
+	Inc(k Key, step int64) (int64, error)
 	// Deletes removes the entry for key k from KV store.
-	Delete(k []byte) error
+	Delete(k Key) error
 	// Commit commites the transaction operations to KV store.
 	Commit() error
 	// Rollback undoes the transaction operations to KV store.
@@ -39,13 +79,13 @@ type Transaction interface {
 	// String implements Stringer.String() interface.
 	String() string
 	// LockKeys tries to lock the entries with the keys in KV store.
-	LockKeys(keys ...[]byte) error
+	LockKeys(keys ...Key) error
 }
 
 // Snapshot defines the interface for the snapshot fetched from KV store.
 type Snapshot interface {
 	// Get gets the value for key k from snapshot.
-	Get(k []byte) ([]byte, error)
+	Get(k Key) ([]byte, error)
 	// NewIterator gets a new iterator on the snapshot.
 	NewIterator(param interface{}) Iterator
 	// Release releases the snapshot to store.
@@ -71,7 +111,7 @@ type Storage interface {
 }
 
 // FnKeyCmp is the function for iterator the keys
-type FnKeyCmp func(key []byte) bool
+type FnKeyCmp func(key Key) bool
 
 // Iterator is the interface for a interator on KV store.
 type Iterator interface {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -18,35 +18,37 @@ import "bytes"
 // EncodedKey represents encoded key in low-level storage engine.
 type EncodedKey []byte
 
-// Key represents high-level Key type
+// Key represents high-level Key type.
 type Key []byte
 
-// Next returns the next key in byte-order
+// Next returns the next key in byte-order.
 func (k Key) Next() Key {
 	// add \x0 to the end of key
-	return append(append([]byte(nil), []byte(k)...), 0)
+	buf := make([]byte, len([]byte(k))+1)
+	copy(buf, []byte(k))
+	return buf
 }
 
-// Cmp returns the comparison result of two key, if A > B returns 1, A = B
-// returns 0, if A < B returns -1.
+// Cmp returns the comparison result of two key.
+// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
 func (k Key) Cmp(another Key) int {
 	return bytes.Compare(k, another)
 }
 
-// Cmp returns the comparison result of two key, if A > B returns 1, A = B
-// returns 0, if A < B returns -1.
+// Cmp returns the comparison result of two key.
+// The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
 func (k EncodedKey) Cmp(another EncodedKey) int {
 	return bytes.Compare(k, another)
 }
 
-// Next returns the next key in byte-order
+// Next returns the next key in byte-order.
 func (k EncodedKey) Next() EncodedKey {
 	return EncodedKey(bytes.Join([][]byte{k, Key{0}}, nil))
 }
 
 // VersionProvider provides increasing IDs.
 type VersionProvider interface {
-	GetCurrentVer() (Version, error)
+	CurrentVersion() (Version, error)
 }
 
 // Version is the wrapper of KV's version.
@@ -57,7 +59,7 @@ type Version struct {
 // DecodeFn is a function that decode data after fetch from store.
 type DecodeFn func(raw interface{}) (interface{}, error)
 
-// EncodeFn is a function that encode data before put into store
+// EncodeFn is a function that encode data before put into store.
 type EncodeFn func(raw interface{}) (interface{}, error)
 
 // Transaction defines the interface for operations inside a Transaction.

--- a/store/localstore/kv_test.go
+++ b/store/localstore/kv_test.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
@@ -168,13 +167,6 @@ func (s *testKVSuite) TestSeek(c *C) {
 	c.Assert(err, IsNil)
 
 	insertData(c, txn)
-
-	ss, _ := s.s.(*dbStore).db.GetSnapshot()
-	i := ss.NewIterator(nil)
-	for i.Next() {
-		log.Warn("!!!!", i.Key(), i.Value())
-	}
-
 	checkSeek(c, txn)
 
 	// Check transaction results
@@ -216,13 +208,11 @@ func (s *testKVSuite) TestInc(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(100))
 
-	log.Info(key)
 	err = txn.Delete(key)
 	c.Assert(err, IsNil)
 
 	err = txn.Commit()
 	c.Assert(err, IsNil)
-
 }
 
 func (s *testKVSuite) TestDelete(c *C) {

--- a/store/localstore/local_version_provider.go
+++ b/store/localstore/local_version_provider.go
@@ -1,29 +1,43 @@
 package localstore
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"github.com/pingcap/tidb/kv"
 )
 
+// ErrOverflow is the error returned by CurrentVersion, it describes if
+// there're too many versions allocations in a very short period of time, ID
+// may conflict.
+var ErrOverflow = errors.New("overflow when allocating new version")
+
 // LocalVersioProvider uses local timestamp for version.
 type LocalVersioProvider struct {
 	mu              sync.Mutex
-	lastTimeStampTs int64
-	n               int64
+	lastTimeStampTs uint64
+	n               uint64
 }
 
-// GetCurrentVer implements the VersionProvider's GetCurrentVer interface.
-func (l *LocalVersioProvider) GetCurrentVer() (kv.Version, error) {
+const (
+	timePrecisionOffset = 18
+)
+
+// CurrentVersion implements the VersionProvider's GetCurrentVer interface.
+func (l *LocalVersioProvider) CurrentVersion() (kv.Version, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
-	ts := (time.Now().UnixNano() / int64(time.Millisecond)) << 18
-	if l.lastTimeStampTs == ts {
+	var ts uint64
+	ts = uint64((time.Now().UnixNano() / int64(time.Millisecond)) << timePrecisionOffset)
+	if l.lastTimeStampTs == uint64(ts) {
 		l.n++
-		return kv.Version{uint64(ts + l.n)}, nil
+		if l.n >= 1<<timePrecisionOffset {
+			return kv.Version{}, ErrOverflow
+		}
+		return kv.Version{ts + l.n}, nil
 	}
 	l.lastTimeStampTs = ts
 	l.n = 0
-	return kv.Version{uint64(ts)}, nil
+	return kv.Version{ts}, nil
 }

--- a/store/localstore/local_version_provider.go
+++ b/store/localstore/local_version_provider.go
@@ -7,12 +7,14 @@ import (
 	"github.com/pingcap/tidb/kv"
 )
 
+// LocalVersioProvider uses local timestamp for version.
 type LocalVersioProvider struct {
 	mu              sync.Mutex
 	lastTimeStampTs int64
 	n               int64
 }
 
+// GetCurrentVer implements the VersionProvider's GetCurrentVer interface.
 func (l *LocalVersioProvider) GetCurrentVer() (kv.Version, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -20,9 +22,8 @@ func (l *LocalVersioProvider) GetCurrentVer() (kv.Version, error) {
 	if l.lastTimeStampTs == ts {
 		l.n++
 		return kv.Version{uint64(ts + l.n)}, nil
-	} else {
-		l.lastTimeStampTs = ts
-		l.n = 0
 	}
+	l.lastTimeStampTs = ts
+	l.n = 0
 	return kv.Version{uint64(ts)}, nil
 }

--- a/store/localstore/local_version_provider.go
+++ b/store/localstore/local_version_provider.go
@@ -1,0 +1,28 @@
+package localstore
+
+import (
+	"sync"
+	"time"
+
+	"github.com/pingcap/tidb/kv"
+)
+
+type LocalVersioProvider struct {
+	mu              sync.Mutex
+	lastTimeStampTs int64
+	n               int64
+}
+
+func (l *LocalVersioProvider) GetCurrentVer() (kv.Version, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	ts := (time.Now().UnixNano() / int64(time.Millisecond)) << 18
+	if l.lastTimeStampTs == ts {
+		l.n++
+		return kv.Version{uint64(ts + l.n)}, nil
+	} else {
+		l.lastTimeStampTs = ts
+		l.n = 0
+	}
+	return kv.Version{uint64(ts)}, nil
+}

--- a/store/localstore/mvcc.go
+++ b/store/localstore/mvcc.go
@@ -1,17 +1,16 @@
 package localstore
 
 import (
-	"bytes"
-
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/codec"
 )
 
-var tombstone = []byte{'\xde', '\xad'}
+// ErrInvalidEncodedKey describes parsing an invalid format of EncodedKey
+var ErrInvalidEncodedKey = errors.New("invalid encoded key")
 
 func isTombstone(v []byte) bool {
-	return bytes.Compare(v, tombstone) == 0
+	return len(v) == 0
 }
 
 // MvccEncodeVersionKey returns the encoded key
@@ -41,7 +40,7 @@ func MvccDecode(encodedKey kv.EncodedKey) (kv.Key, kv.Version, error) {
 		return nil, kv.Version{}, errors.Trace(err)
 	}
 	if len(remainBytes) != 0 {
-		return nil, kv.Version{}, errors.New("invalid encoded key")
+		return nil, kv.Version{}, ErrInvalidEncodedKey
 	}
 	return key, kv.Version{ver}, nil
 }

--- a/store/localstore/mvcc.go
+++ b/store/localstore/mvcc.go
@@ -1,0 +1,44 @@
+package localstore
+
+import (
+	"bytes"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/codec"
+)
+
+var Tombstone = []byte{'\xde', '\xad'}
+
+func IsTombstone(v []byte) bool {
+	return bytes.Compare(v, Tombstone) == 0
+}
+
+func MvccEncodeVersionKey(key kv.Key, ver kv.Version) kv.EncodedKey {
+	b := codec.EncodeBytes(nil, key)
+	ret := codec.EncodeUintDesc(b, ver.Ver)
+	return ret
+}
+
+func MvccDecode(encodedKey kv.EncodedKey) (kv.Key, kv.Version, error) {
+	// Skip DataPrefix
+	remainBytes, key, err := codec.DecodeBytes([]byte(encodedKey))
+	if err != nil {
+		// should never happen
+		return nil, kv.Version{}, errors.Trace(err)
+	}
+	// if it's meta key
+	if len(remainBytes) == 0 {
+		return key, kv.Version{}, nil
+	}
+	var ver uint64
+	remainBytes, ver, err = codec.DecodeUintDesc(remainBytes)
+	if err != nil {
+		// should never happen
+		return nil, kv.Version{}, errors.Trace(err)
+	}
+	if len(remainBytes) != 0 {
+		return nil, kv.Version{}, errors.New("invalid encoded key")
+	}
+	return key, kv.Version{ver}, nil
+}

--- a/store/localstore/mvcc.go
+++ b/store/localstore/mvcc.go
@@ -8,18 +8,21 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 )
 
-var Tombstone = []byte{'\xde', '\xad'}
+var tombstone = []byte{'\xde', '\xad'}
 
-func IsTombstone(v []byte) bool {
-	return bytes.Compare(v, Tombstone) == 0
+func isTombstone(v []byte) bool {
+	return bytes.Compare(v, tombstone) == 0
 }
 
+// MvccEncodeVersionKey returns the encoded key
 func MvccEncodeVersionKey(key kv.Key, ver kv.Version) kv.EncodedKey {
 	b := codec.EncodeBytes(nil, key)
 	ret := codec.EncodeUintDesc(b, ver.Ver)
 	return ret
 }
 
+// MvccDecode parses the origin key and version of an encoded key, if the encoded key is a meta key,
+// just returns the origin key
 func MvccDecode(encodedKey kv.EncodedKey) (kv.Key, kv.Version, error) {
 	// Skip DataPrefix
 	remainBytes, key, err := codec.DecodeBytes([]byte(encodedKey))

--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -1,0 +1,137 @@
+package localstore
+
+import (
+	"bytes"
+
+	"github.com/ngaut/log"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/localstore/goleveldb"
+)
+
+var _ = Suite(&testMvccSuite{})
+
+type testMvccSuite struct {
+	s kv.Storage
+}
+
+func createMemStore() kv.Storage {
+	path := "memory:"
+	d := Driver{
+		goleveldb.MemoryDriver{},
+	}
+	store, err := d.Open(path)
+	if err != nil {
+		panic(err)
+	}
+	return store
+}
+
+func (t *testMvccSuite) addDirtyData() {
+	engineDB := t.s.(*dbStore).db
+	b := engineDB.NewBatch()
+	b.Put([]byte("\xf0dirty"), []byte("testvalue"))
+	b.Put([]byte("\x00dirty"), []byte("testvalue"))
+	engineDB.Commit(b)
+}
+
+func (t *testMvccSuite) TestMvccEncode(c *C) {
+	encodedKey1 := MvccEncodeVersionKey([]byte("A"), kv.Version{1})
+	encodedKey2 := MvccEncodeVersionKey([]byte("A"), kv.Version{2})
+	// A_2
+	// A_1
+	c.Assert(encodedKey1.Cmp(encodedKey2), Greater, 0)
+
+	// decode test
+	key, ver, err := MvccDecode(encodedKey1)
+	c.Assert(err, IsNil)
+	c.Assert(bytes.Compare(key, []byte("A")), Equals, 0)
+	c.Assert(ver.Ver, Equals, uint64(1))
+}
+
+func (t *testMvccSuite) scanRawEngine(c *C, f func([]byte, []byte)) {
+	// scan raw db
+	s, err := t.s.(*dbStore).db.GetSnapshot()
+	c.Assert(err, IsNil)
+	it := s.NewIterator(nil)
+	for it.Next() {
+		f(it.Key(), it.Value())
+	}
+}
+
+func (t *testMvccSuite) SetUpTest(c *C) {
+	// create new store
+	t.s = createMemStore()
+	t.addDirtyData()
+	// insert test data
+	txn, err := t.s.Begin()
+	c.Assert(err, IsNil)
+	for i := 0; i < 5; i++ {
+		val := encodeInt(i)
+		err := txn.Set(val, val)
+		c.Assert(err, IsNil)
+	}
+	txn.Commit()
+
+}
+
+func (t *testMvccSuite) TestMvccGet(c *C) {
+	txn, err := t.s.Begin()
+	c.Assert(err, IsNil)
+	k := encodeInt(1)
+	_, err = txn.Get(k)
+	c.Assert(err, IsNil)
+	// no such key
+	k = encodeInt(1024)
+	_, err = txn.Get(k)
+	c.Assert(err, NotNil)
+	txn.Commit()
+}
+
+func (t *testMvccSuite) TestMvccPutAndDel(c *C) {
+	txn, err := t.s.Begin()
+	c.Assert(err, IsNil)
+	// remove 0,1,2
+	for i := 0; i < 3; i++ {
+		val := encodeInt(i)
+		err := txn.Delete(val)
+		c.Assert(err, IsNil)
+	}
+	txn.Commit()
+
+	txn, _ = t.s.Begin()
+	_, err = txn.Get(encodeInt(0))
+	c.Assert(err, NotNil)
+	v, err := txn.Get(encodeInt(4))
+	c.Assert(err, IsNil)
+	c.Assert(len(v), Greater, 0)
+	txn.Commit()
+
+	cnt := 0
+	t.scanRawEngine(c, func(k, v []byte) {
+		cnt++
+	})
+	txn, _ = t.s.Begin()
+	txn.Set(encodeInt(0), []byte("v"))
+	v, err = txn.Get(encodeInt(0))
+	txn.Commit()
+
+	cnt1 := 0
+	t.scanRawEngine(c, func(k, v []byte) {
+		cnt1++
+	})
+	c.Assert(cnt1, Greater, cnt)
+}
+
+func (t *testMvccSuite) TestMvccNext(c *C) {
+	txn, _ := t.s.Begin()
+	it, err := txn.Seek(encodeInt(2), nil)
+	c.Assert(err, IsNil)
+	c.Assert(it.Valid(), IsTrue)
+	for it.Valid() {
+		log.Error("seeking", []byte(it.Key()))
+		it, err = it.Next(nil)
+		c.Assert(err, IsNil)
+	}
+	txn.Commit()
+}

--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -3,7 +3,6 @@ package localstore
 import (
 	"bytes"
 
-	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
@@ -72,7 +71,6 @@ func (t *testMvccSuite) SetUpTest(c *C) {
 		c.Assert(err, IsNil)
 	}
 	txn.Commit()
-
 }
 
 func (t *testMvccSuite) TestMvccGet(c *C) {
@@ -114,6 +112,7 @@ func (t *testMvccSuite) TestMvccPutAndDel(c *C) {
 	txn, _ = t.s.Begin()
 	txn.Set(encodeInt(0), []byte("v"))
 	v, err = txn.Get(encodeInt(0))
+	c.Assert(err, IsNil)
 	txn.Commit()
 
 	cnt1 := 0
@@ -129,7 +128,6 @@ func (t *testMvccSuite) TestMvccNext(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(it.Valid(), IsTrue)
 	for it.Valid() {
-		log.Error("seeking", []byte(it.Key()))
 		it, err = it.Next(nil)
 		c.Assert(err, IsNil)
 	}

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -14,9 +14,13 @@
 package localstore
 
 import (
+	"bytes"
+	"math"
+
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/localstore/engine"
+	"github.com/pingcap/tidb/util/codec"
 )
 
 var (
@@ -28,15 +32,46 @@ type dbSnapshot struct {
 	engine.Snapshot
 }
 
-func (s *dbSnapshot) Get(k []byte) ([]byte, error) {
+func (s *dbSnapshot) Get(k kv.Key) ([]byte, error) {
 	// engine Snapshot return nil, nil for value not found,
 	// so here we will check nil and return kv.ErrNotExist.
-	v, err := s.Snapshot.Get(k)
-	if err != nil {
-		return nil, err
+
+	// get newest version, (0, MaxUint64)
+	// Key arrangement:
+	// Key -> META
+	// ...
+	// Key_ver
+	// Key_ver-1
+	// Key_ver-2
+	// ...
+	// Key_ver-n
+	// Key_0
+	// NextKey -> META
+	// NextKey_xxx
+	startKey := MvccEncodeVersionKey(k, kv.Version{math.MaxUint64})
+	endKey := MvccEncodeVersionKey(k, kv.Version{0})
+
+	// get raw iterator
+	it := s.Snapshot.NewIterator(startKey)
+	defer it.Release()
+
+	var rawKey []byte
+	var v []byte
+	if it.Next() {
+		// If scan exceed this key's all versions
+		// it.Key() > endKey.
+		if kv.EncodedKey(it.Key()).Cmp(endKey) < 0 {
+			// Check newest version of this key.
+			// If it's tombstone, just skip it.
+			if !IsTombstone(it.Value()) {
+				rawKey = it.Key()
+				v = it.Value()
+			}
+		}
 	}
 
-	if v == nil {
+	// No such key or v is nil.
+	if rawKey == nil || v == nil {
 		return nil, kv.ErrNotExist
 	}
 
@@ -44,13 +79,12 @@ func (s *dbSnapshot) Get(k []byte) ([]byte, error) {
 }
 
 func (s *dbSnapshot) NewIterator(param interface{}) kv.Iterator {
-	startKey, ok := param.([]byte)
+	k, ok := param.([]byte)
 	if !ok {
 		log.Errorf("leveldb iterator parameter error, %+v", param)
 		return nil
 	}
-	it := s.Snapshot.NewIterator(startKey)
-	return newDBIter(it)
+	return newDBIter(s, k)
 }
 
 func (s *dbSnapshot) Release() {
@@ -61,19 +95,67 @@ func (s *dbSnapshot) Release() {
 }
 
 type dbIter struct {
-	engine.Iterator
-	valid bool
+	s        *dbSnapshot
+	startKey kv.Key
+	valid    bool
+	k        kv.Key
+	v        []byte
 }
 
-func newDBIter(it engine.Iterator) *dbIter {
-	return &dbIter{
-		Iterator: it,
-		valid:    it.Next(),
+func newDBIter(s *dbSnapshot, startKey kv.Key) *dbIter {
+	it := &dbIter{
+		s:        s,
+		startKey: startKey,
+		valid:    true,
 	}
+	it.Next(nil)
+	return it
 }
 
 func (it *dbIter) Next(fn kv.FnKeyCmp) (kv.Iterator, error) {
-	it.valid = it.Iterator.Next()
+	encKey := codec.EncodeBytes(nil, it.startKey)
+	// max key
+	encEndKey := codec.EncodeBytes(nil, []byte{0xff, 0xff})
+	for {
+		engineIter := it.s.Snapshot.NewIterator(encKey)
+		defer engineIter.Release()
+
+		// Check if overflow
+		if !engineIter.Next() {
+			it.valid = false
+			return it, nil
+		}
+
+		// Check if overflow
+		metaKey := engineIter.Key()
+		if bytes.Compare(metaKey, encEndKey) >= 0 {
+			it.valid = false
+			return it, nil
+		}
+
+		// Get real key from metaKey
+		key, _, err := MvccDecode(metaKey)
+		if err != nil {
+			// It's not a valid metaKey, maybe overflow.
+			it.valid = false
+			return it, err
+		}
+		// Get kv pair.
+		val, err := it.s.Get(key)
+		if err != nil && err != kv.ErrNotExist {
+			// Get this version error
+			it.valid = false
+			return it, err
+		}
+		if val != nil {
+			it.k = key
+			it.v = val
+			it.startKey = key.Next()
+			return it, nil
+		}
+		// Current key's all versions are deleted, just go next key.
+		encKey = codec.EncodeBytes(nil, key.Next())
+	}
 	return it, nil
 }
 
@@ -82,16 +164,11 @@ func (it *dbIter) Valid() bool {
 }
 
 func (it *dbIter) Key() string {
-	return string(it.Iterator.Key())
+	return string(it.k)
 }
 
 func (it *dbIter) Value() []byte {
-	return it.Iterator.Value()
+	return it.v
 }
 
-func (it *dbIter) Close() {
-	if it.Iterator != nil {
-		it.Iterator.Release()
-		it.Iterator = nil
-	}
-}
+func (it *dbIter) Close() {}

--- a/store/localstore/txn.go
+++ b/store/localstore/txn.go
@@ -198,7 +198,7 @@ func (txn *dbTxn) doCommit() error {
 		b.Put(metaKey, codec.EncodeUint(nil, curVer.Ver))
 		mvccKey := MvccEncodeVersionKey(iter.Key(), curVer)
 		if len(iter.Value()) == 0 { // Deleted marker
-			b.Put(mvccKey, Tombstone)
+			b.Put(mvccKey, tombstone)
 		} else {
 			b.Put(mvccKey, iter.Value())
 		}
@@ -208,7 +208,6 @@ func (txn *dbTxn) doCommit() error {
 		return errors.Trace(err)
 	}
 	return txn.store.writeBatch(b)
-
 }
 
 func (txn *dbTxn) Commit() error {

--- a/store/localstore/txn.go
+++ b/store/localstore/txn.go
@@ -22,6 +22,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/syndtr/goleveldb/leveldb/iterator"
 )
 
@@ -39,7 +40,7 @@ type dbTxn struct {
 	kv.UnionStore
 	store        *dbStore // for commit
 	startTs      time.Time
-	tID          int64
+	tID          uint64
 	valid        bool
 	snapshotVals map[string][]byte // origin version in snapshot
 }
@@ -64,7 +65,7 @@ func (txn *dbTxn) markOrigin(k []byte) error {
 
 // Implement transaction interface
 
-func (txn *dbTxn) Inc(k []byte, step int64) (int64, error) {
+func (txn *dbTxn) Inc(k kv.Key, step int64) (int64, error) {
 	log.Debugf("Inc %q, step %d txn:%d", k, step, txn.tID)
 	k = kv.EncodeKey(k)
 
@@ -103,7 +104,7 @@ func (txn *dbTxn) String() string {
 	return fmt.Sprintf("%d", txn.tID)
 }
 
-func (txn *dbTxn) Get(k []byte) ([]byte, error) {
+func (txn *dbTxn) Get(k kv.Key) ([]byte, error) {
 	log.Debugf("get key:%q, txn:%d", k, txn.tID)
 	k = kv.EncodeKey(k)
 	val, err := txn.UnionStore.Get(k)
@@ -121,7 +122,7 @@ func (txn *dbTxn) Get(k []byte) ([]byte, error) {
 	return val, nil
 }
 
-func (txn *dbTxn) Set(k []byte, data []byte) error {
+func (txn *dbTxn) Set(k kv.Key, data []byte) error {
 	if len(data) == 0 {
 		// Incase someone use it in the wrong way, we can figure it out immediately
 		debug.PrintStack()
@@ -133,7 +134,7 @@ func (txn *dbTxn) Set(k []byte, data []byte) error {
 	return txn.UnionStore.Set(k, data)
 }
 
-func (txn *dbTxn) Seek(k []byte, fnKeyCmp func([]byte) bool) (kv.Iterator, error) {
+func (txn *dbTxn) Seek(k kv.Key, fnKeyCmp func(kv.Key) bool) (kv.Iterator, error) {
 	log.Debugf("seek %q txn:%d", k, txn.tID)
 	k = kv.EncodeKey(k)
 
@@ -155,7 +156,7 @@ func (txn *dbTxn) Seek(k []byte, fnKeyCmp func([]byte) bool) (kv.Iterator, error
 	return iter, nil
 }
 
-func (txn *dbTxn) Delete(k []byte) error {
+func (txn *dbTxn) Delete(k kv.Key) error {
 	log.Debugf("delete %q txn:%d", k, txn.tID)
 	k = kv.EncodeKey(k)
 	return txn.UnionStore.Delete(k)
@@ -190,11 +191,16 @@ func (txn *dbTxn) doCommit() error {
 	}
 
 	// Check dirty store
+	curVer, _ := globalVerProvider.GetCurrentVer()
 	err := txn.each(func(iter iterator.Iterator) error {
+		metaKey := codec.EncodeBytes(nil, iter.Key())
+		// put dummy meta key, write current version
+		b.Put(metaKey, codec.EncodeUint(nil, curVer.Ver))
+		mvccKey := MvccEncodeVersionKey(iter.Key(), curVer)
 		if len(iter.Value()) == 0 { // Deleted marker
-			b.Delete(iter.Key())
+			b.Put(mvccKey, Tombstone)
 		} else {
-			b.Put(iter.Key(), iter.Value())
+			b.Put(mvccKey, iter.Value())
 		}
 		return nil
 	})
@@ -232,7 +238,7 @@ func (txn *dbTxn) Rollback() error {
 	return txn.close()
 }
 
-func (txn *dbTxn) LockKeys(keys ...[]byte) error {
+func (txn *dbTxn) LockKeys(keys ...kv.Key) error {
 	for _, key := range keys {
 		key = kv.EncodeKey(key)
 		if err := txn.markOrigin(key); err != nil {

--- a/util/prefix_helper.go
+++ b/util/prefix_helper.go
@@ -29,7 +29,7 @@ import (
 )
 
 func hasPrefix(prefix []byte) kv.FnKeyCmp {
-	return func(k []byte) bool {
+	return func(k kv.Key) bool {
 		return bytes.HasPrefix(k, prefix)
 	}
 }
@@ -125,7 +125,7 @@ func DecodeHandleFromRowKey(rk string) (int64, error) {
 
 // RowKeyPrefixFilter returns a function which checks whether currentKey has decoded rowKeyPrefix as prefix.
 func RowKeyPrefixFilter(rowKeyPrefix []byte) kv.FnKeyCmp {
-	return func(currentKey []byte) bool {
+	return func(currentKey kv.Key) bool {
 		// Next until key without prefix of this record.
 		raw, err := codec.StripEnd(rowKeyPrefix)
 		if err != nil {


### PR DESCRIPTION
1. Add MVCC to original interfaces (alway handles newest version).
2. Add some tests.  

TODO (I'll put them in next commits, to avoid a big PR):
1. Get/Scan specific version.
2. Compact

the structure of MVCC kv:

Key1 => 3 (newest version)
Key1_3 => ... (value of this version)
Key1_2 => ... (value of this version)
Key2 => 2
Key2_2 =>  Tombstone (this key is deleted in the version)
Key2_1 => ...
Key3 => 4
Key3_4 => ...

