### PR TITLE
optimizer: fix refiner panic when assert like pattern type to string.

### DIFF
--- a/optimizer/plan/range.go
+++ b/optimizer/plan/range.go
@@ -272,7 +272,11 @@ func (r *rangeBuilder) buildFromPatternLike(x *ast.PatternLikeExpr) []rangePoint
 		r.err = ErrUnsupportedType.Gen("NOT LIKE is not supported.")
 		return fullRange
 	}
-	pattern := x.Pattern.GetValue().(string)
+	pattern, err := types.ToString(x.Pattern.GetValue())
+	if err != nil {
+		r.err = errors.Trace(err)
+		return fullRange
+	}
 	lowValue := make([]byte, 0, len(pattern))
 	// unscape the pattern
 	var exclude bool

--- a/optimizer/plan/refiner.go
+++ b/optimizer/plan/refiner.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
+	"github.com/pingcap/tidb/util/types"
 )
 
 // Refine tries to build index range, bypass sort, set limit for source plan.
@@ -222,7 +223,14 @@ func (c *conditionChecker) check(condition ast.ExprNode) bool {
 		if !ast.IsPreEvaluable(x.Pattern) {
 			return false
 		}
-		patternStr := x.Pattern.GetValue().(string)
+		patternVal := x.Pattern.GetValue()
+		if patternVal == nil {
+			return false
+		}
+		patternStr, err := types.ToString(patternVal)
+		if err != nil {
+			return false
+		}
 		firstChar := patternStr[0]
 		return firstChar != '%' && firstChar != '.'
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -909,7 +909,7 @@ func (s *testSessionSuite) TestWhereLike(c *C) {
 	se := newSession(c, store, s.dbName)
 
 	mustExecSQL(c, se, "drop table if exists t")
-	mustExecSQL(c, se, "create table t(c int)")
+	mustExecSQL(c, se, "create table t(c int, index(c))")
 	mustExecSQL(c, se, "insert into t values (1),(2),(3),(-11),(11),(123),(211),(210)")
 	mustExecSQL(c, se, "insert into t values ()")
 
@@ -917,6 +917,8 @@ func (s *testSessionSuite) TestWhereLike(c *C) {
 	rows, err := r.Rows(-1, 0)
 	c.Assert(err, IsNil)
 	c.Assert(rows, HasLen, 6)
+
+	mustExecSQL(c, se, "select c from t where c like binary('abc')")
 }
 
 func (s *testSessionSuite) TestDefaultFlenBug(c *C) {


### PR DESCRIPTION
The pattern value may not be string.