### PR TITLE
*: Fix bug for use new planner as default

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -83,7 +83,7 @@ func main() {
 		perfschema.EnablePerfSchema()
 	}
 
-	if *useNewPlan {
+	if !*useNewPlan {
 		plan.UseNewPlanner = false
 	}
 


### PR DESCRIPTION
plan.UseNewPlanner is true by default. When set --newplan flag to false, we will set UseNewPlanner to false.
It is a bug intruduced in #1542 
@coocood @hanfei19910905 @zimulala @tiancaiamao PTAL

@hanfei19910905 Please send a PR to tidb-test.