### PR TITLE
tidb: fix retry when commit get infoschema change error

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 node {
-    def TIDB_TEST_BRANCH = "master"
+    def TIDB_TEST_BRANCH = "tiancaiamao/retry-infoschema-change"
     def TIKV_BRANCH = "master"
     def PD_BRANCH = "master"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 node {
-    def TIDB_TEST_BRANCH = "tiancaiamao/retry-infoschema-change"
+    def TIDB_TEST_BRANCH = "master"
     def TIKV_BRANCH = "master"
     def PD_BRANCH = "master"
 

--- a/session.go
+++ b/session.go
@@ -341,7 +341,6 @@ func (s *session) isRetryableError(err error) bool {
 	return kv.IsRetryableError(err) || terror.ErrorEqual(err, domain.ErrInfoSchemaChanged)
 }
 
-// retry will rebuild plan if infoschema changed, otherwise it reuse the statement.
 func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 	connID := s.sessionVars.ConnectionID
 	if s.sessionVars.TxnCtx.ForUpdate {
@@ -364,6 +363,7 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 			st := sr.st
 			txt := st.OriginText()
 			if infoSchemaChanged {
+				// Rebuild plan if infoschema changed, reuse the statement otherwise.
 				charset, collation := s.sessionVars.GetCharsetInfo()
 				stmt, err := s.parser.ParseOneStmt(txt, charset, collation)
 				if err != nil {

--- a/session.go
+++ b/session.go
@@ -271,7 +271,7 @@ func (s *session) doCommitWithRetry() error {
 			// We make larger transactions retry less times to prevent cluster resource outage.
 			txnSizeRate := float64(txnSize) / float64(kv.TxnTotalSizeLimit)
 			maxRetryCount := commitRetryLimit - int(float64(commitRetryLimit-1)*txnSizeRate)
-			err = s.retry(maxRetryCount)
+			err = s.retry(maxRetryCount, terror.ErrorEqual(err, domain.ErrInfoSchemaChanged))
 		}
 	}
 	s.cleanRetryInfo()
@@ -341,7 +341,8 @@ func (s *session) isRetryableError(err error) bool {
 	return kv.IsRetryableError(err) || terror.ErrorEqual(err, domain.ErrInfoSchemaChanged)
 }
 
-func (s *session) retry(maxCnt int) error {
+// retry will rebuild plan if infoschema changed, otherwise it reuse the statement.
+func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 	connID := s.sessionVars.ConnectionID
 	if s.sessionVars.TxnCtx.ForUpdate {
 		return errors.Errorf("[%d] can not retry select for update statement", connID)
@@ -362,6 +363,20 @@ func (s *session) retry(maxCnt int) error {
 		for i, sr := range nh.history {
 			st := sr.st
 			txt := st.OriginText()
+			if infoSchemaChanged {
+				charset, collation := s.sessionVars.GetCharsetInfo()
+				stmt, err := s.parser.ParseOneStmt(txt, charset, collation)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				st, err = Compile(s, stmt)
+				if err != nil {
+					// If a txn is inserting data when DDL is dropping column,
+					// it would fail to commit and retry, and run here then.
+					return errors.Trace(err)
+				}
+			}
+
 			if retryCnt == 0 {
 				// We do not have to log the query every time.
 				// We print the queries at the first try only.
@@ -387,6 +402,7 @@ func (s *session) retry(maxCnt int) error {
 			return errors.Trace(err)
 		}
 		retryCnt++
+		infoSchemaChanged = terror.ErrorEqual(err, domain.ErrInfoSchemaChanged)
 		if !s.unlimitedRetryCount && (retryCnt >= maxCnt) {
 			log.Warnf("[%d] Retry reached max count %d", connID, retryCnt)
 			return errors.Trace(err)

--- a/session_test.go
+++ b/session_test.go
@@ -870,7 +870,7 @@ func (s *testSessionSuite) TestSelectForUpdate(c *C) {
 
 	_, err = exec(se1, "commit")
 	c.Assert(err, NotNil)
-	err = se1.(*session).retry(10)
+	err = se1.(*session).retry(10, false)
 	// retry should fail
 	c.Assert(err, NotNil)
 


### PR DESCRIPTION
If transaction commit fail and the error is infoschema changed, retry should not reuse the statement, 
because it may be stale.

Test code is in https://github.com/pingcap/tidb-test/pull/302 to cover TiKV engine.