### PR TITLE
*: add `Table.Seek` method and use handle for RowKeyEntry.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -361,7 +361,7 @@ func (d *ddl) backfillColumnData(t table.Table, columnInfo *model.ColumnInfo, ha
 				return nil
 			}
 
-			value, _, err := tables.GetColDefaultValue(nil, columnInfo)
+			value, _, err := table.GetColDefaultValue(nil, columnInfo)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -103,8 +103,8 @@ func (a *recordsetAdapter) Next() (*oplan.Row, error) {
 	}
 	for _, v := range row.RowKeys {
 		oldRowKey := &oplan.RowKeyEntry{
-			Key: v.Key,
-			Tbl: v.Tbl,
+			Handle: v.Handle,
+			Tbl:    v.Tbl,
 		}
 		oRow.RowKeys = append(oRow.RowKeys, oldRowKey)
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -223,8 +223,11 @@ func (e *TableScanExec) Next() (*Row, error) {
 			continue
 		}
 		handle, found, err := e.t.Seek(e.ctx, e.seekHandle)
-		if err != nil || !found {
+		if err != nil {
 			return nil, errors.Trace(err)
+		}
+		if !found {
+			return nil, nil
 		}
 		if handle > ran.HighVal {
 			// The handle is out of the current range, but may be in following ranges.

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -71,5 +71,5 @@ type RowKeyEntry struct {
 	// The table which this row come from.
 	Tbl table.Table
 	// Row handle.
-	Key string
+	Handle int64
 }

--- a/plan/plans/from.go
+++ b/plan/plans/from.go
@@ -367,8 +367,8 @@ func (r *TableDefaultPlan) Next(ctx context.Context) (row *plan.Row, err error) 
 	}
 	// Put rowKey to the tail of record row
 	rke := &plan.RowKeyEntry{
-		Tbl: r.T,
-		Key: string(rowKey),
+		Tbl:    r.T,
+		Handle: handle,
 	}
 	row.RowKeys = append(row.RowKeys, rke)
 
@@ -444,8 +444,8 @@ func (r *TableDefaultPlan) rangeNext(ctx context.Context) (*plan.Row, error) {
 		}
 		// Put rowKey to the tail of record row
 		rke := &plan.RowKeyEntry{
-			Tbl: r.T,
-			Key: string(rowKey),
+			Tbl:    r.T,
+			Handle: handle,
 		}
 		row.RowKeys = append(row.RowKeys, rke)
 		return row, nil

--- a/plan/plans/index.go
+++ b/plan/plans/index.go
@@ -413,8 +413,8 @@ func (r *indexPlan) lookupRow(ctx context.Context, h int64) (*plan.Row, error) {
 		return nil, errors.Trace(err)
 	}
 	rowKey := &plan.RowKeyEntry{
-		Tbl: r.src,
-		Key: string(r.src.RecordKey(h, nil)),
+		Tbl:    r.src,
+		Handle: h,
 	}
 	row.RowKeys = append(row.RowKeys, rowKey)
 	return row, nil

--- a/stmt/stmts/insert.go
+++ b/stmt/stmts/insert.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/stmt"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/format"
 )
@@ -137,7 +136,7 @@ func (s *InsertValues) getColumns(tableCols []*column.Col) ([]*column.Col, error
 func (s *InsertValues) getColumnDefaultValues(ctx context.Context, cols []*column.Col) (map[interface{}]interface{}, error) {
 	defaultValMap := map[interface{}]interface{}{}
 	for _, col := range cols {
-		if value, ok, err := tables.GetColDefaultValue(ctx, &col.ColumnInfo); ok {
+		if value, ok, err := table.GetColDefaultValue(ctx, &col.ColumnInfo); ok {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -404,7 +403,7 @@ func (s *InsertValues) initDefaultValues(ctx context.Context, t table.Table, row
 			}
 		} else {
 			var value interface{}
-			value, _, err := tables.GetColDefaultValue(ctx, &c.ColumnInfo)
+			value, _, err := table.GetColDefaultValue(ctx, &c.ColumnInfo)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/table/table.go
+++ b/table/table.go
@@ -20,11 +20,14 @@ package table
 import (
 	"fmt"
 
+	"github.com/juju/errors"
 	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/optimizer/evaluator"
 	"github.com/pingcap/tidb/sessionctx/db"
 )
 
@@ -79,7 +82,10 @@ type Table interface {
 	Meta() *model.TableInfo
 
 	// LockRow locks a row.
-	LockRow(ctx context.Context, h int64) error
+	LockRow(ctx context.Context, h int64, forRead bool) error
+
+	// Seek returns the handle greater or equal to h.
+	Seek(ctx context.Context, h int64) (handle int64, found bool, err error)
 }
 
 // TableFromMeta builds a table.Table from *model.TableInfo.
@@ -111,4 +117,33 @@ func (i Ident) String() string {
 		return i.Name.O
 	}
 	return fmt.Sprintf("%s.%s", i.Schema, i.Name)
+}
+
+// GetColDefaultValue gets default value of the column.
+func GetColDefaultValue(ctx context.Context, col *model.ColumnInfo) (interface{}, bool, error) {
+	// Check no default value flag.
+	if mysql.HasNoDefaultValueFlag(col.Flag) && col.Tp != mysql.TypeEnum {
+		return nil, false, errors.Errorf("Field '%s' doesn't have a default value", col.Name)
+	}
+
+	// Check and get timestamp/datetime default value.
+	if col.Tp == mysql.TypeTimestamp || col.Tp == mysql.TypeDatetime {
+		if col.DefaultValue == nil {
+			return nil, true, nil
+		}
+
+		value, err := evaluator.GetTimeValue(ctx, col.DefaultValue, col.Tp, col.Decimal)
+		if err != nil {
+			return nil, true, errors.Errorf("Field '%s' get default value fail - %s", col.Name, errors.Trace(err))
+		}
+		return value, true, nil
+	} else if col.Tp == mysql.TypeEnum {
+		// For enum type, if no default value and not null is set,
+		// the default value is the first element of the enum list
+		if col.DefaultValue == nil && mysql.HasNotNullFlag(col.Flag) {
+			return col.FieldType.Elems[0], true, nil
+		}
+	}
+
+	return col.DefaultValue, true, nil
 }

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -321,7 +321,7 @@ func (t *Table) AddRecord(ctx context.Context, r []interface{}) (recordID int64,
 		return h, errors.Trace(err)
 	}
 
-	if err = t.LockRow(ctx, recordID); err != nil {
+	if err = t.LockRow(ctx, recordID, false); err != nil {
 		return 0, errors.Trace(err)
 	}
 
@@ -333,7 +333,7 @@ func (t *Table) AddRecord(ctx context.Context, r []interface{}) (recordID int64,
 		var value interface{}
 		if col.State == model.StateWriteOnly || col.State == model.StateWriteReorganization {
 			// if col is in write only or write reorganization state, we must add it with its default value.
-			value, _, err = GetColDefaultValue(ctx, &col.ColumnInfo)
+			value, _, err = table.GetColDefaultValue(ctx, &col.ColumnInfo)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}
@@ -478,15 +478,19 @@ func (t *Table) Row(ctx context.Context, h int64) ([]interface{}, error) {
 }
 
 // LockRow implements table.Table LockRow interface.
-func (t *Table) LockRow(ctx context.Context, h int64) error {
+func (t *Table) LockRow(ctx context.Context, h int64, forRead bool) error {
 	txn, err := ctx.GetTxn(false)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// Get row lock key
 	lockKey := t.RecordKey(h, nil)
-	// set row lock key to current txn
-	err = txn.Set(lockKey, []byte(txn.String()))
+	if forRead {
+		err = txn.LockKeys(lockKey)
+	} else {
+		// set row lock key to current txn
+		err = txn.Set(lockKey, []byte(txn.String()))
+	}
 	return errors.Trace(err)
 }
 
@@ -506,7 +510,7 @@ func (t *Table) RemoveRecord(ctx context.Context, h int64, r []interface{}) erro
 }
 
 func (t *Table) removeRowData(ctx context.Context, h int64) error {
-	if err := t.LockRow(ctx, h); err != nil {
+	if err := t.LockRow(ctx, h, false); err != nil {
 		return errors.Trace(err)
 	}
 	txn, err := ctx.GetTxn(false)
@@ -634,33 +638,23 @@ func (t *Table) AllocAutoID() (int64, error) {
 	return t.alloc.Alloc(t.ID)
 }
 
-// GetColDefaultValue gets default value of the column.
-func GetColDefaultValue(ctx context.Context, col *model.ColumnInfo) (interface{}, bool, error) {
-	// Check no default value flag.
-	if mysql.HasNoDefaultValueFlag(col.Flag) && col.Tp != mysql.TypeEnum {
-		return nil, false, errors.Errorf("Field '%s' doesn't have a default value", col.Name)
+// Seek implements table.Table Seek interface.
+func (t *Table) Seek(ctx context.Context, h int64) (int64, bool, error) {
+	seekKey := EncodeRecordKey(t.ID, h, 0)
+	txn, err := ctx.GetTxn(false)
+	if err != nil {
+		return 0, false, errors.Trace(err)
 	}
-
-	// Check and get timestamp/datetime default value.
-	if col.Tp == mysql.TypeTimestamp || col.Tp == mysql.TypeDatetime {
-		if col.DefaultValue == nil {
-			return nil, true, nil
-		}
-
-		value, err := evaluator.GetTimeValue(ctx, col.DefaultValue, col.Tp, col.Decimal)
-		if err != nil {
-			return nil, true, errors.Errorf("Field '%s' get default value fail - %s", col.Name, errors.Trace(err))
-		}
-		return value, true, nil
-	} else if col.Tp == mysql.TypeEnum {
-		// For enum type, if no default value and not null is set,
-		// the default value is the first element of the enum list
-		if col.DefaultValue == nil && mysql.HasNotNullFlag(col.Flag) {
-			return col.FieldType.Elems[0], true, nil
-		}
+	iter, err := txn.Seek(seekKey)
+	if !iter.Valid() || !iter.Key().HasPrefix(t.RecordPrefix()) {
+		// No more records in the table, skip to the end.
+		return 0, false, nil
 	}
-
-	return col.DefaultValue, true, nil
+	handle, err := DecodeRecordKeyHandle(iter.Key())
+	if err != nil {
+		return 0, false, errors.Trace(err)
+	}
+	return handle, true, nil
 }
 
 var (


### PR DESCRIPTION
Avoid calling `table/tables` methods in `executor`, makes `Table` interface independent.