### PR TITLE
domain,executor: ignore restricted sql for statement count metrics

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -454,6 +454,7 @@ func (do *Domain) SysSessionPool() *pools.ResourcePool {
 // LoadPrivilegeLoop create a goroutine loads privilege tables in a loop, it
 // should be called only once in BootstrapSession.
 func (do *Domain) LoadPrivilegeLoop(ctx context.Context) error {
+	ctx.GetSessionVars().InRestrictedSQL = true
 	do.privHandle = privileges.NewHandle()
 	err := do.privHandle.Update(ctx)
 	if err != nil {
@@ -517,6 +518,7 @@ func (do *Domain) CreateStatsHandle(ctx context.Context) {
 // UpdateTableStatsLoop creates a goroutine loads stats info and updates stats info in a loop. It
 // should be called only once in BootstrapSession.
 func (do *Domain) UpdateTableStatsLoop(ctx context.Context) error {
+	ctx.GetSessionVars().InRestrictedSQL = true
 	do.statsHandle = statistics.NewHandle(ctx, do.statsLease)
 	do.ddl.RegisterEventCh(do.statsHandle.DDLEventCh())
 	err := do.statsHandle.Update(do.InfoSchema())

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -42,7 +42,12 @@ func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statemen
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	isExpensive := stmtCount(node, p)
+
+	var isExpensive bool
+	if !ctx.GetSessionVars().InRestrictedSQL {
+		// Don't take restricted SQL into account for metrics.
+		isExpensive = stmtCount(node, p)
+	}
 	sa := &statement{
 		is:        is,
 		plan:      p,


### PR DESCRIPTION
To make the statement count metrics more precise, we should ignore
some background job such as update statistics and load privilege.