### PR TITLE
*: fix set/get var race

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -556,6 +556,9 @@ func (s *testSuite) TestUnion(c *C) {
 	// #issue3771
 	r = tk.MustQuery("SELECT 'a' UNION SELECT CONCAT('a', -4)")
 	r.Sort().Check(testkit.Rows("a", "a-4"))
+
+	// test race
+	tk.MustQuery("SELECT @x:=0 UNION ALL SELECT @x:=0 UNION ALL SELECT @x")
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -155,7 +155,9 @@ func (b *builtinSetVarSig) eval(row []types.Datum) (types.Datum, error) {
 		if err != nil {
 			return types.Datum{}, errors.Trace(err)
 		}
+		sessionVars.Lock()
 		sessionVars.Users[varName] = strings.ToLower(strVal)
+		sessionVars.Unlock()
 	}
 	return args[1], nil
 }
@@ -182,6 +184,8 @@ func (b *builtinGetVarSig) eval(row []types.Datum) (types.Datum, error) {
 	}
 	sessionVars := b.ctx.GetSessionVars()
 	varName, _ := args[0].ToString()
+	sessionVars.RLock()
+	defer sessionVars.RUnlock()
 	if v, ok := sessionVars.Users[varName]; ok {
 		return types.NewDatum(v), nil
 	}

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -155,9 +155,9 @@ func (b *builtinSetVarSig) eval(row []types.Datum) (types.Datum, error) {
 		if err != nil {
 			return types.Datum{}, errors.Trace(err)
 		}
-		sessionVars.Lock()
+		sessionVars.UsersLock.Lock()
 		sessionVars.Users[varName] = strings.ToLower(strVal)
-		sessionVars.Unlock()
+		sessionVars.UsersLock.Unlock()
 	}
 	return args[1], nil
 }
@@ -184,8 +184,8 @@ func (b *builtinGetVarSig) eval(row []types.Datum) (types.Datum, error) {
 	}
 	sessionVars := b.ctx.GetSessionVars()
 	varName, _ := args[0].ToString()
-	sessionVars.RLock()
-	defer sessionVars.RUnlock()
+	sessionVars.UsersLock.RLock()
+	defer sessionVars.UsersLock.RUnlock()
 	if v, ok := sessionVars.Users[varName]; ok {
 		return types.NewDatum(v), nil
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -100,6 +100,7 @@ func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, co
 
 // SessionVars is to handle user-defined or global variables in the current session.
 type SessionVars struct {
+	sync.RWMutex
 	// Users are user defined variables.
 	Users map[string]string
 	// Systems are system variables.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -100,7 +100,8 @@ func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, co
 
 // SessionVars is to handle user-defined or global variables in the current session.
 type SessionVars struct {
-	sync.RWMutex
+	// UsersLock is a lock for user defined variables.
+	UsersLock sync.RWMutex
 	// Users are user defined variables.
 	Users map[string]string
 	// Systems are system variables.


### PR DESCRIPTION
We may read and write user variable at same time, so I use a rw lock to avoid data race.
@zimulala @zz-jason @XuHuaiyu PTAL