### PR TITLE
rawkv: give up supporting empty values.

### DIFF
--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -67,11 +67,8 @@ func (s *testRawKVSuite) TestSimple(c *C) {
 	s.mustGet(c, []byte("key"), []byte("value"))
 	s.mustDelete(c, []byte("key"))
 	s.mustNotExist(c, []byte("key"))
-
-	s.mustPut(c, []byte("key"), []byte(""))
-	s.mustGet(c, []byte("key"), []byte(""))
-	s.mustPut(c, []byte("key"), nil)
-	s.mustGet(c, []byte("key"), []byte(""))
+	err := s.client.Put([]byte("key"), []byte(""))
+	c.Assert(err, NotNil)
 }
 
 func (s *testRawKVSuite) TestSplit(c *C) {


### PR DESCRIPTION
After upgrade to pb3, when receiving response from tikv, we cannot distinguish `nil` from `[]byte{}` any more. So I deicide to give up supporting empty values, which is rarely used.