### PR TITLE
[DNM]parser: use the new lexer as default

### DIFF
--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -27,7 +27,7 @@ import (
 )
 
 // UseNewLexer provides a switch for the tidb-server binary.
-var UseNewLexer bool
+var UseNewLexer bool = true
 
 // Error instances.
 var (

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -48,7 +48,7 @@ var (
 	enablePS     = flag.Bool("perfschema", false, "If enable performance schema.")
 	reportStatus = flag.Bool("report-status", true, "If enable status report HTTP service.")
 	useNewPlan   = flag.Bool("newplan", true, "If use new planner.")
-	useNewLexer  = flag.Bool("newlexer", false, "If use new lexer.")
+	useNewLexer  = flag.Bool("newlexer", true, "If use new lexer.")
 	logFile      = flag.String("log-file", "", "log file path")
 )
 


### PR DESCRIPTION
I've tested that after PR https://github.com/pingcap/tidb/pull/1563 , mysql-test would pass.
the new lexer should be stable enough to use as default.

we can close https://github.com/pingcap/tidb/issues/1544 and https://github.com/pingcap/tidb/issues/1490 also.