### PR TITLE
*: show create table output utf8_bin collate.

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -712,7 +712,7 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) {
 		case ast.TableOptionCharset:
 			tbInfo.Charset = op.StrValue
 		case ast.TableOptionCollate:
-			tbInfo.Charset = op.StrValue
+			tbInfo.Collate = op.StrValue
 		}
 	}
 }

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -207,7 +207,7 @@ func (s *testSuite) TestAlterTableModifyColumn(c *C) {
 	tk.MustExec("alter table mc modify column c2 text")
 	result := tk.MustQuery("show create table mc")
 	createSQL := result.Rows()[0][1]
-	expected := "CREATE TABLE `mc` (\n  `c1` bigint(21) DEFAULT NULL,\n  `c2` text DEFAULT NULL\n) ENGINE=InnoDB"
+	expected := "CREATE TABLE `mc` (\n  `c1` bigint(21) DEFAULT NULL,\n  `c2` text DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
 	c.Assert(createSQL, Equals, expected)
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -504,9 +504,17 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	buf.WriteString("\n")
 
 	buf.WriteString(") ENGINE=InnoDB")
-	if s := tb.Meta().Charset; len(s) > 0 {
-		buf.WriteString(fmt.Sprintf(" DEFAULT CHARSET=%s", s))
+	charsetName := tb.Meta().Charset
+	if len(charsetName) == 0 {
+		charsetName = charset.CharsetUTF8
 	}
+	collate := tb.Meta().Collate
+	if len(collate) == 0 {
+		collate = charset.CollationUTF8
+	}
+	// Because we only support case sensitive utf8_bin collate, we need to explicitly set the default charset and collation
+	// to make it work on MySQL server which has default collate utf8_general_ci.
+	buf.WriteString(fmt.Sprintf(" DEFAULT CHARSET=%s COLLATE=%s", charsetName, collate))
 
 	if tb.Meta().AutoIncID > 0 {
 		buf.WriteString(fmt.Sprintf(" AUTO_INCREMENT=%d", tb.Meta().AutoIncID))

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -47,16 +47,16 @@ func (s *testSuite) TestShow(c *C) {
 	row := result.Rows()[0]
 	// For issue https://github.com/pingcap/tidb/issues/1061
 	expectedRow := []interface{}{
-		"SHOW_test", "CREATE TABLE `SHOW_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `c1` int(11) DEFAULT NULL COMMENT 'c1_comment',\n  `c2` int(11) DEFAULT NULL,\n  `c3` int(11) DEFAULT '1',\n PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=28934 COMMENT='table_comment'"}
+		"SHOW_test", "CREATE TABLE `SHOW_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `c1` int(11) DEFAULT NULL COMMENT 'c1_comment',\n  `c2` int(11) DEFAULT NULL,\n  `c3` int(11) DEFAULT '1',\n PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=28934 COMMENT='table_comment'"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}
 
 	// For issue https://github.com/pingcap/tidb/issues/1918
 	testSQL = `create table ptest(
-		a int primary key, 
-		b double NOT NULL DEFAULT 2.0, 
-		c varchar(10) NOT NULL, 
+		a int primary key,
+		b double NOT NULL DEFAULT 2.0,
+		c varchar(10) NOT NULL,
 		d time unique,
 		e timestamp NULL
 	);`
@@ -66,7 +66,7 @@ func (s *testSuite) TestShow(c *C) {
 	c.Check(result.Rows(), HasLen, 1)
 	row = result.Rows()[0]
 	expectedRow = []interface{}{
-		"ptest", "CREATE TABLE `ptest` (\n  `a` int(11) NOT NULL,\n  `b` double NOT NULL DEFAULT '2.0',\n  `c` varchar(10) NOT NULL,\n  `d` time DEFAULT NULL,\n  `e` timestamp NULL DEFAULT NULL,\n PRIMARY KEY (`a`),\n  UNIQUE KEY `d` (`d`)\n) ENGINE=InnoDB"}
+		"ptest", "CREATE TABLE `ptest` (\n  `a` int(11) NOT NULL,\n  `b` double NOT NULL DEFAULT '2.0',\n  `c` varchar(10) NOT NULL,\n  `d` time DEFAULT NULL,\n  `e` timestamp NULL DEFAULT NULL,\n PRIMARY KEY (`a`),\n  UNIQUE KEY `d` (`d`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}
@@ -209,7 +209,7 @@ func (s *testSuite) TestForeignKeyInShowCreateTable(c *C) {
 		"  `id` int(11) NOT NULL AUTO_INCREMENT,",
 		" PRIMARY KEY (`id`),",
 		"  CONSTRAINT `Fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE",
-		") ENGINE=InnoDB",
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin",
 	}
 	testSQL = strings.Join(sqlLines, "\n")
 	tk.MustExec(testSQL)
@@ -228,7 +228,7 @@ func (s *testSuite) TestForeignKeyInShowCreateTable(c *C) {
 		"  `language_id` int(11) NOT NULL,",
 		"  CONSTRAINT `pilot_language_fkey` FOREIGN KEY (`pilot_id`) REFERENCES `pilots` (`pilot_id`),",
 		"  CONSTRAINT `languages_fkey` FOREIGN KEY (`language_id`) REFERENCES `languages` (`language_id`)",
-		") ENGINE=InnoDB",
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin",
 	}
 	testSQL = strings.Join(sqlLines, "\n")
 	tk.MustExec(testSQL)
@@ -247,7 +247,7 @@ func (s *testSuite) TestForeignKeyInShowCreateTable(c *C) {
 	c.Check(result.Rows(), HasLen, 1)
 	row = result.Rows()[0]
 	expectedRow = []interface{}{
-		"show_test", "CREATE TABLE `show_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n PRIMARY KEY (`id`)\n) ENGINE=InnoDB"}
+		"show_test", "CREATE TABLE `show_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}
@@ -259,7 +259,7 @@ func (s *testSuite) TestForeignKeyInShowCreateTable(c *C) {
 	c.Check(result.Rows(), HasLen, 1)
 	row = result.Rows()[0]
 	expectedRow = []interface{}{
-		"show_test", "CREATE TABLE `show_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n PRIMARY KEY (`id`),\n  CONSTRAINT `Fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE\n) ENGINE=InnoDB"}
+		"show_test", "CREATE TABLE `show_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n PRIMARY KEY (`id`),\n  CONSTRAINT `Fk` FOREIGN KEY (`id`) REFERENCES `t1` (`id`) ON DELETE CASCADE ON UPDATE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5892,23 +5892,23 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeString)
 		x.Flen = $3.(int)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $5.(string)
+		x.Collate = $6.(string)
 		$$ = x
 	}
 |	NationalOpt "CHAR" OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $4.(string)
+		x.Collate = $5.(string)
 		$$ = x
 	}
 |	NationalOpt "VARCHAR" FieldLen OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeVarchar)
 		x.Flen = $3.(int)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $5.(string)
+		x.Collate = $6.(string)
 		$$ = x
 	}
 |	"BINARY" OptFieldLen
@@ -5940,24 +5940,24 @@ StringType:
 |	TextType OptBinary OptCharset OptCollate
 	{
 		x := $1.(*types.FieldType)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $3.(string)
+		x.Collate = $4.(string)
 		$$ = x
 	}
 |	"ENUM" '(' StringList ')' OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeEnum)
 		x.Elems = $3.([]string)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $5.(string)
+		x.Collate = $6.(string)
 		$$ = x
 	}
 |	"SET" '(' StringList ')' OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeSet)
 		x.Elems = $3.([]string)
