### PR TITLE
refactor update/insert/delete qualified name and as name handling

### DIFF
--- a/stmt/stmts/delete_test.go
+++ b/stmt/stmts/delete_test.go
@@ -199,5 +199,8 @@ func (s *testStmtSuite) TestQualifedDelete(c *C) {
 	r = mustExec(c, s.testDB, "delete a, b from t1 as a join t2 as b where a.c2 = b.c1")
 	checkResult(c, r, 2, 0)
 
+	_, err = s.testDB.Exec("delete t1, t2 from t1 as a join t2 as b where a.c2 = b.c1")
+	c.Assert(err, NotNil)
+
 	mustExec(c, s.testDB, "drop table t1, t2")
 }

--- a/stmt/stmts/insert_test.go
+++ b/stmt/stmts/insert_test.go
@@ -89,4 +89,10 @@ func (s *testStmtSuite) TestInsert(c *C) {
 
 	insertSQL := `insert into insert_test (id, c2) values (1, 1) on duplicate key update c2=10;`
 	mustExec(c, s.testDB, insertSQL)
+
+	insertSQL = `insert into insert_test (id, c2) values (1, 1) on duplicate key update insert_test.c2=10;`
+	mustExec(c, s.testDB, insertSQL)
+
+	_, err = s.testDB.Exec(`insert into insert_test (id, c2) values(1, 1) on duplicate key update t.c2 = 10`)
+	c.Assert(err, NotNil)
 }

--- a/stmt/stmts/update.go
+++ b/stmt/stmts/update.go
@@ -255,6 +255,7 @@ func (s *UpdateStmt) Exec(ctx context.Context) (_ rset.Recordset, err error) {
 	}
 
 	m := map[interface{}]interface{}{}
