### PR TITLE
infoschema: fix probably a TABLE_TYPE typo, restore mysql compatibility

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -458,7 +458,7 @@ func dataForTables(schemas []*model.DBInfo) [][]types.Datum {
 				catalogVal,          // TABLE_CATALOG
 				schema.Name.O,       // TABLE_SCHEMA
 				table.Name.O,        // TABLE_NAME
-				"BASE_TABLE",        // TABLE_TYPE
+				"BASE TABLE",        // TABLE_TYPE
 				"InnoDB",            // ENGINE
 				uint64(10),          // VERSION
 				"Compact",           // ROW_FORMAT


### PR DESCRIPTION
Mysql uses `BASE TABLE` without the `_` as can be seen here:

https://github.com/mysql/mysql-server/search?utf8=%E2%9C%93&q=BASE+TABLE&type=

This atleast gets SQLBoiler to detect the tables.