### PR TITLE
Avoid using tipb.KeyRange

### DIFF
--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -124,7 +124,7 @@ func tableHandlesToKVRanges(tid int64, handles []int64) []kv.KeyRange {
 			continue
 		}
 		startKey := tablecodec.EncodeRowKeyWithHandle(tid, h)
-		endKey := startKey.PrefixNext()
+		endKey := tablecodec.EncodeRowKeyWithHandle(tid, h+1)
 		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 	}
 	return krs

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -769,6 +769,7 @@ func (e *XSelectIndexExec) nextForDoubleRead() (*Row, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		idxResult.IgnoreData()
 		idxResult.Fetch()
 
 		// Use a background goroutine to fetch index, put the result in e.tasks.

--- a/executor/executor_xapi.go
+++ b/executor/executor_xapi.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/types"
 	"github.com/pingcap/tidb/xapi"
@@ -101,23 +102,36 @@ func (s *rowsSorter) Swap(i, j int) {
 	s.rows[i], s.rows[j] = s.rows[j], s.rows[i]
 }
 
-func tableRangesToPBRanges(tableRanges []plan.TableRange) []*tipb.KeyRange {
-	hrs := make([]*tipb.KeyRange, 0, len(tableRanges))
+func tableRangesToKVRanges(tid int64, tableRanges []plan.TableRange) []kv.KeyRange {
+	krs := make([]kv.KeyRange, 0, len(tableRanges))
 	for _, tableRange := range tableRanges {
-		pbRange := new(tipb.KeyRange)
-		pbRange.Low = codec.EncodeInt(nil, tableRange.LowVal)
+		startKey := tablecodec.EncodeRowKeyWithHandle(tid, tableRange.LowVal)
 		hi := tableRange.HighVal
 		if hi != math.MaxInt64 {
 			hi++
 		}
-		pbRange.High = codec.EncodeInt(nil, hi)
-		hrs = append(hrs, pbRange)
+		endKey := tablecodec.EncodeRowKeyWithHandle(tid, hi)
+		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 	}
-	return hrs
+	return krs
 }
 
-func indexRangesToPBRanges(ranges []*plan.IndexRange, fieldTypes []*types.FieldType) ([]*tipb.KeyRange, error) {
-	keyRanges := make([]*tipb.KeyRange, 0, len(ranges))
+func tableHandlesToKVRanges(tid int64, handles []int64) []kv.KeyRange {
+	krs := make([]kv.KeyRange, 0, len(handles))
+	for _, h := range handles {
+		if h == math.MaxInt64 {
+			// We can't convert MaxInt64 into an left closed, right open range.
+			continue
+		}
+		startKey := tablecodec.EncodeRowKeyWithHandle(tid, h)
+		endKey := startKey.PrefixNext()
+		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
+	}
+	return krs
+}
+
+func indexRangesToKVRanges(tid, idxID int64, ranges []*plan.IndexRange, fieldTypes []*types.FieldType) ([]kv.KeyRange, error) {
+	krs := make([]kv.KeyRange, 0, len(ranges))
 	for _, ran := range ranges {
 		err := convertIndexRangeTypes(ran, fieldTypes)
 		if err != nil {
@@ -138,9 +152,11 @@ func indexRangesToPBRanges(ranges []*plan.IndexRange, fieldTypes []*types.FieldT
 		if !ran.HighExclude {
 			high = []byte(kv.Key(high).PrefixNext())
 		}
-		keyRanges = append(keyRanges, &tipb.KeyRange{Low: low, High: high})
+		startKey := tablecodec.EncodeIndexSeekKey(tid, idxID, low)
+		endKey := tablecodec.EncodeIndexSeekKey(tid, idxID, high)
+		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 	}
-	return keyRanges, nil
+	return krs, nil
 }
 
 func convertIndexRangeTypes(ran *plan.IndexRange, fieldTypes []*types.FieldType) error {
@@ -842,11 +858,6 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	for i, v := range e.indexPlan.Index.Columns {
 		fieldTypes[i] = &(e.table.Cols()[v.Offset].FieldType)
 	}
-	var err error
-	selIdxReq.Ranges, err = indexRangesToPBRanges(e.indexPlan.Ranges, fieldTypes)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	if !e.indexPlan.DoubleRead || e.where == nil {
 		// TODO: when where condition is all index columns limit can be pushed too.
 		selIdxReq.Limit = e.indexPlan.LimitCount
@@ -860,7 +871,11 @@ func (e *XSelectIndexExec) doIndexRequest() (xapi.SelectResult, error) {
 	} else if e.indexPlan.OutOfOrder {
 		concurrency = defaultConcurrency
 	}
-	return xapi.Select(e.txn.GetClient(), selIdxReq, concurrency, !e.indexPlan.OutOfOrder)
+	keyRanges, err := indexRangesToKVRanges(e.table.Meta().ID, e.indexPlan.Index.ID, e.indexPlan.Ranges, fieldTypes)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return xapi.Select(e.txn.GetClient(), selIdxReq, keyRanges, concurrency, !e.indexPlan.OutOfOrder)
 }
 
 func (e *XSelectIndexExec) buildTableTasks(handles []int64) []*lookupTableTask {
@@ -980,24 +995,12 @@ func (e *XSelectIndexExec) doTableRequest(handles []int64) (xapi.SelectResult, e
 		TableId: e.table.Meta().ID,
 	}
 	selTableReq.TableInfo.Columns = xapi.ColumnsToProto(e.indexPlan.Columns, e.table.Meta().PKIsHandle)
-	selTableReq.Ranges = make([]*tipb.KeyRange, 0, len(handles))
-	for _, h := range handles {
-		if h == math.MaxInt64 {
-			// We can't convert MaxInt64 into an left closed, right open range.
-			continue
-		}
-		pbRange := new(tipb.KeyRange)
-		bs := make([]byte, 0, 8)
-		pbRange.Low = codec.EncodeInt(bs, h)
-		pbRange.High = kv.Key(pbRange.Low).PrefixNext()
-		selTableReq.Ranges = append(selTableReq.Ranges, pbRange)
-	}
 	selTableReq.Where = e.where
 	// Aggregate Info
 	selTableReq.Aggregates = e.aggFuncs
 	selTableReq.GroupBy = e.byItems
-	// Aggregate Info
-	resp, err := xapi.Select(e.txn.GetClient(), selTableReq, defaultConcurrency, false)
+	keyRanges := tableHandlesToKVRanges(e.table.Meta().ID, handles)
+	resp, err := xapi.Select(e.txn.GetClient(), selTableReq, keyRanges, defaultConcurrency, false)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1063,7 +1066,6 @@ func (e *XSelectTableExec) doRequest() error {
 	selReq := new(tipb.SelectRequest)
 	selReq.StartTs = e.txn.StartTS()
 	selReq.Where = e.where
-	selReq.Ranges = tableRangesToPBRanges(e.ranges)
 	columns := e.Columns
 	selReq.TableInfo = &tipb.TableInfo{
 		TableId: e.tableInfo.ID,
@@ -1076,7 +1078,9 @@ func (e *XSelectTableExec) doRequest() error {
 	// Aggregate Info
 	selReq.Aggregates = e.aggFuncs
 	selReq.GroupBy = e.byItems
-	e.result, err = xapi.Select(e.txn.GetClient(), selReq, defaultConcurrency, e.keepOrder)
+
+	kvRanges := tableRangesToKVRanges(e.table.Meta().ID, e.ranges)
+	e.result, err = xapi.Select(e.txn.GetClient(), selReq, kvRanges, defaultConcurrency, e.keepOrder)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/store/localstore/local_client.go
+++ b/store/localstore/local_client.go
@@ -174,6 +174,7 @@ func buildRegionTasks(client *dbClient, req *kv.Request) (tasks []*task) {
 				startKey: info.startKey,
 				endKey:   info.endKey,
 				data:     req.Data,
+				ranges:   req.KeyRanges,
 			}
 			task := &task{
 				region:  info.rs,

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -229,8 +229,7 @@ func (rs *localRegion) getRowsFromAgg(ctx *selectContext) ([]*tipb.Row, error) {
 	return rows, nil
 }
 
-// extractKVRanges extracts kv.KeyRanges slice from a SelectRequest, and also returns if it is in descending order.
-// func (rs *localRegion) extractKVRanges(sel *tipb.SelectRequest) (kvRanges []kv.KeyRange, desc bool) {
+// extractKVRanges extracts kv.KeyRanges slice from ctx.keyRanges, and also returns if it is in descending order.
 func (rs *localRegion) extractKVRanges(ctx *selectContext) (kvRanges []kv.KeyRange, desc bool) {
 	sel := ctx.sel
 	for _, kran := range ctx.keyRanges {

--- a/tablecodec/bench_test.go
+++ b/tablecodec/bench_test.go
@@ -1,0 +1,41 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tablecodec
+
+import (
+	"testing"
+)
+
+func BenchmarkEncodeRowKeyWithHandle(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		EncodeRowKeyWithHandle(100, 100)
+	}
+}
+
+func BenchmarkEncodeEndKey(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		EncodeRowKeyWithHandle(100, 100)
+		EncodeRowKeyWithHandle(100, 101)
+	}
+}
+
+// PrefixNext() is slow than using EncodeRowKeyWithHandle.
+// BenchmarkEncodeEndKey-4		20000000	        97.2 ns/op
+// BenchmarkEncodeRowKeyWithPrefixNex-4	10000000	       121 ns/op
+func BenchmarkEncodeRowKeyWithPrefixNex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		sk := EncodeRowKeyWithHandle(100, 100)
+		sk.PrefixNext()
+	}
+}

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -54,7 +54,7 @@ func EncodeRowKey(tableID int64, encodedHandle []byte) kv.Key {
 func EncodeRowKeyWithHandle(tableID int64, handle int64) kv.Key {
 	buf := make([]byte, 0, recordRowKeyLen+idLen)
 	buf = appendTableRecordPrefix(buf, tableID)
-	buf = EncodeRecordKey(buf, handle)
+	buf = codec.EncodeInt(buf, handle)
 	return buf
 }
 


### PR DESCRIPTION
We do not need to set key ranges in tipb.SelectRequest.
We only need kv.KeyRange and kvproto/coprocessor.KeyRange.
This run faster in some of our cases. I will make code more cleaner latter in this PR.

@coocood @BusyJay @tiancaiamao PTAL