### PR TITLE
ddl/table: make DDL operation run normally

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1279,6 +1279,6 @@ func (s *testDBSuite) TestChangePK(c *C) {
 	s.tk.MustExec("alter table change_column_pk modify column id int not null")
 	sql := "alter table change_column_pk add index idx(id)"
 	_, err := s.tk.Exec(sql)
-	c.Assert(err, NotNil)
+	c.Assert(terror.ErrorEqual(err, table.ErrMissColumn), IsTrue)
 	s.tk.MustExec("drop table change_column_pk")
 }

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1269,3 +1269,16 @@ func (s *testDBSuite) TestGeneratedColumnDDL(c *C) {
 	result = s.tk.MustQuery(`DESC test_gv_ddl`)
 	result.Check(testkit.Rows(`a int(11) YES  <nil> `, `b bigint(21) YES  <nil> VIRTUAL GENERATED`, `cnew bigint(21) YES  <nil> `))
 }
+
+func (s *testDBSuite) TestChangePK(c *C) {
+	defer testleak.AfterTest(c)()
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use test")
+	s.tk.MustExec("create table change_column_pk (id int primary key not null, c int)")
+	s.tk.MustExec("insert into change_column_pk values(1,2)")
+	s.tk.MustExec("alter table change_column_pk modify column id int not null")
+	sql := "alter table change_column_pk add index idx(id)"
+	_, err := s.tk.Exec(sql)
+	c.Assert(err, NotNil)
+	s.tk.MustExec("drop table change_column_pk")
+}

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -572,6 +572,9 @@ func (d *ddl) addTableIndex(t table.Table, indexInfo *model.IndexInfo, reorgInfo
 		if err != nil {
 			log.Warnf("[ddl] total added index for %d rows, this task add index for %d failed, take time %v",
 				addedCount, taskAddedCount, sub)
+			if terror.ErrorEqual(errors.Cause(err), table.ErrMissColumn) {
+				job.State = model.JobCancelled
+			}
 			return errors.Trace(err)
 		}
 		d.setReorgRowCount(addedCount)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -572,7 +572,7 @@ func (d *ddl) addTableIndex(t table.Table, indexInfo *model.IndexInfo, reorgInfo
 		if err != nil {
 			log.Warnf("[ddl] total added index for %d rows, this task add index for %d failed, take time %v",
 				addedCount, taskAddedCount, sub)
-			if terror.ErrorEqual(errors.Cause(err), table.ErrMissColumn) {
+			if terror.ErrorEqual(err, table.ErrMissColumn) {
 				job.State = model.JobCancelled
 			}
 			return errors.Trace(err)

--- a/table/table.go
+++ b/table/table.go
@@ -55,6 +55,8 @@ var (
 	ErrInvalidRecordKey = terror.ClassTable.New(codeInvalidRecordKey, "invalid record key")
 	// ErrTruncateWrongValue returns for truncate wrong value for field.
 	ErrTruncateWrongValue = terror.ClassTable.New(codeTruncateWrongValue, "Incorrect value")
+	// ErrMissColumn returns for column missed.
+	ErrMissColumn = terror.ClassTable.New(codeMissColumn, "Miss column")
 )
 
 // RecordIterFunc is used for low-level record iteration.
@@ -138,6 +140,7 @@ const (
 	codeColumnStateNonPublic = 7
 	codeIndexStateCantNone   = 8
 	codeInvalidRecordKey     = 9
+	codeMissColumn           = 10
 
 	codeColumnCantNull     = 1048
 	codeUnknownColumn      = 1054

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -663,7 +663,7 @@ func (t *Table) IterRecords(ctx context.Context, startKey kv.Key, cols []*table.
 func GetColDefaultValue(ctx context.Context, col *table.Column, defaultVals []types.Datum) (
 	colVal types.Datum, err error) {
 	if col.OriginDefaultValue == nil && mysql.HasNotNullFlag(col.Flag) {
-		return colVal, errors.New("Miss column")
+		return colVal, errors.Trace(table.ErrMissColumn)
 	}
 	if col.State != model.StatePublic {
 		return colVal, nil


### PR DESCRIPTION
We don't support using `change column` operation to drop PK. But we don't stop this operation, then it will make the operation of `add index` failed and other DDLs can't be handled. This PR make it can be run.