### PR TITLE
interpreter: add dbname param

### DIFF
--- a/interpreter/main.go
+++ b/interpreter/main.go
@@ -33,8 +33,9 @@ import (
 
 var (
 	logLevel = flag.String("L", "error", "log level")
-	store    = flag.String("store", "goleveldb", "the name for the registered storage, e.g. memory, goleveldb, boltdb")
-	dbPath   = flag.String("dbpath", "test/test", "db path")
+	store    = flag.String("store", "goleveldb", "the name for the registered storage, e.g. hbase, memory, goleveldb, boltdb")
+	dbPath   = flag.String("dbpath", "test", "db path")
+	dbName   = flag.String("dbname", "test", "default db name")
 	lease    = flag.Int("lease", 1, "schema lease seconds, very dangerous to change only if you know what you do")
 
 	line        *liner.State
@@ -177,7 +178,8 @@ func main() {
 
 	tidb.SetSchemaLease(time.Duration(*lease) * time.Second)
 
-	mdb, err := sql.Open(tidb.DriverName, *store+"://"+*dbPath)
+	// use test as default DB.
+	mdb, err := sql.Open(tidb.DriverName, *store+"://"+*dbPath+"/"+*dbName)
 	if err != nil {
 		log.Fatal(errors.ErrorStack(err))
 	}


### PR DESCRIPTION
avoid this:
./interpreter -store hbase -dbpath localhost/test/test

the command below is more clear:
./interpreter -store hbase -dbpath localhost/tidb -dbname test