### PR TITLE
plan: we won't prune expression that contains set var

### DIFF
--- a/plan/column_pruning.go
+++ b/plan/column_pruning.go
@@ -15,6 +15,7 @@ package plan
 
 import (
 	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 )
 
@@ -30,13 +31,29 @@ func getUsedList(usedCols []*expression.Column, schema expression.Schema) []bool
 	return used
 }
 
+func exprCanPrune(expr expression.Expression) bool {
+	if fun, ok := expr.(*expression.ScalarFunction); ok {
+		canPrune := true
+		if fun.FuncName.L == ast.SetVar {
+			return false
+		}
+		for _, arg := range fun.Args {
+			canPrune = canPrune && exprCanPrune(arg)
+			if !canPrune {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // PruneColumns implements LogicalPlan interface.
 func (p *Projection) PruneColumns(parentUsedCols []*expression.Column) {
 	child := p.GetChildByIndex(0).(LogicalPlan)
 	var selfUsedCols []*expression.Column
 	used := getUsedList(parentUsedCols, p.schema)
 	for i := len(used) - 1; i >= 0; i-- {
-		if !used[i] {
+		if !used[i] && exprCanPrune(p.Exprs[i]) {
 			p.schema = append(p.schema[:i], p.schema[i+1:]...)
 			p.Exprs = append(p.Exprs[:i], p.Exprs[i+1:]...)
 		}

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -577,6 +577,10 @@ func (s *testPlanSuite) TestProjectionElimination(c *C) {
 			sql: "select t1.a from t t1 where t1.a in (select t2.a from t t2 where t1.a > 1)",
 			ans: "Apply{Table(t)->Table(t)->Cache->Selection}->Selection->Projection",
 		},
+		{
+			sql: "select t1.a from t t1, (select @a:=0, @b:=0) t2",
+			ans: "LeftHashJoin{Table(t)->*plan.TableDual->Projection}->Projection",
+		},
 	}
 	for _, ca := range cases {
 		comment := Commentf("for %s", ca.sql)


### PR DESCRIPTION
For query `select t.a, @a from t, (select @a = 0)`, the @a = 0 won't work. because we apply column prunning and then eliminate the projection. We shouldn't prune any expression containing set var expr.
@shenli @coocood @zimulala @tiancaiamao @XuHuaiyu @winoros PTAL