### PR TITLE
tidb: set one statement instead of multi-statement query string

### DIFF
--- a/session.go
+++ b/session.go
@@ -456,7 +456,7 @@ func (s *session) Execute(sql string) ([]ast.RecordSet, error) {
 		sessionExecuteCompileDuration.Observe(time.Since(startTS).Seconds())
 
 		s.stmtState = ph.StartStatement(sql, connID, perfschema.CallerNameSessionExecute, rawStmts[i])
-		s.SetValue(context.QueryString, sql)
+		s.SetValue(context.QueryString, st.OriginText())
 
 		startTS = time.Now()
 		r, err := runStmt(s, st)

--- a/session_test.go
+++ b/session_test.go
@@ -2447,3 +2447,14 @@ func (s *testSessionSuite) TestSelectHaving(c *C) {
 	mustExecMultiSQL(c, se, "select * from select_having_test group by id having null is not null;")
 	mustExecMultiSQL(c, se, "drop table select_having_test")
 }
+
+func (s *testSessionSuite) TestQueryString(c *C) {
+	store := newStore(c, s.dbName)
+	se := newSession(c, store, s.dbName)
+	mustExecute(se, "use "+s.dbName)
+	_, err := se.Execute("create table mutil1 (a int);create table multi2 (a int)")
+	c.Assert(err, IsNil)
+	ctx := se.(context.Context)
+	queryStr := ctx.Value(context.QueryString)
+	c.Assert(queryStr, Equals, "create table multi2 (a int)")
+}


### PR DESCRIPTION
When user executing multi-statement query, we should set only one statement query.