### PR TITLE
kv, store: add MemBuffer for UnionStore

### DIFF
--- a/kv/btree_buffer.go
+++ b/kv/btree_buffer.go
@@ -1,0 +1,117 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Copyright 2015 Wenbin Xiao
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"github.com/pingcap/tidb/kv/memkv"
+	"github.com/pingcap/tidb/util/types"
+)
+
+type btreeBuffer struct {
+	tree *memkv.Tree
+}
+
+// NewBTreeBuffer returns a breeBuffer.
+func NewBTreeBuffer() MemBuffer {
+	return &btreeBuffer{
+		tree: memkv.NewTree(types.Collators[true]),
+	}
+}
+
+// Get returns the value associated with the key; ErrNotExist error if the key does not exist.
+func (b *btreeBuffer) Get(k Key) ([]byte, error) {
+	v, ok := b.tree.Get(toIfaces(k))
+	if !ok {
+		return nil, ErrNotExist
+	}
+	return fromIfaces(v), nil
+}
+
+// Set associates the key with the value.
+func (b *btreeBuffer) Set(k []byte, v []byte) error {
+	b.tree.Set(toIfaces(k), toIfaces(v))
+	return nil
+}
+
+// Release clear the whole buffer.
+func (b *btreeBuffer) Release() {
+	b.tree.Clear()
+}
+
+type btreeIter struct {
+	e  *memkv.Enumerator
+	k  string
+	v  []byte
+	ok bool
+}
+
+// NewIterator creates a new Iterator based on the provided param
+func (b *btreeBuffer) NewIterator(param interface{}) Iterator {
+	var e *memkv.Enumerator
+	var err error
+	if param == nil {
+		e, err = b.tree.SeekFirst()
+		if err != nil {
+			return &btreeIter{ok: false}
+		}
+	} else {
+		key := toIfaces(param.([]byte))
+		e, _ = b.tree.Seek(key)
+	}
+	iter := &btreeIter{e: e}
+	// the initial push...
+	iter.Next()
+	return iter
+}
+
+// Close implements Iterator Close.
+func (i *btreeIter) Close() {
+	//noop
+}
+
+// Key implements Iterator Key.
+func (i *btreeIter) Key() string {
+	return i.k
+}
+
+// Value implements Iterator Value.
+func (i *btreeIter) Value() []byte {
+	return i.v
+}
+
+// Next implements Iterator Next.
+func (i *btreeIter) Next() (Iterator, error) {
+	k, v, err := i.e.Next()
+	// find the first non-nil key
+	i.k, i.v, i.ok = string(fromIfaces(k)), fromIfaces(v), err == nil
+	return i, err
+}
+
+// Valid implements Iterator Valid.
+func (i *btreeIter) Valid() bool {
+	return i.ok
+}
+
+func toIfaces(v []byte) []interface{} {
+	return []interface{}{v}
+}
+
+func fromIfaces(v []interface{}) []byte {
+	if v == nil {
+		return nil
+	}
+	return v[0].([]byte)
+}

