### PR TITLE
expression, plan: move typeinfer of agg funcs to expression rewriter

### DIFF
--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -556,7 +556,7 @@ func (af *avgFunction) Clone() AggregationFunction {
 func (af *avgFunction) GetType() *types.FieldType {
 	ft := types.NewFieldType(mysql.TypeNewDecimal)
 	types.SetBinChsClnFlag(ft)
-	ft.Decimal = af.Args[0].GetType().Decimal
+	ft.Flen, ft.Decimal = mysql.MaxRealWidth, af.Args[0].GetType().Decimal
 	return ft
 }
 

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -404,6 +404,7 @@ func (sf *sumFunction) CalculateDefaultValue(schema *Schema, ctx context.Context
 func (sf *sumFunction) GetType() *types.FieldType {
 	ft := types.NewFieldType(mysql.TypeNewDecimal)
 	types.SetBinChsClnFlag(ft)
+	ft.Flen = mysql.MaxRealWidth
 	ft.Decimal = sf.Args[0].GetType().Decimal
 	return ft
 }

--- a/expression/aggregation.go
+++ b/expression/aggregation.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/types"
 	tipb "github.com/pingcap/tipb/go-tipb"
 )
@@ -404,8 +403,7 @@ func (sf *sumFunction) CalculateDefaultValue(schema *Schema, ctx context.Context
 // GetType implements AggregationFunction interface.
 func (sf *sumFunction) GetType() *types.FieldType {
 	ft := types.NewFieldType(mysql.TypeNewDecimal)
-	ft.Charset = charset.CharsetBin
-	ft.Collate = charset.CollationBin
+	types.SetBinChsClnFlag(ft)
 	ft.Decimal = sf.Args[0].GetType().Decimal
 	return ft
 }
@@ -447,8 +445,7 @@ func (cf *countFunction) CalculateDefaultValue(schema *Schema, ctx context.Conte
 func (cf *countFunction) GetType() *types.FieldType {
 	ft := types.NewFieldType(mysql.TypeLonglong)
 	ft.Flen = 21
-	ft.Charset = charset.CharsetBin
-	ft.Collate = charset.CollationBin
+	types.SetBinChsClnFlag(ft)
 	return ft
 }
 
@@ -557,8 +554,7 @@ func (af *avgFunction) Clone() AggregationFunction {
 // GetType implements AggregationFunction interface.
 func (af *avgFunction) GetType() *types.FieldType {
 	ft := types.NewFieldType(mysql.TypeNewDecimal)
-	ft.Charset = charset.CharsetBin
-	ft.Collate = charset.CollationBin
+	types.SetBinChsClnFlag(ft)
 	ft.Decimal = af.Args[0].GetType().Decimal
 	return ft
 }

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -321,11 +321,6 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.PasswordFunc, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeVarString)
-		c.Assert(tp.Charset, Equals, charset.CharsetUTF8)
-		c.Assert(tp.Collate, Equals, charset.CollationUTF8)
-		c.Assert(tp.Flen, Equals, mysql.PWDHashLen+1)
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)
@@ -338,4 +333,8 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 			}
 		}
 	}
+
+	f, err := funcs[ast.PasswordFunc].getFunction([]Expression{Zero}, s.ctx)
+	c.Assert(err, IsNil)
+	c.Assert(f.isDeterministic(), IsTrue)
 }

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -193,11 +193,6 @@ func (s *testEvaluatorSuite) TestMD5(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.MD5, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeVarString)
-		c.Assert(tp.Charset, Equals, charset.CharsetUTF8)
-		c.Assert(tp.Collate, Equals, charset.CollationUTF8)
-		c.Assert(tp.Flen, Equals, 32)
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -19,8 +19,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -205,12 +205,6 @@ func (s *testEvaluatorSuite) TestLog2(c *C) {
 	for _, test := range tests {
 		f, err := newFunctionForTest(s.ctx, ast.Log2, primitiveValsToConstants([]interface{}{test.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeDouble)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 23)
 
 		result, err := f.Eval(nil)
 		if test.getErr {
@@ -495,12 +489,6 @@ func (s *testEvaluatorSuite) TestDegrees(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Degrees, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeDouble)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 23)
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/types"
@@ -555,12 +554,6 @@ func (s *testEvaluatorSuite) TestSin(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Sin, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeDouble)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 23)
 
 		d, err := f.Eval(nil)
 		if t.getErr {
@@ -597,12 +590,6 @@ func (s *testEvaluatorSuite) TestCos(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Cos, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeDouble)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 23)
 
 		d, err := f.Eval(nil)
 		if t.getErr {
@@ -713,12 +700,6 @@ func (s *testEvaluatorSuite) TestTan(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Tan, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeDouble)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 23)
 
 		d, err := f.Eval(nil)
 		if t.getErr {

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -1378,13 +1378,6 @@ func (s *testEvaluatorSuite) TestOrd(c *C) {
 		f, err := newFunctionForTest(s.ctx, ast.Ord, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
 
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeLonglong)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 10)
-
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -53,12 +53,6 @@ func (s *testEvaluatorSuite) TestLength(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Length, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeLonglong)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 10)
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)
@@ -98,13 +92,6 @@ func (s *testEvaluatorSuite) TestASCII(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.ASCII, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
-
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeLonglong)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 3)
 
 		d, err := f.Eval(nil)
 		if t.getErr {
@@ -168,13 +155,6 @@ func (s *testEvaluatorSuite) TestConcat(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, fcName, primitiveValsToConstants(t.args)...)
 		c.Assert(err, IsNil)
-		retType := f.GetType()
-		c.Assert(retType.Tp, Equals, t.retType.Tp)
-		c.Assert(retType.Charset, Equals, t.retType.Charset)
-		c.Assert(retType.Collate, Equals, t.retType.Collate)
-		c.Assert(retType.Flen, Equals, t.retType.Flen)
-		c.Assert(retType.Decimal, Equals, t.retType.Decimal)
-		c.Assert(retType.Flag, Equals, t.retType.Flag)
 		v, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)
