### PR TITLE
ddl: avoid assert in lock

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -129,8 +129,9 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, true)
 	mu.Lock()
-	s.testColumnDrop(c, ctx, d, publicTable)
+	tb := publicTable
 	mu.Unlock()
+	s.testColumnDrop(c, ctx, d, tb)
 	s.testAddColumnNoDefault(c, ctx, d, tblInfo)
 	d.close()
 }

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -800,9 +800,11 @@ func (s *testColumnSuite) TestAddColumn(c *C) {
 
 	testCheckJobDone(c, d, job, true)
 	mu.Lock()
-	c.Assert(errors.ErrorStack(hookErr), Equals, "")
-	c.Assert(checkOK, IsTrue)
+	hErr := hookErr
+	ok := checkOK
 	mu.Unlock()
+	c.Assert(errors.ErrorStack(hErr), Equals, "")
+	c.Assert(ok, IsTrue)
 
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)
@@ -873,9 +875,11 @@ func (s *testColumnSuite) TestDropColumn(c *C) {
 	job := testDropColumn(c, ctx, s.d, s.dbInfo, tblInfo, colName, false)
 	testCheckJobDone(c, d, job, false)
 	mu.Lock()
-	c.Assert(hookErr, IsNil)
-	c.Assert(checkOK, IsTrue)
+	hErr := hookErr
+	ok := checkOK
 	mu.Unlock()
+	c.Assert(hErr, IsNil)
+	c.Assert(ok, IsTrue)
 
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -159,9 +159,11 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 	mu.Lock()
-	c.Assert(hookErr, IsNil)
-	c.Assert(checkOK, IsTrue)
+	hErr := hookErr
+	ok := checkOK
 	mu.Unlock()
+	c.Assert(hErr, IsNil)
+	c.Assert(ok, IsTrue)
 	v := getSchemaVer(c, ctx)
 	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 
@@ -193,9 +195,11 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	job = testDropForeignKey(c, ctx, d, s.dbInfo, tblInfo, "c1_fk")
 	testCheckJobDone(c, d, job, false)
 	mu.Lock()
-	c.Assert(hookErr, IsNil)
-	c.Assert(checkOK, IsTrue)
+	hErr = hookErr
+	ok = checkOK
 	mu.Unlock()
+	c.Assert(hErr, IsNil)
+	c.Assert(ok, IsTrue)
 
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
assert in lock may cause dead lock