### PR TITLE
store/localstore: fix a bug that blocking store.Close.

### DIFF
--- a/store/localstore/compactor.go
+++ b/store/localstore/compactor.go
@@ -176,7 +176,11 @@ func (gc *localstoreCompactor) Compact(k kv.Key) error {
 	filteredKeys := gc.filterExpiredKeys(keys)
 
 	for _, key := range filteredKeys {
-		gc.delCh <- key
+		select {
+		case <-gc.stopCh:
+			return nil
+		case gc.delCh <- key:
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When Store.Close is called delete worker may exit before checker,
Then delCh may be full, blocking forever.