### PR TITLE
sessionctx/variable: fix default tx_read_only variable value.

### DIFF
--- a/executor/executor_simple_test.go
+++ b/executor/executor_simple_test.go
@@ -120,6 +120,9 @@ func (s *testSuite) TestSetVar(c *C) {
 	tk.MustExec(`set @@global.low_priority_updates="ON";`)
 	tk.MustExec(`set @@session.low_priority_updates=DEFAULT;`) // It will be set to global var value.
 	tk.MustQuery(`select @@session.low_priority_updates;`).Check(testkit.Rows("ON"))
+
+	// For mysql jdbc driver issue.
+	tk.MustQuery(`select @@session.tx_read_only;`).Check(testkit.Rows("0"))
 }
 
 func (s *testSuite) TestSetCharset(c *C) {

--- a/session.go
+++ b/session.go
@@ -762,7 +762,7 @@ func CreateSession(store kv.Storage) (Session, error) {
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = 2
+	currentBootstrapVersion = 3
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -479,7 +479,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "explicit_defaults_for_timestamp", "OFF"},
 	{ScopeNone, "performance_schema_events_waits_history_size", "10"},
 	{ScopeGlobal, "log_syslog_tag", ""},
-	{ScopeGlobal | ScopeSession, "tx_read_only", "OFF"},
+	{ScopeGlobal | ScopeSession, "tx_read_only", "0"},
 	{ScopeGlobal, "rpl_semi_sync_master_wait_point", ""},
 	{ScopeGlobal, "innodb_undo_log_truncate", ""},
 	{ScopeNone, "simplified_binlog_gtid_recovery", "OFF"},


### PR DESCRIPTION
MySQL show this variable as "ON"/"OFF" in documentation, but the real value returned is  "1"/“0”.