### PR TITLE
*: fix lint warnings

### DIFF
--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -246,7 +246,7 @@ func (t *testExecInfo) parseSQLs(p *parser.Parser) error {
 func (t *testExecInfo) compileSQL(idx int) (err error) {
 	for _, info := range t.sqlInfos {
 		c := info.cases[idx]
-		compiler := executor.Compiler{c.session}
+		compiler := executor.Compiler{Ctx: c.session}
 		se := c.session
 		goCtx := goctx.TODO()
 		se.PrepareTxnCtx(goCtx)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1520,7 +1520,7 @@ func (s *testSuite) TestAdapterStatement(c *C) {
 	se, err := tidb.CreateSession4Test(s.store)
 	c.Check(err, IsNil)
 	se.GetSessionVars().TxnCtx.InfoSchema = domain.GetDomain(se).InfoSchema()
-	compiler := &executor.Compiler{se}
+	compiler := &executor.Compiler{Ctx: se}
 	stmtNode, err := s.ParseOneStmt("select 1", "", "")
 	c.Check(err, IsNil)
 	stmt, err := compiler.Compile(goctx.TODO(), stmtNode)

--- a/session.go
+++ b/session.go
@@ -733,7 +733,7 @@ func (s *session) Execute(goCtx goctx.Context, sql string) (recordSets []ast.Rec
 		}
 		sessionExecuteParseDuration.Observe(time.Since(startTS).Seconds())
 
-		compiler := executor.Compiler{s}
+		compiler := executor.Compiler{Ctx: s}
 		for _, stmtNode := range stmtNodes {
 			s.PrepareTxnCtx(goCtx2)
 

--- a/tidb.go
+++ b/tidb.go
@@ -138,7 +138,7 @@ func Parse(ctx context.Context, src string) ([]ast.StmtNode, error) {
 
 // Compile is safe for concurrent use by multiple goroutines.
 func Compile(goCtx goctx.Context, ctx context.Context, stmtNode ast.StmtNode) (ast.Statement, error) {
-	compiler := executor.Compiler{ctx}
+	compiler := executor.Compiler{Ctx: ctx}
 	stmt, err := compiler.Compile(goCtx, stmtNode)
 	return stmt, errors.Trace(err)
 }


### PR DESCRIPTION
```
ddl/ddl_db_change_test.go:249: github.com/pingcap/tidb/executor.Compiler composite literal uses unkeyed fields
executor/executor_test.go:1523: github.com/pingcap/tidb/executor.Compiler composite literal uses unkeyed fields
session.go:736: github.com/pingcap/tidb/executor.Compiler composite literal uses unkeyed fields
tidb.go:141: github.com/pingcap/tidb/executor.Compiler composite literal uses unkeyed fields
```