### PR TITLE
*: Support set variable to default value.

### DIFF
--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -173,7 +173,7 @@ func (e *SimpleExec) executeSet(s *ast.SetStmt) error {
 			if sysVar.Scope&variable.ScopeGlobal == 0 {
 				return errors.Errorf("Variable '%s' is a SESSION variable and can't be used with SET GLOBAL", name)
 			}
-			value, err := evaluator.Eval(e.ctx, v.Value)
+			value, err := e.getVarValue(v, sysVar, nil)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -193,7 +193,7 @@ func (e *SimpleExec) executeSet(s *ast.SetStmt) error {
 			if sysVar.Scope&variable.ScopeSession == 0 {
 				return errors.Errorf("Variable '%s' is a GLOBAL variable and should be set with SET GLOBAL", name)
 			}
-			value, err := evaluator.Eval(e.ctx, v.Value)
+			value, err := e.getVarValue(v, nil, globalVars)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -204,6 +204,27 @@ func (e *SimpleExec) executeSet(s *ast.SetStmt) error {
 		}
 	}
 	return nil
+}
+
+func (e *SimpleExec) getVarValue(v *ast.VariableAssignment, sysVar *variable.SysVar, globalVars variable.GlobalVarAccessor) (value types.Datum, err error) {
+	switch v.Value.(type) {
+	case *ast.DefaultExpr:
+		// To set a SESSION variable to the GLOBAL value or a GLOBAL value
+		// to the compiled-in MySQL default value, use the DEFAULT keyword.
+		// See http://dev.mysql.com/doc/refman/5.7/en/set-statement.html
+		if sysVar != nil {
+			value = types.NewStringDatum(sysVar.Value)
+		} else {
+			s, err1 := globalVars.GetGlobalSysVar(e.ctx, strings.ToLower(v.Name))
+			if err1 != nil {
+				return value, errors.Trace(err1)
+			}
+			value = types.NewStringDatum(s)
+		}
+	default:
+		value, err = evaluator.Eval(e.ctx, v.Value)
+	}
+	return value, errors.Trace(err)
 }
 
 func (e *SimpleExec) setCharset(cs, co string) error {

--- a/executor/executor_simple_test.go
+++ b/executor/executor_simple_test.go
@@ -110,6 +110,21 @@ func (s *testSuite) TestSetVar(c *C) {
 	testSQL = "SET @@global.autocommit=1, @issue998b=6;"
 	tk.MustExec(testSQL)
 	tk.MustQuery(`select @issue998b, @@global.autocommit;`).Check(testkit.Rows("6 1"))
+
+	// Set default
+	// {ScopeGlobal | ScopeSession, "low_priority_updates", "OFF"},
+	// For global var
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	tk.MustExec(`set @@global.low_priority_updates="ON";`)
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("ON"))
+	tk.MustExec(`set @@global.low_priority_updates=DEFAULT;`) // It will be set to compiled-in default value.
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	// For session
+	tk.MustQuery(`select @@session.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	tk.MustExec(`set @@global.low_priority_updates="ON";`)
+	tk.MustExec(`set @@session.low_priority_updates=DEFAULT;`) // It will be set to global var value.
+	tk.MustQuery(`select @@session.low_priority_updates;`).Check(testkit.Rows("ON"))
+
 	plan.UseNewPlanner = false
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -214,6 +214,9 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		// global system variables
 		{"SET GLOBAL autocommit = 1", true},
 		{"SET @@global.autocommit = 1", true},
+		// Set default value
+		{"SET @@global.autocommit = default", true},
+		{"SET @@session.autocommit = default", true},
 		// SET CHARACTER SET
 		{"SET CHARACTER SET utf8mb4;", true},
 		{"SET CHARACTER SET 'utf8mb4';", true},


### PR DESCRIPTION
To set a SESSION variable to the GLOBAL value or a GLOBAL value to the compiled-in MySQL default value, use the DEFAULT keyword.
See http://dev.mysql.com/doc/refman/5.7/en/set-statement.html
@coocood @zimulala @tiancaiamao 