### PR TITLE
stats: if the stats in kv store is invalid, we will replace it with peusdo one.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -407,6 +407,11 @@ func (do *Domain) PrivilegeHandle() *privileges.Handle {
 	return do.privHandle
 }
 
+// StatsHandle returns the statistic handle.
+func (do *Domain) StatsHandle() *statscache.Handle {
+	return do.statsHandle
+}
+
 func (do *Domain) loadTableStats() error {
 	ver, err := do.store.CurrentVersion()
 	if err != nil {

--- a/plan/statscache/statscache.go
+++ b/plan/statscache/statscache.go
@@ -34,8 +34,7 @@ type statsInfo struct {
 
 // Handle can update stats info periodically.
 type Handle struct {
-	ctx context.Context
-	// LastVersion stands for the last time we update stats. We export it only for test.
+	ctx         context.Context
 	lastVersion uint64
 }
 
@@ -123,7 +122,7 @@ func SetStatisticsTableCache(id int64, statsTbl *statistics.Table, version uint6
 		return
 	}
 	if stats.version >= version {
-		//		return
+		return
 	}
 	stats.tbl = statsTbl
 	stats.version = version

--- a/plan/statscache/statscache.go
+++ b/plan/statscache/statscache.go
@@ -68,7 +68,8 @@ func (h *Handle) Update(m *meta.Meta, is infoschema.InfoSchema) error {
 			// Error is not nil may mean that there are some ddl changes on this table, so the origin
 			// statistics can not be used any more, we give it a nil one.
 			if err != nil {
-				log.Errorf("Error occured when convert pb table for table id %d", tableID)
+				log.Errorf("Error occured when convert pb table for table id %d, may be the table struct has changed", tableID)
+				tbl = statistics.PseudoTable(tableInfo)
 			}
 			SetStatisticsTableCache(tableID, tbl, version)
 		}

--- a/plan/statscache/statscache.go
+++ b/plan/statscache/statscache.go
@@ -34,8 +34,14 @@ type statsInfo struct {
 
 // Handle can update stats info periodically.
 type Handle struct {
-	ctx         context.Context
-	lastVersion uint64
+	ctx context.Context
+	// LastVersion stands for the last time we update stats. We export it only for test.
+	LastVersion uint64
+}
+
+// Clear the statsTblCache, only for test.
+func (h *Handle) Clear() {
+	statsTblCache = statsCache{cache: map[int64]*statsInfo{}}
 }
 
 // NewHandle creates a Handle for update stats.
@@ -45,7 +51,7 @@ func NewHandle(ctx context.Context) *Handle {
 
 // Update reads stats meta from store and updates the stats map.
 func (h *Handle) Update(m *meta.Meta, is infoschema.InfoSchema) error {
-	sql := fmt.Sprintf("SELECT version, table_id from mysql.stats_meta where version > %d order by version", h.lastVersion)
+	sql := fmt.Sprintf("SELECT version, table_id from mysql.stats_meta where version > %d order by version", h.LastVersion)
 	rows, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, sql)
 	if err != nil {
 		return errors.Trace(err)
@@ -73,7 +79,7 @@ func (h *Handle) Update(m *meta.Meta, is infoschema.InfoSchema) error {
 			}
 			SetStatisticsTableCache(tableID, tbl, version)
 		}
-		h.lastVersion = version
+		h.LastVersion = version
 	}
 	return nil
 }
@@ -116,7 +122,7 @@ func SetStatisticsTableCache(id int64, statsTbl *statistics.Table, version uint6
 		return
 	}
 	if stats.version >= version {
-		return
+		//		return
 	}
 	stats.tbl = statsTbl
 	stats.version = version

--- a/plan/statscache/statscache_test.go
+++ b/plan/statscache/statscache_test.go
@@ -73,7 +73,6 @@ func (s *testStatsCacheSuite) TestStatsCache(c *C) {
 	snapshot, err := store.GetSnapshot(ver)
 	c.Assert(err, IsNil)
 	m := meta.NewSnapshotMeta(snapshot)
-	do.StatsHandle().LastVersion = 0
 	do.StatsHandle().Clear()
 	do.StatsHandle().Update(m, is)
 	statsTbl = statscache.GetStatisticsTableCache(tableInfo)

--- a/plan/statscache/statscache_test.go
+++ b/plan/statscache/statscache_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/plan/statscache"
 	"github.com/pingcap/tidb/util/testkit"
@@ -61,6 +62,22 @@ func (s *testStatsCacheSuite) TestStatsCache(c *C) {
 	testKit.MustExec("analyze table t")
 	statsTbl = statscache.GetStatisticsTableCache(tableInfo)
 	c.Assert(statsTbl.Pseudo, IsFalse)
+	testKit.MustExec("alter table t drop column c2")
+	is = do.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	tableInfo = tbl.Meta()
+
+	ver, err := store.CurrentVersion()
+	c.Assert(err, IsNil)
+	snapshot, err := store.GetSnapshot(ver)
+	c.Assert(err, IsNil)
+	m := meta.NewSnapshotMeta(snapshot)
+	do.StatsHandle().LastVersion = 0
+	do.StatsHandle().Clear()
+	do.StatsHandle().Update(m, is)
+	statsTbl = statscache.GetStatisticsTableCache(tableInfo)
+	c.Assert(statsTbl.Pseudo, IsTrue)
 }
 
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {


### PR DESCRIPTION
If tidb1 analyze a table, and then do ddl operation. After that if a new tidb2 is on, it will read the stats with old version and panic.

@shenli @coocood @zimulala PTAL