### PR TITLE
tidb-server: disable log highlight when using log file

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -91,6 +91,7 @@ func main() {
 			log.Fatal(errors.ErrorStack(err))
 		}
 		log.SetRotateByDay()
+		log.SetHighlighting(false)
 	}
 
 	if joinCon != nil && *joinCon > 0 {


### PR DESCRIPTION
If we use --log-file, we shouldn't use highlight, otherwise, the log may look ugly in log file. 

@ngaut @shenli @coocood 