### PR TITLE
meta/autoid: fix ID allocator when transaction failed to commit.

### DIFF
--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -18,7 +18,8 @@ import "sync"
 // InjectionConfig is used for fault injections for KV components.
 type InjectionConfig struct {
 	sync.RWMutex
-	getError error // kv.Get() always return this error.
+	getError    error // kv.Get() always return this error.
+	commitError error // Transaction.Commit() always return this error.
 }
 
 // SetGetError injects an error for all kv.Get() methods.
@@ -27,6 +28,13 @@ func (c *InjectionConfig) SetGetError(err error) {
 	defer c.Unlock()
 
 	c.getError = err
+}
+
+// SetCommitError injects an error for all Transaction.Commit() methods.
+func (c *InjectionConfig) SetCommitError(err error) {
+	c.Lock()
+	defer c.Unlock()
+	c.commitError = err
 }
 
 // InjectedStore wraps a Storage with injections.
@@ -84,6 +92,16 @@ func (t *InjectedTransaction) Get(k Key) ([]byte, error) {
 		return nil, t.cfg.getError
 	}
 	return t.Transaction.Get(k)
+}
+
+// Commit returns an error if cfg.commitError is set.
+func (t *InjectedTransaction) Commit() error {
+	t.cfg.RLock()
+	defer t.cfg.RUnlock()
+	if t.cfg.commitError != nil {
+		return t.cfg.commitError
+	}
+	return t.Transaction.Commit()
 }
 
 // InjectedSnapshot wraps a Snapshot with injections.

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/cznic/mathutil"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -56,51 +57,60 @@ func GetStep() int64 {
 }
 
 // Rebase implements autoid.Allocator Rebase interface.
