### PR TITLE
executor: update an error code

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -55,33 +55,35 @@ var (
 
 // Error instances.
 var (
-	ErrUnknownPlan     = terror.ClassExecutor.New(codeUnknownPlan, "Unknown plan")
-	ErrPrepareMulti    = terror.ClassExecutor.New(codePrepareMulti, "Can not prepare multiple statements")
-	ErrStmtNotFound    = terror.ClassExecutor.New(codeStmtNotFound, "Prepared statement not found")
-	ErrSchemaChanged   = terror.ClassExecutor.New(codeSchemaChanged, "Schema has changed")
-	ErrWrongParamCount = terror.ClassExecutor.New(codeWrongParamCount, "Wrong parameter count")
-	ErrRowKeyCount     = terror.ClassExecutor.New(codeRowKeyCount, "Wrong row key entry count")
-	ErrPrepareDDL      = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements")
-	ErrPasswordNoMatch = terror.ClassExecutor.New(CodePasswordNoMatch, "Can't find any matching row in the user table")
-	ErrResultIsEmpty   = terror.ClassExecutor.New(codeResultIsEmpty, "result is empty")
-	ErrBuildExecutor   = terror.ClassExecutor.New(codeErrBuildExec, "Failed to build executor")
-	ErrBatchInsertFail = terror.ClassExecutor.New(codeBatchInsertFail, "Batch insert failed, please clean the table and try again.")
+	ErrUnknownPlan          = terror.ClassExecutor.New(codeUnknownPlan, "Unknown plan")
+	ErrPrepareMulti         = terror.ClassExecutor.New(codePrepareMulti, "Can not prepare multiple statements")
+	ErrStmtNotFound         = terror.ClassExecutor.New(codeStmtNotFound, "Prepared statement not found")
+	ErrSchemaChanged        = terror.ClassExecutor.New(codeSchemaChanged, "Schema has changed")
+	ErrWrongParamCount      = terror.ClassExecutor.New(codeWrongParamCount, "Wrong parameter count")
+	ErrRowKeyCount          = terror.ClassExecutor.New(codeRowKeyCount, "Wrong row key entry count")
+	ErrPrepareDDL           = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements")
+	ErrPasswordNoMatch      = terror.ClassExecutor.New(CodePasswordNoMatch, "Can't find any matching row in the user table")
+	ErrResultIsEmpty        = terror.ClassExecutor.New(codeResultIsEmpty, "result is empty")
+	ErrBuildExecutor        = terror.ClassExecutor.New(codeErrBuildExec, "Failed to build executor")
+	ErrBatchInsertFail      = terror.ClassExecutor.New(codeBatchInsertFail, "Batch insert failed, please clean the table and try again.")
+	ErrWrongValueCountOnRow = terror.ClassExecutor.New(codeWrongValueCountOnRow, "Column count doesn't match value count at row %d")
 )
 
 // Error codes.
 const (
-	codeUnknownPlan     terror.ErrCode = 1
-	codePrepareMulti    terror.ErrCode = 2
-	codeStmtNotFound    terror.ErrCode = 3
-	codeSchemaChanged   terror.ErrCode = 4
-	codeWrongParamCount terror.ErrCode = 5
-	codeRowKeyCount     terror.ErrCode = 6
-	codePrepareDDL      terror.ErrCode = 7
-	codeResultIsEmpty   terror.ErrCode = 8
-	codeErrBuildExec    terror.ErrCode = 9
-	codeBatchInsertFail terror.ErrCode = 10
-	CodePasswordNoMatch terror.ErrCode = 1133 // MySQL error code
-	CodeCannotUser      terror.ErrCode = 1396 // MySQL error code
+	codeUnknownPlan          terror.ErrCode = 1
+	codePrepareMulti         terror.ErrCode = 2
+	codeStmtNotFound         terror.ErrCode = 3
+	codeSchemaChanged        terror.ErrCode = 4
+	codeWrongParamCount      terror.ErrCode = 5
+	codeRowKeyCount          terror.ErrCode = 6
+	codePrepareDDL           terror.ErrCode = 7
+	codeResultIsEmpty        terror.ErrCode = 8
+	codeErrBuildExec         terror.ErrCode = 9
+	codeBatchInsertFail      terror.ErrCode = 10
+	CodePasswordNoMatch      terror.ErrCode = 1133 // MySQL error code
+	CodeCannotUser           terror.ErrCode = 1396 // MySQL error code
+	codeWrongValueCountOnRow terror.ErrCode = 1136 // MySQL error code
 )
 
 // Row represents a result set row, it may be returned from a table, a join, or a projection.
@@ -349,8 +351,9 @@ func init() {
 		}
 	}
 	tableMySQLErrCodes := map[terror.ErrCode]uint16{
-		CodeCannotUser:      mysql.ErrCannotUser,
-		CodePasswordNoMatch: mysql.ErrPasswordNoMatch,
+		CodeCannotUser:           mysql.ErrCannotUser,
+		CodePasswordNoMatch:      mysql.ErrPasswordNoMatch,
+		codeWrongValueCountOnRow: mysql.ErrWrongValueCountOnRow,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassExecutor] = tableMySQLErrCodes
 }

--- a/executor/write.go
+++ b/executor/write.go
@@ -796,7 +796,7 @@ func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, co
 		// "insert into t (c1) values ()" is not valid.
 		return errors.Errorf("INSERT INTO %s: expected %d value(s), have %d", e.Table.Meta().Name.O, len(e.Columns), 0)
 	} else if valueCount > 0 && valueCount != len(cols) {
-		return errors.Errorf("INSERT INTO %s: expected %d value(s), have %d", e.Table.Meta().Name.O, len(cols), valueCount)
+		return ErrWrongValueCountOnRow.GenByArgs(num + 1)
 	}
 	return nil
 }

--- a/executor/write.go
+++ b/executor/write.go
@@ -790,11 +790,11 @@ func (e *InsertValues) checkValueCount(insertValueCount, valueCount, num int, co
 		// "insert into t values (1), ()" is not valid.
 		// "insert into t values (1,2), (1)" is not valid.
 		// So the value count must be same for all insert list.
-		return errors.Errorf("Column count doesn't match value count at row %d", num+1)
+		return ErrWrongValueCountOnRow.GenByArgs(num + 1)
 	}
 	if valueCount == 0 && len(e.Columns) > 0 {
 		// "insert into t (c1) values ()" is not valid.
-		return errors.Errorf("INSERT INTO %s: expected %d value(s), have %d", e.Table.Meta().Name.O, len(e.Columns), 0)
+		return ErrWrongValueCountOnRow.GenByArgs(num + 1)
 	} else if valueCount > 0 && valueCount != len(cols) {
 		return ErrWrongValueCountOnRow.GenByArgs(num + 1)
 	}


### PR DESCRIPTION
Return the same error code as mysql.

```
mysql> create table t (id int);
```

before:

```
mysql> insert into t values (1, 1);
ERROR 1105 (HY000): INSERT INTO t: expected 1 value(s), have 2
```

after:

```
mysql> insert into t values (1, 1);
ERROR 1136 (21S01): Column count doesn't match value count at row 1
```