### PR TITLE
server: defend panic for ill-packet with null connection attribute

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -235,7 +235,7 @@ func handshakeResponseFromData(packet *handshakeResponse41, data []byte) error {
 	}
 
 	if capability&mysql.ClientConnectAtts > 0 {
-		if len(data[pos:]) <= 0 {
+		if len(data[pos:]) == 0 {
 			// Defend some ill-formated packet, connection attribute is not important and can be ignored.
 			return nil
 		}

--- a/server/conn.go
+++ b/server/conn.go
@@ -235,6 +235,10 @@ func handshakeResponseFromData(packet *handshakeResponse41, data []byte) error {
 	}
 
 	if capability&mysql.ClientConnectAtts > 0 {
+		if len(data[pos:]) <= 0 {
+			// Defend some ill-formated packet, connection attribute is not important and can be ignored.
+			return nil
+		}
 		if num, null, off := parseLengthEncodedInt(data[pos:]); !null {
 			pos += off
 			kv := data[pos : pos+int(num)]


### PR DESCRIPTION
if client say it has connection attribute capability, but don't provide the data, TiDB can ignore it and should not panic.