### PR TITLE
mysql: Upgrade version to 0.9.0

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -24,7 +24,7 @@ const (
 	MaxPayloadLen      int  = 1<<24 - 1
 	// The version number should be three digits.
 	// See https://dev.mysql.com/doc/refman/5.7/en/which-version.html
-	TiDBReleaseVersion string = "0.8.0"
+	TiDBReleaseVersion string = "0.9.0"
 )
 
 // ServerVersion is the version information of this tidb-server in MySQL's format.


### PR DESCRIPTION
RC4 uses `0.8.0`. Pre-GA should upgrade it to `0.9.0`.