### PR TITLE
ddl: allocate column ID and index ID in TableInfo.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -77,7 +77,8 @@ func (d *ddl) createColumnInfo(tblInfo *model.TableInfo, colInfo *model.ColumnIn
 		// Insert position is after the mentioned column.
 		position = c.Offset + 1
 	}
-
+	tblInfo.MaxColumnID++
+	colInfo.ID = tblInfo.MaxColumnID
 	colInfo.State = model.StateNone
 	// To support add column asynchronous, we should mark its offset as the last column.
 	// So that we can use origin column offset to get value from row.

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -77,8 +77,7 @@ func (d *ddl) createColumnInfo(tblInfo *model.TableInfo, colInfo *model.ColumnIn
 		// Insert position is after the mentioned column.
 		position = c.Offset + 1
 	}
-	tblInfo.MaxColumnID++
-	colInfo.ID = tblInfo.MaxColumnID
+	colInfo.ID = allocateColumnID(tblInfo)
 	colInfo.State = model.StateNone
 	// To support add column asynchronous, we should mark its offset as the last column.
 	// So that we can use origin column offset to get value from row.
@@ -453,4 +452,9 @@ func (d *ddl) onModifyColumn(t *meta.Meta, job *model.Job) error {
 	job.State = model.JobDone
 	addTableHistoryInfo(job, ver, tblInfo)
 	return nil
+}
+
+func allocateColumnID(tblInfo *model.TableInfo) int64 {
+	tblInfo.MaxColumnID++
+	return tblInfo.MaxColumnID
 }

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -65,11 +65,8 @@ func testCreateColumn(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, t
 		Offset:       len(tblInfo.Columns),
 		DefaultValue: defaultValue,
 	}
-
-	var err error
-	col.ID, err = d.genGlobalID()
-	c.Assert(err, IsNil)
-
+	tblInfo.MaxColumnID++
+	col.ID = tblInfo.MaxColumnID
 	col.FieldType = *types.NewFieldType(mysql.TypeLong)
 
 	job := &model.Job{
@@ -79,7 +76,7 @@ func testCreateColumn(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, t
 		Args:     []interface{}{col, pos, 0},
 	}
 
-	err = d.doDDLJob(ctx, job)
+	err := d.doDDLJob(ctx, job)
 	c.Assert(err, IsNil)
 	v := getSchemaVer(c, ctx)
 	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -65,8 +65,7 @@ func testCreateColumn(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, t
 		Offset:       len(tblInfo.Columns),
 		DefaultValue: defaultValue,
 	}
-	tblInfo.MaxColumnID++
-	col.ID = tblInfo.MaxColumnID
+	col.ID = allocateColumnID(tblInfo)
 	col.FieldType = *types.NewFieldType(mysql.TypeLong)
 
 	job := &model.Job{

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -751,8 +751,7 @@ func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constr
 		return nil, errors.Trace(err)
 	}
 	for _, v := range cols {
-		tbInfo.MaxColumnID++
-		v.ID = tbInfo.MaxColumnID
+		v.ID = allocateColumnID(tbInfo)
 		tbInfo.Columns = append(tbInfo.Columns, v.ToInfo())
 	}
 	for _, constr := range constraints {
@@ -835,8 +834,7 @@ func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constr
 			// Use btree as default index type.
 			idxInfo.Tp = model.IndexTypeBtree
 		}
-		tbInfo.MaxIndexID++
-		idxInfo.ID = tbInfo.MaxIndexID
+		idxInfo.ID = allocateIndexID(tbInfo)
 		tbInfo.Indices = append(tbInfo.Indices, idxInfo)
 	}
 	return

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -466,12 +466,6 @@ func (d *ddl) buildColumnAndConstraint(ctx context.Context, offset int,
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-
-	col.ID, err = d.genGlobalID()
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-
 	return col, cts, nil
 }
 
@@ -757,6 +751,8 @@ func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constr
 		return nil, errors.Trace(err)
 	}
 	for _, v := range cols {
+		tbInfo.MaxColumnID++
+		v.ID = tbInfo.MaxColumnID
 		tbInfo.Columns = append(tbInfo.Columns, v.ToInfo())
 	}
 	for _, constr := range constraints {
@@ -839,10 +835,8 @@ func (d *ddl) buildTableInfo(tableName model.CIStr, cols []*table.Column, constr
 			// Use btree as default index type.
 			idxInfo.Tp = model.IndexTypeBtree
 		}
-		idxInfo.ID, err = d.genGlobalID()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
+		tbInfo.MaxIndexID++
+		idxInfo.ID = tbInfo.MaxIndexID
 		tbInfo.Indices = append(tbInfo.Indices, idxInfo)
 	}
 	return
