### PR TITLE
tidb: Return immediately after upgrading

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -184,6 +184,7 @@ func bootstrap(s Session) {
 	}
 	if b {
 		upgrade(s)
+		return
 	}
 	doDDLWorks(s)
 	doDMLWorks(s)


### PR DESCRIPTION
If the store is already bootstrapped, we should only call upgrade(). doDDLWorks and doDMLWorks are used for full bootstrap work.
@tiancaiamao @zimulala @hanfei1991  PTAL