### PR TITLE
Add release version info

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -27,6 +27,7 @@ const (
 	TiDBReleaseVersion string = "0.8.0"
 )
 
+// ServerVersion is the version information of this tidb-server in MySQL's format.
 var ServerVersion string
 
 // Header information.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -14,6 +14,7 @@
 package mysql
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -23,8 +24,10 @@ const (
 	MaxPayloadLen      int  = 1<<24 - 1
 	// The version number should be three digits.
 	// See https://dev.mysql.com/doc/refman/5.7/en/which-version.html
-	ServerVersion string = "5.7.1-TiDB-1.0"
+	TiDBReleaseVersion string = "0.8.0"
 )
+
+var ServerVersion string
 
 // Header information.
 const (
@@ -489,3 +492,7 @@ const (
 const (
 	PrimaryKeyName = "PRIMARY"
 )
+
+func init() {
+	ServerVersion = fmt.Sprintf("5.7.1-TiDB-%s", TiDBReleaseVersion)
+}

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/ngaut/log"
+	"github.com/pingcap/tidb/mysql"
 )
 
 // Version information.
@@ -31,6 +32,7 @@ var (
 func PrintTiDBInfo() {
 	log.Infof("Welcome to TiDB.")
 	log.Infof("Version:")
+	log.Infof("Release Version: %s", mysql.TiDBReleaseVersion)
 	log.Infof("Git Commit Hash: %s", TiDBGitHash)
 	log.Infof("Git Branch: %s", TiDBGitBranch)
 	log.Infof("UTC Build Time:  %s", TiDBBuildTS)
@@ -38,6 +40,7 @@ func PrintTiDBInfo() {
 
 // PrintRawTiDBInfo prints the TiDB version information without log info.
 func PrintRawTiDBInfo() {
+	fmt.Println("Release Version:", mysql.TiDBReleaseVersion)
 	fmt.Println("Git Commit Hash:", TiDBGitHash)
 	fmt.Println("Git Commit Branch:", TiDBGitBranch)
 	fmt.Println("UTC Build Time: ", TiDBBuildTS)
@@ -45,7 +48,7 @@ func PrintRawTiDBInfo() {
 
 // GetTiDBInfo returns the git hash and build time of this tidb-server binary.
 func GetTiDBInfo() string {
-	return fmt.Sprintf("Git Commit Hash: %s\nGit Branch: %s\nUTC Build Time: %s", TiDBGitHash, TiDBGitBranch, TiDBBuildTS)
+	return fmt.Sprintf("Release Version: %s\nGit Commit Hash: %s\nGit Branch: %s\nUTC Build Time: %s", mysql.TiDBReleaseVersion, TiDBGitHash, TiDBGitBranch, TiDBBuildTS)
 }
 
 // checkValidity checks whether cols and every data have the same length.

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -31,7 +31,6 @@ var (
 // PrintTiDBInfo prints the TiDB version information.
 func PrintTiDBInfo() {
 	log.Infof("Welcome to TiDB.")
-	log.Infof("Version:")
 	log.Infof("Release Version: %s", mysql.TiDBReleaseVersion)
 	log.Infof("Git Commit Hash: %s", TiDBGitHash)
 	log.Infof("Git Branch: %s", TiDBGitBranch)


### PR DESCRIPTION
Add version information in tidb-server's log, `tidb-server -V` output and mysql-client prompt.
So it is easier to get the release information.