### PR TITLE
executor: make seek value with the same length of the index columns.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -84,7 +84,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.IndexScan) Executor {
 	}
 	e := &IndexScanExec{
 		tbl:        tbl,
-		idx:        idx.X,
+		idx:        idx,
 		fields:     v.Fields(),
 		ctx:        b.ctx,
 		Desc:       v.Desc,

--- a/kv/index_iter_test.go
+++ b/kv/index_iter_test.go
@@ -156,8 +156,8 @@ func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 
 	index2 := kv.NewKVIndex("i", "test", 1, false)
 	iter, hit, err := index2.Seek(txn, []interface{}{"abc", nil})
-	defer iter.Close()
 	c.Assert(err, IsNil)
+	defer iter.Close()
 	c.Assert(hit, IsFalse)
 	_, h, err := iter.Next()
 	c.Assert(err, IsNil)

--- a/kv/index_iter_test.go
+++ b/kv/index_iter_test.go
@@ -143,3 +143,23 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	err = txn.Commit()
 	c.Assert(err, IsNil)
 }
+
+func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
+	index := kv.NewKVIndex("i", "test", 1, false)
+
+	txn, err := s.s.Begin()
+	c.Assert(err, IsNil)
+
+	values := []interface{}{"abc", "def"}
+	err = index.Create(txn, values, 1)
+	c.Assert(err, IsNil)
+
+	index2 := kv.NewKVIndex("i", "test", 1, false)
+	iter, hit, err := index2.Seek(txn, []interface{}{"abc", nil})
+	defer iter.Close()
+	c.Assert(err, IsNil)
+	c.Assert(hit, IsFalse)
+	_, h, err := iter.Next()
+	c.Assert(err, IsNil)
+	c.Assert(h, Equals, int64(1))
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1364,6 +1364,13 @@ func (s *testSessionSuite) TestMultiColumnIndex(c *C) {
 	checkPlan(c, se, sql, expectedExplain)
 	mustExecMatch(c, se, sql, [][]interface{}{{1}})
 
+	// Test varchar type.
+	mustExecSQL(c, se, "drop table t;")
+	mustExecSQL(c, se, "create table t (c1 varchar(64), c2 varchar(64), index c1_c2 (c1, c2));")
+	mustExecSQL(c, se, "insert into t values ('abc', 'def')")
+	sql = "select c1 from t where c1 = 'abc'"
+	mustExecMatch(c, se, sql, [][]interface{}{{[]byte("abc")}})
+
 	err := se.Close()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
For composite index with 2 columns, if we just pass one value in `Seek`, we will get the wrong result.
So this change create the seek value with the length of the composite index.