### PR TITLE
plan: cut unuseful search branch to improve performence.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -110,6 +110,20 @@ func BenchmarkTableScan(b *testing.B) {
 	}
 }
 
+func BenchmarkExplainTableScan(b *testing.B) {
+	b.StopTimer()
+	se := prepareBenchSession()
+	prepareBenchData(se, "int", "%v", 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		rs, err := se.Execute("explain select * from t")
+		if err != nil {
+			b.Fatal(err)
+		}
+		readResult(rs[0], 1)
+	}
+}
+
 func BenchmarkTableLookup(b *testing.B) {
 	b.StopTimer()
 	se := prepareBenchSession()
@@ -117,6 +131,20 @@ func BenchmarkTableLookup(b *testing.B) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		rs, err := se.Execute("select * from t where pk = 64")
+		if err != nil {
+			b.Fatal(err)
+		}
+		readResult(rs[0], 1)
+	}
+}
+
+func BenchmarkExplainTableLookup(b *testing.B) {
+	b.StopTimer()
+	se := prepareBenchSession()
+	prepareBenchData(se, "int", "%d", 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		rs, err := se.Execute("explain select * from t where pk = 64")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -135,6 +163,20 @@ func BenchmarkStringIndexScan(b *testing.B) {
 			b.Fatal(err)
 		}
 		readResult(rs[0], smallCount)
+	}
+}
+
+func BenchmarkExplainStringIndexScan(b *testing.B) {
+	b.StopTimer()
+	se := prepareBenchSession()
+	prepareBenchData(se, "varchar(255)", "'hello %d'", 0)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		rs, err := se.Execute("explain select * from t where col > 'hello'")
+		if err != nil {
+			b.Fatal(err)
+		}
+		readResult(rs[0], 1)
 	}
 }
 

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -271,10 +271,10 @@ func (s *testSuite) TestExplain(c *C) {
 		{
 			"select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1",
 			[]string{
-				"TableScan_10", "TableScan_12", "HashAgg_14", "HashLeftJoin_9", "HashAgg_17",
+				"TableScan_10", "TableScan_11", "HashAgg_12", "HashLeftJoin_9", "HashAgg_15",
 			},
 			[]string{
-				"HashLeftJoin_9", "HashAgg_14", "HashLeftJoin_9", "HashAgg_17", "",
+				"HashLeftJoin_9", "HashAgg_12", "HashLeftJoin_9", "HashAgg_15", "",
 			},
 			[]string{`{
     "db": "test",
@@ -314,7 +314,7 @@ func (s *testSuite) TestExplain(c *C) {
     "GroupByItems": [
         "[b.c2]"
     ],
-    "child": "TableScan_12"
+    "child": "TableScan_11"
 }`,
 				`{
     "eqCond": [
@@ -324,7 +324,7 @@ func (s *testSuite) TestExplain(c *C) {
     "rightCond": null,
     "otherCond": null,
     "leftPlan": "TableScan_10",
-    "rightPlan": "HashAgg_14"
+    "rightPlan": "HashAgg_12"
 }`,
 				`{
     "AggFuncs": [


### PR DESCRIPTION
If the prop is empty and selection is nil, we don't need to consider index scan.
If the prop is empty, we don't need to consider enforce sorter.
@shenli @coocood @zimulala @tiancaiamao @XuHuaiyu @winoros PTAL