### PR TITLE
ddl: Avoid assert in the index test

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -225,7 +225,8 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(d *ddl, ctx context.Context, d
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "1 2 <nil>", "2 3 3"))
+	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(),
+		testutil.RowsWithSep(" ", "1 2 <nil>", "2 3 3"))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -240,7 +241,7 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(d *ddl, ctx context.Context, d
 		return errors.Errorf("expect %v, got %v", expect, got)
 	}
 	// DeleteOnlyTable: select * from t
-	err = checkResult(ctx, deleteOnlyTable, testutil.RowsWithSep(" ", "1 2", "2 3"))
+	err = checkResult(ctx, deleteOnlyTable, deleteOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "1 2", "2 3"))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -258,7 +259,7 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(d *ddl, ctx context.Context, d
 		return errors.Trace(err)
 	}
 	// After we update the first row, its default value is also set.
-	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "2 2 3", "2 3 3"))
+	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "2 2 3", "2 3 3"))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -272,7 +273,7 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(d *ddl, ctx context.Context, d
 		return errors.Trace(err)
 	}
 	// After delete table has deleted the first row, check the WriteOnly table records.
-	err = checkResult(ctx, writeOnlyTable, testutil.RowsWithSep(" ", "2 3 3"))
+	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "2 3 3"))
 	return errors.Trace(err)
 }
 
@@ -316,7 +317,7 @@ func (s *testColumnChangeSuite) checkAddPublic(d *ddl, ctx context.Context, writ
 		return errors.Trace(err)
 	}
 	// publicTable select * from t, make sure the new c3 value 4 is not overwritten to default value 3.
-	err = checkResult(ctx, publicTable, testutil.RowsWithSep(" ", "2 3 3", "3 4 4"))
+	err = checkResult(ctx, publicTable, publicTable.WritableCols(), testutil.RowsWithSep(" ", "2 3 3", "3 4 4"))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -345,9 +346,9 @@ func getCurrentTable(d *ddl, schemaID, tableID int64) (table.Table, error) {
 	return tbl, err
 }
 
-func checkResult(ctx context.Context, t table.Table, rows [][]interface{}) error {
+func checkResult(ctx context.Context, t table.Table, cols []*table.Column, rows [][]interface{}) error {
 	var gotRows [][]interface{}
-	t.IterRecords(ctx, t.FirstKey(), t.WritableCols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
+	t.IterRecords(ctx, t.FirstKey(), cols, func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
 		gotRows = append(gotRows, datumsToInterfaces(data))
 		return true, nil
 	})

--- a/ddl/index_test.go
+++ b/ddl/index_test.go
@@ -16,6 +16,7 @@ package ddl
 import (
 	"strings"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
@@ -166,27 +167,42 @@ func getIndex(t table.Table, name string) table.Index {
 	return nil
 }
 
-func (s *testIndexSuite) testGetIndex(c *C, t table.Table, name string, isExist bool) {
+func (s *testIndexSuite) testGetIndex(c *C, t table.Table, name string, isExist bool) error {
 	index := tables.FindIndexByColName(t, name)
 	if isExist {
-		c.Assert(index, NotNil)
-	} else {
-		c.Assert(index, IsNil)
+		if index == nil {
+			return errors.Errorf("index exist got nil, expected not nil")
+		}
+		return nil
 	}
+	if index != nil {
+		return errors.Errorf("index exist got %v, expected nil", index)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol table.Index, columnValues []types.Datum, isExist bool) {
-	c.Assert(len(indexCol.Meta().Columns), Equals, len(columnValues))
+func (s *testIndexSuite) checkIndexKVExist(c *C, ctx context.Context, t table.Table, handle int64, indexCol table.Index, columnValues []types.Datum, isExist bool) error {
+	idxColsLen := len(indexCol.Meta().Columns)
+	if idxColsLen != len(columnValues) {
+		return errors.Errorf("index columns length got %d, expected %d", idxColsLen, len(columnValues))
+	}
 
 	err := ctx.NewTxn()
-	c.Assert(err, IsNil)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	exist, _, err := indexCol.Exist(ctx.Txn(), columnValues, handle)
-	c.Assert(err, IsNil)
-	c.Assert(exist, Equals, isExist)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if exist != isExist {
+		return errors.Errorf("index exist got %v, expected %v", exist, isExist)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum) {
+func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum) error {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
 	columnValues := make([]types.Datum, len(index.Meta().Columns))
@@ -194,337 +210,420 @@ func (s *testIndexSuite) checkNoneIndex(c *C, ctx context.Context, d *ddl, tblIn
 		columnValues[i] = row[column.Offset]
 	}
 
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-	s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	err := s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkDeleteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) error {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i := int64(0)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, row)
-		i++
-		return true, nil
-	})
-	c.Assert(err, IsNil)
-	c.Assert(i, Equals, int64(1))
-
+	err := ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkResult(ctx, t, t.Cols(), [][]interface{}{datumsToInterfaces(row)})
+	if err != nil {
+		return errors.Trace(err)
+	}
 	columnValues := make([]types.Datum, len(index.Meta().Columns))
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = row[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, isDropped)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, isDropped)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test add a new row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newRow := types.MakeDatums(int64(11), int64(22), int64(33))
 	handle, err = t.AddRecord(ctx, newRow)
-	c.Assert(err, IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	rows := [][]types.Datum{row, newRow}
-
-	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, rows[i])
-		i++
-		return true, nil
-	})
-	c.Assert(i, Equals, int64(2))
-
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rows := [][]interface{}{datumsToInterfaces(row), datumsToInterfaces(newRow)}
+	err = checkResult(ctx, t, t.Cols(), rows)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test update a new row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newUpdateRow := types.MakeDatums(int64(44), int64(55), int64(66))
 	touched := map[int]bool{0: true, 1: true, 2: true}
 	err = t.UpdateRecord(ctx, handle, newRow, newUpdateRow, touched)
-	c.Assert(err, IsNil)
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newUpdateRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test remove a row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	err = t.RemoveRecord(ctx, handle, newUpdateRow)
-	c.Assert(err, IsNil)
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i = int64(0)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	count := 0
 	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		i++
+		count++
 		return true, nil
 	})
