### PR TITLE
expression: Fix cast( date as datetime) error

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -991,6 +991,10 @@ func (b *builtinCastTimeAsTimeSig) evalTime(row []types.Datum) (res types.Time, 
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+
+	if res, err = res.Convert(b.tp.Tp); err != nil {
+		return res, true, errors.Trace(err)
+	}
 	res, err = res.RoundFrac(b.tp.Decimal)
 	if b.tp.Tp == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1609,6 +1609,8 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("<nil>"))
 	result = tk.MustQuery(`select cast(8385960 as time);`)
 	result.Check(testkit.Rows("<nil>"))
+	result = tk.MustQuery(`select cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2));`)
+	result.Check(testkit.Rows("2017-01-01 00:00:00.00"))
 
 	// for ISNULL
 	tk.MustExec("drop table if exists t")


### PR DESCRIPTION
for issue #4483 , #4259
**In MySQL**
```sql
mysql> select cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2));
Field   1:  `cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2))`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       DATETIME
Collation:  binary (63)
Length:     22
Max_length: 22
Decimals:   2
Flags:      BINARY


+-------------------------------------------------------------+
| cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2)) |
+-------------------------------------------------------------+
| 2017-01-01 00:00:00.00                                      |
+-------------------------------------------------------------+
1 row in set (0.00 sec)

```

**In TiDB**
```sql
tidb> select cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2));
Field   1:  `cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2))`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       DATETIME
Collation:  binary (63)
Length:     22
Max_length: 10
Decimals:   2
Flags:      BINARY


+-------------------------------------------------------------+
| cast(cast('2017-01-01 01:01:11.12' as date) as datetime(2)) |
+-------------------------------------------------------------+
| 2017-01-01                                                  |
+-------------------------------------------------------------+
1 row in set (0.00 sec)

```

