### PR TITLE
plan: change the way that we find column in group-by items in cbo phase.

### DIFF
--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -629,36 +629,24 @@ func (p *Aggregation) convert2PhysicalPlanStream(prop *requiredProperty) (*physi
 	agg.HasGby = len(p.GroupByItems) > 0
 	agg.SetSchema(p.schema)
 	// TODO: Consider distinct key.
-	gbyCols := make([]*expression.Column, 0, len(p.GroupByItems)+1)
 	info := &physicalPlanInfo{cost: math.MaxFloat64}
-	// TODO: extract columns in monotonic functions.
-	for _, item := range p.GroupByItems {
-		if col, ok := item.(*expression.Column); ok {
-			if !col.Correlated {
-				gbyCols = append(gbyCols, col)
-			}
-		} else {
-			// group by a + b is not interested in any order.
-			return info, nil
-		}
+	gbyCols := p.groupByCols
+	if len(gbyCols) != len(p.GroupByItems) {
+		// group by a + b is not interested in any order.
+		return info, nil
 	}
 	isSortKey := make([]bool, len(gbyCols))
 	newProp := &requiredProperty{
 		props: make([]*columnProp, 0, len(gbyCols)),
 	}
 	for _, pro := range prop.props {
-		var matchedCol *expression.Column
-		for i, col := range gbyCols {
-			if !col.Correlated && col.ColName.L == pro.col.ColName.L {
-				isSortKey[i] = true
-				matchedCol = col
-			}
-		}
-		if matchedCol == nil {
+		idx := p.getGbyColIndex(pro.col)
+		if idx == -1 {
 			return info, nil
 		}
+		isSortKey[idx] = true
 		// We should add columns in aggregation in order to keep index right.
-		newProp.props = append(newProp.props, &columnProp{col: matchedCol, desc: pro.desc})
+		newProp.props = append(newProp.props, &columnProp{col: gbyCols[idx], desc: pro.desc})
 	}
 	newProp.sortKeyLen = len(newProp.props)
 	for i, col := range gbyCols {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -876,6 +876,10 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			best: "Table(t)->StreamAgg",
 		},
 		{
+			sql:  "select count(*) from t group by a order by a",
+			best: "Table(t)->StreamAgg->Trim",
+		},
+		{
 			sql:  "select count(distinct e) from t where c = 1 group by d",
 			best: "Index(t.c_d_e)[[1,1]]->StreamAgg",
 		},


### PR DESCRIPTION
We apply the projection-elimination after cbo. So when we process select count(*) from group by a order by a. The 'a' in order by has been rewritten as agg_1 by projection, so we can't retrieve this column in group-by item.
@shenli @coocood @zimulala @XuHuaiYu @winoros PTAL