### PR TITLE
plans: join filter must use origin result fields

### DIFF
--- a/plan/plans/join.go
+++ b/plan/plans/join.go
@@ -99,7 +99,7 @@ func (r *JoinPlan) explainNode(w format.Formatter, node plan.Plan) {
 
 func (r *JoinPlan) filterNode(ctx context.Context, expr expression.Expression, node plan.Plan) (plan.Plan, bool, error) {
 	if node == nil {
-		return r, false, nil
+		return nil, false, nil
 	}
 
 	e2 := expr.Clone()
@@ -112,14 +112,12 @@ func (r *JoinPlan) Filter(ctx context.Context, expr expression.Expression) (plan
 	// TODO: do more optimization for join plan
 	// now we only use where expression for Filter, but for join
 	// we must use On expression too.
-	if r.Right == nil {
-		return r.Left.Filter(ctx, expr)
-	}
 	newPlan := &JoinPlan{
 		Fields: r.Fields,
 		Type:   r.Type,
 		On:     r.On,
 	}
+
 	p, filteredLeft, err := r.filterNode(ctx, expr, r.Left)
 	if err != nil {
 		return nil, false, errors.Trace(err)

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -841,6 +841,12 @@ func (s *testSessionSuite) TestSelect(c *C) {
 	row, err = r.FirstRow()
 	c.Assert(err, IsNil)
 	match(c, row, 3.12)
+
+	mustExecSQL(c, se, `drop table if exists t;create table t (c int);insert into t values (1);`)
+	r = mustExecSQL(c, se, "select a.c from t as a where c between null and 2")
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	c.Assert(row, IsNil)
 }
 
 func (s *testSessionSuite) TestSubQuery(c *C) {


### PR DESCRIPTION
Fix #363
e,g, `select * from t as a`
The plan phase in from is table plan -> join plan, and we can only get
the alias name in join plan, so if we return origin table plan directly
in join Filter, we may get wrong result fields.

@qiuyesuifeng  @coocood 