### PR TITLE
ddl: Revoke the session when the DDL will close

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -334,11 +334,11 @@ func (d *ddl) close() {
 	}
 
 	close(d.quitCh)
+	d.ownerManager.Cancel()
 	err := d.schemaSyncer.RemoveSelfVersionPath()
 	if err != nil {
 		log.Errorf("[ddl] remove self version path failed %v", err)
 	}
-	d.ownerManager.Cancel()
 
 	d.wait.Wait()
 	log.Infof("close DDL:%s", d.uuid)

--- a/ddl/owner_manager.go
+++ b/ddl/owner_manager.go
@@ -114,7 +114,7 @@ func (m *ownerManager) SetBgOwner(isOwner bool) {
 // ManagerSessionTTL is the etcd session's TTL in seconds. It's exported for testing.
 var ManagerSessionTTL = 60
 
-// setManagerSessionTTL set the ManagerSessionTTL value, it's used for testing.
+// setManagerSessionTTL sets the ManagerSessionTTL value, it's used for testing.
 func setManagerSessionTTL() error {
 	ttl := os.Getenv("manager_ttl")
 	if ttl == "" {

--- a/ddl/owner_manager.go
+++ b/ddl/owner_manager.go
@@ -117,7 +117,7 @@ var ManagerSessionTTL = 60
 // setManagerSessionTTL sets the ManagerSessionTTL value, it's used for testing.
 func setManagerSessionTTL() error {
 	ttl := os.Getenv("manager_ttl")
-	if ttl == "" {
+	if len(ttl) == 0 {
 		return nil
 	}
 	var err error


### PR DESCRIPTION
`setManagerSessionTTL` is used for testing. Setting it to a small value can reduce the waiting time for the next round of campaign leaders when the leader DDL is closed.