### PR TITLE
tidb-server: add a parameter to optionally disable ddl worker.

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -26,10 +26,16 @@ import (
 	"github.com/pingcap/tidb/terror"
 )
 
+// RunWorker indicates if this TiDB server starts DDL worker and can run DDL job.
+var RunWorker = true
+
 // onDDLWorker is for async online schema changing, it will try to become the owner firstly,
 // then wait or pull the job queue to handle a schema change job.
 func (d *ddl) onDDLWorker() {
 	defer d.wait.Done()
+	if !RunWorker {
+		return
+	}
 
 	// We use 4 * lease time to check owner's timeout, so here, we will update owner's status
 	// every 2 * lease time. If lease is 0, we will use default 10s.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ngaut/log"
 	"github.com/ngaut/systimemon"
 	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/perfschema"
 	"github.com/pingcap/tidb/plan"
@@ -62,6 +63,7 @@ var (
 	metricsAddr     = flag.String("metrics-addr", "", "prometheus pushgateway address, leaves it empty will disable prometheus push.")
 	metricsInterval = flag.Int("metrics-interval", 15, "prometheus client push interval in second, set \"0\" to disable prometheus push.")
 	binlogSocket    = flag.String("binlog-socket", "", "socket file to write binlog")
+	runDDL          = flag.Bool("run-ddl", true, "run ddl worker on this tidb-server")
 
 	timeJumpBackCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
@@ -86,6 +88,7 @@ func main() {
 
 	leaseDuration := parseLease()
 	tidb.SetSchemaLease(leaseDuration)
+	ddl.RunWorker = *runDDL
 
 	cfg := &server.Config{
 		Addr:         fmt.Sprintf("%s:%s", *host, *port),


### PR DESCRIPTION
If we don't want the tidb-server run ddl jobs, we can use this parameter `-run-ddl false` to disable it.