### PR TITLE
resolve having column correctly.

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -419,10 +419,10 @@ func colMatch(a *ast.ColumnName, b *ast.ColumnName) bool {
 	return false
 }
 
-func matchField(f *ast.SelectField, col *ast.ColumnNameExpr) bool {
+func matchField(f *ast.SelectField, col *ast.ColumnNameExpr, ignoreAsName bool) bool {
 	// if col specify a table name, resolve from table source directly.
 	if col.Name.Table.L == "" {
-		if f.AsName.L == "" {
+		if f.AsName.L == "" || ignoreAsName {
 			if curCol, isCol := f.Expr.(*ast.ColumnNameExpr); isCol {
 				return curCol.Name.Name.L == col.Name.Name.L
 			}
@@ -434,14 +434,14 @@ func matchField(f *ast.SelectField, col *ast.ColumnNameExpr) bool {
 	return false
 }
 
-func resolveFromSelectFields(v *ast.ColumnNameExpr, fields []*ast.SelectField) (index int, err error) {
+func resolveFromSelectFields(v *ast.ColumnNameExpr, fields []*ast.SelectField, ignoreAsName bool) (index int, err error) {
 	var matchedExpr ast.ExprNode
 	index = -1
 	for i, field := range fields {
 		if field.Auxiliary {
 			continue
 		}
-		if matchField(field, v) {
+		if matchField(field, v, ignoreAsName) {
 			curCol, isCol := field.Expr.(*ast.ColumnNameExpr)
 			if !isCol {
 				return i, nil
@@ -460,7 +460,7 @@ func resolveFromSelectFields(v *ast.ColumnNameExpr, fields []*ast.SelectField) (
 
 // AggregateFuncExtractor visits Expr tree.
 // It converts ColunmNameExpr to AggregateFuncExpr and collects AggregateFuncExpr.
-type AggregateFuncExtractor struct {
+type havingAndOrderbyExprResolver struct {
 	inAggFunc    bool
 	inExpr       bool
 	orderBy      bool
@@ -473,7 +473,7 @@ type AggregateFuncExtractor struct {
 }
 
 // Enter implements Visitor interface.
-func (a *AggregateFuncExtractor) Enter(n ast.Node) (node ast.Node, skipChildren bool) {
+func (a *havingAndOrderbyExprResolver) Enter(n ast.Node) (node ast.Node, skipChildren bool) {
 	switch n.(type) {
 	case *ast.AggregateFuncExpr:
 		a.inAggFunc = true
@@ -488,7 +488,7 @@ func (a *AggregateFuncExtractor) Enter(n ast.Node) (node ast.Node, skipChildren 
 	return n, false
 }
 
-func (a *AggregateFuncExtractor) resolveFromSchema(v *ast.ColumnNameExpr, schema expression.Schema) (int, error) {
+func (a *havingAndOrderbyExprResolver) resolveFromSchema(v *ast.ColumnNameExpr, schema expression.Schema) (int, error) {
 	col, err := schema.FindColumn(v.Name)
 	if err != nil {
 		return -1, errors.Trace(err)
@@ -516,7 +516,7 @@ func (a *AggregateFuncExtractor) resolveFromSchema(v *ast.ColumnNameExpr, schema
 }
 
 // Leave implements Visitor interface.
-func (a *AggregateFuncExtractor) Leave(n ast.Node) (node ast.Node, ok bool) {
+func (a *havingAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, ok bool) {
 	switch v := n.(type) {
 	case *ast.AggregateFuncExpr:
 		a.inAggFunc = false
@@ -541,12 +541,16 @@ func (a *AggregateFuncExtractor) Leave(n ast.Node) (node ast.Node, ok bool) {
 		}
 		index := -1
 		if resolveFieldsFirst {
-			index, a.err = resolveFromSelectFields(v, a.selectFields)
+			index, a.err = resolveFromSelectFields(v, a.selectFields, false)
 			if a.err != nil {
 				return node, false
 			}
 			if index == -1 {
-				index, a.err = a.resolveFromSchema(v, a.p.GetSchema())
+				if a.orderBy {
+					index, a.err = a.resolveFromSchema(v, a.p.GetSchema())
+				} else {
+					index, a.err = resolveFromSelectFields(v, a.selectFields, true)
+				}
 			}
 		} else {
 			index, a.err = a.resolveFromSchema(v, a.p.GetSchema())
@@ -554,7 +558,7 @@ func (a *AggregateFuncExtractor) Leave(n ast.Node) (node ast.Node, ok bool) {
 				return node, false
 			}
 			if index == -1 {
-				index, a.err = resolveFromSelectFields(v, a.selectFields)
+				index, a.err = resolveFromSelectFields(v, a.selectFields, false)
 			}
 		}
 		if a.err != nil {
@@ -574,7 +578,7 @@ func (a *AggregateFuncExtractor) Leave(n ast.Node) (node ast.Node, ok bool) {
 
 func (b *planBuilder) resolveHavingAndOrderBy(sel *ast.SelectStmt, p LogicalPlan) (
 	map[*ast.AggregateFuncExpr]int, map[*ast.AggregateFuncExpr]int) {
-	extractor := &AggregateFuncExtractor{
+	extractor := &havingAndOrderbyExprResolver{
 		p:            p,
 		selectFields: sel.Fields.Fields,
 		aggMapper:    make(map[*ast.AggregateFuncExpr]int),
@@ -652,7 +656,7 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			g.err = errors.Trace(err)
 		} else if col == nil || !g.inExpr {
 			var index = -1
-			index, g.err = resolveFromSelectFields(v, g.fields)
+			index, g.err = resolveFromSelectFields(v, g.fields, false)
 			if g.err != nil {
 				return inNode, false
 			}

--- a/session_test.go
+++ b/session_test.go
@@ -1640,7 +1640,7 @@ func (s *testSessionSuite) TestHaving(c *C) {
 	mustExecMatch(c, se, "select a.c1 from t as a having c1 = 1;", [][]interface{}{{1}})
 	mustExecMatch(c, se, "select c1 as a from t group by c3 having sum(a) = 1;", [][]interface{}{{1}})
 	mustExecMatch(c, se, "select c1 as a from t group by c3 having sum(a) + a = 2;", [][]interface{}{{1}})
-	//	mustExecMatch(c, se, "select a.c1 as c, a.c1 as d from t as a, t as b having c1 = 1 limit 1;", [][]interface{}{{1, 1}})
+	mustExecMatch(c, se, "select a.c1 as c, a.c1 as d from t as a, t as b having c1 = 1 limit 1;", [][]interface{}{{1, 1}})
 
 	mustExecMatch(c, se, "select sum(c1) from t group by c1 having sum(c1)", [][]interface{}{{1}, {2}, {3}})
 	mustExecMatch(c, se, "select sum(c1) - 1 from t group by c1 having sum(c1) - 1", [][]interface{}{{1}, {2}})


### PR DESCRIPTION
for query, select t1.c  as c1, t1.c as c2 from t1, t2 having c < 0; It won't report "ambiguous" error, but retrieve c as t1.c which appearing in select fields.
The rule is that columns in having will resolved by original columns when it can't find the name only by as name.
@shenli @zimulala @coocood @tiancaiamao @XuHuaiyu  PTAL