### PR TITLE
executor: grant statement allow pattern string in db and table name

### DIFF
--- a/executor/grant.go
+++ b/executor/grant.go
@@ -61,6 +61,10 @@ func (e *GrantExec) Next() (*Row, error) {
 	if e.done {
 		return nil, nil
 	}
+	dbName := e.Level.DBName
+	if len(dbName) == 0 {
+		dbName = e.ctx.GetSessionVars().CurrentDB
+	}
 	// Grant for each user
 	for _, user := range e.Users {
 		// Check if user exists.
@@ -79,12 +83,12 @@ func (e *GrantExec) Next() (*Row, error) {
 		// Column scope:	mysql.Columns_priv
 		switch e.Level.Level {
 		case ast.GrantLevelDB:
-			err := checkAndInitDBPriv(e.ctx, e.Level.DBName, e.is, userName, host)
+			err := checkAndInitDBPriv(e.ctx, dbName, e.is, userName, host)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 		case ast.GrantLevelTable:
-			err := checkAndInitTablePriv(e.ctx, e.Level.DBName, e.Level.TableName, e.is, userName, host)
+			err := checkAndInitTablePriv(e.ctx, dbName, e.Level.TableName, e.is, userName, host)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -124,11 +128,7 @@ func (e *GrantExec) Close() error {
 // Check if DB scope privilege entry exists in mysql.DB.
 // If unexists, insert a new one.
 func checkAndInitDBPriv(ctx context.Context, dbName string, is infoschema.InfoSchema, user string, host string) error {
-	db, err := getTargetSchema(ctx, dbName, is)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	ok, err := dbUserExists(ctx, user, host, db.Name.O)
+	ok, err := dbUserExists(ctx, user, host, dbName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -136,17 +136,13 @@ func checkAndInitDBPriv(ctx context.Context, dbName string, is infoschema.InfoSc
 		return nil
 	}
 	// Entry does not exist for user-host-db. Insert a new entry.
-	return initDBPrivEntry(ctx, user, host, db.Name.O)
+	return initDBPrivEntry(ctx, user, host, dbName)
 }
 
 // Check if table scope privilege entry exists in mysql.Tables_priv.
 // If unexists, insert a new one.
-func checkAndInitTablePriv(ctx context.Context, dbName, tableName string, is infoschema.InfoSchema, user string, host string) error {
-	db, tbl, err := getTargetSchemaAndTable(ctx, dbName, tableName, is)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	ok, err := tableUserExists(ctx, user, host, db.Name.O, tbl.Meta().Name.O)
+func checkAndInitTablePriv(ctx context.Context, dbName, tblName string, is infoschema.InfoSchema, user string, host string) error {
+	ok, err := tableUserExists(ctx, user, host, dbName, tblName)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -154,13 +150,13 @@ func checkAndInitTablePriv(ctx context.Context, dbName, tableName string, is inf
 		return nil
 	}
 	// Entry does not exist for user-host-db-tbl. Insert a new entry.
-	return initTablePrivEntry(ctx, user, host, db.Name.O, tbl.Meta().Name.O)
+	return initTablePrivEntry(ctx, user, host, dbName, tblName)
 }
 
 // Check if column scope privilege entry exists in mysql.Columns_priv.
 // If unexists, insert a new one.
 func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast.ColumnName) error {
-	db, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
+	dbName, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -169,7 +165,7 @@ func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c.Name.O)
 		}
-		ok, err := columnPrivEntryExists(e.ctx, user, host, db.Name.O, tbl.Meta().Name.O, col.Name.O)
+		ok, err := columnPrivEntryExists(e.ctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -177,7 +173,7 @@ func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast
 			continue
 		}
 		// Entry does not exist for user-host-db-tbl-col. Insert a new entry.
-		err = initColumnPrivEntry(e.ctx, user, host, db.Name.O, tbl.Meta().Name.O, col.Name.O)
+		err = initColumnPrivEntry(e.ctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -237,39 +233,40 @@ func (e *GrantExec) grantGlobalPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 
 // Manipulate mysql.db table.
 func (e *GrantExec) grantDBPriv(priv *ast.PrivElem, user *ast.UserSpec) error {
-	db, err := getTargetSchema(e.ctx, e.Level.DBName, e.is)
-	if err != nil {
-		return errors.Trace(err)
+	dbName := e.Level.DBName
+	if len(dbName) == 0 {
+		dbName = e.ctx.GetSessionVars().CurrentDB
 	}
 	asgns, err := composeDBPrivUpdate(priv.Priv, "Y")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	userName, host := parseUser(user.User)
-	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s";`, mysql.SystemDB, mysql.DBTable, asgns, userName, host, db.Name.O)
+	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s";`, mysql.SystemDB, mysql.DBTable, asgns, userName, host, dbName)
 	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
 	return errors.Trace(err)
 }
 
 // Manipulate mysql.tables_priv table.
 func (e *GrantExec) grantTablePriv(priv *ast.PrivElem, user *ast.UserSpec) error {
-	db, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
-	if err != nil {
-		return errors.Trace(err)
+	dbName := e.Level.DBName
+	if len(dbName) == 0 {
+		dbName = e.ctx.GetSessionVars().CurrentDB
 	}
+	tblName := e.Level.TableName
 	userName, host := parseUser(user.User)
-	asgns, err := composeTablePrivUpdateForGrant(e.ctx, priv.Priv, userName, host, db.Name.O, tbl.Meta().Name.O)
+	asgns, err := composeTablePrivUpdateForGrant(e.ctx, priv.Priv, userName, host, dbName, tblName)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s";`, mysql.SystemDB, mysql.TablePrivTable, asgns, userName, host, db.Name.O, tbl.Meta().Name.O)
+	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s";`, mysql.SystemDB, mysql.TablePrivTable, asgns, userName, host, dbName, tblName)
 	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
 	return errors.Trace(err)
 }
 
 // Manipulate mysql.tables_priv table.
 func (e *GrantExec) grantColumnPriv(priv *ast.PrivElem, user *ast.UserSpec) error {
-	db, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
+	dbName, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -279,11 +276,11 @@ func (e *GrantExec) grantColumnPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c)
 		}
-		asgns, err := composeColumnPrivUpdateForGrant(e.ctx, priv.Priv, userName, host, db.Name.O, tbl.Meta().Name.O, col.Name.O)
+		asgns, err := composeColumnPrivUpdateForGrant(e.ctx, priv.Priv, userName, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s" AND Column_name="%s";`, mysql.SystemDB, mysql.ColumnPrivTable, asgns, userName, host, db.Name.O, tbl.Meta().Name.O, col.Name.O)
+		sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s" AND Column_name="%s";`, mysql.SystemDB, mysql.ColumnPrivTable, asgns, userName, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
 		if err != nil {
 			return errors.Trace(err)
@@ -527,34 +524,18 @@ func getColumnPriv(ctx context.Context, name string, host string, db string, tbl
 	return cPriv, nil
 }
 
-// Find the schema by dbName.
-func getTargetSchema(ctx context.Context, dbName string, is infoschema.InfoSchema) (*model.DBInfo, error) {
+// Find the schema and table by dbName and tableName.
+func getTargetSchemaAndTable(ctx context.Context, dbName, tableName string, is infoschema.InfoSchema) (string, table.Table, error) {
 	if len(dbName) == 0 {
-		// Grant *, use current schema
 		dbName = ctx.GetSessionVars().CurrentDB
 		if len(dbName) == 0 {
-			return nil, errors.New("miss DB name for grant privilege")
+			return "", nil, errors.New("miss DB name for grant privilege")
 		}
 	}
-	//check if db exists
-	schema := model.NewCIStr(dbName)
-	db, ok := is.SchemaByName(schema)
-	if !ok {
-		return nil, errors.Errorf("Unknown schema name: %s", dbName)
-	}
-	return db, nil
-}
-
-// Find the schema and table by dbName and tableName.
-func getTargetSchemaAndTable(ctx context.Context, dbName, tableName string, is infoschema.InfoSchema) (*model.DBInfo, table.Table, error) {
-	db, err := getTargetSchema(ctx, dbName, is)
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
 	name := model.NewCIStr(tableName)
-	tbl, err := is.TableByName(db.Name, name)
+	tbl, err := is.TableByName(model.NewCIStr(dbName), name)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return "", nil, errors.Trace(err)
 	}
-	return db, tbl, nil
+	return dbName, tbl, nil
 }

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -179,3 +179,11 @@ func (s *testSuite) TestColumnScope(c *C) {
 		c.Assert(strings.Index(p, mysql.Priv2SetStr[v]), Greater, -1)
 	}
 }
+
+func (s *testSuite) TestIssue2456(c *C) {
+	defer testleak.AfterTest(c)()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("CREATE USER 'dduser'@'%' IDENTIFIED by '123456';")
+	tk.MustExec("GRANT ALL PRIVILEGES ON `dddb_%`.* TO 'dduser'@'%';")
+	tk.MustExec("GRANT ALL PRIVILEGES ON `dddb_%`.`te%` to 'dduser'@'%';")
+}


### PR DESCRIPTION
We check the database name very strict before, but maybe user want to specific pattern match for grant statement.

For https://github.com/pingcap/tidb/issues/2456