### PR TITLE
*: close agg push down by default and remove cbo switch

### DIFF
--- a/plan/explain_test.go
+++ b/plan/explain_test.go
@@ -224,6 +224,7 @@ func (s *testExplainSuite) TestExplain(c *C) {
 		},
 	}
 	tk.MustExec("set @@session.tidb_opt_insubquery_unfold = 1")
+	tk.MustExec("set @@session.tidb_opt_agg_push_down = 1")
 	for _, tt := range tests {
 		result := tk.MustQuery("explain " + tt.sql)
 		result.Check(testkit.Rows(tt.expect...))

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -853,6 +853,7 @@ func (s *testPlanSuite) TestAggPushDown(c *C) {
 			colMapper: make(map[*ast.ColumnNameExpr]int),
 			is:        is,
 		}
+		builder.ctx.GetSessionVars().AllowAggPushDown = true
 		p := builder.build(stmt)
 		c.Assert(builder.err, IsNil)
 		lp := p.(LogicalPlan)
@@ -1308,6 +1309,7 @@ func (s *testPlanSuite) TestAggPrune(c *C) {
 			ctx:       mockContext(),
 			is:        is,
 		}
+		builder.ctx.GetSessionVars().AllowAggPushDown = true
 		p := builder.build(stmt).(LogicalPlan)
 		c.Assert(builder.err, IsNil)
 		p, err = logicalOptimize(flagPredicatePushDown|flagPrunColumns|flagBuildKeyInfo|flagAggregationOptimize, p.(LogicalPlan), builder.ctx, builder.allocator)

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -546,6 +546,7 @@ func (s *testPlanSuite) TestCBO(c *C) {
 			colMapper: make(map[*ast.ColumnNameExpr]int),
 			is:        is,
 		}
+		builder.ctx.GetSessionVars().AllowAggPushDown = true
 		p := builder.build(stmt)
 		c.Assert(builder.err, IsNil)
 		lp := p.(LogicalPlan)

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -30,7 +30,7 @@ import (
 
 // UseDAGPlanBuilder checks if we use new DAG planner.
 func UseDAGPlanBuilder(ctx context.Context) bool {
-	return ctx.GetClient().IsRequestTypeSupported(kv.ReqTypeDAG, kv.ReqSubTypeBasic) && ctx.GetSessionVars().CBO
+	return ctx.GetClient().IsRequestTypeSupported(kv.ReqTypeDAG, kv.ReqSubTypeBasic)
 }
 
 // Plan is the description of an execution flow.

--- a/session.go
+++ b/session.go
@@ -1069,7 +1069,6 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.TiDBIndexLookupConcurrency + quoteCommaQuote +
 	variable.TiDBIndexSerialScanConcurrency + quoteCommaQuote +
 	variable.TiDBMaxRowCountForINLJ + quoteCommaQuote +
-	variable.TiDBCBO + quoteCommaQuote +
 	variable.TiDBDistSQLScanConcurrency + "')"
 
 // loadCommonGlobalVariablesIfNeeded loads and applies commonly used global variables for the session.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -219,9 +219,6 @@ type SessionVars struct {
 
 	// MaxRowCountForINLJ defines max row count that the outer table of index nested loop join could be without force hint.
 	MaxRowCountForINLJ int
-
-	// CBO indicates if we use new planner with cbo.
-	CBO bool
 }
 
 // NewSessionVars creates a session vars object.
@@ -236,7 +233,7 @@ func NewSessionVars() *SessionVars {
 		StrictSQLMode:              true,
 		Status:                     mysql.ServerStatusAutocommit,
 		StmtCtx:                    new(StatementContext),
-		AllowAggPushDown:           true,
+		AllowAggPushDown:           false,
 		BuildStatsConcurrencyVar:   DefBuildStatsConcurrency,
 		IndexJoinBatchSize:         DefIndexJoinBatchSize,
 		IndexLookupSize:            DefIndexLookupSize,
@@ -244,7 +241,6 @@ func NewSessionVars() *SessionVars {
 		IndexSerialScanConcurrency: DefIndexSerialScanConcurrency,
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
 		MaxRowCountForINLJ:         DefMaxRowCountForINLJ,
-		CBO:                        true,
 	}
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -613,7 +613,6 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupConcurrency, strconv.Itoa(DefIndexLookupConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBIndexSerialScanConcurrency, strconv.Itoa(DefIndexSerialScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBMaxRowCountForINLJ, strconv.Itoa(DefMaxRowCountForINLJ)},
-	{ScopeGlobal | ScopeSession, TiDBCBO, "ON"},
 	{ScopeGlobal | ScopeSession, TiDBSkipUTF8Check, boolToIntStr(DefSkipUTF8Check)},
 	{ScopeSession, TiDBBatchInsert, boolToIntStr(DefBatchInsert)},
 	{ScopeSession, TiDBBatchDelete, boolToIntStr(DefBatchDelete)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -100,9 +100,6 @@ const (
 	// It controls the max row count of outer table when do index nested loop join without hint.
 	// After the row count of the inner table is accurate, this variable will be removed.
 	TiDBMaxRowCountForINLJ = "tidb_max_row_count_for_inlj"
-
-	// tidb_cbo uses new planner with cost based optimizer.
-	TiDBCBO = "tidb_cbo"
 )
 
 // Default TiDB system variable values.
@@ -115,7 +112,7 @@ const (
 	DefBuildStatsConcurrency      = 4
 	DefMaxRowCountForINLJ         = 128
 	DefSkipUTF8Check              = false
-	DefOptAggPushDown             = true
+	DefOptAggPushDown             = false
 	DefOptInSubqUnfolding         = false
 	DefBatchInsert                = false
 	DefBatchDelete                = false

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -145,8 +145,6 @@ func SetSessionSystemVar(vars *variable.SessionVars, name string, value types.Da
 		vars.BatchDelete = tidbOptOn(sVal)
 	case variable.TiDBMaxRowCountForINLJ:
 		vars.MaxRowCountForINLJ = tidbOptPositiveInt(sVal, variable.DefMaxRowCountForINLJ)
-	case variable.TiDBCBO:
-		vars.CBO = tidbOptOn(sVal)
 	case variable.TiDBCurrentTS:
 		return variable.ErrReadOnly
 	}


### PR DESCRIPTION
Due to the change of function sig push down, the old planner cannot work anymore.