### PR TITLE
*: lowercase type description

### DIFF
--- a/column/column_test.go
+++ b/column/column_test.go
@@ -50,7 +50,7 @@ func (s *testColumnSuite) TestString(c *C) {
 	col.Tp = mysql.TypeEnum
 	col.Flag = 0
 	col.Elems = []string{"a", "b"}
-	c.Assert(col.getTypeDesc(), Equals, "ENUM ('a','b')")
+	c.Assert(col.getTypeDesc(), Equals, "enum ('a','b')")
 }
 
 func (s *testColumnSuite) TestFind(c *C) {

--- a/field/field_test.go
+++ b/field/field_test.go
@@ -43,20 +43,20 @@ func (*testFieldSuite) TestField(c *C) {
 	ft := types.NewFieldType(mysql.TypeLong)
 	ft.Flen = 20
 	ft.Flag |= mysql.UnsignedFlag | mysql.ZerofillFlag
-	c.Assert(ft.String(), Equals, "INT (20) UNSIGNED ZEROFILL")
+	c.Assert(ft.String(), Equals, "int (20) UNSIGNED ZEROFILL")
 
 	ft = types.NewFieldType(mysql.TypeFloat)
 	ft.Flen = 20
 	ft.Decimal = 10
-	c.Assert(ft.String(), Equals, "FLOAT (20, 10)")
+	c.Assert(ft.String(), Equals, "float (20, 10)")
 
 	ft = types.NewFieldType(mysql.TypeTimestamp)
 	ft.Decimal = 8
-	c.Assert(ft.String(), Equals, "TIMESTAMP (8)")
+	c.Assert(ft.String(), Equals, "timestamp (8)")
 
 	ft = types.NewFieldType(mysql.TypeVarchar)
 	ft.Flag |= mysql.BinaryFlag
 	ft.Charset = "utf8"
 	ft.Collate = "utf8_unicode_gi"
-	c.Assert(ft.String(), Equals, "VARCHAR BINARY CHARACTER SET utf8 COLLATE utf8_unicode_gi")
+	c.Assert(ft.String(), Equals, "varchar BINARY CHARACTER SET utf8 COLLATE utf8_unicode_gi")
 }

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -868,7 +868,7 @@ func (s *testSessionSuite) TestShow(c *C) {
 	rows, err := r.Rows(-1, 0)
 	c.Assert(err, IsNil)
 	c.Assert(rows, HasLen, 1)
-	match(c, rows[0], "c", "INT", "YES", "", nil, "")
+	match(c, rows[0], "c", "int", "YES", "", nil, "")
 
 	r = mustExecSQL(c, se, "show collation where Charset = 'utf8' and Collation = 'utf8_bin'")
 	row, err = r.FirstRow()

--- a/util/types/convert_test.go
+++ b/util/types/convert_test.go
@@ -450,9 +450,9 @@ func (s *testTypeConvertSuite) TestFieldTypeToStr(c *C) {
 	v := FieldTypeToStr(mysql.TypeDecimal, "not binary")
 	c.Assert(v, Equals, type2Str[mysql.TypeDecimal])
 	v = FieldTypeToStr(mysql.TypeBlob, charset.CharsetBin)
-	c.Assert(v, Equals, "BLOB")
+	c.Assert(v, Equals, "blob")
 	v = FieldTypeToStr(mysql.TypeString, charset.CharsetBin)
-	c.Assert(v, Equals, "BINARY")
+	c.Assert(v, Equals, "binary")
 }
 
 func accept(c *C, tp byte, value interface{}, unsigned bool, expected string) {

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -53,32 +53,32 @@ func IsTypeChar(tp byte) bool {
 }
 
 var type2Str = map[byte]string{
-	mysql.TypeBit:        "BIT",
-	mysql.TypeBlob:       "TEXT",
-	mysql.TypeDate:       "DATE",
-	mysql.TypeDatetime:   "DATETIME",
-	mysql.TypeDecimal:    "DECIMAL",
-	mysql.TypeNewDecimal: "DECIMAL",
-	mysql.TypeDouble:     "DOUBLE",
-	mysql.TypeEnum:       "ENUM",
-	mysql.TypeFloat:      "FLOAT",
-	mysql.TypeGeometry:   "GEOMETRY",
-	mysql.TypeInt24:      "MEDIUMINT",
-	mysql.TypeLong:       "INT",
-	mysql.TypeLonglong:   "BIGINT",
-	mysql.TypeLongBlob:   "LONGTEXT",
-	mysql.TypeMediumBlob: "MEDIUMTEXT",
-	mysql.TypeNull:       "NULL",
-	mysql.TypeSet:        "SET",
-	mysql.TypeShort:      "SMALLINT",
-	mysql.TypeString:     "CHAR",
-	mysql.TypeDuration:   "TIME",
-	mysql.TypeTimestamp:  "TIMESTAMP",
-	mysql.TypeTiny:       "TINYINT",
-	mysql.TypeTinyBlob:   "TINYTEXT",
-	mysql.TypeVarchar:    "VARCHAR",
-	mysql.TypeVarString:  "VAR_STRING",
-	mysql.TypeYear:       "YEAR",
+	mysql.TypeBit:        "bit",
+	mysql.TypeBlob:       "text",
+	mysql.TypeDate:       "date",
+	mysql.TypeDatetime:   "datetime",
+	mysql.TypeDecimal:    "decimal",
+	mysql.TypeNewDecimal: "decimal",
+	mysql.TypeDouble:     "double",
+	mysql.TypeEnum:       "enum",
+	mysql.TypeFloat:      "float",
+	mysql.TypeGeometry:   "geometry",
+	mysql.TypeInt24:      "mediumint",
+	mysql.TypeLong:       "int",
+	mysql.TypeLonglong:   "bigint",
+	mysql.TypeLongBlob:   "longtext",
+	mysql.TypeMediumBlob: "mediumtext",
+	mysql.TypeNull:       "null",
+	mysql.TypeSet:        "set",
+	mysql.TypeShort:      "smallint",
+	mysql.TypeString:     "char",
+	mysql.TypeDuration:   "time",
+	mysql.TypeTimestamp:  "timestamp",
+	mysql.TypeTiny:       "tinyint",
+	mysql.TypeTinyBlob:   "tinytext",
+	mysql.TypeVarchar:    "varchar",
+	mysql.TypeVarString:  "var_string",
+	mysql.TypeYear:       "year",
 }
 
 // TypeStr converts tp to a string.
@@ -169,9 +169,9 @@ func FieldTypeToStr(tp byte, cs string) (r string) {
 		return ts
 	}
 	if IsTypeBlob(tp) {
-		ts = strings.Replace(ts, "TEXT", "BLOB", 1)
+		ts = strings.Replace(ts, "text", "blob", 1)
 	} else if IsTypeChar(tp) {
-		ts = strings.Replace(ts, "CHAR", "BINARY", 1)
+		ts = strings.Replace(ts, "char", "binary", 1)
 	}
 	return ts
 }

--- a/util/types/etc_test.go
+++ b/util/types/etc_test.go
@@ -65,7 +65,7 @@ func testTypeToStr(c *C, tp byte, binary bool, expect string) {
 }
 
 func (s *testTypeEtcSuite) TestTypeToStr(c *C) {
-	testTypeStr(c, mysql.TypeYear, "YEAR")
+	testTypeStr(c, mysql.TypeYear, "year")
 	testTypeStr(c, 0xdd, "")
 
 	testTypeToStr(c, mysql.TypeBlob, true, "text")

--- a/util/types/field_type_test.go
+++ b/util/types/field_type_test.go
@@ -28,33 +28,33 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	c.Assert(ft.Flen, Equals, UnspecifiedLength)
 	c.Assert(ft.Decimal, Equals, UnspecifiedLength)
 	ft.Decimal = 5
-	c.Assert(ft.String(), Equals, "TIME (5)")
+	c.Assert(ft.String(), Equals, "time (5)")
 
 	ft.Tp = mysql.TypeLong
 	ft.Flag |= mysql.UnsignedFlag | mysql.ZerofillFlag
-	c.Assert(ft.String(), Equals, "INT (5) UNSIGNED ZEROFILL")
+	c.Assert(ft.String(), Equals, "int (5) UNSIGNED ZEROFILL")
 
 	ft = NewFieldType(mysql.TypeFloat)
 	ft.Flen = 10
 	ft.Decimal = 3
-	c.Assert(ft.String(), Equals, "FLOAT (10, 3)")
+	c.Assert(ft.String(), Equals, "float (10, 3)")
 
 	ft = NewFieldType(mysql.TypeBlob)
 	ft.Flen = 10
 	ft.Charset = "UTF8"
 	ft.Collate = "UTF8_UNICODE_GI"
-	c.Assert(ft.String(), Equals, "TEXT (10) CHARACTER SET UTF8 COLLATE UTF8_UNICODE_GI")
+	c.Assert(ft.String(), Equals, "text (10) CHARACTER SET UTF8 COLLATE UTF8_UNICODE_GI")
 
 	ft = NewFieldType(mysql.TypeVarchar)
 	ft.Flen = 10
 	ft.Flag |= mysql.BinaryFlag
-	c.Assert(ft.String(), Equals, "VARCHAR (10) BINARY")
+	c.Assert(ft.String(), Equals, "varchar (10) BINARY")
 
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"a", "b"}
-	c.Assert(ft.String(), Equals, "ENUM ('a','b')")
+	c.Assert(ft.String(), Equals, "enum ('a','b')")
 
 	ft = NewFieldType(mysql.TypeSet)
 	ft.Elems = []string{"a", "b"}
-	c.Assert(ft.String(), Equals, "SET ('a','b')")
+	c.Assert(ft.String(), Equals, "set ('a','b')")
 }


### PR DESCRIPTION
MySQL show columns or show create create table both return lowercase
type description, like int, char, etc…

```
mysql> desc t1;
+-------+---------+------+-----+---------+----------------+
| Field | Type    | Null | Key | Default | Extra          |
+-------+---------+------+-----+---------+----------------+
| c1    | int(11) | NO   | PRI | NULL    | auto_increment |
| c2    | int(11) | YES  |     | 0       |                |
+-------+---------+------+-----+---------+----------------+
```

```
mysql> show create table t1 \G;
*************************** 1. row ***************************
       Table: t1
Create Table: CREATE TABLE `t1` (
  `c1` int(11) NOT NULL AUTO_INCREMENT,
  `c2` int(11) DEFAULT '0',
  PRIMARY KEY (`c1`)
) ENGINE=InnoDB DEFAULT CHARSET=latin1
1 row in set (0.01 sec)
```