### PR TITLE
store/tikv: abstract MVCCStore interface and add test

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -124,8 +124,8 @@ func (b *builtinSleepSig) eval(row []types.Datum) (d types.Datum, err error) {
 	if err != nil {
 		return d, errors.Trace(err)
 	}
-	duration := time.Duration(sleepTime.GetFloat64() * float64(time.Second.Nanoseconds()))
-	time.Sleep(duration)
+	dur := time.Duration(sleepTime.GetFloat64() * float64(time.Second.Nanoseconds()))
+	time.Sleep(dur)
 	d.SetInt64(0)
 	return
 }

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1554,19 +1554,19 @@ func (b *builtinDateArithSig) eval(row []types.Datum) (d types.Datum, err error)
 			interval = fmt.Sprintf("%v", ii)
 		}
 	}
-	year, month, day, duration, err := types.ExtractTimeValue(nodeIntervalUnit, interval)
+	year, month, day, dur, err := types.ExtractTimeValue(nodeIntervalUnit, interval)
 	if err != nil {
 		return d, errors.Trace(err)
 	}
 	if b.op == ast.DateArithSub {
-		year, month, day, duration = -year, -month, -day, -duration
+		year, month, day, dur = -year, -month, -day, -dur
 	}
 	// TODO: Consider time_zone variable.
 	t, err := result.Time.GoTime(time.Local)
 	if err != nil {
 		return d, errors.Trace(err)
 	}
