### PR TITLE
expression, plan: 1. fix arithmetic func type infer 2. add typeinfer for expression.evalAsExpr

### DIFF
--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -202,11 +202,11 @@ func toArithType(ft *types.FieldType) (tp byte) {
 func mergeArithType(fta, ftb *types.FieldType) byte {
 	a, b := toArithType(fta), toArithType(ftb)
 	switch a {
-	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat:
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat, mysql.TypeEnum, mysql.TypeSet:
 		return mysql.TypeDouble
 	}
 	switch b {
-	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat:
+	case mysql.TypeString, mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeDouble, mysql.TypeFloat, mysql.TypeEnum, mysql.TypeSet:
 		return mysql.TypeDouble
 	}
 	if a == mysql.TypeNewDecimal || b == mysql.TypeNewDecimal {

--- a/expression/typeinferer_test.go
+++ b/expression/typeinferer_test.go
@@ -108,6 +108,8 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 		{"c_timestamp + 1", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag},
 		{"c_timestamp + 1.1", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag},
 		{"c_timestamp + '1.1'", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag},
+		{"c_set + 1", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag},
+		{"c_enum + 1", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag},
 		{"1.1 + now()", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag},
 		{"1 + now()", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag},
 		{"1 div 2", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag},

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -44,6 +44,10 @@ func evalAstExpr(expr ast.ExprNode, ctx context.Context) (types.Datum, error) {
 	if ctx.GetSessionVars().TxnCtx.InfoSchema != nil {
 		b.is = ctx.GetSessionVars().TxnCtx.InfoSchema.(infoschema.InfoSchema)
 	}
+	err := expression.InferType(ctx.GetSessionVars().StmtCtx, expr)
+	if err != nil {
+		return types.Datum{}, errors.Trace(err)
+	}
 	newExpr, _, err := b.rewrite(expr, nil, nil, true)
 	if err != nil {
 		return types.Datum{}, errors.Trace(err)


### PR DESCRIPTION
We need correct type infer in new expression evaluation architecture,
so I add the type-inferring process for expression.evalAstExpr.

PTAL @coocood @shenli 