### PR TITLE
codec: fix a bug in json decode. (#4949)

### DIFF
--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -248,9 +248,16 @@ func DecodeOne(b []byte) (remain []byte, d types.Datum, err error) {
 			d.SetValue(v)
 		}
 	case jsonFlag:
+		var size int
+		size, err = json.PeekBytesAsJSON(b)
+		if err != nil {
+			return b, d, err
+		}
+
 		var j json.JSON
 		j, err = json.Deserialize(b)
 		if err == nil {
+			b = b[size:]
 			d.SetMysqlJSON(j)
 		}
 	case NilFlag:

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/types"
+	"github.com/pingcap/tidb/util/types/json"
 )
 
 func TestT(t *testing.T) {
@@ -738,6 +739,36 @@ func (s *testCodecSuite) TestDecimal(c *C) {
 	for i := 0; i < len(decs)-1; i++ {
 		cmp := bytes.Compare(decs[i], decs[i+1])
 		c.Assert(cmp, LessEqual, 0)
+	}
+}
+
+func (s *testCodecSuite) TestJSON(c *C) {
+	defer testleak.AfterTest(c)()
+	tbl := []string{
+		"1234.00",
+		`{"a": "b"}`,
+	}
+
+	datums := make([]types.Datum, 0, len(tbl))
+	for _, t := range tbl {
+		var d types.Datum
+		j, err := json.ParseFromString(t)
+		c.Assert(err, IsNil)
+		d.SetMysqlJSON(j)
+		datums = append(datums, d)
+	}
+
+	bytes := make([]byte, 0, 4096)
+	bytes, err := encode(bytes, datums, false, false)
+	c.Assert(err, IsNil)
+
+	datums1, err := Decode(bytes, 2)
+	c.Assert(err, IsNil)
+
+	for i := range datums1 {
+		lhs := datums[i].GetMysqlJSON().String()
+		rhs := datums1[i].GetMysqlJSON().String()
+		c.Assert(lhs, Equals, rhs)
 	}
 }
 


### PR DESCRIPTION
Previously after decode a JSON from row, we didn't
advance the index in the bytes. This PR fix this.