-	c.Assert(i, Equals, int64(1))
+	if count != 1 {
+		return errors.Errorf("count got %d, expected %d", count, 1)
+	}
 
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-	s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkWriteOnlyIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) error {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i := int64(0)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, row)
-		i++
-		return true, nil
-	})
-	c.Assert(err, IsNil)
-	c.Assert(i, Equals, int64(1))
-
+	err := ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkResult(ctx, t, t.Cols(), [][]interface{}{datumsToInterfaces(row)})
+	if err != nil {
+		return errors.Trace(err)
+	}
 	columnValues := make([]types.Datum, len(index.Meta().Columns))
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = row[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, isDropped)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, isDropped)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test add a new row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newRow := types.MakeDatums(int64(11), int64(22), int64(33))
 	handle, err = t.AddRecord(ctx, newRow)
-	c.Assert(err, IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	rows := [][]types.Datum{row, newRow}
-
-	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, rows[i])
-		i++
-		return true, nil
-	})
-	c.Assert(i, Equals, int64(2))
-
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rows := [][]interface{}{datumsToInterfaces(row), datumsToInterfaces(newRow)}
+	err = checkResult(ctx, t, t.Cols(), rows)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test update a new row.
 	err = ctx.NewTxn()
-	c.Assert(err, IsNil)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newUpdateRow := types.MakeDatums(int64(44), int64(55), int64(66))
 	touched := map[int]bool{0: true, 1: true, 2: true}
 	err = t.UpdateRecord(ctx, handle, newRow, newUpdateRow, touched)
-	c.Assert(err, IsNil)
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newUpdateRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test remove a row.
 	err = ctx.NewTxn()
-	c.Assert(err, IsNil)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	err = t.RemoveRecord(ctx, handle, newUpdateRow)
-	c.Assert(err, IsNil)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	err = ctx.NewTxn()
-	c.Assert(err, IsNil)
-
-	i = int64(0)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	count := 0
 	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		i++
+		count++
 		return true, nil
 	})
-	c.Assert(i, Equals, int64(1))
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-	s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if count != 1 {
+		return errors.Errorf("count got %d, expected %d", count, 1)
+	}
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkReorganizationIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) error {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i := int64(0)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, row)
-		i++
-		return true, nil
-	})
-	c.Assert(err, IsNil)
-	c.Assert(i, Equals, int64(1))
+	err := ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkResult(ctx, t, t.Cols(), [][]interface{}{datumsToInterfaces(row)})
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test add a new row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newRow := types.MakeDatums(int64(11), int64(22), int64(33))
 	handle, err = t.AddRecord(ctx, newRow)
