### PR TITLE
schema info not support unsigned

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -686,7 +686,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 		if decimal == types.UnspecifiedLength {
 			decimal = 0
 		}
-		columnType := col.FieldType.CompactStr()
+		columnType := col.FieldType.InfoSchemaStr()
 		columnDesc := table.NewColDesc(table.ToColumn(col))
 		var columnDefault interface{}
 		if columnDesc.DefaultValue != nil {

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -149,6 +149,15 @@ func (ft *FieldType) CompactStr() string {
 	return ts + suffix
 }
 
+// Add unsigned for support infoschme
+func (ft *FieldType) InfoSchemaStr() string {
+	suffix := ""
+	if mysql.HasUnsignedFlag(ft.Flag) {
+		suffix = " unsigned"
+	}
+	return ft.CompactStr() + suffix
+}
+
 // String joins the information of FieldType and
 // returns a string.
 func (ft *FieldType) String() string {

--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -149,7 +149,7 @@ func (ft *FieldType) CompactStr() string {
 	return ts + suffix
 }
 
-// Add unsigned for support infoschme
+// Add unsigned for support infoschema
 func (ft *FieldType) InfoSchemaStr() string {
 	suffix := ""
 	if mysql.HasUnsignedFlag(ft.Flag) {

--- a/util/types/field_type_test.go
+++ b/util/types/field_type_test.go
@@ -36,6 +36,7 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	ft.Tp = mysql.TypeLong
 	ft.Flag |= mysql.UnsignedFlag | mysql.ZerofillFlag
 	c.Assert(ft.String(), Equals, "int(5) UNSIGNED ZEROFILL")
+	c.Assert(ft.InfoSchemaStr(), Equals, "int(5) unsigned")
 
 	ft = NewFieldType(mysql.TypeFloat)
 	ft.Flen = 10


### PR DESCRIPTION
When execute sql to get column's info from INFOMATION_SCHEMA.COLUMNS, the COLUMN_TYPE is like bigint(64), ignoring the unsigned flag. But mysql keeps the unsigned flag.

It's important for me to do table's auto migrate  from golang code. I define the table with the struct like this as below.

`type Bank struct {
    // 银行ID
    ID uint32 `gorm:"primary_key;column:F_id;ignore_migrate" sql:"type:bigint(64) unsigned auto_increment;not null" json:"id"`
    // 银行名
    BankName string `gorm:"column:F_bank_name" sql:"type:varchar(64);not null;unique_index:I_bank_name" json:"bankName"`
    // 银行logo
    BankLogo string `gorm:"column:F_bank_logo" sql:"type:varchar(128);not null" json:"-"`
    // 逻辑删除标志 1有效;2无效
    Enabled uint8 `gorm:"column:F_enabled" sql:"type:tinyint(8) unsigned;not null;unique_index:I_bank_name" json:"-"`
}`

When I start the service in the staging environment or test environment, I would check the struct and table whether they are same and change the table to fit the struct.