### PR TITLE
*: Fix bug in convert_expr.go that miss SubstringIndexExpr

### DIFF
--- a/executor/converter/convert_expr.go
+++ b/executor/converter/convert_expr.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/subquery"
@@ -117,6 +118,8 @@ func (c *expressionConverter) Leave(in ast.Node) (out ast.Node, ok bool) {
 		c.funcDateArith(v)
 	case *ast.AggregateFuncExpr:
 		c.aggregateFunc(v)
+	case ast.ExprNode:
+		log.Errorf("Unknown expr node %T", v)
 	}
 	return in, c.err == nil
 }

--- a/executor/converter/convert_expr.go
+++ b/executor/converter/convert_expr.go
@@ -106,6 +106,8 @@ func (c *expressionConverter) Leave(in ast.Node) (out ast.Node, ok bool) {
 		c.funcCast(v)
 	case *ast.FuncSubstringExpr:
 		c.funcSubstring(v)
+	case *ast.FuncSubstringIndexExpr:
+		c.funcSubstringIndex(v)
 	case *ast.FuncLocateExpr:
 		c.funcLocate(v)
 	case *ast.FuncTrimExpr:
@@ -361,6 +363,15 @@ func (c *expressionConverter) funcSubstring(v *ast.FuncSubstringExpr) {
 		StrExpr: c.exprMap[v.StrExpr],
 	}
 	c.exprMap[v] = oldSubstring
+}
+
+func (c *expressionConverter) funcSubstringIndex(v *ast.FuncSubstringIndexExpr) {
+	oldSubstrIdx := &expression.FunctionSubstringIndex{
+		Delim:   c.exprMap[v.Delim],
+		Count:   c.exprMap[v.Count],
+		StrExpr: c.exprMap[v.StrExpr],
+	}
+	c.exprMap[v] = oldSubstrIdx
 }
 
 func (c *expressionConverter) funcLocate(v *ast.FuncLocateExpr) {

--- a/executor/converter/convert_expr.go
+++ b/executor/converter/convert_expr.go
@@ -14,12 +14,13 @@
 package converter
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/subquery"
 	"github.com/pingcap/tidb/model"
-	"strings"
 )
 
 func convertExpr(converter *expressionConverter, expr ast.ExprNode) (expression.Expression, error) {

--- a/session_test.go
+++ b/session_test.go
@@ -1373,8 +1373,8 @@ func (s *testSessionSuite) TestSubstringIndexExpr(c *C) {
 	se := newSession(c, store, s.dbName)
 	mustExecSQL(c, se, "drop table if exists t;")
 	mustExecSQL(c, se, "create table t (c varchar(128));")
-	mustExecSQL(c, se, `insert into t values ("www.mysql.com");`)
-	mustExecMatch(c, se, "SELECT DISTINCT SUBSTRING_INDEX(c, '.', 2) from t;", [][]interface{}{{"www.mysql"}})
+	mustExecSQL(c, se, `insert into t values ("www.pingcap.com");`)
+	mustExecMatch(c, se, "SELECT DISTINCT SUBSTRING_INDEX(c, '.', 2) from t;", [][]interface{}{{"www.pingcap"}})
 }
 
 func (s *testSessionSuite) TestGlobalVarAccessor(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -1368,6 +1368,15 @@ func (s *testSessionSuite) TestMultiColumnIndex(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *testSessionSuite) TestSubstringIndexExpr(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+	mustExecSQL(c, se, "drop table if exists t;")
+	mustExecSQL(c, se, "create table t (c varchar(128));")
+	mustExecSQL(c, se, `insert into t values ("www.mysql.com");`)
+	mustExecMatch(c, se, "SELECT DISTINCT SUBSTRING_INDEX(c, '.', 2) from t;", [][]interface{}{{"www.mysql"}})
+}
+
 func (s *testSessionSuite) TestGlobalVarAccessor(c *C) {
 
 	varName := "max_allowed_packet"


### PR DESCRIPTION
@coocood 
When converting ast, we miss FuncSubstringIndexExpr. It will cause panic.