### PR TITLE
expression, util: 1. refine castStrAsReal 2. cast use new architecture

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -963,18 +963,24 @@ func (s *testSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("0.8414709848078965"))
 	result = tk.MustQuery("select sin(100)")
 	result.Check(testkit.Rows("-0.5063656411097588"))
+	result = tk.MustQuery("select sin('abcd')")
+	result.Check(testkit.Rows("0"))
 
 	// test cos
 	result = tk.MustQuery("select cos(0)")
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery("select cos(3.1415926535898)")
 	result.Check(testkit.Rows("-1"))
+	result = tk.MustQuery("select cos('abcd')")
+	result.Check(testkit.Rows("1"))
 
 	//for tan
 	result = tk.MustQuery("select tan(0.00)")
 	result.Check(testkit.Rows("0"))
 	result = tk.MustQuery("select tan(PI()/4)")
 	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select tan('abcd')")
+	result.Check(testkit.Rows("0"))
 
 	// for case
 	tk.MustExec("drop table if exists t")

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -663,16 +663,15 @@ func (b *builtinCastStringAsRealSig) evalReal(row []types.Datum) (res float64, i
 	if IsHybridType(b.args[0]) {
 		return b.args[0].EvalReal(row, sc)
 	}
-	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(row, sc)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	res, err = types.StrToFloat(sc, val)
-	var err1 error
-	res, err1 = types.ProduceFloatWithSpecifiedTp(res, b.tp, sc)
-	if err == nil && err1 != nil {
-		err = err1
+	if err != nil {
+		return 0, false, errors.Trace(err)
 	}
+	res, err = types.ProduceFloatWithSpecifiedTp(res, b.tp, sc)
 	return res, false, errors.Trace(err)
 }
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -532,6 +532,12 @@ func (s *testEvaluatorSuite) TestRadians(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestSin(c *C) {
+	sc := s.ctx.GetSessionVars().StmtCtx
+	origin := sc.IgnoreTruncate
+	sc.IgnoreTruncate = true
+	defer func() {
+		sc.IgnoreTruncate = origin
+	}()
 	defer testleak.AfterTest(c)()
 	cases := []struct {
 		args     interface{}
@@ -548,7 +554,7 @@ func (s *testEvaluatorSuite) TestSin(c *C) {
 		{math.Pi / 6, float64(math.Sin(math.Pi / 6)), false, false}, // Pie/6(30 degrees) ==> 0.5
 		{-math.Pi / 6, float64(math.Sin(-math.Pi / 6)), false, false},
 		{math.Pi * 2, float64(math.Sin(math.Pi * 2)), false, false},
-		{string("adfsdfgs"), 0, false, true},
+		{string("adfsdfgs"), 0, false, false},
 		{"0.000", 0, false, false},
 	}
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -532,12 +532,6 @@ func (s *testEvaluatorSuite) TestRadians(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestSin(c *C) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate
-	sc.IgnoreTruncate = true
-	defer func() {
-		sc.IgnoreTruncate = origin
-	}()
 	defer testleak.AfterTest(c)()
 	cases := []struct {
 		args     interface{}
@@ -554,7 +548,7 @@ func (s *testEvaluatorSuite) TestSin(c *C) {
 		{math.Pi / 6, float64(math.Sin(math.Pi / 6)), false, false}, // Pie/6(30 degrees) ==> 0.5
 		{-math.Pi / 6, float64(math.Sin(-math.Pi / 6)), false, false},
 		{math.Pi * 2, float64(math.Sin(math.Pi * 2)), false, false},
-		{string("adfsdfgs"), 0, false, false},
+		{string("adfsdfgs"), 0, false, true},
 		{"0.000", 0, false, false},
 	}
 
@@ -584,12 +578,6 @@ func (s *testEvaluatorSuite) TestSin(c *C) {
 
 func (s *testEvaluatorSuite) TestCos(c *C) {
 	defer testleak.AfterTest(c)()
-	sc := s.ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate
-	sc.IgnoreTruncate = true
-	defer func() {
-		sc.IgnoreTruncate = origin
-	}()
 	cases := []struct {
 		args     interface{}
 		expected float64
@@ -603,7 +591,7 @@ func (s *testEvaluatorSuite) TestCos(c *C) {
 		{math.Pi / 2, float64(math.Cos(math.Pi / 2)), false, false}, // Pi/2 is some near 0 (6.123233995736766e-17) but not 0. Even in math it is 0.
 		{-math.Pi / 2, float64(math.Cos(-math.Pi / 2)), false, false},
 		{"0.000", float64(1), false, false}, // string value case
-		{"sdfgsfsdf", float64(1), false, false},
+		{"sdfgsfsdf", float64(1), false, true},
 	}
 
 	for _, t := range cases {
@@ -707,12 +695,6 @@ func (s *testEvaluatorSuite) TestAtan(c *C) {
 
 func (s *testEvaluatorSuite) TestTan(c *C) {
 	defer testleak.AfterTest(c)()
-	sc := s.ctx.GetSessionVars().StmtCtx
-	origin := sc.IgnoreTruncate
-	sc.IgnoreTruncate = true
-	defer func() {
-		sc.IgnoreTruncate = origin
-	}()
 	cases := []struct {
 		args     interface{}
 		expected float64
@@ -725,7 +707,7 @@ func (s *testEvaluatorSuite) TestTan(c *C) {
 		{-math.Pi / 4, float64(-1), false, false},
 		{math.Pi * 3 / 4, math.Tan(math.Pi * 3 / 4), false, false}, //in mysql and golang, it equals -1.0000000000000002, not -1
 		{"0.000", float64(0), false, false},
-		{"sdfgsdfg", 0, false, false},
+		{"sdfgsdfg", 0, false, true},
 	}
 
 	for _, t := range cases {

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -562,6 +562,12 @@ func (s *testEvaluatorSuite) TestSin(c *C) {
 
 func (s *testEvaluatorSuite) TestCos(c *C) {
 	defer testleak.AfterTest(c)()
+	sc := s.ctx.GetSessionVars().StmtCtx
+	origin := sc.IgnoreTruncate
+	sc.IgnoreTruncate = true
+	defer func() {
+		sc.IgnoreTruncate = origin
+	}()
 	cases := []struct {
 		args     interface{}
 		expected float64
@@ -575,7 +581,7 @@ func (s *testEvaluatorSuite) TestCos(c *C) {
 		{math.Pi / 2, float64(math.Cos(math.Pi / 2)), false, false}, // Pi/2 is some near 0 (6.123233995736766e-17) but not 0. Even in math it is 0.
 		{-math.Pi / 2, float64(math.Cos(-math.Pi / 2)), false, false},
 		{"0.000", float64(1), false, false}, // string value case
-		{"sdfgsfsdf", float64(0), false, true},
+		{"sdfgsfsdf", float64(1), false, false},
 	}
 
 	for _, t := range cases {
@@ -679,6 +685,12 @@ func (s *testEvaluatorSuite) TestAtan(c *C) {
 
 func (s *testEvaluatorSuite) TestTan(c *C) {
 	defer testleak.AfterTest(c)()
+	sc := s.ctx.GetSessionVars().StmtCtx
+	origin := sc.IgnoreTruncate
+	sc.IgnoreTruncate = true
+	defer func() {
+		sc.IgnoreTruncate = origin
+	}()
 	cases := []struct {
 		args     interface{}
 		expected float64
@@ -691,7 +703,7 @@ func (s *testEvaluatorSuite) TestTan(c *C) {
 		{-math.Pi / 4, float64(-1), false, false},
 		{math.Pi * 3 / 4, math.Tan(math.Pi * 3 / 4), false, false}, //in mysql and golang, it equals -1.0000000000000002, not -1
 		{"0.000", float64(0), false, false},
-		{"sdfgsdfg", 0, false, true},
+		{"sdfgsdfg", 0, false, false},
 	}
 
 	for _, t := range cases {

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -591,7 +591,7 @@ func (s *testEvaluatorSuite) TestCos(c *C) {
 		{math.Pi / 2, float64(math.Cos(math.Pi / 2)), false, false}, // Pi/2 is some near 0 (6.123233995736766e-17) but not 0. Even in math it is 0.
 		{-math.Pi / 2, float64(math.Cos(-math.Pi / 2)), false, false},
 		{"0.000", float64(1), false, false}, // string value case
-		{"sdfgsfsdf", float64(1), false, true},
+		{"sdfgsfsdf", float64(0), false, true},
 	}
 
 	for _, t := range cases {

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -52,7 +52,9 @@ func (s *testUtilSuite) TestSubstituteCorCol2Constant(c *check.C) {
 	defer testleak.AfterTest(c)()
 	ctx := mock.NewContext()
 	corCol1 := &CorrelatedColumn{Data: &One.Value}
+	corCol1.RetType = types.NewFieldType(mysql.TypeLonglong)
 	corCol2 := &CorrelatedColumn{Data: &One.Value}
+	corCol2.RetType = types.NewFieldType(mysql.TypeLonglong)
 	cast := NewCastFunc(types.NewFieldType(mysql.TypeLonglong), corCol1, ctx)
 	plus := newFunction(ast.Plus, cast, corCol2)
 	plus2 := newFunction(ast.Plus, plus, One)


### PR DESCRIPTION
This commit does 2 things:
1. use types.StrToFloat instead of strconv.ParseFloat when cast str as real
2. use new architecture to evaluate cast

PTAL @shenli @hanfei1991 @zz-jason @winkyao 