### PR TITLE
plan: fix panic when explain

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -110,7 +110,8 @@ func (s *testSuite) TestExplain(c *C) {
             "Desc": false
         }
     ],
-    "limit": null,
+    "limit count": null,
+    "limit offset": null,
     "child": "TableScan_6"
 }`,
 			},

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -110,8 +110,7 @@ func (s *testSuite) TestExplain(c *C) {
             "Desc": false
         }
     ],
-    "limit count": null,
-    "limit offset": null,
+    "limit": null,
     "child": "TableScan_6"
 }`,
 			},
@@ -335,6 +334,38 @@ func (s *testSuite) TestExplain(c *C) {
         "a.c1"
     ],
     "child": "HashLeftJoin_9"
+}`,
+			},
+		},
+		{
+			"select * from t2 order by t2.c2 limit 0, 1",
+			[]string{
+				"TableScan_5", "",
+			},
+			[]string{
+				"", "",
+			},
+			[]string{
+				`{
+    "db": "test",
+    "table": "t2",
+    "desc": false,
+    "keep order": true,
+    "push down info": {
+        "limit": 0,
+        "access conditions": null,
+        "filter conditions": null
+    }
+}`,
+				`{
+    "exprs": [
+        {
+            "Expr": "test.t2.c2",
+            "Desc": false
+        }
+    ],
+    "limit": 1,
+    "child": "TableScan_5"
 }`,
 			},
 		},

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -620,19 +620,28 @@ func (p *Sort) Copy() PhysicalPlan {
 
 // MarshalJSON implements json.Marshaler interface.
 func (p *Sort) MarshalJSON() ([]byte, error) {
-	limit, err := json.Marshal(p.ExecLimit)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	exprs, err := json.Marshal(p.ByItems)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	limitCount := []byte("null")
+	limitOffset := []byte("null")
+	if p.ExecLimit != nil {
+		limitCount, err = json.Marshal(p.ExecLimit.Count)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		limitOffset, err = json.Marshal(p.ExecLimit.Offset)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
 	buffer := bytes.NewBufferString("{")
 	buffer.WriteString(fmt.Sprintf(
 		" \"exprs\": %s,\n"+
-			" \"limit\": %s,\n"+
-			" \"child\": \"%s\"}", exprs, limit, p.children[0].GetID()))
+			" \"limit count\": %s,\n"+
+			" \"limit offset\": %s,\n"+
+			" \"child\": \"%s\"}", exprs, limitCount, limitOffset, p.children[0].GetID()))
 	return buffer.Bytes(), nil
 }
 

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -625,13 +625,8 @@ func (p *Sort) MarshalJSON() ([]byte, error) {
 		return nil, errors.Trace(err)
 	}
 	limitCount := []byte("null")
-	limitOffset := []byte("null")
 	if p.ExecLimit != nil {
 		limitCount, err = json.Marshal(p.ExecLimit.Count)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		limitOffset, err = json.Marshal(p.ExecLimit.Offset)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -639,9 +634,8 @@ func (p *Sort) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString("{")
 	buffer.WriteString(fmt.Sprintf(
 		" \"exprs\": %s,\n"+
-			" \"limit count\": %s,\n"+
-			" \"limit offset\": %s,\n"+
-			" \"child\": \"%s\"}", exprs, limitCount, limitOffset, p.children[0].GetID()))
+			" \"limit\": %s,\n"+
+			" \"child\": \"%s\"}", exprs, limitCount, p.children[0].GetID()))
 	return buffer.Bytes(), nil
 }
 


### PR DESCRIPTION
Sql like `explain select * from t order by t.v1 limit 0, 1;` will cause a panic because limit is a property of sort and doesn't has a child. If we call MarshalJSON of *Limit, we will get  a `index out of range` panic

PTAL @hanfei1991 @shenli @zimulala @coocood @XuHuaiyu @tiancaiamao 