### PR TITLE
performance_schema: support insert operation

### DIFF
--- a/perfschema/common.go
+++ b/perfschema/common.go
@@ -84,44 +84,7 @@ func decodeValue(data []byte, cols []*model.ColumnInfo) ([]interface{}, error) {
 // dumpValue is used for debugging purposes only.
 func dumpValue(funcName string, vals []interface{}) {
 	for _, val := range vals {
-		switch v := val.(type) {
-		case bool:
-			log.Debug("[%s] bool: %t", funcName, bool(v))
-		case int:
-			log.Debugf("[%s] int: %d", funcName, int64(v))
-		case int8:
-			log.Debugf("[%s] int8: %d", funcName, int64(v))
-		case int16:
-			log.Debugf("[%s] int16: %d", funcName, int64(v))
-		case int32:
-			log.Debugf("[%s] int32: %d", funcName, int64(v))
-		case int64:
-			log.Debugf("[%s] int64: %d", funcName, int64(v))
-		case uint:
-			log.Debugf("[%s] uint: %d", funcName, uint64(v))
-		case uint8:
-			log.Debugf("[%s] uint8: %d", funcName, uint64(v))
-		case uint16:
-			log.Debugf("[%s] uint16: %d", funcName, uint64(v))
-		case uint32:
-			log.Debugf("[%s] uint32: %d", funcName, uint64(v))
-		case uint64:
-			log.Debugf("[%s] uint64: %d", funcName, uint64(v))
-		case float32:
-			log.Debugf("[%s] float32: %f", funcName, float64(v))
-		case float64:
-			log.Debugf("[%s] float64: %f", funcName, float64(v))
-		case string:
-			log.Debugf("[%s] string: %s", funcName, v)
-		case []byte:
-			log.Debugf("[%s] []byte: %X", funcName, v)
-		case mysql.Enum:
-			log.Debugf("[%s] enum: %s", funcName, v)
-		case nil:
-			log.Debugf("[%s] nil", funcName)
-		default:
-			log.Debugf("[%s] unknown", funcName)
-		}
+		log.Debugf("[%s] %T: %v", funcName, val, val)
 	}
 }
 

--- a/perfschema/common.go
+++ b/perfschema/common.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/codec"
@@ -78,6 +79,50 @@ func decodeValue(data []byte, cols []*model.ColumnInfo) ([]interface{}, error) {
 		}
 	}
 	return rvalues, nil
+}
+
+// dumpValue is used for debugging purposes only.
+func dumpValue(funcName string, vals []interface{}) {
+	for _, val := range vals {
+		switch v := val.(type) {
+		case bool:
+			log.Debug("[%s] bool: %t", funcName, bool(v))
+		case int:
+			log.Debugf("[%s] int: %d", funcName, int64(v))
+		case int8:
+			log.Debugf("[%s] int8: %d", funcName, int64(v))
+		case int16:
+			log.Debugf("[%s] int16: %d", funcName, int64(v))
+		case int32:
+			log.Debugf("[%s] int32: %d", funcName, int64(v))
+		case int64:
+			log.Debugf("[%s] int64: %d", funcName, int64(v))
+		case uint:
+			log.Debugf("[%s] uint: %d", funcName, uint64(v))
+		case uint8:
+			log.Debugf("[%s] uint8: %d", funcName, uint64(v))
+		case uint16:
+			log.Debugf("[%s] uint16: %d", funcName, uint64(v))
+		case uint32:
+			log.Debugf("[%s] uint32: %d", funcName, uint64(v))
+		case uint64:
+			log.Debugf("[%s] uint64: %d", funcName, uint64(v))
+		case float32:
+			log.Debugf("[%s] float32: %f", funcName, float64(v))
+		case float64:
+			log.Debugf("[%s] float64: %f", funcName, float64(v))
+		case string:
+			log.Debugf("[%s] string: %s", funcName, v)
+		case []byte:
+			log.Debugf("[%s] []byte: %X", funcName, v)
+		case mysql.Enum:
+			log.Debugf("[%s] enum: %s", funcName, v)
+		case nil:
+			log.Debugf("[%s] nil", funcName)
+		default:
+			log.Debugf("[%s] unknown", funcName)
+		}
+	}
 }
 
 // findCol finds column in cols by name.

