### PR TITLE
types: Fix i386 float to uint error

### DIFF
--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -178,7 +178,7 @@ func convertUintToUint(val uint64, upperBound uint64, tp byte) (uint64, error) {
 func convertFloatToUint(val float64, upperBound uint64, tp byte) (uint64, error) {
 	val = RoundFloat(val)
 	if val < 0 {
-		return uint64(val), overflow(val, tp)
+		return uint64(int64(val)), overflow(val, tp)
 	}
 
 	if val > float64(upperBound) {


### PR DESCRIPTION
uint64(float64(-1)) will be 0. So we cast float64 to int64 first.
I have tested it on i386 platform.