### PR TITLE
ddl: Support the definition of `not null` when the column type is timestamp

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -920,11 +920,7 @@ func setDefaultAndComment(ctx context.Context, col *table.Column, options []*ast
 		return nil
 	}
 
-	var (
-		hasDefaultValue bool
-		hasNotNull      bool
-		setOnUpdateNow  bool
-	)
+	var hasDefaultValue, setOnUpdateNow bool
 	for _, opt := range options {
 		switch opt.Tp {
 		case ast.ColumnOptionDefaultValue:
@@ -941,7 +937,6 @@ func setDefaultAndComment(ctx context.Context, col *table.Column, options []*ast
 			}
 		case ast.ColumnOptionNotNull:
 			col.Flag |= mysql.NotNullFlag
-			hasNotNull = true
 		case ast.ColumnOptionNull:
 			col.Flag &= ^uint(mysql.NotNullFlag)
 		case ast.ColumnOptionOnUpdate:
@@ -959,10 +954,6 @@ func setDefaultAndComment(ctx context.Context, col *table.Column, options []*ast
 	}
 
 	setTimestampDefaultValue(col, hasDefaultValue, setOnUpdateNow)
-	if col.Tp == mysql.TypeTimestamp && hasNotNull {
-		return errors.Trace(errInvalidUseOfNull)
-	}
-
 	if hasDefaultValue {
 		return errors.Trace(checkDefaultValue(ctx, col, true))
 	}

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -753,20 +753,18 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.tk.MustQuery("select b from t3").Check(testkit.Rows(rowStr, rowStr1, rowStr2))
 	// for timestamp
 	s.mustExec(c, "alter table t3 add column c timestamp not null")
-	s.mustExec(c, "alter table t3 change c c timestamp default '2017-02-11' comment 'col c comment' on update current_timestamp")
+	s.mustExec(c, "alter table t3 change c c timestamp not null default '2017-02-11' comment 'col c comment' on update current_timestamp")
 	is = sessionctx.GetDomain(ctx).InfoSchema()
 	tbl, err = is.TableByName(model.NewCIStr("test_db"), model.NewCIStr("t3"))
 	c.Assert(err, IsNil)
 	tblInfo = tbl.Meta()
 	colC := tblInfo.Columns[2]
 	c.Assert(colC.Comment, Equals, "col c comment")
+	hasNotNull = tmysql.HasNotNullFlag(colC.Flag)
+	c.Assert(hasNotNull, IsTrue)
 
 	// for failing tests
-	sql := "alter table t3 change c c timestamp not null"
-	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
-	sql = "alter table t3 change c c timestamp not null null"
-	s.testErrorCode(c, sql, tmysql.ErrInvalidUseOfNull)
-	sql = "alter table t3 change aa a bigint default ''"
+	sql := "alter table t3 change aa a bigint default ''"
 	s.testErrorCode(c, sql, tmysql.ErrInvalidDefault)
 	sql = "alter table t3 change a testx.t3.aa bigint"
 	s.testErrorCode(c, sql, tmysql.ErrWrongDBName)


### PR DESCRIPTION
mysql> create table t (c timestamp);
Query OK, 0 rows affected (0.02 sec)
mysql> insert t set c=null;
Query OK, 1 row affected (0.00 sec)
mysql> alter table t change c c timestamp not null;
ERROR 1138 (22004): Invalid use of NULL value
mysql> delete from t;
Query OK, 1 row affected (0.01 sec)
mysql> alter table t change c c timestamp not null;
Query OK, 0 rows affected (0.03 sec)
Records: 0  Duplicates: 0  Warnings: 0

`alter table ... change ... timestamp not null` executes failed when the `c` has `null` rows in MySQL. 
Now we can't support `not null` when executes `alter table ... change ... timestamp`. This PR fix it.
But we can't support `alter table ... change ... timestamp not null` like MySQL behavior now. I will add an issue later.