### PR TITLE
binloginfo: skip test for parallel issue

### DIFF
--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -74,6 +74,8 @@ type testBinlogSuite struct {
 }
 
 func (s *testBinlogSuite) SetUpSuite(c *C) {
+	// TODO: find a way to avoid this parallel test issue and remove skip.
+	c.Skip("Some other package may run tests in parallel, makes the test fail.")
 	logLevel := os.Getenv("log_level")
 	log.SetLevelByString(logLevel)
 	store, err := tikv.NewMockTikvStore("")

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -74,8 +74,6 @@ type testBinlogSuite struct {
 }
 
 func (s *testBinlogSuite) SetUpSuite(c *C) {
-	// TODO: find a way to avoid this parallel test issue and remove skip.
-	c.Skip("Some other package may run tests in parallel, makes the test fail.")
 	logLevel := os.Getenv("log_level")
 	log.SetLevelByString(logLevel)
 	store, err := tikv.NewMockTikvStore("")
@@ -113,6 +111,8 @@ func (s *testBinlogSuite) TearDownSuite(c *C) {
 }
 
 func (s *testBinlogSuite) TestBinlog(c *C) {
+	// TODO: find a way to avoid this parallel test issue and remove skip.
+	c.Skip("Some other package may run tests in parallel, makes the test fail.")
 	tk := s.tk
 	pump := s.pump
 	tk.MustExec("drop table if exists local_binlog")


### PR DESCRIPTION
The `PumpClient` variable is a global variable, during the tests, other packages may write binlog too, make the test fail.