### PR TITLE
plan: prune search space.

### DIFF
--- a/plan/explain_test.go
+++ b/plan/explain_test.go
@@ -67,9 +67,9 @@ func (s *testExplainSuite) TestExplain(c *C) {
 		{
 			"select * from t1 order by c2",
 			[]string{
-				"IndexScan_13  cop table:t1, index:c2, range:[<nil>,+inf], out of order:false",
-				"TableScan_14  cop table:t1, keep order:false",
-				"IndexLookUp_15  root index:IndexScan_13, table:TableScan_14",
+				"IndexScan_10  cop table:t1, index:c2, range:[<nil>,+inf], out of order:false",
+				"TableScan_11  cop table:t1, keep order:false",
+				"IndexLookUp_12  root index:IndexScan_10, table:TableScan_11",
 			},
 		},
 		{
@@ -127,11 +127,11 @@ func (s *testExplainSuite) TestExplain(c *C) {
 			[]string{
 				"TableScan_17 HashAgg_16 cop table:b, range:(-inf,+inf), keep order:false",
 				"HashAgg_16  cop type:complete, group by:b.c2, funcs:count(b.c2), firstrow(b.c2)",
-				"TableReader_21 HashAgg_20 root data:HashAgg_16",
-				"HashAgg_20 IndexJoin_9 root type:final, group by:, funcs:count(col_0), firstrow(col_1)",
+				"TableReader_19 HashAgg_18 root data:HashAgg_16",
+				"HashAgg_18 IndexJoin_9 root type:final, group by:, funcs:count(col_0), firstrow(col_1)",
 				"TableScan_12  cop table:a, range:(-inf,+inf), keep order:true",
-				"TableReader_31 IndexJoin_9 root data:TableScan_12",
-				"IndexJoin_9 Projection_8 root outer:TableReader_31, outer key:b.c2, inner key:a.c1",
+				"TableReader_22 IndexJoin_9 root data:TableScan_12",
+				"IndexJoin_9 Projection_8 root outer:TableReader_22, outer key:b.c2, inner key:a.c1",
 				"Projection_8  root cast(join_agg_0)",
 			},
 		},
@@ -140,7 +140,7 @@ func (s *testExplainSuite) TestExplain(c *C) {
 			[]string{
 				"TableScan_7 TopN_5 cop table:t2, range:(-inf,+inf), keep order:false",
 				"TopN_5  cop ",
-				"TableReader_10 TopN_5 root data:TopN_5",
+				"TableReader_8 TopN_5 root data:TopN_5",
 				"TopN_5  root ",
 			},
 		},
@@ -165,17 +165,17 @@ func (s *testExplainSuite) TestExplain(c *C) {
 		{
 			"select sum(t1.c1 in (select c1 from t2)) from t1",
 			[]string{
-				"TableScan_11 HashAgg_10 cop table:t1, range:(-inf,+inf), keep order:false",
-				"HashAgg_10  cop type:complete, funcs:sum(in(test.t1.c1, 1, 2))",
-				"TableReader_14 HashAgg_13 root data:HashAgg_10",
-				"HashAgg_13  root type:final, funcs:sum(col_0)",
+				"TableScan_9 HashAgg_8 cop table:t1, range:(-inf,+inf), keep order:false",
+				"HashAgg_8  cop type:complete, funcs:sum(in(test.t1.c1, 1, 2))",
+				"TableReader_11 HashAgg_10 root data:HashAgg_8",
+				"HashAgg_10  root type:final, funcs:sum(col_0)",
 			},
 		},
 		{
 			"select c1 from t1 where c1 in (select c2 from t2)",
 			[]string{
-				"TableScan_11  cop table:t1, range:[0,0], [1,1], keep order:false",
-				"TableReader_12  root data:TableScan_11",
+				"TableScan_8  cop table:t1, range:[0,0], [1,1], keep order:false",
+				"TableReader_9  root data:TableScan_8",
 			},
 		},
 		{
@@ -183,10 +183,10 @@ func (s *testExplainSuite) TestExplain(c *C) {
 			[]string{
 				"TableScan_13  cop table:t1, range:(-inf,+inf), keep order:false",
 				"TableReader_14 Apply_12 root data:TableScan_13",
-				"TableScan_18  cop table:s, range:(-inf,+inf), keep order:false",
-				"TableReader_19 Selection_4 root data:TableScan_18",
-				"Selection_4 HashAgg_17 root eq(s.c1, test.t1.c1)",
-				"HashAgg_17 Selection_10 root type:complete, funcs:count(1)",
+				"TableScan_16  cop table:s, range:(-inf,+inf), keep order:false",
+				"TableReader_17 Selection_4 root data:TableScan_16",
+				"Selection_4 HashAgg_15 root eq(s.c1, test.t1.c1)",
+				"HashAgg_15 Selection_10 root type:complete, funcs:count(1)",
 				"Selection_10 Apply_12 root ne(k, 0)",
 				"Apply_12 Projection_2 root left outer join, small:Selection_10, right:Selection_10",
 				"Projection_2  root k",
@@ -203,11 +203,11 @@ func (s *testExplainSuite) TestExplain(c *C) {
 			[]string{
 				"TableScan_14  cop table:t1, range:(-inf,+inf), keep order:false",
 				"TableReader_15 Apply_13 root data:TableScan_14",
-				"IndexScan_28  cop table:t2, index:c1, range:[<nil>,+inf], out of order:false",
-				"TableScan_29  cop table:t2, keep order:false",
-				"IndexLookUp_30 Selection_4 root index:IndexScan_28, table:TableScan_29",
-				"Selection_4 Limit_18 root eq(test.t1.c1, test.t2.c1)",
-				"Limit_18 MaxOneRow_9 root offset:0, count:1",
+				"IndexScan_23  cop table:t2, index:c1, range:[<nil>,+inf], out of order:false",
+				"TableScan_24  cop table:t2, keep order:false",
+				"IndexLookUp_25 Selection_4 root index:IndexScan_23, table:TableScan_24",
+				"Selection_4 Limit_16 root eq(test.t1.c1, test.t2.c1)",
+				"Limit_16 MaxOneRow_9 root offset:0, count:1",
 				"MaxOneRow_9 Apply_13 root ",
 				"Apply_13 Projection_2 root left outer join, small:MaxOneRow_9, right:MaxOneRow_9",
 				"Projection_2  root eq(test.t1.c2, test.t2.c2)",

--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -649,13 +649,15 @@ func (p *DataSource) convert2NewPhysicalPlan(prop *requiredProp) (task, error) {
 			return nil, errors.Trace(err)
 		}
 	}
-	for _, idx := range indices {
-		idxTask, err := p.convertToIndexScan(prop, idx)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if idxTask.cost() < t.cost() {
-			t = idxTask
+	if !includeTableScan || len(p.pushedDownConds) > 0 || len(prop.cols) > 0 {
+		for _, idx := range indices {
+			idxTask, err := p.convertToIndexScan(prop, idx)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if idxTask.cost() < t.cost() {
+				t = idxTask
+			}
 		}
 	}
 	return t, p.storeTask(prop, t)


### PR DESCRIPTION
If push down condition and required order is empty, we can ignore index scan. This will prune a lot of redundant search.