### PR TITLE
expression, json: fix a bug of json_unquote.

### DIFF
--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -175,7 +175,10 @@ func JSONUnquote(args []types.Datum, sc *variable.StatementContext) (d types.Dat
 	}
 	djson, err := datum2JSON(args[0], sc)
 	if err != nil {
-		return d, errors.Trace(err)
+		djson, err = args[0].ToMysqlJSON()
+		if err != nil {
+			return d, errors.Trace(err)
+		}
 	}
 	unquoted, err := djson.Unquote()
 	if err != nil {

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -60,6 +60,7 @@ func (s *testEvaluatorSuite) TestJSONUnquote(c *C) {
 		{`{"a": "b"}`, `{"a":"b"}`},
 		{`"hello,\"quoted string\",world"`, `hello,"quoted string",world`},
 		{`"hello,\"宽字符\",world"`, `hello,"宽字符",world`},
+		{`Invalid Json string\tis OK`, `Invalid Json string	is OK`},
 	}
 	dtbl := tblToDtbl(tbl)
 	for _, t := range dtbl {


### PR DESCRIPTION
for this statement:
```sql
select json_unquote("Invalid json string");
```
Previously it will cause fail, but in MySQL it should success.
This PR is for fix this.