### PR TITLE
*: add 'max_allowed_packet' in common variables.

### DIFF
--- a/session.go
+++ b/session.go
@@ -812,6 +812,7 @@ const loadCommonGlobalVarsSQL = "select * from mysql.global_variables where vari
 	variable.AutocommitVar + "', '" +
 	variable.SQLModeVar + "', '" +
 	variable.DistSQLJoinConcurrencyVar + "', '" +
+	variable.MaxAllowedPacket + "', '" +
 	variable.DistSQLScanConcurrencyVar + "')"
 
 // LoadCommonGlobalVariableIfNeeded loads and applies commonly used global variables for the session.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -229,6 +229,7 @@ const (
 	SQLModeVar          = "sql_mode"
 	AutocommitVar       = "autocommit"
 	CharacterSetResults = "character_set_results"
+	MaxAllowedPacket    = "max_allowed_packet"
 	TimeZone            = "time_zone"
 )
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -564,7 +564,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "ndbinfo_show_hidden", ""},
 	{ScopeGlobal | ScopeSession, "net_read_timeout", "30"},
 	{ScopeNone, "innodb_page_size", "16384"},
-	{ScopeGlobal, "max_allowed_packet", "4194304"},
+	{ScopeGlobal, MaxAllowedPacket, "4194304"},
 	{ScopeNone, "innodb_log_file_size", "50331648"},
 	{ScopeGlobal, "sync_relay_log_info", "10000"},
 	{ScopeGlobal | ScopeSession, "optimizer_trace_limit", "1"},


### PR DESCRIPTION
To save a global query to TiKV when a new connection creates.