### PR TITLE
executor, plan: refine typeinfer when UNION

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -546,6 +546,12 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec("CREATE TABLE t (a int, b int)")
 	tk.MustExec("INSERT INTO t VALUES ('1', '1')")
 	r = tk.MustQuery("select b from (SELECT * FROM t UNION ALL SELECT a, b FROM t order by a) t")
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (a DECIMAL(4,2))")
+	tk.MustExec("INSERT INTO t VALUE(12.34)")
+	r = tk.MustQuery("SELECT 1 AS c UNION select a FROM t")
+	r.Check(testkit.Rows("1.00", "12.34"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -494,13 +494,10 @@ func (b *planBuilder) buildUnion(union *ast.UnionStmt) LogicalPlan {
 			 */
 			schemaTp := firstSchema.Columns[i].RetType
 			colTp := col.RetType
-			schemaTp.Decimal = mathutil.Max(schemaTp.Decimal, colTp.Decimal)
-			schemaTp.Flen = mathutil.Max(colTp.Flen-colTp.Decimal, schemaTp.Flen-schemaTp.Flen) + schemaTp.Decimal
-			// For select nul union select "abc", we should not convert "abc" to nil.
-			// And the result field type should be VARCHAR.
-			if firstSchema.Columns[i].RetType.Tp == 0 || firstSchema.Columns[i].RetType.Tp == mysql.TypeNull {
-				firstSchema.Columns[i].RetType.Tp = col.RetType.Tp
-			}
+			schemaTp.Decimal = mathutil.Max(colTp.Decimal, schemaTp.Decimal)
+			// `Flen - Decimal` is the fraction before '.'
+			schemaTp.Flen = mathutil.Max(colTp.Flen-colTp.Decimal, schemaTp.Flen-schemaTp.Decimal) + schemaTp.Decimal
+			schemaTp.Tp = types.MergeFieldType(schemaTp.Tp, colTp.Tp)
 		}
 		sel.SetParents(u)
 	}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cznic/mathutil"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
@@ -491,9 +492,10 @@ func (b *planBuilder) buildUnion(union *ast.UnionStmt) LogicalPlan {
 			 * | bbbbbbbbbb    |
 			 * +---------------+
 			 */
-			if col.RetType.Flen > firstSchema.Columns[i].RetType.Flen {
-				firstSchema.Columns[i].RetType.Flen = col.RetType.Flen
-			}
+			schemaTp := firstSchema.Columns[i].RetType
+			colTp := col.RetType
+			schemaTp.Decimal = mathutil.Max(schemaTp.Decimal, colTp.Decimal)
+			schemaTp.Flen = mathutil.Max(colTp.Flen-colTp.Decimal, schemaTp.Flen-schemaTp.Flen) + schemaTp.Decimal
 			// For select nul union select "abc", we should not convert "abc" to nil.
 			// And the result field type should be VARCHAR.
 			if firstSchema.Columns[i].RetType.Tp == 0 || firstSchema.Columns[i].RetType.Tp == mysql.TypeNull {


### PR DESCRIPTION
Before this commit,

``` sql
create table t (a decimal(4, 2));
insert into t value(12.34)
```

In MySQL:
``` sql
mysql> select 1 as c union select a from t;
+-------+
| c     |
+-------+
|  1.00 |
| 12.34 |
+-------+
2 rows in set (0.01 sec)
```

In TiDB:
``` sql
mysql> select 1 as c union select a from t;
+-------+
| c     |
+-------+
|  1 |
| 12 |
+-------+
2 rows in set (0.01 sec)
```

PTAL @shenli @hanfei1991 @zz-jason 