### PR TITLE
parser: fix .1_t_1_x parsed as .1 _t_1_x

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -516,8 +516,14 @@ func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
 func startWithDot(s *Scanner) (tok int, pos Pos, lit string) {
 	pos = s.r.pos()
 	s.r.inc()
+	save := s.r.pos()
 	if isDigit(s.r.peek()) {
-		return s.scanFloat(&pos)
+		tok, _, lit = s.scanFloat(&pos)
+		if s.r.eof() || unicode.IsSpace(s.r.peek()) {
+			return
+		}
+		// Fail to parse a float, reset to dot.
+		s.r.p = save
 	}
 	tok, lit = int('.'), "."
 	return

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -107,6 +107,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{fmt.Sprintf("%c", 0), invalid},
 		{fmt.Sprintf("t1%c", 0), identifier},
 		{".*", int('.')},
+		{".1_t_1_x", int('.')},
 	}
 	runTest(c, table)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -372,6 +372,7 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		{`SHOW GRANTS`, true},
 		{`SHOW GRANTS FOR 'test'@'localhost'`, true},
 		{`SHOW COLUMNS FROM City;`, true},
+		{`SHOW COLUMNS FROM tv189.1_t_1_x;`, true},
 		{`SHOW FIELDS FROM City;`, true},
 		{`SHOW TRIGGERS LIKE 't'`, true},
 		{`SHOW DATABASES LIKE 'test2'`, true},


### PR DESCRIPTION
```
mysql> show columns from tv189.1_t_1_x;
ERROR 1105 (HY000): line 0 column 25 near "_t_1_x"
```

it should not be parsed as a `.1(float)` and `_t_1_x(identifier)`

instead, it should be `.(dot)` and `1_t_1_x(identifier)`
