### PR TITLE
store/tikv: fix retry open store

### DIFF
--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -57,7 +57,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 	pdCli, err := pd.NewClient(etcdAddrs)
 	if err != nil {
 		if strings.Contains(err.Error(), "i/o timeout") {
-			return nil, errors.Annotate(errors.Trace(err), txnRetryableMark)
+			return nil, errors.Annotate(err, txnRetryableMark)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -56,7 +56,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 
 	pdCli, err := pd.NewClient(etcdAddrs)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, errors.Annotate(errors.Trace(err), "try again later")
 	}
 
 	// FIXME: uuid will be a very long and ugly string, simplify it.

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -57,7 +57,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 	pdCli, err := pd.NewClient(etcdAddrs)
 	if err != nil {
 		if strings.Contains(err.Error(), "i/o timeout") {
-			return nil, errors.Annotate(errors.Trace(err), "try again later")
+			return nil, errors.Annotate(errors.Trace(err), txnRetryableMark)
 		}
 		return nil, errors.Trace(err)
 	}

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -56,7 +56,10 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 
 	pdCli, err := pd.NewClient(etcdAddrs)
 	if err != nil {
-		return nil, errors.Annotate(errors.Trace(err), "try again later")
+		if strings.Contains(err.Error(), "i/o timeout") {
+			return nil, errors.Annotate(errors.Trace(err), "try again later")
+		}
+		return nil, errors.Trace(err)
 	}
 
 	// FIXME: uuid will be a very long and ugly string, simplify it.

--- a/tidb.go
+++ b/tidb.go
@@ -215,7 +215,7 @@ func newStoreWithRetry(path string, maxRetries int) (kv.Storage, error) {
 	var s kv.Storage
 	util.RunWithRetry(maxRetries, retryInterval, func() (bool, error) {
 		s, err = d.Open(path)
-		return kv.IsRetryableError(err), err
+		return true, err
 	})
 	return s, errors.Trace(err)
 }

--- a/tidb.go
+++ b/tidb.go
@@ -215,7 +215,7 @@ func newStoreWithRetry(path string, maxRetries int) (kv.Storage, error) {
 	var s kv.Storage
 	util.RunWithRetry(maxRetries, retryInterval, func() (bool, error) {
 		s, err = d.Open(path)
-		return true, err
+		return kv.IsRetryableError(err), err
 	})
 	return s, errors.Trace(err)
 }


### PR DESCRIPTION
Ref https://github.com/pingcap/pd/pull/391 now PD restart spend more time to get the leader.

`kv.IsRetryableError` not work for  the error return by `driver.Open` , I think we can simply let it be true.

```
2016/11/29 11:27:22 printer.go:34: [info] UTC Build Time:  2016-11-29 01:59:37
2016/11/29 11:27:22 client.go:52: [info] [pd] create pd client with endpoints [127.0.0.1:52379]
2016/11/29 11:27:22 conn.go:67: [warning] failed to get leader from [http://127.0.0.1:52379] 
2016/11/29 11:27:23 main.go:155: [fatal] github.com/pingcap/pd/pd-client/rpc_worker.go:361: [pd] rpc failed: read tcp 127.0.0.1:35656->127.0.0.1:52379: i/o timeout
github.com/pingcap/pd/pd-client/rpc_worker.go:249: 
github.com/pingcap/pd/pd-client/rpc_worker.go:227: 
github.com/pingcap/pd/pd-client/rpc_worker.go:77: 
github.com/pingcap/pd/pd-client/client.go:55: 
/data/jenkins/workspace/BENCH_TEST_ON_UCLOUD/go/src/github.com/pingcap/tidb/store/tikv/kv.go:59: 
/data/jenkins/workspace/BENCH_TEST_ON_UCLOUD/go/src/github.com/pingcap/tidb/tidb.go:220: 
