### PR TITLE
plan: process in subquery correctly.

### DIFF
--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -142,7 +142,6 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 		// For 10 in ((select * from t)), the parser won't set v.Sel.
 		// So we must process this case here.
 		x := v.List[0]
-	loop:
 		for {
 			switch y := x.(type) {
 			case *ast.SubqueryExpr:
@@ -151,7 +150,7 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			case *ast.ParenthesesExpr:
 				x = y.Expr
 			default:
-				break loop
+				return inNode, false
 			}
 		}
 	case *ast.SubqueryExpr:

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -523,17 +523,17 @@ func (s *testPlanSuite) TestLogicalPlanBuilder(c *C) {
 		{
 			// This will be resolved as in sub query.
 			sql:  "select * from t where 10 in (select b from t s where s.a = t.a)",
-			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
+			best: "Apply{DataScan(t)->DataScan(t)->Selection->Projection}->Selection->Projection",
 		},
 		{
 			// This will be resolved as in sub query.
 			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)))",
-			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
+			best: "Apply{DataScan(t)->DataScan(t)->Selection->Projection}->Selection->Projection",
 		},
 		{
 			// This will be resolved as in function.
 			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)), 10)",
-			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection->MaxOneRow)->Selection->Projection",
+			best: "Apply{DataScan(t)->DataScan(t)->Selection->Projection->MaxOneRow}->Selection->Projection",
 		},
 	}
 	for _, ca := range cases {

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -521,17 +521,17 @@ func (s *testPlanSuite) TestLogicalPlanBuilder(c *C) {
 		best string
 	}{
 		{
-			// treated as in sub query.
+			// This will be resolved as in sub query.
 			sql:  "select * from t where 10 in (select b from t s where s.a = t.a)",
 			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
 		},
 		{
-			// treated as in sub query.
+			// This will be resolved as in sub query.
 			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)))",
 			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
 		},
 		{
-			// treated as in function.
+			// This will be resolved as in function.
 			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)), 10)",
 			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection->MaxOneRow)->Selection->Projection",
 		},

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -326,81 +326,6 @@ func mockContext() context.Context {
 	return ctx
 }
 
-func (s *testPlanSuite) TestPushDownAggregation(c *C) {
-	defer testleak.AfterTest(c)()
-	cases := []struct {
-		sql       string
-		best      string
-		aggFuns   string
-		aggFields string
-		gbyItems  string
-	}{
-		{
-			sql:       "select count(*) from t",
-			best:      "Table(t)->HashAgg->Projection",
-			aggFuns:   "[count(1)]",
-			aggFields: "[blob bigint(21)]",
-			gbyItems:  "[]",
-		},
-		{
-			sql:       "select sum(b) from t group by c",
-			best:      "Table(t)->HashAgg->Projection",
-			aggFuns:   "[sum(test.t.b)]",
-			aggFields: "[blob decimal]",
-			gbyItems:  "[test.t.c]",
-		},
-		{
-			sql:       "select max(b + c), min(case when b then 1 else 2 end) from t group by d + e, a",
-			best:      "Table(t)->HashAgg->Projection",
-			aggFuns:   "[max(plus(test.t.b, test.t.c)) min(case(test.t.b, 1, 2))]",
-			aggFields: "[blob bigint bigint]",
-			gbyItems:  "[plus(test.t.d, test.t.e) test.t.a]",
-		},
-	}
-	for _, ca := range cases {
-		comment := Commentf("for %s", ca.sql)
-		stmt, err := s.ParseOneStmt(ca.sql, "", "")
-		c.Assert(err, IsNil, comment)
-		ast.SetFlag(stmt)
-
-		err = mockResolve(stmt)
-		c.Assert(err, IsNil)
-		builder := &planBuilder{
-			allocator: new(idAllocator),
-			ctx:       mockContext(),
-			colMapper: make(map[*ast.ColumnNameExpr]int),
-		}
-		p := builder.build(stmt)
-		c.Assert(builder.err, IsNil)
-		lp := p.(LogicalPlan)
-
-		_, lp, err = lp.PredicatePushDown(nil)
-		c.Assert(err, IsNil)
-		lp.PruneColumns(lp.GetSchema())
-		lp.ResolveIndicesAndCorCols()
-		info, err := lp.convert2PhysicalPlan(&requiredProperty{})
-		c.Assert(err, IsNil)
-		c.Assert(ToString(info.p), Equals, ca.best, Commentf("for %s", ca.sql))
-		p = info.p
-		for {
-			var ts *physicalTableSource
-			switch x := p.(type) {
-			case *PhysicalTableScan:
-				ts = &x.physicalTableSource
-			case *PhysicalIndexScan:
-				ts = &x.physicalTableSource
-			}
-			if ts != nil {
-				c.Assert(fmt.Sprintf("%s", ts.aggFuncs), Equals, ca.aggFuns, Commentf("for %s", ca.sql))
-				c.Assert(fmt.Sprintf("%s", ts.gbyItems), Equals, ca.gbyItems, Commentf("for %s", ca.sql))
-				c.Assert(fmt.Sprintf("%s", ts.AggFields), Equals, ca.aggFields, Commentf("for %s", ca.sql))
-				break
-			}
-			p = p.GetChildByIndex(0)
-		}
-	}
-}
-
 func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 	defer testleak.AfterTest(c)()
 	cases := []struct {
@@ -589,6 +514,47 @@ func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 	}
 }
 
