### PR TITLE
ddl: check unsupported charset.

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -54,6 +54,7 @@ var (
 	errUnsupportedModifyColumn = terror.ClassDDL.New(codeUnsupportedModifyColumn, "unsupported modify column %s")
 	errUnsupportedPKHandle     = terror.ClassDDL.New(codeUnsupportedDropPKHandle,
 		"unsupported drop integer primary key")
+	errUnsupportedCharset = terror.ClassDDL.New(codeUnsupportedCharset, "unsupported charset %s collate %s")
 
 	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specificate a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
@@ -432,6 +433,7 @@ const (
 	codeUnsupportedAddColumn    = 202
 	codeUnsupportedModifyColumn = 203
 	codeUnsupportedDropPKHandle = 204
+	codeUnsupportedCharset      = 205
 
 	codeFileNotFound          = 1017
 	codeErrorOnRename         = 1025

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -114,7 +114,7 @@ func (s *testSuite) TestSetVar(c *C) {
 	tk.MustExec("set names utf8")
 	charset, collation := vars.GetCharsetInfo()
 	c.Assert(charset, Equals, "utf8")
-	c.Assert(collation, Equals, "utf8_general_ci")
+	c.Assert(collation, Equals, "utf8_bin")
 
 	tk.MustExec("set @@character_set_results = NULL")
 
@@ -145,7 +145,7 @@ func (s *testSuite) TestSetCharset(c *C) {
 	}
 	sVar, err := varsutil.GetSessionSystemVar(sessionVars, variable.CollationConnection)
 	c.Assert(err, IsNil)
-	c.Assert(sVar, Equals, "utf8_general_ci")
+	c.Assert(sVar, Equals, "utf8_bin")
 
 	// Issue 1523
 	tk.MustExec(`SET NAMES binary`)

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -23,7 +23,7 @@ import (
 // Now we only support MySQL.
 type Charset struct {
 	Name             string
-	DefaultCollation *Collation
+	DefaultCollation string
 	Collations       map[string]*Collation
 	Desc             string
 	Maxlen           int
@@ -42,11 +42,11 @@ var charsets = make(map[string]*Charset)
 
 // All the supported charsets should be in the following table.
 var charsetInfos = []*Charset{
-	{"utf8", nil, make(map[string]*Collation), "UTF-8 Unicode", 3},
-	{"latin1", nil, make(map[string]*Collation), "cp1252 West European", 1},
-	{"utf8mb4", nil, make(map[string]*Collation), "UTF-8 Unicode", 4},
-	{"ascii", nil, make(map[string]*Collation), "US ASCII", 1},
-	{"binary", nil, make(map[string]*Collation), "binary", 1},
+	{CharsetUTF8, CollationUTF8, make(map[string]*Collation), "UTF-8 Unicode", 3},
+	{CharsetUTF8MB4, CollationUTF8MB4, make(map[string]*Collation), "UTF-8 Unicode", 4},
+	{CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
+	{CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
+	{CharsetBin, CollationBin, make(map[string]*Collation), "binary", 1},
 }
 
 func init() {
@@ -59,9 +59,6 @@ func init() {
 			continue
 		}
 		charset.Collations[c.Name] = c
-		if c.IsDefault {
-			charset.DefaultCollation = c
-		}
 	}
 }
 
@@ -84,7 +81,7 @@ func GetAllCharsets() []*Desc {
 		}
 		desc := &Desc{
 			Name:             c.Name,
-			DefaultCollation: c.DefaultCollation.Name,
+			DefaultCollation: c.DefaultCollation,
 			Desc:             c.Desc,
 			Maxlen:           c.Maxlen,
 		}
@@ -127,7 +124,7 @@ func GetDefaultCollation(charset string) (string, error) {
 	if !ok {
 		return "", errors.Errorf("Unknown charset %s", charset)
 	}
-	return c.DefaultCollation.Name, nil
+	return c.DefaultCollation, nil
 }
 
 // GetCharsetInfo returns charset and collation for cs as name.
@@ -136,7 +133,7 @@ func GetCharsetInfo(cs string) (string, string, error) {
 	if !ok {
 		return "", "", errors.Errorf("Unknown charset %s", cs)
 	}
-	return c.Name, c.DefaultCollation.Name, nil
+	return c.Name, c.DefaultCollation, nil
 }
 
 // GetCollations returns a list for all collations.
@@ -157,6 +154,14 @@ const (
 	CharsetUTF8MB4 = "utf8mb4"
 	// CollationUTF8MB4 is the default collation for CharsetUTF8MB4.
 	CollationUTF8MB4 = "utf8mb4_bin"
+	// CharsetASCII is a subset of UTF8.
+	CharsetASCII = "ascii"
+	// CollationASCII is the default collation for CharsetACSII
+	CollationASCII = "ascii_bin"
+	// CharsetLatin1 is a single byte charset.
+	CharsetLatin1 = "latin1"
+	// CollationLatin1 is the default collation for CharsetLatin1
+	CollationLatin1 = "latin1_bin"
 )
 
 var collations = []*Collation{

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -156,11 +156,11 @@ const (
 	CollationUTF8MB4 = "utf8mb4_bin"
 	// CharsetASCII is a subset of UTF8.
 	CharsetASCII = "ascii"
-	// CollationASCII is the default collation for CharsetACSII
+	// CollationASCII is the default collation for CharsetACSII.
 	CollationASCII = "ascii_bin"
 	// CharsetLatin1 is a single byte charset.
 	CharsetLatin1 = "latin1"
-	// CollationLatin1 is the default collation for CharsetLatin1
+	// CollationLatin1 is the default collation for CharsetLatin1.
 	CollationLatin1 = "latin1_bin"
 )
 

--- a/util/charset/charset_test.go
+++ b/util/charset/charset_test.go
@@ -37,25 +37,27 @@ func testValidCharset(c *C, charset string, collation string, expect bool) {
 
 func (s *testCharsetSuite) TestValidCharset(c *C) {
 	defer testleak.AfterTest(c)()
-	tbl := []struct {
+	tests := []struct {
 		cs   string
 		co   string
 		succ bool
 	}{
 		{"utf8", "utf8_general_ci", true},
 		{"", "utf8_general_ci", true},
-		{"latin1", "", true},
+		{"utf8mb4", "utf8mb4_bin", true},
+		{"latin1", "latin1_bin", true},
 		{"utf8", "utf8_invalid_ci", false},
+		{"utf16", "utf16_bin", false},
 		{"gb2312", "gb2312_chinese_ci", false},
 	}
-	for _, t := range tbl {
-		testValidCharset(c, t.cs, t.co, t.succ)
+	for _, tt := range tests {
+		testValidCharset(c, tt.cs, tt.co, tt.succ)
 	}
 }
 
 func (s *testCharsetSuite) TestGetAllCharsets(c *C) {
 	defer testleak.AfterTest(c)()
-	charset := &Charset{"test", nil, nil, "Test", 5}
+	charset := &Charset{"test", "test_bin", nil, "Test", 5}
 	charsetInfos = append(charsetInfos, charset)
 	descs := GetAllCharsets()
 	c.Assert(len(descs), Equals, len(charsetInfos)-1)
@@ -72,18 +74,21 @@ func testGetDefaultCollation(c *C, charset string, expectCollation string, succ 
 
 func (s *testCharsetSuite) TestGetDefaultCollation(c *C) {
 	defer testleak.AfterTest(c)()
-	tbl := []struct {
+	tests := []struct {
 		cs   string
 		co   string
 		succ bool
 	}{
-		{"utf8", "utf8_general_ci", true},
-		{"UTF8", "utf8_general_ci", true},
-		{"latin1", "latin1_swedish_ci", true},
+		{"utf8", "utf8_bin", true},
+		{"UTF8", "utf8_bin", true},
+		{"utf8mb4", "utf8mb4_bin", true},
+		{"ascii", "ascii_bin", true},
+		{"binary", "binary", true},
+		{"latin1", "latin1_bin", true},
 		{"invalid_cs", "", false},
-		{"", "utf8_general_ci", false},
+		{"", "utf8_bin", false},
 	}
-	for _, t := range tbl {
-		testGetDefaultCollation(c, t.cs, t.co, t.succ)
+	for _, tt := range tests {
+		testGetDefaultCollation(c, tt.cs, tt.co, tt.succ)
 	}
 }


### PR DESCRIPTION
We only support a few charsets, if a charset is not supported, we should return an error.
Also, enforce charset to be lower case.