### PR TITLE
*: Remove leading comment when check IsQuery

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -347,7 +347,7 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		switch ok {
 		case true:
-			c.Assert(len(l.errs), Equals, 0, Commentf("src: %s", t.src))
+			c.Assert(l.errs, HasLen, 0, Commentf("src: %s", t.src))
 		case false:
 			c.Assert(len(l.errs), Not(Equals), 0, Commentf("src: %s", t.src))
 		}
@@ -395,10 +395,18 @@ func (s *testParserSuite) TestParser0(c *C) {
 	c.Assert(cv.FunctionType, Equals, expressions.ConvertFunction)
 
 	// For query start with comment
-	src = "/* some comments */ /*comment*/ SELECT /*comment*/ CONVERT('111', /*comment*/ SIGNED) /*comment*/;"
-	l = NewLexer(src)
-	c.Assert(yyParse(l), Equals, 0)
-	st = l.Stmts()[0]
-	ss, ok = st.(*stmts.SelectStmt)
-	c.Assert(ok, IsTrue)
+	srcs := []string{
+		"/* some comments */ SELECT CONVERT('111', SIGNED) ;",
+		"/* some comments */ /*comment*/ SELECT CONVERT('111', SIGNED) ;",
+		"SELECT /*comment*/ CONVERT('111', SIGNED) ;",
+		"SELECT CONVERT('111', /*comment*/ SIGNED) ;",
+		"SELECT CONVERT('111', SIGNED) /*comment*/;",
+	}
+	for _, src := range srcs {
+		l = NewLexer(src)
+		c.Assert(yyParse(l), Equals, 0)
+		st = l.Stmts()[0]
+		ss, ok = st.(*stmts.SelectStmt)
+		c.Assert(ok, IsTrue)
+	}
 }

--- a/tidb.go
+++ b/tidb.go
@@ -243,9 +243,24 @@ func NewStore(uri string) (kv.Storage, error) {
 
 var queryStmtTable = []string{"explain", "select", "show", "execute", "describe", "desc"}
 
+func trimSQL(sql string) string {
+	// Trim space.
+	sql = strings.TrimSpace(sql)
+	// Trim leading /*comment*/
+	// There may be multiple comments
+	for strings.HasPrefix(sql, "/*") {
+		i := strings.Index(sql, "*/")
+		if i != -1 && i < len(sql)+1 {
+			sql = sql[i+2:]
+		}
+		sql = strings.TrimSpace(sql)
+	}
+	return sql
+}
+
 // IsQuery checks if a sql statement is a query statement.
 func IsQuery(sql string) bool {
-	sqlText := strings.ToLower(strings.TrimSpace(sql))
+	sqlText := strings.ToLower(trimSQL(sql))
 	for _, key := range queryStmtTable {
 		if strings.HasPrefix(sqlText, key) {
 			return true

--- a/tidb.go
+++ b/tidb.go
@@ -252,8 +252,10 @@ func trimSQL(sql string) string {
 		i := strings.Index(sql, "*/")
 		if i != -1 && i < len(sql)+1 {
 			sql = sql[i+2:]
+			sql = strings.TrimSpace(sql)
+			continue
 		}
-		sql = strings.TrimSpace(sql)
+		break
 	}
 	return sql
 }

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -292,6 +292,20 @@ func (s *testMainSuite) TestCheckArgs(c *C) {
 		"abc", []byte("abc"), time.Now(), time.Hour, time.Local)
 }
 
+func (s *testMainSuite) TestIsQuery(c *C) {
+	tbl := []struct {
+		sql string
+		ok  bool
+	}{
+		{"/*comment*/ select 1;", true},
+		{"/*comment*/ /*comment*/ select 1;", true},
+		{"select /*comment*/ 1 /*comment*/;", true},
+	}
+	for _, t := range tbl {
+		c.Assert(IsQuery(t.sql), Equals, t.ok, Commentf(t.sql))
+	}
+}
+
 func sessionExec(c *C, se Session, sql string) ([]rset.Recordset, error) {
 	se.Execute("BEGIN;")
 	r, err := se.Execute(sql)

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -314,6 +314,7 @@ func (s *testMainSuite) TestitrimSQL(c *C) {
 		{"/*comment*/ select 1; ", "select 1;"},
 		{"/*comment*/ /*comment*/ select 1;", "select 1;"},
 		{"select /*comment*/ 1 /*comment*/;", "select /*comment*/ 1 /*comment*/;"},
+		{"/*comment select 1; ", "/*comment select 1;"},
 	}
 	for _, t := range tbl {
 		c.Assert(trimSQL(t.sql), Equals, t.target, Commentf(t.sql))

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -306,6 +306,20 @@ func (s *testMainSuite) TestIsQuery(c *C) {
 	}
 }
 
+func (s *testMainSuite) TestitrimSQL(c *C) {
+	tbl := []struct {
+		sql    string
+		target string
+	}{
+		{"/*comment*/ select 1; ", "select 1;"},
+		{"/*comment*/ /*comment*/ select 1;", "select 1;"},
+		{"select /*comment*/ 1 /*comment*/;", "select /*comment*/ 1 /*comment*/;"},
+	}
+	for _, t := range tbl {
+		c.Assert(trimSQL(t.sql), Equals, t.target, Commentf(t.sql))
+	}
+}
+
 func sessionExec(c *C, se Session, sql string) ([]rset.Recordset, error) {
 	se.Execute("BEGIN;")
 	r, err := se.Execute(sql)


### PR DESCRIPTION
IsQuery check the prefix of sql text, so we need to remove comments.