### PR TITLE
util/types: fix convert Double

### DIFF
--- a/util/types/convert_test.go
+++ b/util/types/convert_test.go
@@ -500,6 +500,7 @@ func (s *testTypeConvertSuite) TestConvert(c *C) {
 	signedAccept(c, mysql.TypeFloat, float32(123), "123")
 	signedAccept(c, mysql.TypeFloat, float64(123), "123")
 	signedAccept(c, mysql.TypeDouble, " -23.54", "-23.54")
+	signedDeny(c, mysql.TypeDouble, "-23.54a", "-23.54")
 
 	// year
 	signedDeny(c, mysql.TypeYear, 123, "<nil>")

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -694,9 +694,6 @@ func (d *Datum) convertToFloat(target *FieldType) (Datum, error) {
 		f = d.GetFloat64()
 	case KindString, KindBytes:
 		f, err = StrToFloat(d.GetString())
-		if err != nil {
-			return ret, errors.Trace(err)
-		}
 	case KindMysqlTime:
 		f, _ = d.GetMysqlTime().ToNumber().ToFloat64()
 	case KindMysqlDuration:
@@ -717,9 +714,10 @@ func (d *Datum) convertToFloat(target *FieldType) (Datum, error) {
 	// For float and following double type, we will only truncate it for float(M, D) format.
 	// If no D is set, we will handle it like origin float whether M is set or not.
 	if target.Flen != UnspecifiedLength && target.Decimal != UnspecifiedLength {
-		f, err = TruncateFloat(f, target.Flen, target.Decimal)
-		if err != nil {
-			return ret, errors.Trace(err)
+		var err1 error
+		f, err1 = TruncateFloat(f, target.Flen, target.Decimal)
+		if err == nil {
+			err = err1
 		}
 	}
 	if target.Tp == mysql.TypeFloat {
@@ -727,7 +725,7 @@ func (d *Datum) convertToFloat(target *FieldType) (Datum, error) {
 	} else {
 		ret.SetFloat64(f)
 	}
-	return ret, nil
+	return ret, errors.Trace(err)
 }
 
 func (d *Datum) convertToString(target *FieldType) (Datum, error) {


### PR DESCRIPTION
When converting a string to double, the returned value should be parsed from valid part to the string