### PR TITLE
parser: grant select on test.* to 'test'

### DIFF
--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -187,3 +187,13 @@ func (s *testSuite) TestIssue2456(c *C) {
 	tk.MustExec("GRANT ALL PRIVILEGES ON `dddb_%`.* TO 'dduser'@'%';")
 	tk.MustExec("GRANT ALL PRIVILEGES ON `dddb_%`.`te%` to 'dduser'@'%';")
 }
+
+func (s *testSuite) TestIssue2654(c *C) {
+	defer testleak.AfterTest(c)()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("DROP USER IF EXISTS 'test'@'%'")
+	tk.MustExec("CREATE USER 'test'@'%' IDENTIFIED BY 'test'")
+	tk.MustExec("GRANT SELECT ON test.* to 'test'")
+	rows := tk.MustQuery("SELECT user,host FROM mysql.user WHERE user='test' and host='%'")
+	rows.Check(testkit.Rows("[116 101 115 116] [37]")) // "test" "%"
+}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5064,7 +5064,11 @@ UserVariable:
 	}
 
 Username:
-	stringLit "AT" stringLit
+	stringLit
+	{
+		$$ = $1 + "@%"
+	}
+|	stringLit "AT" stringLit
 	{
 		$$ = $1 + "@" + $3
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1242,6 +1242,7 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 	defer testleak.AfterTest(c)()
 	table := []testCase{
 		// for create user
+		{`CREATE USER 'test'`, true},
 		{`CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD 'hashstring'`, true},
@@ -1267,6 +1268,7 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 		{"GRANT SELECT, INSERT ON mydb.mytbl TO 'someuser'@'somehost';", true},
 		{"GRANT SELECT (col1), INSERT (col1,col2) ON mydb.mytbl TO 'someuser'@'somehost';", true},
 		{"grant all privileges on zabbix.* to 'zabbix'@'localhost' identified by 'password';", true},
+		{"GRANT SELECT ON test.* to 'test'", true}, // For issue 2654.
 
 		// for revoke statement
 		{"REVOKE ALL ON db1.* FROM 'jeffrey'@'localhost';", true},


### PR DESCRIPTION
fix issue https://github.com/pingcap/tidb/issues/2654
grant select on test.* to 'test' is the same as
grant select on test.* to 'test'@'%'