### PR TITLE
executor: set time zone offset in `tipb.SelectRequest`.

### DIFF
--- a/executor/executor_distsql.go
+++ b/executor/executor_distsql.go
@@ -811,7 +811,7 @@ func (e *XSelectTableExec) Fields() []*ast.ResultField {
 	return nil
 }
 
-// timeZoneOffset return local time zone offset in seconds.
+// timeZoneOffset returns the local time zone offset in seconds.
 func timeZoneOffset() int64 {
 	_, offset := time.Now().Zone()
 	return int64(offset)


### PR DESCRIPTION
The time zone offset will be used by TiKV to compare timestamp type.