### PR TITLE
optimizer/plan: fix build "IN" range.

### DIFF
--- a/optimizer/plan/plan_test.go
+++ b/optimizer/plan/plan_test.go
@@ -187,6 +187,10 @@ func (s *testPlanSuite) TestRangeBuilder(c *C) {
 			exprStr:   `a > NULL`,
 			resultStr: `[]`,
 		},
+		{
+			exprStr:   `a IN (8,8,81,45)`,
+			resultStr: `[[8 8] [45 45] [81 81]]`,
+		},
 	}
 
 	for _, ca := range cases {

--- a/optimizer/plan/range.go
+++ b/optimizer/plan/range.go
@@ -213,7 +213,31 @@ func (r *rangeBuilder) buildFromIn(x *ast.PatternInExpr) []rangePoint {
 	if sorter.err != nil {
 		r.err = sorter.err
 	}
-	return rangePoints
+	// check duplicates
+	hasDuplicate := false
+	isStart := false
+	for _, v := range rangePoints {
+		if isStart == v.start {
+			hasDuplicate = true
+			break
+		}
+		isStart = v.start
+	}
+	if !hasDuplicate {
+		return rangePoints
+	}
+	// remove duplicates
+	distinctRangePoints := make([]rangePoint, 0, len(rangePoints))
+	isStart = false
+	for i := 0; i < len(rangePoints); i++ {
+		current := rangePoints[i]
+		if isStart == current.start {
+			continue
+		}
+		distinctRangePoints = append(distinctRangePoints, current)
+		isStart = current.start
+	}
+	return distinctRangePoints
 }
 
 func (r *rangeBuilder) buildFromBetween(x *ast.BetweenExpr) []rangePoint {


### PR DESCRIPTION
"IN" expression may contains duplicated value, we need to remove duplicates.

If we don't remove duplicates the range going be something like `[[8 [8 8] 8] [45 45] [81 81]]`, which is not disjoint, produces wrong result.