### PR TITLE
tidb-server: log-slow-query command line option

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -62,6 +62,7 @@ const (
 	nmRunDDL          = "run-ddl"
 	nmLogLevel        = "L"
 	nmLogFile         = "log-file"
+	nmLogSlowQuery    = "log-slow-query"
 	nmReportStatus    = "report-status"
 	nmStatusPort      = "status"
 	nmMetricsAddr     = "metrics-addr"
@@ -86,8 +87,9 @@ var (
 	tokenLimit   = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
 
 	// Log
-	logLevel = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
-	logFile  = flag.String(nmLogFile, "", "log file path")
+	logLevel     = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
+	logFile      = flag.String(nmLogFile, "", "log file path")
+	logSlowQuery = flag.String(nmLogSlowQuery, "", "slow query file path")
 
 	// Status
 	reportStatus    = flagBoolean(nmReportStatus, true, "If enable status report HTTP service.")
@@ -285,6 +287,9 @@ func overrideConfig() {
 	}
 	if actualFlags[nmLogFile] {
 		cfg.Log.File.Filename = *logFile
+	}
+	if actualFlags[nmLogSlowQuery] {
+		cfg.Log.SlowQueryFile = *logSlowQuery
 	}
 
 	// Status


### PR DESCRIPTION
Something already in master, but not in release 1.0...

@LinuxGit @coocood @shenli 