### PR TITLE
stats: fix trigger condition for auto analyze

### DIFF
--- a/statistics/update.go
+++ b/statistics/update.go
@@ -159,7 +159,7 @@ func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 		return false
 	}
 	for _, col := range tbl.Columns {
-		if len(col.Buckets) > 0 {
+		if len(col.Buckets) > 0 || col.Count > 0 {
 			return false
 		}
 	}

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -159,7 +159,7 @@ func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 		return false
 	}
 	for _, col := range tbl.Columns {
-		if len(col.Buckets) > 0 || col.Count > 0 {
+		if col.Count > 0 {
 			return false
 		}
 	}

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -304,6 +304,7 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	h.Update(is)
 	stats = h.GetTableStats(tableInfo.ID)
 	c.Assert(stats.Count, Equals, int64(2))
+	// Modify count is non-zero means that we do not analyze the table.
 	c.Assert(stats.ModifyCount, Equals, int64(1))
 
 	_, err = testKit.Exec("create index idx on t(a)")

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -14,6 +14,8 @@
 package statistics_test
 
 import (
+	"time"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
@@ -289,6 +291,21 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	c.Assert(stats.Count, Equals, int64(1))
 	c.Assert(stats.ModifyCount, Equals, int64(0))
 
+	_, err = testKit.Exec("insert into t values (1)")
+	c.Assert(err, IsNil)
+	h.DumpStatsDeltaToKV()
+	h.Clear()
+	// We set `Lease` here so that `Update` will use load by need strategy.
+	h.Lease = time.Second
+	h.Update(is)
+	h.Lease = 0
+	err = h.HandleAutoAnalyze(is)
+	c.Assert(err, IsNil)
+	h.Update(is)
+	stats = h.GetTableStats(tableInfo.ID)
+	c.Assert(stats.Count, Equals, int64(2))
+	c.Assert(stats.ModifyCount, Equals, int64(1))
+
 	_, err = testKit.Exec("create index idx on t(a)")
 	c.Assert(err, IsNil)
 	is = do.InfoSchema()
@@ -298,7 +315,7 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	h.HandleAutoAnalyze(is)
 	h.Update(is)
 	stats = h.GetTableStats(tableInfo.ID)
-	c.Assert(stats.Count, Equals, int64(1))
+	c.Assert(stats.Count, Equals, int64(2))
 	c.Assert(stats.ModifyCount, Equals, int64(0))
 	hg, ok := stats.Indices[tableInfo.Indices[0].ID]
 	c.Assert(ok, IsTrue)


### PR DESCRIPTION
Because of the load by need strategy, if we have a table with no index, we may auto analyze it multiple times.