### PR TITLE
domain: change lease in schema validator test to 5 millisecond

### DIFF
--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -28,7 +28,7 @@ type leaseGrantItem struct {
 
 func (*testSuite) TestSchemaValidator(c *C) {
 	defer testleak.AfterTest(c)()
-	lease := 2 * time.Millisecond
+	lease := 5 * time.Millisecond
 	leaseGrantCh := make(chan leaseGrantItem)
 	oracleCh := make(chan uint64)
 	exit := make(chan struct{})


### PR DESCRIPTION
Sometimes this test fail in CI, when time.Ticker has a low precision.
Change the lease value longer to make it more robust.

@XuHuaiyu @zimulala 