### PR TITLE
util/mvmap: keep the input order when get multiple values.

### DIFF
--- a/util/mvmap/mvmap.go
+++ b/util/mvmap/mvmap.go
@@ -121,7 +121,7 @@ func NewMVMap() *MVMap {
 	m.hashTable = make(map[uint64]entryAddr)
 	m.hashFunc = fnv.New64()
 	m.entryStore.slices = [][]entry{make([]entry, 0, 64)}
-	// append first empty entry so zero entry pointer an represent null.
+	// Append the first empty entry, so the zero entryAddr can represent null.
 	m.entryStore.put(entry{})
 	m.dataStore.slices = [][]byte{make([]byte, 0, 1024)}
 	return m
@@ -139,8 +139,8 @@ func (m *MVMap) Put(key, value []byte) {
 		valLen: uint32(len(value)),
 		next:   oldEntryAddr,
 	}
-	newEntryPtr := m.entryStore.put(e)
-	m.hashTable[hashKey] = newEntryPtr
+	newEntryAddr := m.entryStore.put(e)
+	m.hashTable[hashKey] = newEntryAddr
 }
 
 // Get gets the values of the key.
@@ -156,6 +156,11 @@ func (m *MVMap) Get(key []byte) [][]byte {
 			continue
 		}
 		values = append(values, val)
+	}
+	// Keep the order of input.
+	for i := 0; i < len(values)/2; i++ {
+		j := len(values) - 1 - i
+		values[i], values[j] = values[j], values[i]
 	}
 	return values
 }

--- a/util/mvmap/mvmap_test.go
+++ b/util/mvmap/mvmap_test.go
@@ -27,11 +27,11 @@ func TestMVMap(t *testing.T) {
 	m.Put([]byte("def"), []byte("def1"))
 	m.Put([]byte("def"), []byte("def2"))
 	vals := m.Get([]byte("abc"))
-	if fmt.Sprintf("%s", vals) != "[abc2 abc1]" {
+	if fmt.Sprintf("%s", vals) != "[abc1 abc2]" {
 		t.FailNow()
 	}
 	vals = m.Get([]byte("def"))
-	if fmt.Sprintf("%s", vals) != "[def2 def1]" {
+	if fmt.Sprintf("%s", vals) != "[def1 def2]" {
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
Some ORM tests assumes the input order when join tables.