### PR TITLE
executor: Close() executors when Open() returns an error to avoid goroutine leak (#5469)

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -181,6 +181,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 	}
 
 	if err := e.Open(); err != nil {
+		terror.Call(e.Close)
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
Cherry pick from master