### PR TITLE
kv: refactor UnionStore

### DIFF
--- a/kv/iter.go
+++ b/kv/iter.go
@@ -34,6 +34,10 @@ var (
 	// ErrRetryable is used when KV store occurs RPC error or some other
 	// errors which SQL layer can safely retry.
 	ErrRetryable = errors.New("Error: KV error safe to retry")
+	// ErrCannotSetNilValue is the error when sets an empty value.
+	ErrCannotSetNilValue = errors.New("can not set nil value")
+	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.
+	ErrInvalidTxn = errors.New("invalid transaction")
 )
 
 var (

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -119,26 +119,51 @@ const (
 	PresumeKeyNotExists
 )
 
-// Transaction defines the interface for operations inside a Transaction.
-// This is not thread safe.
-type Transaction interface {
-	// Get gets the value for key k from KV store.
+// MemStore is an abstract KV storage.
+type MemStore interface {
+	// Get gets the value for key k from KV storage.
 	Get(k Key) ([]byte, error)
+	// Set sets the value for key k as v into KV storage.
+	Set(k Key, v []byte) error
+	// Inc increases the value for key k in KV storage by step.
+	Inc(k Key, step int64) (int64, error)
+	// GetInt64 get int64 which created by Inc method.
+	GetInt64(k Key) (int64, error)
+	// Seek searches for the entry with key k in KV storage.
+	Seek(k Key) (Iterator, error)
+	// Delete removes the entry for key k from KV storage.
+	Delete(k Key) error
+}
+
+// UnionStore is an in-memory Store which contains a buffer for write and a
+// snapshot for read.
+type UnionStore interface {
+	MemStore
+	// CheckLazyConditionPairs loads all lazy values from store then checks if all values are matched.
+	// Lazy condition pairs should be checked before transaction commit.
+	CheckLazyConditionPairs() error
+	// WalkWriteBuffer iterates all buffered write kv pairs.
+	WalkWriteBuffer(f func(Iterator) error) error
 	// BatchPrefetch fetches values from KV storage to cache for later use.
 	BatchPrefetch(keys []Key) error
 	// RangePrefetch fetches values in the range [start, end] from KV storage
 	// to cache for later use. Maximum number of values is up to limit.
 	RangePrefetch(start, end Key, limit int) error
-	// Set sets the value for key k as v into KV store.
-	Set(k Key, v []byte) error
-	// Seek searches for the entry with key k in KV store.
-	Seek(k Key) (Iterator, error)
-	// Inc increases the value for key k in KV store by step.
-	Inc(k Key, step int64) (int64, error)
-	// GetInt64 get int64 which created by Inc method.
-	GetInt64(k Key) (int64, error)
-	// Delete removes the entry for key k from KV store.
-	Delete(k Key) error
+	// SetOption sets an option with a value, when val is nil, uses the default
+	// value of this option.
+	SetOption(opt Option, val interface{})
+	// DelOption deletes an option.
+	DelOption(opt Option)
+	// ReleaseSnapshot releases underlying snapshot.
+	ReleaseSnapshot()
+	// Close releases all resources.
+	Close()
+}
+
+// Transaction defines the interface for operations inside a Transaction.
+// This is not thread safe.
+type Transaction interface {
+	UnionStore
 	// Commit commits the transaction operations to KV store.
 	Commit() error
 	// CommittedVersion returns the version of this committed transaction. If this
@@ -150,11 +175,6 @@ type Transaction interface {
 	String() string
 	// LockKeys tries to lock the entries with the keys in KV store.
 	LockKeys(keys ...Key) error
-	// SetOption sets an option with a value, when val is nil, uses the default
-	// value of this option.
-	SetOption(opt Option, val interface{})
-	// DelOption deletes an option.
-	DelOption(opt Option)
 }
 
 // MvccSnapshot is used to get/seek a specific version in a snapshot.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -119,26 +119,36 @@ const (
 	PresumeKeyNotExists
 )
 
-// MemStore is an abstract KV storage.
-type MemStore interface {
+// Retriever is the interface wraps the basic Get and Seek methods.
+type Retriever interface {
 	// Get gets the value for key k from KV storage.
 	Get(k Key) ([]byte, error)
-	// Set sets the value for key k as v into KV storage.
-	Set(k Key, v []byte) error
-	// Inc increases the value for key k in KV storage by step.
-	Inc(k Key, step int64) (int64, error)
-	// GetInt64 get int64 which created by Inc method.
-	GetInt64(k Key) (int64, error)
 	// Seek searches for the entry with key k in KV storage.
 	Seek(k Key) (Iterator, error)
+}
+
+// Updater is the interface wraps the basic Set and Delete methods.
+type Updater interface {
+	// Set sets the value for key k as v into KV storage.
+	Set(k Key, v []byte) error
 	// Delete removes the entry for key k from KV storage.
 	Delete(k Key) error
+}
+
+// RetrieverUpdater is the interface that groups Retriever and Updater interface.
+type RetrieverUpdater interface {
+	Retriever
+	Updater
 }
 
 // UnionStore is an in-memory Store which contains a buffer for write and a
 // snapshot for read.
 type UnionStore interface {
-	MemStore
+	RetrieverUpdater
+	// Inc increases the value for key k in KV storage by step.
+	Inc(k Key, step int64) (int64, error)
+	// GetInt64 get int64 which created by Inc method.
+	GetInt64(k Key) (int64, error)
 	// CheckLazyConditionPairs loads all lazy values from store then checks if all values are matched.
 	// Lazy condition pairs should be checked before transaction commit.
 	CheckLazyConditionPairs() error

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -127,24 +127,24 @@ type Retriever interface {
 	Seek(k Key) (Iterator, error)
 }
 
-// Updater is the interface wraps the basic Set and Delete methods.
-type Updater interface {
+// Mutator is the interface wraps the basic Set and Delete methods.
+type Mutator interface {
 	// Set sets the value for key k as v into KV storage.
 	Set(k Key, v []byte) error
 	// Delete removes the entry for key k from KV storage.
 	Delete(k Key) error
 }
 
-// RetrieverUpdater is the interface that groups Retriever and Updater interface.
-type RetrieverUpdater interface {
+// RetrieverMutator is the interface that groups Retriever and Mutator interface.
+type RetrieverMutator interface {
 	Retriever
-	Updater
+	Mutator
 }
 
 // UnionStore is an in-memory Store which contains a buffer for write and a
 // snapshot for read.
 type UnionStore interface {
-	RetrieverUpdater
+	RetrieverMutator
 	// Inc increases the value for key k in KV storage by step.
 	Inc(k Key, step int64) (int64, error)
 	// GetInt64 get int64 which created by Inc method.

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -117,7 +117,7 @@ func (us *unionStore) Get(key Key) (value []byte, err error) {
 	return value, nil
 }
 
-// Set implements the Updater interface.
+// Set implements the Mutator interface.
 func (us *unionStore) Set(key Key, value []byte) error {
 	if len(value) == 0 {
 		return errors.Trace(ErrCannotSetNilValue)
@@ -172,7 +172,7 @@ func (us *unionStore) Seek(key Key) (Iterator, error) {
 	return newUnionIter(bufferIt, cacheIt), nil
 }
 
-// Delete implements the Updater interface.
+// Delete implements the Mutator interface.
 func (us *unionStore) Delete(k Key) error {
 	// Mark as deleted
 	val, err := us.wbuffer.Get(k)

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -15,7 +15,6 @@ package kv
 
 import (
 	"bytes"
-
 	"strconv"
 
 	"github.com/juju/errors"

--- a/kv/union_store_test.go
+++ b/kv/union_store_test.go
@@ -23,13 +23,11 @@ var _ = Suite(&testUnionStoreSuite{})
 type testUnionStoreSuite struct {
 	store MemBuffer
 	us    UnionStore
-	opts  map[Option]interface{}
 }
 
 func (s *testUnionStoreSuite) SetUpTest(c *C) {
 	s.store = NewMemDbBuffer()
-	s.opts = make(map[Option]interface{})
-	s.us = NewUnionStore(&mockSnapshot{s.store}, mockOptions(s.opts))
+	s.us = NewUnionStore(&mockSnapshot{s.store})
 }
 
 func (s *testUnionStoreSuite) TearDownTest(c *C) {
@@ -65,21 +63,21 @@ func (s *testUnionStoreSuite) TestSeek(c *C) {
 	s.store.Set([]byte("2"), []byte("2"))
 	s.store.Set([]byte("3"), []byte("3"))
 
-	iter, err := s.us.Seek(nil, nil)
+	iter, err := s.us.Seek(nil)
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("1"), []byte("2"), []byte("3")}, [][]byte{[]byte("1"), []byte("2"), []byte("3")})
 
-	iter, err = s.us.Seek([]byte("2"), nil)
+	iter, err = s.us.Seek([]byte("2"))
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("3")}, [][]byte{[]byte("2"), []byte("3")})
 
 	s.us.Set([]byte("4"), []byte("4"))
-	iter, err = s.us.Seek([]byte("2"), nil)
+	iter, err = s.us.Seek([]byte("2"))
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("3"), []byte("4")}, [][]byte{[]byte("2"), []byte("3"), []byte("4")})
 
 	s.us.Delete([]byte("3"))
-	iter, err = s.us.Seek([]byte("2"), nil)
+	iter, err = s.us.Seek([]byte("2"))
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("4")}, [][]byte{[]byte("2"), []byte("4")})
 }
@@ -92,7 +90,7 @@ func (s *testUnionStoreSuite) TestLazyConditionCheck(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("1"))
 
-	s.opts[PresumeKeyNotExists] = 1
+	s.us.SetOption(PresumeKeyNotExists, 1)
 	_, err = s.us.Get([]byte("2"))
 	c.Assert(terror.ErrorEqual(err, ErrNotExist), IsTrue)
 

--- a/store/hbase/txn.go
+++ b/store/hbase/txn.go
@@ -15,8 +15,6 @@ package hbasekv
 
 import (
 	"fmt"
-	"runtime/debug"
-	"strconv"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
@@ -27,10 +25,6 @@ import (
 
 var (
 	_ kv.Transaction = (*hbaseTxn)(nil)
-	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.
-	ErrInvalidTxn = errors.New("invalid transaction")
-	// ErrCannotSetNilValue is the error when sets an empty value
-	ErrCannotSetNilValue = errors.New("can not set nil value")
 )
 
 var (
@@ -56,108 +50,47 @@ type hbaseTxn struct {
 	tid       uint64
 	valid     bool
 	version   kv.Version // commit version
-	opts      map[kv.Option]interface{}
 }
 
 func newHbaseTxn(t themis.Txn, storeName string) *hbaseTxn {
-	opts := make(map[kv.Option]interface{})
-
 	return &hbaseTxn{
 		txn:        t,
 		valid:      true,
 		storeName:  storeName,
 		tid:        t.GetStartTS(),
-		UnionStore: kv.NewUnionStore(newHbaseSnapshot(t, storeName), options(opts)),
-		opts:       opts,
+		UnionStore: kv.NewUnionStore(newHbaseSnapshot(t, storeName)),
 	}
 }
 
 // Implement transaction interface
 
+func (txn *hbaseTxn) Get(k kv.Key) ([]byte, error) {
+	log.Debugf("get key:%q, txn:%d", k, txn.tid)
+	return txn.UnionStore.Get(k)
+}
+
+func (txn *hbaseTxn) Set(k kv.Key, v []byte) error {
+	log.Debugf("seek %q txn:%d", k, txn.tid)
+	return txn.UnionStore.Set(k, v)
+}
+
 func (txn *hbaseTxn) Inc(k kv.Key, step int64) (int64, error) {
 	log.Debugf("Inc %q, step %d txn:%d", k, step, txn.tid)
-	val, err := txn.UnionStore.Get(k)
-	if kv.IsErrNotFound(err) {
-		err = txn.UnionStore.Set(k, []byte(strconv.FormatInt(step, 10)))
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
+	return txn.UnionStore.Inc(k, step)
+}
 
-		return step, nil
-	}
-
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-
-	intVal, err := strconv.ParseInt(string(val), 10, 64)
-	if err != nil {
-		return intVal, errors.Trace(err)
-	}
-
-	intVal += step
-	err = txn.UnionStore.Set(k, []byte(strconv.FormatInt(intVal, 10)))
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	return intVal, nil
+func (txn *hbaseTxn) GetInt64(k kv.Key) (int64, error) {
+	log.Debugf("GetInt64 %q, txn:%d", k, txn.tid)
+	return txn.UnionStore.GetInt64(k)
 }
 
 func (txn *hbaseTxn) String() string {
 	return fmt.Sprintf("%d", txn.tid)
 }
 
-func (txn *hbaseTxn) Get(k kv.Key) ([]byte, error) {
-	log.Debugf("get key:%q, txn:%d", k, txn.tid)
-	val, err := txn.UnionStore.Get(k)
-	if kv.IsErrNotFound(err) || len(val) == 0 {
-		return nil, errors.Trace(kv.ErrNotExist)
-	}
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return val, nil
-}
-
-func (txn *hbaseTxn) BatchPrefetch(keys []kv.Key) error {
-	_, err := txn.UnionStore.Snapshot.BatchGet(keys)
-	return err
-}
-
-func (txn *hbaseTxn) RangePrefetch(start, end kv.Key, limit int) error {
-	_, err := txn.UnionStore.Snapshot.RangeGet(start, end, limit)
-	return err
-}
-
-// GetInt64 get int64 which created by Inc method.
-func (txn *hbaseTxn) GetInt64(k kv.Key) (int64, error) {
-	val, err := txn.UnionStore.Get(k)
-	if kv.IsErrNotFound(err) {
-		return 0, nil
-	}
-
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-
-	intVal, err := strconv.ParseInt(string(val), 10, 64)
-	return intVal, errors.Trace(err)
-}
-
-func (txn *hbaseTxn) Set(k kv.Key, data []byte) error {
-	if len(data) == 0 {
-		// Incase someone use it in the wrong way, we can figure it out immediately
-		debug.PrintStack()
-		return errors.Trace(ErrCannotSetNilValue)
-	}
-
-	log.Debugf("set key:%q, txn:%d", k, txn.tid)
-	return txn.UnionStore.Set(k, data)
-}
-
 func (txn *hbaseTxn) Seek(k kv.Key) (kv.Iterator, error) {
 	log.Debugf("seek %q txn:%d", k, txn.tid)
-	iter, err := txn.UnionStore.Seek(k, txn)
+	iter, err := txn.UnionStore.Seek(k)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -173,23 +106,12 @@ func (txn *hbaseTxn) Delete(k kv.Key) error {
 	return nil
 }
 
-func (txn *hbaseTxn) each(f func(kv.Iterator) error) error {
-	iter := txn.UnionStore.WBuffer.NewIterator(nil)
-	defer iter.Close()
-	for ; iter.Valid(); iter.Next() {
-		if err := f(iter); err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
 func (txn *hbaseTxn) doCommit() error {
 	if err := txn.UnionStore.CheckLazyConditionPairs(); err != nil {
 		return errors.Trace(err)
 	}
 
-	err := txn.each(func(iter kv.Iterator) error {
+	err := txn.WalkWriteBuffer(func(iter kv.Iterator) error {
 		var row, val []byte
 		row = make([]byte, len(iter.Key()))
 		if len(iter.Value()) == 0 { // Deleted marker
@@ -228,7 +150,7 @@ func (txn *hbaseTxn) doCommit() error {
 
 func (txn *hbaseTxn) Commit() error {
 	if !txn.valid {
-		return ErrInvalidTxn
+		return kv.ErrInvalidTxn
 	}
 	log.Debugf("start to commit txn %d", txn.tid)
 	defer func() {
@@ -254,7 +176,7 @@ func (txn *hbaseTxn) close() error {
 //if fail, themis auto rollback
 func (txn *hbaseTxn) Rollback() error {
 	if !txn.valid {
-		return ErrInvalidTxn
+		return kv.ErrInvalidTxn
 	}
 	log.Warnf("Rollback txn %d", txn.tid)
 	return txn.close()
@@ -267,23 +189,4 @@ func (txn *hbaseTxn) LockKeys(keys ...kv.Key) error {
 		}
 	}
 	return nil
-}
-
-func (txn *hbaseTxn) SetOption(opt kv.Option, val interface{}) {
-	if val == nil {
-		txn.opts[opt] = getOptionDefaultVal(opt)
-	} else {
-		txn.opts[opt] = val
-	}
-}
-
-func (txn *hbaseTxn) DelOption(opt kv.Option) {
-	delete(txn.opts, opt)
-}
-
-type options map[kv.Option]interface{}
-
-func (opts options) Get(opt kv.Option) (interface{}, bool) {
-	v, ok := opts[opt]
-	return v, ok
 }

--- a/store/localstore/kv.go
+++ b/store/localstore/kv.go
@@ -163,10 +163,9 @@ func (s *dbStore) Begin() (kv.Transaction, error) {
 		store:        s,
 		version:      kv.MinVersion,
 		snapshotVals: make(map[string]struct{}),
-		opts:         make(map[kv.Option]interface{}),
 	}
 	log.Debugf("Begin txn:%d", txn.tid)
-	txn.UnionStore = kv.NewUnionStore(newSnapshot(s, s.db, beginVer), options(txn.opts))
+	txn.UnionStore = kv.NewUnionStore(newSnapshot(s, s.db, beginVer))
 	return txn, nil
 }
 


### PR DESCRIPTION
1. Export kv.UnionStore as an interface.
2. Introduce `Retriever` and `Updater` interfaces.
3. Move common parts of localstore/txn and hbase/txn into kv.UnionStore.

@ngaut 