### PR TITLE
plan: fix resolving group by.

### DIFF
--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -540,8 +540,7 @@ func (nr *nameResolver) resolveColumnNameInContext(ctx *resolverContext, cn *ast
 				// It is not ambiguous and already resolved from table source.
 				// We should restore its Refer.
 				cn.Refer = r
-			}
-			if _, ok := cn.Refer.Expr.(*ast.AggregateFuncExpr); ok {
+			} else if _, ok := cn.Refer.Expr.(*ast.AggregateFuncExpr); ok {
 				nr.Err = ErrIllegalReference.Gen("Reference '%s' not supported (reference to group function)", cn.Name.Name.O)
 			}
 			return true

--- a/plan/resolver_test.go
+++ b/plan/resolver_test.go
@@ -73,6 +73,7 @@ var resolverTestCases = []resolverTestCase{
 	{"select c1 from t1 group by c1 having c1 = 3", true},
 	{"select c1 from t1 group by c1 having c2 = 3", false},
 	{"select c1 from t1 where exists (select c2)", true},
+	{"select cnt from (select count(c2) as cnt from t1 group by c1) t2 group by cnt", true},
 }
 
 func (ts *testNameResolverSuite) TestNameResolver(c *C) {


### PR DESCRIPTION
When column is resolved by table sources, it should not check if it is aggregate function.