### PR TITLE
Fix #294.

### DIFF
--- a/expression/binop.go
+++ b/expression/binop.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
-
 	mysql "github.com/pingcap/tidb/mysqldef"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/util/types"

--- a/expression/binop_test.go
+++ b/expression/binop_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-
 	"github.com/pingcap/tidb/expression/builtin"
 	"github.com/pingcap/tidb/model"
 	mysql "github.com/pingcap/tidb/mysqldef"

--- a/expression/like.go
+++ b/expression/like.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/util/types"
 )
 
 var (
@@ -78,10 +79,12 @@ func (p *PatternLike) Eval(ctx context.Context, args map[interface{}]interface{}
 	if expr == nil {
 		return nil, nil
 	}
-	sexpr, ok := expr.(string)
-	if !ok {
-		return nil, errors.Errorf("non-string Expression in LIKE: %v (Value of type %T)", expr, expr)
+
+	sexpr, err := types.ToString(expr)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+
 	// We need to compile pattern if it has not been compiled or it is not static.
 	var needCompile = len(p.patChars) == 0 || !p.Pattern.IsStatic()
 	if needCompile {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -1027,6 +1027,21 @@ func (s *testSessionSuite) TestDatabase(c *C) {
 	mustExecSQL(c, se, "drop schema if exists xxx")
 }
 
+func (s *testSessionSuite) TestWhereLike(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+
+	mustExecSQL(c, se, "drop table if exists t")
+	mustExecSQL(c, se, "create table t(c int)")
+	mustExecSQL(c, se, "insert into t values (1),(2),(3),(-11),(11),(123),(211),(210)")
+	mustExecSQL(c, se, "insert into t values ()")
+
+	r := mustExecSQL(c, se, "select c from t where c like '%1%'")
+	rows, err := r.Rows(-1, 0)
+	c.Assert(err, IsNil)
+	c.Assert(rows, HasLen, 6)
+}
+
 func newSession(c *C, store kv.Storage, dbName string) Session {
 	se, err := CreateSession(store)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Update `like` expr Eval by using ToString for type convert.