### PR TITLE
executor: run table lookup tasks concurrently if there is no limit.

### DIFF
--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -206,7 +206,7 @@ func (e *XSelectIndexExec) Next() (*Row, error) {
 			if task.doneCh != nil {
 				err := <-task.doneCh
 				if err != nil {
-					return nil, err
+					return nil, errors.Trace(err)
 				}
 			} else {
 				err := e.executeTask(task)

--- a/optimizer/plan/planbuilder.go
+++ b/optimizer/plan/planbuilder.go
@@ -442,6 +442,7 @@ out:
 }
 
 // buildPseudoSelectPlan pre-builds more complete plans that may affect total cost.
+// Also set OutOfOrder and NoLimit property.
 func (b *planBuilder) buildPseudoSelectPlan(p Plan, sel *ast.SelectStmt) Plan {
 	if sel.OrderBy == nil {
 		return p
@@ -450,6 +451,11 @@ func (b *planBuilder) buildPseudoSelectPlan(p Plan, sel *ast.SelectStmt) Plan {
 		return p
 	}
 	if !pushOrder(p, sel.OrderBy.Items) {
+		switch x := p.(type) {
+		case *IndexScan:
+			x.OutOfOrder = true
+			x.NoLimit = true
+		}
 		np := &Sort{ByItems: sel.OrderBy.Items}
 		np.AddChild(p)
 		p = np
@@ -459,6 +465,11 @@ func (b *planBuilder) buildPseudoSelectPlan(p Plan, sel *ast.SelectStmt) Plan {
 		np.AddChild(p)
 		np.SetLimit(0)
 		p = np
+	} else {
+		switch x := p.(type) {
+		case *IndexScan:
+			x.NoLimit = true
+		}
 	}
 	return p
 }

--- a/optimizer/plan/plans.go
+++ b/optimizer/plan/plans.go
@@ -137,6 +137,9 @@ type IndexScan struct {
 	// OutOfOrder indicates if the index scan can return out of order.
 	OutOfOrder bool
 
+	// NoLimit indicates that this plan need fetch all the rows.
+	NoLimit bool
+
 	// TableName is used to distinguish the same table selected multiple times in different place,
 	// like 'select * from t where exists(select 1 from t as x where t.c < x.c)'
 	TableName *ast.TableName


### PR DESCRIPTION
And set index plan concurrency to 10 if OutOfOrder property is set.