### PR TITLE
lexer: fix panic when input "'\\"

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -530,11 +530,10 @@ func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 			ch0 = handleEscape(s)
 		}
 		mb.writeRune(ch0, s.r.w)
-		if s.r.eof() {
-			break
+		if !s.r.eof() {
+			s.r.inc()
+			ch0 = s.r.peek()
 		}
-		s.r.inc()
-		ch0 = s.r.peek()
 	}
 
 	tok = unicode.ReplacementChar

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -452,6 +452,9 @@ func scanQuotedIdent(s *Scanner) (tok int, pos Pos, lit string) {
 
 func startString(s *Scanner) (tok int, pos Pos, lit string) {
 	tok, pos, lit = s.scanString()
+	if tok == unicode.ReplacementChar {
+		return
+	}
 
 	// Quoted strings placed next to each other are concatenated to a single string.
 	// See http://dev.mysql.com/doc/refman/5.7/en/string-literals.html
@@ -527,6 +530,9 @@ func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 			ch0 = handleEscape(s)
 		}
 		mb.writeRune(ch0, s.r.w)
+		if s.r.eof() {
+			break
+		}
 		s.r.inc()
 		ch0 = s.r.peek()
 	}

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -115,7 +115,6 @@ func (s *testLexerSuite) TestLiteral(c *C) {
 		{"0x3c26", hexLit},
 		{"x'13181C76734725455A'", hexLit},
 		{"0b01", bitLit},
-		{fmt.Sprintf("%c", 0), invalid},
 		{fmt.Sprintf("t1%c", 0), identifier},
 		{".*", int('.')},
 		{".1_t_1_x", int('.')},
@@ -314,4 +313,16 @@ func (s *testLexerSuite) TestSQLModeANSIQuotes(c *C) {
 		c.Assert(tok, Equals, t.tok)
 		c.Assert(v.ident, Equals, t.ident)
 	}
+}
+
+func (s *testLexerSuite) TestIllegal(c *C) {
+	defer testleak.AfterTest(c)()
+	table := []testCaseItem{
+		{"'", 0},
+		{"'fu", 0},
+		{"'\\n", 0},
+		{"'\\", 0},
+		{fmt.Sprintf("%c", 0), invalid},
+	}
+	runTest(c, table)
 }


### PR DESCRIPTION
Panic when using go-fuzz to test parser.

```
panic: runtime error: index out of range

goroutine 1 [running]:
github.com/pingcap/tidb/parser.(*reader).inc(...)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/lexer.go:712
github.com/pingcap/tidb/parser.(*Scanner).scanString(0xc420063228, 0x7fd23da46260, 0x40000000000, 0x10, 0x10, 0xc42000e7d0, 0x7fd23da46260)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/lexer.go:518 +0x778
github.com/pingcap/tidb/parser.startString(0xc420063228, 0x0, 0x0, 0x0, 0x0, 0xc42000e7d0, 0x0)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/lexer.go:454 +0x68
github.com/pingcap/tidb/parser.(*Scanner).scan(0xc420063228, 0x0, 0x0, 0x0, 0x0, 0xc4200fbd40, 0x584614)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/lexer.go:225 +0x3e2
github.com/pingcap/tidb/parser.(*Scanner).Lex(0xc420063228, 0xc420063310, 0x2300000001)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/lexer.go:132 +0x45
github.com/pingcap/tidb/parser.yylex1(0x8a6c40, 0xc420063228, 0xc420063310, 0x0)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/parser.go:10100 +0x6e
github.com/pingcap/tidb/parser.yyParse(0x8a6c40, 0xc420063228, 0xc4200631e0, 0xc4200fde30)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/parser.go:10155 +0x6d07f
github.com/pingcap/tidb/parser.(*Parser).Parse(0xc4200631e0, 0xc4200162e0, 0x2, 0x0, 0x0, 0x0, 0x0, 0xc4200fde60, 0x43faf9, 0xc4200162e0, ...)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/yy_parser.go:96 +0x226
github.com/pingcap/tidb/parser.(*Parser).ParseOneStmt(0xc4200631e0, 0xc4200162e0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x38dc8e13, 0x38dc8e1300000000, 0x597d6d82, ...)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/parser/yy_parser.go:110 +0x95
github.com/pingcap/tidb/fuzztest/sqlparser.Fuzz(0x7fd23d822000, 0x2, 0x200000, 0x3)
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/fuzztest/sqlparser/fuzz.go:11 +0x161
go-fuzz-dep.Main(0x783488)
    /tmp/go-fuzz-build334939343/goroot/src/go-fuzz-dep/main.go:49 +0xad
main.main()
    /tmp/go-fuzz-build334939343/gopath/src/github.com/pingcap/tidb/fuzztest/sqlparser/go.fuzz.main/main.go:10 +0x2d
exit status 2
```

Input is `"'\\"`.

@tiancaiamao @zimulala @hanfei1991  PTAL