### PR TITLE
evaluator: Check function call min and max arguments in new evaluator.

### DIFF
--- a/expression/builtin/builtin.go
+++ b/expression/builtin/builtin.go
@@ -70,7 +70,7 @@ var Funcs = map[string]Func{
 	"curdate":           {builtinCurrentDate, 0, 0, false, false},
 	"current_date":      {builtinCurrentDate, 0, 0, false, false},
 	"current_timestamp": {builtinNow, 0, 1, false, false},
-	"date":              {builtinDate, 8, 8, true, false},
+	"date":              {builtinDate, 1, 1, true, false},
 	"day":               {builtinDay, 1, 1, true, false},
 	"dayofmonth":        {builtinDayOfMonth, 1, 1, true, false},
 	"dayofweek":         {builtinDayOfWeek, 1, 1, true, false},

--- a/optimizer/evaluator/evaluator.go
+++ b/optimizer/evaluator/evaluator.go
@@ -536,6 +536,10 @@ func (e *Evaluator) funcCall(v *ast.FuncCallExpr) bool {
 		e.err = ErrInvalidOperation.Gen("unknown function %s", v.FnName.O)
 		return false
 	}
+	if len(v.Args) < f.MinArgs || len(v.Args) > f.MaxArgs {
+		e.err = ErrInvalidOperation.Gen("number of function arguments must in [%d, %d].", f.MinArgs, f.MaxArgs)
+		return false
+	}
 	a := make([]interface{}, len(v.Args))
 	for i, arg := range v.Args {
 		a[i] = arg.GetValue()

--- a/optimizer/evaluator/evaluator.go
+++ b/optimizer/evaluator/evaluator.go
@@ -536,7 +536,7 @@ func (e *Evaluator) funcCall(v *ast.FuncCallExpr) bool {
 		e.err = ErrInvalidOperation.Gen("unknown function %s", v.FnName.O)
 		return false
 	}
-	if len(v.Args) < f.MinArgs || len(v.Args) > f.MaxArgs {
+	if len(v.Args) < f.MinArgs || (f.MaxArgs != -1 && len(v.Args) > f.MaxArgs) {
 		e.err = ErrInvalidOperation.Gen("number of function arguments must in [%d, %d].", f.MinArgs, f.MaxArgs)
 		return false
 	}

--- a/optimizer/evaluator/evaluator_test.go
+++ b/optimizer/evaluator/evaluator_test.go
@@ -386,12 +386,33 @@ func (s *testEvaluatorSuite) TestConvert(c *C) {
 func (s *testEvaluatorSuite) TestCall(c *C) {
 	ctx := mock.NewContext()
 
-	// Test case for unknown function
+	// Test case for correct number of arguments
 	expr := &ast.FuncCallExpr{
+		FnName: model.NewCIStr("date"),
+		Args:   []ast.ExprNode{ast.NewValueExpr("2015-12-21 11:11:11")},
+	}
+	v, err := Eval(ctx, expr)
+	c.Assert(err, IsNil)
+	value, ok := v.(mysql.Time)
+	c.Assert(ok, IsTrue)
+	c.Assert(value.String(), Equals, "2015-12-21")
+
+	// Test case for unlimited upper bound
+	expr = &ast.FuncCallExpr{
+		FnName: model.NewCIStr("concat"),
+		Args: []ast.ExprNode{ast.NewValueExpr("Ti"),
+			ast.NewValueExpr("D"), ast.NewValueExpr("B")},
+	}
+	v, err = Eval(ctx, expr)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, "TiDB")
+
+	// Test case for unknown function
+	expr = &ast.FuncCallExpr{
 		FnName: model.NewCIStr("unknown"),
 		Args:   []ast.ExprNode{},
 	}
-	_, err := Eval(ctx, expr)
+	_, err = Eval(ctx, expr)
 	c.Assert(err, NotNil)
 
 	// Test case for invalid number of arguments, violating the lower bound
@@ -410,23 +431,6 @@ func (s *testEvaluatorSuite) TestCall(c *C) {
 	}
 	_, err = Eval(ctx, expr)
 	c.Assert(err, NotNil)
-
-	// Test case for correct number of arguments
-	expr = &ast.FuncCallExpr{
-		FnName: model.NewCIStr("date"),
-		Args:   []ast.ExprNode{ast.NewValueExpr("2015-12-21")},
-	}
-	_, err = Eval(ctx, expr)
-	c.Assert(err, IsNil)
-
-	// Test case for unlimited upper bound
-	expr = &ast.FuncCallExpr{
-		FnName: model.NewCIStr("concat"),
-		Args: []ast.ExprNode{ast.NewValueExpr(1),
-			ast.NewValueExpr(2)},
-	}
-	_, err = Eval(ctx, expr)
-	c.Assert(err, IsNil)
 }
 
 func (s *testEvaluatorSuite) TestCast(c *C) {


### PR DESCRIPTION
For github issue [#758](https://github.com/pingcap/tidb/issues/758).

1. Add min and max arguments checking.
2. Fix the incorrect min/max value for `builtinDate` function call.