### PR TITLE
tidb: always rebuild plan for retry.

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -188,6 +188,9 @@ type Statement interface {
 
 	// IsReadOnly returns if the statement is read only. For example: SelectStmt without lock.
 	IsReadOnly() bool
+
+	// RebuildPlan rebuilds the plan of the statement.
+	RebuildPlan() error
 }
 
 // Visitor visits a Node.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -46,18 +46,13 @@ func (c *Compiler) Compile(goCtx goctx.Context, stmtNode ast.StmtNode) (*ExecStm
 		return nil, errors.Trace(err)
 	}
 
-	readOnlyCheckStmt := stmtNode
-	if checkPlan, ok := finalPlan.(*plan.Execute); ok {
-		readOnlyCheckStmt = checkPlan.Stmt
-	}
-
 	return &ExecStmt{
 		InfoSchema: infoSchema,
 		Plan:       finalPlan,
 		Expensive:  stmtCount(stmtNode, finalPlan, c.Ctx.GetSessionVars().InRestrictedSQL),
 		Cacheable:  plan.Cacheable(stmtNode),
 		Text:       stmtNode.Text(),
-		ReadOnly:   ast.IsReadOnly(readOnlyCheckStmt),
+		StmtNode:   stmtNode,
 		Ctx:        c.Ctx,
 	}, nil
 }

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -282,15 +282,10 @@ func CompileExecutePreparedStmt(ctx context.Context, ID uint32, args ...interfac
 		return nil, errors.Trace(err)
 	}
 
-	readOnly := false
-	if execute, ok := execPlan.(*plan.Execute); ok {
-		readOnly = ast.IsReadOnly(execute.Stmt)
-	}
-
 	stmt := &ExecStmt{
 		InfoSchema: GetInfoSchema(ctx),
 		Plan:       execPlan,
-		ReadOnly:   readOnly,
+		StmtNode:   execStmt,
 		Ctx:        ctx,
 	}
 	if prepared, ok := ctx.GetSessionVars().PreparedStmts[ID].(*plan.Prepared); ok {

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1497,6 +1497,23 @@ func (s *testSchemaSuite) TestRetrySchemaChange(c *C) {
 	tk.MustQuery("select * from t where t.b = 5").Check(testkit.Rows("1 5"))
 }
 
+func (s *testSchemaSuite) TestRetryMissingUnionScan(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table t (a int primary key, b int unique, c int)")
+	tk.MustExec("insert into t values (1, 1, 1)")
+
+	tk1.MustExec("begin")
+	tk1.MustExec("update t set b = 1, c = 2 where b = 2")
+	tk1.MustExec("update t set b = 1, c = 2 where a = 1")
+
+	// Create a conflict to reproduces the bug that the second update statement in retry
+	// has a dirty table but doesn't use UnionScan.
+	tk.MustExec("update t set b = 2 where a = 1")
+
+	tk1.MustExec("commit")
+}
+
 func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
 	// Since normally a single region mock tikv only returns one partial result we need to manually split the
 	// table to test multiple chunks.


### PR DESCRIPTION
Fixes a bug that results in index and record inconsistency.

We build UnionScan based on if transaction is dirty, but this is a runtime property, may change during retry.

To simplify the logic and avoid potential bug, always rebuild the plan for retrying statements.