### PR TITLE
executor: let union_scan executor use its own schema.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -350,7 +350,7 @@ func (b *executorBuilder) buildUnionScanExec(v *plan.PhysicalUnionScan) *UnionSc
 	if b.err != nil {
 		return nil
 	}
-	us := &UnionScanExec{ctx: b.ctx, Src: src}
+	us := &UnionScanExec{ctx: b.ctx, Src: src, schema: v.GetSchema()}
 	switch x := src.(type) {
 	case *XSelectTableExec:
 		us.desc = x.desc

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1233,6 +1233,15 @@ func (s *testSuite) TestColumnName(c *C) {
 	c.Check(err, IsNil)
 	c.Check(len(fields), Equals, 1)
 	c.Check(fields[0].Column.Name.L, Equals, "(c) > all (select c from t)")
+	tk.MustExec("begin")
+	tk.MustExec("insert t values(1,1)")
+	rs, err = tk.Exec("select c d, d c from t")
+	c.Check(err, IsNil)
+	fields, err = rs.Fields()
+	c.Check(err, IsNil)
+	c.Check(len(fields), Equals, 2)
+	c.Check(fields[0].Column.Name.L, Equals, "d")
+	c.Check(fields[1].Column.Name.L, Equals, "c")
 }
 
 func (s *testSuite) TestSelectVar(c *C) {

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -108,11 +108,12 @@ type UnionScanExec struct {
 	cursor      int
 	sortErr     error
 	snapshotRow *Row
+	schema      expression.Schema
 }
 
 // Schema implements the Executor Schema interface.
 func (us *UnionScanExec) Schema() expression.Schema {
-	return us.Src.Schema()
+	return us.schema
 }
 
 // Fields implements the Executor Fields interface.


### PR DESCRIPTION
When we apply "projection-elimination" optimization, the top operator may be union scan which inherits projection's schema to get right names and types. But union_scan's executor didn't use its own schema, instead, it returns its child's schema. This pr will fix this problem.

@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL