### PR TITLE
*: Fix cast as signed integer

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -119,6 +119,10 @@ const (
 	ClientPluginAuthLenencClientData
 )
 
+const (
+	MaxIntWidth = 20
+)
+
 // Cache type informations.
 const (
 	TypeNoCache byte = 0xff

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -119,6 +119,7 @@ const (
 	ClientPluginAuthLenencClientData
 )
 
+// MySQL type maximum length.
 const (
 	MaxIntWidth = 20
 )

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4220,6 +4220,11 @@ CastType:
 |	"SIGNED" OptInteger
 	{
 		x := types.NewFieldType(mysql.TypeLonglong)
+		x.Flen = mysql.MaxIntWidth
+		x.Decimal = 0
+		x.Charset = charset.CharsetBin
+		x.Collate = charset.CollationBin
+		x.Flag |= mysql.BinaryFlag
 		$$ = x
 	}
 |	"UNSIGNED" OptInteger

--- a/plan/typeinferer_test.go
+++ b/plan/typeinferer_test.go
@@ -79,6 +79,7 @@ func (ts *testTypeInferrerSuite) TestInferType(c *C) {
 		{"c_double is null", mysql.TypeLonglong, charset.CharsetBin},
 		{"isnull(1/0)", mysql.TypeLonglong, charset.CharsetBin},
 		{"cast(1 as decimal)", mysql.TypeNewDecimal, charset.CharsetBin},
+		{"cast(\"xxx\" as signed integer)", mysql.TypeLonglong, charset.CharsetBin},
 
 		{"1 and 1", mysql.TypeLonglong, charset.CharsetBin},
 		{"1 or 1", mysql.TypeLonglong, charset.CharsetBin},


### PR DESCRIPTION
Fix a compatibility bug:
mysql> create table a (reserved_28 varchar(32));
Query OK, 0 rows affected (0.01 sec)

mysql> select cast(a.reserved_28 as SIGNED INTEGER) from a;
Empty set (0.00 sec)

mysql> insert into a values ("123");
Query OK, 1 row affected (0.00 sec)

mysql> select cast(a.reserved_28 as SIGNED INTEGER) from a;
+---------------------------------------+
| cast(a.reserved_28 as SIGNED INTEGER) |
+---------------------------------------+
|                                   123 |
+---------------------------------------+
1 row in set (0.00 sec)

When using mysqlworkbench or navicat, we will get a error:
Error Code: 0 Server sent uknown charsetnr. Please report

I have tested it with mysqlworkbench. The error disappeared. I will add a test case.