### PR TITLE
eliminate unused plus op.

### DIFF
--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -497,7 +497,8 @@ func (er *expressionRewriter) unaryOpToScalarFunc(v *ast.UnaryOperationExpr) {
 	var op string
 	switch v.Op {
 	case opcode.Plus:
-		op = ast.UnaryPlus
+		// expression (+ a) is equal to a
+		return
 	case opcode.Minus:
 		op = ast.UnaryMinus
 	case opcode.BitNeg:


### PR DESCRIPTION
For example, ( + a) can be rewrite to a, but the old implementation rewrite + a to a scalar function.

@coocood @shenli @zimulala PTAL