### PR TITLE
add ast evaluation for date arith

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -310,15 +310,10 @@ const (
 	// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 	// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-sub
 	DateSub
-	// DateArithDaysForm is to run adddate or subdate function with days form Flag.
-	DateArithDaysForm
 )
 
 // DateArithInterval is the struct of DateArith interval part.
 type DateArithInterval struct {
-	// Form is the flag of DateArith running form.
-	// The function runs with interval or days.
-	Form     DateArithType
 	Unit     string
 	Interval ExprNode
 }

--- a/executor/converter/convert_expr.go
+++ b/executor/converter/convert_expr.go
@@ -402,9 +402,6 @@ func (c *expressionConverter) funcDateArith(v *ast.FuncDateArithExpr) {
 	case ast.DateSub:
 		oldDateArith.Op = expression.DateSub
 	}
-	if v.Form == ast.DateArithDaysForm {
-		oldDateArith.Form = expression.DateArithDaysForm
-	}
 	c.exprMap[v] = oldDateArith
 }
 

--- a/expression/date_arith.go
+++ b/expression/date_arith.go
@@ -37,17 +37,12 @@ const (
 	// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 	// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-sub
 	DateSub
-	// DateArithDaysForm is to run adddate or subdate function with days form Flag.
-	DateArithDaysForm
 )
 
 // DateArith is used for dealing with addition and substraction of time.
 type DateArith struct {
 	// Op is used for distinguishing date_add and date_sub.
-	Op DateArithType
-	// Form is the flag of DateArith running form.
-	// The function runs with interval or days.
-	Form     DateArithType
+	Op       DateArithType
 	Date     Expression
 	Unit     string
 	Interval Expression
@@ -150,7 +145,7 @@ func (da *DateArith) evalArgs(ctx context.Context, args map[interface{}]interfac
 		return ret, errors.Trace(err)
 	}
 	// handle adddate(expr,days) or subdate(expr,days) form
-	if da.Form == DateArithDaysForm {
+	if strings.ToLower(da.Unit) == "day" {
 		if iVal, err = da.evalDaysForm(iVal); err != nil {
 			return ret, errors.Trace(err)
 		}

--- a/expression/date_arith_test.go
+++ b/expression/date_arith_test.go
@@ -135,7 +135,6 @@ func (t *testDateArithSuite) TestDateArith(c *C) {
 	for _, t := range tblDays {
 		e := &DateArith{
 			Op:       DateAdd,
-			Form:     DateArithDaysForm,
 			Unit:     "day",
 			Date:     Value{Val: input},
 			Interval: Value{Val: t.Interval},

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -1375,3 +1375,37 @@ func ExtractTimeValue(unit string, format string) (int64, int64, int64, time.Dur
 		return 0, 0, 0, 0, errors.Errorf("invalid singel timeunit - %s", unit)
 	}
 }
+
+// IsClockUnit returns true when unit is interval unit with hour, minute or second.
+func IsClockUnit(unit string) bool {
+	switch strings.ToUpper(unit) {
+	case "MICROSECOND", "SECOND", "MINUTE", "HOUR",
+		"SECOND_MICROSECOND", "MINUTE_MICROSECOND", "MINUTE_SECOND",
+		"HOUR_MICROSECOND", "HOUR_SECOND", "HOUR_MINUTE",
+		"DAY_MICROSECOND", "DAY_SECOND", "DAY_MINUTE", "DAY_HOUR":
+		return true
+	default:
+		return false
+	}
+}
+
+// IsDateFormat returns true when the specified time format could contain only date.
+func IsDateFormat(format string) bool {
+	format = strings.TrimSpace(format)
+	seps := parseDateFormat(format)
+	length := len(format)
+	switch len(seps) {
+	case 1:
+		if (length == 8) || (length == 6) {
+			return true
+		}
+	case 3:
+		return true
+	}
+	return false
+}
+
+// ParseTimeFromInt64 parses mysql time value from int64.
+func ParseTimeFromInt64(num int64) (Time, error) {
+	return parseDateTimeFromNum(num)
+}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2394,7 +2394,6 @@ DateArithInterval:
 	Expression
 	{
 		$$ = ast.DateArithInterval{
-					Form: ast.DateArithDaysForm,
 					Unit: "day",
 					Interval: $1.(ast.ExprNode),
 		}


### PR DESCRIPTION
Hi there,

When I try to implement some time functions listed in issue #236, I find those functions `adddate, subdate, date_add, date_sub`, which are ticked as done, are not fully working. If they are used in `interpreter`, they just return `NULL`, as the below:

```text
tidb> select adddate("2008-01-02", INTERVAL 1 DAY);
+---------------------------------------+
| adddate("2008-01-02", INTERVAL 1 DAY) |
+---------------------------------------+
| NULL                                  |
+---------------------------------------+
1 row in set (0.00 sec)
tidb> select adddate("2008-01-02", 1);
+--------------------------+
| adddate("2008-01-02", 1) |
+--------------------------+
| NULL                     |
+--------------------------+
1 row in set (0.00 sec)
tidb> select date_add("2008-01-02", INTERVAL 1 DAY);
+----------------------------------------+
| date_add("2008-01-02", INTERVAL 1 DAY) |
+----------------------------------------+
| NULL                                   |
+----------------------------------------+
1 row in set (0.00 sec)
tidb> select subdate("2008-01-02", 1);
+--------------------------+
| subdate("2008-01-02", 1) |
+--------------------------+
| NULL                     |
+--------------------------+
1 row in set (0.00 sec)
```

This PR add ast evalutions for date arith to fix this problem.

```text
tidb> select adddate("2008-01-02", 1);
+---------------------------------------+
| adddate("2008-01-02", INTERVAL 1 DAY) |
+---------------------------------------+
| 2008-01-03                            |
+---------------------------------------+
1 row in set (0.00 sec)
tidb> select subdate("2008-01-02", INTERVAL 1 DAY);
+---------------------------------------+
| subdate("2008-01-02", INTERVAL 1 DAY) |
+---------------------------------------+
| 2008-01-01                            |
+---------------------------------------+
1 row in set (0.00 sec)
tidb> select date_add("2008-01-02", INTERVAL 1 DAY);
+----------------------------------------+
| date_add("2008-01-02", INTERVAL 1 DAY) |
+----------------------------------------+
| 2008-01-03                             |
+----------------------------------------+
1 row in set (0.00 sec)
tidb> select date_sub("2008-01-02", INTERVAL 1 DAY);
+----------------------------------------+
| date_sub("2008-01-02", INTERVAL 1 DAY) |
+----------------------------------------+
| 2008-01-01                             |
+----------------------------------------+
1 row in set (0.00 sec)
```