### PR TITLE
fix a bug when len(hist.Buckets) == 0

### DIFF
--- a/plan/stats.go
+++ b/plan/stats.go
@@ -74,7 +74,7 @@ func (p *DataSource) getStatsProfileByFilter(conds expression.CNFExprs) *statsPr
 	}
 	for i, col := range p.Columns {
 		hist, ok := p.statisticTable.Columns[col.ID]
-		if ok && hist.NDV > 0 {
+		if ok && hist.NDV > 0 && len(hist.Buckets) > 0 {
 			factor := float64(p.statisticTable.Count) / float64(hist.Buckets[len(hist.Buckets)-1].Count)
 			profile.cardinality[i] = float64(hist.NDV) * factor
 		} else {


### PR DESCRIPTION
I got a error below: 
2017/10/19 13:31:40.465 conn.go:388: [error] lastCmd SELECT * FROM ntest limit 551, 1, runtime error: index out of range

then I find it is because len(hist.Buckets) == 0, and this pr fix the bug