-	c.Assert(err, IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	rows := [][]types.Datum{row, newRow}
-
-	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, rows[i])
-		i++
-		return true, nil
-	})
-	c.Assert(i, Equals, int64(2))
-
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rows := [][]interface{}{datumsToInterfaces(row), datumsToInterfaces(newRow)}
+	err = checkResult(ctx, t, t.Cols(), rows)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	columnValues := make([]types.Datum, len(index.Meta().Columns))
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, !isDropped)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, !isDropped)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test update a new row.
-	c.Assert(ctx.NewTxn(), IsNil)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newUpdateRow := types.MakeDatums(int64(44), int64(55), int64(66))
 	touched := map[int]bool{0: true, 1: true, 2: true}
 	err = t.UpdateRecord(ctx, handle, newRow, newUpdateRow, touched)
-	c.Assert(err, IsNil)
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newUpdateRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, !isDropped)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, !isDropped)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test remove a row.
-	c.Assert(ctx.NewTxn(), IsNil)
-	c.Assert(t.RemoveRecord(ctx, handle, newUpdateRow), IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i = int64(0)
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = t.RemoveRecord(ctx, handle, newUpdateRow)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	count := 0
 	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		i++
+		count++
 		return true, nil
 	})
-	c.Assert(i, Equals, int64(1))
-
-	s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if count != 1 {
+		return errors.Errorf("count got %d, expected %d", count, 1)
+	}
+	err = s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum) {
+func (s *testIndexSuite) checkPublicIndex(c *C, ctx context.Context, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum) error {
 	t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	i := int64(0)
-	err := t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, row)
-		i++
-		return true, nil
-	})
-	c.Assert(err, IsNil)
-	c.Assert(i, Equals, int64(1))
-
+	err := ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkResult(ctx, t, t.Cols(), [][]interface{}{datumsToInterfaces(row)})
+	if err != nil {
+		return errors.Trace(err)
+	}
 	columnValues := make([]types.Datum, len(index.Meta().Columns))
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = row[column.Offset]
 	}
-
 	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test add a new row.
 	err = ctx.NewTxn()
-	c.Assert(err, IsNil)
-
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newRow := types.MakeDatums(int64(11), int64(22), int64(33))
 	handle, err = t.AddRecord(ctx, newRow)
-	c.Assert(err, IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-
-	rows := [][]types.Datum{row, newRow}
-
-	i = int64(0)
-	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		c.Assert(data, DeepEquals, rows[i])
-		i++
-		return true, nil
-	})
-	c.Assert(i, Equals, int64(2))
-
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	rows := [][]interface{}{datumsToInterfaces(row), datumsToInterfaces(newRow)}
+	err = checkResult(ctx, t, t.Cols(), rows)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newRow[column.Offset]
 	}
-
 	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test update a new row.
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	newUpdateRow := types.MakeDatums(int64(44), int64(55), int64(66))
 	touched := map[int]bool{0: true, 1: true, 2: true}
-	c.Assert(ctx.NewTxn(), IsNil)
-	c.Assert(t.UpdateRecord(ctx, handle, newRow, newUpdateRow, touched), IsNil)
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = t.UpdateRecord(ctx, handle, newRow, newUpdateRow, touched)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	for i, column := range index.Meta().Columns {
 		columnValues[i] = newUpdateRow[column.Offset]
 	}
-
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
 
 	// Test remove a row.
-	c.Assert(ctx.NewTxn(), IsNil)
-	c.Assert(t.RemoveRecord(ctx, handle, newUpdateRow), IsNil)
-
-	c.Assert(ctx.NewTxn(), IsNil)
-	i = int64(0)
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = t.RemoveRecord(ctx, handle, newUpdateRow)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = ctx.NewTxn()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	count := 0
 	t.IterRecords(ctx, t.FirstKey(), t.Cols(), func(h int64, data []types.Datum, cols []*table.Column) (bool, error) {
-		i++
+		count++
 		return true, nil
 	})
