### PR TITLE
plan: fix bug when access cond is not scalar function

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -419,6 +419,11 @@ func (s *testSuite) TestSelectOrderBy(c *C) {
 	r.Check(testkit.Rows("2"))
 	r = tk.MustQuery("select b from (select a,b from t order by a,c limit 1) t")
 	r.Check(testkit.Rows("2"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int, index idx(a))")
+	tk.MustExec("insert into t values(1, 1), (2, 2)")
+	tk.MustQuery("select * from t where 1 order by b").Check(testkit.Rows("1 1", "2 2"))
 }
 
 func (s *testSuite) TestSelectErrorRow(c *C) {

--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -734,7 +734,10 @@ func (p *DataSource) convertToIndexScan(prop *requiredProp, idx *model.IndexInfo
 			if col.Name.L == prop.cols[0].ColName.L {
 				matchProperty = matchIndicesProp(idx.Columns[i:], prop.cols)
 				break
-			} else if i >= len(is.AccessCondition) || is.AccessCondition[i].(*expression.ScalarFunction).FuncName.L != ast.EQ {
+			} else if i >= len(is.AccessCondition) {
+				matchProperty = false
+				break
+			} else if sf, ok := is.AccessCondition[i].(*expression.ScalarFunction); !ok || sf.FuncName.L != ast.EQ {
 				matchProperty = false
 				break
 			}


### PR DESCRIPTION
Access condition may not be scalar function, so previous check will cause panic.
PTAL @zz-jason @shenli 