### PR TITLE
Travis: Add coveralls support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.out
 tags
 temp_parser_file
 y.output
+profile.coverprofile

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,21 @@ go_import_path: github.com/pingcap/tidb
 go:
   - 1.8
 
-script: make dev
+# https://docs.travis-ci.com/user/customizing-the-build/#Rows-that-are-Allowed-to-Fail
+env:
+    - TRAVIS_COVERAGE=0
+    - TRAVIS_COVERAGE=1
+
+# Run coverage tests.
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: 1.8
+      env: TRAVIS_COVERAGE=1
+
+before_install:  
+  # create /logs/unit-test for unit test.
+  - sudo mkdir /logs
+  - sudo touch /logs/unit-test
+script:
+  - make dev

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/tidb)](https://goreportcard.com/report/github.com/pingcap/tidb)
 ![Project Status](https://img.shields.io/badge/status-rc-yellow.svg)
 [![CircleCI Status](https://circleci.com/gh/pingcap/tidb.svg?style=shield)](https://circleci.com/gh/pingcap/tidb)
+[![Coverage Status](https://coveralls.io/repos/github/pingcap/tidb/badge.svg?branch=master)](https://coveralls.io/github/pingcap/tidb?branch=master)
 
 ## What is TiDB?
 


### PR DESCRIPTION
ref https://github.com/gaocegege/tidb/pull/2 and https://coveralls.io/github/gaocegege/tidb

I'm trying to import coverage analysis via Travis CI and coveralls.

Since [the issue about go test](https://github.com/golang/go/issues/6909), I have to install two deps in CI: https://github.com/go-playground/overalls and https://github.com/mattn/goveralls.

## Advantages

1. We could add a badge about the test coverage such as [![Coverage Status](https://coveralls.io/repos/github/gaocegege/tidb/badge.svg?branch=travis%2Fcoverage)](https://coveralls.io/github/gaocegege/tidb?branch=travis%2Fcoverage) (generated from https://travis-ci.org/gaocegege/tidb/builds/225617634#L353)
2. We could get the statistics about coverage on https://coveralls.io, which allows us to enrich the unit test cases.
3. (Optional) We could add coverage check for every PR.

## Disadvantages

And you can see that the time for one build rises from 4min to 14min. It is not cool.

## TODO List

- [x] Enable pingcap/tidb in coveralls.io
- [ ] Update readme
- [x] Refactor the code in Makefile about coverage report

## Problem

Because of spending more time than before, I'm not sure whether I should continue.

WDYT? @hanfei1991 @zimulala @coocood @zhexuany 

Signed-off-by: Ce Gao <ce.gao@outlook.com>