### PR TITLE
*: add checklist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-
 
 TARGET = ""
 
-.PHONY: all build update parser clean todo test gotest interpreter server dev benchkv benchraw check parserlib
+.PHONY: all build update parser clean todo test gotest interpreter server dev benchkv benchraw check parserlib checklist
 
 default: server buildsucc
 
@@ -33,7 +33,7 @@ buildsucc:
 
 all: dev server benchkv
 
-dev: parserlib build benchkv test check
+dev: checklist parserlib build benchkv test check
 
 build:
 	$(GOBUILD)
@@ -97,7 +97,7 @@ todo:
 	@grep -n BUG */*.go parser/parser.y || true
 	@grep -n println */*.go parser/parser.y || true
 
-test: gotest
+test: checklist gotest
 
 gotest: parserlib
 	@export log_level=error;\
@@ -140,3 +140,6 @@ endif
 	glide vc --only-code --no-tests
 	mkdir -p _vendor
 	mv vendor _vendor/src
+
+checklist:
+	cat checklist.md

--- a/checklist.md
+++ b/checklist.md
@@ -1,0 +1,22 @@
+# Following the checklist saves the reviewers' time and gets your PR reviewed faster.
+
+# Self Review
+Have you reviewed every line of your changes by yourself?
+# Test
+Have you added enough test case to cover the new feature or bug fix?
+Also, add comments to describe your test cases.
+# Naming
+Do function names keep consistent with its behavior?
+Is it easy to infer the function's behavior by its name?
+# Comment
+Is there any code can confuse the reviewer?
+Add comments on them! You'll be asked to do so anyway.
+Make sure there is no syntax or spelling error in your comments.
+Some online syntax checking tool like Grammarly may be helpful.
+# Refactor
+Is there any way to refactor the code to make it more readable?
+If the refactoring touches a lot of existing code, send another PR to do it.
+# Single Purpose
+Make sure the PR does only one thing and nothing else.
+# Diff Size
+Make sure the diff size no more than 500, split it to small PRs if it is too large.

--- a/checklist.md
+++ b/checklist.md
@@ -9,14 +9,14 @@ Also, add comments to describe your test cases.
 Do function names keep consistent with its behavior?
 Is it easy to infer the function's behavior by its name?
 # Comment
-Is there any code can confuse the reviewer?
+Is there any code that confuses the reviewer?
 Add comments on them! You'll be asked to do so anyway.
 Make sure there is no syntax or spelling error in your comments.
-Some online syntax checking tool like Grammarly may be helpful.
+Some online syntax checking tools like Grammarly may be helpful.
 # Refactor
 Is there any way to refactor the code to make it more readable?
 If the refactoring touches a lot of existing code, send another PR to do it.
 # Single Purpose
 Make sure the PR does only one thing and nothing else.
 # Diff Size
-Make sure the diff size no more than 500, split it to small PRs if it is too large.
+Make sure the diff size is no more than 500, split it into small PRs if it is too large.

--- a/checklist.md
+++ b/checklist.md
@@ -3,7 +3,7 @@
 # Self Review
 Have you reviewed every line of your changes by yourself?
 # Test
-Have you added enough test case to cover the new feature or bug fix?
+Have you added enough test cases to cover the new feature or bug fix?
 Also, add comments to describe your test cases.
 # Naming
 Do function names keep consistent with its behavior?


### PR DESCRIPTION
The checklist lists some items to check before sending a PR.
Following the checklist saves reviewers' time, gets PR reviewed and merged faster.

Print the checklist in `make dev` or `make test` to remind the PR author.

The more items may be added when we find something is important but gets ignored frequently.