-		x.Charset = charset.CharsetUTF8
-		x.Collate = charset.CollationUTF8
+		x.Charset = $5.(string)
+		x.Collate = $6.(string)
 		$$ = x
 	}
 

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4176,9 +4176,6 @@ CastType:
 	{
 		x := types.NewFieldType(mysql.TypeString)
 		x.Flen = $2.(int)
-		if $3.(bool) {
-			x.Flag |= mysql.BinaryFlag
-		}
 		x.Charset = $4.(string)
 		$$ = x
 	}
@@ -5895,28 +5892,23 @@ StringType:
 	{
 		x := types.NewFieldType(mysql.TypeString)
 		x.Flen = $3.(int)
-		if $4.(bool) {
-			x.Flag |= mysql.BinaryFlag
-		}
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 |	NationalOpt "CHAR" OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeString)
-		if $3.(bool) {
-			x.Flag |= mysql.BinaryFlag
-		}
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 |	NationalOpt "VARCHAR" FieldLen OptBinary OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeVarchar)
 		x.Flen = $3.(int)
-		if $4.(bool) {
-			x.Flag |= mysql.BinaryFlag
-		}
-		x.Charset = $5.(string)
-		x.Collate = $6.(string)
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 |	"BINARY" OptFieldLen
@@ -5925,6 +5917,7 @@ StringType:
 		x.Flen = $2.(int)
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CharsetBin
+		x.Flag |= mysql.BinaryFlag
 		$$ = x
 	}
 |	"VARBINARY" FieldLen
