### PR TITLE
util/types: fix decimal conversion.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -894,7 +894,7 @@ func (s *testSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("3 2"))
 
 	// test cast
-	result = tk.MustQuery("select cast(1 as decimal(1,2))")
+	result = tk.MustQuery("select cast(1 as decimal(3,2))")
 	result.Check(testkit.Rows("1.00"))
 	result = tk.MustQuery("select cast('1991-09-05 11:11:11' as datetime)")
 	result.Check(testkit.Rows("1991-09-05 11:11:11"))
@@ -1018,6 +1018,7 @@ func (s *testSuite) TestToPBExpr(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a decimal(10,6), b decimal, index idx_b (b))")
+	tk.MustExec("set sql_mode = ''")
 	tk.MustExec("insert t values (1.1, 1.1)")
 	tk.MustExec("insert t values (2.4, 2.4)")
 	tk.MustExec("insert t values (3.3, 2.7)")
@@ -1069,6 +1070,7 @@ func (s *testSuite) TestDatumXAPI(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a decimal(10,6), b decimal, index idx_b (b))")
+	tk.MustExec("set sql_mode = ''")
 	tk.MustExec("insert t values (1.1, 1.1)")
 	tk.MustExec("insert t values (2.2, 2.2)")
 	tk.MustExec("insert t values (3.3, 2.7)")

--- a/mysql/mydecimal.go
+++ b/mysql/mydecimal.go
@@ -2093,3 +2093,20 @@ func NewDecFromStringForTest(s string) *MyDecimal {
 	dec.FromString([]byte(s))
 	return dec
 }
+
+// NewMaxOrMinDec returns the max or min value decimal for given precision and fraction.
+func NewMaxOrMinDec(negative bool, prec, frac int) *MyDecimal {
+	str := make([]byte, prec+2)
+	for i := 0; i < len(str); i++ {
+		str[i] = '9'
+	}
+	if negative {
+		str[0] = '-'
+	} else {
+		str[0] = '+'
+	}
+	str[1+prec-frac] = '.'
+	dec := new(MyDecimal)
+	dec.FromString(str)
+	return dec
+}

--- a/mysql/mydecimal_test.go
+++ b/mysql/mydecimal_test.go
@@ -641,3 +641,23 @@ func (s *testMyDecimalSuite) TestDivMod(c *C) {
 		c.Assert(to.String(), Equals, ca.result)
 	}
 }
+
+func (s *testMyDecimalSuite) TestMaxOrMin(c *C) {
+	type tcase struct {
+		neg    bool
+		prec   int
+		frac   int
+		result string
+	}
+	cases := []tcase{
+		{true, 2, 1, "-9.9"},
+		{false, 1, 1, "0.9"},
+		{true, 1, 0, "-9"},
+		{false, 0, 0, "0"},
+		{false, 4, 2, "99.99"},
+	}
+	for _, ca := range cases {
+		dec := NewMaxOrMinDec(ca.neg, ca.prec, ca.frac)
+		c.Assert(dec.String(), Equals, ca.result)
+	}
+}

--- a/session.go
+++ b/session.go
@@ -828,7 +828,9 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 			break
 		}
 		varName := row.Data[0].GetString()
-		vars.SetSystemVar(varName, row.Data[1])
+		if d := vars.GetSystemVar(varName); d.IsNull() {
+			vars.SetSystemVar(varName, row.Data[1])
+		}
 	}
 	vars.CommonGlobalLoaded = true
 	return nil

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -137,7 +137,7 @@ func countEntriesWithPrefix(ctx context.Context, prefix []byte) (int, error) {
 }
 
 func (ts *testSuite) TestTypes(c *C) {
-	_, err := ts.se.Execute("CREATE TABLE test.t (c1 tinyint, c2 smallint, c3 int, c4 bigint, c5 text, c6 blob, c7 varchar(64), c8 time, c9 timestamp not null default CURRENT_TIMESTAMP, c10 decimal)")
+	_, err := ts.se.Execute("CREATE TABLE test.t (c1 tinyint, c2 smallint, c3 int, c4 bigint, c5 text, c6 blob, c7 varchar(64), c8 time, c9 timestamp not null default CURRENT_TIMESTAMP, c10 decimal(10,1))")
 	c.Assert(err, IsNil)
 	ctx := ts.se.(context.Context)
 	dom := sessionctx.GetDomain(ctx)


### PR DESCRIPTION
When datum converts to decimal, we should check the Flen and Decimal of
the given field type, return max value for overflow and round the value
for truncation.

Fixes https://github.com/pingcap/tidb/issues/1974