-	t = t.Add(duration)
+	t = t.Add(dur)
 	t = t.AddDate(int(year), int(month), int(day))
 	if t.Nanosecond() == 0 {
 		result.Fsp = 0
@@ -2588,7 +2588,7 @@ func (b *builtinTimestampAddSig) eval(row []types.Datum) (d types.Datum, err err
 	if err != nil {
 		return d, errorOrWarning(err, b.ctx)
 	}
-	tm, err := date.Time.GoTime(time.Local)
+	tm1, err := date.Time.GoTime(time.Local)
 	if err != nil {
 		return d, errors.Trace(err)
 	}
@@ -2596,24 +2596,24 @@ func (b *builtinTimestampAddSig) eval(row []types.Datum) (d types.Datum, err err
 	fsp := types.DefaultFsp
 	switch unit {
 	case "MICROSECOND":
-		tb = tm.Add(time.Duration(v) * time.Microsecond)
+		tb = tm1.Add(time.Duration(v) * time.Microsecond)
 		fsp = types.MaxFsp
 	case "SECOND":
-		tb = tm.Add(time.Duration(v) * time.Second)
+		tb = tm1.Add(time.Duration(v) * time.Second)
 	case "MINUTE":
-		tb = tm.Add(time.Duration(v) * time.Minute)
+		tb = tm1.Add(time.Duration(v) * time.Minute)
 	case "HOUR":
-		tb = tm.Add(time.Duration(v) * time.Hour)
+		tb = tm1.Add(time.Duration(v) * time.Hour)
 	case "DAY":
-		tb = tm.AddDate(0, 0, int(v))
+		tb = tm1.AddDate(0, 0, int(v))
 	case "WEEK":
-		tb = tm.AddDate(0, 0, 7*int(v))
+		tb = tm1.AddDate(0, 0, 7*int(v))
 	case "MONTH":
-		tb = tm.AddDate(0, int(v), 0)
+		tb = tm1.AddDate(0, int(v), 0)
 	case "QUARTER":
-		tb = tm.AddDate(0, 3*int(v), 0)
+		tb = tm1.AddDate(0, 3*int(v), 0)
 	case "YEAR":
-		tb = tm.AddDate(int(v), 0, 0)
+		tb = tm1.AddDate(int(v), 0, 0)
 	default:
 		return d, errors.Trace(types.ErrInvalidTimeFormat)
 	}

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -139,7 +139,7 @@ func (s *tikvStore) EtcdAddrs() []string {
 
 type mockOptions struct {
 	cluster        *mocktikv.Cluster
-	mvccStore      *mocktikv.MvccStore
+	mvccStore      mocktikv.MVCCStore
 	clientHijack   func(Client) Client
 	pdClientHijack func(pd.Client) pd.Client
 }
@@ -171,7 +171,7 @@ func WithCluster(cluster *mocktikv.Cluster) MockTiKVStoreOption {
 }
 
 // WithMVCCStore provides the customized mvcc store.
-func WithMVCCStore(store *mocktikv.MvccStore) MockTiKVStoreOption {
+func WithMVCCStore(store mocktikv.MVCCStore) MockTiKVStoreOption {
 	return func(c *mockOptions) {
 		c.mvccStore = store
 	}

--- a/store/tikv/mock-tikv/executor.go
+++ b/store/tikv/mock-tikv/executor.go
@@ -40,7 +40,7 @@ type tableScanExec struct {
 	kvRanges       []kv.KeyRange
 	startTS        uint64
 	isolationLevel kvrpcpb.IsolationLevel
-	mvccStore      *MvccStore
+	mvccStore      MVCCStore
 	cursor         int
 	seekKey        []byte
 
@@ -151,7 +151,7 @@ type indexScanExec struct {
 	kvRanges       []kv.KeyRange
 	startTS        uint64
 	isolationLevel kvrpcpb.IsolationLevel
-	mvccStore      *MvccStore
+	mvccStore      MVCCStore
 	cursor         int
 	seekKey        []byte
 	pkCol          *tipb.ColumnInfo

--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -221,6 +221,27 @@ func (e *rawEntry) Less(than llrb.Item) bool {
 	return bytes.Compare(e.key, than.(*rawEntry).key) < 0
 }
 
+type MVCCStore interface {
+	RawKV
+	Get(key []byte, startTS uint64, isoLevel kvrpcpb.IsolationLevel) ([]byte, error)
+	Scan(startKey, endKey []byte, limit int, startTS uint64, isoLevel kvrpcpb.IsolationLevel) []Pair
+	ReverseScan(startKey, endKey []byte, limit int, startTS uint64, isoLevel kvrpcpb.IsolationLevel) []Pair
+	BatchGet(ks [][]byte, startTS uint64, isoLevel kvrpcpb.IsolationLevel) []Pair
+	Prewrite(mutations []*kvrpcpb.Mutation, primary []byte, startTS uint64, ttl uint64) []error
+	Commit(keys [][]byte, startTS, commitTS uint64) error
+	Rollback(keys [][]byte, startTS uint64) error
+	Cleanup(key []byte, startTS uint64) error
+	ScanLock(startKey, endKey []byte, maxTS uint64) ([]*kvrpcpb.LockInfo, error)
+	ResolveLock(startKey, endKey []byte, startTS, commitTS uint64) error
+}
+
+type RawKV interface {
+	RawGet(key []byte) []byte
+	RawScan(startKey, endKey []byte, limit int) []Pair
+	RawPut(key, value []byte)
+	RawDelete(key []byte)
+}
+
 // MvccStore is an in-memory, multi-versioned, transaction-supported kv storage.
 type MvccStore struct {
 	sync.RWMutex

--- a/store/tikv/mock-tikv/mvcc.go
+++ b/store/tikv/mock-tikv/mvcc.go
@@ -221,6 +221,7 @@ func (e *rawEntry) Less(than llrb.Item) bool {
 	return bytes.Compare(e.key, than.(*rawEntry).key) < 0
 }
 
+// MVCCStore is a mvcc key-value storage.
 type MVCCStore interface {
 	RawKV
 	Get(key []byte, startTS uint64, isoLevel kvrpcpb.IsolationLevel) ([]byte, error)
@@ -235,6 +236,7 @@ type MVCCStore interface {
 	ResolveLock(startKey, endKey []byte, startTS, commitTS uint64) error
 }
 
+// RawKV is a key-value storage. MVCCStore can be implemented upon it with timestamp encoded into key.
 type RawKV interface {
 	RawGet(key []byte) []byte
 	RawScan(startKey, endKey []byte, limit int) []Pair

--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -87,7 +87,7 @@ func convertToPbPairs(pairs []Pair) []*kvrpcpb.KvPair {
 
 type rpcHandler struct {
 	cluster   *Cluster
-	mvccStore *MvccStore
+	mvccStore MVCCStore
 
 	// store id for current request
 	storeID uint64
@@ -339,11 +339,11 @@ func (h *rpcHandler) handleKvRawScan(req *kvrpcpb.RawScanRequest) *kvrpcpb.RawSc
 // RPCClient sends kv RPC calls to mock cluster.
 type RPCClient struct {
 	Cluster   *Cluster
-	MvccStore *MvccStore
+	MvccStore MVCCStore
 }
 
 // NewRPCClient creates an RPCClient.
-func NewRPCClient(cluster *Cluster, mvccStore *MvccStore) *RPCClient {
+func NewRPCClient(cluster *Cluster, mvccStore MVCCStore) *RPCClient {
 	return &RPCClient{
 		Cluster:   cluster,
 		MvccStore: mvccStore,


### PR DESCRIPTION
This commit is a preparation before adding a new persistent mvcc
store, hence mocktikv engine can benefit from the new persistent mvcc store
and be used as default storage.