### PR TITLE
distsql: use utf8_bin for unsupported column collation.

### DIFF
--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -306,6 +306,9 @@ func collationToProto(c string) int32 {
 	if v == mysql.BinaryCollationID {
 		return int32(mysql.BinaryCollationID)
 	}
+	// We only support binary and utf8_bin collation.
+	// Setting other collations to utf8_bin for old data compatibility.
+	// For the data created when we didn't enforce utf8_bin collation in create table.
 	return int32(mysql.DefaultCollationID)
 }
 

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -300,10 +300,11 @@ func columnToProto(c *model.ColumnInfo) *tipb.ColumnInfo {
 	return pc
 }
 
+// TODO: update it when more collate is supported.
 func collationToProto(c string) int32 {
-	v, ok := mysql.CollationNames[c]
-	if ok {
-		return int32(v)
+	v := mysql.CollationNames[c]
+	if v == mysql.BinaryCollationID {
+		return int32(mysql.BinaryCollationID)
 	}
 	return int32(mysql.DefaultCollationID)
 }

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -60,6 +60,16 @@ func (s *testDistsqlSuite) TestColumnToProto(c *C) {
 	for _, v := range pcs {
 		c.Assert(v.GetFlag(), Equals, int32(10))
 	}
+
+	// Make sure we only convert to supported collate.
+	tp = types.NewFieldType(mysql.TypeVarchar)
+	tp.Flag = 10
+	tp.Collate = "latin1_swedish_ci"
+	col = &model.ColumnInfo{
+		FieldType: *tp,
+	}
+	pc = columnToProto(col)
+	c.Assert(pc.Collation, Equals, int32(mysql.DefaultCollationID))
 }
 
 func (s *testDistsqlSuite) TestIndexToProto(c *C) {


### PR DESCRIPTION
Coprocessor will return error if non-supported collation is push down.