### PR TITLE
server: support mvcc get hex key.

### DIFF
--- a/server/http_status.go
+++ b/server/http_status.go
@@ -53,6 +53,7 @@ func (s *Server) startHTTPServer() {
 		router.Handle("/mvcc/key/{db}/{table}/{recordID}", mvccTxnHandler{tikvHandler, opMvccGetByKey})
 		router.Handle("/mvcc/txn/{startTS}/{db}/{table}", mvccTxnHandler{tikvHandler, opMvccGetByTxn})
 		router.Handle("/mvcc/txn/{startTS}", mvccTxnHandler{tikvHandler, opMvccGetByTxn})
+		router.Handle("/mvcc/hex/{hexKey}", mvccTxnHandler{tikvHandler, opMvccGetByHex})
 	}
 	addr := fmt.Sprintf(":%d", s.cfg.Status.StatusPort)
 	if s.cfg.Status.StatusPort == 0 {

--- a/server/region_handler_test.go
+++ b/server/region_handler_test.go
@@ -16,6 +16,7 @@ package server
 import (
 	"bytes"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -268,6 +269,17 @@ func (ts *TidbRegionHandlerTestSuite) TestGetMvcc(c *C) {
 		c.Assert(bytes.Equal(v1, expect.Value), IsTrue)
 		c.Assert(bytes.Equal(v2, expect.Value), IsTrue)
 	}
+
+	_, key, err := codec.DecodeBytes(p1.Key)
+	c.Assert(err, IsNil)
+	hexKey := hex.EncodeToString(key)
+	resp, err = http.Get("http://127.0.0.1:10090/mvcc/hex/" + hexKey)
+	c.Assert(err, IsNil)
+	decoder = json.NewDecoder(resp.Body)
+	var data2 kvrpcpb.MvccGetByKeyResponse
+	err = decoder.Decode(&data2)
+	c.Assert(err, IsNil)
+	c.Assert(data2, DeepEquals, data)
 }
 
 func (ts *TidbRegionHandlerTestSuite) TestGetMvccNotFound(c *C) {


### PR DESCRIPTION
Use `http://{host}:{port}/mvcc/hex/{hexKey}` to get the MVCC info of the full hex key.