### PR TITLE
terror: create a new error type that has class and code for comparison.

### DIFF
--- a/terror/terror.go
+++ b/terror/terror.go
@@ -1,0 +1,111 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terror
+
+import (
+	"fmt"
+	"github.com/juju/errors"
+	"strconv"
+)
+
+// ErrClass represents a class of errors.
+type ErrClass int
+
+// ErrCode represents a specific error type in a error class.
+// Same error code can be used in different error classes.
+type ErrCode int
+
+// Error classes
+const (
+	Parser ErrClass = iota
+	Optimizer
+	KV
+	Server
+	// Add more as needed.
+)
+
+// String implements Stringer interface.
+func (ec ErrClass) String() string {
+	switch ec {
+	case Parser:
+		return "parser"
+	case Optimizer:
+		return "optimizer"
+	case KV:
+		return "kv"
+	case Server:
+		return "server"
+	}
+	return strconv.Itoa(int(ec))
+}
+
+// EqualCode returns true if err is *Error with the same clase and code.
+func (ec ErrClass) EqualCode(err error, code ErrCode) bool {
+	e := errors.Cause(err)
+	if e == nil {
+		return false
+	}
+	if te, ok := e.(*Error); ok {
+		return te.Class == ec && te.Code == code
+	}
+	return false
+}
+
+// NotEqualCode returns true if err is not *Error with the same class
+// and the same code.
+func (ec ErrClass) NotEqualCode(err error, code ErrCode) bool {
+	return !ec.EqualCode(err, code)
+}
+
+// EqualClass return true if err is *Error with the same class.
+func (ec ErrClass) EqualClass(err error) bool {
+	e := errors.Cause(err)
+	if e == nil {
+		return false
+	}
+	if te, ok := e.(*Error); ok {
+		return te.Class == ec
+	}
+	return false
+}
+
+// NotEqualClass return true if err is not *Error with the same class.
+func (ec ErrClass) NotEqualClass(err error) bool {
+	return !ec.EqualClass(err)
+}
+
+// New creates an *Error with an error code, message format and arguments.
+func (ec ErrClass) New(code ErrCode, message string, args ...interface{}) *Error {
+	if len(args) != 0 {
+		message = fmt.Sprintf(message, args...)
+	}
+	return &Error{
+		Class:   ec,
+		Code:    code,
+		Message: message,
+	}
+}
+
+// Error implements error interface and adds integer Class and Code, so
+// errors with different message can be compared.
+type Error struct {
+	Class   ErrClass
+	Code    ErrCode
+	Message string
+}
+
+// Error implements error interface.
+func (te *Error) Error() string {
+	return fmt.Sprintf("[%s:%d]%s", te.Class, te.Code, te.Message)
+}

