### PR TITLE
*: tiny refact move SetProcessInfo

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -106,11 +106,6 @@ func (e *DDLExec) Next() (*Row, error) {
 
 // Close implements the Executor Close interface.
 func (e *DDLExec) Close() error {
-	if pi, ok := e.ctx.(processinfoSetter); ok {
-		if pi != nil {
-			pi.SetProcessInfo("")
-		}
-	}
 	return nil
 }
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -106,6 +106,11 @@ func (e *DDLExec) Next() (*Row, error) {
 
 // Close implements the Executor Close interface.
 func (e *DDLExec) Close() error {
+	if pi, ok := e.ctx.(processinfoSetter); ok {
+		if pi != nil {
+			pi.SetProcessInfo("")
+		}
+	}
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -543,9 +543,6 @@ func (s *session) Execute(sql string) ([]ast.RecordSet, error) {
 		s.stmtState = ph.StartStatement(sql, connID, perfschema.CallerNameSessionExecute, rawStmts[i])
 		s.SetValue(context.QueryString, st.OriginText())
 
-		// Update processinfo, ShowProcess() will use it.
-		s.SetProcessInfo(st.OriginText())
-
 		startTS = time.Now()
 		r, err := runStmt(s, st)
 		ph.EndStatement(s.stmtState)
@@ -637,9 +634,6 @@ func (s *session) ExecutePreparedStmt(stmtID uint32, args ...interface{}) (ast.R
 	}
 	s.prepareTxnCtx()
 	st := executor.CompileExecutePreparedStmt(s, stmtID, args...)
-
-	// Update processinfo, ShowProcess() will use it.
-	s.SetProcessInfo(st.OriginText())
 
 	r, err := runStmt(s, st)
 	return r, errors.Trace(err)


### PR DESCRIPTION
move SetProcessInfo to `statement.Exec()`.

Set and reset process info should be balanced. 
Each time we set it, we should know exactly when to reset it. 

Here is the rules:

1. set it in `statement.Exec`
2. reset it in `recordSet.Close`
3. reset it in `statement.Exec`, if `recordSet.Close` unavailable (error happend or recordSet is nil)
