### PR TITLE
expression: add EvalDuration/EvalTime for expression

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -109,7 +109,7 @@ func (b *baseBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, bool
 func (b *baseBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
 	val, err := b.self.eval(row)
 	if err != nil || val.IsNull() {
-		return nil, val.IsNull(), errors.Trace(err)
+		return types.Time{}, val.IsNull(), errors.Trace(err)
 	}
 	dateVal, err := val.ConvertTo(b.ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeDatetime))
 	return dateVal.GetMysqlTime(), false, errors.Trace(err)
@@ -118,7 +118,7 @@ func (b *baseBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) 
 func (b *baseBuiltinFunc) evalDuration(row []types.Datum) (types.Duration, bool, error) {
 	val, err := b.self.eval(row)
 	if err != nil || val.IsNull() {
-		return nil, val.IsNull(), errors.Trace(err)
+		return types.Duration{}, val.IsNull(), errors.Trace(err)
 	}
 	durationVal, err := val.ConvertTo(b.ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeDuration))
 	return durationVal.GetMysqlDuration(), false, errors.Trace(err)

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -106,7 +106,7 @@ func (b *baseBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, bool
 	return decVal, false, errors.Trace(err)
 }
 
-func (b *baseBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
+func (b *baseBuiltinFunc) evalTime(row []types.Datum) (types.Time, bool, error) {
 	val, err := b.self.eval(row)
 	if err != nil || val.IsNull() {
 		return types.Time{}, val.IsNull(), errors.Trace(err)
@@ -178,7 +178,7 @@ func (b *baseIntBuiltinFunc) evalString(row []types.Datum) (string, bool, error)
 	panic("cannot get STRING result from ClassInt expression")
 }
 
-func (b *baseIntBuiltinFunc) evalDate(row []types.Datum) (*types.MyDecimal, bool, error) {
+func (b *baseIntBuiltinFunc) evalTime(row []types.Datum) (*types.MyDecimal, bool, error) {
 	panic("cannot get DATE result from ClassInt expression")
 }
 
@@ -218,7 +218,7 @@ func (b *baseRealBuiltinFunc) evalString(row []types.Datum) (string, bool, error
 	panic("cannot get STRING result from ClassReal expression")
 }
 
-func (b *baseRealBuiltinFunc) evalDate(row []types.Datum) (*types.MyDecimal, bool, error) {
+func (b *baseRealBuiltinFunc) evalTime(row []types.Datum) (*types.MyDecimal, bool, error) {
 	panic("cannot get DATE result from ClassReal expression")
 }
 
@@ -258,7 +258,7 @@ func (b *baseDecimalBuiltinFunc) evalString(row []types.Datum) (string, bool, er
 	panic("cannot get REAL result from ClassDecimal expression")
 }
 
-func (b *baseDecimalBuiltinFunc) evalDate(row []types.Datum) (float64, bool, error) {
+func (b *baseDecimalBuiltinFunc) evalTime(row []types.Datum) (float64, bool, error) {
 	panic("cannot get DATE result from ClassDecimal expression")
 }
 
@@ -298,7 +298,7 @@ func (b *baseStringBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal
 	panic("cannot get DECIMAL result from ClassString expression")
 }
 
-func (b *baseStringBuiltinFunc) evalDate(row []types.Datum) (float64, bool, error) {
+func (b *baseStringBuiltinFunc) evalTime(row []types.Datum) (float64, bool, error) {
 	panic("cannot get DATE result from ClassString expression")
 }
 
@@ -311,7 +311,7 @@ type baseDateBuiltinFunc struct {
 }
 
 func (b *baseDateBuiltinFunc) eval(row []types.Datum) (d types.Datum, err error) {
-	val, isNull, err := b.self.evalDate(row)
+	val, isNull, err := b.self.evalTime(row)
 	if err != nil || isNull {
 		return d, errors.Trace(err)
 	}
@@ -319,8 +319,8 @@ func (b *baseDateBuiltinFunc) eval(row []types.Datum) (d types.Datum, err error)
 	return
 }
 
-func (b *baseDateBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
-	return b.self.evalDate(row)
+func (b *baseDateBuiltinFunc) evalTime(row []types.Datum) (types.Time, bool, error) {
+	return b.self.evalTime(row)
 }
 
 func (b *baseDateBuiltinFunc) evalString(row []types.Datum) (string, bool, error) {
@@ -360,7 +360,7 @@ func (b *baseDurationBuiltinFunc) evalDuration(row []types.Datum) (types.Duratio
 	return b.self.evalDuration(row)
 }
 
-func (b *baseDurationBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
+func (b *baseDurationBuiltinFunc) evalTime(row []types.Datum) (types.Time, bool, error) {
 	panic("cannot get DATE result from DURATION expression")
 }
 
@@ -392,8 +392,8 @@ type builtinFunc interface {
 	evalString(row []types.Datum) (val string, isNull bool, err error)
 	// evalDecimal evaluates decimal representation of builtinFunc by given row.
 	evalDecimal(row []types.Datum) (val *types.MyDecimal, isNull bool, err error)
-	// evalDate evaluates date/datetime representation of builtinFunc by given row.
-	evalDate(row []types.Datum) (val types.Time, isNull bool, err error)
+	// evalTime evaluates DATE/DATETIME/TIMESTAMP representation of builtinFunc by given row.
+	evalTime(row []types.Datum) (val types.Time, isNull bool, err error)
 	// evaTime evaluates duration representation of builtinFunc by given row.
 	evalDuration(row []types.Datum) (val types.Duration, isNull bool, err error)
 	// getArgs returns the arguments expressions.

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -105,6 +106,24 @@ func (b *baseBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, bool
 	return decVal, false, errors.Trace(err)
 }
 
+func (b *baseBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
+	val, err := b.self.eval(row)
+	if err != nil || val.IsNull() {
+		return nil, val.IsNull(), errors.Trace(err)
+	}
+	dateVal, err := val.ConvertTo(b.ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeDatetime))
+	return dateVal.GetMysqlTime(), false, errors.Trace(err)
+}
+
+func (b *baseBuiltinFunc) evalDuration(row []types.Datum) (types.Duration, bool, error) {
+	val, err := b.self.eval(row)
+	if err != nil || val.IsNull() {
+		return nil, val.IsNull(), errors.Trace(err)
+	}
+	durationVal, err := val.ConvertTo(b.ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeDuration))
+	return durationVal.GetMysqlDuration(), false, errors.Trace(err)
+}
+
 // equal only checks if both functions are non-deterministic and if these arguments are same.
 // Function name will be checked outside.
 func (b *baseBuiltinFunc) equal(fun builtinFunc) bool {
@@ -159,6 +178,14 @@ func (b *baseIntBuiltinFunc) evalString(row []types.Datum) (string, bool, error)
 	panic("cannot get STRING result from ClassInt expression")
 }
 
+func (b *baseIntBuiltinFunc) evalDate(row []types.Datum) (*types.MyDecimal, bool, error) {
+	panic("cannot get DATE result from ClassInt expression")
+}
+
+func (b *baseIntBuiltinFunc) evalDuration(row []types.Datum) (string, bool, error) {
+	panic("cannot get DURATION result from ClassInt expression")
+}
+
 // baseRealBuiltinFunc represents the functions which return real values.
 // TODO: baseRealBuiltinFunc will be removed later after all built-in function signatures been implemented.
 type baseRealBuiltinFunc struct {
@@ -189,6 +216,14 @@ func (b *baseRealBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, 
 
 func (b *baseRealBuiltinFunc) evalString(row []types.Datum) (string, bool, error) {
 	panic("cannot get STRING result from ClassReal expression")
+}
+
+func (b *baseRealBuiltinFunc) evalDate(row []types.Datum) (*types.MyDecimal, bool, error) {
+	panic("cannot get DATE result from ClassReal expression")
+}
+
+func (b *baseRealBuiltinFunc) evalDuration(row []types.Datum) (string, bool, error) {
+	panic("cannot get DURATION result from ClassReal expression")
 }
 
 // baseDecimalBuiltinFunc represents the functions which return decimal values.
@@ -223,6 +258,14 @@ func (b *baseDecimalBuiltinFunc) evalString(row []types.Datum) (string, bool, er
 	panic("cannot get REAL result from ClassDecimal expression")
 }
 
+func (b *baseDecimalBuiltinFunc) evalDate(row []types.Datum) (float64, bool, error) {
+	panic("cannot get DATE result from ClassDecimal expression")
+}
+
+func (b *baseDecimalBuiltinFunc) evalDuration(row []types.Datum) (string, bool, error) {
+	panic("cannot get DURATION result from ClassDecimal expression")
+}
+
 // baseStringBuiltinFunc represents the functions which return string values.
 // TODO: baseStringBuiltinFunc will be removed later after all built-in function signatures been implemented.
 type baseStringBuiltinFunc struct {
@@ -255,6 +298,88 @@ func (b *baseStringBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal
 	panic("cannot get DECIMAL result from ClassString expression")
 }
 
+func (b *baseStringBuiltinFunc) evalDate(row []types.Datum) (float64, bool, error) {
+	panic("cannot get DATE result from ClassString expression")
+}
+
+func (b *baseStringBuiltinFunc) evalDuration(row []types.Datum) (*types.MyDecimal, bool, error) {
+	panic("cannot get DURATION result from ClassString expression")
+}
+
+type baseDateBuiltinFunc struct {
+	baseBuiltinFunc
+}
+
+func (b *baseDateBuiltinFunc) eval(row []types.Datum) (d types.Datum, err error) {
+	val, isNull, err := b.self.evalDate(row)
+	if err != nil || isNull {
+		return d, errors.Trace(err)
+	}
+	d.SetMysqlTime(val)
+	return
+}
+
+func (b *baseDateBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
+	return b.self.evalDate(row)
+}
+
+func (b *baseDateBuiltinFunc) evalString(row []types.Datum) (string, bool, error) {
+	panic("cannot get STRING result from DATETIME expression")
+}
+
+func (b *baseDateBuiltinFunc) evalInt(row []types.Datum) (int64, bool, error) {
+	panic("cannot get INT result from DATETIME expression")
+}
+
+func (b *baseDateBuiltinFunc) evalReal(row []types.Datum) (float64, bool, error) {
+	panic("cannot get REAL result from DATETIME expression")
+}
+
+func (b *baseDateBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, bool, error) {
+	panic("cannot get DECIMAL result from DATETIME expression")
+}
+
+func (b *baseDateBuiltinFunc) evalDuration(row []types.Datum) (types.Duration, bool, error) {
+	panic("cannot get DURATION result from DATETIME expression")
+}
+
+type baseDurationBuiltinFunc struct {
+	baseBuiltinFunc
+}
+
+func (b *baseDurationBuiltinFunc) eval(row []types.Datum) (d types.Datum, err error) {
+	val, isNull, err := b.self.evalDuration(row)
+	if err != nil || isNull {
+		return d, errors.Trace(err)
+	}
+	d.SetMysqlDuration(val)
+	return
+}
+
+func (b *baseDurationBuiltinFunc) evalDuration(row []types.Datum) (types.Duration, bool, error) {
+	return b.self.evalDuration(row)
+}
+
+func (b *baseDurationBuiltinFunc) evalDate(row []types.Datum) (types.Time, bool, error) {
+	panic("cannot get DATE result from DURATION expression")
+}
+
+func (b *baseDurationBuiltinFunc) evalString(row []types.Datum) (string, bool, error) {
+	panic("cannot get STRING result from DURATION expression")
+}
+
+func (b *baseDurationBuiltinFunc) evalInt(row []types.Datum) (int64, bool, error) {
+	panic("cannot get INT result from DURATION expression")
+}
+
+func (b *baseDurationBuiltinFunc) evalReal(row []types.Datum) (float64, bool, error) {
+	panic("cannot get REAL result from DURATION expression")
+}
+
+func (b *baseDurationBuiltinFunc) evalDecimal(row []types.Datum) (*types.MyDecimal, bool, error) {
+	panic("cannot get DECIMAL result from DURATION expression")
+}
+
 // builtinFunc stands for a particular function signature.
 type builtinFunc interface {
 	// eval does evaluation by the given row.
@@ -267,6 +392,10 @@ type builtinFunc interface {
 	evalString(row []types.Datum) (val string, isNull bool, err error)
 	// evalDecimal evaluates decimal representation of builtinFunc by given row.
 	evalDecimal(row []types.Datum) (val *types.MyDecimal, isNull bool, err error)
+	// evalDate evaluates date/datetime representation of builtinFunc by given row.
+	evalDate(row []types.Datum) (val types.Time, isNull bool, err error)
+	// evaTime evaluates duration representation of builtinFunc by given row.
+	evalDuration(row []types.Datum) (val types.Duration, isNull bool, err error)
 	// getArgs returns the arguments expressions.
 	getArgs() []Expression
 	// isDeterministic checks if a function is deterministic.

--- a/expression/column.go
+++ b/expression/column.go
@@ -67,8 +67,8 @@ func (col *CorrelatedColumn) EvalDecimal(row []types.Datum, sc *variable.Stateme
 	return val, isNull, errors.Trace(err)
 }
 
-// EvalDate returns date/datetime representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+// EvalTime returns DATE/DATETIME/TIMESTAMP representation of CorrelatedColumn.
+func (col *CorrelatedColumn) EvalTime(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
 	val, isNull, err := evalExprToDate(col, row, sc)
 	return val, isNull, errors.Trace(err)
 }
@@ -186,8 +186,8 @@ func (col *Column) EvalDecimal(row []types.Datum, sc *variable.StatementContext)
 	return val, isNull, errors.Trace(err)
 }
 
-// EvalDate returns Date/Datetime representation of Column.
-func (col *Column) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+// EvalTime returns DATE/DATETIME/TIMESTAMP representation of Column.
+func (col *Column) EvalTime(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
 	val, isNull, err := evalExprToDate(col, row, sc)
 	return val, isNull, errors.Trace(err)
 }

--- a/expression/column.go
+++ b/expression/column.go
@@ -67,6 +67,18 @@ func (col *CorrelatedColumn) EvalDecimal(row []types.Datum, sc *variable.Stateme
 	return val, isNull, errors.Trace(err)
 }
 
+// EvalDate returns date/datetime representation of CorrelatedColumn.
+func (col *CorrelatedColumn) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+	val, isNull, err := evalExprToDate(col, row, sc)
+	return val, isNull, errors.Trace(err)
+}
+
+// EvalDuration returns Duration representation of CorrelatedColumn.
+func (col *CorrelatedColumn) EvalDuration(row []types.Datum, sc *variable.StatementContext) (types.Duration, bool, error) {
+	val, isNull, err := evalExprToDuration(col, row, sc)
+	return val, isNull, errors.Trace(err)
+}
+
 // Equal implements Expression interface.
 func (col *CorrelatedColumn) Equal(expr Expression, ctx context.Context) bool {
 	if cc, ok := expr.(*CorrelatedColumn); ok {
@@ -171,6 +183,18 @@ func (col *Column) EvalString(row []types.Datum, sc *variable.StatementContext) 
 // EvalDecimal returns decimal representation of Column.
 func (col *Column) EvalDecimal(row []types.Datum, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
 	val, isNull, err := evalExprToDecimal(col, row, sc)
+	return val, isNull, errors.Trace(err)
+}
+
+// EvalDate returns Date/Datetime representation of Column.
+func (col *Column) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+	val, isNull, err := evalExprToDate(col, row, sc)
+	return val, isNull, errors.Trace(err)
+}
+
+// EvalDuration returns Duration representation of Column.
+func (col *Column) EvalDuration(_ []types.Datum, sc *variable.StatementContext) (types.Duration, bool, error) {
+	val, isNull, err := evalExprToDuration(col, nil, sc)
 	return val, isNull, errors.Trace(err)
 }
 

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -66,8 +66,8 @@ type Expression interface {
 	// EvalDecimal returns the decimal representation of expression.
 	EvalDecimal(row []types.Datum, sc *variable.StatementContext) (val *types.MyDecimal, isNull bool, err error)
 
-	// EvalDate returns the date/datetime representation of expression.
-	EvalDate(row []types.Datum, sc *variable.StatementContext) (val types.Time, isNull bool, err error)
+	// EvalTime returns the DATE/DATETIME/TIMESTAMP representation of expression.
+	EvalTime(row []types.Datum, sc *variable.StatementContext) (val types.Time, isNull bool, err error)
 
 	// EvalDuration returns the duration representation of expression.
 	EvalDuration(row []types.Datum, sc *variable.StatementContext) (val types.Duration, isNull bool, err error)
@@ -286,8 +286,8 @@ func (c *Constant) EvalDecimal(_ []types.Datum, sc *variable.StatementContext) (
 	return val, isNull, errors.Trace(err)
 }
 
-// EvalDate returns Date/Datetime representation of Constant.
-func (c *Constant) EvalDate(_ []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+// EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.
+func (c *Constant) EvalTime(_ []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
 	val, isNull, err := evalExprToDate(c, nil, sc)
 	return val, isNull, errors.Trace(err)
 }

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -66,6 +66,12 @@ type Expression interface {
 	// EvalDecimal returns the decimal representation of expression.
 	EvalDecimal(row []types.Datum, sc *variable.StatementContext) (val *types.MyDecimal, isNull bool, err error)
 
+	// EvalDate returns the date/datetime representation of expression.
+	EvalDate(row []types.Datum, sc *variable.StatementContext) (val types.Time, isNull bool, err error)
+
+	// EvalDuration returns the duration representation of expression.
+	EvalDuration(row []types.Datum, sc *variable.StatementContext) (val types.Duration, isNull bool, err error)
+
 	// GetType gets the type that the expression returns.
 	GetType() *types.FieldType
 
@@ -132,7 +138,7 @@ func evalExprToInt(expr Expression, row []types.Datum, sc *variable.StatementCon
 	if tc == types.ClassInt {
 		return val.GetInt64(), false, nil
 	}
-	panic(fmt.Sprintf("cannot get INT result from %s expression", tc.String()))
+	panic(fmt.Sprintf("cannot get INT result from %s expression", types.TypeStr(expr.GetType().Tp)))
 }
 
 // evalExprToReal evaluates `expr` to real type.
@@ -145,7 +151,7 @@ func evalExprToReal(expr Expression, row []types.Datum, sc *variable.StatementCo
 	if tc == types.ClassReal {
 		return val.GetFloat64(), false, nil
 	}
-	panic(fmt.Sprintf("cannot get REAL result from %s expression", tc.String()))
+	panic(fmt.Sprintf("cannot get REAL result from %s expression", types.TypeStr(expr.GetType().Tp)))
 }
 
 // evalExprToDecimal evaluates `expr` to decimal type.
@@ -158,7 +164,7 @@ func evalExprToDecimal(expr Expression, row []types.Datum, sc *variable.Statemen
 	if tc == types.ClassDecimal {
 		return val.GetMysqlDecimal(), false, nil
 	}
-	panic(fmt.Sprintf("cannot get DECIMAL result from %s expression", tc.String()))
+	panic(fmt.Sprintf("cannot get DECIMAL result from %s expression", types.TypeStr(expr.GetType().Tp)))
 }
 
 // evalExprToString evaluates `expr` to string type.
@@ -176,7 +182,33 @@ func evalExprToString(expr Expression, row []types.Datum, _ *variable.StatementC
 		res, err = val.ToString()
 		return res, false, errors.Trace(err)
 	}
-	panic(fmt.Sprintf("cannot get STRING result from %s expression", tc.String()))
+	panic(fmt.Sprintf("cannot get STRING result from %s expression", types.TypeStr(expr.GetType().Tp)))
+}
+
+// evalExprToDate evaluates `expr` to DATE type.
+func evalExprToDate(expr Expression, row []types.Datum, _ *variable.StatementContext) (res types.Time, isNull bool, err error) {
+	val, err := expr.Eval(row)
+	if val.IsNull() || err != nil {
+		return nil, val.IsNull(), errors.Trace(err)
+	}
+	switch expr.GetType().Tp {
+	case mysql.TypeDatetime, mysql.TypeDate, mysql.TypeTimestamp:
+		return val.GetMysqlTime(), false, nil
+	default:
+		panic(fmt.Sprintf("cannot get DATE result from %s expression", types.TypeStr(expr.GetType().Tp)))
+	}
+}
+
+// evalExprToDuration evaluates `expr` to DURATION type.
+func evalExprToDuration(expr Expression, row []types.Datum, _ *variable.StatementContext) (res types.Duration, isNull bool, err error) {
+	val, err := expr.Eval(row)
+	if val.IsNull() || err != nil {
+		return nil, val.IsNull(), errors.Trace(err)
+	}
+	if expr.GetType().Tp == mysql.TypeDuration {
+		return val.GetMysqlDuration(), false, nil
+	}
+	panic(fmt.Sprintf("cannot get DURATION result from %s expression", types.TypeStr(expr.GetType().Tp)))
 }
 
 // One stands for a number 1.
@@ -251,6 +283,18 @@ func (c *Constant) EvalString(_ []types.Datum, sc *variable.StatementContext) (s
 // EvalDecimal returns decimal representation of Constant.
 func (c *Constant) EvalDecimal(_ []types.Datum, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
 	val, isNull, err := evalExprToDecimal(c, nil, sc)
+	return val, isNull, errors.Trace(err)
+}
+
+// EvalDate returns Date/Datetime representation of Constant.
+func (c *Constant) EvalDate(_ []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+	val, isNull, err := evalExprToDate(c, nil, sc)
+	return val, isNull, errors.Trace(err)
+}
+
+// EvalDuration returns Duration representation of Constant.
+func (c *Constant) EvalDuration(_ []types.Datum, sc *variable.StatementContext) (types.Duration, bool, error) {
+	val, isNull, err := evalExprToDuration(c, nil, sc)
 	return val, isNull, errors.Trace(err)
 }
 

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -189,7 +189,7 @@ func evalExprToString(expr Expression, row []types.Datum, _ *variable.StatementC
 func evalExprToDate(expr Expression, row []types.Datum, _ *variable.StatementContext) (res types.Time, isNull bool, err error) {
 	val, err := expr.Eval(row)
 	if val.IsNull() || err != nil {
-		return nil, val.IsNull(), errors.Trace(err)
+		return types.Time{}, val.IsNull(), errors.Trace(err)
 	}
 	switch expr.GetType().Tp {
 	case mysql.TypeDatetime, mysql.TypeDate, mysql.TypeTimestamp:
@@ -203,7 +203,7 @@ func evalExprToDate(expr Expression, row []types.Datum, _ *variable.StatementCon
 func evalExprToDuration(expr Expression, row []types.Datum, _ *variable.StatementContext) (res types.Duration, isNull bool, err error) {
 	val, err := expr.Eval(row)
 	if val.IsNull() || err != nil {
-		return nil, val.IsNull(), errors.Trace(err)
+		return types.Duration{}, val.IsNull(), errors.Trace(err)
 	}
 	if expr.GetType().Tp == mysql.TypeDuration {
 		return val.GetMysqlDuration(), false, nil

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -170,9 +170,9 @@ func (sf *ScalarFunction) EvalString(row []types.Datum, sc *variable.StatementCo
 	return sf.Function.evalString(row)
 }
 
-// EvalDate implements Expression interface.
-func (sf *ScalarFunction) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
-	return sf.Function.evalDate(row)
+// EvalTime implements Expression interface.
+func (sf *ScalarFunction) EvalTime(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+	return sf.Function.evalTime(row)
 }
 
 // EvalDuration implements Expression interface.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -170,6 +170,16 @@ func (sf *ScalarFunction) EvalString(row []types.Datum, sc *variable.StatementCo
 	return sf.Function.evalString(row)
 }
 
+// EvalDate implements Expression interface.
+func (sf *ScalarFunction) EvalDate(row []types.Datum, sc *variable.StatementContext) (types.Time, bool, error) {
+	return sf.Function.evalDate(row)
+}
+
+// EvalDuration implements Expression interface.
+func (sf *ScalarFunction) EvalDuration(row []types.Datum, sc *variable.StatementContext) (types.Duration, bool, error) {
+	return sf.Function.evalDuration(row)
+}
+
 // HashCode implements Expression interface.
 func (sf *ScalarFunction) HashCode() []byte {
 	var bytes []byte


### PR DESCRIPTION
BuiltinFunc like `addtime(datetime/time, time)` is different from `plus(datetime, time)`.

In `addtime`, we add two args as temporal type;
in `plus`, we add two args as int type.

It will be simpler if we evaluate using type Date/Duration directly 
than use string/numeric representation of Date/Datetime/Timestamp/Duration in some built-in functions.

PTAL @shenli @hanfei1991 @zimulala 