### PR TITLE
plan: fix a bug about doing aggregation plan.

### DIFF
--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -328,6 +328,9 @@ func addPlanToResponse(parent PhysicalPlan, info *physicalPlanInfo) *physicalPla
 // enforceProperty creates a *physicalPlanInfo that satisfies the required property by adding
 // sort or limit as the parent of the given physical plan.
 func enforceProperty(prop *requiredProperty, info *physicalPlanInfo) *physicalPlanInfo {
+	if info.p == nil {
+		return info
+	}
 	if len(prop.props) != 0 {
 		items := make([]*ByItems, 0, len(prop.props))
 		for _, col := range prop.props {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -511,6 +511,10 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			best: "Index(t.c_d_e)[[<nil>,+inf]]->StreamAgg->Projection",
 		},
 		{
+			sql:  "select count(*) from t group by e order by d limit 1",
+			best: "Table(t)->HashAgg->Projection->Sort + Limit(1) + Offset(0)->Trim",
+		},
+		{
 			sql:  "select count(*) from t group by a",
 			best: "Table(t)->StreamAgg->Projection",
 		},


### PR DESCRIPTION
When we do stream agg plan, the child of it may be a nil plan with max cost. At that time, enforceProperty function will raise a panic. Instead, we should handle this case in enforceProperty to make it more sound.
@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL