### PR TITLE
support select from dual

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2716,7 +2716,7 @@ SelectStmt:
 			Distinct:      $2.(bool),
 			Fields:        $3.([]*field.Field),
 			From:          nil,
-			Lock:	$6.(coldef.LockType),
+			Lock:	       $6.(coldef.LockType),
 		}
 	}
 |	"SELECT" SelectStmtOpts SelectStmtFieldList "FROM" 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -116,6 +116,7 @@ import (
 	div 		"DIV"
 	do		"DO"
 	drop		"DROP"
+	dual 		"DUAL"
 	duplicate	"DUPLICATE"
 	elseKwd		"ELSE"
 	end		"END"
@@ -2709,13 +2710,13 @@ RollbackStmt:
 	}
 
 SelectStmt:
-	"SELECT" SelectStmtOpts SelectStmtFieldList SelectStmtLimit SelectLockOpt
+	"SELECT" SelectStmtOpts SelectStmtFieldList FromDual SelectStmtLimit SelectLockOpt
 	{
 		$$ = &stmts.SelectStmt {
 			Distinct:      $2.(bool),
 			Fields:        $3.([]*field.Field),
 			From:          nil,
-			Lock:	$5.(coldef.LockType),
+			Lock:	$6.(coldef.LockType),
 		}
 	}
 |	"SELECT" SelectStmtOpts SelectStmtFieldList "FROM" 
@@ -2753,6 +2754,11 @@ SelectStmt:
 		
 		$$ = st
 	}
+
+FromDual:
+	/* Empty */
+|	"FROM" "DUAL"
+
 
 FromClause:
 	TableRefs

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -364,6 +364,10 @@ func (s *testParserSuite) TestParser0(c *C) {
 		{"select now()", true},
 		{"select now(6)", true},
 		{"select sysdate(), sysdate(6)", true},
+
+		// For dual
+		{"select 1 from dual", true},
+		{"select 1 from dual limit 1", true},
 	}
 
 	for _, t := range table {

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -279,6 +279,7 @@ describe	{d}{e}{s}{c}{r}{i}{b}{e}
 distinct	{d}{i}{s}{t}{i}{n}{c}{t}
 div		{d}{i}{v}
 do		{d}{o}
+dual 		{d}{u}{a}{l}
 duplicate	{d}{u}{p}{l}{i}{c}{a}{t}{e}
 else		{e}{l}{s}{e}
 end		{e}{n}{d}
@@ -568,6 +569,7 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 {div}			return div
 {do}			lval.item = string(l.val)
 			return do
+{dual}			return dual
 {duplicate}		lval.item = string(l.val)
 			return duplicate
 {else}			return elseKwd

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -785,6 +785,16 @@ func (s *testSessionSuite) TestSelect(c *C) {
 
 	_, err = se.Execute("select * from t as a join (select 1) as a")
 	c.Assert(err, IsNil)
+
+	r := mustExecSQL(c, se, "select 1, 2 from dual")
+	row, err := r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, 1, 2)
+
+	r = mustExecSQL(c, se, "select 1, 2")
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, 1, 2)
 }
 
 func (s *testSessionSuite) TestSubQuery(c *C) {


### PR DESCRIPTION
```
select 1, 2, 3 from dual
```

Dual has nothing to do, so `select 1 from dual` is equivalent to `select 1`.