### PR TITLE
*: support common aggregation functions elimination.

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -92,6 +92,8 @@ func (s *testSuite) TestAggregation(c *C) {
 	result.Check(testkit.Rows("1", "2", "2"))
 	result = tk.MustQuery("select sum(c) from t group by d")
 	result.Check(testkit.Rows("2", "4", "5"))
+	result = tk.MustQuery("select sum(c), sum(c+1), sum(c), sum(c+1) from t group by d")
+	result.Check(testkit.Rows("2 4 2 4", "4 6 4 6", "5 7 5 7"))
 	result = tk.MustQuery("select d*2 as ee, sum(c) from t group by ee")
 	result.Check(testkit.Rows("2 2", "4 4", "6 5"))
 	result = tk.MustQuery("select sum(distinct c) from t group by d")

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -61,21 +61,9 @@ type AggregationFunction interface {
 
 	// SetContext sets the aggregate evaluation context.
 	SetContext(ctx map[string](*ast.AggEvaluateContext))
-}
 
-// EqualAgg checks whether the two aggregation functions are equal.
-func EqualAgg(a, b AggregationFunction) bool {
-	if a.GetName() != b.GetName() {
-		return false
-	}
-	if len(a.GetArgs()) == len(b.GetArgs()) {
-		for i, argA := range a.GetArgs() {
-			if !EqualExpression(argA, b.GetArgs()[i]) {
-				return false
-			}
-		}
-	}
-	return true
+	// Equal checks whether two aggregation functions are equal.
+	Equal(agg AggregationFunction) bool
 }
 
 // NewAggFunction creates a new AggregationFunction.
@@ -118,6 +106,21 @@ type aggFunction struct {
 	Distinct     bool
 	resultMapper aggCtxMapper
 	streamCtx    *ast.AggEvaluateContext
+}
+
+// Equal implements AggregationFunction interface.
+func (af *aggFunction) Equal(b AggregationFunction) bool {
+	if af.GetName() != b.GetName() {
+		return false
+	}
+	if len(af.GetArgs()) == len(b.GetArgs()) {
+		for i, argA := range af.GetArgs() {
+			if !argA.Equal(b.GetArgs()[i]) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func (af *aggFunction) String() string {

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -63,7 +63,7 @@ type AggregationFunction interface {
 	SetContext(ctx map[string](*ast.AggEvaluateContext))
 }
 
-// EqualAgg checks whether the two expressions are equal.
+// EqualExpression checks whether the two expressions are equal.
 func EqualExpression(a, b Expression) bool {
 	switch x := a.(type) {
 	case *ScalarFunction:

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -63,44 +63,6 @@ type AggregationFunction interface {
 	SetContext(ctx map[string](*ast.AggEvaluateContext))
 }
 
-// EqualExpression checks whether the two expressions are equal.
-func EqualExpression(a, b Expression) bool {
-	switch x := a.(type) {
-	case *ScalarFunction:
-		y, ok := b.(*ScalarFunction)
-		if !ok {
-			return false
-		}
-		if x.FuncName.L != y.FuncName.L {
-			return false
-		}
-		if len(x.Args) != len(y.Args) {
-			return false
-		}
-		for i, argX := range x.Args {
-			if !EqualExpression(argX, y.Args[i]) {
-				return false
-			}
-		}
-	case *Constant:
-		y, ok := b.(*Constant)
-		if !ok {
-			return false
-		}
-		c, err := x.Value.CompareDatum(y.Value)
-		if err != nil || c != 0 {
-			return false
-		}
-	case *Column:
-		y, ok := b.(*Column)
-		if !ok {
-			return false
-		}
-		return x.FromID == y.FromID && x.Position == y.Position
-	}
-	return true
-}
-
 // EqualAgg checks whether the two aggregation functions are equal.
 func EqualAgg(a, b AggregationFunction) bool {
 	if a.GetName() != b.GetName() {

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -410,13 +410,13 @@ func (c *Constant) Eval(_ []types.Datum, _ context.Context) (types.Datum, error)
 }
 
 // Equal implements Expression interface.
-func (x *Constant) Equal(b Expression) bool {
+func (c *Constant) Equal(b Expression) bool {
 	y, ok := b.(*Constant)
 	if !ok {
 		return false
 	}
-	c, err := x.Value.CompareDatum(y.Value)
-	if err != nil || c != 0 {
+	con, err := c.Value.CompareDatum(y.Value)
+	if err != nil || con != 0 {
 		return false
 	}
 	return true

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -452,3 +452,41 @@ func SplitCNFItems(onExpr Expression) []Expression {
 func SplitDNFItems(onExpr Expression) []Expression {
 	return splitNormalFormItems(onExpr, ast.OrOr)
 }
+
+// EqualExpression checks whether the two expressions are equal.
+func EqualExpression(a, b Expression) bool {
+	switch x := a.(type) {
+	case *ScalarFunction:
+		y, ok := b.(*ScalarFunction)
+		if !ok {
+			return false
+		}
+		if x.FuncName.L != y.FuncName.L {
+			return false
+		}
+		if len(x.Args) != len(y.Args) {
+			return false
+		}
+		for i, argX := range x.Args {
+			if !EqualExpression(argX, y.Args[i]) {
+				return false
+			}
+		}
+	case *Constant:
+		y, ok := b.(*Constant)
+		if !ok {
+			return false
+		}
+		c, err := x.Value.CompareDatum(y.Value)
+		if err != nil || c != 0 {
+			return false
+		}
+	case *Column:
+		y, ok := b.(*Column)
+		if !ok {
+			return false
+		}
+		return x.FromID == y.FromID && x.Position == y.Position
+	}
+	return true
+}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -63,7 +63,6 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 		for j, oldFunc := range agg.AggFuncs {
 			if oldFunc.Equal(newFunc) {
 				aggIndexMap[i] = j
-				newFunc = oldFunc
 				combined = true
 				break
 			}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -61,7 +61,7 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 		newFunc := expression.NewAggFunction(aggFunc.F, newArgList, aggFunc.Distinct)
 		combined := false
 		for j, oldFunc := range agg.AggFuncs {
-			if expression.EqualAgg(oldFunc, newFunc) {
+			if oldFunc.Equal(newFunc) {
 				aggIndexMap[i] = j
 				newFunc = oldFunc
 				combined = true

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -357,8 +357,8 @@ func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 	}{
 		{
 			sql:   "select count(*) from t a, t b where a.a = b.a",
-			first: "Join{DataScan(t)->DataScan(t)}->Selection->Aggr->Projection",
-			best:  "Join{DataScan(t)->DataScan(t)}->Aggr->Projection",
+			first: "Join{DataScan(t)->DataScan(t)}->Selection->Aggr(count(1))->Projection",
+			best:  "Join{DataScan(t)->DataScan(t)}->Aggr(count(1))->Projection",
 		},
 		{
 			sql:   "select a from (select a from t where d = 0) k where k.a = 5",
@@ -457,8 +457,8 @@ func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 		},
 		{
 			sql:   "select (select count(*) from t where t.a = k.a) from t k",
-			first: "DataScan(t)->Apply(DataScan(t)->Selection->Aggr->Projection->MaxOneRow)->Projection",
-			best:  "DataScan(t)->Apply(DataScan(t)->Selection->Aggr->Projection->MaxOneRow)->Projection",
+			first: "DataScan(t)->Apply(DataScan(t)->Selection->Aggr(count(1))->Projection->MaxOneRow)->Projection",
+			best:  "DataScan(t)->Apply(DataScan(t)->Selection->Aggr(count(1))->Projection->MaxOneRow)->Projection",
 		},
 		{
 			sql:   "select a from t where exists(select 1 from t as x where x.a < t.a)",
@@ -560,6 +560,46 @@ func (s *testPlanSuite) TestJoinReOrder(c *C) {
 		info, err := lp.convert2PhysicalPlan(&requiredProperty{})
 		c.Assert(err, IsNil)
 		c.Assert(ToString(info.p), Equals, ca.best, Commentf("for %s", ca.sql))
+	}
+}
+
+func (s *testPlanSuite) TestLogicalPlan(c *C) {
+	defer testleak.AfterTest(c)()
+	cases := []struct {
+		sql  string
+		best string
+	}{
+		{
+			sql:  "select sum(t.a), sum(t.a+1), sum(t.a), count(t.a), sum(t.a) + count(t.a) from t",
+			best: "DataScan(t)->Aggr(sum(test.t.a),sum(plus(test.t.a, 1)),count(test.t.a))->Projection",
+		},
+		{
+			sql:  "select sum(t.a + t.b), sum(t.a + t.c), sum(t.a + t.b), count(t.a) from t having sum(t.a + t.b) > 0 order by sum(t.a + t.c)",
+			best: "DataScan(t)->Aggr(sum(plus(test.t.a, test.t.b)),sum(plus(test.t.a, test.t.c)),count(test.t.a))->Selection->Projection->Sort->Trim",
+		},
+	}
+	for _, ca := range cases {
+		comment := Commentf("for %s", ca.sql)
+		stmt, err := s.ParseOneStmt(ca.sql, "", "")
+		c.Assert(err, IsNil, comment)
+
+		err = mockResolve(stmt)
+		c.Assert(err, IsNil)
+
+		builder := &planBuilder{
+			allocator: new(idAllocator),
+			ctx:       mock.NewContext(),
+			colMapper: make(map[*ast.ColumnNameExpr]int),
+		}
+		p := builder.build(stmt)
+		c.Assert(builder.err, IsNil)
+		lp := p.(LogicalPlan)
+
+		_, lp, err = lp.PredicatePushDown(nil)
+		c.Assert(err, IsNil)
+		_, err = lp.PruneColumnsAndResolveIndices(lp.GetSchema())
+		c.Assert(err, IsNil)
+		c.Assert(ToString(lp), Equals, ca.best, Commentf("for %s", ca.sql))
 	}
 }
 

--- a/plan/stringer.go
+++ b/plan/stringer.go
@@ -120,7 +120,14 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 			str = "HashAgg"
 		}
 	case *Aggregation:
-		str = "Aggr"
+		str = "Aggr("
+		for i, aggFunc := range x.AggFuncs {
+			str += aggFunc.String()
+			if i != len(x.AggFuncs)-1 {
+				str += ","
+			}
+		}
+		str += ")"
 	case *Distinct:
 		str = "Distinct"
 	case *Trim:


### PR DESCRIPTION
For query "select sum(a), sum(b) , sum(a) + sum(b) from t;", currently we put sum(a), sum(b), sum(a), sum(b) to aggregation. Instead, we should only consider sum(a) and sum(b).

@shenli @coocood @XuHuaiyu PTAL