+func (s *testPlanSuite) TestLogicalPlanBuilder(c *C) {
+	defer testleak.AfterTest(c)()
+	cases := []struct {
+		sql  string
+		best string
+	}{
+		{
+			// treated as in sub query.
+			sql:  "select * from t where 10 in (select b from t s where s.a = t.a)",
+			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
+		},
+		{
+			// treated as in sub query.
+			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)))",
+			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection)->Selection->Projection",
+		},
+		{
+			// treated as in function.
+			sql:  "select * from t where 10 in (((select b from t s where s.a = t.a)), 10)",
+			best: "DataScan(t)->Apply(DataScan(t)->Selection->Projection->MaxOneRow)->Selection->Projection",
+		},
+	}
+	for _, ca := range cases {
+		comment := Commentf("for %s", ca.sql)
+		stmt, err := s.ParseOneStmt(ca.sql, "", "")
+		c.Assert(err, IsNil, comment)
+
+		err = mockResolve(stmt)
+		c.Assert(err, IsNil)
+
+		builder := &planBuilder{
+			allocator: new(idAllocator),
+			ctx:       mock.NewContext(),
+			colMapper: make(map[*ast.ColumnNameExpr]int),
+		}
+		p := builder.build(stmt)
+		c.Assert(builder.err, IsNil)
+		c.Assert(ToString(p.(LogicalPlan)), Equals, ca.best, Commentf("for %s", ca.sql))
+	}
+}
+
 func (s *testPlanSuite) TestJoinReOrder(c *C) {
 	defer testleak.AfterTest(c)()
 	cases := []struct {
@@ -648,7 +614,7 @@ func (s *testPlanSuite) TestJoinReOrder(c *C) {
 	}
 }
 
-func (s *testPlanSuite) TestLogicalPlan(c *C) {
+func (s *testPlanSuite) TestAggPushDown(c *C) {
 	defer testleak.AfterTest(c)()
 	cases := []struct {
 		sql  string

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -25,6 +25,81 @@ import (
 	"github.com/pingcap/tidb/util/testleak"
 )
 
+func (s *testPlanSuite) TestPushDownAggregation(c *C) {
+	defer testleak.AfterTest(c)()
+	cases := []struct {
+		sql       string
+		best      string
+		aggFuns   string
+		aggFields string
+		gbyItems  string
+	}{
+		{
+			sql:       "select count(*) from t",
+			best:      "Table(t)->HashAgg->Projection",
+			aggFuns:   "[count(1)]",
+			aggFields: "[blob bigint(21)]",
+			gbyItems:  "[]",
+		},
+		{
+			sql:       "select sum(b) from t group by c",
+			best:      "Table(t)->HashAgg->Projection",
+			aggFuns:   "[sum(test.t.b)]",
+			aggFields: "[blob decimal]",
+			gbyItems:  "[test.t.c]",
+		},
+		{
+			sql:       "select max(b + c), min(case when b then 1 else 2 end) from t group by d + e, a",
+			best:      "Table(t)->HashAgg->Projection",
+			aggFuns:   "[max(plus(test.t.b, test.t.c)) min(case(test.t.b, 1, 2))]",
+			aggFields: "[blob bigint bigint]",
+			gbyItems:  "[plus(test.t.d, test.t.e) test.t.a]",
+		},
+	}
+	for _, ca := range cases {
+		comment := Commentf("for %s", ca.sql)
+		stmt, err := s.ParseOneStmt(ca.sql, "", "")
+		c.Assert(err, IsNil, comment)
+		ast.SetFlag(stmt)
+
+		err = mockResolve(stmt)
+		c.Assert(err, IsNil)
+		builder := &planBuilder{
+			allocator: new(idAllocator),
+			ctx:       mockContext(),
+			colMapper: make(map[*ast.ColumnNameExpr]int),
+		}
+		p := builder.build(stmt)
+		c.Assert(builder.err, IsNil)
+		lp := p.(LogicalPlan)
+
+		_, lp, err = lp.PredicatePushDown(nil)
+		c.Assert(err, IsNil)
+		lp.PruneColumns(lp.GetSchema())
+		lp.ResolveIndicesAndCorCols()
+		info, err := lp.convert2PhysicalPlan(&requiredProperty{})
+		c.Assert(err, IsNil)
+		c.Assert(ToString(info.p), Equals, ca.best, Commentf("for %s", ca.sql))
+		p = info.p
+		for {
+			var ts *physicalTableSource
+			switch x := p.(type) {
+			case *PhysicalTableScan:
+				ts = &x.physicalTableSource
+			case *PhysicalIndexScan:
+				ts = &x.physicalTableSource
+			}
+			if ts != nil {
+				c.Assert(fmt.Sprintf("%s", ts.aggFuncs), Equals, ca.aggFuns, Commentf("for %s", ca.sql))
+				c.Assert(fmt.Sprintf("%s", ts.gbyItems), Equals, ca.gbyItems, Commentf("for %s", ca.sql))
+				c.Assert(fmt.Sprintf("%s", ts.AggFields), Equals, ca.aggFields, Commentf("for %s", ca.sql))
+				break
+			}
+			p = p.GetChildByIndex(0)
+		}
+	}
+}
+
 func (s *testPlanSuite) TestPushDownOrderbyAndLimit(c *C) {
 	defer testleak.AfterTest(c)()
 	cases := []struct {


### PR DESCRIPTION
fix #2007
For case "10 in ((select * from t))", the planner will treat in as function and select * from t as scalar function.
After fixing it, it will be treated as in sub query.
@shenli @coocood @winoros @XuHuaiyu @zimulala @tiancaiamao PTAL