### PR TITLE
*: refactor a function name

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -558,7 +558,7 @@ func (b *executorBuilder) buildTableScan(v *plan.PhysicalTableScan) Executor {
 	}
 	table, _ := b.is.TableByID(v.Table.ID)
 	client := b.ctx.GetClient()
-	supportDesc := client.SupportRequestType(kv.ReqTypeSelect, kv.ReqSubTypeDesc)
+	supportDesc := client.IsRequestTypeSupported(kv.ReqTypeSelect, kv.ReqSubTypeDesc)
 	e := &XSelectTableExec{
 		tableInfo:   v.Table,
 		ctx:         b.ctx,
@@ -588,7 +588,7 @@ func (b *executorBuilder) buildIndexScan(v *plan.PhysicalIndexScan) Executor {
 	}
 	table, _ := b.is.TableByID(v.Table.ID)
 	client := b.ctx.GetClient()
-	supportDesc := client.SupportRequestType(kv.ReqTypeIndex, kv.ReqSubTypeDesc)
+	supportDesc := client.IsRequestTypeSupported(kv.ReqTypeIndex, kv.ReqSubTypeDesc)
 	e := &XSelectIndexExec{
 		tableInfo:            v.Table,
 		ctx:                  b.ctx,

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -106,14 +106,14 @@ func (pc pbConverter) datumToPBExpr(d types.Datum) *tipb.Expr {
 	default:
 		return nil
 	}
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tp)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tp)) {
 		return nil
 	}
 	return &tipb.Expr{Tp: tp, Val: val}
 }
 
 func (pc pbConverter) columnToPBExpr(column *Column) *tipb.Expr {
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tipb.ExprType_ColumnRef)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tipb.ExprType_ColumnRef)) {
 		return nil
 	}
 	switch column.GetType().Tp {
@@ -176,7 +176,7 @@ func (pc pbConverter) compareOpsToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 func (pc pbConverter) likeToPBExpr(expr *ScalarFunction) *tipb.Expr {
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tipb.ExprType_Like)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tipb.ExprType_Like)) {
 		return nil
 	}
 	// Only patterns like 'abc', '%abc', 'abc%', '%abc%' can be converted to *tipb.Expr for now.
@@ -265,7 +265,7 @@ func (pc pbConverter) bitwiseFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 func (pc pbConverter) inToPBExpr(expr *ScalarFunction) *tipb.Expr {
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tipb.ExprType_In)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tipb.ExprType_In)) {
 		return nil
 	}
 
@@ -283,7 +283,7 @@ func (pc pbConverter) inToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 func (pc pbConverter) constListToPB(list []Expression) *tipb.Expr {
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tipb.ExprType_ValueList)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tipb.ExprType_ValueList)) {
 		return nil
 	}
 
@@ -370,7 +370,7 @@ func AggFuncToPBExpr(sc *variable.StatementContext, client kv.Client, aggFunc Ag
 	case ast.AggFuncAvg:
 		tp = tipb.ExprType_Avg
 	}
-	if !client.SupportRequestType(kv.ReqTypeSelect, int64(tp)) {
+	if !client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tp)) {
 		return nil
 	}
 