@@ -1275,22 +1269,16 @@ func (d *ddl) CreateIndex(ctx context.Context, ti ast.Ident, unique bool, indexN
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists)
 	}
-	indexID, err := d.genGlobalID()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	// Deal with anonymous index.
 	if len(indexName.L) == 0 {
 		indexName = getAnonymousIndex(t, idxColNames[0].Column.Name)
 	}
-
 	job := &model.Job{
 		SchemaID:   schema.ID,
 		TableID:    t.Meta().ID,
 		Type:       model.ActionAddIndex,
 		BinlogInfo: &model.HistoryInfo{},
-		Args:       []interface{}{unique, indexName, indexID, idxColNames},
+		Args:       []interface{}{unique, indexName, idxColNames},
 	}
 
 	err = d.doDDLJob(ctx, job)
@@ -1299,13 +1287,7 @@ func (d *ddl) CreateIndex(ctx context.Context, ti ast.Ident, unique bool, indexN
 }
 
 func (d *ddl) buildFKInfo(fkName model.CIStr, keys []*ast.IndexColName, refer *ast.ReferenceDef) (*model.FKInfo, error) {
-	fkID, err := d.genGlobalID()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
 	var fkInfo model.FKInfo
-	fkInfo.ID = fkID
 	fkInfo.Name = fkName
 	fkInfo.RefTable = refer.Table.Name
 

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -216,8 +216,7 @@ func (s *testDDLSuite) TestColumnError(c *C) {
 		Offset:       len(tblInfo.Columns),
 		DefaultValue: 0,
 	}
-	tblInfo.MaxColumnID++
-	col.ID = tblInfo.MaxColumnID
+	col.ID = allocateColumnID(tblInfo)
 	col.FieldType = *types.NewFieldType(mysql.TypeLong)
 	pos := &ast.ColumnPosition{Tp: ast.ColumnPositionAfter, RelativeColumn: &ast.ColumnName{Name: model.NewCIStr("c5")}}
 

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -216,9 +216,8 @@ func (s *testDDLSuite) TestColumnError(c *C) {
 		Offset:       len(tblInfo.Columns),
 		DefaultValue: 0,
 	}
-	var err error
-	col.ID, err = d.genGlobalID()
-	c.Assert(err, IsNil)
+	tblInfo.MaxColumnID++
+	col.ID = tblInfo.MaxColumnID
 	col.FieldType = *types.NewFieldType(mysql.TypeLong)
 	pos := &ast.ColumnPosition{Tp: ast.ColumnPositionAfter, RelativeColumn: &ast.ColumnName{Name: model.NewCIStr("c5")}}
 

--- a/ddl/foreign_key.go
+++ b/ddl/foreign_key.go
@@ -33,8 +33,7 @@ func (d *ddl) onCreateForeignKey(t *meta.Meta, job *model.Job) error {
 		job.State = model.JobCancelled
 		return errors.Trace(err)
 	}
-	tblInfo.MaxIndexID++
-	fkInfo.ID = tblInfo.MaxIndexID
+	fkInfo.ID = allocateIndexID(tblInfo)
 	tblInfo.ForeignKeys = append(tblInfo.ForeignKeys, &fkInfo)
 	ver, err := updateSchemaVersion(t, job)
 	if err != nil {

--- a/ddl/foreign_key.go
+++ b/ddl/foreign_key.go
@@ -33,8 +33,9 @@ func (d *ddl) onCreateForeignKey(t *meta.Meta, job *model.Job) error {
 		job.State = model.JobCancelled
 		return errors.Trace(err)
 	}
+	tblInfo.MaxIndexID++
+	fkInfo.ID = tblInfo.MaxIndexID
 	tblInfo.ForeignKeys = append(tblInfo.ForeignKeys, &fkInfo)
-
 	ver, err := updateSchemaVersion(t, job)
 	if err != nil {
 		return errors.Trace(err)

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -57,10 +57,7 @@ func (s *testForeighKeySuite) testCreateForeignKey(c *C, tblInfo *model.TableInf
 		RefKeys[i] = model.NewCIStr(key)
 	}
 
-	fkID, err := s.d.genGlobalID()
-	c.Assert(err, IsNil)
 	fkInfo := &model.FKInfo{
-		ID:       fkID,
 		Name:     FKName,
 		RefTable: RefTable,
 		RefCols:  RefKeys,
@@ -76,7 +73,7 @@ func (s *testForeighKeySuite) testCreateForeignKey(c *C, tblInfo *model.TableInf
 		Type:     model.ActionAddForeignKey,
 		Args:     []interface{}{fkInfo},
 	}
-	err = s.d.doDDLJob(s.ctx, job)
+	err := s.d.doDDLJob(s.ctx, job)
 	c.Assert(err, IsNil)
 	return job
 }

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -156,8 +156,7 @@ func (d *ddl) onCreateIndex(t *meta.Meta, job *model.Job) error {
 			job.State = model.JobCancelled
 			return errors.Trace(err)
 		}
-		tblInfo.MaxIndexID++
-		indexInfo.ID = tblInfo.MaxIndexID
+		indexInfo.ID = allocateIndexID(tblInfo)
 		tblInfo.Indices = append(tblInfo.Indices, indexInfo)
 	}
 
@@ -517,4 +516,9 @@ func (d *ddl) dropTableIndex(indexInfo *model.IndexInfo, job *model.Job) error {
 	deleteAll := -1
 	_, _, err := d.delKeysWithStartKey(startKey, startKey, ddlJobFlag, job, deleteAll)
 	return errors.Trace(err)
+}
+
+func allocateIndexID(tblInfo *model.TableInfo) int64 {
+	tblInfo.MaxIndexID++
+	return tblInfo.MaxIndexID
 }

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -53,16 +53,14 @@ func (s *testIndexSuite) TearDownSuite(c *C) {
 }
 
 func testCreateIndex(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bool, indexName string, colName string) *model.Job {
-	id, err := d.genGlobalID()
-	c.Assert(err, IsNil)
 	job := &model.Job{
 		SchemaID: dbInfo.ID,
 		TableID:  tblInfo.ID,
 		Type:     model.ActionAddIndex,
-		Args:     []interface{}{unique, model.NewCIStr(indexName), id, []*ast.IndexColName{{Column: &ast.ColumnName{Name: model.NewCIStr(colName)}, Length: types.UnspecifiedLength}}},
+		Args:     []interface{}{unique, model.NewCIStr(indexName), []*ast.IndexColName{{Column: &ast.ColumnName{Name: model.NewCIStr(colName)}, Length: types.UnspecifiedLength}}},
 	}
 
-	err = d.doDDLJob(ctx, job)
+	err := d.doDDLJob(ctx, job)
 	c.Assert(err, IsNil)
 	v := getSchemaVer(c, ctx)
 	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -58,9 +58,8 @@ func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 		}
 
 		col.FieldType = *types.NewFieldType(mysql.TypeLong)
-
-		col.ID, err = d.genGlobalID()
-		c.Assert(err, IsNil)
+		tblInfo.MaxColumnID++
+		col.ID = tblInfo.MaxColumnID
 		cols[i] = col
 	}
 

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -58,8 +58,7 @@ func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 		}
 
 		col.FieldType = *types.NewFieldType(mysql.TypeLong)
-		tblInfo.MaxColumnID++
-		col.ID = tblInfo.MaxColumnID
+		col.ID = allocateColumnID(tblInfo)
 		cols[i] = col
 	}
 

--- a/model/model.go
+++ b/model/model.go
@@ -87,6 +87,8 @@ type TableInfo struct {
 	PKIsHandle  bool          `json:"pk_is_handle"`
 	Comment     string        `json:"comment"`
 	AutoIncID   int64         `json:"auto_inc_id"`
+	MaxColumnID int64         `json:"max_col_id"`
+	MaxIndexID  int64         `json:"max_idx_id"`
 }
 
 // Clone clones TableInfo.


### PR DESCRIPTION
A row stores column IDs in varint encoding, smaller integer encodes to less bytes.
Use table info to allocate column ID to reduces disk usage.