### PR TITLE
plan: fix a bug about pushing limit

### DIFF
--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -835,6 +835,9 @@ func (p *Selection) convert2PhysicalPlanPushOrder(prop *requiredProperty) (*phys
 			scanCount := info.count
 			info.count = limit.Count
 			info.cost = np.calculateCost(info.count, scanCount)
+			if limit.Offset > 0 {
+				info = enforceProperty(&requiredProperty{limit: limit}, info)
+			}
 		} else {
 			info = enforceProperty(&requiredProperty{limit: limit}, info)
 		}

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -115,6 +115,12 @@ func (s *testPlanSuite) TestPushDownOrderbyAndLimit(c *C) {
 			limit:        "5",
 		},
 		{
+			sql:          "select * from t where a < 1 limit 1, 1",
+			best:         "Table(t)->Limit->Projection",
+			orderByItmes: "[]",
+			limit:        "2",
+		},
+		{
 			sql:          "select * from t limit 5",
 			best:         "Table(t)->Limit->Projection",
 			orderByItmes: "[]",


### PR DESCRIPTION
fix #2430 
When the offset is not null, we should remain a limit as parent of table scan.
@shenli @coocood @zimulala PTAL