### PR TITLE
tidb-server: change prometrics metric instance name to host_port (#3588)

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -213,7 +213,8 @@ func prometheusPushClient(addr string, interval time.Duration) {
 	job := "tidb"
 	for {
 		err := push.AddFromGatherer(
-			job, push.HostnameGroupingKey(),
+			job,
+			map[string]string{"instance": instanceName()},
 			addr,
 			prometheus.DefaultGatherer,
 		)
@@ -222,6 +223,14 @@ func prometheusPushClient(addr string, interval time.Duration) {
 		}
 		time.Sleep(interval)
 	}
+}
+
+func instanceName() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return fmt.Sprintf("%s_%s", hostname, *port)
 }
 
 // parseLease parses lease argument string.


### PR DESCRIPTION
cherry-pick this commit from master to rc2.2
see https://github.com/pingcap/tidb/pull/3588