### PR TITLE
parser: toInt trim leading zero

### DIFF
--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -222,3 +222,32 @@ func (s *testLexerSuite) TestSpecialComment(c *C) {
 	c.Assert(lit, Equals, "5")
 	c.Assert(pos, Equals, Pos{1, 1, 16})
 }
+
+func (s *testLexerSuite) TestInt(c *C) {
+	tests := []struct {
+		input  string
+		expect uint64
+	}{
+		{"01000001783", 1000001783},
+		{"00001783", 1783},
+		{"0", 0},
+		{"0000", 0},
+		{"01", 1},
+		{"10", 10},
+	}
+	scanner := NewScanner("")
+	for _, t := range tests {
+		var v yySymType
+		scanner.reset(t.input)
+		tok := scanner.Lex(&v)
+		c.Assert(tok, Equals, intLit)
+		switch i := v.item.(type) {
+		case int64:
+			c.Assert(uint64(i), Equals, t.expect)
+		case uint64:
+			c.Assert(i, Equals, t.expect)
+		default:
+			c.Fail()
+		}
+	}
+}

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -138,6 +138,11 @@ func (parser *Parser) endOffset(v *yySymType) int {
 }
 
 func toInt(l yyLexer, lval *yySymType, str string) int {
+	// Trim prefix 0 because 000107823 is a valid int in mysql, equal to 107823.
+	for len(str) > 1 && str[0] == '0' {
+		str = str[1:]
+	}
+
 	n, err := strconv.ParseUint(str, 0, 64)
 	if err != nil {
 		l.Errorf("integer literal: %v", err)


### PR DESCRIPTION
01000001783 is a valid int
Fix https://github.com/pingcap/tidb/issues/2402