### PR TITLE
server: make show processlist doesn't include killed session

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -346,7 +346,7 @@ func (cc *clientConn) Run() {
 	for !cc.killed {
 		cc.alloc.Reset()
 		data, err := cc.readPacket()
-		if err != nil {
+		if err != nil || cc.killed {
 			if terror.ErrorNotEqual(err, io.EOF) {
 				log.Errorf("[%d] read packet error, close this connection %s",
 					cc.connectionID, errors.ErrorStack(err))

--- a/server/conn.go
+++ b/server/conn.go
@@ -351,6 +351,9 @@ func (cc *clientConn) Run() {
 				log.Errorf("[%d] read packet error, close this connection %s",
 					cc.connectionID, errors.ErrorStack(err))
 			}
+			if cc.killed {
+				log.Warnf("[%d] session is killed.", cc.connectionID)
+			}
 			return
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -234,6 +234,9 @@ func (s *Server) ShowProcessList() []util.ProcessInfo {
 	var rs []util.ProcessInfo
 	s.rwlock.RLock()
 	for _, client := range s.clients {
+		if client.killed {
+			continue
+		}
 		rs = append(rs, client.ctx.ShowProcess())
 	}
 	s.rwlock.RUnlock()


### PR DESCRIPTION
`kill tidb sessionid` is a delayed effect, it just mark connClient as killed.

1. In the `show processlist`, we should skip those session marked killed.
2. In the dispatch REPL, we should check again after read, because kill may happens during block read.
