### PR TITLE
fix float precision

### DIFF
--- a/tidb-server/server/util.go
+++ b/tidb-server/server/util.go
@@ -330,7 +330,7 @@ func dumpTextValue(mysqlType uint8, value interface{}) ([]byte, error) {
 	case uint:
 		return strconv.AppendUint(nil, uint64(v), 10), nil
 	case float32:
-		return strconv.AppendFloat(nil, float64(v), 'f', -1, 64), nil
+		return strconv.AppendFloat(nil, float64(v), 'f', -1, 32), nil
 	case float64:
 		return strconv.AppendFloat(nil, float64(v), 'f', -1, 64), nil
 	case []byte:

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -828,6 +828,14 @@ func (s *testSessionSuite) TestSelect(c *C) {
 	match(c, rows[1], 1, 1, 1, 1)
 	match(c, rows[2], 2, 2, 2, nil)
 	match(c, rows[3], 3, 3, nil, 3)
+
+	mustExecSQL(c, se, "drop table if exists t")
+	mustExecSQL(c, se, "create table t (c float(8))")
+	mustExecSQL(c, se, "insert into t values (3.12)")
+	r = mustExecSQL(c, se, "select * from t")
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	match(c, row, 3.12)
 }
 
 func (s *testSessionSuite) TestSubQuery(c *C) {

--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -295,7 +295,9 @@ func Convert(val interface{}, target *FieldType) (v interface{}, err error) { //
 		if err != nil {
 			return invConv(val, tp)
 		}
-		if target.Flen != UnspecifiedLength {
+		// For float and following double type, we will only truncate it for float(M, D) format.
+		// If no D is set, we will handle it like origin float whether M is set or not.
+		if target.Flen != UnspecifiedLength && target.Decimal != UnspecifiedLength {
 			x, err = TruncateFloat(x, target.Flen, target.Decimal)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -307,7 +309,7 @@ func Convert(val interface{}, target *FieldType) (v interface{}, err error) { //
 		if err != nil {
 			return invConv(val, tp)
 		}
-		if target.Flen != UnspecifiedLength {
+		if target.Flen != UnspecifiedLength && target.Decimal != UnspecifiedLength {
 			x, err = TruncateFloat(x, target.Flen, target.Decimal)
 			if err != nil {
 				return nil, errors.Trace(err)


### PR DESCRIPTION
Fix issue #307 

The definition `float(8)` is equivalent to `float`.