### PR TITLE
plan: use single method to set parent and children.

### DIFF
--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -75,9 +75,8 @@ func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 	for _, child := range p.Children() {
 		newChild := doPhysicalProjectionElimination(child.(PhysicalPlan))
 		children = append(children, newChild)
-		newChild.SetParents(p)
 	}
-	p.SetChildren(children...)
+	setParentAndChildren(p, children...)
 
 	proj, isProj := p.(*Projection)
 	if !isProj || !canProjectionBeEliminatedStrict(proj) {
@@ -128,7 +127,7 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 	for _, child := range p.Children() {
 		children = append(children, pe.eliminate(child.(LogicalPlan), replace, childFlag))
 	}
-	p.SetChildren(children...)
+	setParentAndChildren(p, children...)
 
 	switch p.(type) {
 	case *Sort, *TopN, *Limit, *Selection, *MaxOneRow, *Update, *SelectLock:

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -361,7 +361,7 @@ func (er *expressionRewriter) handleOtherComparableSubq(lexpr, rexpr expression.
 	agg := LogicalAggregation{
 		AggFuncs: []aggregation.Aggregation{aggFunc},
 	}.init(er.b.allocator, er.ctx)
-	addChild(agg, np)
+	setParentAndChildren(agg, np)
 	aggCol0 := &expression.Column{
 		ColName:  model.NewCIStr("agg_Col_0"),
 		FromID:   agg.id,
@@ -431,7 +431,7 @@ func (er *expressionRewriter) buildQuantifierPlan(agg *LogicalAggregation, cond,
 		IsAggOrSubq: true,
 		RetType:     cond.GetType(),
 	})
-	addChild(proj, er.p)
+	setParentAndChildren(proj, er.p)
 	er.p = proj
 }
 
@@ -444,7 +444,7 @@ func (er *expressionRewriter) handleNEAny(lexpr, rexpr expression.Expression, np
 	agg := LogicalAggregation{
 		AggFuncs: []aggregation.Aggregation{firstRowFunc, countFunc},
 	}.init(er.b.allocator, er.ctx)
-	addChild(agg, np)
+	setParentAndChildren(agg, np)
 	firstRowResultCol := &expression.Column{
 		ColName:  model.NewCIStr("col_firstRow"),
 		FromID:   agg.id,
@@ -472,7 +472,7 @@ func (er *expressionRewriter) handleEQAll(lexpr, rexpr expression.Expression, np
 	agg := LogicalAggregation{
 		AggFuncs: []aggregation.Aggregation{firstRowFunc, countFunc},
 	}.init(er.b.allocator, er.ctx)
-	addChild(agg, np)
+	setParentAndChildren(agg, np)
 	firstRowResultCol := &expression.Column{
 		ColName:  model.NewCIStr("col_firstRow"),
 		FromID:   agg.id,

--- a/plan/join_reorder.go
+++ b/plan/join_reorder.go
@@ -190,10 +190,8 @@ func (e *joinReOrderSolver) newJoin(lChild, rChild LogicalPlan) *LogicalJoin {
 		JoinType:  InnerJoin,
 		reordered: true,
 	}.init(e.allocator, e.ctx)
-	join.SetChildren(lChild, rChild)
 	join.SetSchema(expression.MergeSchema(lChild.Schema(), rChild.Schema()))
-	lChild.SetParents(join)
-	rChild.SetParents(join)
+	setParentAndChildren(join, lChild, rChild)
 	return join
 }
 

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -401,13 +401,15 @@ type Delete struct {
 	IsMultiTable bool
 }
 
-// AddChild for parent.
-func addChild(parent Plan, child Plan) {
-	if child == nil || parent == nil {
+// setParentAndChildren sets parent and children relationship.
+func setParentAndChildren(parent Plan, children ...Plan) {
+	if children == nil || parent == nil {
 		return
 	}
-	child.AddParent(parent)
-	parent.AddChild(child)
+	for _, child := range children {
+		child.SetParents(parent)
+	}
+	parent.SetChildren(children...)
 }
 
 // InsertPlan means inserting plan between two plans.

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -1564,14 +1564,13 @@ func addCachePlan(p PhysicalPlan, allocator *idAllocator) []*expression.Correlat
 			newChild := Cache{}.init(p.Allocator(), p.context())
 			newChild.SetSchema(child.Schema())
 
-			addChild(newChild, child)
-			newChild.SetParents(p)
+			setParentAndChildren(newChild, child)
 
 			newChildren = append(newChildren, newChild)
 		} else {
 			newChildren = append(newChildren, child)
 		}
 	}
-	p.SetChildren(newChildren...)
+	setParentAndChildren(p, newChildren...)
 	return selfCorCols
 }

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -204,7 +204,7 @@ func (b *planBuilder) buildDo(v *ast.DoStmt) Plan {
 	}
 	dual.SetSchema(expression.NewSchema())
 	p := Projection{Exprs: exprs}.init(b.allocator, b.ctx)
-	addChild(p, dual)
+	setParentAndChildren(p, dual)
 	p.self = p
 	p.SetSchema(expression.NewSchema())
 	return p
@@ -340,7 +340,7 @@ func findIndexByName(indices []*model.IndexInfo, name model.CIStr) *model.IndexI
 
 func (b *planBuilder) buildSelectLock(src Plan, lock ast.SelectLockType) *SelectLock {
 	selectLock := SelectLock{Lock: lock}.init(b.allocator, b.ctx)
-	addChild(selectLock, src)
+	setParentAndChildren(selectLock, src)
 	selectLock.SetSchema(src.Schema())
 	return selectLock
 }
@@ -569,7 +569,7 @@ func (b *planBuilder) buildShow(show *ast.ShowStmt) Plan {
 	}
 	if len(conditions) != 0 {
 		sel := Selection{Conditions: conditions}.init(b.allocator, b.ctx)
-		addChild(sel, p)
+		setParentAndChildren(sel, p)
 		sel.SetSchema(p.Schema())
 		resultPlan = sel
 	}
@@ -865,7 +865,7 @@ func (b *planBuilder) buildInsert(insert *ast.InsertStmt) Plan {
 				return nil
 			}
 		}
-		addChild(insertPlan, selectPlan)
+		setParentAndChildren(insertPlan, selectPlan)
 	}
 
 	// Calculate generated columns.

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -224,8 +224,7 @@ func (p *LogicalJoin) getProj(idx int) *Projection {
 		proj.Exprs = append(proj.Exprs, col.Clone())
 	}
 	proj.SetSchema(child.Schema().Clone())
-	child.SetParents(proj)
-	proj.SetChildren(child)
+	setParentAndChildren(proj, child)
 	proj.SetParents(p)
 	p.children[idx] = proj
 	return proj


### PR DESCRIPTION
Fix a few places where parents is not set properly.
and reduce the risk to forget to set parents in the future.
Physical plan is not handled since they don't need to set parents.