### PR TITLE
*: non-unique index doesn't need store value, write a '0' to reduce space

### DIFF
--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -165,8 +165,7 @@ func (c *index) Create(rm kv.RetrieverMutator, indexedValues []types.Datum, h in
 		return 0, errors.Trace(err)
 	}
 	if !distinct {
-		// TODO: reconsider value
-		err = rm.Set(key, []byte("timestamp?"))
+		err = rm.Set(key, []byte("0"))
 		return 0, errors.Trace(err)
 	}
 

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -165,7 +165,8 @@ func (c *index) Create(rm kv.RetrieverMutator, indexedValues []types.Datum, h in
 		return 0, errors.Trace(err)
 	}
 	if !distinct {
-		err = rm.Set(key, []byte("0"))
+		// non-unique index doesn't need store value, write a '0' to reduce space
+		err = rm.Set(key, []byte{'0'})
 		return 0, errors.Trace(err)
 	}
 


### PR DESCRIPTION
this can save 9 bytes for each unique index

@zimulala @coocood @disksing @shenli 