### PR TITLE
parser: fix aggregate functions.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2510,7 +2510,15 @@ DistinctOpt:
 	{
 		$$ = false
 	}
+|	"ALL"
+	{
+		$$ = false
+	}
 |	"DISTINCT"
+	{
+		$$ = true
+	}
+|	"DISTINCT" "ALL"
 	{
 		$$ = true
 	}
@@ -3144,6 +3152,10 @@ FunctionCallAgg:
 |	"COUNT" '(' "DISTINCT" ExpressionList ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: true}
+	}
+|	"COUNT" '(' "ALL" Expression ')'
+	{
+		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}}
 	}
 |	"COUNT" '(' Expression ')'
 	{

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2507,15 +2507,10 @@ FunctionCallConflict:
 	}
 
 DistinctOpt:
-	"ALL"
 	{
 		$$ = false
 	}
 |	"DISTINCT"
-	{
-		$$ = true
-	}
-|	"DISTINCT" "ALL"
 	{
 		$$ = true
 	}
@@ -3138,21 +3133,21 @@ TrimDirection:
 	}
 
 FunctionCallAgg:
-	"AVG" '(' Expression ')'
+	"AVG" '(' DistinctOpt Expression ')'
+	{
+		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}, Distinct: $3.(bool)}
+	}
+|	"BIT_XOR" '(' Expression ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
 	}
-|	"AVG" '(' DistinctOpt ExpressionList ')'
+|	"COUNT" '(' "DISTINCT" ExpressionList ')'
 	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: $3.(bool)}
+		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: true}
 	}
 |	"COUNT" '(' Expression ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
-	}
-|	"COUNT" '(' DistinctOpt ExpressionList ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: $3.(bool)}
 	}
 |	"COUNT" '(' '*' ')'
 	{
@@ -3163,35 +3158,15 @@ FunctionCallAgg:
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: $3.(bool)}
 	}
-|	"MAX" '(' Expression ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
-	}
 |	"MAX" '(' DistinctOpt Expression ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}, Distinct: $3.(bool)}
-	}
-|	"MIN" '(' Expression ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
 	}
 |	"MIN" '(' DistinctOpt Expression ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}, Distinct: $3.(bool)}
 	}
-|	"SUM" '(' Expression ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
-	}
 |	"SUM" '(' DistinctOpt Expression ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}, Distinct: $3.(bool)}
-	}
-|	"BIT_XOR" '(' Expression ')'
-	{
-		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3.(ast.ExprNode)}}
-	}
-|	"BIT_XOR" '(' DistinctOpt Expression ')'
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4.(ast.ExprNode)}, Distinct: $3.(bool)}
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -799,6 +799,29 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		// For misc functions
 		{`SELECT GET_LOCK('lock1',10);`, true},
 		{`SELECT RELEASE_LOCK('lock1');`, true},
+
+		// For aggregate functions
+		{`select avg(c1,c2) from t;`, false},
+		{`select avg(distinct c1) from t;`, true},
+		{`select avg(c2) from t;`, true},
+		{`select bit_xor(c1) from t;`, true},
+		{`select bit_xor(distinct c1) from t;`, false},
+		{`select max(c1,c2) from t;`, false},
+		{`select max(distinct c1) from t;`, true},
+		{`select max(c2) from t;`, true},
+		{`select min(c1,c2) from t;`, false},
+		{`select min(distinct c1) from t;`, true},
+		{`select min(c2) from t;`, true},
+		{`select sum(c1,c2) from t;`, false},
+		{`select sum(distinct c1) from t;`, true},
+		{`select sum(c2) from t;`, true},
+		{`select count(c1) from t;`, true},
+		{`select count(distinct *) from t;`, false},
+		{`select count(*) from t;`, true},
+		{`select count(distinct c1, c2) from t;`, true},
+		{`select count(c1, c2) from t;`, false},
+		{`select group_concat(c2,c1) from t group by c1;`, true},
+		{`select group_concat(distinct c2,c1) from t group by c1;`, true},
 	}
 	s.RunTest(c, table)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -820,6 +820,7 @@ func (s *testParserSuite) TestBuiltin(c *C) {
 		{`select count(*) from t;`, true},
 		{`select count(distinct c1, c2) from t;`, true},
 		{`select count(c1, c2) from t;`, false},
+		{`select count(all c1) from t;`, true},
 		{`select group_concat(c2,c1) from t group by c1;`, true},
 		{`select group_concat(distinct c2,c1) from t group by c1;`, true},
 	}


### PR DESCRIPTION
`group_concat` failed to parse after https://github.com/pingcap/tidb/pull/2448