### PR TITLE
executor: fix a bug when join exists in subquery.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -463,7 +463,7 @@ type HashJoinExec struct {
 	// For sync multiple join workers.
 	wg sync.WaitGroup
 	// closeMu add a lock for closing executor.
-	closeLock chan bool
+	closeLock chan struct{}
 
 	// Concurrent channels.
 	concurrency      int
@@ -488,9 +488,7 @@ type hashJoinCtx struct {
 // Close implements the Executor Close interface.
 func (e *HashJoinExec) Close() error {
 	e.finished.Store(true)
-	select {
-	case _ = <-e.closeLock:
-	}
+	<-e.closeLock
 	e.prepared = false
 	e.cursor = 0
 	return e.smallExec.Close()
@@ -588,7 +586,7 @@ func (e *HashJoinExec) fetchBigExec() {
 // prepare runs the first time when 'Next' is called, it starts one worker goroutine to fetch rows from the big table,
 // and reads all data from the small table to build a hash table, then starts multiple join worker goroutines.
 func (e *HashJoinExec) prepare() error {
-	e.closeLock = make(chan bool, 1)
+	e.closeLock = make(chan struct{}, 1)
 	e.finished.Store(false)
 	e.bigTableRows = make([]chan []*Row, e.concurrency)
 	e.wg = sync.WaitGroup{}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -666,7 +666,6 @@ func (s *testSuite) TestJoin(c *C) {
 	_, err = tk.Exec("select * from t right join t1 on 1")
 	c.Check(plan.ErrCartesianProductUnsupported.Equal(err), IsTrue)
 	plan.AllowCartesianProduct = true
-
 }
 
 func (s *testSuite) TestMultiJoin(c *C) {
@@ -899,6 +898,14 @@ func (s *testSuite) TestInSubquery(c *C) {
 	tk.MustExec("create table t1 (a float)")
 	tk.MustExec("insert t1 values (281.37)")
 	tk.MustQuery("select a from t1 where (a in (select a from t1))").Check(testkit.Rows("281.37"))
+
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1 (a int, b int)")
+	tk.MustExec("insert into t1 values (0,0),(1,1),(2,2),(3,3),(4,4)")
+	tk.MustExec("create table t2 (a int)")
+	tk.MustExec("insert into t2 values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10)")
+	result = tk.MustQuery("select a from t1 where (1,1) in (select * from t2 s , t2 t where t1.a = s.a and s.a = t.a limit 1)")
+	result.Check(testkit.Rows("1"))
 }
 
 func (s *testSuite) TestDefaultNull(c *C) {


### PR DESCRIPTION
When a join exitsts in subquery, the Close will be called before all rows are processed. In this case, we must ensure all channels have been closed.
fix #2009 
@shenli @coocood @zimulala @winoros @tiancaiamao @XuHuaiyu  PTAL