### PR TITLE
infoschema: do not reuse auto ID allocator for truncate table.

### DIFF
--- a/evaluator/builtin_other.go
+++ b/evaluator/builtin_other.go
@@ -35,7 +35,7 @@ func builtinSleep(args []types.Datum, ctx context.Context) (d types.Datum, err e
 	sessVars := variable.GetSessionVars(ctx)
 	if args[0].IsNull() {
 		if sessVars.StrictSQLMode {
-			return d, errors.New("Incorrect arguments to sleep.")
+			return d, errors.New("incorrect arguments to sleep")
 		}
 		d.SetInt64(0)
 		return
@@ -48,7 +48,7 @@ func builtinSleep(args []types.Datum, ctx context.Context) (d types.Datum, err e
 	}
 	if ret == -1 {
 		if sessVars.StrictSQLMode {
-			return d, errors.New("Incorrect arguments to sleep.")
+			return d, errors.New("incorrect arguments to sleep")
 		}
 		d.SetInt64(0)
 		return

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -111,7 +111,7 @@ func (a *statement) Exec(ctx context.Context) (ast.RecordSet, error) {
 		case *DeleteExec, *InsertExec, *UpdateExec, *ReplaceExec, *LoadData, *DDLExec:
 			snapshotTS := variable.GetSnapshotTS(ctx)
 			if snapshotTS != 0 {
-				return nil, errors.New("Can not execute write statement when 'tidb_snapshot' is set.")
+				return nil, errors.New("can not execute write statement when 'tidb_snapshot' is set")
 			}
 		}
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -568,7 +568,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.PhysicalIndexScan) Executor {
 		st.scanConcurrency, b.err = getScanConcurrency(b.ctx)
 		return st
 	}
-	b.err = errors.New("Not implement yet.")
+	b.err = errors.New("not implement yet")
 	return nil
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1855,7 +1855,7 @@ func (e *MaxOneRowExec) Next() (*Row, error) {
 			return nil, errors.Trace(err)
 		}
 		if srcRow1 != nil {
-			return nil, errors.New("Subquery returns more than 1 row.")
+			return nil, errors.New("subquery returns more than 1 row")
 		}
 		return srcRow, nil
 	}

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -491,7 +491,7 @@ func (e *GrantExec) getTargetSchema() (*model.DBInfo, error) {
 		// Grant *, use current schema
 		dbName = db.GetCurrentSchema(e.ctx)
 		if len(dbName) == 0 {
-			return nil, errors.New("Miss DB name for grant privilege.")
+			return nil, errors.New("miss DB name for grant privilege")
 		}
 	}
 	//check if db exists

--- a/executor/show.go
+++ b/executor/show.go
@@ -529,7 +529,7 @@ func (e *ShowExec) fetchShowGrants() error {
 	// Get checker
 	checker := privilege.GetPrivilegeChecker(e.ctx)
 	if checker == nil {
-		return errors.New("Miss privilege checker!")
+		return errors.New("miss privilege checker")
 	}
 	gs, err := checker.ShowGrants(e.ctx, e.User)
 	if err != nil {

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -56,7 +56,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 	}
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var alloc autoid.Allocator
-	if oldTableID != 0 {
+	if oldTableID != 0 && oldTableID == newTableID {
 		alloc, _ = b.is.AllocByID(oldTableID)
 		b.applyDropTable(roDBInfo.Name.L, oldTableID)
 	}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -56,8 +56,10 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 	}
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var alloc autoid.Allocator
-	if oldTableID != 0 && oldTableID == newTableID {
-		alloc, _ = b.is.AllocByID(oldTableID)
+	if oldTableID != 0 {
+		if oldTableID == newTableID {
+			alloc, _ = b.is.AllocByID(oldTableID)
+		}
 		b.applyDropTable(roDBInfo.Name.L, oldTableID)
 	}
 	if newTableID != 0 {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -212,7 +212,7 @@ func (b *planBuilder) buildJoin(join *ast.Join) LogicalPlan {
 			return nil
 		}
 		if correlated {
-			b.err = errors.New("On condition doesn't support subqueries yet.")
+			b.err = errors.New("ON condition doesn't support subqueries yet")
 		}
 		onCondition := expression.SplitCNFItems(onExpr)
 		eqCond, leftCond, rightCond, otherCond := extractOnCondition(onCondition, leftPlan, rightPlan)

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -134,7 +134,7 @@ func (b *planBuilder) extractSelectAgg(sel *ast.SelectStmt) []*ast.AggregateFunc
 	for _, f := range sel.GetResultFields() {
 		n, ok := f.Expr.Accept(extractor)
 		if !ok {
-			b.err = errors.New("Failed to extract agg expr!")
+			b.err = errors.New("failed to extract agg expr")
 			return nil
 		}
 		ve, ok := f.Expr.(*ast.ValueExpr)

--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -723,7 +723,7 @@ func (nr *nameResolver) createResultFields(field *ast.SelectField) (rfs []*ast.R
 	ctx := nr.currentContext()
 	if field.WildCard != nil {
 		if len(ctx.tables) == 0 {
-			nr.Err = errors.New("No table used.")
+			nr.Err = errors.New("no table used")
 			return
 		}
 		tableRfs := []*ast.ResultField{}

--- a/session.go
+++ b/session.go
@@ -339,7 +339,7 @@ func (s *session) ExecRestrictedSQL(ctx context.Context, sql string) (ast.Record
 	}
 	if len(rawStmts) != 1 {
 		log.Errorf("ExecRestrictedSQL only executes one statement. Too many/few statement in %s", sql)
-		return nil, errors.New("Wrong number of statement.")
+		return nil, errors.New("wrong number of statement")
 	}
 	st, err := Compile(s, rawStmts[0])
 	if err != nil {

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -212,7 +212,7 @@ func (rs *localRegion) Handle(req *regionRequest) (*regionResponse, error) {
 				ctx.descScan = sel.OrderBy[0].Desc
 			} else {
 				if sel.Limit == nil {
-					return nil, errors.New("We don't support pushing down Sort without Limit.")
+					return nil, errors.New("we don't support pushing down Sort without Limit")
 				}
 				ctx.topn = true
 				ctx.topnHeap = &topnHeap{


### PR DESCRIPTION
For truncate table, old table ID is different than new table ID, the same allocator will alloc ID
for different table ID, can not ensure uniqueness.