### PR TITLE
circleci: Remove useless http parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/pingcap/tidb.svg?branch=master)](https://travis-ci.org/pingcap/tidb)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/tidb)](https://goreportcard.com/report/github.com/pingcap/tidb)
 ![Project Status](https://img.shields.io/badge/status-beta-yellow.svg)
-[![CircleCI Status](https://circleci.com/gh/pingcap/tidb.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/pingcap/tidb)
+[![CircleCI Status](https://circleci.com/gh/pingcap/tidb.svg?style=shield)](https://circleci.com/gh/pingcap/tidb)
 
 ## What is TiDB?
 


### PR DESCRIPTION
"circle-token=:circle-token"  is useless.