### PR TITLE
plan: process wildcard correctly.

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -738,17 +738,15 @@ func (b *planBuilder) resolveGbyExprs(p LogicalPlan, gby *ast.GroupByClause, fie
 }
 
 func (b *planBuilder) unfoldWildStar(p LogicalPlan, selectFields []*ast.SelectField) (resultList []*ast.SelectField) {
-	hasWildCard := false
-	for _, field := range selectFields {
+	for i, field := range selectFields {
 		if field.WildCard == nil {
 			resultList = append(resultList, field)
 			continue
 		}
-		if hasWildCard && field.WildCard.Table.L == "" {
-			b.err = ErrMultiWildCard
+		if field.WildCard.Table.L == "" && i > 0 {
+			b.err = ErrInvalidWildCard
 			return
 		}
-		hasWildCard = true
 		dbName := field.WildCard.Schema
 		tblName := field.WildCard.Table
 		for _, col := range p.GetSchema() {

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -101,7 +101,7 @@ func PrepareStmt(is infoschema.InfoSchema, ctx context.Context, node ast.Node) e
 const (
 	CodeOneColumn           terror.ErrCode = 1
 	CodeSameColumns         terror.ErrCode = 2
-	CodeMultiWildCard       terror.ErrCode = 3
+	CodeInvalidWildCard     terror.ErrCode = 3
 	CodeUnsupported         terror.ErrCode = 4
 	CodeInvalidGroupFuncUse terror.ErrCode = 5
 	CodeIllegalReference    terror.ErrCode = 6
@@ -111,7 +111,7 @@ const (
 var (
 	ErrOneColumn                   = terror.ClassOptimizer.New(CodeOneColumn, "Operand should contain 1 column(s)")
 	ErrSameColumns                 = terror.ClassOptimizer.New(CodeSameColumns, "Operands should contain same columns")
-	ErrMultiWildCard               = terror.ClassOptimizer.New(CodeMultiWildCard, "wildcard fields exist more than once without any table name")
+	ErrInvalidWildCard             = terror.ClassOptimizer.New(CodeInvalidWildCard, "Wildcard fields without any table name appears in wrong place")
 	ErrCartesianProductUnsupported = terror.ClassOptimizer.New(CodeUnsupported, "Cartesian product is unsupported")
 	ErrInvalidGroupFuncUse         = terror.ClassOptimizer.New(CodeInvalidGroupFuncUse, "Invalid use of group function")
 	ErrIllegalReference            = terror.ClassOptimizer.New(CodeIllegalReference, "Illegal reference")
@@ -121,7 +121,7 @@ func init() {
 	mySQLErrCodes := map[terror.ErrCode]uint16{
 		CodeOneColumn:           mysql.ErrOperandColumns,
 		CodeSameColumns:         mysql.ErrOperandColumns,
-		CodeMultiWildCard:       mysql.ErrParse,
+		CodeInvalidWildCard:     mysql.ErrParse,
 		CodeInvalidGroupFuncUse: mysql.ErrInvalidGroupFuncUse,
 		CodeIllegalReference:    mysql.ErrIllegalReference,
 	}

--- a/plan/plan_test.go
+++ b/plan/plan_test.go
@@ -2038,6 +2038,18 @@ func (s *testPlanSuite) TestValidate(c *C) {
 			sql: "select (1,2) < 3",
 			err: ErrSameColumns,
 		},
+		{
+			sql: "select 1, * from t",
+			err: ErrInvalidWildCard,
+		},
+		{
+			sql: "select *, 1 from t",
+			err: nil,
+		},
+		{
+			sql: "select 1, t.* from t",
+			err: nil,
+		},
 	}
 	for _, ca := range cases {
 		sql := ca.sql


### PR DESCRIPTION
In MySQL, wildcard without table name can't appear at any place except the first place in select fields.
e.g:
```
mysql> select 1, * from t ;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '* from t' at line 1

mysql> select *,1 from t ;
+------+---+
| id   | 1 |
+------+---+
|    1 | 1 |
| NULL | 1 |
+------+---+
2 rows in set (0.01 sec)
mysql> select 1, t.* from t ;
+---+------+
| 1 | id   |
+---+------+
| 1 |    1 |
| 1 | NULL |
+---+------+
2 rows in set (0.00 sec)
```

@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL