### PR TITLE
tidb-server: change prometrics metric instance name to host_port

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -235,7 +235,7 @@ func instanceName() string {
 	if err != nil {
 		return "unknown"
 	}
-	return fmt.Sprintf("%s:%s", hostname, *port)
+	return fmt.Sprintf("%s_%s", hostname, *port)
 }
 
 // parseLease parses lease argument string.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -218,7 +218,8 @@ func prometheusPushClient(addr string, interval time.Duration) {
 	job := "tidb"
 	for {
 		err := push.AddFromGatherer(
-			job, push.HostnameGroupingKey(),
+			job,
+			map[string]string{"instance": instanceName()},
 			addr,
 			prometheus.DefaultGatherer,
 		)
@@ -227,6 +228,14 @@ func prometheusPushClient(addr string, interval time.Duration) {
 		}
 		time.Sleep(interval)
 	}
+}
+
+func instanceName() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s:%s", hostname, *port)
 }
 
 // parseLease parses lease argument string.


### PR DESCRIPTION
Change the name to "host:port" instead of "host", in case that more than one TiDB 
instance runs on one machine.

PTAL @disksing @shenli @hanfei1991 