### PR TITLE
server: escape database name "use `xxx`" in OpenCtx

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -130,7 +130,7 @@ func (qd *TiDBDriver) OpenCtx(connID uint64, capability uint32, collation uint8,
 	session.SetClientCapability(capability)
 	session.SetConnectionID(connID)
 	if dbname != "" {
-		_, err = session.Execute("use " + dbname)
+		_, err = session.Execute(fmt.Sprintf("use `%s`", dbname))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -160,3 +160,17 @@ func (ts *TidbTestSuite) TestIssue3680(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "Error 1045: Access denied for user 'non_existing_user'@'127.0.0.1' (using password: YES)")
 }
+
+func (ts *TidbTestSuite) TestDBNameEscape(c *C) {
+	c.Parallel()
+	runTests(c, dsn, func(dbt *DBTest) {
+		dbt.mustExec("create database `aa-a`;")
+	})
+	// The database name is aa-a, '-' is not permitted as identifier, it should be `aa-a` to be a legal sql.
+	db, err := sql.Open("mysql", "root@tcp(127.0.0.1:4001)/aa-a")
+	c.Assert(err, IsNil)
+	defer db.Close()
+	c.Assert(db.Ping(), IsNil)
+	_, err = db.Exec("drop database `aa-a`")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
```
➜  bin git:(master) ✗   mysql -h 127.0.0.1 -u root -P 4001 -D aa-b
ERROR 2013 (HY000): Lost connection to MySQL server at 'reading authorization packet'
```
