### PR TITLE
ddl: Speed up the test of `testAddIndex`

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -340,16 +340,12 @@ LOOP:
 	}
 
 	// test index key
+	expectedRows := make([][]interface{}, 0, len(keys))
 	for _, key := range keys {
-		rows := s.mustQuery(c, "select c1 from t1 where c3 = ?", key)
-		matchRows(c, rows, [][]interface{}{{key}})
+		expectedRows = append(expectedRows, []interface{}{key})
 	}
-
-	// test delete key not in index
-	for key := range deletedKeys {
-		rows := s.mustQuery(c, "select c1 from t1 where c3 = ?", key)
-		matchRows(c, rows, nil)
-	}
+	rows := s.mustQuery(c, "select c1 from t1 where c3 >= 0")
+	matchRows(c, rows, expectedRows)
 
 	// test index range
 	for i := 0; i < 100; i++ {

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -836,7 +836,7 @@ func (s *testDBSuite) mustQuery(c *C, query string, args ...interface{}) [][]int
 }
 
 func matchRows(c *C, rows [][]interface{}, expected [][]interface{}) {
-	c.Assert(len(rows), Equals, len(expected), Commentf("%v", expected))
+	c.Assert(len(rows), Equals, len(expected), Commentf("got %v, expected %v", rows, expected))
 	for i := range rows {
 		match(c, rows[i], expected[i]...)
 	}


### PR DESCRIPTION
Fix #3243 

The result of `make test`
Before:
`github.com/pingcap/tidb/ddl    128.060s`
After:
`github.com/pingcap/tidb/ddl    108.885s`