### PR TITLE
ddl: Support some definitions and fix a bug to `modify|change column`

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -69,6 +69,7 @@ var (
 	errErrorOnRename         = terror.ClassDDL.New(codeErrorOnRename, "Error on rename of './%s/%s' to './%s/%s'")
 	errBadField              = terror.ClassDDL.New(codeBadField, "Unknown column '%s' in '%s'")
 	errInvalidDefault        = terror.ClassDDL.New(codeInvalidDefault, "Invalid default value for '%s'")
+	errInvalidUseOfNull      = terror.ClassDDL.New(codeInvalidUseOfNull, "Invalid use of NULL value")
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")
@@ -422,6 +423,7 @@ const (
 	codeCantDropFieldOrKey    = 1091
 	codeWrongDBName           = 1102
 	codeWrongTableName        = 1103
+	codeInvalidUseOfNull      = 1138
 	codeBlobKeyWithoutLength  = 1170
 	codeInvalidOnUpdate       = 1294
 )
@@ -444,6 +446,7 @@ func init() {
 		codeErrorOnRename:         mysql.ErrErrorOnRename,
 		codeBadField:              mysql.ErrBadField,
 		codeInvalidDefault:        mysql.ErrInvalidDefault,
+		codeInvalidUseOfNull:      mysql.ErrInvalidUseOfNull,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassDDL] = ddlMySQLErrCodes
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -289,7 +289,7 @@ func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*ta
 					return nil, nil, errors.Trace(err)
 				}
 			case ast.ColumnOptionFulltext:
-				// Do nothing.
+				// TODO: Support this type.
 			}
 		}
 	}
@@ -846,6 +846,10 @@ func modifiable(origin *types.FieldType, to *types.FieldType) bool {
 			return false
 		}
 	default:
+		if origin.Tp == to.Tp {
+			return true
+		}
+
 		return false
 	}
 }
@@ -873,22 +877,50 @@ func setDefaultAndComment(ctx context.Context, col *table.Column, options []*ast
 		return nil
 	}
 
