### PR TITLE
plan, types: add type class, infer coalesce.

### DIFF
--- a/plan/typeinferer_test.go
+++ b/plan/typeinferer_test.go
@@ -237,6 +237,10 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 		{`md5(123)`, mysql.TypeVarString, "utf8"},
 		{`sha1(123)`, mysql.TypeVarString, "utf8"},
 		{`sha(123)`, mysql.TypeVarString, "utf8"},
+		{`coalesce(null, 0)`, mysql.TypeLonglong, charset.CharsetBin},
+		{`coalesce(null, 0.1)`, mysql.TypeNewDecimal, charset.CharsetBin},
+		{`coalesce(1, "1" + 1)`, mysql.TypeDouble, charset.CharsetBin},
+		{`coalesce(1, "abc")`, mysql.TypeVarString, charset.CharsetUTF8},
 	}
 	for _, ca := range cases {
 		ctx := testKit.Se.(context.Context)

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -26,6 +26,18 @@ const (
 	UnspecifiedLength int = -1
 )
 
+// TypeClass classifies types, used for type inference.
+type TypeClass byte
+
+// TypeClass values.
+const (
+	ClassString  TypeClass = 0
+	ClassReal    TypeClass = 1
+	ClassInt     TypeClass = 2
+	ClassRow     TypeClass = 3
+	ClassDecimal TypeClass = 4
+)
+
 // FieldType records field type information.
 type FieldType struct {
 	Tp      byte
@@ -45,6 +57,37 @@ func NewFieldType(tp byte) *FieldType {
 		Tp:      tp,
 		Flen:    UnspecifiedLength,
 		Decimal: UnspecifiedLength,
+	}
+}
+
+// ToClass maps the field type to a type class.
+func (ft *FieldType) ToClass() TypeClass {
+	switch ft.Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
+		mysql.TypeBit, mysql.TypeYear:
+		return ClassInt
+	case mysql.TypeNewDecimal:
+		return ClassDecimal
+	case mysql.TypeFloat, mysql.TypeDouble:
+		return ClassReal
+	default:
+		return ClassString
+	}
+}
+
+// ToType maps the type class to a type.
+func (tc TypeClass) ToType() byte {
+	switch tc {
+	case ClassString:
+		return mysql.TypeVarString
+	case ClassReal:
+		return mysql.TypeDouble
+	case ClassInt:
+		return mysql.TypeLonglong
+	case ClassDecimal:
+		return mysql.TypeNewDecimal
+	default:
+		return mysql.TypeUnspecified
 	}
 }
 


### PR DESCRIPTION
The implementation reference MySQL's source code.
`TypeClass` corresponds to `Item_result` in MySQL.