### PR TITLE
tidb: sleep for a while and retry when schema out of date

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -55,7 +55,7 @@ type testDBSuite struct {
 func (s *testDBSuite) SetUpSuite(c *C) {
 	var err error
 
-	s.lease = 100 * time.Millisecond
+	s.lease = 200 * time.Millisecond
 	tidb.SetSchemaLease(s.lease)
 	s.schemaName = "test_db"
 	s.store, err = tidb.NewStore(tidb.EngineGoLevelDBMemory)

--- a/session.go
+++ b/session.go
@@ -157,7 +157,7 @@ type schemaLeaseChecker struct {
 const schemaOutOfDateRetryInterval = 500 * time.Millisecond
 
 func (s *schemaLeaseChecker) Check(txnTS uint64) error {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 10; i++ {
 		err := s.checkOnce(txnTS)
 		switch err {
 		case nil:

--- a/session.go
+++ b/session.go
@@ -154,10 +154,13 @@ type schemaLeaseChecker struct {
 	schemaVer int64
 }
 
-const schemaOutOfDateRetryInterval = 500 * time.Millisecond
+const (
+	schemaOutOfDateRetryInterval = 500 * time.Millisecond
+	schemaOutOfDateRetryTimes    = 10
+)
 
 func (s *schemaLeaseChecker) Check(txnTS uint64) error {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < schemaOutOfDateRetryTimes; i++ {
 		err := s.checkOnce(txnTS)
 		switch err {
 		case nil:


### PR DESCRIPTION
also adjust schema lease duration in ddl test