### PR TITLE
kv : Add begin version to dbSnapshot.

### DIFF
--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -193,6 +193,23 @@ func (t *testMvccSuite) TestMvccSuiteGetLatest(c *C) {
 	c.Assert(it.Valid(), IsTrue)
 	c.Assert(string(it.Value()), Equals, string(encodeInt(100+9)))
 	tx.Commit()
+
+	testKey := []byte("testKey")
+	txn0, _ := t.s.Begin()
+	txn0.Set(testKey, []byte("0"))
+	txn0.Commit()
+	txn1, _ := t.s.Begin()
+	{
+		// Commit another version
+		txn2, _ := t.s.Begin()
+		txn2.Set(testKey, []byte("2"))
+		txn2.Commit()
+	}
+	r, err := txn1.Get(testKey)
+	c.Assert(err, IsNil)
+	// Test isolation in transaction.
+	c.Assert(string(r), Equals, "0")
+	txn1.Commit()
 }
 
 func (t *testMvccSuite) TestMvccSnapshotScan(c *C) {

--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -173,6 +173,28 @@ func (t *testMvccSuite) TestSnapshotGet(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (t *testMvccSuite) TestMvccSuiteGetLatest(c *C) {
+	// update some new data
+	for i := 0; i < 10; i++ {
+		tx, _ := t.s.Begin()
+		err := tx.Set(encodeInt(5), encodeInt(100+i))
+		c.Assert(err, IsNil)
+		err = tx.Commit()
+		c.Assert(err, IsNil)
+	}
+	// we can always read newest data
+	tx, _ := t.s.Begin()
+	b, err := tx.Get(encodeInt(5))
+	c.Assert(err, IsNil)
+	c.Assert(string(b), Equals, string(encodeInt(100+9)))
+	// we can always scan newest data
+	it, err := tx.Seek(encodeInt(5), nil)
+	c.Assert(err, IsNil)
+	c.Assert(it.Valid(), IsTrue)
+	c.Assert(string(it.Value()), Equals, string(encodeInt(100+9)))
+	tx.Commit()
+}
+
 func (t *testMvccSuite) TestMvccSnapshotScan(c *C) {
 	tx, _ := t.s.Begin()
 	err := tx.Set(encodeInt(1), []byte("new"))

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -32,6 +32,7 @@ var (
 
 type dbSnapshot struct {
 	engine.Snapshot
+	version kv.Version // transaction begin version
 }
 
 func (s *dbSnapshot) MvccGet(k kv.Key, ver kv.Version) ([]byte, error) {
@@ -83,7 +84,7 @@ func (s *dbSnapshot) NewMvccIterator(k kv.Key, ver kv.Version) kv.Iterator {
 
 func (s *dbSnapshot) Get(k kv.Key) ([]byte, error) {
 	// Get latest version.
-	return s.MvccGet(k, kv.MaxVersion)
+	return s.MvccGet(k, s.version)
 }
 
 func (s *dbSnapshot) NewIterator(param interface{}) kv.Iterator {
@@ -92,7 +93,7 @@ func (s *dbSnapshot) NewIterator(param interface{}) kv.Iterator {
 		log.Errorf("leveldb iterator parameter error, %+v", param)
 		return nil
 	}
-	return newDBIter(s, k, kv.MaxVersion)
+	return newDBIter(s, k, s.version)
 }
 
 func (s *dbSnapshot) MvccRelease() {


### PR DESCRIPTION
When we do MVCC get/scan on latest version, we should start with the version
that this transaction begins, not kv.MaxVersion.