### PR TITLE
executor: fix bug in index lookup join

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -104,6 +104,7 @@ func (s *testSuite) TestJoin(c *C) {
 		testleak.AfterTest(c)()
 	}()
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set @@tidb_index_lookup_size = 1")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c int)")

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -104,7 +104,7 @@ func (s *testSuite) TestJoin(c *C) {
 		testleak.AfterTest(c)()
 	}()
 	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("set @@tidb_index_lookup_size = 1")
+	tk.MustExec("set @@tidb_index_lookup_size = 2")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c int)")
@@ -202,15 +202,15 @@ func (s *testSuite) TestJoin(c *C) {
 	tk.MustExec("create table t(a int primary key, b int)")
 	tk.MustExec("create table t1(a int, b int, key s(b))")
 	tk.MustExec("insert into t values(1, 1), (2, 2), (3, 3)")
-	tk.MustExec("insert into t1 values(1, 2), (1, 3), (3, 4), (4, 5)")
+	tk.MustExec("insert into t1 values(1, 2), (1, 3), (1, 4), (3, 4), (4, 5)")
 
 	// The physical plans of the two sql are tested at physical_plan_test.go
-	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ * from t join t1 on t.a=t1.a").Check(testkit.Rows("1 1 1 2", "1 1 1 3", "3 3 3 4"))
-	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ * from t1 join t on t.a=t1.a and t.a < t1.b").Check(testkit.Rows("1 2 1 1", "1 3 1 1", "3 4 3 3"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ * from t join t1 on t.a=t1.a").Check(testkit.Rows("1 1 1 2", "1 1 1 3", "1 1 1 4", "3 3 3 4"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ * from t1 join t on t.a=t1.a and t.a < t1.b").Check(testkit.Rows("1 2 1 1", "1 3 1 1", "1 4 1 1", "3 4 3 3"))
 	// Test single index reader.
 	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ t1.b from t1 join t on t.b=t1.b").Check(testkit.Rows("2", "3"))
-	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ * from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1 1 1 2", "1 1 1 3", "3 3 3 4", "<nil> <nil> 4 5"))
-	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ avg(t.b) from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1.6667"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ * from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1 1 1 2", "1 1 1 3", "1 1 1 4", "3 3 3 4", "<nil> <nil> 4 5"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ avg(t.b) from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1.5000"))
 
 	// Test that two conflict hints will return error.
 	_, err = tk.Exec("select /*+ TIDB_INLJ(t) TIDB_SMJ(t) */ * from t join t1 on t.a=t1.a")

--- a/executor/new_join.go
+++ b/executor/new_join.go
@@ -92,6 +92,7 @@ func (e *IndexLookUpJoin) Next() (*Row, error) {
 			return nil, nil
 		}
 		e.outerRows = e.outerRows[:0]
+		e.innerRows = e.innerRows[:0]
 		e.resultRows = e.resultRows[:0]
 		e.innerDatums = e.innerDatums[:0]
 		for i := 0; i < e.batchSize; i++ {


### PR DESCRIPTION
We should clear innerRows when every round starts.
Also, this <del>maybe</del> is the reason that index lookup join is so slow.
PTAL @hanfei1991 @winoros 