### PR TITLE
tidb-server: set store default value to goleveldb

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -47,7 +47,7 @@ import (
 
 var (
 	version             = flagBoolean("V", false, "print version information and exit")
-	store               = flag.String("store", "mocktikv", "registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]")
+	store               = flag.String("store", "goleveldb", "registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]")
 	storePath           = flag.String("path", "/tmp/tidb", "tidb storage path")
 	logLevel            = flag.String("L", "info", "log level: info, debug, warn, error, fatal")
 	host                = flag.String("host", "0.0.0.0", "tidb server host")


### PR DESCRIPTION
In the last commit, the store default value is changed to mocktikv, 
but its `ReverseScan` is not implement yet, so CI fail.
Revert the default store temporarily for the sake of CI.
I'll implement ReverseScan and set it back later.

@zimulala @hanfei1991 @shenli 