### PR TITLE
ddl: write DDL binlog when DDL is done.

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -348,9 +348,8 @@ func (d *ddl) handleDDLJobQueue() error {
 			return nil
 		}
 		if binlogStartTS != 0 {
-			var commitTS kv.Version
-			commitTS, err = d.store.CurrentVersion()
-			if err == nil {
+			commitTS, err1 := d.store.CurrentVersion()
+			if err1 == nil {
 				d.writePostDDLBinlog(job.ID, binlogStartTS, commitTS.Ver)
 			}
 		}

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -260,6 +260,14 @@ func (s *testSuite) TestDDL(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, job)
 
+	all, err := t.GetAllHistoryDDLJobs()
+	c.Assert(err, IsNil)
+	var lastID int64
+	for _, job := range all {
+		c.Assert(job.ID, Greater, lastID)
+		lastID = job.ID
+	}
+
 	// DDL background job test
 	err = t.SetBgJobOwner(owner)
 	c.Assert(err, IsNil)

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -92,6 +92,8 @@ type Job struct {
 	// unix nano seconds
 	// TODO: use timestamp allocated by TSO.
 	LastUpdateTS int64 `json:"last_update_ts"`
+	// Query string of the ddl job.
+	Query string `json:"query"`
 }
 
 // SetRowCount sets the number of rows. Make sure it can pass `make race`.
@@ -151,6 +153,11 @@ func (job *Job) String() string {
 // If the job state is Done or Cancelled, it is finished.
 func (job *Job) IsFinished() bool {
 	return job.State == JobDone || job.State == JobCancelled
+}
+
+// IsDone returns whether job is done.
+func (job *Job) IsDone() bool {
+	return job.State == JobDone
 }
 
 // IsRunning returns whether job is still running or not.


### PR DESCRIPTION
Previous implementation write DDL binlog as early as when job is added to the queue,
but DDL job may be canceled, we should not sync the ddl at that time, there would be a long
 time waiting for the DDL to be done.

After this commit, DDL binlog is written right before the DDL job is done, so we don't need to wait.

Also expose a 'GetAllHistoryJobs' method in meta which will be used later.