### PR TITLE
plan, executor: deep clone TopN when push it down through Join

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -743,6 +743,18 @@ func (s *testSuite) TestIssue345(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *testSuite) TestIssue5055(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t1, t2`)
+	tk.MustExec(`create table t1 (a int);`)
+	tk.MustExec(`create table t2 (a int);`)
+	tk.MustExec(`insert into t1 values(1);`)
+	tk.MustExec(`insert into t2 values(1);`)
+	result := tk.MustQuery("select tbl1.* from (select t1.a, 1 from t1) tbl1 left join t2 tbl2 on tbl1.a = tbl2.a order by tbl1.a desc limit 1;")
+	result.Check(testkit.Rows("1 1"))
+}
+
 func (s *testSuite) TestUnion(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -334,8 +334,8 @@ func (s *testSuite) TestShowFullProcessList(c *C) {
 	fullSQL := "show                                                                                        full processlist"
 	simpSQL := "show                                                                                        processlist"
 
-	tk.MustQuery(fullSQL).Check(testutil.RowsWithSep("|", "221|   Query|0|2|"+fullSQL))
-	tk.MustQuery(simpSQL).Check(testutil.RowsWithSep("|", "221|   Query|0|2|"+simpSQL[:100]))
+	tk.MustQuery(fullSQL).Check(testutil.RowsWithSep("|", "223|   Query|0|2|"+fullSQL))
+	tk.MustQuery(simpSQL).Check(testutil.RowsWithSep("|", "223|   Query|0|2|"+simpSQL[:100]))
 
 	se.SetSessionManager(nil) // reset sm so other tests won't use this
 }

--- a/plan/topn_push_down.go
+++ b/plan/topn_push_down.go
@@ -131,7 +131,11 @@ func (p *LogicalJoin) pushDownTopNToChild(topN *TopN, idx int) LogicalPlan {
 				ByItems: make([]*ByItems, len(topN.ByItems)),
 				partial: true,
 			}.init(topN.ctx)
-			copy(newTopN.ByItems, topN.ByItems)
+			// The old topN should be maintained upon Join,
+			// so we clone TopN here and push down a newTopN.
+			for i := range topN.ByItems {
+				newTopN.ByItems[i] = topN.ByItems[i].Clone()
+			}
 		}
 	}
 	return p.children[idx].(LogicalPlan).pushDownTopN(newTopN)


### PR DESCRIPTION
fix #5055 

The builtin copy func in GoLang is not real deep copy,
so if push down TopN though Join, the `ByItem` of TopN may be modified unexpectedly.
PTAL @winoros @hanfei1991 