### PR TITLE
fix a bug about double read index.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1511,6 +1511,17 @@ func (s *testSuite) TestIndexScan(c *C) {
 	tk.MustExec("insert t values (0)")
 	result = tk.MustQuery("select NULL from t ")
 	result.Check(testkit.Rows("<nil>"))
+	// test for double read
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int unique, b int)")
+	tk.MustExec("insert t values (0, 1)")
+	tk.MustExec("insert t values (1, 2)")
+	tk.MustExec("insert t values (2, 1)")
+	tk.MustExec("insert t values (3, 2)")
+	tk.MustExec("insert t values (4, 1)")
+	tk.MustExec("insert t values (5, 2)")
+	result = tk.MustQuery("select * from t where a < 5 and b = 1 limit 2")
+	result.Check(testkit.Rows("0 1", "2 1"))
 }
 
 func (s *testSuite) TestSubquerySameTable(c *C) {

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -835,7 +835,6 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	selIdxReq := new(tipb.SelectRequest)
 	selIdxReq.StartTs = e.txn.StartTS()
 	selIdxReq.IndexInfo = xapi.IndexToProto(e.table.Meta(), e.indexPlan.Index)
-	selIdxReq.Limit = e.indexPlan.LimitCount
 	if e.indexPlan.Desc {
 		selIdxReq.OrderBy = append(selIdxReq.OrderBy, &tipb.ByItem{Desc: e.indexPlan.Desc})
 	}
@@ -854,6 +853,7 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 		selIdxReq.Aggregates = e.aggFuncs
 		selIdxReq.GroupBy = e.byItems
 		selIdxReq.Where = e.where
+		selIdxReq.Limit = e.indexPlan.LimitCount
 	} else if e.indexPlan.OutOfOrder {
 		concurrency = defaultConcurrency
 	}
@@ -969,6 +969,7 @@ func (e *XSelectIndexExec) extractRowsFromPartialResult(t table.Table, partialRe
 func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, error) {
 	// The handles are not in original index order, so we can't push limit here.
 	selTableReq := new(tipb.SelectRequest)
+	selTableReq.Limit = e.indexPlan.LimitCount
 	selTableReq.StartTs = e.txn.StartTS()
 	selTableReq.TableInfo = &tipb.TableInfo{
 		TableId: e.table.Meta().ID,


### PR DESCRIPTION
When we ensure to use double read mode to read index, we shouldn't add limit to index scan plan when we need to push condition to table scan.
@shenli @coocood @zimulala @tiancaiamao @XuHuaiyu PTAL