### PR TITLE
Revert "lexer: support sql_mode 'NO_BACKSLASH_ESCAPES' (#5073)"

### DIFF
--- a/mysql/const.go
+++ b/mysql/const.go
@@ -452,11 +452,6 @@ func (m SQLMode) HasRealAsFloatMode() bool {
 	return m&ModeRealAsFloat == ModeRealAsFloat
 }
 
-// HasNoBackslashEscapesMode detects if 'NO_BACKSLASH_ESCAPES' mode is set in SQLMode
-func (m SQLMode) HasNoBackslashEscapesMode() bool {
-	return m&ModeNoBackslashEscapes == ModeNoBackslashEscapes
-}
-
 // consts for sql modes.
 const (
 	ModeNone        SQLMode = 0

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -191,13 +191,3 @@ func (s *testMySQLConstSuite) TestHighNotPrecedenceMode(c *C) {
 	r = tk.MustQuery(`SELECT NOT 1 BETWEEN -5 AND 5;`)
 	r.Check(testkit.Rows("1"))
 }
-
-func (s *testMySQLConstSuite) TestNoBackslashEscapesMode(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("set sql_mode=''")
-	r := tk.MustQuery("SELECT '\\\\'")
-	r.Check(testkit.Rows("\\"))
-	tk.MustExec("set sql_mode='NO_BACKSLASH_ESCAPES'")
-	r = tk.MustQuery("SELECT '\\\\'")
-	r.Check(testkit.Rows("\\\\"))
-}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -522,7 +522,7 @@ func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 			}
 			str := mb.r.data(&pos)
 			mb.setUseBuf(str[1 : len(str)-1])
-		} else if ch0 == '\\' && !s.sqlMode.HasNoBackslashEscapesMode() {
+		} else if ch0 == '\\' {
 			mb.setUseBuf(mb.r.data(&pos)[1:])
 			ch0 = handleEscape(s)
 		}


### PR DESCRIPTION
This reverts commit 294e348f42b2308be7ac38c218709e6a94eced13.

the pr https://github.com/pingcap/tidb/pull/5073 failed TiDB ci. The reason is subtle, it is not directly caused by this pr, but this pr will introduce another compability problem. TiDB not support all the [capabilities](https://dev.mysql.com/doc/dev/mysql-server/8.0.0/group__group__cs__capabilities__flags.html) in MySQL Protocol, so when mysql-client meet sql_mode `NO_BACKSLASH_ESCAPES`, if TiDB return some capabilities flags correctly in handshake stage, the client will recognize below sql and treat it as "unfinished", and not send it to MySQL/TiDB:

```
mysql> SET SESSION sql_mode = 'no_backslash_escapes';
Query OK, 0 rows affected, 1 warning (0.00 sec)

mysql> insert into t value("foo \x00\n\r\x1a\"'\\");
    '>
```

but in TiDB, the client ignore mode `NO_BACKSLASH_ESCAPES`, and send the sql to TiDB directly, so we got below error:

```
tidb> insert into t value("foo \x00\n\r\x1a\"'\\");
ERROR 1105 (HY000): line 1 column 44 near "" (total length 44)
```
I am not comfirmed which capabilities lead to it, but mysql capabilities is

```
lower 2 bytes:  1111011111111111
upper 2 bytes: 1000000111111111
```

and TiDB is:

```
lower 2 bytes: 1010001010001111
upper 2 bytes: 0000000000011011
```
I'll fix the issue in another pr.

this pr to fix ci.