### PR TITLE
table: change Column type to alias of ColumnInfo

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -464,11 +464,9 @@ func (d *ddl) buildColumnAndConstraint(ctx context.Context, offset int,
 func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*table.Column, []*ast.Constraint, error) {
 	constraints := []*ast.Constraint{}
 	col := &table.Column{
-		ColumnInfo: model.ColumnInfo{
-			Offset:    offset,
-			Name:      colDef.Name.Name,
-			FieldType: *colDef.Tp,
-		},
+		Offset:    offset,
+		Name:      colDef.Name.Name,
+		FieldType: *colDef.Tp,
 	}
 
 	// Check and set TimestampFlag and OnUpdateNowFlag.
@@ -749,7 +747,7 @@ func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constr
 		return nil, errors.Trace(err)
 	}
 	for _, v := range cols {
-		tbInfo.Columns = append(tbInfo.Columns, &v.ColumnInfo)
+		tbInfo.Columns = append(tbInfo.Columns, v.ToInfo())
 	}
 	for _, constr := range constraints {
 		if constr.Tp == ast.ConstraintForeignKey {
@@ -1021,7 +1019,7 @@ func (d *ddl) AddColumn(ctx context.Context, ti ast.Ident, spec *ast.AlterTableS
 		SchemaID: schema.ID,
 		TableID:  t.Meta().ID,
 		Type:     model.ActionAddColumn,
-		Args:     []interface{}{&col.ColumnInfo, spec.Position, 0},
+		Args:     []interface{}{col, spec.Position, 0},
 	}
 
 	err = d.doDDLJob(ctx, job)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1474,7 +1474,7 @@ func (e *TableScanExec) getRow(handle int64) (*Row, error) {
 
 	columns := make([]*table.Column, len(e.schema))
 	for i, v := range e.columns {
-		columns[i] = &table.Column{ColumnInfo: *v}
+		columns[i] = table.ToColumn(v)
 	}
 	row.Data, err = e.t.RowWithCols(e.ctx, handle, columns)
 	if err != nil {

--- a/executor/executor_write.go
+++ b/executor/executor_write.go
@@ -756,7 +756,7 @@ func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, co
 func (e *InsertValues) getColumnDefaultValues(cols []*table.Column) (map[string]types.Datum, error) {
 	defaultValMap := map[string]types.Datum{}
 	for _, col := range cols {
-		if value, ok, err := table.GetColDefaultValue(e.ctx, &col.ColumnInfo); ok {
+		if value, ok, err := table.GetColDefaultValue(e.ctx, col.ToInfo()); ok {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -914,7 +914,7 @@ func (e *InsertValues) initDefaultValues(row []types.Datum, marked map[int]struc
 			}
 		} else {
 			var err error
-			row[i], _, err = table.GetColDefaultValue(e.ctx, &c.ColumnInfo)
+			row[i], _, err = table.GetColDefaultValue(e.ctx, c.ToInfo())
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -376,7 +376,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			decimal = 0
 		}
 		columnType := col.FieldType.CompactStr()
-		columnDesc := table.NewColDesc(&table.Column{ColumnInfo: *col})
+		columnDesc := table.NewColDesc(table.ToColumn(col))
 		var columnDefault interface{}
 		if columnDesc.DefaultValue != nil {
 			columnDefault = fmt.Sprintf("%v", columnDesc.DefaultValue)

--- a/table/column.go
+++ b/table/column.go
@@ -31,9 +31,7 @@ import (
 )
 
 // Column provides meta data describing a table column.
-type Column struct {
-	model.ColumnInfo
-}
+type Column model.ColumnInfo
 
 // PrimaryKeyName defines primary key name.
 const PrimaryKeyName = "PRIMARY"
@@ -50,6 +48,11 @@ func (c *Column) String() string {
 	return strings.Join(ans, " ")
 }
 
+// ToInfo casts Column to model.ColumnInfo
+func (c *Column) ToInfo() *model.ColumnInfo {
+	return (*model.ColumnInfo)(c)
+}
+
 // FindCol finds column in cols by name.
 func FindCol(cols []*Column, name string) *Column {
 	for _, col := range cols {
@@ -58,6 +61,11 @@ func FindCol(cols []*Column, name string) *Column {
 		}
 	}
 	return nil
+}
+
+// ToColumn converts a *model.ColumnInfo to *Column.
+func ToColumn(col *model.ColumnInfo) *Column {
+	return (*Column)(col)
 }
 
 // FindCols finds columns in cols by names.
@@ -91,7 +99,7 @@ func FindOnUpdateCols(cols []*Column) []*Column {
 func CastValues(ctx context.Context, rec []types.Datum, cols []*Column, ignoreErr bool) (err error) {
 	for _, c := range cols {
 		var converted types.Datum
-		converted, err = CastValue(ctx, rec[c.Offset], &c.ColumnInfo)
+		converted, err = CastValue(ctx, rec[c.Offset], c.ToInfo())
 		if err != nil {
 			if ignoreErr {
 				log.Warnf("cast values failed:%v", err)

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -34,10 +34,8 @@ type testColumnSuite struct{}
 func (s *testColumnSuite) TestString(c *C) {
 	defer testleak.AfterTest(c)()
 	col := &Column{
-		model.ColumnInfo{
-			FieldType: *types.NewFieldType(mysql.TypeTiny),
-			State:     model.StatePublic,
-		},
+		FieldType: *types.NewFieldType(mysql.TypeTiny),
+		State:     model.StatePublic,
 	}
 	col.Flen = 2
 	col.Decimal = 1
@@ -198,9 +196,7 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 
 func newCol(name string) *Column {
 	return &Column{
-		model.ColumnInfo{
-			Name:  model.NewCIStr(name),
-			State: model.StatePublic,
-		},
+		Name:  model.NewCIStr(name),
+		State: model.StatePublic,
 	}
 }

--- a/table/tables/bounded_tables.go
+++ b/table/tables/bounded_tables.go
@@ -63,7 +63,7 @@ func BoundedTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo, capa
 	columns := make([]*table.Column, 0, len(tblInfo.Columns))
 	var pkHandleColumn *table.Column
 	for _, colInfo := range tblInfo.Columns {
-		col := &table.Column{ColumnInfo: *colInfo}
+		col := table.ToColumn(colInfo)
 		columns = append(columns, col)
 		if col.IsPKHandleColumn(tblInfo) {
 			pkHandleColumn = col

--- a/table/tables/memory_tables.go
+++ b/table/tables/memory_tables.go
@@ -77,7 +77,7 @@ func MemoryTableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (tabl
 	columns := make([]*table.Column, 0, len(tblInfo.Columns))
 	var pkHandleColumn *table.Column
 	for _, colInfo := range tblInfo.Columns {
-		col := &table.Column{ColumnInfo: *colInfo}
+		col := table.ToColumn(colInfo)
 		columns = append(columns, col)
 		if col.IsPKHandleColumn(tblInfo) {
 			pkHandleColumn = col

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -72,7 +72,7 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 			return nil, table.ErrColumnStateCantNone.Gen("column %s can't be in none state", colInfo.Name)
 		}
 
-		col := &table.Column{ColumnInfo: *colInfo}
+		col := table.ToColumn(colInfo)
 		columns = append(columns, col)
 	}
 
@@ -207,7 +207,7 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData []types.Datum
 	colIDs := make([]int64, 0, len(t.WritableCols()))
 	for i, col := range t.WritableCols() {
 		if col.State != model.StatePublic && currentData[i].IsNull() {
-			defaultVal, _, err1 := table.GetColDefaultValue(ctx, &col.ColumnInfo)
+			defaultVal, _, err1 := table.GetColDefaultValue(ctx, col.ToInfo())
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
@@ -341,7 +341,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		var value types.Datum
 		if col.State == model.StateWriteOnly || col.State == model.StateWriteReorganization {
 			// if col is in write only or write reorganization state, we must add it with its default value.
-			value, _, err = table.GetColDefaultValue(ctx, &col.ColumnInfo)
+			value, _, err = table.GetColDefaultValue(ctx, col.ToInfo())
 			if err != nil {
 				return 0, errors.Trace(err)
 			}


### PR DESCRIPTION
So we can use a ColumnInfo directly, without coping, reduce memory usage.