### PR TITLE
Fix bugs for running phpmyadmin

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -249,11 +249,13 @@ func (n *FuncLocateExpr) Accept(v Visitor) (Node, bool) {
 		return n, false
 	}
 	n.SubStr = node.(ExprNode)
-	node, ok = n.Pos.Accept(v)
-	if !ok {
-		return n, false
+	if n.Pos != nil {
+		node, ok = n.Pos.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Pos = node.(ExprNode)
 	}
-	n.Pos = node.(ExprNode)
 	return v.Leave(n)
 }
 

--- a/executor/converter/convert_stmt.go
+++ b/executor/converter/convert_stmt.go
@@ -822,6 +822,8 @@ func convertShow(converter *expressionConverter, v *ast.ShowStmt) (*stmts.ShowSt
 		oldShow.Target = stmt.ShowCreateTable
 	case ast.ShowDatabases:
 		oldShow.Target = stmt.ShowDatabases
+	case ast.ShowGrants:
+		oldShow.Target = stmt.ShowGrants
 	case ast.ShowTables:
 		oldShow.Target = stmt.ShowTables
 	case ast.ShowEngines:

--- a/session_test.go
+++ b/session_test.go
@@ -684,6 +684,12 @@ func (s *testSessionSuite) TestShow(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(row, HasLen, 1)
 	c.Assert(row[0], Equals, "test")
+
+	r = mustExecSQL(c, se, "grant all on *.* to 'root'@'%'")
+	r = mustExecSQL(c, se, "show grants")
+	row, err = r.FirstRow()
+	c.Assert(err, IsNil)
+	c.Assert(row, HasLen, 1)
 }
 
 func (s *testSessionSuite) TestTimeFunc(c *C) {
@@ -1149,6 +1155,7 @@ func (s *testSessionSuite) TestBuiltin(c *C) {
 
 	// Testcase for https://github.com/pingcap/tidb/issues/382
 	mustExecFailed(c, se, `select cast("xxx 10:10:10" as datetime)`)
+	mustExecMatch(c, se, "select locate('bar', 'foobarbar')", [][]interface{}{{4}})
 }
 
 func (s *testSessionSuite) TestFieldText(c *C) {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -377,6 +377,7 @@ func newStore(c *C, dbPath string) kv.Storage {
 func newSession(c *C, store kv.Storage, dbName string) Session {
 	se, err := CreateSession(store)
 	c.Assert(err, IsNil)
+	se.Auth("root@%", nil, []byte("012345678901234567890"));
 	mustExecSQL(c, se, "create database if not exists "+dbName)
 	mustExecSQL(c, se, "use "+dbName)
 	return se

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -377,7 +377,7 @@ func newStore(c *C, dbPath string) kv.Storage {
 func newSession(c *C, store kv.Storage, dbName string) Session {
 	se, err := CreateSession(store)
 	c.Assert(err, IsNil)
-	se.Auth("root@%", nil, []byte("012345678901234567890"));
+	se.Auth("root@%", nil, []byte("012345678901234567890"))
 	mustExecSQL(c, se, "create database if not exists "+dbName)
 	mustExecSQL(c, se, "use "+dbName)
 	return se

--- a/util/codec/bytes.go
+++ b/util/codec/bytes.go
@@ -185,7 +185,7 @@ func reverseBytes(b []byte) {
 
 // like realloc.
 func reallocBytes(b []byte, n int) []byte {
-	if cap(b) < n {
+	if cap(b) < len(b)+n {
 		bs := make([]byte, len(b), len(b)+n)
 		copy(bs, b)
 		return bs

--- a/util/codec/bytes.go
+++ b/util/codec/bytes.go
@@ -185,8 +185,9 @@ func reverseBytes(b []byte) {
 
 // like realloc.
 func reallocBytes(b []byte, n int) []byte {
-	if cap(b) < len(b)+n {
-		bs := make([]byte, len(b), len(b)+n)
+	newSize := len(b) + n
+	if cap(b) < newSize {
+		bs := make([]byte, len(b), newSize)
 		copy(bs, b)
 		return bs
 	}


### PR DESCRIPTION
1. Add ShowGrants to oldShow convert, phpmyadmin can run up now.
2. Fix a bug in Accept of FuncLocateExpr, handling the error while the Pos arg of LOCATE() not given.