### PR TITLE
ddl: improve ddl test

### DIFF
--- a/ddl/bg_worker_test.go
+++ b/ddl/bg_worker_test.go
@@ -29,8 +29,7 @@ func (s *testDDLSuite) TestDropSchemaError(c *C) {
 	store := testCreateStore(c, "test_drop_schema")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-	d := newDDL(store, nil, nil, lease)
+	d := newDDL(store, nil, nil, testLease)
 	defer d.close()
 
 	job := &model.Job{
@@ -47,7 +46,7 @@ func (s *testDDLSuite) TestDropSchemaError(c *C) {
 	c.Check(err, IsNil)
 	d.startBgJob(job.Type)
 
-	time.Sleep(lease)
+	time.Sleep(testLease)
 	verifyBgJobState(c, d, job, model.JobDone)
 }
 
@@ -68,8 +67,7 @@ func (s *testDDLSuite) TestDropTableError(c *C) {
 	store := testCreateStore(c, "test_drop_table")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-	d := newDDL(store, nil, nil, lease)
+	d := newDDL(store, nil, nil, testLease)
 	defer d.close()
 
 	dbInfo := testSchemaInfo(c, d, "test")
@@ -90,7 +88,7 @@ func (s *testDDLSuite) TestDropTableError(c *C) {
 	c.Check(err, IsNil)
 	d.startBgJob(job.Type)
 
-	time.Sleep(lease)
+	time.Sleep(testLease)
 	verifyBgJobState(c, d, job, model.JobDone)
 }
 
@@ -99,8 +97,7 @@ func (s *testDDLSuite) TestInvalidBgJobType(c *C) {
 	store := testCreateStore(c, "test_invalid_bg_job_type")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-	d := newDDL(store, nil, nil, lease)
+	d := newDDL(store, nil, nil, testLease)
 	defer d.close()
 
 	job := &model.Job{
@@ -115,6 +112,6 @@ func (s *testDDLSuite) TestInvalidBgJobType(c *C) {
 	c.Check(err, IsNil)
 	d.startBgJob(model.ActionDropTable)
 
-	time.Sleep(lease)
+	time.Sleep(testLease)
 	verifyBgJobState(c, d, job, model.JobCancelled)
 }

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -32,8 +32,7 @@ func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 	}
 	err := kv.RunInNewTxn(s.store, true, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
-		err1 := errors.Trace(t.CreateDatabase(s.dbInfo))
-		return errors.Trace(err1)
+		return errors.Trace(t.CreateDatabase(s.dbInfo))
 	})
 	c.Check(err, IsNil)
 }

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -1,0 +1,273 @@
+package ddl
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
+	"github.com/pingcap/tidb/meta/autoid"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/types"
+)
+
+var _ = Suite(&testColumnChangeSuite{})
+
+type testColumnChangeSuite struct {
+	store  kv.Storage
+	dbInfo *model.DBInfo
+}
+
+func (s *testColumnChangeSuite) SetUpSuite(c *C) {
+	s.store = testCreateStore(c, "test_column_change")
+	log.Errorf("test column change store %s", s.store.UUID())
+	s.dbInfo = &model.DBInfo{
+		Name: model.NewCIStr("test_column_change"),
+		ID:   1,
+	}
+	err := kv.RunInNewTxn(s.store, true, func(txn kv.Transaction) error {
+		t := meta.NewMeta(txn)
+		err1 := errors.Trace(t.CreateDatabase(s.dbInfo))
+		return errors.Trace(err1)
+	})
+	c.Check(err, IsNil)
+}
+
+func (s *testColumnChangeSuite) TestColumnChange(c *C) {
+	defer testleak.AfterTest(c)()
+	d := newDDL(s.store, nil, nil, testLease)
+	// create table t (c1 int, c2 int);
+	tblInfo := testTableInfo(c, d, "t", 2)
+	ctx := testNewContext(c, d)
+	_, err := ctx.GetTxn(true)
+	c.Assert(err, IsNil)
+	testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
+	// insert t values (1, 2);
+	originTable := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
+	row := types.MakeDatums(1, 2)
+	_, err = originTable.AddRecord(ctx, row)
+	c.Assert(err, IsNil)
+	err = ctx.CommitTxn()
+	c.Assert(err, IsNil)
+
+	tc := &testDDLCallback{}
+	// set up hook
+	prevState := model.StateNone
+	var (
+		deleteOnlyTable table.Table
+		writeOnlyTable  table.Table
+		publicTable     table.Table
+	)
+	var checkErr error
+	tc.onJobUpdated = func(job *model.Job) {
+		if job.SchemaState == prevState {
+			return
+		}
+		prevState = job.SchemaState
+		var err error
+		switch job.SchemaState {
+		case model.StateDeleteOnly:
+			deleteOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
+			if err != nil {
+				checkErr = errors.Trace(err)
+			}
+		case model.StateWriteOnly:
+			writeOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
+			if err != nil {
+				checkErr = errors.Trace(err)
+			}
+			err = s.checkAddWriteOnly(d, ctx, deleteOnlyTable, writeOnlyTable)
+			if err != nil {
+				checkErr = errors.Trace(err)
+			}
+		case model.StatePublic:
+			publicTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
+			if err != nil {
+				checkErr = errors.Trace(err)
+			}
+			err = s.checkAddPublic(d, ctx, writeOnlyTable, publicTable)
+			if err != nil {
+				checkErr = errors.Trace(err)
+			}
+		}
+	}
+	d.hook = tc
+	defaultValue := int64(3)
+	job := testCreateColumn(c, ctx, d, s.dbInfo, tblInfo, "c3", &ast.ColumnPosition{Tp: ast.ColumnPositionNone}, defaultValue)
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
+	testCheckJobDone(c, d, job, true)
+	s.testColumnDrop(c, ctx, d, publicTable)
+	d.close()
+}
+
+func (s *testColumnChangeSuite) testColumnDrop(c *C, ctx context.Context, d *ddl, tbl table.Table) {
+	d.close()
+	dropCol := tbl.Cols()[0]
+	tc := &testDDLCallback{}
+	// set up hook
+	prevState := model.StateNone
+	var checkErr error
+	tc.onJobUpdated = func(job *model.Job) {
+		if job.SchemaState == prevState {
+			return
+		}
+		prevState = job.SchemaState
+		currentTbl, err := getCurrentTable(d, s.dbInfo.ID, tbl.Meta().ID)
+		if err != nil {
+			checkErr = errors.Trace(err)
+		}
+		for _, col := range currentTbl.Cols() {
+			if col.ID == dropCol.ID {
+				checkErr = errors.Errorf("column is not dropped")
+			}
+		}
+	}
+	d.hook = tc
+	d.start()
+	testDropColumn(c, ctx, d, s.dbInfo, tbl.Meta(), dropCol.Name.L, false)
+}
+
+func (s *testColumnChangeSuite) checkAddWriteOnly(d *ddl, ctx context.Context, deleteOnlyTable, writeOnlyTable table.Table) error {
+	// WriteOnlyTable: insert t values (2, 3)
+	_, err := writeOnlyTable.AddRecord(ctx, types.MakeDatums(2, 3))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.CommitTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "1 2 <nil>", "2 3 3"))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// DeleteOnlyTable: select * from t
+	err = checkResult(ctx, deleteOnlyTable, testutil.RowsWithSep(" ", "1 2", "2 3"))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// WriteOnlyTable: update t set c1 = 2 where c1 = 1
+	h, _, err := writeOnlyTable.Seek(ctx, 0)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = writeOnlyTable.UpdateRecord(ctx, h, types.MakeDatums(1, 2), types.MakeDatums(2, 2), touchedMap(writeOnlyTable))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.CommitTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// After we update the first row, its default value is also set.
+	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "2 2 3", "2 3 3"))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// DeleteOnlyTable: delete from t where c2 = 2
+	err = deleteOnlyTable.RemoveRecord(ctx, h, types.MakeDatums(2, 2))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.CommitTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// After delete table has deleted the first row, check the WriteOnly table records.
+	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "2 3 3"))
+	return errors.Trace(err)
+}
+
+func touchedMap(t table.Table) map[int]bool {
+	touched := make(map[int]bool)
+	for _, col := range t.Cols() {
+		touched[col.Offset] = true
+	}
+	return touched
+}
+
+func (s *testColumnChangeSuite) checkAddPublic(d *ddl, ctx context.Context, writeOnlyTable, publicTable table.Table) error {
+	// publicTable Insert t values (4, 4, 4)
+	h, err := publicTable.AddRecord(ctx, types.MakeDatums(4, 4, 4))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.CommitTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// writeOnlyTable update t set c1 = 3 where c1 = 4
+	oldRow, err := writeOnlyTable.RowWithCols(ctx, h, writeOnlyTable.WritableCols())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(oldRow) != 3 {
+		return errors.Errorf("%v", oldRow)
+	}
+	newRow := types.MakeDatums(3, 4, oldRow[2].GetValue())
+	err = writeOnlyTable.UpdateRecord(ctx, h, oldRow, newRow, touchedMap(writeOnlyTable))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.CommitTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// publicTable select * from t, make sure the new c3 value 4 is not overwritten to default value 3.
+	err = checkResult(ctx, publicTable, testutil.RowsWithSep(" ", "2 3 3", "3 4 4"))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func getCurrentTable(d *ddl, schemaID, tableID int64) (table.Table, error) {
+	var tblInfo *model.TableInfo
+	err := kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
+		t := meta.NewMeta(txn)
+		var err error
+		tblInfo, err = t.GetTable(schemaID, tableID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	alloc := autoid.NewAllocator(d.store, schemaID)
+	tbl, err := table.TableFromMeta(alloc, tblInfo)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return tbl, err
+}
+
+func checkResult(ctx context.Context, t table.Table, rows [][]interface{}) error {
+	var gotRows [][]interface{}
+	t.IterRecords(ctx, t.FirstKey(), t.WritableCols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
+		gotRows = append(gotRows, datumsToInterfaces(data))
+		return true, nil
+	})
+	got := fmt.Sprintf("%v", gotRows)
+	expect := fmt.Sprintf("%v", rows)
+	if got != expect {
+		return errors.Errorf("expect %v, got %v", expect, got)
+	}
+	return nil
+}
+
+func datumsToInterfaces(datums []types.Datum) []interface{} {
+	var ifs []interface{}
+	for _, d := range datums {
+		ifs = append(ifs, d.GetValue())
+	}
+	return ifs
+}

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
-	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
@@ -27,7 +26,6 @@ type testColumnChangeSuite struct {
 
 func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 	s.store = testCreateStore(c, "test_column_change")
-	log.Errorf("test column change store %s", s.store.UUID())
 	s.dbInfo = &model.DBInfo{
 		Name: model.NewCIStr("test_column_change"),
 		ID:   1,

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -50,7 +50,6 @@ func (s *testColumnSuite) SetUpSuite(c *C) {
 }
 
 func (s *testColumnSuite) TearDownSuite(c *C) {
-	//trySkipTest(c)
 	testDropSchema(c, mock.NewContext(), s.d, s.dbInfo)
 	s.d.close()
 

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"reflect"
-	"time"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
@@ -43,19 +42,15 @@ type testColumnSuite struct {
 }
 
 func (s *testColumnSuite) SetUpSuite(c *C) {
-	trySkipTest(c)
-
 	s.store = testCreateStore(c, "test_column")
-	lease := 50 * time.Millisecond
-	s.d = newDDL(s.store, nil, nil, lease)
+	s.d = newDDL(s.store, nil, nil, testLease)
 
 	s.dbInfo = testSchemaInfo(c, s.d, "test_column")
 	testCreateSchema(c, mock.NewContext(), s.d, s.dbInfo)
 }
 
 func (s *testColumnSuite) TearDownSuite(c *C) {
-	trySkipTest(c)
-
+	//trySkipTest(c)
 	testDropSchema(c, mock.NewContext(), s.d, s.dbInfo)
 	s.d.close()
 
@@ -96,14 +91,12 @@ func testDropColumn(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, tbl
 		Type:     model.ActionDropColumn,
 		Args:     []interface{}{model.NewCIStr(colName)},
 	}
-
 	err := d.doDDLJob(ctx, job)
 	if isError {
 		c.Assert(err, NotNil)
 		return nil
 	}
-
-	c.Assert(err, IsNil)
+	c.Assert(errors.ErrorStack(err), Equals, "")
 	return job
 }
 
@@ -736,7 +729,7 @@ func (s *testColumnSuite) testGetColumn(t table.Table, name string, isExist bool
 
 func (s *testColumnSuite) TestAddColumn(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 3)
 	ctx := testNewContext(c, d)
 
@@ -808,7 +801,7 @@ func (s *testColumnSuite) TestAddColumn(c *C) {
 
 func (s *testColumnSuite) TestDropColumn(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 4)
 	ctx := testNewContext(c, d)
 

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -15,7 +15,6 @@ package ddl_test
 
 import (
 	"database/sql"
-	"flag"
 	"fmt"
 	"io"
 	"math/rand"
@@ -36,15 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
-func trySkipDBTest(c *C) {
-	// skip_ddl flag is defined in ddl package, we can't use it directly, so using flag Lookup to help us.
-	if f := flag.Lookup("skip_ddl"); f == nil || strings.ToLower(f.Value.String()) == "false" {
-		return
-	}
-
-	c.Skip("skip DB test")
-}
-
 var _ = Suite(&testDBSuite{})
 
 type testDBSuite struct {
@@ -58,8 +48,6 @@ type testDBSuite struct {
 }
 
 func (s *testDBSuite) SetUpSuite(c *C) {
-	trySkipDBTest(c)
-
 	var err error
 
 	s.schemaName = "test_db"
@@ -84,8 +72,6 @@ func (s *testDBSuite) SetUpSuite(c *C) {
 }
 
 func (s *testDBSuite) TearDownSuite(c *C) {
-	trySkipDBTest(c)
-
 	s.db.Close()
 
 	s.s.Close()

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -47,4 +47,5 @@ func (ts *testSuite) SetUpSuite(c *C) {
 
 func init() {
 	log.SetLevelByString("warn")
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
 }

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"strings"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
@@ -36,14 +35,10 @@ type testForeighKeySuite struct {
 }
 
 func (s *testForeighKeySuite) SetUpSuite(c *C) {
-	trySkipTest(c)
-
 	s.store = testCreateStore(c, "test_foreign")
 }
 
 func (s *testForeighKeySuite) TearDownSuite(c *C) {
-	trySkipTest(c)
-
 	err := s.store.Close()
 	c.Assert(err, IsNil)
 }
@@ -121,7 +116,7 @@ func (s *testForeighKeySuite) testForeignKeyExist(c *C, t table.Table, name stri
 
 func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	s.d = d
 	s.dbInfo = testSchemaInfo(c, d, "test_foreign")
 	ctx := testNewContext(c, d)

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"strings"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
@@ -39,19 +38,14 @@ type testIndexSuite struct {
 }
 
 func (s *testIndexSuite) SetUpSuite(c *C) {
-	trySkipTest(c)
-
 	s.store = testCreateStore(c, "test_index")
-	lease := 50 * time.Millisecond
-	s.d = newDDL(s.store, nil, nil, lease)
+	s.d = newDDL(s.store, nil, nil, testLease)
 
 	s.dbInfo = testSchemaInfo(c, s.d, "test_index")
 	testCreateSchema(c, mock.NewContext(), s.d, s.dbInfo)
 }
 
 func (s *testIndexSuite) TearDownSuite(c *C) {
-	trySkipTest(c)
-
 	testDropSchema(c, mock.NewContext(), s.d, s.dbInfo)
 	s.d.close()
 
@@ -564,7 +558,7 @@ func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *d
 
 func (s *testIndexSuite) TestAddIndex(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 3)
 	ctx := testNewContext(c, d)
 
@@ -632,7 +626,7 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 
 func (s *testIndexSuite) TestDropIndex(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 3)
 	ctx := testNewContext(c, d)
 
@@ -703,7 +697,7 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 
 func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	defer testleak.AfterTest(c)()
-	d := newDDL(s.store, nil, nil, 100*time.Millisecond)
+	d := newDDL(s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 3)
 	// Change c2.DefaultValue to nil
 	tblInfo.Columns[1].DefaultValue = nil

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -37,11 +37,10 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	store := testCreateStore(c, "test_reorg")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-	d := newDDL(store, nil, nil, lease)
+	d := newDDL(store, nil, nil, testLease)
 	defer d.close()
 
-	time.Sleep(lease)
+	time.Sleep(testLease)
 
 	ctx := testNewContext(c, d)
 
@@ -63,7 +62,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 
 	done := make(chan struct{})
 	f := func() error {
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(4 * testLease)
 		close(done)
 		return nil
 	}
@@ -76,7 +75,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 
 	d.close()
 	err = d.runReorgJob(func() error {
-		time.Sleep(1 * time.Second)
+		time.Sleep(4 * testLease)
 		return nil
 	})
 	c.Assert(err, NotNil)
@@ -118,16 +117,14 @@ func (s *testDDLSuite) TestReorgOwner(c *C) {
 	store := testCreateStore(c, "test_reorg_owner")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-
-	d1 := newDDL(store, nil, nil, lease)
+	d1 := newDDL(store, nil, nil, testLease)
 	defer d1.close()
 
 	ctx := testNewContext(c, d1)
 
 	testCheckOwner(c, d1, true, ddlJobFlag)
 
-	d2 := newDDL(store, nil, nil, lease)
+	d2 := newDDL(store, nil, nil, testLease)
 	defer d2.close()
 
 	dbInfo := testSchemaInfo(c, d1, "test")

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -72,7 +72,7 @@ func checkDrop(c *C, t *meta.Meta) bool {
 		return true
 	}
 
-	time.Sleep(5 * time.Millisecond)
+	time.Sleep(testLease)
 	return false
 }
 
@@ -136,9 +136,7 @@ func (s *testSchemaSuite) TestSchema(c *C) {
 	store := testCreateStore(c, "test_schema")
 	defer store.Close()
 
-	lease := 100 * time.Millisecond
-
-	d1 := newDDL(store, nil, nil, lease)
+	d1 := newDDL(store, nil, nil, testLease)
 	defer d1.close()
 
 	ctx := mock.NewContext()
@@ -169,14 +167,12 @@ func (s *testSchemaSuite) TestSchemaWaitJob(c *C) {
 
 	ctx := mock.NewContext()
 
-	lease := 50 * time.Millisecond
-
-	d1 := newDDL(store, nil, nil, lease)
+	d1 := newDDL(store, nil, nil, testLease)
 	defer d1.close()
 
 	testCheckOwner(c, d1, true, ddlJobFlag)
 
-	d2 := newDDL(store, nil, nil, lease)
+	d2 := newDDL(store, nil, nil, testLease)
 	defer d2.close()
 
 	// d2 must not be owner.
@@ -234,9 +230,7 @@ func (s *testSchemaSuite) TestSchemaResume(c *C) {
 	store := testCreateStore(c, "test_schema_resume")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-
-	d1 := newDDL(store, nil, nil, lease)
+	d1 := newDDL(store, nil, nil, testLease)
 	defer d1.close()
 
 	testCheckOwner(c, d1, true, ddlJobFlag)

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -39,12 +39,10 @@ func (s *testStatSuite) TestStat(c *C) {
 	store := testCreateStore(c, "test_stat")
 	defer store.Close()
 
-	lease := 50 * time.Millisecond
-
-	d := newDDL(store, nil, nil, lease)
+	d := newDDL(store, nil, nil, testLease)
 	defer d.close()
 
-	time.Sleep(lease)
+	time.Sleep(testLease)
 
 	dbInfo := testSchemaInfo(c, d, "test")
 	testCreateSchema(c, mock.NewContext(), d, dbInfo)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/context"
@@ -130,8 +129,7 @@ func testGetTable(c *C, d *ddl, schemaID int64, tableID int64) table.Table {
 
 func (s *testTableSuite) SetUpSuite(c *C) {
 	s.store = testCreateStore(c, "test_table")
-	lease := 50 * time.Millisecond
-	s.d = newDDL(s.store, nil, nil, lease)
+	s.d = newDDL(s.store, nil, nil, testLease)
 
 	s.dbInfo = testSchemaInfo(c, s.d, "test")
 	testCreateSchema(c, mock.NewContext(), s.d, s.dbInfo)

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/testutil"
 )
 
 func (s *testSuite) TestExplain(c *C) {
@@ -89,6 +90,6 @@ func (s *testSuite) TestExplain(c *C) {
 	}
 	for _, ca := range cases {
 		result := tk.MustQuery("explain " + ca.sql)
-		result.Check(testkit.RowsWithSep(" | ", ca.result...))
+		result.Check(testutil.RowsWithSep(" | ", ca.result...))
 	}
 }

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -459,9 +459,6 @@ func (t *Table) RowWithCols(ctx context.Context, h int64, cols []*table.Column) 
 		if col == nil {
 			continue
 		}
-		if col.State != model.StatePublic {
-			return nil, table.ErrColumnStateNonPublic.Gen("Cannot use none public column - %v", cols)
-		}
 		if col.IsPKHandleColumn(t.meta) {
 			if mysql.HasUnsignedFlag(col.Flag) {
 				v[i].SetUint64(uint64(h))
@@ -479,10 +476,6 @@ func (t *Table) RowWithCols(ctx context.Context, h int64, cols []*table.Column) 
 	for i, col := range cols {
 		if col == nil {
 			continue
-		}
-		if col.State != model.StatePublic {
-			// TODO: check this
-			return nil, table.ErrColumnStateNonPublic.Gen("Cannot use none public column - %v", cols)
 		}
 		if col.IsPKHandleColumn(t.meta) {
 			continue

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -15,13 +15,13 @@ package testkit
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/testutil"
 )
 
 // TestKit is a utility to run sql test.
@@ -121,22 +121,7 @@ func (tk *TestKit) MustQuery(sql string, args ...interface{}) *Result {
 	return &Result{rows: iRows, c: tk.c, comment: comment}
 }
 
-// RowsWithSep is a convenient function to wrap args to a slice of []interface.
-// The arg represents a row, split by sep.
-func RowsWithSep(sep string, args ...string) [][]interface{} {
-	rows := make([][]interface{}, len(args))
-	for i, v := range args {
-		strs := strings.Split(v, sep)
-		row := make([]interface{}, len(strs))
-		for j, s := range strs {
-			row[j] = s
-		}
-		rows[i] = row
-	}
-	return rows
-}
-
 // Rows is similar to RowsWithSep, use white space as separator string.
 func Rows(args ...string) [][]interface{} {
-	return RowsWithSep(" ", args...)
+	return testutil.RowsWithSep(" ", args...)
 }

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -15,6 +15,7 @@ package testutil
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/types"
@@ -90,4 +91,19 @@ func (checker *datumEqualsChecker) Check(params []interface{}, names []string) (
 		panic(err)
 	}
 	return res == 0, ""
+}
+
+// RowsWithSep is a convenient function to wrap args to a slice of []interface.
+// The arg represents a row, split by sep.
+func RowsWithSep(sep string, args ...string) [][]interface{} {
+	rows := make([][]interface{}, len(args))
+	for i, v := range args {
+		strs := strings.Split(v, sep)
+		row := make([]interface{}, len(strs))
+		for j, s := range strs {
+			row[j] = s
+		}
+		rows[i] = row
+	}
+	return rows
 }


### PR DESCRIPTION
Added `column_change_test.go` which can operate schemas in different state at a given time to verify correctness.

Set lease to a much smaller time so `skip_ddl` flag can be removed.

Following PR will add better index change test in the same way.