### PR TITLE
expression: remove return error in Clone interface

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -25,7 +25,7 @@ import (
 // See https://dev.mysql.com/doc/refman/5.7/en/expressions.html
 type Expression interface {
 	// Clone clones another Expression.
-	Clone() (Expression, error)
+	Clone() Expression
 	// Eval evaluates expression.
 	Eval(ctx context.Context, args map[interface{}]interface{}) (v interface{}, err error)
 	// IsStatic returns whether this expression can be evaluated statically or not.

--- a/expression/expressions/between.go
+++ b/expression/expressions/between.go
@@ -41,23 +41,11 @@ type Between struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (b *Between) Clone() (expression.Expression, error) {
-	expr, err := b.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	left, err := b.Left.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	right, err := b.Right.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return &Between{Expr: expr, Left: left, Right: right, Not: b.Not}, nil
+func (b *Between) Clone() expression.Expression {
+	expr := b.Expr.Clone()
+	left := b.Left.Clone()
+	right := b.Right.Clone()
+	return &Between{Expr: expr, Left: left, Right: right, Not: b.Not}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/between_test.go
+++ b/expression/expressions/between_test.go
@@ -54,8 +54,7 @@ func (s *testBetweenSuite) TestBetween(c *C) {
 		b, err := NewBetween(t.Expr, Value{t.Left}, Value{t.Right}, t.Not)
 		c.Assert(err, IsNil)
 		c.Assert(len(b.String()), Greater, 0)
-		_, err = b.Clone()
-		c.Assert(err, IsNil)
+		c.Assert(b.Clone(), NotNil)
 		c.Assert(b.IsStatic(), Equals, !ContainAggregateFunc(t.Expr))
 
 		v, err := b.Eval(nil, m)
@@ -87,9 +86,7 @@ func (s *testBetweenSuite) TestBetween(c *C) {
 		c.Assert(err, NotNil)
 
 		b := Between{Expr: t.Expr, Left: t.Left, Right: t.Right, Not: false}
-		_, err = b.Clone()
-		c.Assert(err, NotNil)
-
+		c.Assert(b.Clone(), NotNil)
 		_, err = b.Eval(nil, nil)
 		c.Assert(err, NotNil)
 	}

--- a/expression/expressions/binop.go
+++ b/expression/expressions/binop.go
@@ -107,18 +107,10 @@ func (o *BinaryOperation) IsIdentRelOpVal() (bool, string, interface{}, error) {
 }
 
 // Clone implements the Expression Clone interface.
-func (o *BinaryOperation) Clone() (expression.Expression, error) {
-	l, err := o.L.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := o.R.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return NewBinaryOperation(o.Op, l, r), nil
+func (o *BinaryOperation) Clone() expression.Expression {
+	l := o.L.Clone()
+	r := o.R.Clone()
+	return NewBinaryOperation(o.Op, l, r)
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/binop_test.go
+++ b/expression/expressions/binop_test.go
@@ -128,16 +128,13 @@ func (s *testBinOpSuite) TestComparisonOp(c *C) {
 		expr := NewBinaryOperation(t.op, Value{t.arg}, mock)
 		_, err := expr.Eval(nil, nil)
 		c.Assert(err, NotNil)
-
-		_, err = expr.Clone()
-		c.Assert(err, NotNil)
+		c.Assert(expr.Clone(), NotNil)
 
 		expr = NewBinaryOperation(t.op, mock, Value{t.arg})
 		_, err = expr.Eval(nil, nil)
 		c.Assert(err, NotNil)
 
-		_, err = expr.Clone()
-		c.Assert(err, NotNil)
+		c.Assert(expr.Clone(), NotNil)
 	}
 
 	mock.err = nil
@@ -255,8 +252,7 @@ func (s *testBinOpSuite) TestLogicOp(c *C) {
 			c.Assert(v, DeepEquals, int64(x))
 		}
 
-		_, err = expr.Clone()
-		c.Assert(err, IsNil)
+		c.Assert(expr.Clone(), NotNil)
 	}
 
 	// test error

--- a/expression/expressions/builtin_control_test.go
+++ b/expression/expressions/builtin_control_test.go
@@ -107,8 +107,8 @@ func (s *testBuiltinSuite) TestCaseWhen(c *C) {
 	}
 
 	f := FunctionCase{mockExpr{val: 4}, whens0, mockExpr{val: "else"}}
-	cf, err := f.Clone()
-	c.Assert(err, IsNil)
+	cf := f.Clone()
+	c.Assert(cf, NotNil)
 	v, err := f.Eval(nil, nil)
 	c.Assert(err, IsNil)
 	cv, err := cf.Eval(nil, nil)

--- a/expression/expressions/call.go
+++ b/expression/expressions/call.go
@@ -76,13 +76,9 @@ func NewCall(f string, args []expression.Expression, distinct bool) (v expressio
 }
 
 // Clone implements the Expression Clone interface.
-func (c *Call) Clone() (expression.Expression, error) {
-	list, err := cloneExpressionList(c.Args)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Call{F: c.F, Args: list, Distinct: c.Distinct}, nil
+func (c *Call) Clone() expression.Expression {
+	list := cloneExpressionList(c.Args)
+	return &Call{F: c.F, Args: list, Distinct: c.Distinct}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/call_test.go
+++ b/expression/expressions/call_test.go
@@ -30,8 +30,7 @@ func (s *testCallSuite) TestCall(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(f.IsStatic(), IsTrue)
-	_, err = f.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(f.Clone(), NotNil)
 
 	c.Assert(len(f.String()), Greater, 0)
 	m := map[interface{}]interface{}{}
@@ -46,8 +45,7 @@ func (s *testCallSuite) TestCall(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(f.String()), Greater, 0)
 	c.Assert(f.IsStatic(), IsFalse)
-	_, err = f.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(f.Clone(), NotNil)
 
 	// test error
 	f, err = NewCall("abs", []expression.Expression{Value{1}, Value{2}}, true)
@@ -73,9 +71,7 @@ func (s *testCallSuite) TestCall(c *C) {
 	f, err = NewCall("abs", []expression.Expression{mock}, true)
 	c.Assert(err, IsNil)
 
-	_, err = f.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(f.Clone(), NotNil)
 	_, err = f.Eval(nil, nil)
 	c.Assert(err, NotNil)
-
 }

--- a/expression/expressions/case.go
+++ b/expression/expressions/case.go
@@ -71,16 +71,10 @@ func (w *WhenClause) String() string {
 }
 
 // Clone implements the Expression Clone interface.
-func (w *WhenClause) Clone() (expression.Expression, error) {
-	ne, err := w.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-	nr, err := w.Result.Clone()
-	if err != nil {
-		return nil, err
-	}
-	return &WhenClause{Expr: ne, Result: nr}, nil
+func (w *WhenClause) Clone() expression.Expression {
+	ne := w.Expr.Clone()
+	nr := w.Result.Clone()
+	return &WhenClause{Expr: ne, Result: nr}
 }
 
 // IsStatic implements the Expression IsStatic interface.
@@ -99,39 +93,29 @@ type FunctionCase struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (f *FunctionCase) Clone() (expression.Expression, error) {
+func (f *FunctionCase) Clone() expression.Expression {
 	var (
-		nv  expression.Expression
-		ne  expression.Expression
-		nw  expression.Expression
-		err error
+		nv expression.Expression
+		ne expression.Expression
+		nw expression.Expression
 	)
 	if f.Value != nil {
-		nv, err = f.Value.Clone()
-		if err != nil {
-			return nil, err
-		}
+		nv = f.Value.Clone()
 	}
 	ws := make([]*WhenClause, 0, len(f.WhenClauses))
 	for _, w := range f.WhenClauses {
-		nw, err = w.Clone()
-		if err != nil {
-			return nil, err
-		}
+		nw = w.Clone()
 		ws = append(ws, nw.(*WhenClause))
 	}
 
 	if f.ElseClause != nil {
-		ne, err = f.ElseClause.Clone()
-		if err != nil {
-			return nil, err
-		}
+		ne = f.ElseClause.Clone()
 	}
 	return &FunctionCase{
 		Value:       nv,
 		WhenClauses: ws,
 		ElseClause:  ne,
-	}, nil
+	}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/cast.go
+++ b/expression/expressions/cast.go
@@ -46,17 +46,14 @@ type FunctionCast struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (f *FunctionCast) Clone() (expression.Expression, error) {
-	expr, err := f.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
+func (f *FunctionCast) Clone() expression.Expression {
+	expr := f.Expr.Clone()
 	nf := &FunctionCast{
 		Expr:         expr,
 		Tp:           f.Tp,
 		FunctionType: f.FunctionType,
 	}
-	return nf, nil
+	return nf
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/cast_test.go
+++ b/expression/expressions/cast_test.go
@@ -43,8 +43,7 @@ func (s *testCastSuite) TestCast(c *C) {
 	c.Assert(len(expr.String()), Greater, 0)
 
 	f.Tp = mysql.TypeLonglong
-	_, err := expr.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(expr.Clone(), NotNil)
 
 	c.Assert(expr.IsStatic(), IsTrue)
 
@@ -75,8 +74,7 @@ func (s *testCastSuite) TestCast(c *C) {
 	c.Assert(v, Equals, nil)
 
 	expr.Expr = mockExpr{err: errors.New("must error")}
-	_, err = expr.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(expr.Clone(), NotNil)
 
 	_, err = expr.Eval(nil, nil)
 	c.Assert(err, NotNil)

--- a/expression/expressions/cmp_subquery.go
+++ b/expression/expressions/cmp_subquery.go
@@ -39,18 +39,10 @@ type CompareSubQuery struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (cs *CompareSubQuery) Clone() (expression.Expression, error) {
-	l, err := cs.L.Clone()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	r, err := cs.R.Clone()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return &CompareSubQuery{L: l, Op: cs.Op, R: r.(*SubQuery), All: cs.All}, nil
+func (cs *CompareSubQuery) Clone() expression.Expression {
+	l := cs.L.Clone()
+	r := cs.R.Clone()
+	return &CompareSubQuery{L: l, Op: cs.Op, R: r.(*SubQuery), All: cs.All}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/convert.go
+++ b/expression/expressions/convert.go
@@ -32,16 +32,13 @@ type FunctionConvert struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (f *FunctionConvert) Clone() (expression.Expression, error) {
-	expr, err := f.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
+func (f *FunctionConvert) Clone() expression.Expression {
+	expr := f.Expr.Clone()
 	nf := &FunctionConvert{
 		Expr:    expr,
 		Charset: f.Charset,
 	}
-	return nf, nil
+	return nf
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/convert_test.go
+++ b/expression/expressions/convert_test.go
@@ -42,8 +42,8 @@ func (*testConvertSuite) TestConvert(c *C) {
 		fs := f.String()
 		c.Assert(len(fs), Greater, 0)
 
-		f1, err := f.Clone()
-		c.Assert(err, IsNil)
+		f1 := f.Clone()
+		c.Assert(f1, NotNil)
 
 		r, err := f.Eval(nil, nil)
 		c.Assert(err, IsNil)

--- a/expression/expressions/default.go
+++ b/expression/expressions/default.go
@@ -33,9 +33,9 @@ type Default struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (v *Default) Clone() (expression.Expression, error) {
+func (v *Default) Clone() expression.Expression {
 	newV := *v
-	return &newV, nil
+	return &newV
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns false.

--- a/expression/expressions/default_test.go
+++ b/expression/expressions/default_test.go
@@ -26,14 +26,13 @@ func (s *testDefaultSuite) TestDefault(c *C) {
 	e := Default{}
 
 	c.Assert(e.String(), Equals, "default")
-	_, err := e.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(e.Clone(), NotNil)
 
 	c.Assert(e.IsStatic(), IsFalse)
 
 	m := map[interface{}]interface{}{}
 
-	_, err = e.Eval(nil, m)
+	_, err := e.Eval(nil, m)
 	c.Assert(err, NotNil)
 
 	m[ExprEvalDefaultName] = "id"

--- a/expression/expressions/exists_subquery.go
+++ b/expression/expressions/exists_subquery.go
@@ -29,13 +29,9 @@ type ExistsSubQuery struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (es *ExistsSubQuery) Clone() (expression.Expression, error) {
-	sel, err := es.Sel.Clone()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return &ExistsSubQuery{Sel: sel.(*SubQuery)}, nil
+func (es *ExistsSubQuery) Clone() expression.Expression {
+	sel := es.Sel.Clone()
+	return &ExistsSubQuery{Sel: sel.(*SubQuery)}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/exists_subquery_test.go
+++ b/expression/expressions/exists_subquery_test.go
@@ -48,8 +48,8 @@ func (s *testExistsSubQuerySuite) TestExistsSubQuery(c *C) {
 
 		c.Assert(expr.IsStatic(), IsFalse)
 
-		exprc, err := expr.Clone()
-		c.Assert(err, IsNil)
+		exprc := expr.Clone()
+		c.Assert(exprc, NotNil)
 
 		str := exprc.String()
 		c.Assert(len(str), Greater, 0)
@@ -95,8 +95,8 @@ func (s *testExistsSubQuerySuite) TestExistsSubQuery(c *C) {
 
 		expr := NewUnaryOperation(opcode.Not, es)
 
-		exprc, err := expr.Clone()
-		c.Assert(err, IsNil)
+		exprc := expr.Clone()
+		c.Assert(exprc, NotNil)
 
 		str = exprc.String()
 		c.Assert(len(str), Greater, 0)

--- a/expression/expressions/expression_test.go
+++ b/expression/expressions/expression_test.go
@@ -50,9 +50,9 @@ func (m mockExpr) String() string {
 	return "mock expression"
 }
 
-func (m mockExpr) Clone() (expression.Expression, error) {
+func (m mockExpr) Clone() expression.Expression {
 	nm := m
-	return nm, m.err
+	return nm
 }
 
 type mockCtx struct {

--- a/expression/expressions/helper.go
+++ b/expression/expressions/helper.go
@@ -86,15 +86,12 @@ func Expr(v interface{}) expression.Expression {
 	}
 }
 
-func cloneExpressionList(list []expression.Expression) ([]expression.Expression, error) {
+func cloneExpressionList(list []expression.Expression) []expression.Expression {
 	r := make([]expression.Expression, len(list))
-	var err error
 	for i, v := range list {
-		if r[i], err = v.Clone(); err != nil {
-			return nil, err
-		}
+		r[i] = v.Clone()
 	}
-	return r, nil
+	return r
 }
 
 // FastEval evaluates Value and static +/- Unary expression and returns its value.

--- a/expression/expressions/ident.go
+++ b/expression/expressions/ident.go
@@ -35,9 +35,9 @@ type Ident struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (i *Ident) Clone() (expression.Expression, error) {
+func (i *Ident) Clone() expression.Expression {
 	newI := *i
-	return &newI, nil
+	return &newI
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns false.

--- a/expression/expressions/ident_test.go
+++ b/expression/expressions/ident_test.go
@@ -31,7 +31,7 @@ func (s *testIdentSuite) TestIdent(c *C) {
 	c.Assert(e.IsStatic(), IsFalse)
 	c.Assert(e.String(), Equals, "id")
 
-	ec, err := e.Clone()
+	ec := e.Clone()
 	e2, ok := ec.(*Ident)
 	c.Assert(ok, IsTrue)
 	e2.O = "ID"

--- a/expression/expressions/in.go
+++ b/expression/expressions/in.go
@@ -44,23 +44,15 @@ type PatternIn struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (n *PatternIn) Clone() (expression.Expression, error) {
-	expr, err := n.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	list, err := cloneExpressionList(n.List)
-	if err != nil {
-		return nil, err
-	}
-
+func (n *PatternIn) Clone() expression.Expression {
+	expr := n.Expr.Clone()
+	list := cloneExpressionList(n.List)
 	return &PatternIn{
 		Expr: expr,
 		List: list,
 		Not:  n.Not,
 		Sel:  n.Sel,
-	}, nil
+	}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/in_test.go
+++ b/expression/expressions/in_test.go
@@ -41,8 +41,7 @@ func (t *testPatternInSuite) TestPatternIn(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*PatternIn)
 	c.Assert(ok, IsTrue)

--- a/expression/expressions/isnull.go
+++ b/expression/expressions/isnull.go
@@ -34,13 +34,9 @@ type IsNull struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (is *IsNull) Clone() (expression.Expression, error) {
-	expr, err := is.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return &IsNull{Expr: expr, Not: is.Not}, nil
+func (is *IsNull) Clone() expression.Expression {
+	expr := is.Expr.Clone()
+	return &IsNull{Expr: expr, Not: is.Not}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/isnull_test.go
+++ b/expression/expressions/isnull_test.go
@@ -38,8 +38,7 @@ func (t *testIsNullSuite) TestIsNull(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*IsNull)
 	c.Assert(ok, IsTrue)
@@ -58,8 +57,7 @@ func (t *testIsNullSuite) TestIsNull(c *C) {
 	expr.err = errors.New("must error")
 	e.Expr = expr
 
-	_, err = e.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(e.Clone(), NotNil)
 
 	_, err = e.Eval(nil, nil)
 	c.Assert(err, NotNil)

--- a/expression/expressions/istruth.go
+++ b/expression/expressions/istruth.go
@@ -37,13 +37,9 @@ type IsTruth struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (is *IsTruth) Clone() (expression.Expression, error) {
-	expr, err := is.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return &IsTruth{Expr: expr, Not: is.Not, True: is.True}, nil
+func (is *IsTruth) Clone() expression.Expression {
+	expr := is.Expr.Clone()
+	return &IsTruth{Expr: expr, Not: is.Not, True: is.True}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/istruth_test.go
+++ b/expression/expressions/istruth_test.go
@@ -36,8 +36,7 @@ func (t *testIsTruthSuite) TestIsTruth(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*IsTruth)
 	c.Assert(ok, IsTrue)

--- a/expression/expressions/like.go
+++ b/expression/expressions/like.go
@@ -48,24 +48,16 @@ type PatternLike struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (p *PatternLike) Clone() (expression.Expression, error) {
-	expr, err := p.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	pattern, err := p.Pattern.Clone()
-	if err != nil {
-		return nil, err
-	}
-
+func (p *PatternLike) Clone() expression.Expression {
+	expr := p.Expr.Clone()
+	pattern := p.Pattern.Clone()
 	return &PatternLike{
 		Expr:     expr,
 		Pattern:  pattern,
 		patChars: p.patChars,
 		patTypes: p.patTypes,
 		Not:      p.Not,
-	}, nil
+	}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/like_test.go
+++ b/expression/expressions/like_test.go
@@ -69,8 +69,7 @@ func (*testLikeSuite) TestEval(c *C) {
 			Val: "aA",
 		},
 	}
-	cloned, err := pattern.Clone()
-	c.Assert(err, IsNil)
+	cloned := pattern.Clone()
 	pattern = cloned.(*PatternLike)
 	c.Assert(pattern.IsStatic(), IsTrue)
 	c.Assert(pattern.String(), Not(Equals), "")
@@ -83,8 +82,7 @@ func (*testLikeSuite) TestEval(c *C) {
 	c.Assert(val, IsFalse)
 
 	pattern.Pattern = mockExpr{isStatic: false, err: errors.Errorf("test error")}
-	_, err = pattern.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(pattern.Clone(), NotNil)
 	_, err = pattern.Eval(nil, nil)
 	c.Assert(err, NotNil)
 	pattern.Pattern = mockExpr{isStatic: false, val: nil}
@@ -95,8 +93,7 @@ func (*testLikeSuite) TestEval(c *C) {
 	c.Assert(err, NotNil)
 
 	pattern.Expr = mockExpr{isStatic: false, err: errors.Errorf("test error")}
-	_, err = pattern.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(pattern.Clone(), NotNil)
 	_, err = pattern.Eval(nil, nil)
 	c.Assert(err, NotNil)
 	pattern.Expr = mockExpr{isStatic: false, val: 123}

--- a/expression/expressions/param_marker.go
+++ b/expression/expressions/param_marker.go
@@ -28,16 +28,12 @@ type ParamMarker struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (pm *ParamMarker) Clone() (expression.Expression, error) {
+func (pm *ParamMarker) Clone() expression.Expression {
 	np := &ParamMarker{}
 	if pm.Expr != nil {
-		var err error
-		np.Expr, err = pm.Expr.Clone()
-		if err != nil {
-			return nil, err
-		}
+		np.Expr = pm.Expr.Clone()
 	}
-	return np, nil
+	return np
 }
 
 // Eval implements the Expression Eval interface.

--- a/expression/expressions/param_marker_test.go
+++ b/expression/expressions/param_marker_test.go
@@ -36,8 +36,7 @@ func (t *testParamMarkerSuite) TestParamMarker(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*ParamMarker)
 	c.Assert(ok, IsTrue)
@@ -51,6 +50,5 @@ func (t *testParamMarkerSuite) TestParamMarker(c *C) {
 	str = e2.String()
 	c.Assert(str, Equals, "?")
 
-	_, err = e2.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(e2.Clone(), NotNil)
 }

--- a/expression/expressions/pexpr.go
+++ b/expression/expressions/pexpr.go
@@ -35,13 +35,9 @@ type PExpr struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (p *PExpr) Clone() (expression.Expression, error) {
-	expr, err := p.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return &PExpr{Expr: expr}, nil
+func (p *PExpr) Clone() expression.Expression {
+	expr := p.Expr.Clone()
+	return &PExpr{Expr: expr}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/pexpr_test.go
+++ b/expression/expressions/pexpr_test.go
@@ -32,8 +32,7 @@ func (t *testPExprSuite) TestPExpr(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	v, err := ec.Eval(nil, nil)
 	c.Assert(err, IsNil)

--- a/expression/expressions/position.go
+++ b/expression/expressions/position.go
@@ -36,9 +36,9 @@ type Position struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (p *Position) Clone() (expression.Expression, error) {
+func (p *Position) Clone() expression.Expression {
 	newP := *p
-	return &newP, nil
+	return &newP
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns false.

--- a/expression/expressions/position_test.go
+++ b/expression/expressions/position_test.go
@@ -32,8 +32,7 @@ func (s *testPositionSuite) TestPosition(c *C) {
 	str := e.String()
 	c.Assert(len(str), Greater, 0)
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*Position)
 	c.Assert(ok, IsTrue)
@@ -43,7 +42,7 @@ func (s *testPositionSuite) TestPosition(c *C) {
 	c.Assert(len(str), Greater, 0)
 
 	m := map[interface{}]interface{}{}
-	_, err = e2.Eval(nil, m)
+	_, err := e2.Eval(nil, m)
 	c.Assert(err, NotNil)
 
 	m[ExprEvalPositionFunc] = 1

--- a/expression/expressions/regexp.go
+++ b/expression/expressions/regexp.go
@@ -46,24 +46,16 @@ type PatternRegexp struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (p *PatternRegexp) Clone() (expression.Expression, error) {
-	expr, err := p.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	pattern, err := p.Pattern.Clone()
-	if err != nil {
-		return nil, err
-	}
-
+func (p *PatternRegexp) Clone() expression.Expression {
+	expr := p.Expr.Clone()
+	pattern := p.Pattern.Clone()
 	return &PatternRegexp{
 		Expr:    expr,
 		Pattern: pattern,
 		Re:      p.Re,
 		Sexpr:   p.Sexpr,
 		Not:     p.Not,
-	}, nil
+	}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/regexp_test.go
+++ b/expression/expressions/regexp_test.go
@@ -53,18 +53,15 @@ func (rs *testRegexpSuite) TestT(c *C) {
 		Pattern: &mockExpr{err: errors.Errorf("test error")},
 		Expr:    &mockExpr{err: errors.Errorf("test error")},
 	}
-	_, err := pat.Clone()
-	c.Assert(err, NotNil)
-	_, err = pat.Eval(nil, nil)
+	c.Assert(pat.Clone(), NotNil)
+	_, err := pat.Eval(nil, nil)
 	c.Assert(err, NotNil)
 	pat.Expr = &Value{"^$"}
-	_, err = pat.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(pat.Clone(), NotNil)
 	_, err = pat.Eval(nil, nil)
 	c.Assert(err, NotNil)
 	pat.Pattern = &Value{"a"}
-	_, err = pat.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(pat.Clone(), NotNil)
 	_, err = pat.Eval(nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(pat.IsStatic(), IsTrue)

--- a/expression/expressions/row.go
+++ b/expression/expressions/row.go
@@ -29,17 +29,12 @@ type Row struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (r *Row) Clone() (expression.Expression, error) {
+func (r *Row) Clone() expression.Expression {
 	values := make([]expression.Expression, len(r.Values))
-	var err error
 	for i, expr := range r.Values {
-		values[i], err = expr.Clone()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		values[i] = expr.Clone()
 	}
-
-	return &Row{Values: values}, nil
+	return &Row{Values: values}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/row_test.go
+++ b/expression/expressions/row_test.go
@@ -29,12 +29,11 @@ func (s *testRowSuite) TestRow(c *C) {
 	r := Row{Values: []expression.Expression{Value{1}, Value{2}}}
 	c.Assert(r.IsStatic(), IsTrue)
 
-	_, err := r.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(r.Clone(), NotNil)
 
 	c.Assert(r.String(), Equals, "ROW(1, 2)")
 
-	_, err = r.Eval(nil, nil)
+	_, err := r.Eval(nil, nil)
 	c.Assert(err, IsNil)
 
 	expr := mockExpr{}
@@ -43,8 +42,7 @@ func (s *testRowSuite) TestRow(c *C) {
 	r = Row{Values: []expression.Expression{Value{1}, expr}}
 	c.Assert(r.IsStatic(), IsFalse)
 
-	_, err = r.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(r.Clone(), NotNil)
 
 	_, err = r.Eval(nil, nil)
 	c.Assert(err, NotNil)

--- a/expression/expressions/subquery.go
+++ b/expression/expressions/subquery.go
@@ -48,9 +48,9 @@ type SubQuery struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (sq *SubQuery) Clone() (expression.Expression, error) {
+func (sq *SubQuery) Clone() expression.Expression {
 	nsq := &SubQuery{Stmt: sq.Stmt, Value: sq.Value, p: sq.p, UseOuterQuery: sq.UseOuterQuery}
-	return nsq, nil
+	return nsq
 }
 
 // Eval implements the Expression Eval interface.

--- a/expression/expressions/subquery_test.go
+++ b/expression/expressions/subquery_test.go
@@ -34,8 +34,7 @@ func (s *testSubQuerySuite) TestSubQuery(c *C) {
 	str := e.String()
 	c.Assert(str, Equals, "")
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	v, err := ec.Eval(ctx, nil)
 	c.Assert(err, IsNil)

--- a/expression/expressions/substring.go
+++ b/expression/expressions/substring.go
@@ -30,17 +30,14 @@ type FunctionSubstring struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (f *FunctionSubstring) Clone() (expression.Expression, error) {
-	expr, err := f.StrExpr.Clone()
-	if err != nil {
-		return nil, err
-	}
+func (f *FunctionSubstring) Clone() expression.Expression {
+	expr := f.StrExpr.Clone()
 	nf := &FunctionSubstring{
 		StrExpr: expr,
 		Pos:     f.Pos,
 		Len:     f.Len,
 	}
-	return nf, nil
+	return nf
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/substring_test.go
+++ b/expression/expressions/substring_test.go
@@ -51,8 +51,7 @@ func (s *testSubstringSuite) TestSubstring(c *C) {
 		fs := f.String()
 		c.Assert(len(fs), Greater, 0)
 
-		f1, err := f.Clone()
-		c.Assert(err, IsNil)
+		f1 := f.Clone()
 
 		r, err := f.Eval(nil, nil)
 		c.Assert(err, IsNil)

--- a/expression/expressions/unary.go
+++ b/expression/expressions/unary.go
@@ -90,13 +90,9 @@ func NewUnaryOperation(op opcode.Op, l expression.Expression) expression.Express
 }
 
 // Clone implements the Expression Clone interface.
-func (u *UnaryOperation) Clone() (expression.Expression, error) {
-	v, err := u.V.Clone()
-	if err != nil {
-		return nil, err
-	}
-
-	return &UnaryOperation{Op: u.Op, V: v}, nil
+func (u *UnaryOperation) Clone() expression.Expression {
+	v := u.V.Clone()
+	return &UnaryOperation{Op: u.Op, V: v}
 }
 
 // IsStatic implements the Expression IsStatic interface.

--- a/expression/expressions/unary_test.go
+++ b/expression/expressions/unary_test.go
@@ -82,8 +82,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 	for _, t := range tbl {
 		expr := NewUnaryOperation(t.op, Value{t.arg})
 
-		exprc, err := expr.Clone()
-		c.Assert(err, IsNil)
+		exprc := expr.Clone()
 
 		result, err := exprc.Eval(nil, nil)
 		c.Assert(err, IsNil)
@@ -108,8 +107,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 	for _, t := range tbl {
 		expr := NewUnaryOperation(t.op, Value{t.arg})
 
-		exprc, err := expr.Clone()
-		c.Assert(err, IsNil)
+		exprc := expr.Clone()
 
 		result, err := exprc.Eval(nil, nil)
 		c.Assert(err, IsNil)
@@ -163,8 +161,7 @@ func (s *testUnaryOperationSuite) TestUnaryOp(c *C) {
 
 	// test error clone
 	expr := NewUnaryOperation(opcode.Not, mockExpr{err: errors.New("must error")})
-	_, err := expr.Clone()
-	c.Assert(err, NotNil)
+	c.Assert(expr.Clone(), NotNil)
 
 	for _, t := range errTbl {
 		expr := NewUnaryOperation(t.op, Value{t.arg})

--- a/expression/expressions/value.go
+++ b/expression/expressions/value.go
@@ -35,8 +35,8 @@ type Value struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (l Value) Clone() (expression.Expression, error) {
-	return Value{Val: l.Val}, nil
+func (l Value) Clone() expression.Expression {
+	return Value{Val: l.Val}
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns true.

--- a/expression/expressions/value_test.go
+++ b/expression/expressions/value_test.go
@@ -27,8 +27,7 @@ func (s *testValueSuite) TestValue(c *C) {
 	c.Assert(e.IsStatic(), IsTrue)
 	c.Assert(e.String(), Equals, "NULL")
 
-	_, err := e.Clone()
-	c.Assert(err, IsNil)
+	c.Assert(e.Clone(), NotNil)
 
 	v, err := e.Eval(nil, nil)
 	c.Assert(err, IsNil)

--- a/expression/expressions/values.go
+++ b/expression/expressions/values.go
@@ -31,9 +31,9 @@ type Values struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (i *Values) Clone() (expression.Expression, error) {
+func (i *Values) Clone() expression.Expression {
 	newI := *i
-	return &newI, nil
+	return &newI
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns false.

--- a/expression/expressions/values_test.go
+++ b/expression/expressions/values_test.go
@@ -31,7 +31,7 @@ func (s *testValuesSuite) TestValues(c *C) {
 	c.Assert(e.IsStatic(), IsFalse)
 	c.Assert(e.String(), Equals, "id")
 
-	ec, err := e.Clone()
+	ec := e.Clone()
 	e2, ok := ec.(*Values)
 	c.Assert(ok, IsTrue)
 	e2.O = "ID"

--- a/expression/expressions/variable.go
+++ b/expression/expressions/variable.go
@@ -37,9 +37,9 @@ type Variable struct {
 }
 
 // Clone implements the Expression Clone interface.
-func (v *Variable) Clone() (expression.Expression, error) {
+func (v *Variable) Clone() expression.Expression {
 	newVar := *v
-	return &newVar, nil
+	return &newVar
 }
 
 // IsStatic implements the Expression IsStatic interface, always returns false.

--- a/expression/expressions/variable_test.go
+++ b/expression/expressions/variable_test.go
@@ -52,8 +52,7 @@ func (s *testVariableSuite) TestVariable(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, "1234")
 
-	ec, err := e.Clone()
-	c.Assert(err, IsNil)
+	ec := e.Clone()
 
 	e2, ok := ec.(*Variable)
 	c.Assert(ok, IsTrue)

--- a/plan/plans/join.go
+++ b/plan/plans/join.go
@@ -102,11 +102,7 @@ func (r *JoinPlan) filterNode(ctx context.Context, expr expression.Expression, n
 		return r, false, nil
 	}
 
-	e2, err := expr.Clone()
-	if err != nil {
-		return nil, false, err
-	}
-
+	e2 := expr.Clone()
 	return node.Filter(ctx, e2)
 }
 

--- a/rset/rsets/where.go
+++ b/rset/rsets/where.go
@@ -183,11 +183,7 @@ func (r *WhereRset) planStatic(ctx context.Context, e expression.Expression) (pl
 
 // Plan gets NullPlan/FilterDefaultPlan.
 func (r *WhereRset) Plan(ctx context.Context) (plan.Plan, error) {
-	expr, err := r.Expr.Clone()
-	if err != nil {
-		return nil, err
-	}
-
+	expr := r.Expr.Clone()
 	if expr.IsStatic() {
 		// IsStaic means we have a const value for where condition, and we don't need any index.
 		return r.planStatic(ctx, expr)


### PR DESCRIPTION
Our expression implementations do not actually return any error, and `Clone` should not return error in any case.
Remove error make the code cleaner.