### PR TITLE
Change mysql.Time to ptr in datum.

### DIFF
--- a/evaluator/builtin_time.go
+++ b/evaluator/builtin_time.go
@@ -184,7 +184,7 @@ func builtinNow(args []types.Datum, _ context.Context) (d types.Datum, err error
 		d.SetNull()
 		return d, errors.Trace(err)
 	}
-	d.SetMysqlTime(tr)
+	d.SetMysqlTime(&tr)
 	return d, nil
 }
 
@@ -373,7 +373,7 @@ func builtinCurrentDate(args []types.Datum, _ context.Context) (d types.Datum, e
 	t := mysql.Time{
 		Time: time.Date(year, month, day, 0, 0, 0, 0, time.Local),
 		Type: mysql.TypeDate, Fsp: 0}
-	d.SetMysqlTime(t)
+	d.SetMysqlTime(&t)
 	return d, nil
 }
 

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -280,7 +280,10 @@ func (t Time) ConvertToDuration() (Duration, error) {
 
 // Compare returns an integer comparing the time instant t to o.
 // If t is after o, return 1, equal o, return 0, before o, return -1.
-func (t Time) Compare(o Time) int {
+func (t *Time) Compare(o *Time) int {
+	if o == nil {
+		return 1
+	}
 	if t.Time.After(o.Time) {
 		return 1
 	} else if t.Time.Equal(o.Time) {
@@ -299,7 +302,7 @@ func (t Time) CompareString(str string) (int, error) {
 		return 0, errors.Trace(err)
 	}
 
-	return t.Compare(o), nil
+	return t.Compare(&o), nil
 }
 
 // RoundFrac rounds fractional seconds precision with new fsp and returns a new one.
@@ -1027,7 +1030,10 @@ func checkTimestamp(t Time) bool {
 }
 
 // ExtractTimeNum extracts time value number from time unit and format.
-func ExtractTimeNum(unit string, t Time) (int64, error) {
+func ExtractTimeNum(unit string, t *Time) (int64, error) {
+	if t == nil {
+		return 0, errors.Errorf("invalid time t")
+	}
 	switch strings.ToUpper(unit) {
 	case "MICROSECOND":
 		return int64(t.Nanosecond() / 1000), nil

--- a/tidb-server/server/util.go
+++ b/tidb-server/server/util.go
@@ -293,7 +293,7 @@ func dumpRowValuesBinary(alloc arena.Allocator, columns []*ColumnInfo, row []typ
 		case types.KindMysqlDecimal:
 			data = append(data, dumpLengthEncodedString(hack.Slice(val.GetMysqlDecimal().String()), alloc)...)
 		case types.KindMysqlTime:
-			data = append(data, dumpBinaryDateTime(val.GetMysqlTime(), nil)...)
+			data = append(data, dumpBinaryDateTime(*val.GetMysqlTime(), nil)...)
 		case types.KindMysqlDuration:
 			data = append(data, dumpBinaryTime(val.GetMysqlDuration().Duration)...)
 		case types.KindMysqlSet:


### PR DESCRIPTION
In this way, we can save the cost of the alloc of mysql.Time in interface.
In the future, we will change all mysql.Time to ptr to save the cost of copy mysql.Time struct.