### PR TITLE
*: Fix TiDBSkipConstraintCheck session scope variable bug

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -312,6 +312,10 @@ func (s *SessionVars) GetSystemVar(key string) types.Datum {
 	if ok {
 		d.SetString(sVal)
 	}
+	// TiDBSkipConstraintCheck is a session scope vars. We do not store it in the global table.
+	if key == TiDBSkipConstraintCheck {
+		d.SetString(SysVars[TiDBSkipConstraintCheck].Value)
+	}
 	return d
 }
 

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -69,6 +69,10 @@ func (*testSessionSuite) TestSession(c *C) {
 
 	c.Assert(v.SetSystemVar("character_set_results", types.Datum{}), IsNil)
 
+	// Test case for get TiDBSkipConstraintCheck session variable
+	d := v.GetSystemVar(variable.TiDBSkipConstraintCheck)
+	c.Assert(d.GetString(), Equals, "0")
+
 	// Test case for tidb_skip_constraint_check
 	c.Assert(v.SkipConstraintCheck, IsFalse)
 	v.SetSystemVar(variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))


### PR DESCRIPTION
TiDBSkipConstraintCheck is not stored in the mysql.global_variable table. We should return default value when the variable is not set.
@coocood @tiancaiamao @zimulala PTAL