### PR TITLE
plan: a pre-work for changing the cbo framework.

### DIFF
--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -941,14 +941,15 @@ func (p *basePhysicalPlan) getPushedProp(prop *requiredProp) []*requiredProp {
 	return []*requiredProp{prop}
 }
 
-func (p *Limit) getPushedProp(prop *requiredProp) (props []*requiredProp) {
+func (p *Limit) getPushedProp(prop *requiredProp) []*requiredProp {
 	if !prop.isEmpty() {
 		return nil
 	}
+	props := make([]*requiredProp, 0, len(wholeTaskTypes))
 	for _, tp := range wholeTaskTypes {
 		props = append(props, &requiredProp{taskTp: tp})
 	}
-	return
+	return props
 }
 
 func (p *LogicalAggregation) generatePhysicalPlans() []PhysicalPlan {
@@ -962,12 +963,13 @@ func (p *LogicalAggregation) generatePhysicalPlans() []PhysicalPlan {
 	return []PhysicalPlan{ha}
 }
 
-func (p *PhysicalAggregation) getPushedProp(prop *requiredProp) (props []*requiredProp) {
+func (p *PhysicalAggregation) getPushedProp(prop *requiredProp) []*requiredProp {
 	if !prop.isEmpty() {
 		return nil
 	}
+	props := make([]*requiredProp, 0, len(wholeTaskTypes))
 	for _, tp := range wholeTaskTypes {
 		props = append(props, &requiredProp{taskTp: tp})
 	}
-	return
+	return props
 }

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -231,6 +231,9 @@ type LogicalPlan interface {
 	// preparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.
 	preparePossibleProperties() [][]*expression.Column
+
+	// generatePhysicalPlans generate all possible plans.
+	generatePhysicalPlans() []PhysicalPlan
 }
 
 // PhysicalPlan is a tree of the physical operators.
@@ -258,6 +261,9 @@ type PhysicalPlan interface {
 
 	// ToPB converts physical plan to tipb executor.
 	ToPB(ctx context.Context) (*tipb.Executor, error)
+
+	// getPushedProp try to push the required property to its child and get the result property.
+	getPushedProp(prop *requiredProp) []*requiredProp
 }
 
 type baseLogicalPlan struct {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -232,7 +232,7 @@ type LogicalPlan interface {
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.
 	preparePossibleProperties() [][]*expression.Column
 
-	// generatePhysicalPlans generate all possible plans.
+	// generatePhysicalPlans generates all possible plans.
 	generatePhysicalPlans() []PhysicalPlan
 }
 
@@ -262,7 +262,7 @@ type PhysicalPlan interface {
 	// ToPB converts physical plan to tipb executor.
 	ToPB(ctx context.Context) (*tipb.Executor, error)
 
-	// getPushedProp try to push the required property to its child and get the result property.
+	// getPushedProp tries to push the required property to its child and get the result property.
 	getPushedProp(prop *requiredProp) []*requiredProp
 }
 


### PR DESCRIPTION
There are lots of logic can be used in new cbo framework. Two new interfaces are added:
1. `generatePhysicalPlans` to generate all physical plans, like logical join can be converted to hash join, merge join and index join.
2. `getPushedProp` tries to generate all possible properties can be pushed down.

@zimulala @winoros PTAL