### PR TITLE
expression, executor: password should return empty string when parameter is null

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -986,7 +986,7 @@ func (s *testSuite) TestEncryptionBuiltin(c *C) {
 	tk.MustExec("create table t(a char(41), b char(41), c char(41))")
 	tk.MustExec(`insert into t values(NULL, '', 'abc')`)
 	result := tk.MustQuery("select password(a) from t")
-	result.Check(testkit.Rows("<nil>"))
+	result.Check(testkit.Rows(""))
 	result = tk.MustQuery("select password(b) from t")
 	result.Check(testkit.Rows(""))
 	result = tk.MustQuery("select password(c) from t")

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -399,7 +399,7 @@ func (b *builtinPasswordSig) evalString(row []types.Datum) (d string, isNull boo
 	sc := b.ctx.GetSessionVars().StmtCtx
 	pass, isNull, err := b.args[0].EvalString(row, sc)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", false, errors.Trace(err)
 	}
 
 	if len(pass) == 0 {

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -317,7 +317,7 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 		isNil    bool
 		getErr   bool
 	}{
-		{nil, "", true, false},
+		{nil, "", false, false},
 		{"", "", false, false},
 		{"abc", "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E", false, false},
 		{123, "*23AE809DDACAF96AF0FD78ED04B6A265E05AA257", false, false},
@@ -329,15 +329,11 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 		f, err := newFunctionForTest(s.ctx, ast.PasswordFunc, primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
 		d, err := f.Eval(nil)
-		if t.getErr {
-			c.Assert(err, NotNil)
+		c.Assert(err, IsNil)
+		if t.isNil {
+			c.Assert(d.Kind(), Equals, types.KindNull)
 		} else {
-			c.Assert(err, IsNil)
-			if t.isNil {
-				c.Assert(d.Kind(), Equals, types.KindNull)
-			} else {
-				c.Assert(d.GetString(), Equals, t.expected)
-			}
+			c.Assert(d.GetString(), Equals, t.expected)
 		}
 	}
 


### PR DESCRIPTION
fix https://github.com/pingcap/tidb/issues/3879