### PR TITLE
table/tables: fix update unique index in transaction

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -439,6 +439,15 @@ func (s *testSuite) TestUpdate(c *C) {
 	r = tk.MustQuery("select * from update_test;")
 	r.Check(testkit.Rows("2"))
 	tk.MustExec("commit")
+
+	// Test that in a transactio, when a constrain failed in an update statement, the record is not inserted.
+	tk.MustExec("create table update_unique (id int primary key, name int unique)")
+	tk.MustExec("insert update_unique values (1, 1), (2, 2);")
+	tk.MustExec("begin")
+	_, err = tk.Exec("update update_unique set name = 1 where id = 2")
+	c.Assert(err, NotNil)
+	tk.MustExec("commit")
+	tk.MustQuery("select * from update_unique").Check(testkit.Rows("1 1", "2 2"))
 }
 
 func (s *testSuite) fillMultiTableForUpdate(tk *testkit.TestKit) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -440,7 +440,7 @@ func (s *testSuite) TestUpdate(c *C) {
 	r.Check(testkit.Rows("2"))
 	tk.MustExec("commit")
 
-	// Test that in a transactio, when a constrain failed in an update statement, the record is not inserted.
+	// Test that in a transaction, when a constraint failed in an update statement, the record is not inserted.
 	tk.MustExec("create table update_unique (id int primary key, name int unique)")
 	tk.MustExec("insert update_unique values (1, 1), (2, 2);")
 	tk.MustExec("begin")

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -199,10 +199,10 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData []types.Datum
 	// Set new row data into KV.
 	key := t.RecordKey(h)
 	value, err := tablecodec.EncodeRow(currentData, colIDs)
-	if err = txn.Set(key, value); err != nil {
+	if err != nil {
 		return errors.Trace(err)
 	}
-	if err = bs.SaveTo(txn); err != nil {
+	if err = bs.Set(key, value); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
When update a record in a table, the buffer store should be used instead of txn to make it atomic.