### PR TITLE
tidb/tikv: return MySQL error code for Unsafe SafePoint

### DIFF
--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -897,6 +897,7 @@ const (
 	ErrTiKVServerBusy     = 9003
 	ErrResolveLockTimeout = 9004
 	ErrRegionUnavaiable   = 9005
+	ErrGCTooEarly	      = 9006
 
 	ErrTxnTooLarge = 9500
 )

--- a/mysql/errcode.go
+++ b/mysql/errcode.go
@@ -897,7 +897,7 @@ const (
 	ErrTiKVServerBusy     = 9003
 	ErrResolveLockTimeout = 9004
 	ErrRegionUnavaiable   = 9005
-	ErrGCTooEarly	      = 9006
+	ErrGCTooEarly         = 9006
 
 	ErrTxnTooLarge = 9500
 )

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -894,7 +894,7 @@ var MySQLErrName = map[uint16]string{
 	ErrTiKVServerBusy:     "TiKV server is busy",
 	ErrResolveLockTimeout: "Resolve lock timeout",
 	ErrRegionUnavaiable:   "Region is unavaiable",
-	ErrGCTooEarly:	       "GC Interval shorter than transaction duration",
+	ErrGCTooEarly:         "GC Interval shorter than transaction duration",
 
 	ErrTxnTooLarge: "Transaction is too large",
 }

--- a/mysql/errname.go
+++ b/mysql/errname.go
@@ -894,6 +894,7 @@ var MySQLErrName = map[uint16]string{
 	ErrTiKVServerBusy:     "TiKV server is busy",
 	ErrResolveLockTimeout: "Resolve lock timeout",
 	ErrRegionUnavaiable:   "Region is unavaiable",
+	ErrGCTooEarly:	       "GC Interval shorter than transaction duration",
 
 	ErrTxnTooLarge: "Transaction is too large",
 }

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -123,7 +123,7 @@ func (t backoffType) TError() *terror.Error {
 	case boTxnLock, boTxnLockFast:
 		return ErrResolveLockTimeout
 	case boPDRPC:
-		return ErrPDServerTimeout
+		return ErrPDServerTimeout.GenByArgs(txnRetryableMark)
 	case boRegionMiss:
 		return ErrRegionUnavaiable
 	case boServerBusy:

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	// errBodyMissing response body is missing error
-	errBodyMissing   = errors.New("response body is missing")
+	errBodyMissing = errors.New("response body is missing")
 )
 
 // TiDB decides whether to retry transaction by checking if error message contains
