### PR TITLE
plan: benchmark optimize function

### DIFF
--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -15,6 +15,7 @@ package plan_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
@@ -411,4 +412,127 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	tidb.SetStatsLease(0)
 	dom, err := tidb.BootstrapSession(store)
 	return store, dom, errors.Trace(err)
+}
+
+func BenchmarkOptimize(b *testing.B) {
+	c := &C{}
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec("create table t (a int primary key, b int, c varchar(200), d datetime DEFAULT CURRENT_TIMESTAMP, e int, ts timestamp DEFAULT CURRENT_TIMESTAMP)")
+	testKit.MustExec("create index b on t (b)")
+	testKit.MustExec("create index d on t (d)")
+	testKit.MustExec("create index e on t (e)")
+	testKit.MustExec("create index b_c on t (b,c)")
+	testKit.MustExec("create index ts on t (ts)")
+	for i := 0; i < 100; i++ {
+		testKit.MustExec(constructInsertSQL(i, 100))
+	}
+	testKit.MustExec("analyze table t")
+	tests := []struct {
+		sql  string
+		best string
+	}{
+		{
+			sql:  "select count(*) from t group by e",
+			best: "IndexReader(Index(t.e)[[<nil>,+inf]])->StreamAgg",
+		},
+		{
+			sql:  "select count(*) from t where e <= 10 group by e",
+			best: "IndexReader(Index(t.e)[[-inf,10]])->StreamAgg",
+		},
+		{
+			sql:  "select count(*) from t where e <= 50",
+			best: "IndexReader(Index(t.e)[[-inf,50]]->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(*) from t where c > '1' group by b",
+			best: "IndexReader(Index(t.b_c)[[<nil>,+inf]]->Sel([gt(test.t.c, 1)]))->StreamAgg",
+		},
+		{
+			sql:  "select count(*) from t where e = 1 group by b",
+			best: "IndexLookUp(Index(t.e)[[1,1]], Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(*) from t where e > 1 group by b",
+			best: "TableReader(Table(t)->Sel([gt(test.t.e, 1)])->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(e) from t where t.b <= 20",
+			best: "IndexLookUp(Index(t.b)[[-inf,20]], Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(e) from t where t.b <= 30",
+			best: "IndexLookUp(Index(t.b)[[-inf,30]], Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(e) from t where t.b <= 40",
+			best: "IndexLookUp(Index(t.b)[[-inf,40]], Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(e) from t where t.b <= 50",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)])->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select * from t where t.b <= 40",
+			best: "IndexLookUp(Index(t.b)[[-inf,40]], Table(t))",
+		},
+		{
+			sql:  "select * from t where t.b <= 50",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)]))",
+		},
+		// test panic
+		{
+			sql:  "select * from t where 1 and t.b <= 50",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)]))",
+		},
+		{
+			sql:  "select * from t where t.b <= 100 order by t.a limit 1",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 100)])->Limit)->Limit",
+		},
+		{
+			sql:  "select * from t where t.b <= 1 order by t.a limit 10",
+			best: "IndexLookUp(Index(t.b)[[-inf,1]]->TopN([test.t.a],0,10), Table(t))->TopN([test.t.a],0,10)",
+		},
+		{
+			sql:  "select * from t use index(b) where b = 1 order by a",
+			best: "IndexLookUp(Index(t.b)[[1,1]], Table(t))->Sort",
+		},
+		// test datetime
+		{
+			sql:  "select * from t where d < cast('1991-09-05' as datetime)",
+			best: "IndexLookUp(Index(t.d)[[-inf,1991-09-05 00:00:00)], Table(t))",
+		},
+		// test timestamp
+		{
+			sql:  "select * from t where ts < '1991-09-05'",
+			best: "IndexLookUp(Index(t.ts)[[-inf,1991-09-05 00:00:00)], Table(t))",
+		},
+	}
+	for _, tt := range tests {
+		ctx := testKit.Se.(context.Context)
+		stmts, err := tidb.Parse(ctx, tt.sql)
+		c.Assert(err, IsNil)
+		c.Assert(stmts, HasLen, 1)
+		stmt := stmts[0]
+		is := domain.GetDomain(ctx).InfoSchema()
+		err = plan.Preprocess(ctx, stmt, is, false)
+		c.Assert(err, IsNil)
+
+		b.Run(tt.sql, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := plan.Optimize(ctx, stmt, is)
+				c.Assert(err, IsNil)
+			}
+			b.ReportAllocs()
+		})
+	}
 }


### PR DESCRIPTION
go test -test.bench=BenchmarkOptimize -test.run=^XXX

```
pkg: github.com/pingcap/tidb/plan
BenchmarkOptimize/select_count(*)_from_t_group_by_e-4         	   30000	     39279 ns/op	   27376 B/op	     370 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_10_group_by_e-4         	   10000	    100107 ns/op	   67394 B/op	     855 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_50-4                    	   10000	    102730 ns/op	   68466 B/op	     861 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_c_>_'1'_group_by_b-4         	   10000	    113519 ns/op	   78067 B/op	    1079 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_=_1_group_by_b-4           	   10000	    116716 ns/op	   78898 B/op	    1036 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_>_1_group_by_b-4           	   10000	    113030 ns/op	   81554 B/op	    1052 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_20-4                  	   10000	    125467 ns/op	   84153 B/op	    1064 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_30-4                  	   10000	    138241 ns/op	   84155 B/op	    1065 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_40-4                  	   10000	    134946 ns/op	   84155 B/op	    1065 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_50-4                  	   10000	    122163 ns/op	   84154 B/op	    1065 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_40-4                         	   30000	     55954 ns/op	   41520 B/op	     502 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_50-4                         	   30000	     59545 ns/op	   41520 B/op	     502 allocs/op
BenchmarkOptimize/select_*_from_t_where_1_and_t.b_<=_50-4                   	   30000	     55696 ns/op	   41824 B/op	     508 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_100_order_by_t.a_limit_1-4   	   10000	    210889 ns/op	  156849 B/op	    1841 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_1_order_by_t.a_limit_10-4    	   10000	    213800 ns/op	  155407 B/op	    1804 allocs/op
BenchmarkOptimize/select_*_from_t_use_index(b)_where_b_=_1_order_by_a-4     	   50000	     38628 ns/op	   28159 B/op	     371 allocs/op
BenchmarkOptimize/select_*_from_t_where_d_<_cast('1991-09-05'_as_datetime)-4         	   20000	     64924 ns/op	   41585 B/op	     529 allocs/op
BenchmarkOptimize/select_*_from_t_where_ts_<_'1991-09-05'-4                          	   20000	     73385 ns/op	   41682 B/op	     533 allocs/op
```