### PR TITLE
fix a bug when push down conditions.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1324,7 +1324,7 @@ func (s *testSuite) TestDefaultNull(c *C) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 1 <nil>"))
 }
 
-func (s *testSuite) TestUsignedPKColumn(c *C) {
+func (s *testSuite) TestUnsignedPKColumn(c *C) {
 	defer testleak.AfterTest(c)()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -1643,6 +1643,16 @@ func (s *testSuite) TestNewSubquery(c *C) {
 	result.Check(testkit.Rows("<nil>", "<nil>", "<nil>", "<nil>"))
 	result = tk.MustQuery("select (c) > all (select c from t) from t")
 	result.Check(testkit.Rows("0", "0", "0", "<nil>"))
+
+	tk.MustExec("drop table if exists a")
+	tk.MustExec("create table a (c int, d int)")
+	tk.MustExec("insert a values (1, 2)")
+	tk.MustExec("drop table if exists b")
+	tk.MustExec("create table b (c int, d int)")
+	tk.MustExec("insert b values (2, 1)")
+
+	result = tk.MustQuery("select * from a b where c = (select d from b a where a.c = 2 and b.c = 1)")
+	result.Check(testkit.Rows("1 2"))
 }
 
 func (s *testSuite) TestNewTableDual(c *C) {

--- a/executor/new_executor.go
+++ b/executor/new_executor.go
@@ -1013,7 +1013,7 @@ func (b *executorBuilder) columnToPBExpr(client kv.Client, column *expression.Co
 
 	id := int64(-1)
 	for _, col := range tbl.Columns {
-		if tbl.Name == column.TblName && col.Name == column.ColName {
+		if !column.Correlated && col.Name == column.ColName {
 			id = col.ID
 			break
 		}


### PR DESCRIPTION
When we push down a condition to xExecutor, executor builder will check whether a column's table name matches the table name. But in new plan, the column's table name can be the alias table name. Indeed, we will only check whether the column is correlated.
@coocood @shenli @zimulala PTAL 