### PR TITLE
*: Fix auth fail when use fe80::1%lo0

### DIFF
--- a/tidb-server/server/server_test.go
+++ b/tidb-server/server/server_test.go
@@ -222,10 +222,7 @@ func runTestConcurrentUpdate(c *C) {
 
 func runTestAuth(c *C) {
 	runTests(c, dsn, func(dbt *DBTest) {
-		dbt.mustExec(`CREATE USER 'test'@'127.0.0.1' IDENTIFIED BY '123';`)
-		dbt.mustExec(`CREATE USER 'test'@'localhost' IDENTIFIED BY '123';`)
-		dbt.mustExec(`CREATE USER 'test'@'::1' IDENTIFIED BY '123';`)
-		dbt.mustExec(`CREATE USER 'test'@'fe80::1%lo0' IDENTIFIED BY '123';`)
+		dbt.mustExec(`CREATE USER 'test'@'%' IDENTIFIED BY '123';`)
 	})
 	newDsn := "test:123@tcp(localhost:4001)/test?strict=true"
 	runTests(c, newDsn, func(dbt *DBTest) {

--- a/tidb-server/server/server_test.go
+++ b/tidb-server/server/server_test.go
@@ -225,6 +225,7 @@ func runTestAuth(c *C) {
 		dbt.mustExec(`CREATE USER 'test'@'127.0.0.1' IDENTIFIED BY '123';`)
 		dbt.mustExec(`CREATE USER 'test'@'localhost' IDENTIFIED BY '123';`)
 		dbt.mustExec(`CREATE USER 'test'@'::1' IDENTIFIED BY '123';`)
+		dbt.mustExec(`CREATE USER 'test'@'fe80::1%lo0' IDENTIFIED BY '123';`)
 	})
 	newDsn := "test:123@tcp(localhost:4001)/test?strict=true"
 	runTests(c, newDsn, func(dbt *DBTest) {


### PR DESCRIPTION
In some environment, fe80::1%lo0 is localhost. So we should add one more user in tidb-server test case.