### PR TITLE
expression: Fix a null point bug in unix_timestamp()

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1566,6 +1566,10 @@ func builtinUnixTimestamp(args []types.Datum, ctx context.Context) (d types.Datu
 		if err != nil {
 			return d, errors.Trace(err)
 		}
+	case types.KindMysqlTime:
+		t = args[0].GetMysqlTime()
+	default:
+		return d, errors.Errorf("Unkonwn args type for unix_timestamp %d", args[0].Kind())
 	}
 
 	t1, err = t.Time.GoTime(getTimeZone(ctx))

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -832,6 +832,16 @@ func (s *testEvaluatorSuite) TestUnixTimestamp(c *C) {
 	c.Assert(d.GetInt64()-time.Now().Unix(), GreaterEqual, int64(-1))
 	c.Assert(d.GetInt64()-time.Now().Unix(), LessEqual, int64(1))
 
+	// Test case for https://github.com/pingcap/tidb/issues/2496
+	// select unix_timestamp(now());
+	n, err := builtinNow(nil, s.ctx)
+	c.Assert(err, IsNil)
+	args := []types.Datum{n}
+	d, err = builtinUnixTimestamp(args, s.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(d.GetInt64()-time.Now().Unix(), GreaterEqual, int64(-1))
+	c.Assert(d.GetInt64()-time.Now().Unix(), LessEqual, int64(1))
+
 	// Set the time_zone variable, because UnixTimestamp() result depends on it.
 	s.ctx.GetSessionVars().TimeZone = time.UTC
 	tests := []struct {


### PR DESCRIPTION
Fix https://github.com/pingcap/tidb/issues/2496

If UNIX_TIMESTAMP() is called with a date argument, it returns the value of the argument as seconds since '1970-01-01 00:00:00' UTC. date may be a DATE string, a DATETIME string, a TIMESTAMP, or a number in the format YYMMDD or YYYYMMDD, optionally including a fractional seconds part. The server interprets date as a value in the current time zone and converts it to an internal value in UTC. Clients can set their time zone as described in Section 11.6, “MySQL Server Time Zone Support”.
@tiancaiamao @coocood @XuHuaiyu PTAL