### PR TITLE
*: Fix rename table auto id conflict problem

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -103,7 +103,7 @@ func (d *ddl) onDropTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		if err = t.DropTable(job.SchemaID, job.TableID); err != nil {
+		if err = t.DropTable(job.SchemaID, job.TableID, true); err != nil {
 			break
 		}
 		// Finish this job.
@@ -198,7 +198,7 @@ func (d *ddl) onTruncateTable(t *meta.Meta, job *model.Job) (ver int64, _ error)
 		return ver, errors.Trace(err)
 	}
 
-	err = t.DropTable(schemaID, tableID)
+	err = t.DropTable(schemaID, tableID, true)
 	if err != nil {
 		job.State = model.JobCancelled
 		return ver, errors.Trace(err)
@@ -245,7 +245,7 @@ func (d *ddl) onRenameTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		}
 	}
 
-	err = t.DropTable(oldSchemaID, tblInfo.ID)
+	err = t.DropTable(oldSchemaID, tblInfo.ID, false)
 	if err != nil {
 		job.State = model.JobCancelled
 		return ver, errors.Trace(err)

--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -124,7 +124,7 @@ func (s *testSuite) TearDownSuite(c *C) {
 	c.Assert(err, IsNil)
 	t := meta.NewMeta(txn)
 
-	err = t.DropTable(s.dbInfo.ID, s.tbInfo.ID)
+	err = t.DropTable(s.dbInfo.ID, s.tbInfo.ID, true)
 	c.Assert(err, IsNil)
 	err = t.DropDatabase(s.dbInfo.ID)
 	c.Assert(err, IsNil)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -290,7 +290,9 @@ func (m *Meta) DropDatabase(dbID int64) error {
 }
 
 // DropTable drops table in database.
-func (m *Meta) DropTable(dbID int64, tableID int64) error {
+// If delAutoID is true, it will delete the auto_increment id key-value of the table.
+// For rename table, we do not need to rename auto_increment id key-value.
+func (m *Meta) DropTable(dbID int64, tableID int64, delAutoID bool) error {
 	// Check if db exists.
 	dbKey := m.dbKey(dbID)
 	if err := m.checkDBExists(dbKey); err != nil {
@@ -307,10 +309,11 @@ func (m *Meta) DropTable(dbID int64, tableID int64) error {
 		return errors.Trace(err)
 	}
 
-	if err := m.txn.HDel(dbKey, m.autoTalbeIDKey(tableID)); err != nil {
-		return errors.Trace(err)
+	if delAutoID {
+		if err := m.txn.HDel(dbKey, m.autoTalbeIDKey(tableID)); err != nil {
+			return errors.Trace(err)
+		}
 	}
-
 	return nil
 }
 

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -211,7 +211,6 @@ func (s *testSuite) TestMeta(c *C) {
 
 	err = txn.Commit()
 	c.Assert(err, IsNil)
-
 }
 
 func (s *testSuite) TestSnapshot(c *C) {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -135,6 +135,14 @@ func (s *testSuite) TestMeta(c *C) {
 	tables, err := t.ListTables(1)
 	c.Assert(err, IsNil)
 	c.Assert(tables, DeepEquals, []*model.TableInfo{tbInfo, tbInfo2})
+	// Generate an auto id.
+	n, err = t.GenAutoTableID(1, 2, 10)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(10))
+	// Make sure the auto id key-value entry is there.
+	n, err = t.GetAutoTableID(1, 2)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(10))
 
 	err = t.DropTable(1, 2, true)
 	c.Assert(err, IsNil)

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -136,12 +136,40 @@ func (s *testSuite) TestMeta(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tables, DeepEquals, []*model.TableInfo{tbInfo, tbInfo2})
 
-	err = t.DropTable(1, 2)
+	err = t.DropTable(1, 2, true)
 	c.Assert(err, IsNil)
+	// Make sure auto id key-value entry is gone.
+	n, err = t.GetAutoTableID(1, 2)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(0))
 
 	tables, err = t.ListTables(1)
 	c.Assert(err, IsNil)
 	c.Assert(tables, DeepEquals, []*model.TableInfo{tbInfo})
+
+	// Test case for drop a table without delete auto id key-value entry.
+	tid := int64(100)
+	tbInfo100 := &model.TableInfo{
+		ID:   tid,
+		Name: model.NewCIStr("t_rename"),
+	}
+	// Create table.
+	err = t.CreateTable(1, tbInfo100)
+	c.Assert(err, IsNil)
+	// Update auto id.
+	n, err = t.GenAutoTableID(1, tid, 10)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(10))
+	n, err = t.GetAutoTableID(1, tid)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(10))
+	// Drop table without touch auto id key-value entry.
+	err = t.DropTable(1, 100, false)
+	c.Assert(err, IsNil)
+	// Make sure that auto id key-value entry is still there.
+	n, err = t.GetAutoTableID(1, tid)
+	c.Assert(err, IsNil)
+	c.Assert(n, Equals, int64(10))
 
 	err = t.DropDatabase(1)
 	c.Assert(err, IsNil)
@@ -183,6 +211,7 @@ func (s *testSuite) TestMeta(c *C) {
 
 	err = txn.Commit()
 	c.Assert(err, IsNil)
+
 }
 
 func (s *testSuite) TestSnapshot(c *C) {


### PR DESCRIPTION
When renaming a table, we need to do drop-table and create-table with the same tableID. And we should keep the auto_increment id counter untouched. So we can not delete auto_increment id key. 
@zimulala @tiancaiamao @coocood PTAL