### PR TITLE
*: remove an unnecessary rand.NewSource

### DIFF
--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
@@ -355,7 +354,6 @@ func (e *SimpleExec) createStatisticsForTable(tn *ast.TableName) error {
 // collectSamples collects sample from the result set, using Reservoir Sampling algorithm.
 // See https://en.wikipedia.org/wiki/Reservoir_sampling
 func (e *SimpleExec) collectSamples(result ast.RecordSet) (count int64, samples []*ast.Row, err error) {
-	ran := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
 		var row *ast.Row
 		row, err = result.Next()
@@ -368,9 +366,9 @@ func (e *SimpleExec) collectSamples(result ast.RecordSet) (count int64, samples 
 		if len(samples) < maxSampleCount {
 			samples = append(samples, row)
 		} else {
-			shouldAdd := ran.Int63n(count) < maxSampleCount
+			shouldAdd := rand.Int63n(count) < maxSampleCount
 			if shouldAdd {
-				idx := ran.Intn(maxSampleCount)
+				idx := rand.Intn(maxSampleCount)
 				samples[idx] = row
 			}
 		}


### PR DESCRIPTION
pprof shows this is a bottleneck
tidb-bench result before vs after:
insert test data finished ... elapse : 24.335341s tps:410.925003
insert test data finished ... elapse : 17.825512s tps:560.993715