### PR TITLE
privilege/privileges: skip privilege check for information_schema database

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -435,6 +435,11 @@ func (p *MySQLPrivilege) DBIsVisible(user, host, db string) bool {
 		}
 	}
 
+	// INFORMATION_SCHEMA is visible to all users.
+	if strings.EqualFold(db, "INFORMATION_SCHEMA") {
+		return true
+	}
+
 	if record := p.matchDB(user, host, db); record != nil {
 		if record.Privileges > 0 {
 			return true

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -63,6 +63,12 @@ func (p *UserPrivileges) RequestVerification(db, table, column string, priv mysq
 		return true
 	}
 
+	// Skip check for INFORMATION_SCHEMA database.
+	// See https://dev.mysql.com/doc/refman/5.7/en/information-schema.html
+	if strings.EqualFold(db, "INFORMATION_SCHEMA") {
+		return true
+	}
+
 	mysqlPriv := p.Handle.Get()
 	return mysqlPriv.RequestVerification(p.user, p.host, db, table, column, priv)
 }

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -53,7 +53,7 @@ type testPrivilegeSuite struct {
 	createColumnPrivTableSQL string
 }
 
-func (s *testPrivilegeSuite) SetUpSuit(c *C) {
+func (s *testPrivilegeSuite) SetUpSuite(c *C) {
 	logLevel := os.Getenv("log_level")
 	log.SetLevelByString(logLevel)
 }
@@ -260,6 +260,22 @@ func (s *testPrivilegeSuite) TestCheckAuthenticate(c *C) {
 	salt := []byte{85, 92, 45, 22, 58, 79, 107, 6, 122, 125, 58, 80, 12, 90, 103, 32, 90, 10, 74, 82}
 	auth := []byte{24, 180, 183, 225, 166, 6, 81, 102, 70, 248, 199, 143, 91, 204, 169, 9, 161, 171, 203, 33}
 	c.Assert(se.Auth("u2@localhost", auth, salt), IsTrue)
+
+	se1 := newSession(c, s.store, s.dbName)
+	mustExec(c, se1, "drop user 'u1'@'localhost'")
+	mustExec(c, se1, "drop user 'u2'@'localhost'")
+}
+
+func (s *testPrivilegeSuite) TestInformationSchema(c *C) {
+	defer testleak.AfterTest(c)()
+
+	// This test tests no privilege check for INFORMATION_SCHEMA database.
+	se := newSession(c, s.store, s.dbName)
+	mustExec(c, se, `CREATE USER 'u1'@'localhost';`)
+	mustExec(c, se, `FLUSH PRIVILEGES;`)
+	c.Assert(se.Auth("u1@localhost", nil, nil), IsTrue)
+	mustExec(c, se, `select * from information_schema.tables`)
+	mustExec(c, se, `select * from information_schema.key_column_usage`)
 }
 
 func mustExec(c *C, se tidb.Session, sql string) {


### PR DESCRIPTION
Now visit information_schema database won't check privilege, and `show databases`
always return it.

> Each MySQL user has the right to access these tables, but can see only the rows in the tables that correspond to objects for which the user has the proper access privileges. In some cases (for example, the ROUTINE_DEFINITION column in the INFORMATION_SCHEMA.ROUTINES table), users who have insufficient privileges see NULL. These restrictions do not apply for InnoDB tables; you can see them with only the PROCESS privilege.

See https://dev.mysql.com/doc/refman/5.7/en/information-schema.html

@shenli @zimulala 