### PR TITLE
parser: support drop view if exists

### DIFF
--- a/parser/misc.go
+++ b/parser/misc.go
@@ -391,6 +391,7 @@ var tokenMap = map[string]int{
 	"VALUES":              values,
 	"VARIABLES":           variables,
 	"VERSION":             version,
+	"VIEW":                view,
 	"WARNINGS":            warnings,
 	"WEEK":                week,
 	"WEEKDAY":             weekday,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -214,6 +214,7 @@ import (
 	user		"USER"
 	value		"VALUE"
 	variables	"VARIABLES"
+	view		"VIEW"
 	warnings	"WARNINGS"
 	week		"WEEK"
 	yearType	"YEAR"
@@ -471,6 +472,7 @@ import (
 	DropIndexStmt		"DROP INDEX statement"
 	DropTableStmt		"DROP TABLE statement"
 	DropUserStmt		"DROP USER"
+	DropViewStmt		"DROP VIEW statement"
 	EmptyStmt		"empty statement"
 	Enclosed		"Enclosed by"
 	EqOpt			"= or empty"
@@ -1515,6 +1517,12 @@ DropTableStmt:
 		$$ = &ast.DropTableStmt{IfExists: true, Tables: $5.([]*ast.TableName)}
 	}
 
+DropViewStmt:
+	"DROP" "VIEW" "IF" "EXISTS" TableNameList
+	{
+		$$ = &ast.DoStmt{}
+	}
+
 DropUserStmt:
     "DROP" "USER" UsernameList
     {
@@ -1985,7 +1993,7 @@ UnReservedKeyword:
 |	"COLLATION" | "COMMENT" | "AVG_ROW_LENGTH" | "CONNECTION" | "CHECKSUM" | "COMPRESSION" | "KEY_BLOCK_SIZE" | "MAX_ROWS"
 |	"MIN_ROWS" | "NATIONAL" | "ROW" | "ROW_FORMAT" | "QUARTER" | "GRANTS" | "TRIGGERS" | "DELAY_KEY_WRITE" | "ISOLATION"
 |	"REPEATABLE" | "COMMITTED" | "UNCOMMITTED" | "ONLY" | "SERIALIZABLE" | "LEVEL" | "VARIABLES" | "SQL_CACHE" | "INDEXES" | "PROCESSLIST"
-|	"SQL_NO_CACHE" | "DISABLE"  | "ENABLE" | "REVERSE" | "SPACE" | "PRIVILEGES" | "NO" | "BINLOG" | "FUNCTION"
+|	"SQL_NO_CACHE" | "DISABLE"  | "ENABLE" | "REVERSE" | "SPACE" | "PRIVILEGES" | "NO" | "BINLOG" | "FUNCTION" | "VIEW"
 
 NotKeywordToken:
 	"ABS" | "ADDDATE" | "ADMIN" | "COALESCE" | "CONCAT" | "CONCAT_WS" | "CONNECTION_ID" | "CUR_TIME"| "COUNT" | "DAY"
@@ -4251,6 +4259,7 @@ Statement:
 |	DropDatabaseStmt
 |	DropIndexStmt
 |	DropTableStmt
+|	DropViewStmt
 |	DropUserStmt
 |	FlushStmt
 |	GrantStmt

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -807,6 +807,7 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"drop tables xxx, yyy", true},
 		{"drop table if exists xxx", true},
 		{"drop table if not exists xxx", false},
+		{"drop view if exists xxx", true},
 		// For issue 974
 		{`CREATE TABLE address (
 		id bigint(20) NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
mydumper executes this statement before create a table,
since we don't support view, we can simply return success.