### PR TITLE
ddl: fix prepare background job.

### DIFF
--- a/ddl/bg_worker.go
+++ b/ddl/bg_worker.go
@@ -99,7 +99,7 @@ func (d *ddl) runBgJob(t *meta.Meta, job *model.Job) {
 }
 
 // prepareBgJob prepares a background job.
-func (d *ddl) prepareBgJob(ddlJob *model.Job) error {
+func (d *ddl) prepareBgJob(t *meta.Meta, ddlJob *model.Job) error {
 	job := &model.Job{
 		ID:       ddlJob.ID,
 		SchemaID: ddlJob.SchemaID,
@@ -107,14 +107,7 @@ func (d *ddl) prepareBgJob(ddlJob *model.Job) error {
 		Type:     ddlJob.Type,
 		Args:     ddlJob.Args,
 	}
-
-	err := kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
-		t := meta.NewMeta(txn)
-		err1 := t.EnQueueBgJob(job)
-
-		return errors.Trace(err1)
-	})
-
+	err := t.EnQueueBgJob(job)
 	return errors.Trace(err)
 }
 

--- a/ddl/bg_worker_test.go
+++ b/ddl/bg_worker_test.go
@@ -40,7 +40,11 @@ func (s *testDDLSuite) TestDropSchemaError(c *C) {
 			Name: model.CIStr{O: "test"},
 		}},
 	}
-	d.prepareBgJob(job)
+	err := kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		t := meta.NewMeta(txn)
+		return d.prepareBgJob(t, job)
+	})
+	c.Check(err, IsNil)
 	d.startBgJob(job.Type)
 
 	time.Sleep(lease)
@@ -79,7 +83,11 @@ func (s *testDDLSuite) TestDropTableError(c *C) {
 			Name: model.CIStr{O: "t"},
 		}},
 	}
-	d.prepareBgJob(job)
+	err := kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		t := meta.NewMeta(txn)
+		return d.prepareBgJob(t, job)
+	})
+	c.Check(err, IsNil)
 	d.startBgJob(job.Type)
 
 	time.Sleep(lease)
@@ -100,7 +108,11 @@ func (s *testDDLSuite) TestInvalidBgJobType(c *C) {
 		TableID:  1,
 		Type:     model.ActionCreateTable,
 	}
-	d.prepareBgJob(job)
+	err := kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		t := meta.NewMeta(txn)
+		return d.prepareBgJob(t, job)
+	})
+	c.Check(err, IsNil)
 	d.startBgJob(model.ActionDropTable)
 
 	time.Sleep(lease)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -176,7 +176,7 @@ func (d *ddl) finishDDLJob(t *meta.Meta, job *model.Job) error {
 	}
 	switch job.Type {
 	case model.ActionDropSchema, model.ActionDropTable:
-		if err = d.prepareBgJob(job); err != nil {
+		if err = d.prepareBgJob(t, job); err != nil {
 			return errors.Trace(err)
 		}
 	}


### PR DESCRIPTION
`prepareBgJob` should run in the same transaction as `handleDDLJobQueue`.