### PR TITLE
meta: Be compatible with uninitialized auto ID key

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -557,7 +557,8 @@ func upgradeToVer16(s Session) {
 		if originalID > 0 {
 			return nil
 		}
-		err1 = m.SetFirstInitTableID(tableID)
+		err1 = m.SetFirstInitTableID(tableID + 1)
+		log.Infof("upgrade version 16 table ID %d, err1 %v", tableID+1, err1)
 		return errors.Trace(err1)
 	})
 	if err != nil && !strings.Contains(err.Error(), "write confilict") {

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -29,6 +29,8 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
@@ -226,6 +228,7 @@ const (
 	version13 = 13
 	version14 = 14
 	version15 = 15
+	version16 = 16
 )
 
 func checkBootstrapped(s Session) (bool, error) {
@@ -336,6 +339,10 @@ func upgrade(s Session) {
 
 	if ver < version15 {
 		upgradeToVer15(s)
+	}
+
+	if ver < version16 {
+		upgradeToVer16(s)
 	}
 
 	updateBootstrapVer(s)
@@ -532,6 +539,28 @@ func upgradeToVer15(s Session) {
 	var err error
 	_, err = s.Execute(CreateGCDeleteRangeTable)
 	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func upgradeToVer16(s Session) {
+	err := kv.RunInNewTxn(s.GetStore(), true, func(txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		tableID, err1 := m.GetGlobalID()
+		if err1 != nil {
+			return errors.Trace(err1)
+		}
+		originalID, err1 := m.GetFirstInitTableID()
+		if err1 != nil {
+			return errors.Trace(err1)
+		}
+		if originalID > 0 {
+			return nil
+		}
+		err1 = m.SetFirstInitTableID(tableID)
+		return errors.Trace(err1)
+	})
+	if err != nil && !strings.Contains(err.Error(), "write confilict") {
 		log.Fatal(err)
 	}
 }

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -53,19 +53,26 @@ func (s *testSuite) TestMeta(c *C) {
 	n, err := t.GenGlobalID()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(1))
-
 	n, err = t.GetGlobalID()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(1))
 
+	firstID, err := t.GetFirstInitTableID()
+	c.Assert(err, IsNil)
+	c.Assert(firstID, Equals, int64(0))
+	newFirstID := int64(10)
+	err = t.SetFirstInitTableID(newFirstID)
+	c.Assert(err, IsNil)
+	firstID, err = t.GetFirstInitTableID()
+	c.Assert(err, IsNil)
+	c.Assert(firstID, Equals, newFirstID)
+
 	n, err = t.GetSchemaVersion()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(0))
-
 	n, err = t.GenSchemaVersion()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(1))
-
 	n, err = t.GetSchemaVersion()
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(1))

--- a/session.go
+++ b/session.go
@@ -1086,7 +1086,7 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = 15
+	currentBootstrapVersion = 16
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {


### PR DESCRIPTION
It's compatible with uninitialized auto ID key. The auto ID key doesn't initialize before pushing the PR #4862.