### PR TITLE
fix arm/386 build

### DIFF
--- a/optimizer/plan/range.go
+++ b/optimizer/plan/range.go
@@ -464,7 +464,7 @@ func (r *rangeBuilder) buildTableRanges(rangePoints []rangePoint) []TableRange {
 	for i := 0; i < len(rangePoints); i += 2 {
 		startPoint := rangePoints[i]
 		if startPoint.value == nil || startPoint.value == MinNotNullVal {
-			startPoint.value = math.MinInt64
+			startPoint.value = int64(math.MinInt64)
 		}
 		startInt, err := types.ToInt64(startPoint.value)
 		if err != nil {
@@ -481,9 +481,9 @@ func (r *rangeBuilder) buildTableRanges(rangePoints []rangePoint) []TableRange {
 		}
 		endPoint := rangePoints[i+1]
 		if endPoint.value == nil {
-			endPoint.value = math.MinInt64
+			endPoint.value = int64(math.MinInt64)
 		} else if endPoint.value == MaxVal {
-			endPoint.value = math.MaxInt64
+			endPoint.value = int64(math.MaxInt64)
 		}
 		endInt, err := types.ToInt64(endPoint.value)
 		if err != nil {

--- a/store/localstore/kv.go
+++ b/store/localstore/kv.go
@@ -142,7 +142,7 @@ func (s *dbStore) scheduler() {
 		go s.seekWorker(wgSeekWorkers, seekCh)
 	}
 
-	segmentIndex := 0
+	segmentIndex := int64(0)
 
 	tick := time.NewTicker(time.Second)
 	defer tick.Stop()
@@ -174,7 +174,7 @@ func (s *dbStore) scheduler() {
 	}
 }
 
-func (s *dbStore) cleanRecentUpdates(segmentIndex int) {
+func (s *dbStore) cleanRecentUpdates(segmentIndex int64) {
 	m, err := s.recentUpdates.GetSegment(segmentIndex)
 	if err != nil {
 		log.Error(err)

--- a/util/segmentmap/segmentmap.go
+++ b/util/segmentmap/segmentmap.go
@@ -22,14 +22,14 @@ import (
 // SegmentMap is used for handle a big map slice by slice.
 // It's not thread safe.
 type SegmentMap struct {
-	size int
+	size int64
 	maps []map[string]interface{}
 
 	crcTable *crc32.Table
 }
 
 // NewSegmentMap create a new SegmentMap.
-func NewSegmentMap(size int) (*SegmentMap, error) {
+func NewSegmentMap(size int64) (*SegmentMap, error) {
 	if size <= 0 {
 		return nil, errors.Errorf("Invalid size: %d", size)
 	}
@@ -38,7 +38,7 @@ func NewSegmentMap(size int) (*SegmentMap, error) {
 		maps: make([]map[string]interface{}, size),
 		size: size,
 	}
-	for i := 0; i < size; i++ {
+	for i := int64(0); i < size; i++ {
 		sm.maps[i] = make(map[string]interface{})
 	}
 
@@ -48,13 +48,13 @@ func NewSegmentMap(size int) (*SegmentMap, error) {
 
 // Get is the same as map[k].
 func (sm *SegmentMap) Get(key []byte) (interface{}, bool) {
-	idx := int(crc32.Checksum(key, sm.crcTable)) % sm.size
+	idx := int64(crc32.Checksum(key, sm.crcTable)) % sm.size
 	val, ok := sm.maps[idx][string(key)]
 	return val, ok
 }
 
 // GetSegment gets the map specific by index.
-func (sm *SegmentMap) GetSegment(index int) (map[string]interface{}, error) {
+func (sm *SegmentMap) GetSegment(index int64) (map[string]interface{}, error) {
 	if index >= sm.size || index < 0 {
 		return nil, errors.Errorf("index out of bound: %d", index)
 	}
@@ -64,7 +64,7 @@ func (sm *SegmentMap) GetSegment(index int) (map[string]interface{}, error) {
 
 // Set if key not exists, returns whether already exists.
 func (sm *SegmentMap) Set(key []byte, value interface{}, force bool) bool {
-	idx := int(crc32.Checksum(key, sm.crcTable)) % sm.size
+	idx := int64(crc32.Checksum(key, sm.crcTable)) % sm.size
 	k := string(key)
 	_, exist := sm.maps[idx][k]
 	if exist && !force {
@@ -76,6 +76,6 @@ func (sm *SegmentMap) Set(key []byte, value interface{}, force bool) bool {
 }
 
 // SegmentCount returns how many inner segments.
-func (sm *SegmentMap) SegmentCount() int {
+func (sm *SegmentMap) SegmentCount() int64 {
 	return sm.size
 }

--- a/util/segmentmap/segmentmap_test.go
+++ b/util/segmentmap/segmentmap_test.go
@@ -23,7 +23,7 @@ type testSegmentMapSuite struct {
 }
 
 func (s *testSegmentMapSuite) TestSegment(c *C) {
-	segs := 2
+	segs := int64(2)
 	m, err := NewSegmentMap(segs)
 	c.Assert(err, IsNil)
 	c.Assert(m.SegmentCount(), Equals, segs)


### PR DESCRIPTION
Require an explicit usage of int64 for `MinInt64` as constant.

```
optimizer\plan\range.go:467: constant -9223372036854775808 overflows int
optimizer\plan\range.go:484: constant -9223372036854775808 overflows int
optimizer\plan\range.go:486: constant 9223372036854775807 overflows int
```

This fixes compilation on systems where `int` doesn't default to int64.