### PR TITLE
executor: do not log expensive query for system table.

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -938,7 +938,7 @@ func (b *planBuilder) buildDataSource(tn *ast.TableName) LogicalPlan {
 		tableInfo:       tableInfo,
 		baseLogicalPlan: newBaseLogicalPlan(Tbl, b.allocator),
 		statisticTable:  statisticTable,
-		DBName:          &schemaName,
+		DBName:          schemaName,
 	}
 	p.self = p
 	p.initIDAndContext(b.ctx)

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -195,7 +195,7 @@ type DataSource struct {
 	indexHints []*ast.IndexHint
 	tableInfo  *model.TableInfo
 	Columns    []*model.ColumnInfo
-	DBName     *model.CIStr
+	DBName     model.CIStr
 
 	TableAsName *model.CIStr
 

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -1025,7 +1025,7 @@ func (p *Analyze) prepareSimpleTableScan(cols []*model.ColumnInfo) *PhysicalTabl
 		Table:               p.Table.TableInfo,
 		Columns:             cols,
 		TableAsName:         &p.Table.Name,
-		DBName:              &p.Table.DBInfo.Name,
+		DBName:              p.Table.DBInfo.Name,
 		physicalTableSource: physicalTableSource{client: p.ctx.GetClient()},
 	}
 	ts.tp = Tbl
@@ -1045,7 +1045,7 @@ func (p *Analyze) prepareSimpleIndexScan(idxOffset int, cols []*model.ColumnInfo
 		Columns:             cols,
 		TableAsName:         &p.Table.Name,
 		OutOfOrder:          false,
-		DBName:              &p.Table.DBInfo.Name,
+		DBName:              p.Table.DBInfo.Name,
 		physicalTableSource: physicalTableSource{client: p.ctx.GetClient()},
 		DoubleRead:          false,
 	}

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -43,7 +43,7 @@ type PhysicalIndexScan struct {
 	Index      *model.IndexInfo
 	Ranges     []*IndexRange
 	Columns    []*model.ColumnInfo
-	DBName     *model.CIStr
+	DBName     model.CIStr
 	Desc       bool
 	OutOfOrder bool
 	// DoubleRead means if the index executor will read kv two times.
@@ -62,7 +62,7 @@ type PhysicalIndexScan struct {
 type PhysicalMemTable struct {
 	basePlan
 
-	DBName      *model.CIStr
+	DBName      model.CIStr
 	Table       *model.TableInfo
 	Columns     []*model.ColumnInfo
 	Ranges      []TableRange
@@ -329,7 +329,7 @@ type PhysicalTableScan struct {
 
 	Table   *model.TableInfo
 	Columns []*model.ColumnInfo
-	DBName  *model.CIStr
+	DBName  model.CIStr
 	Desc    bool
 	Ranges  []TableRange
 	pkCol   *expression.Column


### PR DESCRIPTION
select all rows from system table is a common query, we should not log it as an expensive query.