### PR TITLE
expression: fix a panic in buildSubquery.

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2093,3 +2093,16 @@ func (s *testSuite) TestSet(c *C) {
 	tk.MustExec("insert into t values (null), ('1')")
 	tk.MustQuery("select c + 1 from t where c = 1").Check(testkit.Rows("2"))
 }
+
+func (s *testSuite) TestSubqueryInValues(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int, name varchar(20))")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (gid int)")
+
+	tk.MustExec("insert into t1 (gid) value (1)")
+	tk.MustExec("insert into t (id, name) value ((select gid from t1) ,'asd')")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 asd"))
+}

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -200,10 +200,14 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 }
 
 func (er *expressionRewriter) buildSubquery(subq *ast.SubqueryExpr) LogicalPlan {
-	outerSchema := er.schema.Clone()
-	er.b.outerSchemas = append(er.b.outerSchemas, outerSchema)
+	if er.schema != nil {
+		outerSchema := er.schema.Clone()
+		er.b.outerSchemas = append(er.b.outerSchemas, outerSchema)
+	}
 	np := er.b.buildResultSetNode(subq.Query)
-	er.b.outerSchemas = er.b.outerSchemas[0 : len(er.b.outerSchemas)-1]
+	if er.schema != nil {
+		er.b.outerSchemas = er.b.outerSchemas[0 : len(er.b.outerSchemas)-1]
+	}
 	if er.b.err != nil {
 		er.err = errors.Trace(er.b.err)
 		return nil


### PR DESCRIPTION
This PR fix #4576.
`er.schema` of subquery in values clause is `nil`, invoke `Clone` on it will panic. 