### PR TITLE
terror: add helper checker to simplify error check in test.

### DIFF
--- a/terror/checker.go
+++ b/terror/checker.go
@@ -1,0 +1,63 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package terror
+
+import (
+	"github.com/pingcap/check"
+)
+
+type isError struct{}
+
+func (e *isError) Check(params []interface{}, names []string) (bool, string) {
+	if len(params) != 2 {
+		return false, "IsError takes 2 error arguments"
+	}
+
+	// both nil returns true.
+	if params[0] == nil && params[1] == nil {
+		return true, ""
+	}
+
+	b1, ok1 := params[0].(error)
+	b2, ok2 := params[1].(error)
+
+	if !(ok1 && ok2) {
+		return false, "Arguments to IsError must both be errors"
+	}
+
+	return ErrorEqual(b1, b2), ""
+}
+
+func (e *isError) Info() *check.CheckerInfo {
+	return &check.CheckerInfo{
+		Name:   "IsError",
+		Params: []string{"error_one", "error_two"},
+	}
+}
+
+// IsError checker checks whether err1 is the same as err2 in test using gocheck.
+//
+// For example:
+//
+//     c.Assert(err1, terror.IsError, err2)
+//
+var IsError = &isError{}
+
+// IsNotError checker checks whether err1 is not the same as err2 in test using gocheck.
+//
+// For example:
+//
+//     c.Assert(err1, terror.IsNotError, err2)
+//
+var IsNotError = check.Not(IsError)

--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -14,11 +14,11 @@
 package terror
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
-	"strings"
 )
 
 func TestT(t *testing.T) {
@@ -109,4 +109,8 @@ func (s *testTErrorSuite) TestErrorEqual(c *C) {
 	c.Assert(ErrorEqual(te1, te2), IsTrue)
 	c.Assert(ErrorEqual(te1, te3), IsFalse)
 	c.Assert(ErrorEqual(te3, te4), IsFalse)
+
+	c.Assert(nil, IsError, nil)
+	c.Assert(te1, IsError, te2)
+	c.Assert(te1, IsNotError, te3)
 }


### PR DESCRIPTION
Now the only way to check error equals may be `c.Assert(ErrorEqual(te1, te2), IsTrue)`, if failed, the gochecker doesn't show the detailed error information.

@qiuyesuifeng  @coocood 