### PR TITLE
executor: fix explicitly insert null value into timestamp column

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -900,7 +900,7 @@ func (e *InsertValues) initDefaultValues(row []types.Datum, hasValue []bool, ign
 			// TODO: Append Warning ErrColumnCantNull.
 		}
 		if mysql.HasAutoIncrementFlag(c.Flag) {
-			needDefaultValue = false // handle it later.
+			needDefaultValue = false
 		}
 		if needDefaultValue {
 			var err error

--- a/executor/write.go
+++ b/executor/write.go
@@ -855,15 +855,13 @@ func (e *InsertValues) getRowsSelect(cols []*table.Column) ([][]types.Datum, err
 
 func (e *InsertValues) fillRowData(cols []*table.Column, vals []types.Datum, ignoreErr bool) ([]types.Datum, error) {
 	row := make([]types.Datum, len(e.Table.Cols()))
-	marked := make(map[int]struct{}, len(vals))
+	hasValue := make([]bool, len(e.Table.Cols()))
 	for i, v := range vals {
 		offset := cols[i].Offset
 		row[offset] = v
-		if !ignoreErr {
-			marked[offset] = struct{}{}
-		}
+		hasValue[offset] = true
 	}
-	err := e.initDefaultValues(row, marked, ignoreErr)
+	err := e.initDefaultValues(row, hasValue, ignoreErr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -889,64 +887,70 @@ func (e *InsertValues) filterErr(err error, ignoreErr bool) error {
 	return nil
 }
 
-func (e *InsertValues) initDefaultValues(row []types.Datum, marked map[int]struct{}, ignoreErr bool) error {
+func (e *InsertValues) initDefaultValues(row []types.Datum, hasValue []bool, ignoreErr bool) error {
 	var defaultValueCols []*table.Column
+	strictSQL := e.ctx.GetSessionVars().StrictSQLMode
 	sc := e.ctx.GetSessionVars().StmtCtx
+	retryInfo := e.ctx.GetSessionVars().RetryInfo
+
 	for i, c := range e.Table.Cols() {
-		// It's used for retry.
-		if mysql.HasAutoIncrementFlag(c.Flag) && row[i].IsNull() &&
-			e.ctx.GetSessionVars().RetryInfo.Retrying {
-			id, err := e.ctx.GetSessionVars().RetryInfo.GetCurrAutoIncrementID()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			row[i].SetInt64(id)
+		var needDefaultValue bool
+		if !hasValue[i] {
+			needDefaultValue = true
+		} else if mysql.HasNotNullFlag(c.Flag) && row[i].IsNull() && !strictSQL {
+			needDefaultValue = true
+			// TODO: Append Warning ErrColumnCantNull.
 		}
-		if !row[i].IsNull() {
-			// Column value isn't nil and column isn't auto-increment, continue.
-			if !mysql.HasAutoIncrementFlag(c.Flag) {
-				continue
-			}
-			val, err := row[i].ToInt64(sc)
-			if e.filterErr(errors.Trace(err), ignoreErr) != nil {
-				return errors.Trace(err)
-			}
-			row[i].SetInt64(val)
-			if val != 0 {
-				e.ctx.GetSessionVars().InsertID = uint64(val)
-				e.Table.RebaseAutoID(val, true)
-				continue
-			}
-		}
-
-		// If the nil value is evaluated in insert list, we will use nil except auto increment column.
-		if _, ok := marked[i]; ok && !mysql.HasAutoIncrementFlag(c.Flag) && !mysql.HasTimestampFlag(c.Flag) {
-			continue
-		}
-
 		if mysql.HasAutoIncrementFlag(c.Flag) {
-			recordID, err := e.Table.AllocAutoID()
-			if err != nil {
-				return errors.Trace(err)
-			}
-			row[i].SetInt64(recordID)
-			// It's compatible with mysql. So it sets last insert id to the first row.
-			if e.currRow == 0 {
-				e.lastInsertID = uint64(recordID)
-			}
-			// It's used for retry.
-			if !e.ctx.GetSessionVars().RetryInfo.Retrying {
-				e.ctx.GetSessionVars().RetryInfo.AddAutoIncrementID(recordID)
-			}
-		} else {
+			needDefaultValue = false // handle it later.
+		}
+
+		if needDefaultValue {
 			var err error
 			row[i], err = table.GetColDefaultValue(e.ctx, c.ToInfo())
 			if e.filterErr(err, ignoreErr) != nil {
 				return errors.Trace(err)
 			}
+			defaultValueCols = append(defaultValueCols, c)
 		}
 
-		defaultValueCols = append(defaultValueCols, c)
+		// Adjust the value if this column has auto increment flag.
+		if mysql.HasAutoIncrementFlag(c.Flag) {
+			if retryInfo.Retrying {
+				id, err := retryInfo.GetCurrAutoIncrementID()
+				if err != nil {
+					return errors.Trace(err)
+				}
+				row[i].SetInt64(id)
+			} else {
+				var err error
+				var recordID int64
+				if !row[i].IsNull() {
+					recordID, err = row[i].ToInt64(sc)
+					if e.filterErr(errors.Trace(err), ignoreErr) != nil {
+						return errors.Trace(err)
+					}
+				}
+				// Use the value if it's not null and not 0, otherwise alloc new id.
+				// TODO: Consider NoAutoValueOnZero SQL mode and change the behavior here.
+				if recordID != 0 {
+					e.Table.RebaseAutoID(recordID, true)
+					e.ctx.GetSessionVars().InsertID = uint64(recordID)
+				} else {
+					recordID, err = e.Table.AllocAutoID()
+					if e.filterErr(errors.Trace(err), ignoreErr) != nil {
+						return errors.Trace(err)
+					}
+					// It's compatible with mysql. So it sets last insert id to the first row.
+					if e.currRow == 0 {
+						e.lastInsertID = uint64(recordID)
+					}
+				}
+
+				row[i].SetInt64(recordID)
+				retryInfo.AddAutoIncrementID(recordID)
+			}
+		}
 	}
 	if err := table.CastValues(e.ctx, row, defaultValueCols, ignoreErr); err != nil {
 		return errors.Trace(err)

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -947,3 +947,19 @@ func (s *testSuite) TestBatchInsert(c *C) {
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("320"))
 }
+
+func (s *testSuite) TestNullDefault(c *C) {
+	defer func() {
+		s.cleanEnv(c)
+		testleak.AfterTest(c)()
+	}()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test; drop table if exists test_null_default;")
+	tk.MustExec("set timestamp = 1234")
+	tk.MustExec("set time_zone = '+08:00'")
+	tk.MustExec("create table test_null_default (ts timestamp null default current_timestamp)")
+	tk.MustExec("insert into test_null_default values (null)")
+	tk.MustQuery("select * from test_null_default").Check(testkit.Rows("<nil>"))
+	tk.MustExec("insert into test_null_default values ()")
+	tk.MustQuery("select * from test_null_default").Check(testkit.Rows("<nil>", "1970-01-01 08:20:34"))
+}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -134,7 +134,7 @@ func countEntriesWithPrefix(ctx context.Context, prefix []byte) (int, error) {
 }
 
 func (ts *testSuite) TestTypes(c *C) {
-	_, err := ts.se.Execute("CREATE TABLE test.t (c1 tinyint, c2 smallint, c3 int, c4 bigint, c5 text, c6 blob, c7 varchar(64), c8 time, c9 timestamp not null default CURRENT_TIMESTAMP, c10 decimal(10,1))")
+	_, err := ts.se.Execute("CREATE TABLE test.t (c1 tinyint, c2 smallint, c3 int, c4 bigint, c5 text, c6 blob, c7 varchar(64), c8 time, c9 timestamp null default CURRENT_TIMESTAMP, c10 decimal(10,1))")
 	c.Assert(err, IsNil)
 	ctx := ts.se.(context.Context)
 	dom := sessionctx.GetDomain(ctx)


### PR DESCRIPTION
```
create table t (ts timestamp null default current_timestamp);
insert into t values (null);
select * from t;
```

get:

```
mysql> select * from t;
+---------------------+
| ts                  |
+---------------------+
| 2017-07-06 15:57:05 |
+---------------------+
1 row in set (0.00 sec)
```

should get:

```
+------+
| ts   |
+------+
| NULL |
+------+
1 row in set (0.00 sec)
```

@zimulala @hanfei1991 @shenli @XuHuaiyu 