### PR TITLE
*: begin a transaction in PrepareTxnCtx, unify in transaction.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -161,11 +161,6 @@ type ResultSetNode interface {
 // If the Exec method requires any Execution domain local data,
 // they must be held out of the implementing instance.
 type Statement interface {
-	// Explain gets the execution plans.
-	//Explain(ctx context.Context, w format.Formatter)
-
-	// IsDDL shows whether the statement is an DDL operation.
-	IsDDL() bool
 
 	// OriginText gets the origin SQL text.
 	OriginText() string

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -161,7 +161,6 @@ type ResultSetNode interface {
 // If the Exec method requires any Execution domain local data,
 // they must be held out of the implementing instance.
 type Statement interface {
-
 	// OriginText gets the origin SQL text.
 	OriginText() string
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -63,10 +63,9 @@ func (a *recordSet) Close() error {
 // statement implements the ast.Statement interface, it builds a plan.Plan to an ast.Statement.
 type statement struct {
 	// The InfoSchema cannot change during execution, so we hold a reference to it.
-	is    infoschema.InfoSchema
-	plan  plan.Plan
-	text  string
-	isDDL bool
+	is   infoschema.InfoSchema
+	plan plan.Plan
+	text string
 }
 
 func (a *statement) OriginText() string {
@@ -76,10 +75,6 @@ func (a *statement) OriginText() string {
 func (a *statement) SetText(text string) {
 	a.text = text
 	return
-}
-
-func (a *statement) IsDDL() bool {
-	return a.isDDL
 }
 
 // Exec implements the ast.Statement Exec interface.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -124,7 +124,7 @@ func (b *executorBuilder) build(p plan.Plan) Executor {
 }
 
 func (b *executorBuilder) buildShowDDL(v *plan.ShowDDL) Executor {
-	// We get ddlInfo here because for Executors that returns result set,
+	// We get DDInfo here because for Executors that returns result set,
 	// next will be called after transaction has been committed.
 	// We need the transaction to get DDLInfo.
 	e := &ShowDDLExec{

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -124,7 +124,7 @@ func (b *executorBuilder) build(p plan.Plan) Executor {
 }
 
 func (b *executorBuilder) buildShowDDL(v *plan.ShowDDL) Executor {
-	// We get DDInfo here because for Executors that returns result set,
+	// We get DDLInfo here because for Executors that returns result set,
 	// next will be called after transaction has been committed.
 	// We need the transaction to get DDLInfo.
 	e := &ShowDDLExec{

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/inspectkv"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/plan"
@@ -123,10 +124,31 @@ func (b *executorBuilder) build(p plan.Plan) Executor {
 }
 
 func (b *executorBuilder) buildShowDDL(v *plan.ShowDDL) Executor {
-	return &ShowDDLExec{
+	// We get ddlInfo here because for Executors that returns result set,
+	// next will be called after transaction has been committed.
+	// We need the transaction to get DDLInfo.
+	e := &ShowDDLExec{
 		ctx:    b.ctx,
 		schema: v.GetSchema(),
 	}
+	txn, err := e.ctx.GetTxn(false)
+	if err != nil {
+		b.err = errors.Trace(err)
+		return nil
+	}
+	ddlInfo, err := inspectkv.GetDDLInfo(txn)
+	if err != nil {
+		b.err = errors.Trace(err)
+		return nil
+	}
+	bgInfo, err := inspectkv.GetBgDDLInfo(txn)
+	if err != nil {
+		b.err = errors.Trace(err)
+		return nil
+	}
+	e.ddlInfo = ddlInfo
+	e.bgInfo = bgInfo
+	return e
 }
 
 func (b *executorBuilder) buildCheckTable(v *plan.CheckTable) Executor {
@@ -146,7 +168,7 @@ func (b *executorBuilder) buildDeallocate(v *plan.Deallocate) Executor {
 
 func (b *executorBuilder) buildSelectLock(v *plan.SelectLock) Executor {
 	src := b.build(v.GetChildByIndex(0))
-	if b.ctx.GetSessionVars().ShouldAutocommit() {
+	if !b.ctx.GetSessionVars().InTxn() {
 		// Locking of rows for update using SELECT FOR UPDATE only applies when autocommit
 		// is disabled (either by beginning transaction with START TRANSACTION or by setting
 		// autocommit to 0. If autocommit is enabled, the rows matching the specification are not locked.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -164,12 +164,10 @@ func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statemen
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	_, isDDL := node.(ast.DDLNode)
 	sa := &statement{
-		is:    is,
-		plan:  p,
-		text:  node.Text(),
-		isDDL: isDDL,
+		is:   is,
+		plan: p,
+		text: node.Text(),
 	}
 	return sa, nil
 }

--- a/executor/executor_ddl.go
+++ b/executor/executor_ddl.go
@@ -72,6 +72,7 @@ func (e *DDLExec) Next() (*Row, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
 	e.done = true
 	return nil, nil
 }

--- a/executor/executor_ddl.go
+++ b/executor/executor_ddl.go
@@ -72,6 +72,7 @@ func (e *DDLExec) Next() (*Row, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// DDL will force commit old transaction, after DDL, in transaction status should be false.
 	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
 	e.done = true
 	return nil, nil

--- a/executor/executor_set_test.go
+++ b/executor/executor_set_test.go
@@ -101,9 +101,9 @@ func (s *testSuite) TestSetVar(c *C) {
 	vars := tk.Se.(context.Context).GetSessionVars()
 	tk.Se.CommitTxn()
 	tk.MustExec("set @@autocommit = 1")
-	c.Assert(vars.ShouldAutocommit(), IsTrue)
+	c.Assert(vars.IsAutocommit(), IsTrue)
 	tk.MustExec("set @@autocommit = 0")
-	c.Assert(vars.ShouldAutocommit(), IsFalse)
+	c.Assert(vars.IsAutocommit(), IsFalse)
 
 	tk.MustExec("set @@sql_mode = 'strict_trans_tables'")
 	c.Assert(vars.StrictSQLMode, IsTrue)

--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -124,9 +124,8 @@ func (e *SimpleExec) executeBegin(s *ast.BeginStmt) error {
 }
 
 func (e *SimpleExec) executeCommit(s *ast.CommitStmt) error {
-	err := e.ctx.CommitTxn()
 	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
-	return errors.Trace(err)
+	return nil
 }
 
 func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {

--- a/executor/executor_simple.go
+++ b/executor/executor_simple.go
@@ -66,7 +66,7 @@ func (e *SimpleExec) Next() (*Row, error) {
 	case *ast.BeginStmt:
 		err = e.executeBegin(x)
 	case *ast.CommitStmt:
-		err = e.executeCommit(x)
+		e.executeCommit(x)
 	case *ast.RollbackStmt:
 		err = e.executeRollback(x)
 	case *ast.CreateUserStmt:
@@ -123,9 +123,8 @@ func (e *SimpleExec) executeBegin(s *ast.BeginStmt) error {
 	return nil
 }
 
-func (e *SimpleExec) executeCommit(s *ast.CommitStmt) error {
+func (e *SimpleExec) executeCommit(s *ast.CommitStmt) {
 	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
-	return nil
 }
 
 func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1407,7 +1407,6 @@ func (s *testSuite) TestAdapterStatement(c *C) {
 	stmt, err := compiler.Compile(ctx, stmtNode)
 	c.Check(err, IsNil)
 	c.Check(stmt.OriginText(), Equals, "select 1")
-	c.Check(stmt.IsDDL(), IsFalse)
 
 	stmtNode, err = s.ParseOneStmt("create table t (a int)", "", "")
 	c.Check(err, IsNil)

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -86,6 +86,9 @@ type Transaction interface {
 	IsReadOnly() bool
 	// StartTS returns the transaction start timestamp.
 	StartTS() uint64
+	// Valid returns if the transaction is valid.
+	// A transaction become invalid after commit or rollback.
+	Valid() bool
 }
 
 // Client is used to send request to KV layer.

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -19,7 +19,8 @@ import (
 
 // mockTxn is a txn that returns a retryAble error when called Commit.
 type mockTxn struct {
-	opts map[Option]interface{}
+	opts  map[Option]interface{}
+	valid bool
 }
 
 // Always returns a retryable error.
@@ -28,6 +29,7 @@ func (t *mockTxn) Commit() error {
 }
 
 func (t *mockTxn) Rollback() error {
+	t.valid = false
 	return nil
 }
 
@@ -79,13 +81,18 @@ func (t *mockTxn) Delete(k Key) error {
 	return nil
 }
 
+func (t *mockTxn) Valid() bool {
+	return t.valid
+}
+
 // mockStorage is used to start a must commit-failed txn.
 type mockStorage struct {
 }
 
 func (s *mockStorage) Begin() (Transaction, error) {
 	tx := &mockTxn{
-		opts: make(map[Option]interface{}),
+		opts:  make(map[Option]interface{}),
+		valid: true,
 	}
 	return tx, nil
 

--- a/session_test.go
+++ b/session_test.go
@@ -310,7 +310,7 @@ func (s *testSessionSuite) TestAutocommit(c *C) {
 
 	checkTxn(c, se, "create table t (id BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL)", 0)
 	checkAutocommit(c, se, 2)
-	checkTxn(c, se, "set autocommit=0;", 0)
+	checkTxn(c, se, "set autocommit=0;", 1)
 	checkAutocommit(c, se, 0)
 	checkTxn(c, se, "insert t values ()", 1)
 	checkAutocommit(c, se, 0)
@@ -348,7 +348,7 @@ func (s *testSessionSuite) TestInTrans(c *C) {
 	checkInTrans(c, se, "commit", 0)
 	checkInTrans(c, se, "insert t values ()", 0)
 
-	checkInTrans(c, se, "set autocommit=0;", 0)
+	checkInTrans(c, se, "set autocommit=0;", 1)
 	checkInTrans(c, se, "begin", 1)
 	checkInTrans(c, se, "insert t values ()", 1)
 	checkInTrans(c, se, "commit", 0)

--- a/session_test.go
+++ b/session_test.go
@@ -310,7 +310,7 @@ func (s *testSessionSuite) TestAutocommit(c *C) {
 
 	checkTxn(c, se, "create table t (id BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL)", 0)
 	checkAutocommit(c, se, 2)
-	checkTxn(c, se, "set autocommit=0;", 1)
+	checkTxn(c, se, "set autocommit=0;", 0)
 	checkAutocommit(c, se, 0)
 	checkTxn(c, se, "insert t values ()", 1)
 	checkAutocommit(c, se, 0)
@@ -348,7 +348,7 @@ func (s *testSessionSuite) TestInTrans(c *C) {
 	checkInTrans(c, se, "commit", 0)
 	checkInTrans(c, se, "insert t values ()", 0)
 
-	checkInTrans(c, se, "set autocommit=0;", 1)
+	checkInTrans(c, se, "set autocommit=0;", 0)
 	checkInTrans(c, se, "begin", 1)
 	checkInTrans(c, se, "insert t values ()", 1)
 	checkInTrans(c, se, "commit", 0)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -199,13 +199,14 @@ func (s *SessionVars) GetStatusFlag(flag uint16) bool {
 	return s.Status&flag > 0
 }
 
-// ShouldAutocommit checks if current session should autocommit.
-// With START TRANSACTION, autocommit remains disabled until you end
-// the transaction with COMMIT or ROLLBACK.
-func (s *SessionVars) ShouldAutocommit() bool {
-	isAutomcommit := s.GetStatusFlag(mysql.ServerStatusAutocommit)
-	inTransaction := s.GetStatusFlag(mysql.ServerStatusInTrans)
-	return isAutomcommit && !inTransaction
+// InTxn returns if the session is in transaction.
+func (s *SessionVars) InTxn() bool {
+	return s.GetStatusFlag(mysql.ServerStatusInTrans)
+}
+
+// IsAutocommit returns if the session is set to autocommit.
+func (s *SessionVars) IsAutocommit() bool {
+	return s.GetStatusFlag(mysql.ServerStatusAutocommit)
 }
 
 // GetNextPreparedStmtID generates and returns the next session scope prepared statement id.

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -72,7 +72,9 @@ func SetSystemVar(vars *variable.SessionVars, name string, value types.Datum) er
 	case variable.AutocommitVar:
 		isAutocommit := strings.EqualFold(sVal, "ON") || sVal == "1"
 		vars.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
-		vars.SetStatusFlag(mysql.ServerStatusInTrans, !isAutocommit)
+		if isAutocommit {
+			vars.SetStatusFlag(mysql.ServerStatusInTrans, false)
+		}
 	case variable.TiDBSkipConstraintCheck:
 		vars.SkipConstraintCheck = (sVal == "1")
 	}

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -72,6 +72,7 @@ func SetSystemVar(vars *variable.SessionVars, name string, value types.Datum) er
 	case variable.AutocommitVar:
 		isAutocommit := strings.EqualFold(sVal, "ON") || sVal == "1"
 		vars.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
+		vars.SetStatusFlag(mysql.ServerStatusInTrans, !isAutocommit)
 	case variable.TiDBSkipConstraintCheck:
 		vars.SkipConstraintCheck = (sVal == "1")
 	}

--- a/store/localstore/txn.go
+++ b/store/localstore/txn.go
@@ -141,3 +141,7 @@ func (txn *dbTxn) IsReadOnly() bool {
 func (txn *dbTxn) StartTS() uint64 {
 	return txn.tid
 }
+
+func (txn *dbTxn) Valid() bool {
+	return txn.valid
+}

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -172,3 +172,7 @@ func (txn *tikvTxn) IsReadOnly() bool {
 func (txn *tikvTxn) StartTS() uint64 {
 	return txn.startTS
 }
+
+func (txn *tikvTxn) Valid() bool {
+	return txn.valid
+}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -117,7 +117,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	_, err = tb.AddRecord(ctx, types.MakeDatums(1, "abc"))
 	c.Assert(err, IsNil)
 	c.Assert(indexCnt(), Greater, 0)
-
+	c.Assert(ctx.CommitTxn(), IsNil)
 	_, err = ts.se.Execute("drop table test.t")
 	c.Assert(err, IsNil)
 }

--- a/tidb.go
+++ b/tidb.go
@@ -189,7 +189,6 @@ func runStmt(ctx context.Context, s ast.Statement) (ast.RecordSet, error) {
 	// All the history should be added here.
 	se := ctx.(*session)
 	getHistory(ctx).add(0, s)
-	// MySQL DDL should be auto-commit.
 	if !se.sessionVars.InTxn() {
 		if err != nil {
 			log.Info("RollbackTxn for ddl/autocommit error.")

--- a/tidb.go
+++ b/tidb.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -143,7 +144,10 @@ func resetStmtCtx(ctx context.Context, s ast.StmtNode) {
 
 // Compile is safe for concurrent use by multiple goroutines.
 func Compile(ctx context.Context, rawStmt ast.StmtNode) (ast.Statement, error) {
-	PrepareTxnCtx(ctx)
+	err := PrepareTxnCtx(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	compiler := executor.Compiler{}
 	st, err := compiler.Compile(ctx, rawStmt)
 	if err != nil {
@@ -153,33 +157,40 @@ func Compile(ctx context.Context, rawStmt ast.StmtNode) (ast.Statement, error) {
 }
 
 // PrepareTxnCtx resets transaction context if session is not in a transaction.
-func PrepareTxnCtx(ctx context.Context) {
+func PrepareTxnCtx(ctx context.Context) error {
 	se := ctx.(*session)
-	if se.txn == nil {
+	if se.txn == nil || !se.txn.Valid() {
 		is := sessionctx.GetDomain(ctx).InfoSchema()
 		se.sessionVars.TxnCtx = &variable.TransactionContext{
 			InfoSchema:    is,
 			SchemaVersion: is.SchemaMetaVersion(),
 		}
+		var err error
+		se.txn, err = se.store.Begin()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = se.loadCommonGlobalVariablesIfNeeded()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !se.sessionVars.IsAutocommit() {
+			se.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
+		}
 	}
+	return nil
 }
 
 // runStmt executes the ast.Statement and commit or rollback the current transaction.
 func runStmt(ctx context.Context, s ast.Statement) (ast.RecordSet, error) {
 	var err error
 	var rs ast.RecordSet
-	if s.IsDDL() {
-		err = ctx.CommitTxn()
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
 	rs, err = s.Exec(ctx)
 	// All the history should be added here.
 	se := ctx.(*session)
 	getHistory(ctx).add(0, s)
 	// MySQL DDL should be auto-commit.
-	if s.IsDDL() || se.sessionVars.ShouldAutocommit() {
+	if !se.sessionVars.InTxn() {
 		if err != nil {
 			log.Info("RollbackTxn for ddl/autocommit error.")
 			ctx.RollbackTxn()


### PR DESCRIPTION
Transaction should has the same life cycle as TxnCtx, so create a
new transaction in PrepareTxnCtx if transaction is nil or invalid.

Unify ShouldAutocommit to InTxn flag, remove IsDDL method.