### PR TITLE
ddl: add limitation for index comment (#4619)

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -105,6 +105,7 @@ var (
 	errJSONUsedAsKey = terror.ClassDDL.New(codeJSONUsedAsKey, mysql.MySQLErrName[mysql.ErrJSONUsedAsKey])
 	// errBlobCantHaveDefault forbiddens to give not null default value to TEXT/BLOB/JSON.
 	errBlobCantHaveDefault = terror.ClassDDL.New(codeBlobCantHaveDefault, mysql.MySQLErrName[mysql.ErrBlobCantHaveDefault])
+	errTooLongIndexComment = terror.ClassDDL.New(codeErrTooLongIndexComment, mysql.MySQLErrName[mysql.ErrTooLongIndexComment])
 
 	// ErrInvalidDBState returns for invalid database state.
 	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")
@@ -563,6 +564,7 @@ const (
 	codeDependentByGeneratedColumn   = 3108
 	codeJSONUsedAsKey                = 3152
 	codeWrongNameForIndex            = terror.ErrCode(mysql.ErrWrongNameForIndex)
+	codeErrTooLongIndexComment       = terror.ErrCode(mysql.ErrTooLongIndexComment)
 )
 
 func init() {
@@ -592,6 +594,7 @@ func init() {
 		codeWrongKeyColumn:               mysql.ErrWrongKeyColumn,
 		codeWrongNameForIndex:            mysql.ErrWrongNameForIndex,
 		codeTooManyFields:                mysql.ErrTooManyFields,
+		codeErrTooLongIndexComment:       mysql.ErrTooLongIndexComment,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassDDL] = ddlMySQLErrCodes
 }

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -34,6 +34,7 @@ import (
 )
 
 const maxPrefixLength = 3072
+const maxCommentLength = 1024
 
 func buildIndexColumns(columns []*model.ColumnInfo, idxColNames []*ast.IndexColName) ([]*model.IndexColumn, error) {
 	// Build offsets.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -660,6 +660,29 @@ func (s *testSuite) TestSelectOrderBy(c *C) {
 	tk.MustQuery("select a from t use index(b) order by b").Check(testkit.Rows("9", "8", "7", "6", "5", "4", "3", "2", "1", "0"))
 }
 
+func (s *testSuite) TestOrderBy(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (c1 int, c2 int, c3 varchar(20))")
+	tk.MustExec("insert into t values (1, 2, 'abc'), (2, 1, 'bcd')")
+
+	// Fix issue https://github.com/pingcap/tidb/issues/337
+	tk.MustQuery("select c1 as a, c1 as b from t order by c1").Check(testkit.Rows("1 1", "2 2"))
+
+	tk.MustQuery("select c1 as a, t.c1 as a from t order by a desc").Check(testkit.Rows("2 2", "1 1"))
+	tk.MustQuery("select c1 as c2 from t order by c2").Check(testkit.Rows("1", "2"))
+	tk.MustQuery("select sum(c1) from t order by sum(c1)").Check(testkit.Rows("3"))
+	tk.MustQuery("select c1 as c2 from t order by c2 + 1").Check(testkit.Rows("2", "1"))
+
+	// Order by position.
+	tk.MustQuery("select * from t order by 1").Check(testkit.Rows("1 2 abc", "2 1 bcd"))
+	tk.MustQuery("select * from t order by 2").Check(testkit.Rows("2 1 bcd", "1 2 abc"))
+
+	// Order by binary.
+	tk.MustQuery("select c1, c3 from t order by binary c1 desc").Check(testkit.Rows("2 bcd", "1 abc"))
+	tk.MustQuery("select c1, c2 from t order by binary c3").Check(testkit.Rows("1 2", "2 1"))
+}
+
 func (s *testSuite) TestSelectErrorRow(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -703,7 +703,7 @@ var MySQLErrName = map[uint16]string{
 	ErrInsideTransactionPreventsSwitchBinlogDirect:           "Cannot modify @@session.binlogDirectNonTransactionalUpdates inside a transaction",
 	ErrStoredFunctionPreventsSwitchBinlogDirect:              "Cannot change the binlog direct flag inside a stored function or trigger",
 	ErrSpatialMustHaveGeomCol:                                "A SPATIAL index may only contain a geometrical type column",
-	ErrTooLongIndexComment:                                   "Comment for index '%-.64s' is too long (max = %lu)",
+	ErrTooLongIndexComment:                                   "Comment for index '%-.64s' is too long (max = %d)",
 	ErrLockAborted:                                           "Wait on a lock was aborted due to a pending exclusive lock",
 	ErrDataOutOfRange:                                        "%s value is out of range in '%s'",
 	ErrWrongSpvarTypeInLimit:                                 "A variable of a non-integer based type in LIMIT clause",

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -1120,6 +1120,27 @@ func (s *testPlanSuite) TestValidate(c *C) {
 			sql: "insert into t set a = 1, b = values(a) + 1",
 			err: nil,
 		},
+		// TODO: Fix Error Code.
+		//{
+		//	sql: "select a, b, c from t order by 0",
+		//	err: ErrUnknownColumn,
+		//},
+		//{
+		//	sql: "select a, b, c from t order by 4",
+		//	err: ErrUnknownColumn,
+		//},
+		{
+			sql: "select a as c1, b as c1 from t order by c1",
+			err: ErrAmbiguous,
+		},
+		{
+			sql: "(select a as b, b from t) union (select a, b from t) order by b",
+			err: ErrAmbiguous,
+		},
+		//{
+		//	sql: "(select a as b, b from t) union (select a, b from t) order by a",
+		//	err: ErrUnknownColumn,
+		//},
 	}
 	for _, tt := range tests {
 		sql := tt.sql
@@ -1127,7 +1148,7 @@ func (s *testPlanSuite) TestValidate(c *C) {
 		stmt, err := s.ParseOneStmt(sql, "", "")
 		c.Assert(err, IsNil, comment)
 		is, err := MockResolve(stmt)
-		c.Assert(err, IsNil)
+		c.Assert(err, IsNil, comment)
 		builder := &planBuilder{
 			allocator: new(idAllocator),
 			ctx:       mockContext(),


### PR DESCRIPTION
move order by and having bugs. Some negative cases can't be migrated, because we use resolver to report error and sometimes get wrong error codes. I will fix resolver in next pr.
