### PR TITLE
domain: shorten the period of stats dump.

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -502,7 +502,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
 	if lease <= 0 {
 		return nil
 	}
-	deltaUpdateDuration := time.Minute
+	deltaUpdateDuration := lease * 5
 	go func(do *Domain) {
 		loadTicker := time.NewTicker(lease)
 		defer loadTicker.Stop()

--- a/tidb.go
+++ b/tidb.go
@@ -102,7 +102,7 @@ var (
 	schemaLease = 1 * time.Second
 
 	// statsLease is the time for reload stats table.
-	statsLease = 1 * time.Second
+	statsLease = 3 * time.Second
 
 	// The maximum number of retries to recover from retryable errors.
 	commitRetryLimit = 10


### PR DESCRIPTION
In past we dumped stats count every one minute, which cannot be configured. Now we shorten it to 5 times of lease, which is 15 secs by default.