### PR TITLE
plan: fix a panic bug when aggregation push across union.

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -285,6 +285,8 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk.MustExec("set @@session.tidb_opt_insubquery_unfold = 0")
 	result = tk.MustQuery("select sum(c1 in (select * from t2)) from t1")
 	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select sum(c1) k from (select * from t1 union all select * from t2)t group by c1 * 2 order by k")
+	result.Check(testkit.Rows("1", "3", "4"))
 }
 
 func (s *testSuite) TestStreamAgg(c *C) {

--- a/plan/aggregation_push_down.go
+++ b/plan/aggregation_push_down.go
@@ -378,7 +378,11 @@ func (a *aggregationOptimizer) aggPushDown(p LogicalPlan) LogicalPlan {
 				agg.SetChildren(projChild)
 				projChild.SetParents(agg)
 			} else if union, ok1 := child.(*Union); ok1 {
-				pushedAgg := a.makeNewAgg(agg.AggFuncs, agg.groupByCols)
+				var gbyCols []*expression.Column
+				for _, gbyExpr := range agg.GroupByItems {
+					gbyCols = append(gbyCols, expression.ExtractColumns(gbyExpr)...)
+				}
+				pushedAgg := a.makeNewAgg(agg.AggFuncs, gbyCols)
 				newChildren := make([]Plan, 0, len(union.children))
 				for _, child := range union.children {
 					newChild := a.pushAggCrossUnion(pushedAgg, union.schema, child.(LogicalPlan))


### PR DESCRIPTION
When pushing aggregation past union, we should extract all columns from groupby.
@shenli @coocood @zimulala @winoros @lamxTyler PTAL