### PR TITLE
*: Do not specify pd version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ godep:
 	go get github.com/pingcap/go-themis
 	go get github.com/pingcap/tso/client
 	go get github.com/pingcap/pd/pd-client
-	git -C $$(echo $(GOPATH)|cut -d':' -f1)/src/github.com/pingcap/pd checkout 264ba607c4f77c85626b9f56e5f4c80a59619903
 	go get github.com/pingcap/ticlient
 	go get github.com/pingcap/tipb/go-tipb
 


### PR DESCRIPTION
pd move vendor to cmd directory, so we do not need to specify its version now.
@coocood @qiuyesuifeng 