### PR TITLE
executor: fix the error when union_scan's src is mem table.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -319,7 +319,7 @@ func (b *executorBuilder) buildExplain(v *plan.Explain) Executor {
 	}
 }
 
-func (b *executorBuilder) buildUnionScanExec(v *plan.PhysicalUnionScan) *UnionScanExec {
+func (b *executorBuilder) buildUnionScanExec(v *plan.PhysicalUnionScan) Executor {
 	src := b.build(v.GetChildByIndex(0))
 	if b.err != nil {
 		return nil
@@ -345,7 +345,7 @@ func (b *executorBuilder) buildUnionScanExec(v *plan.PhysicalUnionScan) *UnionSc
 		us.condition = v.Condition
 		us.buildAndSortAddedRows(x.table, x.asName)
 	default:
-		b.err = ErrUnknownPlan.Gen("Unknown Plan %T", src)
+		return src
 	}
 	return us
 }

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -345,6 +345,7 @@ func (b *executorBuilder) buildUnionScanExec(v *plan.PhysicalUnionScan) Executor
 		us.condition = v.Condition
 		us.buildAndSortAddedRows(x.table, x.asName)
 	default:
+		// The mem table will not be written by sql directly, so we can omit the union scan to avoid err reporting.
 		return src
 	}
 	return us

--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -32,6 +32,7 @@ func (s *testSuite) TestDirtyTransaction(c *C) {
 	tk.MustExec("begin")
 	tk.MustQuery("select * from t").Check(testkit.Rows("2 3", "4 8", "6 8"))
 	tk.MustExec("insert t values (1, 5), (3, 4), (7, 6)")
+	tk.MustQuery("select * from information_schema.columns")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 5", "2 3", "3 4", "4 8", "6 8", "7 6"))
 	tk.MustQuery("select * from t where a = 1").Check(testkit.Rows("1 5"))
 	tk.MustQuery("select * from t order by a desc").Check(testkit.Rows("7 6", "6 8", "4 8", "3 4", "2 3", "1 5"))


### PR DESCRIPTION
When we begin a transaction, we will add a unionscan exec for any table / index scan exec. But union scan will report an error when its src is a mem table.
PTAL @shenli @coocood 