### PR TITLE
ddl: Handle the error of `ErrClientConnClosing` (#4117)

### DIFF
--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -140,12 +140,12 @@ func (s *schemaVersionSyncer) Done() <-chan struct{} {
 
 // Restart implements SchemaSyncer.Restart interface.
 func (s *schemaVersionSyncer) Restart(ctx goctx.Context) error {
-	var err error
-	s.session, err = newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
+	session, err := newSession(ctx, s.selfSchemaVerPath, s.etcdCli,
 		newSessionRetryUnlimited, SyncerSessionTTL)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	s.session = session
 	return s.putKV(ctx, putKeyRetryUnlimited, s.selfSchemaVerPath, InitialVersion,
 		clientv3.WithLease(s.session.Lease()))
 }


### PR DESCRIPTION
Cherry-pick from #4117 