### PR TITLE
store: Make test stable

### DIFF
--- a/store/tikv/conn_pool_test.go
+++ b/store/tikv/conn_pool_test.go
@@ -122,13 +122,10 @@ func (s *testPoolSuite) TestPoolsClose(c *C) {
 	}
 
 	ch := make(chan struct{})
-	var checkErr error
 	go func() {
 		<-ch
-		_, checkErr = pools.GetConn(addr)
 		pools.PutConn(conns[capability-1])
 	}()
 	close(ch)
 	pools.Close()
-	c.Assert(checkErr, NotNil)
 }


### PR DESCRIPTION
This code of `pools.GetConn(addr)` in goroutine may be executed earlier than the code of `pools.Close()`. So this test is blocked.