### PR TITLE
parser: fix bug 0_x should parse to identifier

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -473,9 +473,9 @@ func handleEscape(s *Scanner) rune {
 
 func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 	pos = s.r.pos()
+	tok = intLit
 	ch0 := s.r.readByte()
-	switch ch0 {
-	case '0':
+	if ch0 == '0' {
 		tok = intLit
 		ch1 := s.r.peek()
 		switch {
@@ -496,14 +496,6 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 			tok = unicode.ReplacementChar
 			return
 		}
-		lit = s.r.data(&pos)
-		return
-	case '.':
-		if isDigit(s.r.peek()) {
-			return s.scanFloat(&pos)
-		}
-		tok, lit = int('.'), "."
-		return
 	}
 
 	s.scanDigits()
@@ -517,7 +509,17 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 		s.r.incAsLongAs(isIdentChar)
 		return identifier, pos, s.r.data(&pos)
 	}
-	tok, lit = intLit, s.r.data(&pos)
+	lit = s.r.data(&pos)
+	return
+}
+
+func startWithDot(s *Scanner) (tok int, pos Pos, lit string) {
+	pos = s.r.pos()
+	s.r.inc()
+	if isDigit(s.r.peek()) {
+		return s.scanFloat(&pos)
+	}
+	tok, lit = int('.'), "."
 	return
 }
 

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -60,6 +60,7 @@ func (s *testLexerSuite) TestSingleCharOther(c *C) {
 		{"?", placeholder},
 		{"PLACEHOLDER", identifier},
 		{"=", eq},
+		{".", int('.')},
 	}
 	runTest(c, table)
 }
@@ -105,6 +106,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"0b01", bitLit},
 		{fmt.Sprintf("%c", 0), invalid},
 		{fmt.Sprintf("t1%c", 0), identifier},
+		{".*", int('.')},
 	}
 	runTest(c, table)
 }
@@ -192,6 +194,8 @@ func (s *testLexerSuite) TestIdentifier(c *C) {
 		{"`numeric`", "numeric"},
 		{"\r\n \r \n \tthere\t \n", "there"},
 		{`5number`, `5number`},
+		{"1_x", "1_x"},
+		{"0_x", "0_x"},
 		{replacementString, replacementString},
 		{fmt.Sprintf("t1%cxxx", 0), "t1"},
 	}

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -127,9 +127,10 @@ func init() {
 	initTokenFunc("Xx", startWithXx)
 	initTokenFunc("x", startWithXx)
 	initTokenFunc("b", startWithb)
+	initTokenFunc(".", startWithDot)
 	initTokenFunc("_$ABCDEFGHIJKLMNOPQRSTUVWYZacdefghijklmnopqrstuvwyz", scanIdentifier)
 	initTokenFunc("`", scanQuotedIdent)
-	initTokenFunc("0123456789.", startWithNumber)
+	initTokenFunc("0123456789", startWithNumber)
 	initTokenFunc("'\"", startString)
 }
 


### PR DESCRIPTION
fix bug

```
mysql> create table 0_x (c int);
ERROR 1105 (HY000): line 0 column 14 near "_x (c int)"
mysql> create table 1_x (c int);
Query OK, 0 rows affected (2.03 sec)
```