### PR TITLE
*: online update count in table stats.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -454,13 +454,16 @@ func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
 	if lease <= 0 {
 		return nil
 	}
+	deltaUpdateDuration := 5 * time.Minute
 	go func(do *Domain) {
-		ticker := time.NewTicker(lease)
-		defer ticker.Stop()
+		loadTicker := time.NewTicker(lease)
+		defer loadTicker.Stop()
+		deltaUpdateTicker := time.NewTicker(deltaUpdateDuration)
+		defer deltaUpdateTicker.Stop()
 
 		for {
 			select {
-			case <-ticker.C:
+			case <-loadTicker.C:
 				err := do.statsHandle.Update(do.InfoSchema())
 				if err != nil {
 					log.Error(errors.ErrorStack(err))
@@ -473,6 +476,8 @@ func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
 				if err != nil {
 					log.Error(errors.ErrorStack(err))
 				}
+			case <-deltaUpdateTicker.C:
+				do.statsHandle.DumpUpdateInfoToKV()
 			}
 		}
 	}(do)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -454,7 +454,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
 	if lease <= 0 {
 		return nil
 	}
-	deltaUpdateDuration := 5 * time.Minute
+	deltaUpdateDuration := time.Minute
 	go func(do *Domain) {
 		loadTicker := time.NewTicker(lease)
 		defer loadTicker.Stop()
@@ -477,7 +477,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
 					log.Error(errors.ErrorStack(err))
 				}
 			case <-deltaUpdateTicker.C:
-				do.statsHandle.DumpUpdateInfoToKV()
+				do.statsHandle.DumpStatsDeltaToKV()
 			}
 		}
 	}(do)

--- a/executor/write.go
+++ b/executor/write.go
@@ -131,6 +131,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	} else {
 		sc.AddAffectedRows(2)
 	}
+	sc.UpdateDeltaForTable(t.Meta().ID, 0, 1)
 	return nil
 }
 
@@ -252,6 +253,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 	}
 	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
+	ctx.GetSessionVars().StmtCtx.UpdateDeltaForTable(t.Meta().ID, -1, 1)
 	return nil
 }
 

--- a/executor/write.go
+++ b/executor/write.go
@@ -131,7 +131,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 	} else {
 		sc.AddAffectedRows(2)
 	}
-	sc.UpdateDeltaForTable(t.Meta().ID, 0, 1)
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, 0, 1)
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 	}
 	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
-	ctx.GetSessionVars().StmtCtx.UpdateDeltaForTable(t.Meta().ID, -1, 1)
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, -1, 1)
 	return nil
 }
 

