### PR TITLE
store/tikv: create GC session after bootstrap.

### DIFF
--- a/store/tikv/gc_worker_test.go
+++ b/store/tikv/gc_worker_test.go
@@ -103,3 +103,14 @@ func (s *testGCWorkerSuite) TestPrepareGC(c *C) {
 	c.Assert(err, IsNil)
 	s.timeEqual(c, safePoint.Add(time.Minute*30), now, time.Second)
 }
+
+func (s *testGCWorkerSuite) TestBootstrapped(c *C) {
+	store := newTestStore(c)
+	store.oracle = &mockOracle{}
+	gcWorker, err := NewGCWorker(store)
+	c.Assert(err, IsNil)
+	c.Assert(gcWorker.storeIsBootstrapped(), IsFalse)
+	_, err = tidb.BootstrapSession(store)
+	c.Assert(err, IsNil)
+	c.Assert(gcWorker.storeIsBootstrapped(), IsTrue)
+}

--- a/store/tikv/gc_worker_test.go
+++ b/store/tikv/gc_worker_test.go
@@ -63,6 +63,9 @@ func (s *testGCWorkerSuite) TestGetOracleTime(c *C) {
 func (s *testGCWorkerSuite) TestPrepareGC(c *C) {
 	now, err := s.gcWorker.getOracleTime()
 	c.Assert(err, IsNil)
+	session, err := tidb.CreateSession(s.store)
+	c.Check(err, IsNil)
+	s.gcWorker.session = session
 	ok, _, err := s.gcWorker.prepare()
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsTrue)


### PR DESCRIPTION
When we create TiKV store for the first time, the GC session is created before bootstrap.
After bootstrap, the domain bound to GC session is closed, so the GC InfoSchema never updates,
keeps failing with schema out of date error.