### PR TITLE
server,statistics: add dump_stats api for debug

### DIFF
--- a/server/http_status.go
+++ b/server/http_status.go
@@ -44,6 +44,9 @@ func (s *Server) startHTTPServer() {
 	// HTTP path for prometheus.
 	router.Handle("/metrics", prometheus.Handler())
 
+	// HTTP path for dump statistics.
+	router.Handle("/dump_stats/{db}/{table}", s.newStatsHandler())
+
 	if s.cfg.Store == "tikv" {
 		tikvHandler := s.newRegionHandler()
 		// HTTP path for regions

--- a/server/statistics_handler.go
+++ b/server/statistics_handler.go
@@ -1,0 +1,68 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/gorilla/mux"
+	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/model"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+)
+
+// StatsHandler is the handler for dump statistics
+type StatsHandler struct {
+	store kv.Storage
+	do    *domain.Domain
+}
+
+func (s *Server) newStatsHandler() *StatsHandler {
+	store, ok := s.driver.(*TiDBDriver)
+	if !ok {
+		panic("Invalid KvStore with illegal driver")
+	}
+	var tikvStore kv.Storage
+	if tikvStore, ok = store.store.(kv.Storage); !ok {
+		panic("Invalid KvStore with illegal store")
+	}
+	do, err := tidb.BootstrapSession(tikvStore)
+	if err != nil {
+		log.Error("Failed to bootstrap session", err)
+		return nil
+	}
+	return &StatsHandler{tikvStore, do}
+}
+
+func (sh StatsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	params := mux.Vars(req)
+
+	is := sh.do.InfoSchema()
+	h := sh.do.StatsHandle()
+
+	tbl, err := is.TableByName(model.NewCIStr(params[pDBName]), model.NewCIStr(params[pTableName]))
+	if err != nil {
+		writeError(w, err)
+	} else {
+		js, err := h.DumpStatsToJSON(params[pDBName], tbl.Meta())
+		if err != nil {
+			writeError(w, err)
+		} else {
+			writeData(w, js)
+		}
+	}
+}

--- a/server/statistics_handler_test.go
+++ b/server/statistics_handler_test.go
@@ -1,0 +1,91 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/mocktikv"
+)
+
+type DumpStaTestSuite struct {
+	server *Server
+}
+
+func (ds *DumpStaTestSuite) TestDumpStatsAPI(c *C) {
+	ds.startServer(c)
+	ds.prepareData(c)
+	defer ds.stopServer(c)
+
+	resp, err := http.Get(fmt.Sprint("http://127.0.0.1:10090/dump_stats/tidb/test"))
+	c.Assert(err, IsNil)
+
+	decoder := json.NewDecoder(resp.Body)
+	var jsonTbl *statistics.JSONTable
+	err = decoder.Decode(jsonTbl)
+	c.Assert(err, IsNil)
+	c.Assert(jsonTbl.DatabaseName, Equals, "tidb")
+	c.Assert(jsonTbl.TableName, Equals, "test")
+}
+
+func (ds *DumpStaTestSuite) startServer(c *C) {
+	mvccStore := mocktikv.NewMvccStore()
+	store, err := tikv.NewMockTikvStore(tikv.WithMVCCStore(mvccStore))
+	c.Assert(err, IsNil)
+
+	_, err = tidb.BootstrapSession(store)
+	c.Assert(err, IsNil)
+
+	tidbdrv := NewTiDBDriver(store)
+
+	cfg := config.NewConfig()
+	cfg.Port = 4001
+	cfg.Status.StatusPort = 10090
+	cfg.Status.ReportStatus = true
+
+	server, err := NewServer(cfg, tidbdrv)
+	c.Assert(err, IsNil)
+
+	ds.server = server
+	go server.Run()
+	waitUntilServerOnline(cfg.Status.StatusPort)
+}
+
+func (ds *DumpStaTestSuite) stopServer(c *C) {
+	if ds.server != nil {
+		ds.server.Close()
+	}
+}
+
+func (ds *DumpStaTestSuite) prepareData(c *C) {
+	db, err := sql.Open("mysql", getDSN())
+	c.Assert(err, IsNil, Commentf("Error connecting"))
+	defer db.Close()
+	dbt := &DBTest{c, db}
+
+	dbt.mustExec("create database tidb")
+	dbt.mustExec("use tidb")
+	dbt.mustExec("create table test (a int, b varchar(20))")
+	dbt.mustExec("create index c on test (a, b)")
+	dbt.mustExec("insert test values (1, 2)")
+	dbt.mustExec("analyze table test")
+}

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -125,7 +125,7 @@ func (h *Handle) Update(is infoschema.InfoSchema) error {
 			continue
 		}
 		tableInfo := table.Meta()
-		tbl, err := h.tableStatsFromStorage(tableInfo)
+		tbl, err := h.tableStatsFromStorage(tableInfo, false)
 		// Error is not nil may mean that there are some ddl changes on this table, we will not update it.
 		if err != nil {
 			log.Errorf("Error occurred when read table stats for table id %d. The error message is %s.", tableID, errors.ErrorStack(err))

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -51,6 +52,28 @@ type Table struct {
 	ModifyCount int64 // Total modify count in a table.
 	Version     uint64
 	Pseudo      bool
+}
+
+// JSONTable is used for Dumping statistics
+type JSONTable struct {
+	DatabaseName string                 `json:"database_name"`
+	TableName    string                 `json:"table_name"`
+	Columns      map[string]*jsonColumn `json:"columns"` // Columns[col_name]
+	Indices      map[string]*jsonIndex  `json:"indices"`
+	Count        int64                  `json:"count"`
+	ModifyCount  int64                  `json:"modify_count"`
+	Version      uint64                 `json:"version"`
+}
+
+type jsonColumn struct {
+	Histogram   *tipb.Histogram `json:"histogram"`
+	CMSketch    *tipb.CMSketch  `json:"cm_sketch"`
+	AlreadyLoad bool            `json:"already_load"`
+}
+
+type jsonIndex struct {
+	Histogram *tipb.Histogram `json:"histogram"`
+	CMSketch  *tipb.CMSketch  `json:"cm_sketch"`
 }
 
 func (t *Table) copy() *Table {
@@ -113,7 +136,7 @@ func (h *Handle) indexStatsFromStorage(row types.Row, table *Table, tableInfo *m
 	return nil
 }
 
-func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *model.TableInfo) error {
+func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *model.TableInfo, loadAll bool) error {
 	histID := row.GetInt64(2)
 	distinct := row.GetInt64(3)
 	histVer := row.GetUint64(4)
@@ -125,7 +148,7 @@ func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *
 		}
 		isHandle := tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag)
 		needNotLoad := col == nil || (len(col.Buckets) == 0 && col.LastUpdateVersion < histVer)
-		if h.Lease > 0 && !isHandle && needNotLoad {
+		if h.Lease > 0 && !isHandle && needNotLoad && !loadAll {
 			count, err := columnCountFromStorage(h.ctx, table.TableID, histID)
 			if err != nil {
 				return errors.Trace(err)
@@ -161,7 +184,7 @@ func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *
 }
 
 // tableStatsFromStorage loads table stats info from storage.
-func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo) (*Table, error) {
+func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, loadAll bool) (*Table, error) {
 	table, ok := h.statsCache.Load().(statsCache)[tableInfo.ID]
 	if !ok {
 		table = &Table{
@@ -188,7 +211,7 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo) (*Table, erro
 				return nil, errors.Trace(err)
 			}
 		} else {
-			if err := h.columnStatsFromStorage(row, table, tableInfo); err != nil {
+			if err := h.columnStatsFromStorage(row, table, tableInfo, loadAll); err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
@@ -437,4 +460,129 @@ func getPseudoRowCountByIntRanges(intRanges []ranger.IntColumnRange, tableRowCou
 		rowCount = tableRowCount
 	}
 	return rowCount
+}
+
+// ConvertTo converts Bucket'LowerBound and UpperBound to type t
+func (b *Bucket) ConvertTo(h *Handle, t *types.FieldType) (err error) {
+	b.LowerBound, err = b.LowerBound.ConvertTo(h.ctx.GetSessionVars().StmtCtx, t)
+	if err != nil {
+		return
+	}
+	b.UpperBound, err = b.UpperBound.ConvertTo(h.ctx.GetSessionVars().StmtCtx, t)
+	return err
+}
+
+func (b *Bucket) calScalar() {
+	b.lowerScalar, b.upperScalar, b.commonPfxLen = preCalculateDatumScalar(&b.LowerBound, &b.UpperBound)
+}
+
+// DumpStatsToJSON dumps statistic to json
+func (h *Handle) DumpStatsToJSON(dbName string, tableInfo *model.TableInfo) (*JSONTable, error) {
+	statTable := h.statsCache.Load().(statsCache)[tableInfo.ID]
+	tbl, err := h.tableStatsFromStorage(tableInfo, true)
+
+	if err != nil {
+		return nil, err
+	}
+	jsonTbl := &JSONTable{
+		DatabaseName: dbName,
+		TableName:    tableInfo.Name.L,
+		Columns:      make(map[string]*jsonColumn, len(tbl.Columns)),
+		Indices:      make(map[string]*jsonIndex, len(tbl.Indices)),
+		Count:        tbl.Count,
+		ModifyCount:  tbl.ModifyCount,
+		Version:      tbl.Version,
+	}
+	for key, val := range tbl.Columns {
+		hist := &Histogram{
+			ID:                val.Histogram.ID,
+			NDV:               val.Histogram.NDV,
+			NullCount:         val.Histogram.NullCount,
+			LastUpdateVersion: val.Histogram.LastUpdateVersion,
+			Buckets:           make([]Bucket, len(val.Histogram.Buckets)),
+		}
+
+		// Convert Datum to BytesDatum
+		for i, v := range val.Histogram.Buckets {
+			hist.Buckets[i] = v
+			if err := hist.Buckets[i].ConvertTo(h, types.NewFieldType(mysql.TypeBlob)); err != nil {
+				return nil, err
+			}
+		}
+		// col is the Column in Cache
+		col := statTable.Columns[key]
+		jsonCol := &jsonColumn{
+			Histogram:   HistogramToProto(hist),
+			AlreadyLoad: !(col.Count > 0 && len(col.Buckets) == 0),
+		}
+		if val.CMSketch != nil {
+			jsonCol.CMSketch = CMSketchToProto(val.CMSketch)
+		}
+		jsonTbl.Columns[val.Info.Name.L] = jsonCol
+	}
+
+	for _, val := range tbl.Indices {
+		jsonIdx := &jsonIndex{
+			Histogram: HistogramToProto(&val.Histogram),
+		}
+		if val.CMSketch != nil {
+			jsonIdx.CMSketch = CMSketchToProto(val.CMSketch)
+		}
+		jsonTbl.Indices[val.Info.Name.L] = jsonIdx
+	}
+	return jsonTbl, nil
+}
+
+// LoadStatsFromJSON load statistic from json
+func (h *Handle) LoadStatsFromJSON(tableInfo *model.TableInfo, jsonTbl *JSONTable, loadAll bool) (*Table, error) {
+	tbl := &Table{
+		TableID:     tableInfo.ID,
+		Columns:     make(map[int64]*Column, len(jsonTbl.Columns)),
+		Indices:     make(map[int64]*Index, len(jsonTbl.Indices)),
+		Count:       jsonTbl.Count,
+		Version:     jsonTbl.Version,
+		ModifyCount: jsonTbl.ModifyCount,
+	}
+	for key, val := range jsonTbl.Columns {
+		if loadAll || val.AlreadyLoad {
+			for _, colInfo := range tableInfo.Columns {
+				if colInfo.Name.L == key {
+					col := &Column{
+						Histogram: *HistogramFromProto(val.Histogram),
+						CMSketch:  CMSketchFromProto(val.CMSketch),
+						Info:      colInfo,
+					}
+
+					for i := range col.Histogram.Buckets {
+						if err := col.Histogram.Buckets[i].ConvertTo(h, &colInfo.FieldType); err != nil {
+							return nil, err
+						}
+						col.Histogram.Buckets[i].calScalar()
+					}
+					col.Histogram.ID = colInfo.ID
+					tbl.Columns[colInfo.ID] = col
+					for _, cnt := range val.CMSketch.Rows[0].Counters {
+						tbl.Columns[colInfo.ID].Count += int64(cnt)
+					}
+				}
+			}
+		}
+	}
+	for key, val := range jsonTbl.Indices {
+		for _, idxInfo := range tableInfo.Indices {
+			if idxInfo.Name.L == key {
+				idx := &Index{
+					Histogram: *HistogramFromProto(val.Histogram),
+					CMSketch:  CMSketchFromProto(val.CMSketch),
+					Info:      idxInfo,
+				}
+				for i := range idx.Histogram.Buckets {
+					idx.Histogram.Buckets[i].calScalar()
+				}
+				idx.Histogram.ID = idxInfo.ID
+				tbl.Indices[idxInfo.ID] = idx
+			}
+		}
+	}
+	return tbl, nil
 }

--- a/statistics/table_test.go
+++ b/statistics/table_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+var _ = Suite(&testDumpStatsSuite{})
+
+type testDumpStatsSuite struct {
+	store kv.Storage
+	do    *domain.Domain
+}
+
+func (s *testDumpStatsSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
+	var err error
+	s.store, s.do, err = newStoreWithBootstrap(0)
+	c.Assert(err, IsNil)
+}
+
+func (s *testDumpStatsSuite) TearDownSuite(c *C) {
+	s.do.Close()
+	s.store.Close()
+	testleak.AfterTest(c)()
+}
+
+func (s *testDumpStatsSuite) TestConversion(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("create index c on t(a,b)")
+	tk.MustExec("insert into t(a,b) values (3, 1),(2, 1),(1, 1),(1, 4)")
+	tk.MustExec("analyze table t")
+
+	is := s.do.InfoSchema()
+	h := s.do.StatsHandle()
+
+	tableInfo, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	jsonTbl, err := h.DumpStatsToJSON("test", tableInfo.Meta())
+	c.Assert(err, IsNil)
+	loadTbl, err := h.LoadStatsFromJSON(tableInfo.Meta(), jsonTbl, true)
+	c.Assert(err, IsNil)
+	tbl := h.GetTableStats(tableInfo.Meta().ID)
+	assertTableEqual(c, loadTbl, tbl)
+}


### PR DESCRIPTION
Add the HTTP API for dumping statistics, we can get the JSON type stats info by `dump_stats/{db}/{table}`

@lamxTyler @hanfei1991 @shenli  PTAL

to #5360 