### PR TITLE
store/tikv: fix [TIME_COP_TASK] log print empty store information

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -519,7 +519,6 @@ func (it *copIterator) handleTask(bo *Backoffer, task *copTask, ch chan copRespo
 // If error happened, returns error. If region split or meet lock, returns the remain tasks.
 func (it *copIterator) handleTaskOnce(bo *Backoffer, task *copTask, ch chan copResponse) ([]*copTask, error) {
 	sender := NewRegionRequestSender(it.store.regionCache, it.store.client)
-	task.storeAddr = sender.storeAddr
 	req := &tikvrpc.Request{
 		Type: task.cmdType,
 		Cop: &coprocessor.Request{
@@ -537,6 +536,9 @@ func (it *copIterator) handleTaskOnce(bo *Backoffer, task *copTask, ch chan copR
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	// Set task.storeAddr field so its task.String() method have the store address information.
+	task.storeAddr = sender.storeAddr
+
 	if task.cmdType == tikvrpc.CmdCopStream {
 		return it.handleCopStreamResult(bo, resp.CopStream, task, ch)
 	}


### PR DESCRIPTION
For those log output:

> c2017/12/21 17:19:49.550 coprocessor.go:379: [info] [TIME_COP_TASK] 641.217682ms region(602 3 123) ranges(1) store()
> 2017/12/21 17:19:49.550 coprocessor.go:379: [info] [TIME_COP_TASK] 532.628422ms region(102 3 22) ranges(1) store()

@disksing @shenli 