### PR TITLE
*: Support xapi first row aggregate function in local store.

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -392,6 +392,7 @@ func (a *AggregateFuncExtractor) Leave(n Node) (node Node, ok bool) {
 				Args: []ExprNode{v},
 			}
 			agg.SetFlag((v.GetFlag() | FlagHasAggregateFunc))
+			agg.SetType(v.GetType())
 			a.AggFuncs = append(a.AggFuncs, agg)
 			return agg, true
 		}

--- a/executor/aggregate_xapi.go
+++ b/executor/aggregate_xapi.go
@@ -41,6 +41,8 @@ func (n *finalAggregater) update(count uint64, value types.Datum) error {
 	switch n.name {
 	case ast.AggFuncCount:
 		return n.updateCount(count)
+	case ast.AggFuncFirstRow:
+		return n.updateFirst(value)
 	}
 	return nil
 }
@@ -60,6 +62,16 @@ func (n *finalAggregater) getContext() *ast.AggEvaluateContext {
 func (n *finalAggregater) updateCount(count uint64) error {
 	ctx := n.getContext()
 	ctx.Count += int64(count)
+	return nil
+}
+
+func (n *finalAggregater) updateFirst(val types.Datum) error {
+	ctx := n.getContext()
+	if ctx.Evaluated {
+		return nil
+	}
+	ctx.Value = val.GetValue()
+	ctx.Evaluated = true
 	return nil
 }
 

--- a/executor/aggregate_xapi_test.go
+++ b/executor/aggregate_xapi_test.go
@@ -97,3 +97,84 @@ func (s *testAggFuncSuite) TestXAPICount(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, testutil.DatumEquals, types.NewDatum(int64(0)))
 }
+
+func (s *testAggFuncSuite) TestXAPIFirstRow(c *C) {
+	defer testleak.AfterTest(c)()
+	// Compose aggregate exec for "select c2 from t groupby c1";
+	// c1  c2
+	// 1	11	// region1
+	// 2	21	// region1
+	// 1    1	// region1
+	// 1    nil	// region2
+	// 1    3	// region2
+	// 3    31	// region2
+	//
+	// Expected result:
+	// c2
+	// 11
+	// 21
+	// 31
+	c1 := ast.NewValueExpr([]byte{0})
+	rf1 := &ast.ResultField{Expr: c1}
+	c2 := ast.NewValueExpr(0)
+	rf2 := &ast.ResultField{Expr: c2}
+	col2 := &ast.ColumnNameExpr{Refer: rf2}
+	fc := &ast.AggregateFuncExpr{
+		F:    ast.AggFuncFirstRow,
+		Args: []ast.ExprNode{col2},
+	}
+	// Return row:
+	// GroupKey, Count
+	// Partial result from region1
+	row1 := types.MakeDatums([]byte{1}, 11)
+	row2 := types.MakeDatums([]byte{2}, 21)
+	// Partial result from region2
+	row3 := types.MakeDatums([]byte{1}, nil)
+	row4 := types.MakeDatums([]byte{3}, 31)
+	data := []([]types.Datum){row1, row2, row3, row4}
+
+	rows := make([]*Row, 0, 3)
+	for _, d := range data {
+		rows = append(rows, &Row{Data: d})
+	}
+	src := &mockExec{
+		rows:   rows,
+		fields: []*ast.ResultField{rf1, rf2},
+	}
+	agg := &XAggregateExec{
+		AggFuncs: []*ast.AggregateFuncExpr{fc},
+		Src:      src,
+	}
+	ast.SetFlag(fc)
+	var (
+		row *Row
+		err error
+	)
+	// First Row: 11
+	row, err = agg.Next()
+	c.Assert(err, IsNil)
+	c.Assert(row, NotNil)
+	ctx := mock.NewContext()
+	val, err := evaluator.Eval(ctx, fc)
+	c.Assert(err, IsNil)
+	c.Assert(val, testutil.DatumEquals, types.NewDatum(int64(11)))
+	// Second Row: 21
+	row, err = agg.Next()
+	c.Assert(err, IsNil)
+	c.Assert(row, NotNil)
+	val, err = evaluator.Eval(ctx, fc)
+	c.Assert(err, IsNil)
+	c.Assert(val, testutil.DatumEquals, types.NewDatum(int64(21)))
+	// Third Row: 31
+	row, err = agg.Next()
+	c.Assert(err, IsNil)
+	c.Assert(row, NotNil)
+	val, err = evaluator.Eval(ctx, fc)
+	c.Assert(err, IsNil)
+	c.Assert(val, testutil.DatumEquals, types.NewDatum(int64(31)))
+	agg.Close()
+	// After clear up, fc's value should be default.
+	val, err = evaluator.Eval(ctx, fc)
+	c.Assert(err, IsNil)
+	c.Assert(val, testutil.DatumEquals, types.NewDatum(nil))
+}

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -167,6 +167,7 @@ func (b *planBuilder) extractSelectAgg(sel *ast.SelectStmt) []*ast.AggregateFunc
 				F:    ast.AggFuncFirstRow,
 				Args: []ast.ExprNode{ve},
 			}
+			agg.SetType(ve.GetType())
 			extractor.AggFuncs = append(extractor.AggFuncs, agg)
 			n = agg
 		}

--- a/store/localstore/local_client.go
+++ b/store/localstore/local_client.go
@@ -68,7 +68,7 @@ func supportExpr(exprType tipb.ExprType) bool {
 		return true
 	case tipb.ExprType_Plus, tipb.ExprType_Div:
 		return true
-	case tipb.ExprType_Count:
+	case tipb.ExprType_Count, tipb.ExprType_First:
 		return true
 	case kv.ReqSubTypeDesc:
 		return true


### PR DESCRIPTION
In sql statement "select c1 from t groupby c2", c1 will be converted from ColumnNameExpr to AggFuncFirstRow. For each group, we only keep the first value of c1.
This is implemented in localstore xapi now.
@coocood @zimulala @BusyJay 
