### PR TITLE
variable: remove GoSQLDriverTest

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
@@ -523,9 +522,6 @@ func (e *LoadDataInfo) insertData(cols []string) {
 
 func (e *InsertValues) handleLoadDataWarnings(err error, logInfo string) {
 	sc := e.ctx.GetSessionVars().StmtCtx
-	if variable.GoSQLDriverTest {
-		return
-	}
 	sc.AppendWarning(err)
 	log.Warn(logInfo)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -30,7 +30,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/executor"
 	tmysql "github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/printer"
 )
 
@@ -250,9 +249,7 @@ func runTestLoadData(c *C) {
 		c.Assert(err, IsNil)
 		err = os.Remove(path)
 		c.Assert(err, IsNil)
-		variable.GoSQLDriverTest = false
 	}()
-	variable.GoSQLDriverTest = true
 	_, err = fp.WriteString(`
 xxx row1_col1	- row1_col2	1abc
 xxx row2_col1	- row2_col2	
@@ -262,7 +259,7 @@ xxx row5_col1	- 	row5_col3`)
 	c.Assert(err, IsNil)
 
 	// support ClientLocalFiles capability
-	runTests(c, dsn+"&allowAllFiles=true", func(dbt *DBTest) {
+	runTests(c, dsn+"&allowAllFiles=true&strict=false", func(dbt *DBTest) {
 		dbt.mustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
 		rs, err := dbt.db.Exec("load data local infile '/tmp/load_data_test.csv' into table test")
 		dbt.Assert(err, IsNil)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -310,10 +310,6 @@ type TableDelta struct {
 	Count int64
 }
 
-// GoSQLDriverTest is used for server testing.
-// Because go-sql-driver regards the warnings as errors.
-var GoSQLDriverTest = false
-
 // StatementContext contains variables for a statement.
 // It should be reset before executing a statement.
 type StatementContext struct {

--- a/tidb.go
+++ b/tidb.go
@@ -134,6 +134,7 @@ func Parse(ctx context.Context, src string) ([]ast.StmtNode, error) {
 	return stmts, nil
 }
 
+// resetStmtCtx resets the StmtContext.
 // Before every execution, we must clear statement context.
 func resetStmtCtx(ctx context.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
@@ -150,10 +151,6 @@ func resetStmtCtx(ctx context.Context, s ast.StmtNode) {
 		sc.IgnoreTruncate = false
 		sc.TruncateAsWarning = false
 	case *ast.LoadDataStmt:
-		if variable.GoSQLDriverTest {
-			sc.IgnoreTruncate = true
-			break
-		}
 		sc.IgnoreTruncate = false
 		sc.TruncateAsWarning = !sessVars.StrictSQLMode
 	default:


### PR DESCRIPTION
This variable is introduced in https://github.com/pingcap/tidb/pull/3224 which is a hack to make test pass.
But this variable mixed with working code and makes them more complex.

This PR use another way to pass the test and remove this variable.