### PR TITLE
[WIP]*: refactor compare built-in functions using new type-inferer

### DIFF
--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -68,7 +68,7 @@ func (*testExpressionSuite) TestConstantPropagation(c *C) {
 				newFunction(ast.EQ, newColumn("d"), newLonglong(1)),
 				newFunction(ast.OrOr, newLonglong(1), newColumn("a")),
 			},
-			result: "eq(test.t.a, 1), eq(test.t.b, 1), eq(test.t.c, 1), eq(test.t.d, 1), or(1, 1)",
+			result: "1, eq(test.t.a, 1), eq(test.t.b, 1), eq(test.t.c, 1), eq(test.t.d, 1)",
 		},
 		{
 			conditions: []Expression{
@@ -164,7 +164,7 @@ func (*testExpressionSuite) TestConstantFolding(c *C) {
 		},
 	}
 	for _, tt := range tests {
-		newConds := FoldConstant(tt.condition)
+		newConds := FoldConstant(tt.condition, true)
 		c.Assert(newConds.String(), Equals, tt.result, Commentf("different for expr %s", tt.condition))
 	}
 }

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -599,8 +599,12 @@ func (s *testEvaluatorSuite) TestDynamic(c *C) {
 		ast.RowCount:     0,
 		ast.UUID:         0,
 	}
+	args := make([]Expression, 10)
+	for i := 0; i < len(args); i++ {
+		args[i] = &Constant{Value: types.NewIntDatum(int64(i)), RetType: types.NewFieldType(mysql.TypeLonglong)}
+	}
 	for name, fc := range funcs {
-		f, _ := fc.getFunction(nil, s.ctx)
+		f, _ := fc.getFunction(args, s.ctx)
 		if _, ok := dynamicFuncs[name]; ok {
 			c.Assert(f.isDeterministic(), IsFalse)
 		} else {

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -78,11 +78,12 @@ func NewFunction(ctx context.Context, funcName string, retType *types.FieldType,
 	if retType == nil {
 		return nil, errors.Errorf("RetType cannot be nil for ScalarFunction.")
 	}
-	return &ScalarFunction{
+	function := &ScalarFunction{
 		FuncName: model.NewCIStr(funcName),
 		RetType:  retType,
 		Function: f,
-	}, nil
+	}
+	return FoldConstant(function, false), nil
 }
 
 // ScalarFuncs2Exprs converts []*ScalarFunction to []Expression.

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -80,7 +80,7 @@ func (b *planBuilder) rewrite(expr ast.ExprNode, p LogicalPlan, aggMapper map[*a
 	if getRowLen(er.ctxStack[0]) != 1 {
 		return nil, nil, ErrOperandColumns.GenByArgs(1)
 	}
-	result := expression.FoldConstant(er.ctxStack[0])
+	result := expression.FoldConstant(er.ctxStack[0], true)
 	return result, er.p, nil
 }
 

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -64,7 +64,7 @@ func NewFieldType(tp byte) *FieldType {
 func (ft *FieldType) ToClass() TypeClass {
 	switch ft.Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
-		mysql.TypeBit, mysql.TypeYear:
+		mysql.TypeYear:
 		return ClassInt
 	case mysql.TypeNewDecimal:
 		return ClassDecimal
@@ -180,10 +180,7 @@ func DefaultTypeForValue(value interface{}, tp *FieldType) {
 	case []byte:
 		tp.Tp = mysql.TypeBlob
 		SetBinChsClnFlag(tp)
-	case Bit:
-		tp.Tp = mysql.TypeBit
-		SetBinChsClnFlag(tp)
-	case Hex:
+	case Bit, Hex:
 		tp.Tp = mysql.TypeVarchar
 		SetBinChsClnFlag(tp)
 	case Time:


### PR DESCRIPTION
This commit generates different compare built-in function signatures
according to the compare type of the parameters.

The implementation refers to the following MySQL functions:

1. https://github.com/mysql/mysql-server/blob/5.7/sql/item_cmpfunc.cc#L1132
2. https://github.com/mysql/mysql-server/blob/5.7/sql/item_cmpfunc.cc#L722
3. https://github.com/mysql/mysql-server/blob/5.7/sql/item_cmpfunc.cc#L1016
4. https://github.com/mysql/mysql-server/blob/5.7/sql/field.h#L331
5. https://github.com/mysql/mysql-server/blob/5.7/sql/item.cc#L9316