### PR TITLE
store/tikv: fix bug of cleaning store cache on grpc canceled error

### DIFF
--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -120,7 +120,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
 	// If it failed because the context is canceled, don't retry on this error.
-	if errors.Cause(err) == goctx.Canceled || grpc.Code(err) == codes.Canceled {
+	if errors.Cause(err) == goctx.Canceled || grpc.Code(errors.Cause(err)) == codes.Canceled {
 		return errors.Trace(err)
 	}
 

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -14,12 +14,16 @@
 package tikv
 
 import (
+	"net"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/pingcap/tidb/store/tikv/mock-tikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	goctx "golang.org/x/net/context"
@@ -143,16 +147,91 @@ func (s *testRegionRequestSuite) TestNoReloadRegionWhenCtxCanceled(c *C) {
 // cancelContextClient wraps rpcClient and always cancels context before sending requests.
 type cancelContextClient struct {
 	Client
+	redirectAddr string
 }
 
 func (c *cancelContextClient) SendReq(ctx goctx.Context, addr string, req *tikvrpc.Request) (*tikvrpc.Response, error) {
 	childCtx, cancel := goctx.WithCancel(ctx)
 	cancel()
-	return c.Client.SendReq(childCtx, addr, req)
+	return c.Client.SendReq(childCtx, c.redirectAddr, req)
+}
+
+// mockTikvGrpcServer mock a tikv gprc server for testing.
+type mockTikvGrpcServer struct{}
+
+// KV commands with mvcc/txn supported.
+func (s *mockTikvGrpcServer) KvGet(goctx.Context, *kvrpcpb.GetRequest) (*kvrpcpb.GetResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvScan(goctx.Context, *kvrpcpb.ScanRequest) (*kvrpcpb.ScanResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvPrewrite(goctx.Context, *kvrpcpb.PrewriteRequest) (*kvrpcpb.PrewriteResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvCommit(goctx.Context, *kvrpcpb.CommitRequest) (*kvrpcpb.CommitResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvImport(goctx.Context, *kvrpcpb.ImportRequest) (*kvrpcpb.ImportResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvCleanup(goctx.Context, *kvrpcpb.CleanupRequest) (*kvrpcpb.CleanupResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvBatchGet(goctx.Context, *kvrpcpb.BatchGetRequest) (*kvrpcpb.BatchGetResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvBatchRollback(goctx.Context, *kvrpcpb.BatchRollbackRequest) (*kvrpcpb.BatchRollbackResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvScanLock(goctx.Context, *kvrpcpb.ScanLockRequest) (*kvrpcpb.ScanLockResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvResolveLock(goctx.Context, *kvrpcpb.ResolveLockRequest) (*kvrpcpb.ResolveLockResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) KvGC(goctx.Context, *kvrpcpb.GCRequest) (*kvrpcpb.GCResponse, error) {
+	return nil, errors.New("unreachable")
+}
+
+func (s *mockTikvGrpcServer) RawGet(goctx.Context, *kvrpcpb.RawGetRequest) (*kvrpcpb.RawGetResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) RawPut(goctx.Context, *kvrpcpb.RawPutRequest) (*kvrpcpb.RawPutResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) RawDelete(goctx.Context, *kvrpcpb.RawDeleteRequest) (*kvrpcpb.RawDeleteResponse, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) Coprocessor(goctx.Context, *coprocessor.Request) (*coprocessor.Response, error) {
+	return nil, errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) Raft(tikvpb.Tikv_RaftServer) error {
+	return errors.New("unreachable")
+}
+func (s *mockTikvGrpcServer) Snapshot(tikvpb.Tikv_SnapshotServer) error {
+	return errors.New("unreachable")
 }
 
 func (s *testRegionRequestSuite) TestNoReloadRegionForGrpcWhenCtxCanceled(c *C) {
-	sender := NewRegionRequestSender(s.cache, &cancelContextClient{newRPCClient()}, kvrpcpb.IsolationLevel_SI)
+	// prepare a mock tikv grpc server
+	addr := "localhost:56341"
+	lis, err := net.Listen("tcp", addr)
+	c.Assert(err, IsNil)
+	server := grpc.NewServer()
+	tikvpb.RegisterTikvServer(server, &mockTikvGrpcServer{})
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		server.Serve(lis)
+		wg.Done()
+	}()
+
+	client := &cancelContextClient{
+		Client:       newRPCClient(),
+		redirectAddr: addr,
+	}
+	sender := NewRegionRequestSender(s.cache, client, kvrpcpb.IsolationLevel_SI)
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawPut,
 		RawPut: &kvrpcpb.RawPutRequest{
@@ -163,7 +242,11 @@ func (s *testRegionRequestSuite) TestNoReloadRegionForGrpcWhenCtxCanceled(c *C) 
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 
-	_, err = sender.SendReq(s.bo, req, region.Region, time.Millisecond)
+	_, err = sender.SendReq(s.bo, req, region.Region, 3*time.Second)
 	c.Assert(grpc.Code(errors.Cause(err)), Equals, codes.Canceled)
 	c.Assert(s.cache.getRegionByIDFromCache(s.region), NotNil)
+
+	// cleanup
+	server.Stop()
+	wg.Wait()
 }


### PR DESCRIPTION
Hi,

This PR fixes bug seen in the production cluster. Log messages like 

```
2017/07/06 21:07:37 region_cache.go:419: [info] drop regions of store 49978 from cache due to request fail, err: rpc error: code = Canceled desc = context canceled
```

should not happen. It should not clean buffered store info from region cache when the context is canceled. 

Related to #3390 #3259