### PR TITLE
*: fix gorm-test

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -145,6 +145,21 @@ func (s *testSuite) TestInsert(c *C) {
 	c.Assert(err, IsNil)
 	_, err = tk.Exec("insert into t value(1)")
 	c.Assert(types.ErrOverflow.Equal(err), IsTrue)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(c binary(255))")
+	_, err = tk.Exec("insert into t value(1)")
+	c.Assert(err, IsNil)
+	r = tk.MustQuery("select length(c) from t;")
+	r.Check(testkit.Rows("255"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(c varbinary(255))")
+	_, err = tk.Exec("insert into t value(1)")
+	c.Assert(err, IsNil)
+	r = tk.MustQuery("select length(c) from t;")
+	r.Check(testkit.Rows("1"))
+
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -861,7 +861,7 @@ func produceStrWithSpecifiedTp(s string, tp *FieldType, sc *variable.StatementCo
 		} else if len(s) > flen {
 			err = ErrDataTooLong.Gen("Data Too Long, field len %d, data len %d", flen, len(s))
 			s = truncateStr(s, flen)
-		} else if len(s) < flen {
+		} else if tp.Tp == mysql.TypeString && len(s) < flen {
 			padding := make([]byte, flen-len(s))
 			s = string(append([]byte(s), padding...))
 		}


### PR DESCRIPTION
This commit fixes the bug occurred [here](http://45.249.247.133:8080/job/tidb/job/qupeng%252Fjson-functions/34/execution/node/248/log/).

Before this commit, for sql:

``` sql
create table t (a varbinary(255));
insert into t values("123"), (cast("123" as binary(255)));

create table t2(a binary(255));
insert into values("123"),( cast("123" as binary(255)));

select length(a) from t;
select length(a) from t2;
```
We get:
```sql
MySQL:

mysql> select length(a) from t;
+-----------+
| length(a) |
+-----------+
|         3 |
|       255 |
+-----------+
2 rows in set (0.00 sec)

mysql> select length(a) from t2;
+-----------+
| length(a) |
+-----------+
|       255 |
|       255 |
+-----------+
2 rows in set (0.00 sec)

TiDB:

mysql> select length(a) from t;
+-----------+
| length(a) |
+-----------+
|       255 |
|       255 |
+-----------+
2 rows in set (0.00 sec)

mysql> select length(a) from t2;
+-----------+
| length(a) |
+-----------+
|       255 |
|       255 |
+-----------+
2 rows in set (0.00 sec)

```

that's because that when insert values, in TiDB, the values will be cast as the colFieldType [here](https://github.com/pingcap/tidb/blob/master/executor/write.go#L871).

"123" is filled with 0x00 by mistake. ( [MySQL manual]


