### PR TITLE
should use bytes.Equal(batch.keys[0], c.primary()) instead

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -430,7 +430,7 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 	// Under this circumstance,  we can not declare the commit is complete (may lead to data lost), nor can we throw
 	// an error (may lead to the duplicated key error when upper level restarts the transaction). Currently the best
 	// solution is to populate this error and let upper layer drop the connection to the corresponding mysql client.
-	isPrimary := bytes.Compare(batch.keys[0], c.primary()) == 0
+	isPrimary := bytes.Equal(batch.keys[0], c.primary())
 
 	resp, err := c.store.SendReq(bo, req, batch.region, readTimeoutShort)
 	if err != nil {


### PR DESCRIPTION
should use bytes.Equal(batch.keys[0], c.primary()) instead