### PR TITLE
statistics: process the case that we lack a column in stats table

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -982,9 +982,9 @@ func (b *planBuilder) buildDataSource(tn *ast.TableName) LogicalPlan {
 	var statisticTable *statistics.Table
 	if handle == nil {
 		// When the first session is created, the handle hasn't been initialized.
-		statisticTable = statistics.PseudoTable(tn.TableInfo)
+		statisticTable = statistics.PseudoTable(tn.TableInfo.ID)
 	} else {
-		statisticTable = handle.GetTableStats(tn.TableInfo)
+		statisticTable = handle.GetTableStats(tn.TableInfo.ID)
 	}
 	if b.err != nil {
 		return nil

--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -107,7 +107,7 @@ func (b *Builder) splitAndConcurrentBuild(t *Table, IDs []int64, isSorted bool) 
 // NewTable creates a table statistics.
 func (b *Builder) NewTable() (*Table, error) {
 	t := &Table{
-		Info:    b.TblInfo,
+		tableID: b.TblInfo.ID,
 		Count:   b.Count,
 		Columns: make(map[int64]*Column, len(b.TblInfo.Columns)),
 		Indices: make(map[int64]*Index, len(b.TblInfo.Indices)),

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -227,11 +227,8 @@ func (s *testStatisticsSuite) TestPseudoTable(c *C) {
 		FieldType: *types.NewFieldType(mysql.TypeLonglong),
 	}
 	ti.Columns = append(ti.Columns, colInfo)
-	tbl := PseudoTable(ti)
+	tbl := PseudoTable(ti.ID)
 	c.Assert(tbl.Count, Greater, int64(0))
-	col := tbl.Columns[1]
-	c.Assert(col.ID, Greater, int64(0))
-	c.Assert(col.NDV, Greater, int64(0))
 	sc := new(variable.StatementContext)
 	count, err := tbl.ColumnLessRowCount(sc, types.NewIntDatum(100), colInfo)
 	c.Assert(err, IsNil)

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -41,7 +41,7 @@ const (
 
 // Table represents statistics for a table.
 type Table struct {
-	Info    *model.TableInfo
+	tableID int64
 	Columns map[int64]*Column
 	Indices map[int64]*Index
 	Count   int64 // Total row count in a table.
@@ -50,7 +50,7 @@ type Table struct {
 
 func (t *Table) copy() *Table {
 	nt := &Table{
-		Info:    t.Info,
+		tableID: t.tableID,
 		Count:   t.Count,
 		Pseudo:  t.Pseudo,
 		Columns: make(map[int64]*Column),
@@ -74,34 +74,34 @@ func (h *Handle) SaveToStorage(t *Table) error {
 	}
 	txn := h.ctx.Txn()
 	version := txn.StartTS()
-	deleteSQL := fmt.Sprintf("delete from mysql.stats_meta where table_id = %d", t.Info.ID)
+	deleteSQL := fmt.Sprintf("delete from mysql.stats_meta where table_id = %d", t.tableID)
 	_, err = exec.Execute(deleteSQL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	insertSQL := fmt.Sprintf("insert into mysql.stats_meta (version, table_id, count) values (%d, %d, %d)", version, t.Info.ID, t.Count)
+	insertSQL := fmt.Sprintf("insert into mysql.stats_meta (version, table_id, count) values (%d, %d, %d)", version, t.tableID, t.Count)
 	_, err = exec.Execute(insertSQL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	deleteSQL = fmt.Sprintf("delete from mysql.stats_histograms where table_id = %d", t.Info.ID)
+	deleteSQL = fmt.Sprintf("delete from mysql.stats_histograms where table_id = %d", t.tableID)
 	_, err = exec.Execute(deleteSQL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	deleteSQL = fmt.Sprintf("delete from mysql.stats_buckets where table_id = %d", t.Info.ID)
+	deleteSQL = fmt.Sprintf("delete from mysql.stats_buckets where table_id = %d", t.tableID)
 	_, err = exec.Execute(deleteSQL)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	for _, col := range t.Columns {
-		err = col.saveToStorage(h.ctx, t.Info.ID, 0)
+		err = col.saveToStorage(h.ctx, t.tableID, 0)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
 	for _, idx := range t.Indices {
-		err = idx.saveToStorage(h.ctx, t.Info.ID, 1)
+		err = idx.saveToStorage(h.ctx, t.tableID, 1)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -122,7 +122,7 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 		// We copy it before writing to avoid race.
 		table = table.copy()
 	}
-	table.Info = tableInfo
+	table.tableID = tableInfo.ID
 	table.Count = count
 
 	selSQL := fmt.Sprintf("select table_id, is_index, hist_id, distinct_count, version from mysql.stats_histograms where table_id = %d", tableInfo.ID)
@@ -132,8 +132,6 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 	}
 	// indexCount and columnCount record the number of indices and columns in table stats. If the number don't match with
 	// tableInfo, we will return pseudo table.
-	// TODO: In fact, we can return pseudo column.
-	indexCount, columnCount := 0, 0
 	for _, row := range rows {
 		distinct := row.Data[3].GetInt64()
 		histID := row.Data[2].GetInt64()
@@ -155,10 +153,8 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 			}
 			if idx != nil {
 				table.Indices[histID] = idx
-				indexCount++
 			} else {
-				// TODO: If we support create index ddl, it may be a new created index. We needn't refer tableInfo any more.
-				log.Warnf("We cannot find index id %d in table %s now. It may be deleted.", histID, tableInfo.Name)
+				log.Warnf("We cannot find index id %d in table info %s now. It may be deleted.", histID, tableInfo.Name)
 			}
 		} else {
 			// process column
@@ -177,17 +173,13 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 			}
 			if col != nil {
 				table.Columns[col.ID] = col
-				columnCount++
 			} else {
-				log.Warnf("We cannot find column id %d in table %s now. It may be deleted.", histID, tableInfo.Name)
+				// If we didn't find a Column or Index in tableInfo, we won't load the histogram for it.
+				// But don't worry, next lease the ddl will be updated, and we will load a same table for two times to
+				// avoid error.
+				log.Warnf("We cannot find column id %d in table info %s now. It may be deleted.", histID, tableInfo.Name)
 			}
 		}
-	}
-	if indexCount != len(tableInfo.Indices) {
-		return nil, errors.New("The number of indices doesn't match with the schema")
-	}
-	if columnCount != len(tableInfo.Columns) {
-		return nil, errors.New("The number of columns doesn't match with the schema")
 	}
 	return table, nil
 }
@@ -195,8 +187,11 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 // String implements Stringer interface.
 func (t *Table) String() string {
 	strs := make([]string, 0, len(t.Columns)+1)
-	strs = append(strs, fmt.Sprintf("Table:%d count:%d", t.Info.ID, t.Count))
+	strs = append(strs, fmt.Sprintf("Table:%d Count:%d", t.tableID, t.Count))
 	for _, col := range t.Columns {
+		strs = append(strs, col.String())
+	}
+	for _, col := range t.Indices {
 		strs = append(strs, col.String())
 	}
 	return strings.Join(strs, "\n")
@@ -262,29 +257,11 @@ func (t *Table) GetRowCountByIndexRanges(sc *variable.StatementContext, idxID in
 }
 
 // PseudoTable creates a pseudo table statistics when statistic can not be found in KV store.
-func PseudoTable(ti *model.TableInfo) *Table {
-	t := &Table{Info: ti, Pseudo: true}
+func PseudoTable(tableID int64) *Table {
+	t := &Table{tableID: tableID, Pseudo: true}
 	t.Count = pseudoRowCount
-	t.Columns = make(map[int64]*Column, len(ti.Columns))
-	t.Indices = make(map[int64]*Index, len(ti.Indices))
-	for _, v := range ti.Columns {
-		c := &Column{
-			Histogram: Histogram{
-				ID:  v.ID,
-				NDV: pseudoRowCount / 2,
-			},
-		}
-		t.Columns[v.ID] = c
-	}
-	for _, v := range ti.Indices {
-		idx := &Index{
-			Histogram: Histogram{
-				ID:  v.ID,
-				NDV: pseudoRowCount / 2,
-			},
-		}
-		t.Indices[v.ID] = idx
-	}
+	t.Columns = make(map[int64]*Column)
+	t.Indices = make(map[int64]*Index)
 	return t
 }
 

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -130,8 +130,6 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, count int64) 
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	// indexCount and columnCount record the number of indices and columns in table stats. If the number don't match with
-	// tableInfo, we will return pseudo table.
 	for _, row := range rows {
 		distinct := row.Data[3].GetInt64()
 		histID := row.Data[2].GetInt64()

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -52,13 +52,13 @@ func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
 
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 := h.GetTableStats(tableInfo1)
+	stats1 := h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1))
 
 	tbl2, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
 	c.Assert(err, IsNil)
 	tableInfo2 := tbl2.Meta()
-	stats2 := h.GetTableStats(tableInfo2)
+	stats2 := h.GetTableStats(tableInfo2.ID)
 	c.Assert(stats2.Count, Equals, int64(rowCount2))
 
 	// Test update in a txn.
@@ -67,7 +67,7 @@ func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
 	}
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1*2))
 
 	testKit.MustExec("begin")
@@ -77,7 +77,7 @@ func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
 	testKit.MustExec("commit")
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1*3))
 
 	testKit.MustExec("begin")
@@ -93,9 +93,9 @@ func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
 	testKit.MustExec("commit")
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1*3))
-	stats2 = h.GetTableStats(tableInfo2)
+	stats2 = h.GetTableStats(tableInfo2.ID)
 	c.Assert(stats2.Count, Equals, int64(rowCount2))
 
 	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
@@ -133,7 +133,7 @@ func (s *testStatsUpdateSuite) TestMultiSession(c *C) {
 
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 := h.GetTableStats(tableInfo1)
+	stats1 := h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1))
 
 	for i := 0; i < rowCount1; i++ {
@@ -156,7 +156,7 @@ func (s *testStatsUpdateSuite) TestMultiSession(c *C) {
 
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1*2))
 	rs := testKit.MustQuery("select modify_count from mysql.stats_meta")
 	rs.Check(testkit.Rows("60"))
@@ -185,14 +185,14 @@ func (s *testStatsUpdateSuite) TestTxnWithFailure(c *C) {
 	}
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 := h.GetTableStats(tableInfo1)
+	stats1 := h.GetTableStats(tableInfo1.ID)
 	// have not commit
 	c.Assert(stats1.Count, Equals, int64(0))
 	testKit.MustExec("commit")
 
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1))
 
 	_, err = testKit.Exec("insert into t1 values(0, 2)")
@@ -200,12 +200,12 @@ func (s *testStatsUpdateSuite) TestTxnWithFailure(c *C) {
 
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1))
 
 	testKit.MustExec("insert into t1 values(-1, 2)")
 	h.DumpStatsDeltaToKV()
 	h.Update(is)
-	stats1 = h.GetTableStats(tableInfo1)
+	stats1 = h.GetTableStats(tableInfo1.ID)
 	c.Assert(stats1.Count, Equals, int64(rowCount1+1))
 }


### PR DESCRIPTION
When we can't find a column in stats table, we return a pseudo table for now. It's not reasonable.
We should return a real table and use pseudo estimation for the missed histogram.

@shenli @coocood @zimulala @lamxTyler PTAL