### PR TITLE
store/tikv: encode keys before save to mvcc store.

### DIFF
--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -35,7 +35,8 @@ func (s *testCommitterSuite) SetUpTest(c *C) {
 	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("a"), []byte("b"), []byte("c"))
 	mvccStore := mocktikv.NewMvccStore()
 	client := mocktikv.NewRPCClient(s.cluster, mvccStore)
-	store, err := newTikvStore("mock-tikv-store", mocktikv.NewPDClient(s.cluster), client, false)
+	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
+	store, err := newTikvStore("mock-tikv-store", pdCli, client, false)
 	c.Assert(err, IsNil)
 	s.store = store
 }

--- a/store/tikv/coprocessor_slow_test.go
+++ b/store/tikv/coprocessor_slow_test.go
@@ -34,7 +34,8 @@ func (s *testCoprocessorSuite) TestBuildHugeTasks(c *C) {
 	mocktikv.BootstrapWithMultiRegions(cluster, splitKeys...)
 
 	bo := NewBackoffer(3000, context.Background())
-	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
+	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
+	cache := NewRegionCache(pdCli)
 
 	const rangesPerRegion = 1e6
 	ranges := make([]kv.KeyRange, 0, 26*rangesPerRegion)

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -29,7 +29,8 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 	// <-  0  -> <- 1 -> <- 2 -> <- 3 ->
 	cluster := mocktikv.NewCluster()
 	_, regionIDs, _ := mocktikv.BootstrapWithMultiRegions(cluster, []byte("g"), []byte("n"), []byte("t"))
-	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
+	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
+	cache := NewRegionCache(pdCli)
 
 	bo := NewBackoffer(3000, context.Background())
 
@@ -90,7 +91,8 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	// <-  0  -> <- 1 ->
 	cluster := mocktikv.NewCluster()
 	storeID, regionIDs, peerIDs := mocktikv.BootstrapWithMultiRegions(cluster, []byte("m"))
-	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
+	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
+	cache := NewRegionCache(pdCli)
 	bo := NewBackoffer(3000, context.Background())
 
 	tasks, err := buildCopTasks(bo, cache, s.buildKeyRanges("a", "z"), false)

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -117,7 +117,8 @@ func NewMockTikvStore() (kv.Storage, error) {
 	mvccStore := mocktikv.NewMvccStore()
 	client := mocktikv.NewRPCClient(cluster, mvccStore)
 	uuid := fmt.Sprintf("mock-tikv-store-:%v", time.Now().Unix())
-	return newTikvStore(uuid, mocktikv.NewPDClient(cluster), client, false)
+	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
+	return newTikvStore(uuid, pdCli, client, false)
 }
 
 func (s *tikvStore) Begin() (kv.Transaction, error) {

--- a/store/tikv/mock-tikv/cluster.go
+++ b/store/tikv/mock-tikv/cluster.go
@@ -186,7 +186,7 @@ func (c *Cluster) Split(regionID, newRegionID uint64, key []byte, peerIDs []uint
 	c.Lock()
 	defer c.Unlock()
 
-	newRegion := c.regions[regionID].split(newRegionID, key, peerIDs, leaderPeerID)
+	newRegion := c.regions[regionID].split(newRegionID, encodeKey(key), peerIDs, leaderPeerID)
 	c.regions[newRegionID] = newRegion
 }
 

--- a/store/tikv/mock-tikv/cluster.go
+++ b/store/tikv/mock-tikv/cluster.go
@@ -186,7 +186,7 @@ func (c *Cluster) Split(regionID, newRegionID uint64, key []byte, peerIDs []uint
 	c.Lock()
 	defer c.Unlock()
 
-	newRegion := c.regions[regionID].split(newRegionID, encodeKey(key), peerIDs, leaderPeerID)
+	newRegion := c.regions[regionID].split(newRegionID, []byte(newMvccKey(key)), peerIDs, leaderPeerID)
 	c.regions[newRegionID] = newRegion
 }
 

--- a/store/tikv/mock-tikv/errors.go
+++ b/store/tikv/mock-tikv/errors.go
@@ -18,7 +18,7 @@ import "fmt"
 // ErrLocked is returned when trying to Read/Write on a locked key. Client should
 // backoff or cleanup the lock then retry.
 type ErrLocked struct {
-	Key     []byte
+	Key     mvccKey
 	Primary []byte
 	StartTS uint64
 	TTL     uint64

--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -145,7 +145,7 @@ func (h *rpcHandler) checkContext(ctx *kvrpcpb.Context) *errorpb.Error {
 }
 
 func (h *rpcHandler) keyInRegion(key []byte) bool {
-	return regionContains(h.startKey, h.endKey, encodeKey(key))
+	return regionContains(h.startKey, h.endKey, []byte(newMvccKey(key)))
 }
 
 func (h *rpcHandler) onGet(req *kvrpcpb.CmdGetRequest) *kvrpcpb.CmdGetResponse {
@@ -270,7 +270,7 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 	if locked, ok := err.(*ErrLocked); ok {
 		return &kvrpcpb.KeyError{
 			Locked: &kvrpcpb.LockInfo{
-				Key:         decodeKey(locked.Key),
+				Key:         locked.Key.Raw(),
 				PrimaryLock: locked.Primary,
 				LockVersion: locked.StartTS,
 				LockTtl:     locked.TTL,

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -43,7 +43,8 @@ func (s *testRegionCacheSuite) SetUpTest(c *C) {
 	s.store2 = storeIDs[1]
 	s.peer1 = peerIDs[0]
 	s.peer2 = peerIDs[1]
-	s.cache = NewRegionCache(mocktikv.NewPDClient(s.cluster))
+	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
+	s.cache = NewRegionCache(pdCli)
 	s.bo = NewBackoffer(5000, context.Background())
 }
 

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -33,7 +33,8 @@ func (s *testSplitSuite) SetUpTest(c *C) {
 	mocktikv.BootstrapWithSingleStore(s.cluster)
 	mvccStore := mocktikv.NewMvccStore()
 	client := mocktikv.NewRPCClient(s.cluster, mvccStore)
-	store, err := newTikvStore("mock-tikv-store", mocktikv.NewPDClient(s.cluster), client, false)
+	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
+	store, err := newTikvStore("mock-tikv-store", pdCli, client, false)
 	c.Assert(err, IsNil)
 	s.store = store
 	s.bo = NewBackoffer(5000, context.Background())

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -41,7 +41,8 @@ func (s *testStoreSuite) SetUpTest(c *C) {
 	mocktikv.BootstrapWithSingleStore(s.cluster)
 	mvccStore := mocktikv.NewMvccStore()
 	clientFactory := mocktikv.NewRPCClient(s.cluster, mvccStore)
-	store, err := newTikvStore("mock-tikv-store", mocktikv.NewPDClient(s.cluster), clientFactory, false)
+	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
+	store, err := newTikvStore("mock-tikv-store", pdCli, clientFactory, false)
 	c.Assert(err, IsNil)
 	s.store = store
 }


### PR DESCRIPTION
Fix #2104 

/cc @coocood @zimulala 