### PR TITLE
evaluator: fix unary evaluation bug.

### DIFF
--- a/optimizer/evaluator/evaluator.go
+++ b/optimizer/evaluator/evaluator.go
@@ -350,6 +350,7 @@ func (e *Evaluator) unaryOperation(u *ast.UnaryOperationExpr) bool {
 	a := u.V.GetValue()
 	a = types.RawData(a)
 	if a == nil {
+		u.SetValue(nil)
 		return true
 	}
 	switch op := u.Op; op {
@@ -372,7 +373,6 @@ func (e *Evaluator) unaryOperation(u *ast.UnaryOperationExpr) bool {
 		u.SetValue(uint64(^n))
 	case opcode.Plus:
 		switch x := a.(type) {
-		case nil:
 		case bool:
 			u.SetValue(boolToInt64(x))
 		case float32:
@@ -423,7 +423,6 @@ func (e *Evaluator) unaryOperation(u *ast.UnaryOperationExpr) bool {
 		}
 	case opcode.Minus:
 		switch x := a.(type) {
-		case nil:
 		case bool:
 			if x {
 				u.SetValue(int64(-1))
@@ -595,6 +594,7 @@ func (e *Evaluator) funcConvert(f *ast.FuncConvertExpr) bool {
 
 	// Casting nil to any type returns nil
 	if value == nil {
+		f.SetValue(nil)
 		return true
 	}
 	str, ok := value.(string)

--- a/optimizer/evaluator/evaluator_test.go
+++ b/optimizer/evaluator/evaluator_test.go
@@ -969,8 +969,10 @@ func (s *testEvaluatorSuite) TestUnaryOp(c *C) {
 		{mysql.Set{Name: "a", Value: 1}, opcode.Minus, -1.0},
 	}
 	ctx := mock.NewContext()
+	expr := &ast.UnaryOperationExpr{}
 	for _, t := range tbl {
-		expr := &ast.UnaryOperationExpr{Op: t.op, V: ast.NewValueExpr(t.arg)}
+		expr.Op = t.op
+		expr.V = ast.NewValueExpr(t.arg)
 		result, err := Eval(ctx, expr)
 		c.Assert(err, IsNil)
 		c.Assert(result, DeepEquals, t.result)


### PR DESCRIPTION
When unary operation is evaluated more than once, the old not nil value is not set when new value is evaluated to nil.