### PR TITLE
ddl: Add the function of close

### DIFF
--- a/ddl/bg_worker_test.go
+++ b/ddl/bg_worker_test.go
@@ -29,7 +29,7 @@ func (s *testDDLSuite) TestDropSchemaError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 
 	job := &model.Job{
 		SchemaID: 1,
@@ -64,7 +64,7 @@ func (s *testDDLSuite) TestDropTableError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 
 	dbInfo := testSchemaInfo(c, d, "test")
 	testCreateSchema(c, testNewContext(d), d, dbInfo)
@@ -96,7 +96,7 @@ func (s *testDDLSuite) TestInvalidBgJobType(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 
 	job := &model.Job{
 		SchemaID:   1,

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -55,6 +55,7 @@ func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 	defer testleak.AfterTest(c)()
 	d := newDDL(s.store, nil, nil, testLease)
+	defer d.Stop()
 	// create table t (c1 int, c2 int);
 	tblInfo := testTableInfo(c, d, "t", 2)
 	ctx := testNewContext(d)
@@ -133,11 +134,10 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 	mu.Unlock()
 	s.testColumnDrop(c, ctx, d, tb)
 	s.testAddColumnNoDefault(c, ctx, d, tblInfo)
-	d.close()
 }
 
 func (s *testColumnChangeSuite) testAddColumnNoDefault(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo) {
-	d.close()
+	d.Stop()
 	tc := &testDDLCallback{}
 	// set up hook
 	prevState := model.StateNone
@@ -184,7 +184,7 @@ func (s *testColumnChangeSuite) testAddColumnNoDefault(c *C, ctx context.Context
 }
 
 func (s *testColumnChangeSuite) testColumnDrop(c *C, ctx context.Context, d *ddl, tbl table.Table) {
-	d.close()
+	d.Stop()
 	dropCol := tbl.Cols()[2]
 	tc := &testDDLCallback{}
 	// set up hook

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -52,7 +52,7 @@ func (s *testColumnSuite) SetUpSuite(c *C) {
 
 func (s *testColumnSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(s.d), s.d, s.dbInfo)
-	s.d.close()
+	s.d.Stop()
 
 	err := s.store.Close()
 	c.Assert(err, IsNil)
@@ -791,9 +791,9 @@ func (s *testColumnSuite) TestAddColumn(c *C) {
 	d.setHook(tc)
 
 	// Use local ddl for callback test.
-	s.d.close()
+	s.d.Stop()
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job := testCreateColumn(c, ctx, d, s.dbInfo, tblInfo, newColName, &ast.ColumnPosition{Tp: ast.ColumnPositionNone}, defaultColValue)
@@ -815,7 +815,7 @@ func (s *testColumnSuite) TestAddColumn(c *C) {
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	s.d.start()
 }
 
@@ -867,9 +867,9 @@ func (s *testColumnSuite) TestDropColumn(c *C) {
 	d.setHook(tc)
 
 	// Use local ddl for callback test.
-	s.d.close()
+	s.d.Stop()
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job := testDropColumn(c, ctx, s.d, s.dbInfo, tblInfo, colName, false)
@@ -890,12 +890,13 @@ func (s *testColumnSuite) TestDropColumn(c *C) {
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	s.d.start()
 }
 
 func (s *testColumnSuite) TestModifyColumn(c *C) {
 	d := newDDL(s.store, nil, nil, testLease)
+	defer d.Stop()
 	cases := []struct {
 		origin string
 		to     string
@@ -914,7 +915,6 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 		ftB := s.colDefStrToFieldType(c, ca.to)
 		c.Assert(modifiable(ftA, ftB), Equals, ca.ok)
 	}
-	d.close()
 }
 
 func (s *testColumnSuite) colDefStrToFieldType(c *C, str string) *types.FieldType {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1,4 +1,5 @@
 // Copyright 2013 The ql Authors. All rights reserved.
+
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSES/QL-LICENSE file.
 
@@ -168,6 +169,7 @@ func newDDL(store kv.Storage, infoHandle *infoschema.Handle, hook Callback, leas
 	d.start()
 
 	variable.RegisterStatistics(d)
+	log.Infof("start DDL:%s", d.uuid)
 
 	return d
 }
@@ -208,6 +210,7 @@ func (d *ddl) Stop() error {
 		// Background job's owner is me, clean it so other servers can complete it quickly.
 		return t.SetBgJobOwner(&model.Owner{})
 	})
+	log.Infof("stop DDL:%s", d.uuid)
 
 	return errors.Trace(err)
 }
@@ -244,6 +247,7 @@ func (d *ddl) close() {
 	close(d.quitCh)
 
 	d.wait.Wait()
+	log.Infof("close DDL:%s", d.uuid)
 }
 
 func (d *ddl) isClosed() bool {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -1,5 +1,4 @@
 // Copyright 2013 The ql Authors. All rights reserved.
-
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSES/QL-LICENSE file.
 

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -55,19 +55,19 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 	defer store.Close()
 
 	d1 := newDDL(store, nil, nil, testLease)
-	defer d1.close()
+	defer d1.Stop()
 	time.Sleep(testLease)
 	testCheckOwner(c, d1, true, ddlJobFlag)
 	testCheckOwner(c, d1, true, bgJobFlag)
 
 	// Start a new DDL and the DDL owner is still d1.
 	d2 := newDDL(store, nil, nil, testLease)
-	defer d2.close()
+	defer d2.Stop()
 	testCheckOwner(c, d2, false, ddlJobFlag)
 	testCheckOwner(c, d2, false, bgJobFlag)
 
 	// Change the DDL owner.
-	d1.close()
+	d1.Stop()
 	// Make sure owner is changed.
 	time.Sleep(6 * testLease)
 	testCheckOwner(c, d2, true, ddlJobFlag)
@@ -95,7 +95,7 @@ func (s *testDDLSuite) TestSchemaError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 
 	doDDLJobErr(c, 1, 0, model.ActionCreateSchema, []interface{}{1}, ctx, d)
@@ -107,7 +107,7 @@ func (s *testDDLSuite) TestTableError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 
 	// Schema ID is wrong, so dropping table is failed.
@@ -149,7 +149,7 @@ func (s *testDDLSuite) TestForeignKeyError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 
 	doDDLJobErr(c, -1, 1, model.ActionAddForeignKey, nil, ctx, d)
@@ -168,7 +168,7 @@ func (s *testDDLSuite) TestIndexError(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 
 	// Schema ID is wrong.
@@ -204,7 +204,7 @@ func (s *testDDLSuite) TestColumnError(c *C) {
 	store := testCreateStore(c, "test_column_error")
 	defer store.Close()
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 
 	dbInfo := testSchemaInfo(c, d, "test")

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -111,6 +111,7 @@ func getForeignKey(t table.Table, name string) *model.FKInfo {
 func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	defer testleak.AfterTest(c)()
 	d := newDDL(s.store, nil, nil, testLease)
+	defer d.Stop()
 	s.d = d
 	s.dbInfo = testSchemaInfo(c, d, "test_foreign")
 	ctx := testNewContext(d)
@@ -151,7 +152,7 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	}
 	d.setHook(tc)
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job := s.testCreateForeignKey(c, tblInfo, "c1_fk", []string{"c1"}, "t2", []string{"c1"}, ast.ReferOptionCascade, ast.ReferOptionSetNull)
@@ -189,7 +190,7 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 		checkOK = true
 	}
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job = testDropForeignKey(c, ctx, d, s.dbInfo, tblInfo, "c1_fk")
@@ -207,7 +208,7 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 	tc.onJobUpdated = func(job *model.Job) {
 	}
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
@@ -215,6 +216,4 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
-
-	d.close()
 }

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -49,6 +49,7 @@ func (s *testIndexChangeSuite) SetUpSuite(c *C) {
 func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 	defer testleak.AfterTest(c)()
 	d := newDDL(s.store, nil, nil, testLease)
+	defer d.Stop()
 	// create table t (c1 int primary key, c2 int);
 	tblInfo := testTableInfo(c, d, "t", 2)
 	tblInfo.Columns[0].Flag = mysql.PriKeyFlag | mysql.NotNullFlag

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -46,7 +46,7 @@ func (s *testIndexSuite) SetUpSuite(c *C) {
 
 func (s *testIndexSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(s.d), s.d, s.dbInfo)
-	s.d.close()
+	s.d.Stop()
 
 	err := s.store.Close()
 	c.Assert(err, IsNil)
@@ -534,10 +534,9 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 	ctx := testNewContext(d)
 	testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
 
-	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-
 	c.Assert(ctx.NewTxn(), IsNil)
 	row := types.MakeDatums(int64(1), int64(2), int64(3))
+	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 	handle, err := t.AddRecord(ctx, row)
 	c.Assert(err, IsNil)
 
@@ -545,7 +544,6 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
-
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
 		if checkOK {
@@ -568,9 +566,9 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 	d.setHook(tc)
 
 	// Use local ddl for callback test.
-	s.d.close()
+	s.d.Stop()
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job := testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c1_uni", "c1")
@@ -578,17 +576,15 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 
 	job = testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c1", "c1")
 	testCheckJobDone(c, d, job, true)
-
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)
 
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
 	testCheckJobDone(c, d, job, false)
-
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	s.d.start()
 }
 
@@ -603,9 +599,8 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 
 	testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
 
-	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-
 	row := types.MakeDatums(int64(1), int64(2), int64(3))
+	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 	handle, err := t.AddRecord(ctx, row)
 	c.Assert(err, IsNil)
 
@@ -617,7 +612,6 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 
 	checkOK := false
 	oldIndexCol := tables.NewIndex(tblInfo, &model.IndexInfo{})
-
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
 		if checkOK {
@@ -641,9 +635,9 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 	d.hookMu.Unlock()
 
 	// Use local ddl for callback test.
-	s.d.close()
+	s.d.Stop()
 
-	d.close()
+	d.Stop()
 	d.start()
 
 	job = testDropIndex(c, ctx, d, s.dbInfo, tblInfo, "c1_uni")
@@ -654,11 +648,10 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
 	testCheckJobDone(c, d, job, false)
-
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	s.d.start()
 }
 
@@ -675,10 +668,9 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 
 	testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
 
-	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-
 	// c2 is nil, which is not stored in kv.
 	row := types.MakeDatums(int64(1), nil, int(2))
+	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 	handle, err := t.AddRecord(ctx, row)
 	c.Assert(err, IsNil)
 
@@ -686,7 +678,6 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
-
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
 		if checkOK {
@@ -710,8 +701,8 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	d.hookMu.Unlock()
 
 	// Use local ddl for callback test.
-	s.d.close()
-	d.close()
+	s.d.Stop()
+	d.Stop()
 	d.start()
 
 	job := testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c2", "c2")
@@ -725,6 +716,6 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	s.d.start()
 }

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -38,7 +38,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 
 	time.Sleep(testLease)
 
@@ -75,7 +75,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = d.runReorgJob(f)
 	c.Assert(err, IsNil)
 
-	d.close()
+	d.Stop()
 	err = d.runReorgJob(func() error {
 		time.Sleep(4 * testLease)
 		return nil
@@ -120,14 +120,14 @@ func (s *testDDLSuite) TestReorgOwner(c *C) {
 	defer store.Close()
 
 	d1 := newDDL(store, nil, nil, testLease)
-	defer d1.close()
+	defer d1.Stop()
 
 	ctx := testNewContext(d1)
 
 	testCheckOwner(c, d1, true, ddlJobFlag)
 
 	d2 := newDDL(store, nil, nil, testLease)
-	defer d2.close()
+	defer d2.Stop()
 
 	dbInfo := testSchemaInfo(c, d1, "test")
 	testCreateSchema(c, ctx, d1, dbInfo)
@@ -149,7 +149,7 @@ func (s *testDDLSuite) TestReorgOwner(c *C) {
 	tc := &testDDLCallback{}
 	tc.onJobRunBefore = func(job *model.Job) {
 		if job.SchemaState == model.StateDeleteReorganization {
-			d1.close()
+			d1.Stop()
 		}
 	}
 

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -119,7 +119,7 @@ func (s *testSchemaSuite) TestSchema(c *C) {
 	store := testCreateStore(c, "test_schema")
 	defer store.Close()
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 	ctx := testNewContext(d)
 	dbInfo := testSchemaInfo(c, d, "test")
 
@@ -197,12 +197,12 @@ func (s *testSchemaSuite) TestSchemaWaitJob(c *C) {
 	defer store.Close()
 
 	d1 := newDDL(store, nil, nil, testLease)
-	defer d1.close()
+	defer d1.Stop()
 
 	testCheckOwner(c, d1, true, ddlJobFlag)
 
 	d2 := newDDL(store, nil, nil, testLease*4)
-	defer d2.close()
+	defer d2.Stop()
 	ctx := testNewContext(d2)
 
 	// d2 must not be owner.
@@ -238,7 +238,7 @@ LOOP:
 	for {
 		select {
 		case <-ticker.C:
-			d.close()
+			d.Stop()
 			d.start()
 		case err := <-done:
 			c.Assert(err, IsNil)
@@ -253,7 +253,7 @@ func (s *testSchemaSuite) TestSchemaResume(c *C) {
 	defer store.Close()
 
 	d1 := newDDL(store, nil, nil, testLease)
-	defer d1.close()
+	defer d1.Stop()
 
 	testCheckOwner(c, d1, true, ddlJobFlag)
 

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -40,7 +40,7 @@ func (s *testStatSuite) TestStat(c *C) {
 	defer store.Close()
 
 	d := newDDL(store, nil, nil, testLease)
-	defer d.close()
+	defer d.Stop()
 
 	time.Sleep(testLease)
 

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -198,7 +198,7 @@ func (s *testTableSuite) SetUpSuite(c *C) {
 
 func (s *testTableSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(s.d), s.d, s.dbInfo)
-	s.d.close()
+	s.d.Stop()
 	s.store.Close()
 
 	reorgTableDeleteLimit = 65536


### PR DESCRIPTION
- add logs for starting or stopping DDL

- add the function of close after use. Otherwise，this DDL want to be `owner`, it can interfere with the other tests.

- use Stop instead of close, make owner change faster.