### PR TITLE
perfschema: Fix nil pointer panic when perfschema is uninitialized

### DIFF
--- a/perfschema/statement.go
+++ b/perfschema/statement.go
@@ -250,6 +250,9 @@ func state2Record(state *StatementState) []types.Datum {
 
 func (ps *perfSchema) updateEventsStmtsCurrent(connID uint64, record []types.Datum) error {
 	tbl := ps.mTables[TableStmtsCurrent]
+	if tbl == nil {
+		return nil
+	}
 	handle, ok := ps.stmtHandles[connID]
 	if !ok {
 		newHandle, err := tbl.AddRecord(nil, record)
@@ -268,6 +271,9 @@ func (ps *perfSchema) updateEventsStmtsCurrent(connID uint64, record []types.Dat
 
 func (ps *perfSchema) appendEventsStmtsHistory(record []types.Datum) error {
 	tbl := ps.mTables[TableStmtsHistory]
+	if tbl == nil {
+		return nil
+	}
 	_, err := tbl.AddRecord(nil, record)
 	if err != nil {
 		return errors.Trace(err)

--- a/perfschema/statement_test.go
+++ b/perfschema/statement_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perfschema
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/types"
+)
+
+type testStatementSuit struct {
+	vars map[string]interface{}
+}
+
+var _ = Suite(&testStatementSuit{
+	vars: make(map[string]interface{}),
+})
+
+func (p *testStatementSuit) TestUninitPS(c *C) {
+	defer testleak.AfterTest(c)()
+	// Run init()
+	ps := &perfSchema{}
+	// ps is uninitialized, all mTables are missing.
+	// This cound happend at the bootstrap stage.
+	// So we must make sure the following actions are safe.
+	err := ps.updateEventsStmtsCurrent(0, []types.Datum{})
+	c.Assert(err, IsNil)
+	err = ps.appendEventsStmtsHistory([]types.Datum{})
+	c.Assert(err, IsNil)
+}

--- a/perfschema/statement_test.go
+++ b/perfschema/statement_test.go
@@ -20,12 +20,9 @@ import (
 )
 
 type testStatementSuit struct {
-	vars map[string]interface{}
 }
 
-var _ = Suite(&testStatementSuit{
-	vars: make(map[string]interface{}),
-})
+var _ = Suite(&testStatementSuit{})
 
 func (p *testStatementSuit) TestUninitPS(c *C) {
 	defer testleak.AfterTest(c)()


### PR DESCRIPTION
In bootstrap stage, ps may be not well initialized. We should make it safe.
@nieyy 