--- a/terror/terror.go
+++ b/terror/terror.go
@@ -28,7 +28,7 @@ type ErrCode int
 
 // Error classes
 const (
-	Parser ErrClass = iota
+	Parser ErrClass = iota + 1
 	Optimizer
 	KV
 	Server

--- a/terror/terror.go
+++ b/terror/terror.go
@@ -35,7 +35,7 @@ const (
 	// Add more as needed.
 )
 
-// String implements Stringer interface.
+// String implements fmt.Stringer interface.
 func (ec ErrClass) String() string {
 	switch ec {
 	case Parser:
@@ -50,8 +50,8 @@ func (ec ErrClass) String() string {
 	return strconv.Itoa(int(ec))
 }
 
-// EqualCode returns true if err is *Error with the same clase and code.
-func (ec ErrClass) EqualCode(err error, code ErrCode) bool {
+// Equal returns true if err is *Error with the same clase and code.
+func (ec ErrClass) Equal(err error, code ErrCode) bool {
 	e := errors.Cause(err)
 	if e == nil {
 		return false
@@ -62,13 +62,13 @@ func (ec ErrClass) EqualCode(err error, code ErrCode) bool {
 	return false
 }
 
-// NotEqualCode returns true if err is not *Error with the same class
+// NotEqual returns true if err is not *Error with the same class
 // and the same code.
-func (ec ErrClass) NotEqualCode(err error, code ErrCode) bool {
-	return !ec.EqualCode(err, code)
+func (ec ErrClass) NotEqual(err error, code ErrCode) bool {
+	return !ec.Equal(err, code)
 }
 
-// EqualClass return true if err is *Error with the same class.
+// EqualClass returns true if err is *Error with the same class.
 func (ec ErrClass) EqualClass(err error) bool {
 	e := errors.Cause(err)
 	if e == nil {
@@ -80,7 +80,7 @@ func (ec ErrClass) EqualClass(err error) bool {
 	return false
 }
 
-// NotEqualClass return true if err is not *Error with the same class.
+// NotEqualClass returns true if err is not *Error with the same class.
 func (ec ErrClass) NotEqualClass(err error) bool {
 	return !ec.EqualClass(err)
 }

--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terror
+
+import (
+	"testing"
+
+	"github.com/juju/errors"
+	. "github.com/pingcap/check"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testTErrorSuite{})
+
+type testTErrorSuite struct {
+}
+
+func (s *testTErrorSuite) TestTError(c *C) {
+	c.Assert(Parser.String(), Not(Equals), "")
+	c.Assert(Optimizer.String(), Not(Equals), "")
+	c.Assert(KV.String(), Not(Equals), "")
+	c.Assert(Server.String(), Not(Equals), "")
+
+	parserErr := Parser.New(ErrCode(1), "error 1")
+	c.Assert(parserErr.Error(), Not(Equals), "")
+	c.Assert(Parser.EqualClass(parserErr), IsTrue)
+	c.Assert(Parser.NotEqualClass(parserErr), IsFalse)
+
+	c.Assert(Parser.EqualCode(parserErr, ErrCode(1)), IsTrue)
+	c.Assert(Parser.NotEqualCode(parserErr, ErrCode(1)), IsFalse)
+
+	c.Assert(Parser.EqualCode(parserErr, ErrCode(2)), IsFalse)
+	c.Assert(Optimizer.EqualClass(parserErr), IsFalse)
+
+	optimizerErr := Optimizer.New(ErrCode(2), "abc %s", "def")
+	c.Assert(Optimizer.EqualCode(optimizerErr, ErrCode(2)), IsTrue)
+
+	c.Assert(Optimizer.EqualCode(errors.New("abc"), ErrCode(3)), IsFalse)
+	c.Assert(Optimizer.EqualCode(nil, ErrCode(3)), IsFalse)
+	c.Assert(Optimizer.EqualClass(errors.New("abc")), IsFalse)
+	c.Assert(Optimizer.EqualClass(nil), IsFalse)
+}

--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -40,17 +40,17 @@ func (s *testTErrorSuite) TestTError(c *C) {
 	c.Assert(Parser.EqualClass(parserErr), IsTrue)
 	c.Assert(Parser.NotEqualClass(parserErr), IsFalse)
 
-	c.Assert(Parser.EqualCode(parserErr, ErrCode(1)), IsTrue)
-	c.Assert(Parser.NotEqualCode(parserErr, ErrCode(1)), IsFalse)
+	c.Assert(Parser.Equal(parserErr, ErrCode(1)), IsTrue)
+	c.Assert(Parser.NotEqual(parserErr, ErrCode(1)), IsFalse)
 
-	c.Assert(Parser.EqualCode(parserErr, ErrCode(2)), IsFalse)
+	c.Assert(Parser.Equal(parserErr, ErrCode(2)), IsFalse)
 	c.Assert(Optimizer.EqualClass(parserErr), IsFalse)
 
 	optimizerErr := Optimizer.New(ErrCode(2), "abc %s", "def")
-	c.Assert(Optimizer.EqualCode(optimizerErr, ErrCode(2)), IsTrue)
+	c.Assert(Optimizer.Equal(optimizerErr, ErrCode(2)), IsTrue)
 
-	c.Assert(Optimizer.EqualCode(errors.New("abc"), ErrCode(3)), IsFalse)
-	c.Assert(Optimizer.EqualCode(nil, ErrCode(3)), IsFalse)
+	c.Assert(Optimizer.Equal(errors.New("abc"), ErrCode(3)), IsFalse)
+	c.Assert(Optimizer.Equal(nil, ErrCode(3)), IsFalse)
 	c.Assert(Optimizer.EqualClass(errors.New("abc")), IsFalse)
 	c.Assert(Optimizer.EqualClass(nil), IsFalse)
 }


### PR DESCRIPTION
The current error check can only handle errors that has exactly the same message, when error message is not constant. For example parsing error has the message describe the context of the error, we will not be able to check it.. 

With this error type, we can includes context information in the message and still able to check the error type.