### PR TITLE
DDL: remove all stuff about backgroud DDL worker.

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -545,18 +545,6 @@ func upgradeToVer15(s Session) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = s.NewTxn()
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = ddl.LoadPendingBgJobsIntoDeleteTable(s)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = s.CommitTxn()
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -43,8 +43,6 @@ import (
 const (
 	// currentVersion is for all new DDL jobs.
 	currentVersion = 1
-	// Any background job with version greater or equal this should be processed with delete-range.
-	bgJobMigrateVersion = 1
 )
 
 var (

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -111,19 +111,7 @@ func (d *ddl) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
 	switch job.Type {
 	case model.ActionDropSchema, model.ActionDropTable, model.ActionTruncateTable, model.ActionDropIndex:
 		if job.Version <= currentVersion {
-			if job.Version < bgJobMigrateVersion {
-				// TODO: remove this logic in future.
-				log.Infof("[ddl] deal with old job %d (version %d)", job.ID, job.Version)
-				err = t.EnQueueBgJob(&model.Job{
-					ID:       job.ID,
-					SchemaID: job.SchemaID,
-					TableID:  job.TableID,
-					Type:     job.Type,
-					RawArgs:  job.RawArgs,
-				})
-			} else {
-				err = d.delRangeManager.addDelRangeJob(job)
-			}
+			err = d.delRangeManager.addDelRangeJob(job)
 		} else {
 			err = errInvalidJobVersion.GenByArgs(job.Version, currentVersion)
 		}

--- a/inspectkv/inspectkv.go
+++ b/inspectkv/inspectkv.go
@@ -64,24 +64,6 @@ func GetDDLInfo(txn kv.Transaction) (*DDLInfo, error) {
 	return info, nil
 }
 
-// GetBgDDLInfo returns background DDL information.
-func GetBgDDLInfo(txn kv.Transaction) (*DDLInfo, error) {
-	var err error
-	info := &DDLInfo{}
-	t := meta.NewMeta(txn)
-
-	info.Job, err = t.GetBgJob(0)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	info.SchemaVer, err = t.GetSchemaVersion()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	return info, nil
-}
-
 func nextIndexVals(data []types.Datum) []types.Datum {
 	// Add 0x0 to the end of data.
 	return append(data, types.Datum{})

--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -161,27 +161,6 @@ func (s *testSuite) TestGetDDLInfo(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *testSuite) TestGetBgDDLInfo(c *C) {
-	defer testleak.AfterTest(c)()
-	txn, err := s.store.Begin()
-	c.Assert(err, IsNil)
-	t := meta.NewMeta(txn)
-
-	job := &model.Job{
-		SchemaID: 1,
-		Type:     model.ActionDropTable,
-		RowCount: 0,
-	}
-	err = t.EnQueueBgJob(job)
-	c.Assert(err, IsNil)
-	info, err := GetBgDDLInfo(txn)
-	c.Assert(err, IsNil)
-	c.Assert(info.Job, DeepEquals, job)
-	c.Assert(info.ReorgHandle, Equals, int64(0))
-	err = txn.Commit()
-	c.Assert(err, IsNil)
-}
-
 func (s *testSuite) TestScan(c *C) {
 	defer testleak.AfterTest(c)()
 	alloc := autoid.NewAllocator(s.store, s.dbInfo.ID)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -607,61 +607,6 @@ func (m *Meta) GetDDLReorgHandle(job *model.Job) (int64, error) {
 	return value, errors.Trace(err)
 }
 
-// DDL background job structure
-//	BgJobOnwer: []byte
-//	BgJobList: list jobs
-//	BgJobHistory: hash
-//	BgJobReorg: hash
-//
-// for multi background worker, only one can become the owner
-// to operate background job, and dispatch them to MR background job.
-
-var (
-	mBgJobListKey    = []byte("BgJobList")
-	mBgJobHistoryKey = []byte("BgJobHistory")
-)
-
-// UpdateBgJob updates the background job with index.
-func (m *Meta) UpdateBgJob(index int64, job *model.Job) error {
-	return m.updateDDLJob(index, job, mBgJobListKey)
-}
-
-// GetBgJob returns the background job with index.
-func (m *Meta) GetBgJob(index int64) (*model.Job, error) {
-	job, err := m.getDDLJob(mBgJobListKey, index)
-
-	return job, errors.Trace(err)
-}
-
-// EnQueueBgJob adds a background job to the list.
-func (m *Meta) EnQueueBgJob(job *model.Job) error {
-	var updateRawArgs bool
-	if job.RawArgs == nil {
-		updateRawArgs = true
-	}
-	return m.enQueueDDLJob(mBgJobListKey, job, updateRawArgs)
-}
-
-// BgJobQueueLen returns the background job queue length.
-func (m *Meta) BgJobQueueLen() (int64, error) {
-	return m.txn.LLen(mBgJobListKey)
-}
-
-// AddHistoryBgJob adds background job to history.
-func (m *Meta) AddHistoryBgJob(job *model.Job) error {
-	return m.addHistoryDDLJob(mBgJobHistoryKey, job)
-}
-
-// GetHistoryBgJob gets a history background job.
-func (m *Meta) GetHistoryBgJob(id int64) (*model.Job, error) {
-	return m.getHistoryDDLJob(mBgJobHistoryKey, id)
-}
-
-// DeQueueBgJob pops a background job from the list.
-func (m *Meta) DeQueueBgJob() (*model.Job, error) {
-	return m.deQueueDDLJob(mBgJobListKey)
-}
-
 func (m *Meta) tableStatsKey(tableID int64) []byte {
 	return []byte(fmt.Sprintf("%s:%d", mTableStatsPrefix, tableID))
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -311,33 +311,6 @@ func (s *testSuite) TestDDL(c *C) {
 		lastID = job.ID
 	}
 
-	bgJob := &model.Job{ID: 1}
-	err = t.EnQueueBgJob(bgJob)
-	c.Assert(err, IsNil)
-	n, err = t.BgJobQueueLen()
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(1))
-
-	v, err = t.GetBgJob(0)
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, bgJob)
-	v, err = t.GetBgJob(1)
-	c.Assert(err, IsNil)
-	c.Assert(v, IsNil)
-	bgJob.ID = 2
-	err = t.UpdateBgJob(0, bgJob)
-	c.Assert(err, IsNil)
-
-	v, err = t.DeQueueBgJob()
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, bgJob)
-
-	err = t.AddHistoryBgJob(bgJob)
-	c.Assert(err, IsNil)
-	v, err = t.GetHistoryBgJob(2)
-	c.Assert(err, IsNil)
-	c.Assert(v, DeepEquals, bgJob)
-
 	err = txn.Commit()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
It will causes TiDB upgrade without **VERSION 15** lost something in GC. But if our next version doesn't support inplace upgrade, it's OK.