### PR TITLE
sessionctx/varsutil: fix format str in sysvar error msg

### DIFF
--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -30,7 +30,7 @@ func GetSessionSystemVar(s *variable.SessionVars, key string) (string, error) {
 	key = strings.ToLower(key)
 	sysVar := variable.SysVars[key]
 	if sysVar == nil {
-		return "", variable.UnknownSystemVar
+		return "", variable.UnknownSystemVar.GenByArgs(key)
 	}
 	sVal, ok := s.Systems[key]
 	if ok {
@@ -53,7 +53,7 @@ func GetGlobalSystemVar(s *variable.SessionVars, key string) (string, error) {
 	key = strings.ToLower(key)
 	sysVar := variable.SysVars[key]
 	if sysVar == nil {
-		return "", variable.UnknownSystemVar
+		return "", variable.UnknownSystemVar.GenByArgs(key)
 	}
 	if sysVar.Scope == variable.ScopeSession {
 		return "", variable.ErrIncorrectScope


### PR DESCRIPTION
`UnknownSystemVar` contains unused format placeholder for the variable name.

```go
UnknownSystemVar  = terror.ClassVariable.New(CodeUnknownSystemVar, "unknown system variable '%s'")
```

This fixes:

```
MySQL [test]> SELECT @@whatever_not_a_variable_in_system;
ERROR 1193 (HY000): unknown system variable '%!s(MISSING)'
```