### PR TITLE
distsql, executor: fix select channel bug that may discard error.

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -60,7 +60,6 @@ func (s *testTableCodecSuite) TestGoroutineLeak(c *C) {
 	sr = &selectResult{
 		resp:    &mockResponse{},
 		results: make(chan PartialResult, 5),
-		done:    make(chan error, 1),
 		closed:  make(chan struct{}),
 	}
 	go sr.Fetch()

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -59,7 +59,7 @@ func (s *testTableCodecSuite) TestGoroutineLeak(c *C) {
 
 	sr = &selectResult{
 		resp:    &mockResponse{},
-		results: make(chan PartialResult, 5),
+		results: make(chan resultWithErr, 5),
 		closed:  make(chan struct{}),
 	}
 	go sr.Fetch()


### PR DESCRIPTION
When select receives two channels, both of them can return, which case will
be selected is undetermined.

Use one channel with resp and error to avoid this issue.