### PR TITLE
expression: fix pb2expr panic.

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -42,12 +42,6 @@ func newBaseBuiltinFunc(args []Expression, ctx context.Context) baseBuiltinFunc 
 	}
 }
 
-func (b *baseBuiltinFunc) init(args []Expression, ctx context.Context) {
-	b.args = args
-	b.argValues = make([]types.Datum, len(args))
-	b.ctx = ctx
-}
-
 func (b *baseBuiltinFunc) evalArgs(row []types.Datum) (_ []types.Datum, err error) {
 	for i, arg := range b.args {
 		b.argValues[i], err = arg.Eval(row)
@@ -103,8 +97,6 @@ type builtinFunc interface {
 	equal(builtinFunc) bool
 	// getCtx returns this function's context.
 	getCtx() context.Context
-
-	init(args []Expression, ctx context.Context)
 }
 
 // baseFunctionClass will be contained in every struct that implement functionClass interface.

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -355,7 +355,7 @@ var funcs = map[string]functionClass{
 	ast.In:         &inFunctionClass{baseFunctionClass{ast.In, 1, -1}},
 	ast.IsTruth:    &isTrueOpFunctionClass{baseFunctionClass{ast.IsTruth, 1, 1}, opcode.IsTruth},
 	ast.IsFalsity:  &isTrueOpFunctionClass{baseFunctionClass{ast.IsFalsity, 1, 1}, opcode.IsFalsity},
-	ast.Like:       &likeFunctionClass{baseFunctionClass{ast.Like, 3, 3}},
+	ast.Like:       &likeFunctionClass{baseFunctionClass{ast.Like, 2, 3}},
 	ast.Regexp:     &regexpFunctionClass{baseFunctionClass{ast.Regexp, 2, 2}},
 	ast.Case:       &caseWhenFunctionClass{baseFunctionClass{ast.Case, 1, -1}},
 	ast.RowFunc:    &rowFunctionClass{baseFunctionClass{ast.RowFunc, 2, -1}},

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -164,6 +164,10 @@ func (s *testEvalSuite) TestEval(c *C) {
 			types.NewIntDatum(0),
 		},
 		{
+			buildExpr(tipb.ExprType_And, buildExpr(tipb.ExprType_And, types.NewIntDatum(1), types.NewIntDatum(1)), buildExpr(tipb.ExprType_And, types.NewIntDatum(0), types.NewIntDatum(1))),
+			types.NewIntDatum(0),
+		},
+		{
 			buildExpr(tipb.ExprType_And, types.NewIntDatum(1), types.NewIntDatum(1)),
 			types.NewIntDatum(1),
 		},


### PR DESCRIPTION
every time we get builtinFunctionSignature, we should copy it.
A temp fix is to get function class directly.
@shenli @coocood @zimulala PTAL