### PR TITLE
plan: refine code when retrieving agg columns.

### DIFF
--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -14,7 +14,6 @@ package plan
 
 import (
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 )
@@ -290,15 +289,7 @@ func (p *Union) PredicatePushDown(predicates []expression.Expression) (ret []exp
 
 // getGbyColIndex gets the column's index in the group-by columns.
 func (p *Aggregation) getGbyColIndex(col *expression.Column) int {
-	id := p.GetSchema().GetColumnIndex(col)
-	if p.AggFuncs[id].GetName() != ast.AggFuncFirstRow {
-		return -1
-	}
-	colOriginal, isColumn := p.AggFuncs[id].GetArgs()[0].(*expression.Column)
-	if !isColumn {
-		return -1
-	}
-	return expression.NewSchema(p.groupByCols).GetColumnIndex(colOriginal)
+	return expression.NewSchema(p.groupByCols).GetColumnIndex(col)
 }
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.


### PR DESCRIPTION
Now, the names of aggregation's first row schema columns are the same as its arguments. So we can simplify some codes.
@winoros @shenli @coocood @zimulala @lamxTyler PTAL