### PR TITLE
go 1.7 is required

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,7 +27,7 @@ Read the documents for [binary deployment](https://github.com/pingcap/docs/blob/
 
 #### __Pre-requirement__
 
-Go environment. Currently a 64-bit version of go >= 1.5 is required.
+Go environment. Currently a 64-bit version of go >= 1.7 is required.
 ```
 git clone https://github.com/pingcap/tidb.git $GOPATH/src/github.com/pingcap/tidb
 cd $GOPATH/src/github.com/pingcap/tidb


### PR DESCRIPTION
go 1.7 is required because package "context" is used in session.go:21:2