### PR TITLE
tidb: avoid privilege check in loadCommonGlobalVariablesIfNeeded

### DIFF
--- a/session.go
+++ b/session.go
@@ -830,7 +830,10 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 	}
 	// Set the variable to true to prevent cyclic recursive call.
 	vars.CommonGlobalLoaded = true
+	save := privilege.GetPrivilegeChecker(s)
+	privilege.BindPrivilegeChecker(s, nil)
 	rs, err := s.ExecRestrictedSQL(s, loadCommonGlobalVarsSQL)
+	privilege.BindPrivilegeChecker(s, save)
 	if err != nil {
 		vars.CommonGlobalLoaded = false
 		log.Errorf("Failed to load common global variables.")


### PR DESCRIPTION
Start with command:
```
./tidb-server -privilege=true
```

And login with a new created account:

```
mysql -h 127.0.0.1 -P 4000 -u genius -p
```

TiDB would log this error:

```
2017/02/15 10:34:12 server.go:115: [info] [1] new connection 127.0.0.1:45284
2017/02/15 10:34:12 session.go:359: [error] Compile select * from mysql.global_variables where variable_name in ('autocommit', 'sql_mode', 'tidb_distsql_join_concurrency', 'max_allowed_packet', 'tidb_distsql_scan_concurrency') with error: privilege check fail
2017/02/15 10:34:12 session.go:836: [error] Failed to load common global variables.
2017/02/15 10:34:12 tidb.go:168: [info] RollbackTxn for ddl/autocommit error. 
2017/02/15 10:34:12 txn.go:143: [info] [kv] Rollback txn 389841171912851456
2017/02/15 10:34:12 session.go:465: [warning] [1] session error:
/media/genius/OS/project/src/github.com/pingcap/tidb/plan/optimizer.go:79: privilege check fail
/media/genius/OS/project/src/github.com/pingcap/tidb/executor/compiler.go:43: 
/media/genius/OS/project/src/github.com/pingcap/tidb/tidb.go:153: 
/media/genius/OS/project/src/github.com/pingcap/tidb/session.go:360: 
/media/genius/OS/project/src/github.com/pingcap/tidb/session.go:837: 
/media/genius/OS/project/src/github.com/pingcap/tidb/session.go:904: 
/media/genius/OS/project/src/github.com/pingcap/tidb/executor/adapter.go:95: 
```

Because `loadCommonGlobalVariablesIfNeeded` use a session with insufficient privilege, this COMMIT is a simple fix.