### PR TITLE
*: support history read with old schema

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -44,6 +44,8 @@ type Domain struct {
 	SchemaValidity *schemaValidityInfo
 }
 
+// loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
+// infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) error {
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {

--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -203,7 +203,7 @@ func (e *SimpleExec) executeSet(s *ast.SetStmt) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if name == "tidb_snapshot" {
+			if name == variable.TiDBSnapshot {
 				err = e.loadSnapshotInfoSchemaIfNeeded(sessionVars)
 				if err != nil {
 					return errors.Trace(err)
@@ -219,7 +219,7 @@ func (e *SimpleExec) loadSnapshotInfoSchemaIfNeeded(sessionVars *variable.Sessio
 		sessionVars.SnapshotInfoschema = nil
 		return nil
 	}
-	log.Infof("loadSnapshotInfoSchema")
+	log.Infof("loadSnapshotInfoSchema, SnapshotTS:%d", sessionVars.SnapshotTS)
 	dom := sessionctx.GetDomain(e.ctx)
 	snapInfo, err := dom.GetSnapshotInfoSchema(sessionVars.SnapshotTS)
 	if err != nil {

--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -203,8 +203,29 @@ func (e *SimpleExec) executeSet(s *ast.SetStmt) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
+			if name == "tidb_snapshot" {
+				err = e.loadSnapshotInfoSchemaIfNeeded(sessionVars)
+				if err != nil {
+					return errors.Trace(err)
+				}
+			}
 		}
 	}
+	return nil
+}
+
+func (e *SimpleExec) loadSnapshotInfoSchemaIfNeeded(sessionVars *variable.SessionVars) error {
+	if sessionVars.SnapshotTS == 0 {
+		sessionVars.SnapshotInfoschema = nil
+		return nil
+	}
+	log.Infof("loadSnapshotInfoSchema")
+	dom := sessionctx.GetDomain(e.ctx)
+	snapInfo, err := dom.GetSnapshotInfoSchema(sessionVars.SnapshotTS)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	sessionVars.SnapshotInfoschema = snapInfo
 	return nil
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1266,4 +1266,15 @@ func (s *testSuite) TestHistoryRead(c *C) {
 	tk.MustExec("insert history_read values (3)")
 	tk.MustExec("update history_read set a = 4 where a = 3")
 	tk.MustExec("delete from history_read where a = 1")
+
+	time.Sleep(time.Millisecond)
+	snapshotTime = time.Now()
+	time.Sleep(time.Millisecond)
+	tk.MustExec("alter table history_read add column b int")
+	tk.MustExec("insert history_read values (8, 8), (9, 9)")
+	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2 <nil>", "4 <nil>", "8 8", "9 9"))
+	tk.MustExec("set @@tidb_snapshot = '" + snapshotTime.Format("2006-01-02 15:04:05.999999") + "'")
+	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2", "4"))
+	tk.MustExec("set @@tidb_snapshot = ''")
+	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2 <nil>", "4 <nil>", "8 8", "9 9"))
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -492,6 +492,15 @@ func (h *Handle) GetPerfHandle() perfschema.PerfSchema {
 	return h.memSchema.perfHandle
 }
 
+// EmptyClone creates a new Handle with the same store and memSchema, but the value is not set.
+func (h *Handle) EmptyClone() *Handle {
+	newHandle := &Handle{
+		store:     h.store,
+		memSchema: h.memSchema,
+	}
+	return newHandle
+}
+
 // Schema error codes.
 const (
 	codeDBDropExists      terror.ErrCode = 1008

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -116,6 +116,10 @@ type SessionVars struct {
 
 	// SnapshotTS is used for reading history data. For simplicity, SnapshotTS only supports distsql request.
 	SnapshotTS uint64
+
+	// SnapshotInfoschema is used with SnapshotTS, when the schema version at snapshotTS less than current schema
+	// version, we load an old version schema for query.
+	SnapshotInfoschema interface{}
 }
 
 // sessionVarsKeyType is a dummy type to avoid naming collision in context.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -226,7 +226,7 @@ func (s *SessionVars) SetCurrentUser(user string) {
 
 // special session variables.
 const (
-	tidbSnapshot        = "tidb_snapshot"
+	TiDBSnapshot        = "tidb_snapshot"
 	sqlMode             = "sql_mode"
 	characterSetResults = "character_set_results"
 )
@@ -252,7 +252,7 @@ func (s *SessionVars) SetSystemVar(key string, value types.Datum) error {
 		} else {
 			s.StrictSQLMode = false
 		}
-	} else if key == tidbSnapshot {
+	} else if key == TiDBSnapshot {
 		err = s.setSnapshotTS(sVal)
 		if err != nil {
 			return errors.Trace(err)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -580,7 +580,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "min_examined_row_limit", "0"},
 	{ScopeGlobal, "sync_frm", "ON"},
 	{ScopeGlobal, "innodb_online_alter_log_max_size", "134217728"},
-	{ScopeSession, tidbSnapshot, ""},
+	{ScopeSession, TiDBSnapshot, ""},
 }
 
 // SetNamesVariables is the system variable names related to set names statements.


### PR DESCRIPTION
When user set 'tidb_snapshot' variable, load and use the schema at the snapshot time.