### PR TITLE
expression: wrap arguments when new built-in function

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -26,6 +26,18 @@ import (
 	"github.com/pingcap/tidb/util/types"
 )
 
+// argTp indicates the specified types that arguments of a built-in function should be.
+type argTp byte
+
+const (
+	tpInt argTp = iota
+	tpReal
+	tpDecimal
+	tpString
+	tpTime
+	tpDuration
+)
+
 // baseBuiltinFunc will be contained in every struct that implement builtinFunc interface.
 type baseBuiltinFunc struct {
 	args          []Expression
@@ -49,17 +61,33 @@ func newBaseBuiltinFunc(args []Expression, ctx context.Context) baseBuiltinFunc 
 }
 
 // newBaseBuiltinFuncWithTp will be renamed to newBaseBuiltinFunc and replaces the older one later.
-// We'll move the type infer work to expression writer,
-// thus the `tp` attribute is needed for `baseBuiltinFunc`
-// to obtain the FieldType of a ScalarFunction.
-func newBaseBuiltinFuncWithTp(args []Expression, tp *types.FieldType, ctx context.Context) baseBuiltinFunc {
+// argTps indicates the types of the args, retType indicates the return type of the built-in function.
+func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx context.Context, argTps ...argTp) (bf baseBuiltinFunc, err error) {
+	for i := range args {
+		switch argTps[i] {
+		case tpInt:
+			args[i], err = WrapWithCastAsInt(args[i], ctx)
+		case tpReal:
+			args[i], err = WrapWithCastAsReal(args[i], ctx)
+		case tpDecimal:
+			args[i], err = WrapWithCastAsDecimal(args[i], ctx)
+		case tpString:
+			args[i], err = WrapWithCastAsString(args[i], ctx)
+		case tpTime:
+			args[i], err = WrapWithCastAsTime(args[i], types.NewFieldType(mysql.TypeDatetime), ctx)
+		case tpDuration:
+			args[i], err = WrapWithCastAsDuration(args[i], ctx)
+		}
+	}
+	if err != nil {
+		return bf, errors.Trace(err)
+	}
 	return baseBuiltinFunc{
 		args:          args,
 		argValues:     make([]types.Datum, len(args)),
 		ctx:           ctx,
 		deterministic: true,
-		tp:            tp,
-	}
+		tp:            retType}, errors.Trace(err)
 }
 
 func (b *baseBuiltinFunc) setSelf(f builtinFunc) builtinFunc {

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -60,7 +60,7 @@ func newBaseBuiltinFunc(args []Expression, ctx context.Context) baseBuiltinFunc 
 	}
 }
 
-// newBaseBuiltinFuncWithTp create a built-in function signature with specified types of arguments and return type.
+// newBaseBuiltinFuncWithTp creates a built-in function signature with specified types of arguments and the return type of the function.
 // argTps indicates the types of the args, retType indicates the return type of the built-in function.
 // Every built-in function needs determined argTps and retType when we create it.
 func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx context.Context, argTps ...argTp) (bf baseBuiltinFunc, err error) {
@@ -82,9 +82,9 @@ func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx c
 		case tpDuration:
 			args[i], err = WrapWithCastAsDuration(args[i], ctx)
 		}
-	}
-	if err != nil {
-		return bf, errors.Trace(err)
+		if err != nil {
+			return bf, errors.Trace(err)
+		}
 	}
 	return baseBuiltinFunc{
 		args:          args,

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -65,7 +65,7 @@ func newBaseBuiltinFunc(args []Expression, ctx context.Context) baseBuiltinFunc 
 // Every built-in function needs determined argTps and retType when we create it.
 func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx context.Context, argTps ...argTp) (bf baseBuiltinFunc, err error) {
 	if len(args) != len(argTps) {
-		panic("unexpected length of args and argTps")
+		return bf, errors.New("unexpected length of args and argTps")
 	}
 	for i := range args {
 		switch argTps[i] {

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -91,7 +91,7 @@ func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx c
 		argValues:     make([]types.Datum, len(args)),
 		ctx:           ctx,
 		deterministic: true,
-		tp:            retType}, errors.Trace(err)
+		tp:            retType}, nil
 }
 
 func (b *baseBuiltinFunc) setSelf(f builtinFunc) builtinFunc {

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -60,9 +60,13 @@ func newBaseBuiltinFunc(args []Expression, ctx context.Context) baseBuiltinFunc 
 	}
 }
 
-// newBaseBuiltinFuncWithTp will be renamed to newBaseBuiltinFunc and replaces the older one later.
+// newBaseBuiltinFuncWithTp create a built-in function signature with specified types of arguments and return type.
 // argTps indicates the types of the args, retType indicates the return type of the built-in function.
