### PR TITLE
ddl: increase reorg delete limit.

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -78,16 +78,16 @@ func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) error {
 	}
 }
 
-// Maximum number of keys to delete for each job run.
-var reorgDeleteLimit = 65536
+// Maximum number of keys to delete for each reorg table job run.
+var reorgTableDeleteLimit = 65536
 
 func (d *ddl) delReorgTable(t *meta.Meta, job *model.Job) error {
-	delCount, err := d.dropTableData(job.TableID, job, reorgDeleteLimit)
+	delCount, err := d.dropTableData(job.TableID, job, reorgTableDeleteLimit)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// finish this background job
-	if delCount < reorgDeleteLimit {
+	if delCount < reorgTableDeleteLimit {
 		job.SchemaState = model.StateNone
 		job.State = model.JobDone
 	}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -79,7 +79,7 @@ func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) error {
 }
 
 // Maximum number of keys to delete for each job run.
-const reorgDeleteLimit = 65536
+var reorgDeleteLimit = 65536
 
 func (d *ddl) delReorgTable(t *meta.Meta, job *model.Job) error {
 	delCount, err := d.dropTableData(job.TableID, job, reorgDeleteLimit)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -78,14 +78,16 @@ func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) error {
 	}
 }
 
+// Maximum number of keys to delete for each job run.
+const reorgDeleteLimit = 65536
+
 func (d *ddl) delReorgTable(t *meta.Meta, job *model.Job) error {
-	limit := defaultBatchSize
-	delCount, err := d.dropTableData(job.TableID, job, limit)
+	delCount, err := d.dropTableData(job.TableID, job, reorgDeleteLimit)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// finish this background job
-	if delCount < limit {
+	if delCount < reorgDeleteLimit {
 		job.SchemaState = model.StateNone
 		job.State = model.JobDone
 	}

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -196,7 +196,7 @@ func (s *testTableSuite) TestTable(c *C) {
 	c.Assert(err, NotNil)
 	testCheckJobCancelled(c, d, job)
 
-	// to drop a table with reorgDeleteLimit+10 records.
+	// To drop a table with reorgDeleteLimit+10 records.
 	tbl := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 	for i := 1; i <= reorgDeleteLimit+10; i++ {
 		_, err = tbl.AddRecord(ctx, types.MakeDatums(i, i, i))
@@ -226,13 +226,13 @@ func (s *testTableSuite) TestTable(c *C) {
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
 	testCheckJobDone(c, d, job, false)
 
-	// check background ddl info
-	time.Sleep(testLease * 500)
+	// Check background ddl info.
+	time.Sleep(time.Second * 5)
 	verifyBgJobState(c, d, job, model.JobDone)
 	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	c.Assert(updatedCount, Equals, 2)
 
-	// for truncate table
+	// For truncate table.
 	tblInfo = testTableInfo(c, d, "tt", 3)
 	job = testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
 	testCheckTableState(c, d, s.dbInfo, tblInfo, model.StatePublic)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -160,7 +160,7 @@ func (s *testTableSuite) SetUpSuite(c *C) {
 	testCreateSchema(c, testNewContext(c, s.d), s.d, s.dbInfo)
 
 	// Use a smaller limit to prevent the test from consuming too much time.
-	reorgDeleteLimit = 2000
+	reorgTableDeleteLimit = 2000
 }
 
 func (s *testTableSuite) TearDownSuite(c *C) {
@@ -168,7 +168,7 @@ func (s *testTableSuite) TearDownSuite(c *C) {
 	s.d.close()
 	s.store.Close()
 
-	reorgDeleteLimit = 65536
+	reorgTableDeleteLimit = 65536
 }
 
 func testNewContext(c *C, d *ddl) context.Context {
@@ -201,9 +201,9 @@ func (s *testTableSuite) TestTable(c *C) {
 	c.Assert(err, NotNil)
 	testCheckJobCancelled(c, d, job)
 
-	// To drop a table with reorgDeleteLimit+10 records.
+	// To drop a table with reorgTableDeleteLimit+10 records.
 	tbl := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-	for i := 1; i <= reorgDeleteLimit+10; i++ {
+	for i := 1; i <= reorgTableDeleteLimit+10; i++ {
 		_, err = tbl.AddRecord(ctx, types.MakeDatums(i, i, i))
 		c.Assert(err, IsNil)
 	}
@@ -218,12 +218,12 @@ func (s *testTableSuite) TestTable(c *C) {
 		job.Mu.Lock()
 		count := job.RowCount
 		job.Mu.Unlock()
-		if updatedCount == 0 && count != int64(reorgDeleteLimit) {
-			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgDeleteLimit)
+		if updatedCount == 0 && count != int64(reorgTableDeleteLimit) {
+			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgTableDeleteLimit)
 			return
 		}
-		if updatedCount == 1 && count != int64(reorgDeleteLimit+10) {
-			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgDeleteLimit+10)
+		if updatedCount == 1 && count != int64(reorgTableDeleteLimit+10) {
+			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgTableDeleteLimit+10)
 		}
 		updatedCount++
 	}

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -158,12 +158,17 @@ func (s *testTableSuite) SetUpSuite(c *C) {
 
 	s.dbInfo = testSchemaInfo(c, s.d, "test")
 	testCreateSchema(c, testNewContext(c, s.d), s.d, s.dbInfo)
+
+	// Use a smaller limit to prevent the test from consuming too much time.
+	reorgDeleteLimit = 2000
 }
 
 func (s *testTableSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(c, s.d), s.d, s.dbInfo)
 	s.d.close()
 	s.store.Close()
+
+	reorgDeleteLimit = 65536
 }
 
 func testNewContext(c *C, d *ddl) context.Context {
@@ -195,9 +200,6 @@ func (s *testTableSuite) TestTable(c *C) {
 	err := d.doDDLJob(ctx, job)
 	c.Assert(err, NotNil)
 	testCheckJobCancelled(c, d, job)
-
-	// Use a smaller limit to prevent it from consuming too much time.
-	reorgDeleteLimit = 2000
 
 	// To drop a table with reorgDeleteLimit+10 records.
 	tbl := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -196,9 +196,9 @@ func (s *testTableSuite) TestTable(c *C) {
 	c.Assert(err, NotNil)
 	testCheckJobCancelled(c, d, job)
 
-	// To drop a table with defaultBatchSize+10 records.
+	// to drop a table with reorgDeleteLimit+10 records.
 	tbl := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-	for i := 1; i <= defaultBatchSize+10; i++ {
+	for i := 1; i <= reorgDeleteLimit+10; i++ {
 		_, err = tbl.AddRecord(ctx, types.MakeDatums(i, i, i))
 		c.Assert(err, IsNil)
 	}
@@ -213,12 +213,12 @@ func (s *testTableSuite) TestTable(c *C) {
 		job.Mu.Lock()
 		count := job.RowCount
 		job.Mu.Unlock()
-		if updatedCount == 0 && count != defaultBatchSize {
-			checkErr = errors.Errorf("row count %v isn't equal to %v", count, defaultBatchSize)
+		if updatedCount == 0 && count != reorgDeleteLimit {
+			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgDeleteLimit)
 			return
 		}
-		if updatedCount == 1 && count != defaultBatchSize+10 {
-			checkErr = errors.Errorf("row count %v isn't equal to %v", count, defaultBatchSize+10)
+		if updatedCount == 1 && count != reorgDeleteLimit+10 {
+			checkErr = errors.Errorf("row count %v isn't equal to %v", count, reorgDeleteLimit+10)
 		}
 		updatedCount++
 	}
@@ -226,8 +226,8 @@ func (s *testTableSuite) TestTable(c *C) {
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
 	testCheckJobDone(c, d, job, false)
 
-	// Check background ddl info.
-	time.Sleep(testLease * 200)
+	// check background ddl info
+	time.Sleep(testLease * 500)
 	verifyBgJobState(c, d, job, model.JobDone)
 	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	c.Assert(updatedCount, Equals, 2)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -197,7 +197,7 @@ func (s *testTableSuite) TestTable(c *C) {
 	testCheckJobCancelled(c, d, job)
 
 	// Use a smaller limit to prevent it from consuming too much time.
-	reorgDeleteLimit = 2048
+	reorgDeleteLimit = 2000
 
 	// To drop a table with reorgDeleteLimit+10 records.
 	tbl := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)


### PR DESCRIPTION
Due to the 1024 limit for each ddl job run, the drop speed is 512 keys per second in practice (ddl job run interval is 2s). 65536 should be more suitable.

@zimulala @coocood 