### PR TITLE
executor: fix a bug when subquery meet update.

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1168,9 +1168,10 @@ func (e *UpdateExec) fetchRows() error {
 		if row == nil {
 			return nil
 		}
-		data := make([]types.Datum, e.SelectExec.Schema().Len())
-		newData := make([]types.Datum, e.SelectExec.Schema().Len())
-		for i := range e.SelectExec.Schema().Columns {
+		l := len(e.OrderedList)
+		data := make([]types.Datum, l)
+		newData := make([]types.Datum, l)
+		for i := 0; i < l; i++ {
 			data[i] = row.Data[i]
 			newData[i] = data[i]
 			if e.OrderedList[i] != nil {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -129,6 +129,12 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("create table TEST1 (ID INT NOT NULL, VALUE INT DEFAULT NULL, PRIMARY KEY (ID))")
 	_, err = tk.Exec("INSERT INTO TEST1(id,value) VALUE(3,3) on DUPLICATE KEY UPDATE VALUE=4")
 	c.Assert(err, IsNil)
+
+	tk.MustExec("create table t (id int)")
+	tk.MustExec("insert into t values(1)")
+	tk.MustExec("update t t1 set id = (select count(*) + 1 from t t2 where t1.id = t2.id)")
+	r = tk.MustQuery("select * from t;")
+	r.Check(testkit.Rows("2"))
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {


### PR DESCRIPTION
when update meet subquery, the len of rows may be longer than order list.

@shenli @coocood @zimulala PTAL