### PR TITLE
plan: add the missing filter conditions

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -760,6 +760,15 @@ func (s *testSuite) TestIndexScan(c *C) {
 	tk.MustExec("insert t values (5, 2)")
 	result = tk.MustQuery("select * from t where a < 5 and b = 1 limit 2")
 	result.Check(testkit.Rows("0 1", "2 1"))
+	tk.MustExec("drop table if exists tab1")
+	tk.MustExec("CREATE TABLE tab1(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT)")
+	tk.MustExec("CREATE INDEX idx_tab1_0 on tab1 (col0)")
+	tk.MustExec("CREATE INDEX idx_tab1_1 on tab1 (col1)")
+	tk.MustExec("CREATE INDEX idx_tab1_3 on tab1 (col3)")
+	tk.MustExec("CREATE INDEX idx_tab1_4 on tab1 (col4)")
+	tk.MustExec("INSERT INTO tab1 VALUES(1,37,20.85,30,10.69)")
+	result = tk.MustQuery("SELECT pk FROM tab1 WHERE ((col3 <= 6 OR col3 < 29 AND (col0 < 41)) OR col3 > 42) AND col1 >= 96.1 AND col3 = 30 AND col3 > 17 AND (col0 BETWEEN 36 AND 42)")
+	result.Check(testkit.Rows())
 }
 
 func (s *testSuite) TestSubquerySameTable(c *C) {

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -462,6 +462,10 @@ func (s *testPlanSuite) TestPushDownExpression(c *C) {
 			cond: "or(test.t.a, and(test.t.b, test.t.c))",
 		},
 		{
+			sql:  "c=1 and d =1 and e =1 and b=1",
+			cond: "eq(test.t.b, 1)",
+		},
+		{
 			sql:  "a or b",
 			cond: "or(test.t.a, test.t.b)",
 		},

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -156,7 +156,8 @@ func detachIndexScanConditions(conditions []expression.Expression, indexScan *Ph
 	indexScan.accessInAndEqCount = indexScan.accessEqualCount
 	// We should remove all accessConds , so that they will not be added to filter conditions.
 	conditions = removeAccessConditions(conditions, accessConds)
-	for curIndex := indexScan.accessEqualCount; curIndex < len(indexScan.Index.Columns); curIndex++ {
+	var curIndex int
+	for curIndex = indexScan.accessEqualCount; curIndex < len(indexScan.Index.Columns); curIndex++ {
 		checker := &conditionChecker{
 			tableName:    indexScan.Table.Name,
 			idx:          indexScan.Index,
@@ -176,6 +177,10 @@ func detachIndexScanConditions(conditions []expression.Expression, indexScan *Ph
 			filterConds = append(filterConds, conditions[accessIdx])
 		}
 		conditions = append(conditions[:accessIdx], conditions[accessIdx+1:]...)
+	}
+	// If curIndex equals to len of index columns, it means the rest conditions haven't been appended to filter conditions.
+	if curIndex == len(indexScan.Index.Columns) {
+		filterConds = append(filterConds, conditions...)
 	}
 	return accessConds, filterConds
 }


### PR DESCRIPTION
When the index is (a,b,c) and the condition is a=1,b=1,c=1, we will forget to add the rest of conditions to the filter conditions after calculating range.
PTAL @shenli @coocood @zimulala @XuHuaiyu 