### PR TITLE
privilege/privileges: fix show grants display empty entries

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -479,8 +479,10 @@ func (p *MySQLPrivilege) showGrants(user, host string) []string {
 	for _, record := range p.User {
 		if record.User == user && record.Host == host {
 			g := userPrivToString(record.Privileges)
-			s := fmt.Sprintf(`GRANT %s ON *.* TO '%s'@'%s'`, g, record.User, record.Host)
-			gs = append(gs, s)
+			if len(g) > 0 {
+				s := fmt.Sprintf(`GRANT %s ON *.* TO '%s'@'%s'`, g, record.User, record.Host)
+				gs = append(gs, s)
+			}
 			break // it's unique
 		}
 	}
@@ -489,8 +491,10 @@ func (p *MySQLPrivilege) showGrants(user, host string) []string {
 	for _, record := range p.DB {
 		if record.User == user && record.Host == host {
 			g := dbPrivToString(record.Privileges)
-			s := fmt.Sprintf(`GRANT %s ON %s.* TO '%s'@'%s'`, g, record.DB, record.User, record.Host)
-			gs = append(gs, s)
+			if len(g) > 0 {
+				s := fmt.Sprintf(`GRANT %s ON %s.* TO '%s'@'%s'`, g, record.DB, record.User, record.Host)
+				gs = append(gs, s)
+			}
 		}
 	}
 
@@ -498,8 +502,10 @@ func (p *MySQLPrivilege) showGrants(user, host string) []string {
 	for _, record := range p.TablesPriv {
 		if record.User == user && record.Host == host {
 			g := tablePrivToString(record.TablePriv)
-			s := fmt.Sprintf(`GRANT %s ON %s.%s TO '%s'@'%s'`, g, record.DB, record.TableName, record.User, record.Host)
-			gs = append(gs, s)
+			if len(g) > 0 {
+				s := fmt.Sprintf(`GRANT %s ON %s.%s TO '%s'@'%s'`, g, record.DB, record.TableName, record.User, record.Host)
+				gs = append(gs, s)
+			}
 		}
 	}
 	return gs


### PR DESCRIPTION
If we revoke after grant some privilege, show grants display some wrong results:

```
GRANT ALL PRIVILEGES ON `te%`.* TO 'show'@'localhost'
REVOKE ALL PRIVILEGES ON `te%`.* FROM 'show'@'localhost'
SHOW GRANTS FOR 'show'@'localhost'
```

should get nothing, but get

```
GRANT ON `te%`.* TO 'show'@'localhost'
```