### PR TITLE
*: goyacc generated code tiny change

### DIFF
--- a/parser/goyacc/main.go
+++ b/parser/goyacc/main.go
@@ -421,9 +421,9 @@ type %[1]sXError struct {
 	f.Format("%u}\n")
 
 	// Reduction table
-	f.Format("\n%sReductions = map[int]struct{xsym, components int}{%i\n", *oPref)
-	for r, rule := range p.Rules {
-		f.Format("%d: {%d, %d},\n", r, xlat[rule.Sym.Value], len(rule.Components))
+	f.Format("\n%sReductions = []struct{xsym, components int}{%i\n", *oPref)
+	for _, rule := range p.Rules {
+		f.Format("{%d, %d},\n", xlat[rule.Sym.Value], len(rule.Components))
 	}
 	f.Format("%u}\n")
 


### PR DESCRIPTION
map is an inefficient data struct, always choose array if possible...

before vs after:
```
BenchmarkParse-4	   30000	     51300 ns/op	    5712 B/op	      98 allocs/op
BenchmarkParse-4	   30000	     46423 ns/op	    5712 B/op	      98 allocs/op
```