### PR TITLE
executor: use baseExecutor for all Executors

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -15,47 +15,10 @@ package executor_test
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/executor"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testkit"
 )
-
-type MockExec struct {
-	fields    []*ast.ResultField
-	Rows      []executor.Row
-	curRowIdx int
-}
-
-func (m *MockExec) Schema() *expression.Schema {
-	return expression.NewSchema()
-}
-
-func (m *MockExec) Next() (executor.Row, error) {
-	if m.curRowIdx >= len(m.Rows) {
-		return nil, nil
-	}
-	r := m.Rows[m.curRowIdx]
-	m.curRowIdx++
-	if len(m.fields) > 0 {
-		for i, d := range r {
-			m.fields[i].Expr.SetValue(d.GetValue())
-		}
-	}
-	return r, nil
-}
-
-func (m *MockExec) Close() error {
-	m.curRowIdx = 0
-	return nil
-}
-
-func (m *MockExec) Open() error {
-	m.curRowIdx = 0
-	return nil
-}
 
 func (s *testSuite) TestAggregation(c *C) {
 	plan.JoinConcurrency = 1

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -22,7 +22,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/distsql"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
@@ -38,7 +37,7 @@ var _ Executor = &AnalyzeExec{}
 
 // AnalyzeExec represents Analyze executor.
 type AnalyzeExec struct {
-	ctx   context.Context
+	baseExecutor
 	tasks []*analyzeTask
 }
 
@@ -50,11 +49,6 @@ const (
 	defaultCMSketchDepth = 8
 	defaultCMSketchWidth = 2048
 )
-
-// Schema implements the Executor Schema interface.
-func (e *AnalyzeExec) Schema() *expression.Schema {
-	return expression.NewSchema()
-}
 
 // Open implements the Executor Open interface.
 func (e *AnalyzeExec) Open() error {

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -18,8 +18,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/context"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -32,15 +30,11 @@ import (
 // DDLExec represents a DDL executor.
 // It grabs a DDL instance from Domain, calling the DDL methods to do the work.
 type DDLExec struct {
+	baseExecutor
+
 	Statement ast.StmtNode
-	ctx       context.Context
 	is        infoschema.InfoSchema
 	done      bool
-}
-
-// Schema implements the Executor Schema interface.
-func (e *DDLExec) Schema() *expression.Schema {
-	return expression.NewSchema()
 }
 
 // Next implements Execution Next interface.

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -125,6 +125,10 @@ func (e *baseExecutor) Schema() *expression.Schema {
 	return e.schema
 }
 
+func (e *baseExecutor) supportChunk() bool {
+	return false
+}
+
 func newBaseExecutor(schema *expression.Schema, ctx context.Context, children ...Executor) baseExecutor {
 	return baseExecutor{
 		children: children,
@@ -139,6 +143,7 @@ type Executor interface {
 	Close() error
 	Open() error
 	Schema() *expression.Schema
+	supportChunk() bool
 }
 
 // CancelDDLJobsExec represents a cancel DDL jobs executor.
@@ -466,22 +471,15 @@ type TableScanExec struct {
 
 	t          table.Table
 	asName     *model.CIStr
-	ctx        context.Context
 	ranges     []types.IntColumnRange
 	seekHandle int64
 	iter       kv.Iterator
 	cursor     int
-	schema     *expression.Schema
 	columns    []*model.ColumnInfo
 
 	isVirtualTable     bool
 	virtualTableRows   [][]types.Datum
 	virtualTableCursor int
-}
-
-// Schema implements the Executor Schema interface.
-func (e *TableScanExec) Schema() *expression.Schema {
-	return e.schema
 }
 
 // Next implements the Executor interface.
@@ -589,6 +587,10 @@ func (e *TableScanExec) Open() error {
 	return nil
 }
 
+func (e *TableScanExec) supportChunk() bool {
+	return false
+}
+
 // ExistsExec represents exists executor.
 type ExistsExec struct {
 	baseExecutor
@@ -670,11 +672,6 @@ type UnionExec struct {
 type execResult struct {
 	rows []Row
 	err  error
-}
-
-// Schema implements the Executor Schema interface.
-func (e *UnionExec) Schema() *expression.Schema {
-	return e.schema
 }
 
 func (e *UnionExec) waitAllFinished() {

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -13,21 +13,12 @@
 
 package executor
 
-import (
-	"github.com/pingcap/tidb/expression"
-)
-
 // ExplainExec represents an explain executor.
 type ExplainExec struct {
 	baseExecutor
 
 	rows   []Row
 	cursor int
-}
-
-// Schema implements the Executor Schema interface.
-func (e *ExplainExec) Schema() *expression.Schema {
-	return e.schema
 }
 
 // Next implements Execution Next interface.

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -41,20 +40,16 @@ var (
 
 // GrantExec executes GrantStmt.
 type GrantExec struct {
+	baseExecutor
+
 	Privs      []*ast.PrivElem
 	ObjectType ast.ObjectTypeType
 	Level      *ast.GrantLevel
 	Users      []*ast.UserSpec
 	WithGrant  bool
 
-	ctx  context.Context
 	is   infoschema.InfoSchema
 	done bool
-}
-
-// Schema implements the Executor Schema interface.
-func (e *GrantExec) Schema() *expression.Schema {
-	return expression.NewSchema()
 }
 
 // Next implements Execution Next interface.

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -14,77 +14,14 @@
 package executor_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
-	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/executor"
-	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
-	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 )
-
-func (s *testSuite) TestNestedLoopJoin(c *C) {
-	bigExec := &MockExec{Rows: []executor.Row{
-		types.MakeDatums(1),
-		types.MakeDatums(2),
-		types.MakeDatums(3),
-		types.MakeDatums(4),
-		types.MakeDatums(5),
-		types.MakeDatums(6),
-	}}
-	smallExec := &MockExec{Rows: []executor.Row{
-		types.MakeDatums(1),
-		types.MakeDatums(2),
-		types.MakeDatums(3),
-		types.MakeDatums(4),
-		types.MakeDatums(5),
-		types.MakeDatums(6),
-	}}
-	col0 := &expression.Column{Index: 0, RetType: types.NewFieldType(mysql.TypeLong)}
-	col1 := &expression.Column{Index: 1, RetType: types.NewFieldType(mysql.TypeLong)}
-	con := &expression.Constant{Value: types.NewDatum(6), RetType: types.NewFieldType(mysql.TypeLong)}
-	bigFilter := expression.NewFunctionInternal(mock.NewContext(), ast.LT, types.NewFieldType(mysql.TypeTiny), col0, con)
-	smallFilter := bigFilter.Clone()
-	otherFilter := expression.NewFunctionInternal(mock.NewContext(), ast.EQ, types.NewFieldType(mysql.TypeTiny), col0, col1)
-	join := &executor.NestedLoopJoinExec{
-		BigExec:     bigExec,
-		SmallExec:   smallExec,
-		Ctx:         mock.NewContext(),
-		BigFilter:   []expression.Expression{bigFilter},
-		SmallFilter: []expression.Expression{smallFilter},
-		OtherFilter: []expression.Expression{otherFilter},
-	}
-	row, err := join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, NotNil)
-	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "1 1")
-	row, err = join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, NotNil)
-	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "2 2")
-	row, err = join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, NotNil)
-	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "3 3")
-	row, err = join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, NotNil)
-	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "4 4")
-	row, err = join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, NotNil)
-	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "5 5")
-	row, err = join.Next()
-	c.Check(err, IsNil)
-	c.Check(row, IsNil)
-}
 
 func (s *testSuite) TestJoinPanic(c *C) {
 	tk := testkit.NewTestKit(c, s.store)

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -1,0 +1,108 @@
+package executor
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+var _ = Suite(&pkgTestSuite{})
+
+type pkgTestSuite struct {
+}
+
+type MockExec struct {
+	baseExecutor
+
+	fields    []*ast.ResultField
+	Rows      []Row
+	curRowIdx int
+}
+
+func (m *MockExec) Next() (Row, error) {
+	if m.curRowIdx >= len(m.Rows) {
+		return nil, nil
+	}
+	r := m.Rows[m.curRowIdx]
+	m.curRowIdx++
+	if len(m.fields) > 0 {
+		for i, d := range r {
+			m.fields[i].Expr.SetValue(d.GetValue())
+		}
+	}
+	return r, nil
+}
+
+func (m *MockExec) Close() error {
+	m.curRowIdx = 0
+	return nil
+}
+
+func (m *MockExec) Open() error {
+	m.curRowIdx = 0
+	return nil
+}
+
+func (s *pkgTestSuite) TestNestedLoopJoin(c *C) {
+	ctx := mock.NewContext()
+	bigExec := &MockExec{
+		baseExecutor: newBaseExecutor(nil, ctx),
+		Rows: []Row{
+			types.MakeDatums(1),
+			types.MakeDatums(2),
+			types.MakeDatums(3),
+			types.MakeDatums(4),
+			types.MakeDatums(5),
+			types.MakeDatums(6),
+		}}
+	smallExec := &MockExec{Rows: []Row{
+		types.MakeDatums(1),
+		types.MakeDatums(2),
+		types.MakeDatums(3),
+		types.MakeDatums(4),
+		types.MakeDatums(5),
+		types.MakeDatums(6),
+	}}
+	col0 := &expression.Column{Index: 0, RetType: types.NewFieldType(mysql.TypeLong)}
+	col1 := &expression.Column{Index: 1, RetType: types.NewFieldType(mysql.TypeLong)}
+	con := &expression.Constant{Value: types.NewDatum(6), RetType: types.NewFieldType(mysql.TypeLong)}
+	bigFilter := expression.NewFunctionInternal(ctx, ast.LT, types.NewFieldType(mysql.TypeTiny), col0, con)
+	smallFilter := bigFilter.Clone()
+	otherFilter := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), col0, col1)
+	join := &NestedLoopJoinExec{
+		baseExecutor: newBaseExecutor(nil, ctx),
+		BigExec:      bigExec,
+		SmallExec:    smallExec,
+		BigFilter:    []expression.Expression{bigFilter},
+		SmallFilter:  []expression.Expression{smallFilter},
+		OtherFilter:  []expression.Expression{otherFilter},
+	}
+	row, err := join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, NotNil)
+	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "1 1")
+	row, err = join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, NotNil)
+	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "2 2")
+	row, err = join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, NotNil)
+	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "3 3")
+	row, err = join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, NotNil)
+	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "4 4")
+	row, err = join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, NotNil)
+	c.Check(fmt.Sprintf("%v %v", row[0].GetValue(), row[1].GetValue()), Equals, "5 5")
+	row, err = join.Next()
+	c.Check(err, IsNil)
+	c.Check(row, IsNil)
+}

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -68,8 +68,9 @@ func (e *paramMarkerExtractor) Leave(in ast.Node) (ast.Node, bool) {
 
 // PrepareExec represents a PREPARE executor.
 type PrepareExec struct {
+	baseExecutor
+
 	IS      infoschema.InfoSchema
-	Ctx     context.Context
 	Name    string
 	SQLText string
 
@@ -79,10 +80,13 @@ type PrepareExec struct {
 	Fields     []*ast.ResultField
 }
 
-// Schema implements the Executor Schema interface.
-func (e *PrepareExec) Schema() *expression.Schema {
-	// Will never be called.
-	return expression.NewSchema()
+// NewPrepareExec creates a new PrepareExec.
+func NewPrepareExec(ctx context.Context, is infoschema.InfoSchema, sqlTxt string) *PrepareExec {
+	return &PrepareExec{
+		baseExecutor: newBaseExecutor(nil, ctx),
+		IS:           is,
+		SQLText:      sqlTxt,
+	}
 }
 
 // Next implements the Executor Next interface.
@@ -104,7 +108,7 @@ func (e *PrepareExec) Open() error {
 // DoPrepare prepares the statement, it can be called multiple times without
 // side effect.
 func (e *PrepareExec) DoPrepare() {
-	vars := e.Ctx.GetSessionVars()
+	vars := e.ctx.GetSessionVars()
 	if e.ID != 0 {
 		// Must be the case when we retry a prepare.
 		// Make sure it is idempotent.
@@ -118,7 +122,7 @@ func (e *PrepareExec) DoPrepare() {
 		stmts []ast.StmtNode
 		err   error
 	)
-	if sqlParser, ok := e.Ctx.(sqlexec.SQLParser); ok {
+	if sqlParser, ok := e.ctx.(sqlexec.SQLParser); ok {
 		stmts, err = sqlParser.ParseSQL(e.SQLText, charset, collation)
 	} else {
 		stmts, err = parser.New().Parse(e.SQLText, charset, collation)
@@ -138,7 +142,7 @@ func (e *PrepareExec) DoPrepare() {
 	}
 	var extractor paramMarkerExtractor
 	stmt.Accept(&extractor)
-	err = plan.Preprocess(e.Ctx, stmt, e.IS, true)
+	err = plan.Preprocess(e.ctx, stmt, e.IS, true)
 	if err != nil {
 		e.Err = errors.Trace(err)
 		return
@@ -160,7 +164,7 @@ func (e *PrepareExec) DoPrepare() {
 	}
 	prepared.UseCache = plan.PreparedPlanCacheEnabled && plan.Cacheable(stmt)
 
-	err = plan.Preprocess(e.Ctx, stmt, e.IS, true)
+	err = plan.Preprocess(e.ctx, stmt, e.IS, true)
 	if err != nil {
 		e.Err = errors.Trace(err)
 		return
@@ -179,20 +183,15 @@ func (e *PrepareExec) DoPrepare() {
 // It cannot be executed by itself, all it needs to do is to build
 // another Executor from a prepared statement.
 type ExecuteExec struct {
+	baseExecutor
+
 	IS        infoschema.InfoSchema
-	Ctx       context.Context
 	Name      string
 	UsingVars []expression.Expression
 	ID        uint32
 	StmtExec  Executor
 	Stmt      ast.StmtNode
 	Plan      plan.Plan
-}
-
-// Schema implements the Executor Schema interface.
-func (e *ExecuteExec) Schema() *expression.Schema {
-	// Will never be called.
-	return expression.NewSchema()
 }
 
 // Next implements the Executor Next interface.
@@ -216,35 +215,30 @@ func (e *ExecuteExec) Close() error {
 // After Build, e.StmtExec will be used to do the real execution.
 func (e *ExecuteExec) Build() error {
 	var err error
-	if IsPointGetWithPKOrUniqueKeyByAutoCommit(e.Ctx, e.Plan) {
-		err = e.Ctx.InitTxnWithStartTS(math.MaxUint64)
+	if IsPointGetWithPKOrUniqueKeyByAutoCommit(e.ctx, e.Plan) {
+		err = e.ctx.InitTxnWithStartTS(math.MaxUint64)
 	} else {
-		err = e.Ctx.ActivePendingTxn()
+		err = e.ctx.ActivePendingTxn()
 	}
 	if err != nil {
 		return errors.Trace(err)
 	}
-	b := newExecutorBuilder(e.Ctx, e.IS, kv.PriorityNormal)
+	b := newExecutorBuilder(e.ctx, e.IS, kv.PriorityNormal)
 	stmtExec := b.build(e.Plan)
 	if b.err != nil {
 		return errors.Trace(b.err)
 	}
 	e.StmtExec = stmtExec
-	ResetStmtCtx(e.Ctx, e.Stmt)
-	stmtCount(e.Stmt, e.Plan, e.Ctx.GetSessionVars().InRestrictedSQL)
+	ResetStmtCtx(e.ctx, e.Stmt)
+	stmtCount(e.Stmt, e.Plan, e.ctx.GetSessionVars().InRestrictedSQL)
 	return nil
 }
 
 // DeallocateExec represent a DEALLOCATE executor.
 type DeallocateExec struct {
-	Name string
-	ctx  context.Context
-}
+	baseExecutor
 
-// Schema implements the Executor Schema interface.
-func (e *DeallocateExec) Schema() *expression.Schema {
-	// Will never be called.
-	return expression.NewSchema()
+	Name string
 }
 
 // Next implements the Executor Next interface.

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -334,8 +334,8 @@ func (s *testSuite) TestShowFullProcessList(c *C) {
 	fullSQL := "show                                                                                        full processlist"
 	simpSQL := "show                                                                                        processlist"
 
-	tk.MustQuery(fullSQL).Check(testutil.RowsWithSep("|", "220|   Query|0|2|"+fullSQL))
-	tk.MustQuery(simpSQL).Check(testutil.RowsWithSep("|", "220|   Query|0|2|"+simpSQL[:100]))
+	tk.MustQuery(fullSQL).Check(testutil.RowsWithSep("|", "219|   Query|0|2|"+fullSQL))
+	tk.MustQuery(simpSQL).Check(testutil.RowsWithSep("|", "219|   Query|0|2|"+simpSQL[:100]))
 
 	se.SetSessionManager(nil) // reset sm so other tests won't use this
 }

--- a/executor/write.go
+++ b/executor/write.go
@@ -165,11 +165,6 @@ type DeleteExec struct {
 	finished bool
 }
 
-// Schema implements the Executor Schema interface.
-func (e *DeleteExec) Schema() *expression.Schema {
-	return expression.NewSchema()
-}
-
 // Next implements the Executor Next interface.
 func (e *DeleteExec) Next() (Row, error) {
 	if e.finished {
@@ -327,7 +322,7 @@ func (e *DeleteExec) Open() error {
 func NewLoadDataInfo(row []types.Datum, ctx context.Context, tbl table.Table, cols []*table.Column) *LoadDataInfo {
 	return &LoadDataInfo{
 		row:       row,
-		insertVal: &InsertValues{ctx: ctx, Table: tbl},
+		insertVal: &InsertValues{baseExecutor: newBaseExecutor(nil, ctx), Table: tbl},
 		Table:     tbl,
 		Ctx:       ctx,
 		columns:   cols,
@@ -602,6 +597,8 @@ func (e *InsertValues) handleLoadDataWarnings(err error, logInfo string) {
 
 // LoadData represents a load data executor.
 type LoadData struct {
+	baseExecutor
+
 	IsLocal      bool
 	loadDataInfo *LoadDataInfo
 }
@@ -642,11 +639,6 @@ func (e *LoadData) Next() (Row, error) {
 	return nil, nil
 }
 
-// Schema implements the Executor Schema interface.
-func (e *LoadData) Schema() *expression.Schema {
-	return expression.NewSchema()
-}
-
 // Close implements the Executor Close interface.
 func (e *LoadData) Close() error {
 	return nil
@@ -659,10 +651,11 @@ func (e *LoadData) Open() error {
 
 // InsertValues is the data to insert.
 type InsertValues struct {
+	baseExecutor
+
 	currRow               int64
 	batchRows             int64
 	lastInsertID          uint64
-	ctx                   context.Context
 	needFillDefaultValues bool
 
 	SelectExec Executor
@@ -687,11 +680,6 @@ type InsertExec struct {
 	IgnoreErr bool
 
 	finished bool
-}
-
-// Schema implements the Executor Schema interface.
-func (e *InsertExec) Schema() *expression.Schema {
-	return expression.NewSchema()
 }
 
 // BatchInsertSize is the batch size of auto-splitted insert data.
@@ -1176,11 +1164,6 @@ type ReplaceExec struct {
 	*InsertValues
 	Priority int
 	finished bool
-}
-
-// Schema implements the Executor Schema interface.
-func (e *ReplaceExec) Schema() *expression.Schema {
-	return expression.NewSchema()
 }
 
 // Close implements the Executor Close interface.

--- a/session.go
+++ b/session.go
@@ -791,11 +791,7 @@ func (s *session) PrepareStmt(sql string) (stmtID uint32, paramCount int, fields
 		// We don't need to create a transaction for prepare statement, just get information schema will do.
 		s.sessionVars.TxnCtx.InfoSchema = sessionctx.GetDomain(s).InfoSchema()
 	}
-	prepareExec := &executor.PrepareExec{
-		IS:      executor.GetInfoSchema(s),
-		Ctx:     s,
-		SQLText: sql,
-	}
+	prepareExec := executor.NewPrepareExec(s, executor.GetInfoSchema(s), sql)
 	prepareExec.DoPrepare()
 	return prepareExec.ID, prepareExec.ParamCount, prepareExec.Fields, prepareExec.Err
 }


### PR DESCRIPTION
Makes it easy to add new method on Executor interface.