### PR TITLE
util/types, table: truncate string by rune count, remove UTF8 validation

### DIFF
--- a/executor/executor_write_test.go
+++ b/executor/executor_write_test.go
@@ -106,6 +106,8 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("create table insert_err (id int, c1 varchar(8))")
 	_, err = tk.Exec("insert insert_err values (1, 'abcdabcdabcd')")
 	c.Assert(types.ErrDataTooLong.Equal(err), IsTrue)
+	_, err = tk.Exec("insert insert_err values (1, '你好，世界')")
+	c.Assert(err, IsNil)
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/table/table.go
+++ b/table/table.go
@@ -53,8 +53,6 @@ var (
 	ErrIndexStateCantNone = terror.ClassTable.New(codeIndexStateCantNone, "index can not be in none state")
 	// ErrInvalidRecordKey returns for invalid record key.
 	ErrInvalidRecordKey = terror.ClassTable.New(codeInvalidRecordKey, "invalid record key")
-	// ErrInvalidUTF8Value returns for inserting invalid UTF8 value to a utf8 column.
-	ErrInvalidUTF8Value = terror.ClassTable.New(codeInvalidUTF8Value, "invalid utf8 value")
 )
 
 // RecordIterFunc is used for low-level record iteration.
@@ -138,7 +136,6 @@ const (
 	codeColumnStateNonPublic = 7
 	codeIndexStateCantNone   = 8
 	codeInvalidRecordKey     = 9
-	codeInvalidUTF8Value     = 10
 
 	codeColumnCantNull  = 1048
 	codeUnknownColumn   = 1054

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -19,7 +19,6 @@ package tables
 
 import (
 	"strings"
-	"unicode/utf8"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
@@ -213,9 +212,6 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData []types.Datum
 			}
 			currentData[i] = defaultVal
 		}
-		if col.Charset == "utf8" && !utf8.Valid(currentData[i].GetBytes()) {
-			return table.ErrInvalidUTF8Value.Gen("invalid utf8 value %q", currentData[i].GetBytes())
-		}
 		colIDs = append(colIDs, col.ID)
 	}
 	// Set new row data into KV.
@@ -350,9 +346,6 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 			if col.DefaultValue == nil && r[col.Offset].IsNull() {
 				// Save storage space by not storing null value.
 				continue
-			}
-			if col.Charset == "utf8" && !utf8.Valid(value.GetBytes()) {
-				return 0, table.ErrInvalidUTF8Value.Gen("invalid utf8 value %q", value.GetBytes())
 			}
 		}
 		colIDs = append(colIDs, col.ID)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
@@ -86,13 +85,6 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, NotNil)
 	_, err = tb.AddRecord(ctx, types.MakeDatums(2, "abc"))
 	c.Assert(err, NotNil)
-
-	// Test input invalid utf8 value.
-	_, err = tb.AddRecord(ctx, types.MakeDatums(3, []byte{255}))
-	c.Assert(terror.ErrorEqual(err, table.ErrInvalidUTF8Value), IsTrue)
-	touched := map[int]bool{1: true}
-	err = tb.UpdateRecord(ctx, 1, types.MakeDatums(1, "abc"), types.MakeDatums(1, []byte{255}), touched)
-	c.Assert(terror.ErrorEqual(err, table.ErrInvalidUTF8Value), IsTrue)
 
 	c.Assert(tb.UpdateRecord(ctx, rid, types.MakeDatums(1, "abc"), types.MakeDatums(1, "cba"), map[int]bool{0: false, 1: true}), IsNil)
 

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -147,6 +147,14 @@ const (
 	CharsetBin = "binary"
 	// CollationBin is the default collation for CharsetBin.
 	CollationBin = "binary"
+	// CharsetUTF8 is the default charset for string types.
+	CharsetUTF8 = "utf8"
+	// CollationUTF8 is the default collation for CharsetUTF8.
+	CollationUTF8 = "utf8_general_ci"
+	// CharsetUTF8MB4 represents 4 bytes utf8, which works the same way as utf8 in Go.
+	CharsetUTF8MB4 = "utf8mb4"
+	// CollationUTF8MB4 is the default collation for CharsetUTF8MB4.
+	CollationUTF8MB4 = "utf8mb4_general_ci"
 )
 
 var collations = []*Collation{


### PR DESCRIPTION
Column length defined in create table should limits the rune count rather than bytes.
And MySQL doesn't return error for inserting invalid UTF8 string, we should not do it.