### PR TITLE
expression, util: rewrite IsHybridType func

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -260,7 +260,7 @@ type builtinCastStringAsIntSig struct {
 }
 
 func (b *builtinCastStringAsIntSig) evalInt(row []types.Datum) (res int64, isNull bool, err error) {
-	if types.IsHybridType(b.args[0].GetType().Tp) {
+	if IsHybridType(b.args[0]) {
 		return b.args[0].EvalInt(row, b.getCtx().GetSessionVars().StmtCtx)
 	}
 	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)
@@ -276,7 +276,7 @@ type builtinCastStringAsRealSig struct {
 }
 
 func (b *builtinCastStringAsRealSig) evalReal(row []types.Datum) (res float64, isNull bool, err error) {
-	if types.IsHybridType(b.args[0].GetType().Tp) {
+	if IsHybridType(b.args[0]) {
 		return b.args[0].EvalReal(row, b.getCtx().GetSessionVars().StmtCtx)
 	}
 	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)
@@ -292,7 +292,7 @@ type builtinCastStringAsDecimalSig struct {
 }
 
 func (b *builtinCastStringAsDecimalSig) evalDecimal(row []types.Datum) (res *types.MyDecimal, isNull bool, err error) {
-	if types.IsHybridType(b.args[0].GetType().Tp) {
+	if IsHybridType(b.args[0]) {
 		return b.args[0].EvalDecimal(row, b.getCtx().GetSessionVars().StmtCtx)
 	}
 	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -520,28 +520,6 @@ func NewValuesFunc(offset int, retTp *types.FieldType, ctx context.Context) *Sca
 	}
 }
 
-// IsHybridType checks whether a ClassString expression is a hybrid type value which will return different types of value in different context.
-//
-// For ENUM/SET which is consist of a string attribute `Name` and an int attribute `Value`,
-// it will cause an error if we convert ENUM/SET to int as a string value.
-//
-// For Bit/Hex, we will get a wrong result if we convert it to int as a string value.
-// For example, when convert `0b101` to int, the result should be 5, but we will get 101 if we regard it as a string.
-func IsHybridType(expr Expression) bool {
-	switch expr.GetType().Tp {
-	case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
-		return true
-	}
-	// For a constant, the field type will be inferred as `VARCHAR` when the kind of it is `HEX` or `BIT`.
-	if con, ok := expr.(*Constant); ok {
-		switch con.Value.Kind() {
-		case types.KindMysqlHex, types.KindMysqlBit:
-			return true
-		}
-	}
-	return false
-}
-
 func init() {
 	expressionMySQLErrCodes := map[terror.ErrCode]uint16{
 		codeIncorrectParameterCount: mysql.ErrWrongParamcountToNativeFct,

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -532,7 +532,7 @@ func IsHybridType(expr Expression) bool {
 	case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
 		return true
 	}
-	// For a constant, the field type will be inferred as `varstring` when the kind of it is `HEX` or `BIT`.
+	// For a constant, the field type will be inferred as `VARCHAR` when the kind of it is `HEX` or `BIT`.
 	if con, ok := expr.(*Constant); ok {
 		switch con.Value.Kind() {
 		case types.KindMysqlHex, types.KindMysqlBit:

--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -601,3 +601,25 @@ func mergeTypeClass(a, b types.TypeClass, aUnsigned, bUnsigned bool) types.TypeC
 	}
 	return types.ClassInt
 }
+
+// IsHybridType checks whether a ClassString expression is a hybrid type value which will return different types of value in different context.
+//
+// For ENUM/SET which is consist of a string attribute `Name` and an int attribute `Value`,
+// it will cause an error if we convert ENUM/SET to int as a string value.
+//
+// For Bit/Hex, we will get a wrong result if we convert it to int as a string value.
+// For example, when convert `0b101` to int, the result should be 5, but we will get 101 if we regard it as a string.
+func IsHybridType(expr Expression) bool {
+	switch expr.GetType().Tp {
+	case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
+		return true
+	}
+	// For a constant, the field type will be inferred as `VARCHAR` when the kind of it is `HEX` or `BIT`.
+	if con, ok := expr.(*Constant); ok {
+		switch con.Value.Kind() {
+		case types.KindMysqlHex, types.KindMysqlBit:
+			return true
+		}
+	}
+	return false
+}

--- a/expression/typeinferer_test.go
+++ b/expression/typeinferer_test.go
@@ -364,6 +364,57 @@ func (s *testTypeInferrerSuite) TestColumnInfoModified(c *C) {
 	c.Assert(col.Tp, Equals, mysql.TypeLong)
 }
 
+func (s *testTypeInferrerSuite) TestIsHybridType(c *C) {
+	defer testleak.AfterTest(c)()
+	store, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	sql := `create table t (
+		c_enum enum('a', 'b', 'c', 'd'),
+		c_set set('a', 'b', 'c', 'd'),
+		c_bit bit(10),
+		c_dt datetime,
+		c_date date,
+		c_time time,
+		c_int int)`
+	testKit.MustExec(sql)
+	tests := []struct {
+		expr         string
+		tp           byte
+		isHybridType bool
+	}{
+		{"c_enum", mysql.TypeEnum, true},
+		{"c_set", mysql.TypeSet, true},
+		{"c_bit", mysql.TypeBit, true},
+		{"0b1001", mysql.TypeVarchar, true},
+		{"0xFFFF", mysql.TypeVarchar, true},
+		{"c_dt", mysql.TypeDatetime, false},
+		{"c_date", mysql.TypeDate, false},
+		{"c_time", mysql.TypeDuration, false},
+		{"c_int", mysql.TypeLong, false},
+	}
+	for _, tt := range tests {
+		ctx := testKit.Se.(context.Context)
+		stmts, err := tidb.Parse(ctx, "select "+tt.expr+" from t")
+		c.Assert(err, IsNil)
+		c.Assert(stmts, HasLen, 1)
+		stmt := stmts[0].(*ast.SelectStmt)
+		is := sessionctx.GetDomain(ctx).InfoSchema()
+		err = plan.ResolveName(stmt, is, ctx)
+		c.Assert(err, IsNil)
+		expression.InferType(ctx.GetSessionVars().StmtCtx, stmt)
+		tp := stmt.GetResultFields()[0].Column.Tp
+		c.Assert(tp, Equals, tt.tp, Commentf("Tp for %s", tt.expr))
+		p, err := plan.BuildLogicalPlan(ctx, stmt, is)
+		c.Assert(err, IsNil)
+		proj := p.(*plan.Projection)
+		c.Assert(expression.IsHybridType(proj.Exprs[0]), Equals, tt.isHybridType)
+	}
+}
+
 func newStoreWithBootstrap() (kv.Storage, error) {
 	store, err := tidb.NewStore(tidb.EngineGoLevelDBMemory)
 	if err != nil {

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -1101,18 +1101,3 @@ func SetBinChsClnFlag(ft *FieldType) {
 	ft.Collate = charset.CollationBin
 	ft.Flag |= mysql.BinaryFlag
 }
-
-// IsHybridType checks whether a ClassString type is hybrid type.
-//
-// For ENUM/SET which is consist of a string attribute `Name` and an int attribute `Value`,
-// it will cause an error if we convert ENUM/SET to int as a string value.
-//
-// For Bit, we will get a wrong result if we convert it to int as a string value.
-func IsHybridType(tp byte) bool {
-	switch tp {
-	case mysql.TypeEnum, mysql.TypeBit, mysql.TypeSet:
-		return true
-	default:
-		return false
-	}
-}


### PR DESCRIPTION
For a `Hex( e.g. 0xFFFF )` or a `Bit( e.g. 0b10101 )` ValueExpr, we infer the type 
of it as [mysql.TypeVarchar](https://github.com/pingcap/tidb/blob/master/util/types/field_type.go#L199),
so it cannot be checked whether a `constant` is HybridType just using the field type.

@shenli @hanfei1991 