### PR TITLE
executor: set scanConcurrency varialbe for distsql Executor on building.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -548,6 +548,7 @@ func (b *executorBuilder) buildTableScan(v *plan.PhysicalTableScan) Executor {
 			byItems:     v.GbyItems,
 			orderByList: v.SortItems,
 		}
+		st.scanConcurrency, b.err = getScanConcurrency(b.ctx)
 		return st
 	}
 
@@ -595,6 +596,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.PhysicalIndexScan) Executor {
 			aggFields:      v.AggFields,
 			byItems:        v.GbyItems,
 		}
+		st.scanConcurrency, b.err = getScanConcurrency(b.ctx)
 		return st
 	}
 	b.err = errors.New("Not implement yet.")

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -302,9 +302,9 @@ func (s *SessionVars) GetSystemVar(key string) types.Datum {
 	return d
 }
 
-// GetTiDBSystemVar get variable value for name.
+// GetTiDBSystemVar gets variable value for name.
 // The variable should be a TiDB specific system variable (The vars in tidbSysVars map).
-// If the session scope variable is not set, it will get global scope value and fill session scope value.
+// We load the variable from session first, if not found, use local defined default variable.
 func (s *SessionVars) GetTiDBSystemVar(ctx context.Context, name string) (string, error) {
 	key := strings.ToLower(name)
 	_, ok := tidbSysVars[key]

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -316,27 +316,5 @@ func (s *SessionVars) GetTiDBSystemVar(ctx context.Context, name string) (string
 	if ok {
 		return sVal, nil
 	}
-
-	if ctx.Value(context.Initing) != nil {
-		// When running bootstrap or upgrade job, we should not access global storage.
-		return SysVars[key].Value, nil
-	}
-
-	if key == DistSQLScanConcurrencyVar {
-		// Get global variable need to scan table which depends on DistSQLScanConcurrencyVar.
-		// So we should add it here to break the dependency loop.
-		s.systems[DistSQLScanConcurrencyVar] = SysVars[key].Value
-	}
-
-	globalVars := GetGlobalVarAccessor(ctx)
-	globalVal, err := globalVars.GetGlobalSysVar(ctx, key)
-	if err != nil {
-		if key == DistSQLScanConcurrencyVar {
-			// Clean up.
-			delete(s.systems, DistSQLScanConcurrencyVar)
-		}
-		return "", errors.Trace(err)
-	}
-	s.systems[key] = globalVal
-	return globalVal, nil
+	return SysVars[key].Value, nil
 }


### PR DESCRIPTION
Prevent worker goroutines from reading session variable map, Fixes race.