### PR TITLE
parser: year support field length option

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3776,7 +3776,7 @@ DateAndTimeType:
 		x.Decimal = $2.(int)
 		$$ = x
 	}
-|	"YEAR"
+|	"YEAR" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeYear)
 		$$ = x

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -426,6 +426,9 @@ func (s *testParserSuite) TestParser0(c *C) {
 
 		// For check
 		{"create table t (c1 bool, c2 bool, check (c1 in (0, 1)), check (c2 in (0, 1)))", true},
+
+		// For year
+		{"create table t (y year(4), y1 year)", true},
 	}
 
 	for _, t := range table {


### PR DESCRIPTION
MySQL manual doesn’t say it, but SQLAlchemy has this test and MySQL
parser handles it too.