### PR TITLE
store/tikv: reduce the use of region.Clone().

### DIFF
--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -106,7 +106,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	regionIDs = append(regionIDs, cluster.AllocID())
 	peerIDs = append(peerIDs, cluster.AllocID())
 	cluster.Split(regionIDs[1], regionIDs[2], []byte("q"), []uint64{peerIDs[2]}, storeID)
-	cache.DropRegion(tasks[1].region.VerID())
+	cache.DropRegion(tasks[1].region)
 
 	tasks, err = buildCopTasks(bo, cache, s.buildKeyRanges("a", "z"), true)
 	c.Assert(err, IsNil)
@@ -156,7 +156,7 @@ func (s *testCoprocessorSuite) buildKeyRanges(keys ...string) *copRanges {
 }
 
 func (s *testCoprocessorSuite) taskEqual(c *C, task *copTask, regionID uint64, keys ...string) {
-	c.Assert(task.region.GetID(), Equals, regionID)
+	c.Assert(task.region.id, Equals, regionID)
 	for i := 0; i < task.ranges.len(); i++ {
 		r := task.ranges.at(i)
 		c.Assert(string(r.StartKey), Equals, keys[2*i])

--- a/store/tikv/gc_worker.go
+++ b/store/tikv/gc_worker.go
@@ -265,11 +265,11 @@ func (w *GCWorker) resolveLocks(safePoint uint64) error {
 		default:
 		}
 
-		region, err := w.store.regionCache.GetRegion(bo, key)
+		loc, err := w.store.regionCache.LocateKey(bo, key)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		resp, err := w.store.SendKVReq(bo, req, region.VerID(), readTimeoutMedium)
+		resp, err := w.store.SendKVReq(bo, req, loc.Region, readTimeoutMedium)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -305,7 +305,7 @@ func (w *GCWorker) resolveLocks(safePoint uint64) error {
 		}
 		regions++
 		totalResolvedLocks += len(locks)
-		key = region.EndKey()
+		key = loc.EndKey
 		if len(key) == 0 {
 			break
 		}
@@ -339,11 +339,11 @@ func (w *GCWorker) DoGC(safePoint uint64) error {
 		default:
 		}
 
-		region, err := w.store.regionCache.GetRegion(bo, key)
+		loc, err := w.store.regionCache.LocateKey(bo, key)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		resp, err := w.store.SendKVReq(bo, req, region.VerID(), readTimeoutLong)
+		resp, err := w.store.SendKVReq(bo, req, loc.Region, readTimeoutLong)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -362,7 +362,7 @@ func (w *GCWorker) DoGC(safePoint uint64) error {
 			return errors.Errorf("unexpected gc error: %s", gcResp.GetError())
 		}
 		regions++
-		key = region.EndKey()
+		key = loc.EndKey
 		if len(key) == 0 {
 			break
 		}

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -191,9 +191,9 @@ func (s *testLockSuite) mustGetLock(c *C, key []byte) *Lock {
 			Version: ver.Ver,
 		},
 	}
-	region, err := s.store.regionCache.GetRegion(bo, key)
+	loc, err := s.store.regionCache.LocateKey(bo, key)
 	c.Assert(err, IsNil)
-	resp, err := s.store.SendKVReq(bo, req, region.VerID(), readTimeoutShort)
+	resp, err := s.store.SendKVReq(bo, req, loc.Region, readTimeoutShort)
 	c.Assert(err, IsNil)
 	cmdGetResp := resp.GetCmdGetResp()
 	c.Assert(cmdGetResp, NotNil)

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -118,11 +118,11 @@ func (c *RawKVClient) sendKVReq(key []byte, req *kvrpcpb.Request) (*kvrpcpb.Resp
 	bo := NewBackoffer(rawkvMaxBackoff, context.Background())
 	sender := NewRegionRequestSender(bo, c.regionCache, c.rpcClient)
 	for {
-		region, err := c.regionCache.GetRegion(bo, key)
+		loc, err := c.regionCache.LocateKey(bo, key)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		resp, err := sender.SendKVReq(req, region.VerID(), readTimeoutShort)
+		resp, err := sender.SendKVReq(req, loc.Region, readTimeoutShort)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -76,13 +76,13 @@ func (s *testRawKVSuite) TestSimple(c *C) {
 }
 
 func (s *testRawKVSuite) TestSplit(c *C) {
-	region1, err := s.client.regionCache.GetRegion(s.bo, []byte("k"))
+	loc, err := s.client.regionCache.LocateKey(s.bo, []byte("k"))
 	c.Assert(err, IsNil)
 	s.mustPut(c, []byte("k1"), []byte("v1"))
 	s.mustPut(c, []byte("k3"), []byte("v3"))
 
 	newRegionID, peerID := s.cluster.AllocID(), s.cluster.AllocID()
-	s.cluster.Split(region1.GetID(), newRegionID, []byte("k2"), []uint64{peerID}, peerID)
+	s.cluster.Split(loc.Region.id, newRegionID, []byte("k2"), []uint64{peerID}, peerID)
 
 	s.mustGet(c, []byte("k1"), []byte("v1"))
 	s.mustGet(c, []byte("k3"), []byte("v3"))

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -60,9 +60,14 @@ func (s *testRegionCacheSuite) checkCache(c *C, len int) {
 	}
 }
 
-func (s *testRegionCacheSuite) TestSimple(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+func (s *testRegionCacheSuite) getRegion(c *C, key []byte) *Region {
+	_, err := s.cache.LocateKey(s.bo, key)
 	c.Assert(err, IsNil)
+	return s.cache.getRegionFromCache(key)
+}
+
+func (s *testRegionCacheSuite) TestSimple(c *C) {
+	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.GetAddress(), Equals, s.storeAddr(s.store1))
@@ -72,7 +77,7 @@ func (s *testRegionCacheSuite) TestSimple(c *C) {
 func (s *testRegionCacheSuite) TestDropStore(c *C) {
 	bo := NewBackoffer(100, context.Background())
 	s.cluster.RemoveStore(s.store1)
-	r, err := s.cache.GetRegion(bo, []byte("a"))
+	r, err := s.cache.LocateKey(bo, []byte("a"))
 	c.Assert(err, NotNil)
 	c.Assert(r, IsNil)
 	s.checkCache(c, 0)
@@ -86,20 +91,19 @@ func (s *testRegionCacheSuite) TestDropStoreRetry(c *C) {
 		s.cluster.AddStore(s.store1, s.storeAddr(s.store1))
 		close(done)
 	}()
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	c.Assert(r.GetID(), Equals, s.region1)
+	c.Assert(loc.Region.id, Equals, s.region1)
 	<-done
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// tikv-server reports `NotLeader`
-	s.cache.UpdateLeader(r.VerID(), s.peer2)
+	s.cache.UpdateLeader(loc.Region, s.peer2)
 
-	r, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.curPeerIdx, Equals, 1)
@@ -107,7 +111,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// new store3 becomes leader
 	store3 := s.cluster.AllocID()
@@ -115,11 +119,10 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	s.cluster.AddStore(store3, s.storeAddr(store3))
 	s.cluster.AddPeer(s.region1, store3, peer3)
 	// tikv-server reports `NotLeader`
-	s.cache.UpdateLeader(r.VerID(), peer3)
+	s.cache.UpdateLeader(loc.Region, peer3)
 
 	// Store3 does not exist in cache, causes a reload from PD.
-	r, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.curPeerIdx, Equals, 0)
@@ -129,8 +132,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	s.cluster.ChangeLeader(s.region1, peer3)
 	// tikv-server reports `NotLeader` again.
 	s.cache.UpdateLeader(r.VerID(), peer3)
-	r, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	r = s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.curPeerIdx, Equals, 2)
@@ -138,7 +140,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// store2 becomes leader
 	s.cluster.ChangeLeader(s.region1, s.peer2)
@@ -151,10 +153,10 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	// tikv-server notifies new leader to pd-server.
 	s.cluster.ChangeLeader(s.region1, peer3)
 	// tikv-server reports `NotLeader`(store2 is the leader)
-	s.cache.UpdateLeader(r.VerID(), s.peer2)
+	s.cache.UpdateLeader(loc.Region, s.peer2)
 
 	// Store2 does not exist any more, causes a reload from PD.
-	r, err = s.cache.GetRegion(s.bo, []byte("a"))
+	r := s.getRegion(c, []byte("a"))
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
@@ -164,8 +166,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestSplit(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("x"))
-	c.Assert(err, IsNil)
+	r := s.getRegion(c, []byte("x"))
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.GetAddress(), Equals, s.storeAddr(s.store1))
 
@@ -178,8 +179,7 @@ func (s *testRegionCacheSuite) TestSplit(c *C) {
 	s.cache.DropRegion(r.VerID())
 	s.checkCache(c, 0)
 
-	r, err = s.cache.GetRegion(s.bo, []byte("x"))
-	c.Assert(err, IsNil)
+	r = s.getRegion(c, []byte("x"))
 	c.Assert(r.GetID(), Equals, region2)
 	c.Assert(r.GetAddress(), Equals, s.storeAddr(s.store1))
 	s.checkCache(c, 1)
@@ -191,32 +191,31 @@ func (s *testRegionCacheSuite) TestMerge(c *C) {
 	newPeers := s.cluster.AllocIDs(2)
 	s.cluster.Split(s.region1, region2, []byte("m"), newPeers, newPeers[0])
 
-	r, err := s.cache.GetRegion(s.bo, []byte("x"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("x"))
 	c.Assert(err, IsNil)
-	c.Assert(r.GetID(), Equals, region2)
+	c.Assert(loc.Region.id, Equals, region2)
 
 	// merge to single region
 	s.cluster.Merge(s.region1, region2)
 
 	// tikv-server reports `NotInRegion`
-	s.cache.DropRegion(r.VerID())
+	s.cache.DropRegion(loc.Region)
 	s.checkCache(c, 0)
 
-	r, err = s.cache.GetRegion(s.bo, []byte("x"))
+	loc, err = s.cache.LocateKey(s.bo, []byte("x"))
 	c.Assert(err, IsNil)
-	c.Assert(r.GetID(), Equals, s.region1)
+	c.Assert(loc.Region.id, Equals, s.region1)
 	s.checkCache(c, 1)
 }
 
 func (s *testRegionCacheSuite) TestReconnect(c *C) {
-	r, err := s.cache.GetRegion(s.bo, []byte("a"))
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 
 	// connect tikv-server failed, cause drop cache
-	s.cache.DropRegion(r.VerID())
+	s.cache.DropRegion(loc.Region)
 
-	r, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
 	c.Assert(r.GetAddress(), Equals, s.storeAddr(s.store1))
@@ -224,18 +223,15 @@ func (s *testRegionCacheSuite) TestReconnect(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestNextPeer(c *C) {
-	region, err := s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	region := s.getRegion(c, []byte("a"))
 	c.Assert(region.curPeerIdx, Equals, 0)
 
 	s.cache.NextPeer(region.VerID())
-	region, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	region = s.getRegion(c, []byte("a"))
 	c.Assert(region.curPeerIdx, Equals, 1)
 
 	s.cache.NextPeer(region.VerID())
-	region, err = s.cache.GetRegion(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
+	region = s.getRegion(c, []byte("a"))
 	// Out of range of Peers, so get Region again and pick Stores[0] as leader.
 	c.Assert(region.curPeerIdx, Equals, 0)
 }

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -190,11 +190,11 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 		},
 	}
 	for {
-		region, err := s.store.regionCache.GetRegion(bo, k)
+		loc, err := s.store.regionCache.LocateKey(bo, k)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		resp, err := s.store.SendKVReq(bo, req, region.VerID(), readTimeoutShort)
+		resp, err := s.store.SendKVReq(bo, req, loc.Region, readTimeoutShort)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
Add `LocateKey()` and `GetRPCContext()` to reduce use of `region.Clone()`.
ref #1562