### PR TITLE
*: refactor, move index and column into table package.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -354,7 +354,7 @@ func (d *ddl) backfillColumnData(t table.Table, columnInfo *model.ColumnInfo, ha
 				return nil
 			}
 
-			backfillKey := t.RecordKey(handle, &table.Col{ColumnInfo: *columnInfo})
+			backfillKey := t.RecordKey(handle, &table.Column{ColumnInfo: *columnInfo})
 			backfillValue, err := txn.Get(backfillKey)
 			if err != nil && !kv.IsErrNotFound(err) {
 				return errors.Trace(err)
@@ -399,7 +399,7 @@ func (d *ddl) dropTableColumn(t table.Table, colInfo *model.ColumnInfo, reorgInf
 	version := reorgInfo.SnapshotVer
 	seekHandle := reorgInfo.Handle
 
-	col := &table.Col{ColumnInfo: *colInfo}
+	col := &table.Column{ColumnInfo: *colInfo}
 	for {
 		handles, err := d.getSnapshotRows(t, version, seekHandle)
 		if err != nil {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -17,7 +17,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -355,7 +354,7 @@ func (d *ddl) backfillColumnData(t table.Table, columnInfo *model.ColumnInfo, ha
 				return nil
 			}
 
-			backfillKey := t.RecordKey(handle, &column.Col{ColumnInfo: *columnInfo})
+			backfillKey := t.RecordKey(handle, &table.Col{ColumnInfo: *columnInfo})
 			backfillValue, err := txn.Get(backfillKey)
 			if err != nil && !kv.IsErrNotFound(err) {
 				return errors.Trace(err)
@@ -400,7 +399,7 @@ func (d *ddl) dropTableColumn(t table.Table, colInfo *model.ColumnInfo, reorgInf
 	version := reorgInfo.SnapshotVer
 	seekHandle := reorgInfo.Handle
 
-	col := &column.Col{ColumnInfo: *colInfo}
+	col := &table.Col{ColumnInfo: *colInfo}
 	for {
 		handles, err := d.getSnapshotRows(t, version, seekHandle)
 		if err != nil {

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -123,7 +123,7 @@ func (s *testColumnSuite) TestColumn(c *C) {
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, HasLen, 3)
 		c.Assert(data[0].GetInt64(), Equals, i)
 		c.Assert(data[1].GetInt64(), Equals, 10*i)
@@ -142,7 +142,7 @@ func (s *testColumnSuite) TestColumn(c *C) {
 	c.Assert(table.FindCol(t.Cols(), "c4"), NotNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, HasLen, 4)
 		c.Assert(data[0].GetInt64(), Equals, i)
 		c.Assert(data[1].GetInt64(), Equals, 10*i)
@@ -256,7 +256,7 @@ func (s *testColumnSuite) TestColumn(c *C) {
 	testDropTable(c, ctx, s.d, s.dbInfo, tblInfo)
 }
 
-func (s *testColumnSuite) checkColumnKVExist(c *C, ctx context.Context, t table.Table, handle int64, col *table.Col, columnValue interface{}, isExist bool) {
+func (s *testColumnSuite) checkColumnKVExist(c *C, ctx context.Context, t table.Table, handle int64, col *table.Column, columnValue interface{}, isExist bool) {
 	txn, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
@@ -278,20 +278,20 @@ func (s *testColumnSuite) checkColumnKVExist(c *C, ctx context.Context, t table.
 	c.Assert(err, IsNil)
 }
 
-func (s *testColumnSuite) checkNoneColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, columnValue interface{}) {
+func (s *testColumnSuite) checkNoneColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, columnValue interface{}) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 	s.checkColumnKVExist(c, ctx, t, handle, col, columnValue, false)
 	s.testGetColumn(c, t, col.Name.L, false)
 }
 
-func (s *testColumnSuite) checkDeleteOnlyColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, row []types.Datum, columnValue interface{}, isDropped bool) {
+func (s *testColumnSuite) checkDeleteOnlyColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, row []types.Datum, columnValue interface{}, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -315,7 +315,7 @@ func (s *testColumnSuite) checkDeleteOnlyColumn(c *C, ctx context.Context, d *dd
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -335,7 +335,7 @@ func (s *testColumnSuite) checkDeleteOnlyColumn(c *C, ctx context.Context, d *dd
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -345,14 +345,14 @@ func (s *testColumnSuite) checkDeleteOnlyColumn(c *C, ctx context.Context, d *dd
 	s.testGetColumn(c, t, col.Name.L, false)
 }
 
-func (s *testColumnSuite) checkWriteOnlyColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, row []types.Datum, columnValue interface{}, isDropped bool) {
+func (s *testColumnSuite) checkWriteOnlyColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, row []types.Datum, columnValue interface{}, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -376,7 +376,7 @@ func (s *testColumnSuite) checkWriteOnlyColumn(c *C, ctx context.Context, d *ddl
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -396,7 +396,7 @@ func (s *testColumnSuite) checkWriteOnlyColumn(c *C, ctx context.Context, d *ddl
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -406,14 +406,14 @@ func (s *testColumnSuite) checkWriteOnlyColumn(c *C, ctx context.Context, d *ddl
 	s.testGetColumn(c, t, col.Name.L, false)
 }
 
-func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, row []types.Datum, columnValue interface{}, isDropped bool) {
+func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, row []types.Datum, columnValue interface{}, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -435,7 +435,7 @@ func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -455,7 +455,7 @@ func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -464,7 +464,7 @@ func (s *testColumnSuite) checkReorganizationColumn(c *C, ctx context.Context, d
 	s.testGetColumn(c, t, col.Name.L, false)
 }
 
-func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, row []types.Datum, columnValue interface{}) {
+func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, row []types.Datum, columnValue interface{}) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
@@ -472,7 +472,7 @@ func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, t
 
 	i := int64(0)
 	oldRow := append(row, types.NewDatum(columnValue))
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, oldRow)
 		i++
 		return true, nil
@@ -494,7 +494,7 @@ func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, t
 	rows := [][]types.Datum{oldRow, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -512,7 +512,7 @@ func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, t
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, oldRow)
 		i++
 		return true, nil
@@ -524,7 +524,7 @@ func (s *testColumnSuite) checkPublicColumn(c *C, ctx context.Context, d *ddl, t
 	s.testGetColumn(c, t, col.Name.L, true)
 }
 
-func (s *testColumnSuite) checkAddOrDropColumn(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Col, row []types.Datum, columnValue interface{}, isDropped bool) {
+func (s *testColumnSuite) checkAddOrDropColumn(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, col *table.Column, row []types.Datum, columnValue interface{}, isDropped bool) {
 	ctx := testNewContext(c, d)
 
 	switch state {
@@ -640,7 +640,7 @@ func (s *testColumnSuite) TestDropColumn(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
-	oldCol := &table.Col{}
+	oldCol := &table.Column{}
 
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -340,7 +340,7 @@ func getDefaultCharsetAndCollate() (string, string) {
 	return "utf8", "utf8_unicode_ci"
 }
 
-func setColumnFlagWithConstraint(colMap map[string]*table.Col, v *ast.Constraint) {
+func setColumnFlagWithConstraint(colMap map[string]*table.Column, v *ast.Constraint) {
 	switch v.Tp {
 	case ast.ConstraintPrimaryKey:
 		for _, key := range v.Keys {
@@ -388,9 +388,9 @@ func setColumnFlagWithConstraint(colMap map[string]*table.Col, v *ast.Constraint
 }
 
 func (d *ddl) buildColumnsAndConstraints(ctx context.Context, colDefs []*ast.ColumnDef,
-	constraints []*ast.Constraint) ([]*table.Col, []*ast.Constraint, error) {
-	var cols []*table.Col
-	colMap := map[string]*table.Col{}
+	constraints []*ast.Constraint) ([]*table.Column, []*ast.Constraint, error) {
+	var cols []*table.Column
+	colMap := map[string]*table.Column{}
 	for i, colDef := range colDefs {
 		col, cts, err := d.buildColumnAndConstraint(ctx, i, colDef)
 		if err != nil {
@@ -409,7 +409,7 @@ func (d *ddl) buildColumnsAndConstraints(ctx context.Context, colDefs []*ast.Col
 }
 
 func (d *ddl) buildColumnAndConstraint(ctx context.Context, offset int,
-	colDef *ast.ColumnDef) (*table.Col, []*ast.Constraint, error) {
+	colDef *ast.ColumnDef) (*table.Column, []*ast.Constraint, error) {
 	// Set charset.
 	if len(colDef.Tp.Charset) == 0 {
 		switch colDef.Tp.Tp {
@@ -435,9 +435,9 @@ func (d *ddl) buildColumnAndConstraint(ctx context.Context, offset int,
 }
 
 // columnDefToCol converts ColumnDef to Col and TableConstraints.
-func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*table.Col, []*ast.Constraint, error) {
+func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*table.Column, []*ast.Constraint, error) {
 	constraints := []*ast.Constraint{}
-	col := &table.Col{
+	col := &table.Column{
 		ColumnInfo: model.ColumnInfo{
 			Offset:    offset,
 			Name:      colDef.Name.Name,
@@ -573,7 +573,7 @@ func getDefaultValue(ctx context.Context, c *ast.ColumnOption, tp byte, fsp int)
 	return v.GetValue(), nil
 }
 
-func removeOnUpdateNowFlag(c *table.Col) {
+func removeOnUpdateNowFlag(c *table.Column) {
 	// For timestamp Col, if it is set null or default value,
 	// OnUpdateNowFlag should be removed.
 	if mysql.HasTimestampFlag(c.Flag) {
@@ -581,7 +581,7 @@ func removeOnUpdateNowFlag(c *table.Col) {
 	}
 }
 
-func setTimestampDefaultValue(c *table.Col, hasDefaultValue bool, setOnUpdateNow bool) {
+func setTimestampDefaultValue(c *table.Column, hasDefaultValue bool, setOnUpdateNow bool) {
 	if hasDefaultValue {
 		return
 	}
@@ -596,7 +596,7 @@ func setTimestampDefaultValue(c *table.Col, hasDefaultValue bool, setOnUpdateNow
 	}
 }
 
-func setNoDefaultValueFlag(c *table.Col, hasDefaultValue bool) {
+func setNoDefaultValueFlag(c *table.Column, hasDefaultValue bool) {
 	if hasDefaultValue {
 		return
 	}
@@ -611,7 +611,7 @@ func setNoDefaultValueFlag(c *table.Col, hasDefaultValue bool) {
 	}
 }
 
-func checkDefaultValue(c *table.Col, hasDefaultValue bool) error {
+func checkDefaultValue(c *table.Column, hasDefaultValue bool) error {
 	if !hasDefaultValue {
 		return nil
 	}
@@ -705,7 +705,7 @@ func (d *ddl) checkConstraintNames(constraints []*ast.Constraint) error {
 	return nil
 }
 
-func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Col, constraints []*ast.Constraint) (tbInfo *model.TableInfo, err error) {
+func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constraints []*ast.Constraint) (tbInfo *model.TableInfo, err error) {
 	tbInfo = &model.TableInfo{
 		Name: tableName,
 	}

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -177,14 +177,14 @@ LOOP:
 	ctx := s.s.(context.Context)
 	t := s.testGetTable(c, "t1")
 	handles := make(map[int64]struct{})
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		handles[h] = struct{}{}
 		return true, nil
 	})
 	c.Assert(err, IsNil)
 
 	// check in index
-	var nidx *table.IndexedCol
+	var nidx *table.IndexedColumn
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			nidx = tidx
@@ -229,7 +229,7 @@ func (s *testDBSuite) testDropIndex(c *C) {
 		s.mustExec(c, "insert into t1 values (?, ?, ?)", i, i, i)
 	}
 	t := s.testGetTable(c, "t1")
-	var c3idx *table.IndexedCol
+	var c3idx *table.IndexedColumn
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			c3idx = tidx
@@ -273,7 +273,7 @@ LOOP:
 	handles := make(map[int64]struct{})
 
 	t = s.testGetTable(c, "t1")
-	var nidx *table.IndexedCol
+	var nidx *table.IndexedColumn
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			nidx = tidx
@@ -381,7 +381,7 @@ LOOP:
 	i := 0
 	j := 0
 	defer ctx.FinishTxn(true)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		// c4 must be -1 or > 0
 		v, err1 := types.ToInt64(data[3].GetValue())
@@ -462,7 +462,7 @@ LOOP:
 	i := 0
 	t = s.testGetTable(c, "t2")
 	// check c4 does not exist
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		k := t.RecordKey(h, col)
 		_, err1 := txn.Get(k)

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -25,12 +25,12 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	_ "github.com/pingcap/tidb"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
@@ -177,14 +177,14 @@ LOOP:
 	ctx := s.s.(context.Context)
 	t := s.testGetTable(c, "t1")
 	handles := make(map[int64]struct{})
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		handles[h] = struct{}{}
 		return true, nil
 	})
 	c.Assert(err, IsNil)
 
 	// check in index
-	var nidx *column.IndexedCol
+	var nidx *table.IndexedCol
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			nidx = tidx
@@ -194,7 +194,7 @@ LOOP:
 	// Make sure there is index with name c3_index
 	c.Assert(nidx, NotNil)
 	c.Assert(nidx.ID, Greater, int64(0))
-	idx := kv.NewKVIndex(t.IndexPrefix(), "c3_index", nidx.ID, false)
+	idx := tables.NewIndex(t.IndexPrefix(), "c3_index", nidx.ID, false)
 	txn, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 	defer ctx.FinishTxn(true)
@@ -229,7 +229,7 @@ func (s *testDBSuite) testDropIndex(c *C) {
 		s.mustExec(c, "insert into t1 values (?, ?, ?)", i, i, i)
 	}
 	t := s.testGetTable(c, "t1")
-	var c3idx *column.IndexedCol
+	var c3idx *table.IndexedCol
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			c3idx = tidx
@@ -273,7 +273,7 @@ LOOP:
 	handles := make(map[int64]struct{})
 
 	t = s.testGetTable(c, "t1")
-	var nidx *column.IndexedCol
+	var nidx *table.IndexedCol
 	for _, tidx := range t.Indices() {
 		if tidx.Name.L == "c3_index" {
 			nidx = tidx
@@ -282,7 +282,7 @@ LOOP:
 	}
 	// Make sure there is no index with name c3_index
 	c.Assert(nidx, IsNil)
-	idx := kv.NewKVIndex(t.IndexPrefix(), "c3_index", c3idx.ID, false)
+	idx := tables.NewIndex(t.IndexPrefix(), "c3_index", c3idx.ID, false)
 	txn, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 	defer ctx.FinishTxn(true)
@@ -381,7 +381,7 @@ LOOP:
 	i := 0
 	j := 0
 	defer ctx.FinishTxn(true)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		// c4 must be -1 or > 0
 		v, err1 := types.ToInt64(data[3].GetValue())
@@ -462,7 +462,7 @@ LOOP:
 	i := 0
 	t = s.testGetTable(c, "t2")
 	// check c4 does not exist
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		k := t.RecordKey(h, col)
 		_, err1 := txn.Get(k)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -416,7 +416,7 @@ func lockRow(txn kv.Transaction, t table.Table, h int64) error {
 }
 
 func (d *ddl) backfillTableIndex(t table.Table, indexInfo *model.IndexInfo, handles []int64, reorgInfo *reorgInfo) error {
-	kvX := kv.NewKVIndex(t.IndexPrefix(), indexInfo.Name.L, indexInfo.ID, indexInfo.Unique)
+	kvX := tables.NewIndex(t.IndexPrefix(), indexInfo.Name.L, indexInfo.ID, indexInfo.Unique)
 
 	for _, handle := range handles {
 		log.Debug("[ddl] building index...", handle)
@@ -473,7 +473,7 @@ func (d *ddl) backfillTableIndex(t table.Table, indexInfo *model.IndexInfo, hand
 }
 
 func (d *ddl) dropTableIndex(t table.Table, indexInfo *model.IndexInfo) error {
-	prefix := kv.GenIndexPrefix(t.IndexPrefix(), indexInfo.ID)
+	prefix := tables.GenIndexPrefix(t.IndexPrefix(), indexInfo.ID)
 	err := d.delKeysWithPrefix(prefix)
 
 	return errors.Trace(err)

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -110,7 +110,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data[0].GetInt64(), Equals, i)
 		i++
 		return true, nil
@@ -158,7 +158,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func getIndex(t table.Table, name string) *table.IndexedCol {
+func getIndex(t table.Table, name string) *table.IndexedColumn {
 	for _, idx := range t.Indices() {
 		// only public index can be read.
 
@@ -178,7 +178,7 @@ func (s *testIndexSuite) testGetIndex(c *C, t table.Table, name string, isExist 
 	}
 }
 
-func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol *table.IndexedCol, columnValues []types.Datum, isExist bool) {
+func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol *table.IndexedColumn, columnValues []types.Datum, isExist bool) {
 	c.Assert(len(indexCol.Columns), Equals, len(columnValues))
 
 	txn, err := ctx.GetTxn(true)
@@ -192,7 +192,7 @@ func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Ta
 	c.Assert(err, IsNil)
 }
 
-func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum) {
+func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	columnValues := make([]types.Datum, len(indexCol.Columns))
@@ -204,14 +204,14 @@ func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblIn
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -240,7 +240,7 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -281,7 +281,7 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -291,14 +291,14 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -327,7 +327,7 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -368,7 +368,7 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -378,14 +378,14 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -407,7 +407,7 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -449,7 +449,7 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -458,14 +458,14 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum) {
+func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -494,7 +494,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -535,7 +535,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -545,7 +545,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, true)
 }
 
-func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedColumn, row []types.Datum, isDropped bool) {
 	ctx := testNewContext(c, d)
 
 	switch state {
@@ -657,7 +657,7 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
-	oldIndexCol := &table.IndexedCol{}
+	oldIndexCol := &table.IndexedColumn{}
 
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
@@ -111,7 +110,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data[0].GetInt64(), Equals, i)
 		i++
 		return true, nil
@@ -159,7 +158,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func getIndex(t table.Table, name string) *column.IndexedCol {
+func getIndex(t table.Table, name string) *table.IndexedCol {
 	for _, idx := range t.Indices() {
 		// only public index can be read.
 
@@ -179,7 +178,7 @@ func (s *testIndexSuite) testGetIndex(c *C, t table.Table, name string, isExist 
 	}
 }
 
-func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol *column.IndexedCol, columnValues []types.Datum, isExist bool) {
+func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol *table.IndexedCol, columnValues []types.Datum, isExist bool) {
 	c.Assert(len(indexCol.Columns), Equals, len(columnValues))
 
 	txn, err := ctx.GetTxn(true)
@@ -193,7 +192,7 @@ func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Ta
 	c.Assert(err, IsNil)
 }
 
-func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum) {
+func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	columnValues := make([]types.Datum, len(indexCol.Columns))
@@ -205,14 +204,14 @@ func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblIn
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -241,7 +240,7 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -282,7 +281,7 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -292,14 +291,14 @@ func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl,
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -328,7 +327,7 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -369,7 +368,7 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -379,14 +378,14 @@ func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, 
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -408,7 +407,7 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -450,7 +449,7 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -459,14 +458,14 @@ func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, false)
 }
 
-func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum) {
+func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum) {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	_, err := ctx.GetTxn(true)
 	c.Assert(err, IsNil)
 
 	i := int64(0)
-	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	err = t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, row)
 		i++
 		return true, nil
@@ -495,7 +494,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	rows := [][]types.Datum{row, newRow}
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		c.Assert(data, DeepEquals, rows[i])
 		i++
 		return true, nil
@@ -536,7 +535,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	c.Assert(err, IsNil)
 
 	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		i++
 		return true, nil
 	})
@@ -546,7 +545,7 @@ func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tbl
 	s.testGetIndex(c, t, indexCol.Columns[0].Name.L, true)
 }
 
-func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *column.IndexedCol, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, indexCol *table.IndexedCol, row []types.Datum, isDropped bool) {
 	ctx := testNewContext(c, d)
 
 	switch state {
@@ -658,7 +657,7 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
-	oldIndexCol := &column.IndexedCol{}
+	oldIndexCol := &table.IndexedCol{}
 
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -296,7 +296,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.IndexScan) Executor {
 		return b.buildFilter(e, remained)
 	}
 
-	var idx *table.IndexedCol
+	var idx *table.IndexedColumn
 	for _, val := range tbl.Indices() {
 		if val.IndexInfo.Name.L == v.Index.Name.L {
 			idx = val

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
@@ -28,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx/autocommit"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -296,7 +296,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.IndexScan) Executor {
 		return b.buildFilter(e, remained)
 	}
 
-	var idx *column.IndexedCol
+	var idx *table.IndexedCol
 	for _, val := range tbl.Indices() {
 		if val.IndexInfo.Name.L == v.Index.Name.L {
 			idx = val

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -316,7 +316,7 @@ func (e *TableScanExec) getRow(handle int64) (*Row, error) {
 	row := &Row{}
 	var err error
 
-	columns := make([]*table.Col, len(e.fields))
+	columns := make([]*table.Column, len(e.fields))
 	for i, v := range e.fields {
 		if v.Referenced {
 			columns[i] = e.t.Cols()[i]
@@ -453,7 +453,7 @@ func indexCompare(idxKey []types.Datum, boundVals []types.Datum) (int, error) {
 func (e *IndexRangeExec) lookupRow(h int64) (*Row, error) {
 	row := &Row{}
 	var err error
-	columns := make([]*table.Col, len(e.scan.fields))
+	columns := make([]*table.Column, len(e.scan.fields))
 	for i, v := range e.scan.fields {
 		if v.Referenced {
 			columns[i] = e.scan.tbl.Cols()[i]
@@ -486,7 +486,7 @@ func (e *IndexRangeExec) Close() error {
 type IndexScanExec struct {
 	tbl         table.Table
 	tableAsName *model.CIStr
-	idx         *table.IndexedCol
+	idx         *table.IndexedColumn
 	fields      []*ast.ResultField
 	Ranges      []*IndexRangeExec
 	Desc        bool

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/evaluator"
 	"github.com/pingcap/tidb/inspectkv"
@@ -317,7 +316,7 @@ func (e *TableScanExec) getRow(handle int64) (*Row, error) {
 	row := &Row{}
 	var err error
 
-	columns := make([]*column.Col, len(e.fields))
+	columns := make([]*table.Col, len(e.fields))
 	for i, v := range e.fields {
 		if v.Referenced {
 			columns[i] = e.t.Cols()[i]
@@ -364,7 +363,7 @@ type IndexRangeExec struct {
 	highVals    []types.Datum
 	highExclude bool
 
-	iter       kv.IndexIterator
+	iter       table.IndexIterator
 	skipLowCmp bool
 	finished   bool
 }
@@ -454,7 +453,7 @@ func indexCompare(idxKey []types.Datum, boundVals []types.Datum) (int, error) {
 func (e *IndexRangeExec) lookupRow(h int64) (*Row, error) {
 	row := &Row{}
 	var err error
-	columns := make([]*column.Col, len(e.scan.fields))
+	columns := make([]*table.Col, len(e.scan.fields))
 	for i, v := range e.scan.fields {
 		if v.Referenced {
 			columns[i] = e.scan.tbl.Cols()[i]
@@ -487,7 +486,7 @@ func (e *IndexRangeExec) Close() error {
 type IndexScanExec struct {
 	tbl         table.Table
 	tableAsName *model.CIStr
-	idx         *column.IndexedCol
+	idx         *table.IndexedCol
 	fields      []*ast.ResultField
 	Ranges      []*IndexRangeExec
 	Desc        bool

--- a/executor/executor_write.go
+++ b/executor/executor_write.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/evaluator"
 	"github.com/pingcap/tidb/kv"
@@ -194,11 +193,11 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	}
 
 	// Check whether new value is valid.
-	if err := column.CastValues(ctx, newData, cols); err != nil {
+	if err := table.CastValues(ctx, newData, cols); err != nil {
 		return errors.Trace(err)
 	}
 
-	if err := column.CheckNotNull(cols, newData); err != nil {
+	if err := table.CheckNotNull(cols, newData); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -483,8 +482,8 @@ func (e *InsertExec) Close() error {
 // 2 insert ... set x=y...   --> set type column
 // 3 insert ... (select ..)  --> name type column
 // See: https://dev.mysql.com/doc/refman/5.7/en/insert.html
-func (e *InsertValues) getColumns(tableCols []*column.Col) ([]*column.Col, error) {
-	var cols []*column.Col
+func (e *InsertValues) getColumns(tableCols []*table.Col) ([]*table.Col, error) {
+	var cols []*table.Col
 	var err error
 
 	if len(e.Setlist) > 0 {
@@ -494,7 +493,7 @@ func (e *InsertValues) getColumns(tableCols []*column.Col) ([]*column.Col, error
 			columns = append(columns, v.Column.Name.O)
 		}
 
-		cols, err = column.FindCols(tableCols, columns)
+		cols, err = table.FindCols(tableCols, columns)
 		if err != nil {
 			return nil, errors.Errorf("INSERT INTO %s: %s", e.Table.Meta().Name.O, err)
 		}
@@ -508,7 +507,7 @@ func (e *InsertValues) getColumns(tableCols []*column.Col) ([]*column.Col, error
 		for _, v := range e.Columns {
 			columns = append(columns, v.Name.O)
 		}
-		cols, err = column.FindCols(tableCols, columns)
+		cols, err = table.FindCols(tableCols, columns)
 		if err != nil {
 			return nil, errors.Errorf("INSERT INTO %s: %s", e.Table.Meta().Name.O, err)
 		}
@@ -520,7 +519,7 @@ func (e *InsertValues) getColumns(tableCols []*column.Col) ([]*column.Col, error
 	}
 
 	// Check column whether is specified only once.
-	err = column.CheckOnce(cols)
+	err = table.CheckOnce(cols)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -542,7 +541,7 @@ func (e *InsertValues) fillValueList() error {
 	return nil
 }
 
-func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, cols []*column.Col) error {
+func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, cols []*table.Col) error {
 	if insertValueCount != valueCount {
 		// "insert into t values (), ()" is valid.
 		// "insert into t values (), (1)" is not valid.
@@ -560,7 +559,7 @@ func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, co
 	return nil
 }
 
-func (e *InsertValues) getColumnDefaultValues(cols []*column.Col) (map[string]types.Datum, error) {
+func (e *InsertValues) getColumnDefaultValues(cols []*table.Col) (map[string]types.Datum, error) {
 	defaultValMap := map[string]types.Datum{}
 	for _, col := range cols {
 		if value, ok, err := table.GetColDefaultValue(e.ctx, &col.ColumnInfo); ok {
@@ -573,7 +572,7 @@ func (e *InsertValues) getColumnDefaultValues(cols []*column.Col) (map[string]ty
 	return defaultValMap, nil
 }
 
-func (e *InsertValues) getRows(cols []*column.Col) (rows [][]types.Datum, err error) {
+func (e *InsertValues) getRows(cols []*table.Col) (rows [][]types.Datum, err error) {
 	// process `insert|replace ... set x=y...`
 	if err = e.fillValueList(); err != nil {
 		return nil, errors.Trace(err)
@@ -599,7 +598,7 @@ func (e *InsertValues) getRows(cols []*column.Col) (rows [][]types.Datum, err er
 	return
 }
 
-func (e *InsertValues) getRow(cols []*column.Col, list []ast.ExprNode, defaultVals map[string]types.Datum) ([]types.Datum, error) {
+func (e *InsertValues) getRow(cols []*table.Col, list []ast.ExprNode, defaultVals map[string]types.Datum) ([]types.Datum, error) {
 	vals := make([]types.Datum, len(list))
 	var err error
 	for i, expr := range list {
@@ -626,7 +625,7 @@ func (e *InsertValues) getRow(cols []*column.Col, list []ast.ExprNode, defaultVa
 	return e.fillRowData(cols, vals)
 }
 
-func (e *InsertValues) getRowsSelect(cols []*column.Col) ([][]types.Datum, error) {
+func (e *InsertValues) getRowsSelect(cols []*table.Col) ([][]types.Datum, error) {
 	// process `insert|replace into ... select ... from ...`
 	if len(e.SelectExec.Fields()) != len(cols) {
 		return nil, errors.Errorf("Column count %d doesn't match value count %d", len(cols), len(e.SelectExec.Fields()))
@@ -650,7 +649,7 @@ func (e *InsertValues) getRowsSelect(cols []*column.Col) ([][]types.Datum, error
 	return rows, nil
 }
 
-func (e *InsertValues) fillRowData(cols []*column.Col, vals []types.Datum) ([]types.Datum, error) {
+func (e *InsertValues) fillRowData(cols []*table.Col, vals []types.Datum) ([]types.Datum, error) {
 	row := make([]types.Datum, len(e.Table.Cols()))
 	marked := make(map[int]struct{}, len(vals))
 	for i, v := range vals {
@@ -662,17 +661,17 @@ func (e *InsertValues) fillRowData(cols []*column.Col, vals []types.Datum) ([]ty
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err = column.CastValues(e.ctx, row, cols); err != nil {
+	if err = table.CastValues(e.ctx, row, cols); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err = column.CheckNotNull(e.Table.Cols(), row); err != nil {
+	if err = table.CheckNotNull(e.Table.Cols(), row); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return row, nil
 }
 
 func (e *InsertValues) initDefaultValues(row []types.Datum, marked map[int]struct{}) error {
-	var defaultValueCols []*column.Col
+	var defaultValueCols []*table.Col
 	for i, c := range e.Table.Cols() {
 		// It's used for retry.
 		if mysql.HasAutoIncrementFlag(c.Flag) && row[i].Kind() == types.KindNull &&
@@ -729,7 +728,7 @@ func (e *InsertValues) initDefaultValues(row []types.Datum, marked map[int]struc
 
 		defaultValueCols = append(defaultValueCols, c)
 	}
-	if err := column.CastValues(e.ctx, row, defaultValueCols); err != nil {
+	if err := table.CastValues(e.ctx, row, defaultValueCols); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -770,13 +769,13 @@ func (e *InsertExec) onDuplicateUpdate(row []types.Datum, h int64, cols map[int]
 	return nil
 }
 
-func findColumnByName(t table.Table, name string) (*column.Col, error) {
+func findColumnByName(t table.Table, name string) (*table.Col, error) {
 	_, tableName, colName := splitQualifiedName(name)
 	if len(tableName) > 0 && tableName != t.Meta().Name.O {
 		return nil, errors.Errorf("unknown field %s.%s", tableName, colName)
 	}
 
-	c := column.FindCol(t.Cols(), colName)
+	c := table.FindCol(t.Cols(), colName)
 	if c == nil {
 		return nil, errors.Errorf("unknown field %s", colName)
 	}

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -157,7 +156,7 @@ func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast
 		return errors.Trace(err)
 	}
 	for _, c := range cols {
-		col := column.FindCol(tbl.Cols(), c.Name.L)
+		col := table.FindCol(tbl.Cols(), c.Name.L)
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c.Name.O)
 		}
@@ -267,7 +266,7 @@ func (e *GrantExec) grantColumnPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 	}
 	userName, host := parseUser(user.User)
 	for _, c := range priv.Cols {
-		col := column.FindCol(tbl.Cols(), c.Name.L)
+		col := table.FindCol(tbl.Cols(), c.Name.L)
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c)
 		}

--- a/executor/show.go
+++ b/executor/show.go
@@ -340,7 +340,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	// TODO: let the result more like MySQL.
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("CREATE TABLE `%s` (\n", tb.Meta().Name.O))
-	var pkCol *table.Col
+	var pkCol *table.Column
 	for i, col := range tb.Cols() {
 		buf.WriteString(fmt.Sprintf("  `%s` %s", col.Name.O, col.GetTypeDesc()))
 		if mysql.HasAutoIncrementFlag(col.Flag) {

--- a/executor/show.go
+++ b/executor/show.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
@@ -194,7 +193,7 @@ func (e *ShowExec) fetchShowColumns() error {
 			continue
 		}
 
-		desc := column.NewColDesc(col)
+		desc := table.NewColDesc(col)
 
 		// The FULL keyword causes the output to include the column collation and comments,
 		// as well as the privileges you have for each column.
@@ -341,7 +340,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	// TODO: let the result more like MySQL.
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("CREATE TABLE `%s` (\n", tb.Meta().Name.O))
-	var pkCol *column.Col
+	var pkCol *table.Col
 	for i, col := range tb.Cols() {
 		buf.WriteString(fmt.Sprintf("  `%s` %s", col.Name.O, col.GetTypeDesc()))
 		if mysql.HasAutoIncrementFlag(col.Flag) {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -349,9 +348,9 @@ func dataForColumns(schemas []*model.DBInfo) [][]types.Datum {
 	return rows
 }
 
-func dataForColumnsInTable(schema *model.DBInfo, table *model.TableInfo) [][]types.Datum {
+func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types.Datum {
 	rows := [][]types.Datum{}
-	for i, col := range table.Columns {
+	for i, col := range tbl.Columns {
 		colLen := col.Flen
 		if colLen == types.UnspecifiedLength {
 			colLen = mysql.GetDefaultFieldLength(col.Tp)
@@ -361,7 +360,7 @@ func dataForColumnsInTable(schema *model.DBInfo, table *model.TableInfo) [][]typ
 			decimal = 0
 		}
 		columnType := col.FieldType.CompactStr()
-		columnDesc := column.NewColDesc(&column.Col{ColumnInfo: *col})
+		columnDesc := table.NewColDesc(&table.Col{ColumnInfo: *col})
 		var columnDefault interface{}
 		if columnDesc.DefaultValue != nil {
 			columnDefault = fmt.Sprintf("%v", columnDesc.DefaultValue)
@@ -369,7 +368,7 @@ func dataForColumnsInTable(schema *model.DBInfo, table *model.TableInfo) [][]typ
 		record := types.MakeDatums(
 			catalogVal,                           // TABLE_CATALOG
 			schema.Name.O,                        // TABLE_SCHEMA
-			table.Name.O,                         // TABLE_NAME
+			tbl.Name.O,                           // TABLE_NAME
 			col.Name.O,                           // COLUMN_NAME
 			i+1,                                  // ORIGINAL_POSITION
 			columnDefault,                        // COLUMN_DEFAULT

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -360,7 +360,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			decimal = 0
 		}
 		columnType := col.FieldType.CompactStr()
-		columnDesc := table.NewColDesc(&table.Col{ColumnInfo: *col})
+		columnDesc := table.NewColDesc(&table.Column{ColumnInfo: *col})
 		var columnDefault interface{}
 		if columnDesc.DefaultValue != nil {
 			columnDefault = fmt.Sprintf("%v", columnDesc.DefaultValue)

--- a/inspectkv/inspectkv.go
+++ b/inspectkv/inspectkv.go
@@ -163,7 +163,7 @@ func ScanIndexData(txn kv.Transaction, kvIndex table.Index, startVals []types.Da
 // CompareIndexData compares index data one by one.
 // It returns nil if the data from the index is equal to the data from the table columns,
 // otherwise it returns an error with a different set of records.
-func CompareIndexData(txn kv.Transaction, t table.Table, idx *table.IndexedCol) error {
+func CompareIndexData(txn kv.Transaction, t table.Table, idx *table.IndexedColumn) error {
 	err := checkIndexAndRecord(txn, t, idx)
 	if err != nil {
 		return errors.Trace(err)
@@ -172,7 +172,7 @@ func CompareIndexData(txn kv.Transaction, t table.Table, idx *table.IndexedCol) 
 	return checkRecordAndIndex(txn, t, idx)
 }
 
-func checkIndexAndRecord(txn kv.Transaction, t table.Table, idx *table.IndexedCol) error {
+func checkIndexAndRecord(txn kv.Transaction, t table.Table, idx *table.IndexedColumn) error {
 	kvIndex := tables.NewIndex(t.IndexPrefix(), idx.Name.L, idx.ID, idx.Unique)
 	it, err := kvIndex.SeekFirst(txn)
 	if err != nil {
@@ -180,7 +180,7 @@ func checkIndexAndRecord(txn kv.Transaction, t table.Table, idx *table.IndexedCo
 	}
 	defer it.Close()
 
-	cols := make([]*table.Col, len(idx.Columns))
+	cols := make([]*table.Column, len(idx.Columns))
 	for i, col := range idx.Columns {
 		cols[i] = t.Cols()[col.Offset]
 	}
@@ -211,15 +211,15 @@ func checkIndexAndRecord(txn kv.Transaction, t table.Table, idx *table.IndexedCo
 	return nil
 }
 
-func checkRecordAndIndex(txn kv.Transaction, t table.Table, idx *table.IndexedCol) error {
-	cols := make([]*table.Col, len(idx.Columns))
+func checkRecordAndIndex(txn kv.Transaction, t table.Table, idx *table.IndexedColumn) error {
+	cols := make([]*table.Column, len(idx.Columns))
 	for i, col := range idx.Columns {
 		cols[i] = t.Cols()[col.Offset]
 	}
 
 	startKey := t.RecordKey(0, nil)
 	kvIndex := tables.NewIndex(t.IndexPrefix(), idx.Name.L, idx.ID, idx.Unique)
-	filterFunc := func(h1 int64, vals1 []types.Datum, cols []*table.Col) (bool, error) {
+	filterFunc := func(h1 int64, vals1 []types.Datum, cols []*table.Column) (bool, error) {
 		isExist, h2, err := kvIndex.Exist(txn, vals1, h1)
 		if terror.ErrorEqual(err, kv.ErrKeyExists) {
 			record1 := &RecordData{Handle: h1, Values: vals1}
@@ -245,12 +245,12 @@ func checkRecordAndIndex(txn kv.Transaction, t table.Table, idx *table.IndexedCo
 	return nil
 }
 
-func scanTableData(retriever kv.Retriever, t table.Table, cols []*table.Col, startHandle, limit int64) (
+func scanTableData(retriever kv.Retriever, t table.Table, cols []*table.Column, startHandle, limit int64) (
 	[]*RecordData, int64, error) {
 	var records []*RecordData
 
 	startKey := t.RecordKey(startHandle, nil)
-	filterFunc := func(h int64, d []types.Datum, cols []*table.Col) (bool, error) {
+	filterFunc := func(h int64, d []types.Datum, cols []*table.Column) (bool, error) {
 		if limit != 0 {
 			r := &RecordData{
 				Handle: h,
@@ -316,7 +316,7 @@ func CompareTableRecord(txn kv.Transaction, t table.Table, data []*RecordData, e
 	}
 
 	startKey := t.RecordKey(0, nil)
-	filterFunc := func(h int64, vals []types.Datum, cols []*table.Col) (bool, error) {
+	filterFunc := func(h int64, vals []types.Datum, cols []*table.Column) (bool, error) {
 		vals2, ok := m[h]
 		if !ok {
 			record := &RecordData{Handle: h, Values: vals}
@@ -382,7 +382,7 @@ func GetTableRecordsCount(txn kv.Transaction, t table.Table, startHandle int64) 
 	return cnt, nil
 }
 
-func rowWithCols(txn kv.Retriever, t table.Table, h int64, cols []*table.Col) ([]types.Datum, error) {
+func rowWithCols(txn kv.Retriever, t table.Table, h int64, cols []*table.Column) ([]types.Datum, error) {
 	v := make([]types.Datum, len(cols))
 	for i, col := range cols {
 		if col.State != model.StatePublic {
@@ -410,7 +410,7 @@ func rowWithCols(txn kv.Retriever, t table.Table, h int64, cols []*table.Col) ([
 	return v, nil
 }
 
-func iterRecords(retriever kv.Retriever, t table.Table, startKey kv.Key, cols []*table.Col,
+func iterRecords(retriever kv.Retriever, t table.Table, startKey kv.Key, cols []*table.Column,
 	fn table.RecordIterFunc) error {
 	it, err := retriever.Seek(startKey)
 	if err != nil {

--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -216,7 +215,7 @@ func (s *testSuite) TestScan(c *C) {
 
 	idxRow1 := &RecordData{Handle: int64(1), Values: types.MakeDatums(int64(10))}
 	idxRow2 := &RecordData{Handle: int64(2), Values: types.MakeDatums(int64(20))}
-	kvIndex := kv.NewKVIndex(tb.IndexPrefix(), indices[0].Name.L, indices[0].ID, indices[0].Unique)
+	kvIndex := tables.NewIndex(tb.IndexPrefix(), indices[0].Name.L, indices[0].ID, indices[0].Unique)
 	idxRows, nextVals, err := ScanIndexData(txn, kvIndex, idxRow1.Values, 2)
 	c.Assert(err, IsNil)
 	c.Assert(idxRows, DeepEquals, []*RecordData{idxRow1, idxRow2})
@@ -295,7 +294,7 @@ func (s *testSuite) testTableData(c *C, tb table.Table, rs []*RecordData) {
 	c.Assert(err.Error(), DeepEquals, "[inspectkv:2]handle:1 is repeated in data")
 }
 
-func (s *testSuite) testIndex(c *C, tb table.Table, idx *column.IndexedCol) {
+func (s *testSuite) testIndex(c *C, tb table.Table, idx *table.IndexedCol) {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
 

--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -294,7 +294,7 @@ func (s *testSuite) testTableData(c *C, tb table.Table, rs []*RecordData) {
 	c.Assert(err.Error(), DeepEquals, "[inspectkv:2]handle:1 is repeated in data")
 }
 
-func (s *testSuite) testIndex(c *C, tb table.Table, idx *table.IndexedCol) {
+func (s *testSuite) testIndex(c *C, tb table.Table, idx *table.IndexedColumn) {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
 

--- a/optimizer/resolver.go
+++ b/optimizer/resolver.go
@@ -18,12 +18,12 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/db"
+	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -871,7 +871,7 @@ func (nr *nameResolver) fillShowFields(s *ast.ShowStmt) {
 			mysql.TypeDatetime, mysql.TypeDatetime, mysql.TypeDatetime, mysql.TypeVarchar, mysql.TypeVarchar,
 			mysql.TypeVarchar, mysql.TypeVarchar}
 	case ast.ShowColumns:
-		names = column.ColDescFieldNames(s.Full)
+		names = table.ColDescFieldNames(s.Full)
 	case ast.ShowWarnings:
 		names = []string{"Level", "Code", "Message"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeLong, mysql.TypeVarchar}

--- a/table/column.go
+++ b/table/column.go
@@ -1,4 +1,4 @@
-// Copyright 2013 The ql Authors. All rights reserved.
+// Copyright 2016 The ql Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSES/QL-LICENSE file.
 
@@ -15,14 +15,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package column
+package table
 
 import (
 	"strings"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/types"
@@ -39,7 +38,7 @@ const PrimaryKeyName = "PRIMARY"
 // IndexedCol defines an index with info.
 type IndexedCol struct {
 	model.IndexInfo
-	X kv.Index
+	X Index
 }
 
 // String implements fmt.Stringer interface.

--- a/table/column.go
+++ b/table/column.go
@@ -27,22 +27,22 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
-// Col provides meta data describing a table column.
-type Col struct {
+// Column provides meta data describing a table column.
+type Column struct {
 	model.ColumnInfo
 }
 
 // PrimaryKeyName defines primary key name.
 const PrimaryKeyName = "PRIMARY"
 
-// IndexedCol defines an index with info.
-type IndexedCol struct {
+// IndexedColumn defines an index with info.
+type IndexedColumn struct {
 	model.IndexInfo
 	X Index
 }
 
 // String implements fmt.Stringer interface.
-func (c *Col) String() string {
+func (c *Column) String() string {
 	ans := []string{c.Name.O, types.TypeToStr(c.Tp, c.Charset)}
 	if mysql.HasAutoIncrementFlag(c.Flag) {
 		ans = append(ans, "AUTO_INCREMENT")
@@ -54,7 +54,7 @@ func (c *Col) String() string {
 }
 
 // FindCol finds column in cols by name.
-func FindCol(cols []*Col, name string) *Col {
+func FindCol(cols []*Column, name string) *Column {
 	for _, col := range cols {
 		if strings.EqualFold(col.Name.O, name) {
 			return col
@@ -64,8 +64,8 @@ func FindCol(cols []*Col, name string) *Col {
 }
 
 // FindCols finds columns in cols by names.
-func FindCols(cols []*Col, names []string) ([]*Col, error) {
-	var rcols []*Col
+func FindCols(cols []*Column, names []string) ([]*Column, error) {
+	var rcols []*Column
 	for _, name := range names {
 		col := FindCol(cols, name)
 		if col != nil {
@@ -79,8 +79,8 @@ func FindCols(cols []*Col, names []string) ([]*Col, error) {
 }
 
 // FindOnUpdateCols finds columns which have OnUpdateNow flag.
-func FindOnUpdateCols(cols []*Col) []*Col {
-	var rcols []*Col
+func FindOnUpdateCols(cols []*Column) []*Column {
+	var rcols []*Column
 	for _, col := range cols {
 		if mysql.HasOnUpdateNowFlag(col.Flag) {
 			rcols = append(rcols, col)
@@ -91,7 +91,7 @@ func FindOnUpdateCols(cols []*Col) []*Col {
 }
 
 // CastValues casts values based on columns type.
-func CastValues(ctx context.Context, rec []types.Datum, cols []*Col) (err error) {
+func CastValues(ctx context.Context, rec []types.Datum, cols []*Column) (err error) {
 	for _, c := range cols {
 		var converted types.Datum
 		converted, err = rec[c.Offset].ConvertTo(&c.FieldType)
@@ -119,7 +119,7 @@ type ColDesc struct {
 const defaultPrivileges string = "select,insert,update,references"
 
 // GetTypeDesc gets the description for column type.
-func (c *Col) GetTypeDesc() string {
+func (c *Column) GetTypeDesc() string {
 	desc := c.FieldType.CompactStr()
 	if mysql.HasUnsignedFlag(c.Flag) {
 		desc += " UNSIGNED"
@@ -128,7 +128,7 @@ func (c *Col) GetTypeDesc() string {
 }
 
 // NewColDesc returns a new ColDesc for a column.
-func NewColDesc(col *Col) *ColDesc {
+func NewColDesc(col *Column) *ColDesc {
 	// TODO: if we have no primary key and a unique index which's columns are all not null
 	// we will set these columns' flag as PriKeyFlag
 	// see https://dev.mysql.com/doc/refman/5.7/en/show-columns.html
@@ -180,7 +180,7 @@ func ColDescFieldNames(full bool) []string {
 }
 
 // CheckOnce checks if there are duplicated column names in cols.
-func CheckOnce(cols []*Col) error {
+func CheckOnce(cols []*Column) error {
 	m := map[string]struct{}{}
 	for _, col := range cols {
 		name := col.Name
@@ -196,7 +196,7 @@ func CheckOnce(cols []*Col) error {
 }
 
 // CheckNotNull checks if nil value set to a column with NotNull flag is set.
-func (c *Col) CheckNotNull(data types.Datum) error {
+func (c *Column) CheckNotNull(data types.Datum) error {
 	if mysql.HasNotNullFlag(c.Flag) && data.Kind() == types.KindNull {
 		return errors.Errorf("Column %s can't be null.", c.Name)
 	}
@@ -204,12 +204,12 @@ func (c *Col) CheckNotNull(data types.Datum) error {
 }
 
 // IsPKHandleColumn checks if the column is primary key handle column.
-func (c *Col) IsPKHandleColumn(tbInfo *model.TableInfo) bool {
+func (c *Column) IsPKHandleColumn(tbInfo *model.TableInfo) bool {
 	return mysql.HasPriKeyFlag(c.Flag) && tbInfo.PKIsHandle
 }
 
 // CheckNotNull checks if row has nil value set to a column with NotNull flag set.
-func CheckNotNull(cols []*Col, row []types.Datum) error {
+func CheckNotNull(cols []*Column, row []types.Datum) error {
 	for _, c := range cols {
 		if err := c.CheckNotNull(row[c.Offset]); err != nil {
 			return errors.Trace(err)
@@ -219,7 +219,7 @@ func CheckNotNull(cols []*Col, row []types.Datum) error {
 }
 
 // FetchValues fetches indexed values from a row.
-func (idx *IndexedCol) FetchValues(r []types.Datum) ([]types.Datum, error) {
+func (idx *IndexedColumn) FetchValues(r []types.Datum) ([]types.Datum, error) {
 	vals := make([]types.Datum, len(idx.Columns))
 	for i, ic := range idx.Columns {
 		if ic.Offset < 0 || ic.Offset > len(r) {

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 PingCAP, Inc.
+// Copyright 2016 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package column
+package table
 
 import (
 	"testing"

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -33,7 +33,7 @@ type testColumnSuite struct{}
 
 func (s *testColumnSuite) TestString(c *C) {
 	defer testleak.AfterTest(c)()
-	col := &Col{
+	col := &Column{
 		model.ColumnInfo{
 			FieldType: *types.NewFieldType(mysql.TypeTiny),
 			State:     model.StatePublic,
@@ -78,7 +78,7 @@ func (s *testColumnSuite) TestString(c *C) {
 
 func (s *testColumnSuite) TestFind(c *C) {
 	defer testleak.AfterTest(c)()
-	cols := []*Col{
+	cols := []*Column{
 		newCol("a"),
 		newCol("b"),
 		newCol("c"),
@@ -93,7 +93,7 @@ func (s *testColumnSuite) TestCheck(c *C) {
 	defer testleak.AfterTest(c)()
 	col := newCol("a")
 	col.Flag = mysql.AutoIncrementFlag
-	cols := []*Col{col, col}
+	cols := []*Column{col, col}
 	CheckOnce(cols)
 	cols = cols[:1]
 	CheckNotNull(cols, types.MakeDatums(nil))
@@ -112,8 +112,8 @@ func (s *testColumnSuite) TestDesc(c *C) {
 	ColDescFieldNames(true)
 }
 
-func newCol(name string) *Col {
-	return &Col{
+func newCol(name string) *Column {
+	return &Column{
 		model.ColumnInfo{
 			Name:  model.NewCIStr(name),
 			State: model.StatePublic,

--- a/table/index.go
+++ b/table/index.go
@@ -1,0 +1,43 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package table
+
+import (
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/types"
+)
+
+// IndexIterator is the interface for iterator of index data on KV store.
+type IndexIterator interface {
+	Next() (k []types.Datum, h int64, err error)
+	Close()
+}
+
+// Index is the interface for index data on KV store.
+type Index interface {
+	// Create supports insert into statement.
+	Create(rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) error
+	// Delete supports delete from statement.
+	Delete(m kv.Mutator, indexedValues []types.Datum, h int64) error
+	// Drop supports drop table, drop index statements.
+	Drop(rm kv.RetrieverMutator) error
+	// Exist supports check index exists or not.
+	Exist(rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (bool, int64, error)
+	// GenIndexKey generates an index key.
+	GenIndexKey(indexedValues []types.Datum, h int64) (key []byte, distinct bool, err error)
+	// Seek supports where clause.
+	Seek(r kv.Retriever, indexedValues []types.Datum) (iter IndexIterator, hit bool, err error)
+	// SeekFirst supports aggregate min and ascend order by.
+	SeekFirst(r kv.Retriever) (iter IndexIterator, err error)
+}

--- a/table/table.go
+++ b/table/table.go
@@ -29,24 +29,24 @@ import (
 )
 
 // RecordIterFunc is used for low-level record iteration.
-type RecordIterFunc func(h int64, rec []types.Datum, cols []*Col) (more bool, err error)
+type RecordIterFunc func(h int64, rec []types.Datum, cols []*Column) (more bool, err error)
 
 // Table is used to retrieve and modify rows in table.
 type Table interface {
 	// IterRecords iterates records in the table and calls fn.
-	IterRecords(ctx context.Context, startKey kv.Key, cols []*Col, fn RecordIterFunc) error
+	IterRecords(ctx context.Context, startKey kv.Key, cols []*Column, fn RecordIterFunc) error
 
 	// RowWithCols returns a row that contains the given cols.
-	RowWithCols(ctx context.Context, h int64, cols []*Col) ([]types.Datum, error)
+	RowWithCols(ctx context.Context, h int64, cols []*Column) ([]types.Datum, error)
 
 	// Row returns a row for all columns.
 	Row(ctx context.Context, h int64) ([]types.Datum, error)
 
 	// Cols returns the columns of the table which is used in select.
-	Cols() []*Col
+	Cols() []*Column
 
 	// Indices returns the indices of the table.
-	Indices() []*IndexedCol
+	Indices() []*IndexedColumn
 
 	// RecordPrefix returns the record key prefix.
 	RecordPrefix() kv.Key
@@ -58,7 +58,7 @@ type Table interface {
 	FirstKey() kv.Key
 
 	// RecordKey returns the key in KV storage for the column.
-	RecordKey(h int64, col *Col) kv.Key
+	RecordKey(h int64, col *Column) kv.Key
 
 	// Truncate truncates the table.
 	Truncate(ctx context.Context) (err error)

--- a/table/table.go
+++ b/table/table.go
@@ -19,7 +19,6 @@ package table
 
 import (
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/evaluator"
 	"github.com/pingcap/tidb/kv"
@@ -30,24 +29,24 @@ import (
 )
 
 // RecordIterFunc is used for low-level record iteration.
-type RecordIterFunc func(h int64, rec []types.Datum, cols []*column.Col) (more bool, err error)
+type RecordIterFunc func(h int64, rec []types.Datum, cols []*Col) (more bool, err error)
 
 // Table is used to retrieve and modify rows in table.
 type Table interface {
 	// IterRecords iterates records in the table and calls fn.
-	IterRecords(ctx context.Context, startKey kv.Key, cols []*column.Col, fn RecordIterFunc) error
+	IterRecords(ctx context.Context, startKey kv.Key, cols []*Col, fn RecordIterFunc) error
 
 	// RowWithCols returns a row that contains the given cols.
-	RowWithCols(ctx context.Context, h int64, cols []*column.Col) ([]types.Datum, error)
+	RowWithCols(ctx context.Context, h int64, cols []*Col) ([]types.Datum, error)
 
 	// Row returns a row for all columns.
 	Row(ctx context.Context, h int64) ([]types.Datum, error)
 
 	// Cols returns the columns of the table which is used in select.
-	Cols() []*column.Col
+	Cols() []*Col
 
 	// Indices returns the indices of the table.
-	Indices() []*column.IndexedCol
+	Indices() []*IndexedCol
 
 	// RecordPrefix returns the record key prefix.
 	RecordPrefix() kv.Key
@@ -59,7 +58,7 @@ type Table interface {
 	FirstKey() kv.Key
 
 	// RecordKey returns the key in KV storage for the column.
-	RecordKey(h int64, col *column.Col) kv.Key
+	RecordKey(h int64, col *Col) kv.Key
 
 	// Truncate truncates the table.
 	Truncate(ctx context.Context) (err error)

--- a/table/tables/bounded_tables.go
+++ b/table/tables/bounded_tables.go
@@ -50,8 +50,8 @@ type BoundedTable struct {
 	cursor      int64
 	ID          int64
 	Name        model.CIStr
-	Columns     []*table.Col
-	pkHandleCol *table.Col
+	Columns     []*table.Column
+	pkHandleCol *table.Column
 
 	recordPrefix kv.Key
 	alloc        autoid.Allocator
@@ -63,10 +63,10 @@ type BoundedTable struct {
 
 // BoundedTableFromMeta creates a Table instance from model.TableInfo.
 func BoundedTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo, capacity int64) table.Table {
-	columns := make([]*table.Col, 0, len(tblInfo.Columns))
-	var pkHandleColumn *table.Col
+	columns := make([]*table.Column, 0, len(tblInfo.Columns))
+	var pkHandleColumn *table.Column
 	for _, colInfo := range tblInfo.Columns {
-		col := &table.Col{ColumnInfo: *colInfo}
+		col := &table.Column{ColumnInfo: *colInfo}
 		columns = append(columns, col)
 		if col.IsPKHandleColumn(tblInfo) {
 			pkHandleColumn = col
@@ -79,7 +79,7 @@ func BoundedTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo, capa
 }
 
 // newBoundedTable constructs a BoundedTable instance.
-func newBoundedTable(tableID int64, tableName string, cols []*table.Col, alloc autoid.Allocator, capacity int64) *BoundedTable {
+func newBoundedTable(tableID int64, tableName string, cols []*table.Column, alloc autoid.Allocator, capacity int64) *BoundedTable {
 	name := model.NewCIStr(tableName)
 	t := &BoundedTable{
 		ID:           tableID,
@@ -134,7 +134,7 @@ func (t *BoundedTable) Seek(ctx context.Context, handle int64) (int64, bool, err
 }
 
 // Indices implements table.Table Indices interface.
-func (t *BoundedTable) Indices() []*table.IndexedCol {
+func (t *BoundedTable) Indices() []*table.IndexedColumn {
 	return nil
 }
 
@@ -144,7 +144,7 @@ func (t *BoundedTable) Meta() *model.TableInfo {
 }
 
 // Cols implements table.Table Cols interface.
-func (t *BoundedTable) Cols() []*table.Col {
+func (t *BoundedTable) Cols() []*table.Column {
 	return t.Columns
 }
 
@@ -159,7 +159,7 @@ func (t *BoundedTable) IndexPrefix() kv.Key {
 }
 
 // RecordKey implements table.Table RecordKey interface.
-func (t *BoundedTable) RecordKey(h int64, col *table.Col) kv.Key {
+func (t *BoundedTable) RecordKey(h int64, col *table.Column) kv.Key {
 	colID := int64(0)
 	if col != nil {
 		colID = col.ID
@@ -223,7 +223,7 @@ func (t *BoundedTable) AddRecord(ctx context.Context, r []types.Datum) (int64, e
 }
 
 // RowWithCols implements table.Table RowWithCols interface.
-func (t *BoundedTable) RowWithCols(ctx context.Context, h int64, cols []*table.Col) ([]types.Datum, error) {
+func (t *BoundedTable) RowWithCols(ctx context.Context, h int64, cols []*table.Column) ([]types.Datum, error) {
 	row := []types.Datum(nil)
 	for i := int64(0); i < t.capacity; i++ {
 		record := (*boundedItem)(atomic.LoadPointer(&t.records[i]))
@@ -284,7 +284,7 @@ func (t *BoundedTable) RebaseAutoID(newBase int64, isSetStep bool) error {
 }
 
 // IterRecords implements table.Table IterRecords interface.
-func (t *BoundedTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.Col,
+func (t *BoundedTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.Column,
 	fn table.RecordIterFunc) error {
 	return nil
 }

--- a/table/tables/bounded_tables_test.go
+++ b/table/tables/bounded_tables_test.go
@@ -16,7 +16,6 @@ package tables_test
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -99,7 +98,7 @@ func (ts *testBoundedTableSuite) TestBoundedBasic(c *C) {
 	_, err = tb.AddRecord(ctx, types.MakeDatums(2, "abc"))
 	c.Assert(err, IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		return true, nil
 	})
 
@@ -108,7 +107,7 @@ func (ts *testBoundedTableSuite) TestBoundedBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*column.Col{tb.Cols()[1]}
+	cols := []*table.Col{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, rid, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)

--- a/table/tables/bounded_tables_test.go
+++ b/table/tables/bounded_tables_test.go
@@ -98,7 +98,7 @@ func (ts *testBoundedTableSuite) TestBoundedBasic(c *C) {
 	_, err = tb.AddRecord(ctx, types.MakeDatums(2, "abc"))
 	c.Assert(err, IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		return true, nil
 	})
 
@@ -107,7 +107,7 @@ func (ts *testBoundedTableSuite) TestBoundedBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*table.Col{tb.Cols()[1]}
+	cols := []*table.Column{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, rid, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -1,4 +1,4 @@
-// Copyright 2015 PingCAP, Inc.
+// Copyright 2016 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kv
+package tables
 
 import (
 	"bytes"
@@ -19,38 +19,11 @@ import (
 	"io"
 
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/types"
 )
-
-var (
-	_ Index         = (*kvIndex)(nil)
-	_ IndexIterator = (*indexIter)(nil)
-)
-
-// IndexIterator is the interface for iterator of index data on KV store.
-type IndexIterator interface {
-	Next() (k []types.Datum, h int64, err error)
-	Close()
-}
-
-// Index is the interface for index data on KV store.
-type Index interface {
-	// Create supports insert into statement.
-	Create(rm RetrieverMutator, indexedValues []types.Datum, h int64) error
-	// Delete supports delete from statement.
-	Delete(m Mutator, indexedValues []types.Datum, h int64) error
-	// Drop supports drop table, drop index statements.
-	Drop(rm RetrieverMutator) error
-	// Exist supports check index exists or not.
-	Exist(rm RetrieverMutator, indexedValues []types.Datum, h int64) (bool, int64, error)
-	// GenIndexKey generates an index key.
-	GenIndexKey(indexedValues []types.Datum, h int64) (key []byte, distinct bool, err error)
-	// Seek supports where clause.
-	Seek(r Retriever, indexedValues []types.Datum) (iter IndexIterator, hit bool, err error)
-	// SeekFirst supports aggregate min and ascend order by.
-	SeekFirst(r Retriever) (iter IndexIterator, err error)
-}
 
 func encodeHandle(h int64) []byte {
 	buf := &bytes.Buffer{}
@@ -70,9 +43,9 @@ func decodeHandle(data []byte) (int64, error) {
 
 // indexIter is for KV store index iterator.
 type indexIter struct {
-	it     Iterator
-	idx    *kvIndex
-	prefix Key
+	it     kv.Iterator
+	idx    *index
+	prefix kv.Key
 }
 
 // Close does the clean up works when KV store index iterator is closed.
@@ -118,24 +91,24 @@ func (c *indexIter) Next() (val []types.Datum, h int64, err error) {
 }
 
 // kvIndex is the data structure for index data in the KV store.
-type kvIndex struct {
+type index struct {
 	indexName string
 	indexID   int64
 	unique    bool
-	prefix    Key
+	prefix    kv.Key
 }
 
 // GenIndexPrefix generates the index prefix.
-func GenIndexPrefix(indexPrefix Key, indexID int64) Key {
+func GenIndexPrefix(indexPrefix kv.Key, indexID int64) kv.Key {
 	buf := make([]byte, 0, len(indexPrefix)+8)
 	buf = append(buf, indexPrefix...)
 	buf = codec.EncodeInt(buf, indexID)
 	return buf
 }
 
-// NewKVIndex builds a new kvIndex object.
-func NewKVIndex(indexPrefix Key, indexName string, indexID int64, unique bool) Index {
-	index := &kvIndex{
+// NewIndex builds a new Index object.
+func NewIndex(indexPrefix kv.Key, indexName string, indexID int64, unique bool) table.Index {
+	index := &index{
 		indexName: indexName,
 		indexID:   indexID,
 		unique:    unique,
@@ -147,7 +120,7 @@ func NewKVIndex(indexPrefix Key, indexName string, indexID int64, unique bool) I
 
 // GenIndexKey generates storage key for index values. Returned distinct indicates whether the
 // indexed values should be distinct in storage (i.e. whether handle is encoded in the key).
-func (c *kvIndex) GenIndexKey(indexedValues []types.Datum, h int64) (key []byte, distinct bool, err error) {
+func (c *index) GenIndexKey(indexedValues []types.Datum, h int64) (key []byte, distinct bool, err error) {
 	if c.unique {
 		// See: https://dev.mysql.com/doc/refman/5.7/en/create-index.html
 		// A UNIQUE index creates a constraint such that all values in the index must be distinct.
@@ -176,7 +149,7 @@ func (c *kvIndex) GenIndexKey(indexedValues []types.Datum, h int64) (key []byte,
 
 // Create creates a new entry in the kvIndex data.
 // If the index is unique and there is an existing entry with the same key, Create will return ErrKeyExists.
-func (c *kvIndex) Create(rm RetrieverMutator, indexedValues []types.Datum, h int64) error {
+func (c *index) Create(rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) error {
 	key, distinct, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return errors.Trace(err)
@@ -188,16 +161,16 @@ func (c *kvIndex) Create(rm RetrieverMutator, indexedValues []types.Datum, h int
 	}
 
 	_, err = rm.Get(key)
-	if IsErrNotFound(err) {
+	if kv.IsErrNotFound(err) {
 		err = rm.Set(key, encodeHandle(h))
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(ErrKeyExists)
+	return errors.Trace(kv.ErrKeyExists)
 }
 
 // Delete removes the entry for handle h and indexdValues from KV index.
-func (c *kvIndex) Delete(m Mutator, indexedValues []types.Datum, h int64) error {
+func (c *index) Delete(m kv.Mutator, indexedValues []types.Datum, h int64) error {
 	key, _, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return errors.Trace(err)
@@ -207,7 +180,7 @@ func (c *kvIndex) Delete(m Mutator, indexedValues []types.Datum, h int64) error 
 }
 
 // Drop removes the KV index from store.
-func (c *kvIndex) Drop(rm RetrieverMutator) error {
+func (c *index) Drop(rm kv.RetrieverMutator) error {
 	it, err := rm.Seek(c.prefix)
 	if err != nil {
 		return errors.Trace(err)
@@ -232,7 +205,7 @@ func (c *kvIndex) Drop(rm RetrieverMutator) error {
 }
 
 // Seek searches KV index for the entry with indexedValues.
-func (c *kvIndex) Seek(r Retriever, indexedValues []types.Datum) (iter IndexIterator, hit bool, err error) {
+func (c *index) Seek(r kv.Retriever, indexedValues []types.Datum) (iter table.IndexIterator, hit bool, err error) {
 	key, _, err := c.GenIndexKey(indexedValues, 0)
 	if err != nil {
 		return nil, false, errors.Trace(err)
@@ -250,7 +223,7 @@ func (c *kvIndex) Seek(r Retriever, indexedValues []types.Datum) (iter IndexIter
 }
 
 // SeekFirst returns an iterator which points to the first entry of the KV index.
-func (c *kvIndex) SeekFirst(r Retriever) (iter IndexIterator, err error) {
+func (c *index) SeekFirst(r kv.Retriever) (iter table.IndexIterator, err error) {
 	it, err := r.Seek(c.prefix)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -258,14 +231,14 @@ func (c *kvIndex) SeekFirst(r Retriever) (iter IndexIterator, err error) {
 	return &indexIter{it: it, idx: c, prefix: c.prefix}, nil
 }
 
-func (c *kvIndex) Exist(rm RetrieverMutator, indexedValues []types.Datum, h int64) (bool, int64, error) {
+func (c *index) Exist(rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (bool, int64, error) {
 	key, distinct, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return false, 0, errors.Trace(err)
 	}
 
 	value, err := rm.Get(key)
-	if IsErrNotFound(err) {
+	if kv.IsErrNotFound(err) {
 		return false, 0, nil
 	}
 	if err != nil {
@@ -280,7 +253,7 @@ func (c *kvIndex) Exist(rm RetrieverMutator, indexedValues []types.Datum, h int6
 		}
 
 		if handle != h {
-			return true, handle, errors.Trace(ErrKeyExists)
+			return true, handle, errors.Trace(kv.ErrKeyExists)
 		}
 
 		return true, handle, nil

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 PingCAP, Inc.
+// Copyright 2016 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,24 +11,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package kv_test
+package tables_test
 
 import (
 	"io"
-	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
+	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
 )
-
-func TestT(t *testing.T) {
-	TestingT(t)
-}
 
 var _ = Suite(&testIndexSuite{})
 
@@ -51,7 +47,7 @@ func (s *testIndexSuite) TearDownSuite(c *C) {
 
 func (s *testIndexSuite) TestIndex(c *C) {
 	defer testleak.AfterTest(c)()
-	index := kv.NewKVIndex([]byte("i"), "test", 0, false)
+	index := tables.NewIndex([]byte("i"), "test", 0, false)
 
 	// Test ununiq index.
 	txn, err := s.s.Begin()
@@ -121,7 +117,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	err = txn.Commit()
 	c.Assert(err, IsNil)
 
-	index = kv.NewKVIndex([]byte("j"), "test", 1, true)
+	index = tables.NewIndex([]byte("j"), "test", 1, true)
 
 	// Test uniq index.
 	txn, err = s.s.Begin()
@@ -149,7 +145,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 
 func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 	defer testleak.AfterTest(c)()
-	index := kv.NewKVIndex([]byte("i"), "test", 1, false)
+	index := tables.NewIndex([]byte("i"), "test", 1, false)
 
 	txn, err := s.s.Begin()
 	c.Assert(err, IsNil)
@@ -158,7 +154,7 @@ func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 	err = index.Create(txn, values, 1)
 	c.Assert(err, IsNil)
 
-	index2 := kv.NewKVIndex([]byte("i"), "test", 1, false)
+	index2 := tables.NewIndex([]byte("i"), "test", 1, false)
 	iter, hit, err := index2.Seek(txn, types.MakeDatums("abc", nil))
 	c.Assert(err, IsNil)
 	defer iter.Close()

--- a/table/tables/memory_tables.go
+++ b/table/tables/memory_tables.go
@@ -64,8 +64,8 @@ func (k itemKey) Less(item llrb.Item) bool {
 type MemoryTable struct {
 	ID          int64
 	Name        model.CIStr
-	Columns     []*table.Col
-	pkHandleCol *table.Col
+	Columns     []*table.Column
+	pkHandleCol *table.Column
 
 	recordPrefix kv.Key
 	alloc        autoid.Allocator
@@ -77,10 +77,10 @@ type MemoryTable struct {
 
 // MemoryTableFromMeta creates a Table instance from model.TableInfo.
 func MemoryTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Table, error) {
-	columns := make([]*table.Col, 0, len(tblInfo.Columns))
-	var pkHandleColumn *table.Col
+	columns := make([]*table.Column, 0, len(tblInfo.Columns))
+	var pkHandleColumn *table.Column
 	for _, colInfo := range tblInfo.Columns {
-		col := &table.Col{ColumnInfo: *colInfo}
+		col := &table.Column{ColumnInfo: *colInfo}
 		columns = append(columns, col)
 		if col.IsPKHandleColumn(tblInfo) {
 			pkHandleColumn = col
@@ -93,7 +93,7 @@ func MemoryTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (tabl
 }
 
 // newMemoryTable constructs a MemoryTable instance.
-func newMemoryTable(tableID int64, tableName string, cols []*table.Col, alloc autoid.Allocator) *MemoryTable {
+func newMemoryTable(tableID int64, tableName string, cols []*table.Column, alloc autoid.Allocator) *MemoryTable {
 	name := model.NewCIStr(tableName)
 	t := &MemoryTable{
 		ID:           tableID,
@@ -121,7 +121,7 @@ func (t *MemoryTable) Seek(ctx context.Context, handle int64) (int64, bool, erro
 }
 
 // Indices implements table.Table Indices interface.
-func (t *MemoryTable) Indices() []*table.IndexedCol {
+func (t *MemoryTable) Indices() []*table.IndexedColumn {
 	return nil
 }
 
@@ -131,7 +131,7 @@ func (t *MemoryTable) Meta() *model.TableInfo {
 }
 
 // Cols implements table.Table Cols interface.
-func (t *MemoryTable) Cols() []*table.Col {
+func (t *MemoryTable) Cols() []*table.Column {
 	return t.Columns
 }
 
@@ -146,7 +146,7 @@ func (t *MemoryTable) IndexPrefix() kv.Key {
 }
 
 // RecordKey implements table.Table RecordKey interface.
-func (t *MemoryTable) RecordKey(h int64, col *table.Col) kv.Key {
+func (t *MemoryTable) RecordKey(h int64, col *table.Column) kv.Key {
 	colID := int64(0)
 	if col != nil {
 		colID = col.ID
@@ -205,7 +205,7 @@ func (t *MemoryTable) AddRecord(ctx context.Context, r []types.Datum) (recordID 
 }
 
 // RowWithCols implements table.Table RowWithCols interface.
-func (t *MemoryTable) RowWithCols(ctx context.Context, h int64, cols []*table.Col) ([]types.Datum, error) {
+func (t *MemoryTable) RowWithCols(ctx context.Context, h int64, cols []*table.Column) ([]types.Datum, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	item := t.tree.Get(itemKey(h))
@@ -256,7 +256,7 @@ func (t *MemoryTable) RebaseAutoID(newBase int64, isSetStep bool) error {
 }
 
 // IterRecords implements table.Table IterRecords interface.
-func (t *MemoryTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.Col,
+func (t *MemoryTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.Column,
 	fn table.RecordIterFunc) error {
 	return nil
 }

--- a/table/tables/memory_tables.go
+++ b/table/tables/memory_tables.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/petar/GoLLRB/llrb"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -65,8 +64,8 @@ func (k itemKey) Less(item llrb.Item) bool {
 type MemoryTable struct {
 	ID          int64
 	Name        model.CIStr
-	Columns     []*column.Col
-	pkHandleCol *column.Col
+	Columns     []*table.Col
+	pkHandleCol *table.Col
 
 	recordPrefix kv.Key
 	alloc        autoid.Allocator
@@ -78,10 +77,10 @@ type MemoryTable struct {
 
 // MemoryTableFromMeta creates a Table instance from model.TableInfo.
 func MemoryTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Table, error) {
-	columns := make([]*column.Col, 0, len(tblInfo.Columns))
-	var pkHandleColumn *column.Col
+	columns := make([]*table.Col, 0, len(tblInfo.Columns))
+	var pkHandleColumn *table.Col
 	for _, colInfo := range tblInfo.Columns {
-		col := &column.Col{ColumnInfo: *colInfo}
+		col := &table.Col{ColumnInfo: *colInfo}
 		columns = append(columns, col)
 		if col.IsPKHandleColumn(tblInfo) {
 			pkHandleColumn = col
@@ -94,7 +93,7 @@ func MemoryTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (tabl
 }
 
 // newMemoryTable constructs a MemoryTable instance.
-func newMemoryTable(tableID int64, tableName string, cols []*column.Col, alloc autoid.Allocator) *MemoryTable {
+func newMemoryTable(tableID int64, tableName string, cols []*table.Col, alloc autoid.Allocator) *MemoryTable {
 	name := model.NewCIStr(tableName)
 	t := &MemoryTable{
 		ID:           tableID,
@@ -122,7 +121,7 @@ func (t *MemoryTable) Seek(ctx context.Context, handle int64) (int64, bool, erro
 }
 
 // Indices implements table.Table Indices interface.
-func (t *MemoryTable) Indices() []*column.IndexedCol {
+func (t *MemoryTable) Indices() []*table.IndexedCol {
 	return nil
 }
 
@@ -132,7 +131,7 @@ func (t *MemoryTable) Meta() *model.TableInfo {
 }
 
 // Cols implements table.Table Cols interface.
-func (t *MemoryTable) Cols() []*column.Col {
+func (t *MemoryTable) Cols() []*table.Col {
 	return t.Columns
 }
 
@@ -147,7 +146,7 @@ func (t *MemoryTable) IndexPrefix() kv.Key {
 }
 
 // RecordKey implements table.Table RecordKey interface.
-func (t *MemoryTable) RecordKey(h int64, col *column.Col) kv.Key {
+func (t *MemoryTable) RecordKey(h int64, col *table.Col) kv.Key {
 	colID := int64(0)
 	if col != nil {
 		colID = col.ID
@@ -206,7 +205,7 @@ func (t *MemoryTable) AddRecord(ctx context.Context, r []types.Datum) (recordID 
 }
 
 // RowWithCols implements table.Table RowWithCols interface.
-func (t *MemoryTable) RowWithCols(ctx context.Context, h int64, cols []*column.Col) ([]types.Datum, error) {
+func (t *MemoryTable) RowWithCols(ctx context.Context, h int64, cols []*table.Col) ([]types.Datum, error) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	item := t.tree.Get(itemKey(h))
@@ -257,7 +256,7 @@ func (t *MemoryTable) RebaseAutoID(newBase int64, isSetStep bool) error {
 }
 
 // IterRecords implements table.Table IterRecords interface.
-func (t *MemoryTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*column.Col,
+func (t *MemoryTable) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.Col,
 	fn table.RecordIterFunc) error {
 	return nil
 }

--- a/table/tables/memory_tables_test.go
+++ b/table/tables/memory_tables_test.go
@@ -16,7 +16,6 @@ package tables_test
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -97,7 +96,7 @@ func (ts *testMemoryTableSuite) TestMemoryBasic(c *C) {
 	_, err = tb.AddRecord(ctx, types.MakeDatums(2, "abc"))
 	c.Assert(err, IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		return true, nil
 	})
 
@@ -106,7 +105,7 @@ func (ts *testMemoryTableSuite) TestMemoryBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*column.Col{tb.Cols()[1]}
+	cols := []*table.Col{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, rid, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)

--- a/table/tables/memory_tables_test.go
+++ b/table/tables/memory_tables_test.go
@@ -96,7 +96,7 @@ func (ts *testMemoryTableSuite) TestMemoryBasic(c *C) {
 	_, err = tb.AddRecord(ctx, types.MakeDatums(2, "abc"))
 	c.Assert(err, IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		return true, nil
 	})
 
@@ -105,7 +105,7 @@ func (ts *testMemoryTableSuite) TestMemoryBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*table.Col{tb.Cols()[1]}
+	cols := []*table.Column{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, rid, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
-	"github.com/pingcap/tidb/column"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
+	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testleak"
@@ -87,7 +87,7 @@ func (ts *testSuite) TestBasic(c *C) {
 
 	c.Assert(tb.UpdateRecord(ctx, rid, types.MakeDatums(1, "abc"), types.MakeDatums(1, "cba"), map[int]bool{0: false, 1: true}), IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*column.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
 		return true, nil
 	})
 
@@ -102,7 +102,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*column.Col{tb.Cols()[1]}
+	cols := []*table.Col{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, 1, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -87,7 +87,7 @@ func (ts *testSuite) TestBasic(c *C) {
 
 	c.Assert(tb.UpdateRecord(ctx, rid, types.MakeDatums(1, "abc"), types.MakeDatums(1, "cba"), map[int]bool{0: false, 1: true}), IsNil)
 
-	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Col) (bool, error) {
+	tb.IterRecords(ctx, tb.FirstKey(), tb.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		return true, nil
 	})
 
@@ -102,7 +102,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 2)
 	c.Assert(vals[0].GetInt64(), Equals, int64(1))
-	cols := []*table.Col{tb.Cols()[1]}
+	cols := []*table.Column{tb.Cols()[1]}
 	vals, err = tb.RowWithCols(ctx, 1, cols)
 	c.Assert(err, IsNil)
 	c.Assert(vals, HasLen, 1)


### PR DESCRIPTION
`index` was originally in `kv` package which doesn't have the concept of `index`, and `column` is an element in `table`, separate `column` and `table` doesn't make much sense and we have to make a lot of effort to avoid dependency loop.