+// Every built-in function needs determined argTps and retType when we create it.
 func newBaseBuiltinFuncWithTp(args []Expression, retType *types.FieldType, ctx context.Context, argTps ...argTp) (bf baseBuiltinFunc, err error) {
+	if len(args) != len(argTps) {
+		panic("unexpected length of args and argTps")
+	}
 	for i := range args {
 		switch argTps[i] {
 		case tpInt:

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -135,7 +135,8 @@ type castAsIntFunctionClass struct {
 }
 
 func (b *castAsIntFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseIntBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseIntBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastIntAsIntSig{bf}, nil
 	}
@@ -166,7 +167,8 @@ type castAsRealFunctionClass struct {
 }
 
 func (b *castAsRealFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseRealBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseRealBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastRealAsRealSig{bf}, nil
 	}
@@ -197,7 +199,8 @@ type castAsDecimalFunctionClass struct {
 }
 
 func (b *castAsDecimalFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseDecimalBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseDecimalBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastDecimalAsDecimalSig{bf}, nil
 	}
@@ -228,7 +231,8 @@ type castAsStringFunctionClass struct {
 }
 
 func (b *castAsStringFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseStringBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseStringBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastStringAsStringSig{bf}, nil
 	}
@@ -259,7 +263,8 @@ type castAsTimeFunctionClass struct {
 }
 
 func (b *castAsTimeFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseTimeBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseTimeBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastTimeAsTimeSig{bf}, nil
 	}
@@ -290,7 +295,8 @@ type castAsDurationFunctionClass struct {
 }
 
 func (b *castAsDurationFunctionClass) getFunction(args []Expression, ctx context.Context) (sig builtinFunc, err error) {
-	bf := baseDurationBuiltinFunc{newBaseBuiltinFuncWithTp(args, b.tp, ctx)}
+	bf := baseDurationBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = b.tp
 	if IsHybridType(args[0]) {
 		return &builtinCastDurationAsDurationSig{bf}, nil
 	}

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -157,7 +157,7 @@ func (b *castAsIntFunctionClass) getFunction(args []Expression, ctx context.Cont
 			sig = &builtinCastStringAsIntSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type castAsRealFunctionClass struct {
@@ -189,7 +189,7 @@ func (b *castAsRealFunctionClass) getFunction(args []Expression, ctx context.Con
 			sig = &builtinCastStringAsRealSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type castAsDecimalFunctionClass struct {
@@ -221,7 +221,7 @@ func (b *castAsDecimalFunctionClass) getFunction(args []Expression, ctx context.
 			sig = &builtinCastStringAsDecimalSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type castAsStringFunctionClass struct {
@@ -253,7 +253,7 @@ func (b *castAsStringFunctionClass) getFunction(args []Expression, ctx context.C
 			sig = &builtinCastStringAsStringSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type castAsTimeFunctionClass struct {
@@ -285,7 +285,7 @@ func (b *castAsTimeFunctionClass) getFunction(args []Expression, ctx context.Con
 			sig = &builtinCastStringAsTimeSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type castAsDurationFunctionClass struct {
@@ -317,7 +317,7 @@ func (b *castAsDurationFunctionClass) getFunction(args []Expression, ctx context
 			sig = &builtinCastStringAsDurationSig{bf}
 		}
 	}
-	return sig, errors.Trace(b.verifyArgs(args))
+	return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 }
 
 type builtinCastIntAsIntSig struct {

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -138,7 +138,8 @@ func (b *castAsIntFunctionClass) getFunction(args []Expression, ctx context.Cont
 	bf := baseIntBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastIntAsIntSig{bf}, nil
+		sig = &builtinCastIntAsIntSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:
@@ -170,7 +171,8 @@ func (b *castAsRealFunctionClass) getFunction(args []Expression, ctx context.Con
 	bf := baseRealBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastRealAsRealSig{bf}, nil
+		sig = &builtinCastRealAsRealSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:
@@ -202,7 +204,8 @@ func (b *castAsDecimalFunctionClass) getFunction(args []Expression, ctx context.
 	bf := baseDecimalBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastDecimalAsDecimalSig{bf}, nil
+		sig = &builtinCastDecimalAsDecimalSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:
@@ -234,7 +237,8 @@ func (b *castAsStringFunctionClass) getFunction(args []Expression, ctx context.C
 	bf := baseStringBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastStringAsStringSig{bf}, nil
+		sig = &builtinCastStringAsStringSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:
@@ -266,7 +270,8 @@ func (b *castAsTimeFunctionClass) getFunction(args []Expression, ctx context.Con
 	bf := baseTimeBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastTimeAsTimeSig{bf}, nil
+		sig = &builtinCastTimeAsTimeSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:
@@ -298,7 +303,8 @@ func (b *castAsDurationFunctionClass) getFunction(args []Expression, ctx context
 	bf := baseDurationBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
 	bf.tp = b.tp
 	if IsHybridType(args[0]) {
-		return &builtinCastDurationAsDurationSig{bf}, nil
+		sig = &builtinCastDurationAsDurationSig{bf}
+		return sig.setSelf(sig), errors.Trace(b.verifyArgs(args))
 	}
 	switch args[0].GetTypeClass() {
 	case types.ClassInt:

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -160,8 +160,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 	}
 	for i, t := range castToDecCases {
 		args := []Expression{t.before}
-		tp := types.NewFieldType(mysql.TypeNewDecimal)
-		decFunc := baseDecimalBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		decFunc := baseDecimalBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		decFunc.tp = types.NewFieldType(mysql.TypeNewDecimal)
 		switch i {
 		case 0:
 			sig = &builtinCastIntAsDecimalSig{decFunc}
@@ -243,7 +243,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(mysql.TypeNewDecimal)
 		tp.Flen, tp.Decimal = t.flen, t.decimal
-		decFunc := baseDecimalBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		decFunc := baseDecimalBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		decFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastIntAsDecimalSig{decFunc}
@@ -427,7 +428,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		tp := types.NewFieldType(mysql.TypeVarString)
 		tp.Charset = charset.CharsetBin
 		args := []Expression{t.before}
-		stringFunc := baseStringBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		stringFunc := baseStringBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		stringFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsStringSig{stringFunc}
@@ -502,7 +504,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(mysql.TypeVarString)
 		tp.Flen, tp.Charset = t.flen, charset.CharsetBin
-		stringFunc := baseStringBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		stringFunc := baseStringBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		stringFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsStringSig{stringFunc}
@@ -570,7 +573,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(mysql.TypeDatetime)
 		tp.Decimal = types.DefaultFsp
-		timeFunc := baseTimeBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		timeFunc := baseTimeBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		timeFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsTimeSig{timeFunc}
@@ -651,7 +655,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(t.tp)
 		tp.Decimal = t.fsp
-		timeFunc := baseTimeBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		timeFunc := baseTimeBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		timeFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsTimeSig{timeFunc}
@@ -725,7 +730,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(mysql.TypeDuration)
 		tp.Decimal = types.DefaultFsp
-		durationFunc := baseDurationBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		durationFunc := baseDurationBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		durationFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsDurationSig{durationFunc}
@@ -799,7 +805,8 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		args := []Expression{t.before}
 		tp := types.NewFieldType(mysql.TypeDuration)
 		tp.Decimal = t.fsp
-		durationFunc := baseDurationBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}
+		durationFunc := baseDurationBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+		durationFunc.tp = tp
 		switch i {
 		case 0:
 			sig = &builtinCastRealAsDurationSig{durationFunc}
@@ -830,8 +837,9 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 	// null case
 	args := []Expression{&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}}
 	row := []types.Datum{types.NewDatum(nil)}
-	tp := types.NewFieldType(mysql.TypeVarString)
-	sig = &builtinCastRealAsStringSig{baseStringBuiltinFunc{newBaseBuiltinFuncWithTp(args, tp, ctx)}}
+	bf := baseStringBuiltinFunc{newBaseBuiltinFunc(args, ctx)}
+	bf.tp = types.NewFieldType(mysql.TypeVarString)
+	sig = &builtinCastRealAsStringSig{bf}
 	sRes, isNull, err := sig.evalString(row)
 	c.Assert(sRes, Equals, "")
 	c.Assert(isNull, Equals, true)

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -202,17 +202,20 @@ type concatFunctionClass struct {
 }
 
 func (c *concatFunctionClass) getFunction(args []Expression, ctx context.Context) (builtinFunc, error) {
-	sig := &builtinConcatSig{
-		baseStringBuiltinFunc{
-			newBaseBuiltinFuncWithTp(args, c.inferType(args), ctx),
-		},
+	retType, argTps := c.inferType(args)
+	bf, err := newBaseBuiltinFuncWithTp(args, retType, ctx, argTps)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
+	sig := &builtinConcatSig{baseStringBuiltinFunc{bf}}
 	return sig.setSelf(sig), errors.Trace(c.verifyArgs(args))
 }
 
-func (c *concatFunctionClass) inferType(args []Expression) *types.FieldType {
+func (c *concatFunctionClass) inferType(args []Expression) (*types.FieldType, []argTp) {
+	tps := make([]argTp, len(args))
 	existsBinStr, tp := false, mysql.TypeVarString
 	for i := 0; i < len(args); i++ {
+		tps[i] = tpString
 		curArgTp := args[i].GetType()
 		tp = types.MergeFieldType(tp, curArgTp.Tp)
 		if types.IsBinaryStr(curArgTp) {
@@ -225,7 +228,7 @@ func (c *concatFunctionClass) inferType(args []Expression) *types.FieldType {
 		retType.Charset, retType.Collate = charset.CharsetBin, charset.CollationBin
 		retType.Flag |= mysql.BinaryFlag
 	}
-	return retType
+	return retType, tps
 }
 
 type builtinConcatSig struct {
@@ -236,10 +239,6 @@ type builtinConcatSig struct {
 func (b *builtinConcatSig) evalString(row []types.Datum) (d string, isNull bool, err error) {
 	var s []byte
 	for _, a := range b.getArgs() {
-		a, err = WrapWithCastAsString(a, b.ctx)
-		if err != nil {
-			return d, false, errors.Trace(err)
-		}
 		d, isNull, err = a.EvalString(row, b.ctx.GetSessionVars().StmtCtx)
 		if isNull || err != nil {
 			return d, isNull, errors.Trace(err)

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -203,7 +203,7 @@ type concatFunctionClass struct {
 
 func (c *concatFunctionClass) getFunction(args []Expression, ctx context.Context) (builtinFunc, error) {
 	retType, argTps := c.inferType(args)
-	bf, err := newBaseBuiltinFuncWithTp(args, retType, ctx, argTps)
+	bf, err := newBaseBuiltinFuncWithTp(args, retType, ctx, argTps...)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -171,7 +171,7 @@ func (s *testEvaluatorSuite) TestConcat(c *C) {
 	}
 	fc := funcs[fcName].(*concatFunctionClass)
 	for _, t := range typeCases {
-		retType := fc.inferType(t.args)
+		retType, _ := fc.inferType(t.args)
 		c.Assert(retType.Tp, Equals, t.retType.Tp)
 		c.Assert(retType.Charset, Equals, t.retType.Charset)
 		c.Assert(retType.Collate, Equals, t.retType.Collate)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -180,7 +180,6 @@ func evalExprToDecimal(expr Expression, row []types.Datum, sc *variable.Statemen
 		// but what we actually get is store as float64 in Datum.
 		// So if we wrap `CastDecimalAsInt` upon the result, we'll get <nil> when call `arg.EvalDecimal()`.
 		// This will be fixed after all built-in functions be rewrite correctlly.
-		// return val.GetMysqlDecimal(), false, nil
 	} else if IsHybridType(expr) {
 		res, err = val.ToDecimal(sc)
 		return res, false, errors.Trace(err)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -512,6 +512,7 @@ func ColumnInfos2Columns(tblName model.CIStr, colInfos []*model.ColumnInfo) []*C
 
 // NewCastFunc creates a new cast function.
 func NewCastFunc(tp *types.FieldType, arg Expression, ctx context.Context) *ScalarFunction {
+	// TODO: rewrite this function using buildCastFunction()
 	bt := &builtinCastSig{newBaseBuiltinFunc([]Expression{arg}, ctx), tp}
 	return &ScalarFunction{
 		FuncName: model.NewCIStr(ast.Cast),

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -101,10 +102,12 @@ func (sf *ScalarFunction) Clone() Expression {
 	for _, arg := range sf.GetArgs() {
 		newArgs = append(newArgs, arg.Clone())
 	}
-	switch v := sf.Function.(type) {
-	case *builtinCastSig:
-		return NewCastFunc(v.tp, newArgs[0], sf.GetCtx())
-	case *builtinValuesSig:
+	switch sf.FuncName.L {
+	case ast.Cast:
+		newFunc, _ := buildCastFunction(sf.GetArgs()[0], sf.GetType(), sf.GetCtx())
+		return newFunc
+	case ast.Values:
+		v := sf.Function.(*builtinValuesSig)
 		return NewValuesFunc(v.offset, sf.GetType(), sf.GetCtx())
 	}
 	newFunc, _ := NewFunction(sf.GetCtx(), sf.FuncName.L, sf.RetType, newArgs...)


### PR DESCRIPTION
Types of every arguments and return type should be determined
 when building built-in function signatures,
before this commit, we wrap cast in `runtime` which is not efficient,
this commit wrap cast for args when getFunction.

PTAL @hanfei1991 @shenli  