### PR TITLE
Makefile: make race test parallel on package level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,12 +95,7 @@ gotest:
 
 race:
 	@export log_level=debug; \
-	dirs=`go list ./... | grep -vE 'vendor' | awk '{sub("github.com/pingcap/tidb/",""); print}'`;\
-	for dir in $$dirs; do \
-		cd $$dir;\
-		$(GOTEST) -race | awk 'END{if($$1=="FAIL") {exit 1}}' || exit 1;\
-		cd -;\
-	done;
+	$(GOTEST) -race $(PACKAGES)
 
 tikv_integration_test:
 	$(GOTEST) ./store/tikv/. -with-tikv=true


### PR DESCRIPTION
```
for dir in $$dirs 
    go test -race dir
done
```

run the test package sequentially, while

`go test -race A B C` let them parallel on package level