### PR TITLE
xapi: Async fetch xapi result

### DIFF
--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -199,6 +199,7 @@ func (e *XSelectTableExec) doRequest() error {
 		// The returned rows should be aggregate partial result.
 		e.result.SetFields(e.aggFields)
 	}
+	e.result.Fetch()
 	return nil
 }
 
@@ -489,7 +490,12 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	if e.indexPlan.OutOfOrder {
 		concurrency = 10
 	}
-	return xapi.Select(txn.GetClient(), selIdxReq, concurrency, !e.indexPlan.OutOfOrder)
+	sr, err := xapi.Select(txn.GetClient(), selIdxReq, concurrency, !e.indexPlan.OutOfOrder)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	sr.Fetch()
+	return sr, nil
 }
 
 func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, error) {
@@ -533,6 +539,7 @@ func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, e
 		// The returned rows should be aggregate partial result.
 		resp.SetFields(e.aggFields)
 	}
+	resp.Fetch()
 	return resp, nil
 }
 

--- a/executor/new_executor_xapi.go
+++ b/executor/new_executor_xapi.go
@@ -185,6 +185,7 @@ func (e *NewXSelectIndexExec) nextForSingleRead() (*Row, error) {
 			// The returned rows should be aggregate partial result.
 			e.result.SetFields(e.aggFields)
 		}
+		e.result.Fetch()
 	}
 	for {
 		if e.partialResult == nil {
@@ -282,6 +283,7 @@ func (e *NewXSelectIndexExec) fetchHandles() ([]int64, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	idxResult.Fetch()
 	handles, err := extractHandlesFromIndexResult(idxResult)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -492,6 +494,7 @@ func (e *NewXSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult
 		// The returned rows should be aggregate partial result.
 		resp.SetFields(e.aggFields)
 	}
+	resp.Fetch()
 	return resp, nil
 }
 
@@ -573,6 +576,7 @@ func (e *NewXSelectTableExec) doRequest() error {
 		// The returned rows should be aggregate partial result.
 		e.result.SetFields(e.aggFields)
 	}
+	e.result.Fetch()
 	return nil
 }
 

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -244,9 +244,12 @@ func (it *copIterator) run() {
 
 // Return next coprocessor result.
 func (it *copIterator) Next() (io.ReadCloser, error) {
+	it.mu.RLock()
 	if it.mu.finished {
+		it.mu.RUnlock()
 		return nil, nil
 	}
+	it.mu.RUnlock()
 	var (
 		resp *coprocessor.Response
 		err  error

--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -46,6 +46,9 @@ type SelectResult interface {
 	SetFields(fields []*types.FieldType)
 	// Close closes the iterator.
 	Close() error
+	// Fetch fetches partial results from client.
+	// The caller should call SetFields() before call Fetch().
+	Fetch()
 }
 
 // PartialResult is the result from a single region server.
@@ -66,6 +69,10 @@ type selectResult struct {
 
 	results chan PartialResult
 	done    chan error
+}
+
+func (r *selectResult) Fetch() {
+	go r.fetch()
 }
 
 func (r *selectResult) fetch() {
@@ -227,7 +234,6 @@ func Select(client kv.Client, req *tipb.SelectRequest, concurrency int, keepOrde
 	} else {
 		result.aggregate = true
 	}
-	go result.fetch()
 	return result, nil
 }
 


### PR DESCRIPTION
If scanning data from a huge table, proto.Unmarshal() may be time-consuming. So we use goroutine to fetch result and do Unmarshal().
@coocood @zimulala @tiancaiamao @hanfei1991 PTAL