### PR TITLE
executor: Fix the bug in the statement of "on duplicate..." 

### DIFF
--- a/executor/executor_write.go
+++ b/executor/executor_write.go
@@ -46,6 +46,9 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	var newHandle types.Datum
 	for i, hasSetExpr := range assignFlag {
 		if !hasSetExpr {
+			if onDuplicateUpdate {
+				newData[i] = oldData[i]
+			}
 			continue
 		}
 		if i < offset || i >= offset+len(cols) {

--- a/executor/executor_write_test.go
+++ b/executor/executor_write_test.go
@@ -95,8 +95,10 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("rollback")
 
 	// Updating column is PK handle.
+	// Make sure the record is "1, 1, nil, 1".
 	r := tk.MustQuery("select * from insert_test where id = 1;")
 	rowStr := fmt.Sprintf("%v %v %v %v", "1", "1", nil, "1")
+	r.Check(testkit.Rows(rowStr))
 	insertSQL := `insert into insert_test (id, c3) values (1, 2) on duplicate key update id=values(id), c2=10;`
 	tk.MustExec(insertSQL)
 	r = tk.MustQuery("select * from insert_test where id = 1;")

--- a/executor/executor_write_test.go
+++ b/executor/executor_write_test.go
@@ -94,8 +94,14 @@ func (s *testSuite) TestInsert(c *C) {
 	c.Assert(err, NotNil)
 	tk.MustExec("rollback")
 
-	insertSQL := `insert into insert_test (id, c2) values (1, 1) on duplicate key update c2=10;`
+	// Updating column is PK handle.
+	r := tk.MustQuery("select * from insert_test where id = 1;")
+	rowStr := fmt.Sprintf("%v %v %v %v", "1", "1", nil, "1")
+	insertSQL := `insert into insert_test (id, c3) values (1, 2) on duplicate key update id=values(id), c2=10;`
 	tk.MustExec(insertSQL)
+	r = tk.MustQuery("select * from insert_test where id = 1;")
+	rowStr = fmt.Sprintf("%v %v %v %v", "1", "1", "10", "1")
+	r.Check(testkit.Rows(rowStr))
 
 	insertSQL = `insert into insert_test (id, c2) values (1, 1) on duplicate key update insert_test.c2=10;`
 	tk.MustExec(insertSQL)


### PR DESCRIPTION
 Fix the bug in the statement of "on duplicate..." when updating the PK handle.