### PR TITLE
store/tikv: extend lockTTL for txns that takes a long time to read.

### DIFF
--- a/_vendor/src/github.com/coreos/etcd/LICENSE
+++ b/_vendor/src/github.com/coreos/etcd/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/_vendor/src/github.com/coreos/etcd/NOTICE
+++ b/_vendor/src/github.com/coreos/etcd/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2014 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/_vendor/src/github.com/coreos/etcd/pkg/monotime/issue15006.s
+++ b/_vendor/src/github.com/coreos/etcd/pkg/monotime/issue15006.s
@@ -1,0 +1,6 @@
+// Copyright (C) 2016  Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// This file is intentionally empty.
+// It's a workaround for https://github.com/golang/go/issues/15006

--- a/_vendor/src/github.com/coreos/etcd/pkg/monotime/monotime.go
+++ b/_vendor/src/github.com/coreos/etcd/pkg/monotime/monotime.go
@@ -1,0 +1,26 @@
+// Copyright 2016 The etcd Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monotime
+
+import (
+	"time"
+)
+
+// Time represents a point in monotonic time
+type Time uint64
+
+func (t Time) Add(d time.Duration) Time {
+	return Time(uint64(t) + uint64(d.Nanoseconds()))
+}

--- a/_vendor/src/github.com/coreos/etcd/pkg/monotime/nanotime.go
+++ b/_vendor/src/github.com/coreos/etcd/pkg/monotime/nanotime.go
@@ -1,0 +1,24 @@
+// Copyright (C) 2016  Arista Networks, Inc.
+// Use of this source code is governed by the Apache License 2.0
+// that can be found in the COPYING file.
+
+// Package monotime provides a fast monotonic clock source.
+package monotime
+
+import (
+	_ "unsafe" // required to use //go:linkname
+)
+
+//go:noescape
+//go:linkname nanotime runtime.nanotime
+func nanotime() int64
+
+// Now returns the current time in nanoseconds from a monotonic clock.
+// The time returned is based on some arbitrary platform-specific point in the
+// past.  The time returned is guaranteed to increase monotonically at a
+// constant rate, unlike time.Now() from the Go standard library, which may
+// slow down, speed up, jump forward or backward, due to NTP activity or leap
+// seconds.
+func Now() Time {
+	return Time(nanotime())
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7354d469576fe9c413733e7f86f2e82d88120039261121735708ce377b6daad3
-updated: 2016-12-27T20:41:45.64913731+08:00
+hash: e3d0a2c456701c8149ce41bb8941e2c468f3ddd0ece9883cf01278e9fada6c69
+updated: 2017-02-04T13:33:25.390061805+08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -10,11 +10,12 @@ imports:
 - name: github.com/boltdb/bolt
   version: d97499360d1ecebc492ea66c7447ea948f417620
 - name: github.com/coreos/etcd
-  version: e53b99588a05d1f4ef172c178d4ed8e8106b8be4
+  version: 6bef2bddcaced4fc6ed136e7434c4ee72c9e6782
   subpackages:
   - auth/authpb
   - clientv3
   - mvcc/mvccpb
+  - pkg/monotime
   - pkg/tlsutil
 - name: github.com/cznic/golex
   version: da5a7153a51074477ecac5c45a7e5182a0c72448

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,12 +3,13 @@ import:
 - package: github.com/boltdb/bolt
   version: d97499360d1ecebc492ea66c7447ea948f417620
 - package: github.com/coreos/etcd
-  version: e53b99588a05d1f4ef172c178d4ed8e8106b8be4
+  version: 6bef2bddcaced4fc6ed136e7434c4ee72c9e6782
   subpackages:
   - auth/authpb
   - clientv3
   - mvcc/mvccpb
   - pkg/tlsutil
+  - pkg/monotime
 - package: github.com/gengo/grpc-gateway
   version: f52d055dc48aec25854ed7d31862f78913cf17d1
   subpackages:

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -17,12 +17,14 @@ import (
 	"bytes"
 	"math"
 	"sync"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tipb/go-binlog"
 	"golang.org/x/net/context"
@@ -130,21 +132,9 @@ func newTwoPhaseCommitter(txn *tikvTxn) (*twoPhaseCommitter, error) {
 	txnWriteKVCountHistogram.Observe(float64(len(keys)))
 	txnWriteSizeHistogram.Observe(float64(size / 1024))
 
-	// Increase lockTTL for large transactions.
-	// The formula is `ttl = ttlFactor * sqrt(sizeInMiB)`.
-	// When writeSize <= 256K, ttl is defaultTTL (3s);
-	// When writeSize is 1MiB, 100MiB, or 400MiB, ttl is 6s, 60s, 120s correspondingly;
-	// When writeSize >= 400MiB, we return kv.ErrTxnTooLarge.
-	var lockTTL uint64
-	if size > txnCommitBatchSize {
-		sizeMiB := float64(size) / 1024 / 1024
-		lockTTL = uint64(float64(ttlFactor) * math.Sqrt(float64(sizeMiB)))
-		if lockTTL < defaultLockTTL {
-			lockTTL = defaultLockTTL
-		}
-		if lockTTL > maxLockTTL {
-			lockTTL = maxLockTTL
-		}
+	lockTTL, err := txnLockTTL(txn, size)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	return &twoPhaseCommitter{
@@ -159,6 +149,40 @@ func newTwoPhaseCommitter(txn *tikvTxn) (*twoPhaseCommitter, error) {
 
 func (c *twoPhaseCommitter) primary() []byte {
 	return c.keys[0]
+}
+
+func txnLockTTL(txn *tikvTxn, txnSize int) (uint64, error) {
+	// Increase lockTTL for large transactions.
+	// The formula is `ttl = ttlFactor * sqrt(sizeInMiB)`.
+	// When writeSize <= 256K, ttl is defaultTTL (3s);
+	// When writeSize is 1MiB, 100MiB, or 400MiB, ttl is 6s, 60s, 120s correspondingly;
+	// When writeSize >= 400MiB, we return kv.ErrTxnTooLarge.
+	var lockTTL uint64
+	if txnSize > txnCommitBatchSize {
+		sizeMiB := float64(txnSize) / 1024 / 1024
+		lockTTL = uint64(float64(ttlFactor) * math.Sqrt(float64(sizeMiB)))
+		if lockTTL < defaultLockTTL {
+			lockTTL = defaultLockTTL
+		}
+		if lockTTL > maxLockTTL {
+			lockTTL = maxLockTTL
+		}
+	}
+
+	// Increase lockTTL by the transaction's read time.
+	// When resolving a lock, we compare current ts and startTS+lockTTL to decide whether to clean up. If a txn
+	// takes a long time to read, increasing its TTL will help to prevent it from been aborted soon after prewrite.
+	if localElapse := time.Since(txn.startTime); localElapse < time.Second*10 {
+		return lockTTL + uint64(localElapse/time.Millisecond), nil
+	}
+	// If a long value is calculated from the local clock, there may be clock drift, take a new TS from PD to get
+	// the exact value.
+	currentTS, err := txn.store.getTimestampWithRetry(NewBackoffer(tsoMaxBackoff, context.Background()))
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	elapseMS := oracle.ExtractPhysical(currentTS) - oracle.ExtractPhysical(txn.startTS)
+	return lockTTL + uint64(elapseMS), nil
 }
 
 // doActionOnKeys groups keys into primary batch and secondary batches, if primary batch exists in the key,

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -19,12 +19,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/etcd/pkg/monotime"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tipb/go-binlog"
 	"golang.org/x/net/context"
@@ -132,7 +132,7 @@ func newTwoPhaseCommitter(txn *tikvTxn) (*twoPhaseCommitter, error) {
 	txnWriteKVCountHistogram.Observe(float64(len(keys)))
 	txnWriteSizeHistogram.Observe(float64(size / 1024))
 
-	lockTTL, err := txnLockTTL(txn, size)
+	lockTTL, err := txnLockTTL(txn.startTime, size)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -151,7 +151,9 @@ func (c *twoPhaseCommitter) primary() []byte {
 	return c.keys[0]
 }
 
-func txnLockTTL(txn *tikvTxn, txnSize int) (uint64, error) {
+const bytesPerMiB = 1024 * 1024
+
+func txnLockTTL(startTime monotime.Time, txnSize int) (uint64, error) {
 	// Increase lockTTL for large transactions.
 	// The formula is `ttl = ttlFactor * sqrt(sizeInMiB)`.
 	// When writeSize <= 256K, ttl is defaultTTL (3s);
@@ -159,7 +161,7 @@ func txnLockTTL(txn *tikvTxn, txnSize int) (uint64, error) {
 	// When writeSize >= 400MiB, we return kv.ErrTxnTooLarge.
 	var lockTTL uint64
 	if txnSize > txnCommitBatchSize {
-		sizeMiB := float64(txnSize) / 1024 / 1024
+		sizeMiB := float64(txnSize) / bytesPerMiB
 		lockTTL = uint64(float64(ttlFactor) * math.Sqrt(float64(sizeMiB)))
 		if lockTTL < defaultLockTTL {
 			lockTTL = defaultLockTTL
@@ -172,17 +174,8 @@ func txnLockTTL(txn *tikvTxn, txnSize int) (uint64, error) {
 	// Increase lockTTL by the transaction's read time.
 	// When resolving a lock, we compare current ts and startTS+lockTTL to decide whether to clean up. If a txn
 	// takes a long time to read, increasing its TTL will help to prevent it from been aborted soon after prewrite.
-	if localElapse := time.Since(txn.startTime); localElapse < time.Second*10 {
-		return lockTTL + uint64(localElapse/time.Millisecond), nil
-	}
-	// If a long value is calculated from the local clock, there may be clock drift, take a new TS from PD to get
-	// the exact value.
-	currentTS, err := txn.store.getTimestampWithRetry(NewBackoffer(tsoMaxBackoff, context.Background()))
-	if err != nil {
-		return 0, errors.Trace(err)
-	}
-	elapseMS := oracle.ExtractPhysical(currentTS) - oracle.ExtractPhysical(txn.startTS)
-	return lockTTL + uint64(elapseMS), nil
+	elapsed := time.Duration(monotime.Now()-startTime) / time.Millisecond
+	return lockTTL + uint64(elapsed), nil
 }
 
 // doActionOnKeys groups keys into primary batch and secondary batches, if primary batch exists in the key,

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -34,7 +34,7 @@ type tikvTxn struct {
 	us        kv.UnionStore
 	store     *tikvStore // for connection to region.
 	startTS   uint64
-	startTime monotime.Time
+	startTime monotime.Time // Monotonic timestamp for recording txn time consuming.
 	commitTS  uint64
 	valid     bool
 	lockKeys  [][]byte

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/coreos/etcd/pkg/monotime"
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/kv"
@@ -33,7 +34,7 @@ type tikvTxn struct {
 	us        kv.UnionStore
 	store     *tikvStore // for connection to region.
 	startTS   uint64
-	startTime time.Time
+	startTime monotime.Time
 	commitTS  uint64
 	valid     bool
 	lockKeys  [][]byte
@@ -51,7 +52,7 @@ func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
 		us:        kv.NewUnionStore(newTiKVSnapshot(store, ver)),
 		store:     store,
 		startTS:   startTS,
-		startTime: time.Now(),
+		startTime: monotime.Now(),
 		valid:     true,
 	}, nil
 }

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -30,13 +30,14 @@ var (
 
 // tikvTxn implements kv.Transaction.
 type tikvTxn struct {
-	us       kv.UnionStore
-	store    *tikvStore // for connection to region.
-	startTS  uint64
-	commitTS uint64
-	valid    bool
-	lockKeys [][]byte
-	dirty    bool
+	us        kv.UnionStore
+	store     *tikvStore // for connection to region.
+	startTS   uint64
+	startTime time.Time
+	commitTS  uint64
+	valid     bool
+	lockKeys  [][]byte
+	dirty     bool
 }
 
 func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
@@ -47,10 +48,11 @@ func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
 	}
 	ver := kv.NewVersion(startTS)
 	return &tikvTxn{
-		us:      kv.NewUnionStore(newTiKVSnapshot(store, ver)),
-		store:   store,
-		startTS: startTS,
-		valid:   true,
+		us:        kv.NewUnionStore(newTiKVSnapshot(store, ver)),
+		store:     store,
+		startTS:   startTS,
+		startTime: time.Now(),
+		valid:     true,
 	}, nil
 }
 


### PR DESCRIPTION
If a txn takes a long time to read, increasing its TTL will help to prevent it from been aborted soon after prewrite.

/cc @shenli @coocood  @AndreMouche @hhkbp2 