### PR TITLE
kv : Clarify the semantics of MVCC Delete in BoltDB engine implementation

### DIFF
--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -71,12 +71,10 @@ func (s *dbSnapshot) Get(k kv.Key) ([]byte, error) {
 			}
 		}
 	}
-
 	// No such key (or it's tombstone).
 	if rawKey == nil {
 		return nil, kv.ErrNotExist
 	}
-
 	return v, nil
 }
 


### PR DESCRIPTION
Nil is the tombstone in MVCC semantics now, but in the original implementation we can't
use nil as a value.