### PR TITLE
parser/parser.y: add StringType OptCharset OptCollate support

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3861,21 +3861,25 @@ BitValueType:
 	}
 
 StringType:
-	NationalOpt "CHAR" FieldLen OptBinary
+	NationalOpt "CHAR" FieldLen OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
 		x.Flen = $3.(int)
 		if $4.(bool) {
 			x.Flag |= mysql.BinaryFlag
 		}
+		x.Charset = $5.(string)
+		x.Collate = $6.(string)
 		$$ = x
 	}
-|	NationalOpt "CHAR" OptBinary
+|	NationalOpt "CHAR" OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
 		if $3.(bool) {
 			x.Flag |= mysql.BinaryFlag
 		}
+		x.Charset = $4.(string)
+		x.Collate = $5.(string)
 		$$ = x
 	}
 |	NationalOpt "VARCHAR" FieldLen OptBinary OptCharset OptCollate

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -442,6 +442,11 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"CREATE TABLE foo (a SMALLINT UNSIGNED, b INT UNSIGNED) // foo", true},
 		{"CREATE TABLE foo (a SMALLINT UNSIGNED, b INT UNSIGNED) /* foo */", true},
 		{"CREATE TABLE foo /* foo */ (a SMALLINT UNSIGNED, b INT UNSIGNED) /* foo */", true},
+		{"CREATE TABLE foo (name CHAR(50) BINARY)", true},
+		{"CREATE TABLE foo (name CHAR(50) COLLATE utf8_bin)", true},
+		{"CREATE TABLE foo (name CHAR(50) CHARACTER SET utf8)", true},
+		{"CREATE TABLE foo (name CHAR(50) BINARY CHARACTER SET utf8 COLLATE utf8_bin)", true},
+
 		{"CREATE TABLE foo (a.b, b);", false},
 		{"CREATE TABLE foo (a, b.c);", false},
 		// For table option


### PR DESCRIPTION
to support sql like "Create Table test(a CHAR(10) CHARACTER SET utf8)", see details:
"https://dev.mysql.com/doc/refman/5.0/en/create-table.html",
data_type:
    ...
    | CHAR[(length)] [BINARY]
      [CHARACTER SET charset_name] [COLLATE collation_name]