### PR TITLE
mock-tikv: fix golint

### DIFF
--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -191,11 +191,7 @@ func (h *rpcHandler) checkRequest(ctx *kvrpcpb.Context, size int) *errorpb.Error
 	if err := h.checkRequestContext(ctx); err != nil {
 		return err
 	}
-
-	if err := h.checkRequestSize(size); err != nil {
-		return err
-	}
-	return nil
+	return h.checkRequestSize(size)
 }
 
 func (h *rpcHandler) checkKeyInRegion(key []byte) bool {


### PR DESCRIPTION
golint has updated to check redundant `if`.