### PR TITLE
ddl: Use the correct error

### DIFF
--- a/ddl/owner_manager.go
+++ b/ddl/owner_manager.go
@@ -117,7 +117,7 @@ func newSession(ctx goctx.Context, flag string, etcdCli *clientv3.Client, retryC
 	var etcdSession *concurrency.Session
 	for i := 0; i < retryCnt; i++ {
 		if isContextDone(ctx) {
-			return nil, errors.Trace(err)
+			return etcdSession, errors.Trace(ctx.Err())
 		}
 
 		etcdSession, err = concurrency.NewSession(etcdCli,
@@ -180,10 +180,6 @@ func (m *ownerManager) campaignLoop(ctx goctx.Context, etcdSession *concurrency.
 		err = elec.Campaign(ctx, m.ddlID)
 		if err != nil {
 			log.Infof("[ddl] %s failed to campaign, err %v", idInfo, err)
-			if isCtxFinishedInETCD(err) {
-				log.Warnf("[ddl] %s campaign loop, err %v", idInfo, err)
-				return
-			}
 			continue
 		}
 

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -24,8 +24,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	goctx "golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -183,14 +181,6 @@ func (s *schemaVersionSyncer) RemoveSelfVersionPath() error {
 	return errors.Trace(err)
 }
 
-func isCtxFinishedInETCD(err error) bool {
-	errCode := grpc.Code(errors.Cause(err))
-	if errCode == codes.Canceled || errCode == codes.DeadlineExceeded {
-		return true
-	}
-	return false
-}
-
 func isContextDone(ctx goctx.Context) bool {
 	select {
 	case <-ctx.Done():
@@ -212,9 +202,6 @@ func (s *schemaVersionSyncer) OwnerCheckAllVersions(ctx goctx.Context, latestVer
 		}
 
 		resp, err := s.etcdCli.Get(ctx, DDLAllSchemaVersions, clientv3.WithPrefix())
-		if isCtxFinishedInETCD(err) {
-			return errors.Trace(err)
-		}
 		if err != nil {
 			log.Infof("[syncer] check all versions failed %v", err)
 			continue


### PR DESCRIPTION
1. Use the correct error
2. It is unreliable to check whether the error is equal to `grpc.ErrClientConnClosing`.  So I update this logic.