### PR TITLE
plan: fix bug when outer join's condition is false

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -116,6 +116,8 @@ func (s *testSuite) TestAggregation(c *C) {
 	result.Check(testkit.Rows("2", "2"))
 	result = tk.MustQuery("select max(c) from t group by d having sum(c) > 3 order by avg(c) desc")
 	result.Check(testkit.Rows("4", "3"))
+	result = tk.MustQuery("select sum(-1) from t a left outer join t b on not null is null")
+	result.Check(testkit.Rows("-7"))
 	result = tk.MustQuery("select count(*), b.d from t a left join t b on a.c = b.d group by b.d order by b.d")
 	result.Check(testkit.Rows("2 <nil>", "12 1", "2 3"))
 	result = tk.MustQuery("select count(b.d), b.d from t a left join t b on a.c = b.d group by b.d order by b.d")

--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -19,8 +19,8 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/util/types"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/util/types"
 )
 
 type aggPushDownSolver struct {
@@ -227,7 +227,7 @@ func (a *aggPushDownSolver) tryToPushDownAgg(aggFuncs []expression.AggregationFu
 	agg.SetSchema(schema)
 	if len(agg.GroupByItems) == 0 {
 		agg.GroupByItems = []expression.Expression{&expression.Constant{
-			Value: types.NewDatum(0),
+			Value:   types.NewDatum(0),
 			RetType: types.NewFieldType(mysql.TypeLong)}}
 	}
 	if (childIdx == 0 && join.JoinType == RightOuterJoin) || (childIdx == 1 && join.JoinType == LeftOuterJoin) {

--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -225,6 +225,8 @@ func (a *aggPushDownSolver) tryToPushDownAgg(aggFuncs []expression.AggregationFu
 	}
 	agg.AggFuncs = newAggFuncs
 	agg.SetSchema(schema)
+	// If agg has no group by items, it will return a default values, which may cause some bug.
+	// So here we add a group-by item forcely.
 	if len(agg.GroupByItems) == 0 {
 		agg.GroupByItems = []expression.Expression{&expression.Constant{
 			Value:   types.NewDatum(0),

--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -225,7 +225,7 @@ func (a *aggPushDownSolver) tryToPushDownAgg(aggFuncs []expression.AggregationFu
 	}
 	agg.AggFuncs = newAggFuncs
 	agg.SetSchema(schema)
-	// If agg has no group by items, it will return a default values, which may cause some bug.
+	// If agg has no group-by item, it will return a default value, which may cause some bugs.
 	// So here we add a group-by item forcely.
 	if len(agg.GroupByItems) == 0 {
 		agg.GroupByItems = []expression.Expression{&expression.Constant{

--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/util/types"
+	"github.com/pingcap/tidb/mysql"
 )
 
 type aggPushDownSolver struct {
@@ -224,6 +225,11 @@ func (a *aggPushDownSolver) tryToPushDownAgg(aggFuncs []expression.AggregationFu
 	}
 	agg.AggFuncs = newAggFuncs
 	agg.SetSchema(schema)
+	if len(agg.GroupByItems) == 0 {
+		agg.GroupByItems = []expression.Expression{&expression.Constant{
+			Value: types.NewDatum(0),
+			RetType: types.NewFieldType(mysql.TypeLong)}}
+	}
 	if (childIdx == 0 && join.JoinType == RightOuterJoin) || (childIdx == 1 && join.JoinType == LeftOuterJoin) {
 		var existsDefaultValues bool
 		join.DefaultValues, existsDefaultValues = a.getDefaultValues(agg)


### PR DESCRIPTION
When the query is "select sum(-1) from t a left join t b on false", we rewirte it as "select sum(agg0) from t a join (select sum(-1) as agg0 from t where false) b". The table t will never return any record, but sum(-1) without group by will return NULL, which break our default values "-1". To avoid this bug, we should rewrite it to "select sum(agg0) from t a join (select sum(-1) as agg0 from t where false group by 1) b"
@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL