### PR TITLE
executor,localstore: use default value if column not found in row.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -301,7 +301,7 @@ func (d *ddl) addTableColumn(t table.Table, columnInfo *model.ColumnInfo, reorgI
 	// Get column default value.
 	var err error
 	if columnInfo.DefaultValue != nil {
-		colMeta.defaultVal, _, err = table.GetColDefaultValue(ctx, columnInfo)
+		colMeta.defaultVal, err = table.GetColDefaultValue(ctx, columnInfo)
 		if err != nil {
 			job.State = model.JobCancelled
 			log.Errorf("[ddl] fatal: this case shouldn't happen, column %v err %v", columnInfo, err)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -385,7 +385,7 @@ func checkDefaultValue(ctx context.Context, c *table.Column, hasDefaultValue boo
 	}
 
 	if c.DefaultValue != nil {
-		_, _, err := table.GetColDefaultValue(ctx, c.ToInfo())
+		_, err := table.GetColDefaultValue(ctx, c.ToInfo())
 		if terror.ErrorEqual(err, types.ErrTruncated) {
 			return errInvalidDefault.GenByArgs(c.Name)
 		}

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1004,3 +1004,28 @@ func (s *testDBSuite) testRenameTable(c *C, storeStr, sql string) {
 	failSQL = fmt.Sprintf(sql, "test1.t2", "test1.t2")
 	s.testErrorCode(c, failSQL, tmysql.ErrTableExists)
 }
+
+func (s *testDBSuite) TestAddNotNullColumn(c *C) {
+	defer testleak.AfterTest(c)
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test_db")
+	// for different databases
+	s.tk.MustExec("create table tnn (c1 int primary key auto_increment, c2 int)")
+	s.tk.MustExec("insert tnn (c2) values (0)" + strings.Repeat(",(0)", 99))
+	done := make(chan error, 1)
+	sessionExecInGoroutine(c, s.store, "alter table tnn add column c3 int not null default 3", done)
+	updateCnt := 0
+out:
+	for {
+		select {
+		case err := <-done:
+			c.Assert(err, IsNil)
+			break out
+		default:
+			s.tk.MustExec("update tnn set c2 = c2 + 1 where c1 = 99")
+			updateCnt++
+		}
+	}
+	expected := fmt.Sprintf("%d %d", updateCnt, 3)
+	s.tk.MustQuery("select c2, c3 from tnn where c1 = 99").Check(testkit.Rows(expected))
+}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -945,7 +945,7 @@ func setPBColumnsDefaultValue(ctx context.Context, pbColumns []*tipb.ColumnInfo,
 		sessVars := ctx.GetSessionVars()
 		originStrict := sessVars.StrictSQLMode
 		sessVars.StrictSQLMode = false
-		d, _, err := table.GetColDefaultValue(ctx, c)
+		d, err := table.GetColDefaultValue(ctx, c)
 		sessVars.StrictSQLMode = originStrict
 		if err != nil {
 			return errors.Trace(err)

--- a/executor/write.go
+++ b/executor/write.go
@@ -901,7 +901,7 @@ func (e *InsertValues) initDefaultValues(row []types.Datum, marked map[int]struc
 			}
 		} else {
 			var err error
-			row[i], _, err = table.GetColDefaultValue(e.ctx, c.ToInfo())
+			row[i], err = table.GetColDefaultValue(e.ctx, c.ToInfo())
 			if filterErr(err, ignoreErr) != nil {
 				return errors.Trace(err)
 			}

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -527,13 +527,11 @@ func (b *planBuilder) buildSimple(node ast.StmtNode) Plan {
 }
 
 func (b *planBuilder) getDefaultValue(col *table.Column) (*expression.Constant, error) {
-	if value, ok, err := table.GetColDefaultValue(b.ctx, col.ToInfo()); ok {
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		return &expression.Constant{Value: value, RetType: &col.FieldType}, nil
+	value, err := table.GetColDefaultValue(b.ctx, col.ToInfo())
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return &expression.Constant{RetType: &col.FieldType}, nil
+	return &expression.Constant{Value: value, RetType: &col.FieldType}, nil
 }
 
 func (b *planBuilder) findDefaultValue(cols []*table.Column, name *ast.ColumnName) (*expression.Constant, error) {

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -533,12 +533,17 @@ func (rs *localRegion) handleRowData(ctx *selectContext, handle int64, value []b
 			values[col.GetColumnId()] = handleData
 		} else {
 			_, ok := values[col.GetColumnId()]
-			if !ok {
-				if mysql.HasNotNullFlag(uint(col.GetFlag())) {
-					return false, errors.New("Miss column")
-				}
-				values[col.GetColumnId()] = []byte{codec.NilFlag}
+			if ok {
+				continue
 			}
+			if len(col.DefaultVal) > 0 {
+				values[col.GetColumnId()] = col.DefaultVal
+				continue
+			}
+			if mysql.HasNotNullFlag(uint(col.Flag)) {
+				return false, errors.New("Miss column")
+			}
+			values[col.GetColumnId()] = []byte{codec.NilFlag}
 		}
 	}
 	return rs.valuesToRow(ctx, handle, values)

--- a/store/tikv/mock-tikv/cop_handler.go
+++ b/store/tikv/mock-tikv/cop_handler.go
@@ -412,12 +412,17 @@ func (h *rpcHandler) handleRowData(ctx *selectContext, handle int64, value []byt
 			values[col.GetColumnId()] = handleData
 		} else {
 			_, ok := values[col.GetColumnId()]
-			if !ok {
-				if mysql.HasNotNullFlag(uint(col.GetFlag())) {
-					return nil, errors.New("Miss column")
-				}
-				values[col.GetColumnId()] = []byte{codec.NilFlag}
+			if ok {
+				continue
 			}
+			if len(col.DefaultVal) > 0 {
+				values[col.GetColumnId()] = col.DefaultVal
+				continue
+			}
+			if mysql.HasNotNullFlag(uint(col.GetFlag())) {
+				return nil, errors.New("Miss column")
+			}
+			values[col.GetColumnId()] = []byte{codec.NilFlag}
 		}
 	}
 	return h.valuesToRow(ctx, handle, values)

--- a/table/column.go
+++ b/table/column.go
@@ -241,43 +241,41 @@ func CheckNotNull(cols []*Column, row []types.Datum) error {
 
 // GetColDefaultValue gets default value of the column.
 func GetColDefaultValue(ctx context.Context, col *model.ColumnInfo) (types.Datum, bool, error) {
-	// Check no default value flag.
-	if mysql.HasNoDefaultValueFlag(col.Flag) && col.Tp != mysql.TypeEnum {
-		err := errNoDefaultValue.Gen("Field '%s' doesn't have a default value", col.Name)
-		if ctx != nil {
-			sessVars := ctx.GetSessionVars()
-			if !sessVars.StrictSQLMode {
-				// TODO: add warning.
-				return GetZeroValue(col), true, nil
-			}
-		}
-		return types.Datum{}, false, errors.Trace(err)
+	if col.DefaultValue == nil {
+		return getColDefaultValueFromNil(ctx, col)
 	}
 
 	// Check and get timestamp/datetime default value.
 	if col.Tp == mysql.TypeTimestamp || col.Tp == mysql.TypeDatetime {
-		if col.DefaultValue == nil {
-			return types.Datum{}, true, nil
-		}
-
 		value, err := expression.GetTimeValue(ctx, col.DefaultValue, col.Tp, col.Decimal)
 		if err != nil {
 			return types.Datum{}, true, errGetDefaultFailed.Gen("Field '%s' get default value fail - %s",
 				col.Name, errors.Trace(err))
 		}
 		return value, true, nil
-	} else if col.Tp == mysql.TypeEnum {
-		// For enum type, if no default value and not null is set,
-		// the default value is the first element of the enum list
-		if col.DefaultValue == nil && mysql.HasNotNullFlag(col.Flag) {
-			return types.NewDatum(col.FieldType.Elems[0]), true, nil
-		}
 	}
 	value, err := CastValue(ctx, types.NewDatum(col.DefaultValue), col)
 	if err != nil {
 		return types.Datum{}, false, errors.Trace(err)
 	}
 	return value, true, nil
+}
+
+func getColDefaultValueFromNil(ctx context.Context, col *model.ColumnInfo) (types.Datum, bool, error) {
+	if !mysql.HasNotNullFlag(col.Flag) {
+		return types.Datum{}, true, nil
+	}
+	if col.Tp == mysql.TypeEnum {
+		// For enum type, if no default value and not null is set,
+		// the default value is the first element of the enum list
+		return types.NewDatum(col.FieldType.Elems[0]), true, nil
+	}
+	if !ctx.GetSessionVars().StrictSQLMode {
+		// Non strict mode use zero value.
+		// TODO: add warning.
+		return GetZeroValue(col), true, nil
+	}
+	return types.Datum{}, false, errNoDefaultValue.Gen("Field '%s' doesn't have a default value", col.Name)
 }
 
 // GetZeroValue gets zero value for given column type.

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -188,7 +188,7 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData []types.Datum
 	colIDs := make([]int64, 0, len(t.WritableCols()))
 	for i, col := range t.WritableCols() {
 		if col.State != model.StatePublic && currentData[i].IsNull() {
-			defaultVal, _, err1 := table.GetColDefaultValue(ctx, col.ToInfo())
+			defaultVal, err1 := table.GetColDefaultValue(ctx, col.ToInfo())
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
@@ -321,7 +321,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		var value types.Datum
 		if col.State == model.StateWriteOnly || col.State == model.StateWriteReorganization {
 			// if col is in write only or write reorganization state, we must add it with its default value.
-			value, _, err = table.GetColDefaultValue(ctx, col.ToInfo())
+			value, err = table.GetColDefaultValue(ctx, col.ToInfo())
 			if err != nil {
 				return 0, errors.Trace(err)
 			}


### PR DESCRIPTION
Fix failing to update while adding not null column in local store.

TiKV needs to implement this too.