### PR TITLE
plan: fix the bug that we got wrong range when the condition involved in expression.

### DIFF
--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -631,7 +631,12 @@ func (er *expressionRewriter) inToExpression(v *ast.PatternInExpr) {
 	}
 	stkLen := len(er.ctxStack)
 	lLen := len(v.List)
-	function := er.notToExpression(v.Not, ast.In, &v.Type, er.ctxStack[stkLen-lLen-1:stkLen]...)
+	funName := ast.In
+	if lLen == 1 {
+		// a in (1) is treated as a = 1.
+		funName = ast.EQ
+	}
+	function := er.notToExpression(v.Not, funName, &v.Type, er.ctxStack[stkLen-lLen-1:stkLen]...)
 	er.ctxStack = er.ctxStack[:stkLen-lLen-1]
 	er.ctxStack = append(er.ctxStack, function)
 }

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -1110,8 +1110,12 @@ func (s *testPlanSuite) TestRefine(c *C) {
 			best: "Index(t.c_d_e)[(1 3,1 +inf]]->Projection",
 		},
 		{
+			sql:  "select a from t where c in (1,2) and d > 3",
+			best: "Index(t.c_d_e)[[1,1] [2,2]]->Projection",
+		},
+		{
 			sql:  "select a from t where c in (1, 2, 3) and (d > 3 and d < 4 or d > 5 and d < 6)",
-			best: "Index(t.c_d_e)[(1 3,1 4) (1 5,1 6) (2 3,2 4) (2 5,2 6) (3 3,3 4) (3 5,3 6)]->Projection",
+			best: "Index(t.c_d_e)[[1,1] [2,2] [3,3]]->Projection",
 		},
 		{
 			sql:  "select a from t where c in (1, 2, 3)",
@@ -1127,7 +1131,7 @@ func (s *testPlanSuite) TestRefine(c *C) {
 		},
 		{
 			sql:  "select a from t where c not in (1)",
-			best: "Table(t)->Selection->Projection",
+			best: "Index(t.c_d_e)[[-inf,1) (1,+inf]]->Projection",
 		},
 		{
 			sql:  "select a from t where c_str like ''",


### PR DESCRIPTION
If we have found some in expression during calculating range, we should not consider any more column. Because for condition a in (1,3) and b > 5, we should calculate the range like (1 5,2 -inf) and (3 5,4 -inf) when the a is an integer. But when a is a string or float, we can never get a proper range.
So temporarily we don't consider this case.
@shenli @zimulala @coocood @tiancaiamao @XuHuaiyu PTAL