### PR TITLE
when svr doest not return error it is not needed to log it.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CURDIR := $(shell pwd)
 path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(CURDIR)/_vendor:$(GOPATH)))
 export PATH := $(path_to_add):$(PATH)
 
-GO        := GO15VENDOREXPERIMENT="1" go
+GO        := go
 GOBUILD   := GOPATH=$(CURDIR)/_vendor:$(GOPATH) CGO_ENABLED=0 $(GO) build
 GOTEST    := GOPATH=$(CURDIR)/_vendor:$(GOPATH) CGO_ENABLED=1 $(GO) test
 OVERALLS  := GOPATH=$(CURDIR)/_vendor:$(GOPATH) CGO_ENABLED=1 overalls

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -173,7 +173,9 @@ func main() {
 
 	pushMetric(*metricsAddr, time.Duration(*metricsInterval)*time.Second)
 
-	log.Error(svr.Run())
+	if err := svr.Run(); err != nil {
+		log.Error(err)
+	}
 	domain.Close()
 	os.Exit(0)
 }


### PR DESCRIPTION
Two things in one PR. 
1. Make shut down more gracefully. 
2. remove vendor flag since we are using go 1.7 already. It is meaningless still use that flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/3785)
<!-- Reviewable:end -->
