### PR TITLE
ddl: Update reorg wait time

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -63,7 +63,7 @@ func (d *ddl) runReorgJob(job *model.Job, f func() error) error {
 	// we will wait 2 * lease outer and try checking again,
 	// so we use a very little timeout here.
 	if d.lease > 0 {
-		waitTimeout = 1 * time.Millisecond
+		waitTimeout = 50 * time.Millisecond
 	}
 
 	// wait reorganization job done or timeout

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -64,7 +64,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	rowCount := int64(10)
 	f := func() error {
 		d.setReorgRowCount(rowCount)
-		time.Sleep(4 * testLease)
+		time.Sleep(20 * testLease)
 		return nil
 	}
 	job := &model.Job{}


### PR DESCRIPTION
If we do `add index`, every 1ms we need to get the job information. I think it's wasteful.