### PR TITLE
parser: Support window function grammar.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2763,7 +2763,10 @@ SimpleExpr:
 	}
 |	WindowFuncCall
 	{
-		$$ = nil
+		// TODO: Remove this fake ast placeholder.
+		$$ = &ast.ParamMarkerExpr{
+			Offset: yyS[yypt].offset,
+		}
 	}
 |	Literal
 |	paramMarker

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -691,6 +691,30 @@ import (
 	ElseOpt			"Optional else clause"
 	Type			"Types"
 
+	OptExistingWindowName	"Optional existing WINDOW name"
+	OptFromFirstLast	"Optional FROM FIRST/LAST"
+	OptLLDefault		"Optional LEAD/LAG default"
+	OptLeadLagInfo		"Optional LEAD/LAG info"
+	OptNullTreatment	"Optional NULL treatment"
+	OptPartitionClause	"Optional PARTITION clause"
+	OptWindowOrderByClause	"Optional ORDER BY clause in WINDOW"
+	OptWindowFrameClause	"Optional FRAME clause in WINDOW"
+	OptWindowingClause	"Optional OVER clause"
+	WindowingClause		"OVER clause"
+	WindowClauseOptional	"Optional WINDOW clause"
+	WindowDefinitionList	"WINDOW definition list"
+	WindowDefinition	"WINDOW definition"
+	WindowFrameUnits	"WINDOW frame units"
+	WindowFrameBetween	"WINDOW frame between"
+	WindowFrameBound	"WINDOW frame bound"
+	WindowFrameExtent	"WINDOW frame extent"
+	WindowFrameStart	"WINDOW frame start"
+	WindowFuncCall		"WINDOW function call"
+	WindowName		"WINDOW name"
+	WindowNameOrSpec	"WINDOW name or spec"
+	WindowSpec		"WINDOW spec"
+	WindowSpecDetails	"WINDOW spec details"
+
 	BetweenOrNotOp		"Between predicate"
 	IsOrNotOp		"Is predicate"
 	InOrNotOp		"In predicate"
@@ -2737,6 +2761,10 @@ SimpleExpr:
 		// TODO: Create a builtin function hold expr and collation. When do evaluation, convert expr result using the collation.
 		$$ = $1
 	}
+|	WindowFuncCall
+	{
+		$$ = nil
+	}
 |	Literal
 |	paramMarker
 	{
@@ -3191,27 +3219,27 @@ TrimDirection:
 	}
 
 SumExpr:
-	"AVG" '(' BuggyDefaultFalseDistinctOpt Expression ')'
+	"AVG" '(' BuggyDefaultFalseDistinctOpt Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
 	}
-|	"BIT_XOR" '(' Expression ')'
+|	"BIT_XOR" '(' Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3}}
 	}
-|	"COUNT" '(' DistinctKwd ExpressionList ')'
+|	"COUNT" '(' DistinctKwd ExpressionList ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: true}
 	}
-|	"COUNT" '(' "ALL" Expression ')'
+|	"COUNT" '(' "ALL" Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}}
 	}
-|	"COUNT" '(' Expression ')'
+|	"COUNT" '(' Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$3}}
 	}
-|	"COUNT" '(' '*' ')'
+|	"COUNT" '(' '*' ')' OptWindowingClause
 	{
 		args := []ast.ExprNode{ast.NewValueExpr(1)}
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: args}
@@ -3220,15 +3248,15 @@ SumExpr:
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: $4.([]ast.ExprNode), Distinct: $3.(bool)}
 	}
-|	"MAX" '(' BuggyDefaultFalseDistinctOpt Expression ')'
+|	"MAX" '(' BuggyDefaultFalseDistinctOpt Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
 	}
-|	"MIN" '(' BuggyDefaultFalseDistinctOpt Expression ')'
+|	"MIN" '(' BuggyDefaultFalseDistinctOpt Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
 	}
-|	"SUM" '(' BuggyDefaultFalseDistinctOpt Expression ')'
+|	"SUM" '(' BuggyDefaultFalseDistinctOpt Expression ')' OptWindowingClause
 	{
 		$$ = &ast.AggregateFuncExpr{F: $1, Args: []ast.ExprNode{$4}, Distinct: $3.(bool)}
 	}
