### PR TITLE
ddl/model: fix redundant query prints in ddl log

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -316,7 +316,7 @@ func (d *ddl) doDDLJob(ctx context.Context, job *model.Job) error {
 
 	// Notice worker that we push a new job and wait the job done.
 	asyncNotify(d.ddlJobCh)
-	log.Infof("[ddl] start DDL job %s", job)
+	log.Infof("[ddl] start DDL job %s, Query:\n%s", job, job.Query)
 
 	var historyJob *model.Job
 	jobID := job.ID

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -173,8 +173,8 @@ func (job *Job) DecodeArgs(args ...interface{}) error {
 // String implements fmt.Stringer interface.
 func (job *Job) String() string {
 	rowCount := job.GetRowCount()
-	return fmt.Sprintf("ID:%d, Type:%s, State:%s, SchemaState:%s, SchemaID:%d, TableID:%d, RowCount:%d, ArgLen:%d, Query:\n%s",
-		job.ID, job.Type, job.State, job.SchemaState, job.SchemaID, job.TableID, rowCount, len(job.Args), job.Query)
+	return fmt.Sprintf("ID:%d, Type:%s, State:%s, SchemaState:%s, SchemaID:%d, TableID:%d, RowCount:%d, ArgLen:%d",
+		job.ID, job.Type, job.State, job.SchemaState, job.SchemaID, job.TableID, rowCount, len(job.Args))
 }
 
 // IsFinished returns whether job is finished or not.


### PR DESCRIPTION
This fixes:
```
2017/02/06 16:59:08 ddl.go:319: [info] [ddl] start DDL job ID:20, Type:create schema, State:none, SchemaState:none, SchemaID:19, TableID:0, RowCount:0, ArgLen:1, Query:
create database sbtest
2017/02/06 16:59:08 ddl_worker.go:336: [info] [ddl] run DDL job ID:20, Type:create schema, State:none, SchemaState:none, SchemaID:19, TableID:0, RowCount:0, ArgLen:0, Query:
create database sbtest
2017/02/06 16:59:08 ddl_worker.go:184: [info] [ddl] finish DDL job ID:20, Type:create schema, State:done, SchemaState:public, SchemaID:19, TableID:0, RowCount:0, ArgLen:1, Query:
create database sbtest
```

Now:

```
2017/02/06 16:59:08 ddl.go:319: [info] [ddl] start DDL job ID:20, Type:create schema, State:none, SchemaState:none, SchemaID:19, TableID:0, RowCount:0, ArgLen:1, Query:
create database sbtest
2017/02/06 16:59:08 ddl_worker.go:336: [info] [ddl] run DDL job ID:20, Type:create schema, State:none, SchemaState:none, SchemaID:19, TableID:0, RowCount:0, ArgLen:0
2017/02/06 16:59:08 ddl_worker.go:184: [info] [ddl] finish DDL job ID:20, Type:create schema, State:done, SchemaState:public, SchemaID:19, TableID:0, RowCount:0, ArgLen:1
```