### PR TITLE
server: defer handshake packet make TiDB crash

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -182,7 +182,14 @@ type handshakeResponse41 struct {
 	Attrs      map[string]string
 }
 
-func handshakeResponseFromData(packet *handshakeResponse41, data []byte) error {
+func handshakeResponseFromData(packet *handshakeResponse41, data []byte) (err error) {
+	defer func() {
+		// Check malformat packet cause out of range is disgusting, but don't panic!
+		if r := recover(); r != nil {
+			log.Errorf("handshake panic, packet data: %v", data)
+			err = mysql.ErrMalformPacket
+		}
+	}()
 	pos := 0
 	// capability
 	capability := binary.LittleEndian.Uint32(data[:4])

--- a/server/server.go
+++ b/server/server.go
@@ -188,6 +188,10 @@ func (s *Server) Close() {
 // onConn runs in its own goroutine, handles queries from this connection.
 func (s *Server) onConn(c net.Conn) {
 	conn := s.newConn(c)
+	defer func() {
+		log.Infof("[%d] close connection", conn.connectionID)
+	}()
+
 	if err := conn.handshake(); err != nil {
 		// Some keep alive services will send request to TiDB and disconnect immediately.
 		// So we use info log level.
@@ -195,9 +199,6 @@ func (s *Server) onConn(c net.Conn) {
 		c.Close()
 		return
 	}
-	defer func() {
-		log.Infof("[%d] close connection", conn.connectionID)
-	}()
 
 	s.rwlock.Lock()
 	s.clients[conn.connectionID] = conn


### PR DESCRIPTION
malformat packet is just an error
out of range panic should not spread to TiDB

fix https://github.com/pingcap/tidb/issues/2242