### PR TITLE
Util: a optimization of mysql.Decimal in Datum

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -552,16 +552,19 @@ func (e *Evaluator) unaryOperation(u *ast.UnaryOperationExpr) bool {
 		case types.KindFloat32:
 			u.SetFloat32(-aDatum.GetFloat32())
 		case types.KindMysqlDuration:
-			u.SetMysqlDecimal(mysql.ZeroDecimal.Sub(aDatum.GetMysqlDuration().ToNumber()))
+			d := mysql.ZeroDecimal.Sub(aDatum.GetMysqlDuration().ToNumber())
+			u.SetMysqlDecimal(&d)
 		case types.KindMysqlTime:
-			u.SetMysqlDecimal(mysql.ZeroDecimal.Sub(aDatum.GetMysqlTime().ToNumber()))
+			d := mysql.ZeroDecimal.Sub(aDatum.GetMysqlTime().ToNumber())
+			u.SetMysqlDecimal(&d)
 		case types.KindString, types.KindBytes:
 			f, err := types.StrToFloat(aDatum.GetString())
 			e.err = errors.Trace(err)
 			u.SetFloat64(-f)
 		case types.KindMysqlDecimal:
 			f, _ := aDatum.GetMysqlDecimal().Float64()
-			u.SetMysqlDecimal(mysql.NewDecimalFromFloat(-f))
+			d := mysql.NewDecimalFromFloat(-f)
+			u.SetMysqlDecimal(&d)
 		case types.KindMysqlHex:
 			u.SetFloat64(-aDatum.GetMysqlHex().ToNumber())
 		case types.KindMysqlBit:
@@ -701,7 +704,7 @@ func (e *Evaluator) evalAggAvg(v *ast.AggregateFuncExpr) {
 	case mysql.Decimal:
 		t := x.Div(mysql.NewDecimalFromUint(uint64(ctx.Count), 0))
 		ctx.Value = t
-		v.SetMysqlDecimal(t)
+		v.SetMysqlDecimal(&t)
 	}
 }
 

--- a/evaluator/evaluator_binop.go
+++ b/evaluator/evaluator_binop.go
@@ -319,8 +319,8 @@ func computePlus(a, b types.Datum) (d types.Datum, err error) {
 	case types.KindMysqlDecimal:
 		switch b.Kind() {
 		case types.KindMysqlDecimal:
-			r := a.GetMysqlDecimal().Add(b.GetMysqlDecimal())
-			d.SetMysqlDecimal(r)
+			r := (*a.GetMysqlDecimal()).Add(*b.GetMysqlDecimal())
+			d.SetMysqlDecimal(&r)
 			return d, nil
 		}
 	}
@@ -362,8 +362,8 @@ func computeMinus(a, b types.Datum) (d types.Datum, err error) {
 	case types.KindMysqlDecimal:
 		switch b.Kind() {
 		case types.KindMysqlDecimal:
-			r := a.GetMysqlDecimal().Sub(b.GetMysqlDecimal())
-			d.SetMysqlDecimal(r)
+			r := (*a.GetMysqlDecimal()).Sub(*b.GetMysqlDecimal())
+			d.SetMysqlDecimal(&r)
 			return d, nil
 		}
 	}
@@ -405,8 +405,8 @@ func computeMul(a, b types.Datum) (d types.Datum, err error) {
 	case types.KindMysqlDecimal:
 		switch b.Kind() {
 		case types.KindMysqlDecimal:
-			r := a.GetMysqlDecimal().Mul(b.GetMysqlDecimal())
-			d.SetMysqlDecimal(r)
+			r := (*a.GetMysqlDecimal()).Mul(*b.GetMysqlDecimal())
+			d.SetMysqlDecimal(&r)
 			return d, nil
 		}
 	}
@@ -450,8 +450,8 @@ func computeDiv(a, b types.Datum) (d types.Datum, err error) {
 			// division by zero return null
 			return d, nil
 		}
-
-		d.SetMysqlDecimal(xa.Div(xb))
+		xc := xa.Div(xb)
+		d.SetMysqlDecimal(&xc)
 		return d, nil
 	}
 }
@@ -611,7 +611,7 @@ func coerceArithmetic(a types.Datum) (d types.Datum, err error) {
 			d.SetInt64(de.IntPart())
 			return d, nil
 		}
-		d.SetMysqlDecimal(de)
+		d.SetMysqlDecimal(&de)
 		return d, nil
 	case types.KindMysqlDuration:
 		// if duration has no precision, return int64
@@ -621,7 +621,7 @@ func coerceArithmetic(a types.Datum) (d types.Datum, err error) {
 			d.SetInt64(de.IntPart())
 			return d, nil
 		}
-		d.SetMysqlDecimal(de)
+		d.SetMysqlDecimal(&de)
 		return d, nil
 	case types.KindMysqlHex:
 		d.SetFloat64(a.GetMysqlHex().ToNumber())

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -55,7 +55,7 @@ func encode(b []byte, vals []types.Datum, comparable bool) ([]byte, error) {
 			b = EncodeInt(b, int64(val.GetMysqlDuration().Duration))
 		case types.KindMysqlDecimal:
 			b = append(b, decimalFlag)
-			b = EncodeDecimal(b, val.GetMysqlDecimal())
+			b = EncodeDecimal(b, *val.GetMysqlDecimal())
 		case types.KindMysqlHex:
 			b = append(b, intFlag)
 			b = EncodeInt(b, int64(val.GetMysqlHex().ToNumber()))


### PR DESCRIPTION
The space of Datum to save mysql.Decimal can be saved by just a ptr.