### PR TITLE
*: improve query metrics and query log.

### DIFF
--- a/ddl/metrics.go
+++ b/ddl/metrics.go
@@ -33,7 +33,7 @@ var (
 			Subsystem: "ddl",
 			Name:      "handle_job_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) of handle jobs",
-			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 20),
 		}, []string{"type", "action", "result_state"})
 
 	// handle batch data type.
@@ -46,7 +46,7 @@ var (
 			Subsystem: "ddl",
 			Name:      "batch_add_or_del_data_succ",
 			Help:      "Bucketed histogram of processing time (s) of batch handle data",
-			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20),
 		}, []string{"handle_data_type"})
 )
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -554,6 +554,8 @@ func (cc *clientConn) handleLoadData(loadDataInfo *executor.LoadDataInfo) error 
 	return nil
 }
 
+const queryLogMaxLen = 2048
+
 // handleQuery executes the sql query string and writes result set or result ok to the client.
 // As the execution time of this function represents the performance of TiDB, we do time log and metrics here.
 // There is a special query `load data` that does not return result, which is handled differently.
@@ -589,8 +591,8 @@ func (cc *clientConn) handleQuery(sql string) (err error) {
 		err = cc.writeOK()
 	}
 	costTime := time.Since(startTS)
-	if len(sql) > 1024 {
-		sql = sql[:1024]
+	if len(sql) > queryLogMaxLen {
+		sql = sql[:queryLogMaxLen] + fmt.Sprintf("(len:%d)", len(sql))
 	}
 	if costTime < time.Second {
 		log.Debugf("[%d][TIME_QUERY] %v\n%s", cc.connectionID, costTime, sql)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -24,7 +24,7 @@ var (
 			Subsystem: "server",
 			Name:      "handle_query_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) of handled queries.",
-			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 22),
 		})
 
 	queryCounter = prometheus.NewCounterVec(


### PR DESCRIPTION
Change largest query time bucket from 2 seconds to 1024 seconds.
Also log query length if it is longer than 2048 bytes.