### PR TITLE
ddl: Make reorg test stable

### DIFF
--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -71,8 +71,6 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	job := &model.Job{}
 	err = d.runReorgJob(job, f)
 	c.Assert(err, NotNil)
-	c.Assert(job.RowCount, Equals, rowCount)
-	c.Assert(d.reorgRowCount, Equals, rowCount)
 
 	<-done
 	// Make sure the function of f is returned.


### PR DESCRIPTION
It may not have executed the `setReorgRowCount` in the function of `f` after running `runReorgJob`.