### PR TITLE
fix a panic bug for subquery.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1586,6 +1586,8 @@ func (s *testSuite) TestNewSubquery(c *C) {
 	tk.MustExec("commit")
 	result := tk.MustQuery("select * from t where exists(select * from t k where t.c = k.c having sum(c) = 1)")
 	result.Check(testkit.Rows("1 1"))
+	result = tk.MustQuery("select * from t where exists(select k.c, k.d from t k, t p where t.c = k.d)")
+	result.Check(testkit.Rows("1 1", "2 2"))
 	result = tk.MustQuery("select 1 = (select count(*) from t where t.c = k.d) from t k")
 	result.Check(testkit.Rows("1", "1", "0"))
 	result = tk.MustQuery("select 1 = (select count(*) from t where exists( select * from t m where t.c = k.d)) from t k")

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -221,6 +221,10 @@ func (er *expressionRewriter) handleExistSubquery(v *ast.ExistsSubqueryExpr) (as
 		}
 		er.ctxStack = append(er.ctxStack, er.p.GetSchema()[len(er.p.GetSchema())-1])
 	} else {
+		_, np, er.err = np.PredicatePushDown(nil)
+		if er.err != nil {
+			return v, true
+		}
 		_, err := np.PruneColumnsAndResolveIndices(np.GetSchema())
 		if err != nil {
 			er.err = errors.Trace(err)
@@ -322,6 +326,10 @@ func (er *expressionRewriter) handleScalarSubquery(v *ast.SubqueryExpr) (ast.Nod
 		} else {
 			er.ctxStack = append(er.ctxStack, er.p.GetSchema()[len(er.p.GetSchema())-1])
 		}
+		return v, true
+	}
+	_, np, er.err = np.PredicatePushDown(nil)
+	if er.err != nil {
 		return v, true
 	}
 	_, err := np.PruneColumnsAndResolveIndices(np.GetSchema())

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -96,12 +96,6 @@ func (er *expressionRewriter) buildSubquery(subq *ast.SubqueryExpr) (LogicalPlan
 		er.err = errors.Trace(er.b.err)
 		return nil, nil
 	}
-	var err error
-	_, np, err = np.PredicatePushDown(nil)
-	if err != nil {
-		er.err = errors.Trace(err)
-		return np, outerSchema
-	}
 	return np, outerSchema
 }
 

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -854,6 +854,10 @@ func (b *planBuilder) buildApply(p, inner LogicalPlan, schema expression.Schema,
 	}
 	ap.initID()
 	addChild(ap, p)
+	_, inner, b.err = inner.PredicatePushDown(nil)
+	if b.err != nil {
+		return nil
+	}
 	outerColumns, err := inner.PruneColumnsAndResolveIndices(inner.GetSchema())
 	if err != nil {
 		b.err = errors.Trace(err)

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -24,11 +24,6 @@ func addSelection(p LogicalPlan, child LogicalPlan, conditions []expression.Expr
 		baseLogicalPlan: newBaseLogicalPlan(Sel, allocator)}
 	selection.initID()
 	selection.SetSchema(child.GetSchema().DeepCopy())
-	var outer []*expression.Column
-	for _, cond := range conditions {
-		_, outer = extractColumn(cond, nil, outer)
-	}
-	selection.correlated = child.IsCorrelated() || len(outer) > 0
 	return InsertPlan(p, child, selection)
 }
 


### PR DESCRIPTION
when "select * from t where exists (select * from k , p where k.id = t.id)", the subquery plan is 
Join(k, p) -> Selection
the Selection is correlated, but join is non correlated. After ppd, the plan is changed to
Join(k->Selection, p) and join is still non correlated.

Then I give up to do ppd when build subquery, because when a subquery is built as semi join, applying ppd to semi join will also apply ppd to inner plan. when subquery is built as apply, ppd will be applied at this point.
@coocood @zimulala @shenli PTAL