### PR TITLE
plan: fix bug about copy function.

### DIFF
--- a/plan/explain_test.go
+++ b/plan/explain_test.go
@@ -206,7 +206,7 @@ func (s *testExplainSuite) TestExplain(c *C) {
 				"IndexScan_23   cop table:t2, index:c1, range:[<nil>,+inf], out of order:false 1.25",
 				"TableScan_24   cop table:t2, keep order:false 1.25",
 				"IndexLookUp_25 Selection_4  root index:IndexScan_23, table:TableScan_24 1.25",
-				"Selection_4 Limit_16 IndexLookUp_25 root eq(test.t1.c1, test.t2.c1) 6400",
+				"Selection_4 Limit_16 IndexLookUp_25 root eq(test.t1.c1, test.t2.c1) 1",
 				"Limit_16 MaxOneRow_9 Selection_4 root offset:0, count:1 1",
 				"MaxOneRow_9 Apply_13 Limit_16 root  1",
 				"Apply_13 Projection_2 TableReader_15,MaxOneRow_9 root left outer join, small:MaxOneRow_9, right:MaxOneRow_9 8000",

--- a/plan/new_physical_plan_builder.go
+++ b/plan/new_physical_plan_builder.go
@@ -1030,7 +1030,7 @@ func (p *baseLogicalPlan) generatePhysicalPlans() []PhysicalPlan {
 }
 
 func (p *basePhysicalPlan) getChildrenPossibleProps(prop *requiredProp) [][]*requiredProp {
-	p.expectedCnt = prop.expectedCnt
+	p.basePlan.expectedCnt = prop.expectedCnt
 	// By default, physicalPlan can always match the orders.
 	props := make([]*requiredProp, 0, len(p.basePlan.children))
 	for range p.basePlan.children {

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -296,8 +296,6 @@ type baseLogicalPlan struct {
 
 type basePhysicalPlan struct {
 	basePlan *basePlan
-	// expectedCnt means this operator may be closed after fetching expectedCnt records.
-	expectedCnt float64
 }
 
 // ExplainInfo implements PhysicalPlan interface.
@@ -453,6 +451,8 @@ type basePlan struct {
 	ctx       context.Context
 	self      Plan
 	profile   *statsProfile
+	// expectedCnt means this operator may be closed after fetching expectedCnt records.
+	expectedCnt float64
 }
 
 func (p *basePlan) copy() *basePlan {

--- a/plan/stats.go
+++ b/plan/stats.go
@@ -40,9 +40,10 @@ func (s *statsProfile) collapse(factor float64) *statsProfile {
 
 func (p *basePhysicalPlan) statsProfile() *statsProfile {
 	profile := p.basePlan.profile
-	if p.expectedCnt > 0 && p.expectedCnt < profile.count {
-		factor := p.expectedCnt / profile.count
-		profile.count = p.expectedCnt
+	expectedCnt := p.basePlan.expectedCnt
+	if expectedCnt > 0 && expectedCnt < profile.count {
+		factor := expectedCnt / profile.count
+		profile.count = expectedCnt
 		for i := range profile.cardinality {
 			profile.cardinality[i] = profile.cardinality[i] * factor
 		}


### PR DESCRIPTION
When we copy a plan, we should also copy its expected count.