### PR TITLE
bin: add flag to print version information

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -44,6 +44,7 @@ import (
 )
 
 var (
+	version         = flag.Bool("v", false, "print version information and exit")
 	store           = flag.String("store", "goleveldb", "registered store name, [memory, goleveldb, boltdb, tikv]")
 	storePath       = flag.String("path", "/tmp/tidb", "tidb storage path")
 	logLevel        = flag.String("L", "info", "log level: info, debug, warn, error, fatal")
@@ -69,6 +70,10 @@ func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	flag.Parse()
+	if *version {
+		printer.PrintRawTiDBInfo()
+		os.Exit(0)
+	}
 
 	leaseDuration := parseLease()
 	tidb.SetSchemaLease(leaseDuration)

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -15,6 +15,7 @@ package printer
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/ngaut/log"
 )
@@ -31,6 +32,12 @@ func PrintTiDBInfo() {
 	log.Infof("Version:")
 	log.Infof("Git Commit Hash: %s", TiDBGitHash)
 	log.Infof("UTC Build Time:  %s", TiDBBuildTS)
+}
+
+// PrintRawTiDBInfo prints the TiDB version information without log info.
+func PrintRawTiDBInfo() {
+	fmt.Println("Git Commit Hash:", TiDBGitHash)
+	fmt.Println("UTC Build Time: ", TiDBBuildTS)
 }
 
 // checkValidity checks whether cols and every data have the same length.


### PR DESCRIPTION
For #1890 
Exactly the same behavior as https://github.com/pingcap/tikv/pull/1245. Print the version and timestamp (without using logger) then exit.