### PR TITLE
parser: peek neither byte nor a valid UTF8 rune bug fix

### DIFF
--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -181,6 +181,8 @@ func (s *testLexerSuite) TestscanString(c *C) {
 		{`"\"hello"`, `"hello`},
 		{`'disappearing\ backslash'`, "disappearing backslash"},
 		{"'한국의中文UTF8およびテキストトラック'", "한국의中文UTF8およびテキストトラック"},
+		{"'\\a\x90'", "a\x90"},
+		{`"\aèàø»"`, `aèàø»`},
 	}
 
 	for _, v := range table {


### PR DESCRIPTION
find a bug...previously I check the first byte to distinguish utf8 rune, 
but if it's an illegal UTF-8 encoding, I should not write a rune.