### PR TITLE
.travis.yml: Add the config for import path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 
+go_import_path: github.com/pingcap/tidb
+
 go:
   - 1.8
-    
+
 script: make dev


### PR DESCRIPTION
tidb does not set the import_path in travis. If one contributor forks and enables Travis CI in his or her fork, it will always fail. Because the default path is `github.com/<GitHub ID>/tidb`, not `github/pingcap/tidb`

This PR is to solve this problem. After the PR, you could enable CI in your repo.

Signed-off-by: Ce Gao <ce.gao@outlook.com>