### PR TITLE
plan: eliminate tablescan's cost more precisely.

### DIFF
--- a/plan/match_property.go
+++ b/plan/match_property.go
@@ -38,6 +38,10 @@ func (ts *PhysicalTableScan) matchProperty(prop *requiredProperty, infos ...*phy
 		sortedTS.Desc = prop.props[0].desc
 		sortedTS.KeepOrder = true
 		sortedTS.addLimit(prop.limit)
+		// If there exists a table filter, we should calculate the filter scan cost.
+		if len(sortedTS.tableFilterConditions) > 0 {
+			cost += rowCount * cpuFactor
+		}
 		p := sortedTS.tryToAddUnionScan(&sortedTS)
 		return enforceProperty(&requiredProperty{limit: prop.limit}, &physicalPlanInfo{
 			p:     p,

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -937,8 +937,9 @@ func (p *Selection) convert2PhysicalPlanPushOrder(prop *requiredProperty) (*phys
 	if limit != nil && info.p != nil {
 		if np, ok := info.p.(physicalDistSQLPlan); ok {
 			np.addLimit(limit)
+			scanCount := info.count
 			info.count = limit.Count
-			info.cost = np.calculateCost(info.count)
+			info.cost = np.calculateCost(info.count, scanCount)
 		} else {
 			info = enforceProperty(&requiredProperty{limit: limit}, info)
 		}

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -65,11 +65,12 @@ type physicalDistSQLPlan interface {
 	addAggregation(ctx context.Context, agg *PhysicalAggregation) expression.Schema
 	addTopN(ctx context.Context, prop *requiredProperty) bool
 	addLimit(limit *Limit)
-	calculateCost(count uint64) float64
+	calculateCost(count uint64, scanCount uint64) float64
 }
 
-func (p *PhysicalIndexScan) calculateCost(count uint64) float64 {
-	cnt := float64(count)
+func (p *PhysicalIndexScan) calculateCost(resultCount uint64, scanCount uint64) float64 {
+	// TODO: Eliminate index cost more precisely.
+	cnt := float64(resultCount)
 	// network cost
 	cost := cnt * netWorkFactor
 	if p.DoubleRead {
@@ -77,14 +78,17 @@ func (p *PhysicalIndexScan) calculateCost(count uint64) float64 {
 	}
 	// sort cost
 	if !p.OutOfOrder && p.DoubleRead {
-		cost += float64(count) * cpuFactor
+		cost += cnt * cpuFactor
 	}
 	return cost
 }
 
-func (p *PhysicalTableScan) calculateCost(count uint64) float64 {
-	cnt := float64(count)
-	return cnt * netWorkFactor
+func (p *PhysicalTableScan) calculateCost(resultCount uint64, scanCount uint64) float64 {
+	cost := float64(resultCount) * netWorkFactor
+	if len(p.tableFilterConditions) > 0 {
+		cost += float64(scanCount) * cpuFactor
+	}
+	return cost
 }
 
 type physicalTableSource struct {

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -65,7 +65,8 @@ type physicalDistSQLPlan interface {
 	addAggregation(ctx context.Context, agg *PhysicalAggregation) expression.Schema
 	addTopN(ctx context.Context, prop *requiredProperty) bool
 	addLimit(limit *Limit)
-	calculateCost(count uint64, scanCount uint64) float64
+	// scanCount means the original row count that need to be scanned and resultCount means the row count after scanning.
+	calculateCost(resultCount uint64, scanCount uint64) float64
 }
 
 func (p *PhysicalIndexScan) calculateCost(resultCount uint64, scanCount uint64) float64 {


### PR DESCRIPTION
We forget to consider cpu cost when the table scan has a condition.
@shenli @coocood @zimulala PTAL