### PR TITLE
store/tikv: no need to manually drop region when RPC call fails.

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -463,16 +463,6 @@ func (c *RegionCache) OnRequestFail(ctx *RPCContext, err error) {
 	c.storeMu.Lock()
 	delete(c.storeMu.stores, storeID)
 	c.storeMu.Unlock()
-
-	log.Infof("drop regions of store %d from cache due to request fail, err: %v", storeID, err)
-
-	c.mu.Lock()
-	for id, r := range c.mu.regions {
-		if r.region.peer.GetStoreId() == storeID {
-			c.dropRegionFromCache(id)
-		}
-	}
-	c.mu.Unlock()
 }
 
 // OnRegionStale removes the old region and inserts new regions into the cache.

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -277,10 +277,6 @@ func (s *testRegionCacheSuite) TestRequestFail2(c *C) {
 	c.Assert(s.cache.storeMu.stores, HasLen, 1)
 	s.checkCache(c, 2)
 	s.cache.OnRequestFail(ctx, errors.New("test error"))
-	// Both region2 and store should be dropped from cache.
-	c.Assert(s.cache.storeMu.stores, HasLen, 0)
-	c.Assert(s.cache.searchCachedRegion([]byte("x")), IsNil)
-	s.checkCache(c, 1)
 }
 
 func (s *testRegionCacheSuite) TestUpdateStoreAddr(c *C) {


### PR DESCRIPTION
The feature is originally to solve the problem that store down causes a lot of regions' metas out of date. See #2792
After #4506, cached regions are removed based on last access time, so the feature is not necessary any more.