### PR TITLE
Length check for database, table and column name

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -294,6 +294,10 @@ func (d *ddl) CreateSchema(ctx context.Context, schema model.CIStr, charsetInfo 
 		return errors.Trace(infoschema.ErrDatabaseExists)
 	}
 
+	if is.SchemaNameTooLong(schema) {
+		return errors.Trace(infoschema.ErrTooLongIdent)
+	}
+
 	schemaID, err := d.genGlobalID()
 	if err != nil {
 		return errors.Trace(err)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -986,6 +986,10 @@ func (d *ddl) AddColumn(ctx context.Context, ti ast.Ident, spec *ast.AlterTableS
 		return infoschema.ErrColumnExists.Gen("column %s already exists", colName)
 	}
 
+	if len(colName) > mysql.ServerColumnNameLength {
+		return infoschema.ErrTooLongIdent.Gen("too long column %s", colName)
+	}
+
 	// ingore table constraints now, maybe return error later
 	// we use length(t.Cols()) as the default offset first, later we will change the
 	// column's offset later.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -341,14 +341,14 @@ func (d *ddl) DropSchema(ctx context.Context, schema model.CIStr) (err error) {
 }
 
 func checkTooLongSchema(schema model.CIStr) error {
-	if len(schema.L) > mysql.ServerDatabaseNameLength {
+	if len(schema.L) > mysql.MaxDatabaseNameLength {
 		return infoschema.ErrTooLongIdent.Gen("too long schema %s", schema.L)
 	}
 	return nil
 }
 
 func checkTooLongTable(table model.CIStr) error {
-	if len(table.L) > mysql.ServerTableNameLength {
+	if len(table.L) > mysql.MaxTableNameLength {
 		return infoschema.ErrTooLongIdent.Gen("too long table %s", table.L)
 	}
 	return nil
@@ -663,7 +663,7 @@ func checkDuplicateColumn(colDefs []*ast.ColumnDef) error {
 
 func checkTooLongColumn(colDefs []*ast.ColumnDef) error {
 	for _, colDef := range colDefs {
-		if len(colDef.Name.Name.O) > mysql.ServerColumnNameLength {
+		if len(colDef.Name.Name.O) > mysql.MaxColumnNameLength {
 			return infoschema.ErrTooLongIdent.Gen("too long column %s", colDef.Name.Name.L)
 		}
 	}
@@ -1000,7 +1000,7 @@ func (d *ddl) AddColumn(ctx context.Context, ti ast.Ident, spec *ast.AlterTableS
 		return infoschema.ErrColumnExists.Gen("column %s already exists", colName)
 	}
 
-	if len(colName) > mysql.ServerColumnNameLength {
+	if len(colName) > mysql.MaxColumnNameLength {
 		return infoschema.ErrTooLongIdent.Gen("too long column %s", colName)
 	}
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -647,6 +647,15 @@ func checkDuplicateColumn(colDefs []*ast.ColumnDef) error {
 	return nil
 }
 
+func checkTooLongColumn(colDefs []*ast.ColumnDef) error {
+	for _, colDef := range colDefs {
+		if len(colDef.Name.Name.O) > mysql.ServerColumnNameLength {
+			return infoschema.ErrTooLongIdent.Gen("too long column %s", colDef.Name)
+		}
+	}
+	return nil
+}
+
 func checkDuplicateConstraint(namesMap map[string]bool, name string, foreign bool) error {
 	if name == "" {
 		return nil
@@ -825,6 +834,9 @@ func (d *ddl) CreateTable(ctx context.Context, ident ast.Ident, colDefs []*ast.C
 		return errors.Trace(infoschema.ErrTooLongIdent)
 	}
 	if err = checkDuplicateColumn(colDefs); err != nil {
+		return errors.Trace(err)
+	}
+	if err = checkTooLongColumn(colDefs); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -817,6 +817,9 @@ func (d *ddl) CreateTable(ctx context.Context, ident ast.Ident, colDefs []*ast.C
 	if is.TableExists(ident.Schema, ident.Name) {
 		return errors.Trace(infoschema.ErrTableExists)
 	}
+	if is.TableNameTooLong(ident.Schema, ident.Name) {
+		return errors.Trace(infoschema.ErrTooLongIdent)
+	}
 	if err = checkDuplicateColumn(colDefs); err != nil {
 		return errors.Trace(err)
 	}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -295,7 +295,7 @@ func (d *ddl) CreateSchema(ctx context.Context, schema model.CIStr, charsetInfo 
 	}
 
 	if is.SchemaNameTooLong(schema) {
-		return errors.Trace(infoschema.ErrTooLongIdent)
+		return errors.Trace(infoschema.ErrTooLongIdent.Gen("too long schema %s", schema.L))
 	}
 
 	schemaID, err := d.genGlobalID()
@@ -650,7 +650,7 @@ func checkDuplicateColumn(colDefs []*ast.ColumnDef) error {
 func checkTooLongColumn(colDefs []*ast.ColumnDef) error {
 	for _, colDef := range colDefs {
 		if len(colDef.Name.Name.O) > mysql.ServerColumnNameLength {
-			return infoschema.ErrTooLongIdent.Gen("too long column %s", colDef.Name)
+			return infoschema.ErrTooLongIdent.Gen("too long column %s", colDef.Name.Name.L)
 		}
 	}
 	return nil
@@ -831,7 +831,7 @@ func (d *ddl) CreateTable(ctx context.Context, ident ast.Ident, colDefs []*ast.C
 		return errors.Trace(infoschema.ErrTableExists)
 	}
 	if is.TableNameTooLong(ident.Schema, ident.Name) {
-		return errors.Trace(infoschema.ErrTooLongIdent)
+		return errors.Trace(infoschema.ErrTooLongIdent.Gen("too long table %s", ident.Name.L))
 	}
 	if err = checkDuplicateColumn(colDefs); err != nil {
 		return errors.Trace(err)

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -49,7 +49,7 @@ var (
 	ErrDatabaseExists = terror.ClassSchema.New(codeDatabaseExists, "database already exists")
 	// ErrTableExists returns for table already exists.
 	ErrTableExists = terror.ClassSchema.New(codeTableExists, "table already exists")
-	// ErrTooLongIdent returns for table's name too long.
+	// ErrTooLongIdent returns for too long name of database/table/column.
 	ErrTooLongIdent = terror.ClassSchema.New(codeTooLongIdent, "Identifier name too long")
 	// ErrTableDropExists returns for dropping a non-existent table.
 	ErrTableDropExists = terror.ClassSchema.New(codeBadTable, "unknown table")

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -49,6 +49,8 @@ var (
 	ErrDatabaseExists = terror.ClassSchema.New(codeDatabaseExists, "database already exists")
 	// ErrTableExists returns for table already exists.
 	ErrTableExists = terror.ClassSchema.New(codeTableExists, "table already exists")
+	// ErrTooLongIdent returns for table already name too long.
+	ErrTooLongIdent = terror.ClassSchema.New(codeTooLongIdent, "table name too long")
 	// ErrTableDropExists returns for dropping a non-existent table.
 	ErrTableDropExists = terror.ClassSchema.New(codeBadTable, "unknown table")
 	// ErrColumnExists returns for column already exists.
@@ -512,6 +514,7 @@ const (
 	codeBadTable       = 1051
 	codeColumnExists   = 1060
 	codeIndexExists    = 1831
+	codeTooLongIdent   = 1059
 )
 
 func init() {
@@ -527,6 +530,7 @@ func init() {
 		codeBadTable:            mysql.ErrBadTable,
 		codeColumnExists:        mysql.ErrDupFieldName,
 		codeIndexExists:         mysql.ErrDupIndex,
+		codeTooLongIdent:        mysql.ErrTooLongIdent,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassSchema] = schemaMySQLErrCodes
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -65,11 +65,9 @@ var (
 // TODO: add more methods to retrieve tables and columns.
 type InfoSchema interface {
 	SchemaByName(schema model.CIStr) (*model.DBInfo, bool)
-	SchemaNameTooLong(schema model.CIStr) bool
 	SchemaExists(schema model.CIStr) bool
 	TableByName(schema, table model.CIStr) (table.Table, error)
 	TableExists(schema, table model.CIStr) bool
-	TableNameTooLong(schema, table model.CIStr) bool
 	ColumnByName(schema, table, column model.CIStr) (*model.ColumnInfo, bool)
 	ColumnExists(schema, table, column model.CIStr) bool
 	IndexByName(schema, table, index model.CIStr) (*model.IndexInfo, bool)
@@ -157,10 +155,6 @@ func (is *infoSchema) SchemaExists(schema model.CIStr) bool {
 	return ok
 }
 
-func (is *infoSchema) SchemaNameTooLong(schema model.CIStr) bool {
-	return len(schema.L) > mysql.ServerDatabaseNameLength
-}
-
 func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err error) {
 	id, ok := is.tableNameToID[tableName{schema: schema.L, table: table.L}]
 	if !ok {
@@ -173,10 +167,6 @@ func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err
 func (is *infoSchema) TableExists(schema, table model.CIStr) bool {
 	_, ok := is.tableNameToID[tableName{schema: schema.L, table: table.L}]
 	return ok
-}
-
-func (is *infoSchema) TableNameTooLong(schema, table model.CIStr) bool {
-	return len(table.L) > mysql.ServerTableNameLength
 }
 
 func (is *infoSchema) ColumnByName(schema, table, column model.CIStr) (val *model.ColumnInfo, ok bool) {

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -65,6 +65,7 @@ var (
 // TODO: add more methods to retrieve tables and columns.
 type InfoSchema interface {
 	SchemaByName(schema model.CIStr) (*model.DBInfo, bool)
+	SchemaNameTooLong(schema model.CIStr) bool
 	SchemaExists(schema model.CIStr) bool
 	TableByName(schema, table model.CIStr) (table.Table, error)
 	TableExists(schema, table model.CIStr) bool
@@ -154,6 +155,10 @@ func (is *infoSchema) SchemaMetaVersion() int64 {
 func (is *infoSchema) SchemaExists(schema model.CIStr) bool {
 	_, ok := is.schemaNameToID[schema.L]
 	return ok
+}
+
+func (is *infoSchema) SchemaNameTooLong(schema model.CIStr) bool {
+	return len(schema.L) > mysql.ServerDatabaseNameLength
 }
 
 func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err error) {

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -49,8 +49,6 @@ var (
 	ErrDatabaseExists = terror.ClassSchema.New(codeDatabaseExists, "database already exists")
 	// ErrTableExists returns for table already exists.
 	ErrTableExists = terror.ClassSchema.New(codeTableExists, "table already exists")
-	// ErrTooLongIdent returns for too long name of database/table/column.
-	ErrTooLongIdent = terror.ClassSchema.New(codeTooLongIdent, "Identifier name too long")
 	// ErrTableDropExists returns for dropping a non-existent table.
 	ErrTableDropExists = terror.ClassSchema.New(codeBadTable, "unknown table")
 	// ErrColumnExists returns for column already exists.
@@ -509,7 +507,6 @@ const (
 	codeBadTable       = 1051
 	codeColumnExists   = 1060
 	codeIndexExists    = 1831
-	codeTooLongIdent   = 1059
 )
 
 func init() {
@@ -525,7 +522,6 @@ func init() {
 		codeBadTable:            mysql.ErrBadTable,
 		codeColumnExists:        mysql.ErrDupFieldName,
 		codeIndexExists:         mysql.ErrDupIndex,
-		codeTooLongIdent:        mysql.ErrTooLongIdent,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassSchema] = schemaMySQLErrCodes
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -49,8 +49,8 @@ var (
 	ErrDatabaseExists = terror.ClassSchema.New(codeDatabaseExists, "database already exists")
 	// ErrTableExists returns for table already exists.
 	ErrTableExists = terror.ClassSchema.New(codeTableExists, "table already exists")
-	// ErrTooLongIdent returns for table already name too long.
-	ErrTooLongIdent = terror.ClassSchema.New(codeTooLongIdent, "table name too long")
+	// ErrTooLongIdent returns for table's name too long.
+	ErrTooLongIdent = terror.ClassSchema.New(codeTooLongIdent, "Identifier name too long")
 	// ErrTableDropExists returns for dropping a non-existent table.
 	ErrTableDropExists = terror.ClassSchema.New(codeBadTable, "unknown table")
 	// ErrColumnExists returns for column already exists.

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -66,6 +66,7 @@ type InfoSchema interface {
 	SchemaExists(schema model.CIStr) bool
 	TableByName(schema, table model.CIStr) (table.Table, error)
 	TableExists(schema, table model.CIStr) bool
+	TableNameTooLong(schema, table model.CIStr) bool
 	ColumnByName(schema, table, column model.CIStr) (*model.ColumnInfo, bool)
 	ColumnExists(schema, table, column model.CIStr) bool
 	IndexByName(schema, table, index model.CIStr) (*model.IndexInfo, bool)
@@ -165,6 +166,10 @@ func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err
 func (is *infoSchema) TableExists(schema, table model.CIStr) bool {
 	_, ok := is.tableNameToID[tableName{schema: schema.L, table: table.L}]
 	return ok
+}
+
+func (is *infoSchema) TableNameTooLong(schema, table model.CIStr) bool {
+	return len(table.L) > mysql.ServerTableNameLength
 }
 
 func (is *infoSchema) ColumnByName(schema, table, column model.CIStr) (val *model.ColumnInfo, ok bool) {

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -44,6 +44,11 @@ const (
 	ServerPSOutParams              uint16 = 0x1000
 )
 
+// Server limitations
+const (
+	ServerTableNameLength int = 64
+)
+
 // Command informations.
 const (
 	ComSleep byte = iota

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -46,9 +46,9 @@ const (
 
 // Server limitations
 const (
-	ServerTableNameLength    int = 64
-	ServerDatabaseNameLength int = 64
-	ServerColumnNameLength   int = 64
+	MaxTableNameLength    int = 64
+	MaxDatabaseNameLength int = 64
+	MaxColumnNameLength   int = 64
 )
 
 // Command informations.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -44,7 +44,7 @@ const (
 	ServerPSOutParams              uint16 = 0x1000
 )
 
-// Server limitations
+// Identifier length limitations.
 const (
 	MaxTableNameLength    int = 64
 	MaxDatabaseNameLength int = 64

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -46,7 +46,9 @@ const (
 
 // Server limitations
 const (
-	ServerTableNameLength int = 64
+	ServerTableNameLength    int = 64
+	ServerDatabaseNameLength int = 64
+	ServerColumnNameLength   int = 64
 )
 
 // Command informations.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -249,6 +249,8 @@ func runTestErrorCode(c *C) {
 		checkErrorCode(c, err, tmysql.ErrBadTable)
 		_, err = txn2.Exec("drop database unknown_db;")
 		checkErrorCode(c, err, tmysql.ErrDBDropExists)
+		_, err = txn2.Exec("create table aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (a int);")
+		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
 
 		// Optimizer errors
 		_, err = txn2.Exec("select *, * from test;")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -255,6 +255,8 @@ func runTestErrorCode(c *C) {
 		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
 		_, err = txn2.Exec("create table long_column_table (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int);")
 		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
+		_, err = txn2.Exec("alter table test add aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int;")
+		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
 
 		// Optimizer errors
 		_, err = txn2.Exec("select *, * from test;")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -253,6 +253,8 @@ func runTestErrorCode(c *C) {
 		checkErrorCode(c, err, tmysql.ErrDBDropExists)
 		_, err = txn2.Exec("create table aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (a int);")
 		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
+		_, err = txn2.Exec("create table long_column_table (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa int);")
+		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
 
 		// Optimizer errors
 		_, err = txn2.Exec("select *, * from test;")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -243,6 +243,8 @@ func runTestErrorCode(c *C) {
 		checkErrorCode(c, err, tmysql.ErrNoSuchTable)
 		_, err = txn2.Exec("create database test;")
 		checkErrorCode(c, err, tmysql.ErrDBCreateExists)
+		_, err = txn2.Exec("create database aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;")
+		checkErrorCode(c, err, tmysql.ErrTooLongIdent)
 		_, err = txn2.Exec("create table test (c int);")
 		checkErrorCode(c, err, tmysql.ErrTableExists)
 		_, err = txn2.Exec("drop table unknown_table;")


### PR DESCRIPTION
ref #1247 
This PR add length check to database name, table name and column name. The limitation is from [MySQL document](http://dev.mysql.com/doc/refman/5.7/en/identifiers.html) and saved into *mysql/const.go* as const value.

The length check is performed while creating new database or table, and returns error message if name's length is too long.