### PR TITLE
infoschema: change data structure for lookup table by ID.

### DIFF
--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -57,6 +57,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 		newTableID = diff.TableID
 	}
 	b.copySchemaTables(roDBInfo.Name.L)
+	b.copySortedTables(oldTableID, newTableID)
 
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var alloc autoid.Allocator
@@ -76,6 +77,24 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) error {
 	// The old DBInfo still holds a reference to old table info, we need to update it.
 	b.updateDBInfo(roDBInfo, oldTableID, newTableID)
 	return nil
+}
+
+// CopySortedTables copies sortedTables for old table and new table for later modification.
+func (b *Builder) copySortedTables(oldTableID, newTableID int64) {
+	buckets := b.is.sortedTablesBuckets
+	if oldTableID != 0 {
+		bucketIdx := oldTableID % bucketCount
+		oldSortedTables := buckets[bucketIdx]
+		newSortedTables := make(sortedTables, len(oldSortedTables))
+		copy(newSortedTables, oldSortedTables)
+		buckets[bucketIdx] = newSortedTables
+	}
+	if newTableID != 0 && newTableID != oldTableID {
+		oldSortedTables := buckets[newTableID%bucketCount]
+		newSortedTables := make(sortedTables, len(oldSortedTables), len(oldSortedTables)+1)
+		copy(newSortedTables, oldSortedTables)
+		buckets[newTableID%bucketCount] = newSortedTables
+	}
 }
 
 // updateDBInfo clones a new DBInfo from old DBInfo, and update on the new one.
@@ -141,21 +160,26 @@ func (b *Builder) applyCreateTable(m *meta.Meta, roDBInfo *model.DBInfo, tableID
 	}
 	tableNames := b.is.schemasMap[roDBInfo.Name.L]
 	tableNames.tables[tblInfo.Name.L] = tbl
-	b.is.sortedTables = append(b.is.sortedTables, tbl)
-	sort.Sort(b.is.sortedTables)
+	bucketIdx := tableID % bucketCount
+	sortedTables := b.is.sortedTablesBuckets[bucketIdx]
+	sortedTables = append(sortedTables, tbl)
+	sort.Sort(sortedTables)
+	b.is.sortedTablesBuckets[bucketIdx] = sortedTables
 	return nil
 }
 
 func (b *Builder) applyDropTable(di *model.DBInfo, tableID int64) {
-	idx := b.is.searchTable(tableID)
+	bucketIdx := tableID % bucketCount
+	sortedTables := b.is.sortedTablesBuckets[bucketIdx]
+	idx := sortedTables.searchTable(tableID)
 	if idx == -1 {
 		return
 	}
 	if tableNames, ok := b.is.schemasMap[di.Name.L]; ok {
-		delete(tableNames.tables, b.is.sortedTables[idx].Meta().Name.L)
+		delete(tableNames.tables, sortedTables[idx].Meta().Name.L)
 	}
 	// Remove the table in sorted table slice.
-	b.is.sortedTables = append(b.is.sortedTables[0:idx], b.is.sortedTables[idx+1:]...)
+	b.is.sortedTablesBuckets[bucketIdx] = append(sortedTables[0:idx], sortedTables[idx+1:]...)
 }
 
 // InitWithOldInfoSchema initializes an empty new InfoSchema by copies all the data from old InfoSchema.
@@ -163,7 +187,7 @@ func (b *Builder) InitWithOldInfoSchema() *Builder {
 	oldIS := b.handle.Get().(*infoSchema)
 	b.is.schemaMetaVersion = oldIS.schemaMetaVersion
 	b.copySchemasMap(oldIS)
-	b.copySortedTables(oldIS)
+	copy(b.is.sortedTablesBuckets, oldIS.sortedTablesBuckets)
 	return b
 }
 
@@ -185,12 +209,6 @@ func (b *Builder) copySchemaTables(dbName string) {
 		newSchemaTables.tables[k] = v
 	}
 	b.is.schemasMap[dbName] = newSchemaTables
