### PR TITLE
parser: fix bug hexadecimal parsed as string

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -887,7 +887,8 @@ func (s *testParserSuite) TestType(c *C) {
 		{"CREATE TABLE t( c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2) );", true},
 
 		// For hexadecimal
-		{"SELECT x'0a', X'11', 0x11", true},
+		{"select x'0a', X'11', 0x11", true},
+		{"select x'13181C76734725455A'", true},
 		{"select x'0xaa'", false},
 		{"select 0X11", false},
 		{"select 0x4920616D2061206C6F6E672068657820737472696E67", true},

--- a/parser/scanner_test.go
+++ b/parser/scanner_test.go
@@ -94,6 +94,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"23416", intLit},
 		{"0", intLit},
 		{"0x3c26", hexLit},
+		{"x'13181C76734725455A'", hexLit},
 		{"0b01", bitLit},
 	}
 	runTest(c, table)

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -190,7 +190,7 @@ func toHex(l yyLexer, lval *yySymType, str string) int {
 			return int(unicode.ReplacementChar)
 		}
 		lval.item = hexStr
-		return stringLit
+		return hexLit
 	}
 	lval.item = h
 	return hexLit


### PR DESCRIPTION
x'13181C76734725455A' should be parsed as a hexLit, but it's parsed as a string.
before this fix:

```
mysql> select x'13181C76734725455A';
+-----------------------+
| x'13181C76734725455A' |
+-----------------------+
| x'13181C76734725455A' |
+-----------------------+
1 row in set (0.00 sec)
```

after fix:

```
mysql> select x'13181C76734725455A';
+-----------------------+
| x'13181C76734725455A' |
+-----------------------+
| vsG%EZ             |
+-----------------------+
1 row in set (0.00 sec)
```