### PR TITLE
ast, optimizer: add flag attribute to expression.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -40,6 +40,7 @@ type Node interface {
 
 // Flags indicates whether an expression contains certain types of expression.
 const (
+	FlagConstant       uint64 = 0
 	FlagHasParamMarker uint64 = 1 << iota
 	FlagHasFunc
 	FlagHasReference

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -47,6 +47,7 @@ const (
 	FlagHasAggregateFunc
 	FlagHasSubquery
 	FlagHasVariable
+	FlagHasDefault
 )
 
 // ExprNode is a node that can be evaluated.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -38,11 +38,14 @@ type Node interface {
 	SetText(text string)
 }
 
+// Flags indicates whether an expression contains certain types of expression.
 const (
-	FlagHasParamMarker uint64 = 1 < iota
-	FlagHasColumnName
+	FlagHasParamMarker uint64 = 1 << iota
+	FlagHasFunc
+	FlagHasReference
 	FlagHasAggregateFunc
 	FlagHasSubquery
+	FlagHasVariable
 )
 
 // ExprNode is a node that can be evaluated.
@@ -50,8 +53,6 @@ const (
 type ExprNode interface {
 	// Node is embeded in ExprNode.
 	Node
-	// IsStatic means it can be evaluated independently.
-	IsStatic() bool
 	// SetType sets evaluation type to the expression.
 	SetType(tp *types.FieldType)
 	// GetType gets the evaluation type of the expression.
@@ -62,7 +63,7 @@ type ExprNode interface {
 	GetValue() interface{}
 	// SetFlag sets flag to the expression.
 	// Flag indicates whether the expression contains
-	// parameter marker, column name, aggregate function...
+	// parameter marker, reference, aggregate function...
 	SetFlag(flag uint64)
 	// GetFlag returns the flag of the expression.
 	GetFlag() uint64

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -38,6 +38,13 @@ type Node interface {
 	SetText(text string)
 }
 
+const (
+	FlagHasParamMarker uint64 = 1 < iota
+	FlagHasColumnName
+	FlagHasAggregateFunc
+	FlagHasSubquery
+)
+
 // ExprNode is a node that can be evaluated.
 // Name of implementations should have 'Expr' suffix.
 type ExprNode interface {
@@ -53,6 +60,12 @@ type ExprNode interface {
 	SetValue(val interface{})
 	// GetValue gets value of the expression.
 	GetValue() interface{}
+	// SetFlag sets flag to the expression.
+	// Flag indicates whether the expression contains
+	// parameter marker, column name, aggregate function...
+	SetFlag(flag uint64)
+	// GetFlag returns the flag of the expression.
+	GetFlag() uint64
 }
 
 // FuncNode represents function call expression node.

--- a/ast/base.go
+++ b/ast/base.go
@@ -66,11 +66,6 @@ type exprNode struct {
 	flag uint64
 }
 
-// IsStatic implements Expression interface.
-func (en *exprNode) IsStatic() bool {
-	return false
-}
-
 // SetType implements Expression interface.
 func (en *exprNode) SetType(tp *types.FieldType) {
 	en.Type = tp

--- a/ast/base.go
+++ b/ast/base.go
@@ -63,6 +63,7 @@ func (dn *dmlNode) dmlStatement() {}
 type exprNode struct {
 	node
 	types.DataItem
+	flag uint64
 }
 
 // IsStatic implements Expression interface.
@@ -88,6 +89,16 @@ func (en *exprNode) SetValue(val interface{}) {
 // GetValue implements Expression interface.
 func (en *exprNode) GetValue() interface{} {
 	return en.Data
+}
+
+// SetFlag implements Expression interface.
+func (en *exprNode) SetFlag(flag uint64) {
+	en.flag = flag
+}
+
+// GetFlag implements Expression interface.
+func (en *exprNode) GetFlag() uint64 {
+	return en.flag
 }
 
 type funcNode struct {

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -102,11 +102,6 @@ func NewValueExpr(value interface{}) *ValueExpr {
 	return ve
 }
 
-// IsStatic implements ExprNode interface.
-func (n *ValueExpr) IsStatic() bool {
-	return true
-}
-
 // Accept implements Node interface.
 func (n *ValueExpr) Accept(v Visitor) (Node, bool) {
 	newNod, skipChildren := v.Enter(n)
@@ -159,11 +154,6 @@ func (n *BetweenExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *BetweenExpr) IsStatic() bool {
-	return n.Expr.IsStatic() && n.Left.IsStatic() && n.Right.IsStatic()
-}
-
 // BinaryOperationExpr is for binary operation like 1 + 1, 1 - 1, etc.
 type BinaryOperationExpr struct {
 	exprNode
@@ -196,11 +186,6 @@ func (n *BinaryOperationExpr) Accept(v Visitor) (Node, bool) {
 	n.R = node.(ExprNode)
 
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *BinaryOperationExpr) IsStatic() bool {
-	return n.L.IsStatic() && n.R.IsStatic()
 }
 
 // WhenClause is the when clause in Case expression for "when condition then result".
@@ -273,22 +258,6 @@ func (n *CaseExpr) Accept(v Visitor) (Node, bool) {
 		n.ElseClause = node.(ExprNode)
 	}
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *CaseExpr) IsStatic() bool {
-	if n.Value != nil && !n.Value.IsStatic() {
-		return false
-	}
-	for _, w := range n.WhenClauses {
-		if !w.Expr.IsStatic() || !w.Result.IsStatic() {
-			return false
-		}
-	}
-	if n.ElseClause != nil && !n.ElseClause.IsStatic() {
-		return false
-	}
-	return true
 }
 
 // SubqueryExpr represents a subquery.
@@ -517,11 +486,6 @@ func (n *IsNullExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *IsNullExpr) IsStatic() bool {
-	return n.Expr.IsStatic()
-}
-
 // IsTruthExpr is the expression for true/false check.
 type IsTruthExpr struct {
 	exprNode
@@ -546,11 +510,6 @@ func (n *IsTruthExpr) Accept(v Visitor) (Node, bool) {
 	}
 	n.Expr = node.(ExprNode)
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *IsTruthExpr) IsStatic() bool {
-	return n.Expr.IsStatic()
 }
 
 // PatternLikeExpr is the expression for like operator, e.g, expr like "%123%"
@@ -591,11 +550,6 @@ func (n *PatternLikeExpr) Accept(v Visitor) (Node, bool) {
 		n.Pattern = node.(ExprNode)
 	}
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *PatternLikeExpr) IsStatic() bool {
-	return n.Expr.IsStatic() && n.Pattern.IsStatic()
 }
 
 // ParamMarkerExpr expresion holds a place for another expression.
@@ -639,11 +593,6 @@ func (n *ParenthesesExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *ParenthesesExpr) IsStatic() bool {
-	return n.Expr.IsStatic()
-}
-
 // PositionExpr is the expression for order by and group by position.
 // MySQL use position expression started from 1, it looks a little confused inner.
 // maybe later we will use 0 at first.
@@ -653,11 +602,6 @@ type PositionExpr struct {
 	N int
 	// Refer is the result field the position refers to.
 	Refer *ResultField
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *PositionExpr) IsStatic() bool {
-	return false
 }
 
 // Accept implements Node Accept interface.
@@ -706,11 +650,6 @@ func (n *PatternRegexpExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *PatternRegexpExpr) IsStatic() bool {
-	return n.Expr.IsStatic() && n.Pattern.IsStatic()
-}
-
 // RowExpr is the expression for row constructor.
 // See https://dev.mysql.com/doc/refman/5.7/en/row-subqueries.html
 type RowExpr struct {
@@ -736,16 +675,6 @@ func (n *RowExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *RowExpr) IsStatic() bool {
-	for _, v := range n.Values {
-		if !v.IsStatic() {
-			return false
-		}
-	}
-	return true
-}
-
 // UnaryOperationExpr is the expression for unary operator.
 type UnaryOperationExpr struct {
 	exprNode
@@ -768,11 +697,6 @@ func (n *UnaryOperationExpr) Accept(v Visitor) (Node, bool) {
 	}
 	n.V = node.(ExprNode)
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *UnaryOperationExpr) IsStatic() bool {
-	return n.V.IsStatic()
 }
 
 // ValuesExpr is the expression used in INSERT VALUES

--- a/ast/flag.go
+++ b/ast/flag.go
@@ -13,7 +13,7 @@
 
 package ast
 
-const preEvaluable = FlagHasParamMarker | FlagHasFunc | FlagHasVariable
+const preEvaluable = FlagHasParamMarker | FlagHasFunc | FlagHasVariable | FlagHasDefault
 
 // IsPreEvaluable checks if the expression can be evaluated before execution.
 func IsPreEvaluable(expr ExprNode) bool {
@@ -55,6 +55,7 @@ func (f *flagSetter) Leave(in Node) (Node, bool) {
 	case *ColumnNameExpr:
 		x.SetFlag(FlagHasReference)
 	case *DefaultExpr:
+		x.SetFlag(FlagHasDefault)
 	case *ExistsSubqueryExpr:
 		x.SetFlag(x.Sel.GetFlag())
 	case *PatternInExpr:

--- a/ast/flag.go
+++ b/ast/flag.go
@@ -20,6 +20,12 @@ func IsPreEvaluable(expr ExprNode) bool {
 	return expr.GetFlag()|preEvaluable == preEvaluable
 }
 
+// IsConstant check if the expression is constant.
+// A constant expression is safe to be rewritten to value expression.
+func IsConstant(expr ExprNode) bool {
+	return expr.GetFlag() == FlagConstant
+}
+
 // SetFlag sets flag for expression.
 func SetFlag(n Node) {
 	var setter flagSetter

--- a/ast/flag.go
+++ b/ast/flag.go
@@ -15,6 +15,7 @@ package ast
 
 const preEvaluable = FlagHasParamMarker | FlagHasFunc | FlagHasVariable
 
+// IsPreEvaluable checks if the expression can be evaluated before execution.
 func IsPreEvaluable(expr ExprNode) bool {
 	return expr.GetFlag()|preEvaluable == preEvaluable
 }

--- a/ast/flag_test.go
+++ b/ast/flag_test.go
@@ -23,56 +23,60 @@ func (ts *testFlagSuite) TestFlag(c *C) {
 		flag uint64
 	}{
 		{
-			expr: "1 between 0 and 2",
-			flag: ast.FlagConstant,
+			"1 between 0 and 2",
+			ast.FlagConstant,
 		},
 		{
-			expr: "case 1 when 1 then 1 else 0 end",
-			flag: ast.FlagConstant,
+			"case 1 when 1 then 1 else 0 end",
+			ast.FlagConstant,
 		},
 		{
-			expr: "case 1 when 1 then 1 else 0 end",
-			flag: ast.FlagConstant,
+			"case 1 when 1 then 1 else 0 end",
+			ast.FlagConstant,
 		},
 		{
-			expr: "1 = ANY (select 1) OR exists (select 1)",
-			flag: ast.FlagHasSubquery,
+			"1 = ANY (select 1) OR exists (select 1)",
+			ast.FlagHasSubquery,
 		},
 		{
-			expr: "1 in (1) or 1 is true or null is null or 'abc' like 'abc' or 'abc' rlike 'abc'",
-			flag: ast.FlagConstant,
+			"1 in (1) or 1 is true or null is null or 'abc' like 'abc' or 'abc' rlike 'abc'",
+			ast.FlagConstant,
 		},
 		{
-			expr: "row (1, 1) = row (1, 1)",
-			flag: ast.FlagConstant,
+			"row (1, 1) = row (1, 1)",
+			ast.FlagConstant,
 		},
 		{
-			expr: "(1 + a) > ?",
-			flag: ast.FlagHasReference | ast.FlagHasParamMarker,
+			"(1 + a) > ?",
+			ast.FlagHasReference | ast.FlagHasParamMarker,
 		},
 		{
-			expr: "trim('abc ')",
-			flag: ast.FlagHasFunc,
+			"trim('abc ')",
+			ast.FlagHasFunc,
 		},
 		{
-			expr: "now() + EXTRACT(YEAR FROM '2009-07-02') + CAST(1 AS UNSIGNED)",
-			flag: ast.FlagHasFunc,
+			"now() + EXTRACT(YEAR FROM '2009-07-02') + CAST(1 AS UNSIGNED)",
+			ast.FlagHasFunc,
 		},
 		{
-			expr: "substring('abc', 1)",
-			flag: ast.FlagHasFunc,
+			"substring('abc', 1)",
+			ast.FlagHasFunc,
 		},
 		{
-			expr: "sum(a)",
-			flag: ast.FlagHasAggregateFunc | ast.FlagHasReference,
+			"sum(a)",
+			ast.FlagHasAggregateFunc | ast.FlagHasReference,
 		},
 		{
-			expr: "(select 1) as a",
-			flag: ast.FlagHasSubquery,
+			"(select 1) as a",
+			ast.FlagHasSubquery,
 		},
 		{
-			expr: "@auto_commit",
-			flag: ast.FlagHasVariable,
+			"@auto_commit",
+			ast.FlagHasVariable,
+		},
+		{
+			"default(a)",
+			ast.FlagHasDefault,
 		},
 	}
 	for _, ca := range cases {

--- a/ast/flag_test.go
+++ b/ast/flag_test.go
@@ -1,0 +1,86 @@
+package ast_test
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/parser"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testFlagSuite{})
+
+type testFlagSuite struct {
+}
+
+func (ts *testFlagSuite) TestFlag(c *C) {
+	cases := []struct {
+		expr string
+		flag uint64
+	}{
+		{
+			expr: "1 between 0 and 2",
+			flag: ast.FlagConstant,
+		},
+		{
+			expr: "case 1 when 1 then 1 else 0 end",
+			flag: ast.FlagConstant,
+		},
+		{
+			expr: "case 1 when 1 then 1 else 0 end",
+			flag: ast.FlagConstant,
+		},
+		{
+			expr: "1 = ANY (select 1) OR exists (select 1)",
+			flag: ast.FlagHasSubquery,
+		},
+		{
+			expr: "1 in (1) or 1 is true or null is null or 'abc' like 'abc' or 'abc' rlike 'abc'",
+			flag: ast.FlagConstant,
+		},
+		{
+			expr: "row (1, 1) = row (1, 1)",
+			flag: ast.FlagConstant,
+		},
+		{
+			expr: "(1 + a) > ?",
+			flag: ast.FlagHasReference | ast.FlagHasParamMarker,
+		},
+		{
+			expr: "trim('abc ')",
+			flag: ast.FlagHasFunc,
+		},
+		{
+			expr: "now() + EXTRACT(YEAR FROM '2009-07-02') + CAST(1 AS UNSIGNED)",
+			flag: ast.FlagHasFunc,
+		},
+		{
+			expr: "substring('abc', 1)",
+			flag: ast.FlagHasFunc,
+		},
+		{
+			expr: "sum(a)",
+			flag: ast.FlagHasAggregateFunc | ast.FlagHasReference,
+		},
+		{
+			expr: "(select 1) as a",
+			flag: ast.FlagHasSubquery,
+		},
+		{
+			expr: "@auto_commit",
+			flag: ast.FlagHasVariable,
+		},
+	}
+	for _, ca := range cases {
+		lexer := parser.NewLexer("select " + ca.expr)
+		parser.YYParse(lexer)
+		stmt := lexer.Stmts()[0].(*ast.SelectStmt)
+		ast.SetFlag(stmt)
+		expr := stmt.Fields.Fields[0].Expr
+		c.Assert(expr.GetFlag(), Equals, ca.flag, Commentf("For %s", ca.expr))
+	}
+}

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -60,21 +60,6 @@ func (n *FuncCallExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncCallExpr) IsStatic() bool {
-	v := builtin.Funcs[n.FnName.L]
-	if v.F == nil || !v.IsStatic {
-		return false
-	}
-
-	for _, v := range n.Args {
-		if !v.IsStatic() {
-			return false
-		}
-	}
-	return true
-}
-
 // FuncExtractExpr is for time extract function.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 type FuncExtractExpr struct {
@@ -99,11 +84,6 @@ func (n *FuncExtractExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncExtractExpr) IsStatic() bool {
-	return n.Date.IsStatic()
-}
-
 // FuncConvertExpr provides a way to convert data between different character sets.
 // See: https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#function_convert
 type FuncConvertExpr struct {
@@ -112,11 +92,6 @@ type FuncConvertExpr struct {
 	Expr ExprNode
 	// Charset is the target character set to convert.
 	Charset string
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncConvertExpr) IsStatic() bool {
-	return n.Expr.IsStatic()
 }
 
 // Accept implements Node Accept interface.
@@ -154,11 +129,6 @@ type FuncCastExpr struct {
 	Tp *types.FieldType
 	// Cast, Convert and Binary share this struct.
 	FunctionType CastFunctionType
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncCastExpr) IsStatic() bool {
-	return n.Expr.IsStatic()
 }
 
 // Accept implements Node Accept interface.
@@ -211,18 +181,6 @@ func (n *FuncSubstringExpr) Accept(v Visitor) (Node, bool) {
 		n.Len = node.(ExprNode)
 	}
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncSubstringExpr) IsStatic() bool {
-	static := n.StrExpr.IsStatic() && n.Pos.IsStatic()
-	if !static {
-		return false
-	}
-	if n.Len != nil {
-		return n.Len.IsStatic()
-	}
-	return true
 }
 
 // FuncSubstringIndexExpr returns the substring as specified.
@@ -341,14 +299,6 @@ func (n *FuncTrimExpr) Accept(v Visitor) (Node, bool) {
 	return v.Leave(n)
 }
 
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncTrimExpr) IsStatic() bool {
-	if n.RemStr != nil {
-		return n.Str.IsStatic() && n.RemStr.IsStatic()
-	}
-	return n.Str.IsStatic()
-}
-
 // DateArithType is type for DateArith type.
 type DateArithType byte
 
@@ -406,11 +356,6 @@ func (n *FuncDateArithExpr) Accept(v Visitor) (Node, bool) {
 		n.Interval = node.(ExprNode)
 	}
 	return v.Leave(n)
-}
-
-// IsStatic implements the ExprNode IsStatic interface.
-func (n *FuncDateArithExpr) IsStatic() bool {
-	return n.Date.IsStatic() && n.Interval.IsStatic()
 }
 
 // AggregateFuncExpr represents aggregate function expression.

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -14,7 +14,6 @@
 package ast
 
 import (
-	"github.com/pingcap/tidb/expression/builtin"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/util/types"
 )

--- a/optimizer/evaluator/evaluator_like.go
+++ b/optimizer/evaluator/evaluator_like.go
@@ -140,7 +140,7 @@ func (e *Evaluator) patternLike(p *ast.PatternLikeExpr) bool {
 	}
 
 	// We need to compile pattern if it has not been compiled or it is not static.
-	var needCompile = len(p.PatChars) == 0 || p.Pattern.GetFlag() != 0
+	var needCompile = len(p.PatChars) == 0 || p.Pattern.GetFlag() != ast.FlagConstant
 	if needCompile {
 		pattern := p.Pattern.GetValue()
 		if types.IsNil(pattern) {
@@ -179,7 +179,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Expr.GetFlag() == 0 {
+		if p.Expr.GetFlag() == ast.FlagConstant {
 			p.Sexpr = new(string)
 			*p.Sexpr = sexpr
 		}
@@ -203,7 +203,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Pattern.GetFlag() == 0 {
+		if p.Pattern.GetFlag() == ast.FlagConstant {
 			p.Re = re
 		}
 	}

--- a/optimizer/evaluator/evaluator_like.go
+++ b/optimizer/evaluator/evaluator_like.go
@@ -140,7 +140,7 @@ func (e *Evaluator) patternLike(p *ast.PatternLikeExpr) bool {
 	}
 
 	// We need to compile pattern if it has not been compiled or it is not static.
-	var needCompile = len(p.PatChars) == 0 || p.Pattern.GetFlag() != ast.FlagConstant
+	var needCompile = len(p.PatChars) == 0 || !ast.IsConstant(p.Pattern)
 	if needCompile {
 		pattern := p.Pattern.GetValue()
 		if types.IsNil(pattern) {
@@ -179,7 +179,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Expr.GetFlag() == ast.FlagConstant {
+		if ast.IsConstant(p.Expr) {
 			p.Sexpr = new(string)
 			*p.Sexpr = sexpr
 		}
@@ -203,7 +203,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Pattern.GetFlag() == ast.FlagConstant {
+		if ast.IsConstant(p.Pattern) {
 			p.Re = re
 		}
 	}

--- a/optimizer/evaluator/evaluator_like.go
+++ b/optimizer/evaluator/evaluator_like.go
@@ -140,7 +140,7 @@ func (e *Evaluator) patternLike(p *ast.PatternLikeExpr) bool {
 	}
 
 	// We need to compile pattern if it has not been compiled or it is not static.
-	var needCompile = len(p.PatChars) == 0 || !p.Pattern.IsStatic()
+	var needCompile = len(p.PatChars) == 0 || p.Pattern.GetFlag() != 0
 	if needCompile {
 		pattern := p.Pattern.GetValue()
 		if types.IsNil(pattern) {
@@ -179,7 +179,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Expr.IsStatic() {
+		if p.Expr.GetFlag() == 0 {
 			p.Sexpr = new(string)
 			*p.Sexpr = sexpr
 		}
@@ -203,7 +203,7 @@ func (e *Evaluator) patternRegexp(p *ast.PatternRegexpExpr) bool {
 			return false
 		}
 
-		if p.Pattern.IsStatic() {
+		if p.Pattern.GetFlag() == 0 {
 			p.Re = re
 		}
 	}

--- a/optimizer/evaluator/evaluator_test.go
+++ b/optimizer/evaluator/evaluator_test.go
@@ -353,8 +353,6 @@ func (s *testEvaluatorSuite) TestConvert(c *C) {
 			Charset: v.cs,
 		}
 
-		c.Assert(f.IsStatic(), Equals, true)
-
 		fs := f.String()
 		c.Assert(len(fs), Greater, 0)
 
@@ -431,7 +429,7 @@ func (s *testEvaluatorSuite) TestDateArith(c *C) {
 			Unit:     "DAY",
 		},
 	}
-	c.Assert(e.IsStatic(), IsTrue)
+	c.Assert(e.GetFlag(), Equals, ast.FlagHasFunc)
 	_, err := Eval(ctx, e)
 	c.Assert(err, IsNil)
 
@@ -886,7 +884,6 @@ func (s *testEvaluatorSuite) TestSubstring(c *C) {
 		if v.slen != -1 {
 			f.Len = ast.NewValueExpr(v.slen)
 		}
-		c.Assert(f.IsStatic(), Equals, true)
 
 		r, err := Eval(ctx, f)
 		c.Assert(err, IsNil)
@@ -947,7 +944,6 @@ func (s *testEvaluatorSuite) TestTrim(c *C) {
 		if v.remstr != nil {
 			f.RemStr = ast.NewValueExpr(v.remstr)
 		}
-		c.Assert(f.IsStatic(), Equals, true)
 
 		r, err := Eval(ctx, f)
 		c.Assert(err, IsNil)

--- a/optimizer/flagSetter.go
+++ b/optimizer/flagSetter.go
@@ -1,0 +1,93 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimizer
+
+import "github.com/pingcap/tidb/ast"
+
+func setFlag(n ast.Node) {
+
+}
+
+type flagSetter struct {
+
+}
+
+func (f *flagSetter) Enter(in ast.Node) (ast.Node, bool) {
+	return in, false
+}
+
+func (f *flagSetter) Leave(in ast.Node) (ast.Node, bool) {
+	switch x := in.(type) {
+	case *ast.ValueExpr:
+	case *ast.BetweenExpr:
+		x.SetFlag(x.Expr.GetFlag() | x.Left.GetFlag() | x.Right.GetFlag())
+	case *ast.BinaryOperationExpr:
+		x.SetFlag(x.L.GetFlag() | x.R.GetFlag())
+	case *ast.CaseExpr:
+		f.caseExpr(x)
+	case *ast.SubqueryExpr:
+		x.SetFlag(ast.FlagHasSubquery)
+	case *ast.CompareSubqueryExpr:
+		x.SetFlag(x.L.GetFlag() | x.R.GetFlag())
+	case *ast.ColumnNameExpr:
+		x.SetFlag(ast.FlagHasColumnName)
+	case *ast.DefaultExpr:
+	case *ast.ExistsSubqueryExpr:
+		x.SetFlag(x.Sel.GetFlag())
+	case *ast.PatternInExpr:
+		f.patternIn(x)
+	case *ast.IsNullExpr:
+		x.SetFlag(x.Expr.GetFlag())
+	case *ast.IsTruthExpr:
+		x.SetFlag(x.Expr.GetFlag())
+	case *ast.PatternLikeExpr:
+		f.patternLike(x)
+	}
+
+	return in, true
+}
+
+func (f *flagSetter) caseExpr(x *ast.CaseExpr) {
+	var flag uint64
+	if x.Value != nil {
+		flag |= x.Value.GetFlag()
+	}
+	for _, val := range x.WhenClauses {
+		flag |= val.Expr.GetFlag()
+		flag |= val.Result.GetFlag()
+	}
+	if x.ElseClause != nil {
+		flag |= x.ElseClause.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) patternIn(x *ast.PatternInExpr) {
+	flag := x.Expr.GetFlag()
+	for _, val := range x.List {
+		flag |= val.GetFlag()
+	}
+	if x.Sel != nil {
+		flag |= x.Sel.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) patternLike(x *ast.PatternLikeExpr) {
+	flag := x.Pattern.GetFlag()
+	if x.Expr != nil {
+		flag |= x.Expr.GetFlag()
+	}
+	x.SetFlag(flag)
+}

--- a/optimizer/flagSetter.go
+++ b/optimizer/flagSetter.go
@@ -16,11 +16,11 @@ package optimizer
 import "github.com/pingcap/tidb/ast"
 
 func setFlag(n ast.Node) {
-
+	var setter flagSetter
+	n.Accept(&setter)
 }
 
 type flagSetter struct {
-
 }
 
 func (f *flagSetter) Enter(in ast.Node) (ast.Node, bool) {
@@ -41,7 +41,7 @@ func (f *flagSetter) Leave(in ast.Node) (ast.Node, bool) {
 	case *ast.CompareSubqueryExpr:
 		x.SetFlag(x.L.GetFlag() | x.R.GetFlag())
 	case *ast.ColumnNameExpr:
-		x.SetFlag(ast.FlagHasColumnName)
+		x.SetFlag(ast.FlagHasReference)
 	case *ast.DefaultExpr:
 	case *ast.ExistsSubqueryExpr:
 		x.SetFlag(x.Sel.GetFlag())
@@ -53,6 +53,42 @@ func (f *flagSetter) Leave(in ast.Node) (ast.Node, bool) {
 		x.SetFlag(x.Expr.GetFlag())
 	case *ast.PatternLikeExpr:
 		f.patternLike(x)
+	case *ast.ParamMarkerExpr:
+		x.SetFlag(ast.FlagHasParamMarker)
+	case *ast.ParenthesesExpr:
+		x.SetFlag(x.Expr.GetFlag())
+	case *ast.PositionExpr:
+		x.SetFlag(ast.FlagHasReference)
+	case *ast.PatternRegexpExpr:
+		f.patternRegexp(x)
+	case *ast.RowExpr:
+		f.row(x)
+	case *ast.UnaryOperationExpr:
+		x.SetFlag(x.V.GetFlag())
+	case *ast.ValuesExpr:
+		x.SetFlag(ast.FlagHasReference)
+	case *ast.VariableExpr:
+		x.SetFlag(ast.FlagHasVariable)
+	case *ast.FuncCallExpr:
+		f.funcCall(x)
+	case *ast.FuncExtractExpr:
+		x.SetFlag(ast.FlagHasFunc | x.Date.GetFlag())
+	case *ast.FuncConvertExpr:
+		x.SetFlag(ast.FlagHasFunc | x.Expr.GetFlag())
+	case *ast.FuncCastExpr:
+		x.SetFlag(ast.FlagHasFunc | x.Expr.GetFlag())
+	case *ast.FuncSubstringExpr:
+		f.funcSubstring(x)
+	case *ast.FuncSubstringIndexExpr:
+		f.funcSubstringIndex(x)
+	case *ast.FuncLocateExpr:
+		f.funcLocate(x)
+	case *ast.FuncTrimExpr:
+		f.funcTrim(x)
+	case *ast.FuncDateArithExpr:
+		f.funcDateArith(x)
+	case *ast.AggregateFuncExpr:
+		f.aggregateFunc(x)
 	}
 
 	return in, true
@@ -88,6 +124,84 @@ func (f *flagSetter) patternLike(x *ast.PatternLikeExpr) {
 	flag := x.Pattern.GetFlag()
 	if x.Expr != nil {
 		flag |= x.Expr.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) patternRegexp(x *ast.PatternRegexpExpr) {
+	flag := x.Pattern.GetFlag()
+	if x.Expr != nil {
+		flag |= x.Expr.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) row(x *ast.RowExpr) {
+	var flag uint64
+	for _, val := range x.Values {
+		flag |= val.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcCall(x *ast.FuncCallExpr) {
+	flag := ast.FlagHasFunc
+	for _, val := range x.Args {
+		flag |= val.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcSubstring(x *ast.FuncSubstringExpr) {
+	flag := ast.FlagHasFunc | x.StrExpr.GetFlag() | x.Pos.GetFlag()
+	if x.Len != nil {
+		flag |= x.Len.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcSubstringIndex(x *ast.FuncSubstringIndexExpr) {
+	flag := ast.FlagHasFunc | x.StrExpr.GetFlag()
+	if x.Delim != nil {
+		flag |= x.Delim.GetFlag()
+	}
+	if x.Count != nil {
+		flag |= x.Count.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcLocate(x *ast.FuncLocateExpr) {
+	flag := ast.FlagHasFunc | x.Str.GetFlag()
+	if x.SubStr != nil {
+		flag |= x.SubStr.GetFlag()
+	}
+	if x.Pos != nil {
+		flag |= x.Pos.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcTrim(x *ast.FuncTrimExpr) {
+	flag := ast.FlagHasFunc | x.Str.GetFlag()
+	if x.RemStr != nil {
+		flag |= x.RemStr.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) funcDateArith(x *ast.FuncDateArithExpr) {
+	flag := ast.FlagHasFunc | x.Date.GetFlag()
+	if x.Interval != nil {
+		flag |= x.Interval.GetFlag()
+	}
+	x.SetFlag(flag)
+}
+
+func (f *flagSetter) aggregateFunc(x *ast.AggregateFuncExpr) {
+	flag := ast.FlagHasAggregateFunc
+	for _, val := range x.Args {
+		flag |= val.GetFlag()
 	}
 	x.SetFlag(flag)
 }

--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -37,7 +37,7 @@ func Optimize(is infoschema.InfoSchema, ctx context.Context, node ast.Node) (pla
 	if err := inferType(node); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := rewriteStatic(ctx, node); err != nil {
+	if err := preEvaluate(ctx, node); err != nil {
 		return nil, errors.Trace(err)
 	}
 	p, err := plan.BuildPlan(node)

--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -30,7 +30,7 @@ func Optimize(is infoschema.InfoSchema, ctx context.Context, node ast.Node) (pla
 	if err := validate(node); err != nil {
 		return nil, errors.Trace(err)
 	}
-	setFlag(node)
+	ast.SetFlag(node)
 	if err := ResolveName(node, is, ctx); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -30,6 +30,7 @@ func Optimize(is infoschema.InfoSchema, ctx context.Context, node ast.Node) (pla
 	if err := validate(node); err != nil {
 		return nil, errors.Trace(err)
 	}
+	setFlag(node)
 	if err := ResolveName(node, is, ctx); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/optimizer/plan/plan_test.go
+++ b/optimizer/plan/plan_test.go
@@ -297,6 +297,7 @@ func (s *testPlanSuite) TestBestPlan(c *C) {
 		rc := parser.YYParse(lexer)
 		c.Assert(rc, Equals, 0, Commentf("error %v for sql %s", lexer.Errors(), ca.sql))
 		stmt := lexer.Stmts()[0].(*ast.SelectStmt)
+		ast.SetFlag(stmt)
 		mockResolve(stmt)
 		p, err := BuildPlan(stmt)
 		c.Assert(err, IsNil)

--- a/optimizer/plan/refiner.go
+++ b/optimizer/plan/refiner.go
@@ -144,7 +144,7 @@ func (c *conditionChecker) check(condition ast.ExprNode) bool {
 			return false
 		}
 		for _, val := range x.List {
-			if !val.IsStatic() {
+			if !ast.IsPreEvaluable(val) {
 				return false
 			}
 		}
@@ -156,14 +156,14 @@ func (c *conditionChecker) check(condition ast.ExprNode) bool {
 		if !c.checkColumnExpr(x.Expr) {
 			return false
 		}
-		if !x.Pattern.IsStatic() {
+		if !ast.IsPreEvaluable(x.Pattern) {
 			return false
 		}
 		patternStr := x.Pattern.GetValue().(string)
 		firstChar := patternStr[0]
 		return firstChar != '%' && firstChar != '.'
 	case *ast.BetweenExpr:
-		if x.Left.IsStatic() && x.Right.IsStatic() && c.checkColumnExpr(x.Expr) {
+		if ast.IsPreEvaluable(x.Left) && ast.IsPreEvaluable(x.Right) && c.checkColumnExpr(x.Expr) {
 			return true
 		}
 	case *ast.IsNullExpr:
@@ -187,9 +187,9 @@ func (c *conditionChecker) checkBinaryOperation(b *ast.BinaryOperationExpr) bool
 	case opcode.AndAnd:
 		return c.check(b.L) && c.check(b.R)
 	case opcode.EQ, opcode.NE, opcode.GE, opcode.GT, opcode.LE, opcode.LT:
-		if b.L.IsStatic() {
+		if ast.IsPreEvaluable(b.L) {
 			return c.checkColumnExpr(b.R)
-		} else if b.R.IsStatic() {
+		} else if ast.IsPreEvaluable(b.R) {
 			return c.checkColumnExpr(b.L)
 		}
 	}

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -77,7 +77,7 @@ func (r *preEvaluator) Leave(in ast.Node) (ast.Node, bool) {
 				r.err = err
 				return in, false
 			}
-			if expr.GetFlag() == ast.FlagConstant {
+			if ast.IsConstant(expr) {
 				// The expression is constant, rewrite the expression to value expression.
 				valExpr := &ast.ValueExpr{}
 				valExpr.SetText(expr.Text())

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -77,7 +77,7 @@ func (r *preEvaluator) Leave(in ast.Node) (ast.Node, bool) {
 				r.err = err
 				return in, false
 			}
-			if expr.GetFlag() == 0 {
+			if expr.GetFlag() == ast.FlagConstant {
 				// The expression is constant, rewrite the expression to value expression.
 				valExpr := &ast.ValueExpr{}
 				valExpr.SetText(expr.Text())


### PR DESCRIPTION
We care not only about what the expression is, but also what kind of expression it contains.
Adding flag attribute to expression makes it much easy to determine how to deal with the expression.

The old implementation has `IsStatic` method but that's not enough for our use, some expression is not static but can be evaluated before execution. With flag, `IsStatic` method can be removed.