### PR TITLE
*: move stats table delta into a seperate package

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/statistics/update"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
 	goctx "golang.org/x/net/context"
@@ -70,6 +71,9 @@ type Context interface {
 
 	// PreparedPlanCache returns the cache of the physical plan
 	PreparedPlanCache() *kvcache.SimpleLRUCache
+
+	// GetStatsUpdater returns the updater for statistics.
+	GetStatsUpdater() update.Updater
 }
 
 type basicCtxType int

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -320,7 +320,7 @@ func (e *SelectLockExec) Next() (Row, error) {
 				return nil, errors.Trace(err)
 			}
 			// This operation is only for schema validator check.
-			txnCtx.UpdateDeltaForTable(id, 0, 0)
+			e.ctx.GetStatsUpdater().UpdateDelta(id, 0, 0)
 		}
 	}
 	return row, nil

--- a/executor/write.go
+++ b/executor/write.go
@@ -156,7 +156,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 		sc.AddAffectedRows(1)
 	}
 
-	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, 0, 1)
+	ctx.GetStatsUpdater().UpdateDelta(t.Meta().ID, 0, 1)
 	return true, nil
 }
 
@@ -318,7 +318,7 @@ func (e *DeleteExec) removeRow(ctx context.Context, t table.Table, h int64, data
 	}
 	getDirtyDB(ctx).deleteRow(t.Meta().ID, h)
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
-	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, -1, 1)
+	ctx.GetStatsUpdater().UpdateDelta(t.Meta().ID, -1, 1)
 	return nil
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -86,18 +86,6 @@ type TransactionContext struct {
 	Histroy       interface{}
 	SchemaVersion int64
 	StartTS       uint64
-	TableDeltaMap map[int64]TableDelta
-}
-
-// UpdateDeltaForTable updates the delta info for some table.
-func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, count int64) {
-	if tc.TableDeltaMap == nil {
-		tc.TableDeltaMap = make(map[int64]TableDelta)
-	}
-	item := tc.TableDeltaMap[tableID]
-	item.Delta += delta
-	item.Count += count
-	tc.TableDeltaMap[tableID] = item
 }
 
 // SessionVars is to handle user-defined or global variables in the current session.
@@ -335,12 +323,6 @@ const (
 	TimeZone            = "time_zone"
 	TxnIsolation        = "tx_isolation"
 )
-
-// TableDelta stands for the changed count for one table.
-type TableDelta struct {
-	Delta int64
-	Count int64
-}
 
 // StatementContext contains variables for a statement.
 // It should be reset before executing a statement.

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -49,7 +49,7 @@ type Handle struct {
 	// listHead contains all the stats collector required by session.
 	listHead *SessionStatsCollector
 	// globalUpdater contains all the updater from collectors when we dump them to KV.
-	globalMap update.Updater
+	globalUpdater update.Updater
 
 	Lease time.Duration
 }
@@ -65,8 +65,8 @@ func (h *Handle) Clear() {
 	for len(h.analyzeResultCh) > 0 {
 		<-h.analyzeResultCh
 	}
-	h.listHead = &SessionStatsCollector{mapper: update.NewUpdater()}
-	h.globalMap = update.NewUpdater()
+	h.listHead = &SessionStatsCollector{updater: update.NewUpdater()}
+	h.globalUpdater = update.NewUpdater()
 }
 
 // NewHandle creates a Handle for update stats.
@@ -75,8 +75,8 @@ func NewHandle(ctx context.Context, lease time.Duration) *Handle {
 		ctx:             ctx,
 		ddlEventCh:      make(chan *util.Event, 100),
 		analyzeResultCh: make(chan *AnalyzeResult, 100),
-		listHead:        &SessionStatsCollector{mapper: update.NewUpdater()},
-		globalMap:       update.NewUpdater(),
+		listHead:        &SessionStatsCollector{updater: update.NewUpdater()},
+		globalUpdater:   update.NewUpdater(),
 		Lease:           lease,
 	}
 	handle.statsCache.Store(statsCache{})

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -28,7 +28,7 @@ import (
 	goctx "golang.org/x/net/context"
 )
 
-// SessionStatsCollector is a list item that holds the delta updater. If you want to write or read updater, you must lock it.
+// SessionStatsCollector is a list item that holds the updater. If you want to write or read updater, you must lock it.
 type SessionStatsCollector struct {
 	sync.Mutex
 

--- a/statistics/update/update.go
+++ b/statistics/update/update.go
@@ -1,0 +1,52 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+// TableDelta stands for the changed count for one table.
+type TableDelta struct {
+	Delta int64
+	Count int64
+}
+
+// Updater is used to feed runtime statistics information back to statistics.
+type Updater map[int64]TableDelta
+
+// NewUpdater returns a new updater.
+func NewUpdater() Updater {
+	return make(Updater)
+}
+
+// UpdateDelta update delta for table.
+func (m Updater) UpdateDelta(id int64, delta int64, count int64) {
+	item := m[id]
+	item.Delta += delta
+	item.Count += count
+	m[id] = item
+}
+
+// RelatedTableIDs returns the related table IDs in the updater.
+func (m Updater) RelatedTableIDs() []int64 {
+	ids := make([]int64, 0, len(m))
+	for id := range m {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+// Merge merges two updater.
+func (m Updater) Merge(rMap Updater) {
+	for id, item := range rMap {
+		m.UpdateDelta(id, item.Delta, item.Count)
+	}
+}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -388,7 +388,7 @@ func (t *Table) AddRecord(ctx context.Context, r []types.Datum, skipHandleCheck 
 		}
 	}
 	ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
-	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.ID, 1, 1)
+	ctx.GetStatsUpdater().UpdateDelta(t.ID, 1, 1)
 	return recordID, nil
 }
 

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/statistics/update"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
 	goctx "golang.org/x/net/context"
@@ -40,6 +41,7 @@ type Context struct {
 	cancel      goctx.CancelFunc
 	sm          util.SessionManager
 	pcache      *kvcache.SimpleLRUCache
+	updater     update.Updater
 }
 
 // SetValue implements context.Context SetValue interface.
@@ -179,6 +181,11 @@ func (c *Context) GoCtx() goctx.Context {
 	return c.ctx
 }
 
+// GetStatsUpdater implements the context.Context interface.
+func (c *Context) GetStatsUpdater() update.Updater {
+	return c.updater
+}
+
 // NewContext creates a new mocked context.Context.
 func NewContext() *Context {
 	ctx, cancel := goctx.WithCancel(goctx.Background())
@@ -187,5 +194,6 @@ func NewContext() *Context {
 		sessionVars: variable.NewSessionVars(),
 		ctx:         ctx,
 		cancel:      cancel,
+		updater:     update.NewUpdater(),
 	}
 }


### PR DESCRIPTION
Because we need to store the changed data in the delta, but the `types` package depends on `sessionctx/variable` package, so this pr moves the delta into a separate package to avoid circular dependencies.