### PR TITLE
executor: Make admin test stable

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -116,7 +116,6 @@ func (s *testSuite) TestAdmin(c *C) {
 	rowOwnerInfos = strings.Split(row.Data[4].GetString(), ",")
 	ownerInfos = strings.Split(bgInfo.Owner.String(), ",")
 	c.Assert(rowOwnerInfos[0], Equals, ownerInfos[0])
-	c.Assert(row.Data[5].GetString(), Equals, "")
 	row, err = r.Next()
 	c.Assert(err, IsNil)
 	c.Assert(row, IsNil)

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -156,9 +156,9 @@ func (*testSuite) TestConcurrentAlloc(c *C) {
 	allocIDs := func() {
 		alloc := NewAllocator(store, dbID)
 		for j := 0; j < int(step)+5; j++ {
-			id, err := alloc.Alloc(tblID)
-			if err != nil {
-				errCh <- err
+			id, err1 := alloc.Alloc(tblID)
+			if err1 != nil {
+				errCh <- err1
 				break
 			}
 


### PR DESCRIPTION
```
tidb> admin show ddl;
+------------+---------------------------------------------------------------------------+------+---------------+---------------------------------------------------------------------------+--------+
| SCHEMA_VER | OWNER                                                                     | JOB  | BG_SCHEMA_VER | BG_OWNER                                                                  | BG_JOB |
+------------+---------------------------------------------------------------------------+------+---------------+---------------------------------------------------------------------------+--------+
|         10 | ID:bfcb9273-641b-4639-a3b6-cd509c449791, LastUpdateTS:1490679507570834668 |      |            10 | ID:bfcb9273-641b-4639-a3b6-cd509c449791, LastUpdateTS:1490679507570828652 |        |
+------------+---------------------------------------------------------------------------+------+---------------+---------------------------------------------------------------------------+--------+
```
Remove the test that the field of `BG_JOB` is empty.