### PR TITLE
*: Support using hexadecimal literals as string

### DIFF
--- a/mysql/hex.go
+++ b/mysql/hex.go
@@ -56,30 +56,53 @@ func (h Hex) ToString() string {
 	return string(b)
 }
 
-// ParseHex parses hexadecimal literal string.
-// The string format can be X'val', x'val' or 0xval.
-// val must in (0...9, a...z, A...Z).
-func ParseHex(s string) (Hex, error) {
+func uniformHexStrLit(s string) (string, error) {
 	if len(s) == 0 {
-		return Hex{}, errors.Errorf("invalid empty string for parsing hexadecimal literal")
+		return "", errors.Errorf("invalid empty string for parsing hexadecimal literal")
 	}
 
 	if s[0] == 'x' || s[0] == 'X' {
 		// format is x'val' or X'val'
 		s = strings.Trim(s[1:], "'")
 		if len(s)%2 != 0 {
-			return Hex{}, errors.Errorf("invalid hexadecimal format, must even numbers, but %d", len(s))
+			return "", errors.Errorf("invalid hexadecimal format, must even numbers, but %d", len(s))
 		}
 		s = "0x" + s
 	} else if !strings.HasPrefix(s, "0x") {
 		// here means format is not x'val', X'val' or 0xval.
-		return Hex{}, errors.Errorf("invalid hexadecimal format %s", s)
+		return "", errors.Errorf("invalid hexadecimal format %s", s)
 	}
+	return s, nil
+}
 
+// ParseHex parses hexadecimal literal string.
+// The string format can be X'val', x'val' or 0xval.
+// val must in (0...9, a...z, A...Z).
+func ParseHex(s string) (Hex, error) {
+	var err error
+	s, err = uniformHexStrLit(s)
+	if err != nil {
+		return Hex{}, errors.Trace(err)
+	}
 	n, err := strconv.ParseInt(s, 0, 64)
 	if err != nil {
 		return Hex{}, errors.Trace(err)
 	}
 
 	return Hex{Value: n}, nil
+}
+
+// ParseHexStr parses hexadecimal literal as string.
+// See: https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html
+func ParseHexStr(s string) (string, error) {
+	var err error
+	s, err = uniformHexStrLit(s)
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	bs, err := hex.DecodeString(s[2:])
+	if err != nil {
+		return "", errors.Trace(err)
+	}
+	return string(bs), nil
 }

--- a/mysql/hex.go
+++ b/mysql/hex.go
@@ -77,7 +77,7 @@ func uniformHexStrLit(s string) (string, error) {
 
 // ParseHex parses hexadecimal literal string.
 // The string format can be X'val', x'val' or 0xval.
-// val must in (0...9, a...z, A...Z).
+// val must in (0...9, a...f, A...F).
 func ParseHex(s string) (Hex, error) {
 	var err error
 	s, err = uniformHexStrLit(s)

--- a/mysql/hex_test.go
+++ b/mysql/hex_test.go
@@ -65,4 +65,21 @@ func (s *testHexSuite) TestHex(c *C) {
 
 	h.Value = 1
 	c.Assert(h.ToString(), Equals, "\x01")
+
+	/*
+	 mysql> select hex("I am a long hex string");
+	 +----------------------------------------------+
+	 | hex("I am a long hex string")                |
+	 +----------------------------------------------+
+	 | 4920616D2061206C6F6E672068657820737472696E67 |
+	 +----------------------------------------------+
+	 1 row in set (0.00 sec)
+	*/
+	str := "I am a long hex string"
+	hexStr := "0x4920616D2061206C6F6E672068657820737472696E67"
+	_, err = ParseHex(hexStr)
+	c.Assert(err, NotNil)
+	v, err := ParseHexStr(hexStr)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, str)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -788,6 +788,7 @@ func (s *testParserSuite) TestType(c *C) {
 		{"SELECT x'0a', X'11', 0x11", true},
 		{"select x'0xaa'", false},
 		{"select 0X11", false},
+		{"select 0x4920616D2061206C6F6E672068657820737472696E67", true},
 
 		// For bit
 		{"select 0b01, 0b0, b'11', B'11'", true},

--- a/parser/scanner.l
+++ b/parser/scanner.l
@@ -1266,8 +1266,14 @@ func (l *lexer) hex(lval *yySymType) int {
 	s := string(l.val)
 	h, err := mysql.ParseHex(s)
 	if err != nil {
-		l.errf("hexadecimal literal: %v", err)
-		return int(unicode.ReplacementChar)
+		// If parse hexadecimal literal to numerical value error, we should treat it as a string.
+		hexStr, err1 := mysql.ParseHexStr(s)
+		if err1 != nil {
+			l.errf("hex literal: %v", err)
+			return int(unicode.ReplacementChar)
+		}
+		lval.item = hexStr
+		return stringLit 
 	}
 	lval.item = h
 	return hexLit


### PR DESCRIPTION
See: https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html
In numeric contexts, hexadecimal values act like integers (64-bit precision). In string contexts, they act like binary strings, where each pair of hex digits is converted to a character:

We can run [zabbix](http://www.zabbix.com/) now.