### PR TITLE
tidb-server: Use 15 as default value for metrics-interval

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -57,7 +57,7 @@ var (
 	logFile         = flag.String("log-file", "", "log file path")
 	joinCon         = flag.Int("join-concurrency", 5, "the number of goroutines that participate joining.")
 	metricsAddr     = flag.String("metrics-addr", "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
-	metricsInterval = flag.Int("metrics-interval", 0, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
+	metricsInterval = flag.Int("metrics-interval", 15, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
 	binlogSocket    = flag.String("binlog-socket", "", "socket file to write binlog")
 )
 


### PR DESCRIPTION
We only need to set metrics-addr.
@siddontang @coocood @zimulala PTAL