### PR TITLE
Specify the user name when using mysql client to connect to TiDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Run `./tidb-server -h` to see more flag options.
 After you started tidb-server, you can use official mysql client to connect to TiDB.
 
 ```
-mysql -h 127.0.0.1 -P 4000 -D test
+mysql -h 127.0.0.1 -P 4000 -u root -D test
 ```
 
 #### __Run as MySQL protocol server with distributed transactional KV storage engine__


### PR DESCRIPTION
When following the examples in README.md , we found the mysql cmd will use the current system name as user name to connect to the server. When It's not root, users will get the access denied error and be confused.

Update the mysql cmd in README.md to make it clear.