### PR TITLE
fix a bug about update stmt.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1086,6 +1086,14 @@ func (s *testSuite) TestUpdate(c *C) {
 	c.Assert(err.Error(), DeepEquals, "Column 'id' cannot be null")
 
 	tk.MustExec("drop table update_test")
+	tk.MustExec("create table update_test(id int)")
+	tk.MustExec("begin")
+	tk.MustExec("insert into update_test(id) values (1)")
+	tk.MustExec("update update_test set id = 2 where id = 1 limit 1")
+	r = tk.MustQuery("select * from update_test;")
+	r.Check(testkit.Rows("2"))
+	tk.MustExec("commit")
+	tk.MustExec("drop table update_test")
 }
 
 func (s *testSuite) fillMultiTableForUpdate(tk *testkit.TestKit) {

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -134,6 +134,7 @@ func (p *DataSource) handleTableScan(prop *requiredProperty) (*physicalPlanInfo,
 			Condition: expression.ComposeCNFCondition(oldConditions),
 		}
 		us.SetChildren(resultPlan)
+		us.SetSchema(resultPlan.GetSchema())
 		resultPlan = us
 	}
 	statsTbl := p.statisticTable
@@ -246,6 +247,7 @@ func (p *DataSource) handleIndexScan(prop *requiredProperty, index *model.IndexI
 			Condition: expression.ComposeCNFCondition(oldConditions),
 		}
 		us.SetChildren(resultPlan)
+		us.SetSchema(resultPlan.GetSchema())
 		resultPlan = us
 	}
 	is.DoubleRead = !isCoveringIndex(is.Columns, is.Index.Columns, is.Table.PKIsHandle)


### PR DESCRIPTION
When update's child is a union scan which set a empty schema, the update executor will raise a out of range panic.
@shenli @coocood @zimulala PTAL