### PR TITLE
parser: change intLit to decLit when the value out of range

### DIFF
--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -104,6 +104,7 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{`\'a\'`, int('\\')},
 		{`\"a\"`, int('\\')},
 		{"0.2314", decLit},
+		{"1234567890123456789012345678901234567890", decLit},
 		{"132.313", decLit},
 		{"132.3e231", floatLit},
 		{"132.3e-231", floatLit},

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -145,6 +145,10 @@ func (parser *Parser) endOffset(v *yySymType) int {
 func toInt(l yyLexer, lval *yySymType, str string) int {
 	n, err := strconv.ParseUint(str, 10, 64)
 	if err != nil {
+		e := err.(*strconv.NumError)
+		if e.Err == strconv.ErrRange {
+			return toDecimal(l, lval, str)
+		}
 		l.Errorf("integer literal: %v", err)
 		return int(unicode.ReplacementChar)
 	}

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -147,6 +147,14 @@ func toInt(l yyLexer, lval *yySymType, str string) int {
 	if err != nil {
 		e := err.(*strconv.NumError)
 		if e.Err == strconv.ErrRange {
+			// TODO: toDecimal maybe out of range still.
+			// This kind of error should be throw to higher level, because truncated data maybe legal.
+			// For example, this SQL returns error:
+			// create table test (id decimal(30, 0));
+			// insert into test values(123456789012345678901234567890123094839045793405723406801943850);
+			// While this SQL:
+			// select 1234567890123456789012345678901230948390457934057234068019438509023041874359081325875128590860234789847359871045943057;
+			// get value 99999999999999999999999999999999999999999999999999999999999999999
 			return toDecimal(l, lval, str)
 		}
 		l.Errorf("integer literal: %v", err)


### PR DESCRIPTION
If lexer get a intLit and it's out of uint64 range, change it to decimal.
This PR will fix https://github.com/pingcap/tidb/issues/2946

```
mysql> create table test (id decimal(30, 0));
Query OK, 0 rows affected (0.00 sec)

mysql>  insert into test values(123456789012345678901234567890);
ERROR 1105 (HY000): line 0 column 54 near ")"integer literal: strconv.ParseUint: parsing "123456789012345678901234567890": value out of range (total length 55)
```