### PR TITLE
executor: skip the unstable test.

### DIFF
--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -72,6 +72,7 @@ func checkGoroutineExists(keyword string) bool {
 }
 
 func (s *testSuite) TestCopClientSend(c *C) {
+	c.Skip("not stable")
 	if _, ok := s.store.GetClient().(*tikv.CopClient); !ok {
 		// Make sure the store is tikv store.
 		return


### PR DESCRIPTION
Multiple package runs on the same process in parallel, we can't make sure the test always pass.