### PR TITLE
*: Update the owner timeout of background job and pass golint

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -161,6 +161,10 @@ func asyncNotify(ch chan struct{}) {
 	}
 }
 
+// Background job is serial processing, so we can extend the owner timeout to make sure
+// a batch of task will be processed before timeout.
+var minBgOwnerTimeout = 20 * time.Second
+
 func (d *ddl) checkOwner(t *meta.Meta, flag JobType) (*model.Owner, error) {
 	owner, err := d.getJobOwner(t, flag)
 	if err != nil {
@@ -177,6 +181,12 @@ func (d *ddl) checkOwner(t *meta.Meta, flag JobType) (*model.Owner, error) {
 	// the owner will update its owner status every 2 * lease time, so here we use
 	// 4 * lease to check its timeout.
 	maxTimeout := int64(4 * d.lease)
+	if flag == bgJobFlag {
+		// If 4 * lease is less then minBgOwnerTimeout, we will use default minBgOwnerTimeout.
+		if maxTimeout < int64(minBgOwnerTimeout) {
+			maxTimeout = int64(minBgOwnerTimeout)
+		}
+	}
 	sub := now - owner.LastUpdateTS
 	if owner.OwnerID == d.uuid || sub > maxTimeout {
 		owner.OwnerID = d.uuid
@@ -434,7 +444,7 @@ func (d *ddl) runDDLJob(t *meta.Meta, job *model.Job) {
 	if err != nil {
 		// if job is not cancelled, we should log this error.
 		if job.State != model.JobCancelled {
-			log.Errorf("run ddl job err %v", errors.ErrorStack(err))
+			log.Errorf("[ddl] run ddl job err %v", errors.ErrorStack(err))
 		}
 
 		job.Error = toTError(err)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -162,7 +162,7 @@ func asyncNotify(ch chan struct{}) {
 }
 
 // Background job is serial processing, so we can extend the owner timeout to make sure
-// a batch of task will be processed before timeout.
+// a batch of rows will be processed before timeout.
 var minBgOwnerTimeout = 20 * time.Second
 
 func (d *ddl) checkOwner(t *meta.Meta, flag JobType) (*model.Owner, error) {

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -64,6 +64,7 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 	store := testCreateStore(c, "test_owner")
 	defer store.Close()
 
+	minBgOwnerTimeout = testLease
 	d1 := newDDL(store, nil, nil, testLease)
 	defer d1.close()
 
@@ -84,6 +85,9 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 	testCheckOwner(c, d2, true, ddlJobFlag)
 	testCheckOwner(c, d2, true, bgJobFlag)
 
+	time.Sleep(20 * time.Second)
+	testCheckOwner(c, d2, true, bgJobFlag)
+
 	d2.SetLease(1 * time.Second)
 
 	err := d2.Stop()
@@ -101,6 +105,7 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 	d2.SetLease(1 * time.Second)
 	d2.SetLease(2 * time.Second)
 	c.Assert(d2.GetLease(), Equals, 2*time.Second)
+	minBgOwnerTimeout = 20 * time.Second
 }
 
 func (s *testDDLSuite) TestSchemaError(c *C) {

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -85,9 +85,6 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 	testCheckOwner(c, d2, true, ddlJobFlag)
 	testCheckOwner(c, d2, true, bgJobFlag)
 
-	time.Sleep(20 * time.Second)
-	testCheckOwner(c, d2, true, bgJobFlag)
-
 	d2.SetLease(1 * time.Second)
 
 	err := d2.Stop()

--- a/util/types/errors.go
+++ b/util/types/errors.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// ErrDataTooLong is returned when converts a string value that is longer than field type length.
-	ErrDataTooLong *terror.Error = terror.ClassTypes.New(codeDataTooLong, "Data Too Long")
+	ErrDataTooLong = terror.ClassTypes.New(codeDataTooLong, "Data Too Long")
 )
 
 const (


### PR DESCRIPTION
ddl: update the timeout of background job checking owner
        background job is serial processing, so we can extend the owner timeout to make sure a batch of task will be processed before timeout.
util: pass golint