### PR TITLE
session: add connection ID in retry log.

### DIFF
--- a/session.go
+++ b/session.go
@@ -334,6 +334,7 @@ func (s *session) retry(maxCnt int) error {
 		}
 		retryCnt++
 		if !s.unlimitedRetryCount && (retryCnt >= maxCnt) {
+			log.Warnf("[%id] Retry reached max count %d", connID, retryCnt)
 			return errors.Trace(err)
 		}
 		kv.BackOff(retryCnt)

--- a/session.go
+++ b/session.go
@@ -238,7 +238,7 @@ func (s *session) doCommitWithRetry() error {
 	}
 	s.cleanRetryInfo()
 	if err != nil {
-		log.Warnf("finished txn:%s, %v", s.txn, err)
+		log.Warnf("[%d] finished txn:%s, %v", s.sessionVars.ConnectionID, s.txn, err)
 		return errors.Trace(err)
 	}
 	return nil
@@ -298,8 +298,9 @@ func (s *session) isRetryableError(err error) bool {
 }
 
 func (s *session) retry(maxCnt int) error {
+	connID := s.sessionVars.ConnectionID
 	if s.sessionVars.TxnCtx.ForUpdate {
-		return errors.Errorf("can not retry select for update statement")
+		return errors.Errorf("[%d] can not retry select for update statement", connID)
 	}
 	s.sessionVars.RetryInfo.Retrying = true
 	retryCnt := 0
@@ -315,10 +316,7 @@ func (s *session) retry(maxCnt int) error {
 		for _, sr := range nh.history {
 			st := sr.st
 			txt := st.OriginText()
-			if len(txt) > sqlLogMaxLen {
-				txt = txt[:sqlLogMaxLen]
-			}
-			log.Warnf("Retry %s (len:%d)", txt, len(st.OriginText()))
+			log.Warnf("[%d] Retry %s", connID, sqlForLog(txt))
 			_, err = st.Exec(s)
 			if err != nil {
 				break
@@ -331,7 +329,7 @@ func (s *session) retry(maxCnt int) error {
 			}
 		}
 		if !s.isRetryableError(err) {
-			log.Warnf("session:%v, err:%v", s, err)
+			log.Warnf("[%d] session:%v, err:%v", connID, s, err)
 			return errors.Trace(err)
 		}
 		retryCnt++
@@ -341,6 +339,13 @@ func (s *session) retry(maxCnt int) error {
 		kv.BackOff(retryCnt)
 	}
 	return err
+}
+
+func sqlForLog(sql string) string {
+	if len(sql) > sqlLogMaxLen {
+		return sql[:sqlLogMaxLen] + fmt.Sprintf("(len:%d)", len(sql))
+	}
+	return sql
 }
 
 // ExecRestrictedSQL implements RestrictedSQLExecutor interface.


### PR DESCRIPTION
When multiple connections run concurrently, we need to distinguish the retry log for a single session.