### PR TITLE
*: Fix a DDL bug about wait time

### DIFF
--- a/ddl/bg_worker.go
+++ b/ddl/bg_worker.go
@@ -97,7 +97,7 @@ func (d *ddl) prepareBgJob(t *meta.Meta, ddlJob *model.Job) error {
 		SchemaID: ddlJob.SchemaID,
 		TableID:  ddlJob.TableID,
 		Type:     ddlJob.Type,
-		Args:     ddlJob.Args,
+		RawArgs:  ddlJob.RawArgs,
 	}
 
 	err := t.EnQueueBgJob(job)

--- a/ddl/bg_worker_test.go
+++ b/ddl/bg_worker_test.go
@@ -14,6 +14,7 @@
 package ddl
 
 import (
+	"encoding/json"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -91,7 +92,10 @@ func (s *testDDLSuite) TestDropTableError(c *C) {
 				Name: model.CIStr{O: "t"},
 			}},
 	}
-	err := kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+	var err error
+	job.RawArgs, err = json.Marshal(job.Args)
+	c.Assert(err, IsNil)
+	err = kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		return d.prepareBgJob(t, job)
 	})

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -433,7 +433,8 @@ func (d *ddl) doDDLJob(ctx context.Context, job *model.Job) error {
 		}
 
 		// If a job is a history job, the state must be JobDone or JobCancel.
