### PR TITLE
parser: ALTER TABLE t ENGINE = 'string'

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4950,13 +4950,13 @@ TableElementList:
 	}
 
 TableOption:
-	"ENGINE" Identifier
+	"ENGINE" StringName
 	{
-		$$ = &ast.TableOption{Tp: ast.TableOptionEngine, StrValue: $2}
+		$$ = &ast.TableOption{Tp: ast.TableOptionEngine, StrValue: $2.(string)}
 	}
-|	"ENGINE" eq Identifier
+|	"ENGINE" eq StringName
 	{
-		$$ = &ast.TableOption{Tp: ast.TableOptionEngine, StrValue: $3}
+		$$ = &ast.TableOption{Tp: ast.TableOptionEngine, StrValue: $3.(string)}
 	}
 |	DefaultKwdOpt CharsetKw EqOpt CharsetName
 	{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1467,6 +1467,10 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"ALTER TABLE t ADD UNIQUE (a) COMMENT 'a'", true},
 		{"ALTER TABLE t ADD UNIQUE KEY (a) COMMENT 'a'", true},
 		{"ALTER TABLE t ADD UNIQUE INDEX (a) COMMENT 'a'", true},
+		{"ALTER TABLE t ENGINE ''", true},
+		{"ALTER TABLE t ENGINE = ''", true},
+		{"ALTER TABLE t ENGINE = 'innodb'", true},
+		{"ALTER TABLE t ENGINE = innodb", true},
 
 		// For create index statement
 		{"CREATE INDEX idx ON t (a)", true},


### PR DESCRIPTION
MySQL support this:

```
mysql> alter table t engine = 'innodb';
ERROR 1105 (HY000): line 1 column 29 near "" (total length 29)
```

but TiDB just parse:

```
mysql> alter table t engine = innodb;
```

It should be `ENGINE = String` rather than `ENGINE = Identifier`

@wolfstudy 