### PR TITLE
util/chunk: fix get decimal datum.

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -538,6 +538,8 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 	case mysql.TypeNewDecimal:
 		if !r.IsNull(colIdx) {
 			d.SetMysqlDecimal(r.GetMyDecimal(colIdx))
+			d.SetLength(tp.Flen)
+			d.SetFrac(tp.Decimal)
 		}
 	case mysql.TypeEnum:
 		if !r.IsNull(colIdx) {


### PR DESCRIPTION
The length and frac must be set to properly encode a decimal datum.