### PR TITLE
tso_check:make sure each new ts is bigger than old one

### DIFF
--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -14,6 +14,7 @@
 package oracles
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -57,7 +58,7 @@ func NewPdOracle(pdClient pd.Client, updateInterval time.Duration) (oracle.Oracl
 // IsExpired returns whether lockTS+TTL is expired, both are ms. It uses `lastTS`
 // to compare, may return false negative result temporarily.
 func (o *pdOracle) IsExpired(lockTS, TTL uint64) bool {
-	lastTS := atomic.LoadUint64(&o.lastTS)
+	lastTS := o.getLastTS()
 	return oracle.ExtractPhysical(lastTS) >= oracle.ExtractPhysical(lockTS)+int64(TTL)
 }
 
@@ -65,6 +66,12 @@ func (o *pdOracle) IsExpired(lockTS, TTL uint64) bool {
 func (o *pdOracle) GetTimestamp() (uint64, error) {
 	ts, err := o.getTimestamp()
 	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	lastTs := o.getLastTS()
+	if lastTs >= ts {
+		err = fmt.Errorf("Invalid pdOracle with last_ts=%v while current ts=%v", lastTs, ts)
+		log.Warn(err)
 		return 0, errors.Trace(err)
 	}
 	o.setLastTS(ts)
@@ -89,6 +96,10 @@ func (o *pdOracle) setLastTS(ts uint64) {
 	if ts > lastTS {
 		atomic.CompareAndSwapUint64(&o.lastTS, lastTS, ts)
 	}
+}
+
+func (o *pdOracle) getLastTS() uint64 {
+	return atomic.LoadUint64(&o.lastTS)
 }
 
 func (o *pdOracle) updateTS(interval time.Duration) {

--- a/store/tikv/oracle/oracles/pd_test.go
+++ b/store/tikv/oracle/oracles/pd_test.go
@@ -1,0 +1,56 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracles
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/store/tikv/mock-tikv"
+	"github.com/pingcap/tidb/store/tikv/oracle"
+)
+
+type testPdOracleSuite struct {
+	o oracle.Oracle
+}
+
+var _ = Suite(&testPdOracleSuite{})
+
+func (s *testPdOracleSuite) SetUpTest(c *C) {
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithMultiRegions(cluster, []byte("a"), []byte("b"), []byte("c"))
+	pdCli := mocktikv.NewPDClient(cluster)
+	var err error
+	s.o, err = NewPdOracle(pdCli, time.Second*10)
+	c.Assert(err, IsNil)
+}
+
+func (s *testPdOracleSuite) TearDownSuite(c *C) {
+	if s.o != nil {
+		s.o.Close()
+	}
+}
+
+func (s *testPdOracleSuite) TestIllegalOracle(c *C) {
+	ts, err := s.o.GetTimestamp()
+	c.Assert(err, IsNil)
+	ts, err = s.o.GetTimestamp()
+	c.Assert(err, IsNil)
+	// set last ts to a big one
+	s.o.(*pdOracle).setLastTS(ts * 2)
+	_, err = s.o.GetTimestamp()
+	c.Assert(err, NotNil)
+	_, err = s.o.GetTimestamp()
+	c.Assert(err, NotNil)
+}


### PR DESCRIPTION
Hi,all,
     This PR is used to make sure each new `ts` is bigger than old one. It's also related to make sure start_ts is smaller than commit_ts in transaction ([tikv/issue_1688](https://github.com/pingcap/tikv/issues/1688)). @disksing @coocood PTAL