### PR TITLE
ddl: Add a check before building jobs

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -448,8 +448,6 @@ func (d *ddl) onModifyColumn(t *meta.Meta, job *model.Job) error {
 	return nil
 }
 
-// We don't support dropping column with index covered now.
-// We must drop the index first, then drop the column.
 func isColumnWithIndex(colName string, indices []*model.IndexInfo) bool {
 	for _, indexInfo := range indices {
 		for _, col := range indexInfo.Columns {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -224,15 +224,9 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) error {
 	}
 
 	// We don't support dropping column with index covered now.
-	// We must drop the index first, then drop the column.
-	for _, indexInfo := range tblInfo.Indices {
-		for _, col := range indexInfo.Columns {
-			if col.Name.L == colName.L {
-				job.State = model.JobCancelled
-				return errCantDropColWithIndex.Gen("can't drop column %s with index %s covered now",
-					colName, indexInfo.Name)
-			}
-		}
+	if isColumnWithIndex(colName.L, tblInfo.Indices) {
+		job.State = model.JobCancelled
+		return errCantDropColWithIndex.Gen("can't drop column %s with index covered now", colName)
 	}
 
 	ver, err := updateSchemaVersion(t, job)
@@ -452,6 +446,19 @@ func (d *ddl) onModifyColumn(t *meta.Meta, job *model.Job) error {
 	job.State = model.JobDone
 	addTableHistoryInfo(job, ver, tblInfo)
 	return nil
+}
+
+// We don't support dropping column with index covered now.
+// We must drop the index first, then drop the column.
+func isColumnWithIndex(colName string, indices []*model.IndexInfo) bool {
+	for _, indexInfo := range indices {
+		for _, col := range indexInfo.Columns {
+			if col.Name.L == colName {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func allocateColumnID(tblInfo *model.TableInfo) int64 {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -997,7 +997,6 @@ func (d *ddl) AddColumn(ctx context.Context, ti ast.Ident, spec *ast.AlterTableS
 	if !ok {
 		return errors.Trace(infoschema.ErrDatabaseNotExists)
 	}
-
 	t, err := is.TableByName(ti.Schema, ti.Name)
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists)
@@ -1042,7 +1041,6 @@ func (d *ddl) DropColumn(ctx context.Context, ti ast.Ident, colName model.CIStr)
 	if !ok {
 		return errors.Trace(infoschema.ErrDatabaseNotExists)
 	}
-
 	t, err := is.TableByName(ti.Schema, ti.Name)
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists)
@@ -1054,8 +1052,13 @@ func (d *ddl) DropColumn(ctx context.Context, ti ast.Ident, colName model.CIStr)
 		return ErrCantDropFieldOrKey.Gen("column %s doesn't exist", colName)
 	}
 
+	tblInfo := t.Meta()
+	// We don't support dropping column with index covered now.
+	if isColumnWithIndex(colName.L, tblInfo.Indices) {
+		return errCantDropColWithIndex.Gen("can't drop column %s with index covered now", colName)
+	}
 	// We don't support dropping column with PK handle covered now.
-	if col.IsPKHandleColumn(t.Meta()) {
+	if col.IsPKHandleColumn(tblInfo) {
 		return errUnsupportedPKHandle
 	}
 
@@ -1262,15 +1265,20 @@ func (d *ddl) CreateIndex(ctx context.Context, ti ast.Ident, unique bool, indexN
 	if !ok {
 		return infoschema.ErrDatabaseNotExists.GenByArgs(ti.Schema)
 	}
-
 	t, err := is.TableByName(ti.Schema, ti.Name)
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists)
 	}
+
 	// Deal with anonymous index.
 	if len(indexName.L) == 0 {
 		indexName = getAnonymousIndex(t, idxColNames[0].Column.Name)
 	}
+
+	if _, idx := isIndexPublic(indexName.L, t.Meta().Indices); idx != nil {
+		return errDupKeyName.Gen("index already exist %s", indexName)
+	}
+
 	job := &model.Job{
 		SchemaID:   schema.ID,
 		TableID:    t.Meta().ID,
@@ -1368,10 +1376,13 @@ func (d *ddl) DropIndex(ctx context.Context, ti ast.Ident, indexName model.CIStr
 	if !ok {
 		return errors.Trace(infoschema.ErrDatabaseNotExists)
 	}
-
 	t, err := is.TableByName(ti.Schema, ti.Name)
 	if err != nil {
 		return errors.Trace(infoschema.ErrTableNotExists)
+	}
+
+	if _, indexInfo := isIndexPublic(indexName.L, t.Meta().Indices); indexInfo == nil {
+		return ErrCantDropFieldOrKey.Gen("index %s doesn't exist", indexName)
 	}
 
 	job := &model.Job{

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -137,8 +137,8 @@ func (d *ddl) onCreateIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	}
 
-	public, indexInfo := isIndexPublic(indexName.L, tblInfo.Indices)
-	if public {
+	indexInfo := findIndexByName(indexName.L, tblInfo.Indices)
+	if indexInfo != nil && indexInfo.State == model.StatePublic {
 		job.State = model.JobCancelled
 		return errDupKeyName.Gen("index already exist %s", indexName)
 	}
@@ -256,7 +256,7 @@ func (d *ddl) onDropIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	}
 
-	_, indexInfo := isIndexPublic(indexName.L, tblInfo.Indices)
+	indexInfo := findIndexByName(indexName.L, tblInfo.Indices)
 	if indexInfo == nil {
 		job.State = model.JobCancelled
 		return ErrCantDropFieldOrKey.Gen("index %s doesn't exist", indexName)
@@ -504,17 +504,13 @@ func (d *ddl) dropTableIndex(indexInfo *model.IndexInfo, job *model.Job) error {
 	return errors.Trace(err)
 }
 
-func isIndexPublic(idxName string, indices []*model.IndexInfo) (bool, *model.IndexInfo) {
+func findIndexByName(idxName string, indices []*model.IndexInfo) *model.IndexInfo {
 	for _, idx := range indices {
 		if idx.Name.L == idxName {
-			if idx.State == model.StatePublic {
-				// We already have an index with same index name.
-				return true, idx
-			}
-			return false, idx
+			return idx
 		}
 	}
-	return false, nil
+	return nil
 }
 
 func allocateIndexID(tblInfo *model.TableInfo) int64 {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -137,17 +137,10 @@ func (d *ddl) onCreateIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	}
 
-	var indexInfo *model.IndexInfo
-	for _, idx := range tblInfo.Indices {
-		if idx.Name.L == indexName.L {
-			if idx.State == model.StatePublic {
-				// We already have an index with same index name.
-				job.State = model.JobCancelled
-				return errDupKeyName.Gen("index already exist %s", indexName)
-			}
-			indexInfo = idx
-			break
-		}
+	public, indexInfo := isIndexPublic(indexName.L, tblInfo.Indices)
+	if public {
+		job.State = model.JobCancelled
+		return errDupKeyName.Gen("index already exist %s", indexName)
 	}
 
 	if indexInfo == nil {
@@ -263,14 +256,7 @@ func (d *ddl) onDropIndex(t *meta.Meta, job *model.Job) error {
 		return errors.Trace(err)
 	}
 
-	var indexInfo *model.IndexInfo
-	for _, idx := range tblInfo.Indices {
-		if idx.Name.L == indexName.L {
-			indexInfo = idx
-			break
-		}
-	}
-
+	_, indexInfo := isIndexPublic(indexName.L, tblInfo.Indices)
 	if indexInfo == nil {
 		job.State = model.JobCancelled
 		return ErrCantDropFieldOrKey.Gen("index %s doesn't exist", indexName)
@@ -516,6 +502,19 @@ func (d *ddl) dropTableIndex(indexInfo *model.IndexInfo, job *model.Job) error {
 	deleteAll := -1
 	_, _, err := d.delKeysWithStartKey(startKey, startKey, ddlJobFlag, job, deleteAll)
 	return errors.Trace(err)
+}
+
+func isIndexPublic(idxName string, indices []*model.IndexInfo) (bool, *model.IndexInfo) {
+	for _, idx := range indices {
+		if idx.Name.L == idxName {
+			if idx.State == model.StatePublic {
+				// We already have an index with same index name.
+				return true, idx
+			}
+			return false, idx
+		}
+	}
+	return false, nil
 }
 
 func allocateIndexID(tblInfo *model.TableInfo) int64 {


### PR DESCRIPTION
Add a check before building jobs in the operation of adding index, dropping index and dropping column.