### PR TITLE
table/column: disable utf8 check.

### DIFF
--- a/executor/statement_context_test.go
+++ b/executor/statement_context_test.go
@@ -14,10 +14,7 @@
 package executor_test
 
 import (
-	"fmt"
-
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
@@ -69,14 +66,15 @@ func (s *testSuite) TestStatementContext(c *C) {
 	tk.MustExec("delete from sc where a < '1x'")
 	tk.MustQuery("select * from sc where a > '1x'").Check(testkit.Rows("4"))
 
+	// TODO: enable UTF8 check
 	// Test invalid UTF8
-	tk.MustExec("create table sc2 (a varchar(255))")
-	// Insert an invalid UTF8
-	tk.MustExec("insert sc2 values (unhex('4040ffff'))")
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Greater, uint16(0))
-	tk.MustQuery("select * from sc2").Check(testkit.Rows(fmt.Sprintf("%v", []byte("@@"))))
-	tk.MustExec(strictModeSQL)
-	_, err = tk.Exec("insert sc2 values (unhex('4040ffff'))")
-	c.Assert(err, NotNil)
-	c.Assert(terror.ErrorEqual(err, table.ErrTruncateWrongValue), IsTrue)
+	//tk.MustExec("create table sc2 (a varchar(255))")
+	//// Insert an invalid UTF8
+	//tk.MustExec("insert sc2 values (unhex('4040ffff'))")
+	//c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Greater, uint16(0))
+	//tk.MustQuery("select * from sc2").Check(testkit.Rows(fmt.Sprintf("%v", []byte("@@"))))
+	//tk.MustExec(strictModeSQL)
+	//_, err = tk.Exec("insert sc2 values (unhex('4040ffff'))")
+	//c.Assert(err, NotNil)
+	//c.Assert(terror.ErrorEqual(err, table.ErrTruncateWrongValue), IsTrue)
 }

--- a/table/column.go
+++ b/table/column.go
@@ -135,7 +135,7 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 	}
 	if err != nil {
 		// TODO: enable it when find a better way to handle old incorrect data.
-		log.Errorf("invalid UTF8 value %v for column %s", str, col.Name.O)
+		log.Debugf("invalid UTF8 value %v for column %s", str, col.Name.O)
 	}
 	return casted, nil
 }

--- a/table/column.go
+++ b/table/column.go
@@ -125,10 +125,10 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 		return casted, nil
 	}
 	str := casted.GetString()
-	for i, r := range str {
+	for _, r := range str {
 		if r == utf8.RuneError {
 			// Truncate to valid utf8 string.
-			casted = types.NewStringDatum(str[:i])
+			// casted = types.NewStringDatum(str[:i])
 			err = sc.HandleTruncate(ErrTruncateWrongValue)
 			break
 		}

--- a/table/column.go
+++ b/table/column.go
@@ -133,7 +133,11 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 			break
 		}
 	}
-	return casted, errors.Trace(err)
+	if err != nil {
+		// TODO: enable it when find a better way to handle old incorrect data.
+		log.Errorf("invalid UTF8 value %v for column %s", str, col.Name.O)
+	}
+	return casted, nil
 }
 
 // ColDesc describes column information like MySQL desc and show columns do.


### PR DESCRIPTION
When old row has invalid utf8 value and the data doesn't change, we should not fail to update.
So temporarily disable utf8 check until we can handle this problem.