### PR TITLE
infoschema: add more empty tables

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -277,7 +277,7 @@ func (s *testSuite) TestAggregation(c *C) {
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
 	// When adding new memory table in information_schema, please update this variable.
-	columnCountOfAllInformationSchemaTables := "628"
+	columnCountOfAllInformationSchemaTables := "714"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 
 	tk.MustExec("drop table if exists t1")

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -259,6 +259,17 @@ func (*testSuite) TestInfoTables(c *C) {
 		"ENGINES",
 		"VIEWS",
 		"ROUTINES",
+		"SCHEMA_PRIVILEGES",
+		"COLUMN_PRIVILEGES",
+		"TABLE_PRIVILEGES",
+		"PARAMETERS",
+		"EVENTS",
+		"GLOBAL_STATUS",
+		"GLOBAL_VARIABLES",
+		"SESSION_STATUS",
+		"OPTIMIZER_TRACE",
+		"TABLESPACES",
+		"COLLATION_CHARACTER_SET_APPLICABILITY",
 	}
 	for _, t := range info_tables {
 		tb, err1 := is.TableByName(model.NewCIStr(infoschema.Name), model.NewCIStr(t))

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -32,26 +32,37 @@ import (
 )
 
 const (
-	tableSchemata       = "SCHEMATA"
-	tableTables         = "TABLES"
-	tableColumns        = "COLUMNS"
-	tableStatistics     = "STATISTICS"
-	tableCharacterSets  = "CHARACTER_SETS"
-	tableCollations     = "COLLATIONS"
-	tableFiles          = "FILES"
-	catalogVal          = "def"
-	tableProfiling      = "PROFILING"
-	tablePartitions     = "PARTITIONS"
-	tableKeyColumm      = "KEY_COLUMN_USAGE"
-	tableReferConst     = "REFERENTIAL_CONSTRAINTS"
-	tableSessionVar     = "SESSION_VARIABLES"
-	tablePlugins        = "PLUGINS"
-	tableConstraints    = "TABLE_CONSTRAINTS"
-	tableTriggers       = "TRIGGERS"
-	tableUserPrivileges = "USER_PRIVILEGES"
-	tableEngines        = "ENGINES"
-	tableViews          = "VIEWS"
-	tableRoutines       = "ROUTINES"
+	tableSchemata                           = "SCHEMATA"
+	tableTables                             = "TABLES"
+	tableColumns                            = "COLUMNS"
+	tableStatistics                         = "STATISTICS"
+	tableCharacterSets                      = "CHARACTER_SETS"
+	tableCollations                         = "COLLATIONS"
+	tableFiles                              = "FILES"
+	catalogVal                              = "def"
+	tableProfiling                          = "PROFILING"
+	tablePartitions                         = "PARTITIONS"
+	tableKeyColumm                          = "KEY_COLUMN_USAGE"
+	tableReferConst                         = "REFERENTIAL_CONSTRAINTS"
+	tableSessionVar                         = "SESSION_VARIABLES"
+	tablePlugins                            = "PLUGINS"
+	tableConstraints                        = "TABLE_CONSTRAINTS"
+	tableTriggers                           = "TRIGGERS"
+	tableUserPrivileges                     = "USER_PRIVILEGES"
+	tableSchemaPrivileges                   = "SCHEMA_PRIVILEGES"
+	tableTablePrivileges                    = "TABLE_PRIVILEGES"
+	tableColumnPrivileges                   = "COLUMN_PRIVILEGES"
+	tableEngines                            = "ENGINES"
+	tableViews                              = "VIEWS"
+	tableRoutines                           = "ROUTINES"
+	tableParameters                         = "PARAMETERS"
+	tableEvents                             = "EVENTS"
+	tableGlobalStatus                       = "GLOBAL_STATUS"
+	tableGlobalVariables                    = "GLOBAL_VARIABLES"
+	tableSessionStatus                      = "SESSION_STATUS"
+	tableOptimizerTrace                     = "OPTIMIZER_TRACE"
+	tableTableSpaces                        = "TABLESPACES"
+	tableCollationCharacterSetApplicability = "COLLATION_CHARACTER_SET_APPLICABILITY"
 )
 
 type columnInfo struct {
@@ -334,6 +345,33 @@ var tableUserPrivilegesCols = []columnInfo{
 	{"IS_GRANTABLE", mysql.TypeVarchar, 3, 0, nil, nil},
 }
 
+var tableSchemaPrivilegesCols = []columnInfo{
+	{"GRANTEE", mysql.TypeVarchar, 81, mysql.NotNullFlag, nil, nil},
+	{"TABLE_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"TABLE_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"PRIVILEGE_TYPE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"IS_GRANTABLE", mysql.TypeVarchar, 3, mysql.NotNullFlag, nil, nil},
+}
+
+var tableTablePrivilegesCols = []columnInfo{
+	{"GRANTEE", mysql.TypeVarchar, 81, mysql.NotNullFlag, nil, nil},
+	{"TABLE_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"TABLE_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"TABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"PRIVILEGE_TYPE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"IS_GRANTABLE", mysql.TypeVarchar, 3, mysql.NotNullFlag, nil, nil},
+}
+
+var tableColumnPrivilegesCols = []columnInfo{
+	{"GRANTEE", mysql.TypeVarchar, 81, mysql.NotNullFlag, nil, nil},
+	{"TABLE_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"TABLE_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"TABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"COLUMN_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"PRIVILEGE_TYPE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"IS_GRANTABLE", mysql.TypeVarchar, 3, mysql.NotNullFlag, nil, nil},
+}
+
 var tableEnginesCols = []columnInfo{
 	{"ENGINE", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"SUPPORT", mysql.TypeVarchar, 8, 0, nil, nil},
@@ -388,6 +426,98 @@ var tableRoutinesCols = []columnInfo{
 	{"CHARACTER_SET_CLIENT", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
 	{"COLLATION_CONNECTION", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
 	{"DATABASE_COLLATION", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
+}
+
+var tableParametersCols = []columnInfo{
+	{"SPECIFIC_CATALOG", mysql.TypeVarchar, 512, mysql.NotNullFlag, nil, nil},
+	{"SPECIFIC_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"SPECIFIC_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"ORDINAL_POSITION", mysql.TypeVarchar, 21, mysql.NotNullFlag, nil, nil},
+	{"PARAMETER_MODE", mysql.TypeVarchar, 5, 0, nil, nil},
+	{"PARAMETER_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"DATA_TYPE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"CHARACTER_MAXIMUM_LENGTH", mysql.TypeVarchar, 21, 0, nil, nil},
+	{"CHARACTER_OCTET_LENGTH", mysql.TypeVarchar, 21, 0, nil, nil},
+	{"NUMERIC_PRECISION", mysql.TypeVarchar, 21, 0, nil, nil},
+	{"NUMERIC_SCALE", mysql.TypeVarchar, 21, 0, nil, nil},
+	{"DATETIME_PRECISION", mysql.TypeVarchar, 21, 0, nil, nil},
+	{"CHARACTER_SET_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"COLLATION_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"DTD_IDENTIFIER", mysql.TypeLongBlob, 0, mysql.NotNullFlag, nil, nil},
+	{"ROUTINE_TYPE", mysql.TypeVarchar, 9, mysql.NotNullFlag, nil, nil},
+}
+
+var tableEventsCols = []columnInfo{
+	{"EVENT_CATALOG", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"EVENT_SCHEMA", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"EVENT_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"DEFINER", mysql.TypeVarchar, 77, mysql.NotNullFlag, nil, nil},
+	{"TIME_ZONE", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"EVENT_BODY", mysql.TypeVarchar, 8, mysql.NotNullFlag, nil, nil},
+	{"EVENT_DEFINITION", mysql.TypeLongBlob, 0, 0, nil, nil},
+	{"EVENT_TYPE", mysql.TypeVarchar, 9, mysql.NotNullFlag, nil, nil},
+	{"EXECUTE_AT", mysql.TypeDatetime, 0, 0, nil, nil},
+	{"INTERVAL_VALUE", mysql.TypeVarchar, 256, 0, nil, nil},
+	{"INTERVAL_FIELD", mysql.TypeVarchar, 18, 0, nil, nil},
+	{"SQL_MODE", mysql.TypeVarchar, 8192, mysql.NotNullFlag, nil, nil},
+	{"STARTS", mysql.TypeDatetime, 0, 0, nil, nil},
+	{"ENDS", mysql.TypeDatetime, 0, 0, nil, nil},
+	{"STATUS", mysql.TypeVarchar, 18, mysql.NotNullFlag, nil, nil},
+	{"ON_COMPLETION", mysql.TypeVarchar, 12, mysql.NotNullFlag, nil, nil},
+	{"CREATED", mysql.TypeDatetime, 0, mysql.NotNullFlag, "0000-00-00 00:00:00", nil},
+	{"LAST_ALTERED", mysql.TypeDatetime, 0, mysql.NotNullFlag, "0000-00-00 00:00:00", nil},
+	{"LAST_EXECUTED", mysql.TypeDatetime, 0, 0, nil, nil},
+	{"EVENT_COMMENT", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"ORIGINATOR", mysql.TypeLong, 10, mysql.NotNullFlag, 0, nil},
+	{"CHARACTER_SET_CLIENT", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
+	{"COLLATION_CONNECTION", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
+	{"DATABASE_COLLATION", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
+}
+
+var tableGlobalStatusCols = []columnInfo{
+	{"VARIABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"VARIABLE_VALUE", mysql.TypeVarchar, 1024, 0, nil, nil},
+}
+
+var tableGlobalVariablesCols = []columnInfo{
+	{"VARIABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"VARIABLE_VALUE", mysql.TypeVarchar, 1024, 0, nil, nil},
+}
+
+var tableSessionStatusCols = []columnInfo{
+	{"VARIABLE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, nil, nil},
+	{"VARIABLE_VALUE", mysql.TypeVarchar, 1024, 0, nil, nil},
+}
+
+var tableOptimizerTraceCols = []columnInfo{
+	{"QUERY", mysql.TypeLongBlob, 0, mysql.NotNullFlag, "", nil},
+	{"TRACE", mysql.TypeLongBlob, 0, mysql.NotNullFlag, "", nil},
+	{"MISSING_BYTES_BEYOND_MAX_MEM_SIZE", mysql.TypeShort, 20, mysql.NotNullFlag, 0, nil},
+	{"INSUFFICIENT_PRIVILEGES", mysql.TypeTiny, 1, mysql.NotNullFlag, 0, nil},
+}
+
+var tableTableSpacesCols = []columnInfo{
+	{"TABLESPACE_NAME", mysql.TypeVarchar, 64, mysql.NotNullFlag, "", nil},
+	{"ENGINE", mysql.TypeVarchar, 64, mysql.NotNullFlag, "", nil},
+	{"TABLESPACE_TYPE", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"LOGFILE_GROUP_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"EXTENT_SIZE", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"AUTOEXTEND_SIZE", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"MAXIMUM_SIZE", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"NODEGROUP_ID", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"TABLESPACE_COMMENT", mysql.TypeVarchar, 2048, 0, nil, nil},
+}
+
+var tableCollationCharacterSetApplicabilityCols = []columnInfo{
+	{"TABLESPACE_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"ENGINE", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"TABLESPACE_TYPE", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"LOGFILE_GROUP_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"EXTENT_SIZE", mysql.TypeLong, 21, 0, nil, nil},
+	{"AUTOEXTEND_SIZE", mysql.TypeLong, 21, 0, nil, nil},
+	{"MAXIMUM_SIZE", mysql.TypeLong, 21, 0, nil, nil},
+	{"NODEGROUP_ID", mysql.TypeLong, 21, 0, nil, nil},
+	{"TABLESPACE_COMMENT", mysql.TypeVarchar, 2048, 0, nil, nil},
 }
 
 func dataForCharacterSets() (records [][]types.Datum) {
@@ -718,25 +848,36 @@ func dataForTableConstraints(schemas []*model.DBInfo) [][]types.Datum {
 }
 
 var tableNameToColumns = map[string]([]columnInfo){
-	tableSchemata:       schemataCols,
-	tableTables:         tablesCols,
-	tableColumns:        columnsCols,
-	tableStatistics:     statisticsCols,
-	tableCharacterSets:  charsetCols,
-	tableCollations:     collationsCols,
-	tableFiles:          filesCols,
-	tableProfiling:      profilingCols,
-	tablePartitions:     partitionsCols,
-	tableKeyColumm:      keyColumnUsageCols,
-	tableReferConst:     referConstCols,
-	tableSessionVar:     sessionVarCols,
-	tablePlugins:        pluginsCols,
-	tableConstraints:    tableConstraintsCols,
-	tableTriggers:       tableTriggersCols,
-	tableUserPrivileges: tableUserPrivilegesCols,
-	tableEngines:        tableEnginesCols,
-	tableViews:          tableViewsCols,
-	tableRoutines:       tableRoutinesCols,
+	tableSchemata:                           schemataCols,
+	tableTables:                             tablesCols,
+	tableColumns:                            columnsCols,
+	tableStatistics:                         statisticsCols,
+	tableCharacterSets:                      charsetCols,
+	tableCollations:                         collationsCols,
+	tableFiles:                              filesCols,
+	tableProfiling:                          profilingCols,
+	tablePartitions:                         partitionsCols,
+	tableKeyColumm:                          keyColumnUsageCols,
+	tableReferConst:                         referConstCols,
+	tableSessionVar:                         sessionVarCols,
+	tablePlugins:                            pluginsCols,
+	tableConstraints:                        tableConstraintsCols,
+	tableTriggers:                           tableTriggersCols,
+	tableUserPrivileges:                     tableUserPrivilegesCols,
+	tableSchemaPrivileges:                   tableSchemaPrivilegesCols,
+	tableTablePrivileges:                    tableTablePrivilegesCols,
+	tableColumnPrivileges:                   tableColumnPrivilegesCols,
+	tableEngines:                            tableEnginesCols,
+	tableViews:                              tableViewsCols,
+	tableRoutines:                           tableRoutinesCols,
+	tableParameters:                         tableParametersCols,
+	tableEvents:                             tableEventsCols,
+	tableGlobalStatus:                       tableGlobalStatusCols,
+	tableGlobalVariables:                    tableGlobalVariablesCols,
+	tableSessionStatus:                      tableSessionStatusCols,
+	tableOptimizerTrace:                     tableOptimizerTraceCols,
+	tableTableSpaces:                        tableTableSpacesCols,
+	tableCollationCharacterSetApplicability: tableCollationCharacterSetApplicabilityCols,
 }
 
 func createInfoSchemaTable(handle *Handle, meta *model.TableInfo) *infoschemaTable {
@@ -806,6 +947,18 @@ func (it *infoschemaTable) getRows(ctx context.Context, cols []*table.Column) (f
 		fullRows = dataForEngines()
 	case tableViews:
 	case tableRoutines:
+	// TODO: Fill the following tables.
+	case tableSchemaPrivileges:
+	case tableTablePrivileges:
+	case tableColumnPrivileges:
+	case tableParameters:
+	case tableEvents:
+	case tableGlobalStatus:
+	case tableGlobalVariables:
+	case tableSessionStatus:
+	case tableOptimizerTrace:
+	case tableTableSpaces:
+	case tableCollationCharacterSetApplicability:
 	}
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Add more tables:
 ```
| COLLATION_CHARACTER_SET_APPLICABILITY |
| COLUMN_PRIVILEGES |
| EVENTS |
| GLOBAL_STATUS |
| GLOBAL_VARIABLES |
| OPTIMIZER_TRACE |
| PARAMETERS |
| SCHEMA_PRIVILEGES |
| SESSION_STATUS |
| STATISTICS |
| TABLESPACES |
| TABLE_PRIVILEGES |
```