### PR TITLE
plan, stats: remove unnecessary clone

### DIFF
--- a/plan/stats.go
+++ b/plan/stats.go
@@ -96,6 +96,10 @@ func (p *DataSource) getStatsProfileByFilter(conds expression.CNFExprs) *statsPr
 }
 
 func (p *DataSource) prepareStatsProfile() *statsProfile {
+	// PushDownNot here can convert query 'not (a != 1)' to 'a = 1'.
+	for i, expr := range p.pushedDownConds {
+		p.pushedDownConds[i] = expression.PushDownNot(expr, false, nil)
+	}
 	p.profile = p.getStatsProfileByFilter(p.pushedDownConds)
 	return p.profile
 }

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -95,15 +95,11 @@ func (t *Table) Selectivity(ctx context.Context, exprs []expression.Expression) 
 	var sets []*exprSet
 	sc := ctx.GetSessionVars().StmtCtx
 	extractedCols := expression.ExtractColumns(expression.ComposeCNFCondition(ctx, exprs...))
-	exprsClone := make([]expression.Expression, 0, len(exprs))
-	for _, expr := range exprs {
-		exprsClone = append(exprsClone, expr.Clone())
-	}
 	for _, colInfo := range t.Columns {
 		col := expression.ColInfo2Col(extractedCols, colInfo.Info)
 		// This column should have histogram.
 		if col != nil && !t.ColumnIsInvalid(ctx.GetSessionVars().StmtCtx, col.ID) {
-			maskCovered, ranges, err := getMaskAndRanges(ctx, exprsClone, ranger.ColumnRangeType, nil, col)
+			maskCovered, ranges, err := getMaskAndRanges(ctx, exprs, ranger.ColumnRangeType, nil, col)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}
@@ -117,7 +113,7 @@ func (t *Table) Selectivity(ctx context.Context, exprs []expression.Expression) 
 		idxCols, lengths := expression.IndexInfo2Cols(extractedCols, idxInfo.Info)
 		// This index should have histogram.
 		if len(idxCols) > 0 && len(idxInfo.Histogram.Buckets) > 0 {
-			maskCovered, ranges, err := getMaskAndRanges(ctx, exprsClone, ranger.IndexRangeType, lengths, idxCols...)
+			maskCovered, ranges, err := getMaskAndRanges(ctx, exprs, ranger.IndexRangeType, lengths, idxCols...)
 			if err != nil {
 				return 0, errors.Trace(err)
 			}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -160,10 +160,6 @@ func extractAccessAndFilterConds(conditions, accessConds, filterConds []expressi
 func DetachIndexConditions(conditions []expression.Expression, cols []*expression.Column,
 	lengths []int) (accessConds []expression.Expression, filterConds []expression.Expression) {
 	accessConds = make([]expression.Expression, len(cols))
-	// PushDownNot here can convert query 'not (a != 1)' to 'a = 1'.
-	for i, cond := range conditions {
-		conditions[i] = expression.PushDownNot(cond, false, nil)
-	}
 	var equalOrInCount int
 	for _, cond := range conditions {
 		offset := getEqOrInColOffset(cond, cols)
@@ -227,7 +223,6 @@ func detachColumnConditions(conditions []expression.Expression, colName model.CI
 		length:  types.UnspecifiedLength,
 	}
 	for _, cond := range conditions {
-		cond = expression.PushDownNot(cond, false, nil)
 		if !checker.check(cond) {
 			filterConditions = append(filterConditions, cond)
 			continue
@@ -249,9 +244,6 @@ func DetachCondsForTableRange(ctx context.Context, conds []expression.Expression
 	checker := &conditionChecker{
 		colName: col.ColName,
 		length:  types.UnspecifiedLength,
-	}
-	for i, cond := range conds {
-		conds[i] = expression.PushDownNot(cond, false, ctx)
 	}
 	return detachColumnCNFConditions(conds, checker)
 }


### PR DESCRIPTION
By doing `PushDownNot` first, we can avoid repeated work and unnecessary clone.