### PR TITLE
domain,tidb: adjust sysSessionPool size

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -375,14 +375,13 @@ type etcdBackend interface {
 
 // NewDomain creates a new domain. Should not create multiple domains for the same store.
 func NewDomain(store kv.Storage, lease time.Duration, factory pools.Factory) (d *Domain, err error) {
-	minCapacity := 1               // minCapacity for the sysSessionPool size
-	maxCapacity := 500             // maxCapacity for the sysSessionPool size
+	capacity := 200                // capacity of the sysSessionPool size
 	idleTimeout := 3 * time.Minute // sessions in the sysSessionPool will be recycled after idleTimeout
 	d = &Domain{
 		store:           store,
 		SchemaValidator: newSchemaValidator(lease),
 		exit:            make(chan struct{}),
-		sysSessionPool:  pools.NewResourcePool(factory, minCapacity, maxCapacity, idleTimeout),
+		sysSessionPool:  pools.NewResourcePool(factory, capacity, capacity, idleTimeout),
 	}
 
 	if ebd, ok := store.(etcdBackend); ok {

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -363,9 +363,17 @@ func (s *testMainSuite) TestSysSessionPoolGoroutineLeak(c *C) {
 	}
 	wg.Wait()
 	se.sysSessionPool().Close()
+	c.Assert(se.sysSessionPool().IsClosed(), Equals, true)
+	for i := 0; i < 300; i++ {
+		// After and before should be Equal, but this test may be disturbed by other factors.
+		// So I relax the strict check to make CI more stable.
+		after := runtime.NumGoroutine()
+		if after-before < 3 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	after := runtime.NumGoroutine()
-	// After and before should be Equal, but this test may be disturbed by other factors.
-	// So I relax the strict check to make CI more stable.
 	c.Assert(after-before, Less, 3)
 }
 


### PR DESCRIPTION
I misunderstand the argument of `pools.NewResourcePool(factory, cap, maxCap, idleTimeout)`.
Its capacity is decided by `cap`, not `maxCap`.
`maxCap` is used just when we resize its `cap` (but we never do it).

So **the old sysSessionPool is of size 1**, which is not reasonable, I adjust it here.