### PR TITLE
*: Set custom verbose flag to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ bin
 coverage.out
 .idea/
 *.iml
+*.swp
+*.log
+tags
 temp_parser_file
 y.output

--- a/ast/flag_test.go
+++ b/ast/flag_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -31,6 +31,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/distsql/xeval/eval_test.go
+++ b/distsql/xeval/eval_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -36,6 +36,7 @@ import (
 var _ = Suite(&testEvaluatorSuite{})
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -40,6 +40,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/kv/mem_buffer_test.go
+++ b/kv/mem_buffer_test.go
@@ -31,6 +31,7 @@ const (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/mysql/time_test.go
+++ b/mysql/time_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/perfschema/perfschema_test.go
+++ b/perfschema/perfschema_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -38,6 +38,7 @@ import (
 var _ = Suite(&testPlanSuite{})
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -35,6 +35,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/sessionctx/db/db_test.go
+++ b/sessionctx/db/db_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/sessionctx/domainctx_test.go
+++ b/sessionctx/domainctx_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/store/localstore/boltdb/boltdb_test.go
+++ b/store/localstore/boltdb/boltdb_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/store/localstore/goleveldb/goleveldb_test.go
+++ b/store/localstore/goleveldb/goleveldb_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/store/localstore/xapi_test.go
+++ b/store/localstore/xapi_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -44,6 +44,7 @@ const (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/structure/structure_test.go
+++ b/structure/structure_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestTxStructure(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -26,6 +26,7 @@ import (
 var _ = Suite(&testColumnSuite{})
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -38,6 +38,7 @@ var store = flag.String("store", "memory", "registered store name, [memory, gole
 func TestT(t *testing.T) {
 	logLevel := os.Getenv("log_level")
 	log.SetLevelByString(logLevel)
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/charset/charset_test.go
+++ b/util/charset/charset_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/distinct/distinct_test.go
+++ b/util/distinct/distinct_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	check.CustomVerboseFlag = true
 	check.TestingT(t)
 }
 

--- a/util/format/format_test.go
+++ b/util/format/format_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/mock/mock_test.go
+++ b/util/mock/mock_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/prefix_helper_test.go
+++ b/util/prefix_helper_test.go
@@ -31,6 +31,7 @@ const (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/printer/printer_test.go
+++ b/util/printer/printer_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/stringutil/string_util_test.go
+++ b/util/stringutil/string_util_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 

--- a/util/testutil/testutil_test.go
+++ b/util/testutil/testutil_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestT(t *testing.T) {
+	CustomVerboseFlag = true
 	TestingT(t)
 }
 


### PR DESCRIPTION
It will print every test name and the test takes time, it can help us locate problem.
e.g.
PASS: ddl_db_test.go:655: testDBSuite.TestUpdateMultipleTable	6.055s

Pass `make dev` and `make race`