### PR TITLE
server: fix the length metadata of decimal column returned to client

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -338,10 +338,10 @@ func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {
 	}
 	if fld.Column.Tp == mysql.TypeNewDecimal {
 		// Consider the negative sign.
-		ci.ColumnLength += 1
+		ci.ColumnLength++
 		if fld.Column.Decimal > types.DefaultFsp {
 			// Consider the decimal point.
-			ci.ColumnLength += 1
+			ci.ColumnLength++
 		}
 	} else {
 		// Fix issue #4540.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -336,18 +336,27 @@ func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {
 	} else {
 		ci.ColumnLength = uint32(fld.Column.Flen)
 	}
-	// Fix issue #4540.
-	// The flen is a hint, not a precise value, so most client will not use the value.
-	// But we found in race MySQL client, like Navicat for MySQL(version before 12) will truncate
-	// the `show create table` result. To fix this case, we must use a large enough flen to prevent
-	// the truncation, in MySQL, it will multiply bytes length by a multiple based on character set.
-	// For examples:
-	// * latin, the multiple is 1
-	// * gb2312, the multiple is 2
-	// * Utf-8, the multiple is 3
-	// * utf8mb4, the multiple is 4
-	// So the large enough multiple is 4 in here.
-	ci.ColumnLength = ci.ColumnLength * mysql.MaxBytesOfCharacter
+	if fld.Column.Tp == mysql.TypeNewDecimal {
+		// Consider the negative sign.
+		ci.ColumnLength += 1
+		if fld.Column.Decimal > types.DefaultFsp {
+			// Consider the decimal point.
+			ci.ColumnLength += 1
+		}
+	} else {
+		// Fix issue #4540.
+		// The flen is a hint, not a precise value, so most client will not use the value.
+		// But we found in race MySQL client, like Navicat for MySQL(version before 12) will truncate
+		// the `show create table` result. To fix this case, we must use a large enough flen to prevent
+		// the truncation, in MySQL, it will multiply bytes length by a multiple based on character set.
+		// For examples:
+		// * latin, the multiple is 1
+		// * gb2312, the multiple is 2
+		// * Utf-8, the multiple is 3
+		// * utf8mb4, the multiple is 4
+		// So the large enough multiple is 4 in here.
+		ci.ColumnLength = ci.ColumnLength * mysql.MaxBytesOfCharacter
+	}
 
 	if fld.Column.Decimal == types.UnspecifiedLength {
 		ci.Decimal = mysql.NotFixedDec

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -359,7 +359,7 @@ func (ts *TidbTestSuite) TestClientWithCollation(c *C) {
 	runTestClientWithCollation(c)
 }
 
-func (ts *TidbTestSuite) TestShowCreateTableFlen(c *C) {
+func (ts *TidbTestSuite) TestCreateTableFlen(c *C) {
 	// issue #4540
 	ctx, err := ts.tidbdrv.OpenCtx(uint64(0), 0, uint8(tmysql.DefaultCollationID), "test", nil)
 	c.Assert(err, IsNil)
@@ -392,6 +392,8 @@ func (ts *TidbTestSuite) TestShowCreateTableFlen(c *C) {
 		"`v` varchar(50) DEFAULT ''," +
 		"`w` varchar(300) NOT NULL," +
 		"`x` varchar(250) DEFAULT ''," +
+		"`y` decimal(20)," +
+		"`z` decimal(20, 4)," +
 		"PRIMARY KEY (`a`)" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
 	_, err = ctx.Execute(goCtx, testSQL)
@@ -404,6 +406,14 @@ func (ts *TidbTestSuite) TestShowCreateTableFlen(c *C) {
 	c.Assert(len(cols), Equals, 2)
 	c.Assert(int(cols[0].ColumnLength), Equals, 5*tmysql.MaxBytesOfCharacter)
 	c.Assert(int(cols[1].ColumnLength), Equals, len(row.GetString(1))*tmysql.MaxBytesOfCharacter)
+
+	// for issue#5246
+	rs, err = ctx.Execute(goCtx, "select y, z from t1")
+	c.Assert(err, IsNil)
+	cols = rs[0].Columns()
+	c.Assert(len(cols), Equals, 2)
+	c.Assert(int(cols[0].ColumnLength), Equals, 21)
+	c.Assert(int(cols[1].ColumnLength), Equals, 22)
 }
 
 func (ts *TidbTestSuite) TestSumAvg(c *C) {

--- a/session.go
+++ b/session.go
@@ -596,7 +596,6 @@ func (s *session) getExecRet(ctx context.Context, sql string) (string, error) {
 
 // GetGlobalSysVar implements GlobalVarAccessor.GetGlobalSysVar interface.
 func (s *session) GetGlobalSysVar(name string) (string, error) {
-	log.Warning("again")
 	if s.Value(context.Initing) != nil {
 		// When running bootstrap or upgrade, we should not access global storage.
 		return "", nil

--- a/session.go
+++ b/session.go
@@ -596,6 +596,7 @@ func (s *session) getExecRet(ctx context.Context, sql string) (string, error) {
 
 // GetGlobalSysVar implements GlobalVarAccessor.GetGlobalSysVar interface.
 func (s *session) GetGlobalSysVar(name string) (string, error) {
+	log.Warning("again")
 	if s.Value(context.Initing) != nil {
 		// When running bootstrap or upgrade, we should not access global storage.
 		return "", nil


### PR DESCRIPTION
fix #5246 
PTAL @zz-jason @birdstorm 