### PR TITLE
server: update binary protocol for MySQL 5.7

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -80,6 +80,7 @@ type PrepareExec struct {
 	ID         uint32
 	ParamCount int
 	Err        error
+	Fields     []*ast.ResultField
 }
 
 // Schema implements the Executor Schema interface.
@@ -136,6 +137,14 @@ func (e *PrepareExec) DoPrepare() {
 	}
 	var extractor paramMarkerExtractor
 	stmt.Accept(&extractor)
+	err = plan.Preprocess(stmt, e.IS, e.Ctx)
+	if err != nil {
+		e.Err = errors.Trace(err)
+		return
+	}
+	if result, ok := stmt.(ast.ResultSetNode); ok {
+		e.Fields = result.GetResultFields()
+	}
 
 	// The parameter markers are appended in visiting order, which may not
 	// be the same as the position order in the query string. We need to

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -113,6 +113,8 @@ const (
 	ClientPluginAuth
 	ClientConnectAtts
 	ClientPluginAuthLenencClientData
+
+	ClientDeprecateEOF uint32 = 1 << 24
 )
 
 // Cache type informations.

--- a/server/conn.go
+++ b/server/conn.go
@@ -292,7 +292,7 @@ func (cc *clientConn) readHandshakeResponse() error {
 	if err = handshakeResponseFromData(&p, data); err != nil {
 		return errors.Trace(err)
 	}
-	cc.capability = p.Capability & defaultCapability
+	cc.capability = p.Capability
 	cc.user = p.User
 	cc.dbname = p.DBName
 	cc.collation = p.Collation
@@ -770,8 +770,11 @@ func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error
 		}
 		row, err = rs.Next()
 	}
-
-	err = cc.writeEOF(more)
+	if cc.capability&mysql.ClientDeprecateEOF > 0 {
+		err = cc.writeOK()
+	} else {
+		err = cc.writeEOF(more)
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -168,7 +168,7 @@ func (cc *clientConn) handleStmtExecute(data []byte) (err error) {
 		return errors.Trace(err)
 	}
 	if rs == nil {
-		return errors.Trace(cc.writeOK(false))
+		return errors.Trace(cc.writeOK(false, false))
 	}
 
 	return errors.Trace(cc.writeResultset(rs, true, false))
@@ -352,7 +352,7 @@ func (cc *clientConn) handleStmtReset(data []byte) (err error) {
 			strconv.Itoa(stmtID), "stmt_reset")
 	}
 	stmt.Reset()
-	return cc.writeOK(false)
+	return cc.writeOK(false, false)
 }
 
 // See https://dev.mysql.com/doc/internals/en/com-set-option.html

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -77,9 +77,10 @@ func (cc *clientConn) handleStmtPrepare(sql string) error {
 				return errors.Trace(err)
 			}
 		}
-
-		if err := cc.writeEOF(false); err != nil {
-			return errors.Trace(err)
+		if cc.capability&mysql.ClientDeprecateEOF == 0 {
+			if err := cc.writeEOF(false); err != nil {
+				return errors.Trace(err)
+			}
 		}
 	}
 
@@ -93,8 +94,10 @@ func (cc *clientConn) handleStmtPrepare(sql string) error {
 			}
 		}
 
-		if err := cc.writeEOF(false); err != nil {
-			return errors.Trace(err)
+		if cc.capability&mysql.ClientDeprecateEOF == 0 {
+			if err := cc.writeEOF(false); err != nil {
+				return errors.Trace(err)
+			}
 		}
 
 	}

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -168,7 +168,7 @@ func (cc *clientConn) handleStmtExecute(data []byte) (err error) {
 		return errors.Trace(err)
 	}
 	if rs == nil {
-		return errors.Trace(cc.writeOK())
+		return errors.Trace(cc.writeOK(false))
 	}
 
 	return errors.Trace(cc.writeResultset(rs, true, false))
@@ -352,7 +352,7 @@ func (cc *clientConn) handleStmtReset(data []byte) (err error) {
 			strconv.Itoa(stmtID), "stmt_reset")
 	}
 	stmt.Reset()
-	return cc.writeOK()
+	return cc.writeOK(false)
 }
 
 // See https://dev.mysql.com/doc/internals/en/com-set-option.html

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -363,16 +363,6 @@ xxx row5_col1	- 	row5_col3`)
 		rs, err = dbt.db.Exec("load data local infile '/tmp/nonexistence.csv' into table test")
 		dbt.Assert(err, NotNil)
 	})
-
-	// unsupport ClientLocalFiles capability
-	defaultCapability ^= tmysql.ClientLocalFiles
-	runTests(c, dsn+"&allowAllFiles=true", func(dbt *DBTest) {
-		dbt.mustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
-		_, err = dbt.db.Exec("load data local infile '/tmp/load_data_test.csv' into table test")
-		dbt.Assert(err, NotNil)
-		checkErrorCode(c, err, tmysql.ErrNotAllowedCommand)
-	})
-	defaultCapability |= tmysql.ClientLocalFiles
 }
 
 func runTestConcurrentUpdate(c *C) {

--- a/session.go
+++ b/session.go
@@ -490,7 +490,7 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 		SQLText: sql,
 	}
 	prepareExec.DoPrepare()
-	return prepareExec.ID, prepareExec.ParamCount, nil, prepareExec.Err
+	return prepareExec.ID, prepareExec.ParamCount, prepareExec.Fields, prepareExec.Err
 }
 
 // checkArgs makes sure all the arguments' types are known and can be handled.

--- a/session_test.go
+++ b/session_test.go
@@ -81,8 +81,9 @@ func (s *testSessionSuite) TestPrepare(c *C) {
 	mustExecSQL(c, se, s.createTableSQL)
 	// insert data
 	mustExecSQL(c, se, `INSERT INTO t VALUES ("id");`)
-	id, ps, _, err := se.PrepareStmt("select id+? from t")
+	id, ps, fields, err := se.PrepareStmt("select id+? from t")
 	c.Assert(err, IsNil)
+	c.Assert(fields, HasLen, 1)
 	c.Assert(id, Equals, uint32(1))
 	c.Assert(ps, Equals, 1)
 	mustExecSQL(c, se, `set @a=1`)


### PR DESCRIPTION
sysbench 1.0.1 failed to run `oltp_read_only.lua` because binary protocal has updated in MySQL 5.7.

About adding test case, this is very expensive to build an synthetic test for this bug.

Because it can only be verified by MySQL client 5.7.

As we strictly follow the new documentation, it's very unlikely this bug can have regression in the future.

So test case is not added.