### PR TITLE
expression: remove baseExpr struct

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -70,7 +70,6 @@ func (col *CorrelatedColumn) ResolveIndices(_ *Schema) {
 
 // Column represents a column.
 type Column struct {
-	baseExpr
 	FromID  string
 	ColName model.CIStr
 	DBName  model.CIStr

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -46,82 +46,6 @@ const (
 // EvalAstExpr evaluates ast expression directly.
 var EvalAstExpr func(expr ast.ExprNode, ctx context.Context) (types.Datum, error)
 
-// baseExpr will be removed later.
-// baseExpr implements the common implementation of EvalXXX(XXX:Int/Real/Decimal/String) of Expression to guarantee the
-// availability of Constant and Column.
-type baseExpr struct {
-	self Expression
-}
-
-func (be *baseExpr) SetSelf(expr Expression) {
-	be.self = expr
-}
-
-func (be *baseExpr) EvalInt(row []types.Datum, sc *variable.StatementContext) (int64, bool, error) {
-	if be.self.GetType().Tp == mysql.TypeNull {
-		return 0, true, nil
-	}
-	val, err := be.self.Eval(row)
-	if err != nil || val.IsNull() {
-		return 0, val.IsNull(), errors.Trace(err)
-	}
-	switch be.self.GetType().ToClass() {
-	case types.ClassInt:
-		return val.GetInt64(), false, nil
-	default:
-		res, err := val.ToInt64(sc)
-		return res, false, errors.Trace(err)
-	}
-}
-
-func (be *baseExpr) EvalReal(row []types.Datum, sc *variable.StatementContext) (float64, bool, error) {
-	if be.self.GetType().Tp == mysql.TypeNull {
-		return 0, true, nil
-	}
-	val, err := be.self.Eval(row)
-	if err != nil || val.IsNull() {
-		return 0, val.IsNull(), errors.Trace(err)
-	}
-	switch be.self.GetType().ToClass() {
-	case types.ClassReal:
-		return val.GetFloat64(), false, nil
-	default:
-		res, err := val.ToFloat64(sc)
-		return res, false, errors.Trace(err)
-	}
-}
-
-func (be *baseExpr) EvalString(row []types.Datum, sc *variable.StatementContext) (string, bool, error) {
-	if be.self.GetType().Tp == mysql.TypeNull {
-		return "", true, nil
-	}
-	val, err := be.self.Eval(row)
-	if err != nil || val.IsNull() {
-		return "", val.IsNull(), errors.Trace(err)
-	}
-	// We cannot use val.GetString() even if b.self.GetType().ToClass() == types.ClassString here,
-	// because the types like types.KindMysqlHex will get an empty value.
-	res, err := val.ToString()
-	return res, false, errors.Trace(err)
-}
-
-func (be *baseExpr) EvalDecimal(row []types.Datum, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
-	if be.self.GetType().Tp == mysql.TypeNull {
-		return nil, true, nil
-	}
-	val, err := be.self.Eval(row)
-	if err != nil || val.IsNull() {
-		return nil, val.IsNull(), errors.Trace(err)
-	}
-	switch be.self.GetType().ToClass() {
-	case types.ClassDecimal:
-		return val.GetMysqlDecimal(), false, nil
-	default:
-		res, err := val.ToDecimal(sc)
-		return res, false, errors.Trace(err)
-	}
-}
-
 // Expression represents all scalar expression in SQL.
 type Expression interface {
 	fmt.Stringer
@@ -274,7 +198,6 @@ var Null = &Constant{
 
 // Constant stands for a constant value.
 type Constant struct {
-	baseExpr
 	Value   types.Datum
 	RetType *types.FieldType
 }

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -27,7 +27,6 @@ import (
 
 // ScalarFunction is the function that returns a value.
 type ScalarFunction struct {
-	baseExpr
 	FuncName model.CIStr
 	// RetType is the type that ScalarFunction returns.
 	// TODO: Implement type inference here, now we use ast's return type temporarily.


### PR DESCRIPTION
We do not need baseExpr any more since 
ScalarFunction/Constant/Column have implemented EvalXXX() respectively.

@coocood @zimulala PTAL