### PR TITLE
privilege/privileges: fix a data race in test code

### DIFF
--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -15,10 +15,8 @@ package privileges_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
-	"github.com/ngaut/log"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/context"

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -54,8 +54,6 @@ type testPrivilegeSuite struct {
 }
 
 func (s *testPrivilegeSuite) SetUpSuite(c *C) {
-	logLevel := os.Getenv("log_level")
-	log.SetLevelByString(logLevel)
 }
 
 func (s *testPrivilegeSuite) SetUpTest(c *C) {


### PR DESCRIPTION
I fix a typo s/SetUpSuit/SetUpSuite in https://github.com/pingcap/tidb/pull/3675
After that, make race fail because ddl and privilege/privileges unit test run concurrently, one of them is setting log level and the other is using it.