### PR TITLE
tidb: set session variable when load from global variable.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,30 @@
+package tidb
+
+import (
+	"testing"
+
+	"github.com/ngaut/log"
+)
+
+func BenchmarkBasic(b *testing.B) {
+	store, err := NewStore("memory://bench")
+	if err != nil {
+		b.Fatal(err)
+	}
+	log.SetLevel(log.LOG_LEVEL_ERROR)
+	se, err := CreateSession(store)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < b.N; i++ {
+		rs, err := se.Execute("select 1")
+		if err != nil {
+			b.Fatal(err)
+		}
+		row, err := rs[0].Next()
+		if err != nil || row == nil {
+			b.Fatal(err)
+		}
+		rs[0].Close()
+	}
+}

--- a/session.go
+++ b/session.go
@@ -355,6 +355,7 @@ func (s *session) isAutocommit(ctx context.Context) bool {
 			log.Errorf("Get global sys var error: %v", err)
 			return false
 		}
+		variable.GetSessionVars(ctx).Systems["autocommit"] = autocommit
 		ok = true
 	}
 	if ok && (autocommit == "ON" || autocommit == "on" || autocommit == "1") {


### PR DESCRIPTION
When autocommit is not set by session, we use global variable.
Currently it is loaded in every statement, which means we execute a select statement for every statements.
The behaviour not only hurts performance, but also is wrong.
In MySQL, autocommit is determined when session is created, and it will not be affected when global variable updates.

Also added a basic benchmark method to test basic performace test.

The benchmark result has improved from 560us to 40us after this change.