### PR TITLE
plan: handle int64 type when evaluate limit and count.

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -107,4 +107,9 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 	tk.MustExec(`set @c="-1"`)
 	_, err := tk.Exec("execute stmt_test_1 using @c, @c")
 	c.Assert(plan.ErrWrongArguments.Equal(err), IsTrue)
+
+	stmtID, _, _, err := tk.Se.PrepareStmt("select id from prepare_test limit ?")
+	c.Assert(err, IsNil)
+	_, err = tk.Se.ExecutePreparedStmt(stmtID, 1)
+	c.Assert(err, IsNil)
 }

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -436,6 +436,10 @@ func getUintForLimitOffset(sc *variable.StatementContext, val interface{}) (uint
 	switch v := val.(type) {
 	case uint64:
 		return v, nil
+	case int64:
+		if v >= 0 {
+			return uint64(v), nil
+		}
 	case string:
 		uVal, err := types.StrToUint(sc, v)
 		return uVal, errors.Trace(err)


### PR DESCRIPTION
Fix parameter mark limit for prepared statement.