### PR TITLE
*: change terror.ErrorEqual to Error.Equal, which is more effetive

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -311,7 +310,7 @@ func (d *ddl) backfillColumnInTxn(t table.Table, colMeta *columnMeta, handles []
 		rowKey := t.RecordKey(handle)
 		rowVal, err := txn.Get(rowKey)
 		if err != nil {
-			if terror.ErrorEqual(err, kv.ErrNotExist) {
+			if kv.ErrNotExist.Equal(err) {
 				// If row doesn't exist, skip it.
 				continue
 			}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tidb/util/types"
@@ -417,7 +416,7 @@ func checkDefaultValue(ctx context.Context, c *table.Column, hasDefaultValue boo
 
 	if c.DefaultValue != nil {
 		_, err := table.GetColDefaultValue(ctx, c.ToInfo())
-		if terror.ErrorEqual(err, types.ErrTruncated) {
+		if types.ErrTruncated.Equal(err) {
 			return errInvalidDefault.GenByArgs(c.Name)
 		}
 		return errors.Trace(err)

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
 
@@ -181,7 +180,7 @@ func (dr *delRange) doTask(ctx context.Context, r DelRangeTask) error {
 
 			for _, key := range dr.keys {
 				err := txn.Delete(key)
-				if err != nil && !terror.ErrorEqual(err, kv.ErrNotExist) {
+				if err != nil && !kv.ErrNotExist.Equal(err) {
 					return errors.Trace(err)
 				}
 			}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/terror"
 )
 
 func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -72,7 +71,7 @@ func (d *ddl) onDropTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	// Check this table's database.
 	tblInfo, err := t.GetTable(schemaID, tableID)
 	if err != nil {
-		if terror.ErrorEqual(err, meta.ErrDBNotExists) {
+		if meta.ErrDBNotExists.Equal(err) {
 			job.State = model.JobCancelled
 			return ver, errors.Trace(infoschema.ErrDatabaseNotExists.GenByArgs(
 				fmt.Sprintf("(Schema ID %d)", schemaID),
@@ -141,7 +140,7 @@ func getTableInfo(t *meta.Meta, job *model.Job, schemaID int64) (*model.TableInf
 	tableID := job.TableID
 	tblInfo, err := t.GetTable(schemaID, tableID)
 	if err != nil {
-		if terror.ErrorEqual(err, meta.ErrDBNotExists) {
+		if meta.ErrDBNotExists.Equal(err) {
 			job.State = model.JobCancelled
 			return nil, errors.Trace(infoschema.ErrDatabaseNotExists.GenByArgs(
 				fmt.Sprintf("(Schema ID %d)", schemaID),
@@ -254,7 +253,7 @@ func checkTableNotExists(t *meta.Meta, job *model.Job, schemaID int64, tableName
 	// Check this table's database.
 	tables, err := t.ListTables(schemaID)
 	if err != nil {
-		if terror.ErrorEqual(err, meta.ErrDBNotExists) {
+		if meta.ErrDBNotExists.Equal(err) {
 			job.State = model.JobCancelled
 			return infoschema.ErrDatabaseNotExists.GenByArgs("")
 		}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessionctx/varsutil"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -128,7 +127,7 @@ func (e *DDLExec) executeCreateDatabase(s *ast.CreateDatabaseStmt) error {
 	}
 	err := sessionctx.GetDomain(e.ctx).DDL().CreateSchema(e.ctx, model.NewCIStr(s.Name), opt)
 	if err != nil {
-		if terror.ErrorEqual(err, infoschema.ErrDatabaseExists) && s.IfNotExists {
+		if infoschema.ErrDatabaseExists.Equal(err) && s.IfNotExists {
 			err = nil
 		}
 	}
@@ -144,7 +143,7 @@ func (e *DDLExec) executeCreateTable(s *ast.CreateTableStmt) error {
 		referIdent := ast.Ident{Schema: s.ReferTable.Schema, Name: s.ReferTable.Name}
 		err = sessionctx.GetDomain(e.ctx).DDL().CreateTableWithLike(e.ctx, ident, referIdent)
 	}
-	if terror.ErrorEqual(err, infoschema.ErrTableExists) {
+	if infoschema.ErrTableExists.Equal(err) {
 		if s.IfNotExists {
 			return nil
 		}
@@ -162,7 +161,7 @@ func (e *DDLExec) executeCreateIndex(s *ast.CreateIndexStmt) error {
 func (e *DDLExec) executeDropDatabase(s *ast.DropDatabaseStmt) error {
 	dbName := model.NewCIStr(s.Name)
 	err := sessionctx.GetDomain(e.ctx).DDL().DropSchema(e.ctx, dbName)
-	if terror.ErrorEqual(err, infoschema.ErrDatabaseNotExists) {
+	if infoschema.ErrDatabaseNotExists.Equal(err) {
 		if s.IfExists {
 			err = nil
 		} else {

--- a/executor/write.go
+++ b/executor/write.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -706,7 +705,7 @@ func (e *InsertExec) Next() (Row, error) {
 			continue
 		}
 
-		if terror.ErrorEqual(err, kv.ErrKeyExists) {
+		if kv.ErrKeyExists.Equal(err) {
 			// If you use the IGNORE keyword, duplicate-key error that occurs while executing the INSERT statement are ignored.
 			// For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in
 			// the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row is discarded and no error occurs.
@@ -1121,7 +1120,7 @@ func (e *ReplaceExec) Next() (Row, error) {
 			idx++
 			continue
 		}
-		if err1 != nil && !terror.ErrorEqual(err1, kv.ErrKeyExists) {
+		if err1 != nil && !kv.ErrKeyExists.Equal(err1) {
 			return nil, errors.Trace(err1)
 		}
 		oldRow, err1 := e.Table.Row(e.ctx, h)

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/types"
 	"github.com/pingcap/tidb/util/types/json"
@@ -730,7 +729,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(row []types.Datum) (res int64, isNu
 		res, err = to.ToInt()
 	}
 
-	if terror.ErrorEqual(err, types.ErrOverflow) {
+	if types.ErrOverflow.Equal(err) {
 		warnErr := types.ErrTruncatedWrongVal.GenByArgs("DECIMAL", val)
 		err = sc.HandleOverflow(err, warnErr)
 	}
@@ -824,7 +823,7 @@ func (b *builtinCastStringAsIntSig) handleOverflow(origRes int64, origStr string
 	}
 
 	sc := b.getCtx().GetSessionVars().StmtCtx
-	if sc.InSelectStmt && terror.ErrorEqual(origErr, types.ErrOverflow) {
+	if sc.InSelectStmt && types.ErrOverflow.Equal(origErr) {
 		if isNegative {
 			res = math.MinInt64
 		} else {
@@ -944,7 +943,7 @@ func (b *builtinCastStringAsDurationSig) evalDuration(row []types.Datum) (res ty
 		return res, isNull, errors.Trace(err)
 	}
 	res, err = types.ParseDuration(val, b.tp.Decimal)
-	if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
 	return res, false, errors.Trace(err)
@@ -1235,7 +1234,7 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(row []types.Datum) (res type
 		return res, false, errors.Trace(err)
 	}
 	res, err = types.ParseDuration(s, b.tp.Decimal)
-	if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
 	return

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -201,7 +200,7 @@ func (b *builtinBitCountSig) eval(row []types.Datum) (d types.Datum, err error) 
 	sc.IgnoreTruncate = true
 	bin, err := arg.ToInt64(sc)
 	if err != nil {
-		if terror.ErrorEqual(err, types.ErrOverflow) {
+		if types.ErrOverflow.Equal(err) {
 			d.SetInt64(64)
 			return d, nil
 

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/types"
 )
 
@@ -1445,7 +1444,7 @@ func (b *builtinTimeSig) evalDuration(row []types.Datum) (res types.Duration, is
 	}
 
 	res, err = types.ParseDuration(expr, fsp)
-	if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
 	return res, isNull, errors.Trace(err)
@@ -2546,7 +2545,7 @@ func (b *builtinSecToTimeSig) eval(row []types.Datum) (d types.Datum, err error)
 	sc := b.ctx.GetSessionVars().StmtCtx
 	secondsFloat, err := args[0].ToFloat64(sc)
 	if err != nil {
-		if args[0].Kind() == types.KindString && terror.ErrorEqual(err, types.ErrTruncated) {
+		if args[0].Kind() == types.KindString && types.ErrTruncated.Equal(err) {
 			secondsFloat = float64(0)
 		} else {
 			return d, errors.Trace(err)

--- a/inspectkv/inspectkv.go
+++ b/inspectkv/inspectkv.go
@@ -185,7 +185,7 @@ func checkIndexAndRecord(txn kv.Transaction, t table.Table, idx table.Index) err
 		}
 
 		vals2, err := rowWithCols(txn, t, h, cols)
-		if terror.ErrorEqual(err, kv.ErrNotExist) {
+		if kv.ErrNotExist.Equal(err) {
 			record := &RecordData{Handle: h, Values: vals1}
 			err = errDateNotEqual.Gen("index:%v != record:%v", record, nil)
 		}
@@ -211,7 +211,7 @@ func checkRecordAndIndex(txn kv.Transaction, t table.Table, idx table.Index) err
 	startKey := t.RecordKey(0)
 	filterFunc := func(h1 int64, vals1 []types.Datum, cols []*table.Column) (bool, error) {
 		isExist, h2, err := idx.Exist(txn, vals1, h1)
-		if terror.ErrorEqual(err, kv.ErrKeyExists) {
+		if kv.ErrKeyExists.Equal(err) {
 			record1 := &RecordData{Handle: h1, Values: vals1}
 			record2 := &RecordData{Handle: h2, Values: vals1}
 			return false, errDateNotEqual.Gen("index:%v != record:%v", record2, record1)

--- a/kv/error.go
+++ b/kv/error.go
@@ -84,9 +84,9 @@ func IsRetryableError(err error) bool {
 		return false
 	}
 
-	if terror.ErrorEqual(err, ErrRetryable) ||
-		terror.ErrorEqual(err, ErrLockConflict) ||
-		terror.ErrorEqual(err, ErrConditionNotMatch) ||
+	if ErrRetryable.Equal(err) ||
+		ErrLockConflict.Equal(err) ||
+		ErrConditionNotMatch.Equal(err) ||
 		// TiKV exception message will tell you if you should retry or not
 		strings.Contains(err.Error(), "try again later") {
 		return true
@@ -97,7 +97,7 @@ func IsRetryableError(err error) bool {
 
 // IsErrNotFound checks if err is a kind of NotFound error.
 func IsErrNotFound(err error) bool {
-	if terror.ErrorEqual(err, ErrNotExist) {
+	if ErrNotExist.Equal(err) {
 		return true
 	}
 

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/types"
 )
@@ -160,7 +159,7 @@ func (p *DataSource) convert2IndexScan(prop *requiredProperty, index *model.Inde
 			var err error
 			is.Ranges, err = ranger.BuildIndexRange(p.ctx.GetSessionVars().StmtCtx, is.Table, is.Index, is.accessInAndEqCount, is.AccessCondition)
 			if err != nil {
-				if !terror.ErrorEqual(err, types.ErrTruncated) {
+				if !types.ErrTruncated.Equal(err) {
 					return nil, errors.Trace(err)
 				}
 				log.Warn("truncate error in buildIndexRange")

--- a/server/conn.go
+++ b/server/conn.go
@@ -59,7 +59,8 @@ import (
 var defaultCapability = mysql.ClientLongPassword | mysql.ClientLongFlag |
 	mysql.ClientConnectWithDB | mysql.ClientProtocol41 |
 	mysql.ClientTransactions | mysql.ClientSecureConnection | mysql.ClientFoundRows |
-	mysql.ClientMultiResults | mysql.ClientLocalFiles | mysql.ClientConnectAtts
+	mysql.ClientMultiResults | mysql.ClientLocalFiles |
+	mysql.ClientConnectAtts | mysql.ClientPluginAuth
 
 // clientConn represents a connection between server and client, it maintains connection specific state,
 // handles client query.
@@ -160,6 +161,9 @@ func (cc *clientConn) writeInitialHandshake() error {
 	// auth-plugin-data-part-2
 	data = append(data, cc.salt[8:]...)
 	// filler [00]
+	data = append(data, 0)
+	// auth-plugin name
+	data = append(data, []byte("mysql_native_password")...)
 	data = append(data, 0)
 	err := cc.writePacket(data)
 	if err != nil {

--- a/server/conn.go
+++ b/server/conn.go
@@ -365,11 +365,11 @@ func (cc *clientConn) Run() {
 			if terror.ErrorEqual(err, io.EOF) {
 				cc.addMetrics(data[0], startTime, nil)
 				return
-			} else if terror.ErrorEqual(err, terror.ErrResultUndetermined) {
+			} else if terror.ErrResultUndetermined.Equal(err) {
 				log.Errorf("[%d] result undetermined error, close this connection %s",
 					cc.connectionID, errors.ErrorStack(err))
 				return
-			} else if terror.ErrorEqual(err, terror.ErrCritical) {
+			} else if terror.ErrCritical.Equal(err) {
 				log.Errorf("[%d] critical error, stop the server listener %s",
 					cc.connectionID, errors.ErrorStack(err))
 				criticalErrorCounter.Add(1)

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -14,6 +14,10 @@
 package server
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/binary"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
 )
@@ -95,6 +99,37 @@ func (ts ConnTestSuite) TestIssue1768(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(p.Capability&mysql.ClientPluginAuthLenencClientData, Equals, mysql.ClientPluginAuthLenencClientData)
 	c.Assert(len(p.Auth) > 0, IsTrue)
+}
+
+func (ts ConnTestSuite) TestInitialHandshake(c *C) {
+	c.Parallel()
+	var outBuffer bytes.Buffer
+	cc := &clientConn{
+		connectionID: 1,
+		salt:         []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10},
+		pkt: &packetIO{
+			wb: bufio.NewWriter(&outBuffer),
+		},
+	}
+	err := cc.writeInitialHandshake()
+	c.Assert(err, IsNil)
+
+	expected := new(bytes.Buffer)
+	expected.WriteByte(0x0a)                                                           // Protocol
+	expected.WriteString(mysql.ServerVersion)                                          // Version
+	expected.WriteByte(0x00)                                                           // NULL
+	binary.Write(expected, binary.LittleEndian, int32(1))                              // Connection ID
+	expected.Write([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x00})       // Salt
+	binary.Write(expected, binary.LittleEndian, int16(defaultCapability&0xFFFF))       // Server Capability
+	expected.WriteByte(uint8(mysql.DefaultCollationID))                                // Server Language
+	binary.Write(expected, binary.LittleEndian, mysql.ServerStatusAutocommit)          // Server Status
+	binary.Write(expected, binary.LittleEndian, int16((defaultCapability>>16)&0xFFFF)) // Extended Server Capability
+	expected.WriteByte(0x15)                                                           // Authentication Plugin Length
+	expected.Write([]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}) // Unused
+	expected.Write([]byte{0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x00})       // Salt
+	expected.WriteString("mysql_native_password")                                      // Authentication Plugin
+	expected.WriteByte(0x00)                                                           // NULL
+	c.Assert(outBuffer.Bytes()[4:], DeepEquals, expected.Bytes())
 }
 
 func mapIdentical(m1, m2 map[string]string) bool {

--- a/session.go
+++ b/session.go
@@ -47,7 +47,6 @@ import (
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/types"
@@ -291,7 +290,7 @@ func (s *session) doCommitWithRetry() error {
 			// We make larger transactions retry less times to prevent cluster resource outage.
 			txnSizeRate := float64(txnSize) / float64(kv.TxnTotalSizeLimit)
 			maxRetryCount := commitRetryLimit - int(float64(commitRetryLimit-1)*txnSizeRate)
-			err = s.retry(maxRetryCount, terror.ErrorEqual(err, domain.ErrInfoSchemaChanged))
+			err = s.retry(maxRetryCount, domain.ErrInfoSchemaChanged.Equal(err))
 		}
 	}
 	s.cleanRetryInfo()
@@ -364,7 +363,7 @@ func (s *session) isRetryableError(err error) bool {
 	if SchemaChangedWithoutRetry {
 		return kv.IsRetryableError(err)
 	}
-	return kv.IsRetryableError(err) || terror.ErrorEqual(err, domain.ErrInfoSchemaChanged)
+	return kv.IsRetryableError(err) || domain.ErrInfoSchemaChanged.Equal(err)
 }
 
 func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
@@ -420,7 +419,7 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 			return errors.Trace(err)
 		}
 		retryCnt++
-		infoSchemaChanged = terror.ErrorEqual(err, domain.ErrInfoSchemaChanged)
+		infoSchemaChanged = domain.ErrInfoSchemaChanged.Equal(err)
 		if !s.unlimitedRetryCount && (retryCnt >= maxCnt) {
 			log.Warnf("[%d] Retry reached max count %d", connID, retryCnt)
 			return errors.Trace(err)
@@ -653,7 +652,7 @@ func (s *session) Execute(sql string) ([]ast.RecordSet, error) {
 		r, err := runStmt(s, st)
 		ph.EndStatement(s.stmtState)
 		if err != nil {
-			if !terror.ErrorEqual(err, kv.ErrKeyExists) {
+			if !kv.ErrKeyExists.Equal(err) {
 				log.Warnf("[%d] session error:\n%v\n%s", connID, errors.ErrorStack(err), s)
 			}
 			return nil, errors.Trace(err)

--- a/store/localstore/local_region.go
+++ b/store/localstore/local_region.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/types"
 	"github.com/pingcap/tipb/go-tipb"
@@ -435,7 +434,7 @@ func (rs *localRegion) getRowsFromRange(ctx *selectContext, ran kv.KeyRange, lim
 	if ran.IsPoint() {
 		var value []byte
 		value, err = ctx.txn.Get(ran.StartKey)
-		if terror.ErrorEqual(err, kv.ErrNotExist) {
+		if kv.ErrNotExist.Equal(err) {
 			return 0, nil
 		} else if err != nil {
 			return 0, errors.Trace(err)
@@ -827,5 +826,5 @@ func buildLocalRegionServers(store *dbStore) []*localRegion {
 }
 
 func isDefaultNull(err error, col *tipb.ColumnInfo) bool {
-	return terror.ErrorEqual(err, kv.ErrNotExist) && !mysql.HasNotNullFlag(uint(col.GetFlag()))
+	return kv.ErrNotExist.Equal(err) && !mysql.HasNotNullFlag(uint(col.GetFlag()))
 }

--- a/store/localstore/snapshot.go
+++ b/store/localstore/snapshot.go
@@ -117,7 +117,7 @@ func (s *dbSnapshot) reverseMvccSeek(key kv.Key) (kv.Key, []byte, error) {
 			return nil, nil, errors.Trace(err)
 		}
 		resultKey, v, err := s.mvccSeek(revKey, true)
-		if terror.ErrorEqual(err, kv.ErrNotExist) {
+		if kv.ErrNotExist.Equal(err) {
 			key = revKey
 			continue
 		}
@@ -177,7 +177,7 @@ func newDBIter(s *dbSnapshot, key kv.Key, reverse bool) (*dbIter, error) {
 		k, v, err = s.mvccSeek(key, false)
 	}
 	if err != nil {
-		if terror.ErrorEqual(err, kv.ErrNotExist) {
+		if kv.ErrNotExist.Equal(err) {
 			err = nil
 		}
 		return &dbIter{valid: false}, errors.Trace(err)
@@ -202,7 +202,7 @@ func (it *dbIter) Next() error {
 	}
 	if err != nil {
 		it.valid = false
-		if !terror.ErrorEqual(err, kv.ErrNotExist) {
+		if !kv.ErrNotExist.Equal(err) {
 			return errors.Trace(err)
 		}
 	}

--- a/structure/hash.go
+++ b/structure/hash.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/terror"
 )
 
 // HashPair is the pair for (field, value) in a hash.
@@ -57,7 +56,7 @@ func (t *TxStructure) HSet(key []byte, field []byte, value []byte) error {
 func (t *TxStructure) HGet(key []byte, field []byte) ([]byte, error) {
 	dataKey := t.encodeHashDataKey(key, field)
 	value, err := t.reader.Get(dataKey)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
 	return value, errors.Trace(err)
@@ -262,7 +261,7 @@ func (t *TxStructure) iterateHash(key []byte, fn func(k []byte, v []byte) error)
 
 func (t *TxStructure) loadHashMeta(metaKey []byte) (hashMeta, error) {
 	v, err := t.reader.Get(metaKey)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	} else if err != nil {
 		return hashMeta{}, errors.Trace(err)
@@ -283,7 +282,7 @@ func (t *TxStructure) loadHashMeta(metaKey []byte) (hashMeta, error) {
 
 func (t *TxStructure) loadHashValue(dataKey []byte) ([]byte, error) {
 	v, err := t.reader.Get(dataKey)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 		v = nil
 	} else if err != nil {

--- a/structure/list.go
+++ b/structure/list.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/terror"
 )
 
 type listMeta struct {
@@ -195,7 +194,7 @@ func (t *TxStructure) LClear(key []byte) error {
 
 func (t *TxStructure) loadListMeta(metaKey []byte) (listMeta, error) {
 	v, err := t.reader.Get(metaKey)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	} else if err != nil {
 		return listMeta{}, errors.Trace(err)

--- a/structure/string.go
+++ b/structure/string.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/terror"
 )
 
 // Set sets the string value of the key.
@@ -34,7 +33,7 @@ func (t *TxStructure) Set(key []byte, value []byte) error {
 func (t *TxStructure) Get(key []byte) ([]byte, error) {
 	ek := t.encodeStringDataKey(key)
 	value, err := t.reader.Get(ek)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
 	return value, errors.Trace(err)
@@ -60,7 +59,7 @@ func (t *TxStructure) Inc(key []byte, step int64) (int64, error) {
 	ek := t.encodeStringDataKey(key)
 	// txn Inc will lock this key, so we don't lock it here.
 	n, err := kv.IncInt64(t.readWriter, ek, step)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
 	return n, errors.Trace(err)
@@ -73,7 +72,7 @@ func (t *TxStructure) Clear(key []byte) error {
 	}
 	ek := t.encodeStringDataKey(key)
 	err := t.readWriter.Delete(ek)
-	if terror.ErrorEqual(err, kv.ErrNotExist) {
+	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
 	return errors.Trace(err)

--- a/terror/terror.go
+++ b/terror/terror.go
@@ -246,6 +246,10 @@ func (e *Error) Equal(err error) bool {
 	if originErr == nil {
 		return false
 	}
+
+	if error(e) == originErr {
+		return true
+	}
 	inErr, ok := originErr.(*Error)
 	return ok && e.class == inErr.class && e.code == inErr.code
 }

--- a/terror/terror_test.go
+++ b/terror/terror_test.go
@@ -71,6 +71,12 @@ func (s *testTErrorSuite) TestTError(c *C) {
 	sqlErr := e.ToSQLError()
 	c.Assert(sqlErr.Message, Equals, "Duplicate entry '1' for key 'PRIMARY'")
 	c.Assert(sqlErr.Code, Equals, uint16(1062))
+
+	err := errors.Trace(ErrCritical.GenByArgs("test"))
+	c.Assert(ErrCritical.Equal(err), IsTrue)
+
+	err = errors.Trace(ErrCritical)
+	c.Assert(ErrCritical.Equal(err), IsTrue)
 }
 
 func (s *testTErrorSuite) TestJson(c *C) {

--- a/util/types/convert.go
+++ b/util/types/convert.go
@@ -25,7 +25,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/terror"
 )
 
 func truncateStr(str string, flen int) string {
@@ -188,7 +187,7 @@ func StrToDuration(sc *variable.StatementContext, str string, fsp int) (t Time, 
 	}
 
 	duration, err := ParseDuration(str, fsp)
-	if terror.ErrorEqual(err, ErrTruncatedWrongVal) {
+	if ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
 	if err != nil {

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -24,7 +24,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/types/json"
@@ -1138,7 +1137,7 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *variable.State
 		}
 	}
 
-	if terror.ErrorEqual(err, ErrOverflow) {
+	if ErrOverflow.Equal(err) {
 		// TODO: warnErr need to be ErrWarnDataOutOfRange
 		err = sc.HandleOverflow(err, err)
 	}


### PR DESCRIPTION
the `terror.ErrorEqual()` compare whether two error object are equal, it do it correctlly, but not effectivelly. 

```
func ErrorEqual(err1, err2 error) bool {
	e1 := errors.Cause(err1)
	e2 := errors.Cause(err2)

	if e1 == e2 {
		return true
	}

	if e1 == nil || e2 == nil {
		return e1 == e2
	}

	te1, ok1 := e1.(*Error)
	te2, ok2 := e2.(*Error)
	if ok1 && ok2 {
		return te1.class == te2.class && te1.code == te2.code
	}

	return e1.Error() == e2.Error() // in most cases it is unnecessary
}
```

the cases modified in this PR, is the terror.Error object, it have a `Error.Equal` method, the method do the same thing, but it doesn't compare the error string.

`terror.ErrorEqual()` is used to compare the error except `terror.Error`, like below in [ddl_worker.go#L343](https://github.com/pingcap/tidb/blob/master/ddl/ddl_worker.go#L343):

```
if terror.ErrorEqual(err, goctx.DeadlineExceeded) {
	return
}
```
