### PR TITLE
return type stored in baseBuiltinFunc and ScalaFunction should be the same

### DIFF
--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -80,6 +80,9 @@ func NewFunction(ctx context.Context, funcName string, retType *types.FieldType,
 	if retType == nil {
 		return nil, errors.Errorf("RetType cannot be nil for ScalarFunction.")
 	}
+	if builtinRetTp := f.getRetTp(); builtinRetTp.Tp != mysql.TypeUnspecified {
+		retType = builtinRetTp
+	}
 	return &ScalarFunction{
 		FuncName: model.NewCIStr(funcName),
 		RetType:  retType,


### PR DESCRIPTION
currently, function `NewFunction(...)`(expression/scalar_function.go) will set `ScalarFunction`'s return type to it's function parameter `retType`, but during the type inference in `xxxFunctionClass`, we use and update the return type stored in `baseBuiltinFunc`, which should also be stored in `ScalarFunction` to be further used in `Expression`'s interface `GetType()`