### PR TITLE
*: tiny refactor remove record.

### DIFF
--- a/stmt/stmts/delete.go
+++ b/stmt/stmts/delete.go
@@ -100,14 +100,11 @@ func (s *DeleteStmt) plan(ctx context.Context) (plan.Plan, error) {
 }
 
 func removeRow(ctx context.Context, t table.Table, h int64, data []interface{}) error {
-	// remove row's all indexies
-	if err := t.RemoveRowAllIndex(ctx, h, data); err != nil {
-		return err
+	err := t.RemoveRecord(ctx, h, data)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	// remove row
-	if err := t.RemoveRow(ctx, h); err != nil {
-		return err
-	}
+
 	variable.GetSessionVars(ctx).AddAffectedRows(1)
 	return nil
 }

--- a/table/table.go
+++ b/table/table.go
@@ -41,14 +41,8 @@ type Table interface {
 	// Row returns a row for all columns.
 	Row(ctx context.Context, h int64) ([]interface{}, error)
 
-	// RemoveRow removes the row of handle h.
-	RemoveRow(ctx context.Context, h int64) error
-
 	// RemoveRowIndex removes an index of a row.
 	RemoveRowIndex(ctx context.Context, h int64, vals []interface{}, idx *column.IndexedCol) error
-
-	// RemoveRowAllIndex removes all the indices of a row.
-	RemoveRowAllIndex(ctx context.Context, h int64, rec []interface{}) error
 
 	// BuildIndexForRow builds an index for a row.
 	BuildIndexForRow(ctx context.Context, h int64, vals []interface{}, idx *column.IndexedCol) error
@@ -88,6 +82,9 @@ type Table interface {
 
 	// UpdateRecord updates a row in the table.
 	UpdateRecord(ctx context.Context, h int64, currData []interface{}, newData []interface{}, touched []bool) error
+
+	// RemoveRecord removes a row in the table.
+	RemoveRecord(ctx context.Context, h int64, r []interface{}) error
 
 	// TableID returns the ID of the table.
 	TableID() int64

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -88,9 +88,8 @@ func (ts *testSuite) TestBasic(c *C) {
 		return true, nil
 	})
 
-	c.Assert(tb.RemoveRowAllIndex(ctx, rid, []interface{}{1, "cba"}), IsNil)
+	c.Assert(tb.RemoveRecord(ctx, rid, []interface{}{1, "cba"}), IsNil)
 
-	c.Assert(tb.RemoveRow(ctx, rid), IsNil)
 	// Make sure there is index data in the storage.
 	prefix := tb.IndexPrefix()
 	cnt, err := countEntriesWithPrefix(ctx, prefix)


### PR DESCRIPTION
1 Remove `RemoveRow` and `RemoveRowAllIndex` from table interface.
2 Add `RemoveRecord` to table interface which can remove row data and indices.