### PR TITLE
table: add GeneratedExpr in table.Column.

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -240,11 +240,11 @@ func checkColumnCantHaveDefaultValue(col *table.Column, value interface{}) (err 
 // columnDefToCol converts ColumnDef to Col and TableConstraints.
 func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*table.Column, []*ast.Constraint, error) {
 	constraints := []*ast.Constraint{}
-	col := &table.Column{
+	col := table.ToColumn(&model.ColumnInfo{
 		Offset:    offset,
 		Name:      colDef.Name.Name,
 		FieldType: *colDef.Tp,
-	}
+	})
 
 	// Check and set TimestampFlag and OnUpdateNowFlag.
 	if col.Tp == mysql.TypeTimestamp {
@@ -1127,14 +1127,14 @@ func (d *ddl) getModifiableColumnJob(ctx context.Context, ident ast.Ident, origi
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
 
-	newCol := &table.Column{
+	newCol := table.ToColumn(&model.ColumnInfo{
 		ID:                 col.ID,
 		Offset:             col.Offset,
 		State:              col.State,
 		OriginDefaultValue: col.OriginDefaultValue,
 		FieldType:          *spec.NewColumn.Tp,
 		Name:               spec.NewColumn.Name.Name,
-	}
+	})
 	err = setCharsetCollationFlenDecimal(&newCol.FieldType)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -979,7 +979,7 @@ var tableNameToColumns = map[string]([]columnInfo){
 func createInfoSchemaTable(handle *Handle, meta *model.TableInfo) *infoschemaTable {
 	columns := make([]*table.Column, len(meta.Columns))
 	for i, col := range meta.Columns {
-		columns[i] = (*table.Column)(col)
+		columns[i] = table.ToColumn(col)
 	}
 	return &infoschemaTable{
 		handle: handle,

--- a/table/column.go
+++ b/table/column.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"
@@ -31,7 +32,11 @@ import (
 )
 
 // Column provides meta data describing a table column.
-type Column model.ColumnInfo
+type Column struct {
+	*model.ColumnInfo
+	// If this column is a generated column, the expression will be stored here.
+	GeneratedExpr ast.ExprNode
+}
 
 // PrimaryKeyName defines primary key name.
 const PrimaryKeyName = "PRIMARY"
@@ -49,8 +54,9 @@ func (c *Column) String() string {
 }
 
 // ToInfo casts Column to model.ColumnInfo
+// NOTE: DONT modify return value.
 func (c *Column) ToInfo() *model.ColumnInfo {
-	return (*model.ColumnInfo)(c)
+	return c.ColumnInfo
 }
 
 // FindCol finds column in cols by name.
@@ -65,7 +71,10 @@ func FindCol(cols []*Column, name string) *Column {
 
 // ToColumn converts a *model.ColumnInfo to *Column.
 func ToColumn(col *model.ColumnInfo) *Column {
-	return (*Column)(col)
+	return &Column{
+		col,
+		nil,
+	}
 }
 
 // FindCols finds columns in cols by names.

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -36,10 +36,10 @@ type testColumnSuite struct{}
 
 func (s *testColumnSuite) TestString(c *C) {
 	defer testleak.AfterTest(c)()
-	col := &Column{
+	col := ToColumn(&model.ColumnInfo{
 		FieldType: *types.NewFieldType(mysql.TypeTiny),
 		State:     model.StatePublic,
-	}
+	})
 	col.Flen = 2
 	col.Decimal = 1
 	col.Charset = mysql.DefaultCharset
@@ -288,8 +288,8 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 }
 
 func newCol(name string) *Column {
-	return &Column{
+	return ToColumn(&model.ColumnInfo{
 		Name:  model.NewCIStr(name),
 		State: model.StatePublic,
-	}
+	})
 }

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/parser"
 	"github.com/pingcap/tidb/util/types"
 	"github.com/pingcap/tipb/go-binlog"
 )
@@ -71,6 +72,11 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 		}
 
 		col := table.ToColumn(colInfo)
+		if len(colInfo.GeneratedExprString) != 0 {
+			// here we can ignore error because GeneratedExprString has been already
+			// checked when this table or column was added.
+			col.GeneratedExpr, _ = parser.ParseExpression(colInfo.GeneratedExprString)
+		}
 		columns = append(columns, col)
 	}
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -75,7 +75,10 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 		if len(colInfo.GeneratedExprString) != 0 {
 			// here we can ignore error because GeneratedExprString has been already
 			// checked when this table or column was added.
-			col.GeneratedExpr, _ = parser.ParseExpression(colInfo.GeneratedExprString)
+			var err error
+			if col.GeneratedExpr, _ = parser.ParseExpression(colInfo.GeneratedExprString); err != nil {
+				return nil, errors.Trace(err)
+			}
 		}
 		columns = append(columns, col)
 	}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -73,10 +73,8 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 
 		col := table.ToColumn(colInfo)
 		if len(colInfo.GeneratedExprString) != 0 {
-			// here we can ignore error because GeneratedExprString has been already
-			// checked when this table or column was added.
 			var err error
-			if col.GeneratedExpr, _ = parser.ParseExpression(colInfo.GeneratedExprString); err != nil {
+			if col.GeneratedExpr, err = parser.ParseExpression(colInfo.GeneratedExprString); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -73,10 +73,11 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 
 		col := table.ToColumn(colInfo)
 		if len(colInfo.GeneratedExprString) != 0 {
-			var err error
-			if col.GeneratedExpr, err = parser.ParseExpression(colInfo.GeneratedExprString); err != nil {
+			expr, err := parser.ParseExpression(colInfo.GeneratedExprString)
+			if err != nil {
 				return nil, errors.Trace(err)
 			}
+			col.GeneratedExpr = expr
 		}
 		columns = append(columns, col)
 	}

--- a/util/parser/expression.go
+++ b/util/parser/expression.go
@@ -26,7 +26,7 @@ func getDefaultCharsetAndCollate() (string, string) {
 	return "utf8", "utf8_bin"
 }
 
-// ParseExpression parses an ExprNode from string.
+// ParseExpression parses an ExprNode from a string.
 // Where should we use this?
 //   When TiDB bootstraps, it'll load infoschema from TiKV.
 //   Because some ColumnInfos have attribute `GeneratedExprString`,

--- a/util/parser/expression.go
+++ b/util/parser/expression.go
@@ -1,0 +1,43 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/parser"
+)
+
+// getDefaultCharsetAndCollate is copyed from ddl/ddl_api.go.
+func getDefaultCharsetAndCollate() (string, string) {
+	return "utf8", "utf8_bin"
+}
+
+// ParseExpression parses an ExprNode from string.
+// Where should we use this?
+//   When TiDB bootstraps, it'll load infoschema from TiKV.
+//   Because some ColumnInfos have attribute `GeneratedExprString`,
+//   we need to parse that string into ast.ExprNode.
+func ParseExpression(expr string) (node ast.ExprNode, err error) {
+	expr = fmt.Sprintf("select %s", expr)
+	charset, collation := getDefaultCharsetAndCollate()
+	stmts, err := parser.New().Parse(expr, charset, collation)
+	if err == nil {
+		sel := stmts[0].(*ast.SelectStmt)
+		node = sel.Fields.Fields[0].Expr
+	}
+	return node, errors.Trace(err)
+}

--- a/util/parser/expression_test.go
+++ b/util/parser/expression_test.go
@@ -1,0 +1,40 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/ast"
+)
+
+type testParserSuite struct{}
+
+func (s *testParserSuite) TestParseExpression(c *C) {
+	tests := []struct {
+		input   string
+		output  string
+		success bool
+	}{
+		{"json_extract(a, '$.a')", "json_extract", true},
+	}
+	for _, tt := range tests {
+		node, err := ParseExpression(tt.input)
+		if tt.success {
+			fc := node.(*ast.FuncCallExpr)
+			c.Assert(fc.FnName.L, Equals, tt.output)
+		} else {
+			c.Assert(err, NotNil)
+		}
+	}
+}


### PR DESCRIPTION
Why don't add GeneratedExpr in `model.ColumnInfo`?
Because in module `model`, we can't import things from `ast`. So I add it into `table.Column`, just like we add other things into `table.Table`.

@shenli @coocood @hanfei1991 , PTAL, thanks.