### PR TITLE
executor: fix a bug when apply meets index join

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1029,8 +1029,6 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plan.PhysicalIndexJoin) Execut
 		innerKeys:        v.InnerJoinKeys,
 		outerFilter:      v.LeftConditions,
 		innerFilter:      v.RightConditions,
-		outerOrderedRows: newKeyRowBlock(batchSize, true),
-		innerOrderedRows: newKeyRowBlock(batchSize, false),
 		resultGenerator:  newJoinResultGenerator(b.ctx, v.JoinType, v.OuterIndex == 1, v.DefaultValues, v.OtherConditions, nil, nil),
 		maxBatchSize:     batchSize,
 	}

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -113,6 +113,8 @@ func (e *IndexLookUpJoin) Open(goCtx goctx.Context) error {
 		return errors.Trace(err)
 	}
 
+	e.outerOrderedRows = newKeyRowBlock(e.maxBatchSize, true)
+	e.innerOrderedRows = newKeyRowBlock(e.maxBatchSize, false)
 	e.resultCursor = 0
 	e.curBatchSize = 32
 	e.resultBuffer = make([]Row, 0, e.maxBatchSize)
@@ -129,15 +131,8 @@ func (e *IndexLookUpJoin) Close() error {
 	}
 
 	// release all resource references.
-	e.outerExec = nil
-	e.innerExecBuilder = nil
-	e.outerKeys = nil
-	e.innerKeys = nil
-	e.outerFilter = nil
-	e.innerFilter = nil
 	e.outerOrderedRows = nil
 	e.innerOrderedRows = nil
-	e.resultGenerator = nil
 	e.resultBuffer = nil
 	e.buffer4JoinKeys = nil
 	e.buffer4JoinKey = nil

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -597,6 +597,13 @@ func (s *testSuite) TestSubquery(c *C) {
 	tk.MustExec("INSERT INTO t1 values(1)")
 	result = tk.MustQuery("SELECT 1 FROM test.t1, test.t2 WHERE 1 = (SELECT test.t2.d FROM test.t2 WHERE test.t1.a >= 1) and test.t2.d = 1;")
 	result.Check(testkit.Rows())
+
+	tk.MustExec("DROP TABLE IF EXISTS t1")
+	tk.MustExec("CREATE TABLE t1(a int, b int default 0)")
+	tk.MustExec("create index k1 on t1(a)")
+	tk.MustExec("INSERT INTO t1 (a) values(1), (2), (3), (4), (5)")
+	result = tk.MustQuery("select (select /*+ TIDB_INLJ(x1) */ x2.a from t1 x1, t1 x2 where x1.a = t1.a and x1.a = x2.a) from t1")
+	result.Check(testkit.Rows("1", "2", "3", "4", "5"))
 }
 
 func (s *testSuite) TestInSubquery(c *C) {


### PR DESCRIPTION
correct the `Open` and `Close` function