-	for _, v := range options {
-		switch v.Tp {
+	var (
+		hasDefaultValue bool
+		hasNotNull      bool
+		setOnUpdateNow  bool
+	)
+	for _, opt := range options {
+		switch opt.Tp {
 		case ast.ColumnOptionDefaultValue:
-			err := setDefaultValue(ctx, col, v)
+			value, err := getDefaultValue(ctx, opt, col.Tp, col.Decimal)
 			if err != nil {
-				return errors.Trace(err)
+				return ErrColumnBadNull.Gen("invalid default value - %s", err)
 			}
+			col.DefaultValue = value
+			hasDefaultValue = true
 		case ast.ColumnOptionComment:
-			err := setColumnComment(ctx, col, v)
+			err := setColumnComment(ctx, col, opt)
 			if err != nil {
 				return errors.Trace(err)
 			}
+		case ast.ColumnOptionNotNull:
+			col.Flag |= mysql.NotNullFlag
+			hasNotNull = true
+		case ast.ColumnOptionNull:
+			col.Flag &= ^uint(mysql.NotNullFlag)
+		case ast.ColumnOptionOnUpdate:
+			if !expression.IsCurrentTimeExpr(opt.Expr) {
+				return ErrInvalidOnUpdate.Gen("invalid ON UPDATE for - %s", col.Name)
+			}
+
+			col.Flag |= mysql.OnUpdateNowFlag
+			setOnUpdateNow = true
 		default:
 			// TODO: Support other types.
 			return errors.Trace(errUnsupportedModifyColumn)
 		}
+	}
+
+	setTimestampDefaultValue(col, hasDefaultValue, setOnUpdateNow)
+	if mysql.HasTimestampFlag(col.Flag) && hasNotNull {
+		return errors.Trace(errInvalidUseOfNull)
+	}
+
+	if hasDefaultValue {
+		return errors.Trace(checkDefaultValue(ctx, col, true))
 	}
 
 	return nil
@@ -915,6 +947,7 @@ func (d *ddl) getModifiableColumnJob(ctx context.Context, ident ast.Ident, origi
 		// Make sure the column definition is simple field type.
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
+
 	if err := setDefaultAndComment(ctx, col, spec.NewColumn.Options); err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -925,6 +958,8 @@ func (d *ddl) getModifiableColumnJob(ctx context.Context, ident ast.Ident, origi
 
 	newCol := *col
 	newCol.FieldType = *spec.NewColumn.Tp
+	// TODO: Remove this line after merged PR 2627.
+	newCol.Flag = col.Flag
 	newCol.Name = spec.NewColumn.Name.Name
 	job := &model.Job{
 		SchemaID:   schema.ID,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -277,6 +277,7 @@ func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*ta
 				hasDefaultValue = true
 				removeOnUpdateNowFlag(col)
 			case ast.ColumnOptionOnUpdate:
+				// TODO: Support other time functions.
 				if !expression.IsCurrentTimeExpr(v.Expr) {
 					return nil, nil, ErrInvalidOnUpdate.Gen("invalid ON UPDATE for - %s", col.Name)
 				}
@@ -902,6 +903,7 @@ func setDefaultAndComment(ctx context.Context, col *table.Column, options []*ast
 		case ast.ColumnOptionNull:
 			col.Flag &= ^uint(mysql.NotNullFlag)
 		case ast.ColumnOptionOnUpdate:
+			// TODO: Support other time functions.
 			if !expression.IsCurrentTimeExpr(opt.Expr) {
 				return ErrInvalidOnUpdate.Gen("invalid ON UPDATE for - %s", col.Name)
 			}

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -733,21 +733,40 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.tk.MustQuery("select a from t3").Check(testkit.Rows("1", "2"))
 	s.mustExec(c, "alter table t3 change a aa bigint")
 	s.tk.MustQuery("select aa from t3").Check(testkit.Rows("1", "2"))
-	s.mustExec(c, "alter table t3 modify b varchar(20) default 'c' comment 'my comment'")
+	// for the following definitions: 'not null', 'null', 'default value' and 'comment'
+	s.mustExec(c, "alter table t3 change b b varchar(20) not null default 'c' comment 'my comment'")
 	ctx := s.tk.Se.(context.Context)
 	is := sessionctx.GetDomain(ctx).InfoSchema()
 	tbl, err := is.TableByName(model.NewCIStr("test_db"), model.NewCIStr("t3"))
 	c.Assert(err, IsNil)
 	tblInfo := tbl.Meta()
-	c.Assert(tblInfo.Columns[1].Comment, Equals, "my comment")
+	colB := tblInfo.Columns[1]
+	c.Assert(colB.Comment, Equals, "my comment")
+	hasNotNull := tmysql.HasNotNullFlag(colB.Flag)
+	c.Assert(hasNotNull, IsTrue)
 	s.mustExec(c, "insert into t3 set aa = 3")
 	rowStr := fmt.Sprintf("%v", []byte("a"))
 	rowStr1 := fmt.Sprintf("%v", []byte("b"))
 	rowStr2 := fmt.Sprintf("%v", []byte("c"))
 	s.tk.MustQuery("select b from t3").Check(testkit.Rows(rowStr, rowStr1, rowStr2))
+	// for timestamp
+	s.mustExec(c, "alter table t3 add column c timestamp not null")
+	s.mustExec(c, "alter table t3 change c c timestamp default '2017-02-11' comment 'col c comment' on update current_timestamp")
+	is = sessionctx.GetDomain(ctx).InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test_db"), model.NewCIStr("t3"))
+	c.Assert(err, IsNil)
+	tblInfo = tbl.Meta()
+	colC := tblInfo.Columns[2]
+	c.Assert(colC.Comment, Equals, "col c comment")
+	hasNotNull = tmysql.HasNotNullFlag(colC.Flag)
+	c.Assert(hasNotNull, IsTrue)
 
 	// for failing tests
-	sql := "alter table t3 change a testx.t3.aa bigint"
+	sql := "alter table t3 change c c timestamp not null"
+	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
+	sql = "alter table t3 change c c timestamp not null null"
+	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
+	sql = "alter table t3 change a testx.t3.aa bigint"
 	s.testErrorCode(c, sql, tmysql.ErrWrongDBName)
 	sql = "alter table t3 change t.a aa bigint"
 	s.testErrorCode(c, sql, tmysql.ErrWrongTableName)

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -766,6 +766,8 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
 	sql = "alter table t3 change c c timestamp not null null"
 	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
+	sql = "alter table t3 change aa aa int default ''"
+	s.testErrorCode(c, sql, tmysql.ErrInvalidDefault)
 	sql = "alter table t3 change a testx.t3.aa bigint"
 	s.testErrorCode(c, sql, tmysql.ErrWrongDBName)
 	sql = "alter table t3 change t.a aa bigint"


### PR DESCRIPTION
This PR for the statement of `alter table ... modify|change column`.
Support the following definitions: 'not null', 'null', 'default value' and 'comment'.
Fix the same type of change.