-func (alloc *allocator) Rebase(tableID, newBase int64, allocIDs bool) error {
+// The requiredBase is the minimum base value after Rebase.
+// The real base may be greater than the required base.
+func (alloc *allocator) Rebase(tableID, requiredBase int64, allocIDs bool) error {
 	if tableID == 0 {
 		return errInvalidTableID.Gen("Invalid tableID")
 	}
 
 	alloc.mu.Lock()
 	defer alloc.mu.Unlock()
-	if newBase <= alloc.base {
+	if requiredBase <= alloc.base {
+		// Satisfied by alloc.base, nothing to do.
 		return nil
 	}
-	if newBase <= alloc.end {
-		alloc.base = newBase
+	if requiredBase <= alloc.end {
+		// Satisfied by alloc.end, need to updata alloc.base.
+		alloc.base = requiredBase
 		return nil
 	}
-	originBase, originEnd := alloc.base, alloc.end
+	var newBase, newEnd int64
 	err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 		m := meta.NewMeta(txn)
-		end, err := m.GetAutoTableID(alloc.dbID, tableID)
-		if err != nil {
-			return errors.Trace(err)
+		currentEnd, err1 := m.GetAutoTableID(alloc.dbID, tableID)
+		if err1 != nil {
+			return errors.Trace(err1)
 		}
-
-		if newBase < end {
-			newBase = end
+		if allocIDs {
+			newBase = mathutil.MaxInt64(currentEnd, requiredBase)
+			newEnd = newBase + step
+		} else {
+			if currentEnd >= requiredBase {
+				newBase = currentEnd
+				newEnd = currentEnd
+				// Required base satisfied, we don't need to update KV.
+				return nil
+			}
+			// If we don't want to allocate IDs, for example when creating a table with a given base value,
+			// We need to make sure when other TiDB server allocates ID for the first time, requiredBase + 1
+			// will be allocated, so we need to increase the end to exactly the requiredBase.
+			newBase = requiredBase
+			newEnd = requiredBase
 		}
-		newStep := newBase - end + step
-		if !allocIDs {
-			newStep = newBase - end
+		_, err1 = m.GenAutoTableID(alloc.dbID, tableID, newEnd-currentEnd)
+		if err1 != nil {
+			return errors.Trace(err1)
 		}
-		end, err = m.GenAutoTableID(alloc.dbID, tableID, newStep)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		alloc.end = end
-		alloc.base = newBase
 		if !allocIDs {
 			alloc.base = alloc.end
 		}
 		return nil
 	})
 	if err != nil {
-		alloc.base, alloc.end = originBase, originEnd
 		return errors.Trace(err)
 	}
+	alloc.base, alloc.end = newBase, newEnd
 	return nil
 }
 
@@ -112,31 +122,25 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 	alloc.mu.Lock()
 	defer alloc.mu.Unlock()
 	if alloc.base == alloc.end { // step
-		originBase, originEnd := alloc.base, alloc.end
+		var newBase, newEnd int64
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
-			base, err1 := m.GetAutoTableID(alloc.dbID, tableID)
+			var err1 error
+			newBase, err1 = m.GetAutoTableID(alloc.dbID, tableID)
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
-			end, err1 := m.GenAutoTableID(alloc.dbID, tableID, step)
+			newEnd, err1 = m.GenAutoTableID(alloc.dbID, tableID, step)
 			if err1 != nil {
 				return errors.Trace(err1)
-			}
-
-			alloc.end = end
-			if end == step {
-				alloc.base = base
-			} else {
-				alloc.base = end - step
 			}
 			return nil
 		})
 
 		if err != nil {
-			alloc.base, alloc.end = originBase, originEnd
 			return 0, errors.Trace(err)
 		}
+		alloc.base, alloc.end = newBase, newEnd
 	}
 
 	alloc.base++

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -99,13 +99,7 @@ func (alloc *allocator) Rebase(tableID, requiredBase int64, allocIDs bool) error
 			newEnd = requiredBase
 		}
 		_, err1 = m.GenAutoTableID(alloc.dbID, tableID, newEnd-currentEnd)
-		if err1 != nil {
-			return errors.Trace(err1)
-		}
-		if !allocIDs {
-			alloc.base = alloc.end
-		}
-		return nil
+		return errors.Trace(err1)
 	})
 	if err != nil {
 		return errors.Trace(err)

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
+	"github.com/pkg/errors"
 )
 
 func TestT(t *testing.T) {
@@ -185,4 +186,41 @@ func (*testSuite) TestConcurrentAlloc(c *C) {
 	close(errCh)
 	err = <-errCh
 	c.Assert(err, IsNil)
+}
+
+// TestRollbackAlloc tests that when the allocation transaction commit failed,
+// the local variable base and end doesn't change.
+func (*testSuite) TestRollbackAlloc(c *C) {
+	driver := localstore.Driver{Driver: goleveldb.MemoryDriver{}}
+	store, err := driver.Open("memory")
+	c.Assert(err, IsNil)
+	defer store.Close()
+	dbID := int64(1)
+	tblID := int64(2)
+	err = kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		err = m.CreateDatabase(&model.DBInfo{ID: dbID, Name: model.NewCIStr("a")})
+		c.Assert(err, IsNil)
+		err = m.CreateTable(dbID, &model.TableInfo{ID: tblID, Name: model.NewCIStr("t")})
+		c.Assert(err, IsNil)
+		return nil
+	})
+	c.Assert(err, IsNil)
+
+	injectConf := new(kv.InjectionConfig)
+	injectConf.SetCommitError(errors.New("injected"))
+	injectedStore := kv.NewInjectedStore(store, injectConf)
+	alloc := &allocator{
+		store: injectedStore,
+		dbID:  1,
+	}
+	_, err = alloc.Alloc(2)
+	c.Assert(err, NotNil)
+	c.Assert(alloc.base, Equals, int64(0))
+	c.Assert(alloc.end, Equals, int64(0))
+
+	err = alloc.Rebase(2, 100, true)
+	c.Assert(err, NotNil)
+	c.Assert(alloc.base, Equals, int64(0))
+	c.Assert(alloc.end, Equals, int64(0))
 }

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -19,13 +19,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/store/localstore"
 	"github.com/pingcap/tidb/store/localstore/goleveldb"
-	"github.com/pkg/errors"
 )
 
 func TestT(t *testing.T) {

--- a/parser/goyacc/main.go
+++ b/parser/goyacc/main.go
@@ -388,7 +388,7 @@ type %[1]sXError struct {
 		case "$default":
 			nm = *oPref + "Default"
 		case "$end":
-			nm = *oPref + "EofCode"
+			nm = *oPref + "EOFCode"
 		}
 		f.Format("%s%s = %d\n", nm, strings.Repeat(" ", maxTokName-len(nm)+1), nsyms[v].Value)
 	}
@@ -529,7 +529,7 @@ func %[1]sSymName(c int) (s string) {
 func %[1]slex1(yylex %[1]sLexer, lval *%[1]sSymType) (n int) {
 	n = yylex.Lex(lval)
 	if n <= 0 {
-		n = %[1]sEofCode
+		n = %[1]sEOFCode
 	}
 	if %[1]sDebug >= 3 {
 		__yyfmt__.Printf("\nlex %%s(%%#x %%d), %[4]s: %[3]s\n", %[1]sSymName(n), n, n, %[4]s)
@@ -681,7 +681,7 @@ yynewstate:
 			if %[1]sDebug >= 2 {
 				__yyfmt__.Printf("error recovery discards %%s\n", %[1]sSymName(yychar))
 			}
-			if yychar == %[1]sEofCode {
+			if yychar == %[1]sEOFCode {
 				goto ret1
 			}
 


### PR DESCRIPTION
During the execution of transaction, the allocator update its field `base` and `end`,
But didn't set it back when transaction fails.

This PR fix this issue.