### PR TITLE
parser: fix wrong offset for token inner mysql comment

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -298,7 +298,6 @@ func sqlOffsetInComment(comment string) int {
 		if !unicode.IsSpace(rune(comment[offset])) {
 			break
 		}
-
 	}
 	return offset
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -273,7 +273,7 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 				Pos: Pos{
 					pos.Line,
 					pos.Col,
-					pos.Offset + 9, // 9 is length for pattern like "/*!40101 "
+					pos.Offset + sqlOffsetInComment(comment),
 				},
 			}
 		}
@@ -282,6 +282,25 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 	}
 	tok = int('/')
 	return
+}
+
+func sqlOffsetInComment(comment string) int {
+	// find the first SQL token offset in pattern like "/*!40101 mysql specific code */"
+	offset := 0
+	for i := 0; i < len(comment); i++ {
+		if unicode.IsSpace(rune(comment[i])) {
+			offset = i
+			break
+		}
+	}
+	for offset < len(comment) {
+		offset++
+		if !unicode.IsSpace(rune(comment[offset])) {
+			break
+		}
+
+	}
+	return offset
 }
 
 func startWithAt(s *Scanner) (tok int, pos Pos, lit string) {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -273,7 +273,7 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 				Pos: Pos{
 					pos.Line,
 					pos.Col,
-					pos.Offset + len("/*!40101 "),
+					pos.Offset + 9, // 9 is length for pattern like "/*!40101 "
 				},
 			}
 		}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -204,3 +204,18 @@ func (s *testLexerSuite) TestIdentifier(c *C) {
 		c.Assert(v.ident, Equals, item[1])
 	}
 }
+
+func (s *testLexerSuite) TestSpecialComment(c *C) {
+	l := NewScanner("/*!40101 select\n5*/")
+	tok, pos, lit := l.scan()
+	fmt.Println(tok, pos, lit)
+	c.Assert(tok, Equals, identifier)
+	c.Assert(lit, Equals, "select")
+	c.Assert(pos, Equals, Pos{0, 0, 9})
+
+	tok, pos, lit = l.scan()
+	fmt.Println(tok, pos, lit)
+	c.Assert(tok, Equals, intLit)
+	c.Assert(lit, Equals, "5")
+	c.Assert(pos, Equals, Pos{1, 1, 16})
+}


### PR DESCRIPTION
```
CREATE TABLE `t_h_surf_ele` (
 `V01000` int(6) NOT NULL,
 `V06001` double DEFAULT NULL,
 `V05001` double DEFAULT NULL,
 `V07001` double DEFAULT NULL,
 `V04001` int(4) DEFAULT NULL,
 `V04002` int(2) DEFAULT NULL,
 `V04003` int(2) DEFAULT NULL,
 `V04004` int(2) DEFAULT NULL,
 `V02001` int(2) DEFAULT NULL,
 `V20010` float(8,2) DEFAULT NULL,
 `V11001` float(8,2) DEFAULT NULL,
 `V11002` float(8,2) DEFAULT NULL,
 `V10051` float(8,2) DEFAULT NULL,
 `V_3h_var_pressure` float(8,2) DEFAULT NULL,
 `V_weather_condition1` float(8,2) DEFAULT NULL,
 `V_weather_condition2` float(8,2) DEFAULT NULL,
 `V_6h_precipitation` float(8,2) DEFAULT NULL,
 `V_low_clouds` float(8,2) DEFAULT NULL,
 `V_low_cloud_cover` float(8,2) DEFAULT NULL,
 `V_low_cloud_height` float(8,2) DEFAULT NULL,
 `V_dew_point` float(8,2) DEFAULT NULL,
 `V_visibility` float(8,2) DEFAULT NULL,
 `V_weather_condition` int(2) DEFAULT NULL,
 `V12001` float(8,2) DEFAULT NULL,
 `V_medium_clouds` float(8,2) DEFAULT NULL,
 `V_high_clouds` float(8,2) DEFAULT NULL,
 `V_24h_var_tempture` float(8,2) DEFAULT NULL,
 `V_24h_var_pressure` float(8,2) DEFAULT NULL,
 `VDate` datetime NOT NULL,
 PRIMARY KEY (`V01000`,`VDate`),
 KEY `idx_v01_v04_day` (`V01000`,`V04001`,`V04002`,`V04003`) USING BTREE,
 KEY `idx_v04001` (`V04001`) USING BTREE,
 KEY `idx_v04004` (`V04004`) USING BTREE
) ENGINE=MyISAM DEFAULT CHARSET=utf8
/*!50100 PARTITION BY RANGE (Year(VDate))
(PARTITION p1980 VALUES LESS THAN (1980) ENGINE = MyISAM,
PARTITION p1990 VALUES LESS THAN (1990) ENGINE = MyISAM,
PARTITION p2000 VALUES LESS THAN (2000) ENGINE = MyISAM,
PARTITION p2010 VALUES LESS THAN (2010) ENGINE = MyISAM,
PARTITION p2020 VALUES LESS THAN (2020) ENGINE = MyISAM,
PARTITION p2030 VALUES LESS THAN (2030) ENGINE = MyISAM,
PARTITION p2040 VALUES LESS THAN (2040) ENGINE = MyISAM,
PARTITION p2050 VALUES LESS THAN (2050) ENGINE = MyISAM,
PARTITION p2060 VALUES LESS THAN (2060) ENGINE = MyISAM,
PARTITION p2070 VALUES LESS THAN (2070) ENGINE = MyISAM,
PARTITION p2080 VALUES LESS THAN (2080) ENGINE = MyISAM,
PARTITION p2o90 VALUES LESS THAN (2090) ENGINE = MyISAM,
PARTITION pothers VALUES LESS THAN MAXVALUE ENGINE = MyISAM) */
```

fix bug parse token inner `/*! */` offset wrong, and may cause index out of range panic.