### PR TITLE
stats: fix bug when build histograms for columns

### DIFF
--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -144,9 +144,13 @@ func BuildColumn(ctx context.Context, numBuckets, id int64, collector *SampleCol
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	ndv := collector.Sketch.NDV()
+	if ndv > count {
+		ndv = count
+	}
 	hg := &Histogram{
 		ID:        id,
-		NDV:       collector.Sketch.NDV(),
+		NDV:       ndv,
 		NullCount: collector.NullCount,
 		Buckets:   make([]Bucket, 1, numBuckets),
 	}

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -156,6 +156,12 @@ func calculateScalar(hist *Histogram) {
 	}
 }
 
+func checkRepeats(c *C, hg *Histogram) {
+	for _, bkt := range hg.Buckets {
+		c.Assert(bkt.Repeats, Greater, int64(0))
+	}
+}
+
 func (s *testStatisticsSuite) TestBuild(c *C) {
 	bucketCount := int64(256)
 	sketch, _, _ := buildFMSketch(s.rc.(*recordSet).data, 1000)
@@ -169,6 +175,7 @@ func (s *testStatisticsSuite) TestBuild(c *C) {
 		Sketch:    sketch,
 	}
 	col, err := BuildColumn(ctx, bucketCount, 2, collector)
+	checkRepeats(c, col)
 	calculateScalar(col)
 	c.Check(err, IsNil)
 	c.Check(len(col.Buckets), Equals, 232)
@@ -200,7 +207,24 @@ func (s *testStatisticsSuite) TestBuild(c *C) {
 	c.Check(err, IsNil)
 	c.Check(int(count), Equals, 9)
 
+	builder := SampleBuilder{
+		Sc:            mock.NewContext().GetSessionVars().StmtCtx,
+		RecordSet:     s.pk,
+		ColLen:        1,
+		PkID:          -1,
+		MaxSampleSize: 1000,
+		MaxSketchSize: 1000,
+	}
+	s.pk.Close()
+	collectors, _, err := builder.CollectSamplesAndEstimateNDVs()
+	c.Assert(err, IsNil)
+	c.Assert(len(collectors), Equals, 1)
+	col, err = BuildColumn(mock.NewContext(), 256, 2, collectors[0])
+	c.Assert(err, IsNil)
+	checkRepeats(c, col)
+
 	tblCount, col, err := BuildIndex(ctx, bucketCount, 1, ast.RecordSet(s.rc))
+	checkRepeats(c, col)
 	calculateScalar(col)
 	c.Check(err, IsNil)
 	c.Check(int(tblCount), Equals, 100000)
@@ -219,6 +243,7 @@ func (s *testStatisticsSuite) TestBuild(c *C) {
 
 	s.pk.(*recordSet).cursor = 0
 	tblCount, col, err = buildPK(ctx, bucketCount, 4, ast.RecordSet(s.pk))
+	checkRepeats(c, col)
 	calculateScalar(col)
 	c.Check(err, IsNil)
 	c.Check(int(tblCount), Equals, 100000)


### PR DESCRIPTION
Sometimes the NDV calculated from FM Sketch may larger than row count, which will make the `ndvFactor` less than 1, and the Repeats less than 1.