### PR TITLE
*: When sort data by scanning pkcol, xapi TableScan response should keep order

### DIFF
--- a/executor/new_builder.go
+++ b/executor/new_builder.go
@@ -275,6 +275,7 @@ func (b *executorBuilder) buildNewTableScan(v *plan.PhysicalTableScan, s *plan.S
 			ranges:      v.Ranges,
 			desc:        v.Desc,
 			limitCount:  v.LimitCount,
+			keepOrder:   v.KeepOrder,
 		}
 		ret = st
 		if !txn.IsReadOnly() {

--- a/executor/new_executor_xapi.go
+++ b/executor/new_executor_xapi.go
@@ -515,6 +515,7 @@ type NewXSelectTableExec struct {
 	desc          bool
 	limitCount    *int64
 	returnedRows  uint64 // returned rowCount
+	keepOrder     bool
 
 	/*
 		The following attributes are used for aggregation push down.
@@ -566,8 +567,7 @@ func (e *NewXSelectTableExec) doRequest() error {
 	// Aggregate Info
 	selReq.Aggregates = e.aggFuncs
 	selReq.GroupBy = e.byItems
-	keepOrder := false
-	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency, keepOrder)
+	e.result, err = xapi.Select(txn.GetClient(), selReq, defaultConcurrency, e.keepOrder)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/plan/match_property.go
+++ b/plan/match_property.go
@@ -29,6 +29,7 @@ func (ts *PhysicalTableScan) matchProperty(prop requiredProperty, rowCounts []ui
 	if len(prop) == 1 && ts.pkCol != nil && ts.pkCol == prop[0].col {
 		sortedTs := *ts
 		sortedTs.Desc = prop[0].desc
+		sortedTs.KeepOrder = true
 		return &physicalPlanInfo{p: &sortedTs, cost: cost}
 	}
 	return &physicalPlanInfo{p: ts, cost: math.MaxFloat64}

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -57,6 +57,9 @@ type PhysicalTableScan struct {
 	TableAsName *model.CIStr
 
 	LimitCount *int64
+
+	// If sort data by scanning pkcol, KeepOrder should be true.
+	KeepOrder bool
 }
 
 // PhysicalDummyScan is a dummy table that returns nothing.


### PR DESCRIPTION
1. Set keepOrder attr in PhyicalTableScan.
2. Set keepOrder attr in XSelectTableExec.

@coocood @hanfei1991 @zimulala PTAL
I will add a test case later.
/cc @siddontang 