### PR TITLE
parser: parse kill statement

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -320,8 +320,15 @@ type KillStmt struct {
 
 	// If Query is true, terminates the statement the connection is currently executing, but leaves the connection itself intact.
 	// If Query is false, terminates the connection associated with the given ConnectionID, after terminating any statement the connection is executing.
-	Query         bool
-	ConnectionID  uint64
+	Query        bool
+	ConnectionID uint64
+	// When the SQL grammar is "KILL TIDB [CONNECTION | QUERY] connectionID", TiDBExtension will be set.
+	// It's a special grammar extension in TiDB. This extension exists because, when the connection is:
+	// client -> LVS proxy -> TiDB, and type Ctrl+C in client, the following action will be executed:
+	// new a connection; kill xxx;
+	// kill command may send to the wrong TiDB, because the exists of LVS proxy, and kill the wrong session.
+	// So, "KILL TIDB" grammar is introduced, and it REQUIRES DIRECT client -> TiDB TOPOLOGY.
+	// TODO: The standard KILL grammar will be supported once we have global connectionID.
 	TiDBExtension bool
 }
 

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -40,6 +40,7 @@ var (
 	_ StmtNode = &UseStmt{}
 	_ StmtNode = &AnalyzeTableStmt{}
 	_ StmtNode = &FlushStmt{}
+	_ StmtNode = &KillStmt{}
 
 	_ Node = &PrivElem{}
 	_ Node = &VariableAssignment{}
@@ -310,6 +311,26 @@ func (n *FlushStmt) Accept(v Visitor) (Node, bool) {
 		return v.Leave(newNode)
 	}
 	n = newNode.(*FlushStmt)
+	return v.Leave(n)
+}
+
+// KillStmt is a statement to kill a query or connection.
+type KillStmt struct {
+	stmtNode
+
+	// If Query is true, terminates the statement the connection is currently executing, but leaves the connection itself intact.
+	// If Query is false, terminates the connection associated with the given ConnectionID, after terminating any statement the connection is executing.
+	Query        bool
+	ConnectionID uint64
+}
+
+// Accept implements Node Accept interface.
+func (n *KillStmt) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*KillStmt)
 	return v.Leave(n)
 }
 

