### PR TITLE
Dockerfile to build tidb, for #522, close #526

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang
+
+VOLUME /opt
+
+RUN apt-get update && apt-get install -y wget git make ; \
+        cd /opt ; \
+        export PATH=$GOROOT/bin:$GOPATH/bin:$PATH ; \
+        go get -v github.com/pingcap/tidb ; \
+        cd $GOPATH/src/github.com/pingcap/tidb ; \
+        make ; make server ; cp tidb-server/tidb-server /usr/bin/ 
+
+EXPOSE 4000
+
+CMD ["/usr/bin/tidb-server"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ VOLUME /opt
 RUN apt-get update && apt-get install -y wget git make ; \
         cd /opt ; \
         export PATH=$GOROOT/bin:$GOPATH/bin:$PATH ; \
-        go get -v github.com/pingcap/tidb ; \
+        go get -d github.com/pingcap/tidb ; \
         cd $GOPATH/src/github.com/pingcap/tidb ; \
         make ; make server ; cp tidb-server/tidb-server /usr/bin/ 
 


### PR DESCRIPTION
You must install docker first, then

docker build --rm -t tidb-server .

after build success, you may see images via

docker images

docker run -d --name tidb-server tidb-server

Signed-off-by: ZhiFeng Hu <hufeng1987@gmail.com>