### PR TITLE
expression: remove todo that is not longer valid

### DIFF
--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -411,13 +411,6 @@ func (v *typeInferrer) handleFuncCallExpr(x *ast.FuncCallExpr) {
 	case ast.RandomBytes:
 		tp = types.NewFieldType(mysql.TypeVarString)
 	case ast.If:
-		// TODO: fix this
-		// See https://dev.mysql.com/doc/refman/5.5/en/control-flow-functions.html#function_if
-		// The default return type of IF() (which may matter when it is stored into a temporary table) is calculated as follows.
-		// Expression	Return Value
-		// expr2 or expr3 returns a string	string
-		// expr2 or expr3 returns a floating-point value	floating-point
-		// expr2 or expr3 returns an integer	integer
 		tp = x.Args[1].GetType()
 	case ast.Compress:
 		tp = types.NewFieldType(mysql.TypeBlob)


### PR DESCRIPTION
I test with latest tidb. 

This todo seems it was done already. mysql output is the following:

~~~
tidb>  SELECT IF(1>2,2,3);
+-------------+
| IF(1>2,2,3) |
+-------------+
|           3 |
+-------------+
1 row in set (0.00 sec)

tidb> SELECT IF(1<2,'yes','no');
+--------------------+
| IF(1<2,'yes','no') |
+--------------------+
| yes                |
+--------------------+
1 row in set (0.00 sec)

tidb> SELECT IF(STRCMP('test','test1'),'no','yes');
+---------------------------------------+
| IF(STRCMP('test','test1'),'no','yes') |
+---------------------------------------+
| no                                    |
+---------------------------------------+
1 row in set (0.01 sec)

tidb> SELECT IF(STRCMP('test','test1'),'no',0.1);
+-------------------------------------+
| IF(STRCMP('test','test1'),'no',0.1) |
+-------------------------------------+
| no                                  |
+-------------------------------------+
1 row in set (0.01 sec)

tidb> SELECT IF(STRCMP('test','test1'),0.1 , "yes");
+----------------------------------------+
| IF(STRCMP('test','test1'),0.1 , "yes") |
+----------------------------------------+
|                                    0.1 |
+----------------------------------------+
1 row in set (0.00 sec)
~~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/3264)
<!-- Reviewable:end -->
