### PR TITLE
update reorg snapshot version and then run it next time.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -153,8 +153,8 @@ func (d *ddl) onAddColumn(t *meta.Meta, job *model.Job) error {
 	case model.StateWriteReorganization:
 		// reorganization -> public
 		// get the current version for reorganization if we don't have
-		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
-		if err != nil || firstReorg {
+		reorgInfo, err := d.getReorgInfo(t, job)
+		if err != nil || reorgInfo.first {
 			// if we run reorg firstly, we should update the job snapshot version
 			// and then run the reorg next time.
 			return errors.Trace(err)
@@ -263,8 +263,8 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	case model.StateDeleteReorganization:
 		// reorganization -> absent
-		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
-		if err != nil || firstReorg {
+		reorgInfo, err := d.getReorgInfo(t, job)
+		if err != nil || reorgInfo.first {
 			// if we run reorg firstly, we should update the job snapshot version
 			// and then run the reorg next time.
 			return errors.Trace(err)

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -153,8 +153,10 @@ func (d *ddl) onAddColumn(t *meta.Meta, job *model.Job) error {
 	case model.StateWriteReorganization:
 		// reorganization -> public
 		// get the current version for reorganization if we don't have
-		reorgInfo, err := d.getReorgInfo(t, job)
-		if err != nil {
+		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
+		if err != nil || firstReorg {
+			// if we run reorg firstly, we should update the job snapshot version
+			// and then run the reorg next time.
 			return errors.Trace(err)
 		}
 
@@ -261,8 +263,10 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	case model.StateDeleteReorganization:
 		// reorganization -> absent
-		reorgInfo, err := d.getReorgInfo(t, job)
-		if err != nil {
+		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
+		if err != nil || firstReorg {
+			// if we run reorg firstly, we should update the job snapshot version
+			// and then run the reorg next time.
 			return errors.Trace(err)
 		}
 

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -163,8 +163,8 @@ func (d *ddl) onCreateIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	case model.StateWriteReorganization:
 		// reorganization -> public
-		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
-		if err != nil || firstReorg {
+		reorgInfo, err := d.getReorgInfo(t, job)
+		if err != nil || reorgInfo.first {
 			// if we run reorg firstly, we should update the job snapshot version
 			// and then run the reorg next time.
 			return errors.Trace(err)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -163,8 +163,10 @@ func (d *ddl) onCreateIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	case model.StateWriteReorganization:
 		// reorganization -> public
-		reorgInfo, err := d.getReorgInfo(t, job)
-		if err != nil {
+		reorgInfo, firstReorg, err := d.getReorgInfo(t, job)
+		if err != nil || firstReorg {
+			// if we run reorg firstly, we should update the job snapshot version
+			// and then run the reorg next time.
 			return errors.Trace(err)
 		}
 

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -90,7 +90,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		var err1 error
-		info, _, err1 = d.getReorgInfo(t, job)
+		info, err1 = d.getReorgInfo(t, job)
 		c.Assert(err1, IsNil)
 		err1 = info.UpdateHandle(txn, 1)
 		c.Assert(err1, IsNil)
@@ -102,7 +102,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		var err1 error
-		info, _, err1 = d.getReorgInfo(t, job)
+		info, err1 = d.getReorgInfo(t, job)
 		c.Assert(err1, IsNil)
 		c.Assert(info.Handle, Greater, int64(0))
 		return nil

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -90,7 +90,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		var err1 error
-		info, err1 = d.getReorgInfo(t, job)
+		info, _, err1 = d.getReorgInfo(t, job)
 		c.Assert(err1, IsNil)
 		err1 = info.UpdateHandle(txn, 1)
 		c.Assert(err1, IsNil)
@@ -102,7 +102,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		var err1 error
-		info, err1 = d.getReorgInfo(t, job)
+		info, _, err1 = d.getReorgInfo(t, job)
 		c.Assert(err1, IsNil)
 		c.Assert(info.Handle, Greater, int64(0))
 		return nil

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/types"
 )
 
 // Table implements table.Table interface.
@@ -440,6 +441,10 @@ func (t *Table) AddRecord(ctx context.Context, r []interface{}) (recordID int64,
 		if col.State == model.StateWriteOnly || col.State == model.StateWriteReorganization {
 			// if col is in write only or write reorganization state, we must add it with its default value.
 			value, _, err = GetColDefaultValue(ctx, &col.ColumnInfo)
+			if err != nil {
+				return 0, errors.Trace(err)
+			}
+			value, err = types.Convert(value, &col.FieldType)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}


### PR DESCRIPTION
If we run reorganization immediately, the snapshot version is not
updated in meta, so if at this time, server crashes, the snapshot
version is lost but we may have backfilled some wrong data.
So we must update the snapshot version firstly, and then run
reorganization work.

@ngaut  @qiuyesuifeng 