### PR TITLE
parser: support select t.ReservedKeyword from t;

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -941,11 +941,11 @@ ColumnName:
 	{
 		$$ = &ast.ColumnName{Name: model.NewCIStr($1)}
 	}
-|	Identifier '.' Identifier
+|	Identifier '.' IdentifierOrReservedKeyword
 	{
 		$$ = &ast.ColumnName{Table: model.NewCIStr($1), Name: model.NewCIStr($3)}
 	}
-|	Identifier '.' Identifier '.' Identifier
+|	Identifier '.' Identifier '.' IdentifierOrReservedKeyword
 	{
 		$$ = &ast.ColumnName{Schema: model.NewCIStr($1), Table: model.NewCIStr($3), Name: model.NewCIStr($5)}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -69,6 +69,10 @@ func (s *testParserSuite) TestSimple(c *C) {
 		src = fmt.Sprintf("SELECT * FROM %s.desc", kw)
 		_, err = parser.ParseOneStmt(src, "", "")
 		c.Assert(err, IsNil, Commentf("source %s", src))
+
+		src = fmt.Sprintf("SELECT t.%s FROM t", kw)
+		_, err = parser.ParseOneStmt(src, "", "")
+		c.Assert(err, IsNil, Commentf("source %s", src))
 	}
 
 	// Testcase for unreserved keywords


### PR DESCRIPTION
For example "select t.desc from t;"
We should support "select desc.desc.desc from desc.desc;" in the future.

@coocood @tiancaiamao @hanfei1991 PTAL