### PR TITLE
*: fix cast decimal allocates large memory.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -982,6 +982,8 @@ func (s *testSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("1991-09-05 11:11:11"))
 	result = tk.MustQuery("select cast('11:11:11' as time)")
 	result.Check(testkit.Rows("11:11:11"))
+	result = tk.MustQuery("select * from t where a > cast(2 as decimal)")
+	result.Check(testkit.Rows("3 2"))
 
 	// test unhex and hex
 	result = tk.MustQuery("select unhex('4D7953514C')")

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3115,6 +3115,10 @@ CastType:
 		x := types.NewFieldType(mysql.TypeNewDecimal)
 		x.Flen = fopt.Flen
 		x.Decimal = fopt.Decimal
+		if fopt.Flen == types.UnspecifiedLength {
+			x.Flen = mysql.GetDefaultFieldLength(mysql.TypeNewDecimal)
+			x.Decimal = mysql.GetDefaultDecimal(mysql.TypeNewDecimal)
+		}
 		$$ = x
 	}
 |	"TIME" OptFieldLen

--- a/util/types/mydecimal.go
+++ b/util/types/mydecimal.go
@@ -1040,6 +1040,9 @@ with the correct -1/0/+1 result
                 7E F2 04 C7 2D FB 2D
 */
 func (d *MyDecimal) ToBin(precision, frac int) ([]byte, error) {
+	if precision > digitsPerWord*maxWordBufLen || precision < 0 || frac > MaxFraction || frac < 0 {
+		return nil, ErrBadNumber
+	}
 	var err error
 	var mask int32
 	if d.negative {

--- a/util/types/mydecimal_test.go
+++ b/util/types/mydecimal_test.go
@@ -405,7 +405,7 @@ func (s *testMyDecimalSuite) TestToBinFromBin(c *C) {
 		{10, -1},
 	}
 	for _, ca := range errCases {
-		_, err := dec.ToBin(ca.prec, ca.prec)
+		_, err := dec.ToBin(ca.prec, ca.frac)
 		c.Assert(ErrBadNumber.Equal(err), IsTrue)
 	}
 }

--- a/util/types/mydecimal_test.go
+++ b/util/types/mydecimal_test.go
@@ -393,6 +393,21 @@ func (s *testMyDecimalSuite) TestToBinFromBin(c *C) {
 		str := dec2.ToString()
 		c.Assert(string(str), Equals, ca.output)
 	}
+	var dec MyDecimal
+	dec.FromInt(1)
+	errCases := []struct {
+		prec int
+		frac int
+	}{
+		{82, 1},
+		{-1, 1},
+		{10, 31},
+		{10, -1},
+	}
+	for _, ca := range errCases {
+		_, err := dec.ToBin(ca.prec, ca.prec)
+		c.Assert(ErrBadNumber.Equal(err), IsTrue)
+	}
 }
 
 func (s *testMyDecimalSuite) TestCompare(c *C) {


### PR DESCRIPTION
If precision is too large, encode decimal allocates large amount of memory.
This commit set cast decimal unspecified length to default decimal length (10),
also add check on precision and frac on `MyDecimal.ToBin`.