### PR TITLE
expression: NOW() should be folded in constant folding stage (#4385)

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -657,8 +657,8 @@ type builtinFunc interface {
 	// getArgs returns the arguments expressions.
 	getArgs() []Expression
 	// isDeterministic checks if a function is deterministic.
-	// A function is deterministic if it returns same results for same inputs.
-	// e.g. random is non-deterministic.
+	// A function is deterministic if it returns the same result whenever it's called with the same inputs.
+	// e.g. SUBSTR, CONCAT is deterministic, but RANDOM, SYSDATE is not.
 	isDeterministic() bool
 	// equal check if this function equals to another function.
 	equal(builtinFunc) bool
@@ -694,9 +694,6 @@ type functionClass interface {
 	// getFunction gets a function signature by the types and the counts of given arguments.
 	getFunction(args []Expression, ctx context.Context) (builtinFunc, error)
 }
-
-// BuiltinFunc is the function signature for builtin functions
-type BuiltinFunc func([]types.Datum, context.Context) (types.Datum, error)
 
 // funcs holds all registered builtin functions.
 var funcs = map[string]functionClass{

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1691,7 +1691,6 @@ func (c *nowFunctionClass) getFunction(args []Expression, ctx context.Context) (
 	} else {
 		bf.tp.Flen, bf.tp.Decimal = 19, 0
 	}
-	bf.deterministic = false
 
 	var sig builtinFunc
 	if len(args) == 1 {

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -680,7 +680,7 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 		return tt
 	}
 
-	for _, x := range []struct {
+	for i, x := range []struct {
 		fc  functionClass
 		now func() time.Time
 	}{
@@ -689,7 +689,11 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 	} {
 		f, err := x.fc.getFunction(datumsToConstants(nil), s.ctx)
 		c.Assert(err, IsNil)
-		c.Assert(f.isDeterministic(), IsFalse)
+		if i == 0 {
+			c.Assert(f.isDeterministic(), IsTrue)
+		} else {
+			c.Assert(f.isDeterministic(), IsFalse)
+		}
 		v, err := f.eval(nil)
 		ts := x.now()
 		c.Assert(err, IsNil)


### PR DESCRIPTION
this is a cherry-pick to pre-ga