### PR TITLE
ddl: disable alter table modify enum column

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1033,6 +1033,8 @@ func modifiable(origin *types.FieldType, to *types.FieldType) error {
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 			return nil
 		}
+	case mysql.TypeEnum:
+		return errUnsupportedModifyColumn.GenByArgs("modify enum column is not supported")
 	default:
 		if origin.Tp == to.Tp {
 			return nil

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -825,6 +825,8 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	c.Assert(colC.Comment, Equals, "col c comment")
 	hasNotNull = tmysql.HasNotNullFlag(colC.Flag)
 	c.Assert(hasNotNull, IsFalse)
+	// for enum
+	s.mustExec(c, "alter table t3 add column en enum('a', 'b', 'c') not null default 'a'")
 
 	// for failing tests
 	sql := "alter table t3 change aa a bigint default ''"
@@ -834,6 +836,8 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	sql = "alter table t3 change t.a aa bigint"
 	s.testErrorCode(c, sql, tmysql.ErrWrongTableName)
 	sql = "alter table t3 change aa a bigint not null"
+	s.testErrorCode(c, sql, tmysql.ErrUnknown)
+	sql = "alter table t3 modify en enum('a', 'z', 'b', 'c') not null default 'a'"
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
 }
 


### PR DESCRIPTION
In the issue https://github.com/pingcap/tidb/issues/3630, if we want data updated after the alter table statement, 
ddl have to update all values when reorganize, which is not supported currently.

So I prefer to disable alter table modify enum column now.