### PR TITLE
plan, executor: replace sort with logicalSort and physicalSort

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -93,7 +93,7 @@ func (b *executorBuilder) build(p plan.Plan) Executor {
 		return b.buildSimple(v)
 	case *plan.Set:
 		return b.buildSet(v)
-	case *plan.Sort:
+	case *plan.PhysicalSort:
 		return b.buildSort(v)
 	case *plan.TopN:
 		return b.buildTopN(v)
@@ -703,7 +703,7 @@ func (b *executorBuilder) buildMemTable(v *plan.PhysicalMemTable) Executor {
 	return ts
 }
 
-func (b *executorBuilder) buildSort(v *plan.Sort) Executor {
+func (b *executorBuilder) buildSort(v *plan.PhysicalSort) Executor {
 	childExec := b.build(v.Children()[0])
 	if b.err != nil {
 		b.err = errors.Trace(b.err)
@@ -715,12 +715,6 @@ func (b *executorBuilder) buildSort(v *plan.Sort) Executor {
 		schema:       v.Schema(),
 	}
 	sortExec.supportChk = true
-	if v.ExecLimit != nil {
-		return &TopNExec{
-			SortExec: sortExec,
-			limit:    v.ExecLimit,
-		}
-	}
 	return &sortExec
 }
 

--- a/plan/column_pruning.go
+++ b/plan/column_pruning.go
@@ -121,7 +121,7 @@ func (p *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) {
 }
 
 // PruneColumns implements LogicalPlan interface.
-func (p *Sort) PruneColumns(parentUsedCols []*expression.Column) {
+func (p *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) {
 	child := p.children[0].(LogicalPlan)
 	for i := len(p.ByItems) - 1; i >= 0; i-- {
 		cols := expression.ExtractColumns(p.ByItems[i].Expr)

--- a/plan/eliminate_projection.go
+++ b/plan/eliminate_projection.go
@@ -129,7 +129,7 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 	setParentAndChildren(p, children...)
 
 	switch p.(type) {
-	case *Sort, *TopN, *Limit, *LogicalSelection, *MaxOneRow, *SelectLock:
+	case *LogicalSort, *TopN, *Limit, *LogicalSelection, *MaxOneRow, *SelectLock:
 		p.SetSchema(p.Children()[0].Schema())
 	case *LogicalJoin, *LogicalApply:
 		var joinTp JoinType
@@ -255,7 +255,7 @@ func (p *LogicalApply) replaceExprColumns(replace map[string]*expression.Column)
 	}
 }
 
-func (p *Sort) replaceExprColumns(replace map[string]*expression.Column) {
+func (p *LogicalSort) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, byItem := range p.ByItems {
 		resolveExprAndReplace(byItem.Expr, replace)
 	}

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -158,7 +158,7 @@ func (p *TableDual) ExplainInfo() string {
 }
 
 // ExplainInfo implements PhysicalPlan interface.
-func (p *Sort) ExplainInfo() string {
+func (p *PhysicalSort) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
 	for i, item := range p.ByItems {
 		order := "asc"

--- a/plan/gen_physical_plans.go
+++ b/plan/gen_physical_plans.go
@@ -412,3 +412,29 @@ func (p *LogicalSelection) generatePhysicalPlans() []PhysicalPlan {
 	sel.SetSchema(p.Schema())
 	return []PhysicalPlan{sel}
 }
+
+func (p *LogicalSort) getPhysicalSort() *PhysicalSort {
+	ps := PhysicalSort{ByItems: p.ByItems}.init(p.ctx)
+	ps.profile = p.profile
+	ps.SetSchema(p.schema)
+	return ps
+}
+
+func (p *LogicalSort) getPhantomSort() *PhantomSort {
+	prop, canPass := getPropByOrderByItems(p.ByItems)
+	if !canPass {
+		return nil
+	}
+	ps := &PhantomSort{prop: prop}
+	return ps
+}
+
+func (p *LogicalSort) generatePhysicalPlans() []PhysicalPlan {
+	ret := make([]PhysicalPlan, 0, 2)
+	ret = append(ret, p.getPhysicalSort())
+	ps := p.getPhantomSort()
+	if ps != nil {
+		ret = append(ret, ps)
+	}
+	return ret
+}

--- a/plan/gen_physical_plans.go
+++ b/plan/gen_physical_plans.go
@@ -420,7 +420,7 @@ func (p *LogicalSort) getPhysicalSort() *PhysicalSort {
 	return ps
 }
 
-func (p *LogicalSort) getPhantomSort() *NominalSort {
+func (p *LogicalSort) getNominalSort() *NominalSort {
 	prop, canPass := getPropByOrderByItems(p.ByItems)
 	if !canPass {
 		return nil
@@ -432,7 +432,7 @@ func (p *LogicalSort) getPhantomSort() *NominalSort {
 func (p *LogicalSort) generatePhysicalPlans() []PhysicalPlan {
 	ret := make([]PhysicalPlan, 0, 2)
 	ret = append(ret, p.getPhysicalSort())
-	ps := p.getPhantomSort()
+	ps := p.getNominalSort()
 	if ps != nil {
 		ret = append(ret, ps)
 	}

--- a/plan/gen_physical_plans.go
+++ b/plan/gen_physical_plans.go
@@ -420,12 +420,12 @@ func (p *LogicalSort) getPhysicalSort() *PhysicalSort {
 	return ps
 }
 
-func (p *LogicalSort) getPhantomSort() *PhantomSort {
+func (p *LogicalSort) getPhantomSort() *NominalSort {
 	prop, canPass := getPropByOrderByItems(p.ByItems)
 	if !canPass {
 		return nil
 	}
-	ps := &PhantomSort{prop: prop}
+	ps := &NominalSort{prop: prop}
 	return ps
 }
 

--- a/plan/initialize.go
+++ b/plan/initialize.go
@@ -141,9 +141,14 @@ func (p Union) init(ctx context.Context) *Union {
 	return &p
 }
 
-func (p Sort) init(ctx context.Context) *Sort {
+func (p LogicalSort) init(ctx context.Context) *LogicalSort {
 	p.basePlan = newBasePlan(TypeSort, ctx, &p)
 	p.baseLogicalPlan = newBaseLogicalPlan(p.basePlan)
+	return &p
+}
+
+func (p PhysicalSort) init(ctx context.Context) *PhysicalSort {
+	p.basePlan = newBasePlan(TypeSort, ctx, &p)
 	p.basePhysicalPlan = newBasePhysicalPlan(p.basePlan)
 	return &p
 }

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -663,7 +663,7 @@ func (by *ByItems) Clone() *ByItems {
 
 func (b *planBuilder) buildSort(p LogicalPlan, byItems []*ast.ByItem, aggMapper map[*ast.AggregateFuncExpr]int) LogicalPlan {
 	b.curClause = orderByClause
-	sort := Sort{}.init(b.ctx)
+	sort := LogicalSort{}.init(b.ctx)
 	exprs := make([]*ByItems, 0, len(byItems))
 	for _, item := range byItems {
 		it, np, err := b.rewrite(item.Expr, p, aggMapper, true)
@@ -1708,7 +1708,7 @@ out:
 		switch plan := p.(type) {
 		// This can be removed when in exists clause,
 		// e.g. exists(select count(*) from t order by a) is equal to exists t.
-		case *Projection, *Sort:
+		case *Projection, *LogicalSort:
 			p = p.Children()[0].(LogicalPlan)
 			p.SetParents()
 		case *LogicalAggregation:

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -34,7 +34,7 @@ var (
 	_ LogicalPlan = &TableDual{}
 	_ LogicalPlan = &DataSource{}
 	_ LogicalPlan = &Union{}
-	_ LogicalPlan = &Sort{}
+	_ LogicalPlan = &LogicalSort{}
 	_ LogicalPlan = &SelectLock{}
 	_ LogicalPlan = &Limit{}
 	_ LogicalPlan = &Show{}
@@ -322,17 +322,15 @@ type Union struct {
 	basePhysicalPlan
 }
 
-// Sort stands for the order by plan.
-type Sort struct {
+// LogicalSort stands for the order by plan.
+type LogicalSort struct {
 	*basePlan
 	baseLogicalPlan
-	basePhysicalPlan
 
-	ByItems   []*ByItems
-	ExecLimit *Limit // no longer be used by new plan
+	ByItems []*ByItems
 }
 
-func (p *Sort) extractCorrelatedCols() []*expression.CorrelatedColumn {
+func (p *LogicalSort) extractCorrelatedCols() []*expression.CorrelatedColumn {
 	corCols := p.baseLogicalPlan.extractCorrelatedCols()
 	for _, item := range p.ByItems {
 		corCols = append(corCols, extractCorColumns(item.Expr)...)

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -479,6 +479,7 @@ func (p *PhysicalSort) Copy() PhysicalPlan {
 	return &np
 }
 
+// Copy implements the PhysicalPlan Copy interface.
 func (p *PhantomSort) Copy() PhysicalPlan {
 	panic("should not call this function")
 }

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -31,7 +31,7 @@ var (
 	_ PhysicalPlan = &TableDual{}
 	_ PhysicalPlan = &Union{}
 	_ PhysicalPlan = &PhysicalSort{}
-	_ PhysicalPlan = &PhantomSort{}
+	_ PhysicalPlan = &NominalSort{}
 	_ PhysicalPlan = &SelectLock{}
 	_ PhysicalPlan = &Limit{}
 	_ PhysicalPlan = &Show{}
@@ -329,9 +329,9 @@ type PhysicalSort struct {
 	ByItems []*ByItems
 }
 
-// PhantomSort asks sort properties for its child. It is a fake operator that will not
+// NominalSort asks sort properties for its child. It is a fake operator that will not
 // appear in final physical operator tree.
-type PhantomSort struct {
+type NominalSort struct {
 	*basePlan
 	basePhysicalPlan
 
@@ -480,7 +480,7 @@ func (p *PhysicalSort) Copy() PhysicalPlan {
 }
 
 // Copy implements the PhysicalPlan Copy interface.
-func (p *PhantomSort) Copy() PhysicalPlan {
+func (p *NominalSort) Copy() PhysicalPlan {
 	panic("should not call this function")
 }
 

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -30,7 +30,8 @@ var (
 	_ PhysicalPlan = &MaxOneRow{}
 	_ PhysicalPlan = &TableDual{}
 	_ PhysicalPlan = &Union{}
-	_ PhysicalPlan = &Sort{}
+	_ PhysicalPlan = &PhysicalSort{}
+	_ PhysicalPlan = &PhantomSort{}
 	_ PhysicalPlan = &SelectLock{}
 	_ PhysicalPlan = &Limit{}
 	_ PhysicalPlan = &Show{}
@@ -320,6 +321,23 @@ type PhysicalStreamAgg struct {
 	inputCount float64 // inputCount is the input count of this plan.
 }
 
+// PhysicalSort is the physical operator of sort, which implements a memory sort.
+type PhysicalSort struct {
+	*basePlan
+	basePhysicalPlan
+
+	ByItems []*ByItems
+}
+
+// PhantomSort asks sort properties for its child. It is a fake operator that will not
+// appear in final physical operator tree.
+type PhantomSort struct {
+	*basePlan
+	basePhysicalPlan
+
+	prop *requiredProp
+}
+
 // PhysicalUnionScan represents a union scan operator.
 type PhysicalUnionScan struct {
 	*basePlan
@@ -454,12 +472,15 @@ func (p *Union) Copy() PhysicalPlan {
 }
 
 // Copy implements the PhysicalPlan Copy interface.
-func (p *Sort) Copy() PhysicalPlan {
+func (p *PhysicalSort) Copy() PhysicalPlan {
 	np := *p
 	np.basePlan = p.basePlan.copy()
-	np.baseLogicalPlan = newBaseLogicalPlan(np.basePlan)
 	np.basePhysicalPlan = newBasePhysicalPlan(np.basePlan)
 	return &np
+}
+
+func (p *PhantomSort) Copy() PhysicalPlan {
+	panic("should not call this function")
 }
 
 // Copy implements the PhysicalPlan Copy interface.
@@ -536,7 +557,7 @@ func buildJoinSchema(joinType JoinType, join Plan) *expression.Schema {
 
 func buildSchema(p PhysicalPlan) {
 	switch x := p.(type) {
-	case *Limit, *TopN, *Sort, *PhysicalSelection, *MaxOneRow, *SelectLock:
+	case *Limit, *TopN, *PhysicalSort, *PhysicalSelection, *MaxOneRow, *SelectLock:
 		p.SetSchema(p.Children()[0].Schema())
 	case *PhysicalIndexJoin:
 		p.SetSchema(buildJoinSchema(x.JoinType, p))

--- a/plan/prop_generator.go
+++ b/plan/prop_generator.go
@@ -224,7 +224,7 @@ func (p *PhysicalSort) getChildrenPossibleProps(prop *requiredProp) [][]*require
 	return nil
 }
 
-func (p *PhantomSort) getChildrenPossibleProps(prop *requiredProp) [][]*requiredProp {
+func (p *NominalSort) getChildrenPossibleProps(prop *requiredProp) [][]*requiredProp {
 	if prop.isPrefix(p.prop) {
 		p.prop.expectedCnt = prop.expectedCnt
 		return [][]*requiredProp{{p.prop}}

--- a/plan/prop_generator.go
+++ b/plan/prop_generator.go
@@ -29,7 +29,7 @@ func (p *requiredProp) enforceProperty(task task, ctx context.Context) task {
 		return task
 	}
 	task = finishCopTask(task, ctx)
-	sort := Sort{ByItems: make([]*ByItems, 0, len(p.cols))}.init(ctx)
+	sort := PhysicalSort{ByItems: make([]*ByItems, 0, len(p.cols))}.init(ctx)
 	for _, col := range p.cols {
 		sort.ByItems = append(sort.ByItems, &ByItems{col, p.desc})
 	}
@@ -208,4 +208,26 @@ func (p *PhysicalStreamAgg) getChildrenPossibleProps(prop *requiredProp) [][]*re
 		return nil
 	}
 	return [][]*requiredProp{{reqProp}}
+}
+
+func (p *PhysicalSort) getChildrenPossibleProps(prop *requiredProp) [][]*requiredProp {
+	p.expectedCnt = prop.expectedCnt
+	if len(p.ByItems) >= len(prop.cols) {
+		for i, col := range prop.cols {
+			sortItem := p.ByItems[i]
+			if sortItem.Desc != prop.desc || !sortItem.Expr.Equal(col, p.ctx) {
+				return nil
+			}
+		}
+		return [][]*requiredProp{{{expectedCnt: math.MaxFloat64}}}
+	}
+	return nil
+}
+
+func (p *PhantomSort) getChildrenPossibleProps(prop *requiredProp) [][]*requiredProp {
+	if prop.isPrefix(p.prop) {
+		p.prop.expectedCnt = prop.expectedCnt
+		return [][]*requiredProp{{p.prop}}
+	}
+	return nil
 }

--- a/plan/resolve_indices.go
+++ b/plan/resolve_indices.go
@@ -161,7 +161,7 @@ func (p *basePhysicalAgg) ResolveIndices() {
 }
 
 // ResolveIndices implements Plan interface.
-func (p *Sort) ResolveIndices() {
+func (p *PhysicalSort) ResolveIndices() {
 	p.basePlan.ResolveIndices()
 	for _, item := range p.ByItems {
 		item.Expr.ResolveIndices(p.children[0].Schema())

--- a/plan/stringer.go
+++ b/plan/stringer.go
@@ -120,11 +120,8 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 		str = "Lock"
 	case *ShowDDL:
 		str = "ShowDDL"
-	case *Sort:
+	case *LogicalSort, *PhysicalSort:
 		str = "Sort"
-		if x.ExecLimit != nil {
-			str += fmt.Sprintf(" + Limit(%v) + Offset(%v)", x.ExecLimit.Count, x.ExecLimit.Offset)
-		}
 	case *LogicalJoin:
 		last := len(idxs) - 1
 		idx := idxs[last]

--- a/plan/task.go
+++ b/plan/task.go
@@ -322,7 +322,7 @@ func (p *Limit) attach2Task(tasks ...task) task {
 	return t
 }
 
-func (p *Sort) getCost(count float64) float64 {
+func (p *PhysicalSort) getCost(count float64) float64 {
 	if count < 2.0 {
 		count = 2.0
 	}
@@ -351,7 +351,7 @@ func (p *TopN) allColsFromSchema(schema *expression.Schema) bool {
 	return len(schema.ColumnsIndices(cols)) > 0
 }
 
-func (p *Sort) attach2Task(tasks ...task) task {
+func (p *PhysicalSort) attach2Task(tasks ...task) task {
 	if tasks[0].invalid() {
 		return invalidTask
 	}
@@ -359,6 +359,10 @@ func (p *Sort) attach2Task(tasks ...task) task {
 	t = attachPlan2Task(p.Copy(), t)
 	t.addCost(p.getCost(t.count()))
 	return t
+}
+
+func (p *PhantomSort) attach2Task(tasks ...task) task {
+	return tasks[0]
 }
 
 func (p *TopN) attach2Task(tasks ...task) task {

--- a/plan/task.go
+++ b/plan/task.go
@@ -361,7 +361,7 @@ func (p *PhysicalSort) attach2Task(tasks ...task) task {
 	return t
 }
 
-func (p *PhantomSort) attach2Task(tasks ...task) task {
+func (p *NominalSort) attach2Task(tasks ...task) task {
 	return tasks[0]
 }
 

--- a/plan/topn_push_down.go
+++ b/plan/topn_push_down.go
@@ -59,12 +59,12 @@ func (s *TopN) setChild(p LogicalPlan, eliminable bool) LogicalPlan {
 	return s
 }
 
-func (s *Sort) pushDownTopN(topN *TopN) LogicalPlan {
+func (s *LogicalSort) pushDownTopN(topN *TopN) LogicalPlan {
 	if topN == nil {
 		return s.baseLogicalPlan.pushDownTopN(nil)
 	} else if topN.isLimit() {
 		topN.ByItems = s.ByItems
-		// If a Limit is pushed down, the Sort should be converted to topN and be pushed again.
+		// If a Limit is pushed down, the LogicalSort should be converted to topN and be pushed again.
 		return s.children[0].(LogicalPlan).pushDownTopN(topN)
 	}
 	// If a TopN is pushed down, this sort is useless.


### PR DESCRIPTION
No longer reuse sort for physical plan converting. We use two plans :  one is PhysicalSort which represents  memory sort, and another is NominalSort whose sort property is guaranteed by its child. Phantom sort is a fake operator which will not exist in final physical operator tree.