--- a/session.go
+++ b/session.go
@@ -752,11 +752,7 @@ func (s *session) ClearValue(key fmt.Stringer) {
 // Close function does some clean work when session end.
 func (s *session) Close() error {
 	if s.statsCollector != nil {
-		do, err := domap.Get(s.store)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		do.StatsHandle().DelStatsUpdateHandle(s.statsCollector)
+		s.statsCollector.Delete()
 	}
 	return s.RollbackTxn()
 }
@@ -849,7 +845,7 @@ func CreateSession(store kv.Storage) (Session, error) {
 
 	// Add statsUpdateHandle.
 	if do.StatsHandle() != nil {
-		s.statsCollector = do.StatsHandle().NewStatsUpdateHandle()
+		s.statsCollector = do.StatsHandle().NewSessionStatsCollector()
 	}
 
 	return s, nil

--- a/session.go
+++ b/session.go
@@ -275,7 +275,7 @@ func (s *session) doCommitWithRetry() error {
 		log.Warnf("[%d] finished txn:%v, %v", s.sessionVars.ConnectionID, s.txn, err)
 		return errors.Trace(err)
 	}
-	mapper := s.GetSessionVars().StmtCtx.UpdateMapper
+	mapper := s.GetSessionVars().TxnCtx.UpdateMapper
 	if s.statsUpdateHandle != nil && mapper != nil {
 		for id, item := range mapper {
 			s.statsUpdateHandle.Update(id, item.Delta, item.Count)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -81,17 +81,17 @@ type TransactionContext struct {
 	InfoSchema    interface{}
 	Histroy       interface{}
 	SchemaVersion int64
-	UpdateMapper  map[int64]*TableDelta
+	TableDeltaMap map[int64]*TableDelta
 }
 
 // UpdateDeltaForTable updates the delta info for some table.
 func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
-	if tc.UpdateMapper == nil {
-		tc.UpdateMapper = make(map[int64]*TableDelta)
+	if tc.TableDeltaMap == nil {
+		tc.TableDeltaMap = make(map[int64]*TableDelta)
 	}
-	item, ok := tc.UpdateMapper[tableID]
+	item, ok := tc.TableDeltaMap[tableID]
 	if !ok {
-		tc.UpdateMapper[tableID] = &TableDelta{delta, count}
+		tc.TableDeltaMap[tableID] = &TableDelta{delta, count}
 	} else {
 		item.Delta += delta
 		item.Count += count

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -81,6 +81,21 @@ type TransactionContext struct {
 	InfoSchema    interface{}
 	Histroy       interface{}
 	SchemaVersion int64
+	UpdateMapper  map[int64]*TableDelta
+}
+
+// UpdateDeltaForTable updates the delta info for some table.
+func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
+	if tc.UpdateMapper == nil {
+		tc.UpdateMapper = make(map[int64]*TableDelta)
+	}
+	item, ok := tc.UpdateMapper[tableID]
+	if !ok {
+		tc.UpdateMapper[tableID] = &TableDelta{delta, count}
+	} else {
+		item.Delta += delta
+		item.Count += count
+	}
 }
 
 // SessionVars is to handle user-defined or global variables in current session.
@@ -295,7 +310,6 @@ type StatementContext struct {
 		foundRows    uint64
 		warnings     []error
 	}
-	UpdateMapper map[int64]*TableDelta
 }
 
 // AddAffectedRows adds affected rows.
@@ -303,20 +317,6 @@ func (sc *StatementContext) AddAffectedRows(rows uint64) {
 	sc.mu.Lock()
 	sc.mu.affectedRows += rows
 	sc.mu.Unlock()
-}
-
-// UpdateDeltaForTable updates the delta info for some table.
-func (sc *StatementContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
-	if sc.UpdateMapper == nil {
-		sc.UpdateMapper = make(map[int64]*TableDelta)
-	}
-	item, ok := sc.UpdateMapper[tableID]
-	if !ok {
-		sc.UpdateMapper[tableID] = &TableDelta{delta, count}
-	} else {
-		item.Delta += delta
-		item.Count += count
-	}
 }
 
 // AffectedRows gets affected rows.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -81,21 +81,18 @@ type TransactionContext struct {
 	InfoSchema    interface{}
 	Histroy       interface{}
 	SchemaVersion int64
-	TableDeltaMap map[int64]*TableDelta
+	TableDeltaMap map[int64]TableDelta
 }
 
 // UpdateDeltaForTable updates the delta info for some table.
 func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
 	if tc.TableDeltaMap == nil {
-		tc.TableDeltaMap = make(map[int64]*TableDelta)
+		tc.TableDeltaMap = make(map[int64]TableDelta)
 	}
-	item, ok := tc.TableDeltaMap[tableID]
-	if !ok {
-		tc.TableDeltaMap[tableID] = &TableDelta{delta, count}
-	} else {
-		item.Delta += delta
-		item.Count += count
-	}
+	item := tc.TableDeltaMap[tableID]
+	item.Delta += delta
+	item.Count += count
+	tc.TableDeltaMap[tableID] = item
 }
 
 // SessionVars is to handle user-defined or global variables in current session.

--- a/statistics/statscache.go
+++ b/statistics/statscache.go
@@ -52,13 +52,13 @@ func NewHandle(ctx context.Context) *Handle {
 		ctx:        ctx,
 		ddlEventCh: make(chan *ddl.Event, 100),
 		updateManager: &updateManager{
-			listHead: &StatsUpdateHandle{
-				mapper: make(updateMapper),
+			listHead: &SessionStatsCollector{
+				mapper: make(tableDeltaMap),
 			},
 			mapper: struct {
 				sync.Mutex
-				updateMapper
-			}{updateMapper: make(updateMapper)},
+				tableDeltaMap
+			}{tableDeltaMap: make(tableDeltaMap)},
 			ctx: ctx,
 		},
 	}

--- a/statistics/statscache.go
+++ b/statistics/statscache.go
@@ -15,6 +15,7 @@ package statistics
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
 
 	"github.com/juju/errors"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"sync"
 )
 
 type statsCache map[int64]*Table

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -1,0 +1,142 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/util/sqlexec"
+)
+
+type updateItem struct {
+	delta int64
+	count int64
+}
+
+type updateMapper map[int64]*updateItem
+
+func (m updateMapper) update(id int64, delta int64, count int64) {
+	item, ok := m[id]
+	if !ok {
+		m[id] = &updateItem{delta: delta, count: count}
+	} else {
+		item.delta += delta
+		item.count += count
+	}
+}
+
+func (m updateMapper) merge(handle *StatsUpdateHandle) {
+	handle.Lock()
+	defer handle.Unlock()
+	for id, item := range handle.mapper {
+		m.update(id, item.delta, item.count)
+	}
+	handle.mapper = make(updateMapper)
+}
+
+// StatsUpdateHandle is a list item that holds the update mapper. If you want write or read mapper, you must add the lock.
+type StatsUpdateHandle struct {
+	sync.Mutex
+
+	mapper updateMapper
+	prev   *StatsUpdateHandle
+	next   *StatsUpdateHandle
+}
+
+// Update will updates the delta and count for one table id.
+func (h *StatsUpdateHandle) Update(id int64, delta int64, count int64) {
+	h.Lock()
+	defer h.Unlock()
+	h.mapper.update(id, delta, count)
+}
+
+type updateManager struct {
+	listHead *StatsUpdateHandle
+	mapper   struct {
+		sync.Mutex
+		updateMapper
+	}
+	ctx context.Context
+}
+
+func (m *updateManager) newStatsUpdateHandle() *StatsUpdateHandle {
+	m.listHead.Lock()
+	defer m.listHead.Unlock()
+	mapper := &StatsUpdateHandle{
+		mapper: make(updateMapper),
+		next:   m.listHead.next,
+		prev:   m.listHead,
+	}
+	m.listHead.next = mapper
+	return mapper
+}
+
+func (m *updateManager) delStatsUpdateHandle(handle *StatsUpdateHandle) {
+	m.listHead.Lock()
+	nextHandle := handle.next
+	prevHandle := handle.prev
+	prevHandle.next = nextHandle
+	if nextHandle != nil {
+		nextHandle.prev = prevHandle
+	}
+	m.listHead.Unlock()
+	m.mapper.Lock()
+	m.mapper.merge(handle)
+	m.mapper.Unlock()
+}
+
+func (m *updateManager) dumpUpdateMapper2KV() {
+	m.listHead.Lock()
+	for item := m.listHead.next; item != nil; item = item.next {
+		m.mapper.merge(item)
+	}
+	m.listHead.Unlock()
+	m.mapper.Lock()
+	for id, item := range m.mapper.updateMapper {
+		err := m.dumpTableStatToKV(id, item)
+		if err == nil {
+			delete(m.mapper.updateMapper, id)
+		} else {
+			log.Warnf("Error happens when updating stats table, the error message is %s.", err.Error())
+		}
+	}
+	m.mapper.Unlock()
+}
+
+func (m *updateManager) dumpTableStatToKV(id int64, item *updateItem) error {
+	_, err := m.ctx.(sqlexec.SQLExecutor).Execute("begin")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = m.ctx.(sqlexec.SQLExecutor).Execute(fmt.Sprintf("update mysql.stats_meta set version = %d, count = count + %d, modify_count = modify_count + %d where table_id = %d", m.ctx.Txn().StartTS(), item.delta, item.count, id))
+	if err != nil {
+		return errors.Trace(err)
+	}
+	_, err = m.ctx.(sqlexec.SQLExecutor).Execute("commit")
+	return errors.Trace(err)
+}
+
+// NewStatsUpdateHandle creates a new stats update handle. It is called when a session is created first time.
+func (h *Handle) NewStatsUpdateHandle() *StatsUpdateHandle {
+	return h.updateManager.newStatsUpdateHandle()
+}
+
+// DelStatsUpdateHandle deletes a stats update handle from updateManager. It is called when a session is closed.
+func (h *Handle) DelStatsUpdateHandle(handle *StatsUpdateHandle) {
+	h.updateManager.delStatsUpdateHandle(handle)
+}

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -82,6 +82,9 @@ func (m *updateManager) newStatsUpdateHandle() *StatsUpdateHandle {
 		next:   m.listHead.next,
 		prev:   m.listHead,
 	}
