### PR TITLE
ddl: save original schema ID for allocator when rename table.

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -629,6 +629,9 @@ func (d *ddl) CreateTable(ctx context.Context, ident ast.Ident, colDefs []*ast.C
 
 // If create table with auto_increment option, we should rebase tableAutoIncID value.
 func (d *ddl) handleAutoIncID(tbInfo *model.TableInfo, schemaID int64) error {
+	if tbInfo.OldSchemaID != 0 {
+		schemaID = tbInfo.OldSchemaID
+	}
 	alloc := autoid.NewAllocator(d.store, schemaID)
 	tbInfo.State = model.StatePublic
 	tb, err := table.TableFromMeta(alloc, tbInfo)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -142,6 +142,9 @@ func (d *ddl) delReorgTable(t *meta.Meta, job *model.Job) error {
 }
 
 func (d *ddl) getTable(schemaID int64, tblInfo *model.TableInfo) (table.Table, error) {
+	if tblInfo.OldSchemaID != 0 {
+		schemaID = tblInfo.OldSchemaID
+	}
 	alloc := autoid.NewAllocator(d.store, schemaID)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	return tbl, errors.Trace(err)
@@ -235,6 +238,9 @@ func (d *ddl) onRenameTable(t *meta.Meta, job *model.Job) error {
 		err = checkTableNotExists(t, job, newSchemaID, tblInfo.Name.L)
 		if err != nil {
 			return errors.Trace(err)
+		}
+		if tblInfo.OldSchemaID == 0 {
+			tblInfo.OldSchemaID = oldSchemaID
 		}
 	}
 

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -140,7 +140,11 @@ func (b *Builder) applyCreateTable(m *meta.Meta, roDBInfo *model.DBInfo, tableID
 		return ErrTableNotExists
 	}
 	if alloc == nil {
-		alloc = autoid.NewAllocator(b.handle.store, roDBInfo.ID)
+		schemaID := roDBInfo.ID
+		if tblInfo.OldSchemaID != 0 {
+			schemaID = tblInfo.OldSchemaID
+		}
+		alloc = autoid.NewAllocator(b.handle.store, schemaID)
 	}
 	tbl, err := tables.TableFromMeta(alloc, tblInfo)
 	if err != nil {
@@ -241,7 +245,11 @@ func (b *Builder) createSchemaTablesForDB(di *model.DBInfo) error {
 	}
 	b.is.schemaMap[di.Name.L] = schTbls
 	for _, t := range di.Tables {
-		alloc := autoid.NewAllocator(b.handle.store, di.ID)
+		schemaID := di.ID
+		if t.OldSchemaID != 0 {
+			schemaID = t.OldSchemaID
+		}
+		alloc := autoid.NewAllocator(b.handle.store, schemaID)
 		var tbl table.Table
 		tbl, err := tables.TableFromMeta(alloc, t)
 		if err != nil {

--- a/model/model.go
+++ b/model/model.go
@@ -89,6 +89,10 @@ type TableInfo struct {
 	AutoIncID   int64         `json:"auto_inc_id"`
 	MaxColumnID int64         `json:"max_col_id"`
 	MaxIndexID  int64         `json:"max_idx_id"`
+	// Because auto increment ID has schemaID as prefix,
+	// We need to save original schemaID to keep autoID unchanged
+	// while renaming a table from one database to another.
+	OldSchemaID int64 `json:"old_schema_id,omitempty"`
 }
 
 // Clone clones TableInfo.


### PR DESCRIPTION
Fixes a bug that renamed table to another database failed to insert.