+	var records []*plan.Row
 	for {
 		row, err1 := p.Next(ctx)
 		if err1 != nil {
@@ -263,11 +264,16 @@ func (s *UpdateStmt) Exec(ctx context.Context) (_ rset.Recordset, err error) {
 		if row == nil {
 			break
 		}
-		rowData := row.Data
 		if len(row.RowKeys) == 0 {
 			// Nothing to update
-			return nil, nil
+			continue
 		}
+		records = append(records, row)
+	}
+
+	for _, row := range records {
+		rowData := row.Data
+
 		// Set EvalIdentFunc
 		m[expression.ExprEvalIdentFunc] = func(name string) (interface{}, error) {
 			return plans.GetIdentValue(name, p.GetFields(), rowData, field.DefaultFieldFlag)

--- a/stmt/stmts/update_test.go
+++ b/stmt/stmts/update_test.go
@@ -223,96 +223,27 @@ func (s *testStmtSuite) TestIssue345(c *C) {
 	mustCommit(c, tx)
 }
 
-// See https://github.com/pingcap/tidb/issues/369
-func (s *testStmtSuite) TestIssue369(c *C) {
-	testSQL := `DROP TABLE IF EXISTS users, foobar;`
-	mustExec(c, s.testDB, testSQL)
-
-	testSQL = `CREATE TABLE users (
-				id INTEGER NOT NULL AUTO_INCREMENT, 
-			    name VARCHAR(30) NOT NULL, 
-			    some_update VARCHAR(30), 
-			    PRIMARY KEY (id)
-			)ENGINE=MyISAM;
-
-			CREATE TABLE foobar (
-			    id INTEGER NOT NULL AUTO_INCREMENT, 
-			    user_id INTEGER, 
-			    data VARCHAR(30), 
-			    some_update VARCHAR(30), 
-			    PRIMARY KEY (id), 
-			    FOREIGN KEY(user_id) REFERENCES users (id)
-			)ENGINE=MyISAM;`
-	mustExec(c, s.testDB, testSQL)
-	testSQL = `
-		INSERT INTO users (id, name, some_update) VALUES 
-			(8, 'ed', 'value'),
-			(9, 'fred', 'value');
-
-		INSERT INTO foobar (id, user_id, data) VALUES 
-			(2, 8, 'd1'),
-			(3, 8, 'd2'),
-			(4, 9, 'd3');`
-	mustExec(c, s.testDB, testSQL)
-
-	testSQL = `UPDATE users, foobar SET foobar.data=(concat(foobar.data, 'a')), 
-	foobar.some_update='im the other update', users.name='ed2', users.some_update='im the update'
-	WHERE users.id = foobar.user_id AND users.name = 'ed';`
-	r := mustExec(c, s.testDB, testSQL)
-	checkResult(c, r, 3, 0)
-}
-
-// See https://github.com/pingcap/tidb/issues/376
-func (s *testStmtSuite) TestIssue376(c *C) {
+func (s *testStmtSuite) TestMultiUpdate(c *C) {
+	// fix https://github.com/pingcap/tidb/issues/369
 	testSQL := `
-		DROP TABLE IF EXISTS users, foobar, addresses;
-		CREATE TABLE users (
-		    id INTEGER NOT NULL AUTO_INCREMENT, 
-		    name VARCHAR(30) NOT NULL, 
-		    some_update VARCHAR(30), 
-		    PRIMARY KEY (id)
-		)ENGINE=MyISAM;
-
-		CREATE TABLE foobar (
-		    id INTEGER NOT NULL AUTO_INCREMENT, 
-		    user_id INTEGER, 
-		    data VARCHAR(30), 
-		    some_update VARCHAR(30), 
-		    PRIMARY KEY (id), 
-		    FOREIGN KEY(user_id) REFERENCES users (id)
-		)ENGINE=MyISAM;
-
-		CREATE TABLE addresses (
-		    id INTEGER NOT NULL AUTO_INCREMENT, 
-		    user_id INTEGER, 
-		    email_address VARCHAR(50) NOT NULL, 
-		    PRIMARY KEY (id), 
-		    FOREIGN KEY(user_id) REFERENCES users (id)
-		)ENGINE=MyISAM;
-
-		INSERT INTO users (id, name, some_update) VALUES 
-		(8, 'ed', 'value'),
-		(9, 'fred', 'value');
-
-		INSERT INTO addresses (id, user_id, email_address) VALUES 
-		(2, 8, 'ed@wood.com'),
-		(3, 8, 'ed@bettyboop.com'),
-		(4, 9, 'fred@fred.com');
-
-		INSERT INTO foobar (id, user_id, data) VALUES 
-		(2, 8, 'd1'),
-		(3, 8, 'd2'),
-		(4, 9, 'd3');`
-
+		DROP TABLE IF EXISTS t1, t2;
+		create table t1 (c int);
+		create table t2 (c varchar(256));
+		insert into t1 values (1), (2);
+		insert into t2 values ("a"), ("b");
+		update t1, t2 set t1.c = 10, t2.c = "abc";`
 	mustExec(c, s.testDB, testSQL)
-	testSQL = `
-		UPDATE addresses, users SET users.name='ed2', users.some_update='im the update', 
-		addresses.email_address=users.name WHERE users.id = addresses.user_id AND users.name = 'ed';`
-	r := mustExec(c, s.testDB, testSQL)
-	checkResult(c, r, 3, 0)
 
-	testSQL = `SELECT addresses.id, addresses.user_id, addresses.email_address FROM addresses ORDER BY addresses.id;`
-	rows, err := s.testDB.Query(testSQL)
+	// fix https://github.com/pingcap/tidb/issues/376
+	testSQL = `DROP TABLE IF EXISTS t1, t2;
+		create table t1 (c1 int);
+		create table t2 (c2 int);
+		insert into t1 values (1), (2);
+		insert into t2 values (1), (2);
+		update t1, t2 set t1.c1 = 10, t2.c2 = 2 where t2.c2 = 1;`
+	mustExec(c, s.testDB, testSQL)
+
+	rows, err := s.testDB.Query("select * from t1")
 	c.Assert(err, IsNil)
-	matchRows(c, rows, [][]interface{}{{2, 8, "ed"}, {3, 8, "ed"}, {4, 9, "fred@fred.com"}})
+	matchRows(c, rows, [][]interface{}{{10}, {10}})
 }


### PR DESCRIPTION
+ Fix issue #369 
+ Unify qualified and as handling for update/insert/delete.  
+ When use as for a table, we can't use the origin table name. 