### PR TITLE
 ranger: check MaxInt64 and MinInt64 to avoid overflow.

### DIFF
--- a/types/range.go
+++ b/types/range.go
@@ -51,9 +51,6 @@ func (tr IntColumnRange) String() string {
 	}
 	if tr.HighVal == math.MaxInt64 {
 		r = "+inf)"
-	} else if tr.HighVal == math.MinInt64 {
-		// This branch is for nil
-		r = "-inf)"
 	} else {
 		r = strconv.FormatInt(tr.HighVal, 10) + "]"
 	}

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -189,7 +189,7 @@ func points2TableRanges(sc *variable.StatementContext, rangePoints []point) ([]t
 		}
 		endPoint := rangePoints[i+1]
 		if endPoint.value.IsNull() {
-			endPoint.value.SetInt64(math.MinInt64)
+			continue
 		} else if endPoint.value.Kind() == types.KindMaxValue {
 			endPoint.value.SetInt64(math.MaxInt64)
 		}

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -182,6 +182,9 @@ func points2TableRanges(sc *variable.StatementContext, rangePoints []point) ([]t
 			return nil, errors.Trace(err)
 		}
 		if cmp < 0 || (cmp == 0 && startPoint.excl) {
+			if startInt == math.MaxInt64 {
+				continue
+			}
 			startInt++
 		}
 		endPoint := rangePoints[i+1]
@@ -200,6 +203,9 @@ func points2TableRanges(sc *variable.StatementContext, rangePoints []point) ([]t
 			return nil, errors.Trace(err)
 		}
 		if cmp > 0 || (cmp == 0 && endPoint.excl) {
+			if endInt == math.MinInt64 {
+				continue
+			}
 			endInt--
 		}
 		if startInt > endInt {

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -209,7 +209,7 @@ func (s *testRangerSuite) TestTableRange(c *C) {
 			exprStr:     "a IS NULL",
 			accessConds: "[isnull(test.t.a)]",
 			filterConds: "[]",
-			resultStr:   "[(-inf,-inf)]",
+			resultStr:   "[]",
 		},
 		{
 			exprStr:     "a IS NOT NULL",
@@ -227,7 +227,7 @@ func (s *testRangerSuite) TestTableRange(c *C) {
 			exprStr:     "a IS NOT TRUE",
 			accessConds: "[not(istrue(test.t.a))]",
 			filterConds: "[]",
-			resultStr:   "[(-inf,-inf) [0,0]]",
+			resultStr:   "[[0,0]]",
 		},
 		{
 			exprStr:     "a IS FALSE",
@@ -270,6 +270,30 @@ func (s *testRangerSuite) TestTableRange(c *C) {
 			accessConds: "[not(in(test.t.a, 1, 2, 3))]",
 			filterConds: "[]",
 			resultStr:   "[(-inf,0] [4,+inf)]",
+		},
+		{
+			exprStr:     "a > 9223372036854775807",
+			accessConds: "[gt(test.t.a, 9223372036854775807)]",
+			filterConds: "[]",
+			resultStr:   "[]",
+		},
+		{
+			exprStr:     "a >= 9223372036854775807",
+			accessConds: "[ge(test.t.a, 9223372036854775807)]",
+			filterConds: "[]",
+			resultStr:   "[[9223372036854775807,+inf)]",
+		},
+		{
+			exprStr:     "a < -9223372036854775807",
+			accessConds: "[lt(test.t.a, -9223372036854775807)]",
+			filterConds: "[]",
+			resultStr:   "[(-inf,-9223372036854775808]]",
+		},
+		{
+			exprStr:     "a < -9223372036854775808",
+			accessConds: "[lt(test.t.a, -9223372036854775808)]",
+			filterConds: "[]",
+			resultStr:   "[]",
 		},
 	}
 


### PR DESCRIPTION
If overflow, this will make range wrong. And the old code regard `[<nil>, <nil>]` as `[MinInt64, MinInt64]` which is also wrong.
`IntColumnRange` is only used by primary key currently which `NULL` is an impossible case.
fix #5113 