### PR TITLE
Makefile: Filter out golint error about context.Context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ check:
 	@echo "vet --shadow"
 	@ go tool vet --shadow $(FILES) 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 	@echo "golint"
-	@ golint ./... 2>&1 | grep -vE 'LastInsertId|NewLexer|\.pb\.go' | awk '{print} END{if(NR>0) {exit 1}}'
+	@ golint ./... 2>&1 | grep -vE 'context\.Context|LastInsertId|NewLexer|\.pb\.go' | awk '{print} END{if(NR>0) {exit 1}}'
 	@echo "gofmt (simplify)"
 	@ gofmt -s -l -w $(FILES) 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 


### PR DESCRIPTION
golint add a new rule that 'context.Context' should be the first parameter of a function.
But that refers to standard library package, we can ignore it.