### PR TITLE
[DNM]executor: use UTC to decode timestamp in index read executor

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -776,9 +776,7 @@ func (e *XSelectIndexExec) extractRowsFromPartialResult(t table.Table, partialRe
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// Use time.UTC instead of session's timezone because coprocessor evaluator has
-		// already handle the timezone.
-		err = decodeRawValues(values, e.Schema(), time.UTC)
+		err = decodeRawValues(values, e.Schema(), e.ctx.GetSessionVars().GetTimeZone())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1453,7 +1453,7 @@ func (s *testSuite) TestTimestampTimeZone(c *C) {
 	}()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t, t1")
+	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (ts timestamp)")
 	tk.MustExec("set time_zone = '+00:00'")
 	tk.MustExec("insert into t values ('2017-04-27 22:40:42')")
@@ -1469,6 +1469,25 @@ func (s *testSuite) TestTimestampTimeZone(c *C) {
 		tk.MustExec(fmt.Sprintf("set time_zone = '%s'", tt.timezone))
 		tk.MustQuery(fmt.Sprintf("select * from t where ts = '%s'", tt.expect)).Check(testkit.Rows(tt.expect))
 	}
+
+	// For issue https://github.com/pingcap/tidb/issues/3467
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec(`CREATE TABLE t1 (
+	      id bigint(20) NOT NULL AUTO_INCREMENT,
+	      uid int(11) DEFAULT NULL,
+	      datetime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	      ip varchar(128) DEFAULT NULL,
+	    PRIMARY KEY (id),
+	      KEY i_datetime (datetime),
+	      KEY i_userid (uid)
+	    );`)
+	tk.MustExec(`INSERT INTO t1 VALUES (123381351,1734,"2014-03-31 08:57:10","127.0.0.1");`)
+	r := tk.MustQuery("select datetime from t1;") // Cover TableReaderExec
+	r.Check(testkit.Rows("2014-03-31 08:57:10"))
+	r = tk.MustQuery("select datetime from t1 where datetime='2014-03-31 08:57:10';")
+	r.Check(testkit.Rows("2014-03-31 08:57:10")) // Cover IndexReaderExec
+	r = tk.MustQuery("select * from t1 where datetime='2014-03-31 08:57:10';")
+	r.Check(testkit.Rows("123381351 1734 2014-03-31 08:57:10 127.0.0.1")) // Cover IndexLookupExec
 }
 
 func (s *testSuite) TestTiDBCurrentTS(c *C) {

--- a/executor/new_distsql.go
+++ b/executor/new_distsql.go
@@ -14,6 +14,8 @@
 package executor
 
 import (
+	"time"
+
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/distsql"
@@ -208,7 +210,10 @@ func (e *IndexReaderExecutor) Next() (*Row, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		err = decodeRawValues(values, e.schema, e.ctx.GetSessionVars().GetTimeZone())
+		// Use time.UTC instead of session's timezone because coprocessor evaluator has
+		// already handle the timezone.
+		// TODO: Coprocessor should receive and return data in UTC.
+		err = decodeRawValues(values, e.schema, time.UTC)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}


### PR DESCRIPTION
fix issue https://github.com/pingcap/tidb/issues/3467