@@ -423,7 +423,7 @@ func (pc pbConverter) controlFuncsToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 func (pc pbConverter) convertToPBExpr(expr *ScalarFunction, tp tipb.ExprType) *tipb.Expr {
-	if !pc.client.SupportRequestType(kv.ReqTypeSelect, int64(tp)) {
+	if !pc.client.IsRequestTypeSupported(kv.ReqTypeSelect, int64(tp)) {
 		return nil
 	}
 	children := make([]*tipb.Expr, 0, len(expr.GetArgs()))

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -37,11 +37,11 @@ const (
 
 // Those limits is enforced to make sure the transaction can be well handled by TiKV.
 var (
-	// The limit of single entry size (len(key) + len(value)).
+	// TxnEntrySizeLimit is limit of single entry size (len(key) + len(value)).
 	TxnEntrySizeLimit = 6 * 1024 * 1024
-	// The limit of number of entries in the MemBuffer.
+	// TxnEntryCountLimit  is limit of number of entries in the MemBuffer.
 	TxnEntryCountLimit uint64 = 300 * 1000
-	// The limit of the sum of all entry size.
+	// TxnTotalSizeLimit is limit of the sum of all entry size.
 	TxnTotalSizeLimit = 100 * 1024 * 1024
 )
 
@@ -116,8 +116,8 @@ type Client interface {
 	// Send sends request to KV layer, returns a Response.
 	Send(ctx goctx.Context, req *Request) Response
 
-	// SupportRequestType checks if reqType and subType is supported.
-	SupportRequestType(reqType, subType int64) bool
+	// IsRequestTypeSupported checks if reqType and subType is supported.
+	IsRequestTypeSupported(reqType, subType int64) bool
 }
 
 // ReqTypes.
@@ -134,16 +134,15 @@ const (
 
 // Request represents a kv request.
 type Request struct {
-	// The request type.
-	Tp   int64
-	Data []byte
-	// Key Ranges
+	// Tp is the request type.
+	Tp        int64
+	Data      []byte
 	KeyRanges []KeyRange
-	// If KeepOrder is true, the response should be returned in order.
+	// KeepOrder is true, if the response should be returned in order.
 	KeepOrder bool
-	// If desc is true, the request is sent in descending order.
+	// Desc is true, if the request is sent in descending order.
 	Desc bool
-	// If concurrency is 1, it only sends the request to a single storage unit when
+	// Concurrency is 1, if it only sends the request to a single storage unit when
 	// ResponseIterator.Next is called. If concurrency is greater than 1, the request will be
 	// sent to multiple storage units concurrently.
 	Concurrency int
@@ -187,7 +186,7 @@ type Storage interface {
 	GetClient() Client
 	// Close store
 	Close() error
-	// Storage's unique ID
+	// UUID return a unique ID which represents a Storage.
 	UUID() string
 	// CurrentVersion returns current max committed version.
 	CurrentVersion() (Version, error)

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -312,7 +312,7 @@ func (c *mockClient) Send(ctx goctx.Context, _ *kv.Request) kv.Response {
 	return nil
 }
 
-func (c *mockClient) SupportRequestType(reqType, subType int64) bool {
+func (c *mockClient) IsRequestTypeSupported(reqType, subType int64) bool {
 	switch reqType {
 	case kv.ReqTypeSelect, kv.ReqTypeIndex:
 		switch subType {

--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -129,6 +129,7 @@ func (p *LogicalJoin) preferUseMergeJoin() bool {
 	return p.preferMergeJoin && len(p.EqualConditions) == 1
 }
 
+// convert2MergeJoin ...
 // TODO: Now we only process the case that the join has only one equal condition.
 func (p *LogicalJoin) convert2MergeJoin(prop *requiredProp) (taskProfile, error) {
 	lChild := p.children[0].(LogicalPlan)
@@ -335,7 +336,7 @@ func tryToAddUnionScan(cop *copTaskProfile, conds []expression.Expression, ctx c
 func (p *DataSource) tryToGetMemTask(prop *requiredProp) (task taskProfile, err error) {
 	client := p.ctx.GetClient()
 	memDB := infoschema.IsMemoryDB(p.DBName.L)
-	isDistReq := !memDB && client != nil && client.SupportRequestType(kv.ReqTypeSelect, 0)
+	isDistReq := !memDB && client != nil && client.IsRequestTypeSupported(kv.ReqTypeSelect, 0)
 	if isDistReq {
 		return nil, nil
 	}
@@ -417,7 +418,7 @@ func (p *DataSource) convert2NewPhysicalPlan(prop *requiredProp) (taskProfile, e
 	return task, p.storeTaskProfile(prop, task)
 }
 
-// convert2IndexScanner converts the DataSource to index scan with idx.
+// convertToIndexScan converts the DataSource to index scan with idx.
 func (p *DataSource) convertToIndexScan(prop *requiredProp, idx *model.IndexInfo) (task taskProfile, err error) {
 	is := PhysicalIndexScan{
 		Table:            p.tableInfo,

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -136,7 +136,7 @@ func (p *DataSource) convert2IndexScan(prop *requiredProperty, index *model.Inde
 		}
 		is.AccessCondition, newSel.Conditions, is.accessEqualCount, is.accessInAndEqCount = DetachIndexScanConditions(conds, is.Index)
 		memDB := infoschema.IsMemoryDB(p.DBName.L)
-		isDistReq := !memDB && client != nil && client.SupportRequestType(kv.ReqTypeIndex, 0)
+		isDistReq := !memDB && client != nil && client.IsRequestTypeSupported(kv.ReqTypeIndex, 0)
 		if isDistReq {
 			idxConds, tblConds := DetachIndexFilterConditions(newSel.Conditions, is.Index.Columns, is.Table)
 			is.IndexConditionPBExpr, is.indexFilterConditions, idxConds = expression.ExpressionsToPB(sc, idxConds, client)
@@ -213,7 +213,7 @@ func (p *DataSource) convert2PhysicalPlan(prop *requiredProperty) (*physicalPlan
 	}
 	client := p.ctx.GetClient()
 	memDB := infoschema.IsMemoryDB(p.DBName.L)
-	isDistReq := !memDB && client != nil && client.SupportRequestType(kv.ReqTypeSelect, 0)
+	isDistReq := !memDB && client != nil && client.IsRequestTypeSupported(kv.ReqTypeSelect, 0)
 	if !isDistReq {
 		memTable := PhysicalMemTable{
 			DBName:      p.DBName,
@@ -791,7 +791,7 @@ func compareTypeForOrder(lhs *types.FieldType, rhs *types.FieldType) bool {
 	return true
 }
 
-// Generate all possible combinations from join conditions for cost evaluation
+// constructPropertyByJoin generates all possible combinations from join conditions for cost evaluation
 // It will try all keys in join conditions
 func constructPropertyByJoin(join *LogicalJoin) ([][]*requiredProperty, []int, error) {
 	var result [][]*requiredProperty
@@ -1366,7 +1366,7 @@ func (p *Selection) convert2PhysicalPlanPushOrder(prop *requiredProperty) (*phys
 	} else {
 		client := p.ctx.GetClient()
 		memDB := infoschema.IsMemoryDB(ds.DBName.L)
-		isDistReq := !memDB && client != nil && client.SupportRequestType(kv.ReqTypeSelect, 0)
+		isDistReq := !memDB && client != nil && client.IsRequestTypeSupported(kv.ReqTypeSelect, 0)
 		if !isDistReq {
 			info = p.appendSelToInfo(info)
 		}

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -139,9 +139,9 @@ type PhysicalIndexScan struct {
 	// If the query requires the columns that don't belong to index, DoubleRead will be true.
 	DoubleRead bool
 
-	// All conditions in AccessCondition[accessEqualCount:accessInAndEqCount] are IN expressions or equal conditions.
+	// accessInAndEqCount is counter of all conditions in AccessCondition[accessEqualCount:accessInAndEqCount].
 	accessInAndEqCount int
-	// All conditions in AccessCondition[:accessEqualCount] are equal conditions.
+	// accessEqualCount is counter of all conditions in AccessCondition[:accessEqualCount].
 	accessEqualCount int
 
 	TableAsName *model.CIStr
@@ -177,7 +177,6 @@ type physicalDistSQLPlan interface {
 	addAggregation(ctx context.Context, agg *PhysicalAggregation) *expression.Schema
 	addTopN(ctx context.Context, prop *requiredProperty) bool
 	addLimit(limit *Limit)
-	// scanCount means the original row count that need to be scanned and resultCount means the row count after scanning.
 	calculateCost(resultCount float64, scanCount float64) float64
 }
 
@@ -231,6 +230,7 @@ type physicalTableSource struct {
 	SortItemsPB []*tipb.ByItem
 
 	// The following fields are used for explaining and testing. Because pb structures are not human-readable.
+
 	aggFuncs              []expression.AggregationFunction
 	gbyItems              []expression.Expression
 	sortItems             []*ByItems
@@ -336,7 +336,7 @@ func (p *physicalTableSource) addTopN(ctx context.Context, prop *requiredPropert
 		p.addLimit(prop.limit)
 		return true
 	}
-	if p.client == nil || !p.client.SupportRequestType(kv.ReqTypeSelect, kv.ReqSubTypeTopN) {
+	if p.client == nil || !p.client.IsRequestTypeSupported(kv.ReqTypeSelect, kv.ReqSubTypeTopN) {
 		return false
 	}
 	if prop.limit == nil {
@@ -432,7 +432,7 @@ type PhysicalTableScan struct {
 
 	TableAsName *model.CIStr
 
-	// If sort data by scanning pkcol, KeepOrder should be true.
+	// KeepOrder is true, if sort data by scanning pkcol,
 	KeepOrder bool
 }
 

--- a/store/localstore/local_client.go
+++ b/store/localstore/local_client.go
@@ -35,7 +35,7 @@ func (c *dbClient) Send(ctx goctx.Context, req *kv.Request) kv.Response {
 	return it
 }
 
-func (c *dbClient) SupportRequestType(reqType, subType int64) bool {
+func (c *dbClient) IsRequestTypeSupported(reqType, subType int64) bool {
 	switch reqType {
 	case kv.ReqTypeSelect, kv.ReqTypeIndex:
 		switch subType {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -32,8 +32,8 @@ type CopClient struct {
 	store *tikvStore
 }
 
-// SupportRequestType checks whether reqType is supported.
-func (c *CopClient) SupportRequestType(reqType, subType int64) bool {
+// IsRequestTypeSupported checks whether reqType is supported.
+func (c *CopClient) IsRequestTypeSupported(reqType, subType int64) bool {
 	switch reqType {
 	case kv.ReqTypeSelect, kv.ReqTypeIndex:
 		switch subType {
@@ -304,7 +304,7 @@ type copResponse struct {
 
 const minLogCopTaskTime = 300 * time.Millisecond
 
-// The worker function that get a copTask from channel, handle it and
+// work is a worker function that get a copTask from channel, handle it and
 // send the result back.
 func (it *copIterator) work(ctx goctx.Context, taskCh <-chan *copTask) {
 	defer it.wg.Done()
@@ -382,7 +382,7 @@ func (it *copIterator) sendToTaskCh(ctx goctx.Context, t *copTask) (finished boo
 	return
 }
 
-// Return next coprocessor result.
+// Next returns next coprocessor result.
 func (it *copIterator) Next() ([]byte, error) {
 	coprocessorCounter.WithLabelValues("next").Inc()
 
@@ -420,7 +420,7 @@ func (it *copIterator) Next() ([]byte, error) {
 	return resp.Data, nil
 }
 
-// Handle single copTask.
+// handleTask handles single copTask.
 func (it *copIterator) handleTask(bo *Backoffer, task *copTask) []copResponse {
 	coprocessorCounter.WithLabelValues("handle_task").Inc()
 	sender := NewRegionRequestSender(bo, it.store.regionCache, it.store.client)
@@ -471,7 +471,7 @@ func (it *copIterator) handleTask(bo *Backoffer, task *copTask) []copResponse {
 	}
 }
 
-// Rebuild and handle current task. It may be split into multiple tasks (in region split scenario).
+// handleRegionErrorTask handles current task. It may be split into multiple tasks (in region split scenario).
 func (it *copIterator) handleRegionErrorTask(bo *Backoffer, task *copTask) []copResponse {
 	coprocessorCounter.WithLabelValues("rebuild_task").Inc()
 


### PR DESCRIPTION
This changes makes function much more readable. Original `SupportRequestType` may confused people  that this function actually return a RequestType. By renaming it as `IsRequestTypeSupported`, confusion will go away.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/3263)
<!-- Reviewable:end -->
