### PR TITLE
tikv/2pc:prewrite primary first when skip_contraint_check is true

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -60,14 +60,15 @@ func (ca twoPhaseCommitAction) MetricsTag() string {
 
 // twoPhaseCommitter executes a two-phase commit protocol.
 type twoPhaseCommitter struct {
-	store     *tikvStore
-	txn       *tikvTxn
-	startTS   uint64
-	keys      [][]byte
-	mutations map[string]*pb.Mutation
-	lockTTL   uint64
-	commitTS  uint64
-	mu        struct {
+	store             *tikvStore
+	txn               *tikvTxn
+	startTS           uint64
+	keys              [][]byte
+	mutations         map[string]*pb.Mutation
+	lockTTL           uint64
+	commitTS          uint64
+	skipCheckForWrite bool
+	mu                struct {
 		sync.RWMutex
 		writtenKeys  [][]byte
 		committed    bool
@@ -140,13 +141,16 @@ func newTwoPhaseCommitter(txn *tikvTxn) (*twoPhaseCommitter, error) {
 	txnWriteKVCountHistogram.Observe(float64(len(keys)))
 	txnWriteSizeHistogram.Observe(float64(size / 1024))
 
+	optSkipCheck := txn.us.GetOption(kv.SkipCheckForWrite)
+	skip, ok := optSkipCheck.(bool)
 	return &twoPhaseCommitter{
-		store:     txn.store,
-		txn:       txn,
-		startTS:   txn.StartTS(),
-		keys:      keys,
-		mutations: mutations,
-		lockTTL:   txnLockTTL(txn.startTime, size),
+		store:             txn.store,
+		txn:               txn,
+		startTS:           txn.StartTS(),
+		keys:              keys,
+		mutations:         mutations,
+		skipCheckForWrite: ok && skip,
+		lockTTL:           txnLockTTL(txn.startTime, size),
 	}, nil
 }
 
@@ -207,8 +211,9 @@ func (c *twoPhaseCommitter) doActionOnKeys(bo *Backoffer, action twoPhaseCommitA
 	}
 
 	firstIsPrimary := bytes.Equal(keys[0], c.primary())
-	if firstIsPrimary && (action == actionCommit || action == actionCleanup) {
-		// primary should be committed/cleanup first.
+	if firstIsPrimary && (c.skipCheckForWrite || action == actionCommit || action == actionCleanup) {
+		// primary should be committed/cleanup first
+		// primary should be prewrite first when skip_constraint_check is true
 		err = c.doActionOnBatches(bo, action, batches[:1])
 		if err != nil {
 			return errors.Trace(err)
@@ -327,11 +332,6 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 		mutations[i] = c.mutations[string(k)]
 	}
 
-	skipCheck := false
-	optSkipCheck := c.txn.us.GetOption(kv.SkipCheckForWrite)
-	if skip, ok := optSkipCheck.(bool); ok && skip {
-		skipCheck = true
-	}
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdPrewrite,
 		Prewrite: &pb.PrewriteRequest{
@@ -339,7 +339,7 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 			PrimaryLock:         c.primary(),
 			StartVersion:        c.startTS,
 			LockTtl:             c.lockTTL,
-			SkipConstraintCheck: skipCheck,
+			SkipConstraintCheck: c.skipCheckForWrite,
 		},
 	}
 


### PR DESCRIPTION
Hi, 
     This PR is for RC3, it would prewrite primary first when `skip_containt_check` is true.
     The related PR is  https://github.com/pingcap/tidb/pull/3561

 @zhangjinpeng1987 @disksing @shenli PTAL