### PR TITLE
expression: fix comapre two float64.

### DIFF
--- a/util/types/compare.go
+++ b/util/types/compare.go
@@ -29,22 +29,21 @@ func CompareInt64(x, y int64) int {
 
 // CompareUint64 returns an integer comparing the uint64 x to y.
 func CompareUint64(x, y uint64) int {
-	if x-y < floatEpsilon && y-x < floatEpsilon {
-		return 0
-	} else if x < y {
+	if x < y {
 		return -1
+	} else if x == y {
+		return 0
 	}
 	return 1
 }
 
 // CompareFloat64 returns an integer comparing the float64 x to y.
 func CompareFloat64(x, y float64) int {
-	if x < y {
-		return -1
-	} else if x == y {
+	if x-y < floatEpsilon && y-x < floatEpsilon {
 		return 0
+	} else if x < y {
+		return -1
 	}
-
 	return 1
 }
 

--- a/util/types/compare.go
+++ b/util/types/compare.go
@@ -13,6 +13,9 @@
 
 package types
 
+// floatEpsilon is the acceptable error quantity when comparing two float numbers.
+const floatEpsilon float64 = 2.2204460492503131e-16
+
 // CompareInt64 returns an integer comparing the int64 x to y.
 func CompareInt64(x, y int64) int {
 	if x < y {
@@ -26,12 +29,11 @@ func CompareInt64(x, y int64) int {
 
 // CompareUint64 returns an integer comparing the uint64 x to y.
 func CompareUint64(x, y uint64) int {
-	if x < y {
-		return -1
-	} else if x == y {
+	if x-y < floatEpsilon && y-x < floatEpsilon {
 		return 0
+	} else if x < y {
+		return -1
 	}
-
 	return 1
 }
 


### PR DESCRIPTION
Previously we compare two float64 without thinking about precision, which is not a common style.
So I copy a const `floatEpsilon` from `rust`. Any two float64 numbers are equals, if `abs(sub(a,b)) < floatEpsilon`.