### PR TITLE
Reduce growslice

### DIFF
--- a/expression/util.go
+++ b/expression/util.go
@@ -33,6 +33,7 @@ func ExtractColumns(expr Expression) (cols []*Column) {
 	case *Column:
 		return []*Column{v}
 	case *ScalarFunction:
+		cols = make([]*Column, 0, len(v.GetArgs()))
 		for _, arg := range v.GetArgs() {
 			cols = append(cols, ExtractColumns(arg)...)
 		}

--- a/util/ranger/range.go
+++ b/util/ranger/range.go
@@ -437,7 +437,6 @@ func (r *builder) merge(a, b []point, union bool) []point {
 		return nil
 	}
 	var (
-		merged               []point
 		inRangeCount         int
 		requiredInRangeCount int
 	)
@@ -446,6 +445,7 @@ func (r *builder) merge(a, b []point, union bool) []point {
 	} else {
 		requiredInRangeCount = 2
 	}
+	merged := make([]point, 0, len(sorter.points))
 	for _, val := range sorter.points {
 		if val.start {
 			inRangeCount++


### PR DESCRIPTION
Sysbench select-test is improved from 10002 to 10135.66 on my machine.
PS:  I run insert-test  between the two tests. Data size increases from 8.5GB to 10.5GB. So the improvement should be bigger.