### PR TITLE
Makefile: fix GOPATH detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ### Makefile for tidb
 
+GOPATH ?= $(shell go env GOPATH)
+
 # Ensure GOPATH is set before running build process.
 ifeq "$(GOPATH)" ""
   $(error Please set the environment variable GOPATH before running `make`)


### PR DESCRIPTION
go 1.8 will [set a default GOPATH](https://golang.org/doc/go1.8#gopath), which means that GOPATH doesn't have to be set explicitly anymore.

This will be very helpful for people like me who are not familiar with go.
