### PR TITLE
server: check an array out of range for malform packet

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -185,6 +185,10 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			continue
 		}
 
+		if (i<<1)+1 >= len(paramTypes) {
+			return mysql.ErrMalformPacket
+		}
+
 		tp := paramTypes[i<<1]
 		isUnsigned := (paramTypes[(i<<1)+1] & 0x80) > 0
 


### PR DESCRIPTION
For the error message:

```
2016/11/15 17:57:49 conn.go:319: [0;31m[error] lastCmd              , runtime error: index out of range, goroutine 836 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc820130780)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/conn.go:318 +0xc1
panic(0x1002d60, 0xc82000e090)
	/usr/local/go/src/runtime/panic.go:443 +0x4e9
github.com/pingcap/tidb/server.parseStmtArgs(0xc82078b5b0, 0x1, 0x1, 0xc82061e240, 0x1, 0x1, 0xc82078b5aa, 0x1, 0x6, 0x0, ...)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/conn_stmt.go:188 +0x1580
github.com/pingcap/tidb/server.(*clientConn).handleStmtExecute(0xc820130780, 0xc82078b5a1, 0xf, 0xf, 0x0, 0x0)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/conn_stmt.go:156 +0x898
github.com/pingcap/tidb/server.(*clientConn).dispatch(0xc820130780, 0xc82078b5a1, 0xf, 0xf, 0x0, 0x0)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/conn.go:393 +0xaa5
github.com/pingcap/tidb/server.(*clientConn).Run(0xc820130780)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/conn.go:334 +0x274
github.com/pingcap/tidb/server.(*Server).onConn(0xc8201a4400, 0x7f3b0d40c888, 0xc82017c998)
	/home/jenkins/workspace/WORKFLOW_TIDB_BUILDING/go/src/github.com/pingcap/tidb/server/server.go:206 +0x294
```
