### PR TITLE
coprocessor: fix a pb unmarshal related bug.

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -420,6 +420,9 @@ func (it *copIterator) Next() ([]byte, error) {
 	if resp.err != nil {
 		return nil, errors.Trace(resp.err)
 	}
+	if resp.Data == nil {
+		return []byte{}, nil
+	}
 	return resp.Data, nil
 }
 


### PR DESCRIPTION
When tikv returns empty set, after unmarshal, `resp.Data` maybe nil instead of `[]byte{}`.
This is a quick fix. We need to dig into it later.

#3448 may be resolved by this PR.