### PR TITLE
plan: set proper parent for newly projection-eliminated child

### DIFF
--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -72,7 +72,9 @@ func resolveExprAndReplace(origin expression.Expression, replace map[string]*exp
 func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 	children := make([]Plan, 0, len(p.Children()))
 	for _, child := range p.Children() {
-		children = append(children, doPhysicalProjectionElimination(child.(PhysicalPlan)))
+		newChild := doPhysicalProjectionElimination(child.(PhysicalPlan))
+		children = append(children, newChild)
+		newChild.SetParents(p)
 	}
 	p.SetChildren(children...)
 


### PR DESCRIPTION
fix the error in tidb.log:

```
2017/10/10 10:42:37.755 terror.go:342: [error] /Users/jianzhang.zj/opt/gopath/src/github.com/pingcap/tidb/plan/plan.go:519: [plan:2]ReplaceParent Failed!
/Users/jianzhang.zj/opt/gopath/src/github.com/pingcap/tidb/plan/logical_plans.go:446:
```