### PR TITLE
parser: make "ENGINE = xxx" optional in partition definition

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -671,6 +671,8 @@ import (
 	PartitionDefinitionListOpt	"Partition definition list option"
 	PartitionOpt		"Partition option"
 	PartitionNumOpt		"PARTITION NUM option"
+	PartDefValuesOpt	"VALUES {LESS THAN {(expr | value_list) | MAXVALUE} | IN {value_list}"
+	PartDefStorageOpt	"ENGINE = xxx or empty"
 	PasswordOpt		"Password option"
 	ColumnPosition		"Column position [First|After ColumnName]"
 	PreparedStmt		"PreparedStmt"
@@ -1675,13 +1677,23 @@ PartitionDefinitionListOpt:
 PartitionDefinitionList:
 	PartitionDefinition
 	{}
-|	PartitionDefinition ',' PartitionDefinitionList
+|	PartitionDefinitionList ',' PartitionDefinition
 	{}
 
 PartitionDefinition:
-	"PARTITION" Identifier "VALUES" "LESS" "THAN" ExpressionList "ENGINE" eq Identifier
+	"PARTITION" Identifier PartDefValuesOpt PartDefStorageOpt
 	{}
-|	"PARTITION" Identifier "VALUES" "LESS" "THAN" "MAXVALUE" "ENGINE" eq Identifier
+
+PartDefValuesOpt:
+	{}
+|	"VALUES" "LESS" "THAN" "MAXVALUE"
+	{}
+|	"VALUES" "LESS" "THAN" '(' ExpressionList ')'
+	{}
+
+PartDefStorageOpt:
+	{}
+|	"ENGINE" eq Identifier
 	{}
 
 /******************************************************************

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1051,6 +1051,8 @@ func (s *testParserSuite) TestDDL(c *C) {
 		// partition option
 		{"create table t (c int) PARTITION BY HASH (c) PARTITIONS 32;", true},
 		{"create table t (c int) PARTITION BY RANGE (Year(VDate)) (PARTITION p1980 VALUES LESS THAN (1980) ENGINE = MyISAM, PARTITION p1990 VALUES LESS THAN (1990) ENGINE = MyISAM, PARTITION pothers VALUES LESS THAN MAXVALUE ENGINE = MyISAM)", true},
+		{"create table t (c int, `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '') PARTITION BY RANGE (UNIX_TIMESTAMP(create_time)) (PARTITION p201610 VALUES LESS THAN(1477929600), PARTITION p201611 VALUES LESS THAN(1480521600),PARTITION p201612 VALUES LESS THAN(1483200000),PARTITION p201701 VALUES LESS THAN(1485878400),PARTITION p201702 VALUES LESS THAN(1488297600),PARTITION p201703 VALUES LESS THAN(1490976000))", true},
+
 		// for check clause
 		{"create table t (c1 bool, c2 bool, check (c1 in (0, 1)), check (c2 in (0, 1)))", true},
 		{"CREATE TABLE Customer (SD integer CHECK (SD > 0), First_Name varchar(30));", true},


### PR DESCRIPTION
``` 
CREATE TABLE t (
    `id` bigint(20) unsigned NOT NULL auto_increment COMMENT '',
    `create_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '',
    PRIMARY KEY(`id`, `create_time`),
    INDEX `idx_cid`(`content_id`)
) engine= InnoDB DEFAULT CHARSET= `utf8` DEFAULT COLLATE `utf8_general_ci` comment= '' PARTITION BY Range (UNIX_TIMESTAMP(create_time)
)(PARTITION p201610 VALUES LESS THAN(1477929600),
    PARTITION p201611 VALUES LESS THAN(1480521600),
    PARTITION p201612 VALUES LESS THAN(1483200000),
    PARTITION p201701 VALUES LESS THAN(1485878400),
    PARTITION p201702 VALUES LESS THAN(1488297600),
    PARTITION p201703 VALUES LESS THAN(1490976000),
    PARTITION p201704 VALUES LESS THAN(1493568000),
    PARTITION p201705 VALUES LESS THAN(1496246400),
    PARTITION p201706 VALUES LESS THAN(1498838400),
    PARTITION p201707 VALUES LESS THAN(1501516800),
    PARTITION p201708 VALUES LESS THAN(1504195200),
    PARTITION p201709 VALUES LESS THAN(1506787200),
    PARTITION p201710 VALUES LESS THAN(1509465600),
    PARTITION p201711 VALUES LESS THAN(1512057600),
    PARTITION p201712 VALUES LESS THAN(1514736000)
)
```

The above SQL gramma would fail **without engine specified**:

```
    PARTITION p201704 VALUES LESS THAN(1493568000) ENGINE = InnoDB,
    PARTITION p201705 VALUES LESS THAN(1496246400) ENGINE = InnoDB,
    PARTITION p201706 VALUES LESS THAN(1498838400) ENGINE = InnoDB,
    PARTITION p201707 VALUES LESS THAN(1501516800) ENGINE = InnoDB,
    PARTITION p201708 VALUES LESS THAN(1504195200) ENGINE = InnoDB,
```

This PR is a fix.