### PR TITLE
plan/validator: add grammar check of constraints when create table

### DIFF
--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -52,6 +52,8 @@ var (
 	ErrColumnExists = terror.ClassSchema.New(codeColumnExists, "Duplicate column name '%s'")
 	// ErrIndexExists returns for index already exists.
 	ErrIndexExists = terror.ClassSchema.New(codeIndexExists, "Duplicate Index")
+	// ErrMultiplePriKey returns for multiple primary keys.
+	ErrMultiplePriKey = terror.ClassSchema.New(codeMultiplePriKey, "Multiple primary key defined")
 )
 
 // InfoSchema is the interface used to retrieve the schema information.
@@ -298,6 +300,8 @@ const (
 	codeBadTable       = 1051
 	codeColumnExists   = 1060
 	codeIndexExists    = 1831
+
+	codeMultiplePriKey = 1068
 )
 
 func init() {
@@ -314,6 +318,7 @@ func init() {
 		codeBadTable:            mysql.ErrBadTable,
 		codeColumnExists:        mysql.ErrDupFieldName,
 		codeIndexExists:         mysql.ErrDupIndex,
+		codeMultiplePriKey:      mysql.ErrMultiplePriKey,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassSchema] = schemaMySQLErrCodes
 	initInfoSchemaDB()

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -300,7 +300,6 @@ const (
 	codeBadTable       = 1051
 	codeColumnExists   = 1060
 	codeIndexExists    = 1831
-
 	codeMultiplePriKey = 1068
 )
 

--- a/plan/validator.go
+++ b/plan/validator.go
@@ -187,7 +187,7 @@ func (v *validator) checkAutoIncrement(stmt *ast.CreateTableStmt) {
 }
 
 func (v *validator) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
-	countPrimayKey := 0
+	countPrimaryKey := 0
 	for _, colDef := range stmt.Cols {
 		tp := colDef.Tp
 		if tp.Tp == mysql.TypeString &&
@@ -195,8 +195,8 @@ func (v *validator) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 			v.err = errors.Errorf("Column length too big for column '%s' (max = 255); use BLOB or TEXT instead", colDef.Name.Name.O)
 			return
 		}
-		countPrimayKey += isPrimary(colDef.Options)
-		if countPrimayKey > 1 {
+		countPrimaryKey += isPrimary(colDef.Options)
+		if countPrimaryKey > 1 {
 			v.err = infoschema.ErrMultiplePriKey
 			return
 		}
@@ -210,10 +210,11 @@ func (v *validator) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 				return
 			}
 		case ast.ConstraintPrimaryKey:
-			if countPrimayKey > 0 {
+			if countPrimaryKey > 0 {
 				v.err = infoschema.ErrMultiplePriKey
 				return
 			}
+			countPrimaryKey++
 			err := checkDuplicateColumnName(constraint.Keys)
 			if err != nil {
 				v.err = err

--- a/plan/validator_test.go
+++ b/plan/validator_test.go
@@ -54,9 +54,14 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"create table t(id int auto_increment) ENGINE=MYISAM", true, nil},
 		{"create table t(a int primary key, b int, c varchar(10), d char(256));", true, errors.New("Column length too big for column 'd' (max = 255); use BLOB or TEXT instead")},
 		{"create index ib on t(b,a,b);", true, errors.New("[schema:1060]Duplicate column name 'b'")},
-		{"create table t (a int, b int, key(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
-		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("Multiple primary key defined")},
 		{"alter table t add index idx(a, b, A)", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t (a int, b int, index(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t (a int, b int, key(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t (a int, b int, unique(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t (a int, b int, unique key(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t (a int, b int, unique index(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
+		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("[schema:1068]Multiple primary key defined")},
+		{"create table t(c1 int not null primary key, c2 int not null, primary key(c1))", true, errors.New("[schema:1068]Multiple primary key defined")},
 	}
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
 	c.Assert(err, IsNil)

--- a/plan/validator_test.go
+++ b/plan/validator_test.go
@@ -62,7 +62,7 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"create table t (a int, b int, unique index(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
 		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("[schema:1068]Multiple primary key defined")},
 		{"create table t(c1 int not null primary key, c2 int not null, primary key(c1))", true, errors.New("[schema:1068]Multiple primary key defined")},
-		{"create table t(c1 int not null primary key, c2 int not null, primary key(c1), primary key(c2))", true, errors.New("[schema:1068]Multiple primary key defined")},
+		{"create table t(c1 int not null, c2 int not null, primary key(c1), primary key(c2))", true, errors.New("[schema:1068]Multiple primary key defined")},
 	}
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
 	c.Assert(err, IsNil)

--- a/plan/validator_test.go
+++ b/plan/validator_test.go
@@ -62,6 +62,7 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"create table t (a int, b int, unique index(a, b, A))", true, errors.New("[schema:1060]Duplicate column name 'A'")},
 		{"create table t(c1 int not null primary key, c2 int not null primary key)", true, errors.New("[schema:1068]Multiple primary key defined")},
 		{"create table t(c1 int not null primary key, c2 int not null, primary key(c1))", true, errors.New("[schema:1068]Multiple primary key defined")},
+		{"create table t(c1 int not null primary key, c2 int not null, primary key(c1), primary key(c2))", true, errors.New("[schema:1068]Multiple primary key defined")},
 	}
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
fix #2127 and #2128 

Check whether exists duplicate cols in constraints of CreateTableStmt, 
and whether exists duplicate primary keys.

PTAL @coocood @shenli @hanfei1991 @zimulala 