### PR TITLE
store/tikv: update max backoff.

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -118,17 +118,17 @@ func (t backoffType) String() string {
 const (
 	copBuildTaskMaxBackoff  = 5000
 	tsoMaxBackoff           = 5000
-	scannerNextMaxBackoff   = 20000
-	batchGetMaxBackoff      = 20000
-	copNextMaxBackoff       = 20000
-	getMaxBackoff           = 20000
-	prewriteMaxBackoff      = 20000
-	commitMaxBackoff        = 20000
+	scannerNextMaxBackoff   = 15000
+	batchGetMaxBackoff      = 15000
+	copNextMaxBackoff       = 15000
+	getMaxBackoff           = 15000
+	prewriteMaxBackoff      = 15000
+	commitMaxBackoff        = 15000
 	commitPrimaryMaxBackoff = -1
-	cleanupMaxBackoff       = 20000
+	cleanupMaxBackoff       = 15000
 	gcMaxBackoff            = 100000
 	gcResolveLockMaxBackoff = 100000
-	rawkvMaxBackoff         = 20000
+	rawkvMaxBackoff         = 15000
 )
 
 // Backoffer is a utility for retrying queries.

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -118,17 +118,17 @@ func (t backoffType) String() string {
 const (
 	copBuildTaskMaxBackoff  = 5000
 	tsoMaxBackoff           = 5000
-	scannerNextMaxBackoff   = 5000
-	batchGetMaxBackoff      = 10000
-	copNextMaxBackoff       = 10000
-	getMaxBackoff           = 10000
-	prewriteMaxBackoff      = 10000
-	commitMaxBackoff        = 10000
+	scannerNextMaxBackoff   = 20000
+	batchGetMaxBackoff      = 20000
+	copNextMaxBackoff       = 20000
+	getMaxBackoff           = 20000
+	prewriteMaxBackoff      = 20000
+	commitMaxBackoff        = 20000
 	commitPrimaryMaxBackoff = -1
-	cleanupMaxBackoff       = 10000
+	cleanupMaxBackoff       = 20000
 	gcMaxBackoff            = 100000
 	gcResolveLockMaxBackoff = 100000
-	rawkvMaxBackoff         = 5000
+	rawkvMaxBackoff         = 20000
 )
 
 // Backoffer is a utility for retrying queries.


### PR DESCRIPTION
Based on the current tikv-server configuration, the leader election could last for more than 10 seconds. Therefore, max backoff need to be adjusted.

PTAL @coocood 