### PR TITLE
kv: check iter.Next() errors.

### DIFF
--- a/store/localstore/mvcc_test.go
+++ b/store/localstore/mvcc_test.go
@@ -42,14 +42,6 @@ func createMemStore(suffix int) kv.Storage {
 	return store
 }
 
-func (t *testMvccSuite) addDirtyData() {
-	engineDB := t.s.(*dbStore).db
-	b := engineDB.NewBatch()
-	b.Put([]byte("\xf0dirty"), []byte("testvalue"))
-	b.Put([]byte("\x00dirty"), []byte("testvalue"))
-	engineDB.Commit(b)
-}
-
 func (t *testMvccSuite) TestMvccEncode(c *C) {
 	encodedKey1 := MvccEncodeVersionKey([]byte("A"), kv.Version{Ver: 1})
 	encodedKey2 := MvccEncodeVersionKey([]byte("A"), kv.Version{Ver: 2})
@@ -82,7 +74,6 @@ func (t *testMvccSuite) scanRawEngine(c *C, f func([]byte, []byte)) {
 func (t *testMvccSuite) SetUpTest(c *C) {
 	// create new store
 	t.s = createMemStore(time.Now().Nanosecond())
-	t.addDirtyData()
 	// insert test data
 	txn, err := t.s.Begin()
 	c.Assert(err, IsNil)

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -82,7 +82,7 @@ func (s *Scanner) Next() error {
 		if s.idx >= len(s.cache) {
 			if s.eof {
 				s.Close()
-				return kv.ErrNotExist
+				return nil
 			}
 			err := s.getData(bo)
 			if err != nil {

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -45,10 +45,7 @@ func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
 	c.Assert(err, IsNil)
 	for ch := byte('a'); ch <= byte('z'); ch++ {
 		c.Assert([]byte{ch}, BytesEquals, []byte(scanner.Key()))
-		if ch < byte('z') {
-			c.Assert(scanner.Next(), IsNil)
-		}
+		c.Assert(scanner.Next(), IsNil)
 	}
-	c.Assert(scanner.Next(), NotNil)
 	c.Assert(scanner.Valid(), IsFalse)
 }


### PR DESCRIPTION
1. `UnionIter` should not discard errors.
2. `Next()` should return nil when no more keys in db.

@shenli @zimulala 