### PR TITLE
util/testleak: make it work right

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,9 +121,6 @@ race: parserlib
 	@export log_level=debug; \
 	$(GOTEST) -race $(PACKAGES)
 
-echo:
-	echo $(PACKAGES)
-
 leak: parserlib
 	@export log_level=debug; \
 	for dir in $(PACKAGES); do \

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,16 @@ race: parserlib
 	@export log_level=debug; \
 	$(GOTEST) -race $(PACKAGES)
 
+echo:
+	echo $(PACKAGES)
+
+leak: parserlib
+	@export log_level=debug; \
+	for dir in $(PACKAGES); do \
+		echo $$dir; \
+		$(GOTEST) -tags leak $$dir | awk 'END{if($$1=="FAIL") {exit 1}}' || exit 1; \
+	done;
+
 tikv_integration_test: parserlib
 	$(GOTEST) ./store/tikv/. -with-tikv=true
 

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -169,6 +169,7 @@ func (s *testBootstrapSuite) testBootstrapWithError(c *C) {
 func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	defer testleak.AfterTest(c)()
 	store := newStoreWithBootstrap(c, s.dbName)
+	defer store.Close()
 	se := newSession(c, store, s.dbName)
 	mustExecSQL(c, se, "USE mysql;")
 

--- a/tidb_test.go
+++ b/tidb_test.go
@@ -254,6 +254,7 @@ func (s *testMainSuite) TestRetryOpenStore(c *C) {
 func (s *testMainSuite) TestSchemaValidity(c *C) {
 	localstore.MockRemoteStore = true
 	store := newStoreWithBootstrap(c, s.dbName+"schema_validity")
+	defer store.Close()
 	dbName := "test_schema_validity"
 	se := newSession(c, store, dbName)
 	se1 := newSession(c, store, dbName)
@@ -345,6 +346,7 @@ func (s *testMainSuite) TestSchemaValidity(c *C) {
 func (s *testMainSuite) TestSysSessionPoolGoroutineLeak(c *C) {
 	// TODO: testleak package should be able to find this leak.
 	store := newStoreWithBootstrap(c, s.dbName+"goroutine_leak")
+	defer store.Close()
 	se, err := createSession(store)
 	c.Assert(err, IsNil)
 

--- a/util/testleak/fake.go
+++ b/util/testleak/fake.go
@@ -1,0 +1,27 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build !leak
+
+package testleak
+
+import "github.com/pingcap/check"
+
+// BeforeTest is a dummy implementation when build tag 'leak' is not set.
+func BeforeTest() {
+}
+
+// AfterTest is a dummy implementation when build tag 'leak' is not set.
+func AfterTest(c *check.C) func() {
+	return func() {
+	}
+}

--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -42,6 +42,10 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "localstore.(*dbStore).scheduler") ||
 			strings.Contains(stack, "ddl.(*ddl).start") ||
 			strings.Contains(stack, "domain.NewDomain") ||
+			strings.Contains(stack, "testing.(*T).Run") ||
+			strings.Contains(stack, "tidb.asyncGetTSWorker") || // TODO: remove it
+			strings.Contains(stack, "domain.(*Domain).LoadPrivilegeLoop") ||
+			strings.Contains(stack, "domain.(*Domain).UpdateTableStatsLoop") ||
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||
@@ -85,6 +89,7 @@ func AfterTest(c *check.C) func() {
 
 		var leaked []string
 		for i := 0; i < 50; i++ {
+			leaked = leaked[:0]
 			for _, g := range interestingGoroutines() {
 				if !beforeTestGorountines[g] {
 					leaked = append(leaked, g)
@@ -93,7 +98,6 @@ func AfterTest(c *check.C) func() {
 			// Bad stuff found, but goroutines might just still be
 			// shutting down, so give it some time.
 			if len(leaked) != 0 {
-				leaked = leaked[:0]
 				time.Sleep(50 * time.Millisecond)
 				continue
 			}

--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -14,6 +14,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+// +build leak
 
 package testleak
 


### PR DESCRIPTION
Fix a bug of testleak.

After this change, testleak found many `tidb.asyncGetTSWorker` leaks, 
but it's hard to fix them now because too many test cases are involved.

Many  sessions are not closed in test code, even those are fixed,
`sysSessionPool` still makes a big trouble.

Maybe with GetTSAsync API in https://github.com/pingcap/pd/pull/653, I can refactor
`asyncGetTSWorker` and get rid of the the problem.

@zimulala @coocood @shenli 