### PR TITLE
fix format display bugs occurred in DateFormat

### DIFF
--- a/evaluator/builtin_time.go
+++ b/evaluator/builtin_time.go
@@ -160,6 +160,9 @@ func convertDateFormat(arg types.Datum, b byte) (types.Datum, error) {
 		}
 	case 'H', 'k':
 		d, err = builtinHour([]types.Datum{arg}, nil)
+		if err == nil && b == 'H' && !d.IsNull() {
+			d.SetString(fmt.Sprintf("%02d", d.GetInt64()))
+		}
 	case 'h', 'I', 'l':
 		d, err = builtinHour([]types.Datum{arg}, nil)
 		if err == nil && !d.IsNull() {
@@ -196,11 +199,14 @@ func convertDateFormat(arg types.Datum, b byte) (types.Datum, error) {
 		}
 	case 'S', 's':
 		d, err = builtinSecond([]types.Datum{arg}, nil)
-		if err == nil {
+		if err == nil && !d.IsNull() {
 			d.SetString(fmt.Sprintf("%02d", d.GetInt64()))
 		}
 	case 'f':
 		d, err = builtinMicroSecond([]types.Datum{arg}, nil)
+		if err == nil && !d.IsNull() {
+			d.SetString(fmt.Sprintf("%06d", d.GetInt64()))
+		}
 	case 'U':
 		d, err = builtinWeek([]types.Datum{arg, types.NewIntDatum(0)}, nil)
 		if err == nil && !d.IsNull() {
@@ -304,7 +310,6 @@ func builtinDateFormat(args []types.Datum, _ context.Context) (types.Datum, erro
 			ret = append(ret, b)
 		}
 	}
-
 	d.SetString(string(ret))
 	return d, nil
 }

--- a/evaluator/builtin_time_test.go
+++ b/evaluator/builtin_time_test.go
@@ -207,6 +207,9 @@ func (s *testEvaluatorSuite) TestDateFormat(c *C) {
 		{[]string{"2016-09-3 00:59:59.123456",
 			"abc%b %M %m %c %D %d %e %j %k %h %i %p %r %T %s %f %U %u %V %v %a %W %w %X %x %Y %y!123 %%xyz %z"},
 			"abcSep September 09 9 3rd 03 3 247 0 12 59 AM 12:59:59 AM 00:59:59 59 123456 35 35 35 35 Sat Saturday 6 2016 2016 2016 16!123 %xyz z"},
+		{[]string{"2012-10-01 00:00:00",
+			"%b %M %m %c %D %d %e %j %k %H %i %p %r %T %s %f %v %x %Y %y %%"},
+			"Oct October 10 10 1st 01 1 275 0 00 00 AM 12:00:00 AM 00:00:00 00 000000 40 2012 2012 12 %"},
 	}
 	dtblDate := tblToDtbl(tblDate)
 


### PR DESCRIPTION
For DateFormat("2010-01-01 00:00:00", "%H %f"), we should get `00 000000`,
but we get `0 0`.
@shenli @coocood @zimulala @hanfei1991 @tiancaiamao PTAL