### PR TITLE
ddl: Pass go race

### DIFF
--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -77,12 +77,13 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 		deleteOnlyTable table.Table
 		writeOnlyTable  table.Table
 		publicTable     table.Table
+		checkErr        error
 	)
-	var checkErr error
 	tc.onJobUpdated = func(job *model.Job) {
 		if job.SchemaState == prevState {
 			return
 		}
+		ctx1 := testNewContext(c, d)
 		prevState = job.SchemaState
 		var err error
 		switch job.SchemaState {
@@ -96,7 +97,7 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
-			err = s.checkAddWriteOnly(d, ctx, deleteOnlyTable, writeOnlyTable)
+			err = s.checkAddWriteOnly(d, ctx1, deleteOnlyTable, writeOnlyTable)
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
@@ -105,7 +106,7 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
-			err = s.checkAddPublic(d, ctx, writeOnlyTable, publicTable)
+			err = s.checkAddPublic(d, ctx1, writeOnlyTable, publicTable)
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}


### PR DESCRIPTION
Fix the problem about using transaction asynchronously in reorgContext.