### PR TITLE
store/tikv: move safepoint checker to tikvStore.

### DIFF
--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -47,7 +47,7 @@ func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	gcWorker, err := NewGCWorker(s.store)
 	c.Assert(err, IsNil)
-	gcWorker.Start(true)
+	gcWorker.Start()
 	gcWorker.Close()
 	s.gcWorker = gcWorker.(*GCWorker)
 }

--- a/store/tikv/metrics.go
+++ b/store/tikv/metrics.go
@@ -164,6 +164,14 @@ var (
 			Help:      "Number of regions in a transaction.",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 20),
 		}, []string{"type"})
+
+	loadSafepointCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "load_safepoint_total",
+			Help:      "Counter of load safepoint.",
+		}, []string{"type"})
 )
 
 func reportRegionError(e *errorpb.Error) {
@@ -204,4 +212,5 @@ func init() {
 	prometheus.MustRegister(rawkvCmdHistogram)
 	prometheus.MustRegister(rawkvSizeHistogram)
 	prometheus.MustRegister(txnRegionsNumHistogram)
+	prometheus.MustRegister(loadSafepointCounter)
 }

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -28,8 +28,10 @@ import (
 const (
 	GcSavedSafePoint = "/tidb/store/gcworker/saved_safe_point"
 
-	GcSafePointCacheInterval = time.Second * 100
-	gcCPUTimeInaccuracyBound = time.Second
+	GcSafePointCacheInterval       = time.Second * 100
+	gcCPUTimeInaccuracyBound       = time.Second
+	gcSafePointUpdateInterval      = time.Second * 10
+	gcSafePointQuickRepeatInterval = time.Second
 )
 
 // SafePointKV is used for a seamingless integration for mockTest and runtime.

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -25,10 +25,9 @@ import (
 )
 
 type testSafePointSuite struct {
-	store    *tikvStore
-	oracle   *MockOracle
-	gcWorker GCHandler
-	prefix   string
+	store  *tikvStore
+	oracle *MockOracle
+	prefix string
 }
 
 var _ = Suite(&testSafePointSuite{})
@@ -37,10 +36,6 @@ func (s *testSafePointSuite) SetUpSuite(c *C) {
 	s.store = newTestStore(c)
 	s.oracle = &MockOracle{}
 	s.store.oracle = s.oracle
-	gcWorker, err := NewGCHandlerFunc(s.store)
-	gcWorker.Start(false)
-	c.Assert(err, IsNil)
-	s.gcWorker = gcWorker
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
 }
 


### PR DESCRIPTION
The safePointChecker should always run no matter we start gc worker or not. So it's better to be started with tikvStore.