### PR TITLE
parser: support built-in function substr

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -37,7 +37,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"date", "datetime", "deallocate", "do", "end", "engine", "engines", "execute", "first", "full",
 		"local", "names", "offset", "password", "prepare", "quick", "rollback", "session", "signed",
 		"start", "global", "tables", "text", "time", "timestamp", "transaction", "truncate", "unknown",
-		"value", "warnings", "year", "now", "substring", "mode", "any", "some", "user", "identified",
+		"value", "warnings", "year", "now", "substr", "substring", "mode", "any", "some", "user", "identified",
 		"collation", "comment", "avg_row_length", "checksum", "compression", "connection", "key_block_size",
 		"max_rows", "min_rows", "national", "row", "quarter", "escape", "grants", "status", "fields", "triggers",
 		"delay_key_write", "isolation", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
@@ -332,6 +332,11 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"SELECT DAYOFMONTH('2007-02-03');", true},
 		{"SELECT RAND();", true},
 		{"SELECT RAND(1);", true},
+
+		{"SELECT SUBSTR('Quadratically',5);", true},
+		{"SELECT SUBSTR('Quadratically',5, 3);", true},
+		{"SELECT SUBSTR('Quadratically' FROM 5);", true},
+		{"SELECT SUBSTR('Quadratically' FROM 5 FOR 3);", true},
 
 		{"SELECT SUBSTRING('Quadratically',5);", true},
 		{"SELECT SUBSTRING('Quadratically',5, 3);", true},

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -905,7 +905,7 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {share}			return share
 {show}			return show
 {subdate}		return subDate
-{substr}             lval.item = string(l.val)
+{substr}		lval.item = string(l.val)
                         return substring
 {substring}		lval.item = string(l.val)
 			return substring

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -442,6 +442,7 @@ some		{s}{o}{m}{e}
 start		{s}{t}{a}{r}{t}
 status          {s}{t}{a}{t}{u}{s}
 subdate		{s}{u}{b}{d}{a}{t}{e}
+substr		{s}{u}{b}{s}{t}{r}
 substring	{s}{u}{b}{s}{t}{r}{i}{n}{g}
 substring_index	{s}{u}{b}{s}{t}{r}{i}{n}{g}_{i}{n}{d}{e}{x}
 sum		{s}{u}{m}
@@ -904,6 +905,8 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {share}			return share
 {show}			return show
 {subdate}		return subDate
+{substr}             lval.item = string(l.val)
+                        return substring
 {substring}		lval.item = string(l.val)
 			return substring
 {substring_index}	lval.item = string(l.val)

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -906,7 +906,7 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {show}			return show
 {subdate}		return subDate
 {substr}		lval.item = string(l.val)
-                        return substring
+			return substring
 {substring}		lval.item = string(l.val)
 			return substring
 {substring_index}	lval.item = string(l.val)


### PR DESCRIPTION
I find tidb support built-in function substring, but don't support substr. substr is used very frequently
In Oracle and MySQL projects. 
We can find the description of substr in MySQL 5.7 Reference Manual in url:
http://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
which said:
SUBSTR() is a synonym for SUBSTRING().

This patch is to support substr. As tidb has support substring, There is just little work to do. The patch is very simple.
