### PR TITLE
plan: remove the check of task type in `prop.isPrefix`

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -104,9 +104,6 @@ func (p *requiredProp) isPrefix(prop *requiredProp) bool {
 	if len(p.cols) > len(prop.cols) || p.desc != prop.desc {
 		return false
 	}
-	if p.taskTp != prop.taskTp {
-		return false
-	}
 	for i := range p.cols {
 		if !p.cols[i].Equal(prop.cols[i], nil) {
 			return false


### PR DESCRIPTION
A plan's task type needn't be equal to child's task type.