### PR TITLE
expression,util/stringutil: move LIKE pattern match to stringutil package

### DIFF
--- a/expression/builtin_like.go
+++ b/expression/builtin_like.go
@@ -18,13 +18,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tidb/util/types"
-)
-
-const (
-	patMatch = iota + 1
-	patOne
-	patAny
 )
 
 var (
@@ -36,106 +31,6 @@ var (
 	_ builtinFunc = &builtinLikeSig{}
 	_ builtinFunc = &builtinRegexpSig{}
 )
-
-// Handle escapes and wild cards convert pattern characters and pattern types.
-func compilePattern(pattern string, escape byte) (patChars, patTypes []byte) {
-	var lastAny bool
-	patChars = make([]byte, len(pattern))
-	patTypes = make([]byte, len(pattern))
-	patLen := 0
-	for i := 0; i < len(pattern); i++ {
-		var tp byte
-		var c = pattern[i]
-		switch c {
-		case escape:
-			lastAny = false
-			tp = patMatch
-			if i < len(pattern)-1 {
-				i++
-				c = pattern[i]
-				if c == escape || c == '_' || c == '%' {
-					// valid escape.
-				} else {
-					// invalid escape, fall back to escape byte
-					// mysql will treat escape character as the origin value even
-					// the escape sequence is invalid in Go or C.
-					// e.g, \m is invalid in Go, but in MySQL we will get "m" for select '\m'.
-					// Following case is correct just for escape \, not for others like +.
-					// TODO: add more checks for other escapes.
-					i--
-					c = escape
-				}
-			}
-		case '_':
-			lastAny = false
-			tp = patOne
-		case '%':
-			if lastAny {
-				continue
-			}
-			lastAny = true
-			tp = patAny
-		default:
-			lastAny = false
-			tp = patMatch
-		}
-		patChars[patLen] = c
-		patTypes[patLen] = tp
-		patLen++
-	}
-	for i := 0; i < patLen-1; i++ {
-		if (patTypes[i] == patAny) && (patTypes[i+1] == patOne) {
-			patTypes[i] = patOne
-			patTypes[i+1] = patAny
-		}
-	}
-	patChars = patChars[:patLen]
-	patTypes = patTypes[:patLen]
-	return
-}
-
-const caseDiff = 'a' - 'A'
-
-func matchByteCI(a, b byte) bool {
-	if a == b {
-		return true
-	}
-	if a >= 'a' && a <= 'z' && a-caseDiff == b {
-		return true
-	}
-	return a >= 'A' && a <= 'Z' && a+caseDiff == b
-}
-
-func doMatch(str string, patChars, patTypes []byte) bool {
-	var sIdx int
-	for i := 0; i < len(patChars); i++ {
-		switch patTypes[i] {
-		case patMatch:
-			if sIdx >= len(str) || !matchByteCI(str[sIdx], patChars[i]) {
-				return false
-			}
-			sIdx++
-		case patOne:
-			sIdx++
-			if sIdx > len(str) {
-				return false
-			}
-		case patAny:
-			i++
-			if i == len(patChars) {
-				return true
-			}
-			for sIdx < len(str) {
-				if matchByteCI(patChars[i], str[sIdx]) && doMatch(str[sIdx:], patChars[i:], patTypes[i:]) {
-					return true
-				}
-				sIdx++
-			}
-			return false
-		}
-	}
-	return sIdx == len(str)
-}
 
 type likeFunctionClass struct {
 	baseFunctionClass
@@ -177,8 +72,8 @@ func builtinLike(args []types.Datum, _ context.Context) (d types.Datum, err erro
 		return d, errors.Trace(err)
 	}
 	escape := byte(args[2].GetInt64())
-	patChars, patTypes := compilePattern(patternStr, escape)
-	match := doMatch(valStr, patChars, patTypes)
+	patChars, patTypes := stringutil.CompilePattern(patternStr, escape)
+	match := stringutil.DoMatch(valStr, patChars, patTypes)
 	d.SetInt64(boolToInt64(match))
 	return
 }

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
@@ -409,46 +408,6 @@ func (s *testEvaluatorSuite) TestLastInsertID(c *C) {
 
 func (s *testEvaluatorSuite) TestLike(c *C) {
 	defer testleak.AfterTest(c)()
-	tbl := []struct {
-		pattern string
-		input   string
-		escape  byte
-		match   bool
-	}{
-		{"", "a", '\\', false},
-		{"a", "a", '\\', true},
-		{"a", "b", '\\', false},
-		{"aA", "aA", '\\', true},
-		{"_", "a", '\\', true},
-		{"_", "ab", '\\', false},
-		{"__", "b", '\\', false},
-		{"_ab", "AAB", '\\', true},
-		{"%", "abcd", '\\', true},
-		{"%", "", '\\', true},
-		{"%a", "AAA", '\\', true},
-		{"%b", "AAA", '\\', false},
-		{"b%", "BBB", '\\', true},
-		{"%a%", "BBB", '\\', false},
-		{"%a%", "BAB", '\\', true},
-		{"a%", "BBB", '\\', false},
-		{`\%a`, `%a`, '\\', true},
-		{`\%a`, `aa`, '\\', false},
-		{`\_a`, `_a`, '\\', true},
-		{`\_a`, `aa`, '\\', false},
-		{`\\_a`, `\xa`, '\\', true},
-		{`\a\b`, `\a\b`, '\\', true},
-		{"%%_", `abc`, '\\', true},
-		{`+_a`, `_a`, '+', true},
-		{`+%a`, `%a`, '+', true},
-		{`\%a`, `%a`, '+', false},
-		{`++a`, `+a`, '+', true},
-		{`++_a`, `+xa`, '+', true},
-	}
-	for _, v := range tbl {
-		patChars, patTypes := stringutil.CompilePattern(v.pattern, v.escape)
-		match := stringutil.DoMatch(v.input, patChars, patTypes)
-		c.Assert(match, Equals, v.match, Commentf("%v", v))
-	}
 	testCases := []struct {
 		input   string
 		pattern string

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
@@ -444,8 +445,8 @@ func (s *testEvaluatorSuite) TestLike(c *C) {
 		{`++_a`, `+xa`, '+', true},
 	}
 	for _, v := range tbl {
-		patChars, patTypes := compilePattern(v.pattern, v.escape)
-		match := doMatch(v.input, patChars, patTypes)
+		patChars, patTypes := stringutil.CompilePattern(v.pattern, v.escape)
+		match := stringutil.DoMatch(v.input, patChars, patTypes)
 		c.Assert(match, Equals, v.match, Commentf("%v", v))
 	}
 	testCases := []struct {

--- a/util/stringutil/string_util.go
+++ b/util/stringutil/string_util.go
@@ -131,3 +131,111 @@ func Unquote(s string) (t string, err error) {
 	}
 	return string(buf), nil
 }
+
+const (
+	patMatch = iota + 1
+	patOne
+	patAny
+)
+
+// CompilePattern handles escapes and wild cards convert pattern characters and
+// pattern types.
+func CompilePattern(pattern string, escape byte) (patChars, patTypes []byte) {
+	var lastAny bool
+	patChars = make([]byte, len(pattern))
+	patTypes = make([]byte, len(pattern))
+	patLen := 0
+	for i := 0; i < len(pattern); i++ {
+		var tp byte
+		var c = pattern[i]
+		switch c {
+		case escape:
+			lastAny = false
+			tp = patMatch
+			if i < len(pattern)-1 {
+				i++
+				c = pattern[i]
+				if c == escape || c == '_' || c == '%' {
+					// valid escape.
+				} else {
+					// invalid escape, fall back to escape byte
+					// mysql will treat escape character as the origin value even
+					// the escape sequence is invalid in Go or C.
+					// e.g, \m is invalid in Go, but in MySQL we will get "m" for select '\m'.
+					// Following case is correct just for escape \, not for others like +.
+					// TODO: add more checks for other escapes.
+					i--
+					c = escape
+				}
+			}
+		case '_':
+			lastAny = false
+			tp = patOne
+		case '%':
+			if lastAny {
+				continue
+			}
+			lastAny = true
+			tp = patAny
+		default:
+			lastAny = false
+			tp = patMatch
+		}
+		patChars[patLen] = c
+		patTypes[patLen] = tp
+		patLen++
+	}
+	for i := 0; i < patLen-1; i++ {
+		if (patTypes[i] == patAny) && (patTypes[i+1] == patOne) {
+			patTypes[i] = patOne
+			patTypes[i+1] = patAny
+		}
+	}
+	patChars = patChars[:patLen]
+	patTypes = patTypes[:patLen]
+	return
+}
+
+const caseDiff = 'a' - 'A'
+
+func matchByteCI(a, b byte) bool {
+	if a == b {
+		return true
+	}
+	if a >= 'a' && a <= 'z' && a-caseDiff == b {
+		return true
+	}
+	return a >= 'A' && a <= 'Z' && a+caseDiff == b
+}
+
+// DoMatch matches the string with patChars and patTypes.
+func DoMatch(str string, patChars, patTypes []byte) bool {
+	var sIdx int
+	for i := 0; i < len(patChars); i++ {
+		switch patTypes[i] {
+		case patMatch:
+			if sIdx >= len(str) || !matchByteCI(str[sIdx], patChars[i]) {
+				return false
+			}
+			sIdx++
+		case patOne:
+			sIdx++
+			if sIdx > len(str) {
+				return false
+			}
+		case patAny:
+			i++
+			if i == len(patChars) {
+				return true
+			}
+			for sIdx < len(str) {
+				if matchByteCI(patChars[i], str[sIdx]) && DoMatch(str[sIdx:], patChars[i:], patTypes[i:]) {
+					return true
+				}
+				sIdx++
+			}
+			return false
+		}
+	}
+	return sIdx == len(str)
+}

--- a/util/stringutil/string_util.go
+++ b/util/stringutil/string_util.go
@@ -156,14 +156,14 @@ func CompilePattern(pattern string, escape byte) (patChars, patTypes []byte) {
 				i++
 				c = pattern[i]
 				if c == escape || c == '_' || c == '%' {
-					// valid escape.
+					// Valid escape.
 				} else {
-					// invalid escape, fall back to escape byte
+					// Invalid escape, fall back to escape byte.
 					// mysql will treat escape character as the origin value even
 					// the escape sequence is invalid in Go or C.
-					// e.g, \m is invalid in Go, but in MySQL we will get "m" for select '\m'.
+					// e.g., \m is invalid in Go, but in MySQL we will get "m" for select '\m'.
 					// Following case is correct just for escape \, not for others like +.
-					// TODO: add more checks for other escapes.
+					// TODO: Add more checks for other escapes.
 					i--
 					c = escape
 				}


### PR DESCRIPTION
This code will be reused, so it's better put it to stringutil.