### PR TITLE
 plan: no need to double read in some case.

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -358,7 +358,11 @@ func IndexInfo2Cols(cols []*Column, index *model.IndexInfo) ([]*Column, []int) {
 			return retCols, lengths
 		}
 		retCols = append(retCols, col)
-		lengths = append(lengths, c.Length)
+		if c.Length != types.UnspecifiedLength && c.Length == col.RetType.Flen {
+			lengths = append(lengths, types.UnspecifiedLength)
+		} else {
+			lengths = append(lengths, c.Length)
+		}
 	}
 	return retCols, lengths
 }

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -140,7 +140,8 @@ func (s *testEvaluatorSuite) TestColInfo2Col(c *C) {
 func (s *testEvaluatorSuite) TestIndexInfo2Cols(c *C) {
 	defer testleak.AfterTest(c)()
 
-	col0, col1 := &Column{ColName: model.NewCIStr("col0")}, &Column{ColName: model.NewCIStr("col1")}
+	col0 := &Column{ColName: model.NewCIStr("col0"), RetType: types.NewFieldType(mysql.TypeLonglong)}
+	col1 := &Column{ColName: model.NewCIStr("col1"), RetType: types.NewFieldType(mysql.TypeLonglong)}
 	indexCol0, indexCol1 := &model.IndexColumn{Name: model.NewCIStr("col0")}, &model.IndexColumn{Name: model.NewCIStr("col1")}
 	indexInfo := &model.IndexInfo{Columns: []*model.IndexColumn{indexCol0, indexCol1}}
 

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -691,7 +691,8 @@ func isCoveringIndex(columns []*model.ColumnInfo, indexColumns []*model.IndexCol
 		}
 		isIndexColumn := false
 		for _, indexCol := range indexColumns {
-			if colInfo.Name.L == indexCol.Name.L && indexCol.Length == types.UnspecifiedLength {
+			isUnspecifiedLen := indexCol.Length == types.UnspecifiedLength || indexCol.Length == colInfo.Flen
+			if colInfo.Name.L == indexCol.Name.L && isUnspecifiedLen {
 				isIndexColumn = true
 				break
 			}

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -691,8 +691,8 @@ func isCoveringIndex(columns []*model.ColumnInfo, indexColumns []*model.IndexCol
 		}
 		isIndexColumn := false
 		for _, indexCol := range indexColumns {
-			isUnspecifiedLen := indexCol.Length == types.UnspecifiedLength || indexCol.Length == colInfo.Flen
-			if colInfo.Name.L == indexCol.Name.L && isUnspecifiedLen {
+			isFullLen := indexCol.Length == types.UnspecifiedLength || indexCol.Length == colInfo.Flen
+			if colInfo.Name.L == indexCol.Name.L && isFullLen {
 				isIndexColumn = true
 				break
 			}

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -307,7 +307,7 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 	testKit := testkit.NewTestKit(c, store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
-	testKit.MustExec("create table t(a varchar(50), b int, c double, index idx_ab(a, b), index idx_cb(c, a))")
+	testKit.MustExec("create table t(a varchar(50), b int, c double, index idx_ab(a(50), b), index idx_cb(c, a))")
 
 	tests := []struct {
 		indexPos    int


### PR DESCRIPTION
Since index of string type may have length currently, consider one sql like the following:
```sql
create table t(id varchar(50) primary key);
select * from t where id > 'aaa';
```
The select statement will be double read, which single read is enough.