### PR TITLE
optimizer: typeInferrer supports more expression.

### DIFF
--- a/optimizer/optimizer.go
+++ b/optimizer/optimizer.go
@@ -34,7 +34,7 @@ func Optimize(is infoschema.InfoSchema, ctx context.Context, node ast.Node) (pla
 	if err := ResolveName(node, is, ctx); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := inferType(node); err != nil {
+	if err := InferType(node); err != nil {
 		return nil, errors.Trace(err)
 	}
 	if err := preEvaluate(ctx, node); err != nil {

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -107,7 +107,7 @@ func (v *typeInferrer) binaryOperation(x *ast.BinaryOperationExpr) {
 			x.Type = types.NewFieldType(xTp)
 			leftUnsigned := x.L.GetType().Flag & mysql.UnsignedFlag
 			rightUnsigned := x.R.GetType().Flag & mysql.UnsignedFlag
-			// If both operand is unsigned, result is unsigned.
+			// If both operands are unsigned, result is unsigned.
 			x.Type.Flag |= (leftUnsigned & rightUnsigned)
 		}
 	case opcode.Div:

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -84,6 +84,8 @@ func (v *typeInferrer) Leave(in ast.Node) (out ast.Node, ok bool) {
 func (v *typeInferrer) selectStmt(x *ast.SelectStmt) {
 	rf := x.GetResultFields()
 	for _, val := range rf {
+		// column ID is 0 means it is not a real column from table, but a temporary column,
+		// so its type is not pre-defined, we need to set it.
 		if val.Column.ID == 0 && val.Expr.GetType() != nil {
 			val.Column.FieldType = *(val.Expr.GetType())
 		}

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -16,11 +16,14 @@ package optimizer
 import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/optimizer/evaluator"
+	"github.com/pingcap/tidb/parser/opcode"
+	"github.com/pingcap/tidb/util/types"
 )
 
-// inferType infers result type for ast.ExprNode.
-func inferType(node ast.Node) error {
+// InferType infers result type for ast.ExprNode.
+func InferType(node ast.Node) error {
 	var inferrer typeInferrer
 	node.Accept(&inferrer)
 	return inferrer.err
@@ -48,14 +51,111 @@ func (v *typeInferrer) Leave(in ast.Node) (out ast.Node, ok bool) {
 	case *ast.FuncCastExpr:
 		x.SetType(x.Tp)
 	case *ast.SelectStmt:
-		rf := x.GetResultFields()
-		for _, val := range rf {
-			if val.Column.ID == 0 && val.Expr.GetType() != nil {
-				val.Column.FieldType = *(val.Expr.GetType())
+		v.selectStmt(x)
+	case *ast.ParamMarkerExpr:
+		x.SetType(types.DefaultTypeForValue(x.GetValue()))
+	case *ast.BinaryOperationExpr:
+		v.binaryOperation(x)
+	case *ast.UnaryOperationExpr:
+		v.unaryOperation(x)
+	case *ast.BetweenExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.CompareSubqueryExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.ExistsSubqueryExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.PatternInExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.PatternLikeExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.PatternRegexpExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.IsNullExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.IsTruthExpr:
+		x.SetType(types.NewFieldType(mysql.TypeLonglong))
+	case *ast.ParenthesesExpr:
+		x.SetType(x.Expr.GetType())
+		// TODO: handle all expression types.
+	}
+	return in, true
+}
+
+func (v *typeInferrer) selectStmt(x *ast.SelectStmt) {
+	rf := x.GetResultFields()
+	for _, val := range rf {
+		if val.Column.ID == 0 && val.Expr.GetType() != nil {
+			val.Column.FieldType = *(val.Expr.GetType())
+		}
+	}
+}
+
+func (v *typeInferrer) binaryOperation(x *ast.BinaryOperationExpr) {
+	switch x.Op {
+	case opcode.AndAnd, opcode.OrOr, opcode.LogicXor:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+	case opcode.LT, opcode.LE, opcode.GE, opcode.GT, opcode.EQ, opcode.NE, opcode.NullEQ:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+	case opcode.RightShift, opcode.LeftShift, opcode.And, opcode.Or, opcode.Xor:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+		x.Type.Flag |= mysql.UnsignedFlag
+	case opcode.IntDiv:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+	case opcode.Plus, opcode.Minus, opcode.Mul, opcode.Mod:
+		if x.L.GetType() != nil && x.R.GetType() != nil {
+			xTp := mergeArithType(x.L.GetType().Tp, x.R.GetType().Tp)
+			x.Type = types.NewFieldType(xTp)
+			leftUnsigned := x.L.GetType().Flag & mysql.UnsignedFlag
+			rightUnsigned := x.R.GetType().Flag & mysql.UnsignedFlag
+			// If both operand is unsigned, result is unsigned.
+			x.Type.Flag |= (leftUnsigned & rightUnsigned)
+		}
+	case opcode.Div:
+		if x.L.GetType() != nil && x.R.GetType() != nil {
+			xTp := mergeArithType(x.L.GetType().Tp, x.R.GetType().Tp)
+			if xTp == mysql.TypeLonglong {
+				xTp = mysql.TypeDecimal
+			}
+			x.Type = types.NewFieldType(xTp)
+		}
+	}
+}
+
+func mergeArithType(a, b byte) byte {
+	switch a {
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble:
+		return mysql.TypeDouble
+	}
+	switch b {
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat:
+		return mysql.TypeDouble
+	}
+	if a == mysql.TypeNewDecimal || b == mysql.TypeNewDecimal {
+		return mysql.TypeNewDecimal
+	}
+	return mysql.TypeLonglong
+}
+
+func (v *typeInferrer) unaryOperation(x *ast.UnaryOperationExpr) {
+	switch x.Op {
+	case opcode.Not:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+	case opcode.BitNeg:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+		x.Type.Flag |= mysql.UnsignedFlag
+	case opcode.Plus:
+		x.Type = x.V.GetType()
+	case opcode.Minus:
+		x.Type = types.NewFieldType(mysql.TypeLonglong)
+		if x.V.GetType() != nil {
+			switch x.V.GetType().Tp {
+			case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat:
+				x.Type.Tp = mysql.TypeDouble
+			case mysql.TypeNewDecimal:
+				x.Type.Tp = mysql.TypeNewDecimal
 			}
 		}
 	}
-	return in, true
 }
 
 type preEvaluator struct {

--- a/optimizer/typeinferer.go
+++ b/optimizer/typeinferer.go
@@ -123,7 +123,7 @@ func (v *typeInferrer) binaryOperation(x *ast.BinaryOperationExpr) {
 
 func mergeArithType(a, b byte) byte {
 	switch a {
-	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble:
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat:
 		return mysql.TypeDouble
 	}
 	switch b {

--- a/optimizer/typeinferer_test.go
+++ b/optimizer/typeinferer_test.go
@@ -76,7 +76,7 @@ func (ts *testTypeInferrerSuite) TestInterType(c *C) {
 		ctx := testKit.Se.(context.Context)
 		stmts, err := tidb.Parse(ctx, "select "+ca.expr+" from t")
 		c.Assert(err, IsNil)
-		c.Assert(len(stmts), Equals, 1)
+		c.Assert(stmts, HasLen, 1)
 		stmt := stmts[0].(*ast.SelectStmt)
 		is := sessionctx.GetDomain(ctx).InfoSchema()
 		err = optimizer.ResolveName(stmt, is, ctx)

--- a/optimizer/typeinferer_test.go
+++ b/optimizer/typeinferer_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimizer_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/optimizer"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+var _ = Suite(&testTypeInferrerSuite{})
+
+type testTypeInferrerSuite struct {
+}
+
+func (ts *testTypeInferrerSuite) TestInterType(c *C) {
+	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (c1 int, c2 double, c3 text)")
+	cases := []struct {
+		expr string
+		tp   byte
+	}{
+		{"c1", mysql.TypeLong},
+		{"+1", mysql.TypeLonglong},
+		{"-1", mysql.TypeLonglong},
+		{"-'1'", mysql.TypeDouble},
+		{"~1", mysql.TypeLonglong},
+		{"!true", mysql.TypeLonglong},
+
+		{"c1 is true", mysql.TypeLonglong},
+		{"c2 is null", mysql.TypeLonglong},
+		{"cast(1 as decimal)", mysql.TypeNewDecimal},
+
+		{"1 and 1", mysql.TypeLonglong},
+		{"1 or 1", mysql.TypeLonglong},
+		{"1 xor 1", mysql.TypeLonglong},
+
+		{"'1' & 2", mysql.TypeLonglong},
+		{"'1' | 2", mysql.TypeLonglong},
+		{"'1' ^ 2", mysql.TypeLonglong},
+		{"'1' << 1", mysql.TypeLonglong},
+		{"'1' >> 1", mysql.TypeLonglong},
+
+		{"1 + '1'", mysql.TypeDouble},
+		{"1 + 1.1", mysql.TypeNewDecimal},
+		{"1 div 2", mysql.TypeLonglong},
+
+		{"1 > any (select 1)", mysql.TypeLonglong},
+		{"exists (select 1)", mysql.TypeLonglong},
+		{"1 in (2, 3)", mysql.TypeLonglong},
+		{"'abc' like 'abc'", mysql.TypeLonglong},
+		{"'abc' rlike 'abc'", mysql.TypeLonglong},
+		{"(1+1)", mysql.TypeLonglong},
+	}
+	for _, ca := range cases {
+		ctx := testKit.Se.(context.Context)
+		stmts, err := tidb.Parse(ctx, "select "+ca.expr+" from t")
+		c.Assert(err, IsNil)
+		c.Assert(len(stmts), Equals, 1)
+		stmt := stmts[0].(*ast.SelectStmt)
+		is := sessionctx.GetDomain(ctx).InfoSchema()
+		err = optimizer.ResolveName(stmt, is, ctx)
+		c.Assert(err, IsNil)
+		optimizer.InferType(stmt)
+		tp := stmt.GetResultFields()[0].Column.Tp
+		c.Assert(tp, Equals, ca.tp, Commentf("for %s", ca.expr))
+	}
+}

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -142,3 +142,47 @@ func IsDataItem(d interface{}) bool {
 	_, ok := d.(*DataItem)
 	return ok
 }
+
+// DefaultTypeForValue returns the default FieldType for the value.
+func DefaultTypeForValue(value interface{}) *FieldType {
+	switch x := value.(type) {
+	case nil:
+		return NewFieldType(mysql.TypeNull)
+	case bool, int64, int:
+		return NewFieldType(mysql.TypeLonglong)
+	case uint64:
+		tp := NewFieldType(mysql.TypeLonglong)
+		tp.Flag |= mysql.UnsignedFlag
+		return tp
+	case string:
+		tp := NewFieldType(mysql.TypeVarchar)
+		tp.Charset = mysql.DefaultCharset
+		tp.Collate = mysql.DefaultCollationName
+		return tp
+	case float64:
+		return NewFieldType(mysql.TypeNewDecimal)
+	case []byte:
+		tp := NewFieldType(mysql.TypeBlob)
+		tp.Charset = charset.CharsetBin
+		tp.Collate = charset.CharsetBin
+	case mysql.Bit:
+		return NewFieldType(mysql.TypeBit)
+	case mysql.Hex:
+		tp := NewFieldType(mysql.TypeVarchar)
+		tp.Charset = charset.CharsetBin
+		tp.Collate = charset.CharsetBin
+	case mysql.Time:
+		return NewFieldType(x.Type)
+	case mysql.Duration:
+		return NewFieldType(mysql.TypeDuration)
+	case mysql.Decimal:
+		return NewFieldType(mysql.TypeNewDecimal)
+	case mysql.Enum:
+		return NewFieldType(mysql.TypeEnum)
+	case mysql.Set:
+		return NewFieldType(mysql.TypeSet)
+	case *DataItem:
+		return value.(*DataItem).Type
+	}
+	return NewFieldType(mysql.TypeNull)
+}

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/charset"
 )
@@ -182,7 +183,8 @@ func DefaultTypeForValue(value interface{}) *FieldType {
 	case mysql.Set:
 		return NewFieldType(mysql.TypeSet)
 	case *DataItem:
-		return value.(*DataItem).Type
+		return x.Type
 	}
-	return NewFieldType(mysql.TypeNull)
+	log.Errorf("Unknown value type %T for default field type.", value)
+	return nil
 }


### PR DESCRIPTION
This is require for implementing prepared statement, because binary protocol depends more
on the result field type to decode value, we have to correctly set the result field type.

For statement like 'select ?', the type of the field is unknown until we execute the statement with argument,
If the field type of  parameter marker `?' is not set properly, client will not be able to read the value.