### PR TITLE
kv: Tiny cleanup

### DIFF
--- a/kv/key.go
+++ b/kv/key.go
@@ -70,6 +70,17 @@ func (k Key) Clone() Key {
 	return append([]byte(nil), k...)
 }
 
+// KeyRange represents a range where StartKey <= key < EndKey.
+type KeyRange struct {
+	StartKey Key
+	EndKey   Key
+}
+
+// IsPoint checks if the key range represents a point.
+func (r *KeyRange) IsPoint() bool {
+	return bytes.Equal(r.StartKey.PrefixNext(), r.EndKey)
+}
+
 // EncodedKey represents encoded key in low-level storage engine.
 type EncodedKey []byte
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -14,7 +14,6 @@
 package kv
 
 import (
-	"bytes"
 	"io"
 )
 
@@ -110,17 +109,6 @@ const (
 	ReqSubTypeGroupBy = 10001
 	ReqSubTypeTopN    = 10002
 )
-
-// KeyRange represents a range where StartKey <= key < EndKey.
-type KeyRange struct {
-	StartKey Key
-	EndKey   Key
-}
-
-// IsPoint checks if the key range represents a point.
-func (r *KeyRange) IsPoint() bool {
-	return bytes.Equal(r.StartKey.PrefixNext(), r.EndKey)
-}
 
 // Request represents a kv request.
 type Request struct {


### PR DESCRIPTION
Test cases about KeyRange are in key_test.go. KeyRange is related with Key. So I move it to key.go.