### PR TITLE
remove read-only statement from transaction auto retry (#5026)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -176,6 +176,9 @@ type Statement interface {
 
 	// IsPrepared returns whether this statement is prepared statement.
 	IsPrepared() bool
+
+	// IsReadOnly returns if the statement is read only. For example: SelectStmt without lock.
+	IsReadOnly() bool
 }
 
 // Visitor visits a Node.

--- a/ast/read_only_checker.go
+++ b/ast/read_only_checker.go
@@ -1,0 +1,61 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+// IsReadOnly checks whether the input ast is readOnly.
+func IsReadOnly(node Node) bool {
+	switch st := node.(type) {
+	case *SelectStmt:
+		if st.LockTp == SelectLockForUpdate {
+			return false
+		}
+
+		checker := readOnlyChecker{
+			readOnly: true,
+		}
+
+		node.Accept(&checker)
+		return checker.readOnly
+	case *ExplainStmt:
+		return true
+	default:
+		return false
+	}
+}
+
+// readOnlyChecker checks whether a query's ast is readonly, if it satisfied
+// 1. selectstmt;
+// 2. need not to set var;
+// it is readonly statement.
+type readOnlyChecker struct {
+	readOnly bool
+}
+
+// Enter implements Visitor interface.
+func (checker *readOnlyChecker) Enter(in Node) (out Node, skipChildren bool) {
+	switch node := in.(type) {
+	case *VariableExpr:
+		// like func rewriteVariable(), this stands for SetVar.
+		if !node.IsSystem && node.Value != nil {
+			checker.readOnly = false
+			return in, true
+		}
+	}
+	return in, false
+}
+
+// Leave implements Visitor interface.
+func (checker *readOnlyChecker) Leave(in Node) (out Node, ok bool) {
+	return in, checker.readOnly
+}

--- a/ast/read_only_checker_test.go
+++ b/ast/read_only_checker_test.go
@@ -1,0 +1,41 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ast
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testCacheableSuite{})
+
+type testCacheableSuite struct {
+}
+
+func (s *testCacheableSuite) TestCacheable(c *C) {
+	// test non-SelectStmt
+	var stmt Node = &DeleteStmt{}
+	c.Assert(IsReadOnly(stmt), IsFalse)
+
+	stmt = &InsertStmt{}
+	c.Assert(IsReadOnly(stmt), IsFalse)
+
+	stmt = &UpdateStmt{}
+	c.Assert(IsReadOnly(stmt), IsFalse)
+
+	stmt = &ExplainStmt{}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+
+	stmt = &ExplainStmt{}
+	c.Assert(IsReadOnly(stmt), IsTrue)
+}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -113,6 +113,9 @@ type ExecStmt struct {
 	ctx            context.Context
 	startTime      time.Time
 	isPreparedStmt bool
+
+	// ReadOnly represents the statement is read-only.
+	ReadOnly bool
 }
 
 // OriginText implements ast.Statement interface.
@@ -123,6 +126,11 @@ func (a *ExecStmt) OriginText() string {
 // IsPrepared implements ast.Statement interface.
 func (a *ExecStmt) IsPrepared() bool {
 	return a.isPreparedStmt
+}
+
+// IsReadOnly implements ast.Statement interface.
+func (a *ExecStmt) IsReadOnly() bool {
+	return a.ReadOnly
 }
 
 // Exec implements the ast.Statement Exec interface.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -42,12 +42,18 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (*ExecStm
 		return nil, errors.Trace(err)
 	}
 
+	readOnlyCheckStmt := stmtNode
+	if checkPlan, ok := finalPlan.(*plan.Execute); ok {
+		readOnlyCheckStmt = checkPlan.Stmt
+	}
+
 	return &ExecStmt{
 		InfoSchema: infoSchema,
 		Plan:       finalPlan,
 		Expensive:  stmtCount(stmtNode, finalPlan, ctx.GetSessionVars().InRestrictedSQL),
 		Cacheable:  plan.Cacheable(stmtNode),
 		Text:       stmtNode.Text(),
+		ReadOnly:   ast.IsReadOnly(readOnlyCheckStmt),
 	}, nil
 }
 

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -318,9 +318,16 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 		value := ast.NewValueExpr(val)
 		execPlan.UsingVars[i] = &expression.Constant{Value: value.Datum, RetType: &value.Type}
 	}
+
+	readOnly := false
+	if execute, ok := execPlan.(*plan.Execute); ok {
+		readOnly = ast.IsReadOnly(execute.Stmt)
+	}
+
 	stmt := &ExecStmt{
 		InfoSchema: GetInfoSchema(ctx),
 		Plan:       execPlan,
+		ReadOnly:   readOnly,
 	}
 	if prepared, ok := ctx.GetSessionVars().PreparedStmts[ID].(*Prepared); ok {
 		stmt.Text = prepared.Stmt.Text()

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -319,18 +319,15 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 		execPlan.UsingVars[i] = &expression.Constant{Value: value.Datum, RetType: &value.Type}
 	}
 
-	readOnly := false
-	if execute, ok := execPlan.(*plan.Execute); ok {
-		readOnly = ast.IsReadOnly(execute.Stmt)
-	}
-
 	stmt := &ExecStmt{
 		InfoSchema: GetInfoSchema(ctx),
 		Plan:       execPlan,
-		ReadOnly:   readOnly,
+		ReadOnly:   false,
 	}
+
 	if prepared, ok := ctx.GetSessionVars().PreparedStmts[ID].(*Prepared); ok {
 		stmt.Text = prepared.Stmt.Text()
+		stmt.ReadOnly = ast.IsReadOnly(prepared.Stmt)
 	}
 	return stmt
 }

--- a/session.go
+++ b/session.go
@@ -407,6 +407,9 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 		s.sessionVars.RetryInfo.ResetOffset()
 		for i, sr := range nh.history {
 			st := sr.st
+			if st.IsReadOnly() {
+				continue
+			}
 			txt := st.OriginText()
 			if infoSchemaChanged {
 				st, err = updateStatement(st, s, txt)
@@ -694,6 +697,7 @@ func (s *session) Execute(sql string) (recordSets []ast.RecordSet, err error) {
 			Plan:       cacheValue.(*cache.SQLCacheValue).Plan,
 			Expensive:  cacheValue.(*cache.SQLCacheValue).Expensive,
 			Text:       stmtNode.Text(),
+			ReadOnly:   ast.IsReadOnly(stmtNode),
 		}
 
 		s.PrepareTxnCtx()


### PR DESCRIPTION
* *: Ignore readonly statement when retrying

* remove explain statement from retry
* remove all select statement from retry except It has setvar functions
* remove execute statement from retry if it is read-only statement