### PR TITLE
expression: refine builtin-func RAND (fix issue3211)

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -24,12 +24,12 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/util/types"
-	"time"
 )
 
 var (

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
-	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -326,17 +325,14 @@ type randFunctionClass struct {
 
 func (c *randFunctionClass) getFunction(args []Expression, ctx context.Context) (builtinFunc, error) {
 	err := errors.Trace(c.verifyArgs(args))
-	// To fix issue3211, we add an extra argument to record the time that RAND has executed.
-	if len(args) == 1 {
-		args = append(args, &Constant{Value: types.NewIntDatum(0), RetType: types.NewFieldType(mysql.TypeLonglong)})
-	}
-	bt := &builtinRandSig{newBaseBuiltinFunc(args, ctx)}
+	bt := &builtinRandSig{baseBuiltinFunc: newBaseBuiltinFunc(args, ctx)}
 	bt.deterministic = false
 	return bt, errors.Trace(err)
 }
 
 type builtinRandSig struct {
 	baseBuiltinFunc
+	ranGen *rand.Rand
 }
 
 // eval evals a builtinRandSig.
@@ -346,22 +342,18 @@ func (b *builtinRandSig) eval(row []types.Datum) (d types.Datum, err error) {
 	if err != nil {
 		return d, errors.Trace(err)
 	}
-	if len(args) == 2 && !args[0].IsNull() {
-		seed, err := args[0].ToInt64(b.ctx.GetSessionVars().StmtCtx)
-		if err != nil {
-			return d, errors.Trace(err)
+	if len(args) == 1 && !args[0].IsNull() {
+		if b.ranGen == nil {
+			seed, err := args[0].ToInt64(b.ctx.GetSessionVars().StmtCtx)
+			if err != nil {
+				return d, errors.Trace(err)
+			}
+			b.ranGen = rand.New(rand.NewSource(seed))
 		}
-		rand.Seed(seed)
-		cnt := args[1].GetInt64()
-		// To avoid get a same result every time for `rand(seed)`,
-		// we check arg[1] to get the time that RAND has executed,
-		// and skip the first cnt results.
-		for i := 0; i < int(cnt); i++ {
-			rand.Float64()
-		}
-		b.args[1] = &Constant{Value: types.NewIntDatum(cnt + 1), RetType: types.NewFieldType(mysql.TypeLonglong)}
+		d.SetFloat64(b.ranGen.Float64())
+	} else {
+		d.SetFloat64(rand.Float64())
 	}
-	d.SetFloat64(rand.Float64())
 	return d, nil
 }
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"math"
+	"math/rand"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
@@ -22,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
-	"math/rand"
 )
 
 func (s *testEvaluatorSuite) TestAbs(c *C) {

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -192,14 +192,13 @@ func (s *testEvaluatorSuite) TestRand(c *C) {
 	c.Assert(v.GetFloat64(), GreaterEqual, float64(0))
 
 	// issue 3211
-	rand.Seed(20160101)
-	result := []float64{rand.Float64(), rand.Float64(), rand.Float64()}
 	f2, err := fc.getFunction([]Expression{&Constant{Value: types.NewIntDatum(20160101), RetType: types.NewFieldType(mysql.TypeLonglong)}}, s.ctx)
 	c.Assert(err, IsNil)
+	rand.Seed(20160101)
 	for i := 0; i < 3; i++ {
 		v, err = f2.eval(nil)
 		c.Assert(err, IsNil)
-		c.Assert(v.GetFloat64(), Equals, result[i])
+		c.Assert(v.GetFloat64(), Equals, rand.Float64())
 	}
 }
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -196,15 +196,11 @@ func (s *testEvaluatorSuite) TestRand(c *C) {
 	result := []float64{rand.Float64(), rand.Float64(), rand.Float64()}
 	f2, err := fc.getFunction([]Expression{&Constant{Value: types.NewIntDatum(20160101), RetType: types.NewFieldType(mysql.TypeLonglong)}}, s.ctx)
 	c.Assert(err, IsNil)
-	v, err = f2.eval(nil)
-	c.Assert(err, IsNil)
-	c.Assert(v.GetFloat64(), Equals, result[0])
-	v, err = f2.eval(nil)
-	c.Assert(err, IsNil)
-	c.Assert(v.GetFloat64(), Equals, result[1])
-	v, err = f2.eval(nil)
-	c.Assert(err, IsNil)
-	c.Assert(v.GetFloat64(), Equals, result[2])
+	for i := 0; i < 3; i++ {
+		v, err = f2.eval(nil)
+		c.Assert(err, IsNil)
+		c.Assert(v.GetFloat64(), Equals, result[i])
+	}
 }
 
 func (s *testEvaluatorSuite) TestPow(c *C) {

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -194,11 +194,11 @@ func (s *testEvaluatorSuite) TestRand(c *C) {
 	// issue 3211
 	f2, err := fc.getFunction([]Expression{&Constant{Value: types.NewIntDatum(20160101), RetType: types.NewFieldType(mysql.TypeLonglong)}}, s.ctx)
 	c.Assert(err, IsNil)
-	rand.Seed(20160101)
+	randGen := rand.New(rand.NewSource(20160101))
 	for i := 0; i < 3; i++ {
 		v, err = f2.eval(nil)
 		c.Assert(err, IsNil)
-		c.Assert(v.GetFloat64(), Equals, rand.Float64())
+		c.Assert(v.GetFloat64(), Equals, randGen.Float64())
 	}
 }
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -18,9 +18,11 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
+	"math/rand"
 )
 
 func (s *testEvaluatorSuite) TestAbs(c *C) {
@@ -188,6 +190,21 @@ func (s *testEvaluatorSuite) TestRand(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v.GetFloat64(), Less, float64(1))
 	c.Assert(v.GetFloat64(), GreaterEqual, float64(0))
+
+	// issue 3211
+	rand.Seed(20160101)
+	result := []float64{rand.Float64(), rand.Float64(), rand.Float64()}
+	f2, err := fc.getFunction([]Expression{&Constant{Value: types.NewIntDatum(20160101), RetType: types.NewFieldType(mysql.TypeLonglong)}}, s.ctx)
+	c.Assert(err, IsNil)
+	v, err = f2.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(v.GetFloat64(), Equals, result[0])
+	v, err = f2.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(v.GetFloat64(), Equals, result[1])
+	v, err = f2.eval(nil)
+	c.Assert(err, IsNil)
+	c.Assert(v.GetFloat64(), Equals, result[2])
 }
 
 func (s *testEvaluatorSuite) TestPow(c *C) {

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -21,6 +21,9 @@ import (
 func FoldConstant(expr Expression) Expression {
 	scalarFunc, ok := expr.(*ScalarFunction)
 	if !ok || !scalarFunc.Function.isDeterministic() {
+		if ok {
+			log.Warning(scalarFunc)
+		}
 		return expr
 	}
 	args := scalarFunc.GetArgs()

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -21,9 +21,6 @@ import (
 func FoldConstant(expr Expression) Expression {
 	scalarFunc, ok := expr.(*ScalarFunction)
 	if !ok || !scalarFunc.Function.isDeterministic() {
-		if ok {
-			log.Warning(scalarFunc)
-		}
 		return expr
 	}
 	args := scalarFunc.GetArgs()


### PR DESCRIPTION
This commit fixes #3211 through recording the state of RAND built-in function.

``` sql
create table t (a int);
insert into t values(1),(2),(3),(4);
select rand(20160101) from t;
```

Before this commit, the query above gets 4 same results,
because rand(20160101) executes 
``` go
rand.Seed(seed)
rand.Float64() 
```
repeatedly.

@shenli @coocood PTAL