--- a/perfschema/init.go
+++ b/perfschema/init.go
@@ -199,9 +199,9 @@ func (ps *perfSchema) buildModel(tbName string, colNames []string, cols []column
 		var ci *model.ColumnInfo
 
 		if col.elems == nil {
-			ci = buildUsualColumnInfo(colNames[i], col.tp, col.size, col.flag, col.deflt)
+			ci = buildUsualColumnInfo(i, colNames[i], col.tp, col.size, col.flag, col.deflt)
 		} else {
-			ci = buildEnumColumnInfo(colNames[i], col.elems, col.flag, col.deflt)
+			ci = buildEnumColumnInfo(i, colNames[i], col.elems, col.flag, col.deflt)
 		}
 
 		rcols[i] = ci
@@ -217,7 +217,7 @@ func (ps *perfSchema) buildModel(tbName string, colNames []string, cols []column
 	ps.fields[tbName] = fields
 }
 
-func buildUsualColumnInfo(name string, tp byte, size int, flag uint, def interface{}) *model.ColumnInfo {
+func buildUsualColumnInfo(offset int, name string, tp byte, size int, flag uint, def interface{}) *model.ColumnInfo {
 	mCharset := charset.CharsetBin
 	mCollation := charset.CharsetBin
 	if tp == mysql.TypeString || tp == mysql.TypeVarchar || tp == mysql.TypeBlob || tp == mysql.TypeLongBlob {
@@ -237,13 +237,14 @@ func buildUsualColumnInfo(name string, tp byte, size int, flag uint, def interfa
 	}
 	colInfo := &model.ColumnInfo{
 		Name:         model.NewCIStr(name),
+		Offset:       offset,
 		FieldType:    fieldType,
 		DefaultValue: def,
 	}
 	return colInfo
 }
 
-func buildEnumColumnInfo(name string, elems []string, flag uint, def interface{}) *model.ColumnInfo {
+func buildEnumColumnInfo(offset int, name string, elems []string, flag uint, def interface{}) *model.ColumnInfo {
 	mCharset := charset.CharsetBin
 	mCollation := charset.CharsetBin
 	if def == nil {
@@ -258,6 +259,7 @@ func buildEnumColumnInfo(name string, elems []string, flag uint, def interface{}
 	}
 	colInfo := &model.ColumnInfo{
 		Name:         model.NewCIStr(name),
+		Offset:       offset,
 		FieldType:    fieldType,
 		DefaultValue: def,
 	}

--- a/perfschema/insert.go
+++ b/perfschema/insert.go
@@ -58,7 +58,8 @@ func (ps *perfSchema) addRecords(tableIdent table.Ident, rows [][]interface{}) e
 	var lastLsn uint64
 
 	// Same as MySQL, we only support INSERT operations for setup_actors & setup_objects.
-	switch strings.ToUpper(tableIdent.Name.O) {
+	name := strings.ToUpper(tableIdent.Name.O)
+	switch name {
 	case TableSetupActors:
 		store = ps.stores[TableSetupActors]
 		lastLsn = atomic.AddUint64(ps.lsns[TableSetupActors], uint64(len(rows)))
@@ -76,7 +77,6 @@ func (ps *perfSchema) addRecords(tableIdent table.Ident, rows [][]interface{}) e
 	}()
 
 	for i, row := range rows {
-		// dumpValue("addRecords", row)
 		lsn := lastLsn - uint64(len(rows)) + uint64(i)
 		rawKey := []interface{}{uint64(lsn)}
 		key, err := codec.EncodeKey(nil, rawKey...)
@@ -121,20 +121,16 @@ func fillRowData(t *model.TableInfo, cols []*model.ColumnInfo, vals []interface{
 		row[offset] = v
 		marked[offset] = struct{}{}
 	}
-	// dumpValue("fillRowData", row)
 	err := initDefaultValues(t, row, marked)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// dumpValue("initDefaultValues", row)
 	if err = castValues(row, cols); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// dumpValue("castValues", row)
 	if err = checkNotNulls(t.Columns, row); err != nil {
 		return nil, errors.Trace(err)
 	}
-	// dumpValue("checkNotNulls", row)
 	return row, nil
 }
 
@@ -237,7 +233,6 @@ func (ps *perfSchema) getRows(insertVals *InsertValues, t *model.TableInfo, cols
 			}
 		}
 
-		// dumpValue("getRows", vals)
 		rows[i], err = fillRowData(t, cols, vals)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -266,7 +261,6 @@ func initDefaultValues(t *model.TableInfo, row []interface{}, marked map[int]str
 			// Column value is not nil, continue.
 			continue
 		}
-
 		// If the nil value is evaluated in insert list, we will use nil.
 		if _, ok := marked[i]; ok {
 			continue
@@ -277,15 +271,12 @@ func initDefaultValues(t *model.TableInfo, row []interface{}, marked map[int]str
 		if err != nil {
 			return errors.Trace(err)
 		}
-
 		row[i] = value
-
 		defaultValueCols = append(defaultValueCols, c)
 	}
 
 	if err := castValues(row, defaultValueCols); err != nil {
 		return errors.Trace(err)
 	}
-
 	return nil
 }

--- a/perfschema/insert.go
+++ b/perfschema/insert.go
@@ -1,0 +1,291 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perfschema
+
+import (
+	"strings"
+	"sync/atomic"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+// InsertValues is the rest part of insert/replace into statement.
+type InsertValues struct {
+	ColNames   []string
+	Lists      [][]expression.Expression
+	TableIdent table.Ident
+	Setlist    []*expression.Assignment
+}
+
+// Simulate the behavior of an INSERT statement.
+func (ps *perfSchema) ExecInsert(insertVals *InsertValues) error {
+	t := ps.getTable(insertVals.TableIdent)
+	if t == nil {
+		return errors.Errorf("INSERT INTO %s: operation not permitted", insertVals.TableIdent)
+	}
+
+	cols, err := ps.getColumns(insertVals, t.Columns)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	rows, err := ps.getRows(insertVals, t, cols)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return ps.addRecords(insertVals.TableIdent, rows)
+}
+
+func (ps *perfSchema) addRecords(tableIdent table.Ident, rows [][]interface{}) error {
+	var store *leveldb.DB
+	var lastLsn uint64
+
+	// Same as MySQL, we only support INSERT operations for setup_actors & setup_objects.
+	switch strings.ToUpper(tableIdent.Name.O) {
+	case TableSetupActors:
+		store = ps.stores[TableSetupActors]
+		lastLsn = atomic.AddUint64(ps.lsns[TableSetupActors], uint64(len(rows)))
+	case TableSetupObjects:
+		store = ps.stores[TableSetupObjects]
+		lastLsn = atomic.AddUint64(ps.lsns[TableSetupObjects], uint64(len(rows)))
+	default:
+		return errors.Errorf("INSERT INTO %s: operation not permitted", tableIdent)
+	}
+
+	batch := pool.Get().(*leveldb.Batch)
+	defer func() {
+		batch.Reset()
+		pool.Put(batch)
+	}()
+
+	for i, row := range rows {
+		// dumpValue("addRecords", row)
+		lsn := lastLsn - uint64(len(rows)) + uint64(i)
+		rawKey := []interface{}{uint64(lsn)}
+		key, err := codec.EncodeKey(nil, rawKey...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		val, err := codec.EncodeValue(nil, row...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		batch.Put(key, val)
+	}
+
+	err := store.Write(batch, nil)
+	return errors.Trace(err)
+}
+
+func checkValueCount(insertVals *InsertValues, insertValueCount, valueCount, num int, cols []*model.ColumnInfo) error {
+	if insertValueCount != valueCount {
+		// "insert into t values (), ()" is valid.
+		// "insert into t values (), (1)" is not valid.
+		// "insert into t values (1), ()" is not valid.
+		// "insert into t values (1,2), (1)" is not valid.
+		// So the value count must be same for all insert list.
+		return errors.Errorf("Column count doesn't match value count at row %d", num+1)
+	}
+	if valueCount == 0 && len(insertVals.ColNames) > 0 {
+		// "insert into t (c1) values ()" is not valid.
+		return errors.Errorf("INSERT INTO %s: expected %d value(s), have %d", insertVals.TableIdent, len(insertVals.ColNames), 0)
+	} else if valueCount > 0 && valueCount != len(cols) {
+		return errors.Errorf("INSERT INTO %s: expected %d value(s), have %d", insertVals.TableIdent, len(cols), valueCount)
+	}
+
+	return nil
+}
+
+func fillRowData(t *model.TableInfo, cols []*model.ColumnInfo, vals []interface{}) ([]interface{}, error) {
+	row := make([]interface{}, len(t.Columns))
+	marked := make(map[int]struct{}, len(vals))
+	for i, v := range vals {
+		offset := cols[i].Offset
+		row[offset] = v
+		marked[offset] = struct{}{}
+	}
+	// dumpValue("fillRowData", row)
+	err := initDefaultValues(t, row, marked)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	// dumpValue("initDefaultValues", row)
+	if err = castValues(row, cols); err != nil {
+		return nil, errors.Trace(err)
+	}
+	// dumpValue("castValues", row)
+	if err = checkNotNulls(t.Columns, row); err != nil {
+		return nil, errors.Trace(err)
+	}
+	// dumpValue("checkNotNulls", row)
+	return row, nil
+}
+
+func fillValueList(insertVals *InsertValues) error {
+	if len(insertVals.Setlist) > 0 {
+		if len(insertVals.Lists) > 0 {
+			return errors.Errorf("INSERT INTO %s: set type should not use values", insertVals.TableIdent)
+		}
+
+		var l []expression.Expression
+		for _, v := range insertVals.Setlist {
+			l = append(l, v.Expr)
+		}
+		insertVals.Lists = append(insertVals.Lists, l)
+	}
+
+	return nil
+}
+
+func getColumnDefaultValues(cols []*model.ColumnInfo) (map[interface{}]interface{}, error) {
+	defaultValMap := map[interface{}]interface{}{}
+	for _, col := range cols {
+		if value, ok, err := getColDefaultValue(col); ok {
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+
+			defaultValMap[col.Name.L] = value
+		}
+	}
+
+	return defaultValMap, nil
+}
+
+// There are three types of insert statements:
+// 1 insert ... values(...)  --> name type column
+// 2 insert ... set x=y...   --> set type column
+// 3 insert ... (select ..)  --> name type column
+// See: https://dev.mysql.com/doc/refman/5.7/en/insert.html
+func (ps *perfSchema) getColumns(insertVals *InsertValues, tableCols []*model.ColumnInfo) ([]*model.ColumnInfo, error) {
+	var cols []*model.ColumnInfo
+	var err error
+
+	if len(insertVals.Setlist) > 0 {
+		// Process `set` type column.
+		columns := make([]string, 0, len(insertVals.Setlist))
+		for _, v := range insertVals.Setlist {
+			columns = append(columns, v.ColName)
+		}
+
+		cols, err = findCols(tableCols, columns)
+		if err != nil {
+			return nil, errors.Errorf("INSERT INTO %s: %s", insertVals.TableIdent, err)
+		}
+
+		if len(cols) == 0 {
+			return nil, errors.Errorf("INSERT INTO %s: empty column", insertVals.TableIdent)
+		}
+	} else {
+		// Process `name` type column.
+		cols, err = findCols(tableCols, insertVals.ColNames)
+		if err != nil {
+			return nil, errors.Errorf("INSERT INTO %s: %s", insertVals.TableIdent, err)
+		}
+
+		// If cols are empty, use all columns instead.
+		if len(cols) == 0 {
+			cols = tableCols
+		}
+	}
+
+	return cols, nil
+}
+
+func (ps *perfSchema) getRows(insertVals *InsertValues, t *model.TableInfo, cols []*model.ColumnInfo) (rows [][]interface{}, err error) {
+	// process `insert|replace ... set x=y...`
+	if err = fillValueList(insertVals); err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	evalMap, err := getColumnDefaultValues(cols)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	rows = make([][]interface{}, len(insertVals.Lists))
+	for i, list := range insertVals.Lists {
+		if err = checkValueCount(insertVals, len(insertVals.Lists[0]), len(list), i, cols); err != nil {
+			return nil, errors.Trace(err)
+		}
+
+		vals := make([]interface{}, len(list))
+		for j, expr := range list {
+			// For "insert into t values (default)" Default Eval.
+			evalMap[expression.ExprEvalDefaultName] = cols[j].Name.O
+
+			vals[j], err = expr.Eval(nil, evalMap)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+
+		// dumpValue("getRows", vals)
+		rows[i], err = fillRowData(t, cols, vals)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return
+}
+
+func (ps *perfSchema) getTable(tableIdent table.Ident) *model.TableInfo {
+	tbName := strings.ToUpper(tableIdent.Name.O)
+
+	// Same as MySQL, we only support INSERT operations for setup_actors & setup_objects.
+	switch tbName {
+	case TableSetupActors:
+	case TableSetupObjects:
+	default:
+		return nil
+	}
+	return ps.tables[tbName]
+}
+
+func initDefaultValues(t *model.TableInfo, row []interface{}, marked map[int]struct{}) error {
+	var defaultValueCols []*model.ColumnInfo
+	for i, c := range t.Columns {
+		if row[i] != nil {
+			// Column value is not nil, continue.
+			continue
+		}
+
+		// If the nil value is evaluated in insert list, we will use nil.
+		if _, ok := marked[i]; ok {
+			continue
+		}
+
+		var value interface{}
+		value, _, err := getColDefaultValue(c)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		row[i] = value
+
+		defaultValueCols = append(defaultValueCols, c)
+	}
+
+	if err := castValues(row, defaultValueCols); err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}

--- a/perfschema/perfschema.go
+++ b/perfschema/perfschema.go
@@ -26,6 +26,9 @@ import (
 type PerfSchema interface {
 	// For SELECT statement only.
 	NewPerfSchemaPlan(tableName string) (plan.Plan, error)
+
+	// For INSERT statement only.
+	ExecInsert(insertVals *InsertValues) error
 }
 
 type perfSchema struct {

--- a/perfschema/perfschema_test.go
+++ b/perfschema/perfschema_test.go
@@ -132,3 +132,19 @@ func (p *testPerfSchemaSuit) TestSelect(c *C) {
 
 	mustFailQuery(c, testDB, "select * from performance_schema.unknown_table")
 }
+
+func (p *testPerfSchemaSuit) TestInsert(c *C) {
+	testDB, err := sql.Open(tidb.DriverName, tidb.EngineGoLevelDBMemory+"/test/test")
+	defer testDB.Close()
+	c.Assert(err, IsNil)
+
+	r := mustExec(c, testDB, `insert into performance_schema.setup_actors values("localhost", "nieyy", "contributor", "NO", "NO");`)
+	checkResult(c, r, 1, 0)
+	cnt := mustQuery(c, testDB, "select * from performance_schema.setup_actors")
+	c.Assert(cnt, Equals, 2)
+
+	r = mustExec(c, testDB, `insert into performance_schema.setup_objects values("EVENT", "test", "%", "NO", "NO")`)
+	checkResult(c, r, 1, 0)
+	cnt = mustQuery(c, testDB, "select * from performance_schema.setup_objects")
+	c.Assert(cnt, Equals, 13)
+}

--- a/perfschema/perfschema_test.go
+++ b/perfschema/perfschema_test.go
@@ -83,6 +83,13 @@ func mustExec(c *C, currDB *sql.DB, sql string) sql.Result {
 	return r
 }
 
+func mustFailExec(c *C, currDB *sql.DB, sql string) {
+	tx := mustBegin(c, currDB)
+	_, err := tx.Exec(sql)
+	c.Assert(err, NotNil)
+	mustCommit(c, tx)
+}
+
 func checkResult(c *C, r sql.Result, affectedRows int64, insertID int64) {
 	gotRows, err := r.RowsAffected()
 	c.Assert(err, IsNil)
@@ -95,8 +102,8 @@ func checkResult(c *C, r sql.Result, affectedRows int64, insertID int64) {
 
 func (p *testPerfSchemaSuit) TestSelect(c *C) {
 	testDB, err := sql.Open(tidb.DriverName, tidb.EngineGoLevelDBMemory+"/test/test")
-	defer testDB.Close()
 	c.Assert(err, IsNil)
+	defer testDB.Close()
 
 	cnt := mustQuery(c, testDB, "select * from performance_schema.setup_actors")
 	c.Assert(cnt, Equals, 1)
@@ -135,16 +142,32 @@ func (p *testPerfSchemaSuit) TestSelect(c *C) {
 
 func (p *testPerfSchemaSuit) TestInsert(c *C) {
 	testDB, err := sql.Open(tidb.DriverName, tidb.EngineGoLevelDBMemory+"/test/test")
-	defer testDB.Close()
 	c.Assert(err, IsNil)
+	defer testDB.Close()
 
 	r := mustExec(c, testDB, `insert into performance_schema.setup_actors values("localhost", "nieyy", "contributor", "NO", "NO");`)
 	checkResult(c, r, 1, 0)
 	cnt := mustQuery(c, testDB, "select * from performance_schema.setup_actors")
 	c.Assert(cnt, Equals, 2)
 
+	r = mustExec(c, testDB, `insert into performance_schema.setup_actors (host, user, role) values ("localhost", "lijian", "contributor");`)
+	checkResult(c, r, 1, 0)
+	cnt = mustQuery(c, testDB, "select * from performance_schema.setup_actors")
+	c.Assert(cnt, Equals, 3)
+
 	r = mustExec(c, testDB, `insert into performance_schema.setup_objects values("EVENT", "test", "%", "NO", "NO")`)
 	checkResult(c, r, 1, 0)
 	cnt = mustQuery(c, testDB, "select * from performance_schema.setup_objects")
 	c.Assert(cnt, Equals, 13)
+
+	r = mustExec(c, testDB, `insert into performance_schema.setup_objects (object_schema, object_name) values ("test1", "%")`)
+	checkResult(c, r, 1, 0)
+	cnt = mustQuery(c, testDB, "select * from performance_schema.setup_objects")
+	c.Assert(cnt, Equals, 14)
+
+	mustFailExec(c, testDB, `insert into performance_schema.setup_actors (host) values (null);`)
+	mustFailExec(c, testDB, `insert into performance_schema.setup_objects (object_type) values (null);`)
+	mustFailExec(c, testDB, `insert into performance_schema.setup_instruments values("select", "YES", "YES");`)
+	mustFailExec(c, testDB, `insert into performance_schema.setup_consumers values("events_stages_current", "YES");`)
+	mustFailExec(c, testDB, `insert into performance_schema.setup_timers values("timer1", "NANOSECOND");`)
 }

--- a/stmt/stmts/insert.go
+++ b/stmt/stmts/insert.go
@@ -18,6 +18,8 @@
 package stmts
 
 import (
+	"strings"
+
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
@@ -25,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/field"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/perfschema"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/rset"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -164,6 +167,21 @@ func (s *InsertValues) fillValueList() error {
 
 // Exec implements the stmt.Statement Exec interface.
 func (s *InsertIntoStmt) Exec(ctx context.Context) (_ rset.Recordset, err error) {
+	if strings.EqualFold(s.TableIdent.Schema.O, perfschema.Name) {
+		if s.Sel != nil {
+			return nil, errors.Errorf("INSERT|REPLACE INTO %s ... SELECT ... FROM ...: operation not permitted", s.TableIdent)
+		}
+		// Only support a subset of INSERT commands
+		insertVals := &perfschema.InsertValues{
+			ColNames:   s.ColNames,
+			Lists:      s.Lists,
+			TableIdent: s.TableIdent,
+			Setlist:    s.Setlist,
+		}
+		err := perfschema.PerfHandle.ExecInsert(insertVals)
+		return nil, errors.Trace(err)
+	}
+
 	t, err := getTable(ctx, s.TableIdent)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Support `INSERT` operation for `setup_actors` & `setup_objects`, other tables are `UPDATE` only.