-}
-
-func (b *Builder) copySortedTables(oldIS *infoSchema) {
-	// make an extra capacity for create table.
-	b.is.sortedTables = make([]table.Table, len(oldIS.sortedTables), len(oldIS.sortedTables)+1)
-	copy(b.is.sortedTables, oldIS.sortedTables)
 }
 
 // InitWithDBInfos initializes an empty new InfoSchema with a slice of DBInfo and schema version.
@@ -215,10 +233,13 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 				return nil, errors.Trace(err)
 			}
 			schTbls.tables[t.Name.L] = tbl
-			info.sortedTables = append(info.sortedTables, tbl)
+			sortedTables := info.sortedTablesBuckets[t.ID%bucketCount]
+			info.sortedTablesBuckets[t.ID%bucketCount] = append(sortedTables, tbl)
 		}
 	}
-	sort.Sort(info.sortedTables)
+	for _, v := range info.sortedTablesBuckets {
+		sort.Sort(v)
+	}
 	return b, nil
 }
 
@@ -233,7 +254,8 @@ func (b *Builder) initMemorySchemas() error {
 	for _, t := range infoSchemaDB.Tables {
 		tbl := b.handle.memSchema.nameToTable[t.Name.L]
 		infoSchemaTblNames.tables[t.Name.L] = tbl
-		info.sortedTables = append(info.sortedTables, tbl)
+		bucketIdx := t.ID % bucketCount
+		info.sortedTablesBuckets[bucketIdx] = append(info.sortedTablesBuckets[bucketIdx], tbl)
 	}
 
 	perfHandle := b.handle.memSchema.perfHandle
@@ -250,7 +272,8 @@ func (b *Builder) initMemorySchemas() error {
 			return ErrTableNotExists.Gen("table `%s` is missing.", t.Name)
 		}
 		perfSchemaTblNames.tables[t.Name.L] = tbl
-		info.sortedTables = append(info.sortedTables, tbl)
+		bucketIdx := t.ID % bucketCount
+		info.sortedTablesBuckets[bucketIdx] = append(info.sortedTablesBuckets[bucketIdx], tbl)
 	}
 	return nil
 }
