### PR TITLE
parser: set flag in parse function.

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -66,7 +66,6 @@ func statementLabel(node ast.StmtNode) string {
 // If it is not supported, the node will be converted to old statement.
 func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statement, error) {
 	stmtNodeCounter.WithLabelValues(statementLabel(node)).Inc()
-	ast.SetFlag(node)
 	if _, ok := node.(*ast.UpdateStmt); ok {
 		sVars := variable.GetSessionVars(ctx)
 		sVars.InUpdateStmt = true

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -110,6 +110,9 @@ func (parser *Parser) Parse(sql, charset, collation string) ([]ast.StmtNode, err
 	if len(l.Errors()) != 0 {
 		return nil, errors.Trace(l.Errors()[0])
 	}
+	for _, stmt := range parser.result {
+		ast.SetFlag(stmt)
+	}
 	return parser.result, nil
 }
 
@@ -123,6 +126,7 @@ func (parser *Parser) ParseOneStmt(sql, charset, collation string) (ast.StmtNode
 	if len(stmts) != 1 {
 		return nil, ErrSyntax
 	}
+	ast.SetFlag(stmts[0])
 	return stmts[0], nil
 }
 

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -64,7 +64,6 @@ func Optimize(ctx context.Context, node ast.Node, is infoschema.InfoSchema) (Pla
 // The statement must be prepared before it can be passed to optimize function.
 // We pass InfoSchema instead of getting from Context in case it is changed after resolving name.
 func PrepareStmt(is infoschema.InfoSchema, ctx context.Context, node ast.Node) error {
-	ast.SetFlag(node)
 	if err := Preprocess(node, is, ctx); err != nil {
 		return errors.Trace(err)
 	}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -236,7 +236,6 @@ func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 		comment := Commentf("for %s", ca.sql)
 		stmt, err := s.ParseOneStmt(ca.sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
@@ -293,7 +292,6 @@ func (s *testPlanSuite) TestJoinReOrder(c *C) {
 		comment := Commentf("for %s", ca.sql)
 		stmt, err := s.ParseOneStmt(ca.sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
@@ -409,7 +407,6 @@ func (s *testPlanSuite) TestCBO(c *C) {
 		comment := Commentf("for %s", ca.sql)
 		stmt, err := s.ParseOneStmt(ca.sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
@@ -572,7 +569,6 @@ func (s *testPlanSuite) TestRefine(c *C) {
 		comment := Commentf("for %s", ca.sql)
 		stmt, err := s.ParseOneStmt(ca.sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
@@ -707,7 +703,6 @@ func (s *testPlanSuite) TestColumnPruning(c *C) {
 		comment := Commentf("for %s", ca.sql)
 		stmt, err := s.ParseOneStmt(ca.sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
@@ -929,7 +924,6 @@ func (s *testPlanSuite) TestTableScanWithOrder(c *C) {
 	sql := "select * from t order by a limit 1;"
 	stmt, err := s.ParseOneStmt(sql, "", "")
 	c.Assert(err, IsNil)
-	ast.SetFlag(stmt)
 
 	err = mockResolve(stmt)
 	c.Assert(err, IsNil)
@@ -1114,7 +1108,6 @@ func (s *testPlanSuite) TestConstantPropagation(c *C) {
 		comment := Commentf("for %s", sql)
 		stmt, err := s.ParseOneStmt(sql, "", "")
 		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
 		err = mockResolve(stmt)
 		c.Assert(err, IsNil)
 		builder := &planBuilder{


### PR DESCRIPTION
Every `ast.Statement` needs to set flag before use, set the flag in parse function,
so we don't need to set it somewhere else and won't forget to do it.