### PR TITLE
check_tso:make sure commit_ts > start_ts during commit in transaction

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -506,6 +506,15 @@ func (c *twoPhaseCommitter) execute() error {
 		log.Warnf("2PC get commitTS failed: %v, tid: %d", err, c.startTS)
 		return errors.Trace(err)
 	}
+
+	// check commitTS
+	if commitTS <= c.startTS {
+		err = errors.Errorf("Invalid transaction tso with start_ts=%v while commit_ts=%v",
+			c.startTS,
+			commitTS)
+		log.Warning(err)
+		return errors.Trace(err)
+	}
 	c.commitTS = commitTS
 	if err := c.checkSchemaValid(); err != nil {
 		return errors.Trace(err)

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -512,7 +512,7 @@ func (c *twoPhaseCommitter) execute() error {
 		err = errors.Errorf("Invalid transaction tso with start_ts=%v while commit_ts=%v",
 			c.startTS,
 			commitTS)
-		log.Warning(err)
+		log.Error(err)
 		return errors.Trace(err)
 	}
 	c.commitTS = commitTS


### PR DESCRIPTION
This PR is used to make sure `start_ts` is smaller than `commit_ts` in transaction and it's also related to ([tikv/issue_1688](https://github.com/pingcap/tikv/issues/1688)). @disksing @coocood PTAL