### PR TITLE
executor: Support session-scoped status variables

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -139,7 +139,7 @@ type DDL interface {
 	// GetLease returns current schema lease time.
 	GetLease() time.Duration
 	// Stats returns the DDL statistics.
-	Stats() (map[string]interface{}, error)
+	Stats(vars *variable.SessionVars) (map[string]interface{}, error)
 	// GetScope gets the status variables scope.
 	GetScope(status string) variable.ScopeFlag
 	// Stop stops DDL worker.

--- a/ddl/stat.go
+++ b/ddl/stat.go
@@ -57,11 +57,11 @@ var (
 // GetScope gets the status variables scope.
 func (d *ddl) GetScope(status string) variable.ScopeFlag {
 	// Now ddl status variables scope are all default scope.
-	return variable.DefaultScopeFlag
+	return variable.DefaultStatusVarScopeFlag
 }
 
 // Stats returns the DDL statistics.
-func (d *ddl) Stats() (map[string]interface{}, error) {
+func (d *ddl) Stats(vars *variable.SessionVars) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
 	m[serverID] = d.uuid
 	var ddlInfo, bgInfo *inspectkv.DDLInfo

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -29,7 +29,7 @@ type testStatSuite struct {
 }
 
 func (s *testStatSuite) getDDLSchemaVer(c *C, d *ddl) int64 {
-	m, err := d.Stats()
+	m, err := d.Stats(nil)
 	c.Assert(err, IsNil)
 	v := m[ddlSchemaVersion]
 	return v.(int64)
@@ -49,7 +49,7 @@ func (s *testStatSuite) TestStat(c *C) {
 	testCreateSchema(c, testNewContext(d), d, dbInfo)
 
 	// TODO: Get this information from etcd.
-	//	m, err := d.Stats()
+	//	m, err := d.Stats(nil)
 	//	c.Assert(err, IsNil)
 	//	c.Assert(m[ddlOwnerID], Equals, d.uuid)
 
@@ -81,7 +81,7 @@ LOOP:
 		case err := <-done:
 			c.Assert(err, IsNil)
 			// TODO: Get this information from etcd.
-			// m, err := d.Stats()
+			// m, err := d.Stats(nil)
 			// c.Assert(err, IsNil)
 			// c.Assert(m[bgOwnerID], Equals, d.uuid)
 			break LOOP

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -242,7 +242,7 @@ func (do *Domain) Store() kv.Storage {
 // GetScope gets the status variables scope.
 func (do *Domain) GetScope(status string) variable.ScopeFlag {
 	// Now domain status variables scope are all default scope.
-	return variable.DefaultScopeFlag
+	return variable.DefaultStatusVarScopeFlag
 }
 
 func (do *Domain) mockReloadFailed() error {

--- a/executor/show.go
+++ b/executor/show.go
@@ -367,7 +367,8 @@ func (e *ShowExec) fetchShowVariables() error {
 }
 
 func (e *ShowExec) fetchShowStatus() error {
-	statusVars, err := variable.GetStatusVars()
+	sessionVars := e.ctx.GetSessionVars()
+	statusVars, err := variable.GetStatusVars(sessionVars)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -177,9 +177,9 @@ func (s *testSuite) TestShowVisibility(c *C) {
 type stats struct {
 }
 
-func (s stats) GetScope(status string) variable.ScopeFlag { return variable.DefaultScopeFlag }
+func (s stats) GetScope(status string) variable.ScopeFlag { return variable.DefaultStatusVarScopeFlag }
 
-func (s stats) Stats() (map[string]interface{}, error) {
+func (s stats) Stats(vars *variable.SessionVars) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
 	var a, b interface{}
 	b = "123"

--- a/sessionctx/variable/statusvar.go
+++ b/sessionctx/variable/statusvar.go
@@ -20,8 +20,8 @@ import (
 var statisticsList []Statistics
 var globalStatusScopes = make(map[string]ScopeFlag)
 
-// DefaultScopeFlag is the status default scope.
-var DefaultScopeFlag = ScopeGlobal | ScopeSession
+// DefaultStatusVarScopeFlag is the status default scope.
+var DefaultStatusVarScopeFlag = ScopeGlobal | ScopeSession
 
 // StatusVal is the value of the corresponding status variable.
 type StatusVal struct {
@@ -34,7 +34,7 @@ type Statistics interface {
 	// GetScope gets the status variables scope.
 	GetScope(status string) ScopeFlag
 	// Stats returns the statistics status variables.
-	Stats() (map[string]interface{}, error)
+	Stats(*SessionVars) (map[string]interface{}, error)
 }
 
 // RegisterStatistics registers statistics.
@@ -43,11 +43,11 @@ func RegisterStatistics(s Statistics) {
 }
 
 // GetStatusVars gets registered statistics status variables.
-func GetStatusVars() (map[string]*StatusVal, error) {
+func GetStatusVars(vars *SessionVars) (map[string]*StatusVal, error) {
 	statusVars := make(map[string]*StatusVal)
 
 	for _, statistics := range statisticsList {
-		vals, err := statistics.Stats()
+		vals, err := statistics.Stats(vars)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/sessionctx/variable/statusvar_test.go
+++ b/sessionctx/variable/statusvar_test.go
@@ -45,13 +45,13 @@ var specificStatusScopes = map[string]ScopeFlag{
 func (ms *mockStatistics) GetScope(status string) ScopeFlag {
 	scope, ok := specificStatusScopes[status]
 	if !ok {
-		return DefaultScopeFlag
+		return DefaultStatusVarScopeFlag
 	}
 
 	return scope
 }
 
-func (ms *mockStatistics) Stats() (map[string]interface{}, error) {
+func (ms *mockStatistics) Stats(vars *SessionVars) (map[string]interface{}, error) {
 	m := make(map[string]interface{}, len(specificStatusScopes))
 	m[testStatus] = testStatusVal
 
@@ -61,12 +61,12 @@ func (ms *mockStatistics) Stats() (map[string]interface{}, error) {
 func (s *testStatusVarSuite) TestStatusVar(c *C) {
 	defer testleak.AfterTest(c)()
 	scope := s.ms.GetScope(testStatus)
-	c.Assert(scope, Equals, DefaultScopeFlag)
+	c.Assert(scope, Equals, DefaultStatusVarScopeFlag)
 	scope = s.ms.GetScope(testSessionStatus)
 	c.Assert(scope, Equals, ScopeSession)
 
-	vars, err := GetStatusVars()
+	vars, err := GetStatusVars(nil)
 	c.Assert(err, IsNil)
-	v := &StatusVal{Scope: DefaultScopeFlag, Value: testStatusVal}
+	v := &StatusVal{Scope: DefaultStatusVarScopeFlag, Value: testStatusVal}
 	c.Assert(v, DeepEquals, vars[testStatus])
 }


### PR DESCRIPTION
This PR passes `sessionVars` when retrieving status variables (i.e. `SHOW STATUS`) so that we can implement those status variables based on information about the current session (i.e. session-scoped status variables).

Cherry picked from https://github.com/pingcap/tidb/pull/3716 .