### PR TITLE
privilege: rename interface name from Checker to Manager

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -212,7 +212,7 @@ func (e *DDLExec) executeDropTable(s *ast.DropTableStmt) error {
 			return errors.Trace(err)
 		}
 		// Check Privilege
-		privChecker := privilege.GetPrivilegeChecker(e.ctx)
+		privChecker := privilege.GetPrivilegeManager(e.ctx)
 		hasPriv, err := privChecker.Check(e.ctx, schema, tb.Meta(), mysql.DropPriv)
 		if err != nil {
 			return errors.Trace(err)

--- a/executor/show.go
+++ b/executor/show.go
@@ -138,7 +138,7 @@ func (e *ShowExec) fetchShowEngines() error {
 
 func (e *ShowExec) fetchShowDatabases() error {
 	dbs := e.is.AllSchemaNames()
-	checker := privilege.GetPrivilegeChecker(e.ctx)
+	checker := privilege.GetPrivilegeManager(e.ctx)
 	// TODO: let information_schema be the first database
 	sort.Strings(dbs)
 	for _, d := range dbs {
@@ -183,7 +183,7 @@ func (e *ShowExec) fetchShowTables() error {
 	if !e.is.SchemaExists(e.DBName) {
 		return errors.Errorf("Can not find DB: %s", e.DBName)
 	}
-	checker := privilege.GetPrivilegeChecker(e.ctx)
+	checker := privilege.GetPrivilegeManager(e.ctx)
 	// sort for tables
 	var tableNames []string
 	for _, v := range e.is.SchemaTables(e.DBName) {
@@ -561,7 +561,7 @@ func (e *ShowExec) fetchShowCollation() error {
 
 func (e *ShowExec) fetchShowGrants() error {
 	// Get checker
-	checker := privilege.GetPrivilegeChecker(e.ctx)
+	checker := privilege.GetPrivilegeManager(e.ctx)
 	if checker == nil {
 		return errors.New("miss privilege checker")
 	}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -368,8 +368,8 @@ func dataForSessionVar(ctx context.Context) (records [][]types.Datum, err error)
 }
 
 func dataForUserPrivileges(ctx context.Context) [][]types.Datum {
-	checker := privilege.GetPrivilegeChecker(ctx)
-	return checker.UserPrivilegesTable()
+	pm := privilege.GetPrivilegeManager(ctx)
+	return pm.UserPrivilegesTable()
 }
 
 var filesCols = []columnInfo{

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -69,8 +69,8 @@ func Optimize(ctx context.Context, node ast.Node, is infoschema.InfoSchema) (Pla
 
 	// Maybe it's better to move this to Preprocess, but check privilege need table
 	// information, which is collected into visitInfo during logical plan builder.
-	if checker := privilege.GetPrivilegeChecker(ctx); checker != nil {
-		if !checkPrivilege(checker, builder.visitInfo) {
+	if pm := privilege.GetPrivilegeManager(ctx); pm != nil {
+		if !checkPrivilege(pm, builder.visitInfo) {
 			return nil, errors.New("privilege check fail")
 		}
 	}
@@ -81,9 +81,9 @@ func Optimize(ctx context.Context, node ast.Node, is infoschema.InfoSchema) (Pla
 	return p, nil
 }
 
-func checkPrivilege(checker privilege.Checker, vs []visitInfo) bool {
+func checkPrivilege(pm privilege.Manager, vs []visitInfo) bool {
 	for _, v := range vs {
-		if !checker.RequestVerification(v.db, v.table, v.column, v.privilege) {
+		if !pm.RequestVerification(v.db, v.table, v.column, v.privilege) {
 			return false
 		}
 	}

--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -26,8 +26,8 @@ func (k keyType) String() string {
 	return "privilege-key"
 }
 
-// Checker is the interface for check privileges.
-type Checker interface {
+// Manager is the interface for providing privilege related operations.
+type Manager interface {
 	// Check checks privilege.
 	// If tbl is nil, only check global/db scope privileges.
 	// If tbl is not nil, check global/db/table scope privileges.
@@ -49,14 +49,14 @@ type Checker interface {
 
 const key keyType = 0
 
-// BindPrivilegeChecker binds Checker to context.
-func BindPrivilegeChecker(ctx context.Context, pc Checker) {
+// BindPrivilegeManager binds Manager to context.
+func BindPrivilegeManager(ctx context.Context, pc Manager) {
 	ctx.SetValue(key, pc)
 }
 
-// GetPrivilegeChecker gets Checker from context.
-func GetPrivilegeChecker(ctx context.Context) Checker {
-	if v, ok := ctx.Value(key).(Checker); ok {
+// GetPrivilegeManager gets Checker from context.
+func GetPrivilegeManager(ctx context.Context) Manager {
+	if v, ok := ctx.Value(key).(Manager); ok {
 		return v
 	}
 	return nil

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -48,7 +48,7 @@ var (
 	errInvalidUserNameFormat = terror.ClassPrivilege.New(codeInvalidUserNameFormat, "wrong username format")
 )
 
-var _ privilege.Checker = (*UserPrivileges)(nil)
+var _ privilege.Manager = (*UserPrivileges)(nil)
 
 type privileges struct {
 	Level ast.GrantLevelType
@@ -173,7 +173,7 @@ func (ps *userPrivileges) ShowGrants() []string {
 	return gs
 }
 
-// UserPrivileges implements privilege.Checker interface.
+// UserPrivileges implements privilege.Manager interface.
 // This is used to check privilege for the current user.
 type UserPrivileges struct {
 	// TODO: Clean up the old implementation.
@@ -183,7 +183,7 @@ type UserPrivileges struct {
 	*Handle
 }
 
-// RequestVerification implements the Checker interface.
+// RequestVerification implements the Manager interface.
 func (p *UserPrivileges) RequestVerification(db, table, column string, priv mysql.PrivilegeType) bool {
 	if !Enable || SkipWithGrant {
 		return true
@@ -213,7 +213,7 @@ func (p *UserPrivileges) RequestVerification(db, table, column string, priv mysq
 // PWDHashLen is the length of password's hash.
 const PWDHashLen = 40
 
-// ConnectionVerification implements the Checker interface.
+// ConnectionVerification implements the Manager interface.
 func (p *UserPrivileges) ConnectionVerification(user, host string, auth, salt []byte) bool {
 	if SkipWithGrant {
 		p.User = user + "@" + host
@@ -246,7 +246,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, auth, salt []
 	return true
 }
 
-// DBIsVisible implements the Checker interface.
+// DBIsVisible implements the Manager interface.
 func (p *UserPrivileges) DBIsVisible(db string) bool {
 	if !Enable || SkipWithGrant {
 		return true
@@ -271,13 +271,13 @@ func (p *UserPrivileges) DBIsVisible(db string) bool {
 	return mysqlPriv.DBIsVisible(user, host, db)
 }
 
-// UserPrivilegesTable implements the Checker interface.
+// UserPrivilegesTable implements the Manager interface.
 func (p *UserPrivileges) UserPrivilegesTable() [][]types.Datum {
 	mysqlPriv := p.Handle.Get()
 	return mysqlPriv.UserPrivilegesTable()
 }
 
-// Check implements Checker.Check interface.
+// Check implements Manager.Check interface.
 func (p *UserPrivileges) Check(ctx context.Context, db *model.DBInfo, tbl *model.TableInfo, privilege mysql.PrivilegeType) (bool, error) {
 	if p.privs == nil {
 		// Lazy load
@@ -452,7 +452,7 @@ func (p *UserPrivileges) loadTableScopePrivileges(ctx context.Context) error {
 	return nil
 }
 
-// ShowGrants implements privilege.Checker ShowGrants interface.
+// ShowGrants implements privilege.Manager ShowGrants interface.
 func (p *UserPrivileges) ShowGrants(ctx context.Context, user string) ([]string, error) {
 	// If user is current user
 	if user == p.User && p.privs != nil {

--- a/session.go
+++ b/session.go
@@ -764,17 +764,17 @@ func (s *session) Auth(user string, auth []byte, salt []byte) bool {
 	// Get user password.
 	name := strs[0]
 	host := strs[1]
-	checker := privilege.GetPrivilegeChecker(s)
+	pm := privilege.GetPrivilegeManager(s)
 
 	// Check IP.
-	if checker.ConnectionVerification(name, host, auth, salt) {
+	if pm.ConnectionVerification(name, host, auth, salt) {
 		s.sessionVars.User = name + "@" + host
 		return true
 	}
 
 	// Check Hostname.
 	for _, addr := range getHostByIP(host) {
-		if checker.ConnectionVerification(name, addr, auth, salt) {
+		if pm.ConnectionVerification(name, addr, auth, salt) {
 			s.sessionVars.User = name + "@" + addr
 			return true
 		}
@@ -816,10 +816,10 @@ func CreateSession(store kv.Storage) (Session, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	privChecker := &privileges.UserPrivileges{
+	pm := &privileges.UserPrivileges{
 		Handle: do.PrivilegeHandle(),
 	}
-	privilege.BindPrivilegeChecker(s, privChecker)
+	privilege.BindPrivilegeManager(s, pm)
 
 	return s, nil
 }

--- a/store/tikv/gc_worker.go
+++ b/store/tikv/gc_worker.go
@@ -117,7 +117,7 @@ func (w *GCWorker) start() {
 					break
 				}
 				// Disable privilege check for gc worker session.
-				privilege.BindPrivilegeChecker(w.session, nil)
+				privilege.BindPrivilegeManager(w.session, nil)
 			}
 
 			isLeader, err := w.checkLeader()


### PR DESCRIPTION
Checker is not an accurate name for the interface now, it have not only `Check` method,
but also many other privilege related methods.