### PR TITLE
fix 'binary BINARY' for special field type

### DIFF
--- a/util/types/field_type.go
+++ b/util/types/field_type.go
@@ -234,7 +234,7 @@ func (ft *FieldType) String() string {
 	if mysql.HasZerofillFlag(ft.Flag) {
 		strs = append(strs, "ZEROFILL")
 	}
-	if mysql.HasBinaryFlag(ft.Flag) {
+	if mysql.HasBinaryFlag(ft.Flag) && ft.Tp != mysql.TypeString {
 		strs = append(strs, "BINARY")
 	}
 

--- a/util/types/field_type_test.go
+++ b/util/types/field_type_test.go
@@ -67,6 +67,11 @@ func (s *testFieldTypeSuite) TestFieldType(c *C) {
 	ft.Flag |= mysql.BinaryFlag
 	c.Assert(ft.String(), Equals, "varchar(10) BINARY")
 
+	ft = NewFieldType(mysql.TypeString)
+	ft.Charset = charset.CollationBin
+	ft.Flag |= mysql.BinaryFlag
+	c.Assert(ft.String(), Equals, "binary")
+
 	ft = NewFieldType(mysql.TypeEnum)
 	ft.Elems = []string{"a", "b"}
 	c.Assert(ft.String(), Equals, "enum('a','b')")


### PR DESCRIPTION
fix: avoid 'binary BINARY' for special field type

When parsing DML like 'ALTER TABLE t MODIFY COLUMN a binary', there will
be a node parsed as '... binary BINARY...'. That is wrong, the right result should be '... binary ...'