@@ -39,7 +39,7 @@ var (
 	ErrPDServerTimeout    = terror.ClassTiKV.New(mysql.ErrPDServerTimeout, mysql.MySQLErrName[mysql.ErrPDServerTimeout]+"%v")
 	ErrRegionUnavaiable   = terror.ClassTiKV.New(mysql.ErrRegionUnavaiable, mysql.MySQLErrName[mysql.ErrRegionUnavaiable]+txnRetryableMark)
 	ErrTiKVServerBusy     = terror.ClassTiKV.New(mysql.ErrTiKVServerBusy, mysql.MySQLErrName[mysql.ErrTiKVServerBusy]+txnRetryableMark)
-	ErrGCTooEarly	      = terror.ClassTiKV.New(mysql.ErrGCTooEarly, mysql.MySQLErrName[mysql.ErrGCTooEarly])
+	ErrGCTooEarly         = terror.ClassTiKV.New(mysql.ErrGCTooEarly, mysql.MySQLErrName[mysql.ErrGCTooEarly])
 )
 
 func init() {
@@ -49,7 +49,7 @@ func init() {
 		mysql.ErrPDServerTimeout:    mysql.ErrPDServerTimeout,
 		mysql.ErrRegionUnavaiable:   mysql.ErrRegionUnavaiable,
 		mysql.ErrTiKVServerBusy:     mysql.ErrTiKVServerBusy,
-		mysql.ErrGCTooEarly:	     mysql.ErrGCTooEarly,
+		mysql.ErrGCTooEarly:         mysql.ErrGCTooEarly,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassTiKV] = tikvMySQLErrCodes
 }

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -41,6 +41,7 @@ var (
 	ErrPDServerTimeout    = terror.ClassTiKV.New(mysql.ErrPDServerTimeout, mysql.MySQLErrName[mysql.ErrPDServerTimeout]+txnRetryableMark)
 	ErrRegionUnavaiable   = terror.ClassTiKV.New(mysql.ErrRegionUnavaiable, mysql.MySQLErrName[mysql.ErrRegionUnavaiable]+txnRetryableMark)
 	ErrTiKVServerBusy     = terror.ClassTiKV.New(mysql.ErrTiKVServerBusy, mysql.MySQLErrName[mysql.ErrTiKVServerBusy]+txnRetryableMark)
+	ErrGCTooEarly	      = terror.ClassTiKV.New(mysql.ErrGCTooEarly, mysql.MySQLErrName[mysql.ErrGCTooEarly])
 )
 
 func init() {
@@ -50,6 +51,7 @@ func init() {
 		mysql.ErrPDServerTimeout:    mysql.ErrPDServerTimeout,
 		mysql.ErrRegionUnavaiable:   mysql.ErrRegionUnavaiable,
 		mysql.ErrTiKVServerBusy:     mysql.ErrTiKVServerBusy,
+		mysql.ErrGCTooEarly:	     mysql.ErrGCTooEarly,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassTiKV] = tikvMySQLErrCodes
 }

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -22,8 +22,6 @@ import (
 var (
 	// errBodyMissing response body is missing error
 	errBodyMissing   = errors.New("response body is missing")
-	errMayFallBehind = errors.New("start timestamp may fall behind safe point")
-	errFallBehind    = errors.New("start timestamp fall behind safe point")
 )
 
 // TiDB decides whether to retry transaction by checking if error message contains
@@ -38,7 +36,7 @@ const txnRetryableMark = "[try again later]"
 var (
 	ErrTiKVServerTimeout  = terror.ClassTiKV.New(mysql.ErrTiKVServerTimeout, mysql.MySQLErrName[mysql.ErrTiKVServerTimeout]+txnRetryableMark)
 	ErrResolveLockTimeout = terror.ClassTiKV.New(mysql.ErrResolveLockTimeout, mysql.MySQLErrName[mysql.ErrResolveLockTimeout]+txnRetryableMark)
-	ErrPDServerTimeout    = terror.ClassTiKV.New(mysql.ErrPDServerTimeout, mysql.MySQLErrName[mysql.ErrPDServerTimeout]+txnRetryableMark)
+	ErrPDServerTimeout    = terror.ClassTiKV.New(mysql.ErrPDServerTimeout, mysql.MySQLErrName[mysql.ErrPDServerTimeout]+"%v")
 	ErrRegionUnavaiable   = terror.ClassTiKV.New(mysql.ErrRegionUnavaiable, mysql.MySQLErrName[mysql.ErrRegionUnavaiable]+txnRetryableMark)
 	ErrTiKVServerBusy     = terror.ClassTiKV.New(mysql.ErrTiKVServerBusy, mysql.MySQLErrName[mysql.ErrTiKVServerBusy]+txnRetryableMark)
 	ErrGCTooEarly	      = terror.ClassTiKV.New(mysql.ErrGCTooEarly, mysql.MySQLErrName[mysql.ErrGCTooEarly])

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -157,11 +157,11 @@ func (s *tikvStore) CheckVisibility(startTime uint64) error {
 	diff := time.Since(cachedTime)
 
 	if diff > (gcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
-		return ErrGCTooEarly
+		return errMayFallBehind
 	}
 
 	if startTime < cachedSafePoint {
-		return errFallBehind
+		return ErrGCTooEarly
 	}
 
 	return nil

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -157,7 +157,7 @@ func (s *tikvStore) CheckVisibility(startTime uint64) error {
 	diff := time.Since(cachedTime)
 
 	if diff > (gcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
-		return errMayFallBehind
+		return ErrPDServerTimeout.GenByArgs("start timestamp may fall behind safe point")
 	}
 
 	if startTime < cachedSafePoint {

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -157,7 +157,7 @@ func (s *tikvStore) CheckVisibility(startTime uint64) error {
 	diff := time.Since(cachedTime)
 
 	if diff > (gcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
-		return errMayFallBehind
+		return ErrGCTooEarly
 	}
 
 	if startTime < cachedSafePoint {

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -97,8 +97,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, geterr2 := txn2.Get(encodeKey(s.prefix, s08d("key", 0)))
 	c.Assert(geterr2, NotNil)
-	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), errFallBehind)
-	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), errMayFallBehind)
+	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
+	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenByArgs("start timestamp may fall behind safe point"))
 	isBehind := isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -109,8 +109,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, seekerr := txn3.Seek(encodeKey(s.prefix, ""))
 	c.Assert(seekerr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), errFallBehind)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), errMayFallBehind)
+	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -123,8 +123,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 	snapshot := newTiKVSnapshot(s.store, kv.Version{Ver: txn4.StartTS()})
 	_, batchgeterr := snapshot.BatchGet(keys)
 	c.Assert(batchgeterr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), errFallBehind)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), errMayFallBehind)
+	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 }


### PR DESCRIPTION
When start timestamp of a transaction falls behind the safepoint, it returns MySQL Error Code. This indicates the user that larger GC Interval should be set.
When start timestamp of a transaction may fall behind the safepoint, it returns PDServerTimeout. This is the reason for aborting the transaction.