### PR TITLE
expresion, executor: correct the type inference of function "sum" and "avg"

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -298,6 +298,7 @@ func (s *testSuite) TestAggPrune(c *C) {
 	tk.MustExec("create table t(id int primary key, b varchar(50), c int)")
 	tk.MustExec("insert into t values(1, '1ff', NULL), (2, '234.02', 1)")
 	tk.MustQuery("select id, sum(b) from t group by id").Check(testkit.Rows("1 1", "2 234.02"))
+	tk.MustQuery("select sum(b) from t").Check(testkit.Rows("235.02"))
 	tk.MustQuery("select id, count(c) from t group by id").Check(testkit.Rows("1 0", "2 1"))
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(id int primary key, b float, c float)")

--- a/expression/aggregation/avg.go
+++ b/expression/aggregation/avg.go
@@ -37,10 +37,8 @@ func (af *avgFunction) Clone() Aggregation {
 // GetType implements Aggregation interface.
 func (af *avgFunction) GetType() *types.FieldType {
 	var ft *types.FieldType
-	if types.IsTypeFloat(af.Args[0].GetType().Tp) {
-		ft = types.NewFieldType(mysql.TypeDouble)
-		ft.Decimal = af.Args[0].GetType().Decimal
-	} else {
+	switch af.Args[0].GetType().Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
 		ft = types.NewFieldType(mysql.TypeNewDecimal)
 		if af.GetMode() == FinalMode {
 			ft.Decimal = af.Args[1].GetType().Decimal
@@ -51,6 +49,9 @@ func (af *avgFunction) GetType() *types.FieldType {
 			}
 			ft.Decimal += types.DivFracIncr
 		}
+	default:
+		ft = types.NewFieldType(mysql.TypeDouble)
+		ft.Decimal = af.Args[0].GetType().Decimal
 	}
 	ft.Flen = mysql.MaxRealWidth
 	types.SetBinChsClnFlag(ft)

--- a/expression/aggregation/avg.go
+++ b/expression/aggregation/avg.go
@@ -38,6 +38,8 @@ func (af *avgFunction) Clone() Aggregation {
 func (af *avgFunction) GetType() *types.FieldType {
 	var ft *types.FieldType
 	switch af.Args[0].GetType().Tp {
+	// For child returns integer or decimal type, "avg" should returns a "decimal",
+	// otherwise it returns a "double".
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
 		ft = types.NewFieldType(mysql.TypeNewDecimal)
 		if af.GetMode() == FinalMode {

--- a/expression/aggregation/sum.go
+++ b/expression/aggregation/sum.go
@@ -68,12 +68,13 @@ func (sf *sumFunction) CalculateDefaultValue(schema *expression.Schema, ctx cont
 // GetType implements Aggregation interface.
 func (sf *sumFunction) GetType() *types.FieldType {
 	var ft *types.FieldType
-	if types.IsTypeFloat(sf.Args[0].GetType().Tp) {
-		ft = types.NewFieldType(mysql.TypeDouble)
-	} else {
+	switch sf.Args[0].GetType().Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
 		ft = types.NewFieldType(mysql.TypeNewDecimal)
+	default:
+		ft = types.NewFieldType(mysql.TypeDouble)
 	}
-	types.SetBinChsClnFlag(ft)
 	ft.Flen, ft.Decimal = mysql.MaxRealWidth, sf.Args[0].GetType().Decimal
+	types.SetBinChsClnFlag(ft)
 	return ft
 }

--- a/expression/aggregation/sum.go
+++ b/expression/aggregation/sum.go
@@ -68,6 +68,8 @@ func (sf *sumFunction) CalculateDefaultValue(schema *expression.Schema, ctx cont
 // GetType implements Aggregation interface.
 func (sf *sumFunction) GetType() *types.FieldType {
 	var ft *types.FieldType
+	// For child returns integer or decimal type, "sum" should returns a "decimal",
+	// otherwise it returns a "double".
 	switch sf.Args[0].GetType().Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
 		ft = types.NewFieldType(mysql.TypeNewDecimal)

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -826,12 +826,14 @@ func (s *testInferTypeSuite) createTestCase4Aggregations() []typeInferTestCase {
 		{"sum(c_decimal)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 3},
 		{"sum(1.0)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 1},
 		{"sum(1.2e2)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"sum(c_char)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 0},
 		{"avg(c_int_d)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 4},
 		{"avg(c_float_d)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"avg(c_double_d)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
 		{"avg(c_decimal)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 7},
 		{"avg(1.0)", mysql.TypeNewDecimal, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 5},
 		{"avg(1.2e2)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, types.UnspecifiedLength},
+		{"avg(c_char)", mysql.TypeDouble, charset.CharsetBin, mysql.BinaryFlag, mysql.MaxRealWidth, 0},
 	}
 }
 


### PR DESCRIPTION
fix #5494 