### PR TITLE
store/tikv: increase minLogCopTaskTime.

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -308,7 +308,7 @@ type copIterator struct {
 	errChan  chan error
 }
 
-const minLogCopTaskTime = 50 * time.Millisecond
+const minLogCopTaskTime = time.Second
 
 // Pick the next new copTask and send request to tikv-server.
 func (it *copIterator) work(ctx goctx.Context) {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -308,7 +308,7 @@ type copIterator struct {
 	errChan  chan error
 }
 
-const minLogCopTaskTime = time.Second
+const minLogCopTaskTime = 300 * time.Millisecond
 
 // Pick the next new copTask and send request to tikv-server.
 func (it *copIterator) work(ctx goctx.Context) {


### PR DESCRIPTION
50ms produces too many logs in some environment.
And there are other places to log distsql.