### PR TITLE
tikv: enlarge batch size

### DIFF
--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	scanBatchSize = 100
+	scanBatchSize = 256
 	batchGetSize  = 5120
 )
 


### PR DESCRIPTION
Enlarge batch size from 128 to 256 to reduce network round trip. 