### PR TITLE
Makefile: remove target 'benchkv' and 'build' from 'make dev'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ buildsucc:
 
 all: dev server benchkv
 
-dev: checklist parserlib build benchkv test check
+dev: checklist parserlib test check
 
 build:
 	$(GOBUILD)


### PR DESCRIPTION
benchkv and build is unnecessary for `make dev`, it's a waste of life waiting those things.