### PR TITLE
rename EmptyFieldList to more sense FromDual name

### DIFF
--- a/plan/plans/fields.go
+++ b/plan/plans/fields.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	_ plan.Plan = (*SelectFieldsDefaultPlan)(nil)
-	_ plan.Plan = (*SelectEmptyFieldListPlan)(nil)
+	_ plan.Plan = (*SelectFromDualPlan)(nil)
 )
 
 // SelectFieldsDefaultPlan extracts specific fields from Src Plan.
@@ -94,19 +94,19 @@ func (r *SelectFieldsDefaultPlan) Close() error {
 	return r.Src.Close()
 }
 
-// SelectEmptyFieldListPlan is the plan for "select expr, expr, ..."" with no FROM.
-type SelectEmptyFieldListPlan struct {
+// SelectFromDualPlan is the plan for "select expr, expr, ..."" or "select expr, expr, ... from dual".
+type SelectFromDualPlan struct {
 	Fields []*field.Field
 	done   bool
 }
 
 // Explain implements the plan.Plan Explain interface.
-func (s *SelectEmptyFieldListPlan) Explain(w format.Formatter) {
+func (s *SelectFromDualPlan) Explain(w format.Formatter) {
 	// TODO: finish this
 }
 
 // GetFields implements the plan.Plan GetFields interface.
-func (s *SelectEmptyFieldListPlan) GetFields() []*field.ResultField {
+func (s *SelectFromDualPlan) GetFields() []*field.ResultField {
 	ans := make([]*field.ResultField, 0, len(s.Fields))
 	if len(s.Fields) > 0 {
 		for _, f := range s.Fields {
@@ -119,12 +119,12 @@ func (s *SelectEmptyFieldListPlan) GetFields() []*field.ResultField {
 }
 
 // Filter implements the plan.Plan Filter interface.
-func (s *SelectEmptyFieldListPlan) Filter(ctx context.Context, expr expression.Expression) (plan.Plan, bool, error) {
+func (s *SelectFromDualPlan) Filter(ctx context.Context, expr expression.Expression) (plan.Plan, bool, error) {
 	return s, false, nil
 }
 
 // Next implements plan.Plan Next interface.
-func (s *SelectEmptyFieldListPlan) Next(ctx context.Context) (row *plan.Row, err error) {
+func (s *SelectFromDualPlan) Next(ctx context.Context) (row *plan.Row, err error) {
 	if s.done {
 		return
 	}
@@ -138,7 +138,7 @@ func (s *SelectEmptyFieldListPlan) Next(ctx context.Context) (row *plan.Row, err
 }
 
 // Close implements plan.Plan Close interface.
-func (s *SelectEmptyFieldListPlan) Close() error {
+func (s *SelectFromDualPlan) Close() error {
 	s.done = false
 	return nil
 }

--- a/plan/plans/fields_test.go
+++ b/plan/plans/fields_test.go
@@ -113,7 +113,7 @@ func (s *testFieldsSuit) TestDefaultFieldsPlan(c *C) {
 }
 
 func (s *testFieldsSuit) TestSelectExprPlan(c *C) {
-	pln := &plans.SelectEmptyFieldListPlan{
+	pln := &plans.SelectFromDualPlan{
 		Fields: []*field.Field{
 			{
 				Expr: &expression.Value{

--- a/rset/rsets/fields.go
+++ b/rset/rsets/fields.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	_ plan.Planner = (*SelectFieldsRset)(nil)
-	_ plan.Planner = (*FieldRset)(nil)
+	_ plan.Planner = (*SelectFromDualRset)(nil)
 )
 
 // SelectFieldsRset is record set to select fields.
@@ -80,12 +80,12 @@ func (r *SelectFieldsRset) Plan(ctx context.Context) (plan.Plan, error) {
 	return p, nil
 }
 
-// FieldRset is Recordset for select expression, like `select 1, 1+1`.
-type FieldRset struct {
+// SelectFromDualRset is Recordset for select from dual, like `select 1, 1+1` or `select 1 from dual`.
+type SelectFromDualRset struct {
 	Fields []*field.Field
 }
 
 // Plan gets SelectExprPlan.
-func (r *FieldRset) Plan(ctx context.Context) (plan.Plan, error) {
-	return &plans.SelectEmptyFieldListPlan{Fields: r.Fields}, nil
+func (r *SelectFromDualRset) Plan(ctx context.Context) (plan.Plan, error) {
+	return &plans.SelectFromDualPlan{Fields: r.Fields}, nil
 }

--- a/rset/rsets/fields_test.go
+++ b/rset/rsets/fields_test.go
@@ -26,7 +26,7 @@ var _ = Suite(&testSelectFieldsPlannerSuite{})
 
 type testSelectFieldsPlannerSuite struct {
 	sr *SelectFieldsRset
-	fr *FieldRset
+	fr *SelectFromDualRset
 }
 
 func (s *testSelectFieldsPlannerSuite) SetUpSuite(c *C) {
@@ -47,7 +47,7 @@ func (s *testSelectFieldsPlannerSuite) SetUpSuite(c *C) {
 	}
 
 	s.sr = &SelectFieldsRset{Src: tblPlan, SelectList: selectList}
-	s.fr = &FieldRset{Fields: fields}
+	s.fr = &SelectFromDualRset{Fields: fields}
 }
 
 func (s *testSelectFieldsPlannerSuite) TestDistinctPlanner(c *C) {
@@ -106,6 +106,6 @@ func (s *testSelectFieldsPlannerSuite) TestFieldPlanner(c *C) {
 	p, err := s.fr.Plan(nil)
 	c.Assert(err, IsNil)
 
-	_, ok := p.(*plans.SelectEmptyFieldListPlan)
+	_, ok := p.(*plans.SelectFromDualPlan)
 	c.Assert(ok, IsTrue)
 }

--- a/stmt/stmts/select.go
+++ b/stmt/stmts/select.go
@@ -131,7 +131,7 @@ func (s *SelectStmt) Plan(ctx context.Context) (plan.Plan, error) {
 		}
 	} else if s.Fields != nil {
 		// Only evaluate fields values.
-		fr := &rsets.FieldRset{Fields: s.Fields}
+		fr := &rsets.SelectFromDualRset{Fields: s.Fields}
 		r, err = fr.Plan(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Dual is a dummy table, `select 1, 2` is equivalent to `select 1, 2 from
dual`, and dual is widely known.