### PR TITLE
*: Fix bug for parse repeat function

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -414,11 +414,14 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		// For issue 224
 		{`SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8) COLLATE utf8_bin;`, true},
 
-		// For trim
+		// For string functions
+		// Trim
 		{`SELECT TRIM('  bar   ');`, true},
 		{`SELECT TRIM(LEADING 'x' FROM 'xxxbarxxx');`, true},
 		{`SELECT TRIM(BOTH 'x' FROM 'xxxbarxxx');`, true},
 		{`SELECT TRIM(TRAILING 'xyz' FROM 'barxxyz');`, true},
+		// Repeat
+		{`SELECT REPEAT("a", 10);`, true},
 
 		// For date_add
 		{`select date_add("2011-11-11 10:10:10.123456", interval 10 microsecond)`, true},

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -879,7 +879,8 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {rand}			lval.item = string(l.val)
 			return rand
 {read}			return read
-{repeat}		return repeat
+{repeat}		lval.item = string(l.val)
+			return repeat
 {repeatable}		lval.item = string(l.val)
 			return repeatable
 {regexp}		return regexp


### PR DESCRIPTION
"repeat" is a reserved keyword. So I remove "{repeat}		lval.item = string(l.val)" in the previous pr.
But is can be function name and we need its literal.