### PR TITLE
executor: fix bug when auto_increment meets unsigned.

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1088,7 +1088,11 @@ func (e *InsertValues) adjustAutoIncrementDatum(row []types.Datum, i int, c *tab
 		if err != nil {
 			return errors.Trace(err)
 		}
-		row[i].SetInt64(id)
+		if mysql.HasUnsignedFlag(c.Flag) {
+			row[i].SetUint64(uint64(id))
+		} else {
+			row[i].SetInt64(id)
+		}
 		return nil
 	}
 
@@ -1107,6 +1111,11 @@ func (e *InsertValues) adjustAutoIncrementDatum(row []types.Datum, i int, c *tab
 			return errors.Trace(err)
 		}
 		e.ctx.GetSessionVars().InsertID = uint64(recordID)
+		if mysql.HasUnsignedFlag(c.Flag) {
+			row[i].SetUint64(uint64(recordID))
+		} else {
+			row[i].SetInt64(recordID)
+		}
 		row[i].SetInt64(recordID)
 		retryInfo.AddAutoIncrementID(recordID)
 		return nil
@@ -1125,7 +1134,11 @@ func (e *InsertValues) adjustAutoIncrementDatum(row []types.Datum, i int, c *tab
 		}
 	}
 
-	row[i].SetInt64(recordID)
+	if mysql.HasUnsignedFlag(c.Flag) {
+		row[i].SetUint64(uint64(recordID))
+	} else {
+		row[i].SetInt64(recordID)
+	}
 	retryInfo.AddAutoIncrementID(recordID)
 	return nil
 }

--- a/executor/write.go
+++ b/executor/write.go
@@ -1116,7 +1116,6 @@ func (e *InsertValues) adjustAutoIncrementDatum(row []types.Datum, i int, c *tab
 		} else {
 			row[i].SetInt64(recordID)
 		}
-		row[i].SetInt64(recordID)
 		retryInfo.AddAutoIncrementID(recordID)
 		return nil
 	}

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -195,6 +195,13 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("set sql_mode = 'strict_all_tables';")
 	r = tk.MustQuery("SELECT * FROM t;")
 	r.Check(testkit.Rows("2017-00-00 00:00:00"))
+
+	// test auto_increment with unsigned.
+	tk.MustExec("drop table if exists test")
+	tk.MustExec("CREATE TABLE test(id int(10) UNSIGNED NOT NULL AUTO_INCREMENT, p int(10) UNSIGNED NOT NULL, PRIMARY KEY(p), KEY(id))")
+	tk.MustExec("insert into test(p) value(1)")
+	tk.MustQuery("select * from test").Check(testkit.Rows("1 1"))
+	tk.MustQuery("select * from test use index (id) where id = 1").Check(testkit.Rows("1 1"))
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -202,6 +202,10 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("insert into test(p) value(1)")
 	tk.MustQuery("select * from test").Check(testkit.Rows("1 1"))
 	tk.MustQuery("select * from test use index (id) where id = 1").Check(testkit.Rows("1 1"))
+	tk.MustExec("insert into test values(NULL, 2)")
+	tk.MustQuery("select * from test use index (id) where id = 2").Check(testkit.Rows("2 2"))
+	tk.MustExec("insert into test values(2, 3)")
+	tk.MustQuery("select * from test use index (id) where id = 2").Check(testkit.Rows("2 2", "2 3"))
 }
 
 func (s *testSuite) TestInsertAutoInc(c *C) {


### PR DESCRIPTION
fix #4817 
This bug will make the index key encoded to wrong value and make range query failed.
PTAL @shenli @coocood @hanfei1991 