### PR TITLE
parser: parse position expression in parser, fix order by position.

### DIFF
--- a/executor/converter/convert_expr.go
+++ b/executor/converter/convert_expr.go
@@ -272,7 +272,7 @@ func (c *expressionConverter) parentheses(v *ast.ParenthesesExpr) {
 }
 
 func (c *expressionConverter) position(v *ast.PositionExpr) {
-	c.exprMap[v] = &expression.Position{N: v.N}
+	c.exprMap[v] = expression.Value{Val: int64(v.N)}
 }
 
 func (c *expressionConverter) patternRegexp(v *ast.PatternRegexpExpr) {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1955,7 +1955,15 @@ ByList:
 ByItem:
 	Expression Order 
 	{
-		$$ = &ast.ByItem{Expr: $1.(ast.ExprNode), Desc: $2.(bool)}
+		expr := $1
+		valueExpr, ok := expr.(*ast.ValueExpr)
+		if ok {
+			position, isPosition := valueExpr.GetValue().(int64)
+			if isPosition {
+				expr = &ast.PositionExpr{N: int(position)}
+			}
+		}
+		$$ = &ast.ByItem{Expr: expr.(ast.ExprNode), Desc: $2.(bool)}
 	}
 
 Order:

--- a/session_test.go
+++ b/session_test.go
@@ -985,6 +985,12 @@ func (s *testSessionSuite) TestOrderBy(c *C) {
 	mustExecMatch(c, se, "select sum(c1) from t order by sum(c1)", [][]interface{}{{3}})
 	mustExecMatch(c, se, "select c1 as c2 from t order by c2 + 1", [][]interface{}{{2}, {1}})
 
+	// Order by position
+	mustExecMatch(c, se, "select * from t order by 1", [][]interface{}{{1, 2}, {2, 1}})
+	mustExecMatch(c, se, "select * from t order by 2", [][]interface{}{{2, 1}, {1, 2}})
+	mustExecFailed(c, se, "select * from t order by 0")
+	mustExecFailed(c, se, "select * from t order by 3")
+
 	mustExecFailed(c, se, "select c1 as a, c2 as a from t order by a")
 
 	mustExecFailed(c, se, "(select c1 as c2, c2 from t) union (select c1, c2 from t) order by c2")


### PR DESCRIPTION
The position expression, like "1" in "order by 1" was parsed ito `*ast.ValueExpr` in parser, replaced to position expression by resolver,
But flag setter sets flag before resolving process, so position flag is not set.