### PR TITLE
store/tikv: add disableGC flag.

### DIFF
--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -45,12 +45,12 @@ type Driver struct {
 }
 
 // Open opens or creates an TiKV storage with given path.
-// Path example: tikv://etcd-node1:port,etcd-node2:port?cluster=1
+// Path example: tikv://etcd-node1:port,etcd-node2:port?cluster=1&disableGC=false
 func (d Driver) Open(path string) (kv.Storage, error) {
 	mc.Lock()
 	defer mc.Unlock()
 
-	etcdAddrs, clusterID, err := parsePath(path)
+	etcdAddrs, clusterID, disableGC, err := parsePath(path)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -64,7 +64,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	s, err := newTikvStore(uuid, &codecPDClient{pdCli}, newRPCClient(), true)
+	s, err := newTikvStore(uuid, &codecPDClient{pdCli}, newRPCClient(), !disableGC)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -248,7 +248,7 @@ func (s *tikvStore) SendKVReq(bo *Backoffer, req *pb.Request, regionID RegionVer
 	}
 }
 
-func parsePath(path string) (etcdAddrs []string, clusterID uint64, err error) {
+func parsePath(path string) (etcdAddrs []string, clusterID uint64, disableGC bool, err error) {
 	var u *url.URL
 	u, err = url.Parse(path)
 	if err != nil {
@@ -256,14 +256,22 @@ func parsePath(path string) (etcdAddrs []string, clusterID uint64, err error) {
 		return
 	}
 	if strings.ToLower(u.Scheme) != "tikv" {
-		log.Errorf("Uri scheme expected[tikv] but found [%s]", u.Scheme)
-		err = errors.Trace(err)
+		err = errors.Trace(errors.Errorf("Uri scheme expected[tikv] but found [%s]", u.Scheme))
+		log.Error(err)
 		return
 	}
 	clusterID, err = strconv.ParseUint(u.Query().Get("cluster"), 10, 64)
 	if err != nil {
 		log.Errorf("Parse clusterID error [%s]", err)
 		err = errors.Trace(err)
+		return
+	}
+	switch strings.ToLower(u.Query().Get("disableGC")) {
+	case "true":
+		disableGC = true
+	case "false", "":
+	default:
+		err = errors.Trace(errors.New("disableGC flag should be true/false"))
 		return
 	}
 	etcdAddrs = strings.Split(u.Host, ",")

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -256,7 +256,7 @@ func parsePath(path string) (etcdAddrs []string, clusterID uint64, disableGC boo
 		return
 	}
 	if strings.ToLower(u.Scheme) != "tikv" {
-		err = errors.Trace(errors.Errorf("Uri scheme expected[tikv] but found [%s]", u.Scheme))
+		err = errors.Errorf("Uri scheme expected[tikv] but found [%s]", u.Scheme)
 		log.Error(err)
 		return
 	}
@@ -271,7 +271,7 @@ func parsePath(path string) (etcdAddrs []string, clusterID uint64, disableGC boo
 		disableGC = true
 	case "false", "":
 	default:
-		err = errors.Trace(errors.New("disableGC flag should be true/false"))
+		err = errors.New("disableGC flag should be true/false")
 		return
 	}
 	etcdAddrs = strings.Split(u.Host, ",")

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -46,6 +46,22 @@ func (s *testStoreSuite) SetUpTest(c *C) {
 	s.store = store
 }
 
+func (s *testStoreSuite) TestParsePath(c *C) {
+	etcdAddrs, clusterID, disableGC, err := parsePath("tikv://node1:2379,node2:2379?cluster=1")
+	c.Assert(err, IsNil)
+	c.Assert(etcdAddrs, DeepEquals, []string{"node1:2379", "node2:2379"})
+	c.Assert(clusterID, Equals, uint64(1))
+	c.Assert(disableGC, IsFalse)
+
+	_, _, _, err = parsePath("tikv://node1:2379")
+	c.Assert(err, NotNil)
+	_, _, _, err = parsePath("tidb://node1:2379?cluster=1")
+	c.Assert(err, NotNil)
+	_, _, disableGC, err = parsePath("tikv://node1:2379?cluster=1&disableGC=true")
+	c.Assert(err, IsNil)
+	c.Assert(disableGC, IsTrue)
+}
+
 func (s *testStoreSuite) TestOracle(c *C) {
 	o := &mockOracle{}
 	s.store.oracle = o


### PR DESCRIPTION
In practice, only tidb server need to start the gc worker. This PR add an option to turn gc off for other use cases, for instance, the binlog collector.

@coocood @iamxy 