### PR TITLE
types, ranger: move `Range` to package ranger.

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	goctx "golang.org/x/net/context"
 )
@@ -185,9 +186,9 @@ type AnalyzeIndexExec struct {
 }
 
 func (e *AnalyzeIndexExec) open() error {
-	idxRange := &types.IndexRange{LowVal: []types.Datum{types.MinNotNullDatum()}, HighVal: []types.Datum{types.MaxValueDatum()}}
+	idxRange := &ranger.IndexRange{LowVal: []types.Datum{types.MinNotNullDatum()}, HighVal: []types.Datum{types.MaxValueDatum()}}
 	var builder requestBuilder
-	kvReq, err := builder.SetIndexRanges(e.tblInfo.ID, e.idxInfo.ID, []*types.IndexRange{idxRange}).
+	kvReq, err := builder.SetIndexRanges(e.tblInfo.ID, e.idxInfo.ID, []*ranger.IndexRange{idxRange}).
 		SetAnalyzeRequest(e.analyzePB).
 		SetKeepOrder(true).
 		SetPriority(e.priority).
@@ -276,7 +277,7 @@ type AnalyzeColumnsExec struct {
 }
 
 func (e *AnalyzeColumnsExec) open() error {
-	ranges := []types.IntColumnRange{{LowVal: math.MinInt64, HighVal: math.MaxInt64}}
+	ranges := []ranger.IntColumnRange{{LowVal: math.MinInt64, HighVal: math.MaxInt64}}
 	var builder requestBuilder
 	kvReq, err := builder.SetTableRanges(e.tblInfo.ID, ranges).
 		SetAnalyzeRequest(e.analyzePB).

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -903,7 +903,7 @@ func (b *executorBuilder) constructDAGReq(plans []plan.PhysicalPlan) (*tipb.DAGR
 	return dagReq, nil
 }
 
-func (b *executorBuilder) constructTableRanges(ts *plan.PhysicalTableScan) (newRanges []types.IntColumnRange, err error) {
+func (b *executorBuilder) constructTableRanges(ts *plan.PhysicalTableScan) (newRanges []ranger.IntColumnRange, err error) {
 	sc := b.ctx.GetSessionVars().StmtCtx
 	cols := expression.ColumnInfos2ColumnsWithDBName(ts.DBName, ts.Table.Name, ts.Columns)
 	newRanges = ranger.FullIntRange()
@@ -914,7 +914,7 @@ func (b *executorBuilder) constructTableRanges(ts *plan.PhysicalTableScan) (newR
 		}
 	}
 	if pkCol != nil {
-		var ranges []types.Range
+		var ranges []ranger.Range
 		ranges, err = ranger.BuildRange(sc, ts.AccessCondition, ranger.IntRangeType, []*expression.Column{pkCol}, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -924,13 +924,13 @@ func (b *executorBuilder) constructTableRanges(ts *plan.PhysicalTableScan) (newR
 	return newRanges, nil
 }
 
-func (b *executorBuilder) constructIndexRanges(is *plan.PhysicalIndexScan) (newRanges []*types.IndexRange, err error) {
+func (b *executorBuilder) constructIndexRanges(is *plan.PhysicalIndexScan) (newRanges []*ranger.IndexRange, err error) {
 	sc := b.ctx.GetSessionVars().StmtCtx
 	cols := expression.ColumnInfos2ColumnsWithDBName(is.DBName, is.Table.Name, is.Columns)
 	idxCols, colLengths := expression.IndexInfo2Cols(cols, is.Index)
 	newRanges = ranger.FullIndexRange()
 	if len(idxCols) > 0 {
-		var ranges []types.Range
+		var ranges []ranger.Range
 		ranges, err = ranger.BuildRange(sc, is.AccessCondition, ranger.IndexRangeType, idxCols, colLengths)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -1105,7 +1105,7 @@ func (b *executorBuilder) buildIndexLookUpReader(v *plan.PhysicalIndexLookUpRead
 		b.err = errors.Trace(err1)
 		return nil
 	}
-	ranges := make([]*types.IndexRange, 0, len(newRanges))
+	ranges := make([]*ranger.IndexRange, 0, len(newRanges))
 	for _, rangeInPlan := range newRanges {
 		ranges = append(ranges, rangeInPlan.Clone())
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/ranger"
 	goctx "golang.org/x/net/context"
 )
 
@@ -524,7 +525,7 @@ type TableScanExec struct {
 
 	t          table.Table
 	asName     *model.CIStr
-	ranges     []types.IntColumnRange
+	ranges     []ranger.IntColumnRange
 	seekHandle int64
 	iter       kv.Iterator
 	cursor     int

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -765,7 +765,7 @@ func (p *DataSource) convertToIndexScan(prop *requiredProp, idx *model.IndexInfo
 			conds = append(conds, cond.Clone())
 		}
 		if len(idxCols) > 0 {
-			var ranges []types.Range
+			var ranges []ranger.Range
 			is.AccessCondition, is.filterCondition = ranger.DetachIndexConditions(conds, idxCols, colLengths)
 			ranges, err = ranger.BuildRange(sc, is.AccessCondition, ranger.IndexRangeType, idxCols, colLengths)
 			if err != nil {
@@ -1011,7 +1011,7 @@ func (p *DataSource) convertToTableScan(prop *requiredProp) (task task, err erro
 			conds = append(conds, cond.Clone())
 		}
 		if pkCol != nil {
-			var ranges []types.Range
+			var ranges []ranger.Range
 			ts.AccessCondition, ts.filterCondition = ranger.DetachCondsForTableRange(p.ctx, conds, pkCol)
 			ranges, err = ranger.BuildRange(sc, ts.AccessCondition, ranger.IntRangeType, []*expression.Column{pkCol}, nil)
 			ts.Ranges = ranger.Ranges2IntRanges(ranges)

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/ranger"
 )
 
 var (
@@ -121,7 +122,7 @@ type PhysicalIndexScan struct {
 
 	Table      *model.TableInfo
 	Index      *model.IndexInfo
-	Ranges     []*types.IndexRange
+	Ranges     []*ranger.IndexRange
 	Columns    []*model.ColumnInfo
 	DBName     model.CIStr
 	Desc       bool
@@ -150,7 +151,7 @@ type PhysicalMemTable struct {
 	DBName      model.CIStr
 	Table       *model.TableInfo
 	Columns     []*model.ColumnInfo
-	Ranges      []types.IntColumnRange
+	Ranges      []ranger.IntColumnRange
 	TableAsName *model.CIStr
 }
 
@@ -185,7 +186,7 @@ type PhysicalTableScan struct {
 	Columns []*model.ColumnInfo
 	DBName  model.CIStr
 	Desc    bool
-	Ranges  []types.IntColumnRange
+	Ranges  []ranger.IntColumnRange
 	pkCol   *expression.Column
 
 	TableAsName *model.CIStr

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
 	goctx "golang.org/x/net/context"
@@ -476,7 +477,7 @@ func (c *Column) equalRowCount(sc *stmtctx.StatementContext, val types.Datum) (f
 }
 
 // getIntColumnRowCount estimates the row count by a slice of IntColumnRange.
-func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []types.IntColumnRange,
+func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []ranger.IntColumnRange,
 	totalRowCount float64) (float64, error) {
 	var rowCount float64
 	for _, rg := range intRanges {
@@ -510,7 +511,7 @@ func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []
 }
 
 // getColumnRowCount estimates the row count by a slice of ColumnRange.
-func (c *Column) getColumnRowCount(sc *stmtctx.StatementContext, ranges []*types.ColumnRange) (float64, error) {
+func (c *Column) getColumnRowCount(sc *stmtctx.StatementContext, ranges []*ranger.ColumnRange) (float64, error) {
 	var rowCount float64
 	for _, rg := range ranges {
 		cmp, err := rg.Low.CompareDatum(sc, &rg.High)
@@ -577,7 +578,7 @@ func (idx *Index) equalRowCount(sc *stmtctx.StatementContext, b []byte) (float64
 	return count, errors.Trace(err)
 }
 
-func (idx *Index) getRowCount(sc *stmtctx.StatementContext, indexRanges []*types.IndexRange) (float64, error) {
+func (idx *Index) getRowCount(sc *stmtctx.StatementContext, indexRanges []*ranger.IndexRange) (float64, error) {
 	totalCount := float64(0)
 	for _, indexRange := range indexRanges {
 		indexRange.Align(len(idx.Info.Columns))

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/ranger"
 )
 
@@ -35,7 +34,7 @@ type exprSet struct {
 	// mask is a bit pattern whose ith bit will indicate whether the ith expression is covered by this index/column.
 	mask int64
 	// ranges contains all the ranges we got.
-	ranges []types.Range
+	ranges []ranger.Range
 }
 
 // The type of the exprSet.
@@ -152,7 +151,7 @@ func (t *Table) Selectivity(ctx context.Context, exprs []expression.Expression) 
 }
 
 func getMaskAndRanges(ctx context.Context, exprs []expression.Expression, rangeType int,
-	lengths []int, cols ...*expression.Column) (int64, []types.Range, error) {
+	lengths []int, cols ...*expression.Column) (int64, []ranger.Range, error) {
 	exprsClone := make([]expression.Expression, 0, len(exprs))
 	for _, expr := range exprs {
 		exprsClone = append(exprsClone, expr.Clone())

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/ranger"
 	goctx "golang.org/x/net/context"
 )
 
@@ -468,7 +469,7 @@ func (s *testStatisticsSuite) TestColumnRange(c *C) {
 		Count:   int64(col.totalRowCount()),
 		Columns: make(map[int64]*Column),
 	}
-	ran := []*types.ColumnRange{{
+	ran := []*ranger.ColumnRange{{
 		Low:  types.Datum{},
 		High: types.MaxValueDatum(),
 	}}
@@ -535,7 +536,7 @@ func (s *testStatisticsSuite) TestIntColumnRanges(c *C) {
 		Count:   int64(col.totalRowCount()),
 		Columns: make(map[int64]*Column),
 	}
-	ran := []types.IntColumnRange{{
+	ran := []ranger.IntColumnRange{{
 		LowVal:  math.MinInt64,
 		HighVal: math.MaxInt64,
 	}}
@@ -597,7 +598,7 @@ func (s *testStatisticsSuite) TestIndexRanges(c *C) {
 		Count:   int64(idx.totalRowCount()),
 		Indices: make(map[int64]*Index),
 	}
-	ran := []*types.IndexRange{{
+	ran := []*ranger.IndexRange{{
 		LowVal:  []types.Datum{types.MinNotNullDatum()},
 		HighVal: []types.Datum{types.MaxValueDatum()},
 	}}

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -121,13 +121,13 @@ var fullRange = []point{
 }
 
 // FullIntRange is (-∞, +∞) for IntColumnRange.
-func FullIntRange() []types.IntColumnRange {
-	return []types.IntColumnRange{{LowVal: math.MinInt64, HighVal: math.MaxInt64}}
+func FullIntRange() []IntColumnRange {
+	return []IntColumnRange{{LowVal: math.MinInt64, HighVal: math.MaxInt64}}
 }
 
 // FullIndexRange is (-∞, +∞) for IndexRange.
-func FullIndexRange() []*types.IndexRange {
-	return []*types.IndexRange{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}
+func FullIndexRange() []*IndexRange {
+	return []*IndexRange{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}
 }
 
 // builder is the range builder struct.

--- a/util/ranger/range.go
+++ b/util/ranger/range.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package ranger
 
 import (
 	"fmt"
@@ -21,6 +21,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
 )
 
 // Range is the interface of the three type of range.
@@ -74,8 +75,8 @@ func (tr IntColumnRange) Convert2IndexRange() *IndexRange {
 
 // ColumnRange represents a range for a column.
 type ColumnRange struct {
-	Low      Datum
-	High     Datum
+	Low      types.Datum
+	High     types.Datum
 	LowExcl  bool
 	HighExcl bool
 }
@@ -112,8 +113,8 @@ func (cr *ColumnRange) Convert2IndexRange() *IndexRange {
 
 // IndexRange represents a range for an index.
 type IndexRange struct {
-	LowVal  []Datum
-	HighVal []Datum
+	LowVal  []types.Datum
+	HighVal []types.Datum
 
 	LowExclude  bool // Low value is exclusive.
 	HighExclude bool // High value is exclusive.
@@ -122,8 +123,8 @@ type IndexRange struct {
 // Clone clones a IndexRange.
 func (ir *IndexRange) Clone() *IndexRange {
 	newRange := &IndexRange{
-		LowVal:      make([]Datum, 0, len(ir.LowVal)),
-		HighVal:     make([]Datum, 0, len(ir.HighVal)),
+		LowVal:      make([]types.Datum, 0, len(ir.LowVal)),
+		HighVal:     make([]types.Datum, 0, len(ir.HighVal)),
 		LowExclude:  ir.LowExclude,
 		HighExclude: ir.HighExclude,
 	}
@@ -144,7 +145,7 @@ func (ir *IndexRange) IsPoint(sc *stmtctx.StatementContext) bool {
 	for i := range ir.LowVal {
 		a := ir.LowVal[i]
 		b := ir.HighVal[i]
-		if a.Kind() == KindMinNotNull || b.Kind() == KindMaxValue {
+		if a.Kind() == types.KindMinNotNull || b.Kind() == types.KindMaxValue {
 			return false
 		}
 		cmp, err := a.CompareDatum(sc, &b)
@@ -197,16 +198,16 @@ func (ir *IndexRange) Convert2IndexRange() *IndexRange {
 func (ir *IndexRange) Align(numColumns int) {
 	for i := len(ir.LowVal); i < numColumns; i++ {
 		if ir.LowExclude {
-			ir.LowVal = append(ir.LowVal, MaxValueDatum())
+			ir.LowVal = append(ir.LowVal, types.MaxValueDatum())
 		} else {
-			ir.LowVal = append(ir.LowVal, Datum{})
+			ir.LowVal = append(ir.LowVal, types.Datum{})
 		}
 	}
 	for i := len(ir.HighVal); i < numColumns; i++ {
 		if ir.HighExclude {
-			ir.HighVal = append(ir.HighVal, Datum{})
+			ir.HighVal = append(ir.HighVal, types.Datum{})
 		} else {
-			ir.HighVal = append(ir.HighVal, MaxValueDatum())
+			ir.HighVal = append(ir.HighVal, types.MaxValueDatum())
 		}
 	}
 }
@@ -227,11 +228,11 @@ func (ir *IndexRange) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) 
 	return len(ir.LowVal), nil
 }
 
-func formatDatum(d Datum) string {
-	if d.Kind() == KindMinNotNull {
+func formatDatum(d types.Datum) string {
+	if d.Kind() == types.KindMinNotNull {
 		return "-inf"
 	}
-	if d.Kind() == KindMaxValue {
+	if d.Kind() == types.KindMaxValue {
 		return "+inf"
 	}
 	return fmt.Sprintf("%v", d.GetValue())

--- a/util/ranger/range_test.go
+++ b/util/ranger/range_test.go
@@ -11,13 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package ranger_test
 
 import (
 	"math"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/ranger"
 )
 
 var _ = Suite(&testRangeSuite{})
@@ -27,45 +29,45 @@ type testRangeSuite struct {
 
 func (s *testRangeSuite) TestRange(c *C) {
 	alignedTests := []struct {
-		ran IndexRange
+		ran ranger.IndexRange
 		str string
 	}{
 		{
-			ran: IndexRange{
-				LowVal:  []Datum{NewIntDatum(1)},
-				HighVal: []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:  []types.Datum{types.NewIntDatum(1)},
+				HighVal: []types.Datum{types.NewIntDatum(1)},
 			},
 			str: "[1 <nil>,1 +inf]",
 		},
 		{
-			ran: IndexRange{
-				LowVal:      []Datum{NewIntDatum(1)},
-				HighVal:     []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
 			},
 			str: "[1 <nil>,1 <nil>)",
 		},
 		{
-			ran: IndexRange{
-				LowVal:      []Datum{NewIntDatum(1)},
-				HighVal:     []Datum{NewIntDatum(2)},
+			ran: ranger.IndexRange{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(2)},
 				LowExclude:  true,
 				HighExclude: true,
 			},
 			str: "(1 +inf,2 <nil>)",
 		},
 		{
-			ran: IndexRange{
-				LowVal:      []Datum{NewFloat64Datum(1.1)},
-				HighVal:     []Datum{NewFloat64Datum(1.9)},
+			ran: ranger.IndexRange{
+				LowVal:      []types.Datum{types.NewFloat64Datum(1.1)},
+				HighVal:     []types.Datum{types.NewFloat64Datum(1.9)},
 				HighExclude: true,
 			},
 			str: "[1.1 <nil>,1.9 <nil>)",
 		},
 		{
-			ran: IndexRange{
-				LowVal:      []Datum{MinNotNullDatum()},
-				HighVal:     []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:      []types.Datum{types.MinNotNullDatum()},
+				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
 			},
 			str: "[-inf <nil>,1 <nil>)",
@@ -77,50 +79,50 @@ func (s *testRangeSuite) TestRange(c *C) {
 	}
 
 	isPointTests := []struct {
-		ran     IndexRange
+		ran     ranger.IndexRange
 		isPoint bool
 	}{
 		{
-			ran: IndexRange{
-				LowVal:  []Datum{NewIntDatum(1)},
-				HighVal: []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:  []types.Datum{types.NewIntDatum(1)},
+				HighVal: []types.Datum{types.NewIntDatum(1)},
 			},
 			isPoint: true,
 		},
 		{
-			ran: IndexRange{
-				LowVal:  []Datum{NewStringDatum("abc")},
-				HighVal: []Datum{NewStringDatum("abc")},
+			ran: ranger.IndexRange{
+				LowVal:  []types.Datum{types.NewStringDatum("abc")},
+				HighVal: []types.Datum{types.NewStringDatum("abc")},
 			},
 			isPoint: true,
 		},
 		{
-			ran: IndexRange{
-				LowVal:  []Datum{NewIntDatum(1)},
-				HighVal: []Datum{NewIntDatum(1), NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:  []types.Datum{types.NewIntDatum(1)},
+				HighVal: []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1)},
 			},
 			isPoint: false,
 		},
 		{
-			ran: IndexRange{
-				LowVal:     []Datum{NewIntDatum(1)},
-				HighVal:    []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:     []types.Datum{types.NewIntDatum(1)},
+				HighVal:    []types.Datum{types.NewIntDatum(1)},
 				LowExclude: true,
 			},
 			isPoint: false,
 		},
 		{
-			ran: IndexRange{
-				LowVal:      []Datum{NewIntDatum(1)},
-				HighVal:     []Datum{NewIntDatum(1)},
+			ran: ranger.IndexRange{
+				LowVal:      []types.Datum{types.NewIntDatum(1)},
+				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
 			},
 			isPoint: false,
 		},
 		{
-			ran: IndexRange{
-				LowVal:  []Datum{NewIntDatum(1)},
-				HighVal: []Datum{NewIntDatum(2)},
+			ran: ranger.IndexRange{
+				LowVal:  []types.Datum{types.NewIntDatum(1)},
+				HighVal: []types.Datum{types.NewIntDatum(2)},
 			},
 			isPoint: false,
 		},
@@ -133,18 +135,18 @@ func (s *testRangeSuite) TestRange(c *C) {
 
 func (s *testRangeSuite) TestIntColumnRangeString(c *C) {
 	tests := []struct {
-		ran IntColumnRange
+		ran ranger.IntColumnRange
 		ans string
 	}{
 		{
-			ran: IntColumnRange{
+			ran: ranger.IntColumnRange{
 				LowVal:  math.MinInt64,
 				HighVal: 2,
 			},
 			ans: "(-inf,2]",
 		},
 		{
-			ran: IntColumnRange{
+			ran: ranger.IntColumnRange{
 				LowVal:  3,
 				HighVal: math.MaxInt64,
 			},
@@ -158,29 +160,29 @@ func (s *testRangeSuite) TestIntColumnRangeString(c *C) {
 
 func (s *testRangeSuite) TestColumnRangeString(c *C) {
 	tests := []struct {
-		ran ColumnRange
+		ran ranger.ColumnRange
 		ans string
 	}{
 		{
-			ran: ColumnRange{
-				Low:      NewStringDatum("a"),
-				High:     MaxValueDatum(),
+			ran: ranger.ColumnRange{
+				Low:      types.NewStringDatum("a"),
+				High:     types.MaxValueDatum(),
 				HighExcl: true,
 			},
 			ans: "[a,+inf)",
 		},
 		{
-			ran: ColumnRange{
-				Low:     NewFloat64Datum(3.2),
+			ran: ranger.ColumnRange{
+				Low:     types.NewFloat64Datum(3.2),
 				LowExcl: true,
-				High:    NewFloat64Datum(6.4),
+				High:    types.NewFloat64Datum(6.4),
 			},
 			ans: "(3.2,6.4]",
 		},
 		{
-			ran: ColumnRange{
-				Low:  Datum{},
-				High: Datum{},
+			ran: ranger.ColumnRange{
+				Low:  types.Datum{},
+				High: types.Datum{},
 			},
 			ans: "[<nil>,<nil>]",
 		},


### PR DESCRIPTION
If we store bytes instead of datums in `range` struct, we will need import `codec` package due to the `String` method which needs to decode the bytes. And cause cyclic import.
So move it to ranger package.
PTAL @coocood @hanfei1991 @zz-jason 