### PR TITLE
parser: handle MySQL-specific-code comment syntax in parser

### DIFF
--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -121,7 +121,7 @@ func (s *testLexerSuite) TestComment(c *C) {
 
 	table := []testCaseItem{
 		{"-- select --\n1", intLit},
-		{"/*!40101 SET character_set_client = utf8 */;", int(';')},
+		{"/*!40101 SET character_set_client = utf8 */;", set},
 		{"/* some comments */ SELECT ", selectKwd},
 		{`-- comment continues to the end of line
 SELECT`, selectKwd},

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -122,6 +122,7 @@ func (s *testLexerSuite) TestComment(c *C) {
 	table := []testCaseItem{
 		{"-- select --\n1", intLit},
 		{"/*!40101 SET character_set_client = utf8 */;", set},
+		{"/* SET character_set_client = utf8 */;", int(';')},
 		{"/* some comments */ SELECT ", selectKwd},
 		{`-- comment continues to the end of line
 SELECT`, selectKwd},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -80,6 +80,16 @@ func (s *testParserSuite) TestSimple(c *C) {
 	_, ok := stmt.(*ast.SetStmt)
 	c.Assert(ok, IsTrue)
 
+	// For issue #2017
+	src = "insert into blobtable (a) values ('/*! truncated */');"
+	stmt, err = parser.ParseOneStmt(src, "", "")
+	c.Assert(err, IsNil)
+	is, ok := stmt.(*ast.InsertStmt)
+	c.Assert(ok, IsTrue)
+	c.Assert(is.Lists, HasLen, 1)
+	c.Assert(is.Lists[0], HasLen, 1)
+	c.Assert(is.Lists[0][0].GetDatum().GetString(), Equals, "/*! truncated */")
+
 	// Testcase for CONVERT(expr,type)
 	src = "SELECT CONVERT('111', SIGNED);"
 	st, err := parser.ParseOneStmt(src, "", "")

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -17,7 +17,6 @@ import (
 	"math"
 	"regexp"
 	"strconv"
-	"strings"
 	"unicode"
 
 	"github.com/juju/errors"
@@ -45,20 +44,6 @@ var (
 func trimComment(txt string) string {
 	txt = specCodeStart.ReplaceAllString(txt, "")
 	return specCodeEnd.ReplaceAllString(txt, "")
-}
-
-// See http://dev.mysql.com/doc/refman/5.7/en/comments.html
-// Convert "/*!VersionNumber MySQL-specific-code */" to "MySQL-specific-code".
-// TODO: Find a better way:
-// 1. RegExpr is slow.
-// 2. Handle nested comment.
-func handleMySQLSpecificCode(sql string) string {
-	if strings.Index(sql, "/*!") == -1 {
-		// Fast way to check if text contains MySQL-specific code.
-		return sql
-	}
-	// SQL text contains MySQL-specific code. We should convert it to normal SQL text.
-	return specCodePattern.ReplaceAllStringFunc(sql, trimComment)
 }
 
 // Parser represents a parser instance. Some temporary objects are stored in it to reduce object allocation during Parse function.

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -100,8 +100,6 @@ func (parser *Parser) Parse(sql, charset, collation string) ([]ast.StmtNode, err
 	parser.src = sql
 	parser.result = parser.result[:0]
 
-	sql = handleMySQLSpecificCode(sql)
-
 	var l yyLexer
 	parser.lexer.reset(sql)
 	l = &parser.lexer


### PR DESCRIPTION
previously we handle [MySQL-specific code comment syntax](http://dev.mysql.com/doc/refman/5.7/en/comments.html) before enter parser, 
but it cause blob data `/*! */` been throw away
now move this process into parser.

fix issue https://github.com/pingcap/tidb/issues/2017