@@ -5933,36 +5926,38 @@ StringType:
 		x.Flen = $2.(int)
 		x.Charset = charset.CharsetBin
 		x.Collate = charset.CharsetBin
+		x.Flag |= mysql.BinaryFlag
 		$$ = x
 	}
 |	BlobType
 	{
+		x := $1.(*types.FieldType)
+		x.Charset = charset.CharsetBin
+		x.Collate = charset.CharsetBin
+		x.Flag |= mysql.BinaryFlag
 		$$ = $1.(*types.FieldType)
 	}
 |	TextType OptBinary OptCharset OptCollate
 	{
 		x := $1.(*types.FieldType)
-		if $2.(bool) {
-			x.Flag |= mysql.BinaryFlag
-		}
-		x.Charset = $3.(string)
-		x.Collate = $4.(string)
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 |	"ENUM" '(' StringList ')' OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeEnum)
 		x.Elems = $3.([]string)
-		x.Charset = $5.(string)
-		x.Collate = $6.(string)
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 |	"SET" '(' StringList ')' OptCharset OptCollate
 	{
 		x := types.NewFieldType(mysql.TypeSet)
 		x.Elems = $3.([]string)
-		x.Charset = $5.(string)
-		x.Collate = $6.(string)
+		x.Charset = charset.CharsetUTF8
+		x.Collate = charset.CollationUTF8
 		$$ = x
 	}
 
