### PR TITLE
session: log retryable errors.

### DIFF
--- a/session.go
+++ b/session.go
@@ -255,7 +255,7 @@ func (s *session) doCommitWithRetry() error {
 	err := s.doCommit()
 	if err != nil {
 		if s.isRetryableError(err) {
-			log.Warnf("[%d] retryable error: %v, txn: %v", err, s.txn)
+			log.Warnf("[%d] retryable error: %v, txn: %v", s.sessionVars.ConnectionID, err, s.txn)
 			// Transactions will retry 2 ~ commitRetryLimit times.
 			// We make larger transactions retry less times to prevent cluster resource outage.
 			txnSizeRate := float64(txnSize) / float64(kv.TxnTotalSizeLimit)
@@ -367,7 +367,7 @@ func (s *session) retry(maxCnt int) error {
 			log.Warnf("[%d] Retry reached max count %d", connID, retryCnt)
 			return errors.Trace(err)
 		}
-		log.Warnf("[%d] retryable error: %v, txn: %v", err, s.txn)
+		log.Warnf("[%d] retryable error: %v, txn: %v", connID, err, s.txn)
 		kv.BackOff(retryCnt)
 	}
 	return err

--- a/session.go
+++ b/session.go
@@ -255,6 +255,7 @@ func (s *session) doCommitWithRetry() error {
 	err := s.doCommit()
 	if err != nil {
 		if s.isRetryableError(err) {
+			log.Warnf("[%d] retryable error: %v, txn: %v", err, s.txn)
 			// Transactions will retry 2 ~ commitRetryLimit times.
 			// We make larger transactions retry less times to prevent cluster resource outage.
 			txnSizeRate := float64(txnSize) / float64(kv.TxnTotalSizeLimit)
@@ -363,9 +364,10 @@ func (s *session) retry(maxCnt int) error {
 		}
 		retryCnt++
 		if !s.unlimitedRetryCount && (retryCnt >= maxCnt) {
-			log.Warnf("[%id] Retry reached max count %d", connID, retryCnt)
+			log.Warnf("[%d] Retry reached max count %d", connID, retryCnt)
 			return errors.Trace(err)
 		}
+		log.Warnf("[%d] retryable error: %v, txn: %v", err, s.txn)
 		kv.BackOff(retryCnt)
 	}
 	return err


### PR DESCRIPTION
We need the logs to diagnose the reason that a transaction runs out retry limit.
cc @coocood @shenli 