### PR TITLE
varsutil: remove dependency on 'types' for 'variable' package

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -620,7 +621,7 @@ func (e *Evaluator) variable(v *ast.VariableExpr) bool {
 	}
 
 	if !v.IsGlobal {
-		d := sessionVars.GetSystemVar(name)
+		d := varsutil.GetSystemVar(sessionVars, name)
 		if d.IsNull() {
 			if sysVar.Scope&variable.ScopeGlobal == 0 {
 				d.SetString(sysVar.Value)
@@ -632,7 +633,7 @@ func (e *Evaluator) variable(v *ast.VariableExpr) bool {
 					return false
 				}
 				d.SetString(globalVal)
-				err = sessionVars.SetSystemVar(name, d)
+				err = varsutil.SetSystemVar(sessionVars, name, d)
 				if err != nil {
 					e.err = errors.Trace(err)
 					return false

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/opcode"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -950,7 +951,7 @@ func (s *testEvaluatorSuite) TestGetTimeValue(c *C) {
 
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
-	sessionVars.SetSystemVar("timestamp", types.NewStringDatum(""))
+	varsutil.SetSystemVar(sessionVars, "timestamp", types.NewStringDatum(""))
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -958,7 +959,7 @@ func (s *testEvaluatorSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	sessionVars.SetSystemVar("timestamp", types.NewStringDatum("0"))
+	varsutil.SetSystemVar(sessionVars, "timestamp", types.NewStringDatum("0"))
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -966,7 +967,7 @@ func (s *testEvaluatorSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	sessionVars.SetSystemVar("timestamp", types.Datum{})
+	varsutil.SetSystemVar(sessionVars, "timestamp", types.Datum{})
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -974,7 +975,7 @@ func (s *testEvaluatorSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	sessionVars.SetSystemVar("timestamp", types.NewStringDatum("1234"))
+	varsutil.SetSystemVar(sessionVars, "timestamp", types.NewStringDatum("1234"))
 
 	tbl := []struct {
 		Expr interface{}

--- a/evaluator/helper.go
+++ b/evaluator/helper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -117,7 +118,7 @@ func getSystemTimestamp(ctx context.Context) (time.Time, error) {
 
 	// check whether use timestamp varibale
 	sessionVars := ctx.GetSessionVars()
-	ts := sessionVars.GetSystemVar("timestamp")
+	ts := varsutil.GetSystemVar(sessionVars, "timestamp")
 	if !ts.IsNull() && ts.GetString() != "" {
 		timestamp, err := ts.ToInt64()
 		if err != nil {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -217,8 +217,17 @@ func (b *executorBuilder) buildSimple(v *plan.Simple) Executor {
 	switch s := v.Statement.(type) {
 	case *ast.GrantStmt:
 		return b.buildGrant(s)
+	case *ast.SetStmt:
+		return b.buildSet(s)
 	}
 	return &SimpleExec{Statement: v.Statement, ctx: b.ctx}
+}
+
+func (b *executorBuilder) buildSet(v *ast.SetStmt) Executor {
+	return &SetExecutor{
+		ctx:  b.ctx,
+		stmt: v,
+	}
 }
 
 func (b *executorBuilder) buildInsert(v *plan.Insert) Executor {

--- a/executor/executor_ddl.go
+++ b/executor/executor_ddl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -139,11 +140,11 @@ func (e *DDLExec) executeDropDatabase(s *ast.DropDatabaseStmt) error {
 	sessionVars := e.ctx.GetSessionVars()
 	if err == nil && strings.ToLower(sessionVars.CurrentDB) == dbName.L {
 		sessionVars.CurrentDB = ""
-		err = sessionVars.SetSystemVar(variable.CharsetDatabase, types.NewStringDatum("utf8"))
+		err = varsutil.SetSystemVar(sessionVars, variable.CharsetDatabase, types.NewStringDatum("utf8"))
 		if err != nil {
 			return errors.Trace(err)
 		}
-		err = sessionVars.SetSystemVar(variable.CollationDatabase, types.NewStringDatum("utf8_unicode_ci"))
+		err = varsutil.SetSystemVar(sessionVars, variable.CollationDatabase, types.NewStringDatum("utf8_unicode_ci"))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/executor/executor_set.go
+++ b/executor/executor_set.go
@@ -1,0 +1,202 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/evaluator"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/util/charset"
+	"github.com/pingcap/tidb/util/types"
+)
+
+// SetExecutor executes set statement.
+type SetExecutor struct {
+	stmt *ast.SetStmt
+	ctx  context.Context
+	done bool
+}
+
+// Next implements the Executor Next interface.
+func (e *SetExecutor) Next() (*Row, error) {
+	if e.done {
+		return nil, nil
+	}
+	err := e.executeSet()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	e.done = true
+	return nil, nil
+}
+
+func (e *SetExecutor) executeSet() error {
+	sessionVars := e.ctx.GetSessionVars()
+	for _, v := range e.stmt.Variables {
+		// Variable is case insensitive, we use lower case.
+		if v.Name == ast.SetNames {
+			// This is set charset stmt.
+			cs := v.Value.GetValue().(string)
+			var co string
+			if v.ExtendValue != nil {
+				co = v.ExtendValue.GetValue().(string)
+			}
+			err := e.setCharset(cs, co)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			continue
+		}
+		name := strings.ToLower(v.Name)
+		if !v.IsSystem {
+			// Set user variable.
+			value, err := evaluator.Eval(e.ctx, v.Value)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			if value.IsNull() {
+				delete(sessionVars.Users, name)
+			} else {
+				svalue, err1 := value.ToString()
+				if err1 != nil {
+					return errors.Trace(err1)
+				}
+				sessionVars.Users[name] = fmt.Sprintf("%v", svalue)
+			}
+			continue
+		}
+
+		// Set system variable
+		sysVar := variable.GetSysVar(name)
+		if sysVar == nil {
+			return variable.UnknownSystemVar.Gen("Unknown system variable '%s'", name)
+		}
+		if sysVar.Scope == variable.ScopeNone {
+			return errors.Errorf("Variable '%s' is a read only variable", name)
+		}
+		if v.IsGlobal {
+			// Set global scope system variable.
+			if sysVar.Scope&variable.ScopeGlobal == 0 {
+				return errors.Errorf("Variable '%s' is a SESSION variable and can't be used with SET GLOBAL", name)
+			}
+			value, err := e.getVarValue(v, sysVar)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if value.IsNull() {
+				value.SetString("")
+			}
+			svalue, err := value.ToString()
+			if err != nil {
+				return errors.Trace(err)
+			}
+			err = sessionVars.GlobalVarsAccessor.SetGlobalSysVar(name, svalue)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		} else {
+			// Set session scope system variable.
+			if sysVar.Scope&variable.ScopeSession == 0 {
+				return errors.Errorf("Variable '%s' is a GLOBAL variable and should be set with SET GLOBAL", name)
+			}
+			value, err := e.getVarValue(v, nil)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			err = varsutil.SetSystemVar(sessionVars, name, value)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			e.loadSnapshotInfoSchemaIfNeeded(name)
+			log.Infof("[%d] set system variable %s = %s", sessionVars.ConnectionID, name, value.GetString())
+		}
+	}
+	return nil
+}
+
+// Schema implements the Executor Schema interface.
+func (e *SetExecutor) Schema() expression.Schema {
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *SetExecutor) Close() error {
+	return nil
+}
+
+func (e *SetExecutor) setCharset(cs, co string) error {
+	var err error
+	if len(co) == 0 {
+		co, err = charset.GetDefaultCollation(cs)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	sessionVars := e.ctx.GetSessionVars()
+	for _, v := range variable.SetNamesVariables {
+		sessionVars.Systems[v] = cs
+	}
+	sessionVars.Systems[variable.CollationConnection] = co
+	return nil
+}
+
+func (e *SetExecutor) getVarValue(v *ast.VariableAssignment, sysVar *variable.SysVar) (value types.Datum, err error) {
+	switch v.Value.(type) {
+	case *ast.DefaultExpr:
+		// To set a SESSION variable to the GLOBAL value or a GLOBAL value
+		// to the compiled-in MySQL default value, use the DEFAULT keyword.
+		// See http://dev.mysql.com/doc/refman/5.7/en/set-statement.html
+		if sysVar != nil {
+			value = types.NewStringDatum(sysVar.Value)
+		} else {
+			s, err1 := e.ctx.GetSessionVars().GlobalVarsAccessor.GetGlobalSysVar(strings.ToLower(v.Name))
+			if err1 != nil {
+				return value, errors.Trace(err1)
+			}
+			value = types.NewStringDatum(s)
+		}
+	default:
+		value, err = evaluator.Eval(e.ctx, v.Value)
+	}
+	return value, errors.Trace(err)
+}
+
+func (e *SetExecutor) loadSnapshotInfoSchemaIfNeeded(name string) error {
+	if name != variable.TiDBSnapshot {
+		return nil
+	}
+	vars := e.ctx.GetSessionVars()
+	if vars.SnapshotTS == 0 {
+		vars.SnapshotInfoschema = nil
+		return nil
+	}
+	log.Infof("[%d] loadSnapshotInfoSchema, SnapshotTS:%d", vars.ConnectionID, vars.SnapshotTS)
+	dom := sessionctx.GetDomain(e.ctx)
+	snapInfo, err := dom.GetSnapshotInfoSchema(vars.SnapshotTS)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	vars.SnapshotInfoschema = snapInfo
+	return nil
+}

--- a/executor/executor_set_test.go
+++ b/executor/executor_set_test.go
@@ -1,0 +1,148 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+func (s *testSuite) TestSetVar(c *C) {
+	defer testleak.AfterTest(c)()
+	tk := testkit.NewTestKit(c, s.store)
+	testSQL := "SET @a = 1;"
+	tk.MustExec(testSQL)
+
+	testSQL = `SET @a = "1";`
+	tk.MustExec(testSQL)
+
+	testSQL = "SET @a = null;"
+	tk.MustExec(testSQL)
+
+	testSQL = "SET @@global.autocommit = 1;"
+	tk.MustExec(testSQL)
+
+	// TODO: this test case should returns error.
+	// testSQL = "SET @@global.autocommit = null;"
+	// _, err := tk.Exec(testSQL)
+	// c.Assert(err, NotNil)
+
+	testSQL = "SET @@autocommit = 1;"
+	tk.MustExec(testSQL)
+
+	testSQL = "SET @@autocommit = null;"
+	_, err := tk.Exec(testSQL)
+	c.Assert(err, NotNil)
+
+	errTestSql := "SET @@date_format = 1;"
+	_, err = tk.Exec(errTestSql)
+	c.Assert(err, NotNil)
+
+	errTestSql = "SET @@rewriter_enabled = 1;"
+	_, err = tk.Exec(errTestSql)
+	c.Assert(err, NotNil)
+
+	errTestSql = "SET xxx = abcd;"
+	_, err = tk.Exec(errTestSql)
+	c.Assert(err, NotNil)
+
+	errTestSql = "SET @@global.a = 1;"
+	_, err = tk.Exec(errTestSql)
+	c.Assert(err, NotNil)
+
+	errTestSql = "SET @@global.timestamp = 1;"
+	_, err = tk.Exec(errTestSql)
+	c.Assert(err, NotNil)
+
+	// For issue 998
+	testSQL = "SET @issue998a=1, @issue998b=5;"
+	tk.MustExec(testSQL)
+	tk.MustQuery(`select @issue998a, @issue998b;`).Check(testkit.Rows("1 5"))
+	testSQL = "SET @@autocommit=0, @issue998a=2;"
+	tk.MustExec(testSQL)
+	tk.MustQuery(`select @issue998a, @@autocommit;`).Check(testkit.Rows("2 0"))
+	testSQL = "SET @@global.autocommit=1, @issue998b=6;"
+	tk.MustExec(testSQL)
+	tk.MustQuery(`select @issue998b, @@global.autocommit;`).Check(testkit.Rows("6 1"))
+
+	// Set default
+	// {ScopeGlobal | ScopeSession, "low_priority_updates", "OFF"},
+	// For global var
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	tk.MustExec(`set @@global.low_priority_updates="ON";`)
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("ON"))
+	tk.MustExec(`set @@global.low_priority_updates=DEFAULT;`) // It will be set to compiled-in default value.
+	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	// For session
+	tk.MustQuery(`select @@session.low_priority_updates;`).Check(testkit.Rows("OFF"))
+	tk.MustExec(`set @@global.low_priority_updates="ON";`)
+	tk.MustExec(`set @@session.low_priority_updates=DEFAULT;`) // It will be set to global var value.
+	tk.MustQuery(`select @@session.low_priority_updates;`).Check(testkit.Rows("ON"))
+
+	// For mysql jdbc driver issue.
+	tk.MustQuery(`select @@session.tx_read_only;`).Check(testkit.Rows("0"))
+
+	// Test session variable states.
+	vars := tk.Se.(context.Context).GetSessionVars()
+	tk.Se.CommitTxn()
+	tk.MustExec("set @@autocommit = 1")
+	c.Assert(vars.ShouldAutocommit(), IsTrue)
+	tk.MustExec("set @@autocommit = 0")
+	c.Assert(vars.ShouldAutocommit(), IsFalse)
+
+	tk.MustExec("set @@sql_mode = 'strict_trans_tables'")
+	c.Assert(vars.StrictSQLMode, IsTrue)
+	tk.MustExec("set @@sql_mode = ''")
+	c.Assert(vars.StrictSQLMode, IsFalse)
+
+	tk.MustExec("set names utf8")
+	charset, collation := vars.GetCharsetInfo()
+	c.Assert(charset, Equals, "utf8")
+	c.Assert(collation, Equals, "utf8_general_ci")
+
+	tk.MustExec("set @@character_set_results = NULL")
+
+	c.Assert(vars.SkipConstraintCheck, IsFalse)
+	tk.MustExec("set @@tidb_skip_constraint_check = '1'")
+	c.Assert(vars.SkipConstraintCheck, IsTrue)
+	tk.MustExec("set @@tidb_skip_constraint_check = '0'")
+	c.Assert(vars.SkipConstraintCheck, IsFalse)
+}
+
+func (s *testSuite) TestSetCharset(c *C) {
+	defer testleak.AfterTest(c)()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`SET NAMES latin1`)
+
+	ctx := tk.Se.(context.Context)
+	sessionVars := ctx.GetSessionVars()
+	for _, v := range variable.SetNamesVariables {
+		sVar := varsutil.GetSystemVar(sessionVars, v)
+		c.Assert(sVar.GetString() != "utf8", IsTrue)
+	}
+	tk.MustExec(`SET NAMES utf8`)
+	for _, v := range variable.SetNamesVariables {
+		sVar := varsutil.GetSystemVar(sessionVars, v)
+		c.Assert(sVar.GetString(), Equals, "utf8")
+	}
+	sVar := varsutil.GetSystemVar(sessionVars, variable.CollationConnection)
+	c.Assert(sVar.GetString(), Equals, "utf8_general_ci")
+
+	// Issue 1523
+	tk.MustExec(`SET NAMES binary`)
+}

--- a/executor/show.go
+++ b/executor/show.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/types"
@@ -308,14 +309,14 @@ func (e *ShowExec) fetchShowVariables() error {
 		var value string
 		if !e.GlobalScope {
 			// Try to get Session Scope variable value first.
-			sv := sessionVars.GetSystemVar(v.Name)
+			sv := varsutil.GetSystemVar(sessionVars, v.Name)
 			if sv.IsNull() {
 				value, err = globalVars.GetGlobalSysVar(v.Name)
 				if err != nil {
 					return errors.Trace(err)
 				}
 				sv.SetString(value)
-				err = sessionVars.SetSystemVar(v.Name, sv)
+				err = varsutil.SetSystemVar(sessionVars, v.Name, sv)
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -468,7 +469,7 @@ func (er *expressionRewriter) rewriteVariable(v *ast.VariableExpr) {
 		er.ctxStack = append(er.ctxStack, datumToConstant(types.NewDatum(value), mysql.TypeString))
 		return
 	}
-	d := sessionVars.GetSystemVar(name)
+	d := varsutil.GetSystemVar(sessionVars, name)
 	if d.IsNull() {
 		if sysVar.Scope&variable.ScopeGlobal == 0 {
 			d.SetString(sysVar.Value)
@@ -480,7 +481,7 @@ func (er *expressionRewriter) rewriteVariable(v *ast.VariableExpr) {
 				return
 			}
 			d.SetString(globalVal)
-			err = sessionVars.SetSystemVar(name, d)
+			err = varsutil.SetSystemVar(sessionVars, name, d)
 			if err != nil {
 				er.err = errors.Trace(err)
 				return

--- a/session.go
+++ b/session.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/forupdate"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
@@ -674,7 +675,7 @@ func (s *session) Auth(user string, auth []byte, salt []byte) bool {
 	if !bytes.Equal(auth, checkAuth) {
 		return false
 	}
-	s.sessionVars.SetCurrentUser(user)
+	s.sessionVars.User = user
 	return true
 }
 
@@ -823,8 +824,8 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 			break
 		}
 		varName := row.Data[0].GetString()
-		if d := vars.GetSystemVar(varName); d.IsNull() {
-			vars.SetSystemVar(varName, row.Data[1])
+		if d := varsutil.GetSystemVar(vars, varName); d.IsNull() {
+			varsutil.SetSystemVar(s.sessionVars, varName, row.Data[1])
 		}
 	}
 	vars.CommonGlobalLoaded = true

--- a/session_test.go
+++ b/session_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testleak"
@@ -2379,7 +2380,7 @@ func (s *testSessionSuite) TestRetryAttempts(c *C) {
 	c.Assert(se, NotNil)
 	sv := se.sessionVars
 	// Prevent getting variable value from storage.
-	sv.SetSystemVar("autocommit", types.NewDatum("ON"))
+	varsutil.SetSystemVar(se.sessionVars, "autocommit", types.NewDatum("ON"))
 	sv.CommonGlobalLoaded = true
 
 	// Add retry info.

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -15,9 +15,7 @@ package variable_test
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/types"
 )
 
 var _ = Suite(&testSessionSuite{})
@@ -46,42 +44,4 @@ func (*testSessionSuite) TestSession(c *C) {
 	// For last insert id
 	v.SetLastInsertID(uint64(1))
 	c.Assert(v.LastInsertID, Equals, uint64(1))
-
-	v.SetSystemVar("autocommit", types.NewStringDatum("1"))
-	val := v.GetSystemVar("autocommit")
-	c.Assert(val.GetString(), Equals, "1")
-	c.Assert(v.SetSystemVar("autocommit", types.Datum{}), NotNil)
-
-	v.SetSystemVar("sql_mode", types.NewStringDatum("strict_trans_tables"))
-	val = v.GetSystemVar("sql_mode")
-	c.Assert(val.GetString(), Equals, "STRICT_TRANS_TABLES")
-	c.Assert(v.StrictSQLMode, IsTrue)
-	v.SetSystemVar("sql_mode", types.NewStringDatum(""))
-	c.Assert(v.StrictSQLMode, IsFalse)
-
-	v.SetSystemVar("character_set_connection", types.NewStringDatum("utf8"))
-	v.SetSystemVar("collation_connection", types.NewStringDatum("utf8_general_ci"))
-	charset, collation := v.GetCharsetInfo()
-	c.Assert(charset, Equals, "utf8")
-	c.Assert(collation, Equals, "utf8_general_ci")
-
-	c.Assert(v.SetSystemVar("character_set_results", types.Datum{}), IsNil)
-
-	// Test case for get TiDBSkipConstraintCheck session variable
-	d := v.GetSystemVar(variable.TiDBSkipConstraintCheck)
-	c.Assert(d.GetString(), Equals, "0")
-
-	// Test case for tidb_skip_constraint_check
-	c.Assert(v.SkipConstraintCheck, IsFalse)
-	v.SetSystemVar(variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
-	c.Assert(v.SkipConstraintCheck, IsFalse)
-	v.SetSystemVar(variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
-	c.Assert(v.SkipConstraintCheck, IsTrue)
-	v.SetSystemVar(variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
-	c.Assert(v.SkipConstraintCheck, IsFalse)
-
-	// Test case for change TiDBSkipConstraintCheck session variable.
-	v.SetSystemVar(variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
-	d = v.GetSystemVar(variable.TiDBSkipConstraintCheck)
-	c.Assert(d.GetString(), Equals, "1")
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -364,7 +364,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "binlog_direct_non_transactional_updates", "OFF"},
 	{ScopeGlobal, "innodb_change_buffering", "all"},
 	{ScopeGlobal | ScopeSession, "sql_big_selects", "ON"},
-	{ScopeGlobal | ScopeSession, characterSetResults, "latin1"},
+	{ScopeGlobal | ScopeSession, CharacterSetResults, "latin1"},
 	{ScopeGlobal, "innodb_max_purge_lag_delay", "0"},
 	{ScopeGlobal | ScopeSession, "session_track_schema", ""},
 	{ScopeGlobal, "innodb_io_capacity_max", "2000"},

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -1,0 +1,94 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package varsutil
+
+import (
+	"strings"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/types"
+)
+
+// GetSystemVar gets a system variable.
+func GetSystemVar(s *variable.SessionVars, key string) types.Datum {
+	var d types.Datum
+	key = strings.ToLower(key)
+	sVal, ok := s.Systems[key]
+	if ok {
+		d.SetString(sVal)
+	} else {
+		// TiDBSkipConstraintCheck is a session scope vars. We do not store it in the global table.
+		if key == variable.TiDBSkipConstraintCheck {
+			d.SetString(variable.SysVars[variable.TiDBSkipConstraintCheck].Value)
+		}
+	}
+	return d
+}
+
+// epochShiftBits is used to reserve logical part of the timestamp.
+const epochShiftBits = 18
+
+// SetSystemVar sets system variable and updates SessionVars states.
+func SetSystemVar(vars *variable.SessionVars, name string, value types.Datum) error {
+	name = strings.ToLower(name)
+	if value.IsNull() {
+		if name != variable.CharacterSetResults {
+			return variable.ErrCantSetToNull
+		}
+		delete(vars.Systems, name)
+		return nil
+	}
+	sVal, err := value.ToString()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	switch name {
+	case variable.SQLModeVar:
+		sVal = strings.ToUpper(sVal)
+		if strings.Contains(sVal, "STRICT_TRANS_TABLES") || strings.Contains(sVal, "STRICT_ALL_TABLES") {
+			vars.StrictSQLMode = true
+		} else {
+			vars.StrictSQLMode = false
+		}
+	case variable.TiDBSnapshot:
+		err = setSnapshotTS(vars, sVal)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	case variable.AutocommitVar:
+		isAutocommit := strings.EqualFold(sVal, "ON") || sVal == "1"
+		vars.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
+	case variable.TiDBSkipConstraintCheck:
+		vars.SkipConstraintCheck = (sVal == "1")
+	}
+	vars.Systems[name] = sVal
+	return nil
+}
+
+func setSnapshotTS(s *variable.SessionVars, sVal string) error {
+	if sVal == "" {
+		s.SnapshotTS = 0
+		return nil
+	}
+	t, err := types.ParseTime(sVal, mysql.TypeTimestamp, types.MaxFsp)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	ts := (t.UnixNano() / int64(time.Millisecond)) << epochShiftBits
+	s.SnapshotTS = uint64(ts)
+	return nil
+}

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -30,7 +30,7 @@ var _ = Suite(&testVarsutilSuite{})
 type testVarsutilSuite struct {
 }
 
-func (s *testVarsutilSuite) TestDomain(c *C) {
+func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	defer testleak.AfterTest(c)()
 	v := variable.NewSessionVars()
 

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package varsutil
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/types"
+	"testing"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testVarsutilSuite{})
+
+type testVarsutilSuite struct {
+}
+
+func (s *testVarsutilSuite) TestDomain(c *C) {
+	defer testleak.AfterTest(c)()
+	v := variable.NewSessionVars()
+
+	SetSystemVar(v, "autocommit", types.NewStringDatum("1"))
+	val := GetSystemVar(v, "autocommit")
+	c.Assert(val.GetString(), Equals, "1")
+	c.Assert(SetSystemVar(v, "autocommit", types.Datum{}), NotNil)
+
+	SetSystemVar(v, "sql_mode", types.NewStringDatum("strict_trans_tables"))
+	val = GetSystemVar(v, "sql_mode")
+	c.Assert(val.GetString(), Equals, "STRICT_TRANS_TABLES")
+	c.Assert(v.StrictSQLMode, IsTrue)
+	SetSystemVar(v, "sql_mode", types.NewStringDatum(""))
+	c.Assert(v.StrictSQLMode, IsFalse)
+
+	SetSystemVar(v, "character_set_connection", types.NewStringDatum("utf8"))
+	SetSystemVar(v, "collation_connection", types.NewStringDatum("utf8_general_ci"))
+	charset, collation := v.GetCharsetInfo()
+	c.Assert(charset, Equals, "utf8")
+	c.Assert(collation, Equals, "utf8_general_ci")
+
+	c.Assert(SetSystemVar(v, "character_set_results", types.Datum{}), IsNil)
+
+	// Test case for get TiDBSkipConstraintCheck session variable
+	d := GetSystemVar(v, variable.TiDBSkipConstraintCheck)
+	c.Assert(d.GetString(), Equals, "0")
+
+	// Test case for tidb_skip_constraint_check
+	c.Assert(v.SkipConstraintCheck, IsFalse)
+	SetSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
+	c.Assert(v.SkipConstraintCheck, IsFalse)
+	SetSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
+	c.Assert(v.SkipConstraintCheck, IsTrue)
+	SetSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
+	c.Assert(v.SkipConstraintCheck, IsFalse)
+
+	// Test case for change TiDBSkipConstraintCheck session variable.
+	SetSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
+	d = GetSystemVar(v, variable.TiDBSkipConstraintCheck)
+	c.Assert(d.GetString(), Equals, "1")
+}

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -14,11 +14,12 @@
 package varsutil
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
-	"testing"
 )
 
 func TestT(t *testing.T) {


### PR DESCRIPTION
'variable' package will be used in 'types', remove dependency on 'types' by
moving functions to a new 'varsutil' package.

Also extract 'SetExec' from 'SimpleExec'