### PR TITLE
util/chunk: add mutable row type.

### DIFF
--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -58,7 +58,7 @@ func MutRowFromDatums(datums []types.Datum) MutRow {
 	return MutRow{c: c, idx: 0}
 }
 
-// MutRowFromTypes creates a MutRow from a datum slice, each column is initialized to default
+// MutRowFromTypes creates a MutRow from a FieldType slice, each column is initialized to zero value.
 func MutRowFromTypes(types []*types.FieldType) MutRow {
 	c := &Chunk{}
 	for _, tp := range types {

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -1,0 +1,350 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"encoding/binary"
+	"math"
+	"unsafe"
+
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/hack"
+)
+
+// MutRow represents a mutable Row.
+// The underlying columns only contains one row and not exposed to the user.
+type MutRow Row
+
+// ToRow converts the MutRow to Row, so it can be used to read data.
+func (mr MutRow) ToRow() Row {
+	return Row(mr)
+}
+
+// Len returns the number of columns.
+func (mr MutRow) Len() int {
+	return len(mr.c.columns)
+}
+
+// MutRowFromValues creates a MutRow from a interface slice.
+func MutRowFromValues(vals ...interface{}) MutRow {
+	c := &Chunk{}
+	for _, val := range vals {
+		col := makeMutRowColumn(val)
+		c.columns = append(c.columns, col)
+	}
+	return MutRow{c: c}
+}
+
+// MutRowFromDatums creates a MutRow from a datum slice.
+func MutRowFromDatums(datums []types.Datum) MutRow {
+	c := &Chunk{}
+	for _, d := range datums {
+		col := makeMutRowColumn(d.GetValue())
+		c.columns = append(c.columns, col)
+	}
+	return MutRow{c: c, idx: 0}
+}
+
+// MutRowFromTypes creates a MutRow from a datum slice, each column is initialized to default
+func MutRowFromTypes(types []*types.FieldType) MutRow {
+	c := &Chunk{}
+	for _, tp := range types {
+		col := makeMutRowColumn(zeroValForType(tp))
+		c.columns = append(c.columns, col)
+	}
+	return MutRow{c: c, idx: 0}
+}
+
+func zeroValForType(tp *types.FieldType) interface{} {
+	switch tp.Tp {
+	case mysql.TypeFloat:
+		return float32(0)
+	case mysql.TypeDouble:
+		return float64(0)
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
+		if mysql.HasUnsignedFlag(tp.Flag) {
+			return uint64(0)
+		}
+		return int64(0)
+	case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar:
+		return ""
+	case mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		return []byte{}
+	case mysql.TypeDuration:
+		return types.ZeroDuration
+	case mysql.TypeNewDecimal:
+		return types.NewDecFromInt(0)
+	case mysql.TypeDate:
+		return types.ZeroDate
+	case mysql.TypeDatetime:
+		return types.ZeroDatetime
+	case mysql.TypeTimestamp:
+		return types.ZeroTimestamp
+	case mysql.TypeBit:
+		return types.BinaryLiteral{}
+	case mysql.TypeSet:
+		return types.Set{}
+	case mysql.TypeEnum:
+		return types.Enum{}
+	case mysql.TypeJSON:
+		return json.CreateJSON(nil)
+	default:
+		return nil
+	}
+}
+
+func makeMutRowColumn(in interface{}) *column {
+	switch x := in.(type) {
+	case nil:
+		col := makeMutRowUint64Column(uint64(0))
+		col.nullBitmap[0] = 0
+		return col
+	case int:
+		return makeMutRowUint64Column(uint64(x))
+	case int64:
+		return makeMutRowUint64Column(uint64(x))
+	case uint64:
+		return makeMutRowUint64Column(x)
+	case float64:
+		return makeMutRowUint64Column(math.Float64bits(x))
+	case float32:
+		col := newMutRowFixedLenColumn(4)
+		*(*uint32)(unsafe.Pointer(&col.data[0])) = math.Float32bits(x)
+		return col
+	case string:
+		return makeMutRowBytesColumn(hack.Slice(x))
+	case []byte:
+		return makeMutRowBytesColumn(x)
+	case types.BinaryLiteral:
+		return makeMutRowBytesColumn(x)
+	case *types.MyDecimal:
+		col := newMutRowFixedLenColumn(types.MyDecimalStructSize)
+		*(*types.MyDecimal)(unsafe.Pointer(&col.data[0])) = *x
+		return col
+	case types.Time:
+		return makeMutRowInterfaceColumn(x)
+	case json.JSON:
+		return makeMutRowInterfaceColumn(x)
+	case types.Duration:
+		col := newMutRowFixedLenColumn(16)
+		*(*types.Duration)(unsafe.Pointer(&col.data[0])) = x
+		return col
+	case types.Enum:
+		col := newMutRowVarLenColumn(len(x.Name) + 8)
+		*(*uint64)(unsafe.Pointer(&col.data[0])) = x.Value
+		copy(col.data[8:], x.Name)
+		return col
+	case types.Set:
+		col := newMutRowVarLenColumn(len(x.Name) + 8)
+		*(*uint64)(unsafe.Pointer(&col.data[0])) = x.Value
+		copy(col.data[8:], x.Name)
+		return col
+	default:
+		return makeMutRowInterfaceColumn(x)
+	}
+}
+
+func newMutRowFixedLenColumn(elemSize int) *column {
+	buf := make([]byte, elemSize+1)
+	col := &column{
+		length:     1,
+		elemBuf:    buf[:elemSize],
+		data:       buf[:elemSize],
+		nullBitmap: buf[elemSize:],
+	}
+	col.nullBitmap[0] = 1
+	return col
+}
+
+func newMutRowVarLenColumn(valSize int) *column {
+	buf := make([]byte, valSize+1)
+	col := &column{
+		length:     1,
+		offsets:    []int32{0, int32(valSize)},
+		data:       buf[:valSize],
+		nullBitmap: buf[valSize:],
+	}
+	col.nullBitmap[0] = 1
+	return col
+}
+
+func makeMutRowUint64Column(val uint64) *column {
+	buf := make([]byte, 9)
+	col := &column{
+		length:     1,
+		data:       buf[:8],
+		nullBitmap: buf[8:],
+	}
+	*(*uint64)(unsafe.Pointer(&col.data[0])) = val
+	col.nullBitmap[0] = 1
+	return col
+}
+
+func makeMutRowBytesColumn(bin []byte) *column {
+	buf := make([]byte, len(bin)+1)
+	col := &column{
+		length:     1,
+		offsets:    []int32{0, int32(len(bin))},
+		data:       buf[:len(bin)],
+		nullBitmap: buf[len(bin):],
+	}
+	copy(col.data, bin)
+	col.nullBitmap[0] = 1
+	return col
+}
+
+func makeMutRowInterfaceColumn(in interface{}) *column {
+	col := &column{
+		length:     1,
+		nullBitmap: []byte{1},
+		ifaces:     []interface{}{in},
+	}
+	return col
+}
+
+// SetRow sets the MutRow with Row.
+func (mr MutRow) SetRow(row Row) {
+	for colIdx, rCol := range row.c.columns {
+		mrCol := mr.c.columns[colIdx]
+		elemLen := len(rCol.elemBuf)
+		if elemLen > 0 {
+			copy(mrCol.data, rCol.data[row.idx*elemLen:(row.idx+1)*elemLen])
+		} else if len(rCol.offsets) > 0 {
+			setMutRowBytes(mrCol, rCol.data[rCol.offsets[row.idx]:rCol.offsets[row.idx+1]])
+		} else {
+			mrCol.ifaces[0] = rCol.ifaces[row.idx]
+		}
+		if rCol.isNull(colIdx) {
+			mrCol.nullBitmap[0] = 0
+		} else {
+			mrCol.nullBitmap[0] = 1
+		}
+	}
+}
+
+// SetValues sets the MutRow with values.
+func (mr MutRow) SetValues(vals ...interface{}) {
+	for i, v := range vals {
+		mr.SetValue(i, v)
+	}
+}
+
+// SetValue sets the MutRow with colIdx and value.
+func (mr MutRow) SetValue(colIdx int, val interface{}) {
+	col := mr.c.columns[colIdx]
+	if val == nil {
+		col.nullBitmap[0] = 0
+		return
+	}
+	col.nullBitmap[0] = 1
+	switch x := val.(type) {
+	case int:
+		binary.LittleEndian.PutUint64(col.data, uint64(x))
+	case int64:
+		binary.LittleEndian.PutUint64(col.data, uint64(x))
+	case uint64:
+		binary.LittleEndian.PutUint64(col.data, x)
+	case float64:
+		binary.LittleEndian.PutUint64(col.data, math.Float64bits(x))
+	case float32:
+		binary.LittleEndian.PutUint32(col.data, math.Float32bits(x))
+	case string:
+		setMutRowBytes(col, hack.Slice(x))
+	case []byte:
+		setMutRowBytes(col, x)
+	case types.BinaryLiteral:
+		setMutRowBytes(col, x)
+	case types.Duration:
+		*(*types.Duration)(unsafe.Pointer(&col.data[0])) = x
+	case *types.MyDecimal:
+		*(*types.MyDecimal)(unsafe.Pointer(&col.data[0])) = *x
+	case types.Time:
+		col.ifaces[0] = x
+	case types.Enum:
+		setMutRowNameValue(col, x.Name, x.Value)
+	case types.Set:
+		setMutRowNameValue(col, x.Name, x.Value)
+	case json.JSON:
+		col.ifaces[0] = x
+	}
+}
+
+// SetDatums sets the MutRow with datum slice.
+func (mr MutRow) SetDatums(datums ...types.Datum) {
+	for i, d := range datums {
+		mr.SetDatum(i, d)
+	}
+}
+
+// SetDatum sets the MutRow with colIdx and datum.
+func (mr MutRow) SetDatum(colIdx int, d types.Datum) {
+	col := mr.c.columns[colIdx]
+	if d.IsNull() {
+		col.nullBitmap[0] = 0
+		return
+	}
+	col.nullBitmap[0] = 1
+	switch d.Kind() {
+	case types.KindInt64, types.KindUint64, types.KindFloat64:
+		binary.LittleEndian.PutUint64(mr.c.columns[colIdx].data, d.GetUint64())
+	case types.KindFloat32:
+		binary.LittleEndian.PutUint32(mr.c.columns[colIdx].data, math.Float32bits(d.GetFloat32()))
+	case types.KindString, types.KindBytes, types.KindBinaryLiteral:
+		setMutRowBytes(col, d.GetBytes())
+	case types.KindMysqlTime:
+		col.ifaces[0] = d.GetMysqlTime()
+	case types.KindMysqlDuration:
+		*(*types.Duration)(unsafe.Pointer(&col.data[0])) = d.GetMysqlDuration()
+	case types.KindMysqlDecimal:
+		*(*types.MyDecimal)(unsafe.Pointer(&col.data[0])) = *d.GetMysqlDecimal()
+	case types.KindMysqlJSON:
+		col.ifaces[0] = d.GetMysqlJSON()
+	case types.KindMysqlEnum:
+		e := d.GetMysqlEnum()
+		setMutRowNameValue(col, e.Name, e.Value)
+	case types.KindMysqlSet:
+		s := d.GetMysqlSet()
+		setMutRowNameValue(col, s.Name, s.Value)
+	default:
+		mr.c.columns[colIdx] = makeMutRowColumn(d.GetValue())
+	}
+}
+
+func setMutRowBytes(col *column, bin []byte) {
+	if len(col.data) >= len(bin) {
+		col.data = col.data[:len(bin)]
+	} else {
+		buf := make([]byte, len(bin)+1)
+		col.data = buf[:len(bin)]
+		col.nullBitmap = buf[len(bin):]
+	}
+	copy(col.data, bin)
+	col.offsets[1] = int32(len(bin))
+}
+
+func setMutRowNameValue(col *column, name string, val uint64) {
+	dataLen := len(name) + 8
+	if len(col.data) >= dataLen {
+		col.data = col.data[:dataLen]
+	} else {
+		buf := make([]byte, dataLen+1)
+		col.data = buf[:dataLen]
+		col.nullBitmap = buf[dataLen:]
+	}
+	binary.LittleEndian.PutUint64(col.data, val)
+	copy(col.data[8:], name)
+	col.offsets[1] = int32(dataLen)
+}

--- a/util/chunk/mutrow_test.go
+++ b/util/chunk/mutrow_test.go
@@ -36,15 +36,34 @@ func (s *testChunkSuite) TestMutRow(c *check.C) {
 	}
 
 	mutRow = MutRowFromValues("abc", 123)
+	c.Assert(row.IsNull(0), check.IsFalse)
 	c.Assert(mutRow.ToRow().GetString(0), check.Equals, "abc")
+	c.Assert(row.IsNull(1), check.IsFalse)
 	c.Assert(mutRow.ToRow().GetInt64(1), check.Equals, int64(123))
 	mutRow.SetValues("abcd", 456)
 	row = mutRow.ToRow()
 	c.Assert(row.GetString(0), check.Equals, "abcd")
+	c.Assert(row.IsNull(0), check.IsFalse)
 	c.Assert(row.GetInt64(1), check.Equals, int64(456))
+	c.Assert(row.IsNull(1), check.IsFalse)
 	mutRow.SetDatums(types.NewStringDatum("defgh"), types.NewIntDatum(33))
+	c.Assert(row.IsNull(0), check.IsFalse)
 	c.Assert(row.GetString(0), check.Equals, "defgh")
+	c.Assert(row.IsNull(1), check.IsFalse)
 	c.Assert(row.GetInt64(1), check.Equals, int64(33))
+
+	mutRow.SetRow(MutRowFromValues("foobar", nil).ToRow())
+	row = mutRow.ToRow()
+	c.Assert(row.IsNull(0), check.IsFalse)
+	c.Assert(row.IsNull(1), check.IsTrue)
+
+	nRow := MutRowFromValues(nil, 111).ToRow()
+	c.Assert(nRow.IsNull(0), check.IsTrue)
+	c.Assert(nRow.IsNull(1), check.IsFalse)
+	mutRow.SetRow(nRow)
+	row = mutRow.ToRow()
+	c.Assert(row.IsNull(0), check.IsTrue)
+	c.Assert(row.IsNull(1), check.IsFalse)
 }
 
 func BenchmarkMutRowSetRow(b *testing.B) {

--- a/util/chunk/mutrow_test.go
+++ b/util/chunk/mutrow_test.go
@@ -1,0 +1,104 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"testing"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+)
+
+func (s *testChunkSuite) TestMutRow(c *check.C) {
+	mutRow := MutRowFromTypes(allTypes)
+	row := mutRow.ToRow()
+	sc := new(stmtctx.StatementContext)
+	for i := 0; i < row.Len(); i++ {
+		val := zeroValForType(allTypes[i])
+		d := row.GetDatum(i, allTypes[i])
+		d2 := types.NewDatum(val)
+		cmp, err := d.CompareDatum(sc, &d2)
+		c.Assert(err, check.IsNil)
+		c.Assert(cmp, check.Equals, 0)
+	}
+
+	mutRow = MutRowFromValues("abc", 123)
+	c.Assert(mutRow.ToRow().GetString(0), check.Equals, "abc")
+	c.Assert(mutRow.ToRow().GetInt64(1), check.Equals, int64(123))
+	mutRow.SetValues("abcd", 456)
+	row = mutRow.ToRow()
+	c.Assert(row.GetString(0), check.Equals, "abcd")
+	c.Assert(row.GetInt64(1), check.Equals, int64(456))
+	mutRow.SetDatums(types.NewStringDatum("defgh"), types.NewIntDatum(33))
+	c.Assert(row.GetString(0), check.Equals, "defgh")
+	c.Assert(row.GetInt64(1), check.Equals, int64(33))
+}
+
+func BenchmarkMutRowSetRow(b *testing.B) {
+	b.ReportAllocs()
+	rowChk := newChunk(8, 0)
+	rowChk.AppendInt64(0, 1)
+	rowChk.AppendString(1, "abcd")
+	row := rowChk.GetRow(0)
+	mutRow := MutRowFromValues(1, "abcd")
+	for i := 0; i < b.N; i++ {
+		mutRow.SetRow(row)
+	}
+}
+
+func BenchmarkMutRowSetDatums(b *testing.B) {
+	b.ReportAllocs()
+	mutRow := MutRowFromValues(1, "abcd")
+	datums := []types.Datum{types.NewDatum(1), types.NewDatum("abcd")}
+	for i := 0; i < b.N; i++ {
+		mutRow.SetDatums(datums...)
+	}
+}
+
+func BenchmarkMutRowSetValues(b *testing.B) {
+	b.ReportAllocs()
+	mutRow := MutRowFromValues(1, "abcd")
+	for i := 0; i < b.N; i++ {
+		mutRow.SetValues(1, "abcd")
+	}
+}
+
+func BenchmarkMutRowFromTypes(b *testing.B) {
+	b.ReportAllocs()
+	tps := []*types.FieldType{
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeVarchar),
+	}
+	for i := 0; i < b.N; i++ {
+		MutRowFromTypes(tps)
+	}
+}
+
+func BenchmarkMutRowFromDatums(b *testing.B) {
+	b.ReportAllocs()
+	datums := []types.Datum{types.NewDatum(1), types.NewDatum("abc")}
+	for i := 0; i < b.N; i++ {
+		MutRowFromDatums(datums)
+	}
+}
+
+func BenchmarkMutRowFromValues(b *testing.B) {
+	b.ReportAllocs()
+	values := []interface{}{1, "abc"}
+	for i := 0; i < b.N; i++ {
+		MutRowFromValues(values)
+	}
+}


### PR DESCRIPTION
`MutRow` has `Set` methods and can be easily created and converted to chunk.Row, can be used for write statements.