### PR TITLE
add not push down during refining.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1508,6 +1508,8 @@ func (s *testSuite) TestToPBExpr(c *C) {
 	result.Check(testkit.Rows("1.100000 1"))
 	result = tk.MustQuery("select * from t where b >= 3")
 	result.Check(testkit.Rows("3.300000 3"))
+	result = tk.MustQuery("select * from t where not (b = 1)")
+	result.Check(testkit.Rows("2.400000 2", "3.300000 3"))
 	// TODO: This test cannot pass temporarily, because local store doesn't support decimal correctly.
 	//result = tk.MustQuery("select * from t where b&1 = a|1")
 	//result.Check(testkit.Rows("1.100000 1"))
@@ -1528,6 +1530,16 @@ func (s *testSuite) TestToPBExpr(c *C) {
 	result.Check(testkit.Rows(rowStr0, rowStr1))
 	result = tk.MustQuery("select * from t where a like 'ab_12'")
 	result.Check(nil)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key)")
+	tk.MustExec("insert t values (1)")
+	tk.MustExec("insert t values (2)")
+	result = tk.MustQuery("select * from t where not (a = 1)")
+	result.Check(testkit.Rows("2"))
+	result = tk.MustQuery("select * from t where not(not (a = 1))")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select * from t where not(a != 1 and a != 2)")
+	result.Check(testkit.Rows("1", "2"))
 	plan.UseNewPlanner = false
 }
 

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -471,7 +471,7 @@ func pushDownNot(expr expression.Expression, not bool) expression.Expression {
 			if not {
 				args := f.Args
 				for i, a := range args {
-					args[i] = pushDownNot(a, !not)
+					args[i] = pushDownNot(a, true)
 				}
 				nf, _ := expression.NewFunction(ast.OrOr, f.GetType(), args...)
 				return nf
@@ -484,7 +484,7 @@ func pushDownNot(expr expression.Expression, not bool) expression.Expression {
 			if not {
 				args := f.Args
 				for i, a := range args {
-					args[i] = pushDownNot(a, !not)
+					args[i] = pushDownNot(a, true)
 				}
 				nf, _ := expression.NewFunction(ast.AndAnd, f.GetType(), args...)
 				return nf

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -444,7 +444,7 @@ func (c *conditionChecker) checkColumn(expr expression.Expression) bool {
 	return true
 }
 
-var oppositeOp map[string]string = map[string]string{
+var oppositeOp = map[string]string{
 	ast.LT: ast.GE,
 	ast.GE: ast.LT,
 	ast.GT: ast.LE,


### PR DESCRIPTION
when select * from t where not (id = 1) and id is pk, the refiner won't process, lt, gt, le, ge, eq, ne, and, or etc.
This pr implements it by adding a not push down logic.
@shenli @coocood @zimulala PTAL