### PR TITLE
executor: fix show create table null timestamp.

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -389,6 +389,9 @@ func (e *ShowExec) fetchShowCreateTable() error {
 				switch col.DefaultValue {
 				case nil:
 					if !mysql.HasNotNullFlag(col.Flag) {
+						if mysql.HasTimestampFlag(col.Flag) {
+							buf.WriteString(" NULL")
+						}
 						buf.WriteString(" DEFAULT NULL")
 					}
 				case "CURRENT_TIMESTAMP":

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -49,7 +49,8 @@ func (s *testSuite) TestShow(c *C) {
 		a int primary key, 
 		b double NOT NULL DEFAULT 2.0, 
 		c varchar(10) NOT NULL, 
-		d time unique
+		d time unique,
+		e timestamp NULL
 	);`
 	tk.MustExec(testSQL)
 	testSQL = "show create table ptest;"
@@ -57,7 +58,7 @@ func (s *testSuite) TestShow(c *C) {
 	c.Check(result.Rows(), HasLen, 1)
 	row = result.Rows()[0]
 	expectedRow = []interface{}{
-		"ptest", "CREATE TABLE `ptest` (\n  `a` int(11) NOT NULL,\n  `b` double NOT NULL DEFAULT '2',\n  `c` varchar(10) NOT NULL,\n  `d` time DEFAULT NULL,\n PRIMARY KEY (`a`),\n  UNIQUE KEY `d` (`d`)\n) ENGINE=InnoDB"}
+		"ptest", "CREATE TABLE `ptest` (\n  `a` int(11) NOT NULL,\n  `b` double NOT NULL DEFAULT '2',\n  `c` varchar(10) NOT NULL,\n  `d` time DEFAULT NULL,\n  `e` timestamp NULL DEFAULT NULL,\n PRIMARY KEY (`a`),\n  UNIQUE KEY `d` (`d`)\n) ENGINE=InnoDB"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}


### PR DESCRIPTION
Without the extra 'NULL', the create table statement would fail to execute.