### PR TITLE
ddl: Make verification background job more stable

### DIFF
--- a/ddl/bg_worker.go
+++ b/ddl/bg_worker.go
@@ -74,6 +74,7 @@ func (d *ddl) handleBgJobQueue() error {
 
 // runBgJob runs a background job.
 func (d *ddl) runBgJob(t *meta.Meta, job *model.Job) {
+	log.Infof("[ddl] run background job %s", job)
 	job.State = model.JobRunning
 
 	var err error

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
@@ -250,8 +249,7 @@ func (s *testTableSuite) TestTable(c *C) {
 	testCheckJobDone(c, d, job, false)
 
 	// Check background ddl info.
-	time.Sleep(testLease * 400)
-	verifyBgJobState(c, d, job, model.JobDone)
+	verifyBgJobState(c, d, job, model.JobDone, testLease*350)
 	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	c.Assert(updatedCount, Equals, 2)
 


### PR DESCRIPTION
Make verification background job more stable and add a test for dropping the database.