### PR TITLE
parser: fix parsing curtime

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -104,6 +104,7 @@ import (
 	cross 		"CROSS"
 	curDate 	"CURDATE"
 	currentDate 	"CURRENT_DATE"
+	curTime 	"CUR_TIME"
 	currentTime 	"CURRENT_TIME"
 	currentUser	"CURRENT_USER"
 	database	"DATABASE"
@@ -1688,7 +1689,7 @@ NotKeywordToken:
 |	"DAYOFWEEK" | "DAYOFYEAR" | "FOUND_ROWS" | "GROUP_CONCAT"| "HOUR" | "IFNULL" | "LENGTH" | "LOCATE" | "MAX"
 |	"MICROSECOND" | "MIN" | "MINUTE" | "NULLIF" | "MONTH" | "NOW" | "RAND" | "SECOND" | "SQL_CALC_FOUND_ROWS"
 |	"SUBDATE" | "SUBSTRING" %prec lowerThanLeftParen | "SUBSTRING_INDEX" | "SUM" | "TRIM" | "WEEKDAY" | "WEEKOFYEAR"
-|	"YEARWEEK" | "CONNECTION_ID"
+|	"YEARWEEK" | "CONNECTION_ID" | "CUR_TIME" 
 
 /************************************************************************************
  *
@@ -2137,6 +2138,14 @@ FunctionCallNonKeyword:
 |	"CURDATE" '(' ')'
 	{
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+	}
+|	"CUR_TIME" '(' ExpressionOpt ')' 
+	{
+		args := []ast.ExprNode{}
+		if $3 != nil {
+			args = append(args, $3.(ast.ExprNode))
+		}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
 	}
 |	"CURRENT_TIME" FuncDatetimePrec
 	{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -41,6 +41,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"collation", "comment", "avg_row_length", "checksum", "compression", "connection", "key_block_size",
 		"max_rows", "min_rows", "national", "row", "quarter", "escape", "grants", "status", "fields", "triggers",
 		"delay_key_write", "isolation", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
+		"curtime",
 	}
 	for _, kw := range unreservedKws {
 		src := fmt.Sprintf("SELECT %s FROM tbl;", kw)
@@ -398,7 +399,6 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"select current_time", true},
 		{"select current_time()", true},
 		{"select current_time(6)", true},
-		{"select curtime", true},
 		{"select curtime()", true},
 		{"select curtime(6)", true},
 

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -695,7 +695,7 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {current_date}		lval.item = string(l.val)
 			return currentDate
 {curtime}		lval.item = string(l.val)
-			return currentTime
+			return curTime
 {current_time}		lval.item = string(l.val)
 			return currentTime
 {current_user}		lval.item = string(l.val)


### PR DESCRIPTION
1. It can be used as an identifier
2. It should be called with parentheses

@yanzhe-chen 