### PR TITLE
plan: fix distinct bug.

### DIFF
--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -689,6 +689,11 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		sql  string
 		best string
 	}{
+		// Test distinct.
+		{
+			sql:  "select distinct b from t",
+			best: "TableReader(Table(t)->HashAgg)->HashAgg",
+		},
 		// Test agg + table.
 		{
 			sql:  "select sum(a), avg(b + c) from t group by d",

--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -122,7 +122,7 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 	childFlag := canEliminate
 	if _, isUnion := p.(*Union); isUnion {
 		childFlag = false
-	} else if isProj {
+	} else if _, isAgg := p.(*LogicalAggregation); isAgg || isProj {
 		childFlag = true
 	}
 	for _, child := range p.Children() {


### PR DESCRIPTION
When the query is `select distinct`, the root plan is aggregation, so its child projection should be eliminated.
This will fix #4819 