### PR TITLE
executor: fix decode row panic

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -292,6 +292,10 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk.MustExec("insert into t values(1, 2, 3), (1, 2, 4)")
 	result = tk.MustQuery("select count(distinct c), count(distinct a,b) from t")
 	result.Check(testkit.Rows("2 1"))
+
+	tk.MustExec("create table idx_agg (a int, b int, index (b))")
+	tk.MustExec("insert idx_agg values (1, 1), (1, 2), (2, 2)")
+	tk.MustQuery("select sum(a), sum(b) from idx_agg where b > 0 and b < 10")
 }
 
 func (s *testSuite) TestStreamAgg(c *C) {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -449,7 +449,10 @@ func (e *XSelectIndexExec) nextForSingleRead() (*Row, error) {
 			schema = e.idxColsSchema
 		}
 		values := make([]types.Datum, schema.Len())
-		codec.SetRawValues(rowData, values)
+		err = codec.SetRawValues(rowData, values)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		err = decodeRawValues(values, schema)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -731,8 +734,11 @@ func (e *XSelectIndexExec) extractRowsFromPartialResult(t table.Table, partialRe
 		if rowData == nil {
 			break
 		}
-		values := make([]types.Datum, len(e.indexPlan.Columns))
-		codec.SetRawValues(rowData, values)
+		values := make([]types.Datum, e.Schema().Len())
+		err = codec.SetRawValues(rowData, values)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		err = decodeRawValues(values, e.Schema())
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -912,7 +918,10 @@ func (e *XSelectTableExec) Next() (*Row, error) {
 		}
 		e.returnedRows++
 		values := make([]types.Datum, e.schema.Len())
-		codec.SetRawValues(rowData, values)
+		err = codec.SetRawValues(rowData, values)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 		err = decodeRawValues(values, e.schema)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -277,17 +277,8 @@ func EvaluateExprWithNull(ctx context.Context, schema *Schema, expr Expression) 
 
 // TableInfo2Schema converts table info to schema.
 func TableInfo2Schema(tbl *model.TableInfo) *Schema {
-	cols := make([]*Column, 0, len(tbl.Columns))
+	cols := ColumnInfos2Columns(tbl.Name, tbl.Columns)
 	keys := make([]KeyInfo, 0, len(tbl.Indices)+1)
-	for i, col := range tbl.Columns {
-		newCol := &Column{
-			ColName:  col.Name,
-			TblName:  tbl.Name,
-			RetType:  &col.FieldType,
-			Position: i,
-		}
-		cols = append(cols, newCol)
-	}
 	for _, idx := range tbl.Indices {
 		if !idx.Unique || idx.State != model.StatePublic {
 			continue
@@ -326,6 +317,21 @@ func TableInfo2Schema(tbl *model.TableInfo) *Schema {
 	schema := NewSchema(cols...)
 	schema.SetUniqueKeys(keys)
 	return schema
+}
+
+// ColumnInfos2Columns converts a slice of ColumnInfo to a slice of Column.
+func ColumnInfos2Columns(tblName model.CIStr, colInfos []*model.ColumnInfo) []*Column {
+	columns := make([]*Column, 0, len(colInfos))
+	for i, col := range colInfos {
+		newCol := &Column{
+			ColName:  col.Name,
+			TblName:  tblName,
+			RetType:  &col.FieldType,
+			Position: i,
+		}
+		columns = append(columns, newCol)
+	}
+	return columns
 }
 
 // NewCastFunc creates a new cast function.

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -1392,7 +1392,7 @@ func (p *Analyze) prepareSimpleTableScan(cols []*model.ColumnInfo) *PhysicalTabl
 	}
 	ts.tp = Tbl
 	ts.allocator = p.allocator
-	ts.SetSchema(p.Schema())
+	ts.SetSchema(expression.NewSchema(expression.ColumnInfos2Columns(ts.Table.Name, cols)...))
 	ts.initIDAndContext(p.ctx)
 	ts.readOnly = true
 	ts.Ranges = []TableRange{{math.MinInt64, math.MaxInt64}}
@@ -1414,7 +1414,7 @@ func (p *Analyze) prepareSimpleIndexScan(idxOffset int, cols []*model.ColumnInfo
 	is.tp = Aly
 	is.allocator = p.allocator
 	is.initIDAndContext(p.ctx)
-	is.SetSchema(p.Schema())
+	is.SetSchema(expression.NewSchema(expression.ColumnInfos2Columns(tblInfo.Name, cols)...))
 	is.readOnly = true
 	rb := rangeBuilder{sc: p.ctx.GetSessionVars().StmtCtx}
 	is.Ranges = rb.buildIndexRanges(fullRange, types.NewFieldType(mysql.TypeNull))


### PR DESCRIPTION
Index Schema may be replaced by aggregation schema, which may be longer than
original schema length, in this case decode row will panic.