### PR TITLE
Remove go 1.6 from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 
 go:
-  - 1.6
   - 1.7
     
 script: make dev


### PR DESCRIPTION
CI: remove go 1.6 to make CI faster.