### PR TITLE
fix a bug in projection elimination

### DIFF
--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -35,13 +35,10 @@ func EliminateProjection(p LogicalPlan) LogicalPlan {
 		RemovePlan(p)
 		p = EliminateProjection(child)
 	case *DataSource:
-		// predicates may be pushed down when build physical plan, and the schema of Selection operator is
-		// always the same as the child operator, so here we copy the schema of Selection to DataSource.
+		// predicates may be pushed down when build physical plan,
+		// so here we copy the schema of Selection to DataSource.
 		if sel, ok := plan.GetParentByIndex(0).(*Selection); ok {
 			plan.SetSchema(sel.GetSchema())
-			for i, cond := range sel.Conditions {
-				sel.Conditions[i], _ = retrieveColumnsInExpression(cond, plan.GetSchema())
-			}
 		}
 	}
 	if len(p.GetChildren()) == 1 {

--- a/session_test.go
+++ b/session_test.go
@@ -963,6 +963,17 @@ func (s *testSessionSuite) TestIndex(c *C) {
 	mustExecSQL(c, se, "create table if not exists test_varchar_index (c1 varchar(255), index(c1))")
 	mustExecSQL(c, se, "insert test_varchar_index values (''), ('a')")
 	mustExecMatch(c, se, "select * from test_varchar_index where c1 like ''", [][]interface{}{{[]byte("")}})
+
+	mustExecSQL(c, se, "drop table if exists t")
+	mustExecSQL(c, se, "create table t (c1 int, c2 int)")
+	mustExecSQL(c, se, "insert into t values (1,2), (1,2)")
+	mustExecSQL(c, se, "create index idx_0 on t(c1)")
+	mustExecSQL(c, se, "create index idx_1 on t(c2)")
+	r = mustExecSQL(c, se, "select c1 as c2 from t where c1 >= 2")
+	rows, err = GetRows(r)
+	c.Assert(err, IsNil)
+	matches(c, rows, [][]interface{}{})
+
 	err = store.Close()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
a bug occurred in such case:
``` sql
create table t (col1 int, col2 int)
insert into t values(1, 2)
insert into t values(1, 2)
create index idx_t_0 on t (col1)
create index idx_t_1 on t (col2)

select col1 as col2 from t where col1 >= 2;
```
before this bug is handled, we get:
[1,1]
after this bug is handled, we get:
[]