### PR TITLE
Reduce slice growth

### DIFF
--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -981,7 +981,8 @@ func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, e
 			continue
 		}
 		pbRange := new(tipb.KeyRange)
-		pbRange.Low = codec.EncodeInt(nil, h)
+		bs := make([]byte, 0, 8)
+		pbRange.Low = codec.EncodeInt(bs, h)
 		pbRange.High = kv.Key(pbRange.Low).PrefixNext()
 		selTableReq.Ranges = append(selTableReq.Ranges, pbRange)
 	}

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -974,6 +974,7 @@ func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, e
 		TableId: e.table.Meta().ID,
 	}
 	selTableReq.TableInfo.Columns = xapi.ColumnsToProto(e.indexPlan.Columns, e.table.Meta().PKIsHandle)
+	selTableReq.Ranges = make([]*tipb.KeyRange, 0, len(handles))
 	for _, h := range handles {
 		if h == math.MaxInt64 {
 			// We can't convert MaxInt64 into an left closed, right open range.

--- a/util/codec/bench_test.go
+++ b/util/codec/bench_test.go
@@ -47,3 +47,16 @@ func BenchmarkDecodeWithOutSize(b *testing.B) {
 		Decode(bs, 1)
 	}
 }
+
+func BenchmarkEncodeIntWithSize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		data := make([]byte, 0, 8)
+		EncodeInt(data, 10)
+	}
+}
+
+func BenchmarkEncodeIntWithOutSize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		EncodeInt(nil, 10)
+	}
+}


### PR DESCRIPTION
BenchmarkEncodeIntWithSize-8   	100000000	        13.0 ns/op
BenchmarkEncodeIntWithOutSize-8	30000000	        56.5 ns/op
