### PR TITLE
expression, executor: fix unhex(binary) error

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -887,6 +887,11 @@ func (s *testSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("1267"))
 	result = tk.MustQuery("select hex(unhex(1267))")
 	result.Check(testkit.Rows("1267"))
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a binary(8))")
+	tk.MustExec(`insert into t values('test')`)
+	result = tk.MustQuery("select unhex(a) from t")
+	result.Check(testkit.Rows("<nil>"))
 
 	// select from_unixtime
 	result = tk.MustQuery("select from_unixtime(1451606400)")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -892,7 +892,7 @@ func (s *testSuite) TestBuiltin(c *C) {
 	tk.MustExec(`insert into t values('test')`)
 	result = tk.MustQuery("select hex(a) from t")
 	result.Check(testkit.Rows("7465737400000000"))
-  result = tk.MustQuery("select unhex(a) from t")
+	result = tk.MustQuery("select unhex(a) from t")
 	result.Check(testkit.Rows("<nil>"))
 
 	// select from_unixtime

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -989,7 +989,7 @@ func (b *builtinUnHexSig) eval(row []types.Datum) (d types.Datum, err error) {
 	switch args[0].Kind() {
 	case types.KindNull:
 		return d, nil
-	case types.KindString:
+	case types.KindString, types.KindBytes:
 		x, err := args[0].ToString()
 		if err != nil {
 			return d, errors.Trace(err)


### PR DESCRIPTION
Keep the same behavior with mysql when column type is binary. 

```
create table t (a binary(8));
insert into t value('test');
select unhex(s) from t1;
+----------+
| unhex(s) |
+----------+
| NULL     |
+----------+
```
@shenli @XuHuaiyu PTAL
