### PR TITLE
stats: fix bug when merge sample collectors

### DIFF
--- a/executor/new_analyze.go
+++ b/executor/new_analyze.go
@@ -174,6 +174,7 @@ func (e *AnalyzeColumnsExec) buildHistograms() (hists []*statistics.Histogram, e
 	collectors := make([]*statistics.SampleCollector, len(e.colsInfo))
 	for i := range collectors {
 		collectors[i] = &statistics.SampleCollector{
+			IsMerger:      true,
 			Sketch:        statistics.NewFMSketch(maxSketchSize),
 			MaxSampleSize: maxSampleSize,
 		}

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -27,8 +27,9 @@ import (
 // SampleCollector will collect Samples and calculate the count and ndv of an attribute.
 type SampleCollector struct {
 	Samples       []types.Datum
+	sampleCount   int64 // sampleCount is the current seen samples.
 	NullCount     int64
-	Count         int64
+	Count         int64 // Count is the number of non-null rows.
 	MaxSampleSize int64
 	Sketch        *FMSketch
 }
@@ -75,13 +76,14 @@ func (c *SampleCollector) collect(d types.Datum, insertSketch bool) error {
 		c.NullCount++
 		return nil
 	}
+	c.sampleCount++
 	// The following code use types.CopyDatum(d) because d may have a deep reference
 	// to the underlying slice, GC can't free them which lead to memory leak eventually.
 	// TODO: Refactor the proto to avoid copying here.
 	if len(c.Samples) < int(c.MaxSampleSize) {
 		c.Samples = append(c.Samples, types.CopyDatum(d))
 	} else {
-		shouldAdd := rand.Int63n(c.Count) < c.MaxSampleSize
+		shouldAdd := rand.Int63n(c.sampleCount) < c.MaxSampleSize
 		if shouldAdd {
 			idx := rand.Intn(int(c.MaxSampleSize))
 			c.Samples[idx] = types.CopyDatum(d)

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -27,7 +27,7 @@ import (
 // SampleCollector will collect Samples and calculate the count and ndv of an attribute.
 type SampleCollector struct {
 	Samples       []types.Datum
-	seenSamples   int64 // seenSamples is the current seen samples.
+	seenValues    int64 // seenValues is the current seen values.
 	NullCount     int64
 	Count         int64 // Count is the number of non-null rows.
 	MaxSampleSize int64
@@ -72,24 +72,24 @@ func SampleCollectorFromProto(collector *tipb.SampleCollector) *SampleCollector 
 }
 
 func (c *SampleCollector) collect(d types.Datum, insertSketch bool) error {
-	if d.IsNull() {
-		c.NullCount++
-		return nil
-	}
-	c.seenSamples++
 	if insertSketch {
+		if d.IsNull() {
+			c.NullCount++
+			return nil
+		}
 		c.Count++
 		if err := c.Sketch.InsertValue(d); err != nil {
 			return errors.Trace(err)
 		}
 	}
+	c.seenValues++
 	// The following code use types.CopyDatum(d) because d may have a deep reference
 	// to the underlying slice, GC can't free them which lead to memory leak eventually.
 	// TODO: Refactor the proto to avoid copying here.
 	if len(c.Samples) < int(c.MaxSampleSize) {
 		c.Samples = append(c.Samples, types.CopyDatum(d))
 	} else {
-		shouldAdd := rand.Int63n(c.seenSamples) < c.MaxSampleSize
+		shouldAdd := rand.Int63n(c.seenValues) < c.MaxSampleSize
 		if shouldAdd {
 			idx := rand.Intn(int(c.MaxSampleSize))
 			c.Samples[idx] = types.CopyDatum(d)

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -36,6 +36,7 @@ type SampleCollector struct {
 // MergeSampleCollector merges two sample collectors.
 func (c *SampleCollector) MergeSampleCollector(rc *SampleCollector) {
 	c.NullCount += rc.NullCount
+	c.Count += rc.Count
 	c.Sketch.mergeFMSketch(rc.Sketch)
 	for _, val := range rc.Samples {
 		err := c.collect(val, false)
@@ -74,7 +75,6 @@ func (c *SampleCollector) collect(d types.Datum, insertSketch bool) error {
 		c.NullCount++
 		return nil
 	}
-	c.Count++
 	// The following code use types.CopyDatum(d) because d may have a deep reference
 	// to the underlying slice, GC can't free them which lead to memory leak eventually.
 	// TODO: Refactor the proto to avoid copying here.
@@ -88,6 +88,7 @@ func (c *SampleCollector) collect(d types.Datum, insertSketch bool) error {
 		}
 	}
 	if insertSketch {
+		c.Count++
 		return errors.Trace(c.Sketch.InsertValue(d))
 	}
 	return nil

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -105,6 +105,7 @@ func (s *testSampleSuite) TestMergeSampleCollector(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(pkBuilder, IsNil)
 	c.Assert(len(collectors), Equals, 2)
+	collectors[0].IsMerger = true
 	collectors[0].MergeSampleCollector(collectors[1])
 	c.Assert(collectors[0].Sketch.NDV(), Equals, int64(9280))
 	c.Assert(len(collectors[0].Samples), Equals, 1000)

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -96,7 +96,7 @@ func (s *testSampleSuite) TestMergeSampleCollector(c *C) {
 		RecordSet:     s.rs,
 		ColLen:        2,
 		PkID:          -1,
-		MaxSampleSize: 10000,
+		MaxSampleSize: 1000,
 		MaxBucketSize: 256,
 		MaxSketchSize: 1000,
 	}
@@ -107,7 +107,7 @@ func (s *testSampleSuite) TestMergeSampleCollector(c *C) {
 	c.Assert(len(collectors), Equals, 2)
 	collectors[0].MergeSampleCollector(collectors[1])
 	c.Assert(collectors[0].Sketch.NDV(), Equals, int64(9280))
-	c.Assert(len(collectors[0].Samples), Equals, 10000)
+	c.Assert(len(collectors[0].Samples), Equals, 1000)
 	c.Assert(collectors[0].NullCount, Equals, int64(1000))
 	c.Assert(collectors[0].Count, Equals, int64(19000))
 }


### PR DESCRIPTION
`Count` should be the total number of non-null rows, not sampled rows.
PTAL @coocood @hanfei1991 @winoros 