### PR TITLE
*: add INFORMATION_SCHEMA.USER_PRIVILEGES table

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -270,7 +270,7 @@ func (s *testSuite) TestAggregation(c *C) {
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
 	// When adding new memory table in information_schema, please update this variable.
-	columnCountOfAllInformationSchemaTables := "576"
+	columnCountOfAllInformationSchemaTables := "580"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 
 	tk.MustExec("drop table if exists t1")

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -255,6 +255,7 @@ func (*testSuite) TestInfoTables(c *C) {
 		"PLUGINS",
 		"TABLE_CONSTRAINTS",
 		"TRIGGERS",
+		"USER_PRIVILEGES",
 	}
 	for _, t := range info_tables {
 		tb, err1 := is.TableByName(model.NewCIStr(infoschema.Name), model.NewCIStr(t))

--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/util/types"
 )
 
 type keyType int
@@ -41,6 +42,9 @@ type Checker interface {
 
 	// DBIsVisible returns true is the database is visible to current user.
 	DBIsVisible(db string) bool
+
+	// UserPrivilegesTable provide data for INFORMATION_SCHEMA.USERS_PRIVILEGE table.
+	UserPrivilegesTable() [][]types.Datum
 }
 
 const key keyType = 0

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -14,6 +14,7 @@
 package privileges
 
 import (
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -471,6 +472,7 @@ func appendUserPrivilegesTableRow(rows [][]types.Datum, user userRecord) [][]typ
 	} else {
 		isGrantable = "NO"
 	}
+	gurantee := fmt.Sprintf("'%s'@'%s'", user.User, user.Host)
 
 	for _, priv := range mysql.AllGlobalPrivs {
 		if priv == mysql.GrantPriv {
@@ -482,7 +484,7 @@ func appendUserPrivilegesTableRow(rows [][]types.Datum, user userRecord) [][]typ
 			// | GRANTEE                   | TABLE_CATALOG | PRIVILEGE_TYPE          | IS_GRANTABLE |
 			// +---------------------------+---------------+-------------------------+--------------+
 			// | 'root'@'localhost'        | def           | SELECT                  | YES          |
-			record := types.MakeDatums(user.User, "def", privilegeType, isGrantable)
+			record := types.MakeDatums(gurantee, "def", privilegeType, isGrantable)
 			rows = append(rows, record)
 		}
 	}

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -271,6 +271,12 @@ func (p *UserPrivileges) DBIsVisible(db string) bool {
 	return mysqlPriv.DBIsVisible(user, host, db)
 }
 
+// UserPrivilegesTable implements the Checker interface.
+func (p *UserPrivileges) UserPrivilegesTable() [][]types.Datum {
+	mysqlPriv := p.Handle.Get()
+	return mysqlPriv.UserPrivilegesTable()
+}
+
 // Check implements Checker.Check interface.
 func (p *UserPrivileges) Check(ctx context.Context, db *model.DBInfo, tbl *model.TableInfo, privilege mysql.PrivilegeType) (bool, error) {
 	if p.privs == nil {


### PR DESCRIPTION
So that it support this now:
```
mysql> select * from information_schema.user_privileges;
+---------+---------------+----------------+--------------+
| GRANTEE | TABLE_CATALOG | PRIVILEGE_TYPE | IS_GRANTABLE |
+---------+---------------+----------------+--------------+
| genius  | def           | Select         | NO           |
| root    | def           | Select         | YES          |
| root    | def           | Insert         | YES          |
| root    | def           | Update         | YES          |
| root    | def           | Delete         | YES          |
| root    | def           | Create         | YES          |
| root    | def           | Drop           | YES          |
| root    | def           | Alter          | YES          |
| root    | def           | Show Databases | YES          |
| root    | def           | Execute        | YES          |
| root    | def           | Index          | YES          |
| root    | def           | Create User    | YES          |
+---------+---------------+----------------+--------------+
12 rows in set (0.00 sec)
```