### PR TITLE
parser: database.ReservedKeyword as identifier & clean up

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -106,7 +106,7 @@ func (s *Scanner) Lex(v *yySymType) int {
 		return toHex(s, v, lit)
 	case bitLit:
 		return toBit(s, v, lit)
-	case userVar, sysVar, database, currentUser, replace, cast, sysDate, currentTs, curDate, utcDate, extract, repeat, secondMicrosecond, minuteMicrosecond, minuteSecond, hourMicrosecond, hourMinute, hourSecond, dayMicrosecond, dayMinute, daySecond, dayHour, yearMonth, ifKwd, left, convert:
+	case userVar, sysVar, database, replace, cast, sysDate, currentTs, curDate, utcDate, extract, repeat, secondMicrosecond, minuteMicrosecond, minuteSecond, hourMicrosecond, hourMinute, hourSecond, dayMicrosecond, dayMinute, daySecond, dayHour, yearMonth, ifKwd, left, convert:
 		v.item = lit
 		return tok
 	case null:

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -106,7 +106,7 @@ func (s *Scanner) Lex(v *yySymType) int {
 		return toHex(s, v, lit)
 	case bitLit:
 		return toBit(s, v, lit)
-	case userVar, sysVar, database, currentUser, replace, cast, sysDate, currentTs, currentTime, currentDate, curDate, utcDate, extract, repeat, secondMicrosecond, minuteMicrosecond, minuteSecond, hourMicrosecond, hourMinute, hourSecond, dayMicrosecond, dayMinute, daySecond, dayHour, yearMonth, ifKwd, left, convert:
+	case userVar, sysVar, database, currentUser, replace, cast, sysDate, currentTs, curDate, utcDate, extract, repeat, secondMicrosecond, minuteMicrosecond, minuteSecond, hourMicrosecond, hourMinute, hourSecond, dayMicrosecond, dayMinute, daySecond, dayHour, yearMonth, ifKwd, left, convert:
 		v.item = lit
 		return tok
 	case null:

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -137,6 +137,8 @@ func (s *Scanner) scan() (tok int, pos Pos, lit string) {
 		tok, pos, lit = specialComment.scan()
 		if tok != 0 {
 			// return the specialComment scan result as the result
+			pos.Line += s.r.p.Line
+			pos.Offset += s.r.p.Col
 			return
 		}
 		// leave specialComment scan mode after all stream consumed.

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -106,7 +106,7 @@ func (s *Scanner) Lex(v *yySymType) int {
 		return toHex(s, v, lit)
 	case bitLit:
 		return toBit(s, v, lit)
-	case userVar, sysVar, database, replace, cast, sysDate, currentTs, curDate, utcDate, extract, repeat, secondMicrosecond, minuteMicrosecond, minuteSecond, hourMicrosecond, hourMinute, hourSecond, dayMicrosecond, dayMinute, daySecond, dayHour, yearMonth, ifKwd, left, convert:
+	case userVar, sysVar, cast, sysDate, curDate, extract:
 		v.item = lit
 		return tok
 	case null:

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -62,6 +62,7 @@ import (
 	binaryType	"BINARY"
 	blobType	"BLOB"
 	both		"BOTH"
+	charType	"CHAR"
 	by		"BY"
 	cascade		"CASCADE"
 	caseKwd		"CASE"
@@ -75,6 +76,7 @@ import (
 	cross 		"CROSS"
 	currentDate 	"CURRENT_DATE"
 	currentTime 	"CURRENT_TIME"
+	currentTs	"CURRENT_TIMESTAMP"
 	currentUser	"CURRENT_USER"
 	database	"DATABASE"
 	databases	"DATABASES"
@@ -284,6 +286,7 @@ import (
 	booleanType	"BOOLEAN"
 	boolType	"BOOL"
 	btree		"BTREE"
+	byteType	"BYTE"
 	charsetKwd	"CHARSET"
 	checksum	"CHECKSUM"
 	collation	"COLLATION"
@@ -303,6 +306,7 @@ import (
 	delayKeyWrite	"DELAY_KEY_WRITE"
 	disable		"DISABLE"
 	do		"DO"
+	duplicate	"DUPLICATE"
 	dynamic		"DYNAMIC"
 	enable		"ENABLE"
 	end		"END"
@@ -346,6 +350,7 @@ import (
 	rowFormat	"ROW_FORMAT"
 	serializable	"SERIALIZABLE"
 	session		"SESSION"
+	share		"SHARE"
 	signed		"SIGNED"
 	snapshot	"SNAPSHOT"
 	space 		"SPACE"
@@ -382,11 +387,9 @@ import (
 	andand		"&&"
 	andnot		"&^"
 	assignmentEq	":="
-	byteType	"BYTE"
 	cast		"CAST"
 	curDate 	"CURDATE"
 	ddl		"DDL"
-	duplicate	"DUPLICATE"
 	enum 		"ENUM"
 	eq		"="
 	extract		"EXTRACT"
@@ -400,16 +403,11 @@ import (
 	oror		"||"
 	placeholder	"PLACEHOLDER"
 	rsh		">>"
-	share		"SHARE"
 	strcmp		"STRCMP"
 	sysVar		"SYS_VAR"
 	sysDate		"SYSDATE"
-
-
 	underscoreCS	"UNDERSCORE_CHARSET"
 	userVar		"USER_VAR"
-	currentTs	"CURRENT_TIMESTAMP"
-	charType	"CHAR"
 
 %type   <item>
 	AdminStmt		"Check table statement or show ddl statement"
@@ -431,10 +429,8 @@ import (
 	ColumnName		"column name"
 	ColumnNameList		"column name list"
 	ColumnNameListOpt	"column name list opt"
-	ColumnKeywordOpt	"Column keyword or empty"
 	ColumnSetValue		"insert statement set value by column name"
 	ColumnSetValueList	"insert statement set value by column name list"
-	CommaOpt		"optional comma"
 	CommitStmt		"COMMIT statement"
 	CompareOp		"Compare opcode"
 	ColumnOption		"column definition option"
@@ -451,17 +447,13 @@ import (
 	DatabaseOptionListOpt	"CREATE Database specification list opt"
 	CreateTableStmt		"CREATE TABLE statement"
 	CreateUserStmt		"CREATE User statement"
-	CrossOpt		"Cross join option"
 	DateArithOpt		"Date arith dateadd or datesub option"
 	DateArithMultiFormsOpt	"Date arith adddate or subdate option"
 	DateArithInterval       "Date arith interval part"
-	DatabaseSym		"DATABASE or SCHEMA"
 	DBName			"Database Name"
-	DeallocateSym		"Deallocate or drop"
 	DeallocateStmt		"Deallocate prepared statement"
 	Default			"DEFAULT clause"
 	DefaultOpt		"optional DEFAULT clause"
-	DefaultKwdOpt		"optional DEFAULT keyword"
 	DefaultValueExpr	"DefaultValueExpr(Now or Signed Literal)"
 	DeleteFromStmt		"DELETE FROM statement"
 	DistinctOpt		"Distinct option"
@@ -477,7 +469,6 @@ import (
 	EscapedTableRef 	"escaped table reference"
 	Escaped			"Escaped by"
 	ExecuteStmt		"Execute statement"
-	ExplainSym		"EXPLAIN or DESCRIBE or DESC"
 	ExplainStmt		"EXPLAIN statement"
 	Expression		"expression"
 	ExpressionList		"expression list"
@@ -494,14 +485,12 @@ import (
 	FieldList		"field expression list"
 	FieldsOrColumns 	"Fields or columns"
 	FlushStmt		"Flush statement"
-	FromOrIn		"From or In"
 	TableRefsClause		"Table references clause"
 	Function		"function expr"
 	FunctionCallAgg		"Function call on aggregate data"
 	FunctionCallConflict	"Function call with reserved keyword as function name"
 	FunctionCallKeyword	"Function call with keyword as function name"
 	FunctionCallNonKeyword	"Function call with nonkeyword as function name"
-	FunctionNameConflict	"Built-in function call names which are conflict with keywords"
 	FuncDatetimePrec	"Function datetime precision"
 	GlobalScope		"The scope of variable"
 	GrantStmt		"Grant statement"
@@ -525,11 +514,8 @@ import (
 	IndexTypeOpt		"Optional index type"
 	InsertIntoStmt		"INSERT INTO statement"
 	InsertValues		"Rest part of INSERT/REPLACE INTO statement"
-	IntoOpt			"INTO or EmptyString"
-	IsolationLevel		"Isolation level"
 	JoinTable 		"join table"
 	JoinType		"join type"
-	KeyOrIndex		"{KEY|INDEX}"
 	LikeEscapeOpt 		"like escape option"
 	LimitClause		"LIMIT clause"
 	Lines			"Lines clause"
@@ -538,27 +524,21 @@ import (
 	LoadDataStmt		"Load data statement"
 	LocalOpt		"Local opt"
 	LockTablesStmt		"Lock tables statement"
-	LockType		"Table locks type"
 	logAnd			"logical and operator"
 	logOr			"logical or operator"
 	LowPriorityOptional	"LOW_PRIORITY or empty"
-	NationalOpt		"National option"
 	NotOpt			"optional NOT"
-	NowSym			"CURRENT_TIMESTAMP/LOCALTIME/LOCALTIMESTAMP/NOW"
 	NumLiteral		"Num/Int/Float/Decimal Literal"
 	NoWriteToBinLogAliasOpt "NO_WRITE_TO_BINLOG alias LOCAL or empty"
 	ObjectType		"Grant statement object type"
 	OnDuplicateKeyUpdate	"ON DUPLICATE KEY UPDATE value list"
 	Operand			"operand"
 	OptFull			"Full or empty"
-	OptInteger		"Optional Integer keyword"
-	OptTable		"Optional table keyword"
 	Order			"ORDER BY clause optional collation specification"
 	OrderBy			"ORDER BY clause"
 	ByItem			"BY item"
 	OrderByOptional		"Optional ORDER BY clause optional"
 	ByList			"BY list"
-	OuterOpt		"optional OUTER clause"
 	QuickOptional		"QUICK or empty"
 	PasswordOpt		"Password option"
 	ColumnPosition		"Column position [First|After ColumnName]"
@@ -566,7 +546,6 @@ import (
 	PrepareSQL		"Prepare statement sql string"
 	PrimaryExpression	"primary expression"
 	PrimaryFactor		"primary expression factor"
-	PrimaryOpt		"Optional primary keyword"
 	Priority		"insert statement priority"
 	PrivElem		"Privilege element"
 	PrivElemList		"Privilege element list"
@@ -576,7 +555,6 @@ import (
 	OnDeleteOpt		"optional ON DELETE clause"
 	OnUpdateOpt		"optional ON UPDATE clause"
 	ReferOpt		"reference option"
-	RegexpSym		"REGEXP or RLIKE"
 	ReplaceIntoStmt		"REPLACE INTO statement"
 	ReplacePriority		"replace statement priority"
 	RollbackStmt		"ROLLBACK statement"
@@ -596,7 +574,6 @@ import (
 	ShowDatabaseNameOpt	"Show tables/columns statement database name option"
 	ShowTableAliasOpt       "Show table alias option"
 	ShowLikeOrWhereOpt	"Show like or where clause option"
-	ShowIndexKwd		"Show index/indexs/key keyword"
 	SignedLiteral		"Literal or NumLiteral with sign"
 	Starting		"Starting by"
 	Statement		"statement"
@@ -623,9 +600,6 @@ import (
 	TableOptionListOpt	"create table option list opt"
 	TableRef 		"table reference"
 	TableRefs 		"table references"
-	TimeUnit		"Time unit"
-	TransactionChar		"Transaction characteristic"
-	TransactionChars	"Transaction characteristic list"
 	TrimDirection		"Trim string direction"
 	TruncateTableStmt	"TRANSACTION TABLE statement"
 	UnionOpt		"Union Option(empty/ALL/DISTINCT)"
@@ -641,7 +615,6 @@ import (
 	UserVariable		"User defined variable name"
 	UserVariableList	"User defined variable name list"
 	UseStmt			"USE statement"
-	ValueSym		"Value or Values"
 	VariableAssignment	"set variable value"
 	VariableAssignmentList	"set variable value list"
 	Variable		"User or system variable"
@@ -671,11 +644,37 @@ import (
 	FloatOpt		"Floating-point type option"
 	Precision		"Floating-point precision option"
 	OptBinary		"Optional BINARY"
-	CharsetKw		"charset or charater set"
 	OptCharset		"Optional Character setting"
 	OptCollate		"Optional Collate setting"
 	NUM			"numbers"
 	LengthNum		"Field length num(uint64)"
+
+%type	<ident>
+	KeyOrIndex		"{KEY|INDEX}"
+	ColumnKeywordOpt	"Column keyword or empty"
+	PrimaryOpt		"Optional primary keyword"
+	NowSym			"CURRENT_TIMESTAMP/LOCALTIME/LOCALTIMESTAMP/NOW"
+	DefaultKwdOpt		"optional DEFAULT keyword"
+	DatabaseSym		"DATABASE or SCHEMA"
+	ExplainSym		"EXPLAIN or DESCRIBE or DESC"
+	RegexpSym		"REGEXP or RLIKE"
+	IntoOpt			"INTO or EmptyString"
+	ValueSym		"Value or Values"
+	TimeUnit		"Time unit"
+	DeallocateSym		"Deallocate or drop"
+	OuterOpt		"optional OUTER clause"
+	CrossOpt		"Cross join option"
+	TransactionChar		"Transaction characteristic"
+	TransactionChars	"Transaction characteristic list"
+	IsolationLevel		"Isolation level"
+	ShowIndexKwd		"Show index/indexs/key keyword"
+	FromOrIn		"From or In"
+	OptTable		"Optional table keyword"
+	OptInteger		"Optional Integer keyword"
+	NationalOpt		"National option"
+	CharsetKw		"charset or charater set"
+	CommaOpt		"optional comma"
+	LockType		"Table locks type"
 
 %type	<ident>
 	Identifier			"identifier or unreserved keyword"
@@ -683,6 +682,7 @@ import (
 	NotKeywordToken			"Tokens not mysql keyword but treated specially"
 	UnReservedKeyword		"MySQL unreserved keywords"
 	ReservedKeyword			"MySQL reserved keywords"
+	FunctionNameConflict	"Built-in function call names which are conflict with keywords"
 
 %token	tableRefPriority
 
@@ -817,15 +817,11 @@ AlterTableSpec:
 		}
 	}
 
-KeyOrIndex:
-	"KEY"
-	{}
-|"INDEX" {}
+KeyOrIndex: "KEY" | "INDEX"
 
 ColumnKeywordOpt:
 	{}
 |	"COLUMN"
-	{}
 
 ColumnPosition:
 	{
@@ -971,11 +967,8 @@ CommitStmt:
 	}
 
 PrimaryOpt:
-	{} 
+	{}
 | "PRIMARY"
-	{
-		$$ = $1
-	}
 
 ColumnOption:
 	"NOT" "NULL"
@@ -1253,19 +1246,7 @@ DefaultValueExpr:
 
 // TODO: Process other three keywords
 NowSym:
-	"CURRENT_TIMESTAMP"
-|	"LOCALTIME"
-	{
-		$$ = $1
-	}
-|	"LOCALTIMESTAMP"
-	{
-		$$ = $1
-	}
-|	"NOW"
-	{
-		$$ = $1
-	}
+"CURRENT_TIMESTAMP" | "LOCALTIME" | "LOCALTIMESTAMP" | "NOW"
 
 SignedLiteral:
 	Literal
@@ -1438,7 +1419,6 @@ DefaultOpt:
 DefaultKwdOpt:
 	{}
 |	"DEFAULT"
-	{}
 
 /******************************************************************
  * Do statement
@@ -1515,12 +1495,7 @@ DeleteFromStmt:
 	}
 
 DatabaseSym:
-	"DATABASE" 
-	{}
-|	"SCHEMA"
-	{
-		$$ = $1
-	}
+"DATABASE" | "SCHEMA"
 
 DropDatabaseStmt:
 	"DROP" DatabaseSym IfExists DBName
@@ -1565,11 +1540,8 @@ TableOrTables:
 |	"TABLES"
 
 EqOpt:
-	{
-	}
+	{}
 |	eq
-	{
-	}
 
 EmptyStmt:
 	/* EMPTY */
@@ -1578,18 +1550,7 @@ EmptyStmt:
 	}
 
 ExplainSym:
-	"EXPLAIN"
-	{
-		$$ = $1
-	}
-|	"DESCRIBE"
-	{
-		$$ = $1
-	}
-|	"DESC"
-	{
-		$$ = $1
-	}
+"EXPLAIN" | "DESCRIBE" | "DESC"
 
 ExplainStmt:
 	ExplainSym TableName
@@ -1826,8 +1787,7 @@ PredicateExpr:
 |	PrimaryFactor
 
 RegexpSym:
-	"REGEXP" {}
-|	"RLIKE" {}
+"REGEXP" | "RLIKE"
 
 LikeEscapeOpt:
 	%prec lowerThanEscape
@@ -2038,24 +1998,24 @@ ReservedKeyword:
 "ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT"
 | "BINARY" | "BLOB" | "BOTH" | "BY" | "CASCADE" | "CASE" | "CHARACTER" | "CHECK" | "COLLATE"
 | "COLUMN" | "CONSTRAINT" | "CONVERT" | "CREATE" | "CROSS" | "CURRENT_DATE" | "CURRENT_TIME"
-| "CURRENT_USER" | "DATABASE" | "DATABASES" | "DAY_HOUR" | "DAY_MICROSECOND" | "DAY_MINUTE" 
-| "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELETE" | "DESC" | "DESCRIBE" 
-| "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED" 
-| "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM" 
-| "FULLTEXT" | "GRANT" | "GROUP" | "HAVING" | "HOUR_MICROSECOND" | "HOUR_MINUTE" 
+| "CURRENT_TIMESTAMP" | "CURRENT_USER" | "DATABASE" | "DATABASES" | "DAY_HOUR" | "DAY_MICROSECOND"
+| "DAY_MINUTE" | "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELETE" | "DESC" | "DESCRIBE"
+| "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED"
+| "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM"
+| "FULLTEXT" | "GRANT" | "GROUP" | "HAVING" | "HOUR_MICROSECOND" | "HOUR_MINUTE"
 | "HOUR_SECOND" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT" | "INTEGER" | "INTERVAL"
-| "IS" | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME" 
-| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT" 
-| "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC" 
-| "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" | "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL" 
-| "REFERENCES" | "REGEXP" | "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE" 
-| "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT" 
-| "STARTING" | "TERMINATED" | "THEN" | "TINYBLOB" | "TINYINT" | "TINYTEXT" | "TO" 
-| "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED" 
-| "UPDATE" | "USE" | "USING" | "UTC_DATE" | "VALUES" | "VARBINARY" | "VARCHAR" 
+| "IS" | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME"
+| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT"
+| "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC"
+| "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" | "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL"
+| "REFERENCES" | "REGEXP" | "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE"
+| "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT"
+| "STARTING" | "TERMINATED" | "THEN" | "TINYBLOB" | "TINYINT" | "TINYTEXT" | "TO"
+| "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED"
+| "UPDATE" | "USE" | "USING" | "UTC_DATE" | "VALUES" | "VARBINARY" | "VARCHAR"
 | "WHEN" | "WHERE" | "WRITE" | "XOR" | "YEAR_MONTH" | "ZEROFILL"
- /*  
-| "DELAYED" | "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" | "TABLE" | "WITH" 
+ /*
+| "DELAYED" | "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" | "TABLE" | "WITH"
  */
 
 
@@ -2090,11 +2050,8 @@ InsertIntoStmt:
 	}
 
 IntoOpt:
-	{
-	}
+	{}
 |	"INTO"
-	{
-	}
 
 InsertValues:
 	'(' ColumnNameListOpt ')' ValueSym ExpressionListList
@@ -2130,14 +2087,7 @@ InsertValues:
 	}
 
 ValueSym:
-	"VALUE"
-	{
-		$$ = $1
-	}
-|	"VALUES"
-	{
-		$$ = $1
-	}
+"VALUE" | "VALUES"
 
 ExpressionListList:
 	ExpressionListListItem
@@ -2415,47 +2365,20 @@ Function:
 |	FunctionCallAgg
 
 FunctionNameConflict:
-	"DATABASE" 
-	{
-		$$ = $1
-	}
-| "SCHEMA" 
-	{
-		$$ = $1
-	}
-| "IF" 
-	{
-		$$ = $1
-	}
-| "LEFT" 
-	{
-		$$ = $1
-	}
-| "REPEAT" 
-	{
-		$$ = $1
-	}
-| "CURRENT_USER" 
-	{
-		$$ = $1
-	}
-| "UTC_DATE"
-	{
-		$$ = $1
-	}
-| "CURRENT_DATE"
-	{
-		$$ = $1
-	}
-| "VERSION"
-	{
-		$$ = $1
-	}
+	"DATABASE"
+|	"SCHEMA"
+|	"IF"
+|	"LEFT"
+|	"REPEAT"
+|	"CURRENT_USER"
+|	"UTC_DATE"
+|	"CURRENT_DATE"
+|	"VERSION"
 
 FunctionCallConflict:
 	FunctionNameConflict '(' ExpressionListOpt ')'
 	{
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: $3.([]ast.ExprNode)}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1), Args: $3.([]ast.ExprNode)}
 	}
 |	"CURRENT_USER"
 	{
@@ -2588,7 +2511,7 @@ FunctionCallNonKeyword:
 		if $2 != nil {
 			args = append(args, $2.(ast.ExprNode))
 		}
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1), Args: args}
 	}
 |	"ABS" '(' Expression ')'
 	{
@@ -2635,7 +2558,7 @@ FunctionCallNonKeyword:
 		op := ast.NewValueExpr($1)
 		dateArithInterval := ast.NewValueExpr(
 			ast.DateArithInterval{
-				Unit: $7.(string),
+				Unit: $7,
 				Interval: $6.(ast.ExprNode),
 			},
 		)
@@ -2982,7 +2905,7 @@ DateArithInterval:
 	}
 |	"INTERVAL" Expression TimeUnit
 	{
-		$$ = ast.DateArithInterval{Unit: $3.(string), Interval: $2.(ast.ExprNode)}
+		$$ = ast.DateArithInterval{Unit: $3, Interval: $2.(ast.ExprNode)}
 	}
 
 TrimDirection:
@@ -3045,85 +2968,25 @@ FuncDatetimePrec:
 
 TimeUnit:
 	"MICROSECOND"
-	{
-		$$ = $1
-	}
-| "SECOND"
-	{
-		$$ = $1
-	}
-| "MINUTE"
-	{
-		$$ = $1
-	}
-| "HOUR"
-	{
-		$$ = $1
-	}
-| "DAY"
-	{
-		$$ = $1
-	}
-| "WEEK"
-	{
-		$$ = $1
-	}
-| "MONTH"
-	{
-		$$ = $1
-	}
-| "QUARTER" 
-	{
-		$$ = $1
-	}
-| "YEAR" 
-	{
-		$$ = $1
-	}
-| "SECOND_MICROSECOND" 
-	{
-		$$ = $1
-	}
-| "MINUTE_MICROSECOND"
-	{
-		$$ = $1
-	}
-|	"MINUTE_SECOND" 
-	{
-		$$ = $1
-	}
-| "HOUR_MICROSECOND" 
-	{
-		$$ = $1
-	}
-| "HOUR_SECOND" 
-	{
-		$$ = $1
-	}
-| "HOUR_MINUTE"
-	{
-		$$ = $1
-	}
-|	"DAY_MICROSECOND" 
-	{
-		$$ = $1
-	}
-| "DAY_SECOND" 
-	{
-		$$ = $1
-	}
-| "DAY_MINUTE" 
-	{
-		$$ = $1
-	}
-| "DAY_HOUR" 
-	{
-		$$ = $1
-	}
-| "YEAR_MONTH"
-	{
-		$$ = $1
-	}
+|	"SECOND"
+|	"MINUTE"
+|	"HOUR"
+|	"DAY"
+|	"WEEK"
+|	"MONTH"
+|	"QUARTER"
+|	"YEAR"
+|	"SECOND_MICROSECOND"
+|	"MINUTE_MICROSECOND"
+|	"MINUTE_SECOND"
+|	"HOUR_MICROSECOND"
+|	"HOUR_SECOND"
+|	"HOUR_MINUTE"
+|	"DAY_MICROSECOND"
+|	"DAY_SECOND"
+|	"DAY_MINUTE"
+|	"DAY_HOUR"
+|	"YEAR_MONTH"
 
 ExpressionOpt:
 	{
@@ -3405,14 +3268,7 @@ DeallocateStmt:
 	}
 
 DeallocateSym:
-	"DEALLOCATE" 
-	{
-		$$ = $1
-	}
-| "DROP"
-	{
-		$$ = $1
-	}
+"DEALLOCATE" | "DROP"
 
 /****************************Prepared Statement End*******************************/
 
@@ -3710,22 +3566,13 @@ JoinType:
 	}
 
 OuterOpt:
-	{
-		$$ = nil
-	}
+	{}
 |	"OUTER"
-	{
-		$$ = $1
-	}
-
 
 CrossOpt:
 	"JOIN"
-	{}
 |	"CROSS" "JOIN"
-	{}
 |	"INNER" "JOIN"
-	{}
 
 LimitClause:
 	{
@@ -3949,15 +3796,15 @@ TransactionChars:
 |	TransactionChars ',' TransactionChar
 
 TransactionChar:
-	"ISOLATION" "LEVEL" IsolationLevel {}
-|	"READ" "WRITE" {}
-|	"READ" "ONLY" {}
+	"ISOLATION" "LEVEL" IsolationLevel
+|	"READ" "WRITE"
+|	"READ" "ONLY"
 
 IsolationLevel:
-	"REPEATABLE" "READ" {}
-|	"READ"	"COMMITTED" {}
-|	"READ"	"UNCOMMITTED" {}
-|	"SERIALIZABLE" {}
+	"REPEATABLE" "READ"
+|	"READ"	"COMMITTED"
+|	"READ"	"UNCOMMITTED"
+|	"SERIALIZABLE"
 
 VariableAssignment:
 	Identifier eq Expression
@@ -4181,15 +4028,12 @@ ShowStmt:
 	}
 
 ShowIndexKwd:
-	"INDEX" {}
-|	"INDEXES" {}
-|	"KEYS" {}
+	"INDEX"
+|	"INDEXES"
+|	"KEYS"
 
 FromOrIn:
-	"FROM"
-	{}
-|	"IN"
-	{}
+"FROM" | "IN"
 
 ShowTargetFilterable:
 	"ENGINES"
@@ -4606,8 +4450,8 @@ TableOptionList:
 	}
 
 OptTable:
-	{} 
-| "TABLE" {}
+	{}
+|	"TABLE"
 
 TruncateTableStmt:
 	"TRUNCATE" OptTable TableName
@@ -4761,9 +4605,8 @@ IntegerType:
 	}
 
 OptInteger:
-	{} 
-| "INTEGER"
 	{}
+|	"INTEGER"
 
 FixedPointType:
 	"DECIMAL"
@@ -4876,13 +4719,8 @@ StringType:
 	}
 
 NationalOpt:
-	{
-
-	}
+	{}
 |	"NATIONAL"
-	{
-
-	}
 
 BlobType:
 	"TINYBLOB"
@@ -5045,12 +4883,7 @@ OptCharset:
 
 CharsetKw:
 	"CHARACTER" "SET"
-	{
-	}
 |	"CHARSET"
-	{
-		$$ = $1
-	}
 
 OptCollate:
 	{
@@ -5145,11 +4978,9 @@ WhereClauseOptional:
 	}
 
 CommaOpt:
-	{
-	}
+	{}
 |	','
-	{
-	}
+	{}
 
 /************************************************************************************
  *  Account Management Statements
@@ -5481,7 +5312,8 @@ LinesTerminated:
  *********************************************************************/
 
 UnlockTablesStmt:
-	"UNLOCK" "TABLES" {}
+	"UNLOCK" "TABLES"
+	{}
 
 LockTablesStmt:
 	"LOCK" "TABLES" TableLockList
@@ -5489,11 +5321,12 @@ LockTablesStmt:
 
 TableLock:
 	 TableName LockType
+	{}
 
 LockType:
-	"READ" {}
-|	"READ" "LOCAL" {}
-|	"WRITE" {}
+	"READ"
+|	"READ" "LOCAL"
+|	"WRITE"
 
 TableLockList:
 	TableLock

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -51,7 +51,6 @@ import (
 
 	/* the following tokens belong to ReservedKeyword*/
 	add		"ADD"
-	with		"WITH"
 	all 		"ALL"
 	alter		"ALTER"
 	analyze		"ANALYZE"
@@ -167,6 +166,41 @@ import (
 	restrict	"RESTRICT"
 	right		"RIGHT"
 	rlike		"RLIKE"
+	schema		"SCHEMA"
+	schemas		"SCHEMAS"
+	secondMicrosecond	"SECOND_MICROSECOND"
+	selectKwd	"SELECT"
+	set		"SET"
+	show		"SHOW"
+	smallIntType	"SMALLINT"
+	starting	"STARTING"
+	tableKwd	"TABLE"
+	terminated	"TERMINATED"
+	then		"THEN"
+	tinyblobType	"TINYBLOB"
+	tinyIntType	"TINYINT"
+	tinytextType	"TINYTEXT"
+	to		"TO"
+	trailing	"TRAILING"
+	trueKwd		"TRUE"
+	unique		"UNIQUE"
+	union		"UNION"
+	unlock		"UNLOCK"
+	unsigned	"UNSIGNED"
+	update		"UPDATE"
+	use		"USE"
+	using		"USING"
+	utcDate 	"UTC_DATE"
+	values		"VALUES"
+	varcharType	"VARCHAR"
+	varbinaryType	"VARBINARY"
+	when		"WHEN"
+	where		"WHERE"
+	write		"WRITE"
+	with		"WITH"
+	xor 		"XOR"
+	yearMonth	"YEAR_MONTH"
+	zerofill	"ZEROFILL"
 
 	/* the following tokens belong to NotKeywordToken*/
 	abs		"ABS"
@@ -366,58 +400,16 @@ import (
 	oror		"||"
 	placeholder	"PLACEHOLDER"
 	rsh		">>"
-	schema		"SCHEMA"
-	schemas		"SCHEMAS"
-	selectKwd	"SELECT"
-	set		"SET"
 	share		"SHARE"
-	show		"SHOW"
-	starting	"STARTING"
 	strcmp		"STRCMP"
 	sysVar		"SYS_VAR"
 	sysDate		"SYSDATE"
-	tableKwd	"TABLE"
-	terminated	"TERMINATED"
-	then		"THEN"
-	to		"TO"
-	trailing	"TRAILING"
-	trueKwd		"true"
+
+
 	underscoreCS	"UNDERSCORE_CHARSET"
-	union		"UNION"
-	unique		"UNIQUE"
-	unlock		"UNLOCK"
-	unsigned	"UNSIGNED"
-	update		"UPDATE"
-	use		"USE"
 	userVar		"USER_VAR"
-	using		"USING"
-	utcDate 	"UTC_DATE"
-	values		"VALUES"
-	when		"WHEN"
-	where		"WHERE"
-	write		"WRITE"
-	xor 		"XOR"
-	zerofill	"ZEROFILL"
-
-
 	currentTs	"CURRENT_TIMESTAMP"
-
-	tinyIntType	"TINYINT"
-	smallIntType	"SMALLINT"
-
-
-
-
 	charType	"CHAR"
-	varcharType	"VARCHAR"
-	varbinaryType	"VARBINARY"
-	tinyblobType	"TINYBLOB"
-	tinytextType	"TINYTEXT"
-
-	secondMicrosecond	"SECOND_MICROSECOND"
-	yearMonth		"YEAR_MONTH"
-
-
 
 %type   <item>
 	AdminStmt		"Check table statement or show ddl statement"
@@ -1526,6 +1518,9 @@ DatabaseSym:
 	"DATABASE" 
 	{}
 |	"SCHEMA"
+	{
+		$$ = $1
+	}
 
 DropDatabaseStmt:
 	"DROP" DatabaseSym IfExists DBName
@@ -1566,7 +1561,7 @@ DropUserStmt:
     }
 
 TableOrTables:
-	"TABLE"
+	"TABLE" {}
 |	"TABLES"
 
 EqOpt:
@@ -2054,17 +2049,15 @@ ReservedKeyword:
 | "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC" 
 | "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" | "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL" 
 | "REFERENCES" | "REGEXP" | "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE" 
-
- /*  
-
-| "DELAYED"  |  "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" 
-
-
 | "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT" 
-| "STARTING" | "TABLE" | "TERMINATED" | "THEN" | "TINYBLOB" 
-| "TINYINT" | "TINYTEXT" | "TO" | "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED" 
+| "STARTING" | "TERMINATED" | "THEN" | "TINYBLOB" | "TINYINT" | "TINYTEXT" | "TO" 
+| "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED" 
 | "UPDATE" | "USE" | "USING" | "UTC_DATE" | "VALUES" | "VARBINARY" | "VARCHAR" 
-| "WHEN" | "WHERE" | "WITH" | "WRITE" | "XOR" | "YEAR_MONTH" | "ZEROFILL" */
+| "WHEN" | "WHERE" | "WRITE" | "XOR" | "YEAR_MONTH" | "ZEROFILL"
+ /*  
+| "DELAYED" | "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" | "TABLE" | "WITH" 
+ */
+
 
 NotKeywordToken:
 	"ABS" | "ADDDATE" | "ADMIN" | "COALESCE" | "CONCAT" | "CONCAT_WS" | "CONNECTION_ID" | "CUR_TIME"| "COUNT" | "DAY"
@@ -2142,6 +2135,9 @@ ValueSym:
 		$$ = $1
 	}
 |	"VALUES"
+	{
+		$$ = $1
+	}
 
 ExpressionListList:
 	ExpressionListListItem
@@ -2237,7 +2233,7 @@ Literal:
 	{
 		$$ = nil
 	}
-|	"true"
+|	"TRUE"
 	{
 		$$ = int64(1)
 	}
@@ -2424,6 +2420,9 @@ FunctionNameConflict:
 		$$ = $1
 	}
 | "SCHEMA" 
+	{
+		$$ = $1
+	}
 | "IF" 
 	{
 		$$ = $1
@@ -2441,6 +2440,9 @@ FunctionNameConflict:
 		$$ = $1
 	}
 | "UTC_DATE"
+	{
+		$$ = $1
+	}
 | "CURRENT_DATE"
 	{
 		$$ = $1
@@ -2466,7 +2468,7 @@ FunctionCallConflict:
 	}
 |	"UTC_DATE"
 	{
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1)}
 	}
 |	"MOD" '(' PrimaryFactor ',' PrimaryFactor ')'
 	{
@@ -3079,6 +3081,9 @@ TimeUnit:
 		$$ = $1
 	}
 | "SECOND_MICROSECOND" 
+	{
+		$$ = $1
+	}
 | "MINUTE_MICROSECOND"
 	{
 		$$ = $1
@@ -3116,6 +3121,9 @@ TimeUnit:
 		$$ = $1
 	}
 | "YEAR_MONTH"
+	{
+		$$ = $1
+	}
 
 ExpressionOpt:
 	{
@@ -4598,7 +4606,8 @@ TableOptionList:
 	}
 
 OptTable:
-	{} | "TABLE"
+	{} 
+| "TABLE" {}
 
 TruncateTableStmt:
 	"TRUNCATE" OptTable TableName
@@ -5472,7 +5481,7 @@ LinesTerminated:
  *********************************************************************/
 
 UnlockTablesStmt:
-	"UNLOCK" "TABLES"
+	"UNLOCK" "TABLES" {}
 
 LockTablesStmt:
 	"LOCK" "TABLES" TableLockList
@@ -5484,7 +5493,7 @@ TableLock:
 LockType:
 	"READ" {}
 |	"READ" "LOCAL" {}
-|	"WRITE"
+|	"WRITE" {}
 
 TableLockList:
 	TableLock

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -684,6 +684,7 @@ import (
 	ReservedKeyword			"MySQL reserved keywords"
 	FunctionNameConflict	"Built-in function call names which are conflict with keywords"
 
+%precedence lowestOpt
 %token	tableRefPriority
 
 %precedence lowerThanCalcFoundRows
@@ -731,6 +732,15 @@ import (
 %precedence escape
 %precedence lowerThanComma
 %precedence ','
+%precedence lowerThanWith
+%precedence with
+%precedence lowerThanInto
+%precedence into
+%precedence lowerThanIf
+%precedence ifKwd
+%precedence lowerThanIgnore
+%precedence ignore
+%precedence tableKwd
 
 %start	Start
 
@@ -1536,7 +1546,7 @@ DropUserStmt:
     }
 
 TableOrTables:
-	"TABLE" {}
+	"TABLE"
 |	"TABLES"
 
 EqOpt:
@@ -1895,6 +1905,7 @@ HavingClause:
 	}
 
 IfExists:
+	%prec lowestOpt
 	{
 		$$ = false
 	}
@@ -1904,6 +1915,7 @@ IfExists:
 	}
 
 IfNotExists:
+	%prec lowestOpt
 	{
 		$$ = false
 	}
@@ -1914,6 +1926,7 @@ IfNotExists:
 
 
 IgnoreOptional:
+	%prec lowerThanIgnore
 	{
 		$$ = false
 	}
@@ -2003,19 +2016,19 @@ ReservedKeyword:
 | "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED"
 | "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM"
 | "FULLTEXT" | "GRANT" | "GROUP" | "HAVING" | "HOUR_MICROSECOND" | "HOUR_MINUTE"
-| "HOUR_SECOND" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT" | "INTEGER" | "INTERVAL"
-| "IS" | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME"
-| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT"
+| "HOUR_SECOND" | "IF" | "IGNORE" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT" | "INTO" | "INTEGER"
+| "INTERVAL" | "IS" | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD"
+| "LOCALTIME" | "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT"
 | "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC"
 | "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" | "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL"
 | "REFERENCES" | "REGEXP" | "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE"
 | "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT"
-| "STARTING" | "TERMINATED" | "THEN" | "TINYBLOB" | "TINYINT" | "TINYTEXT" | "TO"
+| "STARTING" | "TABLE" | "TERMINATED" | "THEN" | "TINYBLOB" | "TINYINT" | "TINYTEXT" | "TO"
 | "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED"
 | "UPDATE" | "USE" | "USING" | "UTC_DATE" | "VALUES" | "VARBINARY" | "VARCHAR"
 | "WHEN" | "WHERE" | "WRITE" | "XOR" | "YEAR_MONTH" | "ZEROFILL"
  /*
-| "DELAYED" | "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" | "TABLE" | "WITH"
+| "DELAYED" | "HIGH_PRIORITY" | "LOW_PRIORITY"| "WITH"
  */
 
 
@@ -2050,6 +2063,7 @@ InsertIntoStmt:
 	}
 
 IntoOpt:
+	%prec lowerThanInto
 	{}
 |	"INTO"
 
@@ -4450,6 +4464,7 @@ TableOptionList:
 	}
 
 OptTable:
+	%prec lowestOpt
 	{}
 |	"TABLE"
 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -76,6 +76,55 @@ import (
 	cross 		"CROSS"
 	currentDate 	"CURRENT_DATE"
 	currentTime 	"CURRENT_TIME"
+	currentUser	"CURRENT_USER"
+	database	"DATABASE"
+	databases	"DATABASES"
+	dayHour		"DAY_HOUR"
+	dayMicrosecond	"DAY_MICROSECOND"
+	dayMinute	"DAY_MINUTE"
+	daySecond 	"DAY_SECOND"
+	decimalType	"DECIMAL"
+	defaultKwd	"DEFAULT"
+	delayed		"DELAYED"
+	deleteKwd	"DELETE"
+	desc		"DESC"
+	describe	"DESCRIBE"
+	distinct	"DISTINCT"
+	div 		"DIV"
+	doubleType	"DOUBLE"
+	drop		"DROP"
+	dual 		"DUAL"
+	elseKwd		"ELSE"
+	enclosed	"ENCLOSED"
+	escaped 	"ESCAPED"
+	exists		"EXISTS"
+	explain		"EXPLAIN"
+	falseKwd	"FALSE"
+	floatType	"FLOAT"
+	forKwd		"FOR"
+	force		"FORCE"
+	foreign		"FOREIGN"
+	from		"FROM"
+	fulltext	"FULLTEXT"
+	grants		"GRANTS"
+	group		"GROUP"
+	having		"HAVING"
+	highPriority	"HIGH_PRIORITY"
+	hourMicrosecond	"HOUR_MICROSECOND"
+	hourMinute	"HOUR_MINUTE"
+	hourSecond	"HOUR_SECOND"
+	ifKwd		"IF"
+	ignore		"IGNORE"
+	in		"IN"
+	index		"INDEX"
+	infile		"INFILE"
+	inner 		"INNER"
+	integerType	"INTEGER"
+	interval	"INTERVAL"
+	into		"INTO"
+	is		"IS"
+	insert		"INSERT"
+	intType		"INT"
 
 	/* the following tokens belong to NotKeywordToken*/
 	abs		"ABS"
@@ -99,6 +148,7 @@ import (
 	dayofyear	"DAYOFYEAR"
 	foundRows	"FOUND_ROWS"
 	fromUnixTime	"FROM_UNIXTIME"
+	grant		"GRANT"
 	groupConcat	"GROUP_CONCAT"
 	greatest	"GREATEST"
 	hour		"HOUR"
@@ -175,7 +225,6 @@ import (
 	datetimeType	"DATETIME"
 	deallocate	"DEALLOCATE"
 	delayKeyWrite	"DELAY_KEY_WRITE"
-	desc		"DESC"
 	disable		"DISABLE"
 	do		"DO"
 	dynamic		"DYNAMIC"
@@ -191,7 +240,6 @@ import (
 	flush		"FLUSH"
 	full		"FULL"
 	function	"FUNCTION"
-	grants		"GRANTS"
 	hash		"HASH"
 	identified	"IDENTIFIED"
 	isolation	"ISOLATION"
@@ -262,48 +310,13 @@ import (
 	byteType	"BYTE"
 	cast		"CAST"
 	curDate 	"CURDATE"
-	currentUser	"CURRENT_USER"
-	database	"DATABASE"
-	databases	"DATABASES"
 	ddl		"DDL"
-	defaultKwd	"DEFAULT"
-	delayed		"DELAYED"
-	deleteKwd	"DELETE"
-	describe	"DESCRIBE"
-	distinct	"DISTINCT"
-	div 		"DIV"
-	drop		"DROP"
-	dual 		"DUAL"
 	duplicate	"DUPLICATE"
-	elseKwd		"ELSE"
-	enclosed	"ENCLOSED"
 	enum 		"ENUM"
 	eq		"="
-	escaped 	"ESCAPED"
-	exists		"EXISTS"
-	explain		"EXPLAIN"
 	extract		"EXTRACT"
-	falseKwd	"false"
-	foreign		"FOREIGN"
-	forKwd		"FOR"
-	force		"FORCE"
-	from		"FROM"
-	fulltext	"FULLTEXT"
+
 	ge		">="
-	grant		"GRANT"
-	group		"GROUP"
-	having		"HAVING"
-	highPriority	"HIGH_PRIORITY"
-	ignore		"IGNORE"
-	ifKwd		"IF"
-	in		"IN"
-	index		"INDEX"
-	infile		"INFILE"
-	inner 		"INNER"
-	insert		"INSERT"
-	interval	"INTERVAL"
-	into		"INTO"
-	is		"IS"
 	join		"JOIN"
 	key		"KEY"
 	keys		"KEYS"
@@ -381,13 +394,9 @@ import (
 	tinyIntType	"TINYINT"
 	smallIntType	"SMALLINT"
 	mediumIntType	"MEDIUMINT"
-	intType		"INT"
-	integerType	"INTEGER"
 
-	decimalType	"DECIMAL"
+
 	numericType	"NUMERIC"
-	floatType	"float"
-	doubleType	"DOUBLE"
 	precisionType	"PRECISION"
 	realType	"REAL"
 
@@ -405,14 +414,8 @@ import (
 	secondMicrosecond	"SECOND_MICROSECOND"
 	minuteMicrosecond	"MINUTE_MICROSECOND"
 	minuteSecond 		"MINUTE_SECOND"
-	hourMicrosecond		"HOUR_MICROSECOND"
-	hourSecond 		"HOUR_SECOND"
-	hourMinute 		"HOUR_MINUTE"
-	dayMicrosecond 		"DAY_MICROSECOND"
-	daySecond 		"DAY_SECOND"
-	dayMinute 		"DAY_MINUTE"
-	dayHour			"DAY_HOUR"
 	yearMonth		"YEAR_MONTH"
+
 
 	restrict	"RESTRICT"
 
@@ -823,7 +826,7 @@ AlterTableSpec:
 	}
 
 KeyOrIndex:
-	"KEY"|"INDEX"
+	"KEY"|"INDEX" {}
 
 ColumnKeywordOpt:
 	{}
@@ -1431,6 +1434,7 @@ DefaultOpt:
 DefaultKwdOpt:
 	{}
 |	"DEFAULT"
+	{}
 
 /******************************************************************
  * Do statement
@@ -1507,7 +1511,9 @@ DeleteFromStmt:
 	}
 
 DatabaseSym:
-	"DATABASE" | "SCHEMA"
+	"DATABASE" 
+	{}
+|	"SCHEMA"
 
 DropDatabaseStmt:
 	"DROP" DatabaseSym IfExists DBName
@@ -1566,7 +1572,13 @@ EmptyStmt:
 
 ExplainSym:
 	"EXPLAIN"
+	{
+		$$ = $1
+	}
 |	"DESCRIBE"
+	{
+		$$ = $1
+	}
 |	"DESC"
 	{
 		$$ = $1
@@ -2019,14 +2031,17 @@ ReservedKeyword:
 "ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT"
 | "BINARY" | "BLOB" | "BOTH" | "BY" | "CASCADE" | "CASE" | "CHARACTER" | "CHECK" | "COLLATE"
 | "COLUMN" | "CONSTRAINT" | "CONVERT" | "CREATE" | "CROSS" | "CURRENT_DATE" | "CURRENT_TIME"
- /*
 | "CURRENT_USER" | "DATABASE" | "DATABASES" | "DAY_HOUR" | "DAY_MICROSECOND" | "DAY_MINUTE" 
-| "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELAYED" | "DELETE" | "DESC" | "DESCRIBE" 
+| "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELETE" | "DESC" | "DESCRIBE" 
 | "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED" 
 | "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM" 
-| "FULLTEXT" | "GENERATED" | "GRANT" | "GROUP" | "HAVING" | "HIGH_PRIORITY" | "HOUR_MICROSECOND" | "HOUR_MINUTE" 
-| "HOUR_SECOND" | "IF" | "IGNORE" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT"
-| "INTEGER" | "INTERVAL" | "INTO" | "IS" 
+| "FULLTEXT" | "GRANT" | "GROUP" | "HAVING" | "HOUR_MICROSECOND" | "HOUR_MINUTE" 
+| "HOUR_SECOND" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT" | "INTEGER" | "INTERVAL"
+| "IS" 
+ /* 
+
+| "DELAYED"  |  "HIGH_PRIORITY" | "IF" | "IGNORE" | "INTO" 
+
 | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME" 
 | "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "LOW_PRIORITY" 
 | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT" 
@@ -2203,7 +2218,7 @@ ReplacePriority:
 /***********************************Replace Statements END************************************/
 
 Literal:
-	"false"
+	"FALSE"
 	{
 		$$ = int64(0)
 	}
@@ -2390,7 +2405,21 @@ Function:
 |	FunctionCallAgg
 
 FunctionNameConflict:
-	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT" | "CURRENT_USER" | "UTC_DATE"
+	"DATABASE" 
+	{
+		$$ = $1
+	}
+| "SCHEMA" 
+| "IF" 
+	{
+		$$ = $1
+	}
+| "LEFT" | "REPEAT" 
+| "CURRENT_USER" 
+	{
+		$$ = $1
+	}
+| "UTC_DATE"
 | "CURRENT_DATE"
 	{
 		$$ = $1
@@ -2408,7 +2437,7 @@ FunctionCallConflict:
 |	"CURRENT_USER"
 	{
 		// See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_current-user
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1)}
 	}
 |	"CURRENT_DATE"
 	{
@@ -3029,8 +3058,36 @@ TimeUnit:
 		$$ = $1
 	}
 | "SECOND_MICROSECOND" | "MINUTE_MICROSECOND"
-|	"MINUTE_SECOND" | "HOUR_MICROSECOND" | "HOUR_SECOND" | "HOUR_MINUTE"
-|	"DAY_MICROSECOND" | "DAY_SECOND" | "DAY_MINUTE" | "DAY_HOUR" | "YEAR_MONTH"
+|	"MINUTE_SECOND" 
+| "HOUR_MICROSECOND" 
+	{
+		$$ = $1
+	}
+| "HOUR_SECOND" 
+	{
+		$$ = $1
+	}
+| "HOUR_MINUTE"
+	{
+		$$ = $1
+	}
+|	"DAY_MICROSECOND" 
+	{
+		$$ = $1
+	}
+| "DAY_SECOND" 
+	{
+		$$ = $1
+	}
+| "DAY_MINUTE" 
+	{
+		$$ = $1
+	}
+| "DAY_HOUR" 
+	{
+		$$ = $1
+	}
+| "YEAR_MONTH"
 
 ExpressionOpt:
 	{
@@ -3317,6 +3374,9 @@ DeallocateSym:
 		$$ = $1
 	}
 | "DROP"
+	{
+		$$ = $1
+	}
 
 /****************************Prepared Statement End*******************************/
 
@@ -3625,7 +3685,7 @@ CrossOpt:
 |	"CROSS" "JOIN"
 	{}
 |	"INNER" "JOIN"
-
+	{}
 
 LimitClause:
 	{
@@ -4081,12 +4141,15 @@ ShowStmt:
 	}
 
 ShowIndexKwd:
-	"INDEX"
+	"INDEX" {}
 |	"INDEXES" {}
 |	"KEYS"
 
 FromOrIn:
-	"FROM"|"IN"
+	"FROM"
+	{}
+|	"IN"
+	{}
 
 ShowTargetFilterable:
 	"ENGINES"
@@ -4657,7 +4720,9 @@ IntegerType:
 	}
 
 OptInteger:
-	{} | "INTEGER"
+	{} 
+| "INTEGER"
+	{}
 
 FixedPointType:
 	"DECIMAL"
@@ -4670,7 +4735,7 @@ FixedPointType:
 	}
 
 FloatingPointType:
-	"float"
+	"FLOAT"
 	{
 		$$ = mysql.TypeFloat
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -48,6 +48,8 @@ import (
 	/*yy:token "%c"     */	identifier      "identifier"
 	/*yy:token "\"%c\"" */	stringLit       "string literal"
 	invalid		"a special token never used by parser, used by lexer to indicate error"
+	andand		"&&"
+	oror		"||"
 
 	/* the following tokens belong to ReservedKeyword*/
 	add		"ADD"
@@ -384,7 +386,6 @@ import (
 	/*yy:token "%x"     */	hexLit          "hexadecimal literal"
 	/*yy:token "%b"     */	bitLit          "bit literal"
 
-	andand		"&&"
 	andnot		"&^"
 	assignmentEq	":="
 	cast		"CAST"
@@ -400,7 +401,6 @@ import (
 	neq		"!="
 	neqSynonym	"<>"
 	nulleq		"<=>"
-	oror		"||"
 	placeholder	"PLACEHOLDER"
 	rsh		">>"
 	strcmp		"STRCMP"
@@ -483,7 +483,6 @@ import (
 	FieldAsName		"Field alias name"
 	FieldAsNameOpt		"Field alias name opt"
 	FieldList		"field expression list"
-	FieldsOrColumns 	"Fields or columns"
 	FlushStmt		"Flush statement"
 	TableRefsClause		"Table references clause"
 	Function		"function expr"
@@ -524,8 +523,6 @@ import (
 	LoadDataStmt		"Load data statement"
 	LocalOpt		"Local opt"
 	LockTablesStmt		"Lock tables statement"
-	logAnd			"logical and operator"
-	logOr			"logical or operator"
 	LowPriorityOptional	"LOW_PRIORITY or empty"
 	NotOpt			"optional NOT"
 	NumLiteral		"Num/Int/Float/Decimal Literal"
@@ -675,6 +672,9 @@ import (
 	CharsetKw		"charset or charater set"
 	CommaOpt		"optional comma"
 	LockType		"Table locks type"
+	logAnd			"logical and operator"
+	logOr			"logical or operator"
+	FieldsOrColumns 	"Fields or columns"
 
 %type	<ident>
 	Identifier			"identifier or unreserved keyword"
@@ -1646,20 +1646,10 @@ Expression:
 
 
 logOr:
-	"||"
-	{
-	}
-|	"OR"
-	{
-	}
+"||" | "OR"
 
 logAnd:
-	"&&"
-	{
-	}
-|	"AND"
-	{
-	}
+"&&" | "AND"
 
 ExpressionList:
 	Expression
@@ -5262,8 +5252,7 @@ Fields:
 	}
 
 FieldsOrColumns:
-	"FIELDS"{}
-|	"COLUMNS"{}
+"FIELDS" | "COLUMNS"
 
 FieldsTerminated:
 	{
@@ -5335,8 +5324,7 @@ LockTablesStmt:
 	{}
 
 TableLock:
-	 TableName LockType
-	{}
+	TableName LockType
 
 LockType:
 	"READ"

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -125,6 +125,48 @@ import (
 	is		"IS"
 	insert		"INSERT"
 	intType		"INT"
+	join		"JOIN"
+	key		"KEY"
+	keys		"KEYS"
+	leading		"LEADING"
+	left		"LEFT"
+	like		"LIKE"
+	limit		"LIMIT"
+	lines 		"LINES"
+	load		"LOAD"
+	localTime	"LOCALTIME"
+	localTs		"LOCALTIMESTAMP"
+	lock		"LOCK"
+	longblobType	"LONGBLOB"
+	longtextType	"LONGTEXT"
+	lowPriority	"LOW_PRIORITY"
+	mediumblobType	"MEDIUMBLOB"
+	mediumIntType	"MEDIUMINT"
+	mediumtextType	"MEDIUMTEXT"
+	minuteMicrosecond	"MINUTE_MICROSECOND"
+	minuteSecond 		"MINUTE_SECOND"
+	mod 		"MOD"
+	not		"NOT"
+	noWriteToBinLog "NO_WRITE_TO_BINLOG"
+	null		"NULL"
+	numericType	"NUMERIC"
+	on		"ON"
+	option		"OPTION"
+	or		"OR"
+	order		"ORDER"
+	outer		"OUTER"
+	precisionType	"PRECISION"
+	primary		"PRIMARY"
+	procedure	"PROCEDURE"
+	read		"READ"
+	realType	"REAL"
+	references	"REFERENCES"
+	regexpKwd	"REGEXP"
+	repeat		"REPEAT"
+	replace		"REPLACE"
+	restrict	"RESTRICT"
+	right		"RIGHT"
+	rlike		"RLIKE"
 
 	/* the following tokens belong to NotKeywordToken*/
 	abs		"ABS"
@@ -251,7 +293,6 @@ import (
 	modify		"MODIFY"
 	maxRows		"MAX_ROWS"
 	minRows		"MIN_ROWS"
-	noWriteToBinLog "NO_WRITE_TO_BINLOG"
 	names		"NAMES"
 	national	"NATIONAL"
 	no		"NO"
@@ -317,41 +358,13 @@ import (
 	extract		"EXTRACT"
 
 	ge		">="
-	join		"JOIN"
-	key		"KEY"
-	keys		"KEYS"
 	le		"<="
-	leading		"LEADING"
-	left		"LEFT"
-	like		"LIKE"
-	limit		"LIMIT"
-	lines 		"LINES"
-	load		"LOAD"
-	lock		"LOCK"
-	lowPriority	"LOW_PRIORITY"
 	lsh		"<<"
-	mod 		"MOD"
 	neq		"!="
 	neqSynonym	"<>"
-	not		"NOT"
-	null		"NULL"
 	nulleq		"<=>"
-	on		"ON"
-	option		"OPTION"
-	or		"OR"
-	order		"ORDER"
 	oror		"||"
-	outer		"OUTER"
 	placeholder	"PLACEHOLDER"
-	primary		"PRIMARY"
-	procedure	"PROCEDURE"
-	read		"READ"
-	references	"REFERENCES"
-	regexpKwd	"REGEXP"
-	repeat		"REPEAT"
-	replace		"REPLACE"
-	right		"RIGHT"
-	rlike		"RLIKE"
 	rsh		">>"
 	schema		"SCHEMA"
 	schemas		"SCHEMAS"
@@ -388,36 +401,23 @@ import (
 
 
 	currentTs	"CURRENT_TIMESTAMP"
-	localTime	"LOCALTIME"
-	localTs		"LOCALTIMESTAMP"
 
 	tinyIntType	"TINYINT"
 	smallIntType	"SMALLINT"
-	mediumIntType	"MEDIUMINT"
 
 
-	numericType	"NUMERIC"
-	precisionType	"PRECISION"
-	realType	"REAL"
 
 
 	charType	"CHAR"
 	varcharType	"VARCHAR"
 	varbinaryType	"VARBINARY"
 	tinyblobType	"TINYBLOB"
-	mediumblobType	"MEDIUMBLOB"
-	longblobType	"LONGBLOB"
 	tinytextType	"TINYTEXT"
-	mediumtextType	"MEDIUMTEXT"
-	longtextType	"LONGTEXT"
 
 	secondMicrosecond	"SECOND_MICROSECOND"
-	minuteMicrosecond	"MINUTE_MICROSECOND"
-	minuteSecond 		"MINUTE_SECOND"
 	yearMonth		"YEAR_MONTH"
 
 
-	restrict	"RESTRICT"
 
 %type   <item>
 	AdminStmt		"Check table statement or show ddl statement"
@@ -826,7 +826,9 @@ AlterTableSpec:
 	}
 
 KeyOrIndex:
-	"KEY"|"INDEX" {}
+	"KEY"
+	{}
+|"INDEX" {}
 
 ColumnKeywordOpt:
 	{}
@@ -977,7 +979,11 @@ CommitStmt:
 	}
 
 PrimaryOpt:
-	{} | "PRIMARY"
+	{} 
+| "PRIMARY"
+	{
+		$$ = $1
+	}
 
 ColumnOption:
 	"NOT" "NULL"
@@ -1257,7 +1263,13 @@ DefaultValueExpr:
 NowSym:
 	"CURRENT_TIMESTAMP"
 |	"LOCALTIME"
+	{
+		$$ = $1
+	}
 |	"LOCALTIMESTAMP"
+	{
+		$$ = $1
+	}
 |	"NOW"
 	{
 		$$ = $1
@@ -1819,8 +1831,8 @@ PredicateExpr:
 |	PrimaryFactor
 
 RegexpSym:
-	"REGEXP"
-|	"RLIKE"
+	"REGEXP" {}
+|	"RLIKE" {}
 
 LikeEscapeOpt:
 	%prec lowerThanEscape
@@ -2037,18 +2049,17 @@ ReservedKeyword:
 | "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM" 
 | "FULLTEXT" | "GRANT" | "GROUP" | "HAVING" | "HOUR_MICROSECOND" | "HOUR_MINUTE" 
 | "HOUR_SECOND" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT" | "INTEGER" | "INTERVAL"
-| "IS" 
- /* 
-
-| "DELAYED"  |  "HIGH_PRIORITY" | "IF" | "IGNORE" | "INTO" 
-
-| "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME" 
-| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "LOW_PRIORITY" 
-| "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT" 
+| "IS" | "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME" 
+| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT" 
 | "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC" 
-| "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" 
-| "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL" | "REFERENCES" | "REGEXP" 
-| "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE" 
+| "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" | "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL" 
+| "REFERENCES" | "REGEXP" | "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE" 
+
+ /*  
+
+| "DELAYED"  |  "HIGH_PRIORITY" | "LOW_PRIORITY" | "IF" | "IGNORE" | "INTO" 
+
+
 | "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT" 
 | "STARTING" | "TABLE" | "TERMINATED" | "THEN" | "TINYBLOB" 
 | "TINYINT" | "TINYTEXT" | "TO" | "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED" 
@@ -2223,6 +2234,9 @@ Literal:
 		$$ = int64(0)
 	}
 |	"NULL"
+	{
+		$$ = nil
+	}
 |	"true"
 	{
 		$$ = int64(1)
@@ -2414,7 +2428,14 @@ FunctionNameConflict:
 	{
 		$$ = $1
 	}
-| "LEFT" | "REPEAT" 
+| "LEFT" 
+	{
+		$$ = $1
+	}
+| "REPEAT" 
+	{
+		$$ = $1
+	}
 | "CURRENT_USER" 
 	{
 		$$ = $1
@@ -2788,7 +2809,7 @@ FunctionCallNonKeyword:
 |	"REPLACE" '(' Expression ',' Expression ',' Expression ')'
 	{
 		args := []ast.ExprNode{$3.(ast.ExprNode), $5.(ast.ExprNode), $7.(ast.ExprNode)}
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1), Args: args}
 	}
 |	"REVERSE" '(' Expression ')'
 	{
@@ -3057,8 +3078,15 @@ TimeUnit:
 	{
 		$$ = $1
 	}
-| "SECOND_MICROSECOND" | "MINUTE_MICROSECOND"
+| "SECOND_MICROSECOND" 
+| "MINUTE_MICROSECOND"
+	{
+		$$ = $1
+	}
 |	"MINUTE_SECOND" 
+	{
+		$$ = $1
+	}
 | "HOUR_MICROSECOND" 
 	{
 		$$ = $1
@@ -3678,10 +3706,14 @@ OuterOpt:
 		$$ = nil
 	}
 |	"OUTER"
+	{
+		$$ = $1
+	}
 
 
 CrossOpt:
 	"JOIN"
+	{}
 |	"CROSS" "JOIN"
 	{}
 |	"INNER" "JOIN"
@@ -3910,7 +3942,7 @@ TransactionChars:
 
 TransactionChar:
 	"ISOLATION" "LEVEL" IsolationLevel {}
-|	"READ" "WRITE"
+|	"READ" "WRITE" {}
 |	"READ" "ONLY" {}
 
 IsolationLevel:
@@ -4143,7 +4175,7 @@ ShowStmt:
 ShowIndexKwd:
 	"INDEX" {}
 |	"INDEXES" {}
-|	"KEYS"
+|	"KEYS" {}
 
 FromOrIn:
 	"FROM"
@@ -5444,13 +5476,14 @@ UnlockTablesStmt:
 
 LockTablesStmt:
 	"LOCK" "TABLES" TableLockList
+	{}
 
 TableLock:
 	 TableName LockType
 
 LockType:
-	"READ"
-|	"READ" "LOCAL"
+	"READ" {}
+|	"READ" "LOCAL" {}
 |	"WRITE"
 
 TableLockList:

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -49,7 +49,17 @@ import (
 	/*yy:token "\"%c\"" */	stringLit       "string literal"
 	invalid		"a special token never used by parser, used by lexer to indicate error"
 
+	/* the following tokens belong to ReservedKeyword*/
+	add		"ADD"
 	with		"WITH"
+	all 		"ALL"
+	alter		"ALTER"
+	analyze		"ANALYZE"
+	and		"AND"
+	as		"AS"
+	asc		"ASC"
+	between		"BETWEEN"
+	bigIntType	"BIGINT"
 
 	/* the following tokens belong to NotKeywordToken*/
 	abs		"ABS"
@@ -148,6 +158,7 @@ import (
 	datetimeType	"DATETIME"
 	deallocate	"DEALLOCATE"
 	delayKeyWrite	"DELAY_KEY_WRITE"
+	desc		"DESC"
 	disable		"DISABLE"
 	do		"DO"
 	dynamic		"DYNAMIC"
@@ -228,18 +239,10 @@ import (
 	/*yy:token "%x"     */	hexLit          "hexadecimal literal"
 	/*yy:token "%b"     */	bitLit          "bit literal"
 
-	add		"ADD"
-	all 		"ALL"
-	alter		"ALTER"
-	analyze		"ANALYZE"
-	and		"AND"
 	andand		"&&"
 	andnot		"&^"
-	as		"AS"
-	asc		"ASC"
 	assignmentEq	":="
 	at		"AT"
-	between		"BETWEEN"
 	both		"BOTH"
 	by		"BY"
 	byteType	"BYTE"
@@ -263,7 +266,6 @@ import (
 	defaultKwd	"DEFAULT"
 	delayed		"DELAYED"
 	deleteKwd	"DELETE"
-	desc		"DESC"
 	describe	"DESCRIBE"
 	distinct	"DISTINCT"
 	div 		"DIV"
@@ -378,7 +380,6 @@ import (
 	mediumIntType	"MEDIUMINT"
 	intType		"INT"
 	integerType	"INTEGER"
-	bigIntType	"BIGINT"
 
 	decimalType	"DECIMAL"
 	numericType	"NUMERIC"
@@ -682,9 +683,11 @@ import (
 	LengthNum		"Field length num(uint64)"
 
 %type	<ident>
-	Identifier		"identifier or unreserved keyword"
-	NotKeywordToken		"Tokens not mysql keyword but treated specially"
-	UnReservedKeyword	"MySQL unreserved keywords"
+	Identifier			"identifier or unreserved keyword"
+	IdentifierOrReservedKeyword	"Identifier or ReservedKeyword"
+	NotKeywordToken			"Tokens not mysql keyword but treated specially"
+	UnReservedKeyword		"MySQL unreserved keywords"
+	ReservedKeyword			"MySQL reserved keywords"
 
 %token	tableRefPriority
 
@@ -1564,6 +1567,9 @@ ExplainSym:
 	"EXPLAIN"
 |	"DESCRIBE"
 |	"DESC"
+	{
+		$$ = $1
+	}
 
 ExplainStmt:
 	ExplainSym TableName
@@ -1993,6 +1999,9 @@ IndexTypeOpt:
 Identifier:
 identifier | UnReservedKeyword | NotKeywordToken
 
+IdentifierOrReservedKeyword:
+Identifier | ReservedKeyword
+
 UnReservedKeyword:
  "ACTION" | "ASCII" | "AUTO_INCREMENT" | "AFTER" | "AVG" | "BEGIN" | "BIT" | "BOOL" | "BOOLEAN" | "BTREE" | "CHARSET"
 |	"COLUMNS" | "COMMIT" | "COMPACT" | "COMPRESSED" | "CONSISTENT" | "DATA" | "DATE" | "DATETIME" | "DEALLOCATE" | "DO"
@@ -2004,6 +2013,30 @@ UnReservedKeyword:
 |	"MIN_ROWS" | "NATIONAL" | "ROW" | "ROW_FORMAT" | "QUARTER" | "GRANTS" | "TRIGGERS" | "DELAY_KEY_WRITE" | "ISOLATION"
 |	"REPEATABLE" | "COMMITTED" | "UNCOMMITTED" | "ONLY" | "SERIALIZABLE" | "LEVEL" | "VARIABLES" | "SQL_CACHE" | "INDEXES" | "PROCESSLIST"
 |	"SQL_NO_CACHE" | "DISABLE"  | "ENABLE" | "REVERSE" | "SPACE" | "PRIVILEGES" | "NO" | "BINLOG" | "FUNCTION" | "VIEW" | "MODIFY"
+
+ReservedKeyword:
+"ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT" 
+/* | "BINARY" | "BLOB" | "BOTH" | "BY" | "CASCADE" | "CASE" | "CHARACTER" | "CHECK" | "COLLATE" 
+| "COLUMN" | "CONSTRAINT" | "CONVERT" | "CREATE" | "CROSS" | "CURRENT_DATE" | "CURRENT_TIME" 
+| "CURRENT_USER" | "DATABASE" | "DATABASES" | "DAY_HOUR" | "DAY_MICROSECOND" | "DAY_MINUTE" 
+| "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELAYED" | "DELETE" | "DESC" | "DESCRIBE" 
+| "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED" 
+| "EXISTS" | "EXPLAIN" | "FALSE" | "FLOAT" | "FOR" | "FORCE" | "FOREIGN" | "FROM" 
+| "FULLTEXT" | "GENERATED" | "GRANT" | "GROUP" | "HAVING" | "HIGH_PRIORITY" | "HOUR_MICROSECOND" | "HOUR_MINUTE" 
+| "HOUR_SECOND" | "IF" | "IGNORE" | "IN" | "INDEX" | "INFILE" | "INNER" | "INSERT" | "INT"
+| "INTEGER" | "INTERVAL" | "INTO" | "IS" 
+| "JOIN" | "KEY" | "KEYS" | "LEADING" | "LEFT" | "LIKE" | "LIMIT" | "LINES" | "LOAD" | "LOCALTIME" 
+| "LOCALTIMESTAMP" | "LOCK" | "LONGBLOB" | "LONGTEXT" | "LOW_PRIORITY" 
+| "MEDIUMBLOB" | "MEDIUMINT" | "MEDIUMTEXT" 
+| "MINUTE_MICROSECOND" | "MINUTE_SECOND" | "MOD" | "NOT" | "NO_WRITE_TO_BINLOG" | "NULL" | "NUMERIC" 
+| "ON" | "OPTION" | "OR" | "ORDER" | "OUTER" 
+| "PRECISION" | "PRIMARY" | "PROCEDURE" | "READ" | "REAL" | "REFERENCES" | "REGEXP" 
+| "REPEAT" | "REPLACE" | "RESTRICT" | "RIGHT" | "RLIKE" 
+| "SCHEMA" | "SCHEMAS" | "SECOND_MICROSECOND" | "SELECT" | "SET" | "SHOW" | "SMALLINT" 
+| "STARTING" | "TABLE" | "TERMINATED" | "THEN" | "TINYBLOB" 
+| "TINYINT" | "TINYTEXT" | "TO" | "TRAILING" | "TRUE" | "UNION" | "UNIQUE" | "UNLOCK" | "UNSIGNED" 
+| "UPDATE" | "USE" | "USING" | "UTC_DATE" | "VALUES" | "VARBINARY" | "VARCHAR" 
+| "WHEN" | "WHERE" | "WITH" | "WRITE" | "XOR" | "YEAR_MONTH" | "ZEROFILL" */
 
 NotKeywordToken:
 	"ABS" | "ADDDATE" | "ADMIN" | "COALESCE" | "CONCAT" | "CONCAT_WS" | "CONNECTION_ID" | "CUR_TIME"| "COUNT" | "DAY"
@@ -3171,7 +3204,7 @@ TableName:
 	{
 		$$ = &ast.TableName{Name:model.NewCIStr($1)}
 	}
-|	Identifier '.' Identifier
+|	IdentifierOrReservedKeyword '.' IdentifierOrReservedKeyword
 	{
 		$$ = &ast.TableName{Schema:model.NewCIStr($1),	Name:model.NewCIStr($3)}
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -60,6 +60,22 @@ import (
 	asc		"ASC"
 	between		"BETWEEN"
 	bigIntType	"BIGINT"
+	binaryType	"BINARY"
+	blobType	"BLOB"
+	both		"BOTH"
+	by		"BY"
+	cascade		"CASCADE"
+	caseKwd		"CASE"
+	character	"CHARACTER"
+	check 		"CHECK"
+	collate 	"COLLATE"
+	column		"COLUMN"
+	constraint	"CONSTRAINT"
+	convert		"CONVERT"
+	create		"CREATE"
+	cross 		"CROSS"
+	currentDate 	"CURRENT_DATE"
+	currentTime 	"CURRENT_TIME"
 
 	/* the following tokens belong to NotKeywordToken*/
 	abs		"ABS"
@@ -132,6 +148,7 @@ import (
 	after		"AFTER"
 	any 		"ANY"
 	ascii		"ASCII"
+	at		"AT"
 	autoIncrement	"AUTO_INCREMENT"
 	avgRowLength	"AVG_ROW_LENGTH"
 	avg		"AVG"
@@ -242,23 +259,9 @@ import (
 	andand		"&&"
 	andnot		"&^"
 	assignmentEq	":="
-	at		"AT"
-	both		"BOTH"
-	by		"BY"
 	byteType	"BYTE"
-	caseKwd		"CASE"
 	cast		"CAST"
-	character	"CHARACTER"
-	check 		"CHECK"
-	collate 	"COLLATE"
-	column		"COLUMN"
-	constraint	"CONSTRAINT"
-	convert		"CONVERT"
-	create		"CREATE"
-	cross 		"CROSS"
 	curDate 	"CURDATE"
-	currentDate 	"CURRENT_DATE"
-	currentTime 	"CURRENT_TIME"
 	currentUser	"CURRENT_USER"
 	database	"DATABASE"
 	databases	"DATABASES"
@@ -391,10 +394,8 @@ import (
 
 	charType	"CHAR"
 	varcharType	"VARCHAR"
-	binaryType	"BINARY"
 	varbinaryType	"VARBINARY"
 	tinyblobType	"TINYBLOB"
-	blobType	"BLOB"
 	mediumblobType	"MEDIUMBLOB"
 	longblobType	"LONGBLOB"
 	tinytextType	"TINYTEXT"
@@ -414,7 +415,6 @@ import (
 	yearMonth		"YEAR_MONTH"
 
 	restrict	"RESTRICT"
-	cascade		"CASCADE"
 
 %type   <item>
 	AdminStmt		"Check table statement or show ddl statement"
@@ -828,6 +828,7 @@ KeyOrIndex:
 ColumnKeywordOpt:
 	{}
 |	"COLUMN"
+	{}
 
 ColumnPosition:
 	{
@@ -2003,7 +2004,7 @@ IdentifierOrReservedKeyword:
 Identifier | ReservedKeyword
 
 UnReservedKeyword:
- "ACTION" | "ASCII" | "AUTO_INCREMENT" | "AFTER" | "AVG" | "BEGIN" | "BIT" | "BOOL" | "BOOLEAN" | "BTREE" | "CHARSET"
+ "ACTION" | "ASCII" | "AUTO_INCREMENT" | "AFTER" | "AT" | "AVG" | "BEGIN" | "BIT" | "BOOL" | "BOOLEAN" | "BTREE" | "CHARSET"
 |	"COLUMNS" | "COMMIT" | "COMPACT" | "COMPRESSED" | "CONSISTENT" | "DATA" | "DATE" | "DATETIME" | "DEALLOCATE" | "DO"
 |	"DYNAMIC"| "END" | "ENGINE" | "ENGINES" | "ESCAPE" | "EXECUTE" | "FIELDS" | "FIRST" | "FIXED" | "FULL" |"GLOBAL"
 |	"HASH" | "LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" %prec lowerThanEq | "PREPARE" | "QUICK" | "REDUNDANT" | "ROLLBACK"
@@ -2015,9 +2016,10 @@ UnReservedKeyword:
 |	"SQL_NO_CACHE" | "DISABLE"  | "ENABLE" | "REVERSE" | "SPACE" | "PRIVILEGES" | "NO" | "BINLOG" | "FUNCTION" | "VIEW" | "MODIFY"
 
 ReservedKeyword:
-"ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT" 
-/* | "BINARY" | "BLOB" | "BOTH" | "BY" | "CASCADE" | "CASE" | "CHARACTER" | "CHECK" | "COLLATE" 
-| "COLUMN" | "CONSTRAINT" | "CONVERT" | "CREATE" | "CROSS" | "CURRENT_DATE" | "CURRENT_TIME" 
+"ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT"
+| "BINARY" | "BLOB" | "BOTH" | "BY" | "CASCADE" | "CASE" | "CHARACTER" | "CHECK" | "COLLATE"
+| "COLUMN" | "CONSTRAINT" | "CONVERT" | "CREATE" | "CROSS" | "CURRENT_DATE" | "CURRENT_TIME"
+ /*
 | "CURRENT_USER" | "DATABASE" | "DATABASES" | "DAY_HOUR" | "DAY_MICROSECOND" | "DAY_MINUTE" 
 | "DAY_SECOND" | "DECIMAL" | "DEFAULT" | "DELAYED" | "DELETE" | "DESC" | "DESCRIBE" 
 | "DISTINCT" | "DIV" | "DOUBLE" | "DROP" | "DUAL" | "ELSE" | "ENCLOSED" | "ESCAPED" 
@@ -2388,7 +2390,11 @@ Function:
 |	FunctionCallAgg
 
 FunctionNameConflict:
-	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT" | "CURRENT_USER" | "CURRENT_DATE" | "UTC_DATE"
+	"DATABASE" | "SCHEMA" | "IF" | "LEFT" | "REPEAT" | "CURRENT_USER" | "UTC_DATE"
+| "CURRENT_DATE"
+	{
+		$$ = $1
+	}
 | "VERSION"
 	{
 		$$ = $1
@@ -2406,7 +2412,7 @@ FunctionCallConflict:
 	}
 |	"CURRENT_DATE"
 	{
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string))}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1)}
 	}
 |	"UTC_DATE"
 	{
@@ -2460,7 +2466,7 @@ FunctionCallKeyword:
 		// See https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#function_convert
 		charset := ast.NewValueExpr($5)
 		$$ = &ast.FuncCallExpr{
-			FnName: model.NewCIStr($1.(string)),
+			FnName: model.NewCIStr($1),
 			Args: []ast.ExprNode{$3.(ast.ExprNode), charset},
 		}
 	}
@@ -2522,7 +2528,7 @@ FunctionCallNonKeyword:
 		if $2 != nil {
 			args = append(args, $2.(ast.ExprNode))
 		}
-		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1.(string)), Args: args}
+		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1), Args: args}
 	}
 |	"CURRENT_TIMESTAMP" FuncDatetimePrec
 	{
@@ -3617,6 +3623,7 @@ OuterOpt:
 CrossOpt:
 	"JOIN"
 |	"CROSS" "JOIN"
+	{}
 |	"INNER" "JOIN"
 
 
@@ -4932,6 +4939,8 @@ OptCharset:
 
 CharsetKw:
 	"CHARACTER" "SET"
+	{
+	}
 |	"CHARSET"
 	{
 		$$ = $1

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -727,6 +727,9 @@ func (s *testParserSuite) TestIdentifier(c *C) {
 		{`select 1 a, 1 "a", 1 'a'`, true},
 		{`select * from t as "a"`, false},
 		{`select * from t a`, true},
+		// reserved keyword can't be used as identifier directly, but A.B pattern is an exception
+		{`select COUNT from DESC`, false},
+		{`select COUNT from SELECT.DESC`, true},
 		{`select * from t as a`, true},
 		{"select 1 full, 1 row, 1 abs", true},
 		{"select * from t full, t1 row, t2 abs", true},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -37,6 +37,40 @@ type testParserSuite struct {
 func (s *testParserSuite) TestSimple(c *C) {
 	defer testleak.AfterTest(c)()
 	parser := New()
+
+	reservedKws := []string{
+		"add", "all", "alter", "analyze", "and", "as", "asc", "between", "bigint",
+		"binary", "blob", "both", "by", "cascade", "case", "character", "check", "collate",
+		"column", "constraint", "convert", "create", "cross", "current_date", "current_time",
+		"current_timestamp", "current_user", "database", "databases", "day_hour", "day_microsecond",
+		"day_minute", "day_second", "decimal", "default", "delete", "desc", "describe",
+		"distinct", "div", "double", "drop", "dual", "else", "enclosed", "escaped",
+		"exists", "explain", "false", "float", "for", "force", "foreign", "from",
+		"fulltext", "grant", "group", "having", "hour_microsecond", "hour_minute",
+		"hour_second", "if", "ignore", "in", "index", "infile", "inner", "insert", "int", "into", "integer",
+		"interval", "is", "join", "key", "keys", "leading", "left", "like", "limit", "lines", "load",
+		"localtime", "localtimestamp", "lock", "longblob", "longtext", "mediumblob", "mediumint", "mediumtext",
+		"minute_microsecond", "minute_second", "mod", "not", "no_write_to_binlog", "null", "numeric",
+		"on", "option", "or", "order", "outer", "precision", "primary", "procedure", "read", "real",
+		"references", "regexp", "repeat", "replace", "restrict", "right", "rlike",
+		"schema", "schemas", "second_microsecond", "select", "set", "show", "smallint",
+		"starting", "table", "terminated", "then", "tinyblob", "tinyint", "tinytext", "to",
+		"trailing", "true", "union", "unique", "unlock", "unsigned",
+		"update", "use", "using", "utc_date", "values", "varbinary", "varchar",
+		"when", "where", "write", "xor", "year_month", "zerofill",
+		// TODO: support the following keywords
+		// "delayed" , "high_priority" , "low_priority", "with",
+	}
+	for _, kw := range reservedKws {
+		src := fmt.Sprintf("SELECT * FROM db.%s;", kw)
+		_, err := parser.ParseOneStmt(src, "", "")
+		c.Assert(err, IsNil, Commentf("source %s", src))
+
+		src = fmt.Sprintf("SELECT * FROM %s.desc", kw)
+		_, err = parser.ParseOneStmt(src, "", "")
+		c.Assert(err, IsNil, Commentf("source %s", src))
+	}
+
 	// Testcase for unreserved keywords
 	unreservedKws := []string{
 		"auto_increment", "after", "begin", "bit", "bool", "boolean", "charset", "columns", "commit",

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -730,6 +730,8 @@ func (s *testParserSuite) TestIdentifier(c *C) {
 		// reserved keyword can't be used as identifier directly, but A.B pattern is an exception
 		{`select COUNT from DESC`, false},
 		{`select COUNT from SELECT.DESC`, true},
+		{"use `select`", true},
+		{"use select", false},
 		{`select * from t as a`, true},
 		{"select 1 full, 1 row, 1 abs", true},
 		{"select * from t full, t1 row, t2 abs", true},

--- a/server/conn.go
+++ b/server/conn.go
@@ -405,7 +405,9 @@ func (cc *clientConn) dispatch(data []byte) error {
 }
 
 func (cc *clientConn) useDB(db string) (err error) {
-	_, err = cc.ctx.Execute("use " + db)
+	// if input is "use `SELECT`", mysql client just send "SELECT"
+	// so we add `` around db.
+	_, err = cc.ctx.Execute("use `" + db + "`")
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
1. fix a bug test.desc can't be used as identifier, which is valid in mysql
2. introduce ReservedKeyword in parser.y and clean up

desc is a reserved keyword, before fix

```
mysql> select * from test.desc;
ERROR 1105 (HY000): line 0 column 23 near ""
```

after fix

```
mysql> select * from test.desc;
Empty set (0.00 sec)
```