### PR TITLE
Makefile: do not generate ignored error message in parser.go.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,15 +44,12 @@ dev: checklist parserlib build benchkv test check
 build:
 	$(GOBUILD)
 
-TEMP_FILE = temp_parser_file
-
 goyacc:
 	$(GOBUILD) -o bin/goyacc parser/goyacc/main.go
 
 parser: goyacc
 	bin/goyacc -o /dev/null parser/parser.y
-	bin/goyacc -o parser/parser.go parser/parser.y 2>&1 | egrep "(shift|reduce)/reduce" | awk '{print} END {if (NR > 0) {print "Find conflict in parser.y. Please check y.output for more information."; system("rm -f $(TEMP_FILE)"); exit 1;}}'
-	rm -f $(TEMP_FILE)
+	bin/goyacc -o parser/parser.go parser/parser.y 2>&1 | egrep "(shift|reduce)/reduce" | awk '{print} END {if (NR > 0) {print "Find conflict in parser.y. Please check y.output for more information."; exit 1;}}'
 	rm -f y.output
 
 	@if [ $(ARCH) = $(LINUX) ]; \

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ goyacc:
 	$(GOBUILD) -o bin/goyacc parser/goyacc/main.go
 
 parser: goyacc
-	bin/goyacc -o /dev/null -xegen $(TEMP_FILE) parser/parser.y
-	bin/goyacc -o parser/parser.go -xe $(TEMP_FILE) parser/parser.y 2>&1 | egrep "(shift|reduce)/reduce" | awk '{print} END {if (NR > 0) {print "Find conflict in parser.y. Please check y.output for more information."; system("rm -f $(TEMP_FILE)"); exit 1;}}'
+	bin/goyacc -o /dev/null parser/parser.y
+	bin/goyacc -o parser/parser.go parser/parser.y 2>&1 | egrep "(shift|reduce)/reduce" | awk '{print} END {if (NR > 0) {print "Find conflict in parser.y. Please check y.output for more information."; system("rm -f $(TEMP_FILE)"); exit 1;}}'
 	rm -f $(TEMP_FILE)
 	rm -f y.output
 


### PR DESCRIPTION
We ignore the generated error message in code, so there is no need to generate them.

Shrink the size of `parser.go` to 1/3.