### PR TITLE
ddl: Fix a bug when wait schema change timeout

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -358,6 +358,7 @@ func (d *ddl) waitSchemaChanged(waitTime time.Duration, latestSchemaVersion int6
 	err := d.schemaSyncer.OwnerUpdateGlobalVersion(ctx, latestSchemaVersion)
 	if err != nil {
 		log.Infof("[ddl] update latest schema version %d failed %v", latestSchemaVersion, err)
+		return
 	}
 
 	err = d.schemaSyncer.OwnerCheckAllVersions(ctx, latestSchemaVersion)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -358,12 +358,21 @@ func (d *ddl) waitSchemaChanged(waitTime time.Duration, latestSchemaVersion int6
 	err := d.schemaSyncer.OwnerUpdateGlobalVersion(ctx, latestSchemaVersion)
 	if err != nil {
 		log.Infof("[ddl] update latest schema version %d failed %v", latestSchemaVersion, err)
-		return
+		if terror.ErrorEqual(err, goctx.DeadlineExceeded) {
+			return
+		}
 	}
 
 	err = d.schemaSyncer.OwnerCheckAllVersions(ctx, latestSchemaVersion)
 	if err != nil {
 		log.Infof("[ddl] wait latest schema version %d to deadline %v", latestSchemaVersion, err)
+		if terror.ErrorEqual(err, goctx.DeadlineExceeded) {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		}
 	}
 	return
 }

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -57,12 +57,13 @@ type SchemaSyncer interface {
 	UpdateSelfVersion(ctx goctx.Context, version int64) error
 	// RemoveSelfVersionPath remove the self path from etcd.
 	RemoveSelfVersionPath() error
-	// OwnerUpdateGlobalVersion updates the latest version to the global path on etcd.
+	// OwnerUpdateGlobalVersion updates the latest version to the global path on etcd until updating is successful or the ctx is done.
 	OwnerUpdateGlobalVersion(ctx goctx.Context, version int64) error
 	// GlobalVersionCh gets the chan for watching global version.
 	GlobalVersionCh() clientv3.WatchChan
 	// OwnerCheckAllVersions checks whether all followers' schema version are equal to
 	// the latest schema version. If the result is false, wait for a while and check again util the processing time reach 2 * lease.
+	// It returns until all servers' versions are equal to the latest version or the ctx is done.
 	OwnerCheckAllVersions(ctx goctx.Context, latestVer int64) error
 }
 


### PR DESCRIPTION
If `OwnerUpdateGlobalVersion` returns an error, the error must be a contextDeadlineExceeded error, so here need to return.