### PR TITLE
*: add goimports in Makefile and pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ MAC       := "Darwin"
 PACKAGES  := $$(go list ./...| grep -vE 'vendor')
 
 # FILES is used in make check, only modified files need to be checked.
-FILES     := $$(git diff --name-only --diff-filter ACM origin/master | grep '\.go' | grep -vE 'vendor')
+FILES     := $$(git diff --name-only --diff-filter ACM master | grep '\.go' | grep -vE 'vendor')
 
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-parse HEAD)"

--- a/expression/builtin_other_test.go
+++ b/expression/builtin_other_test.go
@@ -14,12 +14,13 @@
 package expression
 
 import (
+	"math"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
-	"math"
 )
 
 var bitCountCases = []struct {

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -13,20 +13,10 @@ readonly green=$(tput bold; tput setaf 2)
 
 exit_code=0
 
-# comment it by default. You can uncomment it.
-# echo -ne "Checking that it builds..."
-# if ! OUT=$(make 2>&1); then
-#     echo
-#     echo "${red}${OUT}"
-#     exit_code=1
-# else
-#     echo "${green}OK"
-# fi
-# echo "${reset}"
+files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v -e "^_vendor"))
 
 echo -ne "Checking for files that need gofmt... "
 files_need_gofmt=()
-files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v -e "^_vendor"))
 for file in "${files[@]}"; do
     # Check for files that fail gofmt.
     diff="$(git show ":${file}" | gofmt -s -d 2>&1)"
@@ -46,12 +36,32 @@ else
 fi
 echo "${reset}"
 
+echo -ne "Checking for files that need goimports... "
+files_need_goimports=()
+for file in "${files[@]}"; do
+    # Check for files that fail goimports.
+    diff="$(git show ":${file}" | goimports -d 2>&1)"
+    if [[ -n "$diff" ]]; then
+        files_need_goimports+=("${file}")
+    fi
+done
+
+if [[ "${#files_need_goimports[@]}" -ne 0 ]]; then
+    echo "${red}ERROR!"
+    echo "Some files have not been goimport'd. To fix these errors, "
+    echo "copy and paste the following:"
+    echo "  goimports -w ${files_need_goimports[@]}"
+    exit_code=1
+else
+    echo "${green}OK"
+fi
+echo "${reset}"
+
 echo -ne "Checking for files that need goword... "
 files_need_goword=()
-files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v -e "^_vendor"))
 for file in "${files[@]}"; do
     # Check for files that fail goword.
-    diff=$(goword ${file})
+    diff="$(git show ":${file}" | goword 2>&1)"
     if [[ -n "$diff" ]]; then
         files_need_goword+=("${file}")
     fi


### PR DESCRIPTION
Use `goimports` to check and automatically format the import order.