### PR TITLE
store/tikv: fix GetRegion()/GetStore() issue caused by canceled context

### DIFF
--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -16,14 +16,13 @@ package tikv
 import (
 	"time"
 
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	goctx "golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 )
 
 // RegionRequestSender sends KV/Cop requests to tikv server. It handles network

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -16,6 +16,9 @@ package tikv
 import (
 	"time"
 
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/kvproto/pkg/errorpb"
@@ -112,14 +115,18 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 }
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
-	// Retry on request failure when it's not Cancelled.
+	// If it failed because the context is canceled, don't retry on this error.
+	if errors.Cause(err) == goctx.Canceled || grpc.Code(err) == codes.Canceled {
+		return errors.Trace(err)
+	}
+
+	s.regionCache.OnRequestFail(ctx)
+
+	// Retry on request failure when it's not canceled.
 	// When a store is not available, the leader of related region should be elected quickly.
 	// TODO: the number of retry time should be limited:since region may be unavailable
 	// when some unrecoverable disaster happened.
-	if errors.Cause(err) != goctx.Canceled {
-		err = bo.Backoff(boTiKVRPC, errors.Errorf("send tikv request error: %v, ctx: %s, try next peer later", err, ctx.KVCtx))
-		s.regionCache.OnRequestFail(ctx)
-	}
+	err = bo.Backoff(boTiKVRPC, errors.Errorf("send tikv request error: %v, ctx: %s, try next peer later", err, ctx.KVCtx))
 	return errors.Trace(err)
 }
 

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -142,9 +142,7 @@ func (s *testRegionRequestSuite) TestNoReloadRegionWhenCtxCanceled(c *C) {
 }
 
 func (s *testRegionRequestSuite) TestNoReloadRegionForGrpcWhenCtxCanceled(c *C) {
-	client := NewGrpcContextCanceledClient()
-	sender := NewRegionRequestSender(s.cache, client)
-
+	sender := NewRegionRequestSender(s.cache, newRPCClient())
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawPut,
 		RawPut: &kvrpcpb.RawPutRequest{
@@ -161,19 +159,4 @@ func (s *testRegionRequestSuite) TestNoReloadRegionForGrpcWhenCtxCanceled(c *C) 
 	_, err = sender.SendReq(bo, req, region.Region, time.Millisecond)
 	c.Assert(grpc.Code(err), Equals, codes.Canceled)
 	c.Assert(s.cache.getRegionByIDFromCache(s.region), NotNil)
-}
-
-type GrpcContextCanceledClient struct {
-}
-
-func NewGrpcContextCanceledClient() *GrpcContextCanceledClient {
-	return &GrpcContextCanceledClient{}
-}
-
-func (c *GrpcContextCanceledClient) SendReq(_ goctx.Context, _ string, _ *tikvrpc.Request) (*tikvrpc.Response, error) {
-	return nil, grpc.Errorf(codes.Canceled, "context canceled error from GrpcContextCanceledClient")
-}
-
-func (c *GrpcContextCanceledClient) Close() error {
-	return nil
 }


### PR DESCRIPTION
Hi,

This PR fixes GetRegion()/GetStore() issue caused by cancelced context. It add the checking for GRPC `Canceled` error, so that a canceled context passed to GPRC interface would cause the region cache to be cleaned exceptionally.

PTAL @tiancaiamao @disksing @siddontang