### PR TITLE
tidb: add a transaction count metric

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -57,6 +57,13 @@ var (
 			Help:      "Bucketed histogram of session retry count.",
 			Buckets:   prometheus.LinearBuckets(0, 1, 10),
 		})
+	transactionCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "transaction_total",
+			Help:      "Counter of transactions.",
+		}, []string{"type"})
 )
 
 func init() {
@@ -65,4 +72,5 @@ func init() {
 	prometheus.MustRegister(sessionExecuteRunDuration)
 	prometheus.MustRegister(schemaLeaseErrorCounter)
 	prometheus.MustRegister(sessionRetry)
+	prometheus.MustRegister(transactionCounter)
 }

--- a/session.go
+++ b/session.go
@@ -319,7 +319,13 @@ func (s *session) doCommitWithRetry() error {
 }
 
 func (s *session) CommitTxn() error {
-	return s.doCommitWithRetry()
+	err := s.doCommitWithRetry()
+	label := "OK"
+	if err != nil {
+		label = "Error"
+	}
+	transactionCounter.WithLabelValues(label).Inc()
+	return errors.Trace(err)
 }
 
 func (s *session) RollbackTxn() error {

--- a/session.go
+++ b/session.go
@@ -781,7 +781,7 @@ func (s *session) Txn() kv.Transaction {
 
 func (s *session) NewTxn() error {
 	if s.txn != nil && s.txn.Valid() {
-		err := s.doCommitWithRetry()
+		err := s.CommitTxn()
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
We have query count metrics but it's based on mysql command.
This metric is based on SQL transaction count.

@coocood @shenli 