### PR TITLE
*: optimization, do not read not referenced columns.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -120,6 +120,9 @@ type ResultField struct {
 	// will be set for every retrieved row.
 	Expr      ExprNode
 	TableName *TableName
+	// Whether this result field has been referenced.
+	// If not, we don't need to get the values.
+	Referenced bool
 }
 
 // Row represents a single row from Recordset.

--- a/optimizer/plan/planbuilder.go
+++ b/optimizer/plan/planbuilder.go
@@ -737,6 +737,9 @@ func (b *planBuilder) buildDistinct(src Plan) Plan {
 func (b *planBuilder) buildUpdate(update *ast.UpdateStmt) Plan {
 	sel := &ast.SelectStmt{From: update.TableRefs, Where: update.Where, OrderBy: update.Order, Limit: update.Limit}
 	p := b.buildFrom(sel)
+	for _, v := range p.Fields() {
+		v.Referenced = true
+	}
 	if sel.OrderBy != nil && !matchOrder(p, sel.OrderBy.Items) {
 		p = b.buildSort(p, sel.OrderBy.Items)
 		if b.err != nil {
@@ -772,6 +775,9 @@ func (b *planBuilder) buildUpdateLists(list []*ast.Assignment, fields []*ast.Res
 func (b *planBuilder) buildDelete(del *ast.DeleteStmt) Plan {
 	sel := &ast.SelectStmt{From: del.TableRefs, Where: del.Where, OrderBy: del.Order, Limit: del.Limit}
 	p := b.buildFrom(sel)
+	for _, v := range p.Fields() {
+		v.Referenced = true
+	}
 	if sel.OrderBy != nil && !matchOrder(p, sel.OrderBy.Items) {
 		p = b.buildSort(p, sel.OrderBy.Items)
 		if b.err != nil {

--- a/optimizer/resolver.go
+++ b/optimizer/resolver.go
@@ -609,6 +609,7 @@ func (nr *nameResolver) resolveColumnInTableSources(cn *ast.ColumnNameExpr, tabl
 	if matchedResultField != nil {
 		// Bind column.
 		cn.Refer = matchedResultField
+		matchedResultField.Referenced = true
 		return true
 	}
 	return false
@@ -638,6 +639,7 @@ func (nr *nameResolver) resolveColumnInResultFields(ctx *resolverContext, cn *as
 			if rf.Column.Name.L == "" {
 				// This is not a real table column, resolve it directly.
 				cn.Refer = rf
+				rf.Referenced = true
 				return true
 			}
 			if matched == nil {
@@ -664,6 +666,7 @@ func (nr *nameResolver) resolveColumnInResultFields(ctx *resolverContext, cn *as
 		}
 		// Bind column.
 		cn.Refer = matched
+		matched.Referenced = true
 		return true
 	}
 	return false
@@ -714,6 +717,7 @@ func (nr *nameResolver) createResultFields(field *ast.SelectField) (rfs []*ast.R
 
 		}
 		for _, trf := range tableRfs {
+			trf.Referenced = true
 			// Convert it to ColumnNameExpr
 			cn := &ast.ColumnName{
 				Schema: trf.DBName,
@@ -799,6 +803,7 @@ func (nr *nameResolver) handlePosition(pos *ast.PositionExpr) {
 	}
 	nf.Expr = expr
 	pos.Refer = &nf
+	pos.Refer.Referenced = true
 	if nr.currentContext().inGroupBy {
 		// make sure item is not aggregate function
 		if ast.HasAggFlag(pos.Refer.Expr) {

--- a/table/tables/memory_tables.go
+++ b/table/tables/memory_tables.go
@@ -216,6 +216,9 @@ func (t *MemoryTable) RowWithCols(ctx context.Context, h int64, cols []*column.C
 	row := item.(*itemPair).data
 	v := make([]types.Datum, len(cols))
 	for i, col := range cols {
+		if col == nil {
+			continue
+		}
 		v[i] = row[col.Offset]
 	}
 	return v, nil

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -437,6 +437,9 @@ func (t *Table) RowWithCols(ctx context.Context, h int64, cols []*column.Col) ([
 	}
 	v := make([]types.Datum, len(cols))
 	for i, col := range cols {
+		if col == nil {
+			continue
+		}
 		if col.State != model.StatePublic {
 			return nil, errors.Errorf("Cannot use none public column - %v", cols)
 		}

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -92,6 +92,12 @@ func (r *SubResult) Next() (handle int64, data []types.Datum, err error) {
 	if err != nil {
 		return 0, nil, errors.Trace(err)
 	}
+	if data == nil {
+		// When no column is referenced, the data may be nil, like 'select count(*) from t'.
+		// In this case, we need to create a zero length datum slice,
+		// as caller will check if data is nil to finish iteration.
+		data = make([]types.Datum, 0)
+	}
 	handleBytes := row.GetHandle()
 	datums, err := codec.Decode(handleBytes)
 	if err != nil {


### PR DESCRIPTION
Currently, scan a row reads all columns.
This change added a `Referenced` field in `ast.ResultField` to mark this column need to be read.
Not referenced columns will not be read.
For example, `select c1 from t` will just read `c1` rather than all columns in table `t`.