### PR TITLE
store: clean up unnecessary debug logs.

### DIFF
--- a/store/localstore/compactor.go
+++ b/store/localstore/compactor.go
@@ -175,9 +175,7 @@ func (gc *localstoreCompactor) Compact(k kv.Key) error {
 		return errors.Trace(err)
 	}
 	filteredKeys := gc.filterExpiredKeys(keys)
-	if len(filteredKeys) > 0 {
-		log.Debugf("[kv] GC send %d keys to delete worker", len(filteredKeys))
-	}
+
 	for _, key := range filteredKeys {
 		gc.delCh <- key
 	}

--- a/store/localstore/txn.go
+++ b/store/localstore/txn.go
@@ -51,12 +51,10 @@ func newTxn(s *dbStore, ver kv.Version) *dbTxn {
 
 // Implement transaction interface
 func (txn *dbTxn) Get(k kv.Key) ([]byte, error) {
-	log.Debugf("[kv] get key:% x, txn:%d", k, txn.tid)
 	return txn.us.Get(k)
 }
 
 func (txn *dbTxn) Set(k kv.Key, data []byte) error {
-	log.Debugf("[kv] set key:% x, txn:%d", k, txn.tid)
 	txn.dirty = true
 	return txn.us.Set(k, data)
 }
@@ -66,17 +64,14 @@ func (txn *dbTxn) String() string {
 }
 
 func (txn *dbTxn) Seek(k kv.Key) (kv.Iterator, error) {
-	log.Debugf("[kv] seek key:% x, txn:%d", k, txn.tid)
 	return txn.us.Seek(k)
 }
 
 func (txn *dbTxn) SeekReverse(k kv.Key) (kv.Iterator, error) {
-	log.Debugf("[kv] seek reverse key:% x, txn:%d", k, txn.tid)
 	return txn.us.SeekReverse(k)
 }
 
 func (txn *dbTxn) Delete(k kv.Key) error {
-	log.Debugf("[kv] delete key:% x, txn:%d", k, txn.tid)
 	txn.dirty = true
 	return txn.us.Delete(k)
 }

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -114,7 +114,6 @@ func (c *rpcClient) SendKVReq(addr string, req *kvrpcpb.Request, timeout time.Du
 
 func (c *rpcClient) doSend(conn *Conn, msg *msgpb.Message, writeTimeout time.Duration, readTimeout time.Duration) error {
 	curMsgID := atomic.AddUint64(&c.msgID, 1)
-	log.Debugf("Send request msgID[%d] type[%v]", curMsgID, msg.GetMsgType())
 	conn.SetWriteDeadline(time.Now().Add(writeTimeout))
 	if err := util.WriteMessage(conn, curMsgID, msg); err != nil {
 		return errors.Trace(err)
@@ -131,7 +130,6 @@ func (c *rpcClient) doSend(conn *Conn, msg *msgpb.Message, writeTimeout time.Dur
 		log.Errorf("Sent msgID[%d] mismatches recv msgID[%d]", curMsgID, msgID)
 		return errors.Trace(errInvalidResponse)
 	}
-	log.Debugf("Receive response msgID[%d] type[%v]", msgID, msg.GetMsgType())
 	return nil
 }
 

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -55,7 +55,6 @@ func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
 
 // Implement transaction interface.
 func (txn *tikvTxn) Get(k kv.Key) ([]byte, error) {
-	log.Debugf("Get key[%q] txn[%d]", k, txn.StartTS())
 	txnCmdCounter.WithLabelValues("get").Inc()
 	start := time.Now()
 	defer func() { txnCmdHistogram.WithLabelValues("get").Observe(time.Since(start).Seconds()) }()
@@ -68,7 +67,6 @@ func (txn *tikvTxn) Get(k kv.Key) ([]byte, error) {
 }
 
 func (txn *tikvTxn) Set(k kv.Key, v []byte) error {
-	log.Debugf("Set key[%q] txn[%d]", k, txn.StartTS())
 	txnCmdCounter.WithLabelValues("set").Inc()
 
 	txn.dirty = true
@@ -80,7 +78,6 @@ func (txn *tikvTxn) String() string {
 }
 
 func (txn *tikvTxn) Seek(k kv.Key) (kv.Iterator, error) {
-	log.Debugf("Seek key[%q] txn[%d]", k, txn.StartTS())
 	txnCmdCounter.WithLabelValues("seek").Inc()
 	start := time.Now()
 	defer func() { txnCmdHistogram.WithLabelValues("seek").Observe(time.Since(start).Seconds()) }()
@@ -90,7 +87,6 @@ func (txn *tikvTxn) Seek(k kv.Key) (kv.Iterator, error) {
 
 // SeekReverse creates a reversed Iterator positioned on the first entry which key is less than k.
 func (txn *tikvTxn) SeekReverse(k kv.Key) (kv.Iterator, error) {
-	log.Debugf("SeekReverse key[%q] txn[%d]", k, txn.StartTS())
 	txnCmdCounter.WithLabelValues("seek_reverse").Inc()
 	start := time.Now()
 	defer func() { txnCmdHistogram.WithLabelValues("seek_reverse").Observe(time.Since(start).Seconds()) }()
@@ -99,7 +95,6 @@ func (txn *tikvTxn) SeekReverse(k kv.Key) (kv.Iterator, error) {
 }
 
 func (txn *tikvTxn) Delete(k kv.Key) error {
-	log.Debugf("Delete key[%q] txn[%d]", k, txn.StartTS())
 	txnCmdCounter.WithLabelValues("delete").Inc()
 
 	txn.dirty = true
@@ -120,7 +115,6 @@ func (txn *tikvTxn) Commit() error {
 	}
 	defer txn.close()
 
-	log.Debugf("[kv] start to commit txn %d", txn.StartTS())
 	txnCmdCounter.WithLabelValues("commit").Inc()
 	start := time.Now()
 	defer func() { txnCmdHistogram.WithLabelValues("commit").Observe(time.Since(start).Seconds()) }()
@@ -143,7 +137,6 @@ func (txn *tikvTxn) Commit() error {
 	}
 	committer.writeFinishBinlog(binlog.BinlogType_Commit, int64(committer.commitTS))
 	txn.commitTS = committer.commitTS
-	log.Debugf("[kv] finish commit txn %d", txn.StartTS())
 	return nil
 }
 


### PR DESCRIPTION
Those debug logs are never used, even in debug mode, so i removed them. After this PR merged, we are able to turn on debug flag even in production.