### PR TITLE
executor: makes dirty table supports XAPI.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -600,6 +600,8 @@ func (b *executorBuilder) buildExplain(v *plan.Explain) Executor {
 	}
 }
 
+// buildUnionScanExec builds a union scan executor, the src Executor is either
+// *XSelectTableExec or *XSelectIndexExec.
 func (b *executorBuilder) buildUnionScanExec(src Executor) *UnionScanExec {
 	us := &UnionScanExec{ctx: b.ctx, Src: src}
 	switch x := src.(type) {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -212,7 +212,7 @@ func (b *executorBuilder) buildTableScan(v *plan.TableScan) Executor {
 		memDB = true
 	}
 	supportDesc := client.SupportRequestType(kv.ReqTypeSelect, kv.ReqSubTypeDesc)
-	if !memDB && client.SupportRequestType(kv.ReqTypeSelect, 0) && txn.IsReadOnly() {
+	if !memDB && client.SupportRequestType(kv.ReqTypeSelect, 0) {
 		log.Debug("xapi select table")
 		e := &XSelectTableExec{
 			table:       table,
@@ -226,9 +226,14 @@ func (b *executorBuilder) buildTableScan(v *plan.TableScan) Executor {
 		}
 		if len(remained) == 0 {
 			e.allFiltersPushed = true
-			return e
 		}
-		return b.buildFilter(e, remained)
+		var ex Executor
+		if txn.IsReadOnly() {
+			ex = e
+		} else {
+			ex = b.buildUnionScanExec(e)
+		}
+		return b.buildFilter(ex, remained)
 	}
 
 	e := &TableScanExec{
@@ -281,7 +286,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.IndexScan) Executor {
 	case "information_schema", "performance_schema":
 		memDB = true
 	}
-	if !memDB && client.SupportRequestType(kv.ReqTypeIndex, 0) && txn.IsReadOnly() {
+	if !memDB && client.SupportRequestType(kv.ReqTypeIndex, 0) {
 		log.Debug("xapi select index")
 		e := &XSelectIndexExec{
 			table:       tbl,
@@ -293,7 +298,13 @@ func (b *executorBuilder) buildIndexScan(v *plan.IndexScan) Executor {
 		if where != nil {
 			e.where = where
 		}
-		return b.buildFilter(e, remained)
+		var ex Executor
+		if txn.IsReadOnly() {
+			ex = e
+		} else {
+			ex = b.buildUnionScanExec(e)
+		}
+		return b.buildFilter(ex, remained)
 	}
 
 	var idx *column.IndexedCol
@@ -587,4 +598,26 @@ func (b *executorBuilder) buildExplain(v *plan.Explain) Executor {
 		StmtPlan: v.StmtPlan,
 		fields:   v.Fields(),
 	}
+}
+
+func (b *executorBuilder) buildUnionScanExec(src Executor) *UnionScanExec {
+	us := &UnionScanExec{ctx: b.ctx, Src: src}
+	switch x := src.(type) {
+	case *XSelectTableExec:
+		us.desc = x.tablePlan.Desc
+		us.dirty = getDirtyDB(b.ctx).getDirtyTable(x.table.Meta().ID)
+		us.condition = b.joinConditions(append(x.tablePlan.AccessConditions, x.tablePlan.FilterConditions...))
+		us.buildAndSortAddedRows(x.table, x.tablePlan.TableAsName)
+	case *XSelectIndexExec:
+		us.desc = x.indexPlan.Desc
+		for _, ic := range x.indexPlan.Index.Columns {
+			us.usedIndex = append(us.usedIndex, ic.Offset)
+		}
+		us.dirty = getDirtyDB(b.ctx).getDirtyTable(x.table.Meta().ID)
+		us.condition = b.joinConditions(append(x.indexPlan.AccessConditions, x.indexPlan.FilterConditions...))
+		us.buildAndSortAddedRows(x.table, x.indexPlan.TableAsName)
+	default:
+		b.err = ErrUnknownPlan
+	}
+	return us
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -57,6 +57,7 @@ var (
 	ErrStmtNotFound    = terror.ClassExecutor.New(CodeStmtNotFound, "Prepared statement not found")
 	ErrSchemaChanged   = terror.ClassExecutor.New(CodeSchemaChanged, "Schema has changed")
 	ErrWrongParamCount = terror.ClassExecutor.New(CodeWrongParamCount, "Wrong parameter count")
+	ErrRowKeyCount     = terror.ClassExecutor.New(CodeRowKeyCount, "Wrong row key entry count")
 )
 
 // Error codes.
@@ -66,6 +67,7 @@ const (
 	CodeStmtNotFound    terror.ErrCode = 3
 	CodeSchemaChanged   terror.ErrCode = 4
 	CodeWrongParamCount terror.ErrCode = 5
+	CodeRowKeyCount     terror.ErrCode = 6
 )
 
 // Row represents a record row.

--- a/executor/executor_ddl.go
+++ b/executor/executor_ddl.go
@@ -81,7 +81,12 @@ func (e *DDLExec) executeTruncateTable(s *ast.TruncateTableStmt) error {
 	if !ok {
 		return errors.New("table not found, should never happen")
 	}
-	return table.Truncate(e.ctx)
+	err := table.Truncate(e.ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	getDirtyDB(e.ctx).TruncateTable(table.Meta().ID)
+	return nil
 }
 
 func (e *DDLExec) executeCreateDatabase(s *ast.CreateDatabaseStmt) error {

--- a/executor/executor_ddl.go
+++ b/executor/executor_ddl.go
@@ -85,7 +85,7 @@ func (e *DDLExec) executeTruncateTable(s *ast.TruncateTableStmt) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	getDirtyDB(e.ctx).TruncateTable(table.Meta().ID)
+	getDirtyDB(e.ctx).truncateTable(table.Meta().ID)
 	return nil
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1293,7 +1293,28 @@ func (s *testSuite) TestDirtyTransaction(c *C) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 5", "2 3", "3 4", "4 8", "6 8", "7 6"))
 	tk.MustQuery("select * from t order by a desc").Check(testkit.Rows("7 6", "6 8", "4 8", "3 4", "2 3", "1 5"))
 	tk.MustQuery("select * from t order by b").Check(testkit.Rows("2 3", "3 4", "1 5", "7 6", "4 8", "6 8"))
-	tk.MustQuery("select * from t order by b desc").Check(testkit.Rows("2 3", "3 4", "1 5", "7 6", "4 8", "6 8"))
+	tk.MustQuery("select * from t order by b desc").Check(testkit.Rows("6 8", "4 8", "7 6", "1 5", "3 4", "2 3"))
+	// Delete a snapshot row and a dirty row.
+	tk.MustExec("delete from t where a = 2 or a = 3")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 5", "4 8", "6 8", "7 6"))
+	tk.MustQuery("select * from t order by a desc").Check(testkit.Rows("7 6", "6 8", "4 8", "1 5"))
+	tk.MustQuery("select * from t order by b").Check(testkit.Rows("1 5", "7 6", "4 8", "6 8"))
+	tk.MustQuery("select * from t order by b desc").Check(testkit.Rows("6 8", "4 8", "7 6", "1 5"))
+	// Add deleted row back.
+	tk.MustExec("insert t values (2, 3), (3, 4)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 5", "2 3", "3 4", "4 8", "6 8", "7 6"))
+	tk.MustQuery("select * from t order by a desc").Check(testkit.Rows("7 6", "6 8", "4 8", "3 4", "2 3", "1 5"))
+	tk.MustQuery("select * from t order by b").Check(testkit.Rows("2 3", "3 4", "1 5", "7 6", "4 8", "6 8"))
+	tk.MustQuery("select * from t order by b desc").Check(testkit.Rows("6 8", "4 8", "7 6", "1 5", "3 4", "2 3"))
+	// Truncate Table
+	tk.MustExec("truncate table t")
+	tk.MustQuery("select * from t").Check(testkit.Rows())
+	tk.MustExec("insert t values (1, 2)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 2"))
+	tk.MustExec("truncate table t")
+	tk.MustExec("insert t values (3, 4)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("3 4"))
+	tk.Exec("abort")
 }
 
 func (s *testSuite) TestDatumXAPI(c *C) {

--- a/executor/executor_write.go
+++ b/executor/executor_write.go
@@ -242,8 +242,8 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	}
 	dirtyDB := getDirtyDB(ctx)
 	tid := t.Meta().ID
-	dirtyDB.DeleteRow(tid, h)
-	dirtyDB.AddRow(tid, h, newData)
+	dirtyDB.deleteRow(tid, h)
+	dirtyDB.addRow(tid, h, newData)
 
 	// Record affected rows.
 	if !onDuplicateUpdate {
@@ -379,7 +379,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 	if err != nil {
 		return errors.Trace(err)
 	}
-	getDirtyDB(ctx).DeleteRow(t.Meta().ID, h)
+	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
 	variable.GetSessionVars(ctx).AddAffectedRows(1)
 	return nil
 }
@@ -455,7 +455,7 @@ func (e *InsertExec) Next() (*Row, error) {
 		h, err := e.Table.AddRecord(e.ctx, row)
 		txn.DelOption(kv.PresumeKeyNotExists)
 		if err == nil {
-			getDirtyDB(e.ctx).AddRow(e.Table.Meta().ID, h, row)
+			getDirtyDB(e.ctx).addRow(e.Table.Meta().ID, h, row)
 			continue
 		}
 
@@ -865,7 +865,7 @@ func (e *ReplaceExec) Next() (*Row, error) {
 		row := rows[idx]
 		h, err1 := e.Table.AddRecord(e.ctx, row)
 		if err1 == nil {
-			getDirtyDB(e.ctx).AddRow(e.Table.Meta().ID, h, row)
+			getDirtyDB(e.ctx).addRow(e.Table.Meta().ID, h, row)
 			idx++
 			continue
 		}
@@ -891,7 +891,7 @@ func (e *ReplaceExec) Next() (*Row, error) {
 		if err1 != nil {
 			return nil, errors.Trace(err1)
 		}
-		getDirtyDB(e.ctx).DeleteRow(e.Table.Meta().ID, h)
+		getDirtyDB(e.ctx).deleteRow(e.Table.Meta().ID, h)
 		variable.GetSessionVars(e.ctx).AddAffectedRows(1)
 	}
 	e.finished = true

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -1,0 +1,243 @@
+package executor
+
+import (
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/evaluator"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/util/types"
+)
+
+type dirtyDB struct {
+	tables map[int64]*dirtyTable
+}
+
+func (udb *dirtyDB) AddRow(tid, handle int64, row []types.Datum) {
+	dt := udb.getDirtyTable(tid)
+	for i := range row {
+		if row[i].Kind() == types.KindString {
+			row[i].SetBytes(row[i].GetBytes())
+		}
+	}
+	dt.addedRows[handle] = row
+}
+
+func (udb *dirtyDB) DeleteRow(tid int64, handle int64) {
+	dt := udb.getDirtyTable(tid)
+	delete(dt.addedRows, handle)
+	dt.deletedRows[handle] = struct{}{}
+}
+
+func (udb *dirtyDB) TruncateTable(tid int64) {
+	dt := udb.getDirtyTable(tid)
+	dt.addedRows = make(map[int64][]types.Datum)
+	dt.truncated = true
+}
+
+func (udb *dirtyDB) getDirtyTable(tid int64) *dirtyTable {
+	dt, ok := udb.tables[tid]
+	if !ok {
+		dt = &dirtyTable{
+			addedRows:   make(map[int64][]types.Datum),
+			deletedRows: make(map[int64]struct{}),
+		}
+		udb.tables[tid] = dt
+	}
+	return dt
+}
+
+type dirtyTable struct {
+	// key is handle.
+	addedRows   map[int64][]types.Datum
+	deletedRows map[int64]struct{}
+	truncated   bool
+}
+
+type dirtyDBKeyType int
+
+func (u dirtyDBKeyType) String() string {
+	return "dirtyDBKeyType"
+}
+
+// DirtyDBKey is the key to *dirtyDB for a context.
+const DirtyDBKey dirtyDBKeyType = 1
+
+func getDirtyDB(ctx context.Context) *dirtyDB {
+	var udb *dirtyDB
+	x := ctx.Value(DirtyDBKey)
+	if x == nil {
+		udb = &dirtyDB{tables: make(map[int64]*dirtyTable)}
+		ctx.SetValue(DirtyDBKey, udb)
+	} else {
+		udb = x.(*dirtyDB)
+	}
+	return udb
+}
+
+// UnionScanExec merges the rows from dirty table and the rows from XAPI request.
+type UnionScanExec struct {
+	ctx   context.Context
+	Src   Executor
+	dirty *dirtyTable
+	// srcUsedIndex is the column offsets of the index which Src executor has used.
+	usedIndex []int
+	desc      bool
+	condition ast.ExprNode
+
+	addedRows []*Row
+	cursor    int
+	sortErr   error
+}
+
+// Fields implements Executor Fields interface.
+func (us *UnionScanExec) Fields() []*ast.ResultField {
+	return us.Src.Fields()
+}
+
+// Next implements Execution Next interface.
+func (us *UnionScanExec) Next() (*Row, error) {
+	for {
+		snapshotRow, err := us.Src.Next()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var addedRow *Row
+		if us.cursor < len(us.addedRows) {
+			addedRow = us.addedRows[us.cursor]
+		}
+		if us.dirty.truncated || snapshotRow == nil {
+			if addedRow != nil {
+				for i, field := range us.Src.Fields() {
+					field.Expr.SetDatum(addedRow.Data[i])
+				}
+				us.cursor++
+				return addedRow, nil
+			}
+			return nil, nil
+		}
+		if addedRow == nil {
+			return snapshotRow, nil
+		}
+		if len(snapshotRow.RowKeys) != 1 {
+			return nil, ErrRowKeyCount
+		}
+		snapshotHandle := snapshotRow.RowKeys[0].Handle
+		if _, ok := us.dirty.deletedRows[snapshotHandle]; ok {
+			continue
+		}
+		if _, ok := us.dirty.addedRows[snapshotHandle]; ok {
+			// If src handle appears in added rows, it means there is conflict and the transaction will fail to
+			// commit, but for simplicity, we don't handle it here.
+			continue
+		}
+		addedCmpSrc, err := us.compare(addedRow, snapshotRow)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		// Compare result will never be 0.
+		var retRow *Row
+		if us.desc {
+			if addedCmpSrc < 0 {
+				retRow = snapshotRow
+			} else {
+				retRow = addedRow
+				us.cursor++
+			}
+		} else {
+			if addedCmpSrc < 0 {
+				retRow = addedRow
+				us.cursor++
+			} else {
+				retRow = snapshotRow
+			}
+		}
+		for i, field := range us.Src.Fields() {
+			field.Expr.SetDatum(retRow.Data[i])
+		}
+		return retRow, nil
+	}
+}
+
+// Close implements Executor Close interface.
+func (us *UnionScanExec) Close() error {
+	return us.Src.Close()
+}
+
+func (us *UnionScanExec) compare(a, b *Row) (int, error) {
+	for _, colOff := range us.usedIndex {
+		aColumn := a.Data[colOff]
+		bColumn := b.Data[colOff]
+		cmp, err := aColumn.CompareDatum(bColumn)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		if cmp != 0 {
+			return cmp, nil
+		}
+	}
+	aHandle := a.RowKeys[0].Handle
+	bHandle := b.RowKeys[0].Handle
+	var cmp int
+	if aHandle == bHandle {
+		cmp = 0
+	} else if aHandle > bHandle {
+		cmp = 1
+	} else {
+		cmp = -1
+	}
+	return cmp, nil
+}
+
+func (us *UnionScanExec) buildAndSortAddedRows(t table.Table, asName *model.CIStr) error {
+	us.addedRows = make([]*Row, 0, len(us.dirty.addedRows))
+	for h, data := range us.dirty.addedRows {
+		for i, field := range us.Src.Fields() {
+			field.Expr.SetDatum(data[i])
+		}
+		if us.condition != nil {
+			matched, err := evaluator.EvalBool(us.ctx, us.condition)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !matched {
+				continue
+			}
+		}
+		rowKeyEntry := &RowKeyEntry{Handle: h, Tbl: t, TableAsName: asName}
+		row := &Row{Data: data, RowKeys: []*RowKeyEntry{rowKeyEntry}}
+		us.addedRows = append(us.addedRows, row)
+	}
+	if us.desc {
+		sort.Sort(sort.Reverse(us))
+	} else {
+		sort.Sort(us)
+	}
+	if us.sortErr != nil {
+		return us.sortErr
+	}
+	return nil
+}
+
+// Len implements sort.Interface interface.
+func (us *UnionScanExec) Len() int {
+	return len(us.addedRows)
+}
+
+// Less implements sort.Interface interface.
+func (us *UnionScanExec) Less(i, j int) bool {
+	cmp, err := us.compare(us.addedRows[i], us.addedRows[j])
+	if err != nil {
+		us.sortErr = errors.Trace(err)
+		return true
+	}
+	return cmp < 0
+}
+
+// Swap implements sort.Interface interface.
+func (us *UnionScanExec) Swap(i, j int) {
+	us.addedRows[i], us.addedRows[j] = us.addedRows[j], us.addedRows[i]
+}

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -1,3 +1,16 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package executor
 
 import (
@@ -12,7 +25,10 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
+// dirtyDB stores uncommitted write operations for a transaction.
+// It is stored and retrieved by context.Value and context.SetValue method.
 type dirtyDB struct {
+	// Key is tableID.
 	tables map[int64]*dirtyTable
 }
 

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -267,7 +267,7 @@ func (us *UnionScanExec) buildAndSortAddedRows(t table.Table, asName *model.CISt
 		sort.Sort(us)
 	}
 	if us.sortErr != nil {
-		return us.sortErr
+		return errors.Trace(us.sortErr)
 	}
 	return nil
 }

--- a/mysql/set.go
+++ b/mysql/set.go
@@ -57,7 +57,7 @@ func ParseSetName(elems []string, name string) (Set, error) {
 		if _, ok := marked[key]; ok {
 			value |= (1 << uint64(i))
 			delete(marked, key)
-			items = append(items, key)
+			items = append(items, n)
 		}
 	}
 

--- a/session.go
+++ b/session.go
@@ -160,13 +160,13 @@ func (s *session) FinishTxn(rollback bool) error {
 		return nil
 	}
 	defer func() {
+		s.ClearValue(executor.DirtyDBKey)
 		s.txn = nil
 		variable.GetSessionVars(s).SetStatusFlag(mysql.ServerStatusInTrans, false)
 		// Update tps metrics
 		if !variable.GetSessionVars(s).RetryInfo.Retrying {
 			tpsMetrics.Add(1)
 		}
-
 	}()
 
 	if rollback {

--- a/store/tikv/mock-tikv/cop_handler.go
+++ b/store/tikv/mock-tikv/cop_handler.go
@@ -264,7 +264,7 @@ func (h *rpcHandler) getRowsFromRange(ctx *selectContext, ran kv.KeyRange, limit
 			if bytes.Compare(pair.Key, startKey) < 0 {
 				break
 			}
-			seekKey = pair.Key
+			seekKey = []byte(tablecodec.TruncateToRowKeyLen(kv.Key(pair.Key)))
 		} else {
 			if bytes.Compare(pair.Key, endKey) >= 0 {
 				break


### PR DESCRIPTION
Currently, if a transaction has written some data, XAPI can not be used, this PR fixes this issue.