### PR TITLE
parser: limit error information size

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -83,7 +83,7 @@ func (s *Scanner) Errorf(format string, a ...interface{}) {
 	if len(val) > 2048 {
 		val = val[:2048]
 	}
-	err := fmt.Errorf("line %d column %d near \"%s\"%s", s.r.p.Line, s.r.p.Col, val, str)
+	err := fmt.Errorf("line %d column %d near \"%s\"%s (len %d)", s.r.p.Line, s.r.p.Col, val, str, len(s.r.s))
 	s.errs = append(s.errs, err)
 }
 

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -80,6 +80,9 @@ func (s *Scanner) stmtText() string {
 func (s *Scanner) Errorf(format string, a ...interface{}) {
 	str := fmt.Sprintf(format, a...)
 	val := s.r.s[s.r.pos().Offset:]
+	if len(val) > 2048 {
+		val = val[:2048]
+	}
 	err := fmt.Errorf("line %d column %d near \"%s\"%s", s.r.p.Line, s.r.p.Col, val, str)
 	s.errs = append(s.errs, err)
 }

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -83,7 +83,7 @@ func (s *Scanner) Errorf(format string, a ...interface{}) {
 	if len(val) > 2048 {
 		val = val[:2048]
 	}
-	err := fmt.Errorf("line %d column %d near \"%s\"%s (len %d)", s.r.p.Line, s.r.p.Col, val, str, len(s.r.s))
+	err := fmt.Errorf("line %d column %d near \"%s\"%s (total length %d)", s.r.p.Line, s.r.p.Col, val, str, len(s.r.s))
 	s.errs = append(s.errs, err)
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -348,9 +348,10 @@ func (cc *clientConn) Run() {
 			}
 			cmd := string(data[1:])
 			if len(cmd) > size {
-				cmd = cmd[:size]
+				log.Warnf("[%d] dispatch error:\n%s\n%s\n%s (len %d)", cc.connectionID, cc, cmd[:size], errors.ErrorStack(err), len(cmd))
+			} else {
+				log.Warnf("[%d] dispatch error:\n%s\n%s\n%s", cc.connectionID, cc, cmd, errors.ErrorStack(err))
 			}
-			log.Warnf("[%d] dispatch error:\n%s\n%s\n%s", cc.connectionID, cc, cmd, errors.ErrorStack(err))
 			cc.writeError(err)
 		}
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -321,10 +321,10 @@ func (cc *clientConn) readHandshakeResponse() error {
 // it will be recovered and log the panic error.
 // This function returns and the connection is closed if there is an IO error or there is a panic.
 func (cc *clientConn) Run() {
+	const size = 4096
 	defer func() {
 		r := recover()
 		if r != nil {
-			const size = 4096
 			buf := make([]byte, size)
 			buf = buf[:runtime.Stack(buf, false)]
 			log.Errorf("lastCmd %s, %v, %s", cc.lastCmd, r, buf)
@@ -347,6 +347,9 @@ func (cc *clientConn) Run() {
 				return
 			}
 			cmd := string(data[1:])
+			if len(cmd) > size {
+				cmd = cmd[:size]
+			}
 			log.Warnf("[%d] dispatch error:\n%s\n%s\n%s", cc.connectionID, cc, cmd, errors.ErrorStack(err))
 			cc.writeError(err)
 		}


### PR DESCRIPTION
So the error message won't be too much, when the total sql is very long.

@shenli 