### PR TITLE
*: use `Chunk` for `TableReader`.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -136,8 +136,8 @@ type RecordSet interface {
 	// Next returns the next row, nil row means there is no more to return.
 	Next() (row types.Row, err error)
 
-	// Read read records into chunk.
-	Read(chk *chunk.Chunk) error
+	// NextChunk reads records into chunk.
+	NextChunk(chk *chunk.Chunk) error
 
 	// NewChunk creates a new chunk with initial capacity.
 	NewChunk() *chunk.Chunk

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 )
 
 // Node is the basic element of the AST.
@@ -134,6 +135,15 @@ type RecordSet interface {
 
 	// Next returns the next row, nil row means there is no more to return.
 	Next() (row types.Row, err error)
+
+	// Read read records into chunk.
+	Read(chk *chunk.Chunk) error
+
+	// NewChunk creates a new chunk with initial capacity.
+	NewChunk() *chunk.Chunk
+
+	// SupportChunk check if the RecordSet supports Chunk structure.
+	SupportChunk() bool
 
 	// Close closes the underlying iterator, call Next after Close will
 	// restart the iteration.

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -45,8 +45,8 @@ type SelectResult interface {
 	Next() (PartialResult, error)
 	// NextRaw gets the next raw result.
 	NextRaw() ([]byte, error)
-	// Read reads the data into chunk.
-	Read(*chunk.Chunk) error
+	// NextChunk reads the data into chunk.
+	NextChunk(*chunk.Chunk) error
 	// Close closes the iterator.
 	Close() error
 	// Fetch fetches partial results from client.
@@ -136,7 +136,7 @@ func (r *selectResult) NextRaw() ([]byte, error) {
 	return re.result, errors.Trace(re.err)
 }
 
-// Read reads data to the chunk.
+// NextChunk reads data to the chunk.
 func (r *selectResult) NextChunk(chk *chunk.Chunk) error {
 	chk.Reset()
 	re := <-r.results

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/goroutine_pool"
 	"github.com/pingcap/tipb/go-tipb"
@@ -44,6 +45,8 @@ type SelectResult interface {
 	Next() (PartialResult, error)
 	// NextRaw gets the next raw result.
 	NextRaw() ([]byte, error)
+	// Read reads the data into chunk.
+	Read(*chunk.Chunk) error
 	// Close closes the iterator.
 	Close() error
 	// Fetch fetches partial results from client.
@@ -68,7 +71,9 @@ type selectResult struct {
 	results chan newResultWithErr
 	closed  chan struct{}
 
-	rowLen int
+	rowLen     int
+	fieldTypes []*types.FieldType
+	loc        *time.Location
 }
 
 type newResultWithErr struct {
@@ -129,6 +134,44 @@ func (r *selectResult) Next() (PartialResult, error) {
 func (r *selectResult) NextRaw() ([]byte, error) {
 	re := <-r.results
 	return re.result, errors.Trace(re.err)
+}
+
+// Read reads data to the chunk.
+func (r *selectResult) Read(chk *chunk.Chunk) error {
+	chk.Reset()
+	re := <-r.results
+	if re.err != nil {
+		return errors.Trace(re.err)
+	}
+	if re.result == nil {
+		return nil
+	}
+	// As we will use streaming soon, we can just write all data to a single *chunk.Chunk.
+	resp := new(tipb.SelectResponse)
+	err := resp.Unmarshal(re.result)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for i := range resp.Chunks {
+		err = r.readRowsData(chk, resp.Chunks[i].RowsData)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+func (r *selectResult) readRowsData(chk *chunk.Chunk, rowsData []byte) error {
+	var err error
+	for len(rowsData) > 0 {
+		for i := 0; i < r.rowLen; i++ {
+			rowsData, err = codec.DecodeOneToChunk(rowsData, chk, i, r.fieldTypes[i], r.loc)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return nil
 }
 
 // Close closes selectResult.
@@ -197,7 +240,7 @@ func (pr *partialResult) Close() error {
 
 // SelectDAG sends a DAG request, returns SelectResult.
 // In kvReq, KeyRanges is required, Concurrency/KeepOrder/Desc/IsolationLevel/Priority are optional.
-func SelectDAG(ctx goctx.Context, client kv.Client, kvReq *kv.Request, colLen int) (SelectResult, error) {
+func SelectDAG(ctx goctx.Context, client kv.Client, kvReq *kv.Request, fieldTypes []*types.FieldType, loc *time.Location) (SelectResult, error) {
 	var err error
 	defer func() {
 		// Add metrics.
@@ -214,11 +257,13 @@ func SelectDAG(ctx goctx.Context, client kv.Client, kvReq *kv.Request, colLen in
 		return nil, errors.Trace(err)
 	}
 	result := &selectResult{
-		label:   "dag",
-		resp:    resp,
-		results: make(chan newResultWithErr, kvReq.Concurrency),
-		closed:  make(chan struct{}),
-		rowLen:  colLen,
+		label:      "dag",
+		resp:       resp,
+		results:    make(chan newResultWithErr, kvReq.Concurrency),
+		closed:     make(chan struct{}),
+		rowLen:     len(fieldTypes),
+		fieldTypes: fieldTypes,
+		loc:        loc,
 	}
 	return result, nil
 }

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -137,7 +137,7 @@ func (r *selectResult) NextRaw() ([]byte, error) {
 }
 
 // Read reads data to the chunk.
-func (r *selectResult) Read(chk *chunk.Chunk) error {
+func (r *selectResult) NextChunk(chk *chunk.Chunk) error {
 	chk.Reset()
 	re := <-r.results
 	if re.err != nil {

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -76,7 +76,7 @@ type selectResult struct {
 	loc        *time.Location
 
 	selectResp *tipb.SelectResponse
-	reapChkIdx int
+	respChkIdx int
 }
 
 type newResultWithErr struct {
@@ -149,16 +149,16 @@ func (r *selectResult) NextChunk(chk *chunk.Chunk) error {
 	if selectResp == nil {
 		return nil
 	}
-	err = r.readRowsData(chk, selectResp.Chunks[r.reapChkIdx].RowsData)
+	err = r.readRowsData(chk, selectResp.Chunks[r.respChkIdx].RowsData)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	r.reapChkIdx++
+	r.respChkIdx++
 	return nil
 }
 
 func (r *selectResult) getSelectResp() (*tipb.SelectResponse, error) {
-	if r.selectResp != nil && r.reapChkIdx < len(r.selectResp.Chunks) {
+	if r.selectResp != nil && r.respChkIdx < len(r.selectResp.Chunks) {
 		return r.selectResp, nil
 	}
 	for {
@@ -178,7 +178,7 @@ func (r *selectResult) getSelectResp() (*tipb.SelectResponse, error) {
 			continue
 		}
 		r.selectResp = resp
-		r.reapChkIdx = 0
+		r.respChkIdx = 0
 		return resp, nil
 	}
 }

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -183,10 +183,6 @@ func (r *selectResult) getSelectResp() (*tipb.SelectResponse, error) {
 	}
 }
 
-func (r *selectResult) readRespChunk(chk *chunk.Chunk, rChkIdx int) {
-	r.readRowsData(chk, r.selectResp.Chunks[rChkIdx].RowsData)
-}
-
 func (r *selectResult) readRowsData(chk *chunk.Chunk, rowsData []byte) error {
 	var err error
 	for len(rowsData) > 0 {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -92,7 +92,7 @@ func (a *recordSet) Next() (types.Row, error) {
 }
 
 func (a *recordSet) NextChunk(chk *chunk.Chunk) error {
-	err := a.executor.Read(chk)
+	err := a.executor.NextChunk(chk)
 	if err != nil {
 		a.lastErr = err
 		return errors.Trace(err)

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 )
 
@@ -88,6 +89,33 @@ func (a *recordSet) Next() (types.Row, error) {
 		a.stmt.ctx.GetSessionVars().StmtCtx.AddFoundRows(1)
 	}
 	return row, nil
+}
+
+func (a *recordSet) Read(chk *chunk.Chunk) error {
+	err := a.executor.Read(chk)
+	if err != nil {
+		a.lastErr = err
+		return errors.Trace(err)
+	}
+	numRows := chk.NumRows()
+	if numRows == 0 {
+		if a.stmt != nil {
+			a.stmt.ctx.GetSessionVars().LastFoundRows = a.stmt.ctx.GetSessionVars().StmtCtx.FoundRows()
+		}
+		return nil
+	}
+	if a.stmt != nil {
+		a.stmt.ctx.GetSessionVars().StmtCtx.AddFoundRows(uint64(numRows))
+	}
+	return nil
+}
+
+func (a *recordSet) NewChunk() *chunk.Chunk {
+	return chunk.NewChunk(a.executor.Schema().ToFieldTypes())
+}
+
+func (a *recordSet) SupportChunk() bool {
+	return a.executor.supportChunk()
 }
 
 func (a *recordSet) Close() error {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -91,7 +91,7 @@ func (a *recordSet) Next() (types.Row, error) {
 	return row, nil
 }
 
-func (a *recordSet) Read(chk *chunk.Chunk) error {
+func (a *recordSet) NextChunk(chk *chunk.Chunk) error {
 	err := a.executor.Read(chk)
 	if err != nil {
 		a.lastErr = err

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -111,7 +111,7 @@ func (a *recordSet) Read(chk *chunk.Chunk) error {
 }
 
 func (a *recordSet) NewChunk() *chunk.Chunk {
-	return chunk.NewChunk(a.executor.Schema().ToFieldTypes())
+	return chunk.NewChunk(a.executor.Schema().GetTypes())
 }
 
 func (a *recordSet) SupportChunk() bool {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1184,7 +1184,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(goCtx goctx.Contex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), builder.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1208,7 +1208,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForDatums(goCtx goctx.Context,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), builder.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -990,6 +990,7 @@ func buildNoRangeTableReader(b *executorBuilder, v *plan.PhysicalTableReader) (*
 		columns:      ts.Columns,
 		priority:     b.priority,
 	}
+	e.baseExecutor.supportChk = true
 
 	for i := range v.Schema().Columns {
 		dagReq.OutputOffsets = append(dagReq.OutputOffsets, uint32(i))
@@ -1183,7 +1184,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(goCtx goctx.Contex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.Len())
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), builder.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1207,7 +1208,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForDatums(goCtx goctx.Context,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.Len())
+	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), builder.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1184,7 +1184,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(goCtx goctx.Contex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().GetTimeZone())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -1208,7 +1208,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForDatums(goCtx goctx.Context,
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(e.ctx.GoCtx(), e.ctx.GetClient(), kvReq, e.schema.GetTypes(), builder.ctx.GetSessionVars().GetTimeZone())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -343,7 +343,7 @@ func timeZoneOffset(ctx context.Context) int64 {
 // Flags are used by tipb.SelectRequest.Flags to handle execution mode, like how to handle truncate error.
 const (
 	// FlagIgnoreTruncate indicates if truncate error should be ignored.
-	// Read-only statements should ignore truncate error, write statements should not ignore truncate error.
+	// NextChunk-only statements should ignore truncate error, write statements should not ignore truncate error.
 	FlagIgnoreTruncate uint64 = 1
 	// FlagTruncateAsWarning indicates if truncate error should be returned as warning.
 	// This flag only matters if FlagIgnoreTruncate is not set, in strict sql mode, truncate error should
@@ -455,8 +455,8 @@ func (e *TableReaderExecutor) Next() (Row, error) {
 	}
 }
 
-// Read implements the Executor Read interface.
-func (e *TableReaderExecutor) Read(chk *chunk.Chunk) error {
+// NextChunk implements the Executor NextChunk interface.
+func (e *TableReaderExecutor) NextChunk(chk *chunk.Chunk) error {
 	return e.result.Read(chk)
 }
 
@@ -476,7 +476,7 @@ func (e *TableReaderExecutor) Open() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().GetTimeZone())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -559,8 +559,8 @@ func (e *IndexReaderExecutor) Next() (Row, error) {
 	}
 }
 
-// Read implements the Executor Read interface.
-func (e *IndexReaderExecutor) Read(chk *chunk.Chunk) error {
+// NextChunk implements the Executor NextChunk interface.
+func (e *IndexReaderExecutor) NextChunk(chk *chunk.Chunk) error {
 	return e.result.Read(chk)
 }
 
@@ -584,7 +584,7 @@ func (e *IndexReaderExecutor) Open() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().GetTimeZone())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -646,7 +646,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(goCtx goctx.Context, kvRanges []k
 		return errors.Trace(err)
 	}
 	// Since the first read only need handle information. So its returned col is only 1.
-	result, err := distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.ctx.GetSessionVars().TimeZone)
+	result, err := distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.ctx.GetSessionVars().GetTimeZone())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -457,7 +457,7 @@ func (e *TableReaderExecutor) Next() (Row, error) {
 
 // NextChunk implements the Executor NextChunk interface.
 func (e *TableReaderExecutor) NextChunk(chk *chunk.Chunk) error {
-	return e.result.Read(chk)
+	return e.result.NextChunk(chk)
 }
 
 // Open implements the Executor Open interface.
@@ -561,7 +561,7 @@ func (e *IndexReaderExecutor) Next() (Row, error) {
 
 // NextChunk implements the Executor NextChunk interface.
 func (e *IndexReaderExecutor) NextChunk(chk *chunk.Chunk) error {
-	return e.result.Read(chk)
+	return e.result.NextChunk(chk)
 }
 
 // Open implements the Executor Open interface.

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -343,7 +343,7 @@ func timeZoneOffset(ctx context.Context) int64 {
 // Flags are used by tipb.SelectRequest.Flags to handle execution mode, like how to handle truncate error.
 const (
 	// FlagIgnoreTruncate indicates if truncate error should be ignored.
-	// NextChunk-only statements should ignore truncate error, write statements should not ignore truncate error.
+	// Read-only statements should ignore truncate error, write statements should not ignore truncate error.
 	FlagIgnoreTruncate uint64 = 1
 	// FlagTruncateAsWarning indicates if truncate error should be returned as warning.
 	// This flag only matters if FlagIgnoreTruncate is not set, in strict sql mode, truncate error should

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -476,7 +476,7 @@ func (e *TableReaderExecutor) Open() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), e.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -584,7 +584,7 @@ func (e *IndexReaderExecutor) Open() error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.ToFieldTypes(), e.ctx.GetSessionVars().TimeZone)
+	e.result, err = distsql.SelectDAG(goCtx, e.ctx.GetClient(), kvReq, e.schema.GetTypes(), e.ctx.GetSessionVars().TimeZone)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -128,12 +128,15 @@ func (e *baseExecutor) Schema() *expression.Schema {
 }
 
 func (e *baseExecutor) supportChunk() bool {
+	if !e.supportChk {
+		return false
+	}
 	for _, child := range e.children {
 		if !child.supportChunk() {
 			return false
 		}
 	}
-	return e.supportChk
+	return true
 }
 
 func (e *baseExecutor) Read(chk *chunk.Chunk) error {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -139,7 +139,7 @@ func (e *baseExecutor) supportChunk() bool {
 	return true
 }
 
-func (e *baseExecutor) Read(chk *chunk.Chunk) error {
+func (e *baseExecutor) NextChunk(chk *chunk.Chunk) error {
 	return nil
 }
 
@@ -158,7 +158,7 @@ type Executor interface {
 	Open() error
 	Schema() *expression.Schema
 	supportChunk() bool
-	Read(chk *chunk.Chunk) error
+	NextChunk(chk *chunk.Chunk) error
 }
 
 // CancelDDLJobsExec represents a cancel DDL jobs executor.

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/types"
 )
 
 // KeyInfo stores the columns of one unique key or primary key.
@@ -206,6 +207,15 @@ func (s *Schema) ColumnsByIndices(offsets []int) []*Column {
 		cols = append(cols, s.Columns[offset])
 	}
 	return cols
+}
+
+// ToFieldTypes creates a field type slice.
+func (s *Schema) ToFieldTypes() []*types.FieldType {
+	fields := make([]*types.FieldType, len(s.Columns))
+	for i := range fields {
+		fields[i] = s.Columns[i].RetType
+	}
+	return fields
 }
 
 // MergeSchema will merge two schema into one schema.

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -209,8 +209,8 @@ func (s *Schema) ColumnsByIndices(offsets []int) []*Column {
 	return cols
 }
 
-// ToFieldTypes creates a field type slice.
-func (s *Schema) ToFieldTypes() []*types.FieldType {
+// GetTypes creates a field type slice.
+func (s *Schema) GetTypes() []*types.FieldType {
 	fields := make([]*types.FieldType, len(s.Columns))
 	for i := range fields {
 		fields[i] = s.Columns[i].RetType

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1466,3 +1466,37 @@ func (s *testSchemaSuite) TestCommitWhenSchemaChanged(c *C) {
 	_, err := tk1.Exec("commit")
 	c.Assert(terror.ErrorEqual(err, executor.ErrWrongValueCountOnRow), IsTrue)
 }
+
+func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
+	// Since normally a single region mock tikv only returns one partial result we need to manually split the
+	// table to test multiple chunks.
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table chk (a int)")
+	for i := 0; i < 100; i++ {
+		tk.MustExec(fmt.Sprintf("insert chk values (%d)", i))
+	}
+	tbl, err := sessionctx.GetDomain(tk.Se).InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("chk"))
+	c.Assert(err, IsNil)
+	s.cluster.SplitTable(s.mvccStore, tbl.Meta().ID, 10)
+
+	rs, err := tk.Exec("select * from chk")
+	c.Assert(err, IsNil)
+	chk := rs.NewChunk()
+	var count int
+	var numChunks int
+	for {
+		err = rs.Read(chk)
+		c.Assert(err, IsNil)
+		numRows := chk.NumRows()
+		if numRows == 0 {
+			break
+		}
+		for i := 0; i < numRows; i++ {
+			c.Assert(chk.GetRow(i).GetInt64(0), Equals, int64(count))
+			count++
+		}
+		numChunks++
+	}
+	c.Assert(count, Equals, 100)
+	c.Assert(numChunks, Equals, 10)
+}

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1485,7 +1485,7 @@ func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
 	var count int
 	var numChunks int
 	for {
-		err = rs.Read(chk)
+		err = rs.NextChunk(chk)
 		c.Assert(err, IsNil)
 		numRows := chk.NumRows()
 		if numRows == 0 {

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1479,6 +1479,7 @@ func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
 	c.Assert(err, IsNil)
 	s.cluster.SplitTable(s.mvccStore, tbl.Meta().ID, 10)
 
+	tk.Se.GetSessionVars().DistSQLScanConcurrency = 1
 	rs, err := tk.Exec("select * from chk")
 	c.Assert(err, IsNil)
 	chk := rs.NewChunk()

--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -69,7 +69,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select a from t where a between 1 and 2 order by c",
 			best: "TableReader(Table(t))->Sort->Projection",
 		},
-		// Test DNF condition + Double NextChunk.
+		// Test DNF condition + Double Read.
 		// FIXME: Some bugs still exist in selectivity.
 		//{
 		//	sql:  "select * from t where (t.c > 0 and t.c < 1) or (t.c > 2 and t.c < 3) or (t.c > 4 and t.c < 5) or (t.c > 6 and t.c < 7) or (t.c > 9 and t.c < 10)",
@@ -635,7 +635,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderUnionScan(c *C) {
 		sql  string
 		best string
 	}{
-		// NextChunk table.
+		// Read table.
 		{
 			sql:  "select * from t",
 			best: "TableReader(Table(t))->UnionScan([])",

--- a/plan/dag_plan_test.go
+++ b/plan/dag_plan_test.go
@@ -69,7 +69,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select a from t where a between 1 and 2 order by c",
 			best: "TableReader(Table(t))->Sort->Projection",
 		},
-		// Test DNF condition + Double Read.
+		// Test DNF condition + Double NextChunk.
 		// FIXME: Some bugs still exist in selectivity.
 		//{
 		//	sql:  "select * from t where (t.c > 0 and t.c < 1) or (t.c > 2 and t.c < 3) or (t.c > 4 and t.c < 5) or (t.c > 6 and t.c < 7) or (t.c > 9 and t.c < 10)",
@@ -635,7 +635,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderUnionScan(c *C) {
 		sql  string
 		best string
 	}{
-		// Read table.
+		// NextChunk table.
 		{
 			sql:  "select * from t",
 			best: "TableReader(Table(t))->UnionScan([])",

--- a/server/conn.go
+++ b/server/conn.go
@@ -792,7 +792,7 @@ func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error
 	defer terror.Call(rs.Close)
 	if rs.SupportChunk() {
 		columns := rs.Columns()
-		err := cc.writeColumns(columns)
+		err := cc.writeColumnInfo(columns)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -809,7 +809,7 @@ func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error
 		return errors.Trace(err)
 	}
 	columns := rs.Columns()
-	err = cc.writeColumns(columns)
+	err = cc.writeColumnInfo(columns)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -848,7 +848,7 @@ func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error
 	return errors.Trace(cc.flush())
 }
 
-func (cc *clientConn) writeColumns(columns []*ColumnInfo) error {
+func (cc *clientConn) writeColumnInfo(columns []*ColumnInfo) error {
 	data := make([]byte, 4, 1024)
 	data = dumpLengthEncodedInt(data, uint64(len(columns)))
 	if err := cc.writePacket(data); err != nil {

--- a/server/conn.go
+++ b/server/conn.go
@@ -790,35 +790,30 @@ func (cc *clientConn) handleFieldList(sql string) (err error) {
 // resultsets, it's used to support the MULTI_RESULTS capability in mysql protocol.
 func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error {
 	defer terror.Call(rs.Close)
+	if rs.SupportChunk() {
+		columns := rs.Columns()
+		err := cc.writeColumns(columns)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		err = cc.writeChunks(rs, binary, more)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		return errors.Trace(cc.flush())
+	}
 	// We need to call Next before we get columns.
 	// Otherwise, we will get incorrect columns info.
 	row, err := rs.Next()
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	columns, err := rs.Columns()
+	columns := rs.Columns()
+	err = cc.writeColumns(columns)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	data := cc.alloc.AllocWithLen(4, 1024)
-	data = dumpLengthEncodedInt(data, uint64(len(columns)))
-	if err = cc.writePacket(data); err != nil {
-		return errors.Trace(err)
-	}
-
-	for _, v := range columns {
-		data = data[0:4]
-		data = v.Dump(data)
-		if err = cc.writePacket(data); err != nil {
-			return errors.Trace(err)
-		}
-	}
-
-	if err = cc.writeEOF(false); err != nil {
-		return errors.Trace(err)
-	}
+	data := make([]byte, 4, 1024)
 	for {
 		if err != nil {
 			return errors.Trace(err)
@@ -851,6 +846,55 @@ func (cc *clientConn) writeResultset(rs ResultSet, binary bool, more bool) error
 	}
 
 	return errors.Trace(cc.flush())
+}
+
+func (cc *clientConn) writeColumns(columns []*ColumnInfo) error {
+	data := make([]byte, 4, 1024)
+	data = dumpLengthEncodedInt(data, uint64(len(columns)))
+	if err := cc.writePacket(data); err != nil {
+		return errors.Trace(err)
+	}
+	for _, v := range columns {
+		data = data[0:4]
+		data = v.Dump(data)
+		if err := cc.writePacket(data); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if err := cc.writeEOF(false); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (cc *clientConn) writeChunks(rs ResultSet, binary bool, more bool) error {
+	data := make([]byte, 4, 1024)
+	chk := rs.NewChunk()
+	for {
+		err := rs.Read(chk)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rowCount := chk.NumRows()
+		if rowCount == 0 {
+			break
+		}
+		for i := 0; i < rowCount; i++ {
+			data = data[0:4]
+			if binary {
+				data, err = dumpBinaryRow(data, rs.Columns(), chk.GetRow(i))
+			} else {
+				data, err = dumpTextRow(data, rs.Columns(), chk.GetRow(i))
+			}
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if err = cc.writePacket(data); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return errors.Trace(cc.writeEOF(more))
 }
 
 func (cc *clientConn) writeMultiResultset(rss []ResultSet, binary bool) error {

--- a/server/conn.go
+++ b/server/conn.go
@@ -871,7 +871,7 @@ func (cc *clientConn) writeChunks(rs ResultSet, binary bool, more bool) error {
 	data := make([]byte, 4, 1024)
 	chk := rs.NewChunk()
 	for {
-		err := rs.Read(chk)
+		err := rs.NextChunk(chk)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/server/driver.go
+++ b/server/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
+	"github.com/pingcap/tidb/util/chunk"
 	goctx "golang.org/x/net/context"
 )
 
@@ -120,7 +121,10 @@ type PreparedStatement interface {
 
 // ResultSet is the result set of an query.
 type ResultSet interface {
-	Columns() ([]*ColumnInfo, error)
+	Columns() []*ColumnInfo
 	Next() (types.Row, error)
+	SupportChunk() bool
+	NewChunk() *chunk.Chunk
+	Read(chk *chunk.Chunk) error
 	Close() error
 }

--- a/server/driver.go
+++ b/server/driver.go
@@ -125,6 +125,6 @@ type ResultSet interface {
 	Next() (types.Row, error)
 	SupportChunk() bool
 	NewChunk() *chunk.Chunk
-	Read(chk *chunk.Chunk) error
+	NextChunk(chk *chunk.Chunk) error
 	Close() error
 }

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
+	"github.com/pingcap/tidb/util/chunk"
 	goctx "golang.org/x/net/context"
 )
 
@@ -235,11 +236,7 @@ func (tc *TiDBContext) FieldList(table string) (colums []*ColumnInfo, err error)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	colums, err = rs[0].Columns()
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return
+	return rs[0].Columns(), nil
 }
 
 // GetStatement implements QueryCtx GetStatement method.
@@ -290,23 +287,37 @@ func (tc *TiDBContext) Cancel() {
 
 type tidbResultSet struct {
 	recordSet ast.RecordSet
+	columns   []*ColumnInfo
 }
 
 func (trs *tidbResultSet) Next() (types.Row, error) {
 	return trs.recordSet.Next()
 }
 
+func (trs *tidbResultSet) NewChunk() *chunk.Chunk {
+	return trs.recordSet.NewChunk()
+}
+
+func (trs *tidbResultSet) Read(chk *chunk.Chunk) error {
+	return trs.recordSet.Read(chk)
+}
+
+func (trs *tidbResultSet) SupportChunk() bool {
+	return trs.recordSet.SupportChunk()
+}
+
 func (trs *tidbResultSet) Close() error {
 	return trs.recordSet.Close()
 }
 
-func (trs *tidbResultSet) Columns() ([]*ColumnInfo, error) {
-	fields := trs.recordSet.Fields()
-	var columns []*ColumnInfo
-	for _, v := range fields {
-		columns = append(columns, convertColumnInfo(v))
+func (trs *tidbResultSet) Columns() []*ColumnInfo {
+	if trs.columns == nil {
+		fields := trs.recordSet.Fields()
+		for _, v := range fields {
+			trs.columns = append(trs.columns, convertColumnInfo(v))
+		}
 	}
-	return columns, nil
+	return trs.columns
 }
 
 func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -298,8 +298,8 @@ func (trs *tidbResultSet) NewChunk() *chunk.Chunk {
 	return trs.recordSet.NewChunk()
 }
 
-func (trs *tidbResultSet) Read(chk *chunk.Chunk) error {
-	return trs.recordSet.Read(chk)
+func (trs *tidbResultSet) NextChunk(chk *chunk.Chunk) error {
+	return trs.recordSet.NextChunk(chk)
 }
 
 func (trs *tidbResultSet) SupportChunk() bool {

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -398,7 +398,7 @@ func (ts *TidbTestSuite) TestShowCreateTableFlen(c *C) {
 	rs, err := ctx.Execute(goctx.Background(), "show create table t1")
 	row, err := rs[0].Next()
 	c.Assert(err, IsNil)
-	cols, err := rs[0].Columns()
+	cols := rs[0].Columns()
 	c.Assert(err, IsNil)
 	c.Assert(len(cols), Equals, 2)
 	c.Assert(int(cols[0].ColumnLength), Equals, 5*tmysql.MaxBytesOfCharacter)

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 )
 
@@ -57,6 +58,18 @@ func (r *recordSet) Next() (types.Row, error) {
 	}
 	r.cursor++
 	return types.DatumRow{types.NewIntDatum(int64(r.cursor)), r.data[r.cursor-1]}, nil
+}
+
+func (r *recordSet) Read(chk *chunk.Chunk) error {
+	return nil
+}
+
+func (r *recordSet) NewChunk() *chunk.Chunk {
+	return nil
+}
+
+func (r *recordSet) SupportChunk() bool {
+	return false
 }
 
 func (r *recordSet) Close() error {

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -60,7 +60,7 @@ func (r *recordSet) Next() (types.Row, error) {
 	return types.DatumRow{types.NewIntDatum(int64(r.cursor)), r.data[r.cursor-1]}, nil
 }
 
-func (r *recordSet) Read(chk *chunk.Chunk) error {
+func (r *recordSet) NextChunk(chk *chunk.Chunk) error {
 	return nil
 }
 

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mock"
 )
@@ -75,6 +76,18 @@ func (r *recordSet) Next() (types.Row, error) {
 	}
 	r.cursor++
 	return types.DatumRow{r.data[r.cursor-1]}, nil
+}
+
+func (r *recordSet) Read(chk *chunk.Chunk) error {
+	return nil
+}
+
+func (r *recordSet) NewChunk() *chunk.Chunk {
+	return nil
+}
+
+func (r *recordSet) SupportChunk() bool {
+	return false
 }
 
 func (r *recordSet) Close() error {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -78,7 +78,7 @@ func (r *recordSet) Next() (types.Row, error) {
 	return types.DatumRow{r.data[r.cursor-1]}, nil
 }
 
-func (r *recordSet) Read(chk *chunk.Chunk) error {
+func (r *recordSet) NextChunk(chk *chunk.Chunk) error {
 	return nil
 }
 

--- a/store/tikv/mock-tikv/analyze.go
+++ b/store/tikv/mock-tikv/analyze.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -194,6 +195,18 @@ func (e *analyzeColumnsExec) Next() (row types.Row, err error) {
 		datumRow = append(datumRow, d)
 	}
 	return datumRow, nil
+}
+
+func (e *analyzeColumnsExec) Read(chk *chunk.Chunk) error {
+	return nil
+}
+
+func (e *analyzeColumnsExec) NewChunk() *chunk.Chunk {
+	return nil
+}
+
+func (e *analyzeColumnsExec) SupportChunk() bool {
+	return false
 }
 
 // Close implements the ast.RecordSet Close interface.

--- a/store/tikv/mock-tikv/analyze.go
+++ b/store/tikv/mock-tikv/analyze.go
@@ -197,7 +197,7 @@ func (e *analyzeColumnsExec) Next() (row types.Row, err error) {
 	return datumRow, nil
 }
 
-func (e *analyzeColumnsExec) Read(chk *chunk.Chunk) error {
+func (e *analyzeColumnsExec) NextChunk(chk *chunk.Chunk) error {
 	return nil
 }
 

--- a/tidb.go
+++ b/tidb.go
@@ -178,23 +178,40 @@ func GetHistory(ctx context.Context) *StmtHistory {
 	return hist
 }
 
-// GetRows gets all the rows from a RecordSet.
+// GetRows gets all the rows from a RecordSet, only used for test.
 func GetRows(rs ast.RecordSet) ([]types.Row, error) {
 	if rs == nil {
 		return nil, nil
 	}
 	var rows []types.Row
 	defer terror.Call(rs.Close)
-	// Negative limit means no limit.
-	for {
-		row, err := rs.Next()
-		if err != nil {
-			return nil, errors.Trace(err)
+	if rs.SupportChunk() {
+		for {
+			// Since we collect all the rows, we can not reuse the chunk.
+			chk := rs.NewChunk()
+			err := rs.Read(chk)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			rowCnt := chk.NumRows()
+			if rowCnt == 0 {
+				break
+			}
+			for i := 0; i < rowCnt; i++ {
+				rows = append(rows, chk.GetRow(i))
+			}
 		}
-		if row == nil {
-			break
+	} else {
+		for {
+			row, err := rs.Next()
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if row == nil {
+				break
+			}
+			rows = append(rows, row)
 		}
-		rows = append(rows, row)
 	}
 	return rows, nil
 }

--- a/tidb.go
+++ b/tidb.go
@@ -189,7 +189,7 @@ func GetRows(rs ast.RecordSet) ([]types.Row, error) {
 		for {
 			// Since we collect all the rows, we can not reuse the chunk.
 			chk := rs.NewChunk()
-			err := rs.Read(chk)
+			err := rs.NextChunk(chk)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -76,7 +76,7 @@ func (c *Chunk) addColumnByFieldType(fieldTp *types.FieldType, initCap int) {
 	case mysql.TypeFloat:
 		c.addFixedLenColumn(4, initCap)
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
-		mysql.TypeDouble:
+		mysql.TypeDouble, mysql.TypeYear:
 		c.addFixedLenColumn(8, initCap)
 	case mysql.TypeDuration:
 		c.addFixedLenColumn(16, initCap)
@@ -433,7 +433,7 @@ func (r Row) GetJSON(colIdx int) json.JSON {
 func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 	var d types.Datum
 	switch tp.Tp {
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
 		if !r.IsNull(colIdx) {
 			if mysql.HasUnsignedFlag(tp.Flag) {
 				d.SetUint64(r.GetUint64(colIdx))

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -32,45 +32,56 @@ type Chunk struct {
 	columns []*column
 }
 
-// AddFixedLenColumn adds a fixed length column with elemLen and initial data capacity.
-func (c *Chunk) AddFixedLenColumn(elemLen, initCap int) {
+const initialCapacity = 32
+
+// NewChunk creates a new chunk with field types.
+func NewChunk(fields []*types.FieldType) *Chunk {
+	chk := new(Chunk)
+	for _, f := range fields {
+		chk.addColumnByFieldType(f, initialCapacity)
+	}
+	return chk
+}
+
+// addFixedLenColumn adds a fixed length column with elemLen and initial data capacity.
+func (c *Chunk) addFixedLenColumn(elemLen, initCap int) {
 	c.columns = append(c.columns, &column{
 		elemBuf: make([]byte, elemLen),
 		data:    make([]byte, 0, initCap),
 	})
 }
 
-// AddVarLenColumn adds a variable length column with initial data capacity.
-func (c *Chunk) AddVarLenColumn(initCap int) {
+// addVarLenColumn adds a variable length column with initial data capacity.
+func (c *Chunk) addVarLenColumn(initCap int) {
 	c.columns = append(c.columns, &column{
 		offsets: []int32{0},
 		data:    make([]byte, 0, initCap),
 	})
 }
 
-// AddInterfaceColumn adds an interface column which holds element as interface.
-func (c *Chunk) AddInterfaceColumn() {
+// addInterfaceColumn adds an interface column which holds element as interface.
+func (c *Chunk) addInterfaceColumn() {
 	c.columns = append(c.columns, &column{
 		ifaces: []interface{}{},
 	})
 }
 
-// AddColumnByFieldType adds a column by field type.
-func (c *Chunk) AddColumnByFieldType(fieldTp byte, initCap int) {
-	switch fieldTp {
+// addColumnByFieldType adds a column by field type.
+func (c *Chunk) addColumnByFieldType(fieldTp *types.FieldType, initCap int) {
+	switch fieldTp.Tp {
 	case mysql.TypeFloat:
-		c.AddFixedLenColumn(4, initCap)
+		c.addFixedLenColumn(4, initCap)
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
 		mysql.TypeDouble:
-		c.AddFixedLenColumn(8, initCap)
+		c.addFixedLenColumn(8, initCap)
 	case mysql.TypeDuration:
-		c.AddFixedLenColumn(16, initCap)
+		c.addFixedLenColumn(16, initCap)
 	case mysql.TypeNewDecimal:
-		c.AddFixedLenColumn(types.MyDecimalStructSize, initCap)
+		c.addFixedLenColumn(types.MyDecimalStructSize, initCap)
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeJSON:
-		c.AddInterfaceColumn()
+		c.addInterfaceColumn()
 	default:
-		c.AddVarLenColumn(initCap)
+		c.addVarLenColumn(initCap)
 	}
 }
 

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -32,13 +32,17 @@ type Chunk struct {
 	columns []*column
 }
 
-const initialCapacity = 32
+// Capacity constants.
+const (
+	InitialCapacity = 32
+	MaxCapacity     = 1024
+)
 
 // NewChunk creates a new chunk with field types.
 func NewChunk(fields []*types.FieldType) *Chunk {
 	chk := new(Chunk)
 	for _, f := range fields {
-		chk.addColumnByFieldType(f, initialCapacity)
+		chk.addColumnByFieldType(f, InitialCapacity)
 	}
 	return chk
 }

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -128,11 +128,11 @@ func newChunk(elemLen ...int) *Chunk {
 	chk := &Chunk{}
 	for _, l := range elemLen {
 		if l > 0 {
-			chk.AddFixedLenColumn(l, 0)
+			chk.addFixedLenColumn(l, 0)
 		} else if l == 0 {
-			chk.AddVarLenColumn(0)
+			chk.addVarLenColumn(0)
 		} else {
-			chk.AddInterfaceColumn()
+			chk.addInterfaceColumn()
 		}
 	}
 	return chk

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -905,8 +905,8 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		{json.CreateJSON("abc"), types.NewFieldType(mysql.TypeJSON)},
 	}
 
-	var datums []types.Datum
-	var tps []*types.FieldType
+	datums := make([]types.Datum, 0, len(table))
+	tps := make([]*types.FieldType, 0, len(table))
 	for _, t := range table {
 		tps = append(tps, t.tp)
 		datums = append(datums, types.NewDatum(t.value))

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -903,6 +903,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		{types.Set{Name: "a", Value: 0}, &types.FieldType{Tp: mysql.TypeSet, Elems: []string{"a"}}},
 		{types.BinaryLiteral{100}, &types.FieldType{Tp: mysql.TypeBit, Flen: 8}},
 		{json.CreateJSON("abc"), types.NewFieldType(mysql.TypeJSON)},
+		{int64(1), types.NewFieldType(mysql.TypeYear)},
 	}
 
 	datums := make([]types.Datum, 0, len(table))

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -907,7 +907,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 	chk := new(chunk.Chunk)
 	var datums []types.Datum
 	for _, t := range table {
-		chk.AddColumnByFieldType(t.tp.Tp, 0)
+		chk.addColumnByFieldType(t.tp, 0)
 		datums = append(datums, types.NewDatum(t.value))
 	}
 

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -904,13 +904,14 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		{types.BinaryLiteral{100}, &types.FieldType{Tp: mysql.TypeBit, Flen: 8}},
 		{json.CreateJSON("abc"), types.NewFieldType(mysql.TypeJSON)},
 	}
-	chk := new(chunk.Chunk)
+
 	var datums []types.Datum
+	var tps []*types.FieldType
 	for _, t := range table {
-		chk.addColumnByFieldType(t.tp, 0)
+		tps = append(tps, t.tp)
 		datums = append(datums, types.NewDatum(t.value))
 	}
-
+	chk := chunk.NewChunk(tps)
 	rowCount := 3
 	for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
 		encoded, err := EncodeValue(nil, datums...)


### PR DESCRIPTION
This is the first executor to use Chunk.
If the executor is a single `TableReader`, `Read(*chunk.Chunk)` will be used instead of `Next`.