### PR TITLE
plan: fix index filter condition push down

### DIFF
--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -151,6 +151,10 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from t where t.c = 1 and t.a = 1 order by t.d limit 1",
 			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit, Table(t))->Limit",
 		},
+		{
+			sql:  "select * from t use index(e_d_c_str_prefix) where t.c_str = 'c' and t.d_str = 'd' and t.e_str = 'e'",
+			best: "IndexLookUp(Index(t.e_d_c_str_prefix)[[e d c,e d c]], Table(t)->Sel([eq(test.t.c_str, c)]))",
+		},
 	}
 	for _, tt := range tests {
 		comment := Commentf("for %s", tt.sql)

--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -151,9 +151,10 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from t where t.c = 1 and t.a = 1 order by t.d limit 1",
 			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit, Table(t))->Limit",
 		},
+		// Test index filter condition push down.
 		{
-			sql:  "select * from t use index(e_d_c_str_prefix) where t.c_str = 'c' and t.d_str = 'd' and t.e_str = 'e'",
-			best: "IndexLookUp(Index(t.e_d_c_str_prefix)[[e d c,e d c]], Table(t)->Sel([eq(test.t.c_str, c)]))",
+			sql:  "select * from t use index(e_d_c_str_prefix) where t.c_str = 'abcdefghijk' and t.d_str = 'd' and t.e_str = 'e'",
+			best: "IndexLookUp(Index(t.e_d_c_str_prefix)[[e d [97 98 99 100 101 102 103 104 105 106],e d [97 98 99 100 101 102 103 104 105 106]]], Table(t)->Sel([eq(test.t.c_str, abcdefghijk)]))",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When the index in index filter condition contains prefix length, it should not be push down to the index plan.
PTAL @hanfei1991  @winoros 