### PR TITLE
*: Support character string literal

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1892,7 +1892,7 @@ Literal:
 		co, err := charset.GetDefaultCollation(tp.Charset)
 		if err != nil {
 			l := yylex.(*lexer)
-			l.err(fmt.Sprintf("Get collation error for charset: %s", tp.Charset))
+			l.errf("Get collation error for charset: %s", tp.Charset)
 			return 1
 		}
 		tp.Collate = co

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -747,6 +747,7 @@ Assignment:
 		x, err := expression.NewAssignment($1.(string), $3.(expression.Expression))
 		if err != nil {
 			yylex.(*lexer).errf("Parse Assignment error: %s", $1.(string))
+			return 1
 		}
 		$$ = x
 	}
@@ -1067,6 +1068,7 @@ CreateDatabaseStmt:
 		ok := charset.ValidCharsetAndCollation(cs, co)
 		if !ok {
 			yylex.(*lexer).errf("Unknown character set %s or collate %s ", cs, co)
+			return 1
 		}
 		dbopt := &coldef.CharsetOpt{Chs: cs, Col: co}
 
@@ -1891,6 +1893,7 @@ Literal:
 		if err != nil {
 			l := yylex.(*lexer)
 			l.err(fmt.Sprintf("Get collation error for charset: %s", tp.Charset))
+			return 1
 		}
 		tp.Collate = co
 		$$ = &types.DataItem{
@@ -1931,6 +1934,7 @@ Operand:
 		l := yylex.(*lexer)
 		if !l.prepare {
 			l.err("Can not accept placeholder when not parsing prepare sql")
+			return 1
 		}
 		pm := &expression.ParamMarker{}
 		l.ParamList = append(l.ParamList, pm)
@@ -3912,6 +3916,7 @@ NumericType:
 			x.Flen = 1
 		} else if x.Flen > 64 {
 			yylex.(*lexer).errf("invalid field length %d for bit type, must in [1, 64]", x.Flen)
+			return 1
 		}
 		$$ = x
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -321,6 +321,7 @@ func (s *testParserSuite) TestExpression(c *C) {
 		{`select '\'a\'';`, true},
 		{`select "\"a\"";`, true},
 		{`select """a""";`, true},
+		{`select _utf8"string";`, true},
 		// For comparison
 		{"select 1 <=> 0, 1 <=> null, 1 = null", true},
 	}

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -27,6 +27,7 @@ import (
 	
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/util/stringutil"
+	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/mysql"
 )
 
@@ -1016,7 +1017,7 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 			return integerType
 
 {ident}			lval.item = string(l.val)
-			return identifier
+			return l.handleIdent(lval)
 
 .			return c0
 
@@ -1106,4 +1107,20 @@ func (l *lexer) bit(lval *yySymType) int {
 	}
 	lval.item = b
 	return bitLit
+}
+
+func (l *lexer) handleIdent(lval *yySymType) int {
+	s := lval.item.(string)
+	// A character string literal may have an optional character set introducer and COLLATE clause:
+	// [_charset_name]'string' [COLLATE collation_name]
+	// See: https://dev.mysql.com/doc/refman/5.7/en/charset-literal.html
+	if !strings.HasPrefix(s, "_") {
+		return identifier	
+	}
+	cs, _, err := charset.GetCharsetInfo(s[1:])
+	if err != nil {
+		return identifier	
+	}
+	lval.item = cs
+	return underscoreCS
 }

--- a/stmt/stmts/select_test.go
+++ b/stmt/stmts/select_test.go
@@ -37,12 +37,7 @@ func (s *testStmtSuite) TestSelectWithoutFrom(c *C) {
 	tx = mustBegin(c, s.testDB)
 	rows, err = tx.Query(`select _utf8"string";`)
 	c.Assert(err, IsNil)
-
-	for rows.Next() {
-		var str string
-		rows.Scan(&str)
-		c.Assert(str, Equals, "string")
-	}
+	matchRows(c, rows, [][]interface{}{{"string"}})
 	rows.Close()
 	mustCommit(c, tx)
 }

--- a/stmt/stmts/select_test.go
+++ b/stmt/stmts/select_test.go
@@ -33,6 +33,18 @@ func (s *testStmtSuite) TestSelectWithoutFrom(c *C) {
 
 	rows.Close()
 	mustCommit(c, tx)
+
+	tx = mustBegin(c, s.testDB)
+	rows, err = tx.Query(`select _utf8"string";`)
+	c.Assert(err, IsNil)
+
+	for rows.Next() {
+		var str string
+		rows.Scan(&str)
+		c.Assert(str, Equals, "string")
+	}
+	rows.Close()
+	mustCommit(c, tx)
 }
 
 func (s *testStmtSuite) TestSelectExplain(c *C) {

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -14,7 +14,9 @@
 package charset
 
 import (
-	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
 )
 
 // Charset is a charset.
@@ -118,9 +120,18 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 func GetDefaultCollation(charset string) (string, error) {
 	c, ok := charsets[charset]
 	if !ok {
-		return "", fmt.Errorf("Unkown charset %s", charset)
+		return "", errors.Errorf("Unkown charset %s", charset)
 	}
 	return c.DefaultCollation.Name, nil
+}
+
+// GetCharsetInfo return charset and collation for cs as name.
+func GetCharsetInfo(cs string) (string, string, error) {
+	c, ok := charsets[strings.ToLower(cs)]
+	if !ok {
+		return "", "", errors.Errorf("Unknown charset %s", cs)
+	}
+	return c.Name, c.DefaultCollation.Name, nil
 }
 
 // GetCollations returns a list for all collations.

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -125,7 +125,7 @@ func GetDefaultCollation(charset string) (string, error) {
 	return c.DefaultCollation.Name, nil
 }
 
-// GetCharsetInfo return charset and collation for cs as name.
+// GetCharsetInfo returns charset and collation for cs as name.
 func GetCharsetInfo(cs string) (string, string, error) {
 	c, ok := charsets[strings.ToLower(cs)]
 	if !ok {


### PR DESCRIPTION
See: https://dev.mysql.com/doc/refman/5.7/en/charset-literal.html
Done: SELECT _latin1'string';
TODO:   SELECT _latin1'string' COLLATE latin1_danish_ci;