### PR TITLE
*: add constraint for the length of the index prefix

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -60,7 +60,7 @@ var (
 
 	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specificate a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
-	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, "Specified key was too long; max key length is 255 bytes")
+	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, "Specified key was too long; max key length is 767 bytes")
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -60,7 +60,7 @@ var (
 
 	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specificate a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
-	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, fmt.Sprintf("Specified key was too long; max key length is %d bytes", prefixLength))
+	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, fmt.Sprintf("Specified key was too long; max key length is %d bytes", maxPrefixLength))
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -60,6 +60,7 @@ var (
 
 	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specificate a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
+	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, "Specified key was too long; max key length is 255 bytes")
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")
@@ -1253,6 +1254,7 @@ const (
 	codeInvalidOnUpdate     = 1294
 	codeTooLongIdent        = 1059
 
+	codeTooLongKey           = 1071
 	codeBlobKeyWithoutLength = 1170
 	codeIncorrectPrefixKey   = 1089
 )
@@ -1266,6 +1268,7 @@ func init() {
 		codeBlobKeyWithoutLength: mysql.ErrBlobKeyWithoutLength,
 		codeIncorrectPrefixKey:   mysql.ErrWrongSubKey,
 		codeTooLongIdent:         mysql.ErrTooLongIdent,
+		codeTooLongKey:           mysql.ErrTooLongKey,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassDDL] = ddlMySQLERrCodes
 }

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -60,7 +60,7 @@ var (
 
 	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specificate a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
-	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, "Specified key was too long; max key length is 767 bytes")
+	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey, fmt.Sprintf("Specified key was too long; max key length is %d bytes", prefixLength))
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -30,6 +30,8 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
+const prefixLength = 767
+
 func buildIndexInfo(tblInfo *model.TableInfo, unique bool, indexName model.CIStr, indexID int64,
 	idxColNames []*ast.IndexColName) (*model.IndexInfo, error) {
 	// build offsets
@@ -52,7 +54,7 @@ func buildIndexInfo(tblInfo *model.TableInfo, unique bool, indexName model.CIStr
 			return nil, errors.Trace(errIncorrectPrefixKey)
 		}
 
-		if ic.Length > 255 {
+		if ic.Length > prefixLength {
 			return nil, errors.Trace(errTooLongKey)
 		}
 

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -52,6 +52,10 @@ func buildIndexInfo(tblInfo *model.TableInfo, unique bool, indexName model.CIStr
 			return nil, errors.Trace(errIncorrectPrefixKey)
 		}
 
+		if ic.Length > 255 {
+			return nil, errors.Trace(errTooLongKey)
+		}
+
 		idxColumns = append(idxColumns, &model.IndexColumn{
 			Name:   col.Name,
 			Offset: col.Offset,

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
-const prefixLength = 767
+const maxPrefixLength = 767
 
 func buildIndexInfo(tblInfo *model.TableInfo, unique bool, indexName model.CIStr, indexID int64,
 	idxColNames []*ast.IndexColName) (*model.IndexInfo, error) {
@@ -54,7 +54,7 @@ func buildIndexInfo(tblInfo *model.TableInfo, unique bool, indexName model.CIStr
 			return nil, errors.Trace(errIncorrectPrefixKey)
 		}
 
-		if ic.Length > prefixLength {
+		if ic.Length > maxPrefixLength {
 			return nil, errors.Trace(errTooLongKey)
 		}
 

--- a/session_test.go
+++ b/session_test.go
@@ -2148,7 +2148,7 @@ func (s *testSessionSuite) TestSpecifyIndexPrefixLength(c *C) {
 	c.Assert(err, NotNil)
 
 	_, err = exec(c, se, "create index idx_c1 on t (c2(555555));")
-	// ERROR 1071 (42000): Specified key was too long; max key length is 3072 bytes
+	// ERROR 1071 (42000): Specified key was too long; max key length is 767 bytes
 	c.Assert(err, NotNil)
 
 	_, err = exec(c, se, "create index idx_c1 on t (c1(5))")

--- a/session_test.go
+++ b/session_test.go
@@ -2147,6 +2147,10 @@ func (s *testSessionSuite) TestSpecifyIndexPrefixLength(c *C) {
 	// ERROR 1170 (42000): BLOB/TEXT column 'c2' used in key specification without a key length
 	c.Assert(err, NotNil)
 
+	_, err = exec(c, se, "create index idx_c1 on t (c2(555555));")
+	// ERROR 1071 (42000): Specified key was too long; max key length is 3072 bytes
+	c.Assert(err, NotNil)
+
 	_, err = exec(c, se, "create index idx_c1 on t (c1(5))")
 	// ERROR 1089 (HY000): Incorrect prefix key;
 	// the used key part isn't a string, the used length is longer than the key part,


### PR DESCRIPTION
See https://github.com/pingcap/tidb/issues/1429

it seems that MySQL use 3072 for length limit if the column doesn't specify blob length or specify a number larger than 255, otherwise the constraint length is 255.