### PR TITLE
fix bug of limit.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -491,21 +491,9 @@ func (b *executorBuilder) buildSort(v *plan.Sort) Executor {
 
 func (b *executorBuilder) buildLimit(v *plan.Limit) Executor {
 	src := b.build(v.GetChildByIndex(0))
-	cnt := int64(v.Offset + v.Count)
-	switch x := src.(type) {
-	case *NewXSelectIndexExec:
-		if x.indexPlan.LimitCount == nil {
-			x.indexPlan.LimitCount = &cnt
-			if v.Offset == 0 {
-				return src
-			}
-		}
-	case *NewXSelectTableExec:
-		if x.limitCount != nil {
-			x.limitCount = &cnt
-			if v.Offset == 0 {
-				return src
-			}
+	if x, ok := src.(NewXExecutor); ok {
+		if x.AddLimit(v) && v.Offset == 0 {
+			return src
 		}
 	}
 	e := &LimitExec{

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -608,6 +608,9 @@ func (s *testSuite) TestSelectLimit(c *C) {
 	r.Check(testkit.Rows(rowStr1))
 	tk.MustExec("commit")
 
+	r = tk.MustQuery("select id from (select * from select_limit limit 1) k where id != 1;")
+	r.Check(testkit.Rows())
+
 	tk.MustExec("begin")
 	r = tk.MustQuery("select * from select_limit limit 18446744073709551615 offset 0;")
 	rowStr2 := fmt.Sprintf("%v %v", 2, []byte("hello"))

--- a/executor/new_builder.go
+++ b/executor/new_builder.go
@@ -204,9 +204,17 @@ func (b *executorBuilder) buildSelection(v *plan.Selection) Executor {
 	var src Executor
 	switch x := child.(type) {
 	case *plan.PhysicalTableScan:
-		src = b.buildNewTableScan(x, v)
+		if x.LimitCount == nil {
+			src = b.buildNewTableScan(x, v)
+		} else {
+			src = b.buildNewTableScan(x, nil)
+		}
 	case *plan.PhysicalIndexScan:
-		src = b.buildNewIndexScan(x, v)
+		if x.LimitCount == nil {
+			src = b.buildNewIndexScan(x, v)
+		} else {
+			src = b.buildNewIndexScan(x, nil)
+		}
 	default:
 		src = b.build(x)
 	}

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -217,8 +217,9 @@ func (p *Apply) PredicatePushDown(predicates []expression.Expression) (ret []exp
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
 func (p *Limit) PredicatePushDown(predicates []expression.Expression) ([]expression.Expression, LogicalPlan, error) {
-	ret, _, err := p.baseLogicalPlan.PredicatePushDown(predicates)
-	return ret, p, errors.Trace(err)
+	// Limit forbids any condition to push down.
+	_, _, err := p.baseLogicalPlan.PredicatePushDown(nil)
+	return predicates, p, errors.Trace(err)
 }
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.


### PR DESCRIPTION
1. select id from (select * from t limit 1) t where id = 1, condition id = 1 will push through limit, it's wrong.
2. select * from t where a = 1 and b < 1 limit 1, when a = 1 is access condition and b < 1 is filter condition.
after doing physical optimization, the plan will be TableScan(t)-> Selection(b < 1) -> Limit -> Projection.
The Limit will not pushed into table scan and this pr will fix it.

@shenli @coocood @zimulala @tiancaiamao  PTAL