+	if m.listHead.next != nil {
+		m.listHead.next.prev = mapper
+	}
 	m.listHead.next = mapper
 	return mapper
 }
@@ -102,11 +105,11 @@ func (m *updateManager) delStatsUpdateHandle(handle *StatsUpdateHandle) {
 
 func (m *updateManager) dumpUpdateMapper2KV() {
 	m.listHead.Lock()
+	m.mapper.Lock()
 	for item := m.listHead.next; item != nil; item = item.next {
 		m.mapper.merge(item)
 	}
 	m.listHead.Unlock()
-	m.mapper.Lock()
 	for id, item := range m.mapper.updateMapper {
 		err := m.dumpTableStatToKV(id, item)
 		if err == nil {

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -41,18 +41,18 @@ func (m tableDeltaMap) merge(handle *SessionStatsCollector) {
 	handle.mapper = make(tableDeltaMap)
 }
 
-// SessionStatsCollector is a list item that holds the update mapper. If you want write or read mapper, you must add the lock.
+// SessionStatsCollector is a list item that holds the delta mapper. If you want to write or read mapper, you must lock it.
 type SessionStatsCollector struct {
 	sync.Mutex
 
 	mapper tableDeltaMap
 	prev   *SessionStatsCollector
 	next   *SessionStatsCollector
-	// If a session is close, it only set this flag true. Every time we sweep the list, we will remove the useless collector.
+	// If a session is closed, it only sets this flag true. Every time we sweep the list, we will remove the useless collector.
 	deleted bool
 }
 
-// Delete only set the deleted flag true, it will be deleted from list when DumpStatsDeltaToKV is called.
+// Delete only sets the deleted flag true, it will be deleted from list when DumpStatsDeltaToKV is called.
 func (s *SessionStatsCollector) Delete() {
 	s.Lock()
 	defer s.Unlock()
@@ -66,7 +66,7 @@ func (s *SessionStatsCollector) Update(id int64, delta int64, count int64) {
 	s.mapper.update(id, delta, count)
 }
 
-// tryToRemoveFromList will remove this collector from the list if its deleted flag is set.
+// tryToRemoveFromList will remove this collector from the list if it's deleted flag is set.
 func (s *SessionStatsCollector) tryToRemoveFromList() {
 	s.Lock()
 	defer s.Unlock()
@@ -115,6 +115,7 @@ func (h *Handle) DumpStatsDeltaToKV() {
 	}
 }
 
+// dumpTableStatDeltaToKV dumps a single delta with some table to KV and updates the version.
 func (h *Handle) dumpTableStatDeltaToKV(id int64, delta variable.TableDelta) error {
 	_, err := h.ctx.(sqlexec.SQLExecutor).Execute("begin")
 	if err != nil {

--- a/statistics/update_list_test.go
+++ b/statistics/update_list_test.go
@@ -26,20 +26,22 @@ func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
 	h := NewHandle(nil)
 	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {
-		items = append(items, h.NewStatsUpdateHandle())
+		items = append(items, h.NewSessionStatsCollector())
 	}
-	h.DelStatsUpdateHandle(items[0]) // delete tail
-	h.DelStatsUpdateHandle(items[2]) // delete middle
-	h.DelStatsUpdateHandle(items[4]) // delete head
+	items[0].Delete() // delete tail
+	items[2].Delete() // delete middle
+	items[4].Delete() // delete head
+	h.DumpStatsDeltaToKV()
 
-	c.Assert(h.updateManager.listHead.next, Equals, items[3])
+	c.Assert(h.listHead.next, Equals, items[3])
 	c.Assert(items[3].next, Equals, items[1])
-	c.Assert(h.updateManager.listHead.next.next.next, IsNil)
+	c.Assert(items[1].next, IsNil)
 	c.Assert(items[1].prev, Equals, items[3])
-	c.Assert(items[3].prev, Equals, h.updateManager.listHead)
+	c.Assert(items[3].prev, Equals, h.listHead)
 
 	// delete rest
-	h.DelStatsUpdateHandle(items[1])
-	h.DelStatsUpdateHandle(items[3])
-	c.Assert(h.updateManager.listHead.next, IsNil)
+	items[1].Delete()
+	items[3].Delete()
+	h.DumpStatsDeltaToKV()
+	c.Assert(h.listHead.next, IsNil)
 }

--- a/statistics/update_list_test.go
+++ b/statistics/update_list_test.go
@@ -24,7 +24,7 @@ type testUpdateListSuite struct {
 
 func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
 	h := NewHandle(nil)
-	var items []*StatsUpdateHandle
+	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {
 		items = append(items, h.NewStatsUpdateHandle())
 	}

--- a/statistics/update_list_test.go
+++ b/statistics/update_list_test.go
@@ -1,0 +1,45 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testUpdateListSuite{})
+
+type testUpdateListSuite struct {
+}
+
+func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
+	h := NewHandle(nil)
+	var items []*StatsUpdateHandle
+	for i := 0; i < 5; i++ {
+		items = append(items, h.NewStatsUpdateHandle())
+	}
+	h.DelStatsUpdateHandle(items[0]) // delete tail
+	h.DelStatsUpdateHandle(items[2]) // delete middle
+	h.DelStatsUpdateHandle(items[4]) // delete head
+
+	c.Assert(h.updateManager.listHead.next, Equals, items[3])
+	c.Assert(items[3].next, Equals, items[1])
+	c.Assert(h.updateManager.listHead.next.next.next, IsNil)
+	c.Assert(items[1].prev, Equals, items[3])
+	c.Assert(items[3].prev, Equals, h.updateManager.listHead)
+
+	// delete rest
+	h.DelStatsUpdateHandle(items[1])
+	h.DelStatsUpdateHandle(items[3])
+	c.Assert(h.updateManager.listHead.next, IsNil)
+}

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -1,0 +1,63 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/model"
+)
+
+var _ = Suite(&testStatsUpdateSuite{})
+
+type testStatsUpdateSuite struct{}
+
+func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
+	store, do, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t1 (c1 int, c2 int)")
+	testKit.MustExec("create table t2 (c1 int, c2 int)")
+
+	rowCount1 := 10
+	rowCount2 := 20
+	for i := 0; i < rowCount1; i ++ {
+		testKit.MustExec("insert into t1 values(1, 2)")
+	}
+	for i := 0; i < rowCount2; i ++ {
+		testKit.MustExec("insert into t2 values(1, 2)")
+	}
+
+	is := do.InfoSchema()
+	tbl1, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	tableInfo1 := tbl1.Meta()
+	h := do.StatsHandle()
+
+	h.HandleDDLEvent(<-h.DDLEventCh())
+	h.HandleDDLEvent(<-h.DDLEventCh())
+
+	h.DumpUpdateInfoToKV()
+	h.Update(is)
+	stats1 := h.GetTableStats(tableInfo1)
+	c.Assert(stats1.Count, Equals, int64(rowCount1))
+
+	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
+	c.Assert(err, IsNil)
+	tableInfo2 := tbl2.Meta()
+	stats2 := h.GetTableStats(tableInfo2)
+	c.Assert(stats2.Count, Equals, int64(rowCount2))
+}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -355,6 +355,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Insert)
 	}
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
+	ctx.GetSessionVars().StmtCtx.UpdateDeltaForTable(t.ID, 1, 1)
 	return recordID, nil
 }
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -355,7 +355,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum) (recordID int64,
 		mutation.Sequence = append(mutation.Sequence, binlog.MutationType_Insert)
 	}
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
-	ctx.GetSessionVars().StmtCtx.UpdateDeltaForTable(t.ID, 1, 1)
+	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.ID, 1, 1)
 	return recordID, nil
 }
 


### PR DESCRIPTION
When insert and update happens, we will cache the changed info in every session. After a duration(five minutes now) passes, handle will sweep every cache and merge them. Then dump the delta info to TiKV.
@shenli @coocood @zimulala @lamxTyler PTAL