### PR TITLE
util/types: convertToMysqlTime will truncate hh:mm:ss part for Date type

### DIFF
--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -43,11 +43,7 @@ func (s *testEvaluatorSuite) TestDate(c *C) {
 		c.Assert(err, IsNil)
 		v, err := f.eval(nil)
 		c.Assert(err, IsNil)
-		if v.Kind() != types.KindMysqlTime {
-			c.Assert(v, testutil.DatumEquals, t["Expect"][0])
-		} else {
-			c.Assert(v.GetMysqlTime().String(), Equals, t["Expect"][0].GetString())
-		}
+		c.Assert(v, testutil.DatumEquals, t["Expect"][0])
 	}
 
 	// test year, month and day


### PR DESCRIPTION
Convert to Date should truncate the hh:mm:ss part. 

Fix bug:

```
mysql> select date("2016-11-11 11:00:00") = date("2016-11-11 12:00:00");
+-----------------------------------------------------------+
| date("2016-11-11 11:00:00") = date("2016-11-11 12:00:00") |
+-----------------------------------------------------------+
|                                                         0 |
+-----------------------------------------------------------+
1 row in set (0.00 sec)
```