### PR TITLE
executor: fix bug of union type converting.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1045,18 +1045,16 @@ func (e *UnionExec) fetchData(idx int) {
 				}
 				return
 			}
-			if idx != 0 {
-				// TODO: Add cast function in plan building phase.
-				for j := range row.Data {
-					col := e.schema.Columns[j]
-					val, err := row.Data[j].ConvertTo(e.ctx.GetSessionVars().StmtCtx, col.RetType)
-					if err != nil {
-						e.finished.Store(true)
-						e.errCh <- err
-						return
-					}
-					row.Data[j] = val
+			// TODO: Add cast function in plan building phase.
+			for j := range row.Data {
+				col := e.schema.Columns[j]
+				val, err := row.Data[j].ConvertTo(e.ctx.GetSessionVars().StmtCtx, col.RetType)
+				if err != nil {
+					e.finished.Store(true)
+					e.errCh <- err
+					return
 				}
+				row.Data[j] = val
 			}
 			rows = append(rows, row)
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -530,6 +530,12 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec("insert into t (c1, c2) values (2, 3)")
 	r = tk.MustQuery("select * from t where t.c1 = 1 union select * from t where t.id = 1")
 	r.Check(testkit.Rows("1 1 1", "2 1 2"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (f1 DATE)")
+	tk.MustExec("INSERT INTO t VALUES ('1978-11-26')")
+	r = tk.MustQuery("SELECT f1+0 FROM t UNION SELECT f1+0 FROM t")
+	r.Check(testkit.Rows("19781126"))
 }
 
 func (s *testSuite) TestIn(c *C) {


### PR DESCRIPTION
fix #2317 
Type inferer sometimes behaves differently from `CoerceArithmetic`. 
e.g. inferer thinks date + int would be mysql.LongLong but CoerceArithmetic will convert it to datum.KindDecimal.
Considering we are refactoring type inferer, I don't hope to make type inferer more complex. So I let every union branch do converting.

@shenli @coocood @zimulala @XuHuaiyu @tiancaiamao PTAL