### PR TITLE
*: fix timestamp column data and index inconsistent involving timezone

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -489,9 +489,7 @@ func (e *XSelectIndexExec) nextForSingleRead() (*Row, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// Use time.UTC instead of session's timezone because coprocessor evaluator has
-		// already handle the timezone.
-		err = decodeRawValues(values, schema, time.UTC)
+		err = decodeRawValues(values, schema, e.ctx.GetSessionVars().GetTimeZone())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -776,9 +774,7 @@ func (e *XSelectIndexExec) extractRowsFromPartialResult(t table.Table, partialRe
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		// Use time.UTC instead of session's timezone because coprocessor evaluator has
-		// already handle the timezone.
-		err = decodeRawValues(values, e.Schema(), time.UTC)
+		err = decodeRawValues(values, e.Schema(), e.ctx.GetSessionVars().GetTimeZone())
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1515,7 +1515,7 @@ func (s *testSuite) TestTimestampTimeZone(c *C) {
 	}()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t, t1")
+	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (ts timestamp)")
 	tk.MustExec("set time_zone = '+00:00'")
 	tk.MustExec("insert into t values ('2017-04-27 22:40:42')")
@@ -1529,8 +1529,43 @@ func (s *testSuite) TestTimestampTimeZone(c *C) {
 	}
 	for _, tt := range tests {
 		tk.MustExec(fmt.Sprintf("set time_zone = '%s'", tt.timezone))
-		tk.MustQuery(fmt.Sprintf("select * from t where ts = '%s'", tt.expect)).Check(testkit.Rows(tt.expect))
+		tk.MustQuery("select * from t").Check(testkit.Rows(tt.expect))
 	}
+
+	// For issue https://github.com/pingcap/tidb/issues/3467
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec(`CREATE TABLE t1 (
+ 	      id bigint(20) NOT NULL AUTO_INCREMENT,
+ 	      uid int(11) DEFAULT NULL,
+ 	      datetime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ 	      ip varchar(128) DEFAULT NULL,
+ 	    PRIMARY KEY (id),
+ 	      KEY i_datetime (datetime),
+ 	      KEY i_userid (uid)
+ 	    );`)
+	tk.MustExec(`INSERT INTO t1 VALUES (123381351,1734,"2014-03-31 08:57:10","127.0.0.1");`)
+	r := tk.MustQuery("select datetime from t1;") // Cover TableReaderExec
+	r.Check(testkit.Rows("2014-03-31 08:57:10"))
+	r = tk.MustQuery("select datetime from t1 where datetime='2014-03-31 08:57:10';")
+	r.Check(testkit.Rows("2014-03-31 08:57:10")) // Cover IndexReaderExec
+	r = tk.MustQuery("select * from t1 where datetime='2014-03-31 08:57:10';")
+	r.Check(testkit.Rows("123381351 1734 2014-03-31 08:57:10 127.0.0.1")) // Cover IndexLookupExec
+
+	// For issue https://github.com/pingcap/tidb/issues/3485
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec(`CREATE TABLE t1 (
+	    id bigint(20) NOT NULL AUTO_INCREMENT,
+	    datetime timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	    PRIMARY KEY (id)
+	  );`)
+	tk.MustExec(`INSERT INTO t1 VALUES (123381351,"2014-03-31 08:57:10");`)
+	r = tk.MustQuery(`select * from t1 where datetime="2014-03-31 08:57:10";`)
+	r.Check(testkit.Rows("123381351 2014-03-31 08:57:10"))
+	tk.MustExec(`alter table t1 add key i_datetime (datetime);`)
+	r = tk.MustQuery(`select * from t1 where datetime="2014-03-31 08:57:10";`)
+	r.Check(testkit.Rows("123381351 2014-03-31 08:57:10"))
+	r = tk.MustQuery(`select * from t1;`)
+	r.Check(testkit.Rows("123381351 2014-03-31 08:57:10"))
 }
 
 func (s *testSuite) TestTiDBCurrentTS(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1566,6 +1566,8 @@ func (s *testSuite) TestTimestampTimeZone(c *C) {
 	r.Check(testkit.Rows("123381351 2014-03-31 08:57:10"))
 	r = tk.MustQuery(`select * from t1;`)
 	r.Check(testkit.Rows("123381351 2014-03-31 08:57:10"))
+	r = tk.MustQuery("select datetime from t1 where datetime='2014-03-31 08:57:10';")
+	r.Check(testkit.Rows("2014-03-31 08:57:10"))
 }
 
 func (s *testSuite) TestTiDBCurrentTS(c *C) {

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -332,6 +332,7 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 func ResetStmtCtx(ctx context.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
 	sc := new(variable.StatementContext)
+	sc.TimeZone = sessVars.GetTimeZone()
 	switch s.(type) {
 	case *ast.UpdateStmt, *ast.InsertStmt, *ast.DeleteStmt:
 		sc.IgnoreTruncate = false

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -120,7 +120,9 @@ func getTimeValue(ctx context.Context, v interface{}, tp byte, fsp int) (d types
 	default:
 		return d, nil
 	}
-
+	if tp == mysql.TypeTimestamp {
+		value.TimeZone = ctx.GetSessionVars().GetTimeZone()
+	}
 	d.SetMysqlTime(value)
 	return d, nil
 }

--- a/expression/helper_test.go
+++ b/expression/helper_test.go
@@ -28,13 +28,13 @@ import (
 
 func (s *testExpressionSuite) TestGetTimeValue(c *C) {
 	defer testleak.AfterTest(c)()
-	v, err := GetTimeValue(nil, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
+	ctx := mock.NewContext()
+	v, err := GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
 	c.Assert(v.Kind(), Equals, types.KindMysqlTime)
 	timeValue := v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
-	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum(""))
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -330,7 +330,7 @@ type StatementContext struct {
 		warnings     []error
 	}
 
-	// Copied from SessionVars.TimeZone
+	// Copied from SessionVars.TimeZone.
 	TimeZone *time.Location
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -329,6 +329,9 @@ type StatementContext struct {
 		foundRows    uint64
 		warnings     []error
 	}
+
+	// Copied from SessionVars.TimeZone
+	TimeZone *time.Location
 }
 
 // AddAffectedRows adds affected rows.

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -186,6 +186,9 @@ func (s *testColumnSuite) TestGetZeroValue(c *C) {
 }
 
 func (s *testColumnSuite) TestGetDefaultValue(c *C) {
+	ctx := mock.NewContext()
+	zeroTimestamp := types.ZeroTimestamp
+	zeroTimestamp.TimeZone = ctx.GetSessionVars().GetTimeZone()
 	tests := []struct {
 		colInfo *model.ColumnInfo
 		strict  bool
@@ -246,7 +249,7 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 				DefaultValue: "0000-00-00 00:00:00",
 			},
 			false,
-			types.NewDatum(types.ZeroTimestamp),
+			types.NewDatum(zeroTimestamp),
 			nil,
 		},
 		{
@@ -257,7 +260,7 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 				},
 			},
 			true,
-			types.NewDatum(types.ZeroTimestamp),
+			types.NewDatum(zeroTimestamp),
 			errNoDefaultValue,
 		},
 		{
@@ -272,8 +275,6 @@ func (s *testColumnSuite) TestGetDefaultValue(c *C) {
 			nil,
 		},
 	}
-
-	ctx := mock.NewContext()
 
 	for _, tt := range tests {
 		ctx.GetSessionVars().StrictSQLMode = tt.strict

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -189,7 +189,7 @@ func flatten(data types.Datum, loc *time.Location) (types.Datum, error) {
 	case types.KindMysqlTime:
 		// for mysql datetime, timestamp and date type
 		t := data.GetMysqlTime()
-		if t.Type == mysql.TypeTimestamp && !t.IsZero() {
+		if t.Type == mysql.TypeTimestamp && !t.IsZero() && loc != time.UTC {
 			raw, err := t.Time.GoTime(loc)
 			if err != nil {
 				return data, errors.Trace(err)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -189,7 +189,7 @@ func flatten(data types.Datum, loc *time.Location) (types.Datum, error) {
 	case types.KindMysqlTime:
 		// for mysql datetime, timestamp and date type
 		t := data.GetMysqlTime()
-		if t.Type == mysql.TypeTimestamp && !t.IsZero() && loc != time.UTC {
+		if t.Type == mysql.TypeTimestamp && loc != time.UTC {
 			t.ConvertTimeZone(loc, time.UTC)
 		}
 		v, err := t.ToPackedUint()

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -190,12 +190,7 @@ func flatten(data types.Datum, loc *time.Location) (types.Datum, error) {
 		// for mysql datetime, timestamp and date type
 		t := data.GetMysqlTime()
 		if t.Type == mysql.TypeTimestamp && !t.IsZero() && loc != time.UTC {
-			raw, err := t.Time.GoTime(loc)
-			if err != nil {
-				return data, errors.Trace(err)
-			}
-			converted := raw.In(time.UTC)
-			t.Time = types.FromGoTime(converted)
+			t.ConvertTimeZone(loc, time.UTC)
 		}
 		v, err := t.ToPackedUint()
 		return types.NewUintDatum(v), errors.Trace(err)
@@ -412,13 +407,7 @@ func unflatten(datum types.Datum, ft *types.FieldType, loc *time.Location) (type
 			return datum, errors.Trace(err)
 		}
 		if ft.Tp == mysql.TypeTimestamp && !t.IsZero() {
-			raw, err := t.Time.GoTime(time.UTC)
-			if err != nil {
-				return datum, errors.Trace(err)
-			}
-			converted := raw.In(loc)
-			t.Time = types.FromGoTime(converted)
-			t.TimeZone = loc
+			t.ConvertTimeZone(time.UTC, loc)
 		}
 		datum.SetMysqlTime(t)
 		return datum, nil

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -418,6 +418,7 @@ func unflatten(datum types.Datum, ft *types.FieldType, loc *time.Location) (type
 			}
 			converted := raw.In(loc)
 			t.Time = types.FromGoTime(converted)
+			t.TimeZone = loc
 		}
 		datum.SetMysqlTime(t)
 		return datum, nil

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -56,13 +56,8 @@ func encode(b []byte, vals []types.Datum, comparable bool) ([]byte, error) {
 			t := val.GetMysqlTime()
 			// Encoding timestamp need to consider timezone.
 			// If it's not in UTC, transform to UTC first.
-			if t.Type == mysql.TypeTimestamp && t.TimeZone != time.UTC && !t.IsZero() {
-				raw, err := t.Time.GoTime(t.TimeZone)
-				if err != nil {
-					return b, errors.Trace(err)
-				}
-				converted := raw.In(time.UTC)
-				t.Time = types.FromGoTime(converted)
+			if t.Type == mysql.TypeTimestamp && t.TimeZone != time.UTC {
+				t.ConvertTimeZone(t.TimeZone, time.UTC)
 			}
 			v, err := t.ToPackedUint()
 			if err != nil {

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -55,7 +55,7 @@ func encode(b []byte, vals []types.Datum, comparable bool) ([]byte, error) {
 			b = append(b, uintFlag)
 			t := val.GetMysqlTime()
 			// Encoding timestamp need to consider timezone.
-			// if it's not in UTC, transform to UTC first.
+			// If it's not in UTC, transform to UTC first.
 			if t.Type == mysql.TypeTimestamp && t.TimeZone != time.UTC && !t.IsZero() {
 				raw, err := t.Time.GoTime(t.TimeZone)
 				if err != nil {

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -532,6 +532,7 @@ func (s *testCodecSuite) TestTime(c *C) {
 		var t types.Time
 		t.Type = mysql.TypeDatetime
 		t.FromPackedUint(v[0].GetUint64())
+		t.TimeZone = nil
 		c.Assert(types.NewDatum(t), DeepEquals, m)
 	}
 

--- a/util/types/convert_test.go
+++ b/util/types/convert_test.go
@@ -40,6 +40,7 @@ type invalidMockType struct {
 func Convert(val interface{}, target *FieldType) (v interface{}, err error) {
 	d := NewDatum(val)
 	sc := new(variable.StatementContext)
+	sc.TimeZone = time.UTC
 	ret, err := d.ConvertTo(sc, target)
 	if err != nil {
 		return ret.GetValue(), errors.Trace(err)

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -959,7 +959,7 @@ func (d *Datum) convertToMysqlTimestamp(sc *variable.StatementContext, target *F
 		case t.TimeZone == nil:
 			t.TimeZone = loc
 		case t.TimeZone == time.UTC:
-			// Convert to session timezone
+			// Convert to session timezone.
 			if !t.IsZero() {
 				raw, err := t.Time.GoTime(time.UTC)
 				if err != nil {
@@ -971,8 +971,6 @@ func (d *Datum) convertToMysqlTimestamp(sc *variable.StatementContext, target *F
 			t.TimeZone = loc
 		case t.TimeZone == sc.TimeZone:
 			break
-		default:
-			return ret, errors.New("something wrong")
 		}
 		t, err = t.RoundFrac(fsp)
 		if err != nil {
@@ -1014,9 +1012,6 @@ func (d *Datum) convertToMysqlTime(sc *variable.StatementContext, target *FieldT
 		t   Time
 		err error
 	)
-	if tp == mysql.TypeTimestamp {
-		return ret, errors.New("should not run to here")
-	}
 	switch d.k {
 	case KindMysqlTime:
 		t, err = d.GetMysqlTime().Convert(tp)

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -963,7 +963,7 @@ func (d *Datum) convertToMysqlTimestamp(sc *variable.StatementContext, target *F
 			t.ConvertTimeZone(time.UTC, loc)
 		case t.TimeZone == sc.TimeZone:
 		default:
-			return ret, errors.New("convertToMysqlTimestamp get a wrong input")
+			return ret, errors.New("get a wrong input")
 		}
 		t, err = t.RoundFrac(fsp)
 	case KindMysqlDuration:

--- a/util/types/time.go
+++ b/util/types/time.go
@@ -173,6 +173,21 @@ func CurrentTime(tp uint8) Time {
 	return Time{Time: FromGoTime(gotime.Now()), Type: tp, Fsp: 0}
 }
 
+// ConvertTimeZone converts the time value from one timezone to another.
+// The input time should be a valid timestamp.
+func (t *Time) ConvertTimeZone(from, to *gotime.Location) error {
+	if !t.IsZero() {
+		raw, err := t.Time.GoTime(from)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		converted := raw.In(to)
+		t.Time = FromGoTime(converted)
+	}
+	t.TimeZone = to
+	return nil
+}
+
 func (t Time) String() string {
 	if t.Type == mysql.TypeDate {
 		// We control the format, so no error would occur.

--- a/util/types/time_test.go
+++ b/util/types/time_test.go
@@ -834,8 +834,8 @@ func (s *testTimeSuite) TestTamestampDiff(c *C) {
 	}
 
 	for _, test := range tests {
-		t1 := Time{test.t1, mysql.TypeDatetime, 6}
-		t2 := Time{test.t2, mysql.TypeDatetime, 6}
+		t1 := Time{test.t1, mysql.TypeDatetime, 6, nil}
+		t2 := Time{test.t2, mysql.TypeDatetime, 6, nil}
 		c.Assert(TimestampDiff(test.unit, t1, t2), Equals, test.expect)
 	}
 }

--- a/util/types/time_test.go
+++ b/util/types/time_test.go
@@ -855,3 +855,24 @@ func (s *testTimeSuite) TestDateFSP(c *C) {
 		c.Assert(DateFSP(test.date), Equals, test.expect)
 	}
 }
+
+func (s *testTimeSuite) TestConvertTimeZone(c *C) {
+	loc, _ := time.LoadLocation("Asia/Shanghai")
+	tests := []struct {
+		input  TimeInternal
+		from   *time.Location
+		to     *time.Location
+		expect TimeInternal
+	}{
+		{FromDate(2017, 1, 1, 0, 0, 0, 0), time.UTC, loc, FromDate(2017, 1, 1, 8, 0, 0, 0)},
+		{FromDate(2017, 1, 1, 8, 0, 0, 0), loc, time.UTC, FromDate(2017, 1, 1, 0, 0, 0, 0)},
+		{FromDate(0, 0, 0, 0, 0, 0, 0), loc, time.UTC, FromDate(0, 0, 0, 0, 0, 0, 0)},
+	}
+
+	for _, test := range tests {
+		var t Time
+		t.Time = test.input
+		t.ConvertTimeZone(test.from, test.to)
+		c.Assert(compareTime(t.Time, test.expect), Equals, 0)
+	}
+}


### PR DESCRIPTION
To tell the truth, there are many things involved in the bug:
1. Encode/Decode kv range in distsql does not consider timezone
2. DDL background job backfill index always use UTC
    
I find a clever fix, here it is:
Add a TimeZone field to Time struct, if it's from TiKV, set TimeZone to UTC,
if it's converted from TiDB input, set TimeZone to session's TimeZone.

codec would take TimeZone information when it encoding a timestamp value,
convert the TimeZone when necessary.