### PR TITLE
localstore: remove MultiSeek method and fix concurrent bug

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/ngaut/log"
 )
 
 var _ = Suite(&testSessionSuite{})
@@ -57,6 +58,7 @@ func (s *testSessionSuite) SetUpSuite(c *C) {
 	s.dropTableSQL = `Drop TABLE if exists t;`
 	s.createTableSQL = `CREATE TABLE t(id TEXT);`
 	s.selectSQL = `SELECT * from t;`
+	log.SetLevelByString("error")
 }
 
 func (s *testSessionSuite) TearDownSuite(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/executor"
@@ -32,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testleak"
-	"github.com/ngaut/log"
 )
 
 var _ = Suite(&testSessionSuite{})

--- a/store/localstore/boltdb/boltdb.go
+++ b/store/localstore/boltdb/boltdb.go
@@ -51,34 +51,6 @@ func (d *db) Get(key []byte) ([]byte, error) {
 	return value, errors.Trace(err)
 }
 
-func (d *db) MultiSeek(keys [][]byte) []*engine.MSeekResult {
-	res := make([]*engine.MSeekResult, 0, len(keys))
-	d.DB.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket(bucketName)
-		c := b.Cursor()
-		for _, key := range keys {
-			var k, v []byte
-			if key == nil {
-				k, v = c.First()
-			} else {
-				k, v = c.Seek(key)
-			}
-
-			r := &engine.MSeekResult{}
-			if k == nil {
-				r.Err = engine.ErrNotFound
-			} else {
-				r.Key, r.Value, r.Err = bytes.CloneBytes(k), bytes.CloneBytes(v), nil
-			}
-
-			res = append(res, r)
-		}
-		return nil
-	})
-
-	return res
-}
-
 func (d *db) Seek(startKey []byte) ([]byte, []byte, error) {
 	var key, value []byte
 	err := d.DB.View(func(tx *bolt.Tx) error {

--- a/store/localstore/boltdb/boltdb_test.go
+++ b/store/localstore/boltdb/boltdb_test.go
@@ -151,22 +151,3 @@ func (s *testSuite) TestSeek(c *C) {
 	c.Assert(k, IsNil)
 	c.Assert(v, IsNil)
 }
-
-func (s *testSuite) TestMultiSeek(c *C) {
-	defer testleak.AfterTest(c)()
-	b := s.db.NewBatch()
-	b.Put([]byte("a"), []byte("1"))
-	b.Put([]byte("b"), []byte("2"))
-	err := s.db.Commit(b)
-	c.Assert(err, IsNil)
-
-	m := s.db.MultiSeek([][]byte{[]byte("z"), []byte("a"), []byte("a1")})
-	c.Assert(m, HasLen, 3)
-	c.Assert(m[0].Err, NotNil)
-	c.Assert(m[1].Err, IsNil)
-	c.Assert(m[1].Key, BytesEquals, []byte("a"))
-	c.Assert(m[1].Value, BytesEquals, []byte("1"))
-	c.Assert(m[2].Err, IsNil)
-	c.Assert(m[2].Key, BytesEquals, []byte("b"))
-	c.Assert(m[2].Value, BytesEquals, []byte("2"))
-}

--- a/store/localstore/engine/engine.go
+++ b/store/localstore/engine/engine.go
@@ -39,8 +39,6 @@ type DB interface {
 	// Seek searches for the first key in the engine which is >= key in byte order, returns (nil, nil, ErrNotFound)
 	// if such key is not found.
 	Seek(key []byte) ([]byte, []byte, error)
-	// MultiSeek seeks multiple keys from the engine.
-	MultiSeek(keys [][]byte) []*MSeekResult
 	// NewBatch creates a Batch for writing.
 	NewBatch() Batch
 	// Commit writes the changed data in Batch.

--- a/store/localstore/goleveldb/goleveldb.go
+++ b/store/localstore/goleveldb/goleveldb.go
@@ -63,24 +63,6 @@ func (d *db) Seek(startKey []byte) ([]byte, []byte, error) {
 	return iter.Key(), iter.Value(), nil
 }
 
-func (d *db) MultiSeek(keys [][]byte) []*engine.MSeekResult {
-	iter := d.DB.NewIterator(&util.Range{Start: []byte{0x0}}, nil)
-	defer iter.Release()
-
-	res := make([]*engine.MSeekResult, 0, len(keys))
-	for _, k := range keys {
-		if ok := iter.Seek(k); !ok {
-			res = append(res, &engine.MSeekResult{Err: engine.ErrNotFound})
-		} else {
-			res = append(res, &engine.MSeekResult{
-				Key:   append([]byte(nil), iter.Key()...),
-				Value: append([]byte(nil), iter.Value()...),
-			})
-		}
-	}
-	return res
-}
-
 func (d *db) Commit(b engine.Batch) error {
 	batch, ok := b.(*leveldb.Batch)
 	if !ok {

--- a/store/localstore/goleveldb/goleveldb.go
+++ b/store/localstore/goleveldb/goleveldb.go
@@ -57,7 +57,7 @@ func (d *db) NewBatch() engine.Batch {
 func (d *db) Seek(startKey []byte) ([]byte, []byte, error) {
 	iter := d.DB.NewIterator(&util.Range{Start: startKey}, nil)
 	defer iter.Release()
-	if ok := iter.Next(); !ok {
+	if ok := iter.First(); !ok {
 		return nil, nil, errors.Trace(engine.ErrNotFound)
 	}
 	return iter.Key(), iter.Value(), nil

--- a/store/localstore/goleveldb/goleveldb.go
+++ b/store/localstore/goleveldb/goleveldb.go
@@ -57,7 +57,7 @@ func (d *db) NewBatch() engine.Batch {
 func (d *db) Seek(startKey []byte) ([]byte, []byte, error) {
 	iter := d.DB.NewIterator(&util.Range{Start: startKey}, nil)
 	defer iter.Release()
-	if ok := iter.First(); !ok {
+	if ok := iter.Next(); !ok {
 		return nil, nil, errors.Trace(engine.ErrNotFound)
 	}
 	return iter.Key(), iter.Value(), nil

--- a/store/localstore/goleveldb/goleveldb_test.go
+++ b/store/localstore/goleveldb/goleveldb_test.go
@@ -107,22 +107,3 @@ func (s *testSuite) TestSeek(c *C) {
 	c.Assert(k, IsNil)
 	c.Assert(v, IsNil)
 }
-
-func (s *testSuite) TestMultiSeek(c *C) {
-	defer testleak.AfterTest(c)()
-	b := s.db.NewBatch()
-	b.Put([]byte("a"), []byte("1"))
-	b.Put([]byte("b"), []byte("2"))
-	err := s.db.Commit(b)
-	c.Assert(err, IsNil)
-
-	m := s.db.MultiSeek([][]byte{[]byte("z"), []byte("a"), []byte("a1")})
-	c.Assert(m, HasLen, 3)
-	c.Assert(m[0].Err, NotNil)
-	c.Assert(m[1].Err, IsNil)
-	c.Assert(m[1].Key, BytesEquals, []byte("a"))
-	c.Assert(m[1].Value, BytesEquals, []byte("1"))
-	c.Assert(m[2].Err, IsNil)
-	c.Assert(m[2].Key, BytesEquals, []byte("b"))
-	c.Assert(m[2].Value, BytesEquals, []byte("2"))
-}

--- a/store/localstore/kv.go
+++ b/store/localstore/kv.go
@@ -74,8 +74,11 @@ func (s *dbStore) Seek(key []byte) ([]byte, []byte, error) {
 		s.mu.Unlock()
 		return nil, nil, ErrDBClosed
 	}
+	s.wg.Add(1)
 	s.mu.Unlock()
-	return s.db.Seek(key)
+	key, val, err := s.db.Seek(key)
+	s.wg.Done()
+	return key, val, err
 }
 
 // Commit writes the changed data in Batch.

--- a/store/localstore/kv.go
+++ b/store/localstore/kv.go
@@ -125,6 +125,10 @@ func (s *dbStore) doCommit(txn *dbTxn) error {
 		committing := s.committingTS != 0
 		if !closed && !committing {
 			commitVer, err = globalVersionProvider.CurrentVersion()
+			if err != nil {
+				s.mu.Unlock()
+				return errors.Trace(err)
+			}
 			s.committingTS = commitVer.Ver
 			s.wg.Add(1)
 		}

--- a/store/localstore/kv.go
+++ b/store/localstore/kv.go
@@ -69,6 +69,12 @@ type commitArgs struct {
 // Seek searches for the first key in the engine which is >= key in byte order, returns (nil, nil, ErrNotFound)
 // if such key is not found.
 func (s *dbStore) Seek(key []byte) ([]byte, []byte, error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return nil, nil, ErrDBClosed
+	}
+	s.mu.Unlock()
 	return s.db.Seek(key)
 }
 

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -64,7 +64,7 @@ func (s *dbSnapshot) mvccSeek(key kv.Key, exact bool) (kv.Key, []byte, error) {
 	// EOF
 	for {
 		mvccKey := MvccEncodeVersionKey(key, s.version)
-		mvccK, v, err := s.store.Seek([]byte(mvccKey)) // search for [3...EOF)
+		mvccK, v, err := s.store.Seek([]byte(mvccKey), s.version.Ver) // search for [3...EOF)
 		if err != nil {
 			if terror.ErrorEqual(err, engine.ErrNotFound) { // EOF
 				return nil, nil, errors.Trace(kv.ErrNotExist)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/kv"
@@ -59,9 +60,11 @@ func (s *testKVSuite) SetUpSuite(c *C) {
 
 	cacheS, _ := tidb.NewStore(fmt.Sprintf("%s://%s", *testStore, *testStorePath))
 	c.Assert(cacheS, Equals, store)
+	log.SetLevelByString("warn")
 }
 
 func (s *testKVSuite) TearDownSuite(c *C) {
+	log.SetLevelByString("debug")
 	err := s.s.Close()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
Before:
```
BenchmarkBasic-4                   50000	     32574 ns/op
BenchmarkTableScan-4         	    1000	   2093847 ns/op
BenchmarkTableLookup-4       	   10000	    112250 ns/op
BenchmarkStringIndexScan-4   	     500	   3506790 ns/op
BenchmarkStringIndexLookup-4 	   10000	    207038 ns/op
BenchmarkIntegerIndexScan-4  	     500	   3444936 ns/op
BenchmarkIntegerIndexLookup-4	   10000	    194365 ns/op
BenchmarkDecimalIndexScan-4  	     300	   4423639 ns/op
BenchmarkDecimalIndexLookup-4	    5000	    231001 ns/op
BenchmarkInsertWithIndex-4   	   20000	    265147 ns/op
BenchmarkInsertNoIndex-4     	   10000	    206556 ns/op
```

After:
```
BenchmarkBasic-4                   50000	     32286 ns/op
BenchmarkTableScan-4         	    1000	   1431793 ns/op
BenchmarkTableLookup-4       	   10000	    105119 ns/op
BenchmarkStringIndexScan-4   	     500	   2420872 ns/op
BenchmarkStringIndexLookup-4 	   10000	    181779 ns/op
BenchmarkIntegerIndexScan-4  	    1000	   2436715 ns/op
BenchmarkIntegerIndexLookup-4	   10000	    185647 ns/op
BenchmarkDecimalIndexScan-4  	     500	   3067935 ns/op
BenchmarkDecimalIndexLookup-4	    5000	    211426 ns/op
BenchmarkInsertWithIndex-4   	   20000	    138176 ns/op
BenchmarkInsertNoIndex-4     	   10000	    144457 ns/op
```