### PR TITLE
*: Use standard error code/message for incorrect function argument count error

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -30,12 +30,14 @@ import (
 
 // Error instances.
 var (
-	errInvalidOperation = terror.ClassExpression.New(codeInvalidOperation, "invalid operation")
+	errInvalidOperation        = terror.ClassExpression.New(codeInvalidOperation, "invalid operation")
+	errIncorrectParameterCount = terror.ClassExpression.New(codeIncorrectParameterCount, "Incorrect parameter count")
 )
 
 // Error codes.
 const (
-	codeInvalidOperation terror.ErrCode = 1
+	codeInvalidOperation        terror.ErrCode = 1
+	codeIncorrectParameterCount                = 2
 )
 
 // EvalAstExpr evaluates ast expression directly.
@@ -266,4 +268,11 @@ func TableInfo2Schema(tbl *model.TableInfo) Schema {
 		schema.Append(newCol)
 	}
 	return schema
+}
+
+func init() {
+	expressionMySQLErrCodes := map[terror.ErrCode]uint16{
+		codeIncorrectParameterCount: mysql.ErrWrongParamcountToNativeFct,
+	}
+	terror.ErrClassToMySQLCodes[terror.ClassExpression] = expressionMySQLErrCodes
 }

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -37,7 +37,7 @@ var (
 // Error codes.
 const (
 	codeInvalidOperation        terror.ErrCode = 1
-	codeIncorrectParameterCount                = 2
+	codeIncorrectParameterCount                = 1582
 )
 
 // EvalAstExpr evaluates ast expression directly.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -60,8 +60,7 @@ func NewFunction(funcName string, retType *types.FieldType, args ...Expression) 
 		return nil, errors.Errorf("Function %s is not implemented.", funcName)
 	}
 	if len(args) < f.MinArgs || (f.MaxArgs != -1 && len(args) > f.MaxArgs) {
-		return nil, errInvalidOperation.Gen("number of function arguments must in [%d, %d].",
-			f.MinArgs, f.MaxArgs)
+		return nil, errIncorrectParameterCount.Gen("Incorrect parameter count in the call to native function %s", funcName)
 	}
 	funcArgs := make([]Expression, len(args))
 	copy(funcArgs, args)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -447,6 +447,10 @@ func runTestErrorCode(c *C) {
 		checkErrorCode(c, err, tmysql.ErrUnknownSystemVariable)
 		_, err = txn2.Exec("set @@unknown_sys_var='1';")
 		checkErrorCode(c, err, tmysql.ErrUnknownSystemVariable)
+
+		// Expression errors
+		_, err = txn2.Exec("select greatest(2);")
+		checkErrorCode(c, err, tmysql.ErrWrongParamcountToNativeFct)
 	})
 }
 


### PR DESCRIPTION
@coocood @zimulala @tiancaiamao PTAL
Fix https://github.com/pingcap/tidb/issues/2333

mysql> select greatest(2);
ERROR 1582 (42000): Incorrect parameter count in the call to native function greatest
mysql> 
