### PR TITLE
plan: reset join's DefaultValues when predicate push down.

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -728,3 +728,13 @@ func (s *testSuite) TestIssue5255(c *C) {
 	tk.MustExec("insert into t2 values(1)")
 	tk.MustQuery("select /*+ TIDB_INLJ(t2) */ * from t1 join t2 on t1.a=t2.a").Check(testkit.Rows("1 2017-11-29 2.2 1"))
 }
+
+func (s *testSuite) TestIssue5278(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, tt")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("create table tt(a varchar(10), b int)")
+	tk.MustExec("insert into t values(1, 1)")
+	tk.MustQuery("select * from t left join tt on t.a=tt.a left join t ttt on t.a=ttt.a").Check(testkit.Rows("1 1 <nil> <nil> 1 1"))
+}

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -154,6 +154,12 @@ func (p *LogicalJoin) PredicatePushDown(predicates []expression.Expression) (ret
 		p.LeftJoinKeys = append(p.LeftJoinKeys, eqCond.GetArgs()[0].(*expression.Column))
 		p.RightJoinKeys = append(p.RightJoinKeys, eqCond.GetArgs()[1].(*expression.Column))
 	}
+	// After predicate push down, the size of schema may change, so we should also change the len of default value.
+	if p.JoinType == LeftOuterJoin {
+		p.DefaultValues = make([]types.Datum, p.children[1].Schema().Len())
+	} else if p.JoinType == RightOuterJoin {
+		p.DefaultValues = make([]types.Datum, p.children[0].Schema().Len())
+	}
 	p.mergeSchema()
 	p.buildKeyInfo()
 	return


### PR DESCRIPTION
fix #5338 and fix #5278 
~~~I'll try to find a simple test first. Otherwise i'll add a test in integration test.~~~ added
@hanfei1991 @zz-jason @lamxTyler 