### PR TITLE
expression: keep the return value of builtin conv consistent with mysql

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -498,6 +498,7 @@ func (b *builtinConvSig) eval(row []types.Datum) (d types.Datum, err error) {
 	}
 	n = getValidPrefix(strings.TrimSpace(n), fromBase)
 	if len(n) == 0 {
+		d.SetString("0")
 		return d, nil
 	}
 	if n[0] == '-' {

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -271,7 +271,7 @@ func (s *testEvaluatorSuite) TestConv(c *C) {
 		{[]interface{}{"TIDB", 10, 8}, "0"},
 		{[]interface{}{"aa", 10, 2}, "0"},
 		{[]interface{}{" A", -10, 16}, "0"},
-		{[]interface{}{"6E", 10, 8}, "0"},
+		{[]interface{}{"a6a", 10, 8}, "0"},
 	}
 
 	Dtbl := tblToDtbl(tbl)

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -271,7 +271,7 @@ func (s *testEvaluatorSuite) TestConv(c *C) {
 		{[]interface{}{"TIDB", 10, 8}, "0"},
 		{[]interface{}{"aa", 10, 2}, "0"},
 		{[]interface{}{" A", -10, 16}, "0"},
-		{[]interface{}{"6E", 18, 8}, "0"},
+		{[]interface{}{"6E", 10, 8}, "0"},
 	}
 
 	Dtbl := tblToDtbl(tbl)

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -268,6 +268,10 @@ func (s *testEvaluatorSuite) TestConv(c *C) {
 		{[]interface{}{"18446744073709551615", -10, 16}, "7FFFFFFFFFFFFFFF"},
 		{[]interface{}{"12F", -10, 16}, "C"},
 		{[]interface{}{"  FF ", 16, 10}, "255"},
+		{[]interface{}{"TIDB", 10, 8}, "0"},
+		{[]interface{}{"aa", 10, 2}, "0"},
+		{[]interface{}{" A", -10, 16}, "0"},
+		{[]interface{}{"6E", 18, 8}, "0"},
 	}
 
 	Dtbl := tblToDtbl(tbl)


### PR DESCRIPTION
when the input value is invalid, set the return value to "0"  