### PR TITLE
validator: check duplicate key cols when create table

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
@@ -1206,7 +1207,7 @@ func getAnonymousIndex(t table.Table, colName model.CIStr) model.CIStr {
 }
 
 func (d *ddl) CreateIndex(ctx context.Context, ti ast.Ident, unique bool, indexName model.CIStr, idxColNames []*ast.IndexColName) error {
-	err := checkDuplicateColumnName(idxColNames)
+	err := plan.CheckDuplicateColumnName(idxColNames)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1430,20 +1431,6 @@ func findCol(cols []*model.ColumnInfo, name string) *model.ColumnInfo {
 		}
 	}
 
-	return nil
-}
-
-// checkDuplicateColumnName checks if index exists duplicated columns.
-func checkDuplicateColumnName(indexColNames []*ast.IndexColName) error {
-	for i := 0; i < len(indexColNames); i++ {
-		name1 := indexColNames[i].Column.Name
-		for j := i + 1; j < len(indexColNames); j++ {
-			name2 := indexColNames[j].Column.Name
-			if name1.L == name2.L {
-				return infoschema.ErrColumnExists.GenByArgs(name2)
-			}
-		}
-	}
 	return nil
 }
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
@@ -1207,10 +1206,6 @@ func getAnonymousIndex(t table.Table, colName model.CIStr) model.CIStr {
 }
 
 func (d *ddl) CreateIndex(ctx context.Context, ti ast.Ident, unique bool, indexName model.CIStr, idxColNames []*ast.IndexColName) error {
-	err := plan.CheckDuplicateColumnName(idxColNames)
-	if err != nil {
-		return errors.Trace(err)
-	}
 	is := d.infoHandle.Get()
 	schema, ok := is.SchemaByName(ti.Schema)
 	if !ok {

--- a/plan/validator_test.go
+++ b/plan/validator_test.go
@@ -56,6 +56,7 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"create index ib on t(b,a,b);", true, errors.New("[schema:1060]Duplicate column name 'b'")},
 		{"create table t (a int, b int, key(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
 		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("Multiple primary key defined")},
+		{"alter table t add index idx(a, b, A)", true, errors.New("[schema:1060]Duplicate column name 'A'")},
 	}
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
 	c.Assert(err, IsNil)

--- a/plan/validator_test.go
+++ b/plan/validator_test.go
@@ -54,6 +54,7 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"create table t(id int auto_increment) ENGINE=MYISAM", true, nil},
 		{"create table t(a int primary key, b int, c varchar(10), d char(256));", true, errors.New("Column length too big for column 'd' (max = 255); use BLOB or TEXT instead")},
 		{"create index ib on t(b,a,b);", true, errors.New("[schema:1060]Duplicate column name 'b'")},
+		{"create table t (a int, b int, key(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
 		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("Multiple primary key defined")},
 	}
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)


### PR DESCRIPTION
fix #1939 
This commit check duplicate cols in constraints' key when create table.
PTAL @shenli @coocood @hanfei1991 @zimulala 
