### PR TITLE
*: Add keepOrder parameter for xapi.Select

### DIFF
--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -193,7 +193,7 @@ func (e *XSelectTableExec) doRequest() error {
 	// Aggregate Info
 	selReq.Aggregates = e.aggFuncs
 	selReq.GroupBy = e.byItems
-	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency)
+	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency, true)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -492,7 +492,7 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	if e.indexPlan.OutOfOrder {
 		concurrency = 10
 	}
-	return xapi.Select(txn.GetClient(), selIdxReq, concurrency)
+	return xapi.Select(txn.GetClient(), selIdxReq, concurrency, !e.indexPlan.OutOfOrder)
 }
 
 func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, error) {
@@ -529,7 +529,7 @@ func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, e
 	// Aggregate Info
 	selTableReq.Aggregates = e.aggFuncs
 	selTableReq.GroupBy = e.byItems
-	resp, err := xapi.Select(txn.GetClient(), selTableReq, defaultConcurrency)
+	resp, err := xapi.Select(txn.GetClient(), selTableReq, defaultConcurrency, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/new_executor_xapi.go
+++ b/executor/new_executor_xapi.go
@@ -327,7 +327,7 @@ func (e *NewXSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	} else if e.indexPlan.OutOfOrder {
 		concurrency = defaultConcurrency
 	}
-	return xapi.Select(txn.GetClient(), selIdxReq, concurrency)
+	return xapi.Select(txn.GetClient(), selIdxReq, concurrency, !e.indexPlan.OutOfOrder)
 }
 
 func (e *NewXSelectIndexExec) buildTableTasks(handles []int64) {
@@ -487,7 +487,7 @@ func (e *NewXSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult
 	selTableReq.Aggregates = e.aggFuncs
 	selTableReq.GroupBy = e.byItems
 	// Aggregate Info
-	resp, err := xapi.Select(txn.GetClient(), selTableReq, defaultConcurrency)
+	resp, err := xapi.Select(txn.GetClient(), selTableReq, defaultConcurrency, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -567,7 +567,8 @@ func (e *NewXSelectTableExec) doRequest() error {
 	// Aggregate Info
 	selReq.Aggregates = e.aggFuncs
 	selReq.GroupBy = e.byItems
-	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency)
+	keepOrder := false
+	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency, keepOrder)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -160,7 +160,7 @@ func (r *partialResult) Close() error {
 // keepOrder: If the result should returned in key order. For example if we need keep data in order by
 //            scan index, we should set keepOrder to true.
 func Select(client kv.Client, req *tipb.SelectRequest, concurrency int, keepOrder bool) (SelectResult, error) {
-	// Convert tipb.*Request to kv.Request
+	// Convert tipb.*Request to kv.Request.
 	kvReq, err := composeRequest(req, concurrency, keepOrder)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -156,9 +156,12 @@ func (r *partialResult) Close() error {
 }
 
 // Select do a select request, returns SelectResult.
-func Select(client kv.Client, req *tipb.SelectRequest, concurrency int) (SelectResult, error) {
+// conncurrency: The max concurrency for underlying coprocessor request.
+// keepOrder: If the result should returned in key order. For example if we need keep data in order by
+//            scan index, we should set keepOrder to true.
+func Select(client kv.Client, req *tipb.SelectRequest, concurrency int, keepOrder bool) (SelectResult, error) {
 	// Convert tipb.*Request to kv.Request
-	kvReq, err := composeRequest(req, concurrency)
+	kvReq, err := composeRequest(req, concurrency, keepOrder)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -187,10 +190,10 @@ func Select(client kv.Client, req *tipb.SelectRequest, concurrency int) (SelectR
 }
 
 // Convert tipb.Request to kv.Request.
-func composeRequest(req *tipb.SelectRequest, concurrency int) (*kv.Request, error) {
+func composeRequest(req *tipb.SelectRequest, concurrency int, keepOrder bool) (*kv.Request, error) {
 	kvReq := &kv.Request{
 		Concurrency: concurrency,
-		KeepOrder:   true,
+		KeepOrder:   keepOrder,
 	}
 	if req.IndexInfo != nil {
 		kvReq.Tp = kv.ReqTypeIndex


### PR DESCRIPTION
Not all xapi request should return in key order. tikv-client will split the request by key range into multiple subrequest and send them to tikv concurrently in key order. If keepOrder is false, xapi will return the result by their response arrival time, not in key order.

@hanfei1991 @coocood @zimulala @tiancaiamao PTAL