### PR TITLE
executor, plan: add cast for the expr of assignments of updateList

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -603,6 +603,13 @@ func (s *testSuite) TestUpdate(c *C) {
 	r = tk.MustQuery("SHOW WARNINGS;")
 	r.Check(testkit.Rows("Warning 1062 key already exist"))
 	tk.MustQuery("select * from t").Check(testkit.Rows("1", "2"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id integer auto_increment, t1 datetime, t2 datetime, primary key (id))")
+	tk.MustExec("insert into t(t1, t2) values('2000-10-01 01:01:01', '2017-01-01 10:10:10')")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 2000-10-01 01:01:01 2017-01-01 10:10:10"))
+	tk.MustExec("update t set t1 = '2017-10-01 10:10:11', t2 = date_add(t1, INTERVAL 10 MINUTE) where id = 1")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1 2017-10-01 10:10:11 2017-10-01 10:20:11"))
 }
 
 // For issue #4514.

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -1553,8 +1553,8 @@ func (b *planBuilder) buildUpdateLists(tableList []*ast.TableName, list []*ast.A
 				return expr
 			}
 			newExpr, np, err = b.rewriteWithPreprocess(assign.Expr, p, nil, false, rewritePreprocess)
-			newExpr = expression.BuildCastFunction(b.ctx, newExpr, col.GetType())
 		}
+		newExpr = expression.BuildCastFunction(b.ctx, newExpr, col.GetType())
 		if err != nil {
 			b.err = errors.Trace(err)
 			return nil, nil


### PR DESCRIPTION
Before this commit, we only add cast for generated columns in updateList.
for query like the follow case may cause a panic:
``` sql
create table test (id integer auto_increment, t1 datetime, t2 datetime, primary key (id));
insert into test (t1, t2) values (now(), '2017-01-01 10:10:10');
update test set t1 = '2017-10-01 10:10:11', t2 = date_add(t1, INTERVAL 10 MINUTE) where id = 1;
```
PTAL @shenli @coocood @zz-jason 