### PR TITLE
*: improve time codec.

### DIFF
--- a/mysql/time.go
+++ b/mysql/time.go
@@ -30,7 +30,6 @@ var (
 	ErrInvalidTimeFormat = errors.New("invalid time format")
 	ErrInvalidYearFormat = errors.New("invalid year format")
 	ErrInvalidYear       = errors.New("invalid year")
-	ErrInvalidBinary     = errors.New("invalid time binary")
 )
 
 // Time format without fractional seconds precision.

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -313,7 +313,7 @@ func (t Time) ToPackedUint() uint64 {
 	return ((ymd<<17 | hms) << 24) | micro
 }
 
-// FromPackedUint decodes Time from an packed uint64 value.
+// FromPackedUint decodes Time from a packed uint64 value.
 func (t *Time) FromPackedUint(packed uint64) error {
 	if packed == 0 {
 		t.Time = ZeroTime

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -321,14 +321,14 @@ func (t *Time) FromPackedUint(packed uint64) error {
 	}
 	ymdhms := packed >> 24
 	ymd := ymdhms >> 17
-	day := int(ymd % (1 << 5))
+	day := int(ymd & (1<<5 - 1))
 	ym := ymd >> 5
 	month := int(ym % 13)
 	year := int(ym / 13)
 
-	hms := ymdhms % (1 << 17)
-	second := int(hms % (1 << 6))
-	minute := int((hms >> 6) % (1 << 6))
+	hms := ymdhms & (1<<17 - 1)
+	second := int(hms & (1<<6 - 1))
+	minute := int((hms >> 6) & (1<<6 - 1))
 	hour := int(hms >> 12)
 
 	nanosec := int(packed%(1<<24)) * 1000

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -307,10 +307,10 @@ func (t Time) ToPackedUint() uint64 {
 	}
 	year, month, day := tm.Date()
 	hour, minute, sec := tm.Clock()
-	ymd := uint64(((year * 13 + int(month)) << 5) | day)
-	hms := uint64(hour << 12 | minute << 6 | sec)
-	micro := uint64(tm.Nanosecond()/1000)
-	return ((ymd << 17 | hms) << 24) | micro
+	ymd := uint64(((year*13 + int(month)) << 5) | day)
+	hms := uint64(hour<<12 | minute<<6 | sec)
+	micro := uint64(tm.Nanosecond() / 1000)
+	return ((ymd<<17 | hms) << 24) | micro
 }
 
 // FromPackedUint decodes Time from an packed uint64 value.
@@ -321,17 +321,17 @@ func (t *Time) FromPackedUint(packed uint64) error {
 	}
 	ymdhms := packed >> 24
 	ymd := ymdhms >> 17
-	day := int(ymd % (1<<5))
+	day := int(ymd % (1 << 5))
 	ym := ymd >> 5
 	month := int(ym % 13)
-	year := int(ym/13)
+	year := int(ym / 13)
 
 	hms := ymdhms % (1 << 17)
-	second := int(hms % (1<<6))
+	second := int(hms % (1 << 6))
 	minute := int((hms >> 6) % (1 << 6))
 	hour := int(hms >> 12)
 
-	nanosec := int(packed % (1 << 24)) * 1000
+	nanosec := int(packed%(1<<24)) * 1000
 	err := checkTime(year, month, day, hour, minute, second, nanosec)
 	if err != nil {
 		return errors.Trace(err)

--- a/mysql/time.go
+++ b/mysql/time.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unicode"
 
+	"encoding/binary"
 	"github.com/juju/errors"
 )
 
@@ -30,6 +31,7 @@ var (
 	ErrInvalidTimeFormat = errors.New("invalid time format")
 	ErrInvalidYearFormat = errors.New("invalid year format")
 	ErrInvalidYear       = errors.New("invalid year")
+	ErrInvalidBinary     = errors.New("invalid binary")
 )
 
 // Time format without fractional seconds precision.
@@ -61,7 +63,7 @@ var (
 	ZeroDuration = Duration{Duration: time.Duration(0), Fsp: DefaultFsp}
 
 	// ZeroTime is the zero value for time.Time type.
-	ZeroTime = time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)
+	ZeroTime = time.Date(0, 0, 0, 0, 0, 0, 0, time.Local)
 
 	// ZeroDatetime is the zero value for datetime Time.
 	ZeroDatetime = Time{
@@ -83,6 +85,8 @@ var (
 		Type: TypeDate,
 		Fsp:  DefaultFsp,
 	}
+
+	local = time.Local
 )
 
 var (
@@ -157,71 +161,6 @@ func (t Time) String() string {
 // IsZero returns a boolean indicating whether the time is equal to ZeroTime.
 func (t Time) IsZero() bool {
 	return t.Time.Equal(ZeroTime)
-}
-
-// Marshal returns the binary encoding of time.
-func (t Time) Marshal() ([]byte, error) {
-	var (
-		b   []byte
-		err error
-	)
-
-	switch t.Type {
-	case TypeDatetime, TypeDate:
-		// We must use t's Zone not current Now Zone,
-		// For EDT/EST, even we create the time with time.Local location,
-		// we may still have a different zone with current Now time.
-		_, offset := t.Zone()
-		// For datetime and date type, we have a trick to marshal.
-		// e.g, if local time is 2010-10-10T10:10:10 UTC+8
-		// we will change this to 2010-10-10T10:10:10 UTC and then marshal.
-		b, err = t.Time.Add(time.Duration(offset) * time.Second).UTC().MarshalBinary()
-	case TypeTimestamp:
-		b, err = t.Time.UTC().MarshalBinary()
-	default:
-		err = errors.Errorf("invalid time type %d", t.Type)
-	}
-
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return b, nil
-}
-
-// Unmarshal decodes the binary data into Time with current local time.
-func (t *Time) Unmarshal(b []byte) error {
-	return t.UnmarshalInLocation(b, time.Local)
-}
-
-// UnmarshalInLocation decodes the binary data
-// into Time with a specific time Location.
-func (t *Time) UnmarshalInLocation(b []byte, loc *time.Location) error {
-	if err := t.Time.UnmarshalBinary(b); err != nil {
-		return errors.Trace(err)
-	}
-
-	if t.IsZero() {
-		return nil
-	}
-
-	if t.Type == TypeDatetime || t.Type == TypeDate {
-		// e.g, for 2010-10-10T10:10:10 UTC, we will unmarshal to 2010-10-10T10:10:10 location
-		_, offset := t.Time.In(loc).Zone()
-
-		t.Time = t.Time.Add(-time.Duration(offset) * time.Second).In(loc)
-		if t.Type == TypeDate {
-			// for date type ,we will only use year, month and day.
-			year, month, day := t.Time.Date()
-			t.Time = time.Date(year, month, day, 0, 0, 0, 0, loc)
-		}
-	} else if t.Type == TypeTimestamp {
-		t.Time = t.Time.In(loc)
-	} else {
-		return errors.Errorf("invalid time type %d", t.Type)
-	}
-
-	return nil
 }
 
 const numberFormat = "20060102150405"
@@ -344,6 +283,59 @@ func (t Time) RoundFrac(fsp int) (Time, error) {
 
 	nt := t.Time.Round(time.Duration(math.Pow10(9-fsp)) * time.Nanosecond)
 	return Time{Time: nt, Type: t.Type, Fsp: fsp}, nil
+}
+
+// ToBin encodes Time to 12 bytes binary data.
+func (t Time) ToBin() []byte {
+	bin := make([]byte, 12)
+	tm := t.Time
+	if t.IsZero() {
+		return bin
+	}
+	if t.Type == TypeTimestamp {
+		tm = t.UTC()
+	}
+	year, month, day := tm.Date()
+	hour, minute, sec := tm.Clock()
+	intPart := (year*ten4+int(month)*ten2+day)*ten6 + hour*ten4 + minute*ten2 + sec
+	fracPart := uint32(tm.Nanosecond() / 1000)
+	binary.BigEndian.PutUint64(bin, uint64(intPart))
+	binary.BigEndian.PutUint32(bin[8:], fracPart)
+	return bin
+}
+
+// FromBin decodes 12 bytes binary data to Time.
+func (t *Time) FromBin(bin []byte) error {
+	if len(bin) != 12 {
+		return ErrInvalidBinary
+	}
+	intPart := int(binary.BigEndian.Uint64(bin))
+	fracPart := binary.BigEndian.Uint32(bin[8:])
+	if intPart == 0 && fracPart == 0 {
+		t.Time = ZeroTime
+		return nil
+	}
+	x := intPart / ten6 // date
+	year := x / ten4
+	x = x % ten4
+	month := x / ten2
+	day := x % ten2
+	x = intPart % ten6 // clock
+	hour := x / ten4
+	x = x % ten4
+	minute := x / ten2
+	second := x % ten2
+	nanosec := int(fracPart) * 1000
+	err := checkTime(year, month, day, hour, minute, second, nanosec)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	loc := local
+	if t.Type == TypeTimestamp {
+		loc = time.UTC
+	}
+	t.Time = time.Date(year, time.Month(month), day, hour, minute, second, nanosec, loc).In(local)
+	return nil
 }
 
 func parseDateFormat(format string) []string {

--- a/mysql/time_test.go
+++ b/mysql/time_test.go
@@ -321,49 +321,47 @@ func (s *testTimeSuite) TestCodec(c *C) {
 	defer testleak.AfterTest(c)()
 	t, err := ParseTimestamp("2010-10-10 10:11:11")
 	c.Assert(err, IsNil)
-	b, err := t.Marshal()
+	b := t.ToBin()
 	c.Assert(err, IsNil)
 
 	var t1 Time
 	t1.Type = TypeTimestamp
 
 	z := s.getLocation(c)
-
-	err = t1.UnmarshalInLocation(b, z)
+	local = z
+	err = t1.FromBin(b)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Not(Equals), t1.String())
 
-	err = t1.UnmarshalInLocation(b, time.Local)
+	local = time.Local
+	err = t1.FromBin(b)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Equals, t1.String())
 
 	t1.Time = time.Now()
-	b, err = t1.Marshal()
-	c.Assert(err, IsNil)
+	b = t1.ToBin()
 
 	var t2 Time
 	t2.Type = TypeTimestamp
-	err = t2.Unmarshal(b)
+	err = t2.FromBin(b)
 	c.Assert(err, IsNil)
 	c.Assert(t1.String(), Equals, t2.String())
 
-	b, err = ZeroDatetime.Marshal()
-	c.Assert(err, IsNil)
+	b = ZeroDatetime.ToBin()
 
 	var t3 Time
 	t3.Type = TypeDatetime
-	err = t3.Unmarshal(b)
+	err = t3.FromBin(b)
 	c.Assert(err, IsNil)
 	c.Assert(t3.String(), Equals, ZeroDatetime.String())
 
 	t, err = ParseDatetime("0001-01-01 00:00:00")
 	c.Assert(err, IsNil)
-	b, err = t.Marshal()
-	c.Assert(err, IsNil)
+	b = t.ToBin()
 
 	var t4 Time
 	t4.Type = TypeDatetime
-	err = t4.Unmarshal(b)
+	err = t4.FromBin(b)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Equals, t4.String())
 
@@ -378,13 +376,12 @@ func (s *testTimeSuite) TestCodec(c *C) {
 		t, err := ParseTime(test, TypeDatetime, MaxFsp)
 		c.Assert(err, IsNil)
 
-		b, err := t.Marshal()
-		c.Assert(err, IsNil)
+		b = t.ToBin()
 
 		var dest Time
 		dest.Type = TypeDatetime
 		dest.Fsp = MaxFsp
-		err = dest.Unmarshal(b)
+		err = dest.FromBin(b)
 		c.Assert(err, IsNil)
 		c.Assert(dest.String(), Equals, test)
 	}

--- a/mysql/time_test.go
+++ b/mysql/time_test.go
@@ -321,47 +321,46 @@ func (s *testTimeSuite) TestCodec(c *C) {
 	defer testleak.AfterTest(c)()
 	t, err := ParseTimestamp("2010-10-10 10:11:11")
 	c.Assert(err, IsNil)
-	b := t.ToBin()
-	c.Assert(err, IsNil)
+	packed := t.ToPackedUint()
 
 	var t1 Time
 	t1.Type = TypeTimestamp
 
 	z := s.getLocation(c)
 	local = z
-	err = t1.FromBin(b)
+	err = t1.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Not(Equals), t1.String())
 
 	local = time.Local
-	err = t1.FromBin(b)
+	err = t1.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Equals, t1.String())
 
 	t1.Time = time.Now()
-	b = t1.ToBin()
+	packed = t1.ToPackedUint()
 
 	var t2 Time
 	t2.Type = TypeTimestamp
-	err = t2.FromBin(b)
+	err = t2.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t1.String(), Equals, t2.String())
 
