### PR TITLE
table: check valid UTF8 value for UTF8 column

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -53,6 +53,8 @@ var (
 	ErrIndexStateCantNone = terror.ClassTable.New(codeIndexStateCantNone, "index can not be in none state")
 	// ErrInvalidRecordKey returns for invalid record key.
 	ErrInvalidRecordKey = terror.ClassTable.New(codeInvalidRecordKey, "invalid record key")
+	// ErrInvalidUTF8Value returns for inserting invalid UTF8 value to a utf8 column.
+	ErrInvalidUTF8Value = terror.ClassTable.New(codeInvalidUTF8Value, "invalid utf8 value")
 )
 
 // RecordIterFunc is used for low-level record iteration.
@@ -139,6 +141,7 @@ const (
 	codeColumnStateNonPublic = 7
 	codeIndexStateCantNone   = 8
 	codeInvalidRecordKey     = 9
+	codeInvalidUTF8Value     = 10
 
 	codeColumnCantNull  = 1048
 	codeUnknownColumn   = 1054

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -19,6 +19,7 @@ package tables
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
@@ -212,6 +213,9 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData []types.Datum
 			}
 			currentData[i] = defaultVal
 		}
+		if col.Charset == "utf8" && !utf8.Valid(currentData[i].GetBytes()) {
+			return table.ErrInvalidUTF8Value.Gen("invalid utf8 value %q", currentData[i].GetBytes())
+		}
 		colIDs = append(colIDs, col.ID)
 	}
 	// Set new row data into KV.
@@ -346,6 +350,9 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 			if col.DefaultValue == nil && r[col.Offset].IsNull() {
 				// Save storage space by not storing null value.
 				continue
+			}
+			if col.Charset == "utf8" && !utf8.Valid(value.GetBytes()) {
+				return 0, table.ErrInvalidUTF8Value.Gen("invalid utf8 value %q", value.GetBytes())
 			}
 		}
 		colIDs = append(colIDs, col.ID)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -90,7 +90,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	// Test input invalid utf8 value.
 	_, err = tb.AddRecord(ctx, types.MakeDatums(3, []byte{255}))
 	c.Assert(terror.ErrorEqual(err, table.ErrInvalidUTF8Value), IsTrue)
-	touched := map[int]bool{2: true}
+	touched := map[int]bool{1: true}
 	err = tb.UpdateRecord(ctx, 1, types.MakeDatums(1, "abc"), types.MakeDatums(1, []byte{255}), touched)
 	c.Assert(terror.ErrorEqual(err, table.ErrInvalidUTF8Value), IsTrue)
 


### PR DESCRIPTION
We need to check if the input data is valid UTF8 string if the column charset is UTF8,
Otherwise, it may cause more serious error in the future, and hard to fix.

This prevents future issue like https://github.com/pingcap/tidb/issues/1808