### PR TITLE
executor, expression: refine substr with null arguments

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -909,6 +909,12 @@ func (s *testSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery("select strcmp('abc', 'abc')")
 	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery("select substr(null, 1, 2)")
+	result.Check(testkit.Rows("<nil>"))
+	result = tk.MustQuery("select substr('123', null, 2)")
+	result.Check(testkit.Rows("<nil>"))
+	result = tk.MustQuery("select substr('123', 1, null)")
+	result.Check(testkit.Rows("<nil>"))
 
 	// for case
 	tk.MustExec("drop table if exists t")

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -724,6 +724,10 @@ func (b *builtinSubstringSig) eval(row []types.Datum) (d types.Datum, err error)
 	// arg[0] -> StrExpr
 	// arg[1] -> Pos
 	// arg[2] -> Len (Optional)
+	if args[0].IsNull() || args[1].IsNull() {
+		return
+	}
+
 	str, err := args[0].ToString()
 	if err != nil {
 		return d, errors.Errorf("Substring invalid args, need string but get %T", args[0].GetValue())
@@ -736,6 +740,9 @@ func (b *builtinSubstringSig) eval(row []types.Datum) (d types.Datum, err error)
 
 	length, hasLen := int64(-1), false
 	if len(args) == 3 {
+		if args[2].IsNull() {
+			return
+		}
 		if args[2].Kind() != types.KindInt64 {
 			return d, errors.Errorf("Substring invalid pos args, need int but get %T", args[2].GetValue())
 		}


### PR DESCRIPTION
As title described.
Before this commit, substr with null args will cause an error.

PTAL @shenli @zimulala 