### PR TITLE
*: ignore debug binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ bin
 /interpreter/test
 /parser/parser.go
 /tidb-server/tidb-server
+/tidb-server/debug
 coverage.out
 .idea/
 *.iml


### PR DESCRIPTION
When debugging using VSCode, the binary is compiled into `/tidb-server/debug`.