### PR TITLE
plan, executor: implement index look up executor.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -848,6 +848,9 @@ func (b *executorBuilder) constructDAGReq(plans []plan.PhysicalPlan) *tipb.DAGRe
 
 func (b *executorBuilder) buildTableReader(v *plan.PhysicalTableReader) Executor {
 	dagReq := b.constructDAGReq(v.TablePlans)
+	if b.err != nil {
+		return nil
+	}
 	ts := v.TablePlans[0].(*plan.PhysicalTableScan)
 	table, _ := b.is.TableByID(ts.Table.ID)
 	e := &TableReaderExecutor{
@@ -872,6 +875,9 @@ func (b *executorBuilder) buildTableReader(v *plan.PhysicalTableReader) Executor
 
 func (b *executorBuilder) buildIndexReader(v *plan.PhysicalIndexReader) Executor {
 	dagReq := b.constructDAGReq(v.IndexPlans)
+	if b.err != nil {
+		return nil
+	}
 	is := v.IndexPlans[0].(*plan.PhysicalIndexScan)
 	table, _ := b.is.TableByID(is.Table.ID)
 	e := &IndexReaderExecutor{
@@ -897,7 +903,13 @@ func (b *executorBuilder) buildIndexReader(v *plan.PhysicalIndexReader) Executor
 
 func (b *executorBuilder) buildIndexLookUpReader(v *plan.PhysicalIndexLookUpReader) Executor {
 	indexReq := b.constructDAGReq(v.IndexPlans)
+	if b.err != nil {
+		return nil
+	}
 	tableReq := b.constructDAGReq(v.TablePlans)
+	if b.err != nil {
+		return nil
+	}
 	is := v.IndexPlans[0].(*plan.PhysicalIndexScan)
 	table, _ := b.is.TableByID(is.Table.ID)
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1305,6 +1305,7 @@ func (s *testSuite) TestSimpleDAG(c *C) {
 	tk.MustExec("insert into t values (1, 1, 1), (2, 1, 1), (3, 1, 2), (4, 2, 3)")
 	plan.UseDAGPlanBuilder = true
 	tk.MustQuery("select a from t").Check(testkit.Rows("1", "2", "3", "4"))
+	tk.MustQuery("select * from t where a = 4").Check(testkit.Rows("4 2 3"))
 	tk.MustQuery("select a from t limit 1").Check(testkit.Rows("1"))
 	tk.MustQuery("select a from t order by a desc").Check(testkit.Rows("4", "3", "2", "1"))
 	tk.MustQuery("select a from t order by a desc limit 1").Check(testkit.Rows("4"))
@@ -1322,4 +1323,9 @@ func (s *testSuite) TestSimpleDAG(c *C) {
 	tk.MustQuery("select a from t where c = 1 and a < 2").Check(testkit.Rows("1"))
 	tk.MustQuery("select a from t where c = 1 order by a limit 1").Check(testkit.Rows("1"))
 	tk.MustQuery("select count(*) from t where c = 1 ").Check(testkit.Rows("2"))
+	tk.MustExec("create index i1 on t(b)")
+	tk.MustQuery("select c from t where b = 2").Check(testkit.Rows("3"))
+	tk.MustQuery("select * from t where b = 2").Check(testkit.Rows("4 2 3"))
+	tk.MustQuery("select count(*) from t where b = 1").Check(testkit.Rows("3"))
+	tk.MustQuery("select * from t where b = 1 and a > 1 limit 1").Check(testkit.Rows("2 1 1"))
 }

--- a/executor/new_distsql.go
+++ b/executor/new_distsql.go
@@ -118,7 +118,7 @@ func (e *TableReaderExecutor) doRequestForHandles(handles []int64, goCtx goctx.C
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.result.Fetch(e.ctx.GoCtx())
+	e.result.Fetch(goCtx)
 	return nil
 }
 
@@ -251,7 +251,7 @@ func (e *IndexLookUpExecutor) doRequest() error {
 	// e.taskChan serves as a pipeline, so fetching index and getting table data can
 	// run concurrently.
 	e.taskChan = make(chan *lookupTableTask, LookupTableTaskChannelSize)
-	go e.fetchHandles()
+	go e.fetchHandlesAndStartWorkers()
 	return nil
 }
 
@@ -284,9 +284,9 @@ func (e *IndexLookUpExecutor) executeTask(task *lookupTableTask, goCtx goctx.Con
 	}
 }
 
-// fetchHandles fetches a batch of handles from index data and builds the index lookup tasks.
+// fetchHandlesAndStartWorkers fetches a batch of handles from index data and builds the index lookup tasks.
 // We initialize some workers to execute this tasks concurrently and put the task to taskCh by order.
-func (e *IndexLookUpExecutor) fetchHandles() {
+func (e *IndexLookUpExecutor) fetchHandlesAndStartWorkers() {
 	// The tasks in workCh will be consumed by workers. When all workers are busy, we should stop to push tasks to channel.
 	// So its length is one.
 	workCh := make(chan *lookupTableTask, 1)

--- a/executor/new_distsql.go
+++ b/executor/new_distsql.go
@@ -260,7 +260,7 @@ func (e *IndexLookUpExecutor) doRequest() error {
 func (e *IndexLookUpExecutor) executeTask(task *lookupTableTask, goCtx goctx.Context) {
 	var err error
 	defer func() {
-		task.doneCh <- err
+		task.doneCh <- errors.Trace(err)
 	}()
 	tableReader := &TableReaderExecutor{
 		asName:  e.asName,

--- a/plan/initialize.go
+++ b/plan/initialize.go
@@ -270,6 +270,7 @@ func (p PhysicalIndexLookUpReader) init(allocator *idAllocator, ctx context.Cont
 	p.basePhysicalPlan = newBasePhysicalPlan(p.basePlan)
 	p.TablePlans = flattenPushDownPlan(p.tablePlan)
 	p.IndexPlans = flattenPushDownPlan(p.indexPlan)
+	p.schema = p.tablePlan.Schema()
 	return &p
 }
 

--- a/plan/task_profile.go
+++ b/plan/task_profile.go
@@ -94,9 +94,6 @@ func attachPlan2TaskProfile(p PhysicalPlan, t taskProfile) taskProfile {
 // finishIndexPlan means we no longer add plan to index plan, and compute the network cost for it.
 func (t *copTaskProfile) finishIndexPlan() {
 	if !t.indexPlanFinished {
-		if t.tablePlan != nil {
-			t.indexPlan.SetSchema(expression.NewSchema()) // we only need the handle
-		}
 		t.cst += t.cnt * (netWorkFactor + scanFactor)
 		t.indexPlanFinished = true
 	}
@@ -169,7 +166,6 @@ func finishCopTask(task taskProfile, ctx context.Context, allocator *idAllocator
 	}
 	if t.indexPlan != nil && t.tablePlan != nil {
 		newTask.p = PhysicalIndexLookUpReader{tablePlan: t.tablePlan, indexPlan: t.indexPlan}.init(allocator, ctx)
-		newTask.p.SetSchema(t.tablePlan.Schema())
 	} else if t.indexPlan != nil {
 		newTask.p = PhysicalIndexReader{indexPlan: t.indexPlan}.init(allocator, ctx)
 	} else {


### PR DESCRIPTION
index look up executor implements index double reading. we reuse the concurrency algorithm in old index executor.

@shenli @coocood @zimulala @tiancaiamao PTAL