### PR TITLE
util/types: use GenByArgs for ErrOverflow.

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -509,7 +509,7 @@ func (b *builtinConvSig) eval(row []types.Datum) (d types.Datum, err error) {
 
 	val, err := strconv.ParseUint(n, int(fromBase), 64)
 	if err != nil {
-		return d, errors.Trace(types.ErrOverflow)
+		return d, types.ErrOverflow.GenByArgs("BIGINT UNSINGED", n)
 	}
 	// See https://github.com/mysql/mysql-server/blob/5.7/strings/ctype-simple.c#L598
 	if signed {

--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -140,7 +140,7 @@ func StrToInt(sc *variable.StatementContext, str string) (int64, error) {
 	validPrefix, err := getValidIntPrefix(sc, str)
 	iVal, err1 := strconv.ParseInt(validPrefix, 10, 64)
 	if err1 != nil {
-		return iVal, errors.Trace(ErrOverflow)
+		return iVal, ErrOverflow.GenByArgs("BIGINT", validPrefix)
 	}
 	return iVal, errors.Trace(err)
 }
@@ -154,7 +154,7 @@ func StrToUint(sc *variable.StatementContext, str string) (uint64, error) {
 	}
 	uVal, err1 := strconv.ParseUint(validPrefix, 10, 64)
 	if err1 != nil {
-		return uVal, errors.Trace(ErrOverflow)
+		return uVal, ErrOverflow.GenByArgs("BIGINT UNSIGNED", validPrefix)
 	}
 	return uVal, errors.Trace(err)
 }
@@ -204,7 +204,7 @@ func floatStrToIntStr(validFloat string) (string, error) {
 	}
 	if exp > 0 && int64(intCnt) > (math.MaxInt64-int64(exp)) {
 		// (exp + incCnt) overflows MaxInt64.
-		return validFloat, errors.Trace(ErrOverflow)
+		return validFloat, ErrOverflow.GenByArgs("BIGINT", validFloat)
 	}
 	intCnt += exp
 	if intCnt <= 0 {
@@ -220,7 +220,7 @@ func floatStrToIntStr(validFloat string) (string, error) {
 		extraZeroCount := intCnt - len(digits)
 		if extraZeroCount > 20 {
 			// Return overflow to avoid allocating too much memory.
-			return validFloat, errors.Trace(ErrOverflow)
+			return validFloat, ErrOverflow.GenByArgs("BIGINT", validFloat)
 		}
 		validInt = string(digits) + strings.Repeat("0", extraZeroCount)
 	}

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -1000,7 +1000,7 @@ func (d *Datum) convertToMysqlDecimal(sc *variable.StatementContext, target *Fie
 		prec, frac := dec.PrecisionAndFrac()
 		if prec-frac > target.Flen-target.Decimal {
 			dec = NewMaxOrMinDec(dec.IsNegative(), target.Flen, target.Decimal)
-			err = errors.Trace(ErrOverflow)
+			err = ErrOverflow.GenByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
 		} else if frac != target.Decimal {
 			dec.Round(dec, target.Decimal)
 			if frac > target.Decimal {

--- a/util/types/helper.go
+++ b/util/types/helper.go
@@ -58,7 +58,7 @@ func getMaxFloat(flen int, decimal int) float64 {
 func TruncateFloat(f float64, flen int, decimal int) (float64, error) {
 	if math.IsNaN(f) {
 		// nan returns 0
-		return 0, ErrOverflow
+		return 0, ErrOverflow.GenByArgs("DOUBLE", "")
 	}
 
 	maxF := getMaxFloat(flen, decimal)
@@ -70,10 +70,10 @@ func TruncateFloat(f float64, flen int, decimal int) (float64, error) {
 	var err error
 	if f > maxF {
 		f = maxF
-		err = ErrOverflow
+		err = ErrOverflow.GenByArgs("DOUBLE", "")
 	} else if f < -maxF {
 		f = -maxF
-		err = ErrOverflow
+		err = ErrOverflow.GenByArgs("DOUBLE", "")
 	}
 
 	return f, errors.Trace(err)


### PR DESCRIPTION
ErrOverflow has changed to a format, we need to use GenByArgs to get a valid message.