### PR TITLE
fix primary key's type

### DIFF
--- a/executor/executor_distsql.go
+++ b/executor/executor_distsql.go
@@ -440,7 +440,7 @@ func (e *XSelectIndexExec) nextForSingleRead() (*Row, error) {
 func (e *XSelectIndexExec) indexRowToTableRow(handle int64, indexRow []types.Datum) []types.Datum {
 	tableRow := make([]types.Datum, len(e.indexPlan.Columns))
 	for i, tblCol := range e.indexPlan.Columns {
-		if mysql.HasPriKeyFlag(tblCol.Flag) && e.indexPlan.Table.PKIsHandle {
+		if table.ToColumn(tblCol).IsPKHandleColumn(e.indexPlan.Table) {
 			if mysql.HasUnsignedFlag(tblCol.FieldType.Flag) {
 				tableRow[i] = types.NewUintDatum(uint64(handle))
 			} else {

--- a/executor/executor_distsql.go
+++ b/executor/executor_distsql.go
@@ -441,7 +441,11 @@ func (e *XSelectIndexExec) indexRowToTableRow(handle int64, indexRow []types.Dat
 	tableRow := make([]types.Datum, len(e.indexPlan.Columns))
 	for i, tblCol := range e.indexPlan.Columns {
 		if mysql.HasPriKeyFlag(tblCol.Flag) && e.indexPlan.Table.PKIsHandle {
-			tableRow[i] = types.NewIntDatum(handle)
+			if mysql.HasUnsignedFlag(tblCol.FieldType.Flag) {
+				tableRow[i] = types.NewUintDatum(uint64(handle))
+			} else {
+				tableRow[i] = types.NewIntDatum(handle)
+			}
 			continue
 		}
 		for j, idxCol := range e.indexPlan.Index.Columns {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -521,6 +521,14 @@ func (s *testSuite) TestUnion(c *C) {
 	r.Check(testkit.Rows("1"))
 	r = tk.MustQuery("select (select * from t1 where a != t.a union all (select * from t2 where a != t.a) order by a limit 1) from t1 t")
 	r.Check(testkit.Rows("1", "2"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int unsigned primary key auto_increment, c1 int, c2 int, index c1_c2 (c1, c2))")
+	tk.MustExec("insert into t (c1, c2) values (1, 1)")
+	tk.MustExec("insert into t (c1, c2) values (1, 2)")
+	tk.MustExec("insert into t (c1, c2) values (2, 3)")
+	r = tk.MustQuery("select * from t where t.c1 = 1 union select * from t where t.id = 1")
+	r.Check(testkit.Rows("1 1 1","2 1 2"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -528,7 +528,7 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec("insert into t (c1, c2) values (1, 2)")
 	tk.MustExec("insert into t (c1, c2) values (2, 3)")
 	r = tk.MustQuery("select * from t where t.c1 = 1 union select * from t where t.id = 1")
-	r.Check(testkit.Rows("1 1 1","2 1 2"))
+	r.Check(testkit.Rows("1 1 1", "2 1 2"))
 }
 
 func (s *testSuite) TestIn(c *C) {


### PR DESCRIPTION
When we do index single read, if primary key is handle, then it's type should also be determined by its flag. Otherwise, it may cause some error. For example, when one of the union statement is index single read, primary key's type will become signed int, while another is still unsigned int, it will cause **distinct** statement think they are different.