### PR TITLE
*: fix batch insert test data race

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -40,7 +40,7 @@ var (
 	// The limit of single entry size (len(key) + len(value)).
 	TxnEntrySizeLimit = 6 * 1024 * 1024
 	// The limit of number of entries in the MemBuffer.
-	TxnEntryCountLimit = 300 * 1000
+	TxnEntryCountLimit uint64 = 300 * 1000
 	// The limit of the sum of all entry size.
 	TxnTotalSizeLimit = 100 * 1024 * 1024
 )

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/etcd/pkg/monotime"
@@ -123,7 +124,8 @@ func newTwoPhaseCommitter(txn *tikvTxn) (*twoPhaseCommitter, error) {
 			size += len(lockKey)
 		}
 	}
-	if len(keys) > kv.TxnEntryCountLimit || size > kv.TxnTotalSizeLimit {
+	entrylimit := atomic.LoadUint64(&kv.TxnEntryCountLimit)
+	if len(keys) > int(entrylimit) || size > kv.TxnTotalSizeLimit {
 		return nil, kv.ErrTxnTooLarge
 	}
 	const logEntryCount = 10000


### PR DESCRIPTION
Use atomic functions to access limit variable.