### PR TITLE
parser, ast: Support part of window function ast

### DIFF
--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -28,6 +28,8 @@ func (ts *testDMLSuite) TestDMLVisitorCover(c *C) {
 
 	tableRefsClause := &TableRefsClause{TableRefs: &Join{Left: &TableSource{Source: &TableName{}}, On: &OnCondition{Expr: ce}}}
 
+	windowDef := &WindowDef{Spec: &WindowSpec{}}
+
 	stmts := []struct {
 		node             Node
 		expectedEnterCnt int
@@ -50,6 +52,10 @@ func (ts *testDMLSuite) TestDMLVisitorCover(c *C) {
 		{tableRefsClause, 1, 1},
 		{&TableSource{Source: &TableName{}}, 0, 0},
 		{&WildCardField{}, 0, 0},
+		{&WindowSpec{}, 0, 0},
+		{windowDef, 0, 0},
+		{&WindowClause{Defs: []*WindowDef{windowDef, windowDef}}, 0, 0},
+		{&WindowingClause{Spec: &WindowSpec{}}, 0, 0},
 
 		// TODO: cover childrens
 		{&InsertStmt{Table: tableRefsClause}, 1, 1},

--- a/ast/functions.go
+++ b/ast/functions.go
@@ -22,6 +22,7 @@ var (
 	_ FuncNode = &AggregateFuncExpr{}
 	_ FuncNode = &FuncCallExpr{}
 	_ FuncNode = &FuncCastExpr{}
+	_ FuncNode = &WindowFuncExpr{}
 )
 
 // List scalar function names.
@@ -434,5 +435,29 @@ func (n *AggregateFuncExpr) Accept(v Visitor) (Node, bool) {
 		}
 		n.Args[i] = node.(ExprNode)
 	}
+	return v.Leave(n)
+}
+
+// WindowFuncExpr represents window function expression.
+type WindowFuncExpr struct {
+	funcNode
+	// F is the function name.
+	F string
+	// Window is the windowing clause of the function.
+	Window *WindowingClause
+}
+
+// Accept implements Node Accept interface.
+func (n *WindowFuncExpr) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*WindowFuncExpr)
+	node, ok := n.Window.Accept(v)
+	if !ok {
+		return n, false
+	}
+	n.Window = node.(*WindowingClause)
 	return v.Leave(n)
 }

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -27,6 +27,7 @@ func (ts *testFunctionsSuite) TestFunctionsVisitorCover(c *C) {
 		&AggregateFuncExpr{Args: []ExprNode{&ValueExpr{}}},
 		&FuncCallExpr{Args: []ExprNode{&ValueExpr{}}},
 		&FuncCastExpr{Expr: &ValueExpr{}},
+		&WindowFuncExpr{Window: &WindowingClause{Spec: &WindowSpec{}}},
 	}
 
 	for _, stmt := range stmts {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2763,9 +2763,13 @@ SimpleExpr:
 	}
 |	WindowFuncCall
 	{
-		// TODO: Remove this fake ast placeholder.
-		$$ = &ast.ParamMarkerExpr{
-			Offset: yyS[yypt].offset,
+		if $1 != nil {
+			$$ = $1.(*ast.WindowFuncExpr)
+		} else {
+			// TODO: Remove this fake ast placeholder.
+			$$ = &ast.ParamMarkerExpr{
+				Offset: yyS[yypt].offset,
+			}
 		}
 	}
 |	Literal
@@ -3769,6 +3773,10 @@ SelectStmt:
 			st.Having = $8.(*ast.HavingClause)
 		}
 
+		if $9 != nil {
+			st.Window = $9.(*ast.WindowClause)
+		}
+
 		if $10 != nil {
 			st.OrderBy = $10.(*ast.OrderByClause)
 		}
@@ -3789,41 +3797,49 @@ WindowClauseOptional:
 	}
 |	"WINDOW" WindowDefinitionList
 	{
-		$$ = nil
+		$$ = &ast.WindowClause{Defs: $2.([]*ast.WindowDef)}
 	}
 
 WindowDefinitionList:
 	WindowDefinition
 	{
-		$$ = nil
+		$$ = []*ast.WindowDef{$1.(*ast.WindowDef)}
 	}
 |	WindowDefinitionList ',' WindowDefinition
 	{
-		$$ = nil
+		$$ = append($1.([]*ast.WindowDef), $3.(*ast.WindowDef))
 	}
 
 WindowDefinition:
 	WindowName "AS" WindowSpec
 	{
-		$$ = nil
+		$$ = &ast.WindowDef{Name: $1.(model.CIStr), Spec: $3.(*ast.WindowSpec)}
 	}
 
 WindowName:
 	Identifier
 	{
-		$$ = nil
+		$$ = model.NewCIStr($1)
 	}
 
 WindowSpec:
 	'(' WindowSpecDetails ')'
 	{
-		$$ = nil
+		$$ = $2
 	}
 
 WindowSpecDetails:
 	OptExistingWindowName OptPartitionClause OptWindowOrderByClause OptWindowFrameClause
 	{
-		$$ = nil
+		spec := &ast.WindowSpec{}
+		if $1 != nil {
+			spec.ExistingWindowName = $1.(model.CIStr)
+			spec.HasExistingWindowName = true
+		} else {
+			spec.HasExistingWindowName = false
+		}
+		// TODO: Support partition by clause, order by clause and frame clause.
+		$$ = spec
 	}
 
 OptExistingWindowName:
@@ -3832,7 +3848,7 @@ OptExistingWindowName:
 	}
 |	WindowName
 	{
-		$$ = nil
+		$$ = $1
 	}
 
 OptPartitionClause:
@@ -3948,27 +3964,30 @@ OptWindowingClause:
 WindowingClause:
 	"OVER" WindowNameOrSpec
 	{
-		$$ = nil
+		$$ = &ast.WindowingClause{Spec: $2.(*ast.WindowSpec)}
 	}
 
 WindowNameOrSpec:
 	WindowName
 	{
-		$$ = nil
+		$$ = &ast.WindowSpec{
+			ExistingWindowName:	$1.(model.CIStr),
+			HasExistingWindowName:	true,
+		}
 	}
 |	WindowSpec
 	{
-		$$ = nil
+		$$ = $1
 	}
 
 WindowFuncCall:
 	"ROW_NUMBER" '(' ')' WindowingClause
 	{
-		$$ = nil
+		$$ = &ast.WindowFuncExpr{F: $1, Window: $4.(*ast.WindowingClause)}
 	}
 |	"RANK" '(' ')' WindowingClause
 	{
-		$$ = nil
+		$$ = &ast.WindowFuncExpr{F: $1, Window: $4.(*ast.WindowingClause)}
 	}
 |	"DENSE_RANK" '(' ')' WindowingClause
 	{


### PR DESCRIPTION
Added window clause, over clause (with only non-modified window) support of ast.
Also added `ROW_NUMBER()` and `RANK()` window functions support of ast.
These statements and functions will be parsed but not planned.
e.g.
```
mysql> select rank() over() from t;
ERROR 1105 (HY000): UnknownType: *ast.WindowSpec
```