### PR TITLE
fix a cbo plan bug when executing join distributely

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -258,7 +258,7 @@ func (s *testSuite) TestMultiTableDelete(c *C) {
 	c.Assert(r.Rows(), HasLen, 3)
 }
 
-func (s *testSuite) TestQualifedDelete(c *C) {
+func (s *testSuite) TestQualifiedDelete(c *C) {
 	defer testleak.AfterTest(c)()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -1143,6 +1143,14 @@ func (s *testSuite) TestJoin(c *C) {
 	tk.MustExec("insert into t1 values (1, 2), (1, NULL)")
 	result = tk.MustQuery("select * from t a , t1 b where (a.c1, a.c2) = (b.c1, b.c2);")
 	result.Check(testkit.Rows("1 2 1 2"))
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 int, index k(c1))")
+	tk.MustExec("create table t1(c1 int)")
+	tk.MustExec("insert into t values (1),(2),(3),(4),(5),(6),(7)")
+	tk.MustExec("insert into t1 values (1),(2),(3),(4),(5),(6),(7)")
+	result = tk.MustQuery("select a.c1 from t a , t1 b where a.c1 = b.c1 order by a.c1;")
+	result.Check(testkit.Rows("1", "2", "3", "4", "5", "6", "7"))
 
 }
 

--- a/executor/new_executor.go
+++ b/executor/new_executor.go
@@ -175,7 +175,7 @@ func (e *HashJoinExec) prepare() error {
 	e.finished = false
 	e.bigTableRows = make([]chan []*Row, e.concurrency)
 	for i := 0; i < e.concurrency; i++ {
-		e.bigTableRows[i] = make(chan []*Row, e.concurrency*100)
+		e.bigTableRows[i] = make(chan []*Row, e.concurrency*batchSize)
 	}
 	e.bigTableErr = make(chan error, 1)
 

--- a/plan/match_property.go
+++ b/plan/match_property.go
@@ -107,6 +107,9 @@ func (p *PhysicalHashJoin) matchProperty(prop requiredProperty, rowCounts []uint
 	lCount, rCount := float64(rowCounts[0]), float64(rowCounts[1])
 	np := *p
 	np.SetChildren(lRes.p, rRes.p)
+	if len(prop) != 0 {
+		np.Concurrency = 1
+	}
 	cost := lRes.cost + rRes.cost
 	if p.SmallTable == 1 {
 		cost += lCount + memoryFactor*rCount

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -328,7 +328,7 @@ func (p *Join) handleLeftJoin(prop requiredProperty, innerJoin bool) (*physicalP
 		return nil, nil, 0, errors.Trace(err)
 	}
 	sortedPlanInfo := join.matchProperty(prop, []uint64{lCount, rCount}, lSortedPlanInfo, rSortedPlanInfo)
-	unSortedPlanInfo := join.matchProperty(prop, []uint64{lCount, rCount}, lUnSortedPlanInfo, rUnSortedPlanInfo)
+	unSortedPlanInfo := join.matchProperty(nil, []uint64{lCount, rCount}, lUnSortedPlanInfo, rUnSortedPlanInfo)
 	return sortedPlanInfo, unSortedPlanInfo, estimateJoinCount(lCount, rCount), nil
 }
 
@@ -370,7 +370,7 @@ func (p *Join) handleRightJoin(prop requiredProperty, innerJoin bool) (*physical
 		rSortedPlanInfo.cost = math.MaxFloat64
 	}
 	sortedPlanInfo := join.matchProperty(prop, []uint64{lCount, rCount}, lSortedPlanInfo, rSortedPlanInfo)
-	unSortedPlanInfo := join.matchProperty(prop, []uint64{lCount, rCount}, lUnSortedPlanInfo, rUnSortedPlanInfo)
+	unSortedPlanInfo := join.matchProperty(nil, []uint64{lCount, rCount}, lUnSortedPlanInfo, rUnSortedPlanInfo)
 	return sortedPlanInfo, unSortedPlanInfo, estimateJoinCount(lCount, rCount), nil
 }
 


### PR DESCRIPTION
when doing a join b and requring the properties that sorted by a.id, distributed join will break this property. So when the planner decides that it should keep the a's order, set the join-concurrency to 1.
@shenli @coocood @zimulala @tiancaiamao @XuHuaiYu