### PR TITLE
builtin: add version()

### DIFF
--- a/expression/builtin/builtin.go
+++ b/expression/builtin/builtin.go
@@ -114,6 +114,7 @@ var Funcs = map[string]Func{
 	"found_rows":    {builtinFoundRows, 0, 0, false, false},
 	"user":          {builtinUser, 0, 0, false, false},
 	"connection_id": {builtinConnectionID, 0, 0, true, false},
+	"version":       {builtinVersion, 0, 0, true, false},
 }
 
 func invArg(arg interface{}, s string) error {

--- a/expression/builtin/info.go
+++ b/expression/builtin/info.go
@@ -20,6 +20,7 @@ package builtin
 import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/db"
 	"github.com/pingcap/tidb/sessionctx/variable"
 )
@@ -75,4 +76,8 @@ func builtinConnectionID(args []interface{}, data map[interface{}]interface{}) (
 	}
 	ctx := c.(context.Context)
 	return variable.GetSessionVars(ctx).ConnectionID, nil
+}
+
+func builtinVersion(args []interface{}, data map[interface{}]interface{}) (v interface{}, err error) {
+	return mysql.ServerVersion, nil
 }

--- a/expression/builtin/info_test.go
+++ b/expression/builtin/info_test.go
@@ -15,6 +15,7 @@ package builtin
 
 import (
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/db"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/mock"
@@ -93,4 +94,11 @@ func (s *testBuiltinSuite) TestConnectionID(c *C) {
 	v, err := builtinConnectionID(nil, m)
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, uint64(1))
+}
+
+func (s *testBuiltinSuite) TestVersion(c *C) {
+	m := map[interface{}]interface{}{}
+	v, err := builtinVersion(nil, m)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, mysql.ServerVersion)
 }

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -278,6 +278,7 @@ import (
 	value		"VALUE"
 	values		"VALUES"
 	variables	"VARIABLES"
+	version		"VERSION"
 	warnings	"WARNINGS"
 	week		"WEEK"
 	weekday		"WEEKDAY"
@@ -1693,7 +1694,7 @@ NotKeywordToken:
 |	"DAYOFWEEK" | "DAYOFYEAR" | "FOUND_ROWS" | "GROUP_CONCAT"| "HOUR" | "IFNULL" | "LENGTH" | "LOCATE" | "MAX"
 |	"MICROSECOND" | "MIN" | "MINUTE" | "NULLIF" | "MONTH" | "NOW" | "POW" | "POWER" | "RAND" | "SECOND" | "SQL_CALC_FOUND_ROWS"
 |	"SUBDATE" | "SUBSTRING" %prec lowerThanLeftParen | "SUBSTRING_INDEX" | "SUM" | "TRIM" | "WEEKDAY" | "WEEKOFYEAR"
-|	"YEARWEEK" | "CONNECTION_ID" | "CUR_TIME" 
+|	"YEARWEEK" | "CONNECTION_ID" | "CUR_TIME" | "VERSION"
 
 /************************************************************************************
  *
@@ -2040,7 +2041,7 @@ Function:
 |	FunctionCallAgg
 
 FunctionNameConflict:
-	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT" | "CURRENT_USER" | "CURRENT_DATE"
+	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT" | "CURRENT_USER" | "CURRENT_DATE" | "VERSION"
 
 FunctionCallConflict:
 	FunctionNameConflict '(' ExpressionListOpt ')' 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -41,7 +41,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"collation", "comment", "avg_row_length", "checksum", "compression", "connection", "key_block_size",
 		"max_rows", "min_rows", "national", "row", "quarter", "escape", "grants", "status", "fields", "triggers",
 		"delay_key_write", "isolation", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
-		"curtime", "variables", "dayname",
+		"curtime", "variables", "dayname", "version",
 	}
 	for _, kw := range unreservedKws {
 		src := fmt.Sprintf("SELECT %s FROM tbl;", kw)
@@ -351,6 +351,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{"SELECT CURRENT_USER();", true},
 		{"SELECT CURRENT_USER;", true},
 		{"SELECT CONNECTION_ID();", true},
+		{"SELECT VERSION();", true},
 
 		{"SELECT SUBSTRING_INDEX('www.mysql.com', '.', 2);", true},
 		{"SELECT SUBSTRING_INDEX('www.mysql.com', '.', -2);", true},

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -475,6 +475,7 @@ upper		{u}{p}{p}{e}{r}
 value		{v}{a}{l}{u}{e}
 values		{v}{a}{l}{u}{e}{s}
 variables	{v}{a}{r}{i}{a}{b}{l}{e}{s}
+version		{v}{e}{r}{s}{i}{o}{n}
 warnings	{w}{a}{r}{n}{i}{n}{g}{s}
 week		{w}{e}{e}{k}
 weekday		{w}{e}{e}{k}{d}{a}{y}
@@ -967,6 +968,8 @@ year_month		{y}{e}{a}{r}_{m}{o}{n}{t}{h}
 {values}		return values
 {variables}		lval.item = string(l.val)
 			return variables
+{version}		lval.item = string(l.val)
+			return version
 {warnings}		lval.item = string(l.val)
 			return warnings
 {week}			lval.item = string(l.val)


### PR DESCRIPTION
`VERSION()` function is needed by MySQL workbench (I'm using 6.3 with default configuration) and perhaps some other applications.


After this fix, MySQL workbench can successfully connect to TiDB.
(However cannot execute any query due to `Error Code: 0 Server sent unknown charsetnr (0) .`.. This will be a separate issue)

Update #273 #702  