### PR TITLE
Rename err2 to err1 where possible

### DIFF
--- a/executor/executor_ddl_test.go
+++ b/executor/executor_ddl_test.go
@@ -58,8 +58,8 @@ func (s *testSuite) TestCreateTable(c *C) {
 	rs, err := tk.Exec(`desc issue312_1`)
 	c.Assert(err, IsNil)
 	for {
-		row, err2 := rs.Next()
-		c.Assert(err2, IsNil)
+		row, err1 := rs.Next()
+		c.Assert(err1, IsNil)
 		if row == nil {
 			break
 		}
@@ -68,8 +68,8 @@ func (s *testSuite) TestCreateTable(c *C) {
 	rs, err = tk.Exec(`desc issue312_2`)
 	c.Assert(err, IsNil)
 	for {
-		row, err2 := rs.Next()
-		c.Assert(err2, IsNil)
+		row, err1 := rs.Next()
+		c.Assert(err1, IsNil)
 		if row == nil {
 			break
 		}

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -98,14 +98,14 @@ func (e *GrantExec) Next() (*Row, error) {
 			if len(priv.Cols) > 0 {
 				// Check column scope privilege entry.
 				// TODO: Check validity before insert new entry.
-				err1 := e.checkAndInitColumnPriv(userName, host, priv.Cols)
-				if err1 != nil {
-					return nil, errors.Trace(err1)
+				err := e.checkAndInitColumnPriv(userName, host, priv.Cols)
+				if err != nil {
+					return nil, errors.Trace(err)
 				}
 			}
-			err2 := e.grantPriv(priv, user)
-			if err2 != nil {
-				return nil, errors.Trace(err2)
+			err := e.grantPriv(priv, user)
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
 		}
 	}

--- a/store/localstore/boltdb/boltdb.go
+++ b/store/localstore/boltdb/boltdb.go
@@ -115,17 +115,16 @@ func (d *db) Commit(b engine.Batch) error {
 	}
 	err := d.DB.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(bucketName)
-		// err1 is used for passing `go tool vet --shadow` check.
-		var err1 error
+		var err error
 		for _, w := range bt.writes {
 			if !w.isDelete {
-				err1 = b.Put(w.key, w.value)
+				err = b.Put(w.key, w.value)
 			} else {
-				err1 = b.Delete(w.key)
+				err = b.Delete(w.key)
 			}
 
-			if err1 != nil {
-				return errors.Trace(err1)
+			if err != nil {
+				return errors.Trace(err)
 			}
 		}
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -670,17 +670,17 @@ func (s *testKVSuite) TestIsolationMultiInc(c *C) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < incCnt; j++ {
-				err1 := kv.RunInNewTxn(s.s, true, func(txn kv.Transaction) error {
+				err := kv.RunInNewTxn(s.s, true, func(txn kv.Transaction) error {
 					for _, key := range keys {
-						_, err2 := kv.IncInt64(txn, key, 1)
-						if err2 != nil {
-							return err2
+						_, err1 := kv.IncInt64(txn, key, 1)
+						if err1 != nil {
+							return err1
 						}
 					}
 
 					return nil
 				})
-				c.Assert(err1, IsNil)
+				c.Assert(err, IsNil)
 			}
 		}()
 	}

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -143,11 +143,11 @@ func (s *testTiclientSuite) TestCleanLock(c *C) {
 
 	txn2 := s.beginTxn(c)
 	for i := 0; i < keyNum; i++ {
-		err2 := txn2.Set(encodeKey(s.prefix, s08d("key", i)), valueBytes(i+1))
-		c.Assert(err2, IsNil)
+		err := txn2.Set(encodeKey(s.prefix, s08d("key", i)), valueBytes(i+1))
+		c.Assert(err, IsNil)
 	}
-	err2 := txn2.Commit()
-	c.Assert(err2, IsNil)
+	err1 := txn2.Commit()
+	c.Assert(err1, IsNil)
 }
 
 func (s *testTiclientSuite) TestNotExist(c *C) {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -92,8 +92,8 @@ func (ts *testSuite) TestBasic(c *C) {
 	})
 
 	indexCnt := func() int {
-		cnt, err2 := countEntriesWithPrefix(ctx, tb.IndexPrefix())
-		c.Assert(err2, IsNil)
+		cnt, err1 := countEntriesWithPrefix(ctx, tb.IndexPrefix())
+		c.Assert(err1, IsNil)
 		return cnt
 	}
 

--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -196,9 +196,9 @@ func StrToFloat(str string) (float64, error) {
 	if validStr != str {
 		err = ErrValueTruncated
 	}
-	f, err2 := strconv.ParseFloat(validStr, 64)
+	f, err1 := strconv.ParseFloat(validStr, 64)
 	if err == nil {
-		err = err2
+		err = err1
 	}
 	return f, errors.Trace(err)
 }


### PR DESCRIPTION
https://github.com/pingcap/tidb/pull/1330#discussion_r67594923
> We default err is err0, so here err2 -> err1 is beterr.

So here is a pull request to improve consistency with this rule.

I confirmed `make` passes with this pull request (that is, both `go tool vet -shadow .` and `go build` passes).