### PR TITLE
makefile: Add the argument of "-check.v" in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export PATH := $(path_to_add):$(PATH)
 
 GO        := GO15VENDOREXPERIMENT="1" go
 GOBUILD   := GOPATH=$(CURDIR)/_vendor:$(GOPATH) $(GO) build
-GOTEST    := GOPATH=$(CURDIR)/_vendor:$(GOPATH) $(GO) test
+GOTEST    := GOPATH=$(CURDIR)/_vendor:$(GOPATH) $(GO) test -check.v
 
 ARCH      := "`uname -s`"
 LINUX     := "Linux"


### PR DESCRIPTION
It will print every test name and the test takes time, it can help us locate problem.
e.g.
PASS: ddl_db_test.go:655: testDBSuite.TestUpdateMultipleTable	6.055s
