### PR TITLE
variable: define StatementContext.

### DIFF
--- a/evaluator/builtin_info.go
+++ b/evaluator/builtin_info.go
@@ -40,7 +40,7 @@ func builtinFoundRows(arg []types.Datum, ctx context.Context) (d types.Datum, er
 		return d, errors.Errorf("Missing session variable when evalue builtin")
 	}
 
-	d.SetUint64(data.FoundRows)
+	d.SetUint64(data.StmtCtx.FoundRows())
 	return d, nil
 }
 

--- a/evaluator/builtin_other.go
+++ b/evaluator/builtin_other.go
@@ -408,7 +408,7 @@ func isTrueOpFactory(op opcode.Op) BuiltinFunc {
 }
 
 func unaryOpFactory(op opcode.Op) BuiltinFunc {
-	return func(args []types.Datum, _ context.Context) (d types.Datum, err error) {
+	return func(args []types.Datum, ctx context.Context) (d types.Datum, err error) {
 		defer func() {
 			if er := recover(); er != nil {
 				err = errors.Errorf("%v", er)
@@ -507,12 +507,12 @@ func CastFuncFactory(tp *types.FieldType) (BuiltinFunc, error) {
 	// Parser has restricted this.
 	case mysql.TypeString, mysql.TypeDuration, mysql.TypeDatetime,
 		mysql.TypeDate, mysql.TypeLonglong, mysql.TypeNewDecimal:
-		return func(args []types.Datum, _ context.Context) (d types.Datum, err error) {
+		return func(args []types.Datum, ctx context.Context) (d types.Datum, err error) {
 			d = args[0]
 			if d.IsNull() {
 				return
 			}
-			return d.ConvertTo(tp)
+			return d.ConvertTo(ctx.GetSessionVars().StmtCtx, tp)
 		}, nil
 	}
 	return nil, errors.Errorf("unknown cast type - %v", tp)

--- a/evaluator/builtin_string.go
+++ b/evaluator/builtin_string.go
@@ -462,7 +462,7 @@ func builtinLocate(args []types.Datum, _ context.Context) (d types.Datum, err er
 const spaceChars = "\n\t\r "
 
 // See http://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
-func builtinHex(args []types.Datum, _ context.Context) (d types.Datum, err error) {
+func builtinHex(args []types.Datum, ctx context.Context) (d types.Datum, err error) {
 	switch args[0].Kind() {
 	case types.KindNull:
 		return d, nil
@@ -474,7 +474,7 @@ func builtinHex(args []types.Datum, _ context.Context) (d types.Datum, err error
 		d.SetString(strings.ToUpper(hex.EncodeToString(hack.Slice(x))))
 		return d, nil
 	case types.KindInt64, types.KindUint64, types.KindMysqlHex, types.KindFloat32, types.KindFloat64, types.KindMysqlDecimal:
-		x, _ := args[0].Cast(types.NewFieldType(mysql.TypeLonglong))
+		x, _ := args[0].Cast(ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeLonglong))
 		h := fmt.Sprintf("%x", uint64(x.GetInt64()))
 		d.SetString(strings.ToUpper(h))
 		return d, nil
@@ -484,7 +484,7 @@ func builtinHex(args []types.Datum, _ context.Context) (d types.Datum, err error
 }
 
 // See http://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_unhex
-func builtinUnHex(args []types.Datum, _ context.Context) (d types.Datum, err error) {
+func builtinUnHex(args []types.Datum, ctx context.Context) (d types.Datum, err error) {
 	switch args[0].Kind() {
 	case types.KindNull:
 		return d, nil
@@ -500,7 +500,7 @@ func builtinUnHex(args []types.Datum, _ context.Context) (d types.Datum, err err
 		d.SetString(string(bytes))
 		return d, nil
 	case types.KindInt64, types.KindUint64, types.KindMysqlHex, types.KindFloat32, types.KindFloat64, types.KindMysqlDecimal:
-		x, _ := args[0].Cast(types.NewFieldType(mysql.TypeString))
+		x, _ := args[0].Cast(ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeString))
 		if x.IsNull() {
 			return d, nil
 		}

--- a/evaluator/builtin_string_test.go
+++ b/evaluator/builtin_string_test.go
@@ -675,9 +675,9 @@ func (s *testEvaluatorSuite) TestHexFunc(c *C) {
 	}
 
 	dtbl := tblToDtbl(tbl)
-
+	ctx := mock.NewContext()
 	for _, t := range dtbl {
-		d, err := builtinHex(t["Input"], nil)
+		d, err := builtinHex(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(d, testutil.DatumEquals, t["Expect"][0])
 
@@ -695,9 +695,9 @@ func (s *testEvaluatorSuite) TestUnhexFunc(c *C) {
 	}
 
 	dtbl := tblToDtbl(tbl)
-
+	ctx := mock.NewContext()
 	for _, t := range dtbl {
-		d, err := builtinUnHex(t["Input"], nil)
+		d, err := builtinUnHex(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(d, testutil.DatumEquals, t["Expect"][0])
 

--- a/evaluator/builtin_time_test.go
+++ b/evaluator/builtin_time_test.go
@@ -38,9 +38,9 @@ func (s *testEvaluatorSuite) TestDate(c *C) {
 		{"2011-11-11 10:10:10", "2011-11-11"},
 	}
 	dtblDate := tblToDtbl(tblDate)
-
+	ctx := mock.NewContext()
 	for _, t := range dtblDate {
-		v, err := builtinDate(t["Input"], nil)
+		v, err := builtinDate(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		if v.Kind() != types.KindMysqlTime {
 			c.Assert(v, testutil.DatumEquals, t["Expect"][0])
@@ -72,47 +72,47 @@ func (s *testEvaluatorSuite) TestDate(c *C) {
 	dtbl := tblToDtbl(tbl)
 	for _, t := range dtbl {
 		args := t["Input"]
-		v, err := builtinYear(args, nil)
+		v, err := builtinYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Year"][0])
 
-		v, err = builtinMonth(args, nil)
+		v, err = builtinMonth(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Month"][0])
 
-		v, err = builtinMonthName(args, nil)
+		v, err = builtinMonthName(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["MonthName"][0])
 
-		v, err = builtinDayOfMonth(args, nil)
+		v, err = builtinDayOfMonth(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfMonth"][0])
 
-		v, err = builtinDayOfWeek(args, nil)
+		v, err = builtinDayOfWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfWeek"][0])
 
-		v, err = builtinDayOfYear(args, nil)
+		v, err = builtinDayOfYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfYear"][0])
 
-		v, err = builtinWeekDay(args, nil)
+		v, err = builtinWeekDay(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["WeekDay"][0])
 
-		v, err = builtinDayName(args, nil)
+		v, err = builtinDayName(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayName"][0])
 
-		v, err = builtinWeek(args, nil)
+		v, err = builtinWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Week"][0])
 
-		v, err = builtinWeekOfYear(args, nil)
+		v, err = builtinWeekOfYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["WeekOfYear"][0])
 
-		v, err = builtinYearWeek(args, nil)
+		v, err = builtinYearWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["YearWeek"][0])
 	}
@@ -139,47 +139,47 @@ func (s *testEvaluatorSuite) TestDate(c *C) {
 	dtblNil := tblToDtbl(tblNil)
 	for _, t := range dtblNil {
 		args := t["Input"]
-		v, err := builtinYear(args, nil)
+		v, err := builtinYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Year"][0])
 
-		v, err = builtinMonth(args, nil)
+		v, err = builtinMonth(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Month"][0])
 
-		v, err = builtinMonthName(args, nil)
+		v, err = builtinMonthName(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["MonthName"][0])
 
-		v, err = builtinDayOfMonth(args, nil)
+		v, err = builtinDayOfMonth(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfMonth"][0])
 
-		v, err = builtinDayOfWeek(args, nil)
+		v, err = builtinDayOfWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfWeek"][0])
 
-		v, err = builtinDayOfYear(args, nil)
+		v, err = builtinDayOfYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayOfYear"][0])
 
-		v, err = builtinWeekDay(args, nil)
+		v, err = builtinWeekDay(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["WeekDay"][0])
 
-		v, err = builtinWeekDay(args, nil)
+		v, err = builtinWeekDay(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["DayName"][0])
 
-		v, err = builtinWeek(args, nil)
+		v, err = builtinWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Week"][0])
 
-		v, err = builtinWeekOfYear(args, nil)
+		v, err = builtinWeekOfYear(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["WeekOfYear"][0])
 
-		v, err = builtinYearWeek(args, nil)
+		v, err = builtinYearWeek(args, ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["YearWeek"][0])
 	}
@@ -211,9 +211,9 @@ func (s *testEvaluatorSuite) TestDateFormat(c *C) {
 			"Oct October 10 10 1st 01 1 275 0 00 00 AM 12:00:00 AM 00:00:00 00 000000 40 2012 2012 12 %"},
 	}
 	dtblDate := tblToDtbl(tblDate)
-
+	ctx := mock.NewContext()
 	for i, t := range dtblDate {
-		v, err := builtinDateFormat(t["Input"], nil)
+		v, err := builtinDateFormat(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Expect"][0], Commentf("no.%d \nobtain:%v \nexpect:%v\n", i,
 			v.GetValue(), t["Expect"][0].GetValue()))
@@ -222,7 +222,7 @@ func (s *testEvaluatorSuite) TestDateFormat(c *C) {
 	// error
 	ds := types.MakeDatums("0000-01-00 00:00:00.123456",
 		"%b %M %m %c %D %d %e %j %k %h %i %p %r %T %s %f %U %u %V %v %a %W %w %X %x %Y %y %%")
-	_, err := builtinDateFormat(ds, nil)
+	_, err := builtinDateFormat(ds, ctx)
 	// Some like dayofweek() doesn't support the date format like 2000-00-00 returns 0,
 	// so it returns an error.
 	c.Assert(err, NotNil)
@@ -245,47 +245,48 @@ func (s *testEvaluatorSuite) TestClock(c *C) {
 		{"2010-10-10 11:11:11.11", 11, 11, 11, 110000, "11:11:11.11"},
 	}
 
+	ctx := mock.NewContext()
 	dtbl := tblToDtbl(tbl)
 	for _, t := range dtbl {
-		v, err := builtinHour(t["Input"], nil)
+		v, err := builtinHour(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Hour"][0])
 
-		v, err = builtinMinute(t["Input"], nil)
+		v, err = builtinMinute(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Minute"][0])
 
-		v, err = builtinSecond(t["Input"], nil)
+		v, err = builtinSecond(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Second"][0])
 
-		v, err = builtinMicroSecond(t["Input"], nil)
+		v, err = builtinMicroSecond(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["MicroSecond"][0])
 
-		v, err = builtinTime(t["Input"], nil)
+		v, err = builtinTime(t["Input"], ctx)
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, t["Time"][0])
 	}
 
 	// nil
-	v, err := builtinHour(types.MakeDatums(nil), nil)
+	v, err := builtinHour(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
-	v, err = builtinMinute(types.MakeDatums(nil), nil)
+	v, err = builtinMinute(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
-	v, err = builtinSecond(types.MakeDatums(nil), nil)
+	v, err = builtinSecond(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
-	v, err = builtinMicroSecond(types.MakeDatums(nil), nil)
+	v, err = builtinMicroSecond(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
-	v, err = builtinTime(types.MakeDatums(nil), nil)
+	v, err = builtinTime(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
@@ -297,58 +298,60 @@ func (s *testEvaluatorSuite) TestClock(c *C) {
 
 	for _, t := range errTbl {
 		td := types.MakeDatums(t)
-		_, err := builtinHour(td, nil)
+		_, err := builtinHour(td, ctx)
 		c.Assert(err, NotNil)
 
-		_, err = builtinMinute(td, nil)
+		_, err = builtinMinute(td, ctx)
 		c.Assert(err, NotNil)
 
-		_, err = builtinSecond(td, nil)
+		_, err = builtinSecond(td, ctx)
 		c.Assert(err, NotNil)
 
-		_, err = builtinMicroSecond(td, nil)
+		_, err = builtinMicroSecond(td, ctx)
 		c.Assert(err, NotNil)
 
-		_, err = builtinTime(td, nil)
+		_, err = builtinTime(td, ctx)
 		c.Assert(err, NotNil)
 	}
 }
 
 func (s *testEvaluatorSuite) TestNow(c *C) {
 	defer testleak.AfterTest(c)()
-	v, err := builtinNow(nil, nil)
+	ctx := mock.NewContext()
+	v, err := builtinNow(nil, ctx)
 	c.Assert(err, IsNil)
 	t := v.GetMysqlTime()
 	// we canot use a constant value to check now, so here
 	// just to check whether has fractional seconds part.
 	c.Assert(strings.Contains(t.String(), "."), IsFalse)
 
-	v, err = builtinNow(types.MakeDatums(6), nil)
+	v, err = builtinNow(types.MakeDatums(6), ctx)
 	c.Assert(err, IsNil)
 	t = v.GetMysqlTime()
 	c.Assert(strings.Contains(t.String(), "."), IsTrue)
 
-	_, err = builtinNow(types.MakeDatums(8), nil)
+	_, err = builtinNow(types.MakeDatums(8), ctx)
 	c.Assert(err, NotNil)
 
-	_, err = builtinNow(types.MakeDatums(-2), nil)
+	_, err = builtinNow(types.MakeDatums(-2), ctx)
 	c.Assert(err, NotNil)
 }
 
 func (s *testEvaluatorSuite) TestSysDate(c *C) {
 	defer testleak.AfterTest(c)()
 	last := time.Now()
-	v, err := builtinSysDate(types.MakeDatums(nil), nil)
+	ctx := mock.NewContext()
+	v, err := builtinSysDate(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	n := v.GetMysqlTime()
 	c.Assert(n.String(), GreaterEqual, last.Format(types.TimeFormat))
 
-	v, err = builtinSysDate(types.MakeDatums(6), nil)
+	v, err = builtinSysDate(types.MakeDatums(6), ctx)
 	c.Assert(err, IsNil)
 	n = v.GetMysqlTime()
 	c.Assert(n.String(), GreaterEqual, last.Format(types.TimeFormat))
 
-	_, err = builtinSysDate(types.MakeDatums(-2), nil)
+	_, err = builtinSysDate(types.MakeDatums(-2), ctx)
 	c.Assert(err, NotNil)
 }
 
@@ -372,7 +375,7 @@ func (s *testEvaluatorSuite) TestFromUnixTime(c *C) {
 		{true, 1451606400, 999999000, 1451606400.999999, "%Y %D %M %h:%i:%s %x", 26},
 		{true, 1451606400, 999999900, 1451606400.9999999, "%Y %D %M %h:%i:%s %x", 19},
 	}
-
+	ctx := mock.NewContext()
 	for _, t := range tbl {
 		var timestamp types.Datum
 		if !t.isDecimal {
@@ -383,25 +386,25 @@ func (s *testEvaluatorSuite) TestFromUnixTime(c *C) {
 		// result of from_unixtime() is dependent on specific time zone.
 		unixTime := time.Unix(t.integralPart, t.fractionalPart).Round(time.Microsecond).String()[:t.ansLen]
 		if len(t.format) == 0 {
-			v, err := builtinFromUnixTime([]types.Datum{timestamp}, nil)
+			v, err := builtinFromUnixTime([]types.Datum{timestamp}, ctx)
 			c.Assert(err, IsNil)
 			ans := v.GetMysqlTime()
 			c.Assert(ans.String(), Equals, unixTime)
 		} else {
 			format := types.NewStringDatum(t.format)
-			v, err := builtinFromUnixTime([]types.Datum{timestamp, format}, nil)
+			v, err := builtinFromUnixTime([]types.Datum{timestamp, format}, ctx)
 			c.Assert(err, IsNil)
-			result, err := builtinDateFormat([]types.Datum{types.NewStringDatum(unixTime), format}, nil)
+			result, err := builtinDateFormat([]types.Datum{types.NewStringDatum(unixTime), format}, ctx)
 			c.Assert(err, IsNil)
 			c.Assert(v.GetString(), Equals, result.GetString())
 		}
 	}
 
-	v, err := builtinFromUnixTime([]types.Datum{types.NewIntDatum(-12345)}, nil)
+	v, err := builtinFromUnixTime([]types.Datum{types.NewIntDatum(-12345)}, ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 
-	_, err = builtinFromUnixTime([]types.Datum{types.NewIntDatum(math.MaxInt32 + 1)}, nil)
+	_, err = builtinFromUnixTime([]types.Datum{types.NewIntDatum(math.MaxInt32 + 1)}, ctx)
 	c.Assert(err, IsNil)
 	c.Assert(v.Kind(), Equals, types.KindNull)
 }
@@ -409,7 +412,7 @@ func (s *testEvaluatorSuite) TestFromUnixTime(c *C) {
 func (s *testEvaluatorSuite) TestCurrentDate(c *C) {
 	defer testleak.AfterTest(c)()
 	last := time.Now()
-	v, err := builtinCurrentDate(types.MakeDatums(nil), nil)
+	v, err := builtinCurrentDate(types.MakeDatums(nil), mock.NewContext())
 	c.Assert(err, IsNil)
 	n := v.GetMysqlTime()
 	c.Assert(n.String(), GreaterEqual, last.Format(types.DateFormat))
@@ -419,36 +422,37 @@ func (s *testEvaluatorSuite) TestCurrentTime(c *C) {
 	defer testleak.AfterTest(c)()
 	tfStr := "15:04:05"
 
+	ctx := mock.NewContext()
 	last := time.Now()
-	v, err := builtinCurrentTime(types.MakeDatums(nil), nil)
+	v, err := builtinCurrentTime(types.MakeDatums(nil), ctx)
 	c.Assert(err, IsNil)
 	n := v.GetMysqlDuration()
 	c.Assert(n.String(), HasLen, 8)
 	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
-	v, err = builtinCurrentTime(types.MakeDatums(3), nil)
+	v, err = builtinCurrentTime(types.MakeDatums(3), ctx)
 	c.Assert(err, IsNil)
 	n = v.GetMysqlDuration()
 	c.Assert(n.String(), HasLen, 12)
 	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
-	v, err = builtinCurrentTime(types.MakeDatums(6), nil)
+	v, err = builtinCurrentTime(types.MakeDatums(6), ctx)
 	c.Assert(err, IsNil)
 	n = v.GetMysqlDuration()
 	c.Assert(n.String(), HasLen, 15)
 	c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
 
-	v, err = builtinCurrentTime(types.MakeDatums(-1), nil)
+	v, err = builtinCurrentTime(types.MakeDatums(-1), ctx)
 	c.Assert(err, NotNil)
 
-	v, err = builtinCurrentTime(types.MakeDatums(7), nil)
+	v, err = builtinCurrentTime(types.MakeDatums(7), ctx)
 	c.Assert(err, NotNil)
 }
 
 func (s *testEvaluatorSuite) TestUTCDate(c *C) {
 	defer testleak.AfterTest(c)()
 	last := time.Now().UTC()
-	v, err := builtinUTCDate(types.MakeDatums(nil), nil)
+	v, err := builtinUTCDate(types.MakeDatums(nil), mock.NewContext())
 	c.Assert(err, IsNil)
 	n := v.GetMysqlTime()
 	c.Assert(n.String(), GreaterEqual, last.Format(types.DateFormat))
@@ -593,10 +597,11 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		{"16-50 2016 11 22", "%H-%i-%s%Y%m%d", false, time.Time{}},
 	}
 
+	ctx := mock.NewContext()
 	for _, test := range tests {
 		date := types.NewStringDatum(test.Date)
 		format := types.NewStringDatum(test.Format)
-		result, err := builtinStrToDate([]types.Datum{date, format}, nil)
+		result, err := builtinStrToDate([]types.Datum{date, format}, ctx)
 		if !test.Success {
 			c.Assert(err, IsNil)
 			c.Assert(result.IsNull(), IsTrue)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -684,7 +684,7 @@ func (e *Evaluator) funcCast(v *ast.FuncCastExpr) bool {
 		return true
 	}
 	var err error
-	d, err = d.Cast(v.Tp)
+	d, err = d.Cast(e.ctx.GetSessionVars().StmtCtx, v.Tp)
 	if err != nil {
 		e.err = errors.Trace(err)
 		return false

--- a/evaluator/helper.go
+++ b/evaluator/helper.go
@@ -83,7 +83,7 @@ func getTimeValue(ctx context.Context, v interface{}, tp byte, fsp int) (d types
 			return d, errors.Trace(err)
 		}
 		ft := types.NewFieldType(mysql.TypeLonglong)
-		xval, err := v.ConvertTo(ft)
+		xval, err := v.ConvertTo(ctx.GetSessionVars().StmtCtx, ft)
 		if err != nil {
 			return d, errors.Trace(err)
 		}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -640,6 +640,7 @@ func (b *executorBuilder) buildUnion(v *plan.Union) Executor {
 	e := &UnionExec{
 		schema: v.GetSchema(),
 		Srcs:   make([]Executor, len(v.GetChildren())),
+		ctx:    b.ctx,
 	}
 	for i, sel := range v.GetChildren() {
 		selExec := b.build(sel)

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -154,14 +154,6 @@ func getSelectStmtLabel(x *ast.SelectStmt) string {
 // then wrappped to an adapter *statement as stmt.Statement.
 func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statement, error) {
 	stmtCount(node)
-	if _, ok := node.(*ast.UpdateStmt); ok {
-		sVars := ctx.GetSessionVars()
-		sVars.InUpdateStmt = true
-		defer func() {
-			sVars.InUpdateStmt = false
-		}()
-	}
-
 	var is infoschema.InfoSchema
 	sessVar := ctx.GetSessionVars()
 	if snap := sessVar.SnapshotInfoschema; snap != nil {

--- a/executor/executor_distsql.go
+++ b/executor/executor_distsql.go
@@ -154,10 +154,10 @@ func tableHandlesToKVRanges(tid int64, handles []int64) []kv.KeyRange {
 	return krs
 }
 
-func indexRangesToKVRanges(tid, idxID int64, ranges []*plan.IndexRange, fieldTypes []*types.FieldType) ([]kv.KeyRange, error) {
+func indexRangesToKVRanges(sc *variable.StatementContext, tid, idxID int64, ranges []*plan.IndexRange, fieldTypes []*types.FieldType) ([]kv.KeyRange, error) {
 	krs := make([]kv.KeyRange, 0, len(ranges))
 	for _, ran := range ranges {
-		err := convertIndexRangeTypes(ran, fieldTypes)
+		err := convertIndexRangeTypes(sc, ran, fieldTypes)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -183,13 +183,13 @@ func indexRangesToKVRanges(tid, idxID int64, ranges []*plan.IndexRange, fieldTyp
 	return krs, nil
 }
 
-func convertIndexRangeTypes(ran *plan.IndexRange, fieldTypes []*types.FieldType) error {
+func convertIndexRangeTypes(sc *variable.StatementContext, ran *plan.IndexRange, fieldTypes []*types.FieldType) error {
 	for i := range ran.LowVal {
 		if ran.LowVal[i].Kind() == types.KindMinNotNull {
 			ran.LowVal[i].SetBytes([]byte{})
 			continue
 		}
-		converted, err := ran.LowVal[i].ConvertTo(fieldTypes[i])
+		converted, err := ran.LowVal[i].ConvertTo(sc, fieldTypes[i])
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -218,7 +218,7 @@ func convertIndexRangeTypes(ran *plan.IndexRange, fieldTypes []*types.FieldType)
 		if ran.HighVal[i].Kind() == types.KindMaxValue {
 			continue
 		}
-		converted, err := ran.HighVal[i].ConvertTo(fieldTypes[i])
+		converted, err := ran.HighVal[i].ConvertTo(sc, fieldTypes[i])
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -582,7 +582,8 @@ func (e *XSelectIndexExec) doIndexRequest() (distsql.SelectResult, error) {
 	for i, v := range e.indexPlan.Index.Columns {
 		fieldTypes[i] = &(e.table.Cols()[v.Offset].FieldType)
 	}
-	keyRanges, err := indexRangesToKVRanges(e.table.Meta().ID, e.indexPlan.Index.ID, e.indexPlan.Ranges, fieldTypes)
+	sc := e.ctx.GetSessionVars().StmtCtx
+	keyRanges, err := indexRangesToKVRanges(sc, e.table.Meta().ID, e.indexPlan.Index.ID, e.indexPlan.Ranges, fieldTypes)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/executor_write.go
+++ b/executor/executor_write.go
@@ -105,7 +105,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	if !rowChanged {
 		// See https://dev.mysql.com/doc/refman/5.7/en/mysql-real-connect.html  CLIENT_FOUND_ROWS
 		if ctx.GetSessionVars().ClientCapability&mysql.ClientFoundRows > 0 {
-			ctx.GetSessionVars().AddAffectedRows(1)
+			ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 		}
 		return nil
 	}
@@ -131,9 +131,9 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 
 	// Record affected rows.
 	if !onDuplicateUpdate {
-		ctx.GetSessionVars().AddAffectedRows(1)
+		ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 	} else {
-		ctx.GetSessionVars().AddAffectedRows(2)
+		ctx.GetSessionVars().StmtCtx.AddAffectedRows(2)
 	}
 	return nil
 }
@@ -240,7 +240,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 		return errors.Trace(err)
 	}
 	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
-	ctx.GetSessionVars().AddAffectedRows(1)
+	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 	return nil
 }
 
@@ -408,7 +408,7 @@ func (e *LoadDataInfo) InsertData(prevData, curData []byte) ([]byte, error) {
 		e.insertVal.currRow++
 	}
 	if e.insertVal.lastInsertID != 0 {
-		e.insertVal.ctx.GetSessionVars().LastInsertID = e.insertVal.lastInsertID
+		e.insertVal.ctx.GetSessionVars().SetLastInsertID(e.insertVal.lastInsertID)
 	}
 
 	return curData, nil
@@ -619,7 +619,7 @@ func (e *InsertExec) Next() (*Row, error) {
 	}
 
 	if e.lastInsertID != 0 {
-		e.ctx.GetSessionVars().LastInsertID = e.lastInsertID
+		e.ctx.GetSessionVars().SetLastInsertID(e.lastInsertID)
 	}
 	e.finished = true
 	return nil, nil
@@ -1048,7 +1048,7 @@ func (e *ReplaceExec) Next() (*Row, error) {
 		}
 		if rowUnchanged {
 			// If row unchanged, we do not need to do insert.
-			e.ctx.GetSessionVars().AddAffectedRows(1)
+			e.ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 			idx++
 			continue
 		}
@@ -1058,11 +1058,11 @@ func (e *ReplaceExec) Next() (*Row, error) {
 			return nil, errors.Trace(err1)
 		}
 		getDirtyDB(e.ctx).deleteRow(e.Table.Meta().ID, h)
-		e.ctx.GetSessionVars().AddAffectedRows(1)
+		e.ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 	}
 
 	if e.lastInsertID != 0 {
-		e.ctx.GetSessionVars().LastInsertID = e.lastInsertID
+		e.ctx.GetSessionVars().SetLastInsertID(e.lastInsertID)
 	}
 	e.finished = true
 	return nil, nil

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"context"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
@@ -66,7 +65,6 @@ type propagateConstantSolver struct {
 	eqList     []*Constant    // if eqList[i] != nil, it means col_i = eqList[i]
 	columns    []*Column      // columns stores all columns appearing in the conditions
 	conditions []Expression
-	ctx        context.Context
 }
 
 // propagateInEQ propagates all in-equal conditions.

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"context"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
@@ -65,6 +66,7 @@ type propagateConstantSolver struct {
 	eqList     []*Constant    // if eqList[i] != nil, it means col_i = eqList[i]
 	columns    []*Column      // columns stores all columns appearing in the conditions
 	conditions []Expression
+	ctx        context.Context
 }
 
 // propagateInEQ propagates all in-equal conditions.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/evaluator"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -82,7 +83,9 @@ func NewFunction(funcName string, retType *types.FieldType, args ...Expression) 
 
 	if canConstantFolding {
 		fn := f.F
-		newArgs, err := fn(datums, nil)
+		// TODO: add argument in NewFunction and replace mock context.
+		ctx := mock.NewContext()
+		newArgs, err := fn(datums, ctx)
 		if err != nil {
 			log.Warnf("There may exist an error during constant folding. The function name is %s, args are %s", funcName, args)
 		} else {

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -83,7 +83,7 @@ func NewFunction(funcName string, retType *types.FieldType, args ...Expression) 
 
 	if canConstantFolding {
 		fn := f.F
-		// TODO: add argument in NewFunction and replace mock context.
+		// TODO: Add argument in NewFunction and replace mock context.
 		ctx := mock.NewContext()
 		newArgs, err := fn(datums, ctx)
 		if err != nil {

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -227,7 +228,7 @@ func mockResolve(node ast.Node) error {
 	if err != nil {
 		return err
 	}
-	return InferType(node)
+	return InferType(ctx.GetSessionVars().StmtCtx, node)
 }
 
 func supportExpr(exprType tipb.ExprType) bool {
@@ -1063,7 +1064,7 @@ func (s *testPlanSuite) TestAllocID(c *C) {
 
 func (s *testPlanSuite) TestRangeBuilder(c *C) {
 	defer testleak.AfterTest(c)()
-	rb := &rangeBuilder{}
+	rb := &rangeBuilder{sc: new(variable.StatementContext)}
 
 	cases := []struct {
 		exprStr   string

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -30,7 +30,7 @@ var AllowCartesianProduct = true
 // The node must be prepared first.
 func Optimize(ctx context.Context, node ast.Node, is infoschema.InfoSchema) (Plan, error) {
 	// We have to infer type again because after parameter is set, the expression type may change.
-	if err := InferType(node); err != nil {
+	if err := InferType(ctx.GetSessionVars().StmtCtx, node); err != nil {
 		return nil, errors.Trace(err)
 	}
 	allocator := new(idAllocator)

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -244,7 +244,7 @@ func (p *DataSource) convert2IndexScan(prop *requiredProperty, index *model.Inde
 				is.ConditionPBExpr, is.conditions, newSel.Conditions = expressionsToPB(newSel.Conditions, client)
 			}
 		}
-		err := buildIndexRange(is)
+		err := buildIndexRange(p.ctx.GetSessionVars().StmtCtx, is)
 		if err != nil {
 			if !terror.ErrorEqual(err, types.ErrTruncated) {
 				return nil, errors.Trace(err)
@@ -261,7 +261,7 @@ func (p *DataSource) convert2IndexScan(prop *requiredProperty, index *model.Inde
 			resultPlan = &newSel
 		}
 	} else {
-		rb := rangeBuilder{}
+		rb := rangeBuilder{sc: p.ctx.GetSessionVars().StmtCtx}
 		is.Ranges = rb.buildIndexRanges(fullRange, types.NewFieldType(mysql.TypeNull))
 	}
 	is.DoubleRead = !isCoveringIndex(is.Columns, is.Index.Columns, is.Table.PKIsHandle)

--- a/plan/range.go
+++ b/plan/range.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -95,6 +96,7 @@ func (r *rangePointSorter) Swap(i, j int) {
 
 type rangeBuilder struct {
 	err error
+	sc  *variable.StatementContext
 }
 
 func (r *rangeBuilder) build(expr expression.Expression) []rangePoint {
@@ -472,7 +474,7 @@ func (r *rangeBuilder) convertPoint(point rangePoint, tp *types.FieldType) range
 	case types.KindMaxValue, types.KindMinNotNull:
 		return point
 	}
-	casted, err := point.value.ConvertTo(tp)
+	casted, err := point.value.ConvertTo(r.sc, tp)
 	if err != nil {
 		r.err = errors.Trace(err)
 	}

--- a/plan/refiner.go
+++ b/plan/refiner.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -29,8 +30,8 @@ var fullRange = []rangePoint{
 	{value: types.MaxValueDatum()},
 }
 
-func buildIndexRange(p *PhysicalIndexScan) error {
-	rb := rangeBuilder{}
+func buildIndexRange(sc *variable.StatementContext, p *PhysicalIndexScan) error {
+	rb := rangeBuilder{sc: sc}
 	for i := 0; i < p.accessInAndEqCount; i++ {
 		// Build ranges for equal or in access conditions.
 		point := rb.build(p.AccessCondition[i])

--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -365,9 +365,9 @@ func (nr *nameResolver) handleTableName(tn *ast.TableName) {
 		ast.ValueExpr
 		ast.ResultField
 	}, len(tn.TableInfo.Columns))
-	sVars := nr.Ctx.GetSessionVars()
+	status := nr.Ctx.GetSessionVars().StmtCtx
 	for i, v := range tn.TableInfo.Columns {
-		if sVars.InUpdateStmt {
+		if status.InUpdateStmt {
 			switch v.State {
 			case model.StatePublic, model.StateWriteOnly, model.StateWriteReorganization:
 			default:

--- a/plan/typeinferer_test.go
+++ b/plan/typeinferer_test.go
@@ -156,7 +156,7 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 		is := sessionctx.GetDomain(ctx).InfoSchema()
 		err = plan.ResolveName(stmt, is, ctx)
 		c.Assert(err, IsNil)
-		plan.InferType(stmt)
+		plan.InferType(ctx.GetSessionVars().StmtCtx, stmt)
 		tp := stmt.GetResultFields()[0].Column.Tp
 		chs := stmt.GetResultFields()[0].Column.Charset
 		c.Assert(tp, Equals, ca.tp, Commentf("Tp for %s", ca.expr))

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -15,11 +15,11 @@ package variable
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
-	"sync"
 )
 
 const (

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
+	"sync"
 )
 
 const (
@@ -89,16 +90,12 @@ type SessionVars struct {
 	// following variables are special for current session
 	Status       uint16
 	LastInsertID uint64
-	AffectedRows uint64
 
 	// Client capability
 	ClientCapability uint32
 
 	// Connection ID
 	ConnectionID uint64
-
-	// Found rows
-	FoundRows uint64
 
 	// Current user
 	User string
@@ -111,9 +108,6 @@ type SessionVars struct {
 
 	// CommonGlobalLoaded indicates if common global variable has been loaded for this session.
 	CommonGlobalLoaded bool
-
-	// InUpdateStmt indicates if the session is handling update stmt.
-	InUpdateStmt bool
 
 	// InRestrictedSQL indicates if the session is handling restricted SQL execution.
 	InRestrictedSQL bool
@@ -130,6 +124,9 @@ type SessionVars struct {
 
 	// GlobalAccessor is used to set and get global variables.
 	GlobalVarsAccessor GlobalVarAccessor
+
+	// StmtCtx holds variables for current executing statement.
+	StmtCtx *StatementContext
 }
 
 // NewSessionVars creates a session vars object.
@@ -142,6 +139,7 @@ func NewSessionVars() *SessionVars {
 		RetryInfo:            &RetryInfo{},
 		StrictSQLMode:        true,
 		Status:               mysql.ServerStatusAutocommit,
+		StmtCtx:              new(StatementContext),
 	}
 }
 
@@ -169,21 +167,6 @@ func (s *SessionVars) GetCharsetInfo() (charset, collation string) {
 // TODO: we may store the result for last_insert_id sys var later.
 func (s *SessionVars) SetLastInsertID(insertID uint64) {
 	s.LastInsertID = insertID
-}
-
-// SetAffectedRows saves the affected rows to the session context.
-func (s *SessionVars) SetAffectedRows(affectedRows uint64) {
-	s.AffectedRows = affectedRows
-}
-
-// AddAffectedRows adds affected rows with the argument rows.
-func (s *SessionVars) AddAffectedRows(rows uint64) {
-	s.AffectedRows += rows
-}
-
-// AddFoundRows adds found rows with the argument rows.
-func (s *SessionVars) AddFoundRows(rows uint64) {
-	s.FoundRows += rows
 }
 
 // SetStatusFlag sets the session server status variable.
@@ -239,4 +222,73 @@ func (s *SessionVars) GetTiDBSystemVar(name string) (string, error) {
 		return sVal, nil
 	}
 	return SysVars[key].Value, nil
+}
+
+// StatementContext contains variables for a statement.
+// It should be reset before executing a statement.
+type StatementContext struct {
+	/* Variables that are set before execution */
+	InUpdateStmt    bool
+	TruncateAsError bool
+
+	/* Variables that changes during execution. */
+	mu struct {
+		sync.Mutex
+		affectedRows uint64
+		foundRows    uint64
+		warnings     []error
+	}
+}
+
+// AddAffectedRows adds affected rows.
+func (sc *StatementContext) AddAffectedRows(rows uint64) {
+	sc.mu.Lock()
+	sc.mu.affectedRows += rows
+	sc.mu.Unlock()
+}
+
+// AffectedRows gets affected rows.
+func (sc *StatementContext) AffectedRows() uint64 {
+	sc.mu.Lock()
+	rows := sc.mu.affectedRows
+	sc.mu.Unlock()
+	return rows
+}
+
+// FoundRows gets found rows.
+func (sc *StatementContext) FoundRows() uint64 {
+	sc.mu.Lock()
+	rows := sc.mu.foundRows
+	sc.mu.Unlock()
+	return rows
+}
+
+// AddFoundRows adds found rows.
+func (sc *StatementContext) AddFoundRows(rows uint64) {
+	sc.mu.Lock()
+	sc.mu.foundRows += rows
+	sc.mu.Unlock()
+}
+
+// GetWarnings gets warnings.
+func (sc *StatementContext) GetWarnings() []error {
+	sc.mu.Lock()
+	warns := make([]error, len(sc.mu.warnings))
+	copy(warns, sc.mu.warnings)
+	sc.mu.Unlock()
+	return warns
+}
+
+// SetWarnings sets warnings.
+func (sc *StatementContext) SetWarnings(warns []error) {
+	sc.mu.Lock()
+	sc.mu.warnings = warns
+	sc.mu.Unlock()
+}
+
+// AppendWarning appends a warning.
+func (sc *StatementContext) AppendWarning(warn error) {
+	sc.mu.Lock()
+	sc.mu.warnings = append(sc.mu.warnings, warn)
+	sc.mu.Unlock()
 }

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -26,22 +26,22 @@ type testSessionSuite struct {
 func (*testSessionSuite) TestSession(c *C) {
 	ctx := mock.NewContext()
 
-	v := ctx.GetSessionVars()
-	c.Assert(v, NotNil)
+	ss := ctx.GetSessionVars().StmtCtx
+	c.Assert(ss, NotNil)
 
 	// For AffectedRows
-	v.AddAffectedRows(1)
-	c.Assert(v.AffectedRows, Equals, uint64(1))
-	v.AddAffectedRows(1)
-	c.Assert(v.AffectedRows, Equals, uint64(2))
+	ss.AddAffectedRows(1)
+	c.Assert(ss.AffectedRows(), Equals, uint64(1))
+	ss.AddAffectedRows(1)
+	c.Assert(ss.AffectedRows(), Equals, uint64(2))
 
 	// For FoundRows
-	v.AddFoundRows(1)
-	c.Assert(v.FoundRows, Equals, uint64(1))
-	v.AddFoundRows(1)
-	c.Assert(v.FoundRows, Equals, uint64(2))
+	ss.AddFoundRows(1)
+	c.Assert(ss.FoundRows(), Equals, uint64(1))
+	ss.AddFoundRows(1)
+	c.Assert(ss.FoundRows(), Equals, uint64(2))
 
 	// For last insert id
-	v.SetLastInsertID(uint64(1))
-	c.Assert(v.LastInsertID, Equals, uint64(1))
+	ctx.GetSessionVars().SetLastInsertID(1)
+	c.Assert(ctx.GetSessionVars().LastInsertID, Equals, uint64(1))
 }

--- a/table/column.go
+++ b/table/column.go
@@ -113,7 +113,7 @@ func CastValues(ctx context.Context, rec []types.Datum, cols []*Column, ignoreEr
 
 // CastValue casts a value based on column type.
 func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (casted types.Datum, err error) {
-	casted, err = val.ConvertTo(&col.FieldType)
+	casted, err = val.ConvertTo(ctx.GetSessionVars().StmtCtx, &col.FieldType)
 	if err != nil {
 		if ctx.GetSessionVars().StrictSQLMode {
 			return casted, errors.Trace(err)

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -188,7 +189,8 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 		State:        model.StatePublic,
 		DefaultValue: 1.0,
 	}
-	val, ok, err := GetColDefaultValue(nil, colInfo)
+	ctx := mock.NewContext()
+	val, ok, err := GetColDefaultValue(ctx, colInfo)
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsTrue)
 	c.Assert(val.Kind(), Equals, types.KindInt64)

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -369,7 +369,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		mutation.InsertedRows = append(mutation.InsertedRows, bin)
 		mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Insert)
 	}
-	ctx.GetSessionVars().AddAffectedRows(1)
+	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 	return recordID, nil
 }
 

--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -27,16 +27,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 )
 
-var (
-	// ErrValueTruncated is used when a value has been truncated during conversion.
-	ErrValueTruncated = errors.New("value has been truncated")
-)
-
-// InvConv returns a failed conversion error.
-func invConv(val interface{}, tp byte) (interface{}, error) {
-	return nil, errors.Errorf("cannot convert %v (type %T) to type %s", val, val, TypeStr(tp))
-}
-
 func truncateStr(str string, flen int) string {
 	if flen != UnspecifiedLength && len(str) > flen {
 		str = str[:flen]
@@ -146,16 +136,6 @@ func isCastType(tp byte) bool {
 	return false
 }
 
-// Convert converts the val with type tp.
-func Convert(val interface{}, target *FieldType) (v interface{}, err error) {
-	d := NewDatum(val)
-	ret, err := d.ConvertTo(target)
-	if err != nil {
-		return ret.GetValue(), errors.Trace(err)
-	}
-	return ret.GetValue(), nil
-}
-
 // StrToInt converts a string to an integer in best effort.
 // TODO: handle overflow and add unittest.
 func StrToInt(str string) (int64, error) {
@@ -194,7 +174,7 @@ func StrToFloat(str string) (float64, error) {
 	validStr := getValidFloatPrefix(str)
 	var err error
 	if validStr != str {
-		err = ErrValueTruncated
+		err = ErrTruncated
 	}
 	f, err1 := strconv.ParseFloat(validStr, 64)
 	if err == nil {

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
 )
@@ -632,15 +633,15 @@ func (d *Datum) compareRow(row []Datum) (int, error) {
 }
 
 // Cast casts datum to certain types.
-func (d *Datum) Cast(target *FieldType) (ad Datum, err error) {
+func (d *Datum) Cast(sc *variable.StatementContext, target *FieldType) (ad Datum, err error) {
 	if !isCastType(target.Tp) {
 		return ad, errors.Errorf("unknown cast type - %v", target)
 	}
-	return d.ConvertTo(target)
+	return d.ConvertTo(sc, target)
 }
 
 // ConvertTo converts a datum to the target field type.
-func (d *Datum) ConvertTo(target *FieldType) (Datum, error) {
+func (d *Datum) ConvertTo(sc *variable.StatementContext, target *FieldType) (Datum, error) {
 	if d.k == KindNull {
 		return Datum{}, nil
 	}

--- a/util/types/datum_test.go
+++ b/util/types/datum_test.go
@@ -16,6 +16,7 @@ package types
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/variable"
 )
 
 var _ = Suite(&testDatumSuite{})
@@ -152,20 +153,21 @@ func (ts *testTypeConvertSuite) TestToInt64(c *C) {
 func (ts *testTypeConvertSuite) TestToFloat32(c *C) {
 	ft := NewFieldType(mysql.TypeFloat)
 	var datum = NewFloat64Datum(281.37)
-	converted, err := datum.ConvertTo(ft)
+	sc := new(variable.StatementContext)
+	converted, err := datum.ConvertTo(sc, ft)
 	c.Assert(err, IsNil)
 	c.Assert(converted.Kind(), Equals, KindFloat32)
 	c.Assert(converted.GetFloat32(), Equals, float32(281.37))
 
 	datum.SetString("281.37")
-	converted, err = datum.ConvertTo(ft)
+	converted, err = datum.ConvertTo(sc, ft)
 	c.Assert(err, IsNil)
 	c.Assert(converted.Kind(), Equals, KindFloat32)
 	c.Assert(converted.GetFloat32(), Equals, float32(281.37))
 
 	ft = NewFieldType(mysql.TypeDouble)
 	datum = NewFloat32Datum(281.37)
-	converted, err = datum.ConvertTo(ft)
+	converted, err = datum.ConvertTo(sc, ft)
 	c.Assert(err, IsNil)
 	c.Assert(converted.Kind(), Equals, KindFloat64)
 	// Convert to float32 and convert back to float64, we will get a different value.


### PR DESCRIPTION
StatementContext is used to hold statement execution mode and state.
As every computation need this, there are many API changes to make, this is just a start.