@@ -403,12 +383,6 @@ func (s *testEvaluatorSuite) TestStrcmp(c *C) {
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Strcmp, primitiveValsToConstants(t.args)...)
 		c.Assert(err, IsNil)
-		tp := f.GetType()
-		c.Assert(tp.Tp, Equals, mysql.TypeLonglong)
-		c.Assert(tp.Charset, Equals, charset.CharsetBin)
-		c.Assert(tp.Collate, Equals, charset.CollationBin)
-		c.Assert(tp.Flag, Equals, uint(mysql.BinaryFlag))
-		c.Assert(tp.Flen, Equals, 2)
 		d, err := f.Eval(nil)
 		if t.getErr {
 			c.Assert(err, NotNil)

--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -129,33 +129,6 @@ func (v *typeInferrer) selectStmt(x *ast.SelectStmt) {
 	}
 }
 
-func (v *typeInferrer) aggregateFunc(x *ast.AggregateFuncExpr) {
-	name := strings.ToLower(x.F)
-	switch name {
-	case ast.AggFuncCount:
-		ft := types.NewFieldType(mysql.TypeLonglong)
-		ft.Flen = 21
-		types.SetBinChsClnFlag(ft)
-		x.SetType(ft)
-	case ast.AggFuncMax, ast.AggFuncMin:
-		x.SetType(x.Args[0].GetType())
-	case ast.AggFuncSum, ast.AggFuncAvg:
-		ft := types.NewFieldType(mysql.TypeNewDecimal)
-		types.SetBinChsClnFlag(ft)
-		ft.Decimal = x.Args[0].GetType().Decimal
-		x.SetType(ft)
-	case ast.AggFuncGroupConcat:
-		ft := types.NewFieldType(mysql.TypeVarString)
-		ft.Charset = v.defaultCharset
-		cln, err := charset.GetDefaultCollation(v.defaultCharset)
-		if err != nil {
-			v.err = err
-		}
-		ft.Collate = cln
-		x.SetType(ft)
-	}
-}
-
 func (v *typeInferrer) binaryOperation(x *ast.BinaryOperationExpr) {
 	switch x.Op {
 	case opcode.AndAnd, opcode.OrOr, opcode.LogicXor:

--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -14,8 +14,6 @@
 package expression
 
 import (
-	"strings"
-
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pingcap/tidb/ast"

--- a/expression/typeinferer.go
+++ b/expression/typeinferer.go
@@ -52,8 +52,6 @@ func (v *typeInferrer) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 
 func (v *typeInferrer) Leave(in ast.Node) (out ast.Node, ok bool) {
 	switch x := in.(type) {
-	case *ast.AggregateFuncExpr:
-		v.aggregateFunc(x)
 	case *ast.BetweenExpr:
 		x.SetType(types.NewFieldType(mysql.TypeLonglong))
 		types.SetBinChsClnFlag(&x.Type)

--- a/expression/typeinferer_test.go
+++ b/expression/typeinferer_test.go
@@ -124,7 +124,6 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 
 		// Functions
 		{"version()", mysql.TypeVarString, charset.CharsetUTF8, 0},
-		{"count(c_int)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag},
 		{"abs()", mysql.TypeNull, charset.CharsetBin, mysql.BinaryFlag},
 		{"abs(1)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag},
 		{"abs(1.1)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag},

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -91,7 +91,7 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 				ColName:     model.NewCIStr(fmt.Sprintf("%s_col_%d", agg.id, position)),
 				Position:    position,
 				IsAggOrSubq: true,
-				RetType:     aggFunc.GetType()})
+				RetType:     newFunc.GetType()})
 		}
 	}
 	for _, col := range p.Schema().Columns {

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -58,7 +58,7 @@ func (s *testPlanSuite) TestPushDownAggregation(c *C) {
 			sql:       "select sum(b) from t group by c",
 			best:      "Table(t)->HashAgg->Projection",
 			aggFuns:   "[sum(test.t.b)]",
-			aggFields: "[blob decimal BINARY]",
+			aggFields: "[blob decimal(23) BINARY]",
 			gbyItems:  "[test.t.c]",
 		},
 		{

--- a/plan/typeinfer_test.go
+++ b/plan/typeinfer_test.go
@@ -72,6 +72,10 @@ func (s *testPlanSuite) TestInferType(c *C) {
 		{"sin(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"tan(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"ascii(c_char)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 3, 0},
+		{"password(c_char)", mysql.TypeVarString, charset.CharsetUTF8, 0, mysql.PWDHashLen + 1, types.UnspecifiedLength},
+		{"ord(c_char)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 10, 0},
+		{"log2(c_int)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"degrees(c_int)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 	}
 	for _, tt := range tests {
 		ctx := testKit.Se.(context.Context)

--- a/plan/typeinfer_test.go
+++ b/plan/typeinfer_test.go
@@ -1,0 +1,85 @@
+package plan_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/context"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/plan"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/util/charset"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/types"
+)
+
+func (s *testPlanSuite) TestInferType(c *C) {
+	store, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	se, err := tidb.CreateSession(store)
+	c.Assert(err, IsNil)
+	defer func() {
+		testleak.AfterTest(c)()
+	}()
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	sql := `create table t (
+		c_int int,
+		c_bigint bigint,
+		c_float float,
+		c_double double,
+		c_decimal decimal(6, 3),
+		c_datetime datetime(2),
+		c_time time,
+		c_timestamp timestamp,
+		c_char char(20),
+		c_varchar varchar(20),
+		c_text text,
+		c_binary binary(20),
+		c_varbinary varbinary(20),
+		c_blob blob,
+		c_set set('a', 'b', 'c'),
+		c_enum enum('a', 'b', 'c'))`
+	testKit.MustExec(sql)
+
+	tests := []struct {
+		sql     string
+		tp      byte
+		chs     string
+		flag    byte
+		flen    int
+		decimal int
+	}{
+		{"sum(c_int)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"strcmp(c_char, c_char)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 2, 0},
+		{"concat(c_binary, c_int)", mysql.TypeVarString, charset.CharsetBin, mysql.BinaryFlag, 31, types.UnspecifiedLength},
+		{"cos(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"sin(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"tan(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+	}
+	for _, tt := range tests {
+		ctx := testKit.Se.(context.Context)
+		sql := "select " + tt.sql + " from t"
+		comment := Commentf("for %s", sql)
+		stmt, err := s.ParseOneStmt(sql, "", "")
+		c.Assert(err, IsNil, comment)
+
+		err = se.NewTxn()
+		c.Assert(err, IsNil)
+
+		is := sessionctx.GetDomain(ctx).InfoSchema()
+		err = plan.ResolveName(stmt, is, ctx)
+		c.Assert(err, IsNil)
+		p, err := plan.BuildLogicalPlan(ctx, stmt, is)
+		c.Assert(err, IsNil)
+		tp := p.Schema().Columns[0].RetType
+
+		c.Assert(tp.Tp, Equals, tt.tp, comment)
+		c.Assert(tp.Charset, Equals, tt.chs, comment)
+		c.Assert(tp.Flag^uint(tt.flag), Equals, uint(0x0), comment)
+		c.Assert(tp.Flen, Equals, tt.flen, comment)
+		c.Assert(tp.Decimal, Equals, tt.decimal, comment)
+	}
+}

--- a/plan/typeinfer_test.go
+++ b/plan/typeinfer_test.go
@@ -1,3 +1,16 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package plan_test
 
 import (

--- a/plan/typeinfer_test.go
+++ b/plan/typeinfer_test.go
@@ -76,6 +76,7 @@ func (s *testPlanSuite) TestInferType(c *C) {
 		{"ord(c_char)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 10, 0},
 		{"log2(c_int)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"degrees(c_int)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"md5(c_int)", mysql.TypeVarString, charset.CharsetUTF8, 0, 32, types.UnspecifiedLength},
 	}
 	for _, tt := range tests {
 		ctx := testKit.Se.(context.Context)

--- a/plan/typeinfer_test.go
+++ b/plan/typeinfer_test.go
@@ -58,6 +58,7 @@ func (s *testPlanSuite) TestInferType(c *C) {
 		{"cos(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"sin(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"tan(c_double)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"ascii(c_char)", mysql.TypeLonglong, charset.CharsetBin, mysql.BinaryFlag, 3, 0},
 	}
 	for _, tt := range tests {
 		ctx := testKit.Se.(context.Context)


### PR DESCRIPTION
we try to move typeinfer process from expression/typeinferer.go to plan/expression_rewriter.go
avoid traversing ast tree twice.

PTAL @hanfei1991 