### PR TITLE
tidb: load and apply common global variables for the session

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -173,12 +173,7 @@ func (b *executorBuilder) joinConditions(conditions []ast.ExprNode) ast.ExprNode
 
 func (b *executorBuilder) buildSelectLock(v *plan.SelectLock) Executor {
 	src := b.build(v.GetChildByIndex(0))
-	ac, err := autocommit.ShouldAutocommit(b.ctx)
-	if err != nil {
-		b.err = errors.Trace(err)
-		return src
-	}
-	if ac {
+	if autocommit.ShouldAutocommit(b.ctx) {
 		// Locking of rows for update using SELECT FOR UPDATE only applies when autocommit
 		// is disabled (either by beginning transaction with START TRANSACTION or by setting
 		// autocommit to 0. If autocommit is enabled, the rows matching the specification are not locked.

--- a/session.go
+++ b/session.go
@@ -404,43 +404,18 @@ func (s *session) SetGlobalSysVar(ctx context.Context, name string, value string
 }
 
 // IsAutocommit checks if it is in the auto-commit mode.
-func (s *session) isAutocommit(ctx context.Context) (bool, error) {
+func (s *session) isAutocommit(ctx context.Context) bool {
 	sessionVar := variable.GetSessionVars(ctx)
-	autocommit := sessionVar.GetSystemVar("autocommit")
-	if autocommit.IsNull() {
-		if ctx.Value(context.Initing) != nil {
-			return false, nil
-		}
-		autocommitStr, err := s.GetGlobalSysVar(ctx, "autocommit")
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-		autocommit.SetString(autocommitStr)
-		err = sessionVar.SetSystemVar("autocommit", autocommit)
-		if err != nil {
-			return false, errors.Trace(err)
-		}
-	}
-	autocommitStr := autocommit.GetString()
-	if autocommitStr == "ON" || autocommitStr == "on" || autocommitStr == "1" {
-		variable.GetSessionVars(ctx).SetStatusFlag(mysql.ServerStatusAutocommit, true)
-		return true, nil
-	}
-	variable.GetSessionVars(ctx).SetStatusFlag(mysql.ServerStatusAutocommit, false)
-	return false, nil
+	return sessionVar.GetStatusFlag(mysql.ServerStatusAutocommit)
 }
 
-func (s *session) ShouldAutocommit(ctx context.Context) (bool, error) {
+func (s *session) ShouldAutocommit(ctx context.Context) bool {
 	// With START TRANSACTION, autocommit remains disabled until you end
 	// the transaction with COMMIT or ROLLBACK.
-	ac, err := s.isAutocommit(ctx)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-	if variable.GetSessionVars(ctx).Status&mysql.ServerStatusInTrans == 0 && ac {
-		return true, nil
-	}
-	return false, nil
+	sessVar := variable.GetSessionVars(ctx)
+	isAutomcommit := sessVar.GetStatusFlag(mysql.ServerStatusAutocommit)
+	inTransaction := sessVar.GetStatusFlag(mysql.ServerStatusInTrans)
+	return isAutomcommit && !inTransaction
 }
 
 func (s *session) ParseSQL(sql, charset, collation string) ([]ast.StmtNode, error) {
@@ -590,15 +565,16 @@ func (s *session) GetTxn(forceNew bool) (kv.Transaction, error) {
 		ac  bool
 	)
 	if s.txn == nil {
+		err = s.loadCommonGlobalVariablesIfNeeded()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		s.resetHistory()
 		s.txn, err = s.store.Begin()
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ac, err = s.isAutocommit(s)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		ac = s.isAutocommit(s)
 		if !ac {
 			variable.GetSessionVars(s).SetStatusFlag(mysql.ServerStatusInTrans, true)
 		}
@@ -612,12 +588,9 @@ func (s *session) GetTxn(forceNew bool) (kv.Transaction, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ac, err = s.isAutocommit(s)
+		ac = s.isAutocommit(s)
 		if !ac {
 			variable.GetSessionVars(s).SetStatusFlag(mysql.ServerStatusInTrans, true)
-		}
-		if err != nil {
-			return nil, errors.Trace(err)
 		}
 		log.Warnf("Force new txn:%s in session:%d", s.txn, s.sid)
 	}
@@ -810,4 +783,46 @@ func finishBootstrap(store kv.Storage) {
 	if err != nil {
 		log.Fatalf("finish bootstrap err %v", err)
 	}
+}
+
+const loadCommonGlobalVarsSQL = "select * from mysql.global_variables where variable_name in ('" +
+	variable.AutocommitVar + "', '" +
+	variable.SQLModeVar + "', '" +
+	variable.DistSQLJoinConcurrencyVar + "', '" +
+	variable.DistSQLScanConcurrencyVar + "')"
+
+// LoadCommonGlobalVariableIfNeeded load and apply commonly used global variable for the session
+// right before creating a transaction for the first time in the session.
+func (s *session) loadCommonGlobalVariablesIfNeeded() error {
+	vars := variable.GetSessionVars(s)
+	if vars.CommonGlobalLoaded {
+		return nil
+	}
+	if s.Value(context.Initing) != nil {
+		// When running bootstrap or upgrade, we should not access global storage.
+		return nil
+	}
+	// Set the variable to true to prevent cyclic recursive call.
+	vars.CommonGlobalLoaded = true
+	rs, err := s.ExecRestrictedSQL(s, loadCommonGlobalVarsSQL)
+	if err != nil {
+		vars.CommonGlobalLoaded = false
+		log.Errorf("Failed to load common global variables.")
+		return errors.Trace(err)
+	}
+	for {
+		row, err1 := rs.Next()
+		if err1 != nil {
+			vars.CommonGlobalLoaded = false
+			log.Errorf("Failed to load common global variables.")
+			return errors.Trace(err1)
+		}
+		if row == nil {
+			break
+		}
+		varName := row.Data[0].GetString()
+		vars.SetSystemVar(varName, row.Data[1])
+	}
+	vars.CommonGlobalLoaded = true
+	return nil
 }

--- a/session.go
+++ b/session.go
@@ -791,8 +791,8 @@ const loadCommonGlobalVarsSQL = "select * from mysql.global_variables where vari
 	variable.DistSQLJoinConcurrencyVar + "', '" +
 	variable.DistSQLScanConcurrencyVar + "')"
 
-// LoadCommonGlobalVariableIfNeeded load and apply commonly used global variable for the session
-// right before creating a transaction for the first time in the session.
+// LoadCommonGlobalVariableIfNeeded loads and applies commonly used global variables for the session
+// right before creating a transaction for the first time.
 func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 	vars := variable.GetSessionVars(s)
 	if vars.CommonGlobalLoaded {

--- a/session_test.go
+++ b/session_test.go
@@ -2366,6 +2366,7 @@ func (s *testSessionSuite) TestRetryAttempts(c *C) {
 	sv := variable.GetSessionVars(se)
 	// Prevent getting variable value from storage.
 	sv.SetSystemVar("autocommit", types.NewDatum("ON"))
+	sv.CommonGlobalLoaded = true
 
 	// Add retry info.
 	retryInfo := sv.RetryInfo

--- a/session_test.go
+++ b/session_test.go
@@ -306,7 +306,7 @@ func (s *testSessionSuite) TestAutocommit(c *C) {
 	checkAutocommit(c, se, 0)
 	checkTxn(c, se, "drop table if exists t;", 0)
 	checkAutocommit(c, se, 0)
-	checkTxn(c, se, "set autocommit=1;", 0)
+	checkTxn(c, se, "set autocommit='On';", 0)
 	checkAutocommit(c, se, 2)
 
 	mustExecSQL(c, se, s.dropDBSQL)

--- a/sessionctx/autocommit/autocommit.go
+++ b/sessionctx/autocommit/autocommit.go
@@ -21,7 +21,7 @@ import (
 // TODO: Choose a better name.
 type Checker interface {
 	// ShouldAutocommit returns true if it should autocommit in the context.
-	ShouldAutocommit(ctx context.Context) (bool, error)
+	ShouldAutocommit(ctx context.Context) bool
 }
 
 // keyType is a dummy type to avoid naming collision in context.
@@ -40,7 +40,7 @@ func BindAutocommitChecker(ctx context.Context, checker Checker) {
 }
 
 // ShouldAutocommit gets checker from ctx and checks if it should autocommit.
-func ShouldAutocommit(ctx context.Context) (bool, error) {
+func ShouldAutocommit(ctx context.Context) bool {
 	v, ok := ctx.Value(key).(Checker)
 	if !ok {
 		panic("Miss autocommit checker")

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -267,7 +267,7 @@ func (s *SessionVars) SetSystemVar(key string, value types.Datum) error {
 			return errors.Trace(err)
 		}
 	case AutocommitVar:
-		isAutocommit := sVal == "ON" || sVal == "on" || sVal == "1"
+		isAutocommit := strings.EqualFold(sVal, "ON") || sVal == "1"
 		s.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
 	}
 	s.systems[key] = sVal

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -108,6 +108,9 @@ type SessionVars struct {
 	// Strict SQL mode
 	StrictSQLMode bool
 
+	// CommonGlobalLoaded indicates if common global variable has been loaded for this session.
+	CommonGlobalLoaded bool
+
 	// InUpdateStmt indicates if the session is handling update stmt.
 	InUpdateStmt bool
 
@@ -213,6 +216,11 @@ func (s *SessionVars) SetStatusFlag(flag uint16, on bool) {
 	s.Status &= (^flag)
 }
 
+// GetStatusFlag gets the session server status variable, returns true if it is on.
+func (s *SessionVars) GetStatusFlag(flag uint16) bool {
+	return s.Status&flag > 0
+}
+
 // GetNextPreparedStmtID generates and returns the next session scope prepared statement id.
 func (s *SessionVars) GetNextPreparedStmtID() uint32 {
 	s.preparedStmtID++
@@ -226,7 +234,8 @@ func (s *SessionVars) SetCurrentUser(user string) {
 
 // special session variables.
 const (
-	sqlMode             = "sql_mode"
+	SQLModeVar          = "sql_mode"
+	AutocommitVar       = "autocommit"
 	characterSetResults = "character_set_results"
 )
 
@@ -244,18 +253,22 @@ func (s *SessionVars) SetSystemVar(key string, value types.Datum) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if key == sqlMode {
+	switch key {
+	case SQLModeVar:
 		sVal = strings.ToUpper(sVal)
 		if strings.Contains(sVal, "STRICT_TRANS_TABLES") || strings.Contains(sVal, "STRICT_ALL_TABLES") {
 			s.StrictSQLMode = true
 		} else {
 			s.StrictSQLMode = false
 		}
-	} else if key == TiDBSnapshot {
+	case TiDBSnapshot:
 		err = s.setSnapshotTS(sVal)
 		if err != nil {
 			return errors.Trace(err)
 		}
+	case AutocommitVar:
+		isAutocommit := sVal == "ON" || sVal == "on" || sVal == "1"
+		s.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
 	}
 	s.systems[key] = sVal
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -128,7 +128,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "skip_name_resolve", "OFF"},
 	{ScopeNone, "performance_schema_max_file_handles", "32768"},
 	{ScopeSession, "transaction_allow_batching", ""},
-	{ScopeGlobal | ScopeSession, sqlMode, "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"},
+	{ScopeGlobal | ScopeSession, SQLModeVar, "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"},
 	{ScopeNone, "performance_schema_max_statement_classes", "168"},
 	{ScopeGlobal, "server_id", "0"},
 	{ScopeGlobal, "innodb_flushing_avg_loops", "30"},

--- a/tidb.go
+++ b/tidb.go
@@ -153,11 +153,7 @@ func runStmt(ctx context.Context, s ast.Statement, args ...interface{}) (ast.Rec
 	se := ctx.(*session)
 	se.history.add(0, s)
 	// MySQL DDL should be auto-commit.
-	ac, err1 := autocommit.ShouldAutocommit(ctx)
-	if err1 != nil {
-		return nil, errors.Trace(err1)
-	}
-	if s.IsDDL() || ac {
+	if s.IsDDL() || autocommit.ShouldAutocommit(ctx) {
 		if err != nil {
 			log.Info("RollbackTxn for ddl/autocommit error.")
 			ctx.RollbackTxn()


### PR DESCRIPTION
Fixes a bug some global variables like 'sql_mode' not applied to session.