### PR TITLE
expression: workaround for wrong timediff function input

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -383,7 +383,11 @@ func (s *testSuite) TestIssue2612(c *C) {
 		create_at datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
 		finish_at datetime NOT NULL DEFAULT '1000-01-01 00:00:00');`)
 	tk.MustExec(`insert into t values ('2016-02-13 15:32:24',  '2016-02-11 17:23:22');`)
-	tk.MustExec(`select timediff(finish_at, create_at) from t;`)
+	rs, err := tk.Exec(`select timediff(finish_at, create_at) from t;`)
+	c.Assert(err, IsNil)
+	row, err := rs.Next()
+	c.Assert(err, IsNil)
+	row.Data[0].GetMysqlDuration().String()
 }
 
 // For https://github.com/pingcap/tidb/issues/345

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -370,6 +370,22 @@ func (s *testSuite) TestSelectErrorRow(c *C) {
 	tk.MustExec("commit")
 }
 
+// For https://github.com/pingcap/tidb/issues/2612
+func (s *testSuite) TestIssue2612(c *C) {
+	defer func() {
+		s.cleanEnv(c)
+		testleak.AfterTest(c)()
+	}()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t`)
+	tk.MustExec(`create table t (
+		create_at datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
+		finish_at datetime NOT NULL DEFAULT '1000-01-01 00:00:00');`)
+	tk.MustExec(`insert into t values ('2016-02-13 15:32:24',  '2016-02-11 17:23:22');`)
+	tk.MustExec(`select timediff(finish_at, create_at) from t;`)
+}
+
 // For https://github.com/pingcap/tidb/issues/345
 func (s *testSuite) TestIssue345(c *C) {
 	defer func() {

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -255,6 +255,9 @@ func (b *builtinTimeDiffSig) eval(row []types.Datum) (d types.Datum, err error) 
 	}
 
 	t := t1.Sub(&t2)
+	// TODO: It should be the larger between t1.Fsp and t2.Fsp, rather than types.MaxFsp
+	// But there is a bug both t1.Fsp and t2.Fsp is -1, we should fix it.
+	t.Fsp = types.MaxFsp
 	d.SetMysqlDuration(t)
 	return d, nil
 }

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -255,7 +255,7 @@ func (b *builtinTimeDiffSig) eval(row []types.Datum) (d types.Datum, err error) 
 	}
 
 	t := t1.Sub(&t2)
-	// TODO: It should be the larger between t1.Fsp and t2.Fsp, rather than types.MaxFsp
+	// TODO: It should be the larger between t1.Fsp and t2.Fsp, rather than MaxFsp.
 	// But there is a bug both t1.Fsp and t2.Fsp is -1, we should fix it.
 	t.Fsp = types.MaxFsp
 	d.SetMysqlDuration(t)


### PR DESCRIPTION
there is bug that builtinTimeDiffSig.eval's input is not legal:
row[0] row[1] may be a datetime with Fsp=-1

this COMMIT is a workaroud for the case

-----------------------------------

Input SQL:

```
CREATE TABLE `t` (
  `create_at` datetime NOT NULL DEFAULT '1000-01-01 00:00:00',
  `finish_at` datetime NOT NULL DEFAULT '1000-01-01 00:00:00'
);

INSERT INTO t values ('2016-02-13 15:32:24',  '2016-02-11 17:23:22');
SELECT timediff(finish_at, create_at) from t;
```

The session would panic:

```
2017/02/08 16:09:20 conn.go:330: [error] lastCmd select timediff(finish_at, create_at) from t, runtime error: slice bounds out of range, goroutine 98 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc420204000)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:329 +0xe2
panic(0xce1480, 0xc42000c160)
	/media/genius/OS/project/go/src/runtime/panic.go:458 +0x243
github.com/pingcap/tidb/util/types.Duration.formatFrac(0xffff68e50d1b9400, 0xffff, 0x0, 0x1, 0x0)
	/media/genius/OS/project/src/github.com/pingcap/tidb/util/types/time.go:656 +0xd9
github.com/pingcap/tidb/util/types.Duration.String(0xffff68e50d1b9400, 0xffff, 0x7f3174d92e10, 0xc4203b37f8)
	/media/genius/OS/project/src/github.com/pingcap/tidb/util/types/time.go:646 +0x36a
github.com/pingcap/tidb/server.dumpTextValue(0xc42020400b, 0xffff0009, 0xffff68e50d1b9400, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1510500, 0x10, ...)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/util.go:330 +0x57e
github.com/pingcap/tidb/server.(*clientConn).writeResultset(0xc420204000, 0x12eb440, 0xc420664b00, 0xc420660000, 0x0, 0x0)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:705 +0x65f
github.com/pingcap/tidb/server.(*clientConn).handleQuery(0xc420204000, 0xc420663381, 0x2c, 0x0, 0x0)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:600 +0x182
github.com/pingcap/tidb/server.(*clientConn).dispatch(0xc420204000, 0xc420663381, 0x2d, 0x2c, 0x0, 0x0)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:390 +0x5f5
github.com/pingcap/tidb/server.(*clientConn).Run(0xc420204000)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:345 +0x10a
github.com/pingcap/tidb/server.(*Server).onConn(0xc420bd40c0, 0x12f3120, 0xc420141fe0)
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/server.go:209 +0x13e
created by github.com/pingcap/tidb/server.(*Server).Run
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/server.go:173 +0x96

```