### PR TITLE
xapi: reduce memory allocation.

### DIFF
--- a/xapi/xapi.go
+++ b/xapi/xapi.go
@@ -184,11 +184,11 @@ func (pr *partialResult) Next() (handle int64, data []types.Datum, err error) {
 	}
 	if !pr.aggregate {
 		handleBytes := row.GetHandle()
-		datums, err := codec.Decode(handleBytes, 1)
+		_, datum, err := codec.DecodeOne(handleBytes)
 		if err != nil {
 			return 0, nil, errors.Trace(err)
 		}
-		handle = datums[0].GetInt64()
+		handle = datum.GetInt64()
 	}
 	pr.cursor++
 	return


### PR DESCRIPTION
This commit reduce one memory allocation per row.
```
go test -bench=TableScan -benchmem -run=None
```
before:
```
BenchmarkTableScan-4   	    2000	    650698 ns/op	  236072 B/op	    4060 allocs/op
```
after:
```
BenchmarkTableScan-4   	    2000	    638012 ns/op	  229668 B/op	    3960 allocs/op
```