### PR TITLE
expression: handle timestampdiff with null argument.

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -206,6 +206,9 @@ func (b *builtinDateDiffSig) eval(row []types.Datum) (d types.Datum, err error) 
 	if err != nil {
 		return types.Datum{}, errors.Trace(err)
 	}
+	if args[0].IsNull() || args[1].IsNull() {
+		return d, nil
+	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	t1, err := convertDatumToTime(sc, args[0])
 	if err != nil {
@@ -243,6 +246,9 @@ func (b *builtinTimeDiffSig) eval(row []types.Datum) (d types.Datum, err error) 
 	args, err := b.evalArgs(row)
 	if err != nil {
 		return types.Datum{}, errors.Trace(err)
+	}
+	if args[0].IsNull() || args[1].IsNull() {
+		return d, nil
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	t1, err := convertDatumToTime(sc, args[0])
@@ -1399,6 +1405,9 @@ func (b *builtinTimestampDiffSig) eval(row []types.Datum) (d types.Datum, err er
 	args, err := b.evalArgs(row)
 	if err != nil {
 		return types.Datum{}, errors.Trace(err)
+	}
+	if args[1].IsNull() || args[2].IsNull() {
+		return d, nil
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	t1, err := convertDatumToTime(sc, args[1])

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -740,6 +740,12 @@ func (s *testEvaluatorSuite) TestDateDiff(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(result.IsNull(), Equals, true)
+
+	f, err = fc.getFunction(datumsToConstants([]types.Datum{{}, types.NewStringDatum("2017-01-01")}), s.ctx)
+	c.Assert(err, IsNil)
+	d, err := f.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(d.IsNull(), IsTrue)
 }
 
 func (s *testEvaluatorSuite) TestTimeDiff(c *C) {
@@ -763,6 +769,11 @@ func (s *testEvaluatorSuite) TestTimeDiff(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(result.GetMysqlDuration().String(), Equals, test.expectStr)
 	}
+	f, err := fc.getFunction(datumsToConstants([]types.Datum{{}, types.NewStringDatum("2017-01-01")}), s.ctx)
+	c.Assert(err, IsNil)
+	d, err := f.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(d.IsNull(), IsTrue)
 }
 
 func (s *testEvaluatorSuite) TestWeek(c *C) {
@@ -849,6 +860,13 @@ func (s *testEvaluatorSuite) TestTimestampDiff(c *C) {
 	c.Assert(err, IsNil)
 	d, err := f.eval(nil)
 	c.Assert(d.Kind(), Equals, types.KindNull)
+
+	f, err = fc.getFunction(datumsToConstants([]types.Datum{types.NewStringDatum("DAY"),
+		{}, types.NewStringDatum("2017-01-01")}), s.ctx)
+	c.Assert(err, IsNil)
+	d, err = f.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(d.IsNull(), IsTrue)
 }
 
 func (s *testEvaluatorSuite) TestUnixTimestamp(c *C) {


### PR DESCRIPTION
Fixes https://github.com/pingcap/tidb/issues/2662