### PR TITLE
store/tikv: export mocktikv as a storage engine.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -57,7 +57,7 @@ func (s *testSuite) SetUpSuite(c *C) {
 	flag.Lookup("mockTikv")
 	useMockTikv := *mockTikv
 	if useMockTikv {
-		store, err := tikv.NewMockTikvStore()
+		store, err := tikv.NewMockTikvStore("")
 		c.Assert(err, IsNil)
 		s.store = store
 		tidb.SetSchemaLease(0)

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -75,7 +75,7 @@ type testBinlogSuite struct {
 func (s *testBinlogSuite) SetUpSuite(c *C) {
 	logLevel := os.Getenv("log_level")
 	log.SetLevelByString(logLevel)
-	store, err := tikv.NewMockTikvStore()
+	store, err := tikv.NewMockTikvStore("")
 	c.Assert(err, IsNil)
 	s.store = store
 	tidb.SetSchemaLease(0)

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -81,7 +81,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 type MockDriver struct {
 }
 
-// Open creates an MockTiKV storage.
+// Open creates a MockTiKV storage.
 func (d MockDriver) Open(path string) (kv.Storage, error) {
 	u, err := url.Parse(path)
 	if err != nil {

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -77,6 +77,22 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 	return s, nil
 }
 
+// MockDriver is in memory mock TiKV driver.
+type MockDriver struct {
+}
+
+// Open creates an MockTiKV storage.
+func (d MockDriver) Open(path string) (kv.Storage, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if !strings.EqualFold(u.Scheme, "mocktikv") {
+		return nil, errors.Errorf("Uri scheme expected(mocktikv) but found (%s)", u.Scheme)
+	}
+	return NewMockTikvStore(u.Path)
+}
+
 // update oracle's lastTS every 2000ms.
 var oracleUpdateInterval = 2000
 
@@ -118,8 +134,12 @@ func (s *tikvStore) EtcdAddrs() []string {
 	return s.etcdAddrs
 }
 
-// NewMockTikvStore creates a mocked tikv store.
-func NewMockTikvStore() (kv.Storage, error) {
+// NewMockTikvStore creates a mocked tikv store, the path is the file path to store the data.
+// Zero length string represents in memory storage.
+func NewMockTikvStore(path string) (kv.Storage, error) {
+	if path != "" {
+		return nil, errors.New("persistent mockTiKV is not supported yet")
+	}
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	mvccStore := mocktikv.NewMvccStore()

--- a/store/tikv/mock-tikv/cluster_test.go
+++ b/store/tikv/mock-tikv/cluster_test.go
@@ -34,7 +34,7 @@ type testClusterSuite struct {
 }
 
 func (s *testClusterSuite) TestClusterSplit(c *C) {
-	store, err := tikv.NewMockTikvStore()
+	store, err := tikv.NewMockTikvStore("")
 	c.Assert(err, IsNil)
 
 	txn, err := store.Begin()

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -24,7 +24,7 @@ type testScanMockSuite struct {
 var _ = Suite(&testScanMockSuite{})
 
 func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
-	kvStore, err := NewMockTikvStore()
+	kvStore, err := NewMockTikvStore("")
 	c.Assert(err, IsNil)
 	defer kvStore.Close()
 

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -40,7 +40,7 @@ func newTestStore(c *C) *tikvStore {
 		c.Assert(err, IsNil)
 		return store.(*tikvStore)
 	}
-	store, err := NewMockTikvStore()
+	store, err := NewMockTikvStore("")
 	c.Assert(err, IsNil)
 	return store.(*tikvStore)
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -45,7 +45,7 @@ import (
 
 var (
 	version         = flag.Bool("V", false, "print version information and exit")
-	store           = flag.String("store", "goleveldb", "registered store name, [memory, goleveldb, boltdb, tikv]")
+	store           = flag.String("store", "goleveldb", "registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]")
 	storePath       = flag.String("path", "/tmp/tidb", "tidb storage path")
 	logLevel        = flag.String("L", "info", "log level: info, debug, warn, error, fatal")
 	host            = flag.String("host", "0.0.0.0", "tidb server host")
@@ -78,6 +78,7 @@ var (
 func main() {
 	tidb.RegisterLocalStore("boltdb", boltdb.Driver{})
 	tidb.RegisterStore("tikv", tikv.Driver{})
+	tidb.RegisterStore("mocktikv", tikv.MockDriver{})
 
 	runtime.GOMAXPROCS(runtime.NumCPU())
 


### PR DESCRIPTION
So DAG mocktikv can run integration tests.