@@ -270,7 +293,8 @@ func NewBuilder(handle *Handle) *Builder {
 	b := new(Builder)
 	b.handle = handle
 	b.is = &infoSchema{
-		schemasMap: map[string]*schemaTables{},
+		schemasMap:          map[string]*schemaTables{},
+		sortedTablesBuckets: make([]sortedTables, bucketCount),
 	}
 	return b
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -137,7 +137,7 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 	for _, tb := range tbList {
 		tbl := table.MockTableFromMeta(tb)
 		tableNames.tables[tb.Name.L] = tbl
-		bucketIdx := tb.ID % bucketCount
+		bucketIdx := tableBucketIdx(tb.ID)
 		result.sortedTablesBuckets[bucketIdx] = append(result.sortedTablesBuckets[bucketIdx], tbl)
 	}
 	for i := range result.sortedTablesBuckets {
@@ -193,7 +193,7 @@ func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
 }
 
 func (is *infoSchema) TableByID(id int64) (val table.Table, ok bool) {
-	slice := is.sortedTablesBuckets[id%bucketCount]
+	slice := is.sortedTablesBuckets[tableBucketIdx(id)]
 	idx := slice.searchTable(id)
 	if idx == -1 {
 		return nil, false

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -82,18 +82,28 @@ const (
 	Name = "INFORMATION_SCHEMA"
 )
 
-type tableSlice []table.Table
+type sortedTables []table.Table
 
-func (s tableSlice) Len() int {
+func (s sortedTables) Len() int {
 	return len(s)
 }
 
-func (s tableSlice) Swap(i, j int) {
+func (s sortedTables) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
-func (s tableSlice) Less(i, j int) bool {
+func (s sortedTables) Less(i, j int) bool {
 	return s[i].Meta().ID < s[j].Meta().ID
+}
+
+func (s sortedTables) searchTable(id int64) int {
+	idx := sort.Search(len(s), func(i int) bool {
+		return s[i].Meta().ID >= id
+	})
+	if idx == len(s) || s[idx].Meta().ID != id {
+		return -1
+	}
+	return idx
 }
 
 type schemaTables struct {
@@ -101,26 +111,23 @@ type schemaTables struct {
 	tables map[string]table.Table
 }
 
+const bucketCount = 512
+
 type infoSchema struct {
 	schemasMap map[string]*schemaTables
 
-	// sortedTables is sorted by ID, used to search table by ID.
-	sortedTables tableSlice
+	// sortedTablesBuckets is a slice of sortedTables, a table's bucket index is (tableID % bucketCount).
+	sortedTablesBuckets []sortedTables
 
 	// We should check version when change schema.
 	schemaMetaVersion int64
-}
-
-type schemaHandle struct {
-	tableNameToID map[string]int64
 }
 
 // MockInfoSchema only serves for test.
 func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 	result := &infoSchema{}
 	result.schemasMap = make(map[string]*schemaTables)
-	result.sortedTables = make(tableSlice, 0, len(tbList))
-
+	result.sortedTablesBuckets = make([]sortedTables, bucketCount)
 	dbInfo := &model.DBInfo{ID: 0, Name: model.NewCIStr("test"), Tables: tbList}
 	tableNames := &schemaTables{
 		dbInfo: dbInfo,
@@ -130,9 +137,12 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 	for _, tb := range tbList {
 		tbl := table.MockTableFromMeta(tb)
 		tableNames.tables[tb.Name.L] = tbl
-		result.sortedTables = append(result.sortedTables, tbl)
+		bucketIdx := tb.ID % bucketCount
+		result.sortedTablesBuckets[bucketIdx] = append(result.sortedTablesBuckets[bucketIdx], tbl)
 	}
-	sort.Sort(result.sortedTables)
+	for i := range result.sortedTablesBuckets {
+		sort.Sort(result.sortedTablesBuckets[i])
+	}
 	return result
 }
 
@@ -173,14 +183,6 @@ func (is *infoSchema) TableExists(schema, table model.CIStr) bool {
 	return false
 }
 
-func makeTableName(schema, table string) []byte {
-	name := make([]byte, len(schema)+1+len(table))
-	copy(name, schema)
-	name[len(schema)] = '.'
-	copy(name[len(schema)+1:], table)
-	return name
-}
-
 func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
 	for _, v := range is.schemasMap {
 		if v.dbInfo.ID == id {
@@ -190,22 +192,13 @@ func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
 	return nil, false
 }
 
-func (is *infoSchema) searchTable(id int64) int {
-	idx := sort.Search(len(is.sortedTables), func(i int) bool {
-		return is.sortedTables[i].Meta().ID >= id
-	})
-	if idx == len(is.sortedTables) || is.sortedTables[idx].Meta().ID != id {
-		return -1
-	}
-	return idx
-}
-
 func (is *infoSchema) TableByID(id int64) (val table.Table, ok bool) {
-	idx := is.searchTable(id)
+	slice := is.sortedTablesBuckets[id%bucketCount]
+	idx := slice.searchTable(id)
 	if idx == -1 {
 		return nil, false
 	}
-	return is.sortedTables[idx], true
+	return slice[idx], true
 }
 
 func (is *infoSchema) AllocByID(id int64) (autoid.Allocator, bool) {

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -114,7 +114,7 @@ type schemaTables struct {
 const bucketCount = 512
 
 type infoSchema struct {
-	schemasMap map[string]*schemaTables
+	schemaMap map[string]*schemaTables
 
 	// sortedTablesBuckets is a slice of sortedTables, a table's bucket index is (tableID % bucketCount).
 	sortedTablesBuckets []sortedTables
@@ -126,14 +126,14 @@ type infoSchema struct {
 // MockInfoSchema only serves for test.
 func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 	result := &infoSchema{}
-	result.schemasMap = make(map[string]*schemaTables)
+	result.schemaMap = make(map[string]*schemaTables)
 	result.sortedTablesBuckets = make([]sortedTables, bucketCount)
 	dbInfo := &model.DBInfo{ID: 0, Name: model.NewCIStr("test"), Tables: tbList}
 	tableNames := &schemaTables{
 		dbInfo: dbInfo,
 		tables: make(map[string]table.Table),
 	}
-	result.schemasMap["test"] = tableNames
+	result.schemaMap["test"] = tableNames
 	for _, tb := range tbList {
 		tbl := table.MockTableFromMeta(tb)
 		tableNames.tables[tb.Name.L] = tbl
@@ -149,7 +149,7 @@ func MockInfoSchema(tbList []*model.TableInfo) InfoSchema {
 var _ InfoSchema = (*infoSchema)(nil)
 
 func (is *infoSchema) SchemaByName(schema model.CIStr) (val *model.DBInfo, ok bool) {
-	tableNames, ok := is.schemasMap[schema.L]
+	tableNames, ok := is.schemaMap[schema.L]
 	if !ok {
 		return
 	}
@@ -161,12 +161,12 @@ func (is *infoSchema) SchemaMetaVersion() int64 {
 }
 
 func (is *infoSchema) SchemaExists(schema model.CIStr) bool {
-	_, ok := is.schemasMap[schema.L]
+	_, ok := is.schemaMap[schema.L]
 	return ok
 }
 
 func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err error) {
-	if tbNames, ok := is.schemasMap[schema.L]; ok {
+	if tbNames, ok := is.schemaMap[schema.L]; ok {
 		if t, ok = tbNames.tables[table.L]; ok {
 			return
 		}
@@ -175,7 +175,7 @@ func (is *infoSchema) TableByName(schema, table model.CIStr) (t table.Table, err
 }
 
 func (is *infoSchema) TableExists(schema, table model.CIStr) bool {
-	if tbNames, ok := is.schemasMap[schema.L]; ok {
+	if tbNames, ok := is.schemaMap[schema.L]; ok {
 		if _, ok = tbNames.tables[table.L]; ok {
 			return true
 		}
@@ -184,7 +184,7 @@ func (is *infoSchema) TableExists(schema, table model.CIStr) bool {
 }
 
 func (is *infoSchema) SchemaByID(id int64) (val *model.DBInfo, ok bool) {
-	for _, v := range is.schemasMap {
+	for _, v := range is.schemaMap {
 		if v.dbInfo.ID == id {
 			return v.dbInfo, true
 		}
@@ -210,21 +210,21 @@ func (is *infoSchema) AllocByID(id int64) (autoid.Allocator, bool) {
 }
 
 func (is *infoSchema) AllSchemaNames() (names []string) {
-	for _, v := range is.schemasMap {
+	for _, v := range is.schemaMap {
 		names = append(names, v.dbInfo.Name.O)
 	}
 	return
 }
 
 func (is *infoSchema) AllSchemas() (schemas []*model.DBInfo) {
-	for _, v := range is.schemasMap {
+	for _, v := range is.schemaMap {
 		schemas = append(schemas, v.dbInfo)
 	}
 	return
 }
 
 func (is *infoSchema) SchemaTables(schema model.CIStr) (tables []table.Table) {
-	schemaTables, ok := is.schemasMap[schema.L]
+	schemaTables, ok := is.schemaMap[schema.L]
 	if !ok {
 		return
 	}
@@ -235,7 +235,7 @@ func (is *infoSchema) SchemaTables(schema model.CIStr) (tables []table.Table) {
 }
 
 func (is *infoSchema) Clone() (result []*model.DBInfo) {
-	for _, v := range is.schemasMap {
+	for _, v := range is.schemaMap {
 		result = append(result, v.dbInfo.Clone())
 	}
 	return


### PR DESCRIPTION
Use 512 of table slice to lookup table by ID.
When schema is updated, only 1/512 of memory need to be allocated.