### PR TITLE
executor: fix a problem that may cause system hang.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -562,7 +562,7 @@ func (e *HashJoinExec) fetchBigExec() {
 		done := false
 		for i := 0; i < curBatchSize; i++ {
 			if e.finished.Load().(bool) {
-				break
+				return
 			}
 			row, err := e.bigExec.Next()
 			if err != nil {


### PR DESCRIPTION
When the "fetch big data" check the finish is false and break, it will enter an infinite loop. it should return directly.
@coocood @shenli @zimulala @XuHuaiyu @winoros PTAL