### PR TITLE
expression: fix VectorizedFilter

### DIFF
--- a/expression/chunk_executor.go
+++ b/expression/chunk_executor.go
@@ -258,6 +258,7 @@ func VectorizedFilter(ctx context.Context, filters []Expression, input *chunk.Ch
 				}
 				selected[row.Idx()] = selected[row.Idx()] && !isNull && (filterResult != 0)
 			} else {
+				// TODO: should rewrite the filter to `cast(expr as SIGNED) != 0` and always use `EvalInt`.
 				bVal, err := EvalBool([]Expression{filter}, row, ctx)
 				if err != nil {
 					return nil, errors.Trace(err)

--- a/expression/chunk_executor.go
+++ b/expression/chunk_executor.go
@@ -243,15 +243,27 @@ func VectorizedFilter(ctx context.Context, filters []Expression, input *chunk.Ch
 		selected = append(selected, true)
 	}
 	for _, filter := range filters {
+		isIntType := true
+		if filter.GetType().EvalType() != types.ETInt {
+			isIntType = false
+		}
 		for row := input.Begin(); row != input.End(); row = row.Next() {
 			if !selected[row.Idx()] {
 				continue
 			}
-			filterResult, isNull, err := filter.EvalInt(row, ctx.GetSessionVars().StmtCtx)
-			if err != nil {
-				return nil, errors.Trace(err)
+			if isIntType {
+				filterResult, isNull, err := filter.EvalInt(row, ctx.GetSessionVars().StmtCtx)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				selected[row.Idx()] = selected[row.Idx()] && !isNull && (filterResult != 0)
+			} else {
+				bVal, err := EvalBool([]Expression{filter}, row, ctx)
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				selected[row.Idx()] = selected[row.Idx()] && bVal
 			}
-			selected[row.Idx()] = selected[row.Idx()] && !isNull && (filterResult != 0)
 		}
 	}
 	return selected, nil

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3142,6 +3142,12 @@ func (s *testIntegrationSuite) TestIssues(c *C) {
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|",
 		"Warning|1292|Truncated incorrect DOUBLE value: '1e649'",
 		"Warning|1292|Truncated incorrect DOUBLE value: '-1e649'"))
+
+	// for issue #5293
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert t values (1)")
+	tk.MustQuery("select * from t where cast(a as binary)").Check(testkit.Rows("1"))
 }
 
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {


### PR DESCRIPTION
A filter may not be of Int type, we should check the filter's type first or Call `EvalBool`.
Another solution is to wrap an ` != 0 ` to the expression, but that is not as simple as this one.

to #5293 