### PR TITLE
mysql: Fix server version number format

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -15,9 +15,11 @@ package mysql
 
 // Version informations.
 const (
-	MinProtocolVersion byte   = 10
-	MaxPayloadLen      int    = 1<<24 - 1
-	ServerVersion      string = "5.7-TiDB-1.0"
+	MinProtocolVersion byte = 10
+	MaxPayloadLen      int  = 1<<24 - 1
+	// The version number should be three digits.
+	// See: https://dev.mysql.com/doc/refman/5.7/en/which-version.html
+	ServerVersion string = "5.7.1-TiDB-1.0"
 )
 
 // Header informations.


### PR DESCRIPTION
Some mysql tools (for example mydumper) will read and parse mysql server version. They will complain when get malformed version number. 