### PR TITLE
variable: Enlarge default value for max_allowed_packet

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -2431,7 +2431,7 @@ func (s *testSessionSuite) TestGlobalVarAccessor(c *C) {
 	defer testleak.AfterTest(c)()
 
 	varName := "max_allowed_packet"
-	varValue := "4194304" // This is the default value for max_allowed_packet
+	varValue := "67108864" // This is the default value for max_allowed_packet
 	varValue1 := "4194305"
 	varValue2 := "4194306"
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -564,7 +564,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "ndbinfo_show_hidden", ""},
 	{ScopeGlobal | ScopeSession, "net_read_timeout", "30"},
 	{ScopeNone, "innodb_page_size", "16384"},
-	{ScopeGlobal, MaxAllowedPacket, "4194304"},
+	{ScopeGlobal, MaxAllowedPacket, "67108864"},
 	{ScopeNone, "innodb_log_file_size", "50331648"},
 	{ScopeGlobal, "sync_relay_log_info", "10000"},
 	{ScopeGlobal | ScopeSession, "optimizer_trace_limit", "1"},


### PR DESCRIPTION
4194304 is too small in some scenarios.