### PR TITLE
mysql: change the default decimal for datetime.

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -291,9 +291,6 @@ func (b *builtinTimeDiffSig) eval(row []types.Datum) (d types.Datum, err error) 
 	}
 
 	t := t1.Sub(&t2)
-	// TODO: It should be the larger between t1.Fsp and t2.Fsp, rather than MaxFsp.
-	// But there is a bug both t1.Fsp and t2.Fsp is -1, we should fix it.
-	t.Fsp = types.MaxFsp
 	d.SetMysqlDuration(t)
 	return d, nil
 }

--- a/mysql/util.go
+++ b/mysql/util.go
@@ -47,6 +47,8 @@ func GetDefaultDecimal(tp byte) int {
 	case TypeNewDecimal:
 		// See https://dev.mysql.com/doc/refman/5.7/en/fixed-point-types.html
 		return 0
+	case TypeDatetime:
+		return 0
 	default:
 		//TODO: Add more types.
 		return -1


### PR DESCRIPTION
the default fsp for datetime should be 0 but -1. Fix #2612
@shenli @coocood @zimulala @tiancaiamao PTAL