-		if historyJob.State == model.JobDone {
+		// TODO:
+		if historyJob.State == model.JobWaited {
 			log.Infof("[ddl] DDL job %d is finished", jobID)
 			return nil
 		}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -432,9 +432,8 @@ func (d *ddl) doDDLJob(ctx context.Context, job *model.Job) error {
 			continue
 		}
 
-		// If a job is a history job, the state must be JobDone or JobCancel.
-		// TODO:
-		if historyJob.State == model.JobWaited {
+		// If a job is a history job, the state must be JobSynced or JobCancel.
+		if historyJob.State == model.JobSynced {
 			log.Infof("[ddl] DDL job %d is finished", jobID)
 			return nil
 		}

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -75,6 +75,10 @@ func checkEqualTable(c *C, t1, t2 *model.TableInfo) {
 	c.Assert(t1.AutoIncID, DeepEquals, t2.AutoIncID)
 }
 
+func checkHistoryJob(c *C, job *model.Job) {
+	c.Assert(job.State, Equals, model.JobWaited)
+}
+
 func checkHistoryJobArgs(c *C, ctx context.Context, id int64, args *historyJobArgs) {
 	c.Assert(ctx.NewTxn(), IsNil)
 	t := meta.NewMeta(ctx.Txn())
@@ -94,14 +98,6 @@ func checkHistoryJobArgs(c *C, ctx context.Context, id int64, args *historyJobAr
 	if args.db != nil && len(args.tblIDs) == 0 {
 		return
 	}
-	// only for dropping schema job
-	var ids []int64
-	historyJob.DecodeArgs(&ids)
-	for _, id := range ids {
-		c.Assert(args.tblIDs, HasKey, id)
-		delete(args.tblIDs, id)
-	}
-	c.Assert(len(args.tblIDs), Equals, 0)
 }
 
 func testCreateIndex(c *C, ctx context.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bool, indexName string, colName string) *model.Job {

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -76,7 +76,7 @@ func checkEqualTable(c *C, t1, t2 *model.TableInfo) {
 }
 
 func checkHistoryJob(c *C, job *model.Job) {
-	c.Assert(job.State, Equals, model.JobWaited)
+	c.Assert(job.State, Equals, model.JobSynced)
 }
 
 func checkHistoryJobArgs(c *C, ctx context.Context, id int64, args *historyJobArgs) {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -188,7 +188,7 @@ func (d *ddl) handleDDLJobQueue() error {
 				return errors.Trace(err)
 			}
 
-			if job.IsRunning() {
+			if job.IsRunning() || job.IsWaited() {
 				// If we enter a new state, crash when waiting 2 * lease time, and restart quickly,
 				// we may run the job immediately again, but we don't wait enough 2 * lease time to
 				// let other servers update the schema.
@@ -205,6 +205,12 @@ func (d *ddl) handleDDLJobQueue() error {
 			}
 			once = false
 
+			if job.IsDone() {
+				job.State = model.JobWaited
+				err = d.finishDDLJob(t, job)
+				return errors.Trace(err)
+			}
+
 			d.hookMu.Lock()
 			d.hook.OnJobRunBefore(job)
 			d.hookMu.Unlock()
@@ -214,10 +220,12 @@ func (d *ddl) handleDDLJobQueue() error {
 			schemaVer = d.runDDLJob(t, job)
 			if job.IsFinished() {
 				binloginfo.SetDDLBinlog(d.workerVars.BinlogClient, txn, job.ID, job.Query)
-				err = d.finishDDLJob(t, job)
-			} else {
-				err = d.updateDDLJob(t, job, txn.StartTS())
+				if job.IsCancelled() {
+					err = d.finishDDLJob(t, job)
+					return errors.Trace(err)
+				}
 			}
+			err = d.updateDDLJob(t, job, txn.StartTS())
 			return errors.Trace(err)
 		})
 		if err != nil {
@@ -237,7 +245,7 @@ func (d *ddl) handleDDLJobQueue() error {
 		if job.State == model.JobRunning || job.State == model.JobDone {
 			d.waitSchemaChanged(waitTime, schemaVer)
 		}
-		if job.IsFinished() {
+		if job.IsWaited() {
 			d.startBgJob(job.Type)
 			asyncNotify(d.ddlJobDoneCh)
 		}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -188,7 +188,7 @@ func (d *ddl) handleDDLJobQueue() error {
 				return errors.Trace(err)
 			}
 
-			if job.IsRunning() || job.IsSynced() {
+			if job.IsRunning() || job.IsDone() {
 				// If we enter a new state, crash when waiting 2 * lease time, and restart quickly,
 				// we may run the job immediately again, but we don't wait enough 2 * lease time to
 				// let other servers update the schema.

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -188,7 +188,7 @@ func (d *ddl) handleDDLJobQueue() error {
 				return errors.Trace(err)
 			}
 
-			if job.IsRunning() || job.IsWaited() {
+			if job.IsRunning() || job.IsSynced() {
 				// If we enter a new state, crash when waiting 2 * lease time, and restart quickly,
 				// we may run the job immediately again, but we don't wait enough 2 * lease time to
 				// let other servers update the schema.
@@ -206,7 +206,7 @@ func (d *ddl) handleDDLJobQueue() error {
 			once = false
 
 			if job.IsDone() {
-				job.State = model.JobWaited
+				job.State = model.JobSynced
 				err = d.finishDDLJob(t, job)
 				return errors.Trace(err)
 			}
@@ -245,7 +245,7 @@ func (d *ddl) handleDDLJobQueue() error {
 		if job.State == model.JobRunning || job.State == model.JobDone {
 			d.waitSchemaChanged(waitTime, schemaVer)
 		}
-		if job.IsWaited() {
+		if job.IsSynced() {
 			d.startBgJob(job.Type)
 			asyncNotify(d.ddlJobDoneCh)
 		}

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -203,7 +203,7 @@ func testCheckJobDone(c *C, d *ddl, job *model.Job, isAdd bool) {
 		t := meta.NewMeta(txn)
 		historyJob, err := t.GetHistoryDDLJob(job.ID)
 		c.Assert(err, IsNil)
-		c.Assert(historyJob.State, Equals, model.JobDone)
+		checkHistoryJob(c, historyJob)
 		if isAdd {
 			c.Assert(historyJob.SchemaState, Equals, model.StatePublic)
 		} else {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -435,8 +435,8 @@ var (
 	mDDLJobReorgKey   = []byte("DDLJobReorg")
 )
 
-func (m *Meta) enQueueDDLJob(key []byte, job *model.Job) error {
-	b, err := job.Encode()
+func (m *Meta) enQueueDDLJob(key []byte, job *model.Job, updateRawArgs bool) error {
+	b, err := job.Encode(updateRawArgs)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -445,7 +445,7 @@ func (m *Meta) enQueueDDLJob(key []byte, job *model.Job) error {
 
 // EnQueueDDLJob adds a DDL job to the list.
 func (m *Meta) EnQueueDDLJob(job *model.Job) error {
-	return m.enQueueDDLJob(mDDLJobListKey, job)
+	return m.enQueueDDLJob(mDDLJobListKey, job, true)
 }
 
 func (m *Meta) deQueueDDLJob(key []byte) (*model.Job, error) {
@@ -482,7 +482,7 @@ func (m *Meta) GetDDLJob(index int64) (*model.Job, error) {
 }
 
 func (m *Meta) updateDDLJob(index int64, job *model.Job, key []byte) error {
-	b, err := job.Encode()
+	b, err := job.Encode(true)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -506,7 +506,7 @@ func (m *Meta) jobIDKey(id int64) []byte {
 }
 
 func (m *Meta) addHistoryDDLJob(key []byte, job *model.Job) error {
-	b, err := job.Encode()
+	b, err := job.Encode(true)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -631,7 +631,11 @@ func (m *Meta) GetBgJob(index int64) (*model.Job, error) {
 
 // EnQueueBgJob adds a background job to the list.
 func (m *Meta) EnQueueBgJob(job *model.Job) error {
-	return m.enQueueDDLJob(mBgJobListKey, job)
+	var updateRawArgs bool
+	if job.RawArgs == nil {
+		updateRawArgs = true
+	}
+	return m.enQueueDDLJob(mBgJobListKey, job, updateRawArgs)
 }
 
 // BgJobQueueLen returns the background job queue length.

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -144,11 +144,14 @@ func (job *Job) GetRowCount() int64 {
 }
 
 // Encode encodes job with json format.
-func (job *Job) Encode() ([]byte, error) {
+// updateRawArgs is used to determine whether to update the raw args.
+func (job *Job) Encode(updateRawArgs bool) ([]byte, error) {
 	var err error
-	job.RawArgs, err = json.Marshal(job.Args)
-	if err != nil {
-		return nil, errors.Trace(err)
+	if updateRawArgs {
+		job.RawArgs, err = json.Marshal(job.Args)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	var b []byte
@@ -186,6 +189,16 @@ func (job *Job) IsFinished() bool {
 	return job.State == JobDone || job.State == JobRollbackDone || job.State == JobCancelled
 }
 
+// IsCancelled returns whether the job is cancelled or not.
+func (job *Job) IsCancelled() bool {
+	return job.State == JobCancelled || job.State == JobRollbackDone
+}
+
+// IsWaited returns whether the job is waited or not.
+func (job *Job) IsWaited() bool {
+	return job.State == JobWaited
+}
+
 // IsDone returns whether job is done.
 func (job *Job) IsDone() bool {
 	return job.State == JobDone
@@ -210,6 +223,8 @@ const (
 	JobRollbackDone
 	JobDone
 	JobCancelled
+	// TODO: complete comments.
+	JobWaited
 )
 
 // String implements fmt.Stringer interface.
@@ -225,6 +240,8 @@ func (s JobState) String() string {
 		return "done"
 	case JobCancelled:
 		return "cancelled"
+	case JobWaited:
+		return "waited"
 	default:
 		return "none"
 	}

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -194,9 +194,9 @@ func (job *Job) IsCancelled() bool {
 	return job.State == JobCancelled || job.State == JobRollbackDone
 }
 
-// IsWaited returns whether the job is waited or not.
-func (job *Job) IsWaited() bool {
-	return job.State == JobWaited
+// IsSynced returns whether the job is waited or not.
+func (job *Job) IsSynced() bool {
+	return job.State == JobSynced
 }
 
 // IsDone returns whether job is done.
@@ -223,8 +223,9 @@ const (
 	JobRollbackDone
 	JobDone
 	JobCancelled
-	// TODO: complete comments.
-	JobWaited
+	// JobSynced is used to mark the information about the completion of this job
+	// has been synchronized to all servers.
+	JobSynced
 )
 
 // String implements fmt.Stringer interface.
@@ -240,8 +241,8 @@ func (s JobState) String() string {
 		return "done"
 	case JobCancelled:
 		return "cancelled"
-	case JobWaited:
-		return "waited"
+	case JobSynced:
+		return "synced"
 	default:
 		return "none"
 	}

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -194,7 +194,7 @@ func (job *Job) IsCancelled() bool {
 	return job.State == JobCancelled || job.State == JobRollbackDone
 }
 
-// IsSynced returns whether the job is waited or not.
+// IsSynced returns whether the DDL modification is synced among all TiDB servers.
 func (job *Job) IsSynced() bool {
 	return job.State == JobSynced
 }

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -125,7 +125,7 @@ func (*testSuite) TestJobCodec(c *C) {
 	c.Assert(job.IsDone(), IsTrue)
 	c.Assert(job.IsFinished(), IsTrue)
 	c.Assert(job.IsRunning(), IsFalse)
-	c.Assert(job.IsWaited(), IsFalse)
+	c.Assert(job.IsSynced(), IsFalse)
 }
 
 func (testSuite) TestState(c *C) {

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -93,26 +93,39 @@ func (*testSuite) TestJobCodec(c *C) {
 	job.BinlogInfo.AddDBInfo(123, &DBInfo{ID: 1, Name: NewCIStr("test_history_db")})
 	job.BinlogInfo.AddTableInfo(123, &TableInfo{ID: 1, Name: NewCIStr("test_history_tbl")})
 
-	b, err := job.Encode()
+	b, err := job.Encode(false)
 	c.Assert(err, IsNil)
-
 	newJob := &Job{}
 	err = newJob.Decode(b)
 	c.Assert(err, IsNil)
 	c.Assert(newJob.BinlogInfo, DeepEquals, job.BinlogInfo)
-
 	name := CIStr{}
 	a := A{}
 	err = newJob.DecodeArgs(&name, &a)
 	c.Assert(err, IsNil)
+	c.Assert(name, DeepEquals, NewCIStr(""))
+	c.Assert(a, DeepEquals, A{Name: ""})
+	c.Assert(len(newJob.String()), Greater, 0)
+
+	b1, err := job.Encode(true)
+	c.Assert(err, IsNil)
+	newJob = &Job{}
+	err = newJob.Decode(b1)
+	c.Assert(err, IsNil)
+	c.Assert(newJob.BinlogInfo, DeepEquals, job.BinlogInfo)
+	name = CIStr{}
+	a = A{}
+	err = newJob.DecodeArgs(&name, &a)
+	c.Assert(err, IsNil)
 	c.Assert(name, DeepEquals, NewCIStr("a"))
 	c.Assert(a, DeepEquals, A{Name: "abc"})
-
 	c.Assert(len(newJob.String()), Greater, 0)
 
 	job.State = JobDone
+	c.Assert(job.IsDone(), IsTrue)
 	c.Assert(job.IsFinished(), IsTrue)
 	c.Assert(job.IsRunning(), IsFalse)
+	c.Assert(job.IsWaited(), IsFalse)
 }
 
 func (testSuite) TestState(c *C) {


### PR DESCRIPTION
If the DDL job is done, this job will put to the DDL history queue,  then the owner waits for 2*lease or checks all servers schema version. 
At the same time, the TiDB that puts the DDL job to the DDL queue (the TiDB that receives the DDL statement) may get the DDL job from history queue, and it will think that this statement has been completed.
So it is a bug, this PR fixed the bug.