### PR TITLE
infoschema: Add empty table REFERENTIAL_CONSTRAINTS

### DIFF
--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -224,6 +224,43 @@ func (testSuite) TestConcurrent(c *C) {
 	wg.Wait()
 }
 
+// Make sure that all tables of infomation_schema could be found in infoschema handle.
+func (*testSuite) TestInfoTables(c *C) {
+	defer testleak.AfterTest(c)()
+	driver := localstore.Driver{Driver: goleveldb.MemoryDriver{}}
+	store, err := driver.Open("memory")
+	c.Assert(err, IsNil)
+	defer store.Close()
+	handle, err := infoschema.NewHandle(store)
+	c.Assert(err, IsNil)
+	builder, err := infoschema.NewBuilder(handle).InitWithDBInfos(nil, 0)
+	c.Assert(err, IsNil)
+	err = builder.Build()
+	c.Assert(err, IsNil)
+	is := handle.Get()
+	c.Assert(is, NotNil)
+
+	info_tables := []string{
+		"SCHEMATA",
+		"TABLES",
+		"COLUMNS",
+		"STATISTICS",
+		"CHARACTER_SETS",
+		"COLLATIONS",
+		"FILES",
+		"PROFILING",
+		"PARTITIONS",
+		"KEY_COLUMN_USAGE",
+		"REFERENTIAL_CONSTRAINTS",
+	}
+	for _, t := range info_tables {
+		tb, err1 := is.TableByName(model.NewCIStr(infoschema.Name), model.NewCIStr(t))
+		c.Assert(err1, IsNil)
+		c.Assert(tb, NotNil)
+	}
+
+}
+
 func genGlobalID(store kv.Storage) (int64, error) {
 	var globalID int64
 	err := kv.RunInNewTxn(store, true, func(txn kv.Transaction) error {

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -258,7 +258,6 @@ func (*testSuite) TestInfoTables(c *C) {
 		c.Assert(err1, IsNil)
 		c.Assert(tb, NotNil)
 	}
-
 }
 
 func genGlobalID(store kv.Storage) (int64, error) {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -38,6 +38,7 @@ const (
 	tableProfiling     = "PROFILING"
 	tablePartitions    = "PARTITIONS"
 	tableKeyColumm     = "KEY_COLUMN_USAGE"
+	tableReferConst    = "REFERENTIAL_CONSTRAINTS"
 )
 
 type columnInfo struct {
@@ -211,6 +212,21 @@ var keyColumnUsageCols = []columnInfo{
 	{"REFERENCED_TABLE_SCHEMA", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"REFERENCED_TABLE_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"REFERENCED_COLUMN_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+}
+
+// See http://dev.mysql.com/doc/refman/5.7/en/referential-constraints-table.html
+var referConstCols = []columnInfo{
+	{"CONSTRAINT_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"CONSTRAINT_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"CONSTRAINT_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"UNIQUE_CONSTRAINT_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"UNIQUE_CONSTRAINT_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"UNIQUE_CONSTRAINT_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"MATCH_OPTION", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"UPDATE_RULE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"DELETE_RULE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"TABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"REFERENCED_TABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
 }
 
 // See https://dev.mysql.com/doc/refman/5.7/en/partitions-table.html
@@ -498,6 +514,7 @@ var tableNameToColumns = map[string]([]columnInfo){
 	tableProfiling:     profilingCols,
 	tablePartitions:    partitionsCols,
 	tableKeyColumm:     keyColumnUsageCols,
+	tableReferConst:    referConstCols,
 }
 
 func createMemoryTable(meta *model.TableInfo, alloc autoid.Allocator) (table.Table, error) {


### PR DESCRIPTION
Add a empty table REFERENTIAL_CONSTRAINTS in information_schema database to make some java connector happy.
Add test case to check infomation_schema tables.