### PR TITLE
ddl: fix reorg state test bug.

### DIFF
--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -415,8 +415,6 @@ func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d
 	c.Assert(err, IsNil)
 	c.Assert(i, Equals, int64(1))
 
-	s.checkColumnKVExist(c, ctx, t, handle, col, columnValue, isDropped)
-
 	// Test add a new row.
 	_, err = ctx.GetTxn(true)
 	c.Assert(err, IsNil)
@@ -457,7 +455,6 @@ func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d
 	})
 	c.Assert(i, Equals, int64(1))
 
-	s.checkColumnKVExist(c, ctx, t, handle, col, columnValue, false)
 	s.testGetColumn(c, t, col.Name.L, false)
 }
 

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -384,13 +384,6 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	c.Assert(err, IsNil)
 	c.Assert(i, Equals, int64(1))
 
-	columnValues := make([]interface{}, len(indexCol.Columns))
-	for i, column := range indexCol.Columns {
-		columnValues[i] = row[column.Offset]
-	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, indexCol, columnValues, isDropped)
-
 	// Test add a new row.
 	_, err = ctx.GetTxn(true)
 	c.Assert(err, IsNil)
@@ -412,6 +405,7 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	})
 	c.Assert(i, Equals, int64(2))
 
+	columnValues := make([]interface{}, len(indexCol.Columns))
 	for i, column := range indexCol.Columns {
 		columnValues[i] = newRow[column.Offset]
 	}
@@ -452,7 +446,6 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	})
 	c.Assert(i, Equals, int64(1))
 
-	s.checkIndexKVExist(c, ctx, t, handle, indexCol, columnValues, false)
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 


### PR DESCRIPTION
If added column is in reorg state, we cannot make sure whether the column data has been backfilled.
So remove column value exist chek test.
Same with drop column, add/drop index.