### PR TITLE
*: Refactor dist-agg partial result data layout

### DIFF
--- a/executor/aggregate_xapi.go
+++ b/executor/aggregate_xapi.go
@@ -169,13 +169,12 @@ func (e *XAggregateExec) innerNext() (bool, error) {
 	for _, agg := range e.aggregaters {
 		var count uint64
 		var value types.Datum
-		if agg.name == ast.AggFuncCount || agg.name == ast.AggFuncAvg {
+		if needCount(agg.name) {
 			// count partial result field
 			count = row.Data[cursor].GetUint64()
 			cursor++
 		}
-		if agg.name == ast.AggFuncSum || agg.name == ast.AggFuncAvg || agg.name == ast.AggFuncFirstRow ||
-			agg.name == ast.AggFuncMax || agg.name == ast.AggFuncMin || agg.name == ast.AggFuncGroupConcat {
+		if needValue(agg.name) {
 			// value partial result field
 			value = row.Data[cursor]
 			cursor++
@@ -195,4 +194,17 @@ func (e *XAggregateExec) Close() error {
 		return e.Src.Close()
 	}
 	return nil
+}
+
+// The argument if the name of a aggregate function.
+// This function will check if the aggregate function need count in partial result.
+func needCount(name string) bool {
+	return name == ast.AggFuncCount || name == ast.AggFuncAvg
+}
+
+// The argument if the name of a aggregate function.
+// This function will check if the aggregate function need value in partial result.
+func needValue(name string) bool {
+	return name == ast.AggFuncSum || name == ast.AggFuncAvg || name == ast.AggFuncFirstRow ||
+		name == ast.AggFuncMax || name == ast.AggFuncMin || name == ast.AggFuncGroupConcat
 }

--- a/executor/aggregate_xapi_test.go
+++ b/executor/aggregate_xapi_test.go
@@ -52,11 +52,11 @@ func (s *testAggFuncSuite) TestXAPICount(c *C) {
 	// Return row:
 	// GroupKey, Count, Value
 	// Partial result from region1
-	row1 := types.MakeDatums([]byte{1}, 2, nil)
-	row2 := types.MakeDatums([]byte{2}, 1, nil)
+	row1 := types.MakeDatums([]byte{1}, 2)
+	row2 := types.MakeDatums([]byte{2}, 1)
 	// Partial result from region2
-	row3 := types.MakeDatums([]byte{1}, 1, nil)
-	row4 := types.MakeDatums([]byte{2}, 1, nil)
+	row3 := types.MakeDatums([]byte{1}, 1)
+	row4 := types.MakeDatums([]byte{2}, 1)
 	data := []([]types.Datum){row1, row2, row3, row4}
 
 	rows := make([]*Row, 0, 3)

--- a/executor/aggregate_xapi_test.go
+++ b/executor/aggregate_xapi_test.go
@@ -50,7 +50,7 @@ func (s *testAggFuncSuite) TestXAPICount(c *C) {
 		Args: []ast.ExprNode{col2},
 	}
 	// Return row:
-	// GroupKey, Count, Value
+	// GroupKey, Count
 	// Partial result from region1
 	row1 := types.MakeDatums([]byte{1}, 2)
 	row2 := types.MakeDatums([]byte{2}, 1)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"math"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
@@ -407,19 +408,30 @@ func (b *executorBuilder) buildAggregate(v *plan.Aggregate) Executor {
 	// We should infer fields type.
 	// Each agg item will be splitted into two datums: count and value
 	// The first field should be group key.
-	fields := make([]*types.FieldType, 1+2*len(v.AggFuncs))
+	fields := make([]*types.FieldType, 0, 1+2*len(v.AggFuncs))
 	gk := types.NewFieldType(mysql.TypeBlob)
 	gk.Charset = charset.CharsetBin
 	gk.Collate = charset.CollationBin
-	fields[0] = gk
-	// There will be two fields in the result row for each AggregateFuncExpr.
-	for i, agg := range v.AggFuncs {
-		ft := types.NewFieldType(mysql.TypeLonglong)
-		ft.Flen = 21
-		ft.Charset = charset.CharsetBin
-		ft.Collate = charset.CollationBin
-		fields[2*i+1] = ft
-		fields[2*i+2] = agg.GetType()
+	fields = append(fields, gk)
+	// There will be one or two fields in the result row for each AggregateFuncExpr.
+	// Count needs count partial result field.
+	// Sum, FirstRow, Max, Min, GroupConcat need value partial result field.
+	// Avg needs both count and value partial result field.
+	for _, agg := range v.AggFuncs {
+		name := strings.ToLower(agg.F)
+		if name == ast.AggFuncCount || name == ast.AggFuncAvg {
+			// count partial result field
+			ft := types.NewFieldType(mysql.TypeLonglong)
+			ft.Flen = 21
+			ft.Charset = charset.CharsetBin
+			ft.Collate = charset.CollationBin
+			fields = append(fields, ft)
+		}
+		if name == ast.AggFuncSum || name == ast.AggFuncAvg || name == ast.AggFuncFirstRow ||
+			name == ast.AggFuncMax || name == ast.AggFuncMin || name == ast.AggFuncGroupConcat {
+			// value partial result field
+			fields = append(fields, agg.GetType())
+		}
 	}
 	xSrc.AddAggregate(pbAggFuncs, pbByItems, fields)
 	hasGroupBy := len(v.GroupByItems) > 0

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -419,7 +419,7 @@ func (b *executorBuilder) buildAggregate(v *plan.Aggregate) Executor {
 	// Avg needs both count and value partial result field.
 	for _, agg := range v.AggFuncs {
 		name := strings.ToLower(agg.F)
-		if name == ast.AggFuncCount || name == ast.AggFuncAvg {
+		if needCount(name) {
 			// count partial result field
 			ft := types.NewFieldType(mysql.TypeLonglong)
 			ft.Flen = 21
@@ -427,8 +427,7 @@ func (b *executorBuilder) buildAggregate(v *plan.Aggregate) Executor {
 			ft.Collate = charset.CollationBin
 			fields = append(fields, ft)
 		}
-		if name == ast.AggFuncSum || name == ast.AggFuncAvg || name == ast.AggFuncFirstRow ||
-			name == ast.AggFuncMax || name == ast.AggFuncMin || name == ast.AggFuncGroupConcat {
+		if needValue(name) {
 			// value partial result field
 			fields = append(fields, agg.GetType())
 		}

--- a/store/localstore/local_aggregate.go
+++ b/store/localstore/local_aggregate.go
@@ -114,14 +114,7 @@ func (n *aggregateFuncExpr) toDatums() []types.Datum {
 // Convert count and value to datum list.
 func (n *aggregateFuncExpr) getCountValue() []types.Datum {
 	item := n.getAggItem()
-	if item == nil {
-		// TODO: should this happen?
-		return nil
-	}
-	ds := make([]types.Datum, 2)
-	ds[0] = types.NewUintDatum(item.count)
-	ds[1] = item.value
-	return ds
+	return []types.Datum{types.NewUintDatum(item.count)}
 }
 
 var singleGroupKey = []byte("SingleGroup")

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -164,27 +164,22 @@ func (rs *localRegion) getRowsFromSelectReq(ctx *selectContext) ([]*tipb.Row, er
 /*
  * Convert aggregate partial result to rows.
  * Data layout example:
- *	SQL:	select count(c1), sum(c2) from t;
- *	Aggs:	count(c1), sum(c2)
- *	Rows:	groupKey1, count1, value1, count2, value2
- *		groupKey2, count1, value1, count2, value2
+ *	SQL:	select count(c1), sum(c2), avg(c3) from t;
+ *	Aggs:	count(c1), sum(c2), avg(c3)
+ *	Rows:	groupKey1, count1, value2, count3, value3
+ *		groupKey2, count1, value2, count3, value3
  */
 func (rs *localRegion) getRowsFromAgg(ctx *selectContext) ([]*tipb.Row, error) {
 	rows := make([]*tipb.Row, 0, len(ctx.groupKeys))
 	for _, gk := range ctx.groupKeys {
 		row := new(tipb.Row)
 		// Each aggregate partial result will be converted to two datum.
-		rowData := make([]types.Datum, 1+2*len(ctx.aggregates))
+		rowData := make([]types.Datum, 0, 1+2*len(ctx.aggregates))
 		// The first column is group key.
-		rowData[0] = types.NewBytesDatum(gk)
-		for i, agg := range ctx.aggregates {
+		rowData = append(rowData, types.NewBytesDatum(gk))
+		for _, agg := range ctx.aggregates {
 			agg.currentGroup = gk
-			ds := agg.toDatums()
-			if ds == nil {
-				return nil, errors.Errorf("Aggregate partial result is nil. This should not happend!")
-			}
-			rowData[2*i+1] = ds[0]
-			rowData[2*i+2] = ds[1]
+			rowData = append(rowData, agg.toDatums()...)
 		}
 		var err error
 		row.Data, err = codec.EncodeValue(nil, rowData...)

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -173,7 +173,7 @@ func (rs *localRegion) getRowsFromAgg(ctx *selectContext) ([]*tipb.Row, error) {
 	rows := make([]*tipb.Row, 0, len(ctx.groupKeys))
 	for _, gk := range ctx.groupKeys {
 		row := new(tipb.Row)
-		// Each aggregate partial result will be converted to two datum.
+		// Each aggregate partial result will be converted to one or two datums.
 		rowData := make([]types.Datum, 0, 1+2*len(ctx.aggregates))
 		// The first column is group key.
 		rowData = append(rowData, types.NewBytesDatum(gk))


### PR DESCRIPTION
Make result more compact. @coocood @BusyJay 
For example, count() do not need value field and sum() do not need count field.
SQL:	select count(c1), sum(c2), avg(c3) from t;
Aggs:	count(c1), sum(c2), avg(c3)
Rows:
Before this PR:
         	groupKey1, count1, value1, count2, value2, count3, value3
                groupKey2, count1, value1, count2, value2, count3, value3
After this PR:
                groupKey1, count1, value2, count3, value3
                groupKey2, count1, value2, count3, value3