### PR TITLE
mock-tikv: fix write write conflict check.

### DIFF
--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -109,11 +109,12 @@ func (e *mvccEntry) Get(ts uint64) ([]byte, error) {
 }
 
 func (e *mvccEntry) Prewrite(mutation *kvrpcpb.Mutation, startTS uint64, primary []byte, ttl uint64) error {
-	if len(e.values) > 0 {
-		if e.values[0].commitTS >= startTS {
+	for _, value := range e.values {
+		if value.commitTS >= startTS {
 			return ErrRetryable("write conflict")
 		}
 	}
+
 	if e.lock != nil {
 		if e.lock.startTS != startTS {
 			return e.lockErr()

--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -27,7 +27,7 @@ import (
 type mvccValueType int
 
 const (
-	typePut      mvccValueType = iota
+	typePut mvccValueType = iota
 	typeDelete
 	typeRollback
 )


### PR DESCRIPTION
Mock-tikv will fail to check `write write conflict` when there is a rollback between two conflict write.
This error cause #3283.