### PR TITLE
*: slow log and metrics includes execute prepared statement.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -164,9 +164,6 @@ type Statement interface {
 	// OriginText gets the origin SQL text.
 	OriginText() string
 
-	// SetText sets the executive SQL text.
-	SetText(text string)
-
 	// Exec executes SQL and gets a Recordset.
 	Exec(ctx context.Context) (RecordSet, error)
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -41,12 +41,14 @@ import (
 	"io"
 	"net"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/executor"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/arena"
@@ -342,21 +344,72 @@ func (cc *clientConn) Run() {
 			return
 		}
 
-		if err := cc.dispatch(data); err != nil {
+		startTime := time.Now()
+		if err = cc.dispatch(data); err != nil {
 			if terror.ErrorEqual(err, io.EOF) {
+				cc.addMetrics(data[0], startTime, nil)
 				return
 			}
-			cmd := string(data[1:])
-			if len(cmd) > size {
-				log.Warnf("[%d] dispatch error:\n%s\n%s\n%s (len %d)", cc.connectionID, cc, cmd[:size], errors.ErrorStack(err), len(cmd))
-			} else {
-				log.Warnf("[%d] dispatch error:\n%s\n%s\n%s", cc.connectionID, cc, cmd, errors.ErrorStack(err))
-			}
+			log.Warnf("[%d] dispatch error:\n%s\n%s\n%s",
+				cc.connectionID, cc, queryStrForLog(string(data[1:])), errStrForLog(err))
 			cc.writeError(err)
 		}
-
+		cc.addMetrics(data[0], startTime, err)
 		cc.pkt.sequence = 0
 	}
+}
+
+func queryStrForLog(query string) string {
+	const size = 4096
+	if len(query) > size {
+		return query[:size] + fmt.Sprintf("(len: %d)", len(query))
+	}
+	return query
+}
+
+func errStrForLog(err error) string {
+	if kv.ErrKeyExists.Equal(err) {
+		// Do not log stack for duplicated entry error.
+		return err.Error()
+	}
+	return errors.ErrorStack(err)
+}
+
+func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
+	var label string
+	switch cmd {
+	case mysql.ComSleep:
+		label = "Sleep"
+	case mysql.ComQuit:
+		label = "Quit"
+	case mysql.ComQuery:
+		label = "Query"
+	case mysql.ComPing:
+		label = "Ping"
+	case mysql.ComInitDB:
+		label = "InitDB"
+	case mysql.ComFieldList:
+		label = "FieldList"
+	case mysql.ComStmtPrepare:
+		label = "StmtPrepare"
+	case mysql.ComStmtExecute:
+		label = "StmtExecute"
+	case mysql.ComStmtClose:
+		label = "StmtClose"
+	case mysql.ComStmtSendLongData:
+		label = "StmtSendLongData"
+	case mysql.ComStmtReset:
+		label = "StmtReset"
+	case mysql.ComSetOption:
+		label = "SetOption"
+	default:
+		label = strconv.Itoa(int(cmd))
+	}
+	if err != nil {
+		label += "Error"
+	}
+	queryCounter.WithLabelValues(label).Inc()
+	queryHistogram.Observe(time.Since(startTime).Seconds())
 }
 
 // dispatch handles client request based on command which is the first byte of the data.
@@ -366,13 +419,9 @@ func (cc *clientConn) dispatch(data []byte) error {
 	cmd := data[0]
 	data = data[1:]
 	cc.lastCmd = hack.String(data)
-
 	token := cc.server.getToken()
-
-	startTS := time.Now()
 	defer func() {
 		cc.server.releaseToken(token)
-		log.Debugf("[TIME_CMD] %v %d", time.Since(startTS), cmd)
 	}()
 
 	switch cmd {
@@ -395,7 +444,6 @@ func (cc *clientConn) dispatch(data []byte) error {
 	case mysql.ComPing:
 		return cc.writeOK()
 	case mysql.ComInitDB:
-		log.Debug("init db", hack.String(data))
 		if err := cc.useDB(hack.String(data)); err != nil {
 			return errors.Trace(err)
 		}
@@ -600,32 +648,10 @@ func (cc *clientConn) handleLoadData(loadDataInfo *executor.LoadDataInfo) error 
 	return errors.Trace(txn.Commit())
 }
 
-const queryLogMaxLen = 2048
-
 // handleQuery executes the sql query string and writes result set or result ok to the client.
 // As the execution time of this function represents the performance of TiDB, we do time log and metrics here.
 // There is a special query `load data` that does not return result, which is handled differently.
 func (cc *clientConn) handleQuery(sql string) (err error) {
-	startTime := time.Now()
-	defer func() {
-		costTime := time.Since(startTime)
-		if len(sql) > queryLogMaxLen {
-			sql = sql[:queryLogMaxLen] + fmt.Sprintf("(len:%d)", len(sql))
-		}
-		if costTime < 300*time.Millisecond {
-			log.Debugf("[%d][TIME_QUERY] %v %s", cc.connectionID, costTime, sql)
-		} else {
-			log.Warnf("[%d][TIME_QUERY] %v %s", cc.connectionID, costTime, sql)
-		}
-		// Add metrics
-		queryHistogram.Observe(costTime.Seconds())
-		label := querySucc
-		if err != nil {
-			label = queryFailed
-		}
-		queryCounter.WithLabelValues(label).Inc()
-	}()
-
 	rs, err := cc.ctx.Execute(sql)
 	if err != nil {
 		executeErrorCounter.WithLabelValues(executeErrorToLabel(err)).Inc()

--- a/server/conn.go
+++ b/server/conn.go
@@ -406,9 +406,10 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 		label = strconv.Itoa(int(cmd))
 	}
 	if err != nil {
-		label += "Error"
+		queryCounter.WithLabelValues(label, "Error").Inc()
+	} else {
+		queryCounter.WithLabelValues(label).Inc()
 	}
-	queryCounter.WithLabelValues(label).Inc()
 	queryHistogram.Observe(time.Since(startTime).Seconds())
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -408,7 +408,7 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 	if err != nil {
 		queryCounter.WithLabelValues(label, "Error").Inc()
 	} else {
-		queryCounter.WithLabelValues(label).Inc()
+		queryCounter.WithLabelValues(label, "OK").Inc()
 	}
 	queryHistogram.Observe(time.Since(startTime).Seconds())
 }

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -37,11 +37,7 @@ var (
 			Subsystem: "server",
 			Name:      "query_total",
 			Help:      "Counter of queries.",
-		}, []string{"type"})
-
-	// Query handle result status.
-	querySucc   = "query_succ"
-	queryFailed = "query_failed"
+		}, []string{"type", "status"})
 
 	connGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
Execute prepared statement was ignored in slow query log and query metrics.