### PR TITLE
table/tables: fix IterRecords.

### DIFF
--- a/inspectkv/inspectkv.go
+++ b/inspectkv/inspectkv.go
@@ -463,7 +463,11 @@ func iterRecords(retriever kv.Retriever, t table.Table, startKey kv.Key, cols []
 		}
 		data := make([]types.Datum, 0, len(cols))
 		for _, col := range cols {
-			data = append(data, rowMap[col.ID])
+			if col.IsPKHandleColumn(t.Meta()) {
+				data = append(data, types.NewIntDatum(handle))
+			} else {
+				data = append(data, rowMap[col.ID])
+			}
 		}
 		more, err := fn(handle, data, cols)
 		if !more || err != nil {

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -627,7 +627,11 @@ func (t *Table) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.
 		}
 		data := make([]types.Datum, 0, len(cols))
 		for _, col := range cols {
-			data = append(data, rowMap[col.ID])
+			if col.IsPKHandleColumn(t.Meta()) {
+				data = append(data, types.NewIntDatum(handle))
+			} else {
+				data = append(data, rowMap[col.ID])
+			}
 		}
 		more, err := fn(handle, data, cols)
 		if !more || err != nil {


### PR DESCRIPTION
We should append handle for PK handle column as it is not stored in row value.