### PR TITLE
parser: support add  fulltext index and clean redundant code

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1065,7 +1065,7 @@ KeyOrIndex: "KEY" | "INDEX"
 
 KeyOrIndexOpt:
 	{}
-|   KeyOrIndex
+|   	KeyOrIndex
 
 ColumnKeywordOpt:
 	{}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1062,6 +1062,11 @@ LockClause:
 
 KeyOrIndex: "KEY" | "INDEX"
 
+
+KeyOrIndexOpt:
+	{}
+|   KeyOrIndex
+
 ColumnKeywordOpt:
 	{}
 |	"COLUMN"
@@ -1324,7 +1329,7 @@ ConstraintElem:
 		}
 		$$ = c
 	}
-|	"FULLTEXT" "KEY" IndexName '(' IndexColNameList ')' IndexOptionList
+|	"FULLTEXT" KeyOrIndex IndexName '(' IndexColNameList ')' IndexOptionList
 	{
 		c := &ast.Constraint{
 			Tp:	ast.ConstraintFulltext,
@@ -1336,7 +1341,7 @@ ConstraintElem:
 		}
 		$$ = c
 	}
-|	"INDEX" IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
+|	KeyOrIndex IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
 	{
 		c := &ast.Constraint{
 			Tp:	ast.ConstraintIndex,
@@ -1354,64 +1359,10 @@ ConstraintElem:
 		}
 		$$ = c
 	}
-|	"KEY" IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
-	{
-		c := &ast.Constraint{
-			Tp:	ast.ConstraintKey,
-			Keys:	$5.([]*ast.IndexColName),
-			Name:	$2.(string),
-		}
-		if $7 != nil {
-			c.Option = $7.(*ast.IndexOption)
-		}
-		if $3 != nil {
-			if c.Option == nil {
-				c.Option = &ast.IndexOption{}
-			}
-			c.Option.Tp = $3.(model.IndexType)
-		}
-		$$ = c
-	}
-|	"UNIQUE" IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
+|	"UNIQUE" KeyOrIndexOpt IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
 	{
 		c := &ast.Constraint{
 			Tp:	ast.ConstraintUniq,
-			Keys:	$5.([]*ast.IndexColName),
-			Name:	$2.(string),
-		}
-		if $7 != nil {
-			c.Option = $7.(*ast.IndexOption)
-		}
-		if $3 != nil {
-			if c.Option == nil {
-				c.Option = &ast.IndexOption{}
-			}
-			c.Option.Tp = $3.(model.IndexType)
-		}
-		$$ = c
-	}
-|	"UNIQUE" "INDEX" IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
-	{
-		c := &ast.Constraint{
-			Tp:	ast.ConstraintUniqIndex,
-			Keys:	$6.([]*ast.IndexColName),
-			Name:	$3.(string),
-		}
-		if $8 != nil {
-			c.Option = $8.(*ast.IndexOption)
-		}
-		if $4 != nil {
-			if c.Option == nil {
-				c.Option = &ast.IndexOption{}
-			}
-			c.Option.Tp = $4.(model.IndexType)
-		}
-		$$ = c
-	}
-|	"UNIQUE" "KEY" IndexName IndexTypeOpt '(' IndexColNameList ')' IndexOptionList
-	{
-		c := &ast.Constraint{
-			Tp:	ast.ConstraintUniqKey,
 			Keys:	$6.([]*ast.IndexColName),
 			Name:	$3.(string),
 		}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1276,6 +1276,14 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"ALTER TABLE t ADD COLUMN a SMALLINT UNSIGNED, LOCK=DEFAULT", true},
 		{"ALTER TABLE t ADD COLUMN a SMALLINT UNSIGNED, LOCK=SHARED", true},
 		{"ALTER TABLE t ADD COLUMN a SMALLINT UNSIGNED, LOCK=EXCLUSIVE", true},
+		{"ALTER TABLE t ADD FULLTEXT KEY `FullText` (`name` ASC)", true},
+		{"ALTER TABLE t ADD FULLTEXT INDEX `FullText` (`name` ASC)", true},
+		{"ALTER TABLE t ADD INDEX (a) USING BTREE COMMENT 'a'", true},
+		{"ALTER TABLE t ADD KEY (a) USING HASH COMMENT 'a'", true},
+		{"ALTER TABLE t ADD PRIMARY KEY (a) COMMENT 'a'", true},
+		{"ALTER TABLE t ADD UNIQUE (a) COMMENT 'a'", true},
+		{"ALTER TABLE t ADD UNIQUE KEY (a) COMMENT 'a'", true},
+		{"ALTER TABLE t ADD UNIQUE INDEX (a) COMMENT 'a'", true},
 
 		// for rename table statement
 		{"RENAME TABLE t TO t1", true},


### PR DESCRIPTION
1. add  support for `alter table tbl add fulltext index (col) ` 
2. remove redundant code.

@tiancaiamao  @zimulala @hanfei1991  PTAL