### PR TITLE
config: set default value for SlowThreshold and QueryLogMaxlen

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,7 +37,10 @@ var once sync.Once
 // Other parts of the system can read the global configuration use this function.
 func GetGlobalConfig() *Config {
 	once.Do(func() {
-		cfg = &Config{}
+		cfg = &Config{
+			SlowThreshold:  300,
+			QueryLogMaxlen: 2048,
+		}
 	})
 	return cfg
 }


### PR DESCRIPTION
PR https://github.com/pingcap/tidb/pull/3919 introduce the config, but forget to set them.

In the test code, those two config value is not set explicitly,
so the default value should be set.

This cause test code output like this:

```
2017/07/30 13:39:18 adapter.go:237: [warning] [199][TIME_QUERY] 145.693µs (len:67)
```

Every sql is viewed as slow query(SlowThreshold not set), and sql info is truncated(QueryLogMaxlen is not set)