### PR TITLE
support function rpad

### DIFF
--- a/ast/functions.go
+++ b/ast/functions.go
@@ -145,6 +145,7 @@ const (
 	Ucase          = "ucase"
 	Hex            = "hex"
 	Unhex          = "unhex"
+	Rpad           = "rpad"
 
 	// information functions
 	ConnectionID = "connection_id"

--- a/evaluator/builtin.go
+++ b/evaluator/builtin.go
@@ -117,6 +117,7 @@ var Funcs = map[string]Func{
 	ast.Ucase:          {builtinUpper, 1, 1},
 	ast.Hex:            {builtinHex, 1, 1},
 	ast.Unhex:          {builtinUnHex, 1, 1},
+	ast.Rpad:           {builtinRpad, 3, 3},
 
 	// information functions
 	ast.ConnectionID: {builtinConnectionID, 0, 0},

--- a/evaluator/builtin_string.go
+++ b/evaluator/builtin_string.go
@@ -623,29 +623,15 @@ func builtinRpad(args []types.Datum, ctx context.Context) (d types.Datum, err er
 		return d, errors.Trace(err)
 	}
 
-	if len(str) >= l && l >= 0 {
-		d.SetString(str[:l])
-		return d, nil
-	}
-
-	if l < 0 || len(padStr) == 0 {
+	if l < 0 || (len(str) < l && padStr == "") {
 		d.SetNull()
 		return d, nil
 	}
 
-	tailLen := l - len(str)
-	padStrBytes := []byte(padStr)
-	tail := make([]byte, 0, tailLen)
-	for tailLen > len(padStr) {
-		tail = append(tail, padStrBytes...)
-		tailLen -= len(padStr)
+	for len(str) < l {
+		str += padStr
 	}
-	if tailLen > 0 {
-		tail = append(tail, padStrBytes[:tailLen]...)
-	}
-
-	dest := str + string(tail)
-	d.SetString(dest)
+	d.SetString(str[:l])
 
 	return d, nil
 }

--- a/evaluator/builtin_string.go
+++ b/evaluator/builtin_string.go
@@ -603,3 +603,37 @@ func trimRight(str, remstr string) string {
 		str = x
 	}
 }
+
+// See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
+func builtinRpad(args []types.Datum, ctx context.Context) (d types.Datum, err error) {
+	// RPAD(str,len,padstr)
+	// args[0] string, args[1] int, args[2] string
+	str, err := args[0].ToString()
+	if err != nil {
+		return d, errors.Trace(err)
+	}
+	length, err := args[1].ToInt64(ctx.GetSessionVars().StmtCtx)
+	if err != nil {
+		return d, errors.Trace(err)
+	}
+	l := int(length)
+
+	padStr, err := args[2].ToString()
+	if err != nil {
+		return d, errors.Trace(err)
+	}
+
+	if l < 0 || len(padStr) == 0 {
+		d.SetNull()
+		return d, nil
+	}
+
+	if len(str) >= l {
+		d.SetString(str[:l])
+	} else {
+		dest := str + strings.Repeat(padStr, l-len(str))
+		d.SetString(dest)
+	}
+
+	return d, nil
+}

--- a/evaluator/builtin_string.go
+++ b/evaluator/builtin_string.go
@@ -623,17 +623,29 @@ func builtinRpad(args []types.Datum, ctx context.Context) (d types.Datum, err er
 		return d, errors.Trace(err)
 	}
 
+	if len(str) >= l && l >= 0 {
+		d.SetString(str[:l])
+		return d, nil
+	}
+
 	if l < 0 || len(padStr) == 0 {
 		d.SetNull()
 		return d, nil
 	}
 
-	if len(str) >= l {
-		d.SetString(str[:l])
-	} else {
-		dest := str + strings.Repeat(padStr, l-len(str))
-		d.SetString(dest)
+	tailLen := l - len(str)
+	padStrBytes := []byte(padStr)
+	tail := make([]byte, 0, tailLen)
+	for tailLen > len(padStr) {
+		tail = append(tail, padStrBytes...)
+		tailLen -= len(padStr)
 	}
+	if tailLen > 0 {
+		tail = append(tail, padStrBytes[:tailLen]...)
+	}
+
+	dest := str + string(tail)
+	d.SetString(dest)
 
 	return d, nil
 }

--- a/evaluator/builtin_string.go
+++ b/evaluator/builtin_string.go
@@ -628,8 +628,10 @@ func builtinRpad(args []types.Datum, ctx context.Context) (d types.Datum, err er
 		return d, nil
 	}
 
-	for len(str) < l {
-		str += padStr
+	tailLen := l - len(str)
+	if tailLen > 0 {
+		repeatCount := tailLen/len(padStr) + 1
+		str = str + strings.Repeat(padStr, repeatCount)
 	}
 	d.SetString(str[:l])
 

--- a/evaluator/builtin_string_test.go
+++ b/evaluator/builtin_string_test.go
@@ -696,3 +696,29 @@ func (s *testEvaluatorSuite) TestUnhexFunc(c *C) {
 
 	}
 }
+
+func (s *testEvaluatorSuite) TestRpad(c *C) {
+	tests := []struct {
+		str    string
+		len    int64
+		padStr string
+		expect string
+	}{
+		{"hi", 5, "?", "hi???"},
+		{"hi", 1, "?", "h"},
+		{"hi", -1, "?", ""},
+		{"hi", 1, "", ""},
+	}
+	for _, test := range tests {
+		str := types.NewStringDatum(test.str)
+		length := types.NewIntDatum(test.len)
+		padStr := types.NewStringDatum(test.padStr)
+		result, err := builtinRpad([]types.Datum{str, length, padStr}, s.ctx)
+		c.Assert(err, IsNil)
+		if length.GetInt64() < 0 || len(padStr.GetString()) == 0 {
+			c.Assert(result.Kind(), Equals, types.KindNull)
+		} else {
+			c.Assert(result.GetString(), Equals, test.expect)
+		}
+	}
+}

--- a/evaluator/builtin_string_test.go
+++ b/evaluator/builtin_string_test.go
@@ -702,13 +702,14 @@ func (s *testEvaluatorSuite) TestRpad(c *C) {
 		str    string
 		len    int64
 		padStr string
-		expect string
+		expect interface{}
 	}{
 		{"hi", 5, "?", "hi???"},
 		{"hi", 1, "?", "h"},
-		{"hi", -1, "?", ""},
+		{"hi", 0, "?", ""},
+		{"hi", -1, "?", nil},
 		{"hi", 1, "", "h"},
-		{"hi", 5, "", ""},
+		{"hi", 5, "", nil},
 		{"hi", 5, "ab", "hiaba"},
 		{"hi", 6, "ab", "hiabab"},
 	}
@@ -718,10 +719,11 @@ func (s *testEvaluatorSuite) TestRpad(c *C) {
 		padStr := types.NewStringDatum(test.padStr)
 		result, err := builtinRpad([]types.Datum{str, length, padStr}, s.ctx)
 		c.Assert(err, IsNil)
-		if test.expect == "" {
+		if test.expect == nil {
 			c.Assert(result.Kind(), Equals, types.KindNull)
 		} else {
-			c.Assert(result.GetString(), Equals, test.expect)
+			expect, _ := test.expect.(string)
+			c.Assert(result.GetString(), Equals, expect)
 		}
 	}
 }

--- a/evaluator/builtin_string_test.go
+++ b/evaluator/builtin_string_test.go
@@ -707,7 +707,10 @@ func (s *testEvaluatorSuite) TestRpad(c *C) {
 		{"hi", 5, "?", "hi???"},
 		{"hi", 1, "?", "h"},
 		{"hi", -1, "?", ""},
-		{"hi", 1, "", ""},
+		{"hi", 1, "", "h"},
+		{"hi", 5, "", ""},
+		{"hi", 5, "ab", "hiaba"},
+		{"hi", 6, "ab", "hiabab"},
 	}
 	for _, test := range tests {
 		str := types.NewStringDatum(test.str)
@@ -715,7 +718,7 @@ func (s *testEvaluatorSuite) TestRpad(c *C) {
 		padStr := types.NewStringDatum(test.padStr)
 		result, err := builtinRpad([]types.Datum{str, length, padStr}, s.ctx)
 		c.Assert(err, IsNil)
-		if length.GetInt64() < 0 || len(padStr.GetString()) == 0 {
+		if test.expect == "" {
 			c.Assert(result.Kind(), Equals, types.KindNull)
 		} else {
 			c.Assert(result.GetString(), Equals, test.expect)

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -479,6 +479,7 @@ var tokenMap = map[string]int{
 	"ACTION":              action,
 	"PARTITION":           partition,
 	"PARTITIONS":          partitions,
+	"RPAD":                rpad,
 }
 
 func isTokenIdentifier(s string, buf *bytes.Buffer) int {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -286,6 +286,7 @@ import (
 	statsPersistent	"STATS_PERSISTENT"
 	getLock		"GET_LOCK"
 	releaseLock	"RELEASE_LOCK"
+	rpad		"RPAD"
 
 	/* the following tokens belong to UnReservedKeyword*/
 	action		"ACTION"
@@ -2969,6 +2970,13 @@ FunctionCallNonKeyword:
 |	"RELEASE_LOCK" '(' Expression ')'
 	{
 		$$ = &ast.FuncCallExpr{FnName: model.NewCIStr($1), Args: []ast.ExprNode{$3.(ast.ExprNode)}}
+	}
+|	"RPAD" '(' Expression ',' Expression ',' Expression ')'
+	{
+		$$ = &ast.FuncCallExpr{
+			FnName: model.NewCIStr($1),
+			Args: []ast.ExprNode{$3.(ast.ExprNode), $5.(ast.ExprNode), $7.(ast.ExprNode)},
+		}
 	}
 
 DateArithOpt:

--- a/plan/typeinferer.go
+++ b/plan/typeinferer.go
@@ -311,7 +311,7 @@ func (v *typeInferrer) handleFuncCallExpr(x *ast.FuncCallExpr) {
 	case "dayname", "version", "database", "user", "current_user", "schema",
 		"concat", "concat_ws", "left", "lcase", "lower", "repeat",
 		"replace", "ucase", "upper", "convert", "substring",
-		"substring_index", "trim", "ltrim", "rtrim", "reverse", "hex", "unhex", "date_format":
+		"substring_index", "trim", "ltrim", "rtrim", "reverse", "hex", "unhex", "date_format", "rpad":
 		tp = types.NewFieldType(mysql.TypeVarString)
 		chs = v.defaultCharset
 	case "strcmp", "isnull":

--- a/plan/typeinferer_test.go
+++ b/plan/typeinferer_test.go
@@ -153,6 +153,7 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 		{"unhex('TiDB')", mysql.TypeVarString, "utf8"},
 		{"unhex(12)", mysql.TypeVarString, "utf8"},
 		{"DATE_FORMAT('2009-10-04 22:23:00', '%W %M %Y')", mysql.TypeVarString, "utf8"},
+		{"rpad('TiDB', 12, 'go')", mysql.TypeVarString, charset.CharsetUTF8},
 	}
 	for _, ca := range cases {
 		ctx := testKit.Se.(context.Context)


### PR DESCRIPTION
Tried to support the function rpad. It goes alright with `make gotest` and `make server`. The rpad query works with my build on mac.