### PR TITLE
executor: refine the log msg when 'set character_set_results=null' (#5052)

### DIFF
--- a/executor/set.go
+++ b/executor/set.go
@@ -146,8 +146,14 @@ func (e *SetExecutor) executeSet() error {
 				sessionVars.SnapshotTS = oldSnapshotTS
 				return errors.Trace(err)
 			}
-			valStr, err := value.ToString()
-			terror.Log(errors.Trace(err))
+			var valStr string
+			if value.IsNull() {
+				valStr = "NULL"
+			} else {
+				var err error
+				valStr, err = value.ToString()
+				terror.Log(errors.Trace(err))
+			}
 			log.Infof("[%d] set system variable %s = %s", sessionVars.ConnectionID, name, valStr)
 		}
 


### PR DESCRIPTION
PTAL