### PR TITLE
parser: Fix #288

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3004,7 +3004,28 @@ SubSelect:
 	'(' SelectStmt ')'
 	{
 		s := $2.(*stmts.SelectStmt)
-		s.SetText(yylex.(*lexer).src[yyS[yypt - 1].col-1:yyS[yypt].col-1])
+		src := yylex.(*lexer).src
+		lines := yyS[yypt-1].line-1
+		pos := 0
+		if lines > 0 {
+			cnt := 0
+			for ; pos < len(src); pos++{
+				if cnt == lines {
+					break
+				}
+				if src[pos] == '\n' {
+					cnt++
+				}
+			}
+		}
+
+		base := pos+yyS[yypt-1].col-1
+		end := yyS[yypt].col-1
+		if end < base {
+			s.SetText(src[base:])
+		} else{ // when yypt in new line
+			s.SetText(src[base:end])
+		}
 		$$ = &subquery.SubQuery{Stmt: s}
 	}
 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -48,6 +48,7 @@ import (
 %}
 
 %union {
+	offset int // offset
 	line int
 	col  int
 	item interface{}
@@ -3006,27 +3007,7 @@ SubSelect:
 		s := $2.(*stmts.SelectStmt)
 		src := yylex.(*lexer).src
 		// See the implemention of yyParse function
-		lines := yyS[yypt-1].line-1
-		pos := 0
-		if lines > 0 {
-			cnt := 0
-			for ; pos < len(src); pos++{
-				if cnt == lines {
-					break
-				}
-				if src[pos] == '\n' {
-					cnt++
-				}
-			}
-		}
-
-		base := pos+yyS[yypt-1].col-1
-		end := yyS[yypt].col-1
-		if end < base {
-			s.SetText(src[base:])
-		} else { // when yypt in new line
-			s.SetText(src[base:end])
-		}
+		s.SetText(src[yyS[yypt-1].offset-1:yyS[yypt].offset-1])
 		$$ = &subquery.SubQuery{Stmt: s}
 	}
 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3005,6 +3005,7 @@ SubSelect:
 	{
 		s := $2.(*stmts.SelectStmt)
 		src := yylex.(*lexer).src
+		// See the implemention of yyParse function
 		lines := yyS[yypt-1].line-1
 		pos := 0
 		if lines > 0 {
@@ -3023,7 +3024,7 @@ SubSelect:
 		end := yyS[yypt].col-1
 		if end < base {
 			s.SetText(src[base:])
-		} else{ // when yypt in new line
+		} else { // when yypt in new line
 			s.SetText(src[base:end])
 		}
 		$$ = &subquery.SubQuery{Stmt: s}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -88,6 +88,10 @@ func (s *testParserSuite) TestParser0(c *C) {
 		{"CREATE TABLE foo (a SMALLINT UNSIGNED, b INT UNSIGNED) // foo", true},
 		{"CREATE TABLE foo (a SMALLINT UNSIGNED, b INT UNSIGNED) /* foo */", true},
 		{"CREATE TABLE foo /* foo */ (a SMALLINT UNSIGNED, b INT UNSIGNED) /* foo */", true},
+		{`SELECT stuff.id 
+		FROM stuff 
+		WHERE stuff.value >= ALL (SELECT stuff.value 
+		FROM stuff)`, true},
 		/*{`-- Examples
 		ALTER TABLE Stock ADD Qty int;
 

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -51,7 +51,12 @@ type lexer struct {
 	ParamList	[]*expression.ParamMarker
 	stmtStartPos 	int
 	stringLit 	[]byte
+
+	// record token's offset of the input
+	tokenEndOffset   int
+	tokenStartOffset int
 }
+
 
 // NewLexer builds a new lexer.
 func NewLexer(src string) (l *lexer) {
@@ -104,6 +109,7 @@ func (l *lexer) unget(b byte) {
 	l.ungetBuf = append(l.ungetBuf, b)
 	l.i--
 	l.ncol--
+	l.tokenEndOffset--
 }
 
 func (l *lexer) next() int {
@@ -130,6 +136,7 @@ func (l *lexer) next() int {
 	default:
 		l.ncol++
 	}
+	l.tokenEndOffset++
 	return l.c
 }
 
@@ -175,7 +182,8 @@ func (l *lexer) stmtText() string {
 
 func (l *lexer) Lex(lval *yySymType) (r int) {
 	defer func() {
-		lval.line, lval.col = l.line, l.col
+		lval.line, lval.col, lval.offset = l.line, l.col, l.tokenStartOffset
+		l.tokenStartOffset = l.tokenEndOffset
 	}()
 	const (
 		INITIAL = iota


### PR DESCRIPTION
Fix get text of subselect statement.

The solution is not pretty. We may need to change goyacc for getting origin text of expressions.
