### PR TITLE
stmt, kv: prefetch indices for select statement

### DIFF
--- a/kv/cache_snapshot.go
+++ b/kv/cache_snapshot.go
@@ -63,18 +63,19 @@ func (c *cacheSnapshot) BatchGet(keys []Key) (map[string][]byte, error) {
 		if len(v) > 0 {
 			m[string(k)] = v
 		}
+		// If len(v) == 0, it means that the key does not exist.
 	}
 
 	values, err := c.snapshot.BatchGet(missKeys)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	for k, v := range values {
-		c.cache.Set([]byte(k), v)
-		m[k] = v
-	}
 	for _, k := range missKeys {
-		if _, ok := values[string(k)]; !ok {
+		ks := string(k)
+		if v, ok := values[ks]; ok && len(v) > 0 {
+			c.cache.Set(k, v)
+			m[ks] = v
+		} else {
 			c.cache.Set(k, nil)
 		}
 	}

--- a/kv/cache_snapshot.go
+++ b/kv/cache_snapshot.go
@@ -60,7 +60,9 @@ func (c *cacheSnapshot) BatchGet(keys []Key) (map[string][]byte, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		m[string(k)] = v
+		if len(v) > 0 {
+			m[string(k)] = v
+		}
 	}
 
 	values, err := c.snapshot.BatchGet(missKeys)
@@ -70,6 +72,11 @@ func (c *cacheSnapshot) BatchGet(keys []Key) (map[string][]byte, error) {
 	for k, v := range values {
 		c.cache.Set([]byte(k), v)
 		m[k] = v
+	}
+	for _, k := range missKeys {
+		if _, ok := values[string(k)]; !ok {
+			c.cache.Set(k, nil)
+		}
 	}
 	return m, nil
 }

--- a/kv/cache_snapshot_test.go
+++ b/kv/cache_snapshot_test.go
@@ -69,6 +69,13 @@ func (s *testCacheSnapshotSuite) TestBatchGet(c *C) {
 	v, err := s.cache.Get([]byte("1"))
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("1"))
+
+	// nil result should also be saved in cache
+	s.store.Set([]byte("3"), []byte("3"))
+	m, err = s.cache.BatchGet([]Key{[]byte("3")})
+	c.Assert(err, IsNil)
+	_, exist = m["3"]
+	c.Assert(exist, IsFalse)
 }
 
 func (s *testCacheSnapshotSuite) TestRangeGet(c *C) {

--- a/kv/index_iter.go
+++ b/kv/index_iter.go
@@ -120,43 +120,40 @@ func NewKVIndex(indexPrefix, indexName string, unique bool) Index {
 	}
 }
 
-func (c *kvIndex) genIndexKey(indexedValues []interface{}, h int64) ([]byte, error) {
-	var (
-		encVal []byte
-		err    error
-	)
-	// only support single value index
-	if !c.unique {
-		encVal, err = EncodeValue(append(indexedValues, h)...)
-	} else {
+// GenIndexKey generates storage key for index values. Returned distinct indicates whether the
+// indexed values should be distinct in storage (i.e. whether handle is encoded in the key).
+func (c *kvIndex) GenIndexKey(indexedValues []interface{}, h int64) (key []byte, distinct bool, err error) {
+	if c.unique {
 		// See: https://dev.mysql.com/doc/refman/5.7/en/create-index.html
 		// A UNIQUE index creates a constraint such that all values in the index must be distinct.
 		// An error occurs if you try to add a new row with a key value that matches an existing row.
 		// For all engines, a UNIQUE index permits multiple NULL values for columns that can contain NULL.
-		containsNull := false
+		distinct = true
 		for _, cv := range indexedValues {
 			if cv == nil {
-				containsNull = true
+				distinct = false
+				break
 			}
 		}
-		if containsNull {
-			encVal, err = EncodeValue(append(indexedValues, h)...)
-		} else {
-			encVal, err = EncodeValue(indexedValues...)
-		}
+	}
+
+	var encVal []byte
+	if distinct {
+		encVal, err = EncodeValue(indexedValues...)
+	} else {
+		encVal, err = EncodeValue(append(indexedValues, h)...)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, false, errors.Trace(err)
 	}
-	buf := append([]byte(nil), []byte(c.prefix)...)
-	buf = append(buf, encVal...)
-	return buf, nil
+	key = append([]byte(c.prefix), encVal...)
+	return
 }
 
 // Create creates a new entry in the kvIndex data.
 // If the index is unique and there already exists an entry with the same key, Create will return ErrKeyExists
 func (c *kvIndex) Create(txn Transaction, indexedValues []interface{}, h int64) error {
-	key, err := c.genIndexKey(indexedValues, h)
+	key, _, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -177,7 +174,7 @@ func (c *kvIndex) Create(txn Transaction, indexedValues []interface{}, h int64) 
 
 // Delete removes the entry for handle h and indexdValues from KV index.
 func (c *kvIndex) Delete(txn Transaction, indexedValues []interface{}, h int64) error {
-	key, err := c.genIndexKey(indexedValues, h)
+	key, _, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -213,7 +210,7 @@ func (c *kvIndex) Drop(txn Transaction) error {
 
 // Seek searches KV index for the entry with indexedValues.
 func (c *kvIndex) Seek(txn Transaction, indexedValues []interface{}) (iter IndexIterator, hit bool, err error) {
-	key, err := c.genIndexKey(indexedValues, 0)
+	key, _, err := c.GenIndexKey(indexedValues, 0)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
@@ -240,7 +237,7 @@ func (c *kvIndex) SeekFirst(txn Transaction) (iter IndexIterator, err error) {
 }
 
 func (c *kvIndex) Exist(txn Transaction, indexedValues []interface{}, h int64) (bool, int64, error) {
-	key, err := c.genIndexKey(indexedValues, h)
+	key, _, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return false, 0, errors.Trace(err)
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -215,6 +215,7 @@ type Index interface {
 	Delete(txn Transaction, indexedValues []interface{}, h int64) error                          // supports delete from statement
 	Drop(txn Transaction) error                                                                  // supports drop table, drop index statements
 	Exist(txn Transaction, indexedValues []interface{}, h int64) (bool, int64, error)            // supports check index exist
+	GenIndexKey(indexedValues []interface{}, h int64) (key []byte, distinct bool, err error)     // supports index check
 	Seek(txn Transaction, indexedValues []interface{}) (iter IndexIterator, hit bool, err error) // supports where clause
 	SeekFirst(txn Transaction) (iter IndexIterator, err error)                                   // supports aggregate min / ascending order by
 }

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -112,10 +112,12 @@ func (s *dbSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 	m := make(map[string][]byte)
 	for _, k := range keys {
 		v, err := s.Get(k)
-		if err != nil {
+		if err != nil && !kv.IsErrNotFound(err) {
 			return nil, err
 		}
-		m[string(k)] = v
+		if len(v) > 0 {
+			m[string(k)] = v
+		}
 	}
 	return m, nil
 }
@@ -132,7 +134,7 @@ func (s *dbSnapshot) RangeGet(start, end kv.Key, limit int) (map[string][]byte, 
 		if it.Key() > endKey {
 			break
 		}
-		m[string(it.Key())] = it.Value()
+		m[it.Key()] = it.Value()
 		err := it.Next()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
1. Expose kvIndex.GenIndexKey().
2. Prefetch all unique index keys before adding records.