### PR TITLE
domain: Remove a debug log

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -59,7 +59,6 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 		return 0, errors.Trace(err)
 	}
 	if usedSchemaVersion != 0 && usedSchemaVersion == latestSchemaVersion {
-		log.Debugf("[ddl] schema version is still %d, no need reload", usedSchemaVersion)
 		return latestSchemaVersion, nil
 	}
 	startTime := time.Now()


### PR DESCRIPTION
If the log level is on debug mode, this log will always refresh. 