### PR TITLE
plan: fix a bug when calculate range

### DIFF
--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -670,6 +670,10 @@ func (s *testPlanSuite) TestRefine(c *C) {
 			best: "Index(t.c_d_e)[[5,5]]->Selection->Projection",
 		},
 		{
+			sql:  "select a from t where not a",
+			best: "Table(t)->Selection->Projection",
+		},
+		{
 			sql:  "select a from t where c in (1)",
 			best: "Index(t.c_d_e)[[1,1]]->Projection",
 		},

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -254,12 +254,13 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 	case ast.IsNull, ast.IsTruth, ast.IsFalsity:
 		return c.checkColumn(scalar.Args[0])
 	case ast.UnaryNot:
-		// Don't support "not like" and "not in" convert to access conditions.
+		// TODO: support "not like" and "not in" convert to access conditions.
 		if s, ok := scalar.Args[0].(*expression.ScalarFunction); ok {
 			if s.FuncName.L == ast.In || s.FuncName.L == ast.Like {
 				return false
 			}
 		} else {
+			// "not column" or "not constant" can't lead to a range.
 			return false
 		}
 		return c.check(scalar.Args[0])

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -259,6 +259,8 @@ func (c *conditionChecker) checkScalarFunction(scalar *expression.ScalarFunction
 			if s.FuncName.L == ast.In || s.FuncName.L == ast.Like {
 				return false
 			}
+		} else {
+			return false
 		}
 		return c.check(scalar.Args[0])
 	case ast.In:


### PR DESCRIPTION
When we encounter a query like "select * from t where not a" and a is a pk col, we will calucate the range for a. But this will cause a panic bug because "not a column" can't lead to a real range.
So we should check this in "conditionChecker.check" logic.

@zimulala @XuHuaiYu @shenli @coocood PTAL