### PR TITLE
plan: rebuild schema for join after join reordering.

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -199,6 +199,15 @@ func (s *testSuite) TestJoin(c *C) {
 	tk.MustExec("insert into t1 values (1)")
 	result = tk.MustQuery("select t.c1 from t , t1 where t.c1 = t1.c1")
 	result.Check(testkit.Rows("1"))
+	tk.MustExec("drop table if exists t,t2,t1")
+	tk.MustExec("create table t(c1 int)")
+	tk.MustExec("create table t1(c1 int, c2 int)")
+	tk.MustExec("create table t2(c1 int, c2 int)")
+	tk.MustExec("insert into t1 values(1,2),(2,3),(3,4)")
+	tk.MustExec("insert into t2 values(1,0),(2,0),(3,0)")
+	tk.MustExec("insert into t values(1),(2),(3)")
+	result = tk.MustQuery("select * from t1 , t2 where t2.c1 = t1.c1 and t2.c2 = 0 and t1.c2 in (select * from t)")
+	result.Check(testkit.Rows("1 2 1 0", "2 3 2 0"))
 }
 
 func (s *testSuite) TestMultiJoin(c *C) {

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -145,6 +145,7 @@ func (p *Join) PredicatePushDown(predicates []expression.Expression) (ret []expr
 			return nil, nil, errors.Trace(err2)
 		}
 	}
+	p.mergeSchema()
 	p.buildKeyInfo()
 	return
 }


### PR DESCRIPTION
for query like `select * from t1 , t2 where t2.c1 = t1.c1 and t2.c2 = 0 and t1.c2 in (select * from t)`, we will reorder t1 and t2 and rebuild schema. Then we should update the semi-join's schema.