### PR TITLE
executor: fix missing index update when automatic updating for timestamp

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -120,6 +120,7 @@ func updateRecord(ctx context.Context, h int64, oldData, newData []types.Datum, 
 				return false, errors.Trace(errGT)
 			}
 			newData[i] = v
+			modified[i] = true
 		}
 	}
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -626,6 +626,18 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("update tt1 set a=5 where c='b';")
 	r = tk.MustQuery("select * from tt1;")
 	r.Check(testkit.Rows("1 a a", "5 d b"))
+
+	// Automatic Updating for TIMESTAMP
+	tk.MustExec("CREATE TABLE `tsup` (" +
+		"`a` int," +
+		"`ts` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP," +
+		"KEY `idx` (`ts`)" +
+		");")
+	tk.MustExec("insert into tsup values(1, '0000-00-00 00:00:00');")
+	tk.MustExec("update tsup set a=5;")
+	r1 := tk.MustQuery("select ts from tsup use index (idx);")
+	r2 := tk.MustQuery("select ts from tsup;")
+	r1.Check(r2.Rows())
 }
 
 // TestUpdateCastOnlyModifiedValues for issue #4514.


### PR DESCRIPTION
Fix https://github.com/pingcap/tidb/issues/5172

PTAL @hicqu @AndreMouche @hanfei1991 