-	c.Assert(i, Equals, int64(1))
-	s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
-	s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, true)
+	if count != 1 {
+		return errors.Errorf("count got %d, expected %d", count, 1)
+	}
+	err = s.checkIndexKVExist(c, ctx, t, handle, index, columnValues, false)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = s.testGetIndex(c, t, index.Meta().Columns[0].Name.L, true)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
-func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) {
+func (s *testIndexSuite) checkAddOrDropIndex(c *C, state model.SchemaState, d *ddl, tblInfo *model.TableInfo, handle int64, index table.Index, row []types.Datum, isDropped bool) error {
+	var err error
 	ctx := testNewContext(d)
 
 	switch state {
 	case model.StateNone:
-		s.checkNoneIndex(c, ctx, d, tblInfo, handle, index, row)
+		err = s.checkNoneIndex(c, ctx, d, tblInfo, handle, index, row)
 	case model.StateDeleteOnly:
-		s.checkDeleteOnlyIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
+		err = s.checkDeleteOnlyIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
 	case model.StateWriteOnly:
-		s.checkWriteOnlyIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
+		err = s.checkWriteOnlyIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
 	case model.StateWriteReorganization, model.StateDeleteReorganization:
-		s.checkReorganizationIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
+		err = s.checkReorganizationIndex(c, ctx, d, tblInfo, handle, index, row, isDropped)
 	case model.StatePublic:
-		s.checkPublicIndex(c, ctx, d, tblInfo, handle, index, row)
+		err = s.checkPublicIndex(c, ctx, d, tblInfo, handle, index, row)
 	}
+
+	return errors.Trace(err)
 }
 
 func (s *testIndexSuite) TestAddIndex(c *C) {
@@ -544,6 +643,7 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
+	var checkErr error
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
 		if checkOK {
@@ -556,8 +656,10 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 			return
 		}
 
-		s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, false)
-
+		err = s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, false)
+		if err != nil && checkErr == nil {
+			checkErr = errors.Trace(err)
+		}
 		if index.Meta().State == model.StatePublic {
 			checkOK = true
 		}
@@ -572,9 +674,11 @@ func (s *testIndexSuite) TestAddIndex(c *C) {
 	d.start()
 
 	job := testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c1_uni", "c1")
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, true)
 
 	job = testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c1", "c1")
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, true)
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)
@@ -611,6 +715,7 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 	testCheckJobDone(c, d, job, true)
 
 	checkOK := false
+	var checkErr error
 	oldIndexCol := tables.NewIndex(tblInfo, &model.IndexInfo{})
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
@@ -621,12 +726,18 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 		t := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
 		index := getIndex(t, "c1")
 		if index == nil {
-			s.checkAddOrDropIndex(c, model.StateNone, d, tblInfo, handle, oldIndexCol, row, true)
+			err = s.checkAddOrDropIndex(c, model.StateNone, d, tblInfo, handle, oldIndexCol, row, true)
+			if err != nil && checkErr == nil {
+				checkErr = errors.Trace(err)
+			}
 			checkOK = true
 			return
 		}
 
-		s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, true)
+		err = s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, true)
+		if err != nil && checkErr == nil {
+			checkErr = errors.Trace(err)
+		}
 		oldIndexCol = index
 	}
 
@@ -641,12 +752,14 @@ func (s *testIndexSuite) TestDropIndex(c *C) {
 	d.start()
 
 	job = testDropIndex(c, ctx, d, s.dbInfo, tblInfo, "c1_uni")
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, false)
 
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)
 
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, false)
 	err = ctx.Txn().Commit()
 	c.Assert(err, IsNil)
@@ -678,6 +791,7 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	c.Assert(err, IsNil)
 
 	checkOK := false
+	var checkErr error
 	tc := &testDDLCallback{}
 	tc.onJobUpdated = func(job *model.Job) {
 		if checkOK {
@@ -690,7 +804,10 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 		if index == nil {
 			return
 		}
-		s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, false)
+		err = s.checkAddOrDropIndex(c, index.Meta().State, d, tblInfo, handle, index, row, false)
+		if err != nil && checkErr == nil {
+			checkErr = errors.Trace(err)
+		}
 		if index.Meta().State == model.StatePublic {
 			checkOK = true
 		}
@@ -706,11 +823,13 @@ func (s *testIndexSuite) TestAddIndexWithNullColumn(c *C) {
 	d.start()
 
 	job := testCreateIndex(c, ctx, d, s.dbInfo, tblInfo, true, "c2", "c2")
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, true)
 
 	c.Assert(ctx.NewTxn(), IsNil)
 
 	job = testDropTable(c, ctx, d, s.dbInfo, tblInfo)
+	c.Assert(errors.ErrorStack(checkErr), Equals, "")
 	testCheckJobDone(c, d, job, false)
 
 	err = ctx.Txn().Commit()


### PR DESCRIPTION
Used to eliminate the overtime problem of DDL unit tests, and can locate the problem.