### PR TITLE
tidb: Fix schema change problem in running multiple statements

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -1322,6 +1322,13 @@ func (s *testSessionSuite) TestRetryPreparedStmt(c *C) {
 	match(c, row, 21)
 }
 
+func (s *testSessionSuite) TestIssue893(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+	mustExecSQL(c, se, "drop table if exists t1; create table t1(id int ); insert into t1 values (1);")
+	mustExecMatch(c, se, "select * from t1;", [][]interface{}{{1}})
+}
+
 // Testcase for session
 func (s *testSessionSuite) TestSession(c *C) {
 	store := newStore(c, s.dbName)

--- a/stmt/stmts/update_test.go
+++ b/stmt/stmts/update_test.go
@@ -187,7 +187,6 @@ func (s *testStmtSuite) TestIssue345(c *C) {
 }
 
 func (s *testStmtSuite) TestMultiUpdate(c *C) {
-	c.Skip("Need to change `tidb.Compile` function")
 	// fix https://github.com/pingcap/tidb/issues/369
 	testSQL := `
 		DROP TABLE IF EXISTS t1, t2;

--- a/tidb.go
+++ b/tidb.go
@@ -138,17 +138,13 @@ func Parse(ctx context.Context, src string) ([]ast.StmtNode, error) {
 }
 
 // Compile is safe for concurrent use by multiple goroutines.
-func Compile(ctx context.Context, rawStmt []ast.StmtNode) ([]stmt.Statement, error) {
-	stmts := make([]stmt.Statement, len(rawStmt))
-	for i, v := range rawStmt {
-		compiler := &executor.Compiler{}
-		stm, err := compiler.Compile(ctx, v)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		stmts[i] = stm
+func Compile(ctx context.Context, rawStmt ast.StmtNode) (stmt.Statement, error) {
+	compiler := &executor.Compiler{}
+	st, err := compiler.Compile(ctx, rawStmt)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return stmts, nil
+	return st, nil
 }
 
 func runStmt(ctx context.Context, s stmt.Statement, args ...interface{}) (rset.Recordset, error) {


### PR DESCRIPTION
When deal with multiple statements, we should run nameResolver one by one.
See: https://github.com/pingcap/tidb/issues/893

@coocood 