### PR TITLE
plan: support pushing agg across projection.

### DIFF
--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -295,6 +295,23 @@ func (a *aggPushDownSolver) aggPushDown(p LogicalPlan) {
 				rChild.SetParents(join)
 				join.SetSchema(append(lChild.GetSchema().Clone(), rChild.GetSchema().Clone()...))
 			}
+		} else if proj, ok1 := child.(*Projection); ok1 {
+			// TODO: This optimization is not always reasonable. We have not supported pushing projection to kv layer yet,
+			// so we must do this optimization.
+			for i, gbyItem := range agg.GroupByItems {
+				agg.GroupByItems[i] = expression.ColumnSubstitute(gbyItem, proj.schema, proj.Exprs)
+			}
+			agg.collectGroupByColumns()
+			for _, aggFunc := range agg.AggFuncs {
+				newArgs := make([]expression.Expression, 0, len(aggFunc.GetArgs()))
+				for _, arg := range aggFunc.GetArgs() {
+					newArgs = append(newArgs, expression.ColumnSubstitute(arg, proj.schema, proj.Exprs))
+				}
+				aggFunc.SetArgs(newArgs)
+			}
+			projChild := proj.children[0]
+			agg.SetChildren(projChild)
+			projChild.SetParents(agg)
 		}
 	}
 	for _, child := range p.GetChildren() {

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -676,7 +676,7 @@ func (s *testPlanSuite) TestAggPushDown(c *C) {
 			best: "Join{DataScan(a)->Aggr(sum(a.a),firstrow(a.c))->DataScan(b)}(a.c,b.c)->Aggr(sum(join_agg_0))->Projection",
 		},
 		{
-			sql: "select sum(a) from (select * from t) x",
+			sql:  "select sum(a) from (select * from t) x",
 			best: "DataScan(t)->Aggr(sum(test.t.a))->Projection",
 		},
 	}

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -675,6 +675,10 @@ func (s *testPlanSuite) TestAggPushDown(c *C) {
 			sql:  "select sum(a.a) from t a right join t b on a.c = b.c",
 			best: "Join{DataScan(a)->Aggr(sum(a.a),firstrow(a.c))->DataScan(b)}(a.c,b.c)->Aggr(sum(join_agg_0))->Projection",
 		},
+		{
+			sql: "select sum(a) from (select * from t) x",
+			best: "DataScan(t)->Aggr(sum(test.t.a))->Projection",
+		},
 	}
 	for _, ca := range cases {
 		comment := Commentf("for %s", ca.sql)


### PR DESCRIPTION
Because we havn't supported pushing projection down to kv layer, we must push agg  across projection.
@coocood @zimulala @XuHuaiyu @shenli @winoros PTAL