### PR TITLE
ddl: fix column value exist backfill bug.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -329,6 +329,12 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) error {
 	}
 }
 
+// How to backfill column data in reorganization state?
+//  1, Generate a snapshot with special version.
+//  2, Traverse the snapshot, get every row in the table.
+//  3, For one row, if the row has been already deleted, skip to next row.
+//  4, If not deleted, check whether column data has existed, if existed, skip to next row.
+//  5, If column data doesn't exist, backfill the column with default value and then continue to handle next row.
 func (d *ddl) backfillColumn(t table.Table, columnInfo *model.ColumnInfo, version uint64, seekHandle int64) error {
 	for {
 		handles, err := d.getSnapshotRows(t, version, seekHandle)

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -366,9 +366,12 @@ func (d *ddl) backfillColumnData(t table.Table, columnInfo *model.ColumnInfo, ha
 			}
 
 			backfillKey := t.RecordKey(handle, &column.Col{ColumnInfo: *columnInfo})
-			_, err = txn.Get(backfillKey)
+			backfillValue, err := txn.Get(backfillKey)
 			if err != nil && !kv.IsErrNotFound(err) {
 				return errors.Trace(err)
+			}
+			if backfillValue != nil {
+				return nil
 			}
 
 			value, _, err := tables.GetColDefaultValue(nil, columnInfo)

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -305,11 +305,11 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) error {
 }
 
 // How to backfill column data in reorganization state?
-//  1, Generate a snapshot with special version.
-//  2, Traverse the snapshot, get every row in the table.
-//  3, For one row, if the row has been already deleted, skip to next row.
-//  4, If not deleted, check whether column data has existed, if existed, skip to next row.
-//  5, If column data doesn't exist, backfill the column with default value and then continue to handle next row.
+//  1. Generate a snapshot with special version.
+//  2. Traverse the snapshot, get every row in the table.
+//  3. For one row, if the row has been already deleted, skip to next row.
+//  4. If not deleted, check whether column data has existed, if existed, skip to next row.
+//  5. If column data doesn't exist, backfill the column with default value and then continue to handle next row.
 func (d *ddl) backfillColumn(t table.Table, columnInfo *model.ColumnInfo, reorgInfo *reorgInfo) error {
 	seekHandle := reorgInfo.Handle
 	version := reorgInfo.SnapshotVer

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -332,11 +332,11 @@ func fetchRowColVals(txn kv.Transaction, t table.Table, handle int64, indexInfo 
 const maxBatchSize = 1024
 
 // How to add index in reorganization state?
-//  1, Generate a snapshot with special version.
-//  2, Traverse the snapshot, get every row in the table.
-//  3, For one row, if the row has been already deleted, skip to next row.
-//  4, If not deleted, check whether index has existed, if existed, skip to next row.
-//  5, If index doesn't exist, create the index and then continue to handle next row.
+//  1. Generate a snapshot with special version.
+//  2. Traverse the snapshot, get every row in the table.
+//  3. For one row, if the row has been already deleted, skip to next row.
+//  4. If not deleted, check whether index has existed, if existed, skip to next row.
+//  5. If index doesn't exist, create the index and then continue to handle next row.
 func (d *ddl) addTableIndex(t table.Table, indexInfo *model.IndexInfo, reorgInfo *reorgInfo) error {
 	seekHandle := reorgInfo.Handle
 	version := reorgInfo.SnapshotVer


### PR DESCRIPTION
Consider scenario(t table(c1 int, c2 int), c2 is the new added column):
1 A is in public state, add a row(1,3);
2 B is in reorg state, check c2 value exists(here is 3), then it will do nothing.

Current implementation doesn't check new added column value exists, so it is a bug here.
Now it is not easy to build a test case to cover it, i will add it in integration testing later.
