### PR TITLE
ddl: use hookCtx in test

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
@@ -82,6 +83,8 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 		if job.SchemaState == prevState {
 			return
 		}
+		hookCtx := mock.NewContext()
+		hookCtx.Store = s.store
 		prevState = job.SchemaState
 		var err error
 		switch job.SchemaState {
@@ -95,7 +98,7 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
-			err = s.checkAddWriteOnly(d, ctx, deleteOnlyTable, writeOnlyTable)
+			err = s.checkAddWriteOnly(d, hookCtx, deleteOnlyTable, writeOnlyTable)
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
@@ -105,7 +108,7 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}
-			err = s.checkAddPublic(d, ctx, writeOnlyTable, publicTable)
+			err = s.checkAddPublic(d, hookCtx, writeOnlyTable, publicTable)
 			if err != nil {
 				checkErr = errors.Trace(err)
 			}


### PR DESCRIPTION
hook function will be called by ddl worker goroutine. use the same context can cause
context be committed more than once time.

Fixes https://github.com/pingcap/tidb/issues/2158