### PR TITLE
plan,executor: remove HashSemiJoin

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -110,8 +110,6 @@ func (b *executorBuilder) build(p plan.Plan) Executor {
 		return b.buildHashJoin(v)
 	case *plan.PhysicalMergeJoin:
 		return b.buildMergeJoin(v)
-	case *plan.PhysicalHashSemiJoin:
-		return b.buildSemiJoin(v)
 	case *plan.PhysicalIndexJoin:
 		return b.buildIndexLookUpJoin(v)
 	case *plan.PhysicalSelection:
@@ -640,31 +638,6 @@ func (b *executorBuilder) buildHashJoin(v *plan.PhysicalHashJoin) Executor {
 	return e
 }
 
-func (b *executorBuilder) buildSemiJoin(v *plan.PhysicalHashSemiJoin) *HashSemiJoinExec {
-	leftHashKey := make([]*expression.Column, 0, len(v.EqualConditions))
-	rightHashKey := make([]*expression.Column, 0, len(v.EqualConditions))
-	for _, eqCond := range v.EqualConditions {
-		ln, _ := eqCond.GetArgs()[0].(*expression.Column)
-		rn, _ := eqCond.GetArgs()[1].(*expression.Column)
-		leftHashKey = append(leftHashKey, ln)
-		rightHashKey = append(rightHashKey, rn)
-	}
-	e := &HashSemiJoinExec{
-		baseExecutor: newBaseExecutor(v.Schema(), b.ctx),
-		otherFilter:  v.OtherConditions,
-		bigFilter:    v.LeftConditions,
-		smallFilter:  v.RightConditions,
-		bigExec:      b.build(v.Children()[0]),
-		smallExec:    b.build(v.Children()[1]),
-		prepared:     false,
-		bigHashKey:   leftHashKey,
-		smallHashKey: rightHashKey,
-		auxMode:      v.WithAux,
-		anti:         v.Anti,
-	}
-	return e
-}
-
 func (b *executorBuilder) buildHashAgg(v *plan.PhysicalHashAgg) Executor {
 	src := b.build(v.Children()[0])
 	if b.err != nil {
@@ -789,53 +762,52 @@ func (b *executorBuilder) buildTopN(v *plan.PhysicalTopN) Executor {
 }
 
 func (b *executorBuilder) buildNestedLoopJoin(v *plan.PhysicalHashJoin) *NestedLoopJoinExec {
+	leftChild := b.build(v.Children()[0])
+	if b.err != nil {
+		b.err = errors.Trace(b.err)
+		return nil
+	}
+	rightChild := b.build(v.Children()[1])
+	if b.err != nil {
+		b.err = errors.Trace(b.err)
+		return nil
+	}
+	joinSchema := expression.MergeSchema(leftChild.Schema(), rightChild.Schema())
 	for _, cond := range v.EqualConditions {
-		cond.GetArgs()[0].(*expression.Column).ResolveIndices(v.Schema())
-		cond.GetArgs()[1].(*expression.Column).ResolveIndices(v.Schema())
+		col0 := cond.GetArgs()[0].(*expression.Column)
+		col0.ResolveIndices(joinSchema)
+		col1 := cond.GetArgs()[1].(*expression.Column)
+		col1.ResolveIndices(joinSchema)
 	}
+	otherConditions := append(expression.ScalarFuncs2Exprs(v.EqualConditions), v.OtherConditions...)
 	defaultValues := v.DefaultValues
-	if v.SmallChildIdx == 1 {
-		if defaultValues == nil {
-			defaultValues = make([]types.Datum, v.Children()[1].Schema().Len())
-		}
-		return &NestedLoopJoinExec{
-			baseExecutor:  newBaseExecutor(v.Schema(), b.ctx),
-			SmallExec:     b.build(v.Children()[1]),
-			BigExec:       b.build(v.Children()[0]),
-			BigFilter:     v.LeftConditions,
-			SmallFilter:   v.RightConditions,
-			OtherFilter:   append(expression.ScalarFuncs2Exprs(v.EqualConditions), v.OtherConditions...),
-			outer:         v.JoinType != plan.InnerJoin,
-			defaultValues: defaultValues,
-		}
-	}
 	if defaultValues == nil {
-		defaultValues = make([]types.Datum, v.Children()[0].Schema().Len())
+		defaultValues = make([]types.Datum, v.Children()[v.SmallChildIdx].Schema().Len())
+	}
+	generator := newJoinResultGenerator(b.ctx, v.JoinType, v.SmallChildIdx == 0,
+		defaultValues, otherConditions, nil, nil)
+	bigExec, smallExec := leftChild, rightChild
+	bigFilter, smallFilter := v.LeftConditions, v.RightConditions
+	if v.SmallChildIdx == 0 {
+		bigExec, smallExec = rightChild, leftChild
+		bigFilter, smallFilter = v.RightConditions, v.LeftConditions
 	}
 	return &NestedLoopJoinExec{
-		baseExecutor:  newBaseExecutor(v.Schema(), b.ctx),
-		SmallExec:     b.build(v.Children()[0]),
-		BigExec:       b.build(v.Children()[1]),
-		leftSmall:     true,
-		BigFilter:     v.RightConditions,
-		SmallFilter:   v.LeftConditions,
-		OtherFilter:   append(expression.ScalarFuncs2Exprs(v.EqualConditions), v.OtherConditions...),
-		outer:         v.JoinType != plan.InnerJoin,
-		defaultValues: defaultValues,
+		baseExecutor:    newBaseExecutor(v.Schema(), b.ctx),
+		SmallExec:       smallExec,
+		BigExec:         bigExec,
+		BigFilter:       bigFilter,
+		SmallFilter:     smallFilter,
+		outer:           v.JoinType != plan.InnerJoin,
+		resultGenerator: generator,
 	}
 }
 
 func (b *executorBuilder) buildApply(v *plan.PhysicalApply) Executor {
 	var join joinExec
 	switch x := v.PhysicalJoin.(type) {
-	case *plan.PhysicalHashSemiJoin:
-		join = b.buildSemiJoin(x)
 	case *plan.PhysicalHashJoin:
-		if x.JoinType == plan.InnerJoin || x.JoinType == plan.LeftOuterJoin || x.JoinType == plan.RightOuterJoin {
-			join = b.buildNestedLoopJoin(x)
-		} else {
-			b.err = errors.Errorf("Unsupported join type %v in nested loop join", x.JoinType)
-		}
+		join = b.buildNestedLoopJoin(x)
 	default:
 		b.err = errors.Errorf("Unsupported plan type %T in apply", v)
 	}

--- a/executor/metrics.go
+++ b/executor/metrics.go
@@ -254,8 +254,6 @@ func (pa *stmtAttributes) fromPlan(p plan.Plan) {
 			pa.hasRange = true
 		}
 		pa.setIsSystemTable(x.DBName)
-	case *plan.PhysicalHashSemiJoin:
-		pa.hasJoin = true
 	case *plan.Insert:
 		if x.SelectPlan != nil {
 			pa.fromPlan(x.SelectPlan)

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	goctx "golang.org/x/net/context"
@@ -76,13 +77,15 @@ func (s *pkgTestSuite) TestNestedLoopJoin(c *C) {
 	bigFilter := expression.NewFunctionInternal(ctx, ast.LT, types.NewFieldType(mysql.TypeTiny), col0, con)
 	smallFilter := bigFilter.Clone()
 	otherFilter := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), col0, col1)
+	generator := newJoinResultGenerator(ctx, plan.InnerJoin, false,
+		make([]types.Datum, smallExec.Schema().Len()), []expression.Expression{otherFilter}, nil, nil)
 	join := &NestedLoopJoinExec{
-		baseExecutor: newBaseExecutor(nil, ctx),
-		BigExec:      bigExec,
-		SmallExec:    smallExec,
-		BigFilter:    []expression.Expression{bigFilter},
-		SmallFilter:  []expression.Expression{smallFilter},
-		OtherFilter:  []expression.Expression{otherFilter},
+		baseExecutor:    newBaseExecutor(nil, ctx),
+		BigExec:         bigExec,
+		SmallExec:       smallExec,
+		BigFilter:       []expression.Expression{bigFilter},
+		SmallFilter:     []expression.Expression{smallFilter},
+		resultGenerator: generator,
 	}
 	row, err := join.Next(goCtx)
 	c.Check(err, IsNil)

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -216,32 +216,6 @@ func (p *PhysicalHashJoin) ExplainInfo() string {
 }
 
 // ExplainInfo implements PhysicalPlan interface.
-func (p *PhysicalHashSemiJoin) ExplainInfo() string {
-	buffer := bytes.NewBufferString(fmt.Sprintf("right:%s", p.Children()[1].ExplainID()))
-	if p.WithAux {
-		buffer.WriteString(", aux")
-	}
-	if p.Anti {
-		buffer.WriteString(", anti")
-	}
-	if len(p.EqualConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", equal:%s", p.EqualConditions))
-	}
-	if len(p.LeftConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", left cond:%s", p.LeftConditions))
-	}
-	if len(p.RightConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", right cond:%s",
-			expression.ExplainExpressionList(p.RightConditions)))
-	}
-	if len(p.OtherConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", other cond:%s",
-			expression.ExplainExpressionList(p.OtherConditions)))
-	}
-	return buffer.String()
-}
-
-// ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalMergeJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
 	if len(p.EqualConditions) > 0 {

--- a/plan/initialize.go
+++ b/plan/initialize.go
@@ -50,8 +50,6 @@ const (
 	TypeTopN = "TopN"
 	// TypeLimit is the type of Limit.
 	TypeLimit = "Limit"
-	// TypeHashSemiJoin is the type of hash semi join.
-	TypeHashSemiJoin = "HashSemiJoin"
 	// TypeHashLeftJoin is the type of left hash join.
 	TypeHashLeftJoin = "HashLeftJoin"
 	// TypeHashRightJoin is the type of right hash join.
@@ -277,11 +275,6 @@ func (p PhysicalHashJoin) init(ctx context.Context, stats *statsInfo, props ...*
 	p.basePhysicalPlan = newBasePhysicalPlan(tp, ctx, &p)
 	p.childrenReqProps = props
 	p.stats = stats
-	return &p
-}
-
-func (p PhysicalHashSemiJoin) init(ctx context.Context) *PhysicalHashSemiJoin {
-	p.basePhysicalPlan = newBasePhysicalPlan(TypeHashSemiJoin, ctx, &p)
 	return &p
 }
 

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -45,7 +45,6 @@ var (
 	_ PhysicalPlan = &PhysicalApply{}
 	_ PhysicalPlan = &PhysicalIndexJoin{}
 	_ PhysicalPlan = &PhysicalHashJoin{}
-	_ PhysicalPlan = &PhysicalHashSemiJoin{}
 	_ PhysicalPlan = &PhysicalMergeJoin{}
 	_ PhysicalPlan = &PhysicalUnionScan{}
 )
@@ -241,21 +240,6 @@ type PhysicalMergeJoin struct {
 	rightKeys []*expression.Column
 }
 
-// PhysicalHashSemiJoin represents hash join for semi join.
-type PhysicalHashSemiJoin struct {
-	basePhysicalPlan
-
-	WithAux bool
-	Anti    bool
-
-	EqualConditions []*expression.ScalarFunction
-	LeftConditions  []expression.Expression
-	RightConditions []expression.Expression
-	OtherConditions []expression.Expression
-
-	rightChOffset int
-}
-
 // PhysicalLock is the physical operator of lock, which is used for `select ... for update` clause.
 type PhysicalLock struct {
 	basePhysicalPlan
@@ -398,14 +382,6 @@ func buildSchema(p PhysicalPlan) {
 	case *PhysicalApply:
 		buildSchema(x.PhysicalJoin)
 		x.schema = x.PhysicalJoin.Schema()
-	case *PhysicalHashSemiJoin:
-		if x.WithAux {
-			auxCol := x.schema.Columns[x.Schema().Len()-1]
-			x.SetSchema(x.children[0].Schema().Clone())
-			x.schema.Append(auxCol)
-		} else {
-			x.SetSchema(x.children[0].Schema().Clone())
-		}
 	case *PhysicalUnionAll:
 		panic("UnionAll shouldn't rebuild schema")
 	}

--- a/plan/resolve_indices.go
+++ b/plan/resolve_indices.go
@@ -47,26 +47,6 @@ func (p *PhysicalHashJoin) ResolveIndices() {
 }
 
 // ResolveIndices implements Plan interface.
-func (p *PhysicalHashSemiJoin) ResolveIndices() {
-	p.basePlan.ResolveIndices()
-	lSchema := p.children[0].Schema()
-	rSchema := p.children[1].Schema()
-	for _, fun := range p.EqualConditions {
-		fun.GetArgs()[0].ResolveIndices(lSchema)
-		fun.GetArgs()[1].ResolveIndices(rSchema)
-	}
-	for _, expr := range p.LeftConditions {
-		expr.ResolveIndices(lSchema)
-	}
-	for _, expr := range p.RightConditions {
-		expr.ResolveIndices(rSchema)
-	}
-	for _, expr := range p.OtherConditions {
-		expr.ResolveIndices(expression.MergeSchema(lSchema, rSchema))
-	}
-}
-
-// ResolveIndices implements Plan interface.
 func (p *PhysicalMergeJoin) ResolveIndices() {
 	p.basePlan.ResolveIndices()
 	lSchema := p.children[0].Schema()

--- a/plan/stringer.go
+++ b/plan/stringer.go
@@ -57,22 +57,6 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 			r := eq.GetArgs()[1].String()
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
-	case *PhysicalHashSemiJoin:
-		last := len(idxs) - 1
-		idx := idxs[last]
-		children := strs[idx:]
-		strs = strs[:idx]
-		idxs = idxs[:last]
-		if x.WithAux {
-			str = "SemiJoinWithAux{" + strings.Join(children, "->") + "}"
-		} else {
-			str = "SemiJoin{" + strings.Join(children, "->") + "}"
-		}
-		for _, eq := range x.EqualConditions {
-			l := eq.GetArgs()[0].String()
-			r := eq.GetArgs()[1].String()
-			str += fmt.Sprintf("(%s,%s)", l, r)
-		}
 	case *PhysicalMergeJoin:
 		last := len(idxs) - 1
 		idx := idxs[last]

--- a/plan/task.go
+++ b/plan/task.go
@@ -209,27 +209,6 @@ func (p *PhysicalMergeJoin) attach2Task(tasks ...task) task {
 	}
 }
 
-func (p *PhysicalHashSemiJoin) getCost(lCnt, rCnt float64) float64 {
-	if rCnt <= 1 {
-		rCnt = 1
-	}
-	return (lCnt + rCnt) * (1 + math.Log2(rCnt))
-}
-
-func (p *PhysicalHashSemiJoin) attach2Task(tasks ...task) task {
-	if tasks[0].invalid() || tasks[1].invalid() {
-		return invalidTask
-	}
-	lTask := finishCopTask(tasks[0].copy(), p.ctx)
-	rTask := finishCopTask(tasks[1].copy(), p.ctx)
-	p.SetChildren(lTask.plan(), rTask.plan())
-	task := &rootTask{
-		p:   p,
-		cst: lTask.cost() + rTask.cost() + p.getCost(lTask.count(), rTask.count()),
-	}
-	return task
-}
-
 // finishCopTask means we close the coprocessor task and create a root task.
 func finishCopTask(task task, ctx context.Context) task {
 	t, ok := task.(*copTask)


### PR DESCRIPTION
HashSemiJoin is only used in Apply, it exists only because NestedLoopJoin doesn't support SemiJoin type.
This PR support SemiJoin type in NestedLoopJoin executor, so HashSemiJoin can be removed.