### PR TITLE
*: ignore DDL statement for query duration metrics

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -80,6 +80,8 @@ func (t basicCtxType) String() string {
 		return "query_string"
 	case Initing:
 		return "initing"
+	case LastExecuteDDL:
+		return "last_execute_ddl"
 	}
 	return "unknown"
 }
@@ -90,4 +92,6 @@ const (
 	QueryString basicCtxType = 1
 	// Initing is the key for indicating if the server is running bootstrap or upgrad job.
 	Initing basicCtxType = 2
+	// LastExecuteDDL is the key for whether the session execute a ddl command last time.
+	LastExecuteDDL basicCtxType = 3
 )

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1025,6 +1025,15 @@ func (s *testSessionSuite) TestMultiStmts(c *C) {
 	tk.MustQuery("select * from t1;").Check(testkit.Rows("1"))
 }
 
+func (s *testSessionSuite) TestLastExecuteDDLFlag(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(id int)")
+	c.Assert(tk.Se.Value(context.LastExecuteDDL), NotNil)
+	tk.MustExec("insert into t1 values (1)")
+	c.Assert(tk.Se.Value(context.LastExecuteDDL), IsNil)
+}
+
 func (s *testSessionSuite) TestDecimal(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -463,6 +463,7 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 	case mysql.ComQuery:
 		if cc.ctx.Value(context.LastExecuteDDL) != nil {
 			// Don't take DDL execute time into account.
+			// It's already recorded by other metrics in ddl package.
 			return
 		}
 		label = "Query"

--- a/server/conn.go
+++ b/server/conn.go
@@ -49,6 +49,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/juju/errors"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
@@ -460,6 +461,10 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 	case mysql.ComQuit:
 		label = "Quit"
 	case mysql.ComQuery:
+		if cc.ctx.Value(context.LastExecuteDDL) != nil {
+			// Don't take DDL execute time into account.
+			return
+		}
 		label = "Query"
 	case mysql.ComPing:
 		label = "Ping"

--- a/session.go
+++ b/session.go
@@ -684,6 +684,11 @@ func (s *session) SetProcessInfo(sql string) {
 
 func (s *session) executeStatement(connID uint64, stmtNode ast.StmtNode, stmt ast.Statement, recordSets []ast.RecordSet) ([]ast.RecordSet, error) {
 	s.SetValue(context.QueryString, stmt.OriginText())
+	if _, ok := stmtNode.(ast.DDLNode); ok {
+		s.SetValue(context.LastExecuteDDL, true)
+	} else {
+		s.ClearValue(context.LastExecuteDDL)
+	}
 
 	startTS := time.Now()
 	recordSet, err := runStmt(s, stmt)


### PR DESCRIPTION
DDL may be quite slow, take it into account would make our query duration metrics less accurate.

@shenli @zimulala @coocood  