### PR TITLE
builtin/time: support CURRENT_TIME(), CURTIME()

### DIFF
--- a/expression/builtin/builtin.go
+++ b/expression/builtin/builtin.go
@@ -69,9 +69,9 @@ var Funcs = map[string]Func{
 	// time functions
 	"curdate":           {builtinCurrentDate, 0, 0, false, false},
 	"current_date":      {builtinCurrentDate, 0, 0, false, false},
-	"current_time":      {builtinCurrentTime, 0, 0, false, false},
+	"current_time":      {builtinCurrentTime, 0, 1, false, false},
 	"current_timestamp": {builtinNow, 0, 1, false, false},
-	"curtime":           {builtinCurrentTime, 0, 0, false, false},
+	"curtime":           {builtinCurrentTime, 0, 1, false, false},
 	"date":              {builtinDate, 8, 8, true, false},
 	"day":               {builtinDay, 1, 1, true, false},
 	"dayofmonth":        {builtinDayOfMonth, 1, 1, true, false},

--- a/expression/builtin/builtin.go
+++ b/expression/builtin/builtin.go
@@ -69,7 +69,9 @@ var Funcs = map[string]Func{
 	// time functions
 	"curdate":           {builtinCurrentDate, 0, 0, false, false},
 	"current_date":      {builtinCurrentDate, 0, 0, false, false},
+	"current_time":      {builtinCurrentTime, 0, 0, false, false},
 	"current_timestamp": {builtinNow, 0, 1, false, false},
+	"curtime":           {builtinCurrentTime, 0, 0, false, false},
 	"date":              {builtinDate, 8, 8, true, false},
 	"day":               {builtinDay, 1, 1, true, false},
 	"dayofmonth":        {builtinDayOfMonth, 1, 1, true, false},

--- a/expression/builtin/time.go
+++ b/expression/builtin/time.go
@@ -46,9 +46,9 @@ func convertToTime(arg interface{}, tp byte) (interface{}, error) {
 	return t, nil
 }
 
-func convertToDuration(arg interface{}) (interface{}, error) {
+func convertToDuration(arg interface{}, fsp int) (interface{}, error) {
 	f := types.NewFieldType(mysql.TypeDuration)
-	f.Decimal = mysql.MaxFsp
+	f.Decimal = fsp
 
 	v, err := types.Convert(arg, f)
 	if err != nil {
@@ -79,7 +79,7 @@ func builtinDay(args []interface{}, ctx map[interface{}]interface{}) (interface{
 
 // See http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_hour
 func builtinHour(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
-	v, err := convertToDuration(args[0])
+	v, err := convertToDuration(args[0], mysql.MaxFsp)
 	if err != nil || types.IsNil(v) {
 		return v, err
 	}
@@ -91,7 +91,7 @@ func builtinHour(args []interface{}, ctx map[interface{}]interface{}) (interface
 
 // See http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_minute
 func builtinMinute(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
-	v, err := convertToDuration(args[0])
+	v, err := convertToDuration(args[0], mysql.MaxFsp)
 	if err != nil || types.IsNil(v) {
 		return v, err
 	}
@@ -103,7 +103,7 @@ func builtinMinute(args []interface{}, ctx map[interface{}]interface{}) (interfa
 
 // See http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_second
 func builtinSecond(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
-	v, err := convertToDuration(args[0])
+	v, err := convertToDuration(args[0], mysql.MaxFsp)
 	if err != nil || types.IsNil(v) {
 		return v, err
 	}
@@ -115,7 +115,7 @@ func builtinSecond(args []interface{}, ctx map[interface{}]interface{}) (interfa
 
 // See http://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_microsecond
 func builtinMicroSecond(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
-	v, err := convertToDuration(args[0])
+	v, err := convertToDuration(args[0], mysql.MaxFsp)
 	if err != nil || types.IsNil(v) {
 		return v, err
 	}
@@ -318,15 +318,7 @@ func builtinCurrentTime(args []interface{}, ctx map[interface{}]interface{}) (in
 			return nil, errors.Trace(err)
 		}
 	}
-
-	t := mysql.Time{
-		Time: time.Now(),
-		Type: mysql.TypeDuration,
-		// set unspecified for later round
-		Fsp: mysql.UnspecifiedFsp,
-	}
-
-	return t.RoundFrac(int(fsp))
+	return convertToDuration(time.Now().Format("15:04:05.000000"), fsp)
 }
 
 func checkFsp(arg interface{}) (int, error) {

--- a/expression/builtin/time.go
+++ b/expression/builtin/time.go
@@ -309,6 +309,13 @@ func builtinCurrentDate(args []interface{}, ctx map[interface{}]interface{}) (in
 		Type: mysql.TypeDate, Fsp: 0}, nil
 }
 
+// See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curtime
+func builtinCurrentTime(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
+	return mysql.Time{
+		Time: time.Now(),
+		Type: mysql.TypeDuration, Fsp: 0}, nil
+}
+
 func checkFsp(arg interface{}) (int, error) {
 	fsp, err := types.ToInt64(arg)
 	if err != nil {

--- a/expression/builtin/time.go
+++ b/expression/builtin/time.go
@@ -311,9 +311,22 @@ func builtinCurrentDate(args []interface{}, ctx map[interface{}]interface{}) (in
 
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curtime
 func builtinCurrentTime(args []interface{}, ctx map[interface{}]interface{}) (interface{}, error) {
-	return mysql.Time{
+	fsp := 0
+	if len(args) == 1 {
+		var err error
+		if fsp, err = checkFsp(args[0]); err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+
+	t := mysql.Time{
 		Time: time.Now(),
-		Type: mysql.TypeDuration, Fsp: 0}, nil
+		Type: mysql.TypeDuration,
+		// set unspecified for later round
+		Fsp: mysql.UnspecifiedFsp,
+	}
+
+	return t.RoundFrac(int(fsp))
 }
 
 func checkFsp(arg interface{}) (int, error) {

--- a/expression/builtin/time_test.go
+++ b/expression/builtin/time_test.go
@@ -275,3 +275,12 @@ func (s *testBuiltinSuite) TestCurrentDate(c *C) {
 	c.Assert(ok, IsTrue)
 	c.Assert(n.String(), GreaterEqual, last.Format(mysql.DateFormat))
 }
+
+func (s *testBuiltinSuite) TestCurrentTime(c *C) {
+	last := time.Now()
+	v, err := builtinCurrentTime(nil, nil)
+	c.Assert(err, IsNil)
+	n, ok := v.(mysql.Time)
+	c.Assert(ok, IsTrue)
+	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+}

--- a/expression/builtin/time_test.go
+++ b/expression/builtin/time_test.go
@@ -277,27 +277,29 @@ func (s *testBuiltinSuite) TestCurrentDate(c *C) {
 }
 
 func (s *testBuiltinSuite) TestCurrentTime(c *C) {
+	tfStr := "15:04:05"
+
 	last := time.Now()
 	v, err := builtinCurrentTime(nil, nil)
 	c.Assert(err, IsNil)
-	n, ok := v.(mysql.Time)
+	n, ok := v.(mysql.Duration)
 	c.Assert(ok, IsTrue)
 	c.Assert(n.String(), HasLen, 8)
-	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
 	v, err = builtinCurrentTime([]interface{}{3}, nil)
 	c.Assert(err, IsNil)
-	n, ok = v.(mysql.Time)
+	n, ok = v.(mysql.Duration)
 	c.Assert(ok, IsTrue)
 	c.Assert(n.String(), HasLen, 12)
-	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
 	v, err = builtinCurrentTime([]interface{}{6}, nil)
 	c.Assert(err, IsNil)
-	n, ok = v.(mysql.Time)
+	n, ok = v.(mysql.Duration)
 	c.Assert(ok, IsTrue)
 	c.Assert(n.String(), HasLen, 15)
-	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
 	v, err = builtinCurrentTime([]interface{}{-1}, nil)
 	c.Assert(err, NotNil)

--- a/expression/builtin/time_test.go
+++ b/expression/builtin/time_test.go
@@ -282,5 +282,26 @@ func (s *testBuiltinSuite) TestCurrentTime(c *C) {
 	c.Assert(err, IsNil)
 	n, ok := v.(mysql.Time)
 	c.Assert(ok, IsTrue)
+	c.Assert(n.String(), HasLen, 8)
 	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+
+	v, err = builtinCurrentTime([]interface{}{3}, nil)
+	c.Assert(err, IsNil)
+	n, ok = v.(mysql.Time)
+	c.Assert(ok, IsTrue)
+	c.Assert(n.String(), HasLen, 12)
+	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+
+	v, err = builtinCurrentTime([]interface{}{6}, nil)
+	c.Assert(err, IsNil)
+	n, ok = v.(mysql.Time)
+	c.Assert(ok, IsTrue)
+	c.Assert(n.String(), HasLen, 15)
+	c.Assert(n.String(), GreaterEqual, last.Format(mysql.CurrentTimeFormat))
+
+	v, err = builtinCurrentTime([]interface{}{-1}, nil)
+	c.Assert(err, NotNil)
+
+	v, err = builtinCurrentTime([]interface{}{7}, nil)
+	c.Assert(err, NotNil)
 }

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -34,9 +34,8 @@ var (
 
 // Time format without fractional seconds precision.
 const (
-	DateFormat        = "2006-01-02"
-	CurrentTimeFormat = "15:04:05"
-	TimeFormat        = "2006-01-02 15:04:05"
+	DateFormat = "2006-01-02"
+	TimeFormat = "2006-01-02 15:04:05"
 	// TimeFSPFormat is time format with fractional seconds precision.
 	TimeFSPFormat = "2006-01-02 15:04:05.000000"
 )
@@ -126,13 +125,7 @@ func (t Time) String() string {
 		return t.Time.Format(DateFormat)
 	}
 
-	var tfStr string
-	if t.Type == TypeDuration {
-		tfStr = CurrentTimeFormat
-	} else {
-		tfStr = TimeFormat
-	}
-
+	tfStr := TimeFormat
 	if t.Fsp > 0 {
 		tfStr = fmt.Sprintf("%s.%s", tfStr, strings.Repeat("0", t.Fsp))
 	}

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -34,8 +34,9 @@ var (
 
 // Time format without fractional seconds precision.
 const (
-	DateFormat = "2006-01-02"
-	TimeFormat = "2006-01-02 15:04:05"
+	DateFormat    = "2006-01-02"
+	CurtimeFormat = "15:04:05"
+	TimeFormat    = "2006-01-02 15:04:05"
 	// TimeFSPFormat is time format with fractional seconds precision.
 	TimeFSPFormat = "2006-01-02 15:04:05.000000"
 )
@@ -123,6 +124,10 @@ func (t Time) String() string {
 
 	if t.Type == TypeDate {
 		return t.Time.Format(DateFormat)
+	}
+
+	if t.Type == TypeDuration {
+		return t.Time.Format(CurtimeFormat)
 	}
 
 	tfStr := TimeFormat

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -34,9 +34,9 @@ var (
 
 // Time format without fractional seconds precision.
 const (
-	DateFormat    = "2006-01-02"
-	CurtimeFormat = "15:04:05"
-	TimeFormat    = "2006-01-02 15:04:05"
+	DateFormat        = "2006-01-02"
+	CurrentTimeFormat = "15:04:05"
+	TimeFormat        = "2006-01-02 15:04:05"
 	// TimeFSPFormat is time format with fractional seconds precision.
 	TimeFSPFormat = "2006-01-02 15:04:05.000000"
 )
@@ -127,7 +127,7 @@ func (t Time) String() string {
 	}
 
 	if t.Type == TypeDuration {
-		return t.Time.Format(CurtimeFormat)
+		return t.Time.Format(CurrentTimeFormat)
 	}
 
 	tfStr := TimeFormat

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -126,11 +126,13 @@ func (t Time) String() string {
 		return t.Time.Format(DateFormat)
 	}
 
+	var tfStr string
 	if t.Type == TypeDuration {
-		return t.Time.Format(CurrentTimeFormat)
+		tfStr = CurrentTimeFormat
+	} else {
+		tfStr = TimeFormat
 	}
 
-	tfStr := TimeFormat
 	if t.Fsp > 0 {
 		tfStr = fmt.Sprintf("%s.%s", tfStr, strings.Repeat("0", t.Fsp))
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -104,6 +104,8 @@ import (
 	cross 		"CROSS"
 	curDate 	"CURDATE"
 	currentDate 	"CURRENT_DATE"
+	curTime 	"CURTIME"
+	currentTime 	"CURRENT_TIME"
 	currentUser	"CURRENT_USER"
 	database	"DATABASE"
 	databases	"DATABASES"
@@ -2134,6 +2136,14 @@ FunctionCallNonKeyword:
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: $3.([]ast.ExprNode)}
 	}
 |	"CURDATE" '(' ')'
+	{
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+	}
+|	"CURTIME" '(' ')'
+	{
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+	}
+|	"CURRENT_TIME" '(' ')'
 	{
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -104,7 +104,6 @@ import (
 	cross 		"CROSS"
 	curDate 	"CURDATE"
 	currentDate 	"CURRENT_DATE"
-	curTime 	"CURTIME"
 	currentTime 	"CURRENT_TIME"
 	currentUser	"CURRENT_USER"
 	database	"DATABASE"
@@ -2138,14 +2137,6 @@ FunctionCallNonKeyword:
 |	"CURDATE" '(' ')'
 	{
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
-	}
-|	"CURTIME" FuncDatetimePrec
-	{
-		args := []ast.ExprNode{}
-		if $2 != nil {
-			args = append(args, $2.(ast.ExprNode))
-		}
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
 	}
 |	"CURRENT_TIME" FuncDatetimePrec
 	{

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2139,13 +2139,21 @@ FunctionCallNonKeyword:
 	{
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
 	}
-|	"CURTIME" '(' ')'
+|	"CURTIME" FuncDatetimePrec
 	{
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+		args := []ast.ExprNode{}
+		if $2 != nil {
+			args = append(args, $2.(ast.ExprNode))
+		}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
 	}
-|	"CURRENT_TIME" '(' ')'
+|	"CURRENT_TIME" FuncDatetimePrec
 	{
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+		args := []ast.ExprNode{}
+		if $2 != nil {
+			args = append(args, $2.(ast.ExprNode))
+		}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
 	}
 |	"CURRENT_TIMESTAMP" FuncDatetimePrec
 	{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -394,6 +394,14 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select now(6)", true},
 		{"select sysdate(), sysdate(6)", true},
 
+		// Select current_time
+		{"select current_time", true},
+		{"select current_time()", true},
+		{"select current_time(6)", true},
+		{"select curtime", true},
+		{"select curtime()", true},
+		{"select curtime(6)", true},
+
 		// For time extract
 		{`select extract(microsecond from "2011-11-11 10:10:10.123456")`, true},
 		{`select extract(second from "2011-11-11 10:10:10.123456")`, true},

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -323,6 +323,8 @@ create		{c}{r}{e}{a}{t}{e}
 cross		{c}{r}{o}{s}{s}
 curdate 	{c}{u}{r}{d}{a}{t}{e}
 current_date	{c}{u}{r}{r}{e}{n}{t}_{d}{a}{t}{e}
+curtime 	{c}{u}{r}{t}{i}{m}{e}
+current_time	{c}{u}{r}{r}{e}{n}{t}_{t}{i}{m}{e}
 current_user	{c}{u}{r}{r}{e}{n}{t}_{u}{s}{e}{r}
 database	{d}{a}{t}{a}{b}{a}{s}{e}
 databases	{d}{a}{t}{a}{b}{a}{s}{e}{s}
@@ -692,6 +694,10 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 			return curDate
 {current_date}		lval.item = string(l.val)
 			return currentDate
+{curtime}		lval.item = string(l.val)
+			return curTime
+{current_time}		lval.item = string(l.val)
+			return currentTime
 {current_user}		lval.item = string(l.val)
 			return currentUser
 {database}		lval.item = string(l.val)

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -695,7 +695,7 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {current_date}		lval.item = string(l.val)
 			return currentDate
 {curtime}		lval.item = string(l.val)
-			return curTime
+			return currentTime
 {current_time}		lval.item = string(l.val)
 			return currentTime
 {current_user}		lval.item = string(l.val)


### PR DESCRIPTION
This is for issue [#236](https://github.com/pingcap/tidb/issues/236). The change adds two time functions: `CURRENT_TIME` and `CURTIME`.