### PR TITLE
sessionctx/variable: store a copy of timezone in StatementContext

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -332,6 +332,7 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 func ResetStmtCtx(ctx context.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
 	sc := new(variable.StatementContext)
+	sc.TimeZone = sessVars.GetTimeZone()
 	switch s.(type) {
 	case *ast.UpdateStmt, *ast.InsertStmt, *ast.DeleteStmt:
 		sc.IgnoreTruncate = false

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -329,6 +329,9 @@ type StatementContext struct {
 		foundRows    uint64
 		warnings     []error
 	}
+
+	// Copied from SessionVars.TimeZone
+	TimeZone *time.Location
 }
 
 // AddAffectedRows adds affected rows.


### PR DESCRIPTION
There are many place need access to timezone, they come with a StatementContext argument.
So put a copy of timezone into StatementContext to achieve the goal with minimal changes.