### PR TITLE
tidb_server: some tests should use 0 for fast DDL.

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	flag.Parse()
 
-	if *lease <= 0 {
+	if *lease < 0 {
 		log.Fatalf("invalid lease seconds %d", *lease)
 	}
 


### PR DESCRIPTION
@disksing 