### PR TITLE
store/tikv: fix cancel prewrite bug.

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -222,12 +222,13 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 	for i := 0; i < len(batches); i++ {
 		if e := <-ch; e != nil {
 			log.Debugf("2PC doActionOnBatches %s failed: %v, tid: %d", action, e, c.startTS)
+			// Cancel other requests and return the first error.
 			if cancel != nil {
-				// Cancel other requests and return the first error.
 				cancel()
-				return errors.Trace(e)
 			}
-			err = e
+			if err == nil {
+				err = e
+			}
 		}
 	}
 	return errors.Trace(err)

--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -73,6 +73,8 @@ func (h *rpcHandler) handleRequest(req *kvrpcpb.Request) *kvrpcpb.Response {
 		resp.CmdResolveLockResp = h.onResolveLock(req.CmdResolveLockReq)
 	case kvrpcpb.MessageType_CmdResolveLock:
 		resp.CmdResolveLockResp = h.onResolveLock(req.CmdResolveLockReq)
+	case kvrpcpb.MessageType_CmdBatchRollback:
+		resp.CmdBatchRollbackResp = h.onBatchRollback(req.CmdBatchRollbackReq)
 
 	case kvrpcpb.MessageType_CmdRawGet:
 		resp.CmdRawGetResp = h.onRawGet(req.CmdRawGetReq)
@@ -271,6 +273,16 @@ func (h *rpcHandler) onResolveLock(req *kvrpcpb.CmdResolveLockRequest) *kvrpcpb.
 		}
 	}
 	return &kvrpcpb.CmdResolveLockResponse{}
+}
+
+func (h *rpcHandler) onBatchRollback(req *kvrpcpb.CmdBatchRollbackRequest) *kvrpcpb.CmdBatchRollbackResponse {
+	err := h.mvccStore.Rollback(req.Keys, req.StartVersion)
+	if err != nil {
+		return &kvrpcpb.CmdBatchRollbackResponse{
+			Error: convertToKeyError(err),
+		}
+	}
+	return &kvrpcpb.CmdBatchRollbackResponse{}
 }
 
 func (h *rpcHandler) onRawGet(req *kvrpcpb.CmdRawGetRequest) *kvrpcpb.CmdRawGetResponse {


### PR DESCRIPTION
The bug is introduced by https://github.com/pingcap/tidb/pull/2056
Without waiting for all requests finish, some locks will not be cleared in time and will slow down later read.
@shenli @tiancaiamao 