### PR TITLE
executor: fix join leak

### DIFF
--- a/executor/executor_join.go
+++ b/executor/executor_join.go
@@ -81,7 +81,7 @@ type hashJoinCtx struct {
 // Close implements the Executor Close interface.
 func (e *HashJoinExec) Close() error {
 	e.finished.Store(true)
-	for _ = range e.resultRows {
+	for range e.resultRows {
 	}
 	<-e.closeCh
 	e.prepared = false

--- a/executor/executor_join.go
+++ b/executor/executor_join.go
@@ -81,9 +81,7 @@ type hashJoinCtx struct {
 // Close implements the Executor Close interface.
 func (e *HashJoinExec) Close() error {
 	e.finished.Store(true)
-	chLen := len(e.resultRows)
-	for i := 0; i < chLen; i++ {
-		<-e.resultRows
+	for _ = range e.resultRows {
 	}
 	<-e.closeCh
 	e.prepared = false

--- a/executor/executor_join.go
+++ b/executor/executor_join.go
@@ -81,6 +81,10 @@ type hashJoinCtx struct {
 // Close implements the Executor Close interface.
 func (e *HashJoinExec) Close() error {
 	e.finished.Store(true)
+	chLen := len(e.resultRows)
+	for i := 0; i < chLen; i++ {
+		<-e.resultRows
+	}
 	<-e.closeCh
 	e.prepared = false
 	e.cursor = 0

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1348,9 +1348,10 @@ func (s *testSuite) TestHistoryRead(c *C) {
 }
 
 func (s *testSuite) TestJoinLeak(c *C) {
+	savedConcurrency := plan.JoinConcurrency
 	plan.JoinConcurrency = 1
 	defer func() {
-		plan.JoinConcurrency = 5
+		plan.JoinConcurrency = savedConcurrency
 		s.cleanEnv(c)
 		testleak.AfterTest(c)()
 	}()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/testkit"
@@ -1344,4 +1345,28 @@ func (s *testSuite) TestHistoryRead(c *C) {
 	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2", "4"))
 	tk.MustExec("set @@tidb_snapshot = ''")
 	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2 <nil>", "4 <nil>", "8 8", "9 9"))
+}
+
+func (s *testSuite) TestJoinLeak(c *C) {
+	plan.JoinConcurrency = 1
+	defer func() {
+		plan.JoinConcurrency = 5
+		s.cleanEnv(c)
+		testleak.AfterTest(c)()
+	}()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (d int)")
+	tk.MustExec("begin")
+	for i := 0; i < 1002; i++ {
+		tk.MustExec("insert t values (1)")
+	}
+	tk.MustExec("commit")
+	rs, err := tk.Se.Execute("select * from t t1 left join (select 1) t2 on 1")
+	c.Assert(err, IsNil)
+	result := rs[0]
+	result.Next()
+	time.Sleep(100 * time.Millisecond)
+	result.Close()
 }


### PR DESCRIPTION
In HashJoin Executor When Close is called after fetched 1000 rows, the result channel is full,
Close is blocked forever.