### PR TITLE
kv: add BTree implemention of kv.MemBuffer

### DIFF
--- a/kv/btree_buffer.go
+++ b/kv/btree_buffer.go
@@ -1,0 +1,141 @@
+package kv
+
+import (
+	"bytes"
+
+	"github.com/juju/errors"
+	"github.com/tidwall/btree"
+)
+
+const degree = 50
+
+type btreeKey Key
+
+func (k btreeKey) Less(item btree.Item) bool {
+	switch x := item.(type) {
+	case btreeKey:
+		return bytes.Compare(k, x) < 0
+	case *btreePair:
+		return bytes.Compare(k, x.key) < 0
+	}
+	return true
+}
+
+type btreePair struct {
+	key   Key
+	value []byte
+}
+
+func (pair *btreePair) Less(item btree.Item) bool {
+	switch x := item.(type) {
+	case btreeKey:
+		return bytes.Compare(pair.key, x) < 0
+	case *btreePair:
+		return bytes.Compare(pair.key, x.key) < 0
+	}
+	return true
+}
+
+type bTreeBuffer struct {
+	tree *btree.BTree
+}
+
+type bTreeIter struct {
+	tree    *btree.BTree
+	seek    Key
+	pair    *btreePair
+	reverse bool
+}
+
+// NewBTreeBuffer creates a new bTreeBuffer.
+func NewBTreeBuffer() MemBuffer {
+	return &bTreeBuffer{tree: btree.New(degree)}
+}
+
+// Seek creates an Iterator.
+func (m *bTreeBuffer) Seek(k Key) (Iterator, error) {
+	it := &bTreeIter{tree: m.tree, seek: k}
+	it.Next()
+	return it, nil
+}
+
+func (m *bTreeBuffer) SeekReverse(k Key) (Iterator, error) {
+	if k != nil {
+		k = k.Prev()
+	}
+	it := &bTreeIter{tree: m.tree, seek: k, reverse: true}
+	it.Next()
+	return it, nil
+}
+
+// Get returns the value associated with key.
+func (m *bTreeBuffer) Get(k Key) ([]byte, error) {
+	pair := m.tree.Get(btreeKey(k))
+	if pair == nil {
+		return nil, ErrNotExist
+	}
+	return pair.(*btreePair).value, nil
+}
+
+// Set associates key with value.
+func (m *bTreeBuffer) Set(k Key, v []byte) error {
+	if len(v) == 0 {
+		return errors.Trace(ErrCannotSetNilValue)
+	}
+	m.tree.ReplaceOrInsert(&btreePair{key: k, value: v})
+	return nil
+}
+
+// Delete removes the entry from buffer with provided key.
+func (m *bTreeBuffer) Delete(k Key) error {
+	m.tree.ReplaceOrInsert(&btreePair{key: k, value: nil})
+	return nil
+}
+
+// Release reset the buffer.
+func (m *bTreeBuffer) Release() {
+	m.tree = btree.New(degree)
+}
+
+// Next implements the Iterator Next.
+func (i *bTreeIter) Next() error {
+	i.pair = nil
+	if i.reverse {
+		iterFunc := func(item btree.Item) bool {
+			i.pair = item.(*btreePair)
+			i.seek = i.pair.key.Prev()
+			return false
+		}
+		if i.seek == nil {
+			i.tree.Descend(iterFunc)
+		} else {
+			i.tree.DescendLessOrEqual(btreeKey(i.seek), iterFunc)
+		}
+	} else {
+		i.tree.AscendGreaterOrEqual(btreeKey(i.seek), func(item btree.Item) bool {
+			i.pair = item.(*btreePair)
+			i.seek = i.pair.key.Next()
+			return false
+		})
+	}
+	return nil
+}
+
+// Valid implements the Iterator Valid.
+func (i *bTreeIter) Valid() bool {
+	return i.pair != nil
+}
+
+// Key implements the Iterator Key.
+func (i *bTreeIter) Key() Key {
+	return i.pair.key
+}
+
+// Value implements the Iterator Value.
+func (i *bTreeIter) Value() []byte {
+	return i.pair.value
+}
+
+// Close Implements the Iterator Close.
+func (i *bTreeIter) Close() {
+}

--- a/kv/key.go
+++ b/kv/key.go
@@ -26,6 +26,18 @@ func (k Key) Next() Key {
 	return buf
 }
 
+// Prev returns the prev ken in byte-order.
+func (k Key) Prev() Key {
+	buf := make([]byte, len([]byte(k)))
+	copy(buf, []byte(k))
+	if buf[len(buf)-1] == 0 {
+		buf = buf[:len(buf)-1]
+	} else {
+		buf[len(buf)-1]--
+	}
+	return buf
+}
+
 // PrefixNext returns the next prefix key.
 //
 // Assume there are keys like:

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -46,7 +46,7 @@ type Options interface {
 
 var (
 	p = newCache("memdb pool", 100, func() MemBuffer {
-		return NewMemDbBuffer()
+		return NewBTreeBuffer()
 	})
 )
 

--- a/kv/union_store_test.go
+++ b/kv/union_store_test.go
@@ -28,7 +28,7 @@ type testUnionStoreSuite struct {
 }
 
 func (s *testUnionStoreSuite) SetUpTest(c *C) {
-	s.store = NewMemDbBuffer()
+	s.store = NewBTreeBuffer()
 	s.us = NewUnionStore(&mockSnapshot{s.store})
 }
 


### PR DESCRIPTION
> BenchmarkMemDbBufferSequential-4 	       5	 213518329 ns/op	15910211 B/op	      23 allocs/op
BenchmarkRBTreeBufferSequential-4	       5	 314003059 ns/op	 8960080 B/op	  220007 allocs/op
BenchmarkBTreeBufferSequential-4 	      10	 206595532 ns/op	 8619092 B/op	  200630 allocs/op
BenchmarkMemDbBufferRandom-4     	       3	 473334496 ns/op	19695786 B/op	      36 allocs/op
BenchmarkRBTreeBufferRandom-4    	       2	 559104076 ns/op	10400128 B/op	  250012 allocs/op
BenchmarkBTreeBufferRandom-4     	       3	 425498560 ns/op	 9341520 B/op	  201434 allocs/op
BenchmarkRBTreeIter-4            	      10	 140747766 ns/op	 4800105 B/op	  200004 allocs/op
BenchmarkMemDbIter-4             	     100	  19799431 ns/op	     261 B/op	       3 allocs/op
BenchmarkBTreeIter-4             	       5	 303293572 ns/op	 4800188 B/op	  200006 allocs/op
BenchmarkRBTreeCreation-4        	10000000	       150 ns/op	      40 B/op	       3 allocs/op
BenchmarkMemDbCreation-4         	   50000	     36662 ns/op	   15240 B/op	       8 allocs/op
BenchmarkBTreeCreation-4         	 2000000	       812 ns/op	     648 B/op	       7 allocs/op

I'll run tidb-bench tomorrow to see the whole impact of this change.