### PR TITLE
evaluator, util/types: fix mysql week and yearweek function

### DIFF
--- a/evaluator/builtin_time.go
+++ b/evaluator/builtin_time.go
@@ -560,8 +560,16 @@ func builtinWeek(args []types.Datum, ctx context.Context) (types.Datum, error) {
 		return d, nil
 	}
 
-	// TODO: support multi mode for week
-	_, week := t.Time.ISOWeek()
+	var mode int
+	if len(args) > 1 {
+		v, err := args[1].ToInt64(ctx.GetSessionVars().StmtCtx)
+		if err != nil {
+			return d, errors.Trace(err)
+		}
+		mode = int(v)
+	}
+
+	week := t.Time.Week(mode)
 	wi := int64(week)
 	d.SetInt64(wi)
 	return d, nil
@@ -631,9 +639,17 @@ func builtinYearWeek(args []types.Datum, ctx context.Context) (types.Datum, erro
 		return d, nil
 	}
 
-	// TODO: support multi mode for week
-	year, week := t.Time.ISOWeek()
-	d.SetInt64(int64(year*100 + week))
+	var mode int64
+	if len(args) > 1 {
+		v, err := args[1].ToInt64(ctx.GetSessionVars().StmtCtx)
+		if err != nil {
+			return d, errors.Trace(err)
+		}
+		mode = v
+	}
+
+	year, week := t.Time.YearWeek(int(mode))
+	d.SetInt64(int64(week + year*100))
 	if d.GetInt64() < 0 {
 		d.SetInt64(math.MaxUint32)
 	}

--- a/util/types/mytime.go
+++ b/util/types/mytime.go
@@ -60,7 +60,6 @@ func (t mysqlTime) Microsecond() int {
 func (t mysqlTime) Weekday() gotime.Weekday {
 	t1, err := t.GoTime()
 	if err != nil {
-		// TODO: Fix here.
 		return 0
 	}
 	return t1.Weekday()
@@ -75,13 +74,20 @@ func (t mysqlTime) YearDay() int {
 	return t1.YearDay()
 }
 
-func (t mysqlTime) ISOWeek() (int, int) {
-	t1, err := t.GoTime()
-	if err != nil {
-		// TODO: Fix here.
+func (t mysqlTime) YearWeek(mode int) (int, int) {
+	if t.month == 0 || t.day == 0 {
 		return 0, 0
 	}
-	return t1.ISOWeek()
+	behavior := weekMode(mode) | weekBehaviourYear
+	return calcWeek(&t, behavior)
+}
+
+func (t mysqlTime) Week(mode int) int {
+	if t.month == 0 || t.day == 0 {
+		return 0
+	}
+	_, week := calcWeek(&t, weekMode(mode))
+	return week
 }
 
 func (t mysqlTime) GoTime() (gotime.Time, error) {


### PR DESCRIPTION
use the new time implement to replace the old one, remove several `TODO`

`WEEK` and `YEARWEEK` function behavior should be the same with mysql now, and mode is supported.