### PR TITLE
driver: imitate mysql driver, allow access to time.Time directly

### DIFF
--- a/tidb_test.go
+++ b/tidb_test.go
@@ -347,12 +347,12 @@ func (s *testMainSuite) TestParseDSN(c *C) {
 	}
 
 	for _, t := range tbl {
-		storeDSN, dbName, err := parseDriverDSN(t.dsn)
+		params, err := parseDriverDSN(t.dsn)
 		if t.ok {
 			c.Assert(err, IsNil, Commentf("dsn=%v", t.dsn))
-			c.Assert(storeDSN, Equals, t.storeDSN, Commentf("dsn=%v", t.dsn))
-			c.Assert(dbName, Equals, t.dbName, Commentf("dsn=%v", t.dsn))
-			_, err = url.Parse(storeDSN)
+			c.Assert(params.storePath, Equals, t.storeDSN, Commentf("dsn=%v", t.dsn))
+			c.Assert(params.dbName, Equals, t.dbName, Commentf("dsn=%v", t.dsn))
+			_, err = url.Parse(params.storePath)
 			c.Assert(err, IsNil, Commentf("dsn=%v", t.dsn))
 		} else {
 			c.Assert(err, NotNil, Commentf("dsn=%v", t.dsn))


### PR DESCRIPTION
This essentially allows users of the "tidb" driver insteadof the mysql protocol
to decide on their own if they want to use the string form of a `mysql.Time`
or prefer working with the internal `time.Time` object, which should also reduce a tiny bit
of overhead for these cases.

Since mysql.Time.String() only access the time.Time object and doesn't depend
on any other internal data at the moment, this should be safe.
