### PR TITLE
*: Support retrun the error of ErrNoDB

### DIFF
--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
@@ -114,7 +115,12 @@ func (s *testSuite) TestCreateDropDatabase(c *C) {
 	tk.MustExec("create database if not exists drop_test;")
 	tk.MustExec("drop database if exists drop_test;")
 	tk.MustExec("create database drop_test;")
+	tk.MustExec("use drop_test;")
 	tk.MustExec("drop database drop_test;")
+	_, err := tk.Exec("drop table t;")
+	c.Assert(err.Error(), Equals, plan.ErrNoDB.Error())
+	_, err = tk.Exec("select * from t;")
+	c.Assert(err.Error(), Equals, plan.ErrNoDB.Error())
 }
 
 func (s *testSuite) TestCreateDropTable(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1347,11 +1347,11 @@ func (s *testSuite) TestAdapterStatement(c *C) {
 	c.Check(err, IsNil)
 	c.Check(stmt.OriginText(), Equals, "select 1")
 
-	stmtNode, err = s.ParseOneStmt("create table t (a int)", "", "")
+	stmtNode, err = s.ParseOneStmt("create table test.t (a int)", "", "")
 	c.Check(err, IsNil)
 	stmt, err = compiler.Compile(ctx, stmtNode)
 	c.Check(err, IsNil)
-	c.Check(stmt.OriginText(), Equals, "create table t (a int)")
+	c.Check(stmt.OriginText(), Equals, "create table test.t (a int)")
 }
 
 func (s *testSuite) TestPointGet(c *C) {

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -372,6 +372,7 @@ func mockContext() context.Context {
 	ctx.Store = &mockStore{
 		client: &mockClient{},
 	}
+	ctx.GetSessionVars().CurrentDB = "test"
 	do := &domain.Domain{}
 	do.CreateStatsHandle(ctx)
 	sessionctx.BindDomain(ctx, do)

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -199,6 +199,9 @@ const (
 	CodeUnsupported         terror.ErrCode = 4
 	CodeInvalidGroupFuncUse terror.ErrCode = 5
 	CodeIllegalReference    terror.ErrCode = 6
+
+	// MySQL error code.
+	CodeNoDB terror.ErrCode = mysql.ErrNoDB
 )
 
 // Optimizer base errors.
@@ -208,6 +211,7 @@ var (
 	ErrCartesianProductUnsupported = terror.ClassOptimizer.New(CodeUnsupported, "Cartesian product is unsupported")
 	ErrInvalidGroupFuncUse         = terror.ClassOptimizer.New(CodeInvalidGroupFuncUse, "Invalid use of group function")
 	ErrIllegalReference            = terror.ClassOptimizer.New(CodeIllegalReference, "Illegal reference")
+	ErrNoDB                        = terror.ClassOptimizer.New(CodeNoDB, "No database selected")
 )
 
 func init() {
@@ -216,6 +220,7 @@ func init() {
 		CodeInvalidWildCard:     mysql.ErrParse,
 		CodeInvalidGroupFuncUse: mysql.ErrInvalidGroupFuncUse,
 		CodeIllegalReference:    mysql.ErrIllegalReference,
+		CodeNoDB:                mysql.ErrNoDB,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassOptimizer] = mySQLErrCodes
 	expression.EvalAstExpr = evalAstExpr

--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -347,6 +347,11 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 // handleTableName looks up and sets the schema information and result fields for table name.
 func (nr *nameResolver) handleTableName(tn *ast.TableName) {
 	if tn.Schema.L == "" {
+		sessionVars := nr.Ctx.GetSessionVars()
+		if sessionVars.CurrentDB == "" {
+			nr.Err = errors.Trace(ErrNoDB)
+			return
+		}
 		tn.Schema = nr.DefaultSchema
 	}
 	ctx := nr.currentContext()

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -14,11 +14,11 @@
 package varsutil
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
-	"fmt"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"


### PR DESCRIPTION
orignal behavior :
```
mysql> create database db;
Query OK, 0 rows affected (0.00 sec)
mysql> use db;
Database changed
mysql> drop database db;
Query OK, 0 rows affected (0.00 sec)
mysql> select * from t;
ERROR 1146 (42S02): Table '.t' doesn't exist
mysql> drop table t;
ERROR 1051 (42S02): Unknown table 't'
```


present behavior:
```
mysql> create database db;
Query OK, 0 rows affected (0.00 sec)
mysql> use db;
Database changed
mysql> drop database db;
Query OK, 0 rows affected (0.00 sec)
mysql> select * from t;
ERROR 1046 (3D000): No database selected
mysql> drop table t;
ERROR 1046 (3D000): No database selected
```