### PR TITLE
store/tikv/oracle: prometheus metrics for tsFuture wait time

### DIFF
--- a/store/tikv/oracle/oracles/metrics.go
+++ b/store/tikv/oracle/oracles/metrics.go
@@ -27,3 +27,7 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.000005, 2, 18), // 5us ~ 128 ms
 		})
 )
+
+func init() {
+	prometheus.MustRegister(tsFutureWaitDuration)
+}

--- a/store/tikv/oracle/oracles/metrics.go
+++ b/store/tikv/oracle/oracles/metrics.go
@@ -1,0 +1,29 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracles
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	tsFutureWaitDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "pdclient",
+			Name:      "ts_future_wait_seconds",
+			Help:      "Bucketed histogram of seconds cost for waiting timestamp future.",
+			Buckets:   prometheus.ExponentialBuckets(0.000005, 2, 18), // 5us ~ 128 ms
+		})
+)

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -80,7 +80,9 @@ type tsFuture struct {
 
 // Wait implements the oracle.Future interface.
 func (f *tsFuture) Wait() (uint64, error) {
+	now := time.Now()
 	physical, logical, err := f.TSFuture.Wait()
+	tsFutureWaitDuration.Observe(time.Since(now).Seconds())
 	if err != nil {
 		return 0, errors.Trace(err)
 	}


### PR DESCRIPTION
Most time it should not be zero, which means wait for a while, because Parse() & Compile() is slower than GetTS() in normal cases.
When `Wait()` duration is too small, something maybe wrong with Parse() & Compile(), or the runtime, add this metric so we can know that.

