### PR TITLE
Support builtin function schema()

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -145,6 +145,7 @@ const (
 	ConnectionID = "connection_id"
 	CurrentUser  = "current_user"
 	Database     = "database"
+	Schema       = "schema"
 	FoundRows    = "found_rows"
 	LastInsertId = "last_insert_id"
 	User         = "user"

--- a/evaluator/builtin.go
+++ b/evaluator/builtin.go
@@ -117,6 +117,7 @@ var Funcs = map[string]Func{
 	ast.ConnectionID: {builtinConnectionID, 0, 0},
 	ast.CurrentUser:  {builtinCurrentUser, 0, 0},
 	ast.Database:     {builtinDatabase, 0, 0},
+	ast.Schema:       {builtinDatabase, 0, 0},
 	ast.FoundRows:    {builtinFoundRows, 0, 0},
 	ast.LastInsertId: {builtinLastInsertID, 0, 1},
 	ast.User:         {builtinUser, 0, 0},

--- a/evaluator/builtin.go
+++ b/evaluator/builtin.go
@@ -117,6 +117,8 @@ var Funcs = map[string]Func{
 	ast.ConnectionID: {builtinConnectionID, 0, 0},
 	ast.CurrentUser:  {builtinCurrentUser, 0, 0},
 	ast.Database:     {builtinDatabase, 0, 0},
+	// This function is a synonym for DATABASE().
+	// See http://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_schema
 	ast.Schema:       {builtinDatabase, 0, 0},
 	ast.FoundRows:    {builtinFoundRows, 0, 0},
 	ast.LastInsertId: {builtinLastInsertID, 0, 1},

--- a/evaluator/builtin_info_test.go
+++ b/evaluator/builtin_info_test.go
@@ -33,6 +33,7 @@ func (s *testEvaluatorSuite) TestDatabase(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(d.GetString(), Equals, "test")
 
+	// Test case for schema().
 	f := Funcs[ast.Schema]
 	c.Assert(f, NotNil)
 	d, err = f.F(types.MakeDatums(), ctx)

--- a/evaluator/builtin_info_test.go
+++ b/evaluator/builtin_info_test.go
@@ -15,6 +15,7 @@ package evaluator
 
 import (
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -31,6 +32,9 @@ func (s *testEvaluatorSuite) TestDatabase(c *C) {
 	d, err = builtinDatabase(types.MakeDatums(), ctx)
 	c.Assert(err, IsNil)
 	c.Assert(d.GetString(), Equals, "test")
+
+	f := Funcs[ast.Schema]
+	c.Assert(f.F, Equals, builtinDatabase)
 }
 
 func (s *testEvaluatorSuite) TestFoundRows(c *C) {

--- a/evaluator/builtin_info_test.go
+++ b/evaluator/builtin_info_test.go
@@ -34,7 +34,10 @@ func (s *testEvaluatorSuite) TestDatabase(c *C) {
 	c.Assert(d.GetString(), Equals, "test")
 
 	f := Funcs[ast.Schema]
-	c.Assert(f.F, Equals, builtinDatabase)
+	c.Assert(f, NotNil)
+	d, err = f.F(types.MakeDatums(), ctx)
+	c.Assert(err, IsNil)
+	c.Assert(d.GetString(), Equals, "test")
 }
 
 func (s *testEvaluatorSuite) TestFoundRows(c *C) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -517,6 +517,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 
 		// Information Functions
 		{"SELECT DATABASE();", true},
+		{"SELECT SCHEMA();", true},
 		{"SELECT USER();", true},
 		{"SELECT CURRENT_USER();", true},
 		{"SELECT CURRENT_USER;", true},


### PR DESCRIPTION
Fix https://github.com/pingcap/tidb/issues/2172
Schema() is an alias for Database().
See: http://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_schema