### PR TITLE
store: Update pools's close function

### DIFF
--- a/store/tikv/conn_pool.go
+++ b/store/tikv/conn_pool.go
@@ -125,12 +125,19 @@ func (p *Pools) PutConn(c *Conn) {
 
 // Close closes the pool.
 func (p *Pools) Close() {
-	p.m.Lock()
-	defer p.m.Unlock()
+	var pools []*Pool
 
+	p.m.Lock()
 	for _, pool := range p.m.mpools {
-		pool.Close()
+		pools = append(pools, pool)
+	}
+	p.m.Unlock()
+
+	for _, p := range pools {
+		p.Close()
 	}
 
+	p.m.Lock()
 	p.m.mpools = map[string]*Pool{}
+	p.m.Unlock()
 }

--- a/store/tikv/conn_pool_test.go
+++ b/store/tikv/conn_pool_test.go
@@ -93,3 +93,39 @@ func (s *testPoolSuite) TestPool(c *C) {
 	_, err = p.GetConn()
 	c.Assert(err, NotNil)
 }
+
+func (s *testPoolSuite) TestPoolsClose(c *C) {
+	count := 0
+	addr := "127.0.0.1:6379"
+	f := func(addr string) (*Conn, error) {
+		count++
+		return &Conn{
+			addr:   addr,
+			closed: false,
+			nc:     &testDummyConn{}}, nil
+	}
+
+	capability := 4
+	pools := NewPools(capability, f)
+
+	conns := make([]*Conn, 0, capability)
+	for i := 0; i < capability; i++ {
+		conn, err := pools.GetConn(addr)
+		c.Assert(err, IsNil)
+		conns = append(conns, conn)
+	}
+
+	c.Assert(count, Equals, capability)
+
+	for i := 0; i < len(conns)-1; i++ {
+		pools.PutConn(conns[i])
+	}
+
+	ch := make(chan struct{})
+	go func() {
+		<-ch
+		pools.PutConn(conns[capability-1])
+	}()
+	close(ch)
+	pools.Close()
+}

--- a/store/tikv/conn_pool_test.go
+++ b/store/tikv/conn_pool_test.go
@@ -122,10 +122,13 @@ func (s *testPoolSuite) TestPoolsClose(c *C) {
 	}
 
 	ch := make(chan struct{})
+	var checkErr error
 	go func() {
 		<-ch
+		_, checkErr = pools.GetConn(addr)
 		pools.PutConn(conns[capability-1])
 	}()
 	close(ch)
 	pools.Close()
+	c.Assert(checkErr, NotNil)
 }

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -170,12 +170,13 @@ func (s *tikvStore) Close() error {
 	defer mc.Unlock()
 
 	delete(mc.cache, s.uuid)
-	if err := s.client.Close(); err != nil {
-		return errors.Trace(err)
-	}
 	s.oracle.Close()
 	if s.gcWorker != nil {
 		s.gcWorker.Close()
+	}
+	// Make sure all connections are put back into the pools.
+	if err := s.client.Close(); err != nil {
+		return errors.Trace(err)
 	}
 	return nil
 }


### PR DESCRIPTION
The pools can close when there are some connections not put back pools.