### PR TITLE
*: avoid using TypeDecimal

### DIFF
--- a/mysql/type.go
+++ b/mysql/type.go
@@ -47,13 +47,7 @@ const (
 )
 
 // TypeUnspecified is an uninitialized type. TypeDecimal is not used in MySQL.
-var TypeUnspecified = TypeDecimal
-
-// IsUninitializedType check if a type code is uninitialized.
-// TypeDecimal is the old type code for decimal and not be used in the new mysql version.
-func IsUninitializedType(tp byte) bool {
-	return tp == TypeDecimal
-}
+const TypeUnspecified = TypeDecimal
 
 // Flag informations.
 const (

--- a/mysql/util.go
+++ b/mysql/util.go
@@ -30,7 +30,7 @@ func GetDefaultFieldLength(tp byte) int {
 		return 11
 	case TypeLonglong:
 		return 21
-	case TypeDecimal, TypeNewDecimal:
+	case TypeNewDecimal:
 		// See https://dev.mysql.com/doc/refman/5.7/en/fixed-point-types.html
 		return 10
 	case TypeBit, TypeBlob:
@@ -44,7 +44,7 @@ func GetDefaultFieldLength(tp byte) int {
 // GetDefaultDecimal returns the default decimal length for column.
 func GetDefaultDecimal(tp byte) int {
 	switch tp {
-	case TypeDecimal, TypeNewDecimal:
+	case TypeNewDecimal:
 		// See https://dev.mysql.com/doc/refman/5.7/en/fixed-point-types.html
 		return 0
 	default:

--- a/plan/aggregation_pruning.go
+++ b/plan/aggregation_pruning.go
@@ -110,7 +110,7 @@ func (ap *aggPruner) rewriteExpr(exprs []expression.Expression, funcName string)
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 			newExpr = expression.NewCastFunc(types.NewFieldType(mysql.TypeNewDecimal), expr, ap.ctx)
 		// Double and Decimal doesn't need to be cast.
-		case mysql.TypeDouble, mysql.TypeDecimal, mysql.TypeNewDecimal:
+		case mysql.TypeDouble, mysql.TypeNewDecimal:
 			newExpr = expr
 		// Float should be cast to double. And other non-numeric type should be cast to double too.
 		default:

--- a/plan/expr_to_pb.go
+++ b/plan/expr_to_pb.go
@@ -107,7 +107,7 @@ func (pc pbConverter) columnToPBExpr(column *expression.Column) *tipb.Expr {
 		return nil
 	}
 	switch column.GetType().Tp {
-	case mysql.TypeBit, mysql.TypeSet, mysql.TypeEnum, mysql.TypeGeometry, mysql.TypeDecimal:
+	case mysql.TypeBit, mysql.TypeSet, mysql.TypeEnum, mysql.TypeGeometry, mysql.TypeUnspecified:
 		return nil
 	}
 

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -279,7 +279,7 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			pos += 8
 			continue
 
-		case mysql.TypeDecimal, mysql.TypeNewDecimal, mysql.TypeVarchar,
+		case mysql.TypeUnspecified, mysql.TypeNewDecimal, mysql.TypeVarchar,
 			mysql.TypeBit, mysql.TypeEnum, mysql.TypeSet, mysql.TypeTinyBlob,
 			mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob,
 			mysql.TypeVarString, mysql.TypeString, mysql.TypeGeometry,

--- a/util/types/convert_test.go
+++ b/util/types/convert_test.go
@@ -424,8 +424,8 @@ func (s *testTypeConvertSuite) TestStrToNum(c *C) {
 
 func (s *testTypeConvertSuite) TestFieldTypeToStr(c *C) {
 	defer testleak.AfterTest(c)()
-	v := TypeToStr(mysql.TypeDecimal, "not binary")
-	c.Assert(v, Equals, type2Str[mysql.TypeDecimal])
+	v := TypeToStr(mysql.TypeUnspecified, "not binary")
+	c.Assert(v, Equals, type2Str[mysql.TypeUnspecified])
 	v = TypeToStr(mysql.TypeBlob, charset.CharsetBin)
 	c.Assert(v, Equals, "blob")
 	v = TypeToStr(mysql.TypeString, charset.CharsetBin)

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -663,7 +663,7 @@ func (d *Datum) ConvertTo(sc *variable.StatementContext, target *FieldType) (Dat
 		return d.convertToMysqlDuration(sc, target)
 	case mysql.TypeBit:
 		return d.convertToMysqlBit(sc, target)
-	case mysql.TypeDecimal, mysql.TypeNewDecimal:
+	case mysql.TypeNewDecimal:
 		return d.convertToMysqlDecimal(sc, target)
 	case mysql.TypeYear:
 		return d.convertToMysqlYear(sc, target)

--- a/util/types/etc.go
+++ b/util/types/etc.go
@@ -66,7 +66,7 @@ var type2Str = map[byte]string{
 	mysql.TypeBlob:       "text",
 	mysql.TypeDate:       "date",
 	mysql.TypeDatetime:   "datetime",
-	mysql.TypeDecimal:    "decimal",
+	mysql.TypeDecimal:    "unspecified",
 	mysql.TypeNewDecimal: "decimal",
 	mysql.TypeDouble:     "double",
 	mysql.TypeEnum:       "enum",

--- a/util/types/etc_test.go
+++ b/util/types/etc_test.go
@@ -95,7 +95,7 @@ func (s *testTypeEtcSuite) TestTypeToStr(c *C) {
 	testTypeToStr(c, mysql.TypeDate, "binary", "date")
 	testTypeToStr(c, mysql.TypeTimestamp, "binary", "timestamp")
 	testTypeToStr(c, mysql.TypeNewDecimal, "binary", "decimal")
-	testTypeToStr(c, mysql.TypeDecimal, "binary", "decimal")
+	testTypeToStr(c, mysql.TypeUnspecified, "binary", "unspecified")
 	testTypeToStr(c, 0xdd, "binary", "")
 	testTypeToStr(c, mysql.TypeBit, "binary", "bit")
 	testTypeToStr(c, mysql.TypeEnum, "binary", "enum")

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -170,7 +170,7 @@ func DefaultTypeForValue(value interface{}, tp *FieldType) {
 		tp.Charset = charset.CharsetBin
 		tp.Collate = charset.CharsetBin
 	default:
-		tp.Tp = mysql.TypeDecimal
+		tp.Tp = mysql.TypeUnspecified
 	}
 	tp.Flen = UnspecifiedLength
 	tp.Decimal = UnspecifiedLength


### PR DESCRIPTION
TypeDecimal is misleading, it is not used as Decimal type, it's an unspecified type.