### PR TITLE
chunk: add Iterator interface.

### DIFF
--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -41,7 +41,7 @@ type sliceIterator struct {
 
 func (it *sliceIterator) Begin() Row {
 	if len(it.rows) == 0 {
-		return Row{}
+		return it.End()
 	}
 	it.cursor = 1
 	return it.rows[0]
@@ -49,7 +49,7 @@ func (it *sliceIterator) Begin() Row {
 
 func (it *sliceIterator) Next() Row {
 	if it.cursor == len(it.rows) {
-		return Row{}
+		return it.End()
 	}
 	row := it.rows[it.cursor]
 	it.cursor++
@@ -72,7 +72,7 @@ type chunkIterator struct {
 
 func (it *chunkIterator) Begin() Row {
 	if it.chk.NumRows() == 0 {
-		return Row{}
+		return it.End()
 	}
 	it.cursor = 1
 	return it.chk.GetRow(0)
@@ -80,7 +80,7 @@ func (it *chunkIterator) Begin() Row {
 
 func (it *chunkIterator) Next() Row {
 	if it.cursor == it.chk.NumRows() {
-		return Row{}
+		return it.End()
 	}
 	row := it.chk.GetRow(it.cursor)
 	it.cursor++
@@ -104,7 +104,7 @@ type listIterator struct {
 
 func (it *listIterator) Begin() Row {
 	if it.chkCursor == it.li.NumChunks() {
-		return Row{}
+		return it.End()
 	}
 	chk := it.li.GetChunk(0)
 	row := chk.GetRow(0)
@@ -120,7 +120,7 @@ func (it *listIterator) Begin() Row {
 
 func (it *listIterator) Next() Row {
 	if it.chkCursor == it.li.NumChunks() {
-		return Row{}
+		return it.End()
 	}
 	chk := it.li.GetChunk(it.chkCursor)
 	row := chk.GetRow(it.rowCursor)
@@ -149,7 +149,7 @@ type rowPtrIterator struct {
 
 func (it *rowPtrIterator) Begin() Row {
 	if len(it.ptrs) == 0 {
-		return Row{}
+		return it.End()
 	}
 	it.cursor = 1
 	return it.li.GetRow(it.ptrs[0])
@@ -157,7 +157,7 @@ func (it *rowPtrIterator) Begin() Row {
 
 func (it *rowPtrIterator) Next() Row {
 	if it.cursor == len(it.ptrs) {
-		return Row{}
+		return it.End()
 	}
 	row := it.li.GetRow(it.ptrs[it.cursor])
 	it.cursor++

--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -1,0 +1,169 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+// Iterator is used to iterate a number of rows.
+//
+// for row := it.Begin(); row != it.End(); row = it.Next() {
+//     ...
+// }
+type Iterator interface {
+	// Begin resets the cursor of the iterator and returns the first Row.
+	Begin() Row
+
+	// Next returns the next Row.
+	Next() Row
+
+	// End returns the invalid end Row.
+	End() Row
+}
+
+// NewSliceIterator returns a Iterator for Row slice.
+func NewSliceIterator(rows []Row) Iterator {
+	return &sliceIterator{rows: rows}
+}
+
+type sliceIterator struct {
+	rows   []Row
+	cursor int
+}
+
+func (it *sliceIterator) Begin() Row {
+	if len(it.rows) == 0 {
+		return Row{}
+	}
+	it.cursor = 1
+	return it.rows[0]
+}
+
+func (it *sliceIterator) Next() Row {
+	if it.cursor == len(it.rows) {
+		return Row{}
+	}
+	row := it.rows[it.cursor]
+	it.cursor++
+	return row
+}
+
+func (it *sliceIterator) End() Row {
+	return Row{}
+}
+
+// NewChunkIterator returns a iterator for Chunk.
+func NewChunkIterator(chk *Chunk) Iterator {
+	return &chunkIterator{chk: chk}
+}
+
+type chunkIterator struct {
+	chk    *Chunk
+	cursor int
+}
+
+func (it *chunkIterator) Begin() Row {
+	if it.chk.NumRows() == 0 {
+		return Row{}
+	}
+	it.cursor = 1
+	return it.chk.GetRow(0)
+}
+
+func (it *chunkIterator) Next() Row {
+	if it.cursor == it.chk.NumRows() {
+		return Row{}
+	}
+	row := it.chk.GetRow(it.cursor)
+	it.cursor++
+	return row
+}
+
+func (it *chunkIterator) End() Row {
+	return Row{}
+}
+
+// NewListIterator returns a Iterator for List.
+func NewListIterator(li *List) Iterator {
+	return &listIterator{li: li}
+}
+
+type listIterator struct {
+	li        *List
+	chkCursor int
+	rowCursor int
+}
+
+func (it *listIterator) Begin() Row {
+	if it.chkCursor == it.li.NumChunks() {
+		return Row{}
+	}
+	chk := it.li.GetChunk(0)
+	row := chk.GetRow(0)
+	if chk.NumRows() == 1 {
+		it.chkCursor = 1
+		it.rowCursor = 0
+	} else {
+		it.chkCursor = 0
+		it.rowCursor = 1
+	}
+	return row
+}
+
+func (it *listIterator) Next() Row {
+	if it.chkCursor == it.li.NumChunks() {
+		return Row{}
+	}
+	chk := it.li.GetChunk(it.chkCursor)
+	row := chk.GetRow(it.rowCursor)
+	it.rowCursor++
+	if it.rowCursor == chk.NumRows() {
+		it.rowCursor = 0
+		it.chkCursor++
+	}
+	return row
+}
+
+func (it *listIterator) End() Row {
+	return Row{}
+}
+
+// NewRowPtrIterator returns a Iterator for RowPtrs.
+func NewRowPtrIterator(li *List, ptrs []RowPtr) Iterator {
+	return &rowPtrIterator{li: li, ptrs: ptrs}
+}
+
+type rowPtrIterator struct {
+	li     *List
+	ptrs   []RowPtr
+	cursor int
+}
+
+func (it *rowPtrIterator) Begin() Row {
+	if len(it.ptrs) == 0 {
+		return Row{}
+	}
+	it.cursor = 1
+	return it.li.GetRow(it.ptrs[0])
+}
+
+func (it *rowPtrIterator) Next() Row {
+	if it.cursor == len(it.ptrs) {
+		return Row{}
+	}
+	row := it.li.GetRow(it.ptrs[it.cursor])
+	it.cursor++
+	return row
+}
+
+func (it *rowPtrIterator) End() Row {
+	return Row{}
+}

--- a/util/chunk/iterator_test.go
+++ b/util/chunk/iterator_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
+)
+
+func (s *testChunkSuite) TestIterator(c *check.C) {
+	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
+	chk := NewChunk(fields)
+	n := 10
+	var expected []int64
+	for i := 0; i < n; i++ {
+		chk.AppendInt64(0, int64(i))
+		expected = append(expected, int64(i))
+	}
+	var rows []Row
+	li := NewList(fields, 1)
+	li2 := NewList(fields, 5)
+	var ptrs []RowPtr
+	var ptrs2 []RowPtr
+	for i := 0; i < n; i++ {
+		rows = append(rows, chk.GetRow(i))
+		ptr := li.AppendRow(chk.GetRow(i))
+		ptrs = append(ptrs, ptr)
+		ptr2 := li2.AppendRow(chk.GetRow(i))
+		ptrs2 = append(ptrs2, ptr2)
+	}
+
+	it := NewSliceIterator(rows)
+	checkIterator(c, it, expected)
+	it = NewChunkIterator(chk)
+	checkIterator(c, it, expected)
+	it = NewListIterator(li)
+	checkIterator(c, it, expected)
+	it = NewRowPtrIterator(li, ptrs)
+	checkIterator(c, it, expected)
+	it = NewListIterator(li2)
+	checkIterator(c, it, expected)
+	it = NewRowPtrIterator(li2, ptrs2)
+	checkIterator(c, it, expected)
+
+	it = NewSliceIterator(nil)
+	c.Assert(it.Begin(), check.Equals, it.End())
+	it = NewChunkIterator(new(Chunk))
+	c.Assert(it.Begin(), check.Equals, it.End())
+	it = NewListIterator(new(List))
+	c.Assert(it.Begin(), check.Equals, it.End())
+	it = NewRowPtrIterator(li, nil)
+	c.Assert(it.Begin(), check.Equals, it.End())
+}
+
+func checkIterator(c *check.C, it Iterator, expected []int64) {
+	var got []int64
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		got = append(got, row.GetInt64(0))
+	}
+	c.Assert(got, check.DeepEquals, expected)
+}

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -74,8 +74,11 @@ func (l *List) AppendRow(row Row) RowPtr {
 }
 
 // Add adds a chunk to the List, the chunk may be modified later by the list.
-// Caller must make sure the input chk is not used any more and has the same field types.
+// Caller must make sure the input chk is not empty and not used any more and has the same field types.
 func (l *List) Add(chk *Chunk) {
+	if chk.NumRows() == 0 {
+		panic(" add empty chunk")
+	}
 	l.chunks = append(l.chunks, chk)
 	l.length += chk.NumRows()
 	return


### PR DESCRIPTION
This abstraction makes algorithms like join result generator able to iterator chunk rows in different forms.