### PR TITLE
support parsing `'''a'''` `"""a"""` to fix #258, #261

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -394,6 +394,11 @@ func (s *testParserSuite) TestParser0(c *C) {
 		{"create table t (c int) comment 'comment'", true},
 		{"create table t (c int) comment comment", false},
 		{"create table t (comment text)", true},
+
+		// For string literal
+		{`select '''a''', """a"""`, true},
+		{`select ''a''`, false},
+		{`select ""a""`, false},
 	}
 
 	for _, t := range table {

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -482,8 +482,8 @@ sys_var		"@@"(({global}".")|({session}".")|{local}".")?{ident}
 \"			l.sc = S1
 '			l.sc = S2
 
-<S1>(\\.|[^\"])*\"	return l.str(lval, "\"")
-<S2>((\\')|[^']|\n)*'	return l.str(lval, "'")
+<S1>(\\.|[^\"]|\"\")*\"		return l.str(lval, "\"")
+<S2>((\\')|[^']|\n|'')*'	return l.str(lval, "'")
 
 "&&"			return andand
 "&^"			return andnot
@@ -885,9 +885,12 @@ func (l *lexer) str(lval *yySymType, pref string) int {
 	s := string(l.val)
 	// TODO: performance issue.
 	if pref == "'" {
+		s = strings.Replace(s, "''", "'", -1)
 		s = strings.Replace(s, "\\'", "'", -1)    
 		s = strings.TrimSuffix(s, "'") + "\""
 		pref = "\""
+	} else if pref == "\"" {
+		s = strings.Replace(s, "\"\"", "\"", -1)
 	}
 	v, err := strconv.Unquote(pref + s)
 	if err != nil {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -800,6 +800,15 @@ func (s *testSessionSuite) TestSelect(c *C) {
 	row, err = r.FirstRow()
 	c.Assert(err, IsNil)
 	match(c, row, `'a'`, `"a"`, `pingcap '-->' tidb`)
+
+	mustExecSQL(c, se, "drop table if exists t")
+	mustExecSQL(c, se, "create table t (c varchar(20))")
+	mustExecSQL(c, se, `insert t values("pingcap '-->' tidb")`)
+
+	r = mustExecSQL(c, se, `select * from t where c like 'pingcap ''-->'' tidb'`)
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, `pingcap '-->' tidb`)
 }
 
 func (s *testSessionSuite) TestSubQuery(c *C) {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -795,6 +795,11 @@ func (s *testSessionSuite) TestSelect(c *C) {
 	row, err = r.FirstRow()
 	c.Assert(err, IsNil)
 	match(c, row, 1, 2)
+
+	r = mustExecSQL(c, se, `select '''a''', """a""", 'pingcap ''-->'' tidb'`)
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, `'a'`, `"a"`, `pingcap '-->' tidb`)
 }
 
 func (s *testSessionSuite) TestSubQuery(c *C) {


### PR DESCRIPTION
Fix #258 
Fix #261 