### PR TITLE
util/types: ignore string truncate error.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -693,8 +693,9 @@ func (s *testSuite) TestIndexScan(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("CREATE TABLE t (a varchar(3), index(a))")
-	result = tk.MustQuery("select * from t where a >= \"aaaa\" and a < \"aabb\"")
-	result.Check(testkit.Rows())
+	tk.MustExec("insert t values('aaa'), ('aab')")
+	result = tk.MustQuery("select * from t where a >= 'aaaa' and a < 'aabb'")
+	result.Check(testkit.Rows("[97 97 98]"))
 }
 
 func (s *testSuite) TestIndexReverseOrder(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -690,6 +690,11 @@ func (s *testSuite) TestIndexScan(c *C) {
 	tk.MustExec("CREATE INDEX idx_tab1_1 on tab1 (b, a)")
 	result = tk.MustQuery("SELECT pk FROM tab1 WHERE b > 1")
 	result.Check(testkit.Rows("3", "4"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (a varchar(3), index(a))")
+	result = tk.MustQuery("select * from t where a >= \"aaaa\" and a < \"aabb\"")
+	result.Check(testkit.Rows())
 }
 
 func (s *testSuite) TestIndexReverseOrder(c *C) {

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -768,7 +768,7 @@ func (d *Datum) convertToString(sc *variable.StatementContext, target *FieldType
 	}
 
 	var err error
-	if target.Flen >= 0 {
+	if target.Flen >= 0 && !sc.IgnoreTruncate {
 		// Flen is the rune length, not binary length, for UTF8 charset, we need to calculate the
 		// rune count and truncate to Flen runes if it is too long.
 		if target.Charset == charset.CharsetUTF8 || target.Charset == charset.CharsetUTF8MB4 {
@@ -777,7 +777,7 @@ func (d *Datum) convertToString(sc *variable.StatementContext, target *FieldType
 			for i := range s {
 				runeCount++
 				if runeCount == target.Flen+1 {
-					// We do break here because we need to iterate to the end to get runeCount.
+					// We don't break here because we need to iterate to the end to get runeCount.
 					truncateLen = i
 				}
 			}


### PR DESCRIPTION
fix #2653 
create table t (a varchar(3), index (a));
insert t values ("aaaa") should report error.
select a < "aaaa" from t; shoud not report error.
@shenli @coocood @zimulala PTAL