### PR TITLE
tidb/privilege/privileges: make show databases available with any global privilege

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -165,7 +165,7 @@ func (s *testSuite) TestShowVisibility(c *C) {
 	c.Assert(rows, HasLen, 0)
 
 	// Grant any global privilege would make show databases available.
-	tk.MustExec(`grant select on *.* to 'show'@'%'`)
+	tk.MustExec(`grant CREATE on *.* to 'show'@'%'`)
 	tk.MustExec(`flush privileges`)
 	rs, err = se.Execute("show databases")
 	c.Assert(err, IsNil)

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -155,6 +155,24 @@ func (s *testSuite) TestShowVisibility(c *C) {
 	// The user can see t2 but not t1.
 	c.Assert(rows, HasLen, 1)
 
+	// After revoke, show database result should be empty.
+	tk.MustExec(`revoke select on showdatabase.t1 from 'show'@'%'`)
+	tk.MustExec(`flush privileges`)
+	rs, err = se.Execute("show databases")
+	c.Assert(err, IsNil)
+	rows, err = tidb.GetRows(rs[0])
+	c.Assert(err, IsNil)
+	c.Assert(rows, HasLen, 0)
+
+	// Grant any global privilege would make show databases available.
+	tk.MustExec(`grant select on *.* to 'show'@'%'`)
+	tk.MustExec(`flush privileges`)
+	rs, err = se.Execute("show databases")
+	c.Assert(err, IsNil)
+	rows, err = tidb.GetRows(rs[0])
+	c.Assert(err, IsNil)
+	c.Assert(len(rows), GreaterEqual, 1)
+
 	privileges.Enable = save
 	tk.MustExec(`drop user 'show'@'%'`)
 	tk.MustExec("drop database showdatabase")

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -430,7 +430,7 @@ func (p *MySQLPrivilege) RequestVerification(user, host, db, table, column strin
 // DBIsVisible checks whether the user can see the db.
 func (p *MySQLPrivilege) DBIsVisible(user, host, db string) bool {
 	if record := p.matchUser(user, host); record != nil {
-		if record.Privileges&mysql.ShowDBPriv > 0 {
+		if record.Privileges != 0 {
 			return true
 		}
 	}


### PR DESCRIPTION
For issue https://github.com/pingcap/tidb/issues/3656
In the old code, `show databases` returns non-empty result when the user has ShowDBPriv,
now it's change to **any global privilege**.

Ref: https://dev.mysql.com/doc/refman/5.7/en/show-databases.html
The actual behavior is not the same as it says:

> You see only those databases for which you have some kind of privilege, unless you have the global SHOW DATABASES privilege. 

@zimulala @hanfei1991 @shenli @XuHuaiyu 