### PR TITLE
parser: blob and text support field length option

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3700,9 +3700,10 @@ BlobType:
 		x.Collate = charset.CharsetBin
 		$$ = x
 	}
-|	"BLOB"
+|	"BLOB" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeBlob)
+		x.Flen = $2.(int) 
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CharsetBin
 		$$ = x
@@ -3729,9 +3730,10 @@ TextType:
 		$$ = x
 
 	}
-|	"TEXT"
+|	"TEXT" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeBlob)
+		x.Flen = $2.(int) 
 		$$ = x
 	}
 |	"MEDIUMTEXT"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -423,6 +423,9 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		// For national
 		{"create table t (c1 national char(2), c2 national varchar(2))", true},
+
+		// For blob and text field length
+		{"create table t (c1 blob(1024), c2 text(1024))", true},
 	}
 
 	for _, t := range table {


### PR DESCRIPTION
Manual doesn’t point this, but SQLAlchemy has this test and MySQL
parser handles this too.