### PR TITLE
executor, sessionctx, util: treat decimal truncation as warning during inserting

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2088,21 +2088,6 @@ func (s *testSuite) TestTiDBCurrentTS(c *C) {
 	c.Assert(terror.ErrorEqual(err, variable.ErrReadOnly), IsTrue)
 }
 
-func (s *testSuite) TestInsertDecimalTruncated(c *C) {
-	defer func() {
-		s.cleanEnv(c)
-		testleak.AfterTest(c)()
-	}()
-
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("USE test;")
-	tk.MustExec("DROP TABLE IF EXISTS t;")
-	tk.MustExec("CREATE TABLE t(a DECIMAL(4,2));")
-	tk.MustExec("INSERT INTO t SELECT CAST(1.000 AS DECIMAL(4,2));")
-	result := tk.MustQuery("SHOW WARNINGS;")
-	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
-}
-
 func (s *testSuite) TestSelectForUpdate(c *C) {
 	defer func() {
 		s.cleanEnv(c)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2088,6 +2088,21 @@ func (s *testSuite) TestTiDBCurrentTS(c *C) {
 	c.Assert(terror.ErrorEqual(err, variable.ErrReadOnly), IsTrue)
 }
 
+func (s *testSuite) TestInsertDecimalTruncated(c *C) {
+	defer func() {
+		s.cleanEnv(c)
+		testleak.AfterTest(c)()
+	}()
+
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("USE test;")
+	tk.MustExec("DROP TABLE IF EXISTS t;")
+	tk.MustExec("CREATE TABLE t(a DECIMAL(4,2));")
+	tk.MustExec("INSERT INTO t SELECT CAST(1.000 AS DECIMAL(4,2));")
+	result := tk.MustQuery("SHOW WARNINGS;")
+	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
+}
+
 func (s *testSuite) TestSelectForUpdate(c *C) {
 	defer func() {
 		s.cleanEnv(c)

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -334,13 +334,16 @@ func ResetStmtCtx(ctx context.Context, s ast.StmtNode) {
 	sc := new(variable.StatementContext)
 	sc.TimeZone = sessVars.GetTimeZone()
 	switch s.(type) {
-	case *ast.UpdateStmt, *ast.InsertStmt, *ast.DeleteStmt:
+	case *ast.UpdateStmt, *ast.DeleteStmt:
 		sc.IgnoreTruncate = false
 		sc.IgnoreOverflow = false
 		sc.TruncateAsWarning = !sessVars.StrictSQLMode
-		if _, ok := s.(*ast.InsertStmt); !ok {
-			sc.InUpdateOrDeleteStmt = true
-		}
+		sc.InUpdateOrDeleteStmt = true
+	case *ast.InsertStmt:
+		sc.IgnoreTruncate = false
+		sc.IgnoreOverflow = false
+		sc.TruncateAsWarning = !sessVars.StrictSQLMode
+		sc.InInsertStmt = true
 	case *ast.CreateTableStmt, *ast.AlterTableStmt:
 		// Make sure the sql_mode is strict when checking column default value.
 		sc.IgnoreTruncate = false

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -184,6 +184,9 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("INSERT INTO t SELECT CAST(1.000 AS DECIMAL(4,2));")
 	result := tk.MustQuery("SHOW WARNINGS;")
 	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
+	tk.MustExec("INSERT INTO t VALUES (1.000000);")
+	result = tk.MustQuery("SHOW WARNINGS;")
+	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -175,6 +175,15 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("create table t1 (b char(0));")
 	_, err = tk.Exec(`insert into t1 values ("");`)
 	c.Assert(err, IsNil)
+
+	// issue 3895
+	tk = testkit.NewTestKit(c, s.store)
+	tk.MustExec("USE test;")
+	tk.MustExec("DROP TABLE IF EXISTS t;")
+	tk.MustExec("CREATE TABLE t(a DECIMAL(4,2));")
+	tk.MustExec("INSERT INTO t SELECT CAST(1.000 AS DECIMAL(4,2));")
+	result := tk.MustQuery("SHOW WARNINGS;")
+	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -181,12 +181,12 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("USE test;")
 	tk.MustExec("DROP TABLE IF EXISTS t;")
 	tk.MustExec("CREATE TABLE t(a DECIMAL(4,2));")
-	tk.MustExec("INSERT INTO t SELECT CAST(1.000 AS DECIMAL(4,2));")
-	result := tk.MustQuery("SHOW WARNINGS;")
-	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
+	tk.MustExec("INSERT INTO t VALUES (1.000001);")
+	r = tk.MustQuery("SHOW WARNINGS;")
+	r.Check(testkit.Rows("Warning 1265 Data Truncated"))
 	tk.MustExec("INSERT INTO t VALUES (1.000000);")
-	result = tk.MustQuery("SHOW WARNINGS;")
-	result.Check(testkit.Rows("Warning 1265 Data Truncated"))
+	r = tk.MustQuery("SHOW WARNINGS;")
+	r.Check(testkit.Rows())
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -318,6 +318,7 @@ type TableDelta struct {
 type StatementContext struct {
 	// Set the following variables before execution
 
+	InInsertStmt         bool
 	InUpdateOrDeleteStmt bool
 	IgnoreOverflow       bool
 	IgnoreTruncate       bool

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -1118,8 +1118,9 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *variable.State
 			// select (cast 111 as decimal(1)) causes a warning in MySQL.
 			err = ErrOverflow.GenByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", flen, decimal))
 		} else if frac != decimal {
+			old := *dec
 			dec.Round(dec, decimal, ModeHalfEven)
-			if !dec.IsZero() && frac > decimal {
+			if !dec.IsZero() && frac > decimal && dec.Compare(&old) != 0 {
 				if sc.InInsertStmt {
 					// fix https://github.com/pingcap/tidb/issues/3895
 					sc.AppendWarning(ErrTruncated)

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -1120,7 +1120,13 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *variable.State
 		} else if frac != decimal {
 			dec.Round(dec, decimal, ModeHalfEven)
 			if !dec.IsZero() && frac > decimal {
-				err = sc.HandleTruncate(ErrTruncated)
+				if sc.InInsertStmt {
+					// fix https://github.com/pingcap/tidb/issues/3895
+					sc.AppendWarning(ErrTruncated)
+					err = nil
+				} else {
+					err = sc.HandleTruncate(ErrTruncated)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
fix https://github.com/pingcap/tidb/issues/3895