### PR TITLE
optimizer/plan: fix splitWhere

### DIFF
--- a/optimizer/plan/plan_test.go
+++ b/optimizer/plan/plan_test.go
@@ -264,7 +264,19 @@ func (s *testPlanSuite) TestBestPlan(c *C) {
 		},
 		{
 			sql:  "select * from t where c = 0 and d = 0",
-			best: "Index(t.c_d)->Fields",
+			best: "Index(t.c_d_e)->Fields",
+		},
+		{
+			sql:  "select * from t where c = 0 and d = 0 and e = 0",
+			best: "Index(t.c_d_e)->Fields",
+		},
+		{
+			sql:  "select * from t where (d = 0 and e = 0) and c = 0",
+			best: "Index(t.c_d_e)->Fields",
+		},
+		{
+			sql:  "select * from t where e = 0 and (d = 0 and c = 0)",
+			best: "Index(t.c_d_e)->Fields",
 		},
 		{
 			sql:  "select * from t where b like 'abc%'",
@@ -341,13 +353,16 @@ func mockResolve(node ast.Node) {
 			},
 		},
 		{
-			Name: model.NewCIStr("c_d"),
+			Name: model.NewCIStr("c_d_e"),
 			Columns: []*model.IndexColumn{
 				{
 					Name: model.NewCIStr("c"),
 				},
 				{
 					Name: model.NewCIStr("d"),
+				},
+				{
+					Name: model.NewCIStr("e"),
 				},
 			},
 		},

--- a/optimizer/plan/planbuilder.go
+++ b/optimizer/plan/planbuilder.go
@@ -470,11 +470,13 @@ func splitWhere(where ast.ExprNode) []ast.ExprNode {
 	case nil:
 	case *ast.BinaryOperationExpr:
 		if x.Op == opcode.AndAnd {
-			conditions = append(conditions, x.L)
+			conditions = append(conditions, splitWhere(x.L)...)
 			conditions = append(conditions, splitWhere(x.R)...)
 		} else {
 			conditions = append(conditions, x)
 		}
+	case *ast.ParenthesesExpr:
+		conditions = append(conditions, splitWhere(x.Expr)...)
 	default:
 		conditions = append(conditions, where)
 	}


### PR DESCRIPTION
Fixes https://github.com/pingcap/tidb/issues/859

but after a recent refactor, only first column in the index can be used.

I'll add back multi column index support after join plan has been implemented.