### PR TITLE
expression: fix a bug when checking whether two aggregation functions are same.

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -94,6 +94,8 @@ func (s *testSuite) TestAggregation(c *C) {
 	result.Check(testkit.Rows("2", "4", "5"))
 	result = tk.MustQuery("select sum(c), sum(c+1), sum(c), sum(c+1) from t group by d")
 	result.Check(testkit.Rows("2 4 2 4", "4 6 4 6", "5 7 5 7"))
+	result = tk.MustQuery("select count(distinct c,d), count(c,d) from t")
+	result.Check(testkit.Rows("5 6"))
 	result = tk.MustQuery("select d*2 as ee, sum(c) from t group by ee")
 	result.Check(testkit.Rows("2 2", "4 4", "6 5"))
 	result = tk.MustQuery("select sum(distinct c) from t group by d")

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -113,6 +113,9 @@ func (af *aggFunction) Equal(b AggregationFunction) bool {
 	if af.GetName() != b.GetName() {
 		return false
 	}
+	if af.Distinct != b.IsDistinct() {
+		return false
+	}
 	if len(af.GetArgs()) == len(b.GetArgs()) {
 		for i, argA := range af.GetArgs() {
 			if !argA.Equal(b.GetArgs()[i]) {


### PR DESCRIPTION
I forgot to check the distinct value when checking whether two agg functions are same.

@shenli @coocood @XuHuaiyu @zimulala @tiancaiamao PTAL