### PR TITLE
privilege/privileges: make TiDB more robust when mysql.db doesn't exist

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -102,15 +102,18 @@ func (p *MySQLPrivilege) LoadAll(ctx context.Context) error {
 	}
 	err = p.LoadDBTable(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		log.Warn("mysql.db maybe missing:", errors.ErrorStack(err))
+		return nil
 	}
 	err = p.LoadTablesPrivTable(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		log.Warn("mysql.tables_priv missing:", errors.ErrorStack(err))
+		return nil
 	}
 	err = p.LoadColumnsPrivTable(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		log.Warn("mysql.columns_priv missing:", errors.ErrorStack(err))
+		return nil
 	}
 	return nil
 }

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -123,7 +123,7 @@ func (p *MySQLPrivilege) LoadAll(ctx context.Context) error {
 		if !noSuchTable(err) {
 			return errors.Trace(err)
 		}
-		log.Warn("mysql.columns_priv missing:")
+		log.Warn("mysql.columns_priv missing")
 	}
 	return nil
 }

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -245,6 +245,6 @@ func (s *testCacheSuite) TestAbnormalMySQLTable(c *C) {
 	mustExec(c, se, "DROP TABLE mysql.db;")
 	mustExec(c, se, "DROP TABLE mysql.tables_priv;")
 	mustExec(c, se, "DROP TABLE mysql.columns_priv;")
-	err = p.LoadAll()
+	err = p.LoadAll(se)
 	c.Assert(err, IsNil)
 }

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -172,7 +172,7 @@ func (s *testCacheSuite) TestCaseInsensitive(c *C) {
 	c.Assert(p.RequestVerification("genius", "127.0.0.1", "tctrain", "tctrainorder", "", mysql.SelectPriv), IsTrue)
 }
 
-func (s *testCacheSuite) TestAfterSyncMySQLUser(c *C) {
+func (s *testCacheSuite) TestAbnormalMySQLTable(c *C) {
 	privileges.Enable = true
 	store, err := tidb.NewStore("memory://sync_mysql_user")
 	c.Assert(err, IsNil)
@@ -184,6 +184,7 @@ func (s *testCacheSuite) TestAfterSyncMySQLUser(c *C) {
 	c.Assert(err, IsNil)
 	defer se.Close()
 
+	// Simulate the case mysql.user is synchronized from MySQL.
 	mustExec(c, se, "DROP TABLE mysql.user;")
 	mustExec(c, se, "USE mysql;")
 	mustExec(c, se, `CREATE TABLE user (
@@ -239,4 +240,11 @@ func (s *testCacheSuite) TestAfterSyncMySQLUser(c *C) {
 	c.Assert(err, IsNil)
 	// MySQL mysql.user table schema is not identical to TiDB, check it doesn't break privilege.
 	c.Assert(p.RequestVerification("root", "localhost", "test", "", "", mysql.SelectPriv), IsTrue)
+
+	// Absent of those tables doesn't cause error.
+	mustExec(c, se, "DROP TABLE mysql.db;")
+	mustExec(c, se, "DROP TABLE mysql.tables_priv;")
+	mustExec(c, se, "DROP TABLE mysql.columns_priv;")
+	err = p.LoadAll()
+	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
If mysql.db doesn't exist, TiDB should be able to run.

See https://github.com/pingcap/tidb/issues/2715#issuecomment-282350271