### PR TITLE
*: move `StatementContext` to its own package.

### DIFF
--- a/cmd/benchfilesort/main.go
+++ b/cmd/benchfilesort/main.go
@@ -26,7 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -326,7 +326,7 @@ func driveRunCmd() {
 	cLog("Time used: ", time.Since(start))
 	cLog("=================================")
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	fsBuilder := new(filesort.Builder)
 	byDesc := make([]bool, keySize)
 	for i := 0; i < keySize; i++ {

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/plan"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mvmap"
@@ -35,7 +35,7 @@ type HashAggExec struct {
 	executed      bool
 	hasGby        bool
 	aggType       plan.AggregationType
-	sc            *variable.StatementContext
+	sc            *stmtctx.StatementContext
 	AggFuncs      []aggregation.Aggregation
 	aggCtxsMap    aggCtxsMapper
 	groupMap      *mvmap.MVMap
@@ -162,7 +162,7 @@ type StreamAggExec struct {
 
 	executed           bool
 	hasData            bool
-	StmtCtx            *variable.StatementContext
+	StmtCtx            *stmtctx.StatementContext
 	AggFuncs           []aggregation.Aggregation
 	aggCtxs            []*aggregation.AggEvaluateContext
 	GroupByItems       []expression.Expression

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
@@ -291,7 +292,7 @@ const (
 )
 
 // statementContextToFlags converts StatementContext to tipb.SelectRequest.Flags.
-func statementContextToFlags(sc *variable.StatementContext) uint64 {
+func statementContextToFlags(sc *stmtctx.StatementContext) uint64 {
 	var flags uint64
 	if sc.IgnoreTruncate {
 		flags |= FlagIgnoreTruncate

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 )
 
 // MergeJoinExec implements the merge join algorithm.
@@ -30,7 +30,7 @@ import (
 type MergeJoinExec struct {
 	baseExecutor
 
-	stmtCtx  *variable.StatementContext
+	stmtCtx  *stmtctx.StatementContext
 	prepared bool
 
 	outerKeys   []*expression.Column
@@ -50,7 +50,7 @@ const rowBufferSize = 4096
 
 // rowBlockIterator represents a row block with the same join keys
 type rowBlockIterator struct {
-	stmtCtx   *variable.StatementContext
+	stmtCtx   *stmtctx.StatementContext
 	ctx       context.Context
 	reader    Executor
 	filter    []expression.Expression
@@ -144,7 +144,7 @@ func (e *MergeJoinExec) Open() error {
 	return nil
 }
 
-func compareKeys(stmtCtx *variable.StatementContext,
+func compareKeys(stmtCtx *stmtctx.StatementContext,
 	leftRow Row, leftKeys []*expression.Column,
 	rightRow Row, rightKeys []*expression.Column) (int, error) {
 	for i, leftKey := range leftKeys {

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/plan"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
@@ -301,7 +301,7 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 // Before every execution, we must clear statement context.
 func ResetStmtCtx(ctx context.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = sessVars.GetTimeZone()
 
 	switch stmt := s.(type) {

--- a/expression/aggregation/agg_to_pb.go
+++ b/expression/aggregation/agg_to_pb.go
@@ -17,12 +17,12 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
 // AggFuncToPBExpr converts aggregate function to pb.
-func AggFuncToPBExpr(sc *variable.StatementContext, client kv.Client, aggFunc Aggregation) *tipb.Expr {
+func AggFuncToPBExpr(sc *stmtctx.StatementContext, client kv.Client, aggFunc Aggregation) *tipb.Expr {
 	if aggFunc.IsDistinct() {
 		return nil
 	}

--- a/expression/aggregation/agg_to_pb_test.go
+++ b/expression/aggregation/agg_to_pb_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tipb/go-tipb"
@@ -114,7 +114,7 @@ func (s *testEvaluatorSuite) TearDownSuite(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestAggFunc2Pb(c *C) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 

--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	tipb "github.com/pingcap/tipb/go-tipb"
 )
@@ -34,7 +34,7 @@ type Aggregation interface {
 	json.Marshaler
 
 	// Update during executing.
-	Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error
+	Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error
 
 	// GetPartialResult will called by coprocessor to get partial results. For avg function, partial results will return
 	// sum and count values at the same time.
@@ -101,7 +101,7 @@ func NewAggFunction(funcType string, funcArgs []expression.Expression, distinct 
 }
 
 // NewDistAggFunc creates new Aggregate function for mock tikv.
-func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, sc *variable.StatementContext) (Aggregation, error) {
+func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, sc *stmtctx.StatementContext) (Aggregation, error) {
 	args := make([]expression.Expression, 0, len(expr.Children))
 	for _, child := range expr.Children {
 		arg, err := expression.PBToExpr(child, fieldTps, sc)
@@ -245,7 +245,7 @@ func (af *aggFunction) CreateContext() *AggEvaluateContext {
 	return ctx
 }
 
-func (af *aggFunction) updateSum(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (af *aggFunction) updateSum(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := af.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {

--- a/expression/aggregation/avg.go
+++ b/expression/aggregation/avg.go
@@ -16,7 +16,7 @@ package aggregation
 import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 )
@@ -42,7 +42,7 @@ func (af *avgFunction) GetType() *types.FieldType {
 	return ft
 }
 
-func (af *avgFunction) updateAvg(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (af *avgFunction) updateAvg(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := af.Args[1]
 	value, err := a.Eval(row)
 	if err != nil {
@@ -73,7 +73,7 @@ func (af *avgFunction) updateAvg(ctx *AggEvaluateContext, sc *variable.Statement
 }
 
 // Update implements Aggregation interface.
-func (af *avgFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (af *avgFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	if af.mode == FinalMode {
 		return af.updateAvg(ctx, sc, row)
 	}

--- a/expression/aggregation/concat.go
+++ b/expression/aggregation/concat.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -50,7 +50,7 @@ func (cf *concatFunction) writeValue(ctx *AggEvaluateContext, val types.Datum) {
 }
 
 // Update implements Aggregation interface.
-func (cf *concatFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (cf *concatFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	datumBuf := make([]types.Datum, 0, len(cf.Args))
 	for _, a := range cf.Args {
 		value, err := a.Eval(row)

--- a/expression/aggregation/count.go
+++ b/expression/aggregation/count.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -59,7 +59,7 @@ func (cf *countFunction) GetType() *types.FieldType {
 }
 
 // Update implements Aggregation interface.
-func (cf *countFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (cf *countFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	var datumBuf []types.Datum
 	if cf.Distinct {
 		datumBuf = make([]types.Datum, 0, len(cf.Args))

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -40,7 +40,7 @@ func (ff *firstRowFunction) GetType() *types.FieldType {
 }
 
 // Update implements Aggregation interface.
-func (ff *firstRowFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (ff *firstRowFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	if ctx.GotFirstRow {
 		return nil
 	}

--- a/expression/aggregation/max_min.go
+++ b/expression/aggregation/max_min.go
@@ -17,7 +17,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -61,7 +61,7 @@ func (mmf *maxMinFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Dat
 }
 
 // Update implements Aggregation interface.
-func (mmf *maxMinFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (mmf *maxMinFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	if len(mmf.Args) != 1 {
 		return errors.New("Wrong number of args for AggFuncMaxMin")
 	}

--- a/expression/aggregation/sum.go
+++ b/expression/aggregation/sum.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 )
@@ -38,7 +38,7 @@ func (sf *sumFunction) Clone() Aggregation {
 }
 
 // Update implements Aggregation interface.
-func (sf *sumFunction) Update(ctx *AggEvaluateContext, sc *variable.StatementContext, row types.Row) error {
+func (sf *sumFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	return sf.updateSum(ctx, sc, row)
 }
 

--- a/expression/aggregation/util.go
+++ b/expression/aggregation/util.go
@@ -2,7 +2,7 @@ package aggregation
 
 import (
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mvmap"
@@ -38,7 +38,7 @@ func (d *distinctChecker) Check(values []types.Datum) (bool, error) {
 }
 
 // calculateSum adds v to sum.
-func calculateSum(sc *variable.StatementContext, sum, v types.Datum) (data types.Datum, err error) {
+func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.Datum, err error) {
 	// for avg and sum calculation
 	// avg and sum use decimal for integer and decimal type, use float for others
 	// see https://dev.mysql.com/doc/refman/5.7/en/group-by-functions.html

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tipb/go-tipb"
@@ -754,7 +754,7 @@ func (b *builtinIntervalIntSig) evalInt(row types.Row) (int64, bool, error) {
 // All arguments are treated as integers.
 // It is required that arg[0] < args[1] < args[2] < ... < args[n] for this function to work correctly.
 // This is because a binary search is used (very fast).
-func (b *builtinIntervalIntSig) binSearch(sc *variable.StatementContext, target int64, isUint1 bool, args []Expression, row types.Row) (_ int, err error) {
+func (b *builtinIntervalIntSig) binSearch(sc *stmtctx.StatementContext, target int64, isUint1 bool, args []Expression, row types.Row) (_ int, err error) {
 	i, j, cmp := 0, len(args), false
 	for i < j {
 		mid := i + (j-i)/2
@@ -805,7 +805,7 @@ func (b *builtinIntervalRealSig) evalInt(row types.Row) (int64, bool, error) {
 	return int64(idx), err != nil, errors.Trace(err)
 }
 
-func (b *builtinIntervalRealSig) binSearch(sc *variable.StatementContext, target float64, args []Expression, row types.Row) (_ int, err error) {
+func (b *builtinIntervalRealSig) binSearch(sc *stmtctx.StatementContext, target float64, args []Expression, row types.Row) (_ int, err error) {
 	i, j := 0, len(args)
 	for i < j {
 		mid := i + (j-i)/2

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tipb/go-tipb"
@@ -466,7 +466,7 @@ func (b *builtinJSONArraySig) evalJSON(row types.Row) (res json.JSON, isNull boo
 	return json.CreateJSON(jsons), false, nil
 }
 
-func jsonModify(args []Expression, row types.Row, mt json.ModifyType, sc *variable.StatementContext) (res json.JSON, isNull bool, err error) {
+func jsonModify(args []Expression, row types.Row, mt json.ModifyType, sc *stmtctx.StatementContext) (res json.JSON, isNull bool, err error) {
 	res, isNull, err = args[0].EvalJSON(row, sc)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -29,7 +29,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -1426,7 +1426,7 @@ type truncateFunctionClass struct {
 }
 
 // getDecimal returns the `Decimal` value of return type for function `TRUNCATE`.
-func (c *truncateFunctionClass) getDecimal(sc *variable.StatementContext, arg Expression) int {
+func (c *truncateFunctionClass) getDecimal(sc *stmtctx.StatementContext, arg Expression) int {
 	if constant, ok := arg.(*Constant); ok {
 		decimal, isNull, err := constant.EvalInt(nil, sc)
 		if isNull || err != nil {

--- a/expression/builtin_other_test.go
+++ b/expression/builtin_other_test.go
@@ -21,7 +21,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/hack"
@@ -66,7 +66,7 @@ func (s *testEvaluatorSuite) TestBitCount(c *C) {
 			c.Assert(test.count, IsNil)
 			continue
 		}
-		sc := new(variable.StatementContext)
+		sc := new(stmtctx.StatementContext)
 		sc.IgnoreTruncate = true
 		res, err := count.ToInt64(sc)
 		c.Assert(err, IsNil)

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
@@ -1550,7 +1550,7 @@ func trimRight(str, remstr string) string {
 	}
 }
 
-func getFlen4LpadAndRpad(sc *variable.StatementContext, arg Expression) int {
+func getFlen4LpadAndRpad(sc *stmtctx.StatementContext, arg Expression) int {
 	if constant, ok := arg.(*Constant); ok {
 		length, isNull, err := constant.EvalInt(nil, sc)
 		if err != nil {
@@ -2061,7 +2061,7 @@ type makeSetFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *makeSetFunctionClass) getFlen(sc *variable.StatementContext, args []Expression) int {
+func (c *makeSetFunctionClass) getFlen(sc *stmtctx.StatementContext, args []Expression) int {
 	flen, count := 0, 0
 	if constant, ok := args[0].(*Constant); ok {
 		bits, isNull, err := constant.EvalInt(nil, sc)

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -30,7 +30,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 )
@@ -521,7 +521,7 @@ func (b *builtinStringDurationTimeDiffSig) evalDuration(row types.Row) (d types.
 }
 
 // calculateTimeDiff calculates interval difference of two types.Time.
-func calculateTimeDiff(sc *variable.StatementContext, lhs, rhs types.Time) (d types.Duration, isNull bool, err error) {
+func calculateTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Time) (d types.Duration, isNull bool, err error) {
 	d = lhs.Sub(&rhs)
 	d.Duration, err = types.TruncateOverflowMySQLTime(d.Duration)
 	if types.ErrTruncatedWrongVal.Equal(err) {
@@ -531,7 +531,7 @@ func calculateTimeDiff(sc *variable.StatementContext, lhs, rhs types.Time) (d ty
 }
 
 // calculateTimeDiff calculates interval difference of two types.Duration.
-func calculateDurationTimeDiff(sc *variable.StatementContext, lhs, rhs types.Duration) (d types.Duration, isNull bool, err error) {
+func calculateDurationTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Duration) (d types.Duration, isNull bool, err error) {
 	d, err = lhs.Sub(rhs)
 	if err != nil {
 		return d, true, errors.Trace(err)
@@ -652,7 +652,7 @@ func (b *builtinNullTimeDiffSig) evalDuration(row types.Row) (d types.Duration, 
 
 // convertStringToDuration converts string to duration, it return types.Time because in some case
 // it will converts string to datetime.
-func convertStringToDuration(sc *variable.StatementContext, str string, fsp int) (d types.Duration, t types.Time,
+func convertStringToDuration(sc *stmtctx.StatementContext, str string, fsp int) (d types.Duration, t types.Time,
 	isDuration bool, err error) {
 	if n := strings.IndexByte(str, '.'); n >= 0 {
 		lenStrFsp := len(str[n+1:])
@@ -1920,7 +1920,7 @@ type utcTimestampFunctionClass struct {
 	baseFunctionClass
 }
 
-func getFlenAndDecimal4UTCTimestampAndNow(sc *variable.StatementContext, arg Expression) (flen, decimal int) {
+func getFlenAndDecimal4UTCTimestampAndNow(sc *stmtctx.StatementContext, arg Expression) (flen, decimal int) {
 	if constant, ok := arg.(*Constant); ok {
 		fsp, isNull, err := constant.EvalInt(nil, sc)
 		if isNull || err != nil || fsp > int64(types.MaxFsp) {
@@ -3192,7 +3192,7 @@ func isDuration(str string) bool {
 }
 
 // strDatetimeAddDuration adds duration to datetime string, returns a string value.
-func strDatetimeAddDuration(sc *variable.StatementContext, d string, arg1 types.Duration) (string, error) {
+func strDatetimeAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseTime(sc, d, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -3210,7 +3210,7 @@ func strDatetimeAddDuration(sc *variable.StatementContext, d string, arg1 types.
 }
 
 // strDurationAddDuration adds duration to duration string, returns a string value.
-func strDurationAddDuration(sc *variable.StatementContext, d string, arg1 types.Duration) (string, error) {
+func strDurationAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseDuration(d, types.MaxFsp)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -3227,7 +3227,7 @@ func strDurationAddDuration(sc *variable.StatementContext, d string, arg1 types.
 }
 
 // strDatetimeSubDuration subtracts duration from datetime string, returns a string value.
-func strDatetimeSubDuration(sc *variable.StatementContext, d string, arg1 types.Duration) (string, error) {
+func strDatetimeSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseTime(sc, d, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -3250,7 +3250,7 @@ func strDatetimeSubDuration(sc *variable.StatementContext, d string, arg1 types.
 }
 
 // strDurationSubDuration subtracts duration from duration string, returns a string value.
-func strDurationSubDuration(sc *variable.StatementContext, d string, arg1 types.Duration) (string, error) {
+func strDurationSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseDuration(d, types.MaxFsp)
 	if err != nil {
 		return "", errors.Trace(err)
@@ -4565,7 +4565,7 @@ type utcTimeFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *utcTimeFunctionClass) getFlenAndDecimal4UTCTime(sc *variable.StatementContext, args []Expression) (flen, decimal int) {
+func (c *utcTimeFunctionClass) getFlenAndDecimal4UTCTime(sc *stmtctx.StatementContext, args []Expression) (flen, decimal int) {
 	if len(args) == 0 {
 		flen, decimal = 8, 0
 		return

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
@@ -911,7 +911,7 @@ func (s *testEvaluatorSuite) TestSysDate(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func convertToTimeWithFsp(sc *variable.StatementContext, arg types.Datum, tp byte, fsp int) (d types.Datum, err error) {
+func convertToTimeWithFsp(sc *stmtctx.StatementContext, arg types.Datum, tp byte, fsp int) (d types.Datum, err error) {
 	if fsp > types.MaxFsp {
 		fsp = types.MaxFsp
 	}
@@ -936,7 +936,7 @@ func convertToTimeWithFsp(sc *variable.StatementContext, arg types.Datum, tp byt
 	return
 }
 
-func convertToTime(sc *variable.StatementContext, arg types.Datum, tp byte) (d types.Datum, err error) {
+func convertToTime(sc *stmtctx.StatementContext, arg types.Datum, tp byte) (d types.Datum, err error) {
 	return convertToTimeWithFsp(sc, arg, tp, types.MaxFsp)
 }
 

--- a/expression/column.go
+++ b/expression/column.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/codec"
@@ -47,7 +47,7 @@ func (col *CorrelatedColumn) Eval(row types.Row) (types.Datum, error) {
 }
 
 // EvalInt returns int representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalInt(row types.Row, sc *variable.StatementContext) (int64, bool, error) {
+func (col *CorrelatedColumn) EvalInt(row types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
 	if col.Data.IsNull() {
 		return 0, true, nil
 	}
@@ -59,7 +59,7 @@ func (col *CorrelatedColumn) EvalInt(row types.Row, sc *variable.StatementContex
 }
 
 // EvalReal returns real representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalReal(row types.Row, sc *variable.StatementContext) (float64, bool, error) {
+func (col *CorrelatedColumn) EvalReal(row types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
 	if col.Data.IsNull() {
 		return 0, true, nil
 	}
@@ -71,7 +71,7 @@ func (col *CorrelatedColumn) EvalReal(row types.Row, sc *variable.StatementConte
 }
 
 // EvalString returns string representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalString(row types.Row, sc *variable.StatementContext) (string, bool, error) {
+func (col *CorrelatedColumn) EvalString(row types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
 	if col.Data.IsNull() {
 		return "", true, nil
 	}
@@ -84,7 +84,7 @@ func (col *CorrelatedColumn) EvalString(row types.Row, sc *variable.StatementCon
 }
 
 // EvalDecimal returns decimal representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalDecimal(row types.Row, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
+func (col *CorrelatedColumn) EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
 	if col.Data.IsNull() {
 		return nil, true, nil
 	}
@@ -96,7 +96,7 @@ func (col *CorrelatedColumn) EvalDecimal(row types.Row, sc *variable.StatementCo
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalTime(row types.Row, sc *variable.StatementContext) (types.Time, bool, error) {
+func (col *CorrelatedColumn) EvalTime(row types.Row, sc *stmtctx.StatementContext) (types.Time, bool, error) {
 	if col.Data.IsNull() {
 		return types.Time{}, true, nil
 	}
@@ -104,7 +104,7 @@ func (col *CorrelatedColumn) EvalTime(row types.Row, sc *variable.StatementConte
 }
 
 // EvalDuration returns Duration representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalDuration(row types.Row, sc *variable.StatementContext) (types.Duration, bool, error) {
+func (col *CorrelatedColumn) EvalDuration(row types.Row, sc *stmtctx.StatementContext) (types.Duration, bool, error) {
 	if col.Data.IsNull() {
 		return types.Duration{}, true, nil
 	}
@@ -112,7 +112,7 @@ func (col *CorrelatedColumn) EvalDuration(row types.Row, sc *variable.StatementC
 }
 
 // EvalJSON returns JSON representation of CorrelatedColumn.
-func (col *CorrelatedColumn) EvalJSON(row types.Row, sc *variable.StatementContext) (json.JSON, bool, error) {
+func (col *CorrelatedColumn) EvalJSON(row types.Row, sc *stmtctx.StatementContext) (json.JSON, bool, error) {
 	if col.Data.IsNull() {
 		return json.JSON{}, true, nil
 	}
@@ -204,7 +204,7 @@ func (col *Column) Eval(row types.Row) (types.Datum, error) {
 }
 
 // EvalInt returns int representation of Column.
-func (col *Column) EvalInt(row types.Row, sc *variable.StatementContext) (int64, bool, error) {
+func (col *Column) EvalInt(row types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
 	if col.GetType().Hybrid() {
 		val := row.GetDatum(col.Index, col.RetType)
 		if val.IsNull() {
@@ -220,7 +220,7 @@ func (col *Column) EvalInt(row types.Row, sc *variable.StatementContext) (int64,
 }
 
 // EvalReal returns real representation of Column.
-func (col *Column) EvalReal(row types.Row, sc *variable.StatementContext) (float64, bool, error) {
+func (col *Column) EvalReal(row types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
 	if row.IsNull(col.Index) {
 		return 0, true, nil
 	}
@@ -236,7 +236,7 @@ func (col *Column) EvalReal(row types.Row, sc *variable.StatementContext) (float
 }
 
 // EvalString returns string representation of Column.
-func (col *Column) EvalString(row types.Row, sc *variable.StatementContext) (string, bool, error) {
+func (col *Column) EvalString(row types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
 	if col.GetType().Hybrid() {
 		val := row.GetDatum(col.Index, col.RetType)
 		if val.IsNull() {
@@ -263,7 +263,7 @@ func (col *Column) EvalString(row types.Row, sc *variable.StatementContext) (str
 }
 
 // EvalDecimal returns decimal representation of Column.
-func (col *Column) EvalDecimal(row types.Row, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
+func (col *Column) EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
 	val := row.GetDatum(col.Index, col.RetType)
 	if val.IsNull() {
 		return nil, true, nil
@@ -281,7 +281,7 @@ func (col *Column) EvalDecimal(row types.Row, sc *variable.StatementContext) (*t
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Column.
-func (col *Column) EvalTime(row types.Row, sc *variable.StatementContext) (types.Time, bool, error) {
+func (col *Column) EvalTime(row types.Row, sc *stmtctx.StatementContext) (types.Time, bool, error) {
 	if row.IsNull(col.Index) {
 		return types.Time{}, true, nil
 	}
@@ -289,7 +289,7 @@ func (col *Column) EvalTime(row types.Row, sc *variable.StatementContext) (types
 }
 
 // EvalDuration returns Duration representation of Column.
-func (col *Column) EvalDuration(row types.Row, sc *variable.StatementContext) (types.Duration, bool, error) {
+func (col *Column) EvalDuration(row types.Row, sc *stmtctx.StatementContext) (types.Duration, bool, error) {
 	if row.IsNull(col.Index) {
 		return types.Duration{}, true, nil
 	}
@@ -297,7 +297,7 @@ func (col *Column) EvalDuration(row types.Row, sc *variable.StatementContext) (t
 }
 
 // EvalJSON returns JSON representation of Column.
-func (col *Column) EvalJSON(row types.Row, sc *variable.StatementContext) (json.JSON, bool, error) {
+func (col *Column) EvalJSON(row types.Row, sc *stmtctx.StatementContext) (json.JSON, bool, error) {
 	if row.IsNull(col.Index) {
 		return json.JSON{}, true, nil
 	}

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -112,7 +112,7 @@ func (c *Constant) Eval(_ types.Row) (types.Datum, error) {
 }
 
 // EvalInt returns int representation of Constant.
-func (c *Constant) EvalInt(_ types.Row, sc *variable.StatementContext) (int64, bool, error) {
+func (c *Constant) EvalInt(_ types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -139,7 +139,7 @@ func (c *Constant) EvalInt(_ types.Row, sc *variable.StatementContext) (int64, b
 }
 
 // EvalReal returns real representation of Constant.
-func (c *Constant) EvalReal(_ types.Row, sc *variable.StatementContext) (float64, bool, error) {
+func (c *Constant) EvalReal(_ types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -166,7 +166,7 @@ func (c *Constant) EvalReal(_ types.Row, sc *variable.StatementContext) (float64
 }
 
 // EvalString returns string representation of Constant.
-func (c *Constant) EvalString(_ types.Row, sc *variable.StatementContext) (string, bool, error) {
+func (c *Constant) EvalString(_ types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -190,7 +190,7 @@ func (c *Constant) EvalString(_ types.Row, sc *variable.StatementContext) (strin
 }
 
 // EvalDecimal returns decimal representation of Constant.
-func (c *Constant) EvalDecimal(_ types.Row, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
+func (c *Constant) EvalDecimal(_ types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -210,7 +210,7 @@ func (c *Constant) EvalDecimal(_ types.Row, sc *variable.StatementContext) (*typ
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.
-func (c *Constant) EvalTime(_ types.Row, sc *variable.StatementContext) (val types.Time, isNull bool, err error) {
+func (c *Constant) EvalTime(_ types.Row, sc *stmtctx.StatementContext) (val types.Time, isNull bool, err error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -237,7 +237,7 @@ func (c *Constant) EvalTime(_ types.Row, sc *variable.StatementContext) (val typ
 }
 
 // EvalDuration returns Duration representation of Constant.
-func (c *Constant) EvalDuration(_ types.Row, sc *variable.StatementContext) (val types.Duration, isNull bool, err error) {
+func (c *Constant) EvalDuration(_ types.Row, sc *stmtctx.StatementContext) (val types.Duration, isNull bool, err error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -264,7 +264,7 @@ func (c *Constant) EvalDuration(_ types.Row, sc *variable.StatementContext) (val
 }
 
 // EvalJSON returns JSON representation of Constant.
-func (c *Constant) EvalJSON(_ types.Row, sc *variable.StatementContext) (json.JSON, bool, error) {
+func (c *Constant) EvalJSON(_ types.Row, sc *stmtctx.StatementContext) (json.JSON, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mock"
@@ -507,7 +507,7 @@ func getSignatureByPB(ctx context.Context, sigCode tipb.ScalarFuncSig, tp *tipb.
 	return f, nil
 }
 
-func newDistSQLFunctionBySig(sc *variable.StatementContext, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression) (Expression, error) {
+func newDistSQLFunctionBySig(sc *stmtctx.StatementContext, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression) (Expression, error) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx = sc
 	f, err := getSignatureByPB(ctx, sigCode, tp, args)
@@ -522,7 +522,7 @@ func newDistSQLFunctionBySig(sc *variable.StatementContext, sigCode tipb.ScalarF
 }
 
 // newDistSQLFunction only creates function for mock-tikv.
-func newDistSQLFunction(sc *variable.StatementContext, exprType tipb.ExprType, args []Expression) (Expression, error) {
+func newDistSQLFunction(sc *stmtctx.StatementContext, exprType tipb.ExprType, args []Expression) (Expression, error) {
 	name, ok := distFuncs[exprType]
 	if !ok {
 		return nil, errFunctionNotExists.GenByArgs("FUNCTION", exprType)
@@ -534,7 +534,7 @@ func newDistSQLFunction(sc *variable.StatementContext, exprType tipb.ExprType, a
 }
 
 // PBToExpr converts pb structure to expression.
-func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *variable.StatementContext) (Expression, error) {
+func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *stmtctx.StatementContext) (Expression, error) {
 	switch expr.Tp {
 	case tipb.ExprType_ColumnRef:
 		_, offset, err := codec.DecodeInt(expr.Val)

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -18,7 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
@@ -273,7 +273,7 @@ func (s *testEvalSuite) TestEval(c *C) {
 			types.NewFloat64Datum(1.1),
 		},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
 		expr, err := PBToExpr(tt.expr, fieldTps, sc)
 		c.Assert(err, IsNil)
@@ -372,7 +372,7 @@ func (s *testEvalSuite) TestEvalIsNull(c *C) {
 			result: falseAns,
 		},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
 		expr, err := PBToExpr(tt.expr, nil, sc)
 		c.Assert(err, IsNil, Commentf("%v", tt))

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -29,7 +29,7 @@ import (
 )
 
 // ExpressionsToPB converts expression to tipb.Expr.
-func ExpressionsToPB(sc *variable.StatementContext, exprs []Expression, client kv.Client) (pbExpr *tipb.Expr, pushed []Expression, remained []Expression) {
+func ExpressionsToPB(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client) (pbExpr *tipb.Expr, pushed []Expression, remained []Expression) {
 	pc := PbConverter{client: client, sc: sc}
 	for _, expr := range exprs {
 		v := pc.ExprToPB(expr)
@@ -51,7 +51,7 @@ func ExpressionsToPB(sc *variable.StatementContext, exprs []Expression, client k
 }
 
 // ExpressionsToPBList converts expressions to tipb.Expr list for new plan.
-func ExpressionsToPBList(sc *variable.StatementContext, exprs []Expression, client kv.Client) (pbExpr []*tipb.Expr) {
+func ExpressionsToPBList(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client) (pbExpr []*tipb.Expr) {
 	pc := PbConverter{client: client, sc: sc}
 	for _, expr := range exprs {
 		v := pc.ExprToPB(expr)
@@ -63,11 +63,11 @@ func ExpressionsToPBList(sc *variable.StatementContext, exprs []Expression, clie
 // PbConverter supplys methods to convert TiDB expressions to TiPB.
 type PbConverter struct {
 	client kv.Client
-	sc     *variable.StatementContext
+	sc     *stmtctx.StatementContext
 }
 
 // NewPBConverter creates a PbConverter.
-func NewPBConverter(client kv.Client, sc *variable.StatementContext) PbConverter {
+func NewPBConverter(client kv.Client, sc *stmtctx.StatementContext) PbConverter {
 	return PbConverter{client: client, sc: sc}
 }
 
@@ -307,7 +307,7 @@ func (pc PbConverter) jsonFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 }
 
 // GroupByItemToPB converts group by items to pb.
-func GroupByItemToPB(sc *variable.StatementContext, client kv.Client, expr Expression) *tipb.ByItem {
+func GroupByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression) *tipb.ByItem {
 	pc := PbConverter{client: client, sc: sc}
 	e := pc.ExprToPB(expr)
 	if e == nil {
@@ -317,7 +317,7 @@ func GroupByItemToPB(sc *variable.StatementContext, client kv.Client, expr Expre
 }
 
 // SortByItemToPB converts order by items to pb.
-func SortByItemToPB(sc *variable.StatementContext, client kv.Client, expr Expression, desc bool) *tipb.ByItem {
+func SortByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression, desc bool) *tipb.ByItem {
 	pc := PbConverter{client: client, sc: sc}
 	e := pc.ExprToPB(expr)
 	if e == nil {

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/mock"
@@ -93,7 +93,7 @@ func (dg *dataGen4Expr2PbTest) genColumn(tp byte, id int64) *Column {
 func (s *testEvaluatorSuite) TestConstant2Pb(c *C) {
 	c.Skip("constant pb has changed")
 	var constExprs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 
 	// can be transformed
@@ -178,7 +178,7 @@ func (s *testEvaluatorSuite) TestConstant2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestColumn2Pb(c *C) {
 	var colExprs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -280,7 +280,7 @@ func (s *testEvaluatorSuite) TestColumn2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestCompareFunc2Pb(c *C) {
 	var compareExprs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -320,7 +320,7 @@ func (s *testEvaluatorSuite) TestCompareFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestLikeFunc2Pb(c *C) {
 	var likeFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 
 	retTp := types.NewFieldType(mysql.TypeString)
@@ -352,7 +352,7 @@ func (s *testEvaluatorSuite) TestLikeFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestArithmeticalFunc2Pb(c *C) {
 	var arithmeticalFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -388,7 +388,7 @@ func (s *testEvaluatorSuite) TestArithmeticalFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestLogicalFunc2Pb(c *C) {
 	var logicalFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -424,7 +424,7 @@ func (s *testEvaluatorSuite) TestLogicalFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestBitwiseFunc2Pb(c *C) {
 	var bitwiseFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -454,7 +454,7 @@ func (s *testEvaluatorSuite) TestBitwiseFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestControlFunc2Pb(c *C) {
 	var controlFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -495,7 +495,7 @@ func (s *testEvaluatorSuite) TestControlFunc2Pb(c *C) {
 
 func (s *testEvaluatorSuite) TestOtherFunc2Pb(c *C) {
 	var otherFuncs []Expression
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 
@@ -520,7 +520,7 @@ func (s *testEvaluatorSuite) TestOtherFunc2Pb(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestGroupByItem2Pb(c *C) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 	item := dg.genColumn(mysql.TypeDouble, 0)
@@ -537,7 +537,7 @@ func (s *testEvaluatorSuite) TestGroupByItem2Pb(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestSortByItem2Pb(c *C) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	client := new(mockKvClient)
 	dg := new(dataGen4Expr2PbTest)
 	item := dg.genColumn(mysql.TypeDouble, 0)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -40,25 +40,25 @@ type Expression interface {
 	Eval(row types.Row) (types.Datum, error)
 
 	// EvalInt returns the int64 representation of expression.
-	EvalInt(row types.Row, sc *variable.StatementContext) (val int64, isNull bool, err error)
+	EvalInt(row types.Row, sc *stmtctx.StatementContext) (val int64, isNull bool, err error)
 
 	// EvalReal returns the float64 representation of expression.
-	EvalReal(row types.Row, sc *variable.StatementContext) (val float64, isNull bool, err error)
+	EvalReal(row types.Row, sc *stmtctx.StatementContext) (val float64, isNull bool, err error)
 
 	// EvalString returns the string representation of expression.
-	EvalString(row types.Row, sc *variable.StatementContext) (val string, isNull bool, err error)
+	EvalString(row types.Row, sc *stmtctx.StatementContext) (val string, isNull bool, err error)
 
 	// EvalDecimal returns the decimal representation of expression.
-	EvalDecimal(row types.Row, sc *variable.StatementContext) (val *types.MyDecimal, isNull bool, err error)
+	EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (val *types.MyDecimal, isNull bool, err error)
 
 	// EvalTime returns the DATE/DATETIME/TIMESTAMP representation of expression.
-	EvalTime(row types.Row, sc *variable.StatementContext) (val types.Time, isNull bool, err error)
+	EvalTime(row types.Row, sc *stmtctx.StatementContext) (val types.Time, isNull bool, err error)
 
 	// EvalDuration returns the duration representation of expression.
-	EvalDuration(row types.Row, sc *variable.StatementContext) (val types.Duration, isNull bool, err error)
+	EvalDuration(row types.Row, sc *stmtctx.StatementContext) (val types.Duration, isNull bool, err error)
 
 	// EvalJSON returns the JSON representation of expression.
-	EvalJSON(row types.Row, sc *variable.StatementContext) (val json.JSON, isNull bool, err error)
+	EvalJSON(row types.Row, sc *stmtctx.StatementContext) (val json.JSON, isNull bool, err error)
 
 	// GetType gets the type that the expression returns.
 	GetType() *types.FieldType

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -219,37 +219,37 @@ func (sf *ScalarFunction) Eval(row types.Row) (d types.Datum, err error) {
 }
 
 // EvalInt implements Expression interface.
-func (sf *ScalarFunction) EvalInt(row types.Row, sc *variable.StatementContext) (int64, bool, error) {
+func (sf *ScalarFunction) EvalInt(row types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
 	return sf.Function.evalInt(row)
 }
 
 // EvalReal implements Expression interface.
-func (sf *ScalarFunction) EvalReal(row types.Row, sc *variable.StatementContext) (float64, bool, error) {
+func (sf *ScalarFunction) EvalReal(row types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
 	return sf.Function.evalReal(row)
 }
 
 // EvalDecimal implements Expression interface.
-func (sf *ScalarFunction) EvalDecimal(row types.Row, sc *variable.StatementContext) (*types.MyDecimal, bool, error) {
+func (sf *ScalarFunction) EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
 	return sf.Function.evalDecimal(row)
 }
 
 // EvalString implements Expression interface.
-func (sf *ScalarFunction) EvalString(row types.Row, sc *variable.StatementContext) (string, bool, error) {
+func (sf *ScalarFunction) EvalString(row types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
 	return sf.Function.evalString(row)
 }
 
 // EvalTime implements Expression interface.
-func (sf *ScalarFunction) EvalTime(row types.Row, sc *variable.StatementContext) (types.Time, bool, error) {
+func (sf *ScalarFunction) EvalTime(row types.Row, sc *stmtctx.StatementContext) (types.Time, bool, error) {
 	return sf.Function.evalTime(row)
 }
 
 // EvalDuration implements Expression interface.
-func (sf *ScalarFunction) EvalDuration(row types.Row, sc *variable.StatementContext) (types.Duration, bool, error) {
+func (sf *ScalarFunction) EvalDuration(row types.Row, sc *stmtctx.StatementContext) (types.Duration, bool, error) {
 	return sf.Function.evalDuration(row)
 }
 
 // EvalJSON implements Expression interface.
-func (sf *ScalarFunction) EvalJSON(row types.Row, sc *variable.StatementContext) (json.JSON, bool, error) {
+func (sf *ScalarFunction) EvalJSON(row types.Row, sc *stmtctx.StatementContext) (json.JSON, bool, error) {
 	return sf.Function.evalJSON(row)
 }
 

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -15,6 +15,8 @@ package mysql_test
 
 import (
 	"flag"
+	"testing"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/kv"
@@ -24,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/mock-tikv"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
-	"testing"
 )
 
 func TestT(t *testing.T) {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
@@ -683,7 +683,7 @@ func (b *planBuilder) buildSort(p LogicalPlan, byItems []*ast.ByItem, aggMapper 
 // getUintForLimitOffset gets uint64 value for limit/offset.
 // For ordinary statement, limit/offset should be uint64 constant value.
 // For prepared statement, limit/offset is string. We should convert it to uint64.
-func getUintForLimitOffset(sc *variable.StatementContext, val interface{}) (uint64, error) {
+func getUintForLimitOffset(sc *stmtctx.StatementContext, val interface{}) (uint64, error) {
 	switch v := val.(type) {
 	case uint64:
 		return v, nil

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -331,7 +331,7 @@ func (p *PhysicalIndexScan) Copy() PhysicalPlan {
 }
 
 // IsPointGetByUniqueKey checks whether is a point get by unique key.
-func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sc *variable.StatementContext) bool {
+func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sc *stmtctx.StatementContext) bool {
 	return len(p.Ranges) == 1 &&
 		p.Index.Unique &&
 		len(p.Ranges[0].LowVal) == len(p.Index.Columns) &&

--- a/session.go
+++ b/session.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/statistics"
@@ -94,7 +95,7 @@ var (
 type stmtRecord struct {
 	stmtID  uint32
 	st      ast.Statement
-	stmtCtx *variable.StatementContext
+	stmtCtx *stmtctx.StatementContext
 	params  []interface{}
 }
 
@@ -104,7 +105,7 @@ type StmtHistory struct {
 }
 
 // Add appends a stmt to history list.
-func (h *StmtHistory) Add(stmtID uint32, st ast.Statement, stmtCtx *variable.StatementContext, params ...interface{}) {
+func (h *StmtHistory) Add(stmtID uint32, st ast.Statement, stmtCtx *stmtctx.StatementContext, params ...interface{}) {
 	s := &stmtRecord{
 		stmtID:  stmtID,
 		st:      st,

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -1,0 +1,174 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stmtctx
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/pingcap/tidb/mysql"
+)
+
+// StatementContext contains variables for a statement.
+// It should be reset before executing a statement.
+type StatementContext struct {
+	// Set the following variables before execution
+
+	InInsertStmt           bool
+	InUpdateOrDeleteStmt   bool
+	InSelectStmt           bool
+	IgnoreTruncate         bool
+	IgnoreZeroInDate       bool
+	DividedByZeroAsWarning bool
+	TruncateAsWarning      bool
+	OverflowAsWarning      bool
+	InShowWarning          bool
+	UseCache               bool
+	PadCharToFullLength    bool
+
+	// mu struct holds variables that change during execution.
+	mu struct {
+		sync.Mutex
+		affectedRows      uint64
+		foundRows         uint64
+		warnings          []error
+		histogramsNotLoad bool
+	}
+
+	// Copied from SessionVars.TimeZone.
+	TimeZone     *time.Location
+	Priority     mysql.PriorityEnum
+	NotFillCache bool
+}
+
+// AddAffectedRows adds affected rows.
+func (sc *StatementContext) AddAffectedRows(rows uint64) {
+	sc.mu.Lock()
+	sc.mu.affectedRows += rows
+	sc.mu.Unlock()
+}
+
+// AffectedRows gets affected rows.
+func (sc *StatementContext) AffectedRows() uint64 {
+	sc.mu.Lock()
+	rows := sc.mu.affectedRows
+	sc.mu.Unlock()
+	return rows
+}
+
+// FoundRows gets found rows.
+func (sc *StatementContext) FoundRows() uint64 {
+	sc.mu.Lock()
+	rows := sc.mu.foundRows
+	sc.mu.Unlock()
+	return rows
+}
+
+// AddFoundRows adds found rows.
+func (sc *StatementContext) AddFoundRows(rows uint64) {
+	sc.mu.Lock()
+	sc.mu.foundRows += rows
+	sc.mu.Unlock()
+}
+
+// GetWarnings gets warnings.
+func (sc *StatementContext) GetWarnings() []error {
+	sc.mu.Lock()
+	warns := make([]error, len(sc.mu.warnings))
+	copy(warns, sc.mu.warnings)
+	sc.mu.Unlock()
+	return warns
+}
+
+// WarningCount gets warning count.
+func (sc *StatementContext) WarningCount() uint16 {
+	if sc.InShowWarning {
+		return 0
+	}
+	sc.mu.Lock()
+	wc := uint16(len(sc.mu.warnings))
+	sc.mu.Unlock()
+	return wc
+}
+
+// SetWarnings sets warnings.
+func (sc *StatementContext) SetWarnings(warns []error) {
+	sc.mu.Lock()
+	sc.mu.warnings = warns
+	sc.mu.Unlock()
+}
+
+// AppendWarning appends a warning.
+func (sc *StatementContext) AppendWarning(warn error) {
+	sc.mu.Lock()
+	if len(sc.mu.warnings) < math.MaxUint16 {
+		sc.mu.warnings = append(sc.mu.warnings, warn)
+	}
+	sc.mu.Unlock()
+}
+
+// SetHistogramsNotLoad sets histogramsNotLoad.
+func (sc *StatementContext) SetHistogramsNotLoad() {
+	sc.mu.Lock()
+	sc.mu.histogramsNotLoad = true
+	sc.mu.Unlock()
+}
+
+// HistogramsNotLoad gets histogramsNotLoad.
+func (sc *StatementContext) HistogramsNotLoad() bool {
+	sc.mu.Lock()
+	notLoad := sc.mu.histogramsNotLoad
+	sc.mu.Unlock()
+	return notLoad
+}
+
+// HandleTruncate ignores or returns the error based on the StatementContext state.
+func (sc *StatementContext) HandleTruncate(err error) error {
+	// TODO: At present we have not checked whether the error can be ignored or treated as warning.
+	// We will do that later, and then append WarnDataTruncated instead of the error itself.
+	if err == nil {
+		return nil
+	}
+	if sc.IgnoreTruncate {
+		return nil
+	}
+	if sc.TruncateAsWarning {
+		sc.AppendWarning(err)
+		return nil
+	}
+	return err
+}
+
+// HandleOverflow treats ErrOverflow as warnings or returns the error based on the StmtCtx.OverflowAsWarning state.
+func (sc *StatementContext) HandleOverflow(err error, warnErr error) error {
+	if err == nil {
+		return nil
+	}
+
+	if sc.OverflowAsWarning {
+		sc.AppendWarning(warnErr)
+		return nil
+	}
+	return err
+}
+
+// ResetForRetry resets the changed states during execution.
+func (sc *StatementContext) ResetForRetry() {
+	sc.mu.Lock()
+	sc.mu.affectedRows = 0
+	sc.mu.foundRows = 0
+	sc.mu.warnings = nil
+	sc.mu.Unlock()
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -15,11 +15,11 @@ package variable
 
 import (
 	"crypto/tls"
-	"math"
 	"sync"
 	"time"
 
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/auth"
 )
@@ -174,7 +174,7 @@ type SessionVars struct {
 	LastFoundRows uint64
 
 	// StmtCtx holds variables for current executing statement.
-	StmtCtx *StatementContext
+	StmtCtx *stmtctx.StatementContext
 
 	// AllowAggPushDown can be set to false to forbid aggregation push down.
 	AllowAggPushDown bool
@@ -240,7 +240,7 @@ func NewSessionVars() *SessionVars {
 		RetryInfo:                  &RetryInfo{},
 		StrictSQLMode:              true,
 		Status:                     mysql.ServerStatusAutocommit,
-		StmtCtx:                    new(StatementContext),
+		StmtCtx:                    new(stmtctx.StatementContext),
 		AllowAggPushDown:           false,
 		BuildStatsConcurrencyVar:   DefBuildStatsConcurrency,
 		IndexJoinBatchSize:         DefIndexJoinBatchSize,
@@ -340,156 +340,4 @@ const (
 type TableDelta struct {
 	Delta int64
 	Count int64
-}
-
-// StatementContext contains variables for a statement.
-// It should be reset before executing a statement.
-type StatementContext struct {
-	// Set the following variables before execution
-
-	InInsertStmt           bool
-	InUpdateOrDeleteStmt   bool
-	InSelectStmt           bool
-	IgnoreTruncate         bool
-	IgnoreZeroInDate       bool
-	DividedByZeroAsWarning bool
-	TruncateAsWarning      bool
-	OverflowAsWarning      bool
-	InShowWarning          bool
-	UseCache               bool
-	PadCharToFullLength    bool
-
-	// mu struct holds variables that change during execution.
-	mu struct {
-		sync.Mutex
-		affectedRows      uint64
-		foundRows         uint64
-		warnings          []error
-		histogramsNotLoad bool
-	}
-
-	// Copied from SessionVars.TimeZone.
-	TimeZone     *time.Location
-	Priority     mysql.PriorityEnum
-	NotFillCache bool
-}
-
-// AddAffectedRows adds affected rows.
-func (sc *StatementContext) AddAffectedRows(rows uint64) {
-	sc.mu.Lock()
-	sc.mu.affectedRows += rows
-	sc.mu.Unlock()
-}
-
-// AffectedRows gets affected rows.
-func (sc *StatementContext) AffectedRows() uint64 {
-	sc.mu.Lock()
-	rows := sc.mu.affectedRows
-	sc.mu.Unlock()
-	return rows
-}
-
-// FoundRows gets found rows.
-func (sc *StatementContext) FoundRows() uint64 {
-	sc.mu.Lock()
-	rows := sc.mu.foundRows
-	sc.mu.Unlock()
-	return rows
-}
-
-// AddFoundRows adds found rows.
-func (sc *StatementContext) AddFoundRows(rows uint64) {
-	sc.mu.Lock()
-	sc.mu.foundRows += rows
-	sc.mu.Unlock()
-}
-
-// GetWarnings gets warnings.
-func (sc *StatementContext) GetWarnings() []error {
-	sc.mu.Lock()
-	warns := make([]error, len(sc.mu.warnings))
-	copy(warns, sc.mu.warnings)
-	sc.mu.Unlock()
-	return warns
-}
-
-// WarningCount gets warning count.
-func (sc *StatementContext) WarningCount() uint16 {
-	if sc.InShowWarning {
-		return 0
-	}
-	sc.mu.Lock()
-	wc := uint16(len(sc.mu.warnings))
-	sc.mu.Unlock()
-	return wc
-}
-
-// SetWarnings sets warnings.
-func (sc *StatementContext) SetWarnings(warns []error) {
-	sc.mu.Lock()
-	sc.mu.warnings = warns
-	sc.mu.Unlock()
-}
-
-// AppendWarning appends a warning.
-func (sc *StatementContext) AppendWarning(warn error) {
-	sc.mu.Lock()
-	if len(sc.mu.warnings) < math.MaxUint16 {
-		sc.mu.warnings = append(sc.mu.warnings, warn)
-	}
-	sc.mu.Unlock()
-}
-
-// SetHistogramsNotLoad sets histogramsNotLoad.
-func (sc *StatementContext) SetHistogramsNotLoad() {
-	sc.mu.Lock()
-	sc.mu.histogramsNotLoad = true
-	sc.mu.Unlock()
-}
-
-// HistogramsNotLoad gets histogramsNotLoad.
-func (sc *StatementContext) HistogramsNotLoad() bool {
-	sc.mu.Lock()
-	notLoad := sc.mu.histogramsNotLoad
-	sc.mu.Unlock()
-	return notLoad
-}
-
-// HandleTruncate ignores or returns the error based on the StatementContext state.
-func (sc *StatementContext) HandleTruncate(err error) error {
-	// TODO: At present we have not checked whether the error can be ignored or treated as warning.
-	// We will do that later, and then append WarnDataTruncated instead of the error itself.
-	if err == nil {
-		return nil
-	}
-	if sc.IgnoreTruncate {
-		return nil
-	}
-	if sc.TruncateAsWarning {
-		sc.AppendWarning(err)
-		return nil
-	}
-	return err
-}
-
-// HandleOverflow treats ErrOverflow as warnings or returns the error based on the StmtCtx.OverflowAsWarning state.
-func (sc *StatementContext) HandleOverflow(err error, warnErr error) error {
-	if err == nil {
-		return nil
-	}
-
-	if sc.OverflowAsWarning {
-		sc.AppendWarning(warnErr)
-		return nil
-	}
-	return err
-}
-
-// ResetForRetry resets the changed states during execution.
-func (sc *StatementContext) ResetForRetry() {
-	sc.mu.Lock()
-	sc.mu.affectedRows = 0
-	sc.mu.foundRows = 0
-	sc.mu.warnings = nil
-	sc.mu.Unlock()
 }

--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -16,13 +16,13 @@ package statistics
 import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
 // SortedBuilder is used to build histograms for PK and index.
 type SortedBuilder struct {
-	sc              *variable.StatementContext
+	sc              *stmtctx.StatementContext
 	numBuckets      int64
 	valuesPerBucket int64
 	lastNumber      int64
@@ -32,7 +32,7 @@ type SortedBuilder struct {
 }
 
 // NewSortedBuilder creates a new SortedBuilder.
-func NewSortedBuilder(sc *variable.StatementContext, numBuckets, id int64) *SortedBuilder {
+func NewSortedBuilder(sc *stmtctx.StatementContext, numBuckets, id int64) *SortedBuilder {
 	return &SortedBuilder{
 		sc:              sc,
 		numBuckets:      numBuckets,

--- a/statistics/ddl_test.go
+++ b/statistics/ddl_test.go
@@ -16,7 +16,7 @@ package statistics_test
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
 )
@@ -48,7 +48,7 @@ func (s *testStatsCacheSuite) TestDDLAfterLoad(c *C) {
 	c.Assert(err, IsNil)
 	tableInfo = tbl.Meta()
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	count, err := statsTbl.ColumnGreaterRowCount(sc, types.NewDatum(recordCount+1), tableInfo.Columns[0].ID)
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, 0.0)
@@ -123,7 +123,7 @@ func (s *testStatsCacheSuite) TestDDLHistogram(c *C) {
 	tableInfo := tbl.Meta()
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo.ID)
 	c.Assert(statsTbl.Pseudo, IsFalse)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	c.Assert(statsTbl.ColumnIsInvalid(sc, tableInfo.Columns[2].ID), IsTrue)
 	c.Check(statsTbl.Columns[tableInfo.Columns[2].ID].NDV, Equals, int64(0))
 
@@ -137,7 +137,7 @@ func (s *testStatsCacheSuite) TestDDLHistogram(c *C) {
 	tableInfo = tbl.Meta()
 	statsTbl = do.StatsHandle().GetTableStats(tableInfo.ID)
 	c.Assert(statsTbl.Pseudo, IsFalse)
-	sc = new(variable.StatementContext)
+	sc = new(stmtctx.StatementContext)
 	count, err := statsTbl.ColumnEqualRowCount(sc, types.NewIntDatum(0), tableInfo.Columns[3].ID)
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, float64(2))

--- a/statistics/handle_test.go
+++ b/statistics/handle_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/types"
@@ -172,7 +172,7 @@ func (s *testStatsCacheSuite) TestEmptyTable(c *C) {
 	c.Assert(err, IsNil)
 	tableInfo := tbl.Meta()
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo.ID)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	count, err := statsTbl.ColumnGreaterRowCount(sc, types.NewDatum(1), tableInfo.Columns[0].ID)
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, 0.0)
@@ -191,7 +191,7 @@ func (s *testStatsCacheSuite) TestColumnIDs(c *C) {
 	c.Assert(err, IsNil)
 	tableInfo := tbl.Meta()
 	statsTbl := do.StatsHandle().GetTableStats(tableInfo.ID)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	count, err := statsTbl.ColumnLessRowCount(sc, types.NewDatum(2), tableInfo.Columns[0].ID)
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, float64(1))

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -204,7 +204,7 @@ func (hg *Histogram) toString(isIndex bool) string {
 }
 
 // equalRowCount estimates the row count where the column equals to value.
-func (hg *Histogram) equalRowCount(sc *variable.StatementContext, value types.Datum) (float64, error) {
+func (hg *Histogram) equalRowCount(sc *stmtctx.StatementContext, value types.Datum) (float64, error) {
 	index, match, err := hg.lowerBound(sc, value)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -226,7 +226,7 @@ func (hg *Histogram) equalRowCount(sc *variable.StatementContext, value types.Da
 }
 
 // greaterRowCount estimates the row count where the column greater than value.
-func (hg *Histogram) greaterRowCount(sc *variable.StatementContext, value types.Datum) (float64, error) {
+func (hg *Histogram) greaterRowCount(sc *stmtctx.StatementContext, value types.Datum) (float64, error) {
 	lessCount, err := hg.lessRowCount(sc, value)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -243,7 +243,7 @@ func (hg *Histogram) greaterRowCount(sc *variable.StatementContext, value types.
 }
 
 // greaterAndEqRowCount estimates the row count where the column less than or equal to value.
-func (hg *Histogram) greaterAndEqRowCount(sc *variable.StatementContext, value types.Datum) (float64, error) {
+func (hg *Histogram) greaterAndEqRowCount(sc *stmtctx.StatementContext, value types.Datum) (float64, error) {
 	greaterCount, err := hg.greaterRowCount(sc, value)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -256,7 +256,7 @@ func (hg *Histogram) greaterAndEqRowCount(sc *variable.StatementContext, value t
 }
 
 // lessRowCount estimates the row count where the column less than value.
-func (hg *Histogram) lessRowCount(sc *variable.StatementContext, value types.Datum) (float64, error) {
+func (hg *Histogram) lessRowCount(sc *stmtctx.StatementContext, value types.Datum) (float64, error) {
 	index, match, err := hg.lowerBound(sc, value)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -286,7 +286,7 @@ func (hg *Histogram) lessRowCount(sc *variable.StatementContext, value types.Dat
 }
 
 // lessAndEqRowCount estimates the row count where the column less than or equal to value.
-func (hg *Histogram) lessAndEqRowCount(sc *variable.StatementContext, value types.Datum) (float64, error) {
+func (hg *Histogram) lessAndEqRowCount(sc *stmtctx.StatementContext, value types.Datum) (float64, error) {
 	lessCount, err := hg.lessRowCount(sc, value)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -299,7 +299,7 @@ func (hg *Histogram) lessAndEqRowCount(sc *variable.StatementContext, value type
 }
 
 // betweenRowCount estimates the row count where column greater or equal to a and less than b.
-func (hg *Histogram) betweenRowCount(sc *variable.StatementContext, a, b types.Datum) (float64, error) {
+func (hg *Histogram) betweenRowCount(sc *stmtctx.StatementContext, a, b types.Datum) (float64, error) {
 	lessCountA, err := hg.lessRowCount(sc, a)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -321,7 +321,7 @@ func (hg *Histogram) totalRowCount() float64 {
 	return float64(hg.Buckets[len(hg.Buckets)-1].Count)
 }
 
-func (hg *Histogram) lowerBound(sc *variable.StatementContext, target types.Datum) (index int, match bool, err error) {
+func (hg *Histogram) lowerBound(sc *stmtctx.StatementContext, target types.Datum) (index int, match bool, err error) {
 	index = sort.Search(len(hg.Buckets), func(i int) bool {
 		cmp, err1 := hg.Buckets[i].UpperBound.CompareDatum(sc, &target)
 		if err1 != nil {
@@ -404,7 +404,7 @@ func HistogramFromProto(protoHg *tipb.Histogram) *Histogram {
 }
 
 // MergeHistograms merges two histograms.
-func MergeHistograms(sc *variable.StatementContext, lh *Histogram, rh *Histogram, bucketSize int) (*Histogram, error) {
+func MergeHistograms(sc *stmtctx.StatementContext, lh *Histogram, rh *Histogram, bucketSize int) (*Histogram, error) {
 	if len(lh.Buckets) == 0 {
 		return rh, nil
 	}
@@ -469,7 +469,7 @@ func (c *Column) String() string {
 	return c.Histogram.toString(false)
 }
 
-func (c *Column) equalRowCount(sc *variable.StatementContext, val types.Datum) (float64, error) {
+func (c *Column) equalRowCount(sc *stmtctx.StatementContext, val types.Datum) (float64, error) {
 	if c.CMSketch != nil {
 		count, err := c.CMSketch.queryValue(val)
 		return float64(count), errors.Trace(err)
@@ -479,7 +479,7 @@ func (c *Column) equalRowCount(sc *variable.StatementContext, val types.Datum) (
 }
 
 // getIntColumnRowCount estimates the row count by a slice of IntColumnRange.
-func (c *Column) getIntColumnRowCount(sc *variable.StatementContext, intRanges []types.IntColumnRange,
+func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []types.IntColumnRange,
 	totalRowCount float64) (float64, error) {
 	var rowCount float64
 	for _, rg := range intRanges {
@@ -513,7 +513,7 @@ func (c *Column) getIntColumnRowCount(sc *variable.StatementContext, intRanges [
 }
 
 // getColumnRowCount estimates the row count by a slice of ColumnRange.
-func (c *Column) getColumnRowCount(sc *variable.StatementContext, ranges []*types.ColumnRange) (float64, error) {
+func (c *Column) getColumnRowCount(sc *stmtctx.StatementContext, ranges []*types.ColumnRange) (float64, error) {
 	var rowCount float64
 	for _, rg := range ranges {
 		cmp, err := rg.Low.CompareDatum(sc, &rg.High)
@@ -572,7 +572,7 @@ func (idx *Index) String() string {
 	return idx.Histogram.toString(true)
 }
 
-func (idx *Index) equalRowCount(sc *variable.StatementContext, b []byte) (float64, error) {
+func (idx *Index) equalRowCount(sc *stmtctx.StatementContext, b []byte) (float64, error) {
 	if idx.CMSketch != nil {
 		return float64(idx.CMSketch.queryBytes(b)), nil
 	}
@@ -580,7 +580,7 @@ func (idx *Index) equalRowCount(sc *variable.StatementContext, b []byte) (float6
 	return count, errors.Trace(err)
 }
 
-func (idx *Index) getRowCount(sc *variable.StatementContext, indexRanges []*types.IndexRange) (float64, error) {
+func (idx *Index) getRowCount(sc *stmtctx.StatementContext, indexRanges []*types.IndexRange) (float64, error) {
 	totalCount := float64(0)
 	for _, indexRange := range indexRanges {
 		indexRange.Align(len(idx.Info.Columns))

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"
@@ -117,7 +117,7 @@ func (c *SampleCollector) collect(d types.Datum) error {
 // SampleBuilder is used to build samples for columns.
 // Also, if primary key is handle, it will directly build histogram for it.
 type SampleBuilder struct {
-	Sc              *variable.StatementContext
+	Sc              *stmtctx.StatementContext
 	RecordSet       ast.RecordSet
 	ColLen          int   // ColLen is the number of columns need to be sampled.
 	PkID            int64 // If primary key is handle, the PkID is the id of the primary key. If not exists, it is -1.

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
@@ -112,7 +112,7 @@ func (s *testStatisticsSuite) SetUpSuite(c *C) {
 	for i := start; i < len(samples); i += 5 {
 		samples[i].SetInt64(samples[i].GetInt64() + 2)
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	err := types.SortDatums(sc, samples)
 	c.Check(err, IsNil)
 	s.samples = samples
@@ -425,7 +425,7 @@ func (s *testStatisticsSuite) TestPseudoTable(c *C) {
 	ti.Columns = append(ti.Columns, colInfo)
 	tbl := PseudoTable(ti.ID)
 	c.Assert(tbl.Count, Greater, int64(0))
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	count, err := tbl.ColumnLessRowCount(sc, types.NewIntDatum(100), colInfo.ID)
 	c.Assert(err, IsNil)
 	c.Assert(int(count), Equals, 3333)

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -23,7 +23,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
@@ -244,7 +244,7 @@ var histogramNeededColumns = neededColumnMap{cols: map[tableColumnID]struct{}{}}
 
 // ColumnIsInvalid checks if this column is invalid. If this column has histogram but not loaded yet, then we mark it
 // as need histogram.
-func (t *Table) ColumnIsInvalid(sc *variable.StatementContext, colID int64) bool {
+func (t *Table) ColumnIsInvalid(sc *stmtctx.StatementContext, colID int64) bool {
 	if t.Pseudo {
 		return true
 	}
@@ -257,7 +257,7 @@ func (t *Table) ColumnIsInvalid(sc *variable.StatementContext, colID int64) bool
 }
 
 // ColumnGreaterRowCount estimates the row count where the column greater than value.
-func (t *Table) ColumnGreaterRowCount(sc *variable.StatementContext, value types.Datum, colID int64) (float64, error) {
+func (t *Table) ColumnGreaterRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return float64(t.Count) / pseudoLessRate, nil
 	}
@@ -268,7 +268,7 @@ func (t *Table) ColumnGreaterRowCount(sc *variable.StatementContext, value types
 }
 
 // ColumnLessRowCount estimates the row count where the column less than value.
-func (t *Table) ColumnLessRowCount(sc *variable.StatementContext, value types.Datum, colID int64) (float64, error) {
+func (t *Table) ColumnLessRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return float64(t.Count) / pseudoLessRate, nil
 	}
@@ -279,7 +279,7 @@ func (t *Table) ColumnLessRowCount(sc *variable.StatementContext, value types.Da
 }
 
 // ColumnBetweenRowCount estimates the row count where column greater or equal to a and less than b.
-func (t *Table) ColumnBetweenRowCount(sc *variable.StatementContext, a, b types.Datum, colID int64) (float64, error) {
+func (t *Table) ColumnBetweenRowCount(sc *stmtctx.StatementContext, a, b types.Datum, colID int64) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return float64(t.Count) / pseudoBetweenRate, nil
 	}
@@ -290,7 +290,7 @@ func (t *Table) ColumnBetweenRowCount(sc *variable.StatementContext, a, b types.
 }
 
 // ColumnEqualRowCount estimates the row count where the column equals to value.
-func (t *Table) ColumnEqualRowCount(sc *variable.StatementContext, value types.Datum, colID int64) (float64, error) {
+func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return float64(t.Count) / pseudoEqualRate, nil
 	}
@@ -301,7 +301,7 @@ func (t *Table) ColumnEqualRowCount(sc *variable.StatementContext, value types.D
 }
 
 // GetRowCountByIntColumnRanges estimates the row count by a slice of IntColumnRange.
-func (t *Table) GetRowCountByIntColumnRanges(sc *variable.StatementContext, colID int64, intRanges []types.IntColumnRange) (float64, error) {
+func (t *Table) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID int64, intRanges []types.IntColumnRange) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return getPseudoRowCountByIntRanges(intRanges, float64(t.Count)), nil
 	}
@@ -310,7 +310,7 @@ func (t *Table) GetRowCountByIntColumnRanges(sc *variable.StatementContext, colI
 }
 
 // GetRowCountByColumnRanges estimates the row count by a slice of ColumnRange.
-func (t *Table) GetRowCountByColumnRanges(sc *variable.StatementContext, colID int64, colRanges []*types.ColumnRange) (float64, error) {
+func (t *Table) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID int64, colRanges []*types.ColumnRange) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return getPseudoRowCountByColumnRanges(sc, float64(t.Count), colRanges)
 	}
@@ -319,7 +319,7 @@ func (t *Table) GetRowCountByColumnRanges(sc *variable.StatementContext, colID i
 }
 
 // GetRowCountByIndexRanges estimates the row count by a slice of IndexRange.
-func (t *Table) GetRowCountByIndexRanges(sc *variable.StatementContext, idxID int64, indexRanges []*types.IndexRange) (float64, error) {
+func (t *Table) GetRowCountByIndexRanges(sc *stmtctx.StatementContext, idxID int64, indexRanges []*types.IndexRange) (float64, error) {
 	idx := t.Indices[idxID]
 	if t.Pseudo || idx == nil || len(idx.Buckets) == 0 {
 		return getPseudoRowCountByIndexRanges(sc, indexRanges, float64(t.Count))
@@ -338,7 +338,7 @@ func PseudoTable(tableID int64) *Table {
 	return t
 }
 
-func getPseudoRowCountByIndexRanges(sc *variable.StatementContext, indexRanges []*types.IndexRange,
+func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []*types.IndexRange,
 	tableRowCount float64) (float64, error) {
 	if tableRowCount == 0 {
 		return 0, nil
@@ -372,7 +372,7 @@ func getPseudoRowCountByIndexRanges(sc *variable.StatementContext, indexRanges [
 	return totalCount, nil
 }
 
-func getPseudoRowCountByColumnRanges(sc *variable.StatementContext, tableRowCount float64, columnRanges []*types.ColumnRange) (float64, error) {
+func getPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount float64, columnRanges []*types.ColumnRange) (float64, error) {
 	var rowCount float64
 	var err error
 	for _, ran := range columnRanges {

--- a/store/tikv/mock-tikv/cop_handler_dag.go
+++ b/store/tikv/mock-tikv/cop_handler_dag.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -278,7 +278,7 @@ type evalContext struct {
 	colIDs      map[int64]int
 	columnInfos []*tipb.ColumnInfo
 	fieldTps    []*types.FieldType
-	sc          *variable.StatementContext
+	sc          *stmtctx.StatementContext
 	timeZone    *time.Location
 }
 
@@ -322,8 +322,8 @@ const (
 )
 
 // flagsToStatementContext creates a StatementContext from a `tipb.SelectRequest.Flags`.
-func flagsToStatementContext(flags uint64) *variable.StatementContext {
-	sc := new(variable.StatementContext)
+func flagsToStatementContext(flags uint64) *stmtctx.StatementContext {
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = (flags & FlagIgnoreTruncate) > 0
 	sc.TruncateAsWarning = (flags & FlagTruncateAsWarning) > 0
 	sc.PadCharToFullLength = (flags & FlagPadCharToFullLength) > 0

--- a/store/tikv/mock-tikv/executor.go
+++ b/store/tikv/mock-tikv/executor.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -273,7 +273,7 @@ func (e *selectionExec) SetSrcExec(exec executor) {
 }
 
 // evalBool evaluates expression to a boolean value.
-func evalBool(exprs []expression.Expression, row types.DatumRow, ctx *variable.StatementContext) (bool, error) {
+func evalBool(exprs []expression.Expression, row types.DatumRow, ctx *stmtctx.StatementContext) (bool, error) {
 	for _, expr := range exprs {
 		data, err := expr.Eval(row)
 		if err != nil {
@@ -621,7 +621,7 @@ func getRowData(columns []*tipb.ColumnInfo, colIDs map[int64]int, handle int64, 
 	return values, nil
 }
 
-func convertToExprs(sc *variable.StatementContext, fieldTps []*types.FieldType, pbExprs []*tipb.Expr) ([]expression.Expression, error) {
+func convertToExprs(sc *stmtctx.StatementContext, fieldTps []*types.FieldType, pbExprs []*tipb.Expr) ([]expression.Expression, error) {
 	exprs := make([]expression.Expression, 0, len(pbExprs))
 	for _, expr := range pbExprs {
 		e, err := expression.PBToExpr(expr, fieldTps, sc)

--- a/store/tikv/mock-tikv/topn.go
+++ b/store/tikv/mock-tikv/topn.go
@@ -17,7 +17,7 @@ import (
 	"container/heap"
 
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -32,7 +32,7 @@ type topNSorter struct {
 	orderByItems []*tipb.ByItem
 	rows         []*sortRow
 	err          error
-	sc           *variable.StatementContext
+	sc           *stmtctx.StatementContext
 }
 
 func (t *topNSorter) Len() int {

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -194,7 +194,7 @@ func (s *testTableSuite) TestGetZeroValue(c *C) {
 			types.NewDatum(types.Enum{}),
 		},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
 		colInfo := &model.ColumnInfo{FieldType: *tt.ft}
 		zv := GetZeroValue(colInfo)

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -20,7 +20,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/testleak"
@@ -85,7 +85,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 	c.Assert(r, HasLen, 3)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	// Compare decoded row and original row
 	for i, col := range cols {
 		v, ok := r[col.id]
@@ -175,7 +175,7 @@ func (s *testTableCodecSuite) TestTimeCodec(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 	c.Assert(r, HasLen, colLen)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	// Compare decoded row and original row
 	for i, col := range cols {
 		v, ok := r[col.id]

--- a/types/compare_test.go
+++ b/types/compare_test.go
@@ -18,7 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -150,7 +150,7 @@ func (s *testCompareSuite) TestCompare(c *C) {
 }
 
 func compareForTest(a, b interface{}) (int, error) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	aDatum := NewDatum(a)
 	bDatum := NewDatum(b)
@@ -173,7 +173,7 @@ func (s *testCompareSuite) TestCompareDatum(c *C) {
 		{Datum{}, MinNotNullDatum(), -1},
 		{MinNotNullDatum(), MaxValueDatum(), -1},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	for i, t := range cmpTbl {
 		comment := Commentf("%d %v %v", i, t.lhs, t.rhs)

--- a/types/convert.go
+++ b/types/convert.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types/json"
 )
 
@@ -67,7 +67,7 @@ var SignedLowerBound = map[byte]int64{
 }
 
 // ConvertFloatToInt converts a float64 value to a int value.
-func ConvertFloatToInt(sc *variable.StatementContext, fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
+func ConvertFloatToInt(sc *stmtctx.StatementContext, fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
 	val := RoundFloat(fval)
 	if val < float64(lowerBound) {
 		return lowerBound, overflow(val, tp)
@@ -120,7 +120,7 @@ func ConvertUintToUint(val uint64, upperBound uint64, tp byte) (uint64, error) {
 }
 
 // ConvertFloatToUint converts a float value to an uint value.
-func ConvertFloatToUint(sc *variable.StatementContext, fval float64, upperBound uint64, tp byte) (uint64, error) {
+func ConvertFloatToUint(sc *stmtctx.StatementContext, fval float64, upperBound uint64, tp byte) (uint64, error) {
 	val := RoundFloat(fval)
 	if val < 0 {
 		return uint64(int64(val)), overflow(val, tp)
@@ -133,7 +133,7 @@ func ConvertFloatToUint(sc *variable.StatementContext, fval float64, upperBound 
 }
 
 // StrToInt converts a string to an integer at the best-effort.
-func StrToInt(sc *variable.StatementContext, str string) (int64, error) {
+func StrToInt(sc *stmtctx.StatementContext, str string) (int64, error) {
 	str = strings.TrimSpace(str)
 	validPrefix, err := getValidIntPrefix(sc, str)
 	iVal, err1 := strconv.ParseInt(validPrefix, 10, 64)
@@ -144,7 +144,7 @@ func StrToInt(sc *variable.StatementContext, str string) (int64, error) {
 }
 
 // StrToUint converts a string to an unsigned integer at the best-effortt.
-func StrToUint(sc *variable.StatementContext, str string) (uint64, error) {
+func StrToUint(sc *stmtctx.StatementContext, str string) (uint64, error) {
 	str = strings.TrimSpace(str)
 	validPrefix, err := getValidIntPrefix(sc, str)
 	if validPrefix[0] == '+' {
@@ -158,7 +158,7 @@ func StrToUint(sc *variable.StatementContext, str string) (uint64, error) {
 }
 
 // StrToDateTime converts str to MySQL DateTime.
-func StrToDateTime(sc *variable.StatementContext, str string, fsp int) (Time, error) {
+func StrToDateTime(sc *stmtctx.StatementContext, str string, fsp int) (Time, error) {
 	return ParseTime(sc, str, mysql.TypeDatetime, fsp)
 }
 
@@ -166,7 +166,7 @@ func StrToDateTime(sc *variable.StatementContext, str string, fsp int) (Time, er
 // and returns Time when str is in datetime format.
 // when isDuration is true, the d is returned, when it is false, the t is returned.
 // See https://dev.mysql.com/doc/refman/5.5/en/date-and-time-literals.html.
-func StrToDuration(sc *variable.StatementContext, str string, fsp int) (d Duration, t Time, isDuration bool, err error) {
+func StrToDuration(sc *stmtctx.StatementContext, str string, fsp int) (d Duration, t Time, isDuration bool, err error) {
 	str = strings.TrimSpace(str)
 	length := len(str)
 	if length > 0 && str[0] == '-' {
@@ -211,13 +211,13 @@ func NumberToDuration(number int64, fsp int) (t Time, err error) {
 	if number/10000 > TimeMaxHour || number%100 >= 60 || (number/100)%100 >= 60 {
 		return ZeroTimestamp, ErrInvalidTimeFormat
 	}
-	t = Time{Time: newMysqlTime(0, 0, 0, int(number/10000), int((number/100)%100), int(number%100), 0), Type: mysql.TypeDuration, Fsp: fsp, negative: neg}
+	t = Time{Time: newMysqlTime(0, 0, 0, int(number/10000), int((number/100)%100), int(number%100), 0), Type: mysql.TypeDuration, Fsp: fsp, Negative: neg}
 
 	return t, errors.Trace(err)
 }
 
 // getValidIntPrefix gets prefix of the string which can be successfully parsed as int.
-func getValidIntPrefix(sc *variable.StatementContext, str string) (string, error) {
+func getValidIntPrefix(sc *stmtctx.StatementContext, str string) (string, error) {
 	floatPrefix, err := getValidFloatPrefix(sc, str)
 	if err != nil {
 		return floatPrefix, errors.Trace(err)
@@ -286,7 +286,7 @@ func floatStrToIntStr(validFloat string) (string, error) {
 }
 
 // StrToFloat converts a string to a float64 at the best-effort.
-func StrToFloat(sc *variable.StatementContext, str string) (float64, error) {
+func StrToFloat(sc *stmtctx.StatementContext, str string) (float64, error) {
 	str = strings.TrimSpace(str)
 	validStr, err := getValidFloatPrefix(sc, str)
 	f, err1 := strconv.ParseFloat(validStr, 64)
@@ -297,7 +297,7 @@ func StrToFloat(sc *variable.StatementContext, str string) (float64, error) {
 }
 
 // ConvertJSONToInt casts JSON into int64.
-func ConvertJSONToInt(sc *variable.StatementContext, j json.JSON, unsigned bool) (int64, error) {
+func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.JSON, unsigned bool) (int64, error) {
 	switch j.TypeCode {
 	case json.TypeCodeObject, json.TypeCodeArray:
 		return 0, nil
@@ -327,7 +327,7 @@ func ConvertJSONToInt(sc *variable.StatementContext, j json.JSON, unsigned bool)
 }
 
 // ConvertJSONToFloat casts JSON into float64.
-func ConvertJSONToFloat(sc *variable.StatementContext, j json.JSON) (float64, error) {
+func ConvertJSONToFloat(sc *stmtctx.StatementContext, j json.JSON) (float64, error) {
 	switch j.TypeCode {
 	case json.TypeCodeObject, json.TypeCodeArray:
 		return 0, nil
@@ -353,7 +353,7 @@ func ConvertJSONToFloat(sc *variable.StatementContext, j json.JSON) (float64, er
 }
 
 // getValidFloatPrefix gets prefix of string which can be successfully parsed as float.
-func getValidFloatPrefix(sc *variable.StatementContext, s string) (valid string, err error) {
+func getValidFloatPrefix(sc *stmtctx.StatementContext, s string) (valid string, err error) {
 	var (
 		sawDot   bool
 		sawDigit bool

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/charset"
@@ -40,7 +40,7 @@ type invalidMockType struct {
 // Convert converts the val with type tp.
 func Convert(val interface{}, target *FieldType) (v interface{}, err error) {
 	d := NewDatum(val)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = time.UTC
 	ret, err := d.ConvertTo(sc, target)
 	if err != nil {
@@ -245,7 +245,7 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 
 	// Test Datum.ToDecimal with bad number.
 	d := NewDatum("hello")
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	v, err = d.ToDecimal(sc)
 	c.Assert(terror.ErrorEqual(err, ErrBadNumber), IsTrue)
 
@@ -364,7 +364,7 @@ func (s *testTypeConvertSuite) TestConvertToString(c *C) {
 		ft.Flen = tt.flen
 		ft.Charset = tt.charset
 		inputDatum := NewStringDatum(tt.input)
-		sc := new(variable.StatementContext)
+		sc := new(stmtctx.StatementContext)
 		outputDatum, err := inputDatum.ConvertTo(sc, ft)
 		if tt.input != tt.output {
 			c.Assert(ErrDataTooLong.Equal(err), IsTrue)
@@ -376,7 +376,7 @@ func (s *testTypeConvertSuite) TestConvertToString(c *C) {
 }
 
 func testStrToInt(c *C, str string, expect int64, truncateAsErr bool, expectErr error) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = !truncateAsErr
 	val, err := StrToInt(sc, str)
 	if expectErr != nil {
@@ -388,7 +388,7 @@ func testStrToInt(c *C, str string, expect int64, truncateAsErr bool, expectErr 
 }
 
 func testStrToUint(c *C, str string, expect uint64, truncateAsErr bool, expectErr error) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = !truncateAsErr
 	val, err := StrToUint(sc, str)
 	if expectErr != nil {
@@ -400,7 +400,7 @@ func testStrToUint(c *C, str string, expect uint64, truncateAsErr bool, expectEr
 }
 
 func testStrToFloat(c *C, str string, expect float64, truncateAsErr bool, expectErr error) {
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = !truncateAsErr
 	val, err := StrToFloat(sc, str)
 	if expectErr != nil {
@@ -466,7 +466,7 @@ func accept(c *C, tp byte, value interface{}, unsigned bool, expected string) {
 		ft.Flag |= mysql.UnsignedFlag
 	}
 	d := NewDatum(value)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	casted, err := d.ConvertTo(sc, ft)
 	c.Assert(err, IsNil, Commentf("%v", ft))
@@ -493,7 +493,7 @@ func deny(c *C, tp byte, value interface{}, unsigned bool, expected string) {
 		ft.Flag |= mysql.UnsignedFlag
 	}
 	d := NewDatum(value)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	casted, err := d.ConvertTo(sc, ft)
 	c.Assert(err, NotNil)
 	if casted.IsNull() {
@@ -665,7 +665,7 @@ func (s *testTypeConvertSuite) TestGetValidFloat(c *C) {
 		{"123e+", "123"},
 		{"123.e", "123."},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
 		prefix, _ := getValidFloatPrefix(sc, tt.origin)
 		c.Assert(prefix, Equals, tt.valid)
@@ -689,14 +689,14 @@ func (s *testTypeConvertSuite) TestConvertTime(c *C) {
 	}
 
 	for _, timezone := range timezones {
-		sc := &variable.StatementContext{
+		sc := &stmtctx.StatementContext{
 			TimeZone: timezone,
 		}
 		testConvertTimeTimeZone(c, sc)
 	}
 }
 
-func testConvertTimeTimeZone(c *C, sc *variable.StatementContext) {
+func testConvertTimeTimeZone(c *C, sc *stmtctx.StatementContext) {
 	raw := FromDate(2002, 3, 4, 4, 6, 7, 8)
 	tests := []struct {
 		input  Time
@@ -760,7 +760,7 @@ func (s *testTypeConvertSuite) TestConvertJSONToInt(c *C) {
 		j, err := json.ParseFromString(tt.In)
 		c.Assert(err, IsNil)
 
-		casted, _ := ConvertJSONToInt(new(variable.StatementContext), j, false)
+		casted, _ := ConvertJSONToInt(new(stmtctx.StatementContext), j, false)
 		c.Assert(casted, Equals, tt.Out)
 	}
 }
@@ -785,7 +785,7 @@ func (s *testTypeConvertSuite) TestConvertJSONToFloat(c *C) {
 	for _, tt := range tests {
 		j, err := json.ParseFromString(tt.In)
 		c.Assert(err, IsNil)
-		casted, _ := ConvertJSONToFloat(new(variable.StatementContext), j)
+		casted, _ := ConvertJSONToFloat(new(stmtctx.StatementContext), j)
 		c.Assert(casted, Equals, tt.Out)
 	}
 }

--- a/types/datum_eval.go
+++ b/types/datum_eval.go
@@ -19,11 +19,11 @@ import (
 	"github.com/cznic/mathutil"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/parser/opcode"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 )
 
 // CoerceArithmetic converts datum to appropriate datum for arithmetic computing.
-func CoerceArithmetic(sc *variable.StatementContext, a Datum) (d Datum, err error) {
+func CoerceArithmetic(sc *stmtctx.StatementContext, a Datum) (d Datum, err error) {
 	switch a.Kind() {
 	case KindString, KindBytes:
 		// MySQL will convert string to float for arithmetic operation
@@ -214,7 +214,7 @@ func ComputeMul(a, b Datum) (d Datum, err error) {
 }
 
 // ComputeDiv computes the result of a/b.
-func ComputeDiv(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeDiv(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	// MySQL support integer division Div and division operator /
 	// we use opcode.Div for division operator and will use another for integer division later.
 	// for division operator, we will use float64 for calculation.
@@ -258,7 +258,7 @@ func ComputeDiv(sc *variable.StatementContext, a, b Datum) (d Datum, err error) 
 }
 
 // ComputeMod computes the result of a mod b.
-func ComputeMod(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeMod(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	switch a.Kind() {
 	case KindInt64:
 		x := a.GetInt64()
@@ -336,7 +336,7 @@ func ComputeMod(sc *variable.StatementContext, a, b Datum) (d Datum, err error) 
 }
 
 // ComputeIntDiv computes the result of a / b, both a and b are integer.
-func ComputeIntDiv(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeIntDiv(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	switch a.Kind() {
 	case KindInt64:
 		x := a.GetInt64()
@@ -428,7 +428,7 @@ func decimal2RoundUint(x *MyDecimal) (uint64, error) {
 }
 
 // ComputeBitAnd computes the result of a & b.
-func ComputeBitAnd(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeBitAnd(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	aKind, bKind := a.Kind(), b.Kind()
 	if (aKind == KindInt64 || aKind == KindUint64) && (bKind == KindInt64 || bKind == KindUint64) {
 		d.SetUint64(a.GetUint64() & b.GetUint64())
@@ -450,7 +450,7 @@ func ComputeBitAnd(sc *variable.StatementContext, a, b Datum) (d Datum, err erro
 }
 
 // ComputeBitOr computes the result of a | b.
-func ComputeBitOr(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeBitOr(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	aKind, bKind := a.Kind(), b.Kind()
 	if (aKind == KindInt64 || aKind == KindUint64) && (bKind == KindInt64 || bKind == KindUint64) {
 		d.SetUint64(a.GetUint64() | b.GetUint64())
@@ -472,7 +472,7 @@ func ComputeBitOr(sc *variable.StatementContext, a, b Datum) (d Datum, err error
 }
 
 // ComputeBitNeg computes the result of ~a.
-func ComputeBitNeg(sc *variable.StatementContext, a Datum) (d Datum, err error) {
+func ComputeBitNeg(sc *stmtctx.StatementContext, a Datum) (d Datum, err error) {
 	aKind := a.Kind()
 	if aKind == KindInt64 || aKind == KindUint64 {
 		d.SetUint64(^a.GetUint64())
@@ -489,7 +489,7 @@ func ComputeBitNeg(sc *variable.StatementContext, a Datum) (d Datum, err error) 
 }
 
 // ComputeBitXor computes the result of a ^ b.
-func ComputeBitXor(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeBitXor(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	aKind, bKind := a.Kind(), b.Kind()
 	if (aKind == KindInt64 || aKind == KindUint64) && (bKind == KindInt64 || bKind == KindUint64) {
 		d.SetUint64(a.GetUint64() ^ b.GetUint64())
@@ -511,7 +511,7 @@ func ComputeBitXor(sc *variable.StatementContext, a, b Datum) (d Datum, err erro
 }
 
 // ComputeLeftShift computes the result of a >> b.
-func ComputeLeftShift(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeLeftShift(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	aKind, bKind := a.Kind(), b.Kind()
 	if (aKind == KindInt64 || aKind == KindUint64) && (bKind == KindInt64 || bKind == KindUint64) {
 		d.SetUint64(a.GetUint64() << b.GetUint64())
@@ -533,7 +533,7 @@ func ComputeLeftShift(sc *variable.StatementContext, a, b Datum) (d Datum, err e
 }
 
 // ComputeRightShift computes the result of a << b.
-func ComputeRightShift(sc *variable.StatementContext, a, b Datum) (d Datum, err error) {
+func ComputeRightShift(sc *stmtctx.StatementContext, a, b Datum) (d Datum, err error) {
 	aKind, bKind := a.Kind(), b.Kind()
 	if (aKind == KindInt64 || aKind == KindUint64) && (bKind == KindInt64 || bKind == KindUint64) {
 		d.SetUint64(a.GetUint64() >> b.GetUint64())
@@ -555,7 +555,7 @@ func ComputeRightShift(sc *variable.StatementContext, a, b Datum) (d Datum, err 
 }
 
 // convertNonInt2RoundUint64 converts a non-integer to an uint64
-func convertNonInt2RoundUint64(sc *variable.StatementContext, x Datum) (d uint64, err error) {
+func convertNonInt2RoundUint64(sc *stmtctx.StatementContext, x Datum) (d uint64, err error) {
 	decimalX, err := x.ToDecimal(sc)
 	if err != nil {
 		return d, errors.Trace(err)

--- a/types/format_test.go
+++ b/types/format_test.go
@@ -11,11 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package types_test
 
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 )
 
@@ -65,7 +66,7 @@ func (s *testTimeSuite) TestTimeFormatMethod(c *C) {
 		},
 	}
 	for i, t := range tblDate {
-		tm, err := ParseTime(sc, t.Input, mysql.TypeDatetime, 6)
+		tm, err := types.ParseTime(sc, t.Input, mysql.TypeDatetime, 6)
 		c.Assert(err, IsNil, Commentf("parse time fail: %s", t.Input))
 
 		str, err := tm.DateFormat(t.Format)
@@ -81,30 +82,30 @@ func (s *testTimeSuite) TestStrToDate(c *C) {
 	tests := []struct {
 		input  string
 		format string
-		expect TimeInternal
+		expect types.TimeInternal
 	}{
-		{`01,05,2013`, `%d,%m,%Y`, FromDate(2013, 5, 1, 0, 0, 0, 0)},
-		{`May 01, 2013`, `%M %d,%Y`, FromDate(2013, 5, 1, 0, 0, 0, 0)},
-		{`a09:30:17`, `a%h:%i:%s`, FromDate(0, 0, 0, 9, 30, 17, 0)},
-		{`09:30:17a`, `%h:%i:%s`, FromDate(0, 0, 0, 9, 30, 17, 0)},
-		{`abc`, `abc`, ZeroTime},
-		{`09`, `%m`, FromDate(0, 9, 0, 0, 0, 0, 0)},
-		{`09`, `%s`, FromDate(0, 0, 0, 0, 0, 9, 0)},
-		{`12:43:24 AM`, `%r`, FromDate(0, 0, 0, 12, 43, 24, 0)},
-		{`11:43:24 PM`, `%r`, FromDate(0, 0, 0, 23, 43, 24, 0)},
-		{`00:12:13`, `%T`, FromDate(0, 0, 0, 0, 12, 13, 0)},
-		{`23:59:59`, `%T`, FromDate(0, 0, 0, 23, 59, 59, 0)},
-		{`00/00/0000`, `%m/%d/%Y`, ZeroTime},
-		{`04/30/2004`, `%m/%d/%Y`, FromDate(2004, 4, 30, 0, 0, 0, 0)},
-		{`15:35:00`, `%H:%i:%s`, FromDate(0, 0, 0, 15, 35, 0, 0)},
-		{`Jul 17 33`, `%b %k %S`, FromDate(0, 7, 0, 17, 0, 33, 0)},
-		{`2016-January:7 432101`, `%Y-%M:%l %f`, FromDate(2016, 1, 0, 7, 0, 0, 432101)},
-		{`10:13 PM`, `%l:%i %p`, FromDate(0, 0, 0, 22, 13, 0, 0)},
-		{`12:00:00 AM`, `%h:%i:%s %p`, FromDate(0, 0, 0, 0, 0, 0, 0)},
-		{`12:00:00 PM`, `%h:%i:%s %p`, FromDate(0, 0, 0, 12, 0, 0, 0)},
+		{`01,05,2013`, `%d,%m,%Y`, types.FromDate(2013, 5, 1, 0, 0, 0, 0)},
+		{`May 01, 2013`, `%M %d,%Y`, types.FromDate(2013, 5, 1, 0, 0, 0, 0)},
+		{`a09:30:17`, `a%h:%i:%s`, types.FromDate(0, 0, 0, 9, 30, 17, 0)},
+		{`09:30:17a`, `%h:%i:%s`, types.FromDate(0, 0, 0, 9, 30, 17, 0)},
+		{`abc`, `abc`, types.ZeroTime},
+		{`09`, `%m`, types.FromDate(0, 9, 0, 0, 0, 0, 0)},
+		{`09`, `%s`, types.FromDate(0, 0, 0, 0, 0, 9, 0)},
+		{`12:43:24 AM`, `%r`, types.FromDate(0, 0, 0, 12, 43, 24, 0)},
+		{`11:43:24 PM`, `%r`, types.FromDate(0, 0, 0, 23, 43, 24, 0)},
+		{`00:12:13`, `%T`, types.FromDate(0, 0, 0, 0, 12, 13, 0)},
+		{`23:59:59`, `%T`, types.FromDate(0, 0, 0, 23, 59, 59, 0)},
+		{`00/00/0000`, `%m/%d/%Y`, types.ZeroTime},
+		{`04/30/2004`, `%m/%d/%Y`, types.FromDate(2004, 4, 30, 0, 0, 0, 0)},
+		{`15:35:00`, `%H:%i:%s`, types.FromDate(0, 0, 0, 15, 35, 0, 0)},
+		{`Jul 17 33`, `%b %k %S`, types.FromDate(0, 7, 0, 17, 0, 33, 0)},
+		{`2016-January:7 432101`, `%Y-%M:%l %f`, types.FromDate(2016, 1, 0, 7, 0, 0, 432101)},
+		{`10:13 PM`, `%l:%i %p`, types.FromDate(0, 0, 0, 22, 13, 0, 0)},
+		{`12:00:00 AM`, `%h:%i:%s %p`, types.FromDate(0, 0, 0, 0, 0, 0, 0)},
+		{`12:00:00 PM`, `%h:%i:%s %p`, types.FromDate(0, 0, 0, 12, 0, 0, 0)},
 	}
 	for i, tt := range tests {
-		var t Time
+		var t types.Time
 		c.Assert(t.StrToDate(sc, tt.input, tt.format), IsTrue, Commentf("no.%d failed", i))
 		c.Assert(t.Time, Equals, tt.expect, Commentf("no.%d failed", i))
 	}
@@ -122,7 +123,7 @@ func (s *testTimeSuite) TestStrToDate(c *C) {
 		{`00:21:22 AM`, `%h:%i:%s %p`},
 	}
 	for _, tt := range errTests {
-		var t Time
+		var t types.Time
 		c.Assert(t.StrToDate(sc, tt.input, tt.format), IsFalse)
 	}
 }

--- a/types/fsp.go
+++ b/types/fsp.go
@@ -44,10 +44,10 @@ func CheckFsp(fsp int) (int, error) {
 	return fsp, nil
 }
 
-// parseFrac parses the input string according to fsp, returns the microsecond,
+// ParseFrac parses the input string according to fsp, returns the microsecond,
 // and also a bool value to indice overflow. eg:
 // "999" fsp=2 will overflow.
-func parseFrac(s string, fsp int) (v int, overflow bool, err error) {
+func ParseFrac(s string, fsp int) (v int, overflow bool, err error) {
 	if len(s) == 0 {
 		return 0, false, nil
 	}

--- a/types/range.go
+++ b/types/range.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 )
 
 // Range is the interface of the three type of range.
@@ -137,7 +137,7 @@ func (ir *IndexRange) Clone() *IndexRange {
 }
 
 // IsPoint returns if the index range is a point.
-func (ir *IndexRange) IsPoint(sc *variable.StatementContext) bool {
+func (ir *IndexRange) IsPoint(sc *stmtctx.StatementContext) bool {
 	if len(ir.LowVal) != len(ir.HighVal) {
 		return false
 	}
@@ -213,7 +213,7 @@ func (ir *IndexRange) Align(numColumns int) {
 
 // PrefixEqualLen tells you how long the prefix of the range is a point.
 // e.g. If this range is (1 2 3, 1 2 +inf), then the return value is 2.
-func (ir *IndexRange) PrefixEqualLen(sc *variable.StatementContext) (int, error) {
+func (ir *IndexRange) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) {
 	// Here, len(ir.LowVal) always equal to len(ir.HighVal)
 	for i := 0; i < len(ir.LowVal); i++ {
 		cmp, err := ir.LowVal[i].CompareDatum(sc, &ir.HighVal[i])

--- a/types/range_test.go
+++ b/types/range_test.go
@@ -17,7 +17,7 @@ import (
 	"math"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 )
 
 var _ = Suite(&testRangeSuite{})
@@ -125,7 +125,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			isPoint: false,
 		},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, t := range isPointTests {
 		c.Assert(t.ran.IsPoint(sc), Equals, t.isPoint)
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -26,7 +26,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 )
 
@@ -59,7 +59,8 @@ const (
 	MaxTime = gotime.Duration(838*3600+59*60+59) * gotime.Second
 	// ZeroDatetimeStr is the string representation of a zero datetime.
 	ZeroDatetimeStr = "0000-00-00 00:00:00"
-	zeroDateStr     = "0000-00-00"
+	// ZeroDateStr is the string representation of a zero date.
+	ZeroDateStr = "0000-00-00"
 
 	// TimeMaxHour is the max hour for mysql time type.
 	TimeMaxHour = 838
@@ -182,12 +183,12 @@ type Time struct {
 	// TODO: Define a type for timestamp, remove its representation from here.
 	// TimeZone is valid when Type is mysql.Timestamp, it's meaningless for date/datetime.
 	TimeZone *gotime.Location
-	negative bool
+	Negative bool
 }
 
 // MaxMySQLTime returns Time with maximum mysql time type.
 func MaxMySQLTime(neg bool, fsp int) Time {
-	return Time{Time: newMysqlTime(0, 0, 0, TimeMaxHour, TimeMaxMinute, TimeMaxSecond, 0), Type: mysql.TypeDuration, Fsp: fsp, negative: neg}
+	return Time{Time: newMysqlTime(0, 0, 0, TimeMaxHour, TimeMaxMinute, TimeMaxSecond, 0), Type: mysql.TypeDuration, Fsp: fsp, Negative: neg}
 }
 
 // CurrentTime returns current time with type tp.
@@ -212,7 +213,7 @@ func (t *Time) ConvertTimeZone(from, to *gotime.Location) error {
 
 // IsNegative returns a boolean to indicate whether the Time is negative.
 func (t *Time) IsNegative() bool {
-	return t.negative
+	return t.Negative
 }
 
 func (t Time) String() string {
@@ -283,7 +284,7 @@ func (t Time) ToNumber() *MyDecimal {
 }
 
 // Convert converts t with type tp.
-func (t Time) Convert(sc *variable.StatementContext, tp uint8) (Time, error) {
+func (t Time) Convert(sc *stmtctx.StatementContext, tp uint8) (Time, error) {
 	if t.Type == tp || t.IsZero() {
 		return Time{Time: t.Time, Type: tp, Fsp: t.Fsp}, nil
 	}
@@ -306,7 +307,7 @@ func (t Time) ConvertToDuration() (Duration, error) {
 	frac := t.Time.Microsecond() * 1000
 
 	d := gotime.Duration(hour*3600+minute*60+second)*gotime.Second + gotime.Duration(frac)
-	if t.negative {
+	if t.Negative {
 		return Duration{Duration: -d, Fsp: t.Fsp}, nil
 	}
 	// TODO: check convert validation
@@ -342,7 +343,7 @@ func compareTime(a, b TimeInternal) int {
 
 // CompareString is like Compare,
 // but parses string to Time then compares.
-func (t Time) CompareString(sc *variable.StatementContext, str string) (int, error) {
+func (t Time) CompareString(sc *stmtctx.StatementContext, str string) (int, error) {
 	// use MaxFsp to parse the string
 	o, err := ParseTime(sc, str, t.Type, MaxFsp)
 	if err != nil {
@@ -473,7 +474,7 @@ func (t *Time) FromPackedUint(packed uint64) error {
 // check whether t matches valid Time format.
 // If allowZeroInDate is false, it returns ErrZeroDate when month or day is zero.
 // FIXME: See https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sqlmode_no_zero_in_date
-func (t *Time) check(sc *variable.StatementContext) error {
+func (t *Time) check(sc *stmtctx.StatementContext) error {
 	allowZeroInDate := false
 	// We should avoid passing sc as nil here as far as possible.
 	if sc != nil {
@@ -560,7 +561,8 @@ func TimestampDiff(unit string, t1 Time, t2 Time) int64 {
 	return timestampDiff(unit, t1.Time, t2.Time)
 }
 
-func parseDateFormat(format string) []string {
+// ParseDateFormat parses a formatted date string and returns separated components.
+func ParseDateFormat(format string) []string {
 	format = strings.TrimSpace(format)
 
 	start := 0
@@ -599,7 +601,7 @@ func splitDateTime(format string) (seps []string, fracStr string) {
 		format = format[:i]
 	}
 
-	seps = parseDateFormat(format)
+	seps = ParseDateFormat(format)
 	return
 }
 
@@ -695,7 +697,7 @@ func parseDatetime(str string, fsp int, isFloat bool) (Time, error) {
 	var overflow bool
 	if hhmmss {
 		// If input string is "20170118.999", without hhmmss, fsp is meanless.
-		microsecond, overflow, err = parseFrac(fracStr, fsp)
+		microsecond, overflow, err = ParseFrac(fracStr, fsp)
 		if err != nil {
 			return ZeroDatetime, errors.Trace(err)
 		}
@@ -917,7 +919,7 @@ func (d Duration) Compare(o Duration) int {
 
 // CompareString is like Compare,
 // but parses str to Duration then compares.
-func (d Duration) CompareString(sc *variable.StatementContext, str string) (int, error) {
+func (d Duration) CompareString(sc *stmtctx.StatementContext, str string) (int, error) {
 	// use MaxFsp to parse the string
 	o, err := ParseDuration(str, MaxFsp)
 	if err != nil {
@@ -995,7 +997,7 @@ func ParseDuration(str string, fsp int) (Duration, error) {
 	if n := strings.IndexByte(str, '.'); n >= 0 {
 		// It has fractional precision parts.
 		fracStr := str[n+1:]
-		frac, overflow, err = parseFrac(fracStr, fsp)
+		frac, overflow, err = ParseFrac(fracStr, fsp)
 		if err != nil {
 			return ZeroDuration, errors.Trace(err)
 		}
@@ -1104,7 +1106,7 @@ func splitDuration(t gotime.Duration) (int, int, int, int, int) {
 
 var maxDaysInMonth = []int{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 
-func getTime(sc *variable.StatementContext, num int64, tp byte) (Time, error) {
+func getTime(sc *stmtctx.StatementContext, num int64, tp byte) (Time, error) {
 	s1 := num / 1000000
 	s2 := num - s1*1000000
 
@@ -1130,7 +1132,7 @@ func getTime(sc *variable.StatementContext, num int64, tp byte) (Time, error) {
 // parseDateTimeFromNum parses date time from num.
 // See number_to_datetime function.
 // https://github.com/mysql/mysql-server/blob/5.7/sql-common/my_time.c
-func parseDateTimeFromNum(sc *variable.StatementContext, num int64) (Time, error) {
+func parseDateTimeFromNum(sc *stmtctx.StatementContext, num int64) (Time, error) {
 	t := ZeroDate
 	// Check zero.
 	if num == 0 {
@@ -1219,16 +1221,16 @@ func parseDateTimeFromNum(sc *variable.StatementContext, num int64) (Time, error
 // The valid datetime range is from '1000-01-01 00:00:00.000000' to '9999-12-31 23:59:59.999999'.
 // The valid timestamp range is from '1970-01-01 00:00:01.000000' to '2038-01-19 03:14:07.999999'.
 // The valid date range is from '1000-01-01' to '9999-12-31'
-func ParseTime(sc *variable.StatementContext, str string, tp byte, fst int) (Time, error) {
+func ParseTime(sc *stmtctx.StatementContext, str string, tp byte, fst int) (Time, error) {
 	return parseTime(sc, str, tp, fst, false)
 }
 
 // ParseTimeFromFloatString is similar to ParseTime, except that it's used to parse a float converted string.
-func ParseTimeFromFloatString(sc *variable.StatementContext, str string, tp byte, fst int) (Time, error) {
+func ParseTimeFromFloatString(sc *stmtctx.StatementContext, str string, tp byte, fst int) (Time, error) {
 	return parseTime(sc, str, tp, fst, true)
 }
 
-func parseTime(sc *variable.StatementContext, str string, tp byte, fsp int, isFloat bool) (Time, error) {
+func parseTime(sc *stmtctx.StatementContext, str string, tp byte, fsp int, isFloat bool) (Time, error) {
 	fsp, err := CheckFsp(fsp)
 	if err != nil {
 		return Time{Time: ZeroTime, Type: tp}, errors.Trace(err)
@@ -1247,24 +1249,24 @@ func parseTime(sc *variable.StatementContext, str string, tp byte, fsp int, isFl
 }
 
 // ParseDatetime is a helper function wrapping ParseTime with datetime type and default fsp.
-func ParseDatetime(sc *variable.StatementContext, str string) (Time, error) {
+func ParseDatetime(sc *stmtctx.StatementContext, str string) (Time, error) {
 	return ParseTime(sc, str, mysql.TypeDatetime, DefaultFsp)
 }
 
 // ParseTimestamp is a helper function wrapping ParseTime with timestamp type and default fsp.
-func ParseTimestamp(sc *variable.StatementContext, str string) (Time, error) {
+func ParseTimestamp(sc *stmtctx.StatementContext, str string) (Time, error) {
 	return ParseTime(sc, str, mysql.TypeTimestamp, DefaultFsp)
 }
 
 // ParseDate is a helper function wrapping ParseTime with date type.
-func ParseDate(sc *variable.StatementContext, str string) (Time, error) {
+func ParseDate(sc *stmtctx.StatementContext, str string) (Time, error) {
 	// date has no fractional seconds precision
 	return ParseTime(sc, str, mysql.TypeDate, MinFsp)
 }
 
 // ParseTimeFromNum parses a formatted int64,
 // returns the value which type is tp.
-func ParseTimeFromNum(sc *variable.StatementContext, num int64, tp byte, fsp int) (Time, error) {
+func ParseTimeFromNum(sc *stmtctx.StatementContext, num int64, tp byte, fsp int) (Time, error) {
 	fsp, err := CheckFsp(fsp)
 	if err != nil {
 		return Time{Time: ZeroTime, Type: tp}, errors.Trace(err)
@@ -1284,17 +1286,17 @@ func ParseTimeFromNum(sc *variable.StatementContext, num int64, tp byte, fsp int
 }
 
 // ParseDatetimeFromNum is a helper function wrapping ParseTimeFromNum with datetime type and default fsp.
-func ParseDatetimeFromNum(sc *variable.StatementContext, num int64) (Time, error) {
+func ParseDatetimeFromNum(sc *stmtctx.StatementContext, num int64) (Time, error) {
 	return ParseTimeFromNum(sc, num, mysql.TypeDatetime, DefaultFsp)
 }
 
 // ParseTimestampFromNum is a helper function wrapping ParseTimeFromNum with timestamp type and default fsp.
-func ParseTimestampFromNum(sc *variable.StatementContext, num int64) (Time, error) {
+func ParseTimestampFromNum(sc *stmtctx.StatementContext, num int64) (Time, error) {
 	return ParseTimeFromNum(sc, num, mysql.TypeTimestamp, DefaultFsp)
 }
 
 // ParseDateFromNum is a helper function wrapping ParseTimeFromNum with date type.
-func ParseDateFromNum(sc *variable.StatementContext, num int64) (Time, error) {
+func ParseDateFromNum(sc *stmtctx.StatementContext, num int64) (Time, error) {
 	// date has no fractional seconds precision
 	return ParseTimeFromNum(sc, num, mysql.TypeDate, MinFsp)
 }
@@ -1789,7 +1791,7 @@ func IsClockUnit(unit string) bool {
 // IsDateFormat returns true when the specified time format could contain only date.
 func IsDateFormat(format string) bool {
 	format = strings.TrimSpace(format)
-	seps := parseDateFormat(format)
+	seps := ParseDateFormat(format)
 	length := len(format)
 	switch len(seps) {
 	case 1:
@@ -1803,7 +1805,7 @@ func IsDateFormat(format string) bool {
 }
 
 // ParseTimeFromInt64 parses mysql time value from int64.
-func ParseTimeFromInt64(sc *variable.StatementContext, num int64) (Time, error) {
+func ParseTimeFromInt64(sc *stmtctx.StatementContext, num int64) (Time, error) {
 	return parseDateTimeFromNum(sc, num)
 }
 
@@ -1970,7 +1972,7 @@ func abbrDayOfMonth(day int) string {
 
 // StrToDate converts date string according to format.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format
-func (t *Time) StrToDate(sc *variable.StatementContext, date, format string) bool {
+func (t *Time) StrToDate(sc *stmtctx.StatementContext, date, format string) bool {
 	ctx := make(map[string]int)
 	var tm mysqlTime
 	if !strToDate(&tm, date, format, ctx) {

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package types_test
 
 import (
 	"math"
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 )
@@ -57,7 +58,7 @@ func (s *testTimeSuite) TestDateTime(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseDatetime(sc, test.Input)
+		t, err := types.ParseDatetime(sc, test.Input)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -78,12 +79,12 @@ func (s *testTimeSuite) TestDateTime(c *C) {
 	}
 
 	for _, test := range fspTbl {
-		t, err := ParseTime(sc, test.Input, mysql.TypeDatetime, test.Fsp)
+		t, err := types.ParseTime(sc, test.Input, mysql.TypeDatetime, test.Fsp)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
 
-	t, _ := ParseTime(sc, "121231113045.9999999", mysql.TypeDatetime, 6)
+	t, _ := types.ParseTime(sc, "121231113045.9999999", mysql.TypeDatetime, 6)
 	c.Assert(t.Time.Second(), Equals, 46)
 	c.Assert(t.Time.Microsecond(), Equals, 0)
 
@@ -99,7 +100,7 @@ func (s *testTimeSuite) TestDateTime(c *C) {
 	}
 
 	for _, test := range errTable {
-		_, err := ParseDatetime(sc, test)
+		_, err := types.ParseDatetime(sc, test)
 		c.Assert(err, NotNil)
 	}
 }
@@ -114,7 +115,7 @@ func (s *testTimeSuite) TestTimestamp(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseTimestamp(nil, test.Input)
+		t, err := types.ParseTimestamp(nil, test.Input)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -125,7 +126,7 @@ func (s *testTimeSuite) TestTimestamp(c *C) {
 	}
 
 	for _, test := range errTable {
-		_, err := ParseTimestamp(nil, test)
+		_, err := types.ParseTimestamp(nil, test)
 		c.Assert(err, NotNil)
 	}
 }
@@ -146,7 +147,7 @@ func (s *testTimeSuite) TestDate(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseDate(nil, test.Input)
+		t, err := types.ParseDate(nil, test.Input)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -156,7 +157,7 @@ func (s *testTimeSuite) TestDate(c *C) {
 	}
 
 	for _, test := range errTable {
-		_, err := ParseDate(nil, test)
+		_, err := types.ParseDate(nil, test)
 		c.Assert(err, NotNil)
 	}
 }
@@ -193,7 +194,7 @@ func (s *testTimeSuite) TestTime(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseDuration(test.Input, MinFsp)
+		t, err := types.ParseDuration(test.Input, types.MinFsp)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -208,7 +209,7 @@ func (s *testTimeSuite) TestTime(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseDuration(test.Input, MaxFsp)
+		t, err := types.ParseDuration(test.Input, types.MaxFsp)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -219,7 +220,7 @@ func (s *testTimeSuite) TestTime(c *C) {
 	}
 
 	for _, test := range errTable {
-		_, err := ParseDuration(test, DefaultFsp)
+		_, err := types.ParseDuration(test, types.DefaultFsp)
 		c.Assert(err, NotNil)
 	}
 
@@ -235,8 +236,8 @@ func (s *testTimeSuite) TestTime(c *C) {
 	}
 
 	for _, t := range cmpTable {
-		t1 := Duration{time.Duration(t.lhs), DefaultFsp}
-		t2 := Duration{time.Duration(t.rhs), DefaultFsp}
+		t1 := types.Duration{time.Duration(t.lhs), types.DefaultFsp}
+		t2 := types.Duration{time.Duration(t.rhs), types.DefaultFsp}
 		ret := t1.Compare(t2)
 		c.Assert(ret, Equals, t.ret)
 	}
@@ -257,23 +258,23 @@ func (s *testTimeSuite) TestDurationAdd(c *C) {
 		{"00:00:00.099", 3, "00:00:00.001", 3, "00:00:00.100"},
 	}
 	for _, test := range table {
-		t, err := ParseDuration(test.Input, test.Fsp)
+		t, err := types.ParseDuration(test.Input, test.Fsp)
 		c.Assert(err, IsNil)
-		ta, err := ParseDuration(test.InputAdd, test.FspAdd)
+		ta, err := types.ParseDuration(test.InputAdd, test.FspAdd)
 		c.Assert(err, IsNil)
 		result, err := t.Add(ta)
 		c.Assert(err, IsNil)
 		c.Assert(result.String(), Equals, test.Expect)
 	}
-	t, err := ParseDuration("00:00:00", 0)
+	t, err := types.ParseDuration("00:00:00", 0)
 	c.Assert(err, IsNil)
-	ta := new(Duration)
+	ta := new(types.Duration)
 	result, err := t.Add(*ta)
 	c.Assert(err, IsNil)
 	c.Assert(result.String(), Equals, "00:00:00")
 
-	t = Duration{Duration: math.MaxInt64, Fsp: 0}
-	tatmp, err := ParseDuration("00:01:00", 0)
+	t = types.Duration{Duration: math.MaxInt64, Fsp: 0}
+	tatmp, err := types.ParseDuration("00:01:00", 0)
 	c.Assert(err, IsNil)
 	_, err = t.Add(tatmp)
 	c.Assert(err, NotNil)
@@ -292,9 +293,9 @@ func (s *testTimeSuite) TestDurationSub(c *C) {
 		{"00:00:00", 0, "00:00:00.1", 1, "-00:00:00.1"},
 	}
 	for _, test := range table {
-		t, err := ParseDuration(test.Input, test.Fsp)
+		t, err := types.ParseDuration(test.Input, test.Fsp)
 		c.Assert(err, IsNil)
-		ta, err := ParseDuration(test.InputAdd, test.FspAdd)
+		ta, err := types.ParseDuration(test.InputAdd, test.FspAdd)
 		c.Assert(err, IsNil)
 		result, err := t.Sub(ta)
 		c.Assert(err, IsNil)
@@ -319,7 +320,7 @@ func (s *testTimeSuite) TestTimeFsp(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseDuration(test.Input, test.Fsp)
+		t, err := types.ParseDuration(test.Input, test.Fsp)
 		c.Assert(err, IsNil)
 		c.Assert(t.String(), Equals, test.Expect)
 	}
@@ -333,7 +334,7 @@ func (s *testTimeSuite) TestTimeFsp(c *C) {
 	}
 
 	for _, test := range errTable {
-		_, err := ParseDuration(test.Input, test.Fsp)
+		_, err := types.ParseDuration(test.Input, test.Fsp)
 		c.Assert(err, NotNil)
 	}
 }
@@ -350,7 +351,7 @@ func (s *testTimeSuite) TestYear(c *C) {
 	}
 
 	for _, test := range table {
-		t, err := ParseYear(test.Input)
+		t, err := types.ParseYear(test.Input)
 		c.Assert(err, IsNil)
 		c.Assert(t, Equals, test.Expect)
 	}
@@ -366,7 +367,7 @@ func (s *testTimeSuite) TestYear(c *C) {
 	}
 
 	for _, test := range valids {
-		_, err := AdjustYear(test.Year)
+		_, err := types.AdjustYear(test.Year)
 		if test.Expect {
 			c.Assert(err, IsNil)
 		} else {
@@ -399,39 +400,39 @@ func (s *testTimeSuite) getLocation(c *C) *time.Location {
 func (s *testTimeSuite) TestCodec(c *C) {
 	defer testleak.AfterTest(c)()
 	// MySQL timestamp value doesn't allow month=0 or day=0.
-	t, err := ParseTimestamp(nil, "2016-12-00 00:00:00")
+	t, err := types.ParseTimestamp(nil, "2016-12-00 00:00:00")
 	c.Assert(err, NotNil)
 
-	t, err = ParseTimestamp(nil, "2010-10-10 10:11:11")
+	t, err = types.ParseTimestamp(nil, "2010-10-10 10:11:11")
 	c.Assert(err, IsNil)
 	packed, err := t.ToPackedUint()
 	c.Assert(err, IsNil)
 
-	var t1 Time
+	var t1 types.Time
 	t1.Type = mysql.TypeTimestamp
-	t1.Time = FromGoTime(time.Now())
+	t1.Time = types.FromGoTime(time.Now())
 	packed, err = t1.ToPackedUint()
 	c.Assert(err, IsNil)
 
-	var t2 Time
+	var t2 types.Time
 	t2.Type = mysql.TypeTimestamp
 	err = t2.FromPackedUint(packed)
 	c.Assert(err, IsNil)
 	c.Assert(t1.String(), Equals, t2.String())
 
-	packed, _ = ZeroDatetime.ToPackedUint()
+	packed, _ = types.ZeroDatetime.ToPackedUint()
 
-	var t3 Time
+	var t3 types.Time
 	t3.Type = mysql.TypeDatetime
 	err = t3.FromPackedUint(packed)
 	c.Assert(err, IsNil)
-	c.Assert(t3.String(), Equals, ZeroDatetime.String())
+	c.Assert(t3.String(), Equals, types.ZeroDatetime.String())
 
-	t, err = ParseDatetime(nil, "0001-01-01 00:00:00")
+	t, err = types.ParseDatetime(nil, "0001-01-01 00:00:00")
 	c.Assert(err, IsNil)
 	packed, _ = t.ToPackedUint()
 
-	var t4 Time
+	var t4 types.Time
 	t4.Type = mysql.TypeDatetime
 	err = t4.FromPackedUint(packed)
 	c.Assert(err, IsNil)
@@ -445,14 +446,14 @@ func (s *testTimeSuite) TestCodec(c *C) {
 	}
 
 	for _, test := range tbl {
-		t, err := ParseTime(nil, test, mysql.TypeDatetime, MaxFsp)
+		t, err := types.ParseTime(nil, test, mysql.TypeDatetime, types.MaxFsp)
 		c.Assert(err, IsNil)
 
 		packed, _ = t.ToPackedUint()
 
-		var dest Time
+		var dest types.Time
 		dest.Type = mysql.TypeDatetime
-		dest.Fsp = MaxFsp
+		dest.Fsp = types.MaxFsp
 		err = dest.FromPackedUint(packed)
 		c.Assert(err, IsNil)
 		c.Assert(dest.String(), Equals, test)
@@ -471,35 +472,35 @@ func (s *testTimeSuite) TestParseTimeFromNum(c *C) {
 		ExpectDateValue      string
 	}{
 		{20101010111111, false, "2010-10-10 11:11:11", false, "2010-10-10 11:11:11", false, "2010-10-10"},
-		{2010101011111, false, "0201-01-01 01:11:11", true, ZeroDatetimeStr, false, "0201-01-01"},
+		{2010101011111, false, "0201-01-01 01:11:11", true, types.ZeroDatetimeStr, false, "0201-01-01"},
 		{201010101111, false, "2020-10-10 10:11:11", false, "2020-10-10 10:11:11", false, "2020-10-10"},
 		{20101010111, false, "2002-01-01 01:01:11", false, "2002-01-01 01:01:11", false, "2002-01-01"},
-		{2010101011, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
+		{2010101011, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
 		{201010101, false, "2000-02-01 01:01:01", false, "2000-02-01 01:01:01", false, "2000-02-01"},
 		{20101010, false, "2010-10-10 00:00:00", false, "2010-10-10 00:00:00", false, "2010-10-10"},
-		{2010101, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
+		{2010101, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
 		{201010, false, "2020-10-10 00:00:00", false, "2020-10-10 00:00:00", false, "2020-10-10"},
 		{20101, false, "2002-01-01 00:00:00", false, "2002-01-01 00:00:00", false, "2002-01-01"},
-		{2010, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
+		{2010, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
 		{201, false, "2000-02-01 00:00:00", false, "2000-02-01 00:00:00", false, "2000-02-01"},
-		{20, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
-		{2, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
-		{0, false, ZeroDatetimeStr, false, ZeroDatetimeStr, false, zeroDateStr},
-		{-1, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
-		{99999999999999, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
-		{100000000000000, true, ZeroDatetimeStr, true, ZeroDatetimeStr, true, zeroDateStr},
-		{10000102000000, false, "1000-01-02 00:00:00", true, ZeroDatetimeStr, false, "1000-01-02"},
-		{19690101000000, false, "1969-01-01 00:00:00", true, ZeroDatetimeStr, false, "1969-01-01"},
+		{20, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
+		{2, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
+		{0, false, types.ZeroDatetimeStr, false, types.ZeroDatetimeStr, false, types.ZeroDateStr},
+		{-1, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
+		{99999999999999, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
+		{100000000000000, true, types.ZeroDatetimeStr, true, types.ZeroDatetimeStr, true, types.ZeroDateStr},
+		{10000102000000, false, "1000-01-02 00:00:00", true, types.ZeroDatetimeStr, false, "1000-01-02"},
+		{19690101000000, false, "1969-01-01 00:00:00", true, types.ZeroDatetimeStr, false, "1969-01-01"},
 		{991231235959, false, "1999-12-31 23:59:59", false, "1999-12-31 23:59:59", false, "1999-12-31"},
-		{691231235959, false, "2069-12-31 23:59:59", true, ZeroDatetimeStr, false, "2069-12-31"},
+		{691231235959, false, "2069-12-31 23:59:59", true, types.ZeroDatetimeStr, false, "2069-12-31"},
 		{370119031407, false, "2037-01-19 03:14:07", false, "2037-01-19 03:14:07", false, "2037-01-19"},
-		{380120031407, false, "2038-01-20 03:14:07", true, ZeroDatetimeStr, false, "2038-01-20"},
+		{380120031407, false, "2038-01-20 03:14:07", true, types.ZeroDatetimeStr, false, "2038-01-20"},
 		{11111111111, false, "2001-11-11 11:11:11", false, "2001-11-11 11:11:11", false, "2001-11-11"},
 	}
 
 	for ith, test := range table {
-		// test ParseDatetimeFromNum
-		t, err := ParseDatetimeFromNum(nil, test.Input)
+		// testtypes.ParseDatetimeFromNum
+		t, err := types.ParseDatetimeFromNum(nil, test.Input)
 		if test.ExpectDateTimeError {
 			c.Assert(err, NotNil, Commentf("%d", ith))
 		} else {
@@ -508,8 +509,8 @@ func (s *testTimeSuite) TestParseTimeFromNum(c *C) {
 		}
 		c.Assert(t.String(), Equals, test.ExpectDateTimeValue)
 
-		// test ParseTimestampFromNum
-		t, err = ParseTimestampFromNum(nil, test.Input)
+		// testtypes.ParseTimestampFromNum
+		t, err = types.ParseTimestampFromNum(nil, test.Input)
 		if test.ExpectTimeStampError {
 			c.Assert(err, NotNil)
 		} else {
@@ -518,8 +519,8 @@ func (s *testTimeSuite) TestParseTimeFromNum(c *C) {
 		}
 		c.Assert(t.String(), Equals, test.ExpectTimeStampValue)
 
-		// test ParseDateFromNum
-		t, err = ParseDateFromNum(nil, test.Input)
+		// testtypes.ParseDateFromNum
+		t, err = types.ParseDateFromNum(nil, test.Input)
 
 		if test.ExpectDateTimeError {
 			c.Assert(err, NotNil)
@@ -550,7 +551,7 @@ func (s *testTimeSuite) TestToNumber(c *C) {
 	}
 
 	for _, test := range tblDateTime {
-		t, err := ParseTime(nil, test.Input, mysql.TypeDatetime, test.Fsp)
+		t, err := types.ParseTime(nil, test.Input, mysql.TypeDatetime, test.Fsp)
 		c.Assert(err, IsNil)
 		c.Assert(t.ToNumber().String(), Equals, test.Expect)
 	}
@@ -573,7 +574,7 @@ func (s *testTimeSuite) TestToNumber(c *C) {
 	}
 
 	for _, test := range tblDate {
-		t, err := ParseTime(nil, test.Input, mysql.TypeDate, 0)
+		t, err := types.ParseTime(nil, test.Input, mysql.TypeDate, 0)
 		c.Assert(err, IsNil)
 		c.Assert(t.ToNumber().String(), Equals, test.Expect)
 	}
@@ -596,9 +597,9 @@ func (s *testTimeSuite) TestToNumber(c *C) {
 	}
 
 	for _, test := range tblDuration {
-		t, err := ParseDuration(test.Input, test.Fsp)
+		t, err := types.ParseDuration(test.Input, test.Fsp)
 		c.Assert(err, IsNil)
-		// now we can only change Duration's Fsp to check ToNumber with different Fsp
+		// now we can only changetypes.Duration's Fsp to check ToNumber with different Fsp
 		c.Assert(t.ToNumber().String(), Equals, test.Expect)
 	}
 }
@@ -633,7 +634,7 @@ func (s *testTimeSuite) TestParseFrac(c *C) {
 	}
 
 	for _, t := range tbl {
-		v, overflow, err := parseFrac(t.S, t.Fsp)
+		v, overflow, err := types.ParseFrac(t.S, t.Fsp)
 		c.Assert(err, IsNil)
 		c.Assert(v, Equals, t.Ret)
 		c.Assert(overflow, Equals, t.Overflow)
@@ -661,7 +662,7 @@ func (s *testTimeSuite) TestRoundFrac(c *C) {
 	}
 
 	for _, t := range tbl {
-		v, err := ParseTime(sc, t.Input, mysql.TypeDatetime, MaxFsp)
+		v, err := types.ParseTime(sc, t.Input, mysql.TypeDatetime, types.MaxFsp)
 		c.Assert(err, IsNil)
 		nv, err := v.RoundFrac(t.Fsp)
 		c.Assert(err, IsNil)
@@ -682,7 +683,7 @@ func (s *testTimeSuite) TestRoundFrac(c *C) {
 	}
 
 	for _, t := range tbl {
-		v, err := ParseDuration(t.Input, MaxFsp)
+		v, err := types.ParseDuration(t.Input, types.MaxFsp)
 		c.Assert(err, IsNil)
 		nv, err := v.RoundFrac(t.Fsp)
 		c.Assert(err, IsNil)
@@ -707,7 +708,7 @@ func (s *testTimeSuite) TestConvert(c *C) {
 	}
 
 	for _, t := range tbl {
-		v, err := ParseTime(nil, t.Input, mysql.TypeDatetime, t.Fsp)
+		v, err := types.ParseTime(nil, t.Input, mysql.TypeDatetime, t.Fsp)
 		c.Assert(err, IsNil)
 		nv, err := v.ConvertToDuration()
 		c.Assert(err, IsNil)
@@ -725,7 +726,7 @@ func (s *testTimeSuite) TestConvert(c *C) {
 	}
 
 	for _, t := range tblDuration {
-		v, err := ParseDuration(t.Input, t.Fsp)
+		v, err := types.ParseDuration(t.Input, t.Fsp)
 		c.Assert(err, IsNil)
 		year, month, day := time.Now().Date()
 		n := time.Date(year, month, day, 0, 0, 0, 0, time.Local)
@@ -752,7 +753,7 @@ func (s *testTimeSuite) TestCompare(c *C) {
 	}
 
 	for _, t := range tbl {
-		v1, err := ParseTime(nil, t.Arg1, mysql.TypeDatetime, MaxFsp)
+		v1, err := types.ParseTime(nil, t.Arg1, mysql.TypeDatetime, types.MaxFsp)
 		c.Assert(err, IsNil)
 
 		ret, err := v1.CompareString(nil, t.Arg2)
@@ -771,7 +772,7 @@ func (s *testTimeSuite) TestCompare(c *C) {
 	}
 
 	for _, t := range tbl {
-		v1, err := ParseDuration(t.Arg1, MaxFsp)
+		v1, err := types.ParseDuration(t.Arg1, types.MaxFsp)
 		c.Assert(err, IsNil)
 
 		ret, err := v1.CompareString(nil, t.Arg2)
@@ -796,7 +797,7 @@ func (s *testTimeSuite) TestDurationClock(c *C) {
 	}
 
 	for _, t := range tbl {
-		d, err := ParseDuration(t.Input, MaxFsp)
+		d, err := types.ParseDuration(t.Input, types.MaxFsp)
 		c.Assert(err, IsNil)
 		c.Assert(d.Hour(), Equals, t.Hour)
 		c.Assert(d.Minute(), Equals, t.Minute)
@@ -824,7 +825,7 @@ func (s *testTimeSuite) TestParseDateFormat(c *C) {
 	}
 
 	for _, t := range tbl {
-		r := parseDateFormat(t.Input)
+		r := types.ParseDateFormat(t.Input)
 		c.Assert(r, DeepEquals, t.Result)
 	}
 }
@@ -832,23 +833,23 @@ func (s *testTimeSuite) TestParseDateFormat(c *C) {
 func (s *testTimeSuite) TestTamestampDiff(c *C) {
 	tests := []struct {
 		unit   string
-		t1     TimeInternal
-		t2     TimeInternal
+		t1     types.TimeInternal
+		t2     types.TimeInternal
 		expect int64
 	}{
-		{"MONTH", FromDate(2002, 5, 30, 0, 0, 0, 0), FromDate(2001, 1, 1, 0, 0, 0, 0), -16},
-		{"YEAR", FromDate(2002, 5, 1, 0, 0, 0, 0), FromDate(2001, 1, 1, 0, 0, 0, 0), -1},
-		{"MINUTE", FromDate(2003, 2, 1, 0, 0, 0, 0), FromDate(2003, 5, 1, 12, 5, 55, 0), 128885},
-		{"MICROSECOND", FromDate(2002, 5, 30, 0, 0, 0, 0), FromDate(2002, 5, 30, 0, 13, 25, 0), 805000000},
-		{"MICROSECOND", FromDate(2000, 1, 1, 0, 0, 0, 12345), FromDate(2000, 1, 1, 0, 0, 45, 32), 44987687},
-		{"QUARTER", FromDate(2000, 1, 12, 0, 0, 0, 0), FromDate(2016, 1, 1, 0, 0, 0, 0), 63},
-		{"QUARTER", FromDate(2016, 1, 1, 0, 0, 0, 0), FromDate(2000, 1, 12, 0, 0, 0, 0), -63},
+		{"MONTH", types.FromDate(2002, 5, 30, 0, 0, 0, 0), types.FromDate(2001, 1, 1, 0, 0, 0, 0), -16},
+		{"YEAR", types.FromDate(2002, 5, 1, 0, 0, 0, 0), types.FromDate(2001, 1, 1, 0, 0, 0, 0), -1},
+		{"MINUTE", types.FromDate(2003, 2, 1, 0, 0, 0, 0), types.FromDate(2003, 5, 1, 12, 5, 55, 0), 128885},
+		{"MICROSECOND", types.FromDate(2002, 5, 30, 0, 0, 0, 0), types.FromDate(2002, 5, 30, 0, 13, 25, 0), 805000000},
+		{"MICROSECOND", types.FromDate(2000, 1, 1, 0, 0, 0, 12345), types.FromDate(2000, 1, 1, 0, 0, 45, 32), 44987687},
+		{"QUARTER", types.FromDate(2000, 1, 12, 0, 0, 0, 0), types.FromDate(2016, 1, 1, 0, 0, 0, 0), 63},
+		{"QUARTER", types.FromDate(2016, 1, 1, 0, 0, 0, 0), types.FromDate(2000, 1, 12, 0, 0, 0, 0), -63},
 	}
 
 	for _, test := range tests {
-		t1 := Time{test.t1, mysql.TypeDatetime, 6, nil, false}
-		t2 := Time{test.t2, mysql.TypeDatetime, 6, nil, false}
-		c.Assert(TimestampDiff(test.unit, t1, t2), Equals, test.expect)
+		t1 := types.Time{test.t1, mysql.TypeDatetime, 6, nil, false}
+		t2 := types.Time{test.t2, mysql.TypeDatetime, 6, nil, false}
+		c.Assert(types.TimestampDiff(test.unit, t1, t2), Equals, test.expect)
 	}
 }
 
@@ -864,28 +865,28 @@ func (s *testTimeSuite) TestDateFSP(c *C) {
 	}
 
 	for _, test := range tests {
-		c.Assert(DateFSP(test.date), Equals, test.expect)
+		c.Assert(types.DateFSP(test.date), Equals, test.expect)
 	}
 }
 
 func (s *testTimeSuite) TestConvertTimeZone(c *C) {
 	loc, _ := time.LoadLocation("Asia/Shanghai")
 	tests := []struct {
-		input  TimeInternal
+		input  types.TimeInternal
 		from   *time.Location
 		to     *time.Location
-		expect TimeInternal
+		expect types.TimeInternal
 	}{
-		{FromDate(2017, 1, 1, 0, 0, 0, 0), time.UTC, loc, FromDate(2017, 1, 1, 8, 0, 0, 0)},
-		{FromDate(2017, 1, 1, 8, 0, 0, 0), loc, time.UTC, FromDate(2017, 1, 1, 0, 0, 0, 0)},
-		{FromDate(0, 0, 0, 0, 0, 0, 0), loc, time.UTC, FromDate(0, 0, 0, 0, 0, 0, 0)},
+		{types.FromDate(2017, 1, 1, 0, 0, 0, 0), time.UTC, loc, types.FromDate(2017, 1, 1, 8, 0, 0, 0)},
+		{types.FromDate(2017, 1, 1, 8, 0, 0, 0), loc, time.UTC, types.FromDate(2017, 1, 1, 0, 0, 0, 0)},
+		{types.FromDate(0, 0, 0, 0, 0, 0, 0), loc, time.UTC, types.FromDate(0, 0, 0, 0, 0, 0, 0)},
 	}
 
 	for _, test := range tests {
-		var t Time
+		var t types.Time
 		t.Time = test.input
 		t.ConvertTimeZone(test.from, test.to)
-		c.Assert(compareTime(t.Time, test.expect), Equals, 0)
+		c.Assert(t.Compare(types.Time{Time: test.expect}), Equals, 0)
 	}
 }
 
@@ -904,11 +905,11 @@ func (s *testTimeSuite) TestTimeAdd(c *C) {
 	}
 
 	for _, t := range tbl {
-		v1, err := ParseTime(nil, t.Arg1, mysql.TypeDatetime, MaxFsp)
+		v1, err := types.ParseTime(nil, t.Arg1, mysql.TypeDatetime, types.MaxFsp)
 		c.Assert(err, IsNil)
-		dur, err := ParseDuration(t.Arg2, MaxFsp)
+		dur, err := types.ParseDuration(t.Arg2, types.MaxFsp)
 		c.Assert(err, IsNil)
-		result, err := ParseTime(nil, t.Ret, mysql.TypeDatetime, MaxFsp)
+		result, err := types.ParseTime(nil, t.Ret, mysql.TypeDatetime, types.MaxFsp)
 		c.Assert(err, IsNil)
 		v2, err := v1.Add(dur)
 		c.Assert(err, IsNil)
@@ -917,33 +918,33 @@ func (s *testTimeSuite) TestTimeAdd(c *C) {
 }
 
 func (s *testTimeSuite) TestTruncateOverflowMySQLTime(c *C) {
-	t := MaxTime + 1
-	res, err := TruncateOverflowMySQLTime(t)
-	c.Assert(ErrTruncatedWrongVal.Equal(err), IsTrue)
-	c.Assert(res, Equals, MaxTime)
+	t := types.MaxTime + 1
+	res, err := types.TruncateOverflowMySQLTime(t)
+	c.Assert(types.ErrTruncatedWrongVal.Equal(err), IsTrue)
+	c.Assert(res, Equals, types.MaxTime)
 
-	t = MinTime - 1
-	res, err = TruncateOverflowMySQLTime(t)
-	c.Assert(ErrTruncatedWrongVal.Equal(err), IsTrue)
-	c.Assert(res, Equals, MinTime)
+	t = types.MinTime - 1
+	res, err = types.TruncateOverflowMySQLTime(t)
+	c.Assert(types.ErrTruncatedWrongVal.Equal(err), IsTrue)
+	c.Assert(res, Equals, types.MinTime)
 
-	t = MaxTime
-	res, err = TruncateOverflowMySQLTime(t)
+	t = types.MaxTime
+	res, err = types.TruncateOverflowMySQLTime(t)
 	c.Assert(err, IsNil)
-	c.Assert(res, Equals, MaxTime)
+	c.Assert(res, Equals, types.MaxTime)
 
-	t = MinTime
-	res, err = TruncateOverflowMySQLTime(t)
+	t = types.MinTime
+	res, err = types.TruncateOverflowMySQLTime(t)
 	c.Assert(err, IsNil)
-	c.Assert(res, Equals, MinTime)
+	c.Assert(res, Equals, types.MinTime)
 
-	t = MaxTime - 1
-	res, err = TruncateOverflowMySQLTime(t)
+	t = types.MaxTime - 1
+	res, err = types.TruncateOverflowMySQLTime(t)
 	c.Assert(err, IsNil)
-	c.Assert(res, Equals, MaxTime-1)
+	c.Assert(res, Equals, types.MaxTime-1)
 
-	t = MinTime + 1
-	res, err = TruncateOverflowMySQLTime(t)
+	t = types.MinTime + 1
+	res, err = types.TruncateOverflowMySQLTime(t)
 	c.Assert(err, IsNil)
-	c.Assert(res, Equals, MinTime+1)
+	c.Assert(res, Equals, types.MinTime+1)
 }

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -21,7 +21,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
@@ -703,7 +703,7 @@ func (s *testCodecSuite) TestDecimal(c *C) {
 		{uint64(math.MaxUint64), uint64(0), 1},
 		{uint64(0), uint64(math.MaxUint64), -1},
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for _, t := range tblCmp {
 		d1 := types.NewDatum(t.Arg1)
 		dec1, err := d1.ToDecimal(sc)
@@ -923,7 +923,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		}
 	}
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	for colIdx, t := range table {
 		for rowIdx := 0; rowIdx < rowCount; rowIdx++ {
 			got := chk.GetRow(rowIdx).GetDatum(colIdx, t.tp)

--- a/util/codec/decimal_test.go
+++ b/util/codec/decimal_test.go
@@ -15,7 +15,7 @@ package codec
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
 )
@@ -73,7 +73,7 @@ func testFrac(c *C, v *types.MyDecimal) {
 	b := EncodeDecimal([]byte{}, d1)
 	_, d2, err := DecodeDecimal(b)
 	c.Assert(err, IsNil)
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	cmp, err := d1.CompareDatum(sc, &d2)
 	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, 0)

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -158,7 +158,7 @@ func DecodeUvarint(b []byte) ([]byte, uint64, error) {
 }
 
 const (
-	negativeTagEnd   = 8        // Negative tag is (negativeTagEnd - length).
+	negativeTagEnd   = 8        // negative tag is (negativeTagEnd - length).
 	positiveTagStart = 0xff - 8 // Positive tag is (positiveTagStart + length).
 )
 
@@ -263,7 +263,7 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 	var v uint64
 	if first < negativeTagEnd {
 		length = negativeTagEnd - int(first)
-		v = math.MaxUint64 // Negative value has all bits on by default.
+		v = math.MaxUint64 // negative value has all bits on by default.
 	} else {
 		length = int(first) - positiveTagStart
 	}

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -45,7 +45,7 @@ type item struct {
 
 // rowHeap maintains a min-heap property of comparableRows.
 type rowHeap struct {
-	sc     *variable.StatementContext
+	sc     *stmtctx.StatementContext
 	ims    []*item
 	byDesc []bool
 	err    error
@@ -53,7 +53,7 @@ type rowHeap struct {
 
 var headSize = 8
 
-func lessThan(sc *variable.StatementContext, i []types.Datum, j []types.Datum, byDesc []bool) (bool, error) {
+func lessThan(sc *stmtctx.StatementContext, i []types.Datum, j []types.Datum, byDesc []bool) (bool, error) {
 	for k := range byDesc {
 		v1 := i[k]
 		v2 := j[k]
@@ -110,7 +110,7 @@ func (rh *rowHeap) Pop() interface{} {
 // FileSorter sorts the given rows according to the byDesc order.
 // FileSorter can sort rows that exceed predefined memory capacity.
 type FileSorter struct {
-	sc     *variable.StatementContext
+	sc     *stmtctx.StatementContext
 	byDesc []bool
 
 	workers  []*Worker
@@ -152,7 +152,7 @@ type Worker struct {
 
 // Builder builds a new FileSorter.
 type Builder struct {
-	sc       *variable.StatementContext
+	sc       *stmtctx.StatementContext
 	keySize  int
 	valSize  int
 	bufSize  int
@@ -162,7 +162,7 @@ type Builder struct {
 }
 
 // SetSC sets StatementContext instance which is required in row comparison.
-func (b *Builder) SetSC(sc *variable.StatementContext) *Builder {
+func (b *Builder) SetSC(sc *stmtctx.StatementContext) *Builder {
 	b.sc = sc
 	return b
 }

--- a/util/filesort/filesort_test.go
+++ b/util/filesort/filesort_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
 )
@@ -54,7 +54,7 @@ func nextRow(r *rand.Rand, keySize int, valSize int) (key []types.Datum, val []t
 func (s *testFileSortSuite) TestLessThan(c *C) {
 	defer testleak.AfterTest(c)()
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 
 	d0 := types.NewDatum(0)
 	d1 := types.NewDatum(1)
@@ -109,7 +109,7 @@ func (s *testFileSortSuite) TestInMemory(c *C) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	keySize := r.Intn(10) + 1 // random int in range [1, 10]
 	valSize := r.Intn(20) + 1 // random int in range [1, 20]
 	bufSize := 40             // hold up to 40 items per file
@@ -159,7 +159,7 @@ func (s *testFileSortSuite) TestMultipleFiles(c *C) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	keySize := r.Intn(10) + 1 // random int in range [1, 10]
 	valSize := r.Intn(20) + 1 // random int in range [1, 20]
 	bufSize := 40             // hold up to 40 items per file
@@ -209,7 +209,7 @@ func (s *testFileSortSuite) TestMultipleWorkers(c *C) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	keySize := r.Intn(10) + 1 // random int in range [1, 10]
 	valSize := r.Intn(20) + 1 // random int in range [1, 20]
 	bufSize := 40             // hold up to 40 items per file
@@ -259,7 +259,7 @@ func (s *testFileSortSuite) TestClose(c *C) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	keySize := 2
 	valSize := 2
 	bufSize := 40
@@ -338,7 +338,7 @@ func (s *testFileSortSuite) TestMismatchedUsage(c *C) {
 	seed := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(seed)
 
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	keySize := 2
 	valSize := 2
 	bufSize := 40

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -21,7 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 )
@@ -74,7 +74,7 @@ func (rp point) String() string {
 type pointSorter struct {
 	points []point
 	err    error
-	sc     *variable.StatementContext
+	sc     *stmtctx.StatementContext
 }
 
 func (r *pointSorter) Len() int {
@@ -91,7 +91,7 @@ func (r *pointSorter) Less(i, j int) bool {
 	return less
 }
 
-func rangePointLess(sc *variable.StatementContext, a, b point) (bool, error) {
+func rangePointLess(sc *stmtctx.StatementContext, a, b point) (bool, error) {
 	cmp, err := a.value.CompareDatum(sc, &b.value)
 	if cmp != 0 {
 		return cmp < 0, nil
@@ -133,7 +133,7 @@ func FullIndexRange() []*types.IndexRange {
 // builder is the range builder struct.
 type builder struct {
 	err error
-	sc  *variable.StatementContext
+	sc  *stmtctx.StatementContext
 }
 
 func (r *builder) build(expr expression.Expression) []point {

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -19,14 +19,14 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
 // points2IndexRanges build index ranges from range points.
 // Only the first column in the index is built, extra column ranges will be appended by
 // appendPoints2IndexRanges.
-func points2IndexRanges(sc *variable.StatementContext, rangePoints []point, tp *types.FieldType) ([]*types.IndexRange, error) {
+func points2IndexRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.FieldType) ([]*types.IndexRange, error) {
 	indexRanges := make([]*types.IndexRange, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
 		startPoint, err := convertPoint(sc, rangePoints[i], tp)
@@ -55,7 +55,7 @@ func points2IndexRanges(sc *variable.StatementContext, rangePoints []point, tp *
 	return indexRanges, nil
 }
 
-func convertPoint(sc *variable.StatementContext, point point, tp *types.FieldType) (point, error) {
+func convertPoint(sc *stmtctx.StatementContext, point point, tp *types.FieldType) (point, error) {
 	switch point.value.Kind() {
 	case types.KindMaxValue, types.KindMinNotNull:
 		return point, nil
@@ -104,7 +104,7 @@ func convertPoint(sc *variable.StatementContext, point point, tp *types.FieldTyp
 // The additional column ranges can only be appended to point ranges.
 // for example we have an index (a, b), if the condition is (a > 1 and b = 2)
 // then we can not build a conjunctive ranges for this index.
-func appendPoints2IndexRanges(sc *variable.StatementContext, origin []*types.IndexRange, rangePoints []point,
+func appendPoints2IndexRanges(sc *stmtctx.StatementContext, origin []*types.IndexRange, rangePoints []point,
 	ft *types.FieldType) ([]*types.IndexRange, error) {
 	var newIndexRanges []*types.IndexRange
 	for i := 0; i < len(origin); i++ {
@@ -122,7 +122,7 @@ func appendPoints2IndexRanges(sc *variable.StatementContext, origin []*types.Ind
 	return newIndexRanges, nil
 }
 
-func appendPoints2IndexRange(sc *variable.StatementContext, origin *types.IndexRange, rangePoints []point,
+func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *types.IndexRange, rangePoints []point,
 	ft *types.FieldType) ([]*types.IndexRange, error) {
 	newRanges := make([]*types.IndexRange, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
@@ -162,7 +162,7 @@ func appendPoints2IndexRange(sc *variable.StatementContext, origin *types.IndexR
 }
 
 // points2TableRanges will construct the range slice with the given range points
-func points2TableRanges(sc *variable.StatementContext, rangePoints []point) ([]types.IntColumnRange, error) {
+func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []point) ([]types.IntColumnRange, error) {
 	tableRanges := make([]types.IntColumnRange, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
 		startPoint := rangePoints[i]
@@ -216,7 +216,7 @@ func points2TableRanges(sc *variable.StatementContext, rangePoints []point) ([]t
 	return tableRanges, nil
 }
 
-func points2ColumnRanges(sc *variable.StatementContext, points []point, tp *types.FieldType) ([]*types.ColumnRange, error) {
+func points2ColumnRanges(sc *stmtctx.StatementContext, points []point, tp *types.FieldType) ([]*types.ColumnRange, error) {
 	columnRanges := make([]*types.ColumnRange, 0, len(points)/2)
 	for i := 0; i < len(points); i += 2 {
 		startPoint, err := convertPoint(sc, points[i], tp)
@@ -246,7 +246,7 @@ func points2ColumnRanges(sc *variable.StatementContext, points []point, tp *type
 }
 
 // buildTableRange will build range of pk for PhysicalTableScan
-func buildTableRange(accessConditions []expression.Expression, sc *variable.StatementContext) ([]types.IntColumnRange, error) {
+func buildTableRange(accessConditions []expression.Expression, sc *stmtctx.StatementContext) ([]types.IntColumnRange, error) {
 	if len(accessConditions) == 0 {
 		return FullIntRange(), nil
 	}
@@ -267,7 +267,7 @@ func buildTableRange(accessConditions []expression.Expression, sc *variable.Stat
 }
 
 // buildColumnRange builds the range for sampling histogram to calculate the row count.
-func buildColumnRange(conds []expression.Expression, sc *variable.StatementContext, tp *types.FieldType) ([]*types.ColumnRange, error) {
+func buildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*types.ColumnRange, error) {
 	if len(conds) == 0 {
 		return []*types.ColumnRange{{Low: types.Datum{}, High: types.MaxValueDatum()}}, nil
 	}
@@ -287,7 +287,7 @@ func buildColumnRange(conds []expression.Expression, sc *variable.StatementConte
 	return ranges, nil
 }
 
-func buildIndexRange(sc *variable.StatementContext, cols []*expression.Column, lengths []int,
+func buildIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, lengths []int,
 	accessCondition []expression.Expression) ([]*types.IndexRange, error) {
 	rb := builder{sc: sc}
 	var (
@@ -412,7 +412,7 @@ func getEQColOffset(expr expression.Expression, cols []*expression.Column) int {
 }
 
 // BuildRange is a method which can calculate IntColumnRange, ColumnRange, IndexRange.
-func BuildRange(sc *variable.StatementContext, conds []expression.Expression, rangeType int, cols []*expression.Column,
+func BuildRange(sc *stmtctx.StatementContext, conds []expression.Expression, rangeType int, cols []*expression.Column,
 	lengths []int) (retRanges []types.Range, _ error) {
 	if rangeType == IntRangeType {
 		ranges, err := buildTableRange(conds, sc)

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/mock-tikv"
 	"github.com/pingcap/tidb/util/ranger"
@@ -328,7 +328,7 @@ func (s *testRangerSuite) TestTableRange(c *C) {
 		conds, filter = ranger.DetachCondsForTableRange(ctx, conds, col)
 		c.Assert(fmt.Sprintf("%s", conds), Equals, tt.accessConds, Commentf("wrong access conditions for expr: %s", tt.exprStr))
 		c.Assert(fmt.Sprintf("%s", filter), Equals, tt.filterConds, Commentf("wrong filter conditions for expr: %s", tt.exprStr))
-		result, err := ranger.BuildRange(new(variable.StatementContext), conds, ranger.IntRangeType, []*expression.Column{col}, nil)
+		result, err := ranger.BuildRange(new(stmtctx.StatementContext), conds, ranger.IntRangeType, []*expression.Column{col}, nil)
 		c.Assert(err, IsNil)
 		got := fmt.Sprintf("%v", result)
 		c.Assert(got, Equals, tt.resultStr, Commentf("different for expr %s", tt.exprStr))
@@ -518,7 +518,7 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 		conds, filter = ranger.DetachIndexConditions(conds, cols, lengths)
 		c.Assert(fmt.Sprintf("%s", conds), Equals, tt.accessConds, Commentf("wrong access conditions for expr: %s", tt.exprStr))
 		c.Assert(fmt.Sprintf("%s", filter), Equals, tt.filterConds, Commentf("wrong filter conditions for expr: %s", tt.exprStr))
-		result, err := ranger.BuildRange(new(variable.StatementContext), conds, ranger.IndexRangeType, cols, lengths)
+		result, err := ranger.BuildRange(new(stmtctx.StatementContext), conds, ranger.IndexRangeType, cols, lengths)
 		c.Assert(err, IsNil)
 		got := fmt.Sprintf("%v", result)
 		c.Assert(got, Equals, tt.resultStr, Commentf("different for expr %s", tt.exprStr))
@@ -770,7 +770,7 @@ func (s *testRangerSuite) TestColumnRange(c *C) {
 		conds, filter = ranger.DetachCondsForSelectivity(conds, ranger.ColumnRangeType, []*expression.Column{col}, nil)
 		c.Assert(fmt.Sprintf("%s", conds), Equals, tt.accessConds, Commentf("wrong access conditions for expr: %s", tt.exprStr))
 		c.Assert(fmt.Sprintf("%s", filter), Equals, tt.filterConds, Commentf("wrong filter conditions for expr: %s", tt.exprStr))
-		result, err := ranger.BuildRange(new(variable.StatementContext), conds, ranger.ColumnRangeType, []*expression.Column{col}, nil)
+		result, err := ranger.BuildRange(new(stmtctx.StatementContext), conds, ranger.ColumnRangeType, []*expression.Column{col}, nil)
 		c.Assert(err, IsNil)
 		got := fmt.Sprintf("%s", result)
 		c.Assert(got, Equals, tt.resultStr, Commentf("different for expr %s, col: %v", tt.exprStr, col))

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/check"
-	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -86,7 +86,7 @@ func (checker *datumEqualsChecker) Check(params []interface{}, names []string) (
 	if !ok {
 		panic("the second param should be datum")
 	}
-	sc := new(variable.StatementContext)
+	sc := new(stmtctx.StatementContext)
 	res, err := paramFirst.CompareDatum(sc, &paramSecond)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
So that `sessionctx/variable` could depends on `types`.