### PR TITLE
ddl: Handle the error of `ErrClientConnClosing`

### DIFF
--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -123,12 +123,11 @@ func (s *schemaVersionSyncer) Init(ctx goctx.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	session, err := newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
+	s.session, err = newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
 		newSessionDefaultRetryCnt, SyncerSessionTTL)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	s.session = session
 	s.globalVerCh = s.etcdCli.Watch(ctx, DDLGlobalSchemaVersion)
 	return s.putKV(ctx, keyOpDefaultRetryCnt, s.selfSchemaVerPath, InitialVersion,
 		clientv3.WithLease(s.session.Lease()))

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -123,11 +123,12 @@ func (s *schemaVersionSyncer) Init(ctx goctx.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	s.session, err = newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
+	session, err := newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
 		newSessionDefaultRetryCnt, SyncerSessionTTL)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	s.session = session
 	s.globalVerCh = s.etcdCli.Watch(ctx, DDLGlobalSchemaVersion)
 	return s.putKV(ctx, keyOpDefaultRetryCnt, s.selfSchemaVerPath, InitialVersion,
 		clientv3.WithLease(s.session.Lease()))
@@ -140,12 +141,12 @@ func (s *schemaVersionSyncer) Done() <-chan struct{} {
 
 // Restart implements SchemaSyncer.Restart interface.
 func (s *schemaVersionSyncer) Restart(ctx goctx.Context) error {
-	var err error
-	s.session, err = newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
+	session, err := newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
 		newSessionRetryUnlimited, SyncerSessionTTL)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	s.session = session
 	return s.putKV(ctx, putKeyRetryUnlimited, s.selfSchemaVerPath, InitialVersion,
 		clientv3.WithLease(s.session.Lease()))
 }


### PR DESCRIPTION
When we close the `etcdClient` we will get the error of `ErrClientConnClosing`.  Then we do the operation of `newSession` will make`s.session`'s value nil.  This logic is updated [here](https://github.com/pingcap/tidb/pull/3993/files#diff-0d8ba0320c6a278a303b497230d13e95R126).
And the `s.session` may use in `loadSchemaInLoop` . 