### PR TITLE
plan: refine plan's parents to parent, plan never use multiple parents.

### DIFF
--- a/plan/decorrelate.go
+++ b/plan/decorrelate.go
@@ -91,8 +91,8 @@ func (s *decorrelateSolver) optimize(p LogicalPlan, _ context.Context) (LogicalP
 		if len(apply.corCols) == 0 {
 			// If the inner plan is non-correlated, the apply will be simplified to join.
 			join := &apply.LogicalJoin
-			innerPlan.SetParents(join)
-			outerPlan.SetParents(join)
+			innerPlan.SetParent(join)
+			outerPlan.SetParent(join)
 			join.self = join
 			p = join
 		} else if sel, ok := innerPlan.(*LogicalSelection); ok {
@@ -123,7 +123,7 @@ func (s *decorrelateSolver) optimize(p LogicalPlan, _ context.Context) (LogicalP
 				proj.SetSchema(apply.Schema())
 				proj.Exprs = append(expression.Column2Exprs(outerPlan.Schema().Clone().Columns), proj.Exprs...)
 				apply.SetSchema(expression.MergeSchema(outerPlan.Schema(), innerPlan.Schema()))
-				proj.SetParents(apply.Parents()...)
+				proj.SetParent(apply.Parent())
 				np, err := s.optimize(p, nil)
 				if err != nil {
 					return nil, errors.Trace(err)
@@ -147,7 +147,7 @@ func (s *decorrelateSolver) optimize(p LogicalPlan, _ context.Context) (LogicalP
 				newAggFuncs = append(newAggFuncs, agg.AggFuncs...)
 				agg.AggFuncs = newAggFuncs
 				apply.SetSchema(expression.MergeSchema(outerPlan.Schema(), innerPlan.Schema()))
-				agg.SetParents(apply.Parents()...)
+				agg.SetParent(apply.Parent())
 				np, err := s.optimize(p, nil)
 				if err != nil {
 					return nil, errors.Trace(err)

--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -158,7 +158,7 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 	if !(isProj && canEliminate && canProjectionBeEliminatedLoose(proj)) {
 		return p
 	}
-	if join, ok := p.Parents()[0].(*LogicalJoin); ok {
+	if join, ok := p.Parent().(*LogicalJoin); ok {
 		pe.resetDefaultValues(join, p)
 	}
 	exprs := proj.Exprs

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -26,7 +26,7 @@ func setParents4FinalPlan(plan PhysicalPlan) {
 	planMark := map[int]bool{}
 	planMark[plan.ID()] = true
 	for pID := 0; pID < len(allPlans); pID++ {
-		allPlans[pID].SetParents()
+		allPlans[pID].SetParent(nil)
 		switch copPlan := allPlans[pID].(type) {
 		case *PhysicalTableReader:
 			setParents4FinalPlan(copPlan.tablePlan)
@@ -48,7 +48,7 @@ func setParents4FinalPlan(plan PhysicalPlan) {
 	planMark[plan.ID()] = false
 	for pID := 0; pID < len(allPlans); pID++ {
 		for _, p := range allPlans[pID].Children() {
-			p.SetParents(allPlans[pID])
+			p.SetParent(allPlans[pID])
 			if planMark[p.ID()] {
 				planMark[p.ID()] = false
 				allPlans = append(allPlans, p.(PhysicalPlan))

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -606,7 +606,7 @@ func (b *planBuilder) buildUnion(union *ast.UnionStmt) LogicalPlan {
 			sel = proj
 			u.children[i] = proj
 		}
-		sel.SetParents(u)
+		sel.SetParent(u)
 	}
 
 	// infer union type
@@ -1697,8 +1697,8 @@ func (b *planBuilder) buildSemiApply(outerPlan, innerPlan LogicalPlan, condition
 	ap := &LogicalApply{LogicalJoin: *join}
 	ap.tp = TypeApply
 	ap.self = ap
-	ap.children[0].SetParents(ap)
-	ap.children[1].SetParents(ap)
+	ap.children[0].SetParent(ap)
+	ap.children[1].SetParent(ap)
 	return ap
 }
 
@@ -1710,14 +1710,14 @@ out:
 		// e.g. exists(select count(*) from t order by a) is equal to exists t.
 		case *Projection, *Sort:
 			p = p.Children()[0].(LogicalPlan)
-			p.SetParents()
+			p.SetParent(nil)
 		case *LogicalAggregation:
 			if len(plan.GroupByItems) == 0 {
 				p = b.buildTableDual()
 				break out
 			}
 			p = p.Children()[0].(LogicalPlan)
-			p.SetParents()
+			p.SetParent(nil)
 		default:
 			break out
 		}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -28,8 +28,8 @@ import (
 // It is created from ast.Node first, then optimized by the optimizer,
 // finally used by the executor to create a Cursor which executes the statement.
 type Plan interface {
-	// Get all the parents.
-	Parents() []Plan
+	// Get all the parent.
+	Parent() Plan
 	// Get all the children.
 	Children() []Plan
 	// Set the schema.
@@ -40,8 +40,8 @@ type Plan interface {
 	ID() int
 	// Get the ID in explain statement
 	ExplainID() string
-	// SetParents sets the parents for the plan.
-	SetParents(...Plan)
+	// SetParent sets the parent for the plan.
+	SetParent(Plan)
 	// SetChildren sets the children for the plan.
 	SetChildren(...Plan)
 	// replaceExprColumns replace all the column reference in the plan's expression node.
@@ -79,7 +79,7 @@ func (t taskType) String() string {
 	return "UnknownTaskType"
 }
 
-// requiredProp stands for the required physical property by parents.
+// requiredProp stands for the required physical property by parent.
 // It contains the orders, if the order is desc and the task types.
 type requiredProp struct {
 	cols []*expression.Column
@@ -289,7 +289,7 @@ func (p *baseLogicalPlan) PruneColumns(parentUsedCols []*expression.Column) {
 // basePlan implements base Plan interface.
 // Should be used as embedded struct in Plan implementations.
 type basePlan struct {
-	parents  []Plan
+	parent   Plan
 	children []Plan
 
 	schema  *expression.Schema
@@ -329,9 +329,9 @@ func (p *basePlan) Schema() *expression.Schema {
 	return p.schema
 }
 
-// Parents implements Plan Parents interface.
-func (p *basePlan) Parents() []Plan {
-	return p.parents
+// Parent implements Plan Parent interface.
+func (p *basePlan) Parent() Plan {
+	return p.parent
 }
 
 // Children implements Plan Children interface.
@@ -339,9 +339,9 @@ func (p *basePlan) Children() []Plan {
 	return p.children
 }
 
-// SetParents implements Plan SetParents interface.
-func (p *basePlan) SetParents(pars ...Plan) {
-	p.parents = pars
+// SetParent implements Plan SetParent interface.
+func (p *basePlan) SetParent(parent Plan) {
+	p.parent = parent
 }
 
 // SetChildren implements Plan SetChildren interface.

--- a/plan/plans.go
+++ b/plan/plans.go
@@ -320,10 +320,9 @@ func (e *Explain) prepareExplainInfo(p Plan, parent Plan) error {
 // prepareExplainInfo4DAGTask generates the following information for every plan:
 // ["id", "parents", "task", "operator info"].
 func (e *Explain) prepareExplainInfo4DAGTask(p PhysicalPlan, taskType string) {
-	parents := p.Parents()
-	parentIDs := make([]string, 0, len(parents))
-	for _, parent := range parents {
-		parentIDs = append(parentIDs, parent.ExplainID())
+	var parentIDs []string
+	if p.Parent() != nil {
+		parentIDs = []string{p.Parent().ExplainID()}
 	}
 	childrenIDs := make([]string, 0, len(p.Children()))
 	for _, ch := range p.Children() {

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -34,8 +34,8 @@ func addSelection(p Plan, child LogicalPlan, conditions []expression.Expression)
 	selection.SetSchema(child.Schema().Clone())
 	replaceChild(p, child, selection)
 	selection.SetChildren(child)
-	child.SetParents(selection)
-	selection.SetParents(p)
+	child.SetParent(selection)
+	selection.SetParent(p)
 }
 
 // PredicatePushDown implements LogicalPlan interface.
@@ -88,10 +88,9 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		e := joinReOrderSolver{ctx: p.ctx}
 		e.reorderJoin(groups, predicates)
 		newJoin := e.resultJoin
-		if len(p.parents) > 0 {
-			parent := p.parents[0]
-			newJoin.SetParents(parent)
-			replaceChild(parent, p, newJoin)
+		if p.parent != nil {
+			newJoin.SetParent(p.parent)
+			replaceChild(p.parent, p, newJoin)
 		}
 		return newJoin.PredicatePushDown(predicates)
 	}
@@ -221,7 +220,7 @@ func (p *LogicalJoin) getProj(idx int) *Projection {
 	}
 	proj.SetSchema(child.Schema().Clone())
 	setParentAndChildren(proj, child)
-	proj.SetParents(p)
+	proj.SetParent(p)
 	p.children[idx] = proj
 	return proj
 }

--- a/plan/topn_push_down.go
+++ b/plan/topn_push_down.go
@@ -30,7 +30,7 @@ func (s *baseLogicalPlan) pushDownTopN(topN *TopN) LogicalPlan {
 	p := s.basePlan.self.(LogicalPlan)
 	for i, child := range p.Children() {
 		p.Children()[i] = child.(LogicalPlan).pushDownTopN(nil)
-		p.Children()[i].SetParents(p)
+		p.Children()[i].SetParent(p)
 	}
 	if topN != nil {
 		return topN.setChild(p, false)
@@ -94,7 +94,7 @@ func (p *Union) pushDownTopN(topN *TopN) LogicalPlan {
 			}
 		}
 		p.children[i] = child.(LogicalPlan).pushDownTopN(newTopN)
-		p.children[i].SetParents(p)
+		p.children[i].SetParent(p)
 	}
 	if topN != nil {
 		return topN.setChild(p, true)

--- a/plan/util.go
+++ b/plan/util.go
@@ -61,21 +61,21 @@ func setParentAndChildren(parent Plan, children ...Plan) {
 		return
 	}
 	for _, child := range children {
-		child.SetParents(parent)
+		child.SetParent(parent)
 	}
 	parent.SetChildren(children...)
 }
 
 // removePlan removes a plan from its parent and child.
 func removePlan(p Plan) {
-	parents := p.Parents()
+	parent := p.Parent()
 	children := p.Children()
-	if len(parents) == 0 {
+	if parent == nil {
 		child := children[0]
-		child.SetParents()
+		child.SetParent(nil)
 		return
 	}
-	parent, child := parents[0], children[0]
+	child := children[0]
 	replaceChild(parent, p, child)
-	child.SetParents(parent)
+	child.SetParent(parent)
 }


### PR DESCRIPTION
I'm turning for object allocation and come across it, variadic function cause additional allocation:

![image](https://user-images.githubusercontent.com/1420062/33540532-3131dd26-d891-11e7-9127-b66f82ef50c2.png)

I find the interface is unreasonable, a plan never use multiple parents in practice.

@hanfei1991 