### PR TITLE
tidb: remove RestrictedSQLExecutorKey variable in context.

### DIFF
--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -18,14 +18,6 @@ import (
 	"github.com/pingcap/tidb/context"
 )
 
-// RestrictedSQLExecutorKeyType is a dummy type to avoid naming collision in session.
-type RestrictedSQLExecutorKeyType struct{}
-
-// String implements Stringer interface.
-func (k *RestrictedSQLExecutorKeyType) String() string {
-	return "restricted_sql_executor"
-}
-
 // RestrictedSQLExecutor is an interface provides executing restricted sql statement.
 // Why we need this interface?
 // When we execute some management statements, we need to operate system tables.


### PR DESCRIPTION
This variable was intended to prevent restricted SQL from being committed.
But it is executed at statement level, will never be committed, so this is not needed.

Also, when begin a new transaction in executing restricted SQL,
If 'autocommit' is 'on'. This variable makes the new transaction into a unwanted `InTrans` state,
so following statements will not be autocommited.