### PR TITLE
column: fix false negative utf8 check

### DIFF
--- a/executor/statement_context_test.go
+++ b/executor/statement_context_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+	"unicode/utf8"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/table"
@@ -84,4 +85,8 @@ func (s *testSuite) TestStatementContext(c *C) {
 	_, err = tk.Exec("insert sc2 values (unhex('4040ffff'))")
 	c.Assert(err, IsNil)
 	tk.MustQuery("select length(a) from sc2").Check(testkit.Rows("2", "4"))
+
+	tk.MustExec("set @@tidb_skip_utf8_check = '0'")
+	runeErrStr := string(utf8.RuneError)
+	tk.MustExec(fmt.Sprintf("insert sc2 values ('%s')", runeErrStr))
 }

--- a/table/column.go
+++ b/table/column.go
@@ -130,6 +130,9 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 	str := casted.GetString()
 	for i, r := range str {
 		if r == utf8.RuneError {
+			if strings.HasPrefix(str[i:], string(utf8.RuneError)) {
+				continue
+			}
 			log.Errorf("[%d] incorrect utf8 value: %x for column %s",
 				ctx.GetSessionVars().ConnectionID, []byte(str), col.Name)
 			// Truncate to valid utf8 string.


### PR DESCRIPTION
unicode 'u\fffd' is used to represent utf8 error when range a string, but itself is a valid utf8 character.