### PR TITLE
types: fix parse duration when fsp round overflow 60 seconds

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -1069,7 +1069,7 @@ func ParseDuration(str string, fsp int) (Duration, error) {
 	}
 	// Invalid TIME values are converted to '00:00:00'.
 	// See https://dev.mysql.com/doc/refman/5.7/en/time.html
-	if minute >= 60 || second >= 60 {
+	if minute >= 60 || second > 60 || (!overflow && second == 60) {
 		return ZeroDuration, ErrTruncatedWrongVal.GenByArgs("time", origStr)
 	}
 	d := gotime.Duration(day*24*3600+hour*3600+minute*60+second)*gotime.Second + gotime.Duration(frac)*gotime.Microsecond

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -323,6 +323,9 @@ func (s *testTimeSuite) TestTimeFsp(c *C) {
 		// fsp -1 use default 0
 		{"00:00:00.777777", -1, "00:00:01"},
 		{"00:00:00.001", 3, "00:00:00.001"},
+		// fsp round overflow 60 seconds
+		{"08:29:59.537368", 0, "08:30:00"},
+		{"08:59:59.537368", 0, "09:00:00"},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
> FAIL: builtin_time_test.go:1078: testEvaluatorSuite.TestUTCTime
> 
> builtin_time_test.go:1095:
>     c.Assert(err, IsNil)
> ... value *errors.Err = &errors.Err{message:"", cause:(*terror.Error)(0xc4214b36d0), previous:(*terror.Error)(0xc4214b36d0), file:"/home/travis/gopath/src/github.com/pingcap/tidb/expression/builtin_test.go", line:60} ("[types:1292]Truncated incorrect time value: '2017-11-22 08:29:59.537368'")

It's found in the CI after this PR https://github.com/pingcap/tidb/pull/4338 , turn out to be a bug in `types.ParseDuration`

PTAL @lamxTyler @winoros  @coocood 