### PR TITLE
plan: fix a cost calculation bug.

### DIFF
--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -727,6 +727,10 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			best: "Index(t.c_d_e)[[1,1]]->Projection",
 		},
 		{
+			sql:  "select * from t a order by a.c desc limit 2",
+			best: "Index(t.c_d_e)[[<nil>,+inf]]->Limit->Projection",
+		},
+		{
 			sql:  "select * from t t1, t t2 right join t t3 on t2.a = t3.b order by t1.a, t1.b, t2.a, t2.b, t3.a, t3.b",
 			best: "RightHashJoin{Table(t)->RightHashJoin{Table(t)->Table(t)}(t2.a,t3.b)}->Sort->Projection",
 		},


### PR DESCRIPTION
When we process query "select * from t order by c1 limit 1", the rows passing by network should be treated as limit count. If we don't do that, we will get the plan "TableScan->Topn->Projection" but not "IndexScan->Projection".
@shenli @coocood @zimulala @tiancaiamao PTAL
