### PR TITLE
util/types: fix CoerceDatum function behavior

### DIFF
--- a/evaluator/builtin_other.go
+++ b/evaluator/builtin_other.go
@@ -211,7 +211,10 @@ func builtinIn(args []types.Datum, _ context.Context) (d types.Datum, err error)
 			continue
 		}
 
-		a, b := types.CoerceDatum(args[0], v)
+		a, b, err := types.CoerceDatum(args[0], v, opcode.EQ)
+		if err != nil {
+			return d, errors.Trace(err)
+		}
 		ret, err := a.CompareDatum(b)
 		if err != nil {
 			return d, errors.Trace(err)
@@ -256,7 +259,13 @@ func builtinLogicXor(args []types.Datum, _ context.Context) (d types.Datum, err 
 
 func compareFuncFactory(op opcode.Op) BuiltinFunc {
 	return func(args []types.Datum, _ context.Context) (d types.Datum, err error) {
-		a, b := types.CoerceDatum(args[0], args[1])
+		var a, b = args[0], args[1]
+		if op != opcode.NullEQ {
+			a, b, err = types.CoerceDatum(a, b, op)
+			if err != nil {
+				return d, errors.Trace(err)
+			}
+		}
 		if a.IsNull() || b.IsNull() {
 			// for <=>, if a and b are both nil, return true.
 			// if a or b is nil, return false.
@@ -302,7 +311,10 @@ func compareFuncFactory(op opcode.Op) BuiltinFunc {
 
 func bitOpFactory(op opcode.Op) BuiltinFunc {
 	return func(args []types.Datum, _ context.Context) (d types.Datum, err error) {
-		a, b := types.CoerceDatum(args[0], args[1])
+		a, b, err := types.CoerceDatum(args[0], args[1], op)
+		if err != nil {
+			return d, errors.Trace(err)
+		}
 		if a.IsNull() || b.IsNull() {
 			return
 		}
@@ -347,8 +359,10 @@ func arithmeticFuncFactory(op opcode.Op) BuiltinFunc {
 		if err != nil {
 			return d, errors.Trace(err)
 		}
-
-		a, b = types.CoerceDatum(a, b)
+		a, b, err = types.CoerceDatum(a, b, op)
+		if err != nil {
+			return d, errors.Trace(err)
+		}
 		if a.IsNull() || b.IsNull() {
 			return
 		}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -366,7 +366,11 @@ func (e *Evaluator) checkInList(not bool, in types.Datum, list []types.Datum) (d
 			continue
 		}
 
-		a, b := types.CoerceDatum(in, v)
+		a, b, err := types.CoerceDatum(in, v, opcode.EQ)
+		if err != nil {
+			e.err = errors.Trace(err)
+			return d
+		}
 		r, err := a.CompareDatum(b)
 		if err != nil {
 			e.err = errors.Trace(err)

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -1380,8 +1380,9 @@ func (d *Datum) convergeType(hasUint, hasDecimal, hasFloat *bool) (x Datum) {
 }
 
 // CoerceDatum changes type.
-// If a or b is Decimal, changes the both to Decimal.
-// Else if a or b is Float, changes the both to Float.
+// If a or b is Float, changes the both to Float.
+// Else if a or b is Decimal, changes the both to Decimal.
+// Else if a or b is Uint and op is not div, mod, or intDiv changes the both to Uint.
 func CoerceDatum(a, b Datum, op opcode.Op) (x, y Datum, err error) {
 	if a.IsNull() || b.IsNull() {
 		return x, y, nil

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
 	"sort"
@@ -1361,9 +1362,11 @@ func invalidConv(d *Datum, tp byte) (Datum, error) {
 	return Datum{}, errors.Errorf("cannot convert %v to type %s", d, TypeStr(tp))
 }
 
-func (d *Datum) convergeType(hasDecimal, hasFloat *bool) (x Datum) {
+func (d *Datum) convergeType(hasUint, hasDecimal, hasFloat *bool) (x Datum) {
 	x = *d
 	switch d.Kind() {
+	case KindUint64:
+		*hasUint = true
 	case KindFloat32:
 		f := d.GetFloat32()
 		x.SetFloat64(float64(f))
@@ -1379,21 +1382,18 @@ func (d *Datum) convergeType(hasDecimal, hasFloat *bool) (x Datum) {
 // CoerceDatum changes type.
 // If a or b is Decimal, changes the both to Decimal.
 // Else if a or b is Float, changes the both to Float.
-func CoerceDatum(a, b Datum) (x, y Datum) {
-	var hasDecimal bool
-	var hasFloat bool
-	x = a.convergeType(&hasDecimal, &hasFloat)
-	y = b.convergeType(&hasDecimal, &hasFloat)
-	if hasDecimal {
-		d, err := ConvertDatumToDecimal(x)
-		if err == nil {
-			x.SetMysqlDecimal(d)
-		}
-		d, err = ConvertDatumToDecimal(y)
-		if err == nil {
-			y.SetMysqlDecimal(d)
-		}
-	} else if hasFloat {
+func CoerceDatum(a, b Datum, op opcode.Op) (x, y Datum, err error) {
+	if a.IsNull() || b.IsNull() {
+		return x, y, nil
+	}
+	var (
+		hasUint    bool
+		hasDecimal bool
+		hasFloat   bool
+	)
+	x = a.convergeType(&hasUint, &hasDecimal, &hasFloat)
+	y = b.convergeType(&hasUint, &hasDecimal, &hasFloat)
+	if hasFloat {
 		switch x.Kind() {
 		case KindInt64:
 			x.SetFloat64(float64(x.GetInt64()))
@@ -1407,7 +1407,12 @@ func CoerceDatum(a, b Datum) (x, y Datum) {
 			x.SetFloat64(x.GetMysqlEnum().ToNumber())
 		case KindMysqlSet:
 			x.SetFloat64(x.GetMysqlSet().ToNumber())
-
+		case KindMysqlDecimal:
+			fval, err := x.ToFloat64()
+			if err != nil {
+				return x, y, errors.Trace(err)
+			}
+			x.SetFloat64(fval)
 		}
 		switch y.Kind() {
 		case KindInt64:
@@ -1422,6 +1427,36 @@ func CoerceDatum(a, b Datum) (x, y Datum) {
 			y.SetFloat64(y.GetMysqlEnum().ToNumber())
 		case KindMysqlSet:
 			y.SetFloat64(y.GetMysqlSet().ToNumber())
+		case KindMysqlDecimal:
+			fval, err := y.ToFloat64()
+			if err != nil {
+				return x, y, errors.Trace(err)
+			}
+			y.SetFloat64(fval)
+		}
+	} else if hasDecimal {
+		var dec *mysql.MyDecimal
+		dec, err = ConvertDatumToDecimal(x)
+		if err != nil {
+			return x, y, errors.Trace(err)
+		}
+		x.SetMysqlDecimal(dec)
+		dec, err = ConvertDatumToDecimal(y)
+		if err != nil {
+			return x, y, errors.Trace(err)
+		}
+		y.SetMysqlDecimal(dec)
+	} else if hasUint {
+		switch op {
+		case opcode.Plus, opcode.Minus, opcode.Mul:
+			x, err = x.convertToUint(NewFieldType(mysql.TypeLonglong))
+			if err != nil {
+				return x, y, errors.Trace(err)
+			}
+			y, err = y.convertToUint(NewFieldType(mysql.TypeLonglong))
+			if err != nil {
+				return x, y, errors.Trace(err)
+			}
 		}
 	}
 	return

--- a/util/types/datum_test.go
+++ b/util/types/datum_test.go
@@ -16,6 +16,7 @@ package types
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/parser/opcode"
 )
 
 var _ = Suite(&testDatumSuite{})
@@ -193,4 +194,24 @@ func (ts *testDatumSuite) TestIsNull(c *C) {
 func testIsNull(c *C, data interface{}, isnull bool) {
 	d := NewDatum(data)
 	c.Assert(d.IsNull(), Equals, isnull, Commentf("data: %v, isnull: %v", data, isnull))
+}
+
+func (ts *testDatumSuite) TestCoerceDatum(c *C) {
+	testCases := []struct {
+		a    Datum
+		b    Datum
+		kind byte
+	}{
+		{NewIntDatum(1), NewIntDatum(1), KindInt64},
+		{NewUintDatum(1), NewIntDatum(1), KindUint64},
+		{NewUintDatum(1), NewDecimalDatum(mysql.NewDecFromInt(1)), KindMysqlDecimal},
+		{NewFloat64Datum(1), NewDecimalDatum(mysql.NewDecFromInt(1)), KindFloat64},
+		{NewFloat64Datum(1), NewFloat64Datum(1), KindFloat64},
+	}
+	for _, ca := range testCases {
+		x, y, err := CoerceDatum(ca.a, ca.b, opcode.Plus)
+		c.Check(err, IsNil)
+		c.Check(x.Kind(), Equals, y.Kind())
+		c.Check(x.Kind(), Equals, ca.kind)
+	}
 }


### PR DESCRIPTION
When coerce two datums, float64 is a bigger container than decimal, so the result of compute decimal and float64 is float64.