### PR TITLE
domain: fix a data race

### DIFF
--- a/domain/schema_validator.go
+++ b/domain/schema_validator.go
@@ -88,7 +88,10 @@ func (s *schemaValidator) Check(txnTS uint64, schemaVer int64) bool {
 
 // Latest returns the latest schema version it knows.
 func (s *schemaValidator) Latest() int64 {
-	return s.latestSchemaVer
+	s.mux.RLock()
+	ret := s.latestSchemaVer
+	s.mux.RUnlock()
+	return ret
 }
 
 func extractPhysicalTime(ts uint64) time.Time {


### PR DESCRIPTION
```
WARNING: DATA RACE
[Unit Test] Write at 0x00c422dac328 by goroutine 43:
[Unit Test]   github.com/pingcap/tidb/domain.(*schemaValidator).Update()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/domain/schema_validator.go:49 +0x67
[Unit Test]   github.com/pingcap/tidb/domain.(*Domain).Reload()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/domain/domain.go:261 +0x2e8
[Unit Test]   github.com/pingcap/tidb/domain.(*Domain).loadSchemaInLoop()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/domain/domain.go:281 +0x151
[Unit Test] 
[Unit Test] Previous read at 0x00c422dac328 by goroutine 105:
[Unit Test]   github.com/pingcap/tidb/domain.(*schemaValidator).Latest()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/domain/schema_validator.go:91 +0x3c
[Unit Test]   github.com/pingcap/tidb.(*schemaLeaseChecker).checkOnce()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/session.go:180 +0xd3
[Unit Test]   github.com/pingcap/tidb.(*schemaLeaseChecker).Check()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/session.go:164 +0x5e
[Unit Test]   github.com/pingcap/tidb/store/localstore.(*dbTxn).doCommit()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/store/localstore/txn.go:96 +0x355
[Unit Test]   github.com/pingcap/tidb/store/localstore.(*dbTxn).Commit()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/store/localstore/txn.go:126 +0x139
[Unit Test]   github.com/pingcap/tidb.(*session).doCommit()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/session.go:216 +0x264
[Unit Test]   github.com/pingcap/tidb.(*session).doCommitWithRetry()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/session.go:223 +0x50
[Unit Test]   github.com/pingcap/tidb.(*session).CommitTxn()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/session.go:238 +0x38
[Unit Test]   github.com/pingcap/tidb.runStmt()
[Unit Test]       /home/jenkins/workspace/TIDB_POST_COMMIT_FLOW/go/src/github.com/pingcap/tidb/tidb.go:197 +0x2fe

```