### PR TITLE
plan: consider primary key for index scan

### DIFF
--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -114,6 +114,16 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select c, b from t where c = 1 and e = 1 and b = 1 limit 1",
 			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)])->Limit)->Limit->Projection",
 		},
+		// Test PK in index single read.
+		{
+			sql:  "select c from t where t.c = 1 and t.a = 1 order by t.d limit 1",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit)->Limit->Projection->Projection",
+		},
+		// Test PK in index double read.
+		{
+			sql:  "select * from t where t.c = 1 and t.a = 1 order by t.d limit 1",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit, Table(t))->Limit",
+		},
 	}
 	for _, tt := range tests {
 		comment := Commentf("for %s", tt.sql)

--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -292,7 +292,12 @@ func (p *DataSource) convertToIndexScan(prop *requiredProp, idx *model.IndexInfo
 		for _, col := range idx.Columns {
 			indexCols = append(indexCols, &expression.Column{FromID: p.id, Position: col.Offset})
 		}
-		// TODO: We should add PK column to index schema.
+		for i, col := range is.Columns {
+			if is.Table.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {
+				indexCols = append(indexCols, &expression.Column{FromID: p.id, Position: i})
+				break
+			}
+		}
 		copTask.indexPlan.SetSchema(expression.NewSchema(indexCols...))
 	} else {
 		is.SetSchema(p.schema)


### PR DESCRIPTION
index encode handle as value, we consider it when pushing filter.
@shenli @coocood @zimulala @winoros PTAL