### PR TITLE
domain: Make test stable

### DIFF
--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -92,10 +92,6 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	succ = dom.SchemaValidator.Check(ts, schemaVer)
 	c.Assert(succ, IsTrue)
-	ver, err = store.CurrentVersion()
-	c.Assert(err, IsNil)
-	succ = dom.SchemaValidator.Check(ver.Ver, schemaVer)
-	c.Assert(succ, IsTrue)
 
 	err = store.Close()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
 If `reload` takes time more than a lease, like the behavior of `[ddl] loading schema takes a long time 648.711739ms`, which makes the test failed. And this test hard to be stable, so remove it.
