### PR TITLE
 ddl: fix the case that fails to split a table

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -59,6 +59,7 @@ func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		}
 		if EnableSplitTableRegion {
 			err = d.splitTableRegion(tbInfo.ID)
+			// It will be automatically splitting by TiKV later.
 			if err != nil {
 				log.Warnf("[ddl] split table region failed %v", err)
 			}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
+	log "github.com/sirupsen/logrus"
 )
 
 func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -59,7 +60,7 @@ func (d *ddl) onCreateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		if EnableSplitTableRegion {
 			err = d.splitTableRegion(tbInfo.ID)
 			if err != nil {
-				return ver, errors.Trace(err)
+				log.Warnf("[ddl] split table region failed %v", err)
 			}
 		}
 		// Finish this job.


### PR DESCRIPTION
If we fail to split a table, but the table is created, we will get an error as follows:
```
mysql> create database sbtest;
Query OK, 0 rows affected (0.09 sec)
mysql> use sbtest;
Database changed
mysql> CREATE TABLE `shtable` (
    ->   `id` int(11) NOT NULL AUTO_INCREMENT,
    ->    PRIMARY KEY (`id`)
    ->  );
ERROR 1050 (42S01): Table 'shtable' already exists
```
