### PR TITLE
parser: support comment for create table

### DIFF
--- a/parser/coldef/col_def.go
+++ b/parser/coldef/col_def.go
@@ -242,6 +242,8 @@ func ColumnDefToCol(offset int, colDef *ColumnDef) (*column.Col, []*TableConstra
 				setOnUpdateNow = true
 			case ConstrFulltext:
 				// Do nothing.
+			case ConstrComment:
+				// Do nothing.
 			}
 		}
 	}

--- a/parser/coldef/opt.go
+++ b/parser/coldef/opt.go
@@ -105,6 +105,7 @@ const (
 	ConstrNull
 	ConstrOnUpdate
 	ConstrFulltext
+	ConstrComment
 )
 
 // LockType is select lock type.
@@ -124,6 +125,7 @@ const (
 	TblOptCharset
 	TblOptCollate
 	TblOptAutoIncrement
+	TblOptComment
 )
 
 // TableOpt is used for parsing table option from SQL.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -91,6 +91,7 @@ import (
 	collation	"COLLATION"
 	column		"COLUMN"
 	columns		"COLUMNS"
+	comment 	"COMMENT"
 	commit		"COMMIT"
 	concat		"CONCAT"
 	concatWs	"CONCAT_WS"
@@ -777,6 +778,10 @@ Constraint:
 |	"ON" "UPDATE" NowSym
 	{
 		$$ = &coldef.ConstraintOpt{Tp: coldef.ConstrOnUpdate, Evalue: $3.(expression.Expression)}
+	}
+|	"COMMENT" stringLit
+	{
+		$$ = &coldef.ConstraintOpt{Tp: coldef.ConstrComment}
 	}
 
 ConstraintElem:
@@ -1602,6 +1607,7 @@ UnReservedKeyword:
 |	"LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" %prec lowerThanEq | "PREPARE" | "QUICK" | "ROLLBACK" | "SESSION" | "SIGNED" 
 |	"START" | "GLOBAL" | "TABLES"| "TEXT" | "TIME" | "TIMESTAMP" | "TRANSACTION" | "TRUNCATE" | "UNKNOWN" 
 |	"VALUE" | "WARNINGS" | "YEAR" |	"MODE" | "WEEK" | "ANY" | "SOME" | "USER" | "IDENTIFIED" | "COLLATION"
+|	"COMMENT"
 
 NotKeywordToken:
 	"ABS" | "COALESCE" | "CONCAT" | "CONCAT_WS" | "COUNT" | "DAY" | "DAYOFMONTH" | "DAYOFWEEK" | "DAYOFYEAR" | "FOUND_ROWS" | "GROUP_CONCAT" 
@@ -3358,6 +3364,10 @@ TableOpt:
 |	"AUTO_INCREMENT" eq LengthNum
 	{
 		$$ = &coldef.TableOpt{Tp: coldef.TblOptAutoIncrement, UintValue: $3.(uint64)}
+	}
+|	"COMMENT" EqOpt stringLit
+	{
+		$$ = &coldef.TableOpt{Tp: coldef.TblOptComment, StrValue: $3.(string)} 
 	}
 
 TableOptListOpt:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -382,12 +382,19 @@ func (s *testParserSuite) TestParser0(c *C) {
 		// For dual
 		{"select 1 from dual", true},
 		{"select 1 from dual limit 1", true},
+
+		// For comment
+		{"create table t (c int comment 'comment')", true},
+		{"create table t (c int) comment = 'comment'", true},
+		{"create table t (c int) comment 'comment'", true},
+		{"create table t (c int) comment comment", false},
+		{"create table t (comment text)", true},
 	}
 
 	for _, t := range table {
 		l := NewLexer(t.src)
 		ok := yyParse(l) == 0
-		c.Assert(ok, Equals, t.ok, Commentf("source %v", t.src))
+		c.Assert(ok, Equals, t.ok, Commentf("source %v %v", t.src, l.errs))
 
 		switch ok {
 		case true:
@@ -404,7 +411,7 @@ func (s *testParserSuite) TestParser0(c *C) {
 		"local", "names", "offset", "password", "prepare", "quick", "rollback", "session", "signed",
 		"start", "global", "tables", "text", "time", "timestamp", "transaction", "truncate", "unknown",
 		"value", "warnings", "year", "now", "substring", "mode", "any", "some", "user", "identified",
-		"collation",
+		"collation", "comment",
 	}
 	for _, kw := range unreservedKws {
 		src := fmt.Sprintf("SELECT %s FROM tbl;", kw)

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -254,6 +254,7 @@ collate		{c}{o}{l}{l}{a}{t}{e}
 collation	{c}{o}{l}{l}{a}{t}{i}{o}{n}
 column		{c}{o}{l}{u}{m}{n}
 columns		{c}{o}{l}{u}{m}{n}{s}
+comment 	{c}{o}{m}{m}{e}{n}{t}
 commit		{c}{o}{m}{m}{i}{t}
 concat		{c}{o}{n}{c}{a}{t}
 concat_ws	{c}{o}{n}{c}{a}{t}_{w}{s}
@@ -532,6 +533,8 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 {column}		return column
 {columns}		lval.item = string(l.val)
 			return columns
+{comment}		lval.item = string(l.val)
+			return comment
 {commit}		lval.item = string(l.val)
 			return commit
 {concat}		lval.item = string(l.val)


### PR DESCRIPTION
`create table (c int comment ‘this is a comment’)` or
`create table (c int) comment = ‘this is a comment’`

We only support parsing it, and do nothing outside.