### PR TITLE
plan: forbid limit to push across selection.

### DIFF
--- a/plan/match_property.go
+++ b/plan/match_property.go
@@ -231,10 +231,7 @@ func (p *Selection) matchProperty(prop *requiredProperty, childPlanInfo ...*phys
 		res.count = uint64(float64(res.count) * selectionFactor)
 		return res
 	}
-	np := *p
-	np.SetChildren(childPlanInfo[0].p)
-	count := uint64(float64(childPlanInfo[0].count) * selectionFactor)
-	return &physicalPlanInfo{p: &np, cost: childPlanInfo[0].cost, count: count}
+	return childPlanInfo[0]
 }
 
 // matchProperty implements PhysicalPlan matchProperty interface.

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -418,6 +418,14 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			best: "LeftHashJoin{Table(t)->Table(t)}(a.c,b.c)->HashAgg->Sort->Trim",
 		},
 		{
+			sql:  "select * from t t1 left outer join t t2 on true where least(1,2,3,t1.a,t2.b) > 0 order by t2.a limit 10",
+			best: "LeftHashJoin{Table(t)->Table(t)}->Selection->Sort + Limit(10) + Offset(0)",
+		},
+		{
+			sql:  "select * from t t1 left outer join t t2 on true where least(1,2,3,t1.a,t2.b) > 0 limit 10",
+			best: "LeftHashJoin{Table(t)->Table(t)}->Selection->Limit",
+		},
+		{
 			sql:  "select count(*) from t where concat(a,b) = 'abc' group by c",
 			best: "Index(t.c_d_e)[[<nil>,+inf]]->Selection->StreamAgg",
 		},

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -130,6 +130,19 @@ func (p *requiredProperty) getHashKey() ([]byte, error) {
 	return bytes, errors.Trace(err)
 }
 
+// String implements fmt.Stringer interface. Just for test.
+func (p *requiredProperty) String() string {
+	ret := "Prop{"
+	for _, colProp := range p.props {
+		ret += fmt.Sprintf("col: %s, desc %v, ", colProp.col, colProp.desc)
+	}
+	ret += fmt.Sprintf("}, Len: %d", p.sortKeyLen)
+	if p.limit != nil {
+		ret += fmt.Sprintf(", Limit: %d,%d", p.limit.Offset, p.limit.Count)
+	}
+	return ret
+}
+
 type physicalPlanInfo struct {
 	p     PhysicalPlan
 	cost  float64


### PR DESCRIPTION
When the SQL is `Select * from t left join s on true where least(1,2,3,t1.a,t2.b) > 0 order by t2.a limit 10`, the old plan is `Join(t,s)->TopN->Selection`, it's wrong. After fixing it, the plan is `Join(t,s)->Selection->TopN`.
@shenli @coocood @zimulala PTAL