### PR TITLE
tide-server: avoid panic when failed in SetupSuite.

### DIFF
--- a/tidb-server/server/tidb_test.go
+++ b/tidb-server/server/tidb_test.go
@@ -43,7 +43,9 @@ func (ts *TidbTestSuite) SetUpSuite(c *C) {
 }
 
 func (ts *TidbTestSuite) TearDownSuite(c *C) {
-	ts.server.Close()
+	if ts.server != nil {
+		ts.server.Close()
+	}
 }
 
 func (ts *TidbTestSuite) TestRegression(c *C) {


### PR DESCRIPTION
Have taken a look at `go check` source code, `TearDownSuite` will always be called even if it failed in `SetUpSuite`.

avoid panic like 
https://github.com/pingcap/tidb/issues/776#issuecomment-166608023