### PR TITLE
[DNM]*: Add a new syntax to randomize the rowid

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -636,6 +636,7 @@ const (
 	TableOptionDelayKeyWrite
 	TableOptionRowFormat
 	TableOptionStatsPersistent
+	TableOptionRandomScatter
 )
 
 // RowFormat types

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -827,6 +827,9 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) {
 			tbInfo.Charset = op.StrValue
 		case ast.TableOptionCollate:
 			tbInfo.Collate = op.StrValue
+		case ast.TableOptionRandomScatter:
+			// TODO: It should be smaller than 64.
+			tbInfo.RandomScatter = int64(op.UintValue)
 		}
 	}
 }

--- a/executor/show.go
+++ b/executor/show.go
@@ -598,6 +598,10 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(fmt.Sprintf(" AUTO_INCREMENT=%d", tb.Meta().AutoIncID))
 	}
 
+	if tb.Meta().RandomScatter > 0 {
+		buf.WriteString(fmt.Sprintf(" RANDOM_SCATTER=%d", tb.Meta().RandomScatter))
+	}
+
 	if len(tb.Meta().Comment) > 0 {
 		buf.WriteString(fmt.Sprintf(" COMMENT='%s'", format.OutputFormat(tb.Meta().Comment)))
 	}

--- a/model/model.go
+++ b/model/model.go
@@ -113,6 +113,8 @@ type TableInfo struct {
 	// TODO: Remove it.
 	// Now it only uses for compatibility with the old version that already uses this field.
 	OldSchemaID int64 `json:"old_schema_id,omitempty"`
+
+	RandomScatter int64 `json:"random_scatter"`
 }
 
 // GetDBID returns the schema ID that is used to create an allocator.

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -375,6 +375,7 @@ var tokenMap = map[string]int{
 	"QUARTER":                  quarter,
 	"QUERY":                    query,
 	"QUICK":                    quick,
+	"RANDOM_SCATTER":           randomScatter,
 	"RANGE":                    rangeKwd,
 	"READ":                     read,
 	"REAL":                     realType,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -417,6 +417,7 @@ import (
 	cancel		"CANCEL"
 	ddl		"DDL"
 	jobs		"JOBS"
+	randomScatter	"RANDOM_SCATTER"
 	stats		"STATS"
 	statsMeta       "STATS_META"
 	statsHistograms "STATS_HISTOGRAMS"
@@ -5262,6 +5263,10 @@ TableOption:
 |	"STATS_PERSISTENT" EqOpt StatsPersistentVal
 	{
 		$$ = &ast.TableOption{Tp: ast.TableOptionStatsPersistent}
+	}
+|	"RANDOM_SCATTER" EqOpt LengthNum
+	{
+		$$ = &ast.TableOption{Tp: ast.TableOptionRandomScatter, UintValue: $3.(uint64)}
 	}
 
 StatsPersistentVal:


### PR DESCRIPTION
To avoid single hot-region writing. If the random_scatter option is set. We will use bit-operations to randomize the explicit/implicit auto generated id. For example:
```sql
mysql> CREATE TABLE `t` (
    ->   `c` bigint DEFAULT NULL AUTO_INCREMENT KEY
    -> ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin RANDOM_SCATTER=4;
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t values (), (), ();
Query OK, 3 rows affected (0.10 sec)

mysql> select * from t;
+---------------------+
| c                   |
+---------------------+
| 1152921504606846976 |
| 2305843009213693952 |
| 3458764513820540928 |
+---------------------+
3 rows in set (0.00 sec)

mysql> insert into t values (), (), ();
Query OK, 3 rows affected (0.01 sec)

mysql> select * from t;
+---------------------+
| c                   |
+---------------------+
| 1152921504606846976 |
| 2305843009213693952 |
| 3458764513820540928 |
| 4611686018427387904 |
| 5764607523034234880 |
| 6917529027641081856 |
+---------------------+
6 rows in set (0.00 sec)

mysql> insert into t values (), (), ();
Query OK, 3 rows affected (0.00 sec)

mysql> select * from t;
+----------------------+
| c                    |
+----------------------+
| -9223372036854775808 |
| -8070450532247928832 |
|  1152921504606846976 |
|  2305843009213693952 |
|  3458764513820540928 |
|  4611686018427387904 |
|  5764607523034234880 |
|  6917529027641081856 |
|  8070450532247928832 |
+----------------------+
9 rows in set (0.00 sec)
```