### PR TITLE
distsql: fix goroutine leak caused huge memory footprint

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -51,7 +51,7 @@ func (s *testTableCodecSuite) TestColumnToProto(c *C) {
 	c.Assert(pc.GetFlag(), Equals, int32(10))
 }
 
-// For Issue 1791
+// For issue 1791
 func (s *testTableCodecSuite) TestGoroutineLeak(c *C) {
 	var sr SelectResult
 	countBefore := runtime.NumGoroutine()

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -14,13 +14,20 @@
 package distsql
 
 import (
+	"bytes"
+	"errors"
+	"io"
+	"io/ioutil"
+	"runtime"
 	"testing"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 func TestT(t *testing.T) {
@@ -42,4 +49,58 @@ func (s *testTableCodecSuite) TestColumnToProto(c *C) {
 	}
 	pc := columnToProto(col)
 	c.Assert(pc.GetFlag(), Equals, int32(10))
+}
+
+// For Issue 1791
+func (s *testTableCodecSuite) TestGoroutineLeak(c *C) {
+	var sr SelectResult
+	countBefore := runtime.NumGoroutine()
+
+	sr = &selectResult{
+		resp:    &mockResponse{},
+		results: make(chan PartialResult, 5),
+		done:    make(chan error, 1),
+		closed:  make(chan struct{}),
+	}
+	go sr.Fetch()
+	for {
+		// mock test will generate 500 partial result then return error
+		_, err := sr.Next()
+		if err != nil {
+			// close selectResult on error, partialResult's fetch goroutine may leak
+			sr.Close()
+			break
+		}
+	}
+
+	time.Sleep(3 * time.Second)
+	countAfter := runtime.NumGoroutine()
+
+	// if all partialResult's fetch goroutine return, there should not much goroutines.
+	c.Assert(countAfter-countBefore, Less, 5)
+}
+
+type mockResponse struct {
+	count int
+}
+
+func (resp *mockResponse) Next() (io.ReadCloser, error) {
+	resp.count++
+	if resp.count == 500 {
+		return nil, errors.New("error happend")
+	}
+	return mockReaderCloser(), nil
+}
+
+func (resp *mockResponse) Close() error {
+	return nil
+}
+
+func mockReaderCloser() io.ReadCloser {
+	resp := new(tipb.SelectResponse)
+	b, err := resp.Marshal()
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewBuffer(b))
 }

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -73,8 +73,13 @@ func (s *testTableCodecSuite) TestGoroutineLeak(c *C) {
 		}
 	}
 
-	for i := time.Duration(0); i < 3*time.Second; i = i + 10*time.Millisecond {
+	tick := 10 * time.Millisecond
+	totalSleep := time.Duration(0)
+	for totalSleep < 3*time.Second {
+		time.Sleep(tick)
+		totalSleep += tick
 		countAfter := runtime.NumGoroutine()
+
 		if countAfter-countBefore < 5 {
 			return
 		}


### PR DESCRIPTION
fix a bug in https://github.com/pingcap/tidb/issues/1791 
there may still other unknown problems, I'll test tomorrow.
