### PR TITLE
ddl: fix ddl update join table.

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -26,11 +26,14 @@ import (
 	_ "github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -493,4 +496,64 @@ func match(c *C, row []interface{}, expected ...interface{}) {
 		need := fmt.Sprintf("%v", expected[i])
 		c.Assert(got, Equals, need)
 	}
+}
+
+func (s *testDBSuite) TestUpdateMultipleTable(c *C) {
+	defer testleak.AfterTest(c)
+	store, err := tidb.NewStore("memory://update_multiple_table")
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (c1 int, c2 int)")
+	tk.MustExec("insert t1 values (1, 1), (2, 2)")
+	tk.MustExec("create table t2 (c1 int, c2 int)")
+	tk.MustExec("insert t2 values (1, 3), (2, 5)")
+	ctx := tk.Se.(context.Context)
+	domain := sessionctx.GetDomain(ctx)
+	is := domain.InfoSchema()
+	db, ok := is.SchemaByName(model.NewCIStr("test"))
+	c.Assert(ok, IsTrue)
+	t1Tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	t1Info := t1Tbl.Meta()
+
+	// Add a new column in write only state.
+	newColumn := &model.ColumnInfo{
+		ID:           100,
+		Name:         model.NewCIStr("c3"),
+		Offset:       2,
+		DefaultValue: 9,
+		FieldType:    *types.NewFieldType(mysql.TypeLonglong),
+		State:        model.StateWriteOnly,
+	}
+	t1Tbl.Cols()
+	t1Info.Columns = append(t1Info.Columns, newColumn)
+
+	kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		_, err = m.GenSchemaVersion()
+		c.Assert(err, IsNil)
+		c.Assert(m.UpdateTable(db.ID, t1Info), IsNil)
+		return nil
+	})
+	err = domain.Reload()
+	c.Assert(err, IsNil)
+
+	tk.MustExec("update t1, t2 set t1.c1 = 8, t2.c2 = 10 where t1.c2 = t2.c1")
+	tk.MustQuery("select * from t1").Check(testkit.Rows("8 1", "8 2"))
+	tk.MustQuery("select * from t2").Check(testkit.Rows("1 10", "2 10"))
+
+	newColumn.State = model.StatePublic
+
+	kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		_, err = m.GenSchemaVersion()
+		c.Assert(err, IsNil)
+		c.Assert(m.UpdateTable(db.ID, t1Info), IsNil)
+		return nil
+	})
+	err = domain.Reload()
+	c.Assert(err, IsNil)
+
+	tk.MustQuery("select * from t1").Check(testkit.Rows("8 1 9", "8 2 9"))
 }

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -526,7 +526,6 @@ func (s *testDBSuite) TestUpdateMultipleTable(c *C) {
 		FieldType:    *types.NewFieldType(mysql.TypeLonglong),
 		State:        model.StateWriteOnly,
 	}
-	t1Tbl.Cols()
 	t1Info.Columns = append(t1Info.Columns, newColumn)
 
 	kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -160,7 +160,8 @@ func (do *Domain) tryReload() {
 
 const minReloadTimeout = 20 * time.Second
 
-func (do *Domain) reload() error {
+// Reload reloads InfoSchema.
+func (do *Domain) Reload() error {
 	// lock here for only once at same time.
 	do.m.Lock()
 	defer do.m.Unlock()
@@ -206,7 +207,7 @@ func (do *Domain) reload() error {
 
 func (do *Domain) mustReload() {
 	// if reload error, we will terminate whole program to guarantee data safe.
-	err := do.reload()
+	err := do.Reload()
 	if err != nil {
 		log.Fatalf("[ddl] reload schema err %v", errors.ErrorStack(err))
 	}
@@ -222,7 +223,7 @@ func (do *Domain) loadSchemaInLoop(lease time.Duration) {
 	for {
 		select {
 		case <-ticker.C:
-			err := do.reload()
+			err := do.Reload()
 			// we may close store in test, but the domain load schema loop is still checking,
 			// so we can't panic for ErrDBClosed and just return here.
 			if terror.ErrorEqual(err, localstore.ErrDBClosed) {

--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -361,9 +361,14 @@ func (nr *nameResolver) handleTableName(tn *ast.TableName) {
 	rfs := make([]*ast.ResultField, 0, len(tn.TableInfo.Columns))
 	sVars := variable.GetSessionVars(nr.Ctx)
 	for _, v := range tn.TableInfo.Columns {
-		if v.State != model.StatePublic {
-			if !sVars.InUpdateStmt || v.State != model.StateWriteReorganization {
-				// TODO: check this
+		if sVars.InUpdateStmt {
+			switch v.State {
+			case model.StatePublic, model.StateWriteOnly, model.StateWriteReorganization:
+			default:
+				continue
+			}
+		} else {
+			if v.State != model.StatePublic {
 				continue
 			}
 		}


### PR DESCRIPTION
Fix the case when update multiple tables and one table has a column in write-only state.