@@ -3705,7 +3733,7 @@ SelectStmt:
 		$$ = st
 	}
 |	"SELECT" SelectStmtOpts SelectStmtFieldList "FROM"
-	TableRefsClause WhereClauseOptional SelectStmtGroup HavingClause OrderByOptional
+	TableRefsClause WhereClauseOptional SelectStmtGroup HavingClause WindowClauseOptional OrderByOptional
 	SelectStmtLimit SelectLockOpt
 	{
 		opts := $2.(*ast.SelectStmtOpts)
@@ -3714,7 +3742,7 @@ SelectStmt:
 			Distinct:		opts.Distinct,
 			Fields:		$3.(*ast.FieldList),
 			From:		$5.(*ast.TableRefsClause),
-			LockTp:		$11.(ast.SelectLockType),
+			LockTp:		$12.(ast.SelectLockType),
 		}
 		if opts.TableHints != nil {
 			st.TableHints = opts.TableHints
@@ -3722,7 +3750,7 @@ SelectStmt:
 
 		lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 		if lastField.Expr != nil && lastField.AsName.O == "" {
-			lastEnd := parser.endOffset(&yyS[yypt-7])
+			lastEnd := parser.endOffset(&yyS[yypt-8])
 			lastField.SetText(parser.src[lastField.Offset:lastEnd])
 		}
 
@@ -3738,12 +3766,12 @@ SelectStmt:
 			st.Having = $8.(*ast.HavingClause)
 		}
 
