### PR TITLE
expression: Quit builtin function SLEEP when KILLed.

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -116,13 +116,14 @@ func (b *builtinSleepSig) evalInt(row []types.Datum) (int64, bool, error) {
 		return 0, false, nil
 	}
 
-	// TODO: consider it's interrupted using KILL QUERY from other session, or
-	// interrupted by time out.
 	if val > math.MaxFloat64/float64(time.Second.Nanoseconds()) {
 		return 0, false, errIncorrectArgs.GenByArgs("sleep")
 	}
 	dur := time.Duration(val * float64(time.Second.Nanoseconds()))
-	time.Sleep(dur)
+	select {
+	case <-time.After(dur):
+	case <-b.ctx.GoCtx().Done(): // TODO: the channel returned by ctx.Done() is not closed when Ctrl-C is pressed in `mysql` client.
+	}
 	return 0, false, nil
 }
 

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -123,6 +123,8 @@ func (b *builtinSleepSig) evalInt(row []types.Datum) (int64, bool, error) {
 	select {
 	case <-time.After(dur):
 	case <-b.ctx.GoCtx().Done(): // TODO: the channel returned by ctx.Done() is not closed when Ctrl-C is pressed in `mysql` client.
+		// return 1 when SLEEP() is KILLed
+		return 1, false, nil
 	}
 	return 0, false, nil
 }

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -157,6 +157,23 @@ func (s *testEvaluatorSuite) TestSleep(c *C) {
 	c.Assert(ret, Equals, int64(0))
 	sub := time.Since(start)
 	c.Assert(sub.Nanoseconds(), GreaterEqual, int64(0.5*1e9))
+
+	// quit when context canceled.
+	d[0].SetFloat64(2)
+	f, err = fc.getFunction(ctx, s.datumsToConstants(d))
+	c.Assert(err, IsNil)
+	start = time.Now()
+	go func() {
+		time.Sleep(1 * time.Second)
+		ctx.Cancel()
+	}()
+	ret, isNull, err = f.evalInt(nil)
+	sub = time.Since(start)
+	c.Assert(err, IsNil)
+	c.Assert(isNull, IsFalse)
+	c.Assert(ret, Equals, int64(1))
+	c.Assert(sub.Nanoseconds(), LessEqual, int64(2*1e9))
+	c.Assert(sub.Nanoseconds(), GreaterEqual, int64(1*1e9))
 }
 
 func (s *testEvaluatorSuite) TestBinopComparison(c *C) {

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -35,6 +35,8 @@ type Context struct {
 	Store       kv.Storage     // mock global variable
 	sessionVars *variable.SessionVars
 	mux         sync.Mutex // fix data race in ddl test.
+	ctx         goctx.Context
+	cancel      goctx.CancelFunc
 }
 
 // SetValue implements context.Context SetValue interface.
@@ -156,17 +158,21 @@ func (c *Context) GetSessionManager() util.SessionManager {
 
 // Cancel implements the Session interface.
 func (c *Context) Cancel() {
+	c.cancel()
 }
 
 // GoCtx returns standard context.Context that bind with current transaction.
 func (c *Context) GoCtx() goctx.Context {
-	return goctx.Background()
+	return c.ctx
 }
 
 // NewContext creates a new mocked context.Context.
 func NewContext() *Context {
+	ctx, cancel := goctx.WithCancel(goctx.Background())
 	return &Context{
 		values:      make(map[fmt.Stringer]interface{}),
 		sessionVars: variable.NewSessionVars(),
+		ctx:         ctx,
+		cancel:      cancel,
 	}
 }


### PR DESCRIPTION
Use cancellation pattern in SLEEP function by making use of
transaction's context. But, it does not quit when Ctrl-C
pressed. Add TODO for future investigation.

Fix #4378 partially