--- a/kv/btree_buffer.go
+++ b/kv/btree_buffer.go
@@ -95,7 +95,6 @@ func (i *btreeIter) Value() []byte {
 // Next implements Iterator Next.
 func (i *btreeIter) Next() (Iterator, error) {
 	k, v, err := i.e.Next()
-	// find the first non-nil key
 	i.k, i.v, i.ok = string(fromIfaces(k)), fromIfaces(v), err == nil
 	return i, err
 }

--- a/kv/mem_buffer_test.go
+++ b/kv/mem_buffer_test.go
@@ -1,0 +1,304 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Copyright 2015 Wenbin Xiao
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+const (
+	startIndex = 0
+	testCount  = 2
+	indexStep  = 2
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testKVSuite{})
+
+type testKVSuite struct {
+	bs []MemBuffer
+}
+
+func (s *testKVSuite) SetUpSuite(c *C) {
+	s.bs = make([]MemBuffer, 2)
+	s.bs[0] = NewBTreeBuffer()
+	s.bs[1] = NewMemDbBuffer()
+}
+
+func (s *testKVSuite) TearDownSuite(c *C) {
+	for _, buffer := range s.bs {
+		buffer.Release()
+	}
+}
+
+func insertData(c *C, buffer MemBuffer) {
+	for i := startIndex; i < testCount; i++ {
+		val := encodeInt(i * indexStep)
+		err := buffer.Set(val, val)
+		c.Assert(err, IsNil)
+	}
+}
+
+func encodeInt(n int) []byte {
+	return []byte(fmt.Sprintf("%010d", n))
+}
+
+func decodeInt(s []byte) int {
+	var n int
+	fmt.Sscanf(string(s), "%010d", &n)
+	return n
+}
+
+func valToStr(c *C, iter Iterator) string {
+	val := iter.Value()
+	return string(val)
+}
+
+func checkNewIterator(c *C, buffer MemBuffer) {
+	for i := startIndex; i < testCount; i++ {
+		val := encodeInt(i * indexStep)
+		iter := buffer.NewIterator(val)
+		c.Assert(iter.Key(), Equals, string(val))
+		c.Assert(decodeInt([]byte(valToStr(c, iter))), Equals, i*indexStep)
+		iter.Close()
+	}
+
+	// Test iterator Next()
+	for i := startIndex; i < testCount-1; i++ {
+		val := encodeInt(i * indexStep)
+		iter := buffer.NewIterator(val)
+		c.Assert(iter.Key(), Equals, string(val))
+		c.Assert(valToStr(c, iter), Equals, string(val))
+
+		next, err := iter.Next()
+		c.Assert(err, IsNil)
+		c.Assert(next.Valid(), IsTrue)
+
+		val = encodeInt((i + 1) * indexStep)
+		c.Assert(next.Key(), Equals, string(val))
+		c.Assert(valToStr(c, next), Equals, string(val))
+		iter.Close()
+	}
+
+	// Non exist and beyond maximum seek test
+	iter := buffer.NewIterator(encodeInt(testCount * indexStep))
+	c.Assert(iter.Valid(), IsFalse)
+
+	// Non exist but between existing keys seek test,
+	// it returns the smallest key that larger than the one we are seeking
+	inBetween := encodeInt((testCount-1)*indexStep - 1)
+	last := encodeInt((testCount - 1) * indexStep)
+	iter = buffer.NewIterator(inBetween)
+	c.Assert(iter.Valid(), IsTrue)
+	c.Assert(iter.Key(), Not(Equals), string(inBetween))
+	c.Assert(iter.Key(), Equals, string(last))
+	iter.Close()
+}
+
+func mustNotGet(c *C, buffer MemBuffer) {
+	for i := startIndex; i < testCount; i++ {
+		s := encodeInt(i * indexStep)
+		_, err := buffer.Get(s)
+		c.Assert(err, NotNil)
+	}
+}
+
+func mustGet(c *C, buffer MemBuffer) {
+	for i := startIndex; i < testCount; i++ {
+		s := encodeInt(i * indexStep)
+		val, err := buffer.Get(s)
+		c.Assert(err, IsNil)
+		c.Assert(string(val), Equals, string(s))
+	}
+}
+
+func (s *testKVSuite) TestGetSet(c *C) {
+	for _, buffer := range s.bs {
+		insertData(c, buffer)
+		mustGet(c, buffer)
+		buffer.Release()
+	}
+}
+
+func (s *testKVSuite) TestNewIterator(c *C) {
+	for _, buffer := range s.bs {
+		// should be invalid
+		iter := buffer.NewIterator(nil)
+		c.Assert(iter.Valid(), IsFalse)
+
+		insertData(c, buffer)
+		checkNewIterator(c, buffer)
+		buffer.Release()
+	}
+}
+
+func (s *testKVSuite) TestBasicNewIterator(c *C) {
+	for _, buffer := range s.bs {
+		it := buffer.NewIterator([]byte("2"))
+		c.Assert(it.Valid(), Equals, false)
+		buffer.Release()
+	}
+}
+
+func (s *testKVSuite) TestNewIteratorMin(c *C) {
+	kvs := []struct {
+		key   string
+		value string
+	}{
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000001", "lock-version"},
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000001_0002", "1"},
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000001_0003", "hello"},
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000002", "lock-version"},
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000002_0002", "2"},
+		{"DATA_test_main_db_tbl_tbl_test_record__00000000000000000002_0003", "hello"},
+	}
+	for _, buffer := range s.bs {
+		for _, kv := range kvs {
+			buffer.Set([]byte(kv.key), []byte(kv.value))
+		}
+
+		it := buffer.NewIterator(nil)
+		for it.Valid() {
+			fmt.Printf("%s, %s\n", it.Key(), it.Value())
+			it, _ = it.Next()
+		}
+
+		it = buffer.NewIterator([]byte("DATA_test_main_db_tbl_tbl_test_record__00000000000000000000"))
+		c.Assert(string(it.Key()), Equals, "DATA_test_main_db_tbl_tbl_test_record__00000000000000000001")
+
+		buffer.Release()
+
+	}
+}
+
+var opCnt = 100000
+
+func BenchmarkBTreeBufferSequential(b *testing.B) {
+	data := make([][]byte, opCnt)
+	for i := 0; i < opCnt; i++ {
+		data[i] = encodeInt(i)
+	}
+	buffer := NewBTreeBuffer()
+	benchmarkSetGet(b, buffer, data)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkBTreeBufferRandom(b *testing.B) {
+	data := make([][]byte, opCnt)
+	for i := 0; i < opCnt; i++ {
+		data[i] = encodeInt(i)
+	}
+	shuffle(data)
+	buffer := NewBTreeBuffer()
+	benchmarkSetGet(b, buffer, data)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkMemDbBufferSequential(b *testing.B) {
+	data := make([][]byte, opCnt)
+	for i := 0; i < opCnt; i++ {
+		data[i] = encodeInt(i)
+	}
+	buffer := NewMemDbBuffer()
+	benchmarkSetGet(b, buffer, data)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkMemDbBufferRandom(b *testing.B) {
+	data := make([][]byte, opCnt)
+	for i := 0; i < opCnt; i++ {
+		data[i] = encodeInt(i)
+	}
+	shuffle(data)
+	buffer := NewMemDbBuffer()
+	benchmarkSetGet(b, buffer, data)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkBTreeIter(b *testing.B) {
+	buffer := NewBTreeBuffer()
+	benchIterator(b, buffer)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkMemDbIter(b *testing.B) {
+	buffer := NewMemDbBuffer()
+	benchIterator(b, buffer)
+	buffer.Release()
+	b.ReportAllocs()
+}
+
+func BenchmarkBTreeCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		buffer := NewBTreeBuffer()
+		buffer.Release()
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkMemDbCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		buffer := NewMemDbBuffer()
+		buffer.Release()
+	}
+	b.ReportAllocs()
+}
+
+func shuffle(slc [][]byte) {
+	N := len(slc)
+	for i := 0; i < N; i++ {
+		// choose index uniformly in [i, N-1]
+		r := i + rand.Intn(N-i)
+		slc[r], slc[i] = slc[i], slc[r]
+	}
+}
+func benchmarkSetGet(b *testing.B, buffer MemBuffer, data [][]byte) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, k := range data {
+			buffer.Set(k, k)
+		}
+		for _, k := range data {
+			buffer.Get(k)
+		}
+	}
+}
+
+func benchIterator(b *testing.B, buffer MemBuffer) {
+	for k := 0; k < opCnt; k++ {
+		buffer.Set(encodeInt(k), encodeInt(k))
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		iter := buffer.NewIterator(nil)
+		for iter.Valid() {
+			iter.Next()
+		}
+		iter.Close()
+	}
+}

--- a/kv/mem_buffer_test.go
+++ b/kv/mem_buffer_test.go
@@ -155,7 +155,7 @@ func (s *testKVSuite) TestNewIterator(c *C) {
 func (s *testKVSuite) TestBasicNewIterator(c *C) {
 	for _, buffer := range s.bs {
 		it := buffer.NewIterator([]byte("2"))
-		c.Assert(it.Valid(), Equals, false)
+		c.Assert(it.Valid(), IsFalse)
 		buffer.Release()
 	}
 }
@@ -177,17 +177,18 @@ func (s *testKVSuite) TestNewIteratorMin(c *C) {
 			buffer.Set([]byte(kv.key), []byte(kv.value))
 		}
 
+		cnt := 0
 		it := buffer.NewIterator(nil)
 		for it.Valid() {
-			fmt.Printf("%s, %s\n", it.Key(), it.Value())
+			cnt++
 			it, _ = it.Next()
 		}
+		c.Assert(cnt, Equals, 6)
 
 		it = buffer.NewIterator([]byte("DATA_test_main_db_tbl_tbl_test_record__00000000000000000000"))
 		c.Assert(string(it.Key()), Equals, "DATA_test_main_db_tbl_tbl_test_record__00000000000000000001")
 
 		buffer.Release()
-
 	}
 }
 

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -1,0 +1,95 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Copyright 2015 Wenbin Xiao
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import (
+	"github.com/pingcap/tidb/util/errors2"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/comparer"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/memdb"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type memDbBuffer struct {
+	db *memdb.DB
+}
+
+type memDbIter struct {
+	iter iterator.Iterator
+}
+
+// NewMemDbBuffer creates a new memDbBuffer.
+func NewMemDbBuffer() MemBuffer {
+	return &memDbBuffer{db: memdb.New(comparer.DefaultComparer, 1*1024*1024)}
+}
+
+// NewIterator creates an Iterator.
+func (m *memDbBuffer) NewIterator(param interface{}) Iterator {
+	var i Iterator
+	if param == nil {
+		i = &memDbIter{iter: m.db.NewIterator(&util.Range{})}
+	} else {
+		i = &memDbIter{iter: m.db.NewIterator(&util.Range{Start: param.([]byte)})}
+	}
+	i.Next()
+	return i
+}
+
+// Get returns the value associated with key.
+func (m *memDbBuffer) Get(k Key) ([]byte, error) {
+	v, err := m.db.Get(k)
+	if errors2.ErrorEqual(err, leveldb.ErrNotFound) {
+		return nil, ErrNotExist
+	}
+	return v, nil
+}
+
+// Set associates key with value.
+func (m *memDbBuffer) Set(k []byte, v []byte) error {
+	return m.db.Put(k, v)
+}
+
+// Release reset the buffer.
+func (m *memDbBuffer) Release() {
+	m.db.Reset()
+}
+
+// Next implements the Iterator Next.
+func (i *memDbIter) Next() (Iterator, error) {
+	i.iter.Next()
+	return i, nil
+}
+
+// Valid implements the Iterator Valid.
+func (i *memDbIter) Valid() bool {
+	return i.iter.Valid()
+}
+
+// Key implements the Iterator Key.
+func (i *memDbIter) Key() string {
+	return string(i.iter.Key())
+}
+
+// Value implements the Iterator Value.
+func (i *memDbIter) Value() []byte {
+	return i.iter.Value()
+}
+
+// Close Implements the Iterator Close.
+func (i *memDbIter) Close() {
+	i.iter.Release()
+}

--- a/kv/union_iter.go
+++ b/kv/union_iter.go
@@ -17,12 +17,11 @@ import (
 	"bytes"
 
 	"github.com/ngaut/log"
-	"github.com/syndtr/goleveldb/leveldb/iterator"
 )
 
 // UnionIter is the iterator on an UnionStore.
 type UnionIter struct {
-	dirtyIt    iterator.Iterator
+	dirtyIt    Iterator
 	snapshotIt Iterator
 
 	dirtyValid    bool
@@ -32,12 +31,12 @@ type UnionIter struct {
 	isValid    bool
 }
 
-func newUnionIter(dirtyIt iterator.Iterator, snapshotIt Iterator) *UnionIter {
+func newUnionIter(dirtyIt Iterator, snapshotIt Iterator) *UnionIter {
 	it := &UnionIter{
 		dirtyIt:    dirtyIt,
 		snapshotIt: snapshotIt,
 		// leveldb use next for checking valid...
-		dirtyValid:    dirtyIt.Next(),
+		dirtyValid:    dirtyIt.Valid(),
 		snapshotValid: snapshotIt.Valid(),
 	}
 	it.updateCur()
@@ -46,7 +45,8 @@ func newUnionIter(dirtyIt iterator.Iterator, snapshotIt Iterator) *UnionIter {
 
 // Go next and update valid status.
 func (iter *UnionIter) dirtyNext() {
-	iter.dirtyValid = iter.dirtyIt.Next()
+	iter.dirtyIt, _ = iter.dirtyIt.Next()
+	iter.dirtyValid = iter.dirtyIt.Valid()
 }
 
 // Go next and update valid status.
@@ -81,7 +81,7 @@ func (iter *UnionIter) updateCur() {
 		// both valid
 		if iter.snapshotValid && iter.dirtyValid {
 			snapshotKey := []byte(iter.snapshotIt.Key())
-			dirtyKey := iter.dirtyIt.Key()
+			dirtyKey := []byte(iter.dirtyIt.Key())
 			cmp := bytes.Compare(dirtyKey, snapshotKey)
 			// if equal, means both have value
 			if cmp == 0 {
@@ -140,7 +140,7 @@ func (iter *UnionIter) Key() string {
 	if !iter.curIsDirty {
 		return string(DecodeKey([]byte(iter.snapshotIt.Key())))
 	}
-	return string(DecodeKey(iter.dirtyIt.Key()))
+	return string(DecodeKey([]byte(iter.dirtyIt.Key())))
 }
 
 // Valid implements the Iterator Valid interface.
@@ -155,7 +155,7 @@ func (iter *UnionIter) Close() {
 		iter.snapshotIt = nil
 	}
 	if iter.dirtyIt != nil {
-		iter.dirtyIt.Release()
+		iter.dirtyIt.Close()
 		iter.dirtyIt = nil
 	}
 }

--- a/kv/union_iter.go
+++ b/kv/union_iter.go
@@ -33,9 +33,8 @@ type UnionIter struct {
 
 func newUnionIter(dirtyIt Iterator, snapshotIt Iterator) *UnionIter {
 	it := &UnionIter{
-		dirtyIt:    dirtyIt,
-		snapshotIt: snapshotIt,
-		// leveldb use next for checking valid...
+		dirtyIt:       dirtyIt,
+		snapshotIt:    snapshotIt,
 		dirtyValid:    dirtyIt.Valid(),
 		snapshotValid: snapshotIt.Valid(),
 	}

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -17,10 +17,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/pool"
 	"github.com/pingcap/tidb/util/errors2"
-	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/comparer"
-	"github.com/syndtr/goleveldb/leveldb/memdb"
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 // conditionType is the type for condition consts.
@@ -37,7 +33,7 @@ const (
 
 var (
 	p = pool.NewCache("memdb pool", 100, func() interface{} {
-		return memdb.New(comparer.DefaultComparer, 1*1024*1024)
+		return NewMemDbBuffer()
 	})
 )
 
@@ -49,22 +45,31 @@ type conditionValue struct {
 
 // IsErrNotFound checks if err is a kind of NotFound error.
 func IsErrNotFound(err error) bool {
-	if errors2.ErrorEqual(err, leveldb.ErrNotFound) || errors2.ErrorEqual(err, ErrNotExist) {
+	if errors2.ErrorEqual(err, ErrNotExist) {
 		return true
 	}
 
 	return false
 }
 
+// MemBuffer is the interface for transaction buffer of update in a transaction
+type MemBuffer interface {
+	// shares the same interface as the read-only snapshot
+	// and it implies that MemBuffer's iterator should iterate its kv pairs in the same order as snapshot
+	Snapshot
+	// Set associates key with value
+	Set([]byte, []byte) error
+}
+
 // UnionStore is an implement of Store which contains a buffer for update.
 type UnionStore struct {
-	Dirty    *memdb.DB // updates are buffered in memory
+	Dirty    MemBuffer // updates are buffered in memory
 	Snapshot Snapshot  // for read
 }
 
 // NewUnionStore builds a new UnionStore.
 func NewUnionStore(snapshot Snapshot) (UnionStore, error) {
-	dirty := p.Get().(*memdb.DB)
+	dirty := p.Get().(MemBuffer)
 	return UnionStore{
 		Dirty:    dirty,
 		Snapshot: snapshot,
@@ -92,13 +97,13 @@ func (us *UnionStore) Get(key []byte) (value []byte, err error) {
 
 // Set implements the Store Set interface.
 func (us *UnionStore) Set(key []byte, value []byte) error {
-	return us.Dirty.Put(key, value)
+	return us.Dirty.Set(key, value)
 }
 
 // Seek implements the Snapshot Seek interface.
 func (us *UnionStore) Seek(key []byte, txn Transaction) (Iterator, error) {
 	snapshotIt := us.Snapshot.NewIterator(key)
-	dirtyIt := us.Dirty.NewIterator(&util.Range{Start: key})
+	dirtyIt := us.Dirty.NewIterator(key)
 	it := newUnionIter(dirtyIt, snapshotIt)
 	return it, nil
 }
@@ -125,13 +130,13 @@ func (us *UnionStore) Delete(k []byte) error {
 		return errors.Trace(ErrNotExist)
 	}
 
-	return us.Dirty.Put(k, nil)
+	return us.Dirty.Set(k, nil)
 }
 
 // Close implements the Store Close interface.
 func (us *UnionStore) Close() error {
 	us.Snapshot.Release()
-	us.Dirty.Reset()
+	us.Dirty.Release()
 	p.Put(us.Dirty)
 	return nil
 }


### PR DESCRIPTION
This PR is to resolve #400
Add interface `MemBuffer` to decouple UnionStore with specific in-memory buffer. Any implementation of this interface should be able to work with UnionStore.

Currently there are two `MemBuffer` implementations:
* `memDbBuffer` using `memdb` from `goleveldb`
* `btreeBuffer` using `btree` from `memkv` 

Add some micro-benchmark comparing performance of the two implementations:
```
BenchmarkBTreeBufferSequential-8	       1	1353185830 ns/op	225864832 B/op	13500988 allocs/op
BenchmarkBTreeBufferRandom-8    	       1	1705782034 ns/op	219036992 B/op	13011734 allocs/op
BenchmarkMemDbBufferSequential-8	      10	 148360815 ns/op	13759944 B/op	       5 allocs/op
BenchmarkMemDbBufferRandom-8    	       5	 237867121 ns/op	15811740 B/op	       9 allocs/op
BenchmarkBTreeIter-8            	     100	  16262683 ns/op	 1600144 B/op	  100002 allocs/op
BenchmarkMemDbIter-8            	     100	  13160985 ns/op	     245 B/op	       3 allocs/op
BenchmarkBTreeCreation-8        	20000000	       100 ns/op	      72 B/op	       2 allocs/op
BenchmarkMemDbCreation-8        	   10000	    249574 ns/op	 1059780 B/op	       8 allocs/op
```
MemDbBuffer is faster and an educated guess is because it pre-allocates a big chunk of memory.

There is another try with a modified version of memdb(removing all locking instructions, it's not being used in multi-thread environment) but the performance improvement is trivial, therefore it's not included in this PR.

Right now UnionStore is still using memdb as the storage engine.