### PR TITLE
plan: fix bug when push down aggregation.

### DIFF
--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -66,8 +66,13 @@ func (a *aggPushDownSolver) getAggFuncChildIdx(aggFunc expression.AggregationFun
 		return -1
 	} else if fromLeft {
 		return 0
+	} else if fromRight {
+		return 1
+	} else if aggFunc.GetName() == ast.AggFuncCount {
+		return -1
+	} else {
+		return 2
 	}
-	return 1
 }
 
 // collectAggFuncs collects all aggregate functions and splits them into two parts: "leftAggFuncs" and "rightAggFuncs" whose
@@ -85,6 +90,9 @@ func (a *aggPushDownSolver) collectAggFuncs(agg *Aggregation, join *Join) (valid
 		case 0:
 			leftAggFuncs = append(leftAggFuncs, aggFunc)
 		case 1:
+			rightAggFuncs = append(rightAggFuncs, aggFunc)
+		case 2:
+			leftAggFuncs = append(leftAggFuncs, aggFunc)
 			rightAggFuncs = append(rightAggFuncs, aggFunc)
 		default:
 			return false, nil, nil

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -710,6 +710,10 @@ func (s *testPlanSuite) TestAggPushDown(c *C) {
 			sql:  "select sum(c1) from (select c c1, d c2 from t a union all select a c1, b c2 from t b union all select b c1, e c2 from t c) x group by c2",
 			best: "UnionAll{DataScan(a)->Aggr(sum(a.c),firstrow(a.d))->DataScan(b)->Aggr(sum(b.a),firstrow(b.b))->DataScan(c)->Aggr(sum(c.b),firstrow(c.e))}->Aggr(sum(join_agg_0))->Projection",
 		},
+		{
+			sql:  "select count(*) from t a join t b on a.a = b.a",
+			best: "Join{DataScan(a)->DataScan(b)}(a.a,b.a)->Aggr(count(1))->Projection",
+		},
 	}
 	for _, ca := range cases {
 		comment := Commentf("for %s", ca.sql)


### PR DESCRIPTION
For sql `select count(*) from t a join t b on a.a=b.a`, count(*) will be pushed down to left side like `select count(*) from (select t.a, count(*) from t) a join t b on a.a = b.a`. This case is a bug.
After fixed, this case won't be pushed down.
For sql `select sum(1) from t a join t b on a.a=b.a`, it's equal to `select sum(1) from (select a, sum(1) from t) a join (select a, sum(1) from t) b on a.a=b.a`. Since pushing this down will reduce the size of cartesian product. So i push this aggregation down to both sides.
PTAL @shenli @hanfei1991 @coocood @zimulala 