--- a/ast/misc.go
+++ b/ast/misc.go
@@ -320,8 +320,9 @@ type KillStmt struct {
 
 	// If Query is true, terminates the statement the connection is currently executing, but leaves the connection itself intact.
 	// If Query is false, terminates the connection associated with the given ConnectionID, after terminating any statement the connection is executing.
-	Query        bool
-	ConnectionID uint64
+	Query         bool
+	ConnectionID  uint64
+	TiDBExtension bool
 }
 
 // Accept implements Node Accept interface.

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -74,6 +74,8 @@ func (e *SimpleExec) Next() (*Row, error) {
 		err = e.executeDropUser(x)
 	case *ast.SetPwdStmt:
 		err = e.executeSetPwd(x)
+	case *ast.KillStmt:
+		err = e.executeKillStmt(x)
 	case *ast.BinlogStmt:
 		// We just ignore it.
 		return nil, nil
@@ -300,6 +302,11 @@ func (e *SimpleExec) executeSetPwd(s *ast.SetPwdStmt) error {
 	sql := fmt.Sprintf(`UPDATE %s.%s SET password="%s" WHERE User="%s" AND Host="%s";`, mysql.SystemDB, mysql.UserTable, util.EncodePassword(s.Password), userName, host)
 	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
 	return errors.Trace(err)
+}
+
+func (e *SimpleExec) executeKillStmt(s *ast.KillStmt) error {
+	// TODO: Implement it.
+	return nil
 }
 
 func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -377,6 +377,7 @@ var tokenMap = map[string]int{
 	"QUARTER":                    quarter,
 	"QUICK":                      quick,
 	"RADIANS":                    radians,
+	"QUERY":                      query,
 	"QUOTE":                      quote,
 	"RANGE":                      rangeKwd,
 	"RAND":                       rand,
@@ -589,6 +590,7 @@ var tokenMap = map[string]int{
 	"RELEASE_ALL_LOCKS":          releaseAllLocks,
 	"UUID":                       uuid,
 	"UUID_SHORT":                 uuidShort,
+	"KILL":                       kill,
 }
 
 func isTokenIdentifier(s string, buf *bytes.Buffer) int {

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -430,6 +430,7 @@ var tokenMap = map[string]int{
 	"SUBSTRING_INDEX":            substringIndex,
 	"SUM":                        sum,
 	"SYSDATE":                    sysDate,
+	"TIDB":                       tidb,
 	"TABLE":                      tableKwd,
 	"TABLES":                     tables,
 	"TAN":                        tan,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -491,6 +491,7 @@ import (
 	tables		"TABLES"
 	textType	"TEXT"
 	than		"THAN"
+	tidb		"TIDB"
 	timeType	"TIME"
 	timestampType	"TIMESTAMP"
 	timestampDiff	"TIMESTAMPDIFF"
@@ -641,6 +642,7 @@ import (
 	JoinTable 		"join table"
 	JoinType		"join type"
 	KillStmt		"Kill statement"
+	KillOrKillTiDB		"Kill or Kill TiDB"
 	LikeEscapeOpt 		"like escape option"
 	LimitClause		"LIMIT clause"
 	LimitOption		"Limit option could be integer or parameter marker."
@@ -2238,8 +2240,8 @@ UnReservedKeyword:
  "ACTION" | "ASCII" | "AUTO_INCREMENT" | "AFTER" | "AT" | "AVG" | "BEGIN" | "BIT" | "BOOL" | "BOOLEAN" | "BTREE" | "CHARSET"
 | "COLUMNS" | "COMMIT" | "COMPACT" | "COMPRESSED" | "CONSISTENT" | "DATA" | "DATE" | "DATETIME" | "DEALLOCATE" | "DO"
 | "DYNAMIC"| "END" | "ENGINE" | "ENGINES" | "ESCAPE" | "EXECUTE" | "FIELDS" | "FIRST" | "FIXED" | "FORMAT" | "FULL" |"GLOBAL"
-| "HASH" | "LESS" | "LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" %prec lowerThanEq | "PREPARE" | "QUICK" | "REDUNDANT" 
-| "ROLLBACK" | "SESSION" | "SIGNED" | "SNAPSHOT" | "START" | "STATUS" | "TABLES" | "TEXT" | "THAN" | "TIME" | "TIMESTAMP" 
+| "HASH" | "LESS" | "LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" %prec lowerThanEq | "PREPARE" | "QUICK" | "REDUNDANT"
+| "ROLLBACK" | "SESSION" | "SIGNED" | "SNAPSHOT" | "START" | "STATUS" | "TABLES" | "TEXT" | "THAN" | "TIDB" | "TIME" | "TIMESTAMP"
 | "TRANSACTION" | "TRUNCATE" | "UNKNOWN" | "VALUE" | "WARNINGS" | "YEAR" | "MODE"  | "WEEK"  | "ANY" | "SOME" | "USER" | "IDENTIFIED"
 | "COLLATION" | "COMMENT" | "AVG_ROW_LENGTH" | "CONNECTION" | "CHECKSUM" | "COMPRESSION" | "KEY_BLOCK_SIZE" | "MAX_ROWS"
 | "MIN_ROWS" | "NATIONAL" | "ROW" | "ROW_FORMAT" | "QUARTER" | "GRANTS" | "TRIGGERS" | "DELAY_KEY_WRITE" | "ISOLATION"
@@ -6551,24 +6553,37 @@ TableLockList:
  *******************************************************************/
 
 KillStmt:
-	"KILL" NUM
+	KillOrKillTiDB NUM
 	{
 		$$ = &ast.KillStmt{
 			ConnectionID: getUint64FromNUM($2),
+			TiDBExtension: $1.(bool),
 		}
 	}
-|	"KILL" "CONNECTION" NUM
+|	KillOrKillTiDB "CONNECTION" NUM
 	{
 		$$ = &ast.KillStmt{
 			ConnectionID: getUint64FromNUM($3),
+			TiDBExtension: $1.(bool),
 		}
 	}
-|	"KILL" "QUERY" NUM
+|	KillOrKillTiDB "QUERY" NUM
 	{
 		$$ = &ast.KillStmt{
 			ConnectionID: getUint64FromNUM($3),
 			Query: true,
+			TiDBExtension: $1.(bool),
 		}
+	}
+
+KillOrKillTiDB:
+	"KILL"
+	{
+		$$ = false
+	}
+|	"KILL" "TIDB"
+	{
+		$$ = true
 	}
 
 %%

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6581,6 +6581,8 @@ KillOrKillTiDB:
 	{
 		$$ = false
 	}
+/* KILL TIDB is a special grammar extension in TiDB, it can be used only when
+   the client connect to TiDB directly, not proxied under LVS. */
 |	"KILL" "TIDB"
 	{
 		$$ = true

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -80,7 +80,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"auto_increment", "after", "begin", "bit", "bool", "boolean", "charset", "columns", "commit",
 		"date", "datediff", "datetime", "deallocate", "do", "from_days", "end", "engine", "engines", "execute", "first", "full",
 		"local", "names", "offset", "password", "prepare", "quick", "rollback", "session", "signed",
-		"start", "global", "tables", "text", "time", "timestamp", "transaction", "truncate", "unknown",
+		"start", "global", "tables", "text", "time", "timestamp", "tidb", "transaction", "truncate", "unknown",
 		"value", "warnings", "year", "now", "substr", "substring", "mode", "any", "some", "user", "identified",
 		"collation", "comment", "avg_row_length", "checksum", "compression", "connection", "key_block_size",
 		"max_rows", "min_rows", "national", "row", "quarter", "escape", "grants", "status", "fields", "triggers",
@@ -1464,6 +1464,9 @@ func (s *testParserSuite) TestSessionManage(c *C) {
 		{"kill 23123", true},
 		{"kill connection 23123", true},
 		{"kill query 23123", true},
+		{"kill tidb 23123", true},
+		{"kill tidb connection 23123", true},
+		{"kill tidb query 23123", true},
 	}
 	s.RunTest(c, table)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -48,7 +48,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"exists", "explain", "false", "float", "for", "force", "foreign", "from",
 		"fulltext", "grant", "group", "having", "hour_microsecond", "hour_minute",
 		"hour_second", "if", "ignore", "in", "index", "infile", "inner", "insert", "int", "into", "integer",
-		"interval", "is", "join", "key", "keys", "leading", "left", "like", "limit", "lines", "load",
+		"interval", "is", "join", "key", "keys", "kill", "leading", "left", "like", "limit", "lines", "load",
 		"localtime", "localtimestamp", "lock", "longblob", "longtext", "mediumblob", "maxvalue", "mediumint", "mediumtext",
 		"minute_microsecond", "minute_second", "mod", "not", "no_write_to_binlog", "null", "numeric",
 		"on", "option", "or", "order", "outer", "partition", "precision", "primary", "procedure", "range", "read", "real",
@@ -1454,4 +1454,16 @@ func (s *testParserSuite) TestTimestampDiffUnit(c *C) {
 	f, ok = expr.(*ast.FuncCallExpr)
 	c.Assert(ok, IsTrue)
 	c.Assert(f.Args[0].GetDatum().GetString(), Equals, "MONTH")
+}
+
+func (s *testParserSuite) TestSessionManage(c *C) {
+	defer testleak.AfterTest(c)()
+	table := []testCase{
+		// Kill statement.
+		// See https://dev.mysql.com/doc/refman/5.7/en/kill.html
+		{"kill 23123", true},
+		{"kill connection 23123", true},
+		{"kill query 23123", true},
+	}
+	s.RunTest(c, table)
 }

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -201,3 +201,13 @@ func toBit(l yyLexer, lval *yySymType, str string) int {
 	lval.item = b
 	return bitLit
 }
+
+func getUint64FromNUM(num interface{}) uint64 {
+	switch v := num.(type) {
+	case int64:
+		return uint64(v)
+	case uint64:
+		return uint64(v)
+	}
+	return 0
+}

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -116,7 +116,7 @@ func (b *planBuilder) build(node ast.Node) Plan {
 		return b.buildAnalyze(x)
 	case *ast.BinlogStmt, *ast.FlushStmt, *ast.UseStmt,
 		*ast.BeginStmt, *ast.CommitStmt, *ast.RollbackStmt, *ast.CreateUserStmt, *ast.SetPwdStmt,
-		*ast.GrantStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.RevokeStmt:
+		*ast.GrantStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.RevokeStmt, *ast.KillStmt:
 		return b.buildSimple(node.(ast.StmtNode))
 	case ast.DDLNode:
 		return b.buildDDL(x)


### PR DESCRIPTION
Parser support for kill statement https://dev.mysql.com/doc/refman/5.7/en/kill.html:

```
kill [query | connection] sessionID
```

This will be used for cancel session feature https://github.com/pingcap/tidb/issues/2528, together with the`show processlist` statement.