### PR TITLE
executor: support creating user with no password.

### DIFF
--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -322,10 +322,12 @@ func (e *SimpleExec) executeCreateUser(s *ast.CreateUserStmt) error {
 			continue
 		}
 		pwd := ""
-		if spec.AuthOpt.ByAuthString {
-			pwd = util.EncodePassword(spec.AuthOpt.AuthString)
-		} else {
-			pwd = util.EncodePassword(spec.AuthOpt.HashString)
+		if spec.AuthOpt != nil {
+			if spec.AuthOpt.ByAuthString {
+				pwd = util.EncodePassword(spec.AuthOpt.AuthString)
+			} else {
+				pwd = util.EncodePassword(spec.AuthOpt.HashString)
+			}
 		}
 		user := fmt.Sprintf(`("%s", "%s", "%s")`, host, userName, pwd)
 		users = append(users, user)

--- a/executor/executor_simple_test.go
+++ b/executor/executor_simple_test.go
@@ -192,6 +192,18 @@ func (s *testSuite) TestCreateUser(c *C) {
 	c.Check(err, NotNil)
 }
 
+func (s *testSuite) TestCreateUserWithNoPassword(c *C) {
+	defer testleak.AfterTest(c)()
+	tk := testkit.NewTestKit(c, s.store)
+	// Create user test.
+	createUserSQL := `CREATE USER 'test1'@'localhost';`
+	tk.MustExec(createUserSQL)
+	// Make sure user test in mysql.User.
+	result := tk.MustQuery(`SELECT Password FROM mysql.User WHERE User="test1" and Host="localhost"`)
+	rowStr := fmt.Sprintf("%v", []byte(util.EncodePassword("")))
+	result.Check(testkit.Rows(rowStr))
+}
+
 func (s *testSuite) TestSetPwd(c *C) {
 	defer testleak.AfterTest(c)()
 	tk := testkit.NewTestKit(c, s.store)


### PR DESCRIPTION
The sql like "create user ** @ ** " without identify a passwork will cause a panic. This pr solve this problem.

@ngaut @shenli @coocood  PTAL