### PR TITLE
infoschema: further reduce memory allocation when loading schema diff.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -79,7 +79,8 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 		return errors.Trace(err)
 	}
 	log.Infof("[ddl] full load InfoSchema from version %d to %d", usedSchemaVersion, latestSchemaVersion)
-	return newISBuilder.Build()
+	newISBuilder.Build()
+	return nil
 }
 
 func (do *Domain) getAllSchemasWithTablesFromMeta(m *meta.Meta) ([]*model.DBInfo, error) {
@@ -150,10 +151,7 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 			return false, errors.Trace(err)
 		}
 	}
-	err := builder.Build()
-	if err != nil {
-		return false, errors.Trace(err)
-	}
+	builder.Build()
 	return true, nil
 }
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -522,13 +522,14 @@ func (b *executorBuilder) buildTableScan(v *plan.PhysicalTableScan) Executor {
 	}
 
 	ts := &TableScanExec{
-		t:          table,
-		asName:     v.TableAsName,
-		ctx:        b.ctx,
-		columns:    v.Columns,
-		schema:     v.GetSchema(),
-		seekHandle: math.MinInt64,
-		ranges:     v.Ranges,
+		t:            table,
+		asName:       v.TableAsName,
+		ctx:          b.ctx,
+		columns:      v.Columns,
+		schema:       v.GetSchema(),
+		seekHandle:   math.MinInt64,
+		ranges:       v.Ranges,
+		isInfoSchema: v.DBName.L == "information_schema",
 	}
 	if v.Desc {
 		return &ReverseExec{Src: ts}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1430,10 +1430,13 @@ func (e *TableScanExec) nextForInfoSchema() (*Row, error) {
 		for i, v := range e.columns {
 			columns[i] = table.ToColumn(v)
 		}
-		e.t.IterRecords(e.ctx, nil, columns, func(h int64, rec []types.Datum, cols []*table.Column) (bool, error) {
+		err := e.t.IterRecords(e.ctx, nil, columns, func(h int64, rec []types.Datum, cols []*table.Column) (bool, error) {
 			e.infoSchemaRows = append(e.infoSchemaRows, rec)
 			return true, nil
 		})
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	if e.infoSchemaCursor >= len(e.infoSchemaRows) {
 		return nil, nil

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1369,6 +1369,10 @@ type TableScanExec struct {
 	cursor     int
 	schema     expression.Schema
 	columns    []*model.ColumnInfo
+
+	isInfoSchema     bool
+	infoSchemaRows   [][]types.Datum
+	infoSchemaCursor int
 }
 
 // Schema implements the Executor Schema interface.
@@ -1378,6 +1382,9 @@ func (e *TableScanExec) Schema() expression.Schema {
 
 // Next implements the Executor interface.
 func (e *TableScanExec) Next() (*Row, error) {
+	if e.isInfoSchema {
+		return e.nextForInfoSchema()
+	}
 	for {
 		if e.cursor >= len(e.ranges) {
 			return nil, nil
@@ -1415,6 +1422,25 @@ func (e *TableScanExec) Next() (*Row, error) {
 		e.seekHandle = handle + 1
 		return row, nil
 	}
+}
+
+func (e *TableScanExec) nextForInfoSchema() (*Row, error) {
+	if e.infoSchemaRows == nil {
+		columns := make([]*table.Column, len(e.schema))
+		for i, v := range e.columns {
+			columns[i] = table.ToColumn(v)
+		}
+		e.t.IterRecords(e.ctx, nil, columns, func(h int64, rec []types.Datum, cols []*table.Column) (bool, error) {
+			e.infoSchemaRows = append(e.infoSchemaRows, rec)
+			return true, nil
+		})
+	}
+	if e.infoSchemaCursor >= len(e.infoSchemaRows) {
+		return nil, nil
+	}
+	row := &Row{Data: e.infoSchemaRows[e.infoSchemaCursor]}
+	e.infoSchemaCursor++
+	return row, nil
 }
 
 // seekRange increments the range cursor to the range

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -211,79 +211,78 @@ func (b *Builder) copySchemaTables(dbName string) {
 
 // InitWithDBInfos initializes an empty new InfoSchema with a slice of DBInfo and schema version.
 func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) (*Builder, error) {
-	err := b.initMemorySchemas()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	info := b.is
 	info.schemaMetaVersion = schemaVersion
 	for _, di := range dbInfos {
-		schTbls := &schemaTables{
-			dbInfo: di,
-			tables: make(map[string]table.Table),
-		}
-		info.schemasMap[di.Name.L] = schTbls
-		for _, t := range di.Tables {
-			alloc := autoid.NewAllocator(b.handle.store, di.ID)
-			var tbl table.Table
-			tbl, err = table.TableFromMeta(alloc, t)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			schTbls.tables[t.Name.L] = tbl
-			sortedTables := info.sortedTablesBuckets[t.ID%bucketCount]
-			info.sortedTablesBuckets[t.ID%bucketCount] = append(sortedTables, tbl)
+		err := b.createSchemaTablesForDB(di)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
+	b.createSchemaTablesForPerfSchemaDB()
+	b.createSchemaTablesForInfoSchemaDB()
 	for _, v := range info.sortedTablesBuckets {
 		sort.Sort(v)
 	}
 	return b, nil
 }
 
-func (b *Builder) initMemorySchemas() error {
-	info := b.is
-	infoSchemaTblNames := &schemaTables{
-		dbInfo: infoSchemaDB,
+func (b *Builder) createSchemaTablesForDB(di *model.DBInfo) error {
+	schTbls := &schemaTables{
+		dbInfo: di,
 		tables: make(map[string]table.Table),
 	}
-
-	info.schemasMap[infoSchemaDB.Name.L] = infoSchemaTblNames
-	for _, t := range infoSchemaDB.Tables {
-		tbl := b.handle.memSchema.nameToTable[t.Name.L]
-		infoSchemaTblNames.tables[t.Name.L] = tbl
-		bucketIdx := t.ID % bucketCount
-		info.sortedTablesBuckets[bucketIdx] = append(info.sortedTablesBuckets[bucketIdx], tbl)
+	b.is.schemasMap[di.Name.L] = schTbls
+	for _, t := range di.Tables {
+		alloc := autoid.NewAllocator(b.handle.store, di.ID)
+		var tbl table.Table
+		tbl, err := table.TableFromMeta(alloc, t)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		schTbls.tables[t.Name.L] = tbl
+		sortedTables := b.is.sortedTablesBuckets[t.ID%bucketCount]
+		b.is.sortedTablesBuckets[t.ID%bucketCount] = append(sortedTables, tbl)
 	}
+	return nil
+}
 
-	perfHandle := b.handle.memSchema.perfHandle
+func (b *Builder) createSchemaTablesForPerfSchemaDB() {
+	perfHandle := b.handle.perfHandle
 	perfSchemaDB := perfHandle.GetDBMeta()
 	perfSchemaTblNames := &schemaTables{
 		dbInfo: perfSchemaDB,
 		tables: make(map[string]table.Table),
 	}
-	info.schemasMap[perfSchemaDB.Name.L] = perfSchemaTblNames
-
+	b.is.schemasMap[perfSchemaDB.Name.L] = perfSchemaTblNames
 	for _, t := range perfSchemaDB.Tables {
 		tbl, ok := perfHandle.GetTable(t.Name.O)
 		if !ok {
-			return ErrTableNotExists.Gen("table `%s` is missing.", t.Name)
+			continue
 		}
 		perfSchemaTblNames.tables[t.Name.L] = tbl
 		bucketIdx := t.ID % bucketCount
-		info.sortedTablesBuckets[bucketIdx] = append(info.sortedTablesBuckets[bucketIdx], tbl)
+		b.is.sortedTablesBuckets[bucketIdx] = append(b.is.sortedTablesBuckets[bucketIdx], tbl)
 	}
-	return nil
+}
+
+func (b *Builder) createSchemaTablesForInfoSchemaDB() {
+	infoSchemaSchemaTables := &schemaTables{
+		dbInfo: infoSchemaDB,
+		tables: make(map[string]table.Table),
+	}
+	b.is.schemasMap[infoSchemaDB.Name.L] = infoSchemaSchemaTables
+	for _, t := range infoSchemaDB.Tables {
+		tbl := createInfoSchemaTable(b.handle, t)
+		infoSchemaSchemaTables.tables[t.Name.L] = tbl
+		bucketIdx := t.ID % bucketCount
+		b.is.sortedTablesBuckets[bucketIdx] = append(b.is.sortedTablesBuckets[bucketIdx], tbl)
+	}
 }
 
 // Build sets new InfoSchema to the handle in the Builder.
-func (b *Builder) Build() error {
-	err := b.handle.refillMemoryTables(b.is.AllSchemas())
-	if err != nil {
-		return errors.Trace(err)
-	}
+func (b *Builder) Build() {
 	b.handle.value.Store(b.is)
-	return nil
 }
 
 // NewBuilder creates a new Builder with a Handle.

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -65,7 +65,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 		if oldTableID == newTableID {
 			alloc, _ = b.is.AllocByID(oldTableID)
 		}
-		b.applyDropTable(roDBInfo.Name.L, oldTableID)
+		b.applyDropTable(roDBInfo, oldTableID)
 	}
 	if newTableID != 0 {
 		// All types except DropTable.

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -14,6 +14,8 @@
 package infoschema
 
 import (
+	"sort"
+
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -37,7 +39,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 		b.applyDropSchema(diff.SchemaID)
 		return nil
 	}
-	roDBInfo, ok := b.is.schemas[diff.SchemaID]
+	roDBInfo, ok := b.is.SchemaByID(diff.SchemaID)
 	if !ok {
 		return ErrDatabaseNotExists
 	}
@@ -54,11 +56,13 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 		oldTableID = diff.TableID
 		newTableID = diff.TableID
 	}
+	b.copySchemaTables(roDBInfo.Name.L)
+
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var alloc autoid.Allocator
 	if oldTableID != 0 {
 		alloc, _ = b.is.AllocByID(oldTableID)
-		b.applyDropTable(roDBInfo.Name.L, oldTableID)
+		b.applyDropTable(roDBInfo, oldTableID)
 	}
 	if newTableID != 0 {
 		// All types except DropTable.
@@ -79,15 +83,16 @@ func (b *Builder) updateDBInfo(roDBInfo *model.DBInfo, oldTableID, newTableID in
 	newDbInfo.Tables = make([]*model.TableInfo, 0, len(roDBInfo.Tables))
 	if newTableID != 0 {
 		// All types except DropTable.
-		newTblInfo := b.is.tables[newTableID].Meta()
-		newDbInfo.Tables = append(newDbInfo.Tables, newTblInfo)
+		if newTbl, ok := b.is.TableByID(newTableID); ok {
+			newDbInfo.Tables = append(newDbInfo.Tables, newTbl.Meta())
+		}
 	}
 	for _, tblInfo := range roDBInfo.Tables {
 		if tblInfo.ID != oldTableID && tblInfo.ID != newTableID {
 			newDbInfo.Tables = append(newDbInfo.Tables, tblInfo)
 		}
 	}
-	b.is.schemas[newDbInfo.ID] = newDbInfo
+	b.is.schemasMap[roDBInfo.Name.L].dbInfo = newDbInfo
 }
 
 func (b *Builder) applyCreateSchema(m *meta.Meta, diff *model.SchemaDiff) error {
@@ -100,20 +105,18 @@ func (b *Builder) applyCreateSchema(m *meta.Meta, diff *model.SchemaDiff) error 
 		// full load.
 		return ErrDatabaseNotExists
 	}
-	b.is.schemas[di.ID] = di
-	b.is.schemaNameToID[di.Name.L] = di.ID
+	b.is.schemasMap[di.Name.L] = &schemaTables{dbInfo: di, tables: make(map[string]table.Table)}
 	return nil
 }
 
 func (b *Builder) applyDropSchema(schemaID int64) {
-	di, ok := b.is.schemas[schemaID]
+	di, ok := b.is.SchemaByID(schemaID)
 	if !ok {
 		return
 	}
-	delete(b.is.schemas, di.ID)
-	delete(b.is.schemaNameToID, di.Name.L)
+	delete(b.is.schemasMap, di.Name.L)
 	for _, tbl := range di.Tables {
-		b.applyDropTable(di.Name.L, tbl.ID)
+		b.applyDropTable(di, tbl.ID)
 	}
 }
 
@@ -134,58 +137,58 @@ func (b *Builder) applyCreateTable(m *meta.Meta, roDBInfo *model.DBInfo, tableID
 	if err != nil {
 		return errors.Trace(err)
 	}
-	b.is.tables[tblInfo.ID] = tbl
-	tn := makeTableName(roDBInfo.Name.L, tblInfo.Name.L)
-	b.is.tableNameToID[string(tn)] = tblInfo.ID
+	tableNames := b.is.schemasMap[roDBInfo.Name.L]
+	tableNames.tables[tblInfo.Name.L] = tbl
+	b.is.sortedTables = append(b.is.sortedTables, tbl)
+	sort.Sort(b.is.sortedTables)
 	return nil
 }
 
-func (b *Builder) applyDropTable(schemaName string, tableID int64) {
-	tbl, ok := b.is.tables[tableID]
-	if !ok {
+func (b *Builder) applyDropTable(di *model.DBInfo, tableID int64) {
+	idx := b.is.searchTable(tableID)
+	if idx == -1 {
 		return
 	}
-	tblInfo := tbl.Meta()
-	delete(b.is.tables, tblInfo.ID)
-	tn := makeTableName(schemaName, tblInfo.Name.L)
-	delete(b.is.tableNameToID, string(tn))
+	if tableNames, ok := b.is.schemasMap[di.Name.L]; ok {
+		delete(tableNames.tables, b.is.sortedTables[idx].Meta().Name.L)
+	}
+	// Remove the table in sorted table slice.
+	b.is.sortedTables = append(b.is.sortedTables[0:idx], b.is.sortedTables[idx+1:]...)
 }
 
 // InitWithOldInfoSchema initializes an empty new InfoSchema by copies all the data from old InfoSchema.
 func (b *Builder) InitWithOldInfoSchema() *Builder {
 	oldIS := b.handle.Get().(*infoSchema)
 	b.is.schemaMetaVersion = oldIS.schemaMetaVersion
-	b.copySchemaNames(oldIS)
-	b.copyTableNames(oldIS)
-	b.copySchemas(oldIS)
-	b.copyTables(oldIS)
+	b.copySchemasMap(oldIS)
+	b.copySortedTables(oldIS)
 	return b
 }
 
-func (b *Builder) copySchemaNames(oldIS *infoSchema) {
-	for k, v := range oldIS.schemaNameToID {
-		b.is.schemaNameToID[k] = v
+func (b *Builder) copySchemasMap(oldIS *infoSchema) {
+	for k, v := range oldIS.schemasMap {
+		b.is.schemasMap[k] = v
 	}
 }
 
-func (b *Builder) copyTableNames(oldIS *infoSchema) {
-	b.is.tableNameToID = make(map[string]int64, len(oldIS.tableNameToID))
-	for k, v := range oldIS.tableNameToID {
-		b.is.tableNameToID[k] = v
+// When a table in the database has changed, we should create a new schemaTables instance, then do modifications
+// on the new one. Because old schemaTables must be read-only.
+func (b *Builder) copySchemaTables(dbName string) {
+	oldSchemaTables := b.is.schemasMap[dbName]
+	newSchemaTables := &schemaTables{
+		dbInfo: oldSchemaTables.dbInfo,
+		tables: make(map[string]table.Table, len(oldSchemaTables.tables)),
 	}
+	for k, v := range oldSchemaTables.tables {
+		newSchemaTables.tables[k] = v
+	}
+	b.is.schemasMap[dbName] = newSchemaTables
 }
 
-func (b *Builder) copySchemas(oldIS *infoSchema) {
-	for k, v := range oldIS.schemas {
-		b.is.schemas[k] = v
-	}
-}
-
-func (b *Builder) copyTables(oldIS *infoSchema) {
-	b.is.tables = make(map[int64]table.Table, len(oldIS.tables))
-	for k, v := range oldIS.tables {
-		b.is.tables[k] = v
-	}
+func (b *Builder) copySortedTables(oldIS *infoSchema) {
+	// make an extra capacity for create table.
+	b.is.sortedTables = make([]table.Table, len(oldIS.sortedTables), len(oldIS.sortedTables)+1)
+	copy(b.is.sortedTables, oldIS.sortedTables)
 }
 
 // InitWithDBInfos initializes an empty new InfoSchema with a slice of DBInfo and schema version.
@@ -197,8 +200,11 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 	info := b.is
 	info.schemaMetaVersion = schemaVersion
 	for _, di := range dbInfos {
-		info.schemas[di.ID] = di
-		info.schemaNameToID[di.Name.L] = di.ID
+		schTbls := &schemaTables{
+			dbInfo: di,
+			tables: make(map[string]table.Table),
+		}
+		info.schemasMap[di.Name.L] = schTbls
 		for _, t := range di.Tables {
 			alloc := autoid.NewAllocator(b.handle.store, di.ID)
 			var tbl table.Table
@@ -206,38 +212,43 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			info.tables[t.ID] = tbl
-			tname := makeTableName(di.Name.L, t.Name.L)
-			info.tableNameToID[string(tname)] = t.ID
+			schTbls.tables[t.Name.L] = tbl
+			info.sortedTables = append(info.sortedTables, tbl)
 		}
 	}
+	sort.Sort(info.sortedTables)
 	return b, nil
 }
 
 func (b *Builder) initMemorySchemas() error {
 	info := b.is
-	info.schemaNameToID[infoSchemaDB.Name.L] = infoSchemaDB.ID
-	info.schemas[infoSchemaDB.ID] = infoSchemaDB
+	infoSchemaTblNames := &schemaTables{
+		dbInfo: infoSchemaDB,
+		tables: make(map[string]table.Table),
+	}
+
+	info.schemasMap[infoSchemaDB.Name.L] = infoSchemaTblNames
 	for _, t := range infoSchemaDB.Tables {
 		tbl := b.handle.memSchema.nameToTable[t.Name.L]
-		info.tables[t.ID] = tbl
-		tname := makeTableName(infoSchemaDB.Name.L, t.Name.L)
-		info.tableNameToID[string(tname)] = t.ID
+		infoSchemaTblNames.tables[t.Name.L] = tbl
+		info.sortedTables = append(info.sortedTables, tbl)
 	}
 
 	perfHandle := b.handle.memSchema.perfHandle
-	psDB := perfHandle.GetDBMeta()
+	perfSchemaDB := perfHandle.GetDBMeta()
+	perfSchemaTblNames := &schemaTables{
+		dbInfo: perfSchemaDB,
+		tables: make(map[string]table.Table),
+	}
+	info.schemasMap[perfSchemaDB.Name.L] = perfSchemaTblNames
 
-	info.schemaNameToID[psDB.Name.L] = psDB.ID
-	info.schemas[psDB.ID] = psDB
-	for _, t := range psDB.Tables {
+	for _, t := range perfSchemaDB.Tables {
 		tbl, ok := perfHandle.GetTable(t.Name.O)
 		if !ok {
 			return ErrTableNotExists.Gen("table `%s` is missing.", t.Name)
 		}
-		info.tables[t.ID] = tbl
-		tname := makeTableName(psDB.Name.L, t.Name.L)
-		info.tableNameToID[string(tname)] = t.ID
+		perfSchemaTblNames.tables[t.Name.L] = tbl
+		info.sortedTables = append(info.sortedTables, tbl)
 	}
 	return nil
 }
@@ -257,10 +268,7 @@ func NewBuilder(handle *Handle) *Builder {
 	b := new(Builder)
 	b.handle = handle
 	b.is = &infoSchema{
-		schemaNameToID: map[string]int64{},
-		tableNameToID:  map[string]int64{},
-		schemas:        map[int64]*model.DBInfo{},
-		tables:         map[int64]table.Table{},
+		schemasMap: map[string]*schemaTables{},
 	}
 	return b
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	// import table implementation to init table.TableFromMeta
-	"github.com/pingcap/tidb/util/types"
 )
 
 var (
@@ -261,16 +260,6 @@ func NewHandle(store kv.Storage) (*Handle, error) {
 		return nil, errors.Trace(err)
 	}
 	return h, nil
-}
-
-func insertData(tbl table.Table, rows [][]types.Datum) error {
-	for _, r := range rows {
-		_, err := tbl.AddRecord(nil, r)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
 }
 
 // Get gets information schema from Handle.

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -118,8 +118,7 @@ func (*testSuite) TestT(c *C) {
 	checkApplyCreateNonExistsTableDoesNotPanic(c, txn, builder, dbID)
 	txn.Rollback()
 
-	err = builder.Build()
-	c.Assert(err, IsNil)
+	builder.Build()
 
 	is := handle.Get()
 
@@ -236,8 +235,7 @@ func (*testSuite) TestInfoTables(c *C) {
 	c.Assert(err, IsNil)
 	builder, err := infoschema.NewBuilder(handle).InitWithDBInfos(nil, 0)
 	c.Assert(err, IsNil)
-	err = builder.Build()
-	c.Assert(err, IsNil)
+	builder.Build()
 	is := handle.Get()
 	c.Assert(is, NotNil)
 


### PR DESCRIPTION
When creating a lot of table in a short amount of time, the memory growing is still very high.
This PR fixes this issue.