-	b = ZeroDatetime.ToBin()
+	packed = ZeroDatetime.ToPackedUint()
 
 	var t3 Time
 	t3.Type = TypeDatetime
-	err = t3.FromBin(b)
+	err = t3.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t3.String(), Equals, ZeroDatetime.String())
 
 	t, err = ParseDatetime("0001-01-01 00:00:00")
 	c.Assert(err, IsNil)
-	b = t.ToBin()
+	packed = t.ToPackedUint()
 
 	var t4 Time
 	t4.Type = TypeDatetime
-	err = t4.FromBin(b)
+	err = t4.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t.String(), Equals, t4.String())
 
@@ -376,12 +375,12 @@ func (s *testTimeSuite) TestCodec(c *C) {
 		t, err := ParseTime(test, TypeDatetime, MaxFsp)
 		c.Assert(err, IsNil)
 
-		b = t.ToBin()
+		packed = t.ToPackedUint()
 
 		var dest Time
 		dest.Type = TypeDatetime
 		dest.Fsp = MaxFsp
-		err = dest.FromBin(b)
+		err = dest.FromPackedUint(packed)
 		c.Assert(err, IsNil)
 		c.Assert(dest.String(), Equals, test)
 	}

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -136,11 +136,8 @@ func flatten(data types.Datum) (types.Datum, error) {
 	switch data.Kind() {
 	case types.KindMysqlTime:
 		// for mysql datetime, timestamp and date type
-		b, err := data.GetMysqlTime().Marshal()
-		if err != nil {
-			return types.NewDatum(nil), errors.Trace(err)
-		}
-		return types.NewDatum(b), nil
+		bin := data.GetMysqlTime().ToBin()
+		return types.NewBytesDatum(bin), nil
 	case types.KindMysqlDuration:
 		// for mysql time type
 		data.SetInt64(int64(data.GetMysqlDuration().Duration))
@@ -308,16 +305,12 @@ func Unflatten(datum types.Datum, ft *types.FieldType, inIndex bool) (types.Datu
 		return datum, nil
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
 		var t mysql.Time
+		t.Type = ft.Tp
+		t.Fsp = ft.Decimal
 		var err error
-		if inIndex {
-			t, err = mysql.ParseTime(datum.GetString(), ft.Tp, ft.Decimal)
-		} else {
-			t.Type = ft.Tp
-			t.Fsp = ft.Decimal
-			err = t.Unmarshal(datum.GetBytes())
-			if err != nil {
-				return datum, errors.Trace(err)
-			}
+		err = t.FromBin(datum.GetBytes())
+		if err != nil {
+			return datum, errors.Trace(err)
 		}
 		datum.SetMysqlTime(t)
 		return datum, nil

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -136,8 +136,7 @@ func flatten(data types.Datum) (types.Datum, error) {
 	switch data.Kind() {
 	case types.KindMysqlTime:
 		// for mysql datetime, timestamp and date type
-		bin := data.GetMysqlTime().ToBin()
-		return types.NewBytesDatum(bin), nil
+		return types.NewUintDatum(data.GetMysqlTime().ToPackedUint()), nil
 	case types.KindMysqlDuration:
 		// for mysql time type
 		data.SetInt64(int64(data.GetMysqlDuration().Duration))
@@ -308,7 +307,7 @@ func Unflatten(datum types.Datum, ft *types.FieldType, inIndex bool) (types.Datu
 		t.Type = ft.Tp
 		t.Fsp = ft.Decimal
 		var err error
-		err = t.FromBin(datum.GetBytes())
+		err = t.FromPackedUint(datum.GetUint64())
 		if err != nil {
 			return datum, errors.Trace(err)
 		}

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -50,7 +50,8 @@ func encode(b []byte, vals []types.Datum, comparable bool) ([]byte, error) {
 		case types.KindString, types.KindBytes:
 			b = encodeBytes(b, val.GetBytes(), comparable)
 		case types.KindMysqlTime:
-			b = encodeBytes(b, []byte(val.GetMysqlTime().String()), comparable)
+			// As ToBin creates a fixed length(12) bytes, we can encode it in compact bytes, and still comparable.
+			b = encodeBytes(b, val.GetMysqlTime().ToBin(), false)
 		case types.KindMysqlDuration:
 			// duration may have negative value, so we cannot use String to encode directly.
 			b = append(b, durationFlag)

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -50,8 +50,8 @@ func encode(b []byte, vals []types.Datum, comparable bool) ([]byte, error) {
 		case types.KindString, types.KindBytes:
 			b = encodeBytes(b, val.GetBytes(), comparable)
 		case types.KindMysqlTime:
-			// As ToBin creates a fixed length(12) bytes, we can encode it in compact bytes, and still comparable.
-			b = encodeBytes(b, val.GetMysqlTime().ToBin(), false)
+			b = append(b, uintFlag)
+			b = EncodeUint(b, val.GetMysqlTime().ToPackedUint())
 		case types.KindMysqlDuration:
 			// duration may have negative value, so we cannot use String to encode directly.
 			b = append(b, durationFlag)

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -494,7 +494,10 @@ func (s *testCodecSuite) TestTime(c *C) {
 		c.Assert(err, IsNil)
 		v, err := Decode(b)
 		c.Assert(err, IsNil)
-		c.Assert(v, DeepEquals, types.MakeDatums([]byte(t)))
+		var t mysql.Time
+		t.Type = mysql.TypeDatetime
+		t.FromBin(v[0].GetBytes())
+		c.Assert(types.NewDatum(t), DeepEquals, m)
 	}
 
 	tblCmp := []struct {

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -496,7 +496,7 @@ func (s *testCodecSuite) TestTime(c *C) {
 		c.Assert(err, IsNil)
 		var t mysql.Time
 		t.Type = mysql.TypeDatetime
-		t.FromBin(v[0].GetBytes())
+		t.FromPackedUint(v[0].GetUint64())
 		c.Assert(types.NewDatum(t), DeepEquals, m)
 	}
 


### PR DESCRIPTION
Use a more simple and efficient way to encode Time types.