### PR TITLE
*: add comparable varint encoding.

### DIFF
--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -239,6 +239,11 @@ func (s *testCodecSuite) TestNumberCodec(c *C) {
 		_, v, err = DecodeVarint(b)
 		c.Assert(err, IsNil)
 		c.Assert(v, Equals, t)
+
+		b = EncodeComparableVarint(nil, t)
+		_, v, err = DecodeComparableVarint(b)
+		c.Assert(err, IsNil)
+		c.Assert(v, Equals, t)
 	}
 
 	tblUint64 := []uint64{
@@ -270,6 +275,11 @@ func (s *testCodecSuite) TestNumberCodec(c *C) {
 
 		b = EncodeUvarint(nil, t)
 		_, v, err = DecodeUvarint(b)
+		c.Assert(err, IsNil)
+		c.Assert(v, Equals, t)
+
+		b = EncodeComparableUvarint(nil, t)
+		_, v, err = DecodeComparableUvarint(b)
 		c.Assert(err, IsNil)
 		c.Assert(v, Equals, t)
 	}
@@ -309,6 +319,11 @@ func (s *testCodecSuite) TestNumberOrder(c *C) {
 
 		ret = bytes.Compare(b1, b2)
 		c.Assert(ret, Equals, -t.Ret)
+
+		b1 = EncodeComparableVarint(nil, t.Arg1)
+		b2 = EncodeComparableVarint(nil, t.Arg2)
+		ret = bytes.Compare(b1, b2)
+		c.Assert(ret, Equals, t.Ret)
 	}
 
 	tblUint64 := []struct {
@@ -341,6 +356,11 @@ func (s *testCodecSuite) TestNumberOrder(c *C) {
 
 		ret = bytes.Compare(b1, b2)
 		c.Assert(ret, Equals, -t.Ret)
+
+		b1 = EncodeComparableUvarint(nil, t.Arg1)
+		b2 = EncodeComparableUvarint(nil, t.Arg2)
+		ret = bytes.Compare(b1, b2)
+		c.Assert(ret, Equals, t.Ret)
 	}
 }
 

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -283,6 +283,19 @@ func (s *testCodecSuite) TestNumberCodec(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(v, Equals, t)
 	}
+	var b []byte
+	b = EncodeComparableVarint(b, -1)
+	b = EncodeComparableUvarint(b, 1)
+	b = EncodeComparableVarint(b, 2)
+	b, i, err := DecodeComparableVarint(b)
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(-1))
+	b, u, err := DecodeComparableUvarint(b)
+	c.Assert(err, IsNil)
+	c.Assert(u, Equals, uint64(1))
+	b, i, err = DecodeComparableVarint(b)
+	c.Assert(err, IsNil)
+	c.Assert(i, Equals, int64(2))
 }
 
 func (s *testCodecSuite) TestNumberOrder(c *C) {

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -246,7 +246,7 @@ func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
 	for _, c := range b[:length] {
 		v = (v << 8) | uint64(c)
 	}
-	return b, v, nil
+	return b[length:], v, nil
 }
 
 // DecodeComparableVarint decodes mem-comparable varint.
@@ -278,5 +278,5 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 	} else if first < negativeTagEnd && v <= math.MaxInt64 {
 		return nil, 0, errors.Trace(errDecodeInvalid)
 	}
-	return b, int64(v), nil
+	return b[length:], int64(v), nil
 }

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -162,7 +162,7 @@ const (
 	positiveTagStart = 0xff - 8 // Positive tag is (positiveTagStart + length).
 )
 
-// EncodeComparableVarint encodes a int64 to a mem-comparable bytes.
+// EncodeComparableVarint encodes an int64 to a mem-comparable bytes.
 func EncodeComparableVarint(b []byte, v int64) []byte {
 	if v < 0 {
 		// All negative value has a tag byte prefix (negativeTagEnd - length).
@@ -263,7 +263,7 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 	var v uint64
 	if first < negativeTagEnd {
 		length = negativeTagEnd - int(first)
-		v = math.MaxUint64 // negative value has all bits on by default.
+		v = math.MaxUint64 // Negative value has all bits on by default.
 	} else {
 		length = int(first) - positiveTagStart
 	}

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -274,7 +274,9 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 		v = (v << 8) | uint64(c)
 	}
 	if first > positiveTagStart && v > math.MaxInt64 {
-		return nil, 0, errors.New("value overflows int64")
+		return nil, 0, errors.Trace(errDecodeInvalid)
+	} else if first < negativeTagEnd && v <= math.MaxInt64 {
+		return nil, 0, errors.Trace(errDecodeInvalid)
 	}
 	return b, int64(v), nil
 }

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -15,6 +15,7 @@ package codec
 
 import (
 	"encoding/binary"
+	"math"
 
 	"github.com/juju/errors"
 )
