### PR TITLE
executor: Fix show create table with multiple fk

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -426,11 +426,15 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(",\n")
 	}
 
+	firstFK := true
 	for _, fk := range tb.Meta().ForeignKeys {
 		if fk.State != model.StatePublic {
 			continue
 		}
-
+		if !firstFK {
+			buf.WriteString(",\n")
+		}
+		firstFK = false
 		cols := make([]string, 0, len(fk.Cols))
 		for _, c := range fk.Cols {
 			cols = append(cols, c.O)
@@ -451,6 +455,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		if ast.ReferOptionType(fk.OnUpdate) != ast.ReferOptionNoOption {
 			buf.WriteString(fmt.Sprintf(" ON UPDATE %s", ast.ReferOptionType(fk.OnUpdate)))
 		}
+
 	}
 	buf.WriteString("\n")
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -455,7 +455,6 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		if ast.ReferOptionType(fk.OnUpdate) != ast.ReferOptionNoOption {
 			buf.WriteString(fmt.Sprintf(" ON UPDATE %s", ast.ReferOptionType(fk.OnUpdate)))
 		}
-
 	}
 	buf.WriteString("\n")
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -14,6 +14,8 @@
 package executor_test
 
 import (
+	"strings"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testkit"
@@ -126,25 +128,6 @@ func (s *testSuite) TestShow(c *C) {
 	tk.MustExec("use show_test_DB")
 	result = tk.MustQuery("SHOW index from show_index from test where Column_name = 'c'")
 	c.Check(result.Rows(), HasLen, 1)
-
-	// For table with multiple fk.
-	testSQL = `CREATE TABLE pilot_languages (
-			pilot_id int(11) NOT NULL,
-			language_id int(11) NOT NULL,
-			CONSTRAINT pilot_language_fkey FOREIGN KEY (pilot_id) REFERENCES pilots (pilot_id),
-		        CONSTRAINT languages_fkey FOREIGN KEY (language_id) REFERENCES languages (language_id)
-		) ENGINE=InnoDB;`
-	tk.MustExec(testSQL)
-	testSQL = "show create table pilot_languages;"
-	result = tk.MustQuery(testSQL)
-	c.Check(result.Rows(), HasLen, 1)
-	row = result.Rows()[0]
-	expectedRow = []interface{}{
-		"pilot_languages", "CREATE TABLE `pilot_languages` (\n  `pilot_id` int(11) NOT NULL,\n  `language_id` int(11) NOT NULL,\n  CONSTRAINT `pilot_language_fkey` FOREIGN KEY (`pilot_id`) REFERENCES `pilots` (`pilot_id`),\n  CONSTRAINT `languages_fkey` FOREIGN KEY (`language_id`) REFERENCES `languages` (`language_id`)\n) ENGINE=InnoDB"}
-	for i, r := range row {
-		c.Check(r, Equals, expectedRow[i])
-	}
-
 }
 
 type stats struct {
@@ -172,14 +155,39 @@ func (s *testSuite) TestForeignKeyInShowCreateTable(c *C) {
 	testSQL = `CREATE TABLE t1 (id int PRIMARY KEY AUTO_INCREMENT)`
 	tk.MustExec(testSQL)
 
-	testSQL = "create table show_test (`id` int PRIMARY KEY AUTO_INCREMENT, FOREIGN KEY `Fk` (`id`) REFERENCES `t1` (`a`) ON DELETE CASCADE ON UPDATE CASCADE) ENGINE=InnoDB"
+	// For table with single fk.
+	sqlLines := []string{
+		"CREATE TABLE `show_test` (",
+		"  `id` int(11) NOT NULL AUTO_INCREMENT,",
+		" PRIMARY KEY (`id`),",
+		"  CONSTRAINT `Fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE",
+		") ENGINE=InnoDB",
+	}
+	testSQL = strings.Join(sqlLines, "\n")
 	tk.MustExec(testSQL)
-	testSQL = "show create table show_test;"
-	result := tk.MustQuery(testSQL)
+	result := tk.MustQuery("show create table show_test;")
 	c.Check(result.Rows(), HasLen, 1)
 	row := result.Rows()[0]
-	expectedRow := []interface{}{
-		"show_test", "CREATE TABLE `show_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n PRIMARY KEY (`id`),\n  CONSTRAINT `Fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE\n) ENGINE=InnoDB"}
+	expectedRow := []interface{}{"show_test", testSQL}
+	for i, r := range row {
+		c.Check(r, Equals, expectedRow[i])
+	}
+
+	// For table with multiple fk.
+	sqlLines = []string{
+		"CREATE TABLE `pilot_languages` (",
+		"  `pilot_id` int(11) NOT NULL,",
+		"  `language_id` int(11) NOT NULL,",
+		"  CONSTRAINT `pilot_language_fkey` FOREIGN KEY (`pilot_id`) REFERENCES `pilots` (`pilot_id`),",
+		"  CONSTRAINT `languages_fkey` FOREIGN KEY (`language_id`) REFERENCES `languages` (`language_id`)",
+		") ENGINE=InnoDB",
+	}
+	testSQL = strings.Join(sqlLines, "\n")
+	tk.MustExec(testSQL)
+	result = tk.MustQuery("show create table pilot_languages;")
+	c.Check(result.Rows(), HasLen, 1)
+	row = result.Rows()[0]
+	expectedRow = []interface{}{"pilot_languages", testSQL}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}


### PR DESCRIPTION
Use comma to separate multiple foreign keys.