### PR TITLE
*: refactor GetColumnIndex() and some function

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -55,15 +55,15 @@ func (col *CorrelatedColumn) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (col *CorrelatedColumn) Decorrelate(cols []*Column) Expression {
-	if GetColumnIndex(cols, &col.Column) == -1 {
+func (col *CorrelatedColumn) Decorrelate(schema Schema) Expression {
+	if GetColumnIndex(schema.Columns, &col.Column) == -1 {
 		return col
 	}
 	return &col.Column
 }
 
 // ResolveIndices implements Expression interface.
-func (col *CorrelatedColumn) ResolveIndices(_ []*Column) {
+func (col *CorrelatedColumn) ResolveIndices(_ Schema) {
 }
 
 // Column represents a column.
@@ -136,7 +136,7 @@ func (col *Column) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (col *Column) Decorrelate(_ []*Column) Expression {
+func (col *Column) Decorrelate(_ Schema) Expression {
 	return col
 }
 
@@ -150,11 +150,11 @@ func (col *Column) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (col *Column) ResolveIndices(cols []*Column) {
-	col.Index = GetColumnIndex(cols, col)
+func (col *Column) ResolveIndices(schema Schema) {
+	col.Index = GetColumnIndex(schema.Columns, col)
 	// If col's index equals to -1, it means a internal logic error happens.
 	if col.Index == -1 {
-		log.Errorf("Can't find column %s in schema %s", col, cols)
+		log.Errorf("Can't find column %s in schema %s", col, schema)
 	}
 }
 

--- a/expression/column.go
+++ b/expression/column.go
@@ -55,15 +55,15 @@ func (col *CorrelatedColumn) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (col *CorrelatedColumn) Decorrelate(schema Schema) Expression {
-	if schema.GetColumnIndex(&col.Column) == -1 {
+func (col *CorrelatedColumn) Decorrelate(cols []*Column) Expression {
+	if GetColumnIndex(cols, &col.Column) == -1 {
 		return col
 	}
 	return &col.Column
 }
 
 // ResolveIndices implements Expression interface.
-func (col *CorrelatedColumn) ResolveIndices(_ Schema) {
+func (col *CorrelatedColumn) ResolveIndices(_ []*Column) {
 }
 
 // Column represents a column.
@@ -136,7 +136,7 @@ func (col *Column) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (col *Column) Decorrelate(_ Schema) Expression {
+func (col *Column) Decorrelate(_ []*Column) Expression {
 	return col
 }
 
@@ -150,11 +150,11 @@ func (col *Column) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (col *Column) ResolveIndices(schema Schema) {
-	col.Index = schema.GetColumnIndex(col)
+func (col *Column) ResolveIndices(cols []*Column) {
+	col.Index = GetColumnIndex(cols, col)
 	// If col's index equals to -1, it means a internal logic error happens.
 	if col.Index == -1 {
-		log.Errorf("Can't find column %s in schema %s", col, schema)
+		log.Errorf("Can't find column %s in schema %s", col, cols)
 	}
 }
 
@@ -165,4 +165,14 @@ func Column2Exprs(cols []*Column) []Expression {
 		result = append(result, col.Clone())
 	}
 	return result
+}
+
+// GetColumnIndex will get the position of the column in a column slice.
+func GetColumnIndex(cols []*Column, col *Column) int {
+	for i, c := range cols {
+		if c.FromID == col.FromID && c.Position == col.Position {
+			return i
+		}
+	}
+	return -1
 }

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -129,7 +129,7 @@ func (s *propagateConstantSolver) propagateEQ() {
 		}
 		for i, cond := range s.conditions {
 			if !visited[i] {
-				s.conditions[i] = ColumnSubstitute(cond, NewSchema(cols), cons)
+				s.conditions[i] = ColumnSubstitute(cond, cols, cons)
 			}
 		}
 	}

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -63,11 +63,11 @@ type Expression interface {
 	// IsCorrelated checks if this expression has correlated key.
 	IsCorrelated() bool
 
-	// Decorrelate try to decorrelate the expression by columns of schema.
-	Decorrelate(cols []*Column) Expression
+	// Decorrelate try to decorrelate the expression by schema.
+	Decorrelate(schema Schema) Expression
 
-	// ResolveIndices resolves indices by the given columns of schema.
-	ResolveIndices(cols []*Column)
+	// ResolveIndices resolves indices by the given schema.
+	ResolveIndices(schema Schema)
 }
 
 // EvalBool evaluates expression to a boolean value.
@@ -139,7 +139,7 @@ func (c *Constant) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (c *Constant) Decorrelate(_ []*Column) Expression {
+func (c *Constant) Decorrelate(_ Schema) Expression {
 	return c
 }
 
@@ -151,7 +151,7 @@ func (c *Constant) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (c *Constant) ResolveIndices(_ []*Column) {
+func (c *Constant) ResolveIndices(_ Schema) {
 }
 
 // composeConditionWithBinaryOp composes condition with binary operator into a balance deep tree, which benefits a lot for pb decoder/encoder.

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -63,11 +63,11 @@ type Expression interface {
 	// IsCorrelated checks if this expression has correlated key.
 	IsCorrelated() bool
 
-	// Decorrelate try to decorrelate the expression by schema.
-	Decorrelate(schema Schema) Expression
+	// Decorrelate try to decorrelate the expression by columns of schema.
+	Decorrelate(cols []*Column) Expression
 
-	// ResolveIndices resolves indices by the given schema.
-	ResolveIndices(schema Schema)
+	// ResolveIndices resolves indices by the given columns of schema.
+	ResolveIndices(cols []*Column)
 }
 
 // EvalBool evaluates expression to a boolean value.
@@ -139,7 +139,7 @@ func (c *Constant) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (c *Constant) Decorrelate(_ Schema) Expression {
+func (c *Constant) Decorrelate(_ []*Column) Expression {
 	return c
 }
 
@@ -151,7 +151,7 @@ func (c *Constant) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (c *Constant) ResolveIndices(_ Schema) {
+func (c *Constant) ResolveIndices(_ []*Column) {
 }
 
 // composeConditionWithBinaryOp composes condition with binary operator into a balance deep tree, which benefits a lot for pb decoder/encoder.
@@ -243,7 +243,7 @@ func EvaluateExprWithNull(ctx context.Context, schema Schema, expr Expression) (
 		}
 		return FoldConstant(ctx, newFunc), nil
 	case *Column:
-		if schema.GetColumnIndex(x) == -1 {
+		if GetColumnIndex(schema.Columns, x) == -1 {
 			return x, nil
 		}
 		constant := &Constant{Value: types.Datum{}}

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -132,9 +132,9 @@ func (sf *ScalarFunction) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (sf *ScalarFunction) Decorrelate(cols []*Column) Expression {
+func (sf *ScalarFunction) Decorrelate(schema Schema) Expression {
 	for i, arg := range sf.Args {
-		sf.Args[i] = arg.Decorrelate(cols)
+		sf.Args[i] = arg.Decorrelate(schema)
 	}
 	return sf
 }
@@ -166,8 +166,8 @@ func (sf *ScalarFunction) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (sf *ScalarFunction) ResolveIndices(cols []*Column) {
+func (sf *ScalarFunction) ResolveIndices(schema Schema) {
 	for _, arg := range sf.Args {
-		arg.ResolveIndices(cols)
+		arg.ResolveIndices(schema)
 	}
 }

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -132,9 +132,9 @@ func (sf *ScalarFunction) IsCorrelated() bool {
 }
 
 // Decorrelate implements Expression interface.
-func (sf *ScalarFunction) Decorrelate(schema Schema) Expression {
+func (sf *ScalarFunction) Decorrelate(cols []*Column) Expression {
 	for i, arg := range sf.Args {
-		sf.Args[i] = arg.Decorrelate(schema)
+		sf.Args[i] = arg.Decorrelate(cols)
 	}
 	return sf
 }
@@ -166,8 +166,8 @@ func (sf *ScalarFunction) HashCode() []byte {
 }
 
 // ResolveIndices implements Expression interface.
-func (sf *ScalarFunction) ResolveIndices(schema Schema) {
+func (sf *ScalarFunction) ResolveIndices(cols []*Column) {
 	for _, arg := range sf.Args {
-		arg.ResolveIndices(schema)
+		arg.ResolveIndices(cols)
 	}
 }

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -75,21 +75,11 @@ func (s Schema) InitColumnIndices() {
 
 // RetrieveColumn retrieves column in expression from the columns in schema.
 func (s Schema) RetrieveColumn(col *Column) *Column {
-	index := s.GetColumnIndex(col)
+	index := GetColumnIndex(s.Columns, col)
 	if index != -1 {
 		return s.Columns[index]
 	}
 	return nil
-}
-
-// GetColumnIndex finds the index for a column.
-func (s Schema) GetColumnIndex(col *Column) int {
-	for i, c := range s.Columns {
-		if c.FromID == col.FromID && c.Position == col.Position {
-			return i
-		}
-	}
-	return -1
 }
 
 // Len returns the number of columns in schema.

--- a/expression/util.go
+++ b/expression/util.go
@@ -30,10 +30,10 @@ func ExtractColumns(expr Expression) (cols []*Column) {
 
 // ColumnSubstitute substitutes the columns in filter to expressions in select fields.
 // e.g. select * from (select b as a from t) k where a < 10 => select * from (select b as a from t where b < 10) k.
-func ColumnSubstitute(expr Expression, schema Schema, newExprs []Expression) Expression {
+func ColumnSubstitute(expr Expression, cols []*Column, newExprs []Expression) Expression {
 	switch v := expr.(type) {
 	case *Column:
-		id := schema.GetColumnIndex(v)
+		id := GetColumnIndex(cols, v)
 		if id == -1 {
 			return v
 		}
@@ -41,12 +41,12 @@ func ColumnSubstitute(expr Expression, schema Schema, newExprs []Expression) Exp
 	case *ScalarFunction:
 		if v.FuncName.L == ast.Cast {
 			newFunc := v.Clone().(*ScalarFunction)
-			newFunc.Args[0] = ColumnSubstitute(newFunc.Args[0], schema, newExprs)
+			newFunc.Args[0] = ColumnSubstitute(newFunc.Args[0], cols, newExprs)
 			return newFunc
 		}
 		newArgs := make([]Expression, 0, len(v.Args))
 		for _, arg := range v.Args {
-			newArgs = append(newArgs, ColumnSubstitute(arg, schema, newExprs))
+			newArgs = append(newArgs, ColumnSubstitute(arg, cols, newExprs))
 		}
 		fun, _ := NewFunction(v.FuncName.L, v.RetType, newArgs...)
 		return fun

--- a/plan/column_pruning.go
+++ b/plan/column_pruning.go
@@ -22,7 +22,7 @@ import (
 func getUsedList(usedCols []*expression.Column, schema expression.Schema) []bool {
 	used := make([]bool, schema.Len())
 	for _, col := range usedCols {
-		idx := schema.GetColumnIndex(col)
+		idx := expression.GetColumnIndex(schema.Columns, col)
 		if idx == -1 {
 			log.Errorf("Can't find column %s from schema %s.", col, schema)
 		}
@@ -190,9 +190,9 @@ func (p *Join) PruneColumns(parentUsedCols []*expression.Column) {
 	rChild := p.GetChildByIndex(1).(LogicalPlan)
 	var leftCols, rightCols []*expression.Column
 	for _, col := range parentUsedCols {
-		if lChild.GetSchema().GetColumnIndex(col) != -1 {
+		if expression.GetColumnIndex(lChild.GetSchema().Columns, col) != -1 {
 			leftCols = append(leftCols, col)
-		} else if rChild.GetSchema().GetColumnIndex(col) != -1 {
+		} else if expression.GetColumnIndex(rChild.GetSchema().Columns, col) != -1 {
 			rightCols = append(rightCols, col)
 		}
 	}
@@ -225,14 +225,14 @@ func (p *Apply) PruneColumns(parentUsedCols []*expression.Column) {
 		parentUsedCols = append(parentUsedCols, expression.ExtractColumns(p.Checker.Condition)...)
 	}
 	for _, col := range parentUsedCols {
-		if child.GetSchema().GetColumnIndex(col) != -1 {
+		if expression.GetColumnIndex(child.GetSchema().Columns, col) != -1 {
 			usedCols = append(usedCols, col)
 		}
 	}
 	innerPlan.PruneColumns(innerPlan.GetSchema().Columns)
 	corCols := innerPlan.extractCorrelatedCols()
 	for _, corCol := range corCols {
-		idx := child.GetSchema().GetColumnIndex(&corCol.Column)
+		idx := expression.GetColumnIndex(child.GetSchema().Columns, &corCol.Column)
 		if idx != -1 {
 			usedCols = append(usedCols, &corCol.Column)
 		}

--- a/plan/join_reorder.go
+++ b/plan/join_reorder.go
@@ -37,7 +37,7 @@ func tryToGetJoinGroup(j *Join) ([]LogicalPlan, bool) {
 
 func findColumnIndexByGroup(groups []LogicalPlan, col *expression.Column) int {
 	for i, plan := range groups {
-		idx := plan.GetSchema().GetColumnIndex(col)
+		idx := expression.GetColumnIndex(plan.GetSchema().Columns, col)
 		if idx != -1 {
 			return i
 		}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -148,17 +148,19 @@ func extractCorColumns(expr expression.Expression) (cols []*expression.Correlate
 func extractOnCondition(conditions []expression.Expression, left LogicalPlan, right LogicalPlan) (
 	eqCond []*expression.ScalarFunction, leftCond []expression.Expression, rightCond []expression.Expression,
 	otherCond []expression.Expression) {
+	lCols := left.GetSchema().Columns
+	rCols := right.GetSchema().Columns
 	for _, expr := range conditions {
 		binop, ok := expr.(*expression.ScalarFunction)
 		if ok && binop.FuncName.L == ast.EQ {
 			ln, lOK := binop.Args[0].(*expression.Column)
 			rn, rOK := binop.Args[1].(*expression.Column)
 			if lOK && rOK {
-				if left.GetSchema().GetColumnIndex(ln) != -1 && right.GetSchema().GetColumnIndex(rn) != -1 {
+				if expression.GetColumnIndex(lCols, ln) != -1 && expression.GetColumnIndex(rCols, rn) != -1 {
 					eqCond = append(eqCond, binop)
 					continue
 				}
-				if left.GetSchema().GetColumnIndex(rn) != -1 && right.GetSchema().GetColumnIndex(ln) != -1 {
+				if expression.GetColumnIndex(lCols, rn) != -1 && expression.GetColumnIndex(rCols, ln) != -1 {
 					cond, _ := expression.NewFunction(ast.EQ, types.NewFieldType(mysql.TypeTiny), rn, ln)
 					eqCond = append(eqCond, cond.(*expression.ScalarFunction))
 					continue
@@ -168,10 +170,10 @@ func extractOnCondition(conditions []expression.Expression, left LogicalPlan, ri
 		columns := expression.ExtractColumns(expr)
 		allFromLeft, allFromRight := true, true
 		for _, col := range columns {
-			if left.GetSchema().GetColumnIndex(col) == -1 {
+			if expression.GetColumnIndex(lCols, col) == -1 {
 				allFromLeft = false
 			}
-			if right.GetSchema().GetColumnIndex(col) == -1 {
+			if expression.GetColumnIndex(rCols, col) == -1 {
 				allFromRight = false
 			}
 		}
@@ -1005,7 +1007,7 @@ func (b *planBuilder) buildSemiJoin(outerPlan, innerPlan LogicalPlan, onConditio
 	joinPlan.self = joinPlan
 	joinPlan.initIDAndContext(b.ctx)
 	for i, expr := range onCondition {
-		onCondition[i] = expr.Decorrelate(outerPlan.GetSchema())
+		onCondition[i] = expr.Decorrelate(outerPlan.GetSchema().Columns)
 	}
 	eqCond, leftCond, rightCond, otherCond := extractOnCondition(onCondition, outerPlan, innerPlan)
 	joinPlan.EqualConditions = eqCond
@@ -1087,7 +1089,7 @@ func (b *planBuilder) buildUpdateLists(list []*ast.Assignment, p LogicalPlan) ([
 			b.err = errors.Trace(errors.Errorf("column %s not found", assign.Column.Name.O))
 			return nil, nil
 		}
-		offset := schema.GetColumnIndex(col)
+		offset := expression.GetColumnIndex(schema.Columns, col)
 		if offset == -1 {
 			b.err = errors.Trace(errors.Errorf("could not find column %s.%s", col.TblName, col.ColName))
 		}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -1007,7 +1007,7 @@ func (b *planBuilder) buildSemiJoin(outerPlan, innerPlan LogicalPlan, onConditio
 	joinPlan.self = joinPlan
 	joinPlan.initIDAndContext(b.ctx)
 	for i, expr := range onCondition {
-		onCondition[i] = expr.Decorrelate(outerPlan.GetSchema().Columns)
+		onCondition[i] = expr.Decorrelate(outerPlan.GetSchema())
 	}
 	eqCond, leftCond, rightCond, otherCond := extractOnCondition(onCondition, outerPlan, innerPlan)
 	joinPlan.EqualConditions = eqCond

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -201,7 +201,7 @@ func (p *Apply) SetCorrelated() {
 	p.correlated = p.GetChildren()[0].IsCorrelated()
 	for _, corCol := range corCols {
 		// If the outer column can't be resolved from this outer schema, it should be resolved by outer schema.
-		if idx := p.GetChildren()[0].GetSchema().GetColumnIndex(&corCol.Column); idx == -1 {
+		if idx := expression.GetColumnIndex(p.GetChildren()[0].GetSchema().Columns, &corCol.Column); idx == -1 {
 			p.correlated = true
 			break
 		}

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -545,7 +545,7 @@ func (p *PhysicalApply) SetCorrelated() {
 	corColumns := p.GetChildren()[1].extractCorrelatedCols()
 	p.correlated = p.GetChildren()[0].IsCorrelated()
 	for _, corCol := range corColumns {
-		if idx := p.GetChildren()[0].GetSchema().GetColumnIndex(&corCol.Column); idx == -1 {
+		if idx := expression.GetColumnIndex(p.GetChildren()[0].GetSchema().Columns, &corCol.Column); idx == -1 {
 			p.correlated = true
 			break
 		}

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -241,14 +241,14 @@ func (p *Projection) PredicatePushDown(predicates []expression.Expression) (ret 
 		canSubstitute := true
 		extractedCols := expression.ExtractColumns(cond)
 		for _, col := range extractedCols {
-			id := p.GetSchema().GetColumnIndex(col)
+			id := expression.GetColumnIndex(p.GetSchema().Columns, col)
 			if _, ok := p.Exprs[id].(*expression.ScalarFunction); ok {
 				canSubstitute = false
 				break
 			}
 		}
 		if canSubstitute {
-			push = append(push, expression.ColumnSubstitute(cond, p.GetSchema(), p.Exprs))
+			push = append(push, expression.ColumnSubstitute(cond, p.GetSchema().Columns, p.Exprs))
 		} else {
 			ret = append(ret, cond)
 		}
@@ -273,7 +273,7 @@ func (p *Union) PredicatePushDown(predicates []expression.Expression) (ret []exp
 	for _, proj := range p.children {
 		newExprs := make([]expression.Expression, 0, len(predicates))
 		for _, cond := range predicates {
-			newCond := expression.ColumnSubstitute(cond, p.GetSchema(), expression.Column2Exprs(proj.GetSchema().Columns))
+			newCond := expression.ColumnSubstitute(cond, p.GetSchema().Columns, expression.Column2Exprs(proj.GetSchema().Columns))
 			newExprs = append(newExprs, newCond)
 		}
 		retCond, _, err := proj.(LogicalPlan).PredicatePushDown(newExprs)
@@ -289,12 +289,12 @@ func (p *Union) PredicatePushDown(predicates []expression.Expression) (ret []exp
 
 // getGbyColIndex gets the column's index in the group-by columns.
 func (p *Aggregation) getGbyColIndex(col *expression.Column) int {
-	id := p.GetSchema().GetColumnIndex(col)
+	id := expression.GetColumnIndex(p.GetSchema().Columns, col)
 	colOriginal, isColumn := p.AggFuncs[id].GetArgs()[0].(*expression.Column)
 	if !isColumn {
 		return -1
 	}
-	return expression.NewSchema(p.groupByCols).GetColumnIndex(colOriginal)
+	return expression.GetColumnIndex(p.groupByCols, colOriginal)
 }
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
@@ -323,7 +323,7 @@ func (p *Aggregation) PredicatePushDown(predicates []expression.Expression) (ret
 				}
 			}
 			if ok {
-				newFunc := expression.ColumnSubstitute(cond.Clone(), p.GetSchema(), exprsOriginal)
+				newFunc := expression.ColumnSubstitute(cond.Clone(), p.GetSchema().Columns, exprsOriginal)
 				condsToPush = append(condsToPush, newFunc)
 			} else {
 				ret = append(ret, cond)
@@ -344,7 +344,7 @@ func (p *Apply) PredicatePushDown(predicates []expression.Expression) (ret []exp
 		extractedCols := expression.ExtractColumns(cond)
 		canPush := true
 		for _, col := range extractedCols {
-			if child.GetSchema().GetColumnIndex(col) == -1 {
+			if expression.GetColumnIndex(child.GetSchema().Columns, col) == -1 {
 				canPush = false
 				break
 			}


### PR DESCRIPTION
In code, there is something like `expression.NewSchema(p.groupByCols).GetColumnIndex(colOriginal)`. But it's not necessary to create a Schema. So i change this method to `GetColumnIndex(cols []*Column, col *Column)`