### PR TITLE
plan, executor: only rebuild range when using prepare cache.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/admin"
-	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	goctx "golang.org/x/net/context"
 )
@@ -1017,43 +1016,6 @@ func (b *executorBuilder) constructDAGReq(plans []plan.PhysicalPlan) (*tipb.DAGR
 	return dagReq, nil
 }
 
-func (b *executorBuilder) constructTableRanges(ts *plan.PhysicalTableScan) (newRanges []ranger.IntColumnRange, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	cols := expression.ColumnInfos2ColumnsWithDBName(ts.DBName, ts.Table.Name, ts.Columns)
-	newRanges = ranger.FullIntRange()
-	var pkCol *expression.Column
-	if ts.Table.PKIsHandle {
-		if pkColInfo := ts.Table.GetPkColInfo(); pkColInfo != nil {
-			pkCol = expression.ColInfo2Col(cols, pkColInfo)
-		}
-	}
-	if pkCol != nil {
-		var ranges []ranger.Range
-		ranges, err = ranger.BuildRange(sc, ts.AccessCondition, ranger.IntRangeType, []*expression.Column{pkCol}, nil)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		newRanges = ranger.Ranges2IntRanges(ranges)
-	}
-	return newRanges, nil
-}
-
-func (b *executorBuilder) constructIndexRanges(is *plan.PhysicalIndexScan) (newRanges []*ranger.IndexRange, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	cols := expression.ColumnInfos2ColumnsWithDBName(is.DBName, is.Table.Name, is.Columns)
-	idxCols, colLengths := expression.IndexInfo2Cols(cols, is.Index)
-	newRanges = ranger.FullIndexRange()
-	if len(idxCols) > 0 {
-		var ranges []ranger.Range
-		ranges, err = ranger.BuildRange(sc, is.AccessCondition, ranger.IndexRangeType, idxCols, colLengths)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		newRanges = ranger.Ranges2IndexRanges(ranges)
-	}
-	return newRanges, nil
-}
-
 func (b *executorBuilder) buildIndexLookUpJoin(v *plan.PhysicalIndexJoin) Executor {
 	outerExec := b.build(v.Children()[v.OuterIndex])
 	if b.err != nil {
@@ -1163,12 +1125,7 @@ func (b *executorBuilder) buildTableReader(v *plan.PhysicalTableReader) *TableRe
 	}
 
 	ts := v.TablePlans[0].(*plan.PhysicalTableScan)
-	newRanges, err1 := b.constructTableRanges(ts)
-	if err1 != nil {
-		b.err = errors.Trace(err1)
-		return nil
-	}
-	ret.ranges = newRanges
+	ret.ranges = ts.Ranges
 	return ret
 }
 
@@ -1207,12 +1164,7 @@ func (b *executorBuilder) buildIndexReader(v *plan.PhysicalIndexReader) *IndexRe
 	}
 
 	is := v.IndexPlans[0].(*plan.PhysicalIndexScan)
-	newRanges, err1 := b.constructIndexRanges(is)
-	if err1 != nil {
-		b.err = errors.Trace(err1)
-		return nil
-	}
-	ret.ranges = newRanges
+	ret.ranges = is.Ranges
 	return ret
 }
 
@@ -1261,16 +1213,7 @@ func (b *executorBuilder) buildIndexLookUpReader(v *plan.PhysicalIndexLookUpRead
 	}
 
 	is := v.IndexPlans[0].(*plan.PhysicalIndexScan)
-	newRanges, err1 := b.constructIndexRanges(is)
-	if err1 != nil {
-		b.err = errors.Trace(err1)
-		return nil
-	}
-	ranges := make([]*ranger.IndexRange, 0, len(newRanges))
-	for _, rangeInPlan := range newRanges {
-		ranges = append(ranges, rangeInPlan.Clone())
-	}
-	ret.ranges = ranges
+	ret.ranges = is.Ranges
 	return ret
 }
 


### PR DESCRIPTION
The previous changes are introduced by the prepare stmt cache.
Ranges are rebuilt in execution phase even if the plan is not dumped from prepare cache.
This pr corrects the behavior.
PTAL @zz-jason @coocood @hanfei1991 