### PR TITLE
improve MVCC iterator performance

### DIFF
--- a/store/localstore/boltdb/boltdb.go
+++ b/store/localstore/boltdb/boltdb.go
@@ -118,6 +118,14 @@ func (i *iterator) Next() bool {
 	return i.key != nil
 }
 
+func (i *iterator) Seek(startKey []byte) bool {
+	if i.Cursor == nil {
+		i.Cursor = i.tx.Bucket(bucketName).Cursor()
+	}
+	i.key, i.value = i.Cursor.Seek(startKey)
+	return i.key != nil
+}
+
 func (i *iterator) Key() []byte {
 	return i.key
 }

--- a/store/localstore/engine/engine.go
+++ b/store/localstore/engine/engine.go
@@ -49,6 +49,8 @@ type Iterator interface {
 	Value() []byte
 	// Release releases current iterator.
 	Release()
+
+	Seek(startKey []byte) bool
 }
 
 // Batch is the interface for local storage

--- a/store/localstore/engine/engine.go
+++ b/store/localstore/engine/engine.go
@@ -49,7 +49,7 @@ type Iterator interface {
 	Value() []byte
 	// Seek moves the iterator to the first key/value pair whose key is greater
 	// or equal to the given key.
-	// It returns whether such pair exist.
+	// It returns whether such pair exists or not.
 	Seek(startKey []byte) bool
 	// Release releases current iterator.
 	Release()

--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -245,3 +245,41 @@ func (t *testMvccSuite) TestMvccSnapshotScan(c *C) {
 	found = iterFunc(it)
 	c.Assert(found, IsFalse)
 }
+
+func (t *testMvccSuite) TestBufferedIterator(c *C) {
+	s := createMemStore()
+	tx, _ := s.Begin()
+	tx.Set([]byte{0x0, 0x0}, []byte("1"))
+	tx.Set([]byte{0x0, 0xff}, []byte("2"))
+	tx.Set([]byte{0x0, 0xee}, []byte("3"))
+	tx.Set([]byte{0x0, 0xee, 0xff}, []byte("4"))
+	tx.Set([]byte{0xff, 0xff, 0xee, 0xff}, []byte("5"))
+	tx.Set([]byte{0xff, 0xff, 0xff}, []byte("6"))
+	tx.Commit()
+
+	tx, _ = s.Begin()
+	iter, err := tx.Seek([]byte{0}, nil)
+	c.Assert(err, IsNil)
+	cnt := 0
+	for iter.Valid() {
+		iter, err = iter.Next(nil)
+		c.Assert(err, IsNil)
+		cnt += 1
+	}
+	tx.Commit()
+	c.Assert(cnt, Equals, 6)
+
+	tx, _ = s.Begin()
+	it, err := tx.Seek([]byte{0xff, 0xee}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(it.Valid(), IsTrue)
+	c.Assert(it.Key(), Equals, "\xff\xff\xee\xff")
+	tx.Commit()
+
+	// no such key
+	tx, _ = s.Begin()
+	it, err = tx.Seek([]byte{0xff, 0xff, 0xff, 0xff}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(it.Valid(), IsFalse)
+	tx.Commit()
+}

--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -281,5 +281,10 @@ func (t *testMvccSuite) TestBufferedIterator(c *C) {
 	it, err = tx.Seek([]byte{0xff, 0xff, 0xff, 0xff}, nil)
 	c.Assert(err, IsNil)
 	c.Assert(it.Valid(), IsFalse)
+
+	it, err = tx.Seek([]byte{0x0, 0xff}, nil)
+	c.Assert(err, IsNil)
+	c.Assert(it.Valid(), IsTrue)
+	c.Assert(it.Value(), DeepEquals, []byte("2"))
 	tx.Commit()
 }

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -14,8 +14,6 @@
 package localstore
 
 import (
-	"bytes"
-
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/kv"
@@ -32,7 +30,25 @@ var (
 
 type dbSnapshot struct {
 	db      engine.DB
+	rawIt   engine.Iterator
 	version kv.Version // transaction begin version
+}
+
+func (s *dbSnapshot) internalSeek(startKey []byte) (engine.Iterator, error) {
+	if s.rawIt == nil {
+		var err error
+		s.rawIt, err = s.db.Seek([]byte{0})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	ok := s.rawIt.Seek(startKey)
+	if !ok {
+		s.rawIt.Release()
+		s.rawIt = nil
+		return nil, kv.ErrNotExist
+	}
+	return s.rawIt, nil
 }
 
 func (s *dbSnapshot) MvccGet(k kv.Key, ver kv.Version) ([]byte, error) {
@@ -53,32 +69,24 @@ func (s *dbSnapshot) MvccGet(k kv.Key, ver kv.Version) ([]byte, error) {
 	startKey := MvccEncodeVersionKey(k, ver)
 	endKey := MvccEncodeVersionKey(k, kv.MinVersion)
 
-	// get raw iterator
-	it, err := s.db.Seek(startKey)
+	it, err := s.internalSeek(startKey)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	defer it.Release()
 
 	var rawKey []byte
 	var v []byte
-	if it.Next() {
-		// If scan exceed this key's all versions
-		// it.Key() > endKey.
-		if kv.EncodedKey(it.Key()).Cmp(endKey) < 0 {
-			// Check newest version of this key.
-			// If it's tombstone, just skip it.
-			if !isTombstone(it.Value()) {
-				rawKey = it.Key()
-				v = it.Value()
-			}
-		}
+	// Check if the scan is not exceed this key's all versions and the value is not
+	// tombstone.
+	if kv.EncodedKey(it.Key()).Cmp(endKey) < 0 && !isTombstone(it.Value()) {
+		rawKey = it.Key()
+		v = it.Value()
 	}
 	// No such key (or it's tombstone).
 	if rawKey == nil {
 		return nil, kv.ErrNotExist
 	}
-	return v, nil
+	return append([]byte(nil), v...), nil
 }
 
 func (s *dbSnapshot) NewMvccIterator(k kv.Key, ver kv.Version) kv.Iterator {
@@ -103,7 +111,12 @@ func (s *dbSnapshot) MvccRelease() {
 	s.Release()
 }
 
-func (s *dbSnapshot) Release() {}
+func (s *dbSnapshot) Release() {
+	if s.rawIt != nil {
+		s.rawIt.Release()
+		s.rawIt = nil
+	}
+}
 
 type dbIter struct {
 	s               *dbSnapshot
@@ -127,27 +140,18 @@ func newDBIter(s *dbSnapshot, startKey kv.Key, exceptedVer kv.Version) *dbIter {
 
 func (it *dbIter) Next(fn kv.FnKeyCmp) (kv.Iterator, error) {
 	encKey := codec.EncodeBytes(nil, it.startKey)
-	// max key
-	encEndKey := codec.EncodeBytes(nil, []byte{0xff, 0xff})
 	var retErr error
 	var engineIter engine.Iterator
 	for {
-		engineIter, retErr = it.s.db.Seek(encKey)
-		if retErr != nil {
-			return nil, errors.Trace(retErr)
-		}
-		// Check if overflow
-		if !engineIter.Next() {
+		var err error
+		engineIter, err = it.s.internalSeek(encKey)
+		if err != nil {
 			it.valid = false
+			retErr = err
 			break
 		}
 
 		metaKey := engineIter.Key()
-		// Check if meet the end of table.
-		if bytes.Compare(metaKey, encEndKey) >= 0 {
-			it.valid = false
-			break
-		}
 		// Get real key from metaKey
 		key, _, err := MvccDecode(metaKey)
 		if err != nil {
@@ -164,17 +168,14 @@ func (it *dbIter) Next(fn kv.FnKeyCmp) (kv.Iterator, error) {
 			break
 		}
 		if val != nil {
-			it.k = key
-			it.v = val
+			it.k = append([]byte(nil), key...)
+			it.v = append([]byte(nil), val...)
 			it.startKey = key.Next()
 			break
 		}
-		// Release the iterator, and update key
-		engineIter.Release()
 		// Current key's all versions are deleted, just go next key.
 		encKey = codec.EncodeBytes(nil, key.Next())
 	}
-	engineIter.Release()
 	return it, errors.Trace(retErr)
 }
 

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/localstore/engine"
+	"github.com/pingcap/tidb/util/bytes"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/errors2"
 )
@@ -86,7 +87,7 @@ func (s *dbSnapshot) MvccGet(k kv.Key, ver kv.Version) ([]byte, error) {
 	if rawKey == nil {
 		return nil, kv.ErrNotExist
 	}
-	return append([]byte(nil), v...), nil
+	return bytes.CloneBytes(v), nil
 }
 
 func (s *dbSnapshot) NewMvccIterator(k kv.Key, ver kv.Version) kv.Iterator {
@@ -168,8 +169,8 @@ func (it *dbIter) Next(fn kv.FnKeyCmp) (kv.Iterator, error) {
 			break
 		}
 		if val != nil {
-			it.k = append([]byte(nil), key...)
-			it.v = append([]byte(nil), val...)
+			it.k = bytes.CloneBytes(key)
+			it.v = bytes.CloneBytes(val)
 			it.startKey = key.Next()
 			break
 		}

--- a/store/localstore/txn.go
+++ b/store/localstore/txn.go
@@ -227,6 +227,8 @@ func (txn *dbTxn) doCommit() error {
 	}
 	// Update commit version.
 	txn.version = curVer
+	// Release read lock before write. Workaround for BoltDB.
+	txn.Snapshot.Release()
 	return txn.store.writeBatch(b)
 }
 

--- a/util/bytes/bytes.go
+++ b/util/bytes/bytes.go
@@ -1,0 +1,6 @@
+package bytes
+
+// CloneBytes returns a deep copy of slice b
+func CloneBytes(b []byte) []byte {
+	return append([]byte(nil), b...)
+}

--- a/util/bytes/bytes.go
+++ b/util/bytes/bytes.go
@@ -1,6 +1,6 @@
 package bytes
 
-// CloneBytes returns a deep copy of slice b
+// CloneBytes returns a deep copy of slice b.
 func CloneBytes(b []byte) []byte {
 	return append([]byte(nil), b...)
 }

--- a/util/bytes/bytes_test.go
+++ b/util/bytes/bytes_test.go
@@ -15,6 +15,11 @@ func (s *testBytesHelperSuites) TestBytesClone(c *C) {
 	shadowB := b
 	newB := CloneBytes(b)
 	c.Assert(b, DeepEquals, newB)
+	// Ugly hacks.Go doesn't allow compare two slice (except nil).
+	// For example:  b == newB <-- it's invalid.
+	// In this test, we must ensure CloneBytes method returns a new slice with
+	// the same value, so we need to check the new slice's address.
 	c.Assert(fmt.Sprintf("%p", b) != fmt.Sprintf("%p", newB), IsTrue)
+	// But the addresses are the same when it's a shadow copy.
 	c.Assert(fmt.Sprintf("%p", b), Equals, fmt.Sprintf("%p", shadowB))
 }

--- a/util/bytes/bytes_test.go
+++ b/util/bytes/bytes_test.go
@@ -1,0 +1,20 @@
+package bytes
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testBytesHelperSuites{})
+
+type testBytesHelperSuites struct{}
+
+func (s *testBytesHelperSuites) TestBytesClone(c *C) {
+	b := []byte("hello world")
+	shadowB := b
+	newB := CloneBytes(b)
+	c.Assert(b, DeepEquals, newB)
+	c.Assert(fmt.Sprintf("%p", b) != fmt.Sprintf("%p", newB), IsTrue)
+	c.Assert(fmt.Sprintf("%p", b), Equals, fmt.Sprintf("%p", shadowB))
+}


### PR DESCRIPTION
use a long-lived iterator instead of creating new iterator when calling
iteratdor.Next()