### PR TITLE
tidb: update statement history in retry()

### DIFF
--- a/session.go
+++ b/session.go
@@ -371,6 +371,7 @@ func (s *session) retry(maxCnt int, infoSchemaChanged bool) error {
 				if err != nil {
 					return errors.Trace(err)
 				}
+				nh.history[i].st = st
 			}
 
 			if retryCnt == 0 {

--- a/store/tikv/mock-tikv/rpc.go
+++ b/store/tikv/mock-tikv/rpc.go
@@ -190,10 +190,7 @@ func (h *rpcHandler) checkRequest(ctx *kvrpcpb.Context, size int) *errorpb.Error
 		return err
 	}
 
-	if err := h.checkRequestSize(size); err != nil {
-		return err
-	}
-	return nil
+	return h.checkRequestSize(size)
 }
 
 func (h *rpcHandler) checkKeyInRegion(key []byte) bool {


### PR DESCRIPTION
cherry pick bug fix from https://github.com/pingcap/tidb/pull/5202
As rc3 is too old, I did not port the test code to adapt it.