### PR TITLE
executor: make table lookup task size increasing.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -46,11 +46,11 @@ func (s *testSuite) SetUpSuite(c *C) {
 	store, err := tidb.NewStore("memory://test/test")
 	c.Assert(err, IsNil)
 	s.store = store
-	executor.LookupTableTaskLimit = 2
+	executor.BaseLookupTableTaskSize = 2
 }
 
 func (s *testSuite) TearDownSuite(c *C) {
-	executor.LookupTableTaskLimit = 256
+	executor.BaseLookupTableTaskSize = 256
 	s.store.Close()
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -50,7 +50,7 @@ func (s *testSuite) SetUpSuite(c *C) {
 }
 
 func (s *testSuite) TearDownSuite(c *C) {
-	executor.BaseLookupTableTaskSize = 256
+	executor.BaseLookupTableTaskSize = 512
 	s.store.Close()
 }
 

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -147,10 +147,10 @@ type XSelectIndexExec struct {
 }
 
 // BaseLookupTableTaskSize represents base number of handles for a lookupTableTask.
-var BaseLookupTableTaskSize = 512
+var BaseLookupTableTaskSize = 1024
 
 // MaxLookupTableTaskSize represents max number of handles for a lookupTableTask.
-var MaxLookupTableTaskSize = 2048
+var MaxLookupTableTaskSize = 1024
 
 type lookupTableTask struct {
 	handles []int64

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -147,7 +147,7 @@ type XSelectIndexExec struct {
 }
 
 // BaseLookupTableTaskSize represents base number of handles for a lookupTableTask.
-var BaseLookupTableTaskSize = 256
+var BaseLookupTableTaskSize = 512
 
 // MaxLookupTableTaskSize represents max number of handles for a lookupTableTask.
 var MaxLookupTableTaskSize = 2048

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -145,8 +145,11 @@ type XSelectIndexExec struct {
 	indexOrder map[int64]int
 }
 
-// LookupTableTaskLimit represents max number of handles for a lookupTableTask.
-var LookupTableTaskLimit = 256
+// BaseLookupTableTaskSize represents base number of handles for a lookupTableTask.
+var BaseLookupTableTaskSize = 256
+
+// MaxLookupTableTaskSize represents max number of handles for a lookupTableTask.
+var MaxLookupTableTaskSize = 2048
 
 type lookupTableTask struct {
 	handles []int64
@@ -232,23 +235,34 @@ func (e *XSelectIndexExec) fetchHandles() ([]int64, error) {
 }
 
 func (e *XSelectIndexExec) buildTableTasks(handles []int64) {
-	e.tasks = make([]*lookupTableTask, 0, (len(handles)/LookupTableTaskLimit)+1)
-	for {
-		if len(handles) > LookupTableTaskLimit {
-			task := &lookupTableTask{
-				handles: handles[:LookupTableTaskLimit],
-			}
-			e.tasks = append(e.tasks, task)
-			handles = handles[LookupTableTaskLimit:]
-			continue
+	// Build tasks with increasing batch size.
+	var taskSizes []int
+	total := len(handles)
+	batchSize := BaseLookupTableTaskSize
+	for total > 0 {
+		if batchSize > total {
+			batchSize = total
 		}
-		if len(handles) > 0 {
-			task := &lookupTableTask{
-				handles: handles,
-			}
-			e.tasks = append(e.tasks, task)
+		taskSizes = append(taskSizes, batchSize)
+		total -= batchSize
+		if batchSize < MaxLookupTableTaskSize {
+			batchSize *= 2
 		}
-		break
+	}
+	if e.indexPlan.Desc && !e.supportDesc {
+		// Reverse tasks sizes.
+		for i := 0; i < len(taskSizes)/2; i++ {
+			j := len(taskSizes) - i - 1
+			taskSizes[i], taskSizes[j] = taskSizes[j], taskSizes[i]
+		}
+	}
+	e.tasks = make([]*lookupTableTask, len(taskSizes))
+	for i, size := range taskSizes {
+		task := &lookupTableTask{
+			handles: handles[:size],
+		}
+		handles = handles[size:]
+		e.tasks[i] = task
 	}
 	if e.indexPlan.Desc && !e.supportDesc {
 		// Reverse tasks order.

--- a/optimizer/plan/cost.go
+++ b/optimizer/plan/cost.go
@@ -23,7 +23,7 @@ const (
 	HalfRangeCount   = 4000
 	MiddleRangeCount = 100
 	RowCost          = 1.0
-	IndexCost        = 2.0
+	IndexCost        = 1.1
 	SortCost         = 2.0
 	FilterRate       = 0.5
 )
@@ -98,7 +98,7 @@ func (c *costEstimator) indexScan(v *IndexScan) {
 	} else {
 		v.rowCount = math.Min(rowCount, v.limit)
 	}
-	v.totalCost = v.rowCount * RowCost
+	v.totalCost = v.rowCount * IndexCost
 }
 
 // EstimateCost estimates the cost of the plan.

--- a/optimizer/plan/planbuilder.go
+++ b/optimizer/plan/planbuilder.go
@@ -315,7 +315,7 @@ func (b *planBuilder) buildSingleTable(sel *ast.SelectStmt) Plan {
 			bestPlan = v
 			lowestCost = cost
 		}
-		if cost < lowestCost {
+		if cost <= lowestCost {
 			bestPlan = v
 			lowestCost = cost
 		}


### PR DESCRIPTION
Reduce the number of RPC call.