### PR TITLE
plan: change equal filter rate to 1/200

### DIFF
--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -329,6 +329,10 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			best: "Dummy->Projection",
 		},
 		{
+			sql:  "select * from t t1 where c in (1,2,3,4,5,6,7,8,9,0)",
+			best: "Index(t.c_d_e)[[0,0] [1,1] [2,2] [3,3] [4,4] [5,5] [6,6] [7,7] [8,8] [9,9]]->Projection",
+		},
+		{
 			sql:  "select count(*) from t t1 having 1 = 0",
 			best: "Dummy->Aggr->Selection->Projection",
 		},
@@ -454,7 +458,7 @@ func (s *testPlanSuite) TestRefine(c *C) {
 		},
 		{
 			sql:  "select b from t where c = 1 or c = 2 or c = 3 or c = 4 or c = 5",
-			best: "Table(t)->Selection->Projection",
+			best: "Index(t.c_d_e)[[1,1] [2,2] [3,3] [4,4] [5,5]]->Projection",
 		},
 		{
 			sql:  "select a from t where c = 5",

--- a/plan/statistics/statistics.go
+++ b/plan/statistics/statistics.go
@@ -34,7 +34,7 @@ const (
 	// It has row count 10000, equal condition selects 1/10 of total rows, less condition selects 1/3 of total rows,
 	// between condition selects 1/4 of total rows.
 	pseudoRowCount    = 10000
-	pseudoEqualRate   = 10
+	pseudoEqualRate   = 200
 	pseudoLessRate    = 3
 	pseudoBetweenRate = 4
 	pseudoTimestamp   = 1

--- a/plan/statistics/statistics_test.go
+++ b/plan/statistics/statistics_test.go
@@ -124,7 +124,7 @@ func (s *testStatisticsSuite) TestPseudoTable(c *C) {
 	c.Assert(count, Equals, int64(3333))
 	count, err = col.EqualRowCount(types.NewIntDatum(1000))
 	c.Assert(err, IsNil)
-	c.Assert(count, Equals, int64(1000))
+	c.Assert(count, Equals, int64(50))
 	count, err = col.BetweenRowCount(types.NewIntDatum(1000), types.NewIntDatum(5000))
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, int64(2500))


### PR DESCRIPTION
for a query like select * from t where a in (1,2,3,4,5,6,7,8,9,0). It's better to let it use index, so I decrease the rate of equal filter rate.
@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL
