### PR TITLE
store/tikv/mocktikv: rpc handler should put error in response instead of return it

### DIFF
--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -581,14 +581,10 @@ func (c *RPCClient) SendReq(ctx goctx.Context, addr string, req *tikvrpc.Request
 		handler.rawStartKey = MvccKey(handler.startKey).Raw()
 		handler.rawEndKey = MvccKey(handler.endKey).Raw()
 		var res *coprocessor.Response
-		var err error
 		if r.GetTp() == kv.ReqTypeDAG {
-			res, err = handler.handleCopDAGRequest(r)
+			res = handler.handleCopDAGRequest(r)
 		} else {
-			res, err = handler.handleCopAnalyzeRequest(r)
-		}
-		if err != nil {
-			return nil, err
+			res = handler.handleCopAnalyzeRequest(r)
 		}
 		resp.Cop = res
 	case tikvrpc.CmdMvccGetByKey:


### PR DESCRIPTION
Locked error should be put into `tikvrpc.Response`, if it's returned as an error, region request sender will drop region cache mistakenly, and make further request all fail.
This will fix CI in https://github.com/pingcap/tidb/pull/4699
@hanfei1991 