@@ -154,4 +155,126 @@ func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 		return nil, 0, errors.New("value larger than 64 bits")
 	}
 	return nil, 0, errors.New("insufficient bytes to decode value")
+}
+
+const (
+	negativeTagEnd   = 8        // Negative tag is (negativeTagEnd - length).
+	positiveTagStart = 0xff - 8 // Positive tag is (positiveTagStart + length).
+)
+
+// EncodeCompareableVarint encodes a int64 to a mem-comparable bytes.
+func EncodeComparableVarint(b []byte, v int64) []byte {
+	if v < 0 {
+		// All negative value has a tag byte prefix (negativeTagEnd - length).
+		// Smaller negative value encodes to more bytes, has smaller tag.
+		if v >= 0xff {
+			return append(b, negativeTagEnd-1, byte(v))
+		} else if v >= 0xffff {
+			return append(b, negativeTagEnd-2, byte(v>>8), byte(v))
+		} else if v >= 0xffffff {
+			return append(b, negativeTagEnd-3, byte(v>>16), byte(v>>8), byte(v))
+		} else if v >= 0xffffffff {
+			return append(b, negativeTagEnd-4, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+		} else if v >= 0xffffffffff {
+			return append(b, negativeTagEnd-5, byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+		} else if v >= 0xffffffffffff {
+			return append(b, negativeTagEnd-6, byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8),
+				byte(v))
+		} else if v >= 0xffffffffffffff {
+			return append(b, negativeTagEnd-7, byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16),
+				byte(v>>8), byte(v))
+		}
+		return append(b, negativeTagEnd-8, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24),
+			byte(v>>16), byte(v>>8), byte(v))
+	}
+	return EncodeComparableUvarint(b, uint64(v))
+}
+
+// EncodeComparableUvarint encodes uint64 into mem-comparable bytes.
+func EncodeComparableUvarint(b []byte, v uint64) []byte {
+	// The first byte has 256 values, [0, 7] is reserved for negative tags,
+	// [248, 255] is reserved for larger positive tags,
+	// So we can store value [0, 239] in a single byte.
+	// Values cannot be stored in single byte has a tag byte prefix (positiveTagStart+length).
+	// Larger value encodes to more bytes, has larger tag.
+	if v <= positiveTagStart-negativeTagEnd {
+		return append(b, byte(v)+negativeTagEnd)
+	} else if v <= 0xff {
+		return append(b, positiveTagStart+1, byte(v))
+	} else if v <= 0xffff {
+		return append(b, positiveTagStart+2, byte(v>>8), byte(v))
+	} else if v <= 0xffffff {
+		return append(b, positiveTagStart+3, byte(v>>16), byte(v>>8), byte(v))
+	} else if v <= 0xffffffff {
+		return append(b, positiveTagStart+4, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	} else if v <= 0xffffffffff {
+		return append(b, positiveTagStart+5, byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	} else if v <= 0xffffffffffff {
+		return append(b, positiveTagStart+6, byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8),
+			byte(v))
+	} else if v <= 0xffffffffffffff {
+		return append(b, positiveTagStart+7, byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16),
+			byte(v>>8), byte(v))
+	}
+	return append(b, positiveTagStart+8, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24),
+		byte(v>>16), byte(v>>8), byte(v))
+}
+
+var (
+	decodeInsufficientErr = errors.New("insufficient bytes to decode value")
+	decodeInvalidErr      = errors.New("invalid bytes to decode value")
+)
+
+// DecodeComparableUvarint decodes mem-comparable uvarint.
+func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
+	if len(b) == 0 {
+		return nil, 0, decodeInsufficientErr
+	}
+	first := b[0]
+	b = b[1:]
+	if first < negativeTagEnd {
+		return nil, 0, decodeInvalidErr
+	}
+	if first <= positiveTagStart {
+		return b, uint64(first) - negativeTagEnd, nil
+	}
+	length := int(first) - positiveTagStart
+	if len(b) < length {
+		return nil, 0, decodeInsufficientErr
+	}
+	var v uint64
+	for _, c := range b[:length] {
+		v = (v << 8) | uint64(c)
+	}
+	return b, v, nil
+}
+
+// DecodeComparableVarint decodes mem-comparable varint.
+func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
+	if len(b) == 0 {
+		return nil, 0, decodeInsufficientErr
+	}
+	first := b[0]
+	if first >= negativeTagEnd && first <= positiveTagStart {
+		return b, int64(first) - negativeTagEnd, nil
+	}
+	b = b[1:]
+	var length int
+	var v uint64
+	if first < negativeTagEnd {
+		length = negativeTagEnd - int(first)
+		v = math.MaxUint64 // negative value has all bits on by default.
+	} else {
+		length = int(first) - positiveTagStart
+	}
+	if len(b) < length {
+		return nil, 0, errors.New("invalid bytes to decode value")
+	}
+	for _, c := range b[:length] {
+		v = (v << 8) | uint64(c)
+	}
+	if first > positiveTagStart && v > math.MaxInt64 {
+		return nil, 0, errors.New("value overflows int64")
+	}
+	return b, int64(v), nil
 }

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -167,20 +167,20 @@ func EncodeComparableVarint(b []byte, v int64) []byte {
 	if v < 0 {
 		// All negative value has a tag byte prefix (negativeTagEnd - length).
 		// Smaller negative value encodes to more bytes, has smaller tag.
-		if v >= 0xff {
+		if v >= -0xff {
 			return append(b, negativeTagEnd-1, byte(v))
-		} else if v >= 0xffff {
+		} else if v >= -0xffff {
 			return append(b, negativeTagEnd-2, byte(v>>8), byte(v))
-		} else if v >= 0xffffff {
+		} else if v >= -0xffffff {
 			return append(b, negativeTagEnd-3, byte(v>>16), byte(v>>8), byte(v))
-		} else if v >= 0xffffffff {
+		} else if v >= -0xffffffff {
 			return append(b, negativeTagEnd-4, byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
-		} else if v >= 0xffffffffff {
+		} else if v >= -0xffffffffff {
 			return append(b, negativeTagEnd-5, byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
-		} else if v >= 0xffffffffffff {
+		} else if v >= -0xffffffffffff {
 			return append(b, negativeTagEnd-6, byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8),
 				byte(v))
-		} else if v >= 0xffffffffffffff {
+		} else if v >= -0xffffffffffffff {
 			return append(b, negativeTagEnd-7, byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16),
 				byte(v>>8), byte(v))
 		}

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -162,7 +162,7 @@ const (
 	positiveTagStart = 0xff - 8 // Positive tag is (positiveTagStart + length).
 )
 
-// EncodeCompareableVarint encodes a int64 to a mem-comparable bytes.
+// EncodeComparableVarint encodes a int64 to a mem-comparable bytes.
 func EncodeComparableVarint(b []byte, v int64) []byte {
 	if v < 0 {
 		// All negative value has a tag byte prefix (negativeTagEnd - length).
@@ -221,26 +221,26 @@ func EncodeComparableUvarint(b []byte, v uint64) []byte {
 }
 
 var (
-	decodeInsufficientErr = errors.New("insufficient bytes to decode value")
-	decodeInvalidErr      = errors.New("invalid bytes to decode value")
+	errDecodeInsufficient = errors.New("insufficient bytes to decode value")
+	errDecodeInvalid      = errors.New("invalid bytes to decode value")
 )
 
 // DecodeComparableUvarint decodes mem-comparable uvarint.
 func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
 	if len(b) == 0 {
-		return nil, 0, decodeInsufficientErr
+		return nil, 0, errDecodeInsufficient
 	}
 	first := b[0]
 	b = b[1:]
 	if first < negativeTagEnd {
-		return nil, 0, decodeInvalidErr
+		return nil, 0, errors.Trace(errDecodeInvalid)
 	}
 	if first <= positiveTagStart {
 		return b, uint64(first) - negativeTagEnd, nil
 	}
 	length := int(first) - positiveTagStart
 	if len(b) < length {
-		return nil, 0, decodeInsufficientErr
+		return nil, 0, errors.Trace(errDecodeInsufficient)
 	}
 	var v uint64
 	for _, c := range b[:length] {
@@ -252,7 +252,7 @@ func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
 // DecodeComparableVarint decodes mem-comparable varint.
 func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
-		return nil, 0, decodeInsufficientErr
+		return nil, 0, errors.Trace(errDecodeInsufficient)
 	}
 	first := b[0]
 	if first >= negativeTagEnd && first <= positiveTagStart {
@@ -268,7 +268,7 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 		length = int(first) - positiveTagStart
 	}
 	if len(b) < length {
-		return nil, 0, errors.New("invalid bytes to decode value")
+		return nil, 0, errors.Trace(errDecodeInsufficient)
 	}
 	for _, c := range b[:length] {
 		v = (v << 8) | uint64(c)


### PR DESCRIPTION
It will be used to encode key with less bytes.