### PR TITLE
*: make prepare stmt retriable when schema is out-dated.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -174,8 +174,8 @@ type Statement interface {
 	// Exec executes SQL and gets a Recordset.
 	Exec(ctx context.Context) (RecordSet, error)
 
-	// AstNodes return the ast nodes for retry.
-	AstNodes() StmtNode
+	// AstNode return the ast nodes for retry.
+	AstNode() StmtNode
 }
 
 // Visitor visits a Node.

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -174,8 +174,8 @@ type Statement interface {
 	// Exec executes SQL and gets a Recordset.
 	Exec(ctx context.Context) (RecordSet, error)
 
-	// IsPrepared returns whether this statement is prepared statement.
-	IsPrepared() bool
+	// AstNodes return the ast nodes for retry.
+	AstNodes() StmtNode
 }
 
 // Visitor visits a Node.

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -93,20 +93,20 @@ func (a *recordSet) Close() error {
 type statement struct {
 	is infoschema.InfoSchema // The InfoSchema cannot change during execution, so we hold a reference to it.
 
-	ctx            context.Context
-	text           string
-	plan           plan.Plan
-	startTime      time.Time
-	isPreparedStmt bool
-	expensive      bool
+	ctx       context.Context
+	text      string
+	plan      plan.Plan
+	startTime time.Time
+	expensive bool
+	astNodes  ast.StmtNode
 }
 
 func (a *statement) OriginText() string {
 	return a.text
 }
 
-func (a *statement) IsPrepared() bool {
-	return a.isPreparedStmt
+func (a *statement) AstNodes() ast.StmtNode {
+	return a.astNodes
 }
 
 // Exec implements the ast.Statement Exec interface.
@@ -248,7 +248,6 @@ func (a *statement) buildExecutor(ctx context.Context) (Executor, error) {
 			return nil, errors.Trace(err)
 		}
 		a.text = executorExec.Stmt.Text()
-		a.isPreparedStmt = true
 		a.plan = executorExec.Plan
 		e = executorExec.StmtExec
 	}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -98,15 +98,15 @@ type statement struct {
 	plan      plan.Plan
 	startTime time.Time
 	expensive bool
-	astNodes  ast.StmtNode
+	astNode   ast.StmtNode
 }
 
 func (a *statement) OriginText() string {
 	return a.text
 }
 
-func (a *statement) AstNodes() ast.StmtNode {
-	return a.astNodes
+func (a *statement) AstNode() ast.StmtNode {
+	return a.astNode
 }
 
 // Exec implements the ast.Statement Exec interface.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -49,7 +49,7 @@ func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statemen
 		is:        is,
 		plan:      p,
 		text:      node.Text(),
-		astNodes:  node,
+		astNode:   node,
 		expensive: isExpensive,
 	}
 	return sa, nil

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -49,6 +49,7 @@ func (c *Compiler) Compile(ctx context.Context, node ast.StmtNode) (ast.Statemen
 		is:        is,
 		plan:      p,
 		text:      node.Text(),
+		astNodes:  node,
 		expensive: isExpensive,
 	}
 	return sa, nil

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -899,12 +899,11 @@ func (s *testSchemaSuite) TestPrepareStmtCommitWhenSchemaChanged(c *C) {
 	tk1.MustExec("execute stmt using @a, @a")
 	tk1.MustExec("commit")
 
-	// TODO: PrepareStmt should handle this.
-	//tk1.MustExec("begin")
-	//tk.MustExec("alter table t drop column b")
-	//tk1.MustExec("execute stmt using @a, @a")
-	//_, err := tk1.Exec("commit")
-	//c.Assert(terror.ErrorEqual(err, executor.ErrWrongValueCountOnRow), IsTrue, Commentf("err %v", err))
+	tk1.MustExec("begin")
+	tk.MustExec("alter table t drop column b")
+	tk1.MustExec("execute stmt using @a, @a")
+	_, err := tk1.Exec("commit")
+	c.Assert(terror.ErrorEqual(err, executor.ErrWrongValueCountOnRow), IsTrue, Commentf("err %v", err))
 }
 
 func (s *testSchemaSuite) TestCommitWhenSchemaChanged(c *C) {

--- a/session.go
+++ b/session.go
@@ -452,7 +452,7 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 func updateStatement(st ast.Statement, s *session) (ast.Statement, error) {
 	// statement maybe stale because of infoschema changed, this function will return the updated one.
 	// Rebuild plan if infoschema changed, reuse the statement otherwise.
-	resultSt, err := Compile(s, st.AstNodes())
+	resultSt, err := Compile(s, st.AstNode())
 	if err != nil {
 		// If a txn is inserting data when DDL is dropping column,
 		// it would fail to commit and retry, and run here then.

--- a/session.go
+++ b/session.go
@@ -403,9 +403,8 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 		s.sessionVars.RetryInfo.ResetOffset()
 		for i, sr := range nh.history {
 			st := sr.st
-			txt := st.OriginText()
 			if infoSchemaChanged {
-				st, err = updateStatement(st, s, txt)
+				st, err = updateStatement(st, s)
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -414,6 +413,7 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 			if retryCnt == 0 {
 				// We do not have to log the query every time.
 				// We print the queries at the first try only.
+				txt := st.OriginText()
 				log.Warnf("[%d] Retry [%d] query [%d] %s", connID, retryCnt, i, sqlForLog(txt))
 			} else {
 				log.Warnf("[%d] Retry [%d] query [%d]", connID, retryCnt, i)
@@ -449,25 +449,16 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 	return err
 }
 
-func updateStatement(st ast.Statement, s *session, txt string) (ast.Statement, error) {
+func updateStatement(st ast.Statement, s *session) (ast.Statement, error) {
 	// statement maybe stale because of infoschema changed, this function will return the updated one.
-	if st.IsPrepared() {
-		// TODO: Rebuild plan if infoschema changed, reuse the statement otherwise.
-	} else {
-		// Rebuild plan if infoschema changed, reuse the statement otherwise.
-		charset, collation := s.sessionVars.GetCharsetInfo()
-		stmt, err := s.parser.ParseOneStmt(txt, charset, collation)
-		if err != nil {
-			return st, errors.Trace(err)
-		}
-		st, err = Compile(s, stmt)
-		if err != nil {
-			// If a txn is inserting data when DDL is dropping column,
-			// it would fail to commit and retry, and run here then.
-			return st, errors.Trace(err)
-		}
+	// Rebuild plan if infoschema changed, reuse the statement otherwise.
+	resultSt, err := Compile(s, st.AstNodes())
+	if err != nil {
+		// If a txn is inserting data when DDL is dropping column,
+		// it would fail to commit and retry, and run here then.
+		return resultSt, errors.Trace(err)
 	}
-	return st, nil
+	return resultSt, nil
 }
 
 func sqlForLog(sql string) string {


### PR DESCRIPTION
We should use ast node to try instead of raw stmt. Because execute stmt will change its original text for printing log, it's unreasonable !