### PR TITLE
lexer: support sql_mode 'NO_BACKSLASH_ESCAPES'

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -452,6 +452,11 @@ func (m SQLMode) HasRealAsFloatMode() bool {
 	return m&ModeRealAsFloat == ModeRealAsFloat
 }
 
+// HasNoBackslashEscapesMode detects if 'NO_BACKSLASH_ESCAPES' mode is set in SQLMode
+func (m SQLMode) HasNoBackslashEscapesMode() bool {
+	return m&ModeNoBackslashEscapes == ModeNoBackslashEscapes
+}
+
 // consts for sql modes.
 const (
 	ModeNone        SQLMode = 0

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -191,3 +191,13 @@ func (s *testMySQLConstSuite) TestHighNotPrecedenceMode(c *C) {
 	r = tk.MustQuery(`SELECT NOT 1 BETWEEN -5 AND 5;`)
 	r.Check(testkit.Rows("1"))
 }
+
+func (s *testMySQLConstSuite) TestNoBackslashEscapesMode(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set sql_mode=''")
+	r := tk.MustQuery("SELECT '\\\\'")
+	r.Check(testkit.Rows("\\"))
+	tk.MustExec("set sql_mode='NO_BACKSLASH_ESCAPES'")
+	r = tk.MustQuery("SELECT '\\\\'")
+	r.Check(testkit.Rows("\\\\"))
+}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -522,7 +522,7 @@ func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 			}
 			str := mb.r.data(&pos)
 			mb.setUseBuf(str[1 : len(str)-1])
-		} else if ch0 == '\\' {
+		} else if ch0 == '\\' && !s.sqlMode.HasNoBackslashEscapesMode() {
 			mb.setUseBuf(mb.r.data(&pos)[1:])
 			ch0 = handleEscape(s)
 		}


### PR DESCRIPTION
support sql_mode 'NO_BACKSLASH_ESCAPES' for TiDB