### PR TITLE
*: fix BIN test and check error for QUARTER.

### DIFF
--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -14,13 +14,14 @@
 package expression
 
 import (
-	"errors"
 	"strings"
 	"time"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
@@ -1398,10 +1399,13 @@ func (s *testEvaluatorSuite) TestBin(c *C) {
 	}
 	fc := funcs[ast.Bin]
 	dtbl := tblToDtbl(tbl)
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().StmtCtx.IgnoreTruncate = true
 	for _, t := range dtbl {
-		f, err := fc.getFunction(datumsToConstants(types.MakeDatums(t["Input"])), s.ctx)
+		f, err := fc.getFunction(datumsToConstants(t["Input"]), ctx)
 		c.Assert(err, IsNil)
 		r, err := f.eval(nil)
+		c.Assert(err, IsNil, Commentf("%v", errors.ErrorStack(err)))
 		c.Assert(r, testutil.DatumEquals, types.NewDatum(t["Expected"][0]))
 	}
 }

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1187,6 +1187,7 @@ func (s *testEvaluatorSuite) TestQuarter(c *C) {
 	f, err := fc.getFunction(datumsToConstants([]types.Datum{argInvalid}), s.ctx)
 	c.Assert(err, IsNil)
 	result, err := f.eval(nil)
+	c.Assert(err, NotNil)
 	c.Assert(result.IsNull(), IsTrue)
 }
 


### PR DESCRIPTION
The BIN test puts a datum slice into a datum, which is an unknown datum type, `eval` returns error.