### PR TITLE
store/tikv/mock-tikv: add coprocessor support.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -52,6 +53,7 @@ func (s *testSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 	}
+	log.SetLevelByString("warn")
 	executor.BaseLookupTableTaskSize = 2
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/inspectkv"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
@@ -42,9 +43,15 @@ type testSuite struct {
 }
 
 func (s *testSuite) SetUpSuite(c *C) {
-	store, err := tidb.NewStore("memory://test/test")
-	c.Assert(err, IsNil)
-	s.store = store
+	useMockTikv := true
+	if useMockTikv {
+		s.store = tikv.NewMockTikvStore()
+		tidb.SetSchemaLease(0)
+	} else {
+		store, err := tidb.NewStore("memory://test/test")
+		c.Assert(err, IsNil)
+		s.store = store
+	}
 	executor.BaseLookupTableTaskSize = 2
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 	"testing"
@@ -43,8 +44,11 @@ type testSuite struct {
 	store kv.Storage
 }
 
+var mockTikv = flag.Bool("mockTikv", true, "use mock tikv store in executor test")
+
 func (s *testSuite) SetUpSuite(c *C) {
-	useMockTikv := true
+	flag.Lookup("mockTikv")
+	useMockTikv := *mockTikv
 	if useMockTikv {
 		s.store = tikv.NewMockTikvStore()
 		tidb.SetSchemaLease(0)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/pingcap/check"
 	"github.com/ngaut/log"
+	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -638,7 +638,6 @@ func (e *XSelectIndexExec) extractRowsFromSubResult(t table.Table, subResult *xa
 		for i, field := range e.indexPlan.Fields() {
 			if field.Referenced {
 				fullRowData[i] = rowData[j]
-				field.Expr.SetDatum(fullRowData[i])
 				j++
 			}
 		}

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -206,7 +206,7 @@ func (e *XSelectIndexExec) Next() (*Row, error) {
 		if e.indexPlan.LimitCount != nil {
 			limitCount = *e.indexPlan.LimitCount
 		}
-		concurrency := 1
+		concurrency := 2
 		if e.indexPlan.NoLimit {
 			concurrency = len(e.tasks)
 		} else if limitCount > int64(BaseLookupTableTaskSize) {

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -206,7 +206,7 @@ func (e *XSelectIndexExec) Next() (*Row, error) {
 		if e.indexPlan.LimitCount != nil {
 			limitCount = *e.indexPlan.LimitCount
 		}
-		concurrency := 2
+		concurrency := 1
 		if e.indexPlan.NoLimit {
 			concurrency = len(e.tasks)
 		} else if limitCount > int64(BaseLookupTableTaskSize) {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -244,7 +244,7 @@ func (it *copIterator) Next() (io.ReadCloser, error) {
 		resp *coprocessor.Response
 		err  error
 	)
-	// If data order matters, repsone should be returned in the same order as copTask slice.
+	// If data order matters, response should be returned in the same order as copTask slice.
 	// Otherwise all responses are returned from a single channel.
 	if !it.req.KeepOrder {
 		// Get next fetched resp from chan

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -270,7 +270,9 @@ func (it *copIterator) Next() (io.ReadCloser, error) {
 		case resp = <-task.respChan:
 		case err = <-it.errChan:
 		}
+		it.mu.Lock()
 		task.status = taskDone
+		it.mu.Unlock()
 	}
 	if err != nil {
 		it.Close()
@@ -336,8 +338,6 @@ func (it *copIterator) handleTask(task *copTask) (*coprocessor.Response, error) 
 			log.Warnf("coprocessor err: %v", err)
 			return nil, errors.Trace(err)
 		}
-		it.mu.Lock()
-		defer it.mu.Unlock()
 		return resp, nil
 	}
 	return nil, errors.Trace(backoffErr)

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -270,6 +270,7 @@ func (it *copIterator) Next() (io.ReadCloser, error) {
 		case resp = <-task.respChan:
 		case err = <-it.errChan:
 		}
+		task.status = taskDone
 	}
 	if err != nil {
 		it.Close()
@@ -337,7 +338,6 @@ func (it *copIterator) handleTask(task *copTask) (*coprocessor.Response, error) 
 		}
 		it.mu.Lock()
 		defer it.mu.Unlock()
-		task.status = taskDone
 		return resp, nil
 	}
 	return nil, errors.Trace(backoffErr)

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -39,7 +39,10 @@ func (c *CopClient) SupportRequestType(reqType, subType int64) bool {
 	case kv.ReqTypeSelect:
 		return supportExpr(tipb.ExprType(subType))
 	case kv.ReqTypeIndex:
-		return subType == kv.ReqSubTypeBasic
+		switch subType {
+		case kv.ReqSubTypeDesc, kv.ReqSubTypeBasic:
+			return true
+		}
 	}
 	return false
 }
@@ -53,6 +56,8 @@ func supportExpr(exprType tipb.ExprType) bool {
 		tipb.ExprType_GE, tipb.ExprType_GT, tipb.ExprType_NullEQ,
 		tipb.ExprType_In, tipb.ExprType_ValueList,
 		tipb.ExprType_Like, tipb.ExprType_Not:
+		return true
+	case kv.ReqSubTypeDesc:
 		return true
 	default:
 		return false

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -89,7 +89,8 @@ func newTikvStore(uuid string, pdClient pd.Client, factory ClientFactory) *tikvS
 	}
 }
 
-func NewMockTikvStore() *tikvStore {
+// NewMockTikvStore creates a mocked tikv store.
+func NewMockTikvStore() kv.Storage {
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	mvccStore := mocktikv.NewMvccStore()

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -15,18 +15,16 @@ package tikv
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/store/tikv/mock-tikv"
 )
 
 type testLockSuite struct {
-	store   *tikvStore
-	cluster *mocktikv.Cluster
+	store *tikvStore
 }
 
 var _ = Suite(&testLockSuite{})
 
 func (s *testLockSuite) SetUpTest(c *C) {
-	s.store, s.cluster = createMockStoreCluster()
+	s.store = NewMockTikvStore().(*tikvStore)
 }
 
 func (s *testLockSuite) lockKey(c *C, key, value, primaryKey, primaryValue []byte, commitPrimary bool) {
@@ -67,7 +65,6 @@ func (s *testLockSuite) putKV(c *C, key, value []byte) {
 }
 
 func (s *testLockSuite) TestScanLockResolve(c *C) {
-	mocktikv.BootstrapWithSingleStore(s.cluster)
 	s.putAlphabets(c)
 	s.putKV(c, []byte("c"), []byte("cc"))
 	s.lockKey(c, []byte("c"), []byte("c"), []byte("zz"), []byte("zz"), true)

--- a/store/tikv/mock-tikv/cop_handler.go
+++ b/store/tikv/mock-tikv/cop_handler.go
@@ -1,3 +1,16 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mocktikv
 
 import (

--- a/store/tikv/mock-tikv/cop_handler.go
+++ b/store/tikv/mock-tikv/cop_handler.go
@@ -1,0 +1,464 @@
+package mocktikv
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/juju/errors"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/types"
+	"github.com/pingcap/tidb/xapi/tablecodec"
+	"github.com/pingcap/tidb/xapi/xeval"
+	"github.com/pingcap/tipb/go-tipb"
+)
+
+type selectContext struct {
+	sel          *tipb.SelectRequest
+	eval         *xeval.Evaluator
+	whereColumns map[int64]*tipb.ColumnInfo
+}
+
+func (h *rpcHandler) handleCopRequest(req *coprocessor.Request) (*coprocessor.Response, error) {
+	resp := &coprocessor.Response{}
+	if err := h.checkContext(req.GetContext()); err != nil {
+		resp.RegionError = err
+		return resp, nil
+	}
+	if len(req.Ranges) == 0 {
+		return resp, nil
+	}
+	if req.GetTp() == kv.ReqTypeSelect || req.GetTp() == kv.ReqTypeIndex {
+		sel := new(tipb.SelectRequest)
+		err := proto.Unmarshal(req.Data, sel)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ctx := &selectContext{
+			sel: sel,
+		}
+		if sel.Where != nil {
+			ctx.eval = &xeval.Evaluator{Row: make(map[int64]types.Datum)}
+			ctx.whereColumns = make(map[int64]*tipb.ColumnInfo)
+			collectColumnsInWhere(sel.Where, ctx)
+		}
+		var rows []*tipb.Row
+		if req.GetTp() == kv.ReqTypeSelect {
+			rows, err = h.getRowsFromSelectReq(ctx)
+		} else {
+			rows, err = h.getRowsFromIndexReq(ctx)
+		}
+		selResp := new(tipb.SelectResponse)
+		selResp.Error = toPBError(err)
+		selResp.Rows = rows
+		if err != nil {
+			resp.OtherError = proto.String(err.Error())
+		}
+		data, err := proto.Marshal(selResp)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		resp.Data = data
+	}
+	return resp, nil
+}
+
+func collectColumnsInWhere(expr *tipb.Expr, ctx *selectContext) error {
+	if expr == nil {
+		return nil
+	}
+	if expr.GetTp() == tipb.ExprType_ColumnRef {
+		_, i, err := codec.DecodeInt(expr.Val)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		var columns []*tipb.ColumnInfo
+		if ctx.sel.TableInfo != nil {
+			columns = ctx.sel.TableInfo.Columns
+		} else {
+			columns = ctx.sel.IndexInfo.Columns
+		}
+		for _, c := range columns {
+			if c.GetColumnId() == i {
+				ctx.whereColumns[i] = c
+				return nil
+			}
+		}
+		return xeval.ErrInvalid.Gen("column %d not found", i)
+	}
+	for _, child := range expr.Children {
+		err := collectColumnsInWhere(child, ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func toPBError(err error) *tipb.Error {
+	if err == nil {
+		return nil
+	}
+	perr := new(tipb.Error)
+	code := int32(1)
+	perr.Code = &code
+	errStr := err.Error()
+	perr.Msg = &errStr
+	return perr
+}
+
+func (h *rpcHandler) getRowsFromSelectReq(ctx *selectContext) ([]*tipb.Row, error) {
+	kvRanges, desc := h.extractKVRanges(ctx.sel)
+	var rows []*tipb.Row
+	limit := int64(-1)
+	if ctx.sel.Limit != nil {
+		limit = ctx.sel.GetLimit()
+	}
+	for _, ran := range kvRanges {
+		if limit == 0 {
+			break
+		}
+		ranRows, err := h.getRowsFromRange(ctx, ran, limit, desc)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		rows = append(rows, ranRows...)
+		limit -= int64(len(ranRows))
+	}
+	return rows, nil
+}
+
+// extractKVRanges extracts kv.KeyRanges slice from a SelectRequest, and also returns if it is in descending order.
+func (h *rpcHandler) extractKVRanges(sel *tipb.SelectRequest) (kvRanges []kv.KeyRange, desc bool) {
+	var (
+		tid   int64
+		idxID int64
+	)
+	if sel.IndexInfo != nil {
+		tid = sel.IndexInfo.GetTableId()
+		idxID = sel.IndexInfo.GetIndexId()
+	} else {
+		tid = sel.TableInfo.GetTableId()
+	}
+	for _, kran := range sel.Ranges {
+		var upperKey, lowerKey kv.Key
+		if idxID == 0 {
+			upperKey = tablecodec.EncodeRowKey(tid, kran.GetHigh())
+			if bytes.Compare(upperKey, h.startKey) <= 0 {
+				continue
+			}
+			lowerKey = tablecodec.EncodeRowKey(tid, kran.GetLow())
+		} else {
+			upperKey = tablecodec.EncodeIndexSeekKey(tid, idxID, kran.GetHigh())
+			if bytes.Compare(upperKey, h.startKey) <= 0 {
+				continue
+			}
+			lowerKey = tablecodec.EncodeIndexSeekKey(tid, idxID, kran.GetLow())
+		}
+		if len(h.endKey) != 0 && bytes.Compare([]byte(lowerKey), h.endKey) >= 0 {
+			break
+		}
+		var kvr kv.KeyRange
+		kvr.StartKey = kv.Key(maxStartKey(lowerKey, h.startKey))
+		kvr.EndKey = kv.Key(minEndKey(upperKey, h.endKey))
+		kvRanges = append(kvRanges, kvr)
+	}
+	if sel.OrderBy != nil {
+		desc = *sel.OrderBy[0].Desc
+	}
+	if desc {
+		reverseKVRanges(kvRanges)
+	}
+	return
+}
+
+func reverseKVRanges(kvRanges []kv.KeyRange) {
+	for i := 0; i < len(kvRanges)/2; i++ {
+		j := len(kvRanges) - i - 1
+		kvRanges[i], kvRanges[j] = kvRanges[j], kvRanges[i]
+	}
+}
+
+func (h *rpcHandler) getRowsFromRange(ctx *selectContext, ran kv.KeyRange, limit int64, desc bool) ([]*tipb.Row, error) {
+	startKey := maxStartKey(ran.StartKey, h.startKey)
+	endKey := minEndKey(ran.EndKey, h.endKey)
+	if limit == 0 || bytes.Compare(startKey, endKey) >= 0 {
+		return nil, nil
+	}
+	var rows []*tipb.Row
+	if ran.IsPoint() {
+		val, err := h.mvccStore.Get(startKey, ctx.sel.GetStartTs())
+		if len(val) == 0 {
+			return nil, nil
+		} else if err != nil {
+			return nil, errors.Trace(err)
+		}
+		handle, err := tablecodec.DecodeRowKey(kv.Key(startKey))
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		match, err := h.evalWhereForRow(ctx, handle)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !match {
+			return nil, nil
+		}
+		row, err := h.getRowByHandle(ctx, handle)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if row != nil {
+			rows = append(rows, row)
+		}
+		return rows, nil
+	}
+	var seekKey []byte
+	if desc {
+		seekKey = endKey
+	} else {
+		seekKey = startKey
+	}
+	for {
+		if limit == 0 {
+			break
+		}
+		var (
+			pair Pair
+			err  error
+		)
+		if desc {
+			pair = h.mvccStore.SeekReverse(seekKey, ctx.sel.GetStartTs())
+		} else {
+			pair = h.mvccStore.Seek(seekKey, ctx.sel.GetStartTs())
+		}
+		if pair.Err != nil {
+			// TODO: handle lock error.
+			return nil, errors.Trace(pair.Err)
+		}
+		if pair.Key == nil {
+			break
+		}
+		if desc {
+			if bytes.Compare(pair.Key, startKey) < 0 {
+				break
+			}
+			seekKey = pair.Key
+		} else {
+			if bytes.Compare(pair.Key, endKey) >= 0 {
+				break
+			}
+			seekKey = []byte(kv.Key(pair.Key).PrefixNext())
+		}
+		handle, err := tablecodec.DecodeRowKey(pair.Key)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		match, err := h.evalWhereForRow(ctx, handle)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if !match {
+			continue
+		}
+		row, err := h.getRowByHandle(ctx, handle)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if row != nil {
+			rows = append(rows, row)
+			limit--
+		}
+	}
+	return rows, nil
+}
+
+func (h *rpcHandler) getRowByHandle(ctx *selectContext, handle int64) (*tipb.Row, error) {
+	tid := ctx.sel.TableInfo.GetTableId()
+	columns := ctx.sel.TableInfo.Columns
+	row := new(tipb.Row)
+	var d types.Datum
+	d.SetInt64(handle)
+	var err error
+	row.Handle, err = codec.EncodeValue(nil, d)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for _, col := range columns {
+		if *col.PkHandle {
+			row.Data = append(row.Data, row.Handle...)
+		} else {
+			colID := col.GetColumnId()
+			if ctx.whereColumns[colID] != nil {
+				// The column is saved in evaluator, use it directly.
+				datum := ctx.eval.Row[colID]
+				row.Data, err = codec.EncodeValue(row.Data, datum)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+			} else {
+				key := tablecodec.EncodeColumnKey(tid, handle, colID)
+				data, err1 := h.mvccStore.Get(key, ctx.sel.GetStartTs())
+				if err1 != nil {
+					return nil, errors.Trace(err1)
+				}
+				row.Data = append(row.Data, data...)
+			}
+		}
+	}
+	return row, nil
+}
+
+func (h *rpcHandler) evalWhereForRow(ctx *selectContext, handle int64) (bool, error) {
+	if ctx.sel.Where == nil {
+		return true, nil
+	}
+	tid := ctx.sel.TableInfo.GetTableId()
+	for colID, col := range ctx.whereColumns {
+		if col.GetPkHandle() {
+			ctx.eval.Row[colID] = types.NewIntDatum(handle)
+		} else {
+			key := tablecodec.EncodeColumnKey(tid, handle, colID)
+			data, err := h.mvccStore.Get(key, ctx.sel.GetStartTs())
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			_, datum, err := codec.DecodeOne(data)
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			ctx.eval.Row[colID] = datum
+		}
+	}
+	result, err := ctx.eval.Eval(ctx.sel.Where)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	if result.Kind() == types.KindNull {
+		return false, nil
+	}
+	boolResult, err := result.ToBool()
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return boolResult == 1, nil
+}
+
+func (h *rpcHandler) getRowsFromIndexReq(ctx *selectContext) ([]*tipb.Row, error) {
+	kvRanges, desc := h.extractKVRanges(ctx.sel)
+	var rows []*tipb.Row
+	limit := int64(-1)
+	if ctx.sel.Limit != nil {
+		limit = ctx.sel.GetLimit()
+	}
+	for _, ran := range kvRanges {
+		if limit == 0 {
+			break
+		}
+		ranRows, err := h.getIndexRowFromRange(ctx.sel, ran, desc, limit)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		rows = append(rows, ranRows...)
+		limit -= int64(len(ranRows))
+	}
+	return rows, nil
+}
+
+func (h *rpcHandler) getIndexRowFromRange(sel *tipb.SelectRequest, ran kv.KeyRange, desc bool, limit int64) ([]*tipb.Row, error) {
+	startKey := maxStartKey(ran.StartKey, h.startKey)
+	endKey := minEndKey(ran.EndKey, h.endKey)
+	if limit == 0 || bytes.Compare(startKey, endKey) >= 0 {
+		return nil, nil
+	}
+	var rows []*tipb.Row
+	var seekKey kv.Key
+	if desc {
+		seekKey = endKey
+	} else {
+		seekKey = startKey
+	}
+	for {
+		if limit == 0 {
+			break
+		}
+		var pair Pair
+		var err error
+		if desc {
+			pair = h.mvccStore.SeekReverse(seekKey, sel.GetStartTs())
+			seekKey = pair.Key
+		} else {
+			pair = h.mvccStore.Seek(seekKey, sel.GetStartTs())
+			seekKey = kv.Key(pair.Key).PrefixNext()
+		}
+		if pair.Err != nil {
+			// TODO: handle lock error.
+			return nil, errors.Trace(pair.Err)
+		}
+		if pair.Key == nil {
+			break
+		}
+		if desc {
+			if bytes.Compare(pair.Key, startKey) < 0 {
+				break
+			}
+		} else {
+			if bytes.Compare(pair.Key, endKey) >= 0 {
+				break
+			}
+		}
+
+		datums, err := tablecodec.DecodeIndexKey(pair.Key)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var handle types.Datum
+		columns := sel.IndexInfo.Columns
+		if len(datums) > len(columns) {
+			handle = datums[len(columns)]
+			datums = datums[:len(columns)]
+		} else {
+			var intHandle int64
+			intHandle, err = decodeHandle(pair.Value)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			handle.SetInt64(intHandle)
+		}
+		data, err := codec.EncodeValue(nil, datums...)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		handleData, err := codec.EncodeValue(nil, handle)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		row := &tipb.Row{Handle: handleData, Data: data}
+		rows = append(rows, row)
+		limit--
+	}
+	return rows, nil
+}
+
+func maxStartKey(rangeStartKey kv.Key, regionStartKey []byte) []byte {
+	if bytes.Compare([]byte(rangeStartKey), regionStartKey) > 0 {
+		return []byte(rangeStartKey)
+	}
+	return regionStartKey
+}
+
+func minEndKey(rangeEndKey kv.Key, regionEndKey []byte) []byte {
+	if len(regionEndKey) == 0 || bytes.Compare([]byte(rangeEndKey), regionEndKey) < 0 {
+		return []byte(rangeEndKey)
+	}
+	return regionEndKey
+}
+
+func decodeHandle(data []byte) (int64, error) {
+	var h int64
+	buf := bytes.NewBuffer(data)
+	err := binary.Read(buf, binary.BigEndian, &h)
+	return h, errors.Trace(err)
+}

--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -241,10 +241,14 @@ func (s *MvccStore) Scan(startKey, endKey []byte, limit int, startTS uint64) []P
 	return pairs
 }
 
+// Seek searches for the first key in the engine which is >= key in byte order, returns (nil, nil, ErrNotFound)
+// if such key is not found.
 func (s *MvccStore) Seek(key []byte, startTS uint64) Pair {
 	return s.doSeek(key, startTS, false)
 }
 
+// SeekReverse searches the engine in backward order for the first key-value pair which key is less than the key
+// in byte order, returns (nil, nil, ErrNotFound) if such key is not found. If key is nil, the last key is returned.
 func (s *MvccStore) SeekReverse(key []byte, startTS uint64) Pair {
 	return s.doSeek(key, startTS, true)
 }

--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -213,7 +213,7 @@ func regionContains(startKey []byte, endKey []byte, key []byte) bool {
 		(bytes.Compare(key, endKey) < 0 || len(endKey) == 0)
 }
 
-// Scan reads up to limit numbers of Pairs that greater or equal to startKey and less than endKey.
+// Scan reads up to a limited number of Pairs that greater than or equal to startKey and less than endKey.
 func (s *MvccStore) Scan(startKey, endKey []byte, limit int, startTS uint64) []Pair {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -241,7 +241,7 @@ func (s *MvccStore) Scan(startKey, endKey []byte, limit int, startTS uint64) []P
 	return pairs
 }
 
-// ReverseScan reads up to limit numbers of Pairs that greater or equal to startKey and less than endKey
+// ReverseScan reads up to a limited number of Pairs that greater than or equal to startKey and less than endKey
 // in descending order.
 func (s *MvccStore) ReverseScan(startKey, endKey []byte, limit int, startTS uint64) []Pair {
 	s.mu.RLock()

--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -308,7 +308,12 @@ func (c *RPCClient) SendKVReq(req *kvrpcpb.Request) (*kvrpcpb.Response, error) {
 
 // SendCopReq sends a coprocessor request to mock cluster.
 func (c *RPCClient) SendCopReq(req *coprocessor.Request) (*coprocessor.Response, error) {
-	return nil, errors.New("not implemented")
+	store := c.cluster.GetStoreByAddr(c.addr)
+	if store == nil {
+		return nil, errors.New("connect fail")
+	}
+	handler := newRPCHandler(c.cluster, c.mvccStore, store.GetId())
+	return handler.handleCopRequest(req)
 }
 
 // Close closes the client.

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -25,7 +25,7 @@ type testScanMockSuite struct {
 var _ = Suite(&testScanMockSuite{})
 
 func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
-	store := NewMockTikvStore()
+	store := NewMockTikvStore().(*tikvStore)
 	txn, err := store.Begin()
 	c.Assert(err, IsNil)
 	for ch := byte('a'); ch <= byte('z'); ch++ {

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/store/tikv/mock-tikv"
 	"github.com/pingcap/tidb/util/codec"
 )
 
@@ -41,23 +40,7 @@ func newTestStore(c *C) *tikvStore {
 		c.Assert(err, IsNil)
 		return store.(*tikvStore)
 	}
-	store, cluster := createMockStoreCluster()
-	mocktikv.BootstrapWithSingleStore(cluster)
-	return store
-}
-
-func createMockStoreCluster() (*tikvStore, *mocktikv.Cluster) {
-	cluster := mocktikv.NewCluster()
-	mvccStore := mocktikv.NewMvccStore()
-	clientFactory := mockClientFactory(cluster, mvccStore)
-	store := newTikvStore("mock-tikv-store", mocktikv.NewPDClient(cluster), clientFactory)
-	return store, cluster
-}
-
-func mockClientFactory(cluster *mocktikv.Cluster, mvccStore *mocktikv.MvccStore) ClientFactory {
-	return func(addr string) (Client, error) {
-		return mocktikv.NewRPCClient(cluster, mvccStore, addr), nil
-	}
+	return NewMockTikvStore()
 }
 
 type testTiclientSuite struct {

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -40,7 +40,7 @@ func newTestStore(c *C) *tikvStore {
 		c.Assert(err, IsNil)
 		return store.(*tikvStore)
 	}
-	return NewMockTikvStore()
+	return NewMockTikvStore().(*tikvStore)
 }
 
 type testTiclientSuite struct {

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -145,16 +145,13 @@ func composeRequest(req *tipb.SelectRequest, concurrency int) (*kv.Request, erro
 		tid := req.IndexInfo.GetTableId()
 		idxID := req.IndexInfo.GetIndexId()
 		kvReq.KeyRanges = tablecodec.EncodeIndexRanges(tid, idxID, req.Ranges)
-		if req.OrderBy != nil {
-			kvReq.Desc = *req.OrderBy[0].Desc
-		}
 	} else {
 		kvReq.Tp = kv.ReqTypeSelect
 		tid := req.GetTableInfo().GetTableId()
 		kvReq.KeyRanges = tablecodec.EncodeTableRanges(tid, req.Ranges)
-		if req.OrderBy != nil {
-			kvReq.Desc = *req.OrderBy[0].Desc
-		}
+	}
+	if req.OrderBy != nil {
+		kvReq.Desc = *req.OrderBy[0].Desc
 	}
 	var err error
 	kvReq.Data, err = proto.Marshal(req)

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -138,6 +138,7 @@ func Select(client kv.Client, req *tipb.SelectRequest, concurrency int) (*Select
 func composeRequest(req *tipb.SelectRequest, concurrency int) (*kv.Request, error) {
 	kvReq := &kv.Request{
 		Concurrency: concurrency,
+		KeepOrder:   true,
 	}
 	if req.IndexInfo != nil {
 		kvReq.Tp = kv.ReqTypeIndex
@@ -146,12 +147,14 @@ func composeRequest(req *tipb.SelectRequest, concurrency int) (*kv.Request, erro
 		kvReq.KeyRanges = tablecodec.EncodeIndexRanges(tid, idxID, req.Ranges)
 		if req.OrderBy != nil {
 			kvReq.Desc = *req.OrderBy[0].Desc
-			kvReq.KeepOrder = true
 		}
 	} else {
 		kvReq.Tp = kv.ReqTypeSelect
 		tid := req.GetTableInfo().GetTableId()
 		kvReq.KeyRanges = tablecodec.EncodeTableRanges(tid, req.Ranges)
+		if req.OrderBy != nil {
+			kvReq.Desc = *req.OrderBy[0].Desc
+		}
 	}
 	var err error
 	kvReq.Data, err = proto.Marshal(req)


### PR DESCRIPTION
As mockTiKV currently is much slower than `localstore` and do not support store data on disk, currently only `executor` package is set to use mockTikv. `localstore` should still be used for a while.