@@ -5974,30 +5969,22 @@ BlobType:
 	"TINYBLOB"
 	{
 		x := types.NewFieldType(mysql.TypeTinyBlob)
-		x.Charset = charset.CharsetBin
-		x.Collate = charset.CharsetBin
 		$$ = x
 	}
 |	"BLOB" OptFieldLen
 	{
 		x := types.NewFieldType(mysql.TypeBlob)
 		x.Flen = $2.(int)
-		x.Charset = charset.CharsetBin
-		x.Collate = charset.CharsetBin
 		$$ = x
 	}
 |	"MEDIUMBLOB"
 	{
 		x := types.NewFieldType(mysql.TypeMediumBlob)
-		x.Charset = charset.CharsetBin
-		x.Collate = charset.CharsetBin
 		$$ = x
 	}
 |	"LONGBLOB"
 	{
 		x := types.NewFieldType(mysql.TypeLongBlob)
-		x.Charset = charset.CharsetBin
-		x.Collate = charset.CharsetBin
 		$$ = x
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -1546,5 +1547,42 @@ func (s *testParserSuite) TestSQLModeANSIQuotes(c *C) {
 	for _, test := range tests {
 		_, err := parser.Parse(test, "", "")
 		c.Assert(err, IsNil)
+	}
+}
+
+func (s *testParserSuite) TestDDLStatements(c *C) {
+	parser := New()
+	parser.SetSQLMode(mysql.ModeANSIQuotes)
+	// Tests that whatever the charset it is define, we always assign utf8 charset and utf8_bin collate.
+	createTableStr := `CREATE TABLE t (
+		a varchar(64) binary,
+		b char(10) charset utf8 collate utf8_general_ci,
+		c text charset latin1) ENGINE=innoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin`
+	stmts, err := parser.Parse(createTableStr, "", "")
+	c.Assert(err, IsNil)
+	stmt := stmts[0].(*ast.CreateTableStmt)
+	for _, colDef := range stmt.Cols {
+		c.Assert(colDef.Tp.Charset, Equals, charset.CharsetUTF8)
+		c.Assert(colDef.Tp.Collate, Equals, charset.CollationUTF8)
+		c.Assert(mysql.HasBinaryFlag(colDef.Tp.Flag), IsFalse)
+	}
+	for _, tblOpt := range stmt.Options {
+		switch tblOpt.Tp {
+		case ast.TableOptionCharset:
+			c.Assert(tblOpt.StrValue, Equals, "utf8")
+		case ast.TableOptionCollate:
+			c.Assert(tblOpt.StrValue, Equals, "utf8_bin")
+		}
+	}
+	createTableStr = `CREATE TABLE t (
+		a varbinary(64),
+		b binary(10),
+		c blob)`
+	stmts, err = parser.Parse(createTableStr, "", "")
+	stmt = stmts[0].(*ast.CreateTableStmt)
+	for _, colDef := range stmt.Cols {
+		c.Assert(colDef.Tp.Charset, Equals, charset.CharsetBin)
+		c.Assert(colDef.Tp.Collate, Equals, charset.CollationBin)
+		c.Assert(mysql.HasBinaryFlag(colDef.Tp.Flag), IsTrue)
 	}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1562,8 +1562,6 @@ func (s *testParserSuite) TestDDLStatements(c *C) {
 	c.Assert(err, IsNil)
 	stmt := stmts[0].(*ast.CreateTableStmt)
 	for _, colDef := range stmt.Cols {
-		c.Assert(colDef.Tp.Charset, Equals, charset.CharsetUTF8)
-		c.Assert(colDef.Tp.Collate, Equals, charset.CollationUTF8)
 		c.Assert(mysql.HasBinaryFlag(colDef.Tp.Flag), IsFalse)
 	}
 	for _, tblOpt := range stmt.Options {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1552,7 +1552,6 @@ func (s *testParserSuite) TestSQLModeANSIQuotes(c *C) {
 
 func (s *testParserSuite) TestDDLStatements(c *C) {
 	parser := New()
-	parser.SetSQLMode(mysql.ModeANSIQuotes)
 	// Tests that whatever the charset it is define, we always assign utf8 charset and utf8_bin collate.
 	createTableStr := `CREATE TABLE t (
 		a varchar(64) binary,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1576,6 +1576,7 @@ func (s *testParserSuite) TestDDLStatements(c *C) {
 		b binary(10),
 		c blob)`
 	stmts, err = parser.Parse(createTableStr, "", "")
+	c.Assert(err, IsNil)
 	stmt = stmts[0].(*ast.CreateTableStmt)
 	for _, colDef := range stmt.Cols {
 		c.Assert(colDef.Tp.Charset, Equals, charset.CharsetBin)


### PR DESCRIPTION
We only support case sensitive utf8_bin collation right now, but show create table ignored the collation.
So the dumped DDL statement doesn't contains collation option.
When the DDL statement is executed on MySQL, the collation will be changed to utf8_general_ci.
If the string column is defined as unique key, there would be duplicated key error.

This PR enforce utf8 charset and utf8_bin collation when parse a column definition, and enfore table option
`DEFAULT CHARSET=utf8 COLLATE=utf8_bin` in SHOW CREATE TABLE statement.