### PR TITLE
statistics: use `ToPackedUnint` to calculate scalar of MysqlTime type.

### DIFF
--- a/statistics/scalar.go
+++ b/statistics/scalar.go
@@ -70,9 +70,11 @@ func convertDatumToScalar(value *types.Datum, commonPfxLen int) float64 {
 		return float64(value.GetMysqlDuration().Duration)
 	case types.KindMysqlTime:
 		valueTime := value.GetMysqlTime()
-		zeroTime := types.ZeroDatetime
-		zeroTime.Type = valueTime.Type
-		return float64(valueTime.Sub(&zeroTime).Duration)
+		packedUint, err := valueTime.ToPackedUint()
+		if err != nil {
+			return 0
+		}
+		return float64(packedUint)
 	case types.KindString, types.KindBytes:
 		bytes := value.GetBytes()
 		if len(bytes) <= commonPfxLen {

--- a/statistics/scalar_test.go
+++ b/statistics/scalar_test.go
@@ -111,7 +111,7 @@ func (t *testStatisticsSuite) TestCalcFraction(c *C) {
 			lower:    types.NewTimeDatum(getTime(2017, 1, 1)),
 			upper:    types.NewTimeDatum(getTime(2017, 4, 1)),
 			value:    types.NewTimeDatum(getTime(2017, 2, 1)),
-			fraction: 0.34444444444444444,
+			fraction: 0.3333333333333333,
 		},
 		{
 			lower:    types.NewStringDatum("aasad"),
@@ -130,6 +130,6 @@ func (t *testStatisticsSuite) TestCalcFraction(c *C) {
 		lower, upper, common := preCalculateDatumScalar(&test.lower, &test.upper)
 		value := convertDatumToScalar(&test.value, common)
 		fraction := calcFraction(lower, upper, value)
-		c.Check(math.Abs(fraction-test.fraction) < eps, IsTrue)
+		c.Check(math.Abs(fraction-test.fraction) < eps, IsTrue, Commentf("%v, %v", fraction, test.fraction))
 	}
 }


### PR DESCRIPTION
`MysqlTime.Sub(ZeroDatetime)` will generate error log as Datetime is not a valid Go time.

Fixes https://github.com/pingcap/tidb/issues/4758