-		if $9 != nil {
-			st.OrderBy = $9.(*ast.OrderByClause)
+		if $10 != nil {
+			st.OrderBy = $10.(*ast.OrderByClause)
 		}
 
-		if $10 != nil {
-			st.Limit = $10.(*ast.Limit)
+		if $11 != nil {
+			st.Limit = $11.(*ast.Limit)
 		}
 
 		$$ = st
@@ -3751,6 +3779,278 @@ SelectStmt:
 
 FromDual:
 	"FROM" "DUAL"
+
+WindowClauseOptional:
+	{
+		$$ = nil
+	}
+|	"WINDOW" WindowDefinitionList
+	{
+		$$ = nil
+	}
+
+WindowDefinitionList:
+	WindowDefinition
+	{
+		$$ = nil
+	}
+|	WindowDefinitionList ',' WindowDefinition
+	{
+		$$ = nil
+	}
+
+WindowDefinition:
+	WindowName "AS" WindowSpec
+	{
+		$$ = nil
+	}
+
+WindowName:
+	Identifier
+	{
+		$$ = nil
+	}
+
+WindowSpec:
+	'(' WindowSpecDetails ')'
+	{
+		$$ = nil
+	}
+
+WindowSpecDetails:
+	OptExistingWindowName OptPartitionClause OptWindowOrderByClause OptWindowFrameClause
+	{
+		$$ = nil
+	}
+
+OptExistingWindowName:
+	{
+		$$ = nil
+	}
+|	WindowName
+	{
+		$$ = nil
+	}
+
+OptPartitionClause:
+	{
+		$$ = nil
+	}
+|	"PARTITION" "BY" ByList
+	{
+		$$ = nil
+	}
+
+OptWindowOrderByClause:
+	{
+		$$ = nil
+	}
+|	"ORDER" "BY" ByList
+	{
+		$$ = nil
+	}
+
+OptWindowFrameClause:
+	{
+		$$ = nil
+	}
+|	WindowFrameUnits WindowFrameExtent
+	{
+		$$ = nil
+	}
+
+WindowFrameUnits:
+	"ROWS"
+	{
+		$$ = nil
+	}
+|	"RANGE"
+	{
+		$$ = nil
+	}
+|	"GROUPS"
+	{
+		$$ = nil
+	}
+
+WindowFrameExtent:
+	WindowFrameStart
+	{
+		$$ = nil
+	}
+|	WindowFrameBetween
+	{
+		$$ = nil
+	}
+
+WindowFrameStart:
+	"UNBOUNDED" "PRECEDING"
+	{
+		$$ = nil
+	}
+|	NumLiteral "PRECEDING"
+	{
+		$$ = nil
+	}
+|	paramMarker "PRECEDING"
+	{
+		$$ = nil
+	}
+|	"INTERVAL" Expression TimeUnit "PRECEDING"
+	{
+		$$ = nil
+	}
+|	"CURRENT" "ROW"
+	{
+		$$ = nil
+	}
+
+WindowFrameBetween:
+	"BETWEEN" WindowFrameBound "AND" WindowFrameBound
+	{
+		$$ = nil
+	}
+
+WindowFrameBound:
+	WindowFrameStart
+	{
+		$$ = nil
+	}
+|	"UNBOUNDED" "FOLLOWING"
+	{
+		$$ = nil
+	}
+|	NumLiteral "FOLLOWING"
+	{
+		$$ = nil
+	}
+|	paramMarker "FOLLOWING"
+	{
+		$$ = nil
+	}
+|	"INTERVAL" Expression TimeUnit "FOLLOWING"
+	{
+		$$ = nil
+	}
+
+OptWindowingClause:
+	{
+		$$ = nil
+	}
+|	WindowingClause
+	{
+		$$ = nil
+	}
+
+WindowingClause:
+	"OVER" WindowNameOrSpec
+	{
+		$$ = nil
+	}
+
+WindowNameOrSpec:
+	WindowName
+	{
+		$$ = nil
+	}
+|	WindowSpec
+	{
+		$$ = nil
+	}
+
+WindowFuncCall:
+	"ROW_NUMBER" '(' ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"RANK" '(' ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"DENSE_RANK" '(' ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"CUME_DIST" '(' ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"PERCENT_RANK" '(' ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"NTILE" '(' SimpleExpr ')' WindowingClause
+	{
+		$$ = nil
+	}
+|	"LEAD" '(' Expression OptLeadLagInfo ')' OptNullTreatment WindowingClause
+	{
+		$$ = nil
+	}
+|	"LAG" '(' Expression OptLeadLagInfo ')' OptNullTreatment WindowingClause
+	{
+		$$ = nil
+	}
+|	"FIRST_VALUE" '(' Expression ')' OptNullTreatment WindowingClause
+	{
+		$$ = nil
+	}
+|	"LAST_VALUE" '(' Expression ')' OptNullTreatment WindowingClause
+	{
+		$$ = nil
+	}
+|	"NTH_VALUE" '(' Expression ',' SimpleExpr ')' OptFromFirstLast OptNullTreatment WindowingClause
+	{
+		$$ = nil
+	}
+
+OptLeadLagInfo:
+	{
+		$$ = nil
+	}
+|	',' NumLiteral OptLLDefault
+	{
+		$$ = nil
+	}
+|	',' paramMarker OptLLDefault
+	{
+		$$ = nil
+	}
+
+OptLLDefault:
+	{
+		$$ = nil
+	}
+|	',' Expression
+	{
+		$$ = nil
+	}
+
+OptNullTreatment:
+	{
+		$$ = nil
+	}
+|	"RESPECT" "NULLS"
+	{
+		$$ = nil
+	}
+|	"IGNORE" "NULLS"
+	{
+		$$ = nil
+	}
+
+OptFromFirstLast:
+	{
+		$$ = nil
+	}
+|	"FROM" "FIRST"
+	{
+		$$ = nil
+	}
+|	"FROM" "LAST"
+	{
+		$$ = nil
+	}
 
 
 TableRefsClause:

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2008,3 +2008,67 @@ func (s *testParserSuite) TestSetTransaction(c *C) {
 		c.Assert(vars.Value.GetValue(), Equals, t.value)
 	}
 }
+
+func (s *testParserSuite) TestWindowFunctions(c *C) {
+	defer testleak.AfterTest(c)()
+	table := []testCase{
+		// For window function descriptions.
+		// See https://dev.mysql.com/doc/refman/8.0/en/window-function-descriptions.html
+		{`SELECT CUME_DIST() OVER w FROM t;`, true},
+		{`SELECT DENSE_RANK() OVER w FROM t;`, true},
+		{`SELECT FIRST_VALUE(val) OVER w FROM t;`, true},
+		{`SELECT FIRST_VALUE(val) RESPECT NULLS OVER w FROM t;`, true},
+		{`SELECT FIRST_VALUE(val) IGNORE NULLS OVER w FROM t;`, true},
+		{`SELECT LAG(val) OVER w FROM t;`, true},
+		{`SELECT LAG(val, 1) OVER w FROM t;`, true},
+		{`SELECT LAG(val, 1, def) OVER w FROM t;`, true},
+		{`SELECT LAST_VALUE(val) OVER w FROM t;`, true},
+		{`SELECT LEAD(val) OVER w FROM t;`, true},
+		{`SELECT LEAD(val, 1) OVER w FROM t;`, true},
+		{`SELECT LEAD(val, 1, def) OVER w FROM t;`, true},
+		{`SELECT NTH_VALUE(val, 233) OVER w FROM t;`, true},
+		{`SELECT NTH_VALUE(val, 233) FROM FIRST OVER w FROM t;`, true},
+		{`SELECT NTH_VALUE(val, 233) FROM LAST OVER w FROM t;`, true},
+		{`SELECT NTH_VALUE(val, 233) FROM LAST IGNORE NULLS OVER w FROM t;`, true},
+		{`SELECT NTH_VALUE(val) OVER w FROM t;`, false},
+		{`SELECT NTILE(233) OVER w FROM t;`, true},
+		{`SELECT PERCENT_RANK() OVER w FROM t;`, true},
+		{`SELECT RANK() OVER w FROM t;`, true},
+		{`SELECT ROW_NUMBER() OVER w FROM t;`, true},
+		{`SELECT n, LAG(n, 1, 0) OVER w, LEAD(n, 1, 0) OVER w, n + LAG(n, 1, 0) OVER w FROM fib;`, true},
+
+		// For window function concepts and syntax.
+		// See https://dev.mysql.com/doc/refman/8.0/en/window-functions-usage.html
+		{`SELECT SUM(profit) OVER(PARTITION BY country) AS country_profit FROM sales;`, true},
+		{`SELECT SUM(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT AVG(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT BIT_XOR(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT COUNT(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT COUNT(ALL profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT COUNT(*) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT MAX(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT MIN(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT SUM(profit) OVER() AS country_profit FROM sales;`, true},
+		{`SELECT ROW_NUMBER() OVER(PARTITION BY country) AS row_num1 FROM sales;`, true},
+		{`SELECT ROW_NUMBER() OVER(PARTITION BY country, d ORDER BY year, product) AS row_num2 FROM sales;`, true},
+
+		// For window function frame specification.
+		// See https://dev.mysql.com/doc/refman/8.0/en/window-functions-frames.html
+		{`SELECT SUM(val) OVER (PARTITION BY subject ORDER BY time ROWS UNBOUNDED PRECEDING) FROM t;`, true},
+		{`SELECT AVG(val) OVER (PARTITION BY subject ORDER BY time ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t;`, true},
+		{`SELECT AVG(val) OVER (ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM t;`, true},
+		{`SELECT AVG(val) OVER (ROWS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) FROM t;`, true},
+		{`SELECT AVG(val) OVER (RANGE BETWEEN INTERVAL 5 DAY PRECEDING AND INTERVAL '2:30' MINUTE_SECOND FOLLOWING) FROM t;`, true},
+		{`SELECT AVG(val) OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM t;`, true},
+		{`SELECT AVG(val) OVER (RANGE CURRENT ROW) FROM t;`, true},
+
+		// For named windows.
+		// See https://dev.mysql.com/doc/refman/8.0/en/window-functions-named-windows.html
+		{`SELECT RANK() OVER w FROM t WINDOW w AS (ORDER BY val);`, true},
+		{`SELECT RANK() OVER w FROM t WINDOW w AS ();`, true},
+		{`SELECT FIRST_VALUE(year) OVER (w ORDER BY year ASC) AS first FROM sales WINDOW w AS (PARTITION BY country);`, true},
+		{`SELECT RANK() OVER w1 FROM t WINDOW w1 AS (w2), w2 AS (), w3 AS (w1);`, true},
+		{`SELECT RANK() OVER w1 FROM t WINDOW w1 AS (w2), w2 AS (w3), w3 AS (w1);`, true},
+	}
+	s.RunTest(c, table)
+}


### PR DESCRIPTION
Add window function grammar to parser.
The statements containing window clauses will be parsed but not evaluated.
See https://dev.mysql.com/doc/refman/8.0/en/window-functions.html and https://github.com/mysql/mysql-server/blob/8.0/sql/sql_yacc.yy for grammar details.
