### PR TITLE
plans: Fix bug in show full tables

### DIFF
--- a/plan/plans/info_test.go
+++ b/plan/plans/info_test.go
@@ -69,7 +69,8 @@ func mustQuery(c *C, currDB *sql.DB, s string) int {
 }
 
 func mustFailQuery(c *C, currDB *sql.DB, s string) {
-	rows, _ := currDB.Query(s)
+	rows, err := currDB.Query(s)
+	c.Assert(err, IsNil)
 	rows.Next()
 	c.Assert(rows.Err(), NotNil)
 	rows.Close()

--- a/plan/plans/info_test.go
+++ b/plan/plans/info_test.go
@@ -68,6 +68,13 @@ func mustQuery(c *C, currDB *sql.DB, s string) int {
 	return cnt
 }
 
+func mustFailQuery(c *C, currDB *sql.DB, s string) {
+	rows, _ := currDB.Query(s)
+	rows.Next()
+	c.Assert(rows.Err(), NotNil)
+	rows.Close()
+}
+
 func mustExec(c *C, currDB *sql.DB, sql string) sql.Result {
 	tx := mustBegin(c, currDB)
 	r := mustExecuteSql(c, tx, sql)

--- a/plan/plans/show.go
+++ b/plan/plans/show.go
@@ -357,11 +357,9 @@ func (s *ShowPlan) fetchShowTables(ctx context.Context) error {
 		} else if s.Where != nil {
 			m[expression.ExprEvalIdentFunc] = func(name string) (interface{}, error) {
 				// The first column is Tables_in_{database}.
-				// If s.Full is true, there is a column named Table_type at the second place.
-				if strings.EqualFold(name, "Table_type") {
-					if s.Full {
-						return data[1], nil
-					}
+				// If s.Full is true, there will be a column named Table_type at the second place.
+				if s.Full && strings.EqualFold(name, "Table_type") {
+					return data[1], nil
 				}
 				fieldName := fmt.Sprintf("Tables_in_%s", dbName)
 				if strings.EqualFold(name, fieldName) {

--- a/plan/plans/show.go
+++ b/plan/plans/show.go
@@ -356,8 +356,16 @@ func (s *ShowPlan) fetchShowTables(ctx context.Context) error {
 			s.Pattern.Expr = expression.Value{Val: data[0]}
 		} else if s.Where != nil {
 			m[expression.ExprEvalIdentFunc] = func(name string) (interface{}, error) {
-				if s.Full && strings.EqualFold(name, "Table_type") {
-					return data[1], nil
+				// The first column is Tables_in_{database}.
+				// If s.Full is true, there is a column named Table_type at the second place.
+				if strings.EqualFold(name, "Table_type") {
+					if s.Full {
+						return data[1], nil
+					}
+				}
+				fieldName := fmt.Sprintf("Tables_in_%s", dbName)
+				if strings.EqualFold(name, fieldName) {
+					return data[0], nil
 				}
 				return nil, errors.Errorf("unknown field %s", name)
 			}

--- a/plan/plans/show_test.go
+++ b/plan/plans/show_test.go
@@ -360,11 +360,12 @@ func (p *testShowSuit) TestShowTables(c *C) {
 	c.Assert(cnt, Equals, 2)
 	cnt = mustQuery(c, testDB, `show full tables where Table_type != 'VIEW';`)
 	c.Assert(cnt, Equals, 3)
+	cnt = mustQuery(c, testDB, `show full tables where Tables_in_test='tab00' and Table_type != 'VIEW';`)
+	c.Assert(cnt, Equals, 1)
+	mustFailQuery(c, testDB, `show full tables where Tables_in_unknowndb ='tab00' and Table_type != 'VIEW';`)
 
 	mustQuery(c, testDB, `show create table tab00;`)
-	rows, _ := testDB.Query(`show create table abc;`)
-	rows.Next()
-	c.Assert(rows.Err(), NotNil)
+	mustFailQuery(c, testDB, `show create table abc;`)
 }
 
 func (p *testShowSuit) TestShowGrants(c *C) {

--- a/plan/plans/show_test.go
+++ b/plan/plans/show_test.go
@@ -363,6 +363,7 @@ func (p *testShowSuit) TestShowTables(c *C) {
 	cnt = mustQuery(c, testDB, `show full tables where Tables_in_test='tab00' and Table_type != 'VIEW';`)
 	c.Assert(cnt, Equals, 1)
 	mustFailQuery(c, testDB, `show full tables where Tables_in_unknowndb ='tab00' and Table_type != 'VIEW';`)
+	mustFailQuery(c, testDB, `show tables where Tables_in_test ='tab00' and Table_type != 'VIEW';`)
 
 	mustQuery(c, testDB, `show create table tab00;`)
 	mustFailQuery(c, testDB, `show create table abc;`)


### PR DESCRIPTION
Support SHOW FULL TABLES FROM test WHERE Tables_in_test = 't1' AND Table_type != 'VIEW'
The first column is "Tables_in_{db}", we should support it in where expression.