### PR TITLE
util/types: fix order by binary

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -979,8 +979,8 @@ func (s *testSessionSuite) TestOrderBy(c *C) {
 	store := newStore(c, s.dbName)
 	se := newSession(c, store, s.dbName)
 	mustExecSQL(c, se, "drop table if exists t")
-	mustExecSQL(c, se, "create table t (c1 int, c2 int)")
-	mustExecSQL(c, se, "insert into t values (1,2), (2, 1)")
+	mustExecSQL(c, se, "create table t (c1 int, c2 int, c3 varchar(20))")
+	mustExecSQL(c, se, "insert into t values (1, 2, 'abc'), (2, 1, 'bcd')")
 
 	// Fix issue https://github.com/pingcap/tidb/issues/337
 	mustExecMatch(c, se, "select c1 as a, c1 as b from t order by c1", [][]interface{}{{1, 1}, {2, 2}})
@@ -991,15 +991,19 @@ func (s *testSessionSuite) TestOrderBy(c *C) {
 	mustExecMatch(c, se, "select c1 as c2 from t order by c2 + 1", [][]interface{}{{2}, {1}})
 
 	// Order by position
-	mustExecMatch(c, se, "select * from t order by 1", [][]interface{}{{1, 2}, {2, 1}})
-	mustExecMatch(c, se, "select * from t order by 2", [][]interface{}{{2, 1}, {1, 2}})
+	mustExecMatch(c, se, "select * from t order by 1", [][]interface{}{{1, 2, []byte("abc")}, {2, 1, []byte("bcd")}})
+	mustExecMatch(c, se, "select * from t order by 2", [][]interface{}{{2, 1, []byte("bcd")}, {1, 2, []byte("abc")}})
 	mustExecFailed(c, se, "select * from t order by 0")
-	mustExecFailed(c, se, "select * from t order by 3")
+	mustExecFailed(c, se, "select * from t order by 4")
 
 	mustExecFailed(c, se, "select c1 as a, c2 as a from t order by a")
 
 	mustExecFailed(c, se, "(select c1 as c2, c2 from t) union (select c1, c2 from t) order by c2")
 	mustExecFailed(c, se, "(select c1 as c2, c2 from t) union (select c1, c2 from t) order by c1")
+
+	// Ordery by binary
+	mustExecMatch(c, se, "select c1, c3 from t order by binary c1 desc", [][]interface{}{{2, []byte("bcd")}, {1, []byte("abc")}})
+	mustExecMatch(c, se, "select c1, c2 from t order by binary c3", [][]interface{}{{1, 2}, {2, 1}})
 }
 
 func (s *testSessionSuite) TestHaving(c *C) {

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -174,23 +174,13 @@ func collateDesc(a, b []interface{}) int {
 // IsOrderedType returns a boolean
 // whether the type of y can be used by order by.
 func IsOrderedType(v interface{}) (r bool) {
-	switch x := v.(type) {
+	switch RawData(v).(type) {
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, string, []byte,
 		mysql.Decimal, mysql.Time, mysql.Duration,
 		mysql.Hex, mysql.Bit, mysql.Enum, mysql.Set:
 		return true
-	case *DataItem:
-		switch x.Type.Tp {
-		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24,
-			mysql.TypeLong, mysql.TypeLonglong, mysql.TypeFloat,
-			mysql.TypeDouble, mysql.TypeString, mysql.TypeVarchar,
-			mysql.TypeVarString, mysql.TypeDecimal, mysql.TypeNewDecimal,
-			mysql.TypeDate, mysql.TypeDuration, mysql.TypeDatetime,
-			mysql.TypeTimestamp, mysql.TypeBit, mysql.TypeEnum, mysql.TypeSet:
-			return true
-		}
 	}
 	return false
 }

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -174,13 +174,23 @@ func collateDesc(a, b []interface{}) int {
 // IsOrderedType returns a boolean
 // whether the type of y can be used by order by.
 func IsOrderedType(v interface{}) (r bool) {
-	switch v.(type) {
+	switch x := v.(type) {
 	case int, int8, int16, int32, int64,
 		uint, uint8, uint16, uint32, uint64,
 		float32, float64, string, []byte,
 		mysql.Decimal, mysql.Time, mysql.Duration,
 		mysql.Hex, mysql.Bit, mysql.Enum, mysql.Set:
 		return true
+	case *DataItem:
+		switch x.Type.Tp {
+		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24,
+			mysql.TypeLong, mysql.TypeLonglong, mysql.TypeFloat,
+			mysql.TypeDouble, mysql.TypeString, mysql.TypeVarchar,
+			mysql.TypeVarString, mysql.TypeDecimal, mysql.TypeNewDecimal,
+			mysql.TypeDate, mysql.TypeDuration, mysql.TypeDatetime,
+			mysql.TypeTimestamp, mysql.TypeBit, mysql.TypeEnum, mysql.TypeSet:
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
In Orderby Clause, as using BINARY operator to cast the following operand to a binary string, here meet an error. Improved IsOrderedType() to handle it.