### PR TITLE
store/tikv: set undetermined error if not recover from an rpc error.

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -440,7 +440,7 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 	// solution is to populate this error and let upper layer drop the connection to the corresponding mysql client.
 	sender := NewRegionRequestSender(c.store.regionCache, c.store.client)
 	errWrapper := func(err error) error {
-		if bytes.Equal(batch.keys[0], c.primary()) && sender.rpcError != nil {
+		if err != nil && bytes.Equal(batch.keys[0], c.primary()) && sender.rpcError != nil {
 			log.Warnf("2PC commit result undetermined, err: %v, rpcErr: %v, tid: %v", err, sender.rpcError, c.startTS)
 			return errors.Wrap(err, terror.ErrResultUndetermined)
 		}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -72,9 +72,9 @@ type twoPhaseCommitter struct {
 	commitTS  uint64
 	mu        struct {
 		sync.RWMutex
-		writtenKeys  [][]byte
-		committed    bool
-		undetermined bool
+		writtenKeys     [][]byte
+		committed       bool
+		undeterminedErr error // undeterminedErr saves the rpc error we encounter when commit primary key.
 	}
 	priority pb.CommandPri
 	syncLog  bool
@@ -418,6 +418,18 @@ func kvPriorityToCommandPri(pri int) pb.CommandPri {
 	return pb.CommandPri_Normal
 }
 
+func (c *twoPhaseCommitter) setUndeterminedErr(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.undeterminedErr = err
+}
+
+func (c *twoPhaseCommitter) getUndeterminedErr() error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.mu.undeterminedErr
+}
+
 func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) error {
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdCommit,
@@ -433,23 +445,21 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 	}
 	req.Context.Priority = c.priority
 
+	sender := NewRegionRequestSender(c.store.regionCache, c.store.client)
+	resp, err := sender.SendReq(bo, req, batch.region, readTimeoutShort)
+
 	// If we fail to receive response for the request that commits primary key, it will be undetermined whether this
 	// transaction has been successfully committed.
 	// Under this circumstance,  we can not declare the commit is complete (may lead to data lost), nor can we throw
 	// an error (may lead to the duplicated key error when upper level restarts the transaction). Currently the best
 	// solution is to populate this error and let upper layer drop the connection to the corresponding mysql client.
-	sender := NewRegionRequestSender(c.store.regionCache, c.store.client)
-	errWrapper := func(err error) error {
-		if err != nil && bytes.Equal(batch.keys[0], c.primary()) && sender.rpcError != nil {
-			log.Warnf("2PC commit result undetermined, err: %v, rpcErr: %v, tid: %v", err, sender.rpcError, c.startTS)
-			return errors.Wrap(err, terror.ErrResultUndetermined)
-		}
-		return err
+	isPrimary := bytes.Equal(batch.keys[0], c.primary())
+	if isPrimary && sender.rpcError != nil {
+		c.setUndeterminedErr(errors.Trace(sender.rpcError))
 	}
 
-	resp, err := sender.SendReq(bo, req, batch.region, readTimeoutShort)
 	if err != nil {
-		return errors.Trace(errWrapper(err))
+		return errors.Trace(err)
 	}
 	regionErr, err := resp.GetRegionError()
 	if err != nil {
@@ -458,15 +468,20 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 	if regionErr != nil {
 		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
 		if err != nil {
-			return errors.Trace(errWrapper(err))
+			return errors.Trace(err)
 		}
 		// re-split keys and commit again.
 		err = c.commitKeys(bo, batch.keys)
-		return errors.Trace(errWrapper(err))
+		return errors.Trace(err)
 	}
 	commitResp := resp.Commit
 	if commitResp == nil {
 		return errors.Trace(ErrBodyMissing)
+	}
+	// Here we can make sure tikv has processed the commit primary key request. So
+	// we can clean undetermined error.
+	if isPrimary {
+		c.setUndeterminedErr(nil)
 	}
 	if keyErr := commitResp.GetError(); keyErr != nil {
 		c.mu.RLock()
@@ -551,7 +566,7 @@ func (c *twoPhaseCommitter) execute(ctx goctx.Context) error {
 		c.mu.RLock()
 		writtenKeys := c.mu.writtenKeys
 		committed := c.mu.committed
-		undetermined := c.mu.undetermined
+		undetermined := c.mu.undeterminedErr != nil
 		c.mu.RUnlock()
 		if !committed && !undetermined {
 			twoPhaseCommitGP.Go(func() {
@@ -618,8 +633,9 @@ func (c *twoPhaseCommitter) execute(ctx goctx.Context) error {
 
 	err = c.commitKeys(NewBackoffer(commitMaxBackoff, ctx), c.keys)
 	if err != nil {
-		if errors.Cause(err) == terror.ErrResultUndetermined {
-			c.mu.undetermined = true
+		if undeterminedErr := c.getUndeterminedErr(); undeterminedErr != nil {
+			log.Warnf("2PC commit result undetermined, err: %v, rpcErr: %v, tid: %v", err, undeterminedErr, c.startTS)
+			err = errors.Wrap(err, terror.ErrResultUndetermined)
 		}
 		if !c.mu.committed {
 			log.Debugf("2PC failed on commit: %v, tid: %d", err, c.startTS)

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -46,6 +46,7 @@ type RegionRequestSender struct {
 	regionCache *RegionCache
 	client      Client
 	storeAddr   string
+	rpcError    error
 }
 
 // NewRegionRequestSender creates a new sender.
@@ -107,6 +108,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 	defer cancel()
 	resp, err = s.client.SendReq(context, ctx.Addr, req)
 	if err != nil {
+		s.rpcError = err
 		if e := s.onSendFail(bo, ctx, err); e != nil {
 			return nil, false, errors.Trace(e)
 		}


### PR DESCRIPTION
If encounter rpc error, record it in `sender`, then mark the error undetermined later.