### PR TITLE
types:  fix 'select cast(12.1 as decimal(3,4))' core.

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1921,6 +1921,13 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	_, err = tk.Exec("insert into t values(-9223372036854775809)")
 	c.Assert(err, NotNil)
 
+	// test case decimal precision less than the scale.
+	rs, err := tk.Exec("select cast(12.1 as decimal(3, 4));")
+	c.Assert(err, IsNil)
+	_, err = tidb.GetRows(rs)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[types:1427]For float(M,D), double(M,D) or decimal(M,D), M must be >= D (column '').")
+
 	// test unhex and hex
 	result = tk.MustQuery("select unhex('4D7953514C')")
 	result.Check(testkit.Rows("MySQL"))

--- a/util/types/datum.go
+++ b/util/types/datum.go
@@ -1055,6 +1055,9 @@ func (d *Datum) convertToMysqlDecimal(sc *variable.StatementContext, target *Fie
 func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *variable.StatementContext) (_ *MyDecimal, err error) {
 	flen, decimal := tp.Flen, tp.Decimal
 	if flen != UnspecifiedLength && decimal != UnspecifiedLength {
+		if flen < decimal {
+			return nil, ErrMBiggerThanD.GenByArgs("")
+		}
 		prec, frac := dec.PrecisionAndFrac()
 		if !dec.IsZero() && prec-frac > flen-decimal {
 			dec = NewMaxOrMinDec(dec.IsNegative(), flen, decimal)

--- a/util/types/errors.go
+++ b/util/types/errors.go
@@ -47,6 +47,8 @@ var (
 	ErrCastNegIntAsUnsigned = terror.ClassTypes.New(codeUnknown, msgCastNegIntAsUnsigned)
 	// ErrInvalidDefault is returned when meet a invalid default value.
 	ErrInvalidDefault = terror.ClassTypes.New(codeInvalidDefault, "Invalid default value for '%s'")
+	// ErrMBiggerThanD is returned when precision less than the scale.
+	ErrMBiggerThanD = terror.ClassTypes.New(codeMBiggerThanD, mysql.MySQLErrName[mysql.ErrMBiggerThanD])
 )
 
 const (
@@ -64,6 +66,7 @@ const (
 	codeTruncatedWrongValue terror.ErrCode = terror.ErrCode(mysql.ErrTruncatedWrongValue)
 	codeUnknown             terror.ErrCode = terror.ErrCode(mysql.ErrUnknown)
 	codeInvalidDefault      terror.ErrCode = terror.ErrCode(mysql.ErrInvalidDefault)
+	codeMBiggerThanD        terror.ErrCode = terror.ErrCode(mysql.ErrMBiggerThanD)
 )
 
 var (

--- a/util/types/errors.go
+++ b/util/types/errors.go
@@ -90,6 +90,7 @@ func init() {
 		codeTruncatedWrongValue: mysql.ErrTruncatedWrongValue,
 		codeUnknown:             mysql.ErrUnknown,
 		codeInvalidDefault:      mysql.ErrInvalidDefault,
+		codeMBiggerThanD:        mysql.ErrMBiggerThanD,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassTypes] = typesMySQLErrCodes
 }


### PR DESCRIPTION
mysql
```
mysql> select cast(12.1 as decimal(3,4));
ERROR 1427 (42000): For float(M,D), double(M,D) or decimal(M,D), M must be >= D (column '').
mysql> select cast(12.1 as decimal(3,5));
ERROR 1427 (42000): For float(M,D), double(M,D) or decimal(M,D), M must be >= D (column '').
```

tidb
```
tidb>select cast(12.1 as decimal(3,4));
+----------------------------+
| cast(12.1 as decimal(3,4)) |
+----------------------------+
|                     0.9999 |
+----------------------------+
1 row in set, 1 warning (3.01 sec)

tidb>select cast(12.1 as decimal(3,5));
ERROR 2013 (HY000): Lost connection to MySQL server during query

```