### PR TITLE
*: Remove the check of initialized auto ID

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -339,7 +339,7 @@ func getCurrentTable(d *ddl, schemaID, tableID int64) (table.Table, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	alloc := autoid.NewAllocator(d.store, schemaID)
+	alloc := autoid.NewAllocator(d.store, 0, schemaID)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -795,11 +795,7 @@ func (d *ddl) CreateTable(ctx context.Context, ident ast.Ident, colDefs []*ast.C
 // handleAutoIncID handles auto_increment option in DDL. It creates a ID counter for the table and initiates the counter to a proper value.
 // For example if the option sets auto_increment to 10. The counter will be set to 9. So the next allocated ID will be 10.
 func (d *ddl) handleAutoIncID(tbInfo *model.TableInfo, schemaID int64) error {
-	if tbInfo.OldSchemaID != 0 {
-		schemaID = tbInfo.OldSchemaID
-	}
-	alloc := autoid.NewAllocator(d.store, schemaID)
-
+	alloc := autoid.NewAllocator(d.store, tbInfo.OldSchemaID, schemaID)
 	tbInfo.State = model.StatePublic
 	tb, err := table.TableFromMeta(alloc, tbInfo)
 	if err != nil {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -148,10 +148,7 @@ func (d *ddl) splitTableRegion(tableID int64) error {
 }
 
 func (d *ddl) getTable(schemaID int64, tblInfo *model.TableInfo) (table.Table, error) {
-	if tblInfo.OldSchemaID != 0 {
-		schemaID = tblInfo.OldSchemaID
-	}
-	alloc := autoid.NewAllocator(d.store, schemaID)
+	alloc := autoid.NewAllocator(d.store, tblInfo.OldSchemaID, schemaID)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	return tbl, errors.Trace(err)
 }

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -177,7 +177,7 @@ func testGetTableWithError(d *ddl, schemaID, tableID int64) (table.Table, error)
 	if tblInfo == nil {
 		return nil, errors.New("table not found")
 	}
-	alloc := autoid.NewAllocator(d.store, schemaID)
+	alloc := autoid.NewAllocator(d.store, tblInfo.OldSchemaID, schemaID)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -225,7 +225,7 @@ func (s *testSuite) TestRenameTable(c *C) {
 	tk.MustExec("insert rename2.t values ()")
 	tk.MustExec("rename table rename2.t to rename3.t")
 	tk.MustExec("insert rename3.t values ()")
-	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "2", "3"))
+	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "5001", "10001"))
 	tk.MustExec("drop database rename1")
 	tk.MustExec("drop database rename2")
 	tk.MustExec("drop database rename3")

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -73,7 +73,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var alloc autoid.Allocator
 	if tableIDIsValid(oldTableID) {
-		if oldTableID == newTableID {
+		if oldTableID == newTableID && diff.Type != model.ActionRenameTable {
 			alloc, _ = b.is.AllocByID(oldTableID)
 		}
 		if diff.Type == model.ActionRenameTable {
@@ -162,10 +162,7 @@ func (b *Builder) applyCreateTable(m *meta.Meta, roDBInfo *model.DBInfo, tableID
 	}
 	if alloc == nil {
 		schemaID := roDBInfo.ID
-		if tblInfo.OldSchemaID != 0 {
-			schemaID = tblInfo.OldSchemaID
-		}
-		alloc = autoid.NewAllocator(b.handle.store, schemaID)
+		alloc = autoid.NewAllocator(b.handle.store, tblInfo.OldSchemaID, schemaID)
 	}
 	tbl, err := tables.TableFromMeta(alloc, tblInfo)
 	if err != nil {
@@ -267,10 +264,7 @@ func (b *Builder) createSchemaTablesForDB(di *model.DBInfo) error {
 	b.is.schemaMap[di.Name.L] = schTbls
 	for _, t := range di.Tables {
 		schemaID := di.ID
-		if t.OldSchemaID != 0 {
-			schemaID = t.OldSchemaID
-		}
-		alloc := autoid.NewAllocator(b.handle.store, schemaID)
+		alloc := autoid.NewAllocator(b.handle.store, t.OldSchemaID, schemaID)
 		var tbl table.Table
 		tbl, err := tables.TableFromMeta(alloc, t)
 		if err != nil {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -48,7 +48,11 @@ type allocator struct {
 	base  int64
 	end   int64
 	store kv.Storage
-	dbID  int64
+	// originalDBID saves original schemaID to keep autoID unchanged
+	// while renaming a table from one database to another.
+	originalDBID int64
+	// dbID is current database's ID.
+	dbID int64
 }
 
 // GetStep is only used by tests
@@ -78,7 +82,7 @@ func (alloc *allocator) Rebase(tableID, requiredBase int64, allocIDs bool) error
 	var newBase, newEnd int64
 	err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 		m := meta.NewMeta(txn)
-		currentEnd, err1 := m.GetAutoTableID(alloc.dbID, tableID)
+		currentEnd, err1 := m.GetAutoTableID(alloc.originalDBID, tableID)
 		if err1 != nil {
 			return errors.Trace(err1)
 		}
@@ -98,7 +102,7 @@ func (alloc *allocator) Rebase(tableID, requiredBase int64, allocIDs bool) error
 			newBase = requiredBase
 			newEnd = requiredBase
 		}
-		_, err1 = m.GenAutoTableID(alloc.dbID, tableID, newEnd-currentEnd)
+		_, err1 = m.GenAutoTableID(alloc.originalDBID, alloc.dbID, tableID, newEnd-currentEnd)
 		return errors.Trace(err1)
 	})
 	if err != nil {
@@ -120,11 +124,11 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
-			newBase, err1 = m.GetAutoTableID(alloc.dbID, tableID)
+			newBase, err1 = m.GetAutoTableID(alloc.originalDBID, tableID)
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
-			newEnd, err1 = m.GenAutoTableID(alloc.dbID, tableID, step)
+			newEnd, err1 = m.GenAutoTableID(alloc.originalDBID, alloc.dbID, tableID, step)
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
@@ -179,10 +183,15 @@ func (alloc *memoryAllocator) Alloc(tableID int64) (int64, error) {
 }
 
 // NewAllocator returns a new auto increment id generator on the store.
-func NewAllocator(store kv.Storage, dbID int64) Allocator {
+func NewAllocator(store kv.Storage, originalDBID, dbID int64) Allocator {
+	// If original DB ID is zero, it means that the orignial DB ID is equal to the current DB ID.
+	if originalDBID == 0 {
+		originalDBID = dbID
+	}
 	return &allocator{
-		store: store,
-		dbID:  dbID,
+		store:        store,
+		originalDBID: originalDBID,
+		dbID:         dbID,
 	}
 }
 

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -58,7 +58,7 @@ func (*testSuite) TestT(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	alloc := NewAllocator(store, 1)
+	alloc := NewAllocator(store, 0, 1)
 	c.Assert(alloc, NotNil)
 
 	id, err := alloc.Alloc(1)
@@ -92,13 +92,13 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, int64(3011))
 
-	alloc = NewAllocator(store, 1)
+	alloc = NewAllocator(store, 0, 1)
 	c.Assert(alloc, NotNil)
 	id, err = alloc.Alloc(1)
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, int64(GetStep()+1))
 
-	alloc = NewAllocator(store, 1)
+	alloc = NewAllocator(store, 0, 1)
 	c.Assert(alloc, NotNil)
 	err = alloc.Rebase(2, int64(1), false)
 	c.Assert(err, IsNil)
@@ -106,11 +106,11 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(id, Equals, int64(2))
 
-	alloc = NewAllocator(store, 1)
+	alloc = NewAllocator(store, 0, 1)
 	c.Assert(alloc, NotNil)
 	err = alloc.Rebase(3, int64(3210), false)
 	c.Assert(err, IsNil)
-	alloc = NewAllocator(store, 1)
+	alloc = NewAllocator(store, 0, 1)
 	c.Assert(alloc, NotNil)
 	err = alloc.Rebase(3, int64(3000), false)
 	c.Assert(err, IsNil)
@@ -155,7 +155,7 @@ func (*testSuite) TestConcurrentAlloc(c *C) {
 	errCh := make(chan error, count)
 
 	allocIDs := func() {
-		alloc := NewAllocator(store, dbID)
+		alloc := NewAllocator(store, 0, dbID)
 		for j := 0; j < int(step)+5; j++ {
 			id, err1 := alloc.Alloc(tblID)
 			if err1 != nil {

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -101,7 +101,7 @@ func (s *testSuite) TestMeta(c *C) {
 	err = t.CreateTable(1, tbInfo)
 	c.Assert(err, IsNil)
 
-	n, err = t.GenAutoTableID(1, 1, 10)
+	n, err = t.GenAutoTableID(1, 1, 1, 10)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(10))
 
@@ -135,7 +135,7 @@ func (s *testSuite) TestMeta(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tables, DeepEquals, []*model.TableInfo{tbInfo, tbInfo2})
 	// Generate an auto id.
-	n, err = t.GenAutoTableID(1, 2, 10)
+	n, err = t.GenAutoTableID(1, 1, 2, 10)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(10))
 	// Make sure the auto id key-value entry is there.
@@ -145,6 +145,7 @@ func (s *testSuite) TestMeta(c *C) {
 
 	err = t.DropTable(1, tbInfo2, true)
 	c.Assert(err, IsNil)
+	tbInfo2.OldSchemaID = 1
 	// Make sure auto id key-value entry is gone.
 	n, err = t.GetAutoTableID(1, 2)
 	c.Assert(err, IsNil)
@@ -163,38 +164,49 @@ func (s *testSuite) TestMeta(c *C) {
 	// Create table.
 	err = t.CreateTable(1, tbInfo100)
 	c.Assert(err, IsNil)
-	// Update auto id.
-	n, err = t.GenAutoTableID(1, tid, 10)
+	// Update auto ID.
+	originalDBID := int64(1)
+	currentDBID := int64(1)
+	n, err = t.GenAutoTableID(originalDBID, currentDBID, tid, 10)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(10))
-	// Fail to update auto id.
+	// Fail to update auto ID.
+	// The table ID doesn't exist.
 	nonExistentID := int64(1234)
-	_, err = t.GenAutoTableID(1, nonExistentID, 10)
+	_, err = t.GenAutoTableID(originalDBID, currentDBID, nonExistentID, 10)
 	c.Assert(err, NotNil)
-	n, err = t.GetAutoTableID(1, tid)
+	// Fail to update auto ID.
+	// The current database ID doesn't exist.
+	currentDBID = nonExistentID
+	_, err = t.GenAutoTableID(originalDBID, currentDBID, tid, 10)
+	c.Assert(err, NotNil)
+	// Make sure that auto id key-value entry is still 10.
+	n, err = t.GetAutoTableID(originalDBID, tid)
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(10))
+	// Succeed in generating auto ID.
+	// Drop the table from original DB, then create the current DB and create the tbInfo100 under the current DB.
+	tbInfo100.OldSchemaID = currentDBID
 	// Drop table without touch auto id key-value entry.
-	err = t.DropTable(1, tbInfo100, false)
+	err = t.DropTable(originalDBID, tbInfo100, false)
 	c.Assert(err, IsNil)
-	// Make sure that auto id key-value entry is still there.
-	n, err = t.GetAutoTableID(1, tid)
+	dbInfo1234 := &model.DBInfo{
+		ID:   currentDBID,
+		Name: model.NewCIStr("db_x"),
+	}
+	err = t.CreateDatabase(dbInfo1234)
 	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(10))
-	// Drop table with old schema ID.
-	err = t.CreateTable(1, tbInfo100)
+	err = t.CreateTable(currentDBID, tbInfo100)
 	c.Assert(err, IsNil)
-	n, err = t.GenAutoTableID(1, tid, 10)
+	_, err = t.GenAutoTableID(originalDBID, currentDBID, tid, 10)
 	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(10))
-	tbInfo100.OldSchemaID = 1
-	err = t.DropTable(1, tbInfo100, true)
+	n, err = t.GetAutoTableID(originalDBID, tid)
 	c.Assert(err, IsNil)
-	n, err = t.GetAutoTableID(1, tid)
-	c.Assert(err, IsNil)
-	c.Assert(n, Equals, int64(0))
+	c.Assert(n, Equals, int64(20))
 
 	err = t.DropDatabase(1)
+	c.Assert(err, IsNil)
+	err = t.DropDatabase(currentDBID)
 	c.Assert(err, IsNil)
 
 	dbs, err = t.ListDatabases()

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -571,9 +571,9 @@ func (idx *Index) getRowCount(sc *variable.StatementContext, indexRanges []*type
 		}
 		if bytes.Equal(lb, rb) {
 			if !indexRange.LowExclude && !indexRange.HighExclude {
-				rowCount, err := idx.equalRowCount(sc, types.NewBytesDatum(lb))
-				if err != nil {
-					return 0, errors.Trace(err)
+				rowCount, err1 := idx.equalRowCount(sc, types.NewBytesDatum(lb))
+				if err1 != nil {
+					return 0, errors.Trace(err1)
 				}
 				totalCount += rowCount
 			}

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -274,7 +274,7 @@ func (s *testSuite) TestGetHistoryDDLJobs(c *C) {
 
 func (s *testSuite) TestScan(c *C) {
 	defer testleak.AfterTest(c)()
-	alloc := autoid.NewAllocator(s.store, s.dbInfo.ID)
+	alloc := autoid.NewAllocator(s.store, s.tbInfo.OldSchemaID, s.dbInfo.ID)
 	tb, err := tables.TableFromMeta(alloc, s.tbInfo)
 	c.Assert(err, IsNil)
 	indices := tb.Indices()


### PR DESCRIPTION
Using the way to check the initialized auto ID will have a compatibility issue with previous versions.  So we remove the check of initialized auto ID. 