### PR TITLE
ddl: fix index recognized as prefix index when column length is enlarged

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -263,10 +263,6 @@ func columnDefToCol(ctx context.Context, offset int, colDef *ast.ColumnDef) (*ta
 	if colDef.Options != nil {
 		len := types.UnspecifiedLength
 
-		if types.IsTypePrefixable(colDef.Tp.Tp) {
-			len = colDef.Tp.Flen
-		}
-
 		keys := []*ast.IndexColName{
 			{
 				Column: colDef.Name,

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -439,6 +439,15 @@ func (s *testDBSuite) TestAddAnonymousIndex(c *C) {
 	c.Assert(t.Indices()[1].Meta().Name.String(), Equals, "primary_3")
 }
 
+// Issue 5134
+func (s *testDBSuite) TestModifyColumnAfterAddIndex(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use " + s.schemaName)
+	s.mustExec(c, "create table city (city VARCHAR(2) KEY);")
+	s.mustExec(c, "alter table city change column city city varchar(50);")
+	s.mustExec(c, `insert into city values ("abc"), ("abd");`)
+}
+
 func (s *testDBSuite) testAlterLock(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)


### PR DESCRIPTION
fix #5134 

@zimulala @winoros PTAL