### PR TITLE
*: refactor binlog and reenable test

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -229,7 +229,7 @@ func (d *ddl) handleDDLJobQueue() error {
 			// and retry later if the job is not cancelled.
 			schemaVer = d.runDDLJob(t, job)
 			if job.IsFinished() {
-				binloginfo.SetDDLBinlog(txn, job.ID, job.Query)
+				binloginfo.SetDDLBinlog(d.workerVars.BinlogClient, txn, job.ID, job.Query)
 				err = d.finishDDLJob(t, job)
 			} else {
 				err = d.updateDDLJob(t, job, txn.StartTS())

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -27,8 +27,8 @@ const (
 	// PresumeKeyNotExistsError is the option key for error.
 	// When PresumeKeyNotExists is set and condition is not match, should throw the error.
 	PresumeKeyNotExistsError
-	// BinlogData is the binlog data to write.
-	BinlogData
+	// BinlogInfo contains the binlog data and client.
+	BinlogInfo
 	// Skip existing check when "prewrite".
 	SkipCheckForWrite
 	// SchemaLeaseChecker is used for schema lease check.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -150,6 +150,9 @@ type SessionVars struct {
 	// version, we load an old version schema for query.
 	SnapshotInfoschema interface{}
 
+	// BinlogClient is used to write binlog.
+	BinlogClient interface{}
+
 	// GlobalVarsAccessor is used to set and get global variables.
 	GlobalVarsAccessor GlobalVarAccessor
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -696,7 +696,7 @@ func (t *Table) Seek(ctx context.Context, h int64) (int64, bool, error) {
 }
 
 func shouldWriteBinlog(ctx context.Context) bool {
-	if binloginfo.PumpClient == nil {
+	if ctx.GetSessionVars().BinlogClient == nil {
 		return false
 	}
 	return !ctx.GetSessionVars().InRestrictedSQL

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -195,14 +195,14 @@ func createBinlogClient() {
 	if err != nil {
 		log.Fatal(errors.ErrorStack(err))
 	}
-	binloginfo.PumpClient = binlog.NewPumpClient(clientCon)
+	binloginfo.SetPumpClient(binlog.NewPumpClient(clientCon))
 	log.Infof("created binlog client at %s", *binlogSocket)
 }
 
 // Prometheus push.
 const zeroDuration = time.Duration(0)
 
-// PushMetric pushs metircs in background.
+// pushMetric pushs metircs in background.
 func pushMetric(addr string, interval time.Duration) {
 	if interval == zeroDuration || len(addr) == 0 {
 		log.Info("disable Prometheus push client")
@@ -212,7 +212,7 @@ func pushMetric(addr string, interval time.Duration) {
 	go prometheusPushClient(addr, interval)
 }
 
-// PrometheusPushClient pushs metrics to Prometheus Pushgateway.
+// prometheusPushClient pushs metrics to Prometheus Pushgateway.
 func prometheusPushClient(addr string, interval time.Duration) {
 	// TODO: TiDB do not have uniq name, so we use host+port to compose a name.
 	job := "tidb"


### PR DESCRIPTION
Use SessionVars to store binlog client, so parallel test doesn't affect the result.
