### PR TITLE
tidb-server: fix interval format in metric log

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -182,7 +182,7 @@ func pushMetric(addr string, interval time.Duration) {
 		log.Info("disable Prometheus push client")
 		return
 	}
-	log.Infof("start Prometheus push client with server addr %s and interval %d", addr, interval)
+	log.Infof("start Prometheus push client with server addr %s and interval %s", addr, interval)
 	go prometheusPushClient(addr, interval)
 }
 


### PR DESCRIPTION
This fixes:

```
2017/02/06 14:17:09 main.go:182: [info] start Prometheus push client with server addr 
172.233.1.240:9091 and interval 2000000000
```

Now:
```
2017/02/06 14:22:42 main.go:185: [info] start Prometheus push client with server addr 
172.233.1.240:9091 and interval 2s
```