### PR TITLE
store/tikv: fix prewrite return error.

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -223,6 +223,7 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 		if e := <-ch; e != nil {
 			log.Warnf("2PC doActionOnBatches %s failed: %v, tid: %d", action, e, c.startTS)
 			if cancel != nil {
+				// Cancel other requests and return the first error.
 				cancel()
 				return errors.Trace(e)
 			}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -224,6 +224,7 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 			log.Warnf("2PC doActionOnBatches %s failed: %v, tid: %d", action, e, c.startTS)
 			if cancel != nil {
 				cancel()
+				return errors.Trace(e)
 			}
 			err = e
 		}

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"math/rand"
+	"strings"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
@@ -181,4 +182,32 @@ func (s *testCommitterSuite) TestContextCancel(c *C) {
 	cancel() // cancel the context
 	err = committer.prewriteKeys(bo, committer.keys)
 	c.Assert(errors.Cause(err), Equals, context.Canceled)
+}
+
+func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
+	txn1, txn2, txn3 := s.begin(c), s.begin(c), s.begin(c)
+	// txn1 locks "b"
+	err := txn1.Set([]byte("b"), []byte("b1"))
+	c.Assert(err, IsNil)
+	committer, err := newTwoPhaseCommitter(txn1)
+	c.Assert(err, IsNil)
+	err = committer.prewriteKeys(NewBackoffer(prewriteMaxBackoff, context.Background()), committer.keys)
+	c.Assert(err, IsNil)
+	// txn3 writes "c"
+	err = txn3.Set([]byte("c"), []byte("c3"))
+	c.Assert(err, IsNil)
+	err = txn3.Commit()
+	c.Assert(err, IsNil)
+	// txn2 writes "a"(PK), "b", "c" on different regions.
+	// "c" will return a retryable error.
+	// "b" will get a Locked error first, then the context must be canceled after backoff for lock.
+	err = txn2.Set([]byte("a"), []byte("a2"))
+	c.Assert(err, IsNil)
+	err = txn2.Set([]byte("b"), []byte("b2"))
+	c.Assert(err, IsNil)
+	err = txn2.Set([]byte("c"), []byte("c2"))
+	c.Assert(err, IsNil)
+	err = txn2.Commit()
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), txnRetryableMark), IsTrue)
 }


### PR DESCRIPTION
When prewrite multiple regoins and one of them returns error and others are canceled, the final error should be the first error rather than "context is canceled" error.

@tiancaiamao @shenli @zimulala 