### PR TITLE
*: support show stats_histograms

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -945,6 +945,7 @@ const (
 	ShowCreateDatabase
 	ShowEvents
 	ShowStatsMeta
+	ShowStatsHistogram
 )
 
 // ShowStmt is a statement to provide information about databases, tables, columns and so on.

--- a/executor/show.go
+++ b/executor/show.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
@@ -114,6 +115,8 @@ func (e *ShowExec) fetchAll() error {
 		// empty result
 	case ast.ShowStatsMeta:
 		return e.fetchShowStatsMeta()
+	case ast.ShowStatsHistogram:
+		return e.fetchShowStatsHistogram()
 	}
 	return nil
 }
@@ -637,12 +640,11 @@ func (e *ShowExec) fetchShowStatsMeta() error {
 		for _, tbl := range db.Tables {
 			statsTbl := h.GetTableStats(tbl.ID)
 			if !statsTbl.Pseudo {
-				t := time.Unix(0, oracle.ExtractPhysical(statsTbl.Version)*int64(time.Millisecond))
 				row := &Row{
 					Data: types.MakeDatums(
 						db.Name.O,
 						tbl.Name.O,
-						types.Time{Time: types.FromGoTime(t), Type: mysql.TypeDatetime},
+						e.versionToTime(statsTbl.Version),
 						statsTbl.ModifyCount,
 						statsTbl.Count,
 					),
@@ -652,4 +654,43 @@ func (e *ShowExec) fetchShowStatsMeta() error {
 		}
 	}
 	return nil
+}
+
+func (e *ShowExec) fetchShowStatsHistogram() error {
+	do := sessionctx.GetDomain(e.ctx)
+	h := do.StatsHandle()
+	dbs := do.InfoSchema().AllSchemas()
+	for _, db := range dbs {
+		for _, tbl := range db.Tables {
+			statsTbl := h.GetTableStats(tbl.ID)
+			if !statsTbl.Pseudo {
+				for _, col := range statsTbl.Columns {
+					e.rows = append(e.rows, e.histogramToRow(db.Name.O, tbl.Name.O, col.Info.Name.O, 0, col.Histogram))
+				}
+				for _, idx := range statsTbl.Indices {
+					e.rows = append(e.rows, e.histogramToRow(db.Name.O, tbl.Name.O, idx.Info.Name.O, 1, idx.Histogram))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (e *ShowExec) histogramToRow(dbName string, tblName string, colName string, isIndex int, hist statistics.Histogram) *Row {
+	return &Row{
+		Data: types.MakeDatums(
+			dbName,
+			tblName,
+			colName,
+			isIndex,
+			e.versionToTime(hist.LastUpdateVersion),
+			hist.NDV,
+			hist.NullCount,
+		),
+	}
+}
+
+func (e *ShowExec) versionToTime(version uint64) types.Time {
+	t := time.Unix(0, oracle.ExtractPhysical(version)*int64(time.Millisecond))
+	return types.Time{Time: types.FromGoTime(t), Type: mysql.TypeDatetime}
 }

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -264,6 +264,7 @@ func (s *testSuite) TestShowWarnings(c *C) {
 func (s *testSuite) TestShowStatsMeta(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t1")
 	tk.MustExec("create table t (a int, b int)")
 	tk.MustExec("create table t1 (a int, b int)")
 	tk.MustExec("analyze table t, t1")
@@ -282,4 +283,19 @@ func (s *testSuite) TestIssue3641(c *C) {
 	c.Assert(err.Error(), Equals, plan.ErrNoDB.Error())
 	_, err = tk.Exec("show table status;")
 	c.Assert(err.Error(), Equals, plan.ErrNoDB.Error())
+}
+
+func (s *testSuite) TestShowStatsHistogram(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("analyze table t")
+	result := tk.MustQuery("show stats_histogram").Sort()
+	c.Assert(len(result.Rows()), Equals, 2)
+	c.Assert(result.Rows()[0][2], Equals, "a")
+	c.Assert(result.Rows()[1][2], Equals, "b")
+	result = tk.MustQuery("show stats_histogram where column_name = 'a'")
+	c.Assert(len(result.Rows()), Equals, 1)
+	c.Assert(result.Rows()[0][2], Equals, "a")
 }

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -429,6 +429,7 @@ var tokenMap = map[string]int{
 	"START":                      start,
 	"STARTING":                   starting,
 	"STATS":                      stats,
+	"STATS_HISTOGRAM":            statsHistogram,
 	"STATS_META":                 statsMeta,
 	"STATS_PERSISTENT":           statsPersistent,
 	"STATUS":                     status,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -504,6 +504,7 @@ import (
 	sqlNoCache	"SQL_NO_CACHE"
 	start		"START"
 	stats		"STATS"
+	statsHistogram	"STATS_HISTOGRAM"
 	statsMeta	"STATS_META"
 	status		"STATUS"
 	super		"SUPER"
@@ -2365,7 +2366,7 @@ UnReservedKeyword:
 | "MIN_ROWS" | "NATIONAL" | "ROW" | "ROW_FORMAT" | "QUARTER" | "GRANTS" | "TRIGGERS" | "DELAY_KEY_WRITE" | "ISOLATION" | "JSON"
 | "REPEATABLE" | "COMMITTED" | "UNCOMMITTED" | "ONLY" | "SERIALIZABLE" | "LEVEL" | "VARIABLES" | "SQL_CACHE" | "INDEXES" | "PROCESSLIST"
 | "SQL_NO_CACHE" | "DISABLE"  | "ENABLE" | "REVERSE" | "SPACE" | "PRIVILEGES" | "NO" | "BINLOG" | "FUNCTION" | "VIEW" | "MODIFY" | "EVENTS" | "PARTITIONS"
-| "TIMESTAMPDIFF" | "NONE" | "SUPER" | "SHARED" | "EXCLUSIVE" | "STATS" | "STATS_META"
+| "TIMESTAMPDIFF" | "NONE" | "SUPER" | "SHARED" | "EXCLUSIVE" | "STATS" | "STATS_META" | "STATS_HISTOGRAM"
 
 ReservedKeyword:
 "ADD" | "ALL" | "ALTER" | "ANALYZE" | "AND" | "AS" | "ASC" | "BETWEEN" | "BIGINT"
@@ -5122,6 +5123,20 @@ ShowStmt:
 	{
 		stmt := &ast.ShowStmt{
 			Tp: ast.ShowStatsMeta,
+		}
+		if $3 != nil {
+			if x, ok := $3.(*ast.PatternLikeExpr); ok {
+				stmt.Pattern = x
+			} else {
+				stmt.Where = $3.(ast.ExprNode)
+			}
+		}
+		$$ = stmt
+	}
+|	"SHOW" "STATS_HISTOGRAM" ShowLikeOrWhereOpt
+	{
+		stmt := &ast.ShowStmt{
+			Tp: ast.ShowStatsHistogram,
 		}
 		if $3 != nil {
 			if x, ok := $3.(*ast.PatternLikeExpr); ok {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -93,7 +93,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"enable", "disable", "reverse", "space", "privileges", "get_lock", "release_lock", "sleep", "no", "greatest", "least",
 		"binlog", "hex", "unhex", "function", "indexes", "from_unixtime", "processlist", "events", "less", "than", "timediff",
 		"ln", "log", "log2", "log10", "timestampdiff", "pi", "quote", "none", "super", "default", "shared", "exclusive",
-		"always", "stats", "stats_meta",
+		"always", "stats", "stats_meta", "stats_histogram",
 	}
 	for _, kw := range unreservedKws {
 		src := fmt.Sprintf("SELECT %s FROM tbl;", kw)
@@ -409,6 +409,9 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		// for show stats_meta.
 		{"show stats_meta", true},
 		{"show stats_meta where table_name = 't'", true},
+		// for show stats_histogram
+		{"show stats_histogram", true},
+		{"show stats_histogram where col_name = 'a'", true},
 
 		// set
 		// user defined

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -1074,6 +1074,10 @@ func buildShowSchema(s *ast.ShowStmt) (schema *expression.Schema) {
 	case ast.ShowStatsMeta:
 		names = []string{"Db_name", "Table_name", "Update_time", "Modify_count", "Row_count"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeDatetime, mysql.TypeLonglong, mysql.TypeLonglong}
+	case ast.ShowStatsHistogram:
+		names = []string{"Db_name", "Table_name", "Column_name", "Is_index", "Update_time", "Distinct_count", "Null_count"}
+		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeTiny, mysql.TypeDatetime,
+			mysql.TypeLonglong, mysql.TypeLonglong}
 	}
 	return composeShowSchema(names, ftypes)
 }

--- a/plan/resolver.go
+++ b/plan/resolver.go
@@ -964,6 +964,10 @@ func (nr *nameResolver) fillShowFields(s *ast.ShowStmt) {
 	case ast.ShowStatsMeta:
 		names = []string{"Db_name", "Table_name", "Update_time", "Modify_count", "Row_count"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeDatetime, mysql.TypeLonglong, mysql.TypeLonglong}
+	case ast.ShowStatsHistogram:
+		names = []string{"Db_name", "Table_name", "Column_name", "Is_index", "Update_time", "Distinct_count", "Null_count"}
+		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeTiny, mysql.TypeDatetime,
+			mysql.TypeLonglong, mysql.TypeLonglong}
 	}
 	for i, name := range names {
 		f := &ast.ResultField{


### PR DESCRIPTION
The syntax is `show stats_histograms` or `show stats_histograms where ...`.
For example:
```
MySQL [test]> show stats_histograms;
+---------+------------+-------------+----------+---------------------+----------------+------------+
| Db_name | Table_name | Column_name | Is_index | Update_time         | Distinct_count | Null_count |
+---------+------------+-------------+----------+---------------------+----------------+------------+
| test    | t          | a           |        0 | 2017-07-10 14:14:18 |              1 |          0 |
| test    | t          | b           |        0 | 2017-07-10 14:32:08 |              2 |          0 |
| test    | t          | idx         |        1 | 2017-07-10 14:32:08 |              2 |          0 |
+---------+------------+-------------+----------+---------------------+----------------+------------+
```

PTAL @hanfei1991  @zimulala  @winoros 
