### PR TITLE
*: fix prepared statement panic

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -826,6 +826,7 @@ func (b *planBuilder) buildSelect(sel *ast.SelectStmt) LogicalPlan {
 	if b.err != nil {
 		return nil
 	}
+	originalFields := sel.Fields.Fields
 	sel.Fields.Fields = b.unfoldWildStar(p, sel.Fields.Fields)
 	if b.err != nil {
 		return nil
@@ -892,6 +893,7 @@ func (b *planBuilder) buildSelect(sel *ast.SelectStmt) LogicalPlan {
 			return nil
 		}
 	}
+	sel.Fields.Fields = originalFields
 	if oldLen != p.Schema().Len() {
 		return b.buildTrim(p, oldLen)
 	}

--- a/session_test.go
+++ b/session_test.go
@@ -92,7 +92,6 @@ func (s *testSessionSuite) TestPrepare(c *C) {
 	c.Assert(err, IsNil)
 	err = se.DropPreparedStmt(id)
 	c.Assert(err, IsNil)
-	mustExecSQL(c, se, dropDBSQL)
 
 	mustExecSQL(c, se, "prepare stmt from 'select 1+?'")
 	mustExecSQL(c, se, "set @v1=100")
@@ -113,6 +112,20 @@ func (s *testSessionSuite) TestPrepare(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r.Data[0].GetFloat64(), Equals, float64(301))
 	mustExecSQL(c, se, "deallocate prepare stmt")
+
+	// Execute prepared statements for more than one time.
+	mustExecSQL(c, se,"create table multiexec (a int, b int)")
+	mustExecSQL(c, se, "insert multiexec values (1, 1), (2, 2)")
+	id, _, _, err = se.PrepareStmt("select a from multiexec where b = ? order by b")
+	c.Assert(err, IsNil)
+	rs, err = se.ExecutePreparedStmt(id,1)
+	c.Assert(err, IsNil)
+	rs.Close()
+	rs, err = se.ExecutePreparedStmt(id,2)
+	rs.Close()
+	c.Assert(err, IsNil)
+
+	mustExecSQL(c, se, dropDBSQL)
 }
 
 func (s *testSessionSuite) TestAffectedRows(c *C) {

--- a/session_test.go
+++ b/session_test.go
@@ -114,14 +114,14 @@ func (s *testSessionSuite) TestPrepare(c *C) {
 	mustExecSQL(c, se, "deallocate prepare stmt")
 
 	// Execute prepared statements for more than one time.
-	mustExecSQL(c, se,"create table multiexec (a int, b int)")
+	mustExecSQL(c, se, "create table multiexec (a int, b int)")
 	mustExecSQL(c, se, "insert multiexec values (1, 1), (2, 2)")
 	id, _, _, err = se.PrepareStmt("select a from multiexec where b = ? order by b")
 	c.Assert(err, IsNil)
-	rs, err = se.ExecutePreparedStmt(id,1)
+	rs, err = se.ExecutePreparedStmt(id, 1)
 	c.Assert(err, IsNil)
 	rs.Close()
-	rs, err = se.ExecutePreparedStmt(id,2)
+	rs, err = se.ExecutePreparedStmt(id, 2)
 	rs.Close()
 	c.Assert(err, IsNil)
 


### PR DESCRIPTION
`ast.SelectStmt.Fields` is changed during plan building,
newly created `ast.ColumnNameExpr` has nil Refer.