### PR TITLE
fix a few bugs.

### DIFF
--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -179,7 +179,7 @@ func (p *DataSource) handleIndexScan(prop requiredProperty, index *model.IndexIn
 	}
 	for _, colInfo := range is.Columns {
 		for _, indexCol := range is.Index.Columns {
-			if colInfo.Name.L != indexCol.Name.L {
+			if colInfo.Name.L != indexCol.Name.L || indexCol.Length != types.UnspecifiedLength {
 				is.DoubleRead = true
 				break
 			}


### PR DESCRIPTION
1. build select lock after building selection, to process subqueries correctly.
2. when using index with prefix, the index executor will always read two times.
3. if the query is select A, b from t, and the t's original column is a , the output column name is still A.
@shenli @coocood @XuHuaiyu @tiancaiamao @zimulala
PTAL