### PR TITLE
types: remove `Negative` field in `types.Time`.

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -536,16 +536,14 @@ func (b *builtinCastIntAsDurationSig) evalDuration(row types.Row) (res types.Dur
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
-	t, err := types.NumberToDuration(val, b.tp.Decimal)
+	dur, err := types.NumberToDuration(val, b.tp.Decimal)
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
 			err = sc.HandleOverflow(err, err)
 		}
 		return res, true, errors.Trace(err)
 	}
-
-	res, err = t.ConvertToDuration()
-	return res, false, errors.Trace(err)
+	return dur, false, errors.Trace(err)
 }
 
 type builtinCastIntAsJSONSig struct {

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -825,35 +825,28 @@ func (s *testTypeConvertSuite) TestNumberToDuration(c *C) {
 	}
 
 	for _, tc := range testCases {
-		t, err := NumberToDuration(tc.number, tc.fsp)
+		dur, err := NumberToDuration(tc.number, tc.fsp)
 		if tc.hasErr {
 			c.Assert(err, NotNil)
 			continue
 		}
 		c.Assert(err, IsNil)
-		c.Assert(t.Time.Year(), Equals, tc.year)
-		c.Assert(t.Time.Month(), Equals, tc.month)
-		c.Assert(t.Time.Day(), Equals, tc.day)
-		c.Assert(t.Time.Hour(), Equals, tc.hour)
-		c.Assert(t.Time.Minute(), Equals, tc.minute)
-		c.Assert(t.Time.Second(), Equals, tc.second)
+		c.Assert(dur.Hour(), Equals, tc.hour)
+		c.Assert(dur.Minute(), Equals, tc.minute)
+		c.Assert(dur.Second(), Equals, tc.second)
 	}
 
 	var testCases1 = []struct {
 		number int64
-		neg    bool
 		dur    time.Duration
 	}{
-		{171222, false, 17*time.Hour + 12*time.Minute + 22*time.Second},
-		{-171222, true, -(17*time.Hour + 12*time.Minute + 22*time.Second)},
+		{171222, 17*time.Hour + 12*time.Minute + 22*time.Second},
+		{-171222, -(17*time.Hour + 12*time.Minute + 22*time.Second)},
 	}
 
 	for _, tc := range testCases1 {
-		t, err := NumberToDuration(tc.number, 0)
+		dur, err := NumberToDuration(tc.number, 0)
 		c.Assert(err, IsNil)
-		c.Assert(t.IsNegative(), Equals, tc.neg)
-		d, err1 := t.ConvertToDuration()
-		c.Assert(err1, IsNil)
-		c.Assert(d.Duration, Equals, tc.dur)
+		c.Assert(dur.Duration, Equals, tc.dur)
 	}
 }

--- a/types/time.go
+++ b/types/time.go
@@ -183,12 +183,11 @@ type Time struct {
 	// TODO: Define a type for timestamp, remove its representation from here.
 	// TimeZone is valid when Type is mysql.Timestamp, it's meaningless for date/datetime.
 	TimeZone *gotime.Location
-	Negative bool
 }
 
 // MaxMySQLTime returns Time with maximum mysql time type.
-func MaxMySQLTime(neg bool, fsp int) Time {
-	return Time{Time: newMysqlTime(0, 0, 0, TimeMaxHour, TimeMaxMinute, TimeMaxSecond, 0), Type: mysql.TypeDuration, Fsp: fsp, Negative: neg}
+func MaxMySQLTime(fsp int) Time {
+	return Time{Time: newMysqlTime(0, 0, 0, TimeMaxHour, TimeMaxMinute, TimeMaxSecond, 0), Type: mysql.TypeDuration, Fsp: fsp}
 }
 
 // CurrentTime returns current time with type tp.
@@ -209,11 +208,6 @@ func (t *Time) ConvertTimeZone(from, to *gotime.Location) error {
 	}
 	t.TimeZone = to
 	return nil
-}
-
-// IsNegative returns a boolean to indicate whether the Time is negative.
-func (t *Time) IsNegative() bool {
-	return t.Negative
 }
 
 func (t Time) String() string {
@@ -307,9 +301,6 @@ func (t Time) ConvertToDuration() (Duration, error) {
 	frac := t.Time.Microsecond() * 1000
 
 	d := gotime.Duration(hour*3600+minute*60+second)*gotime.Second + gotime.Duration(frac)
-	if t.Negative {
-		return Duration{Duration: -d, Fsp: t.Fsp}, nil
-	}
 	// TODO: check convert validation
 	return Duration{Duration: d, Fsp: t.Fsp}, nil
 }

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -861,14 +861,12 @@ func (s *testTimeSuite) TestTamestampDiff(c *C) {
 			Type:     mysql.TypeDatetime,
 			Fsp:      6,
 			TimeZone: nil,
-			Negative: false,
 		}
 		t2 := types.Time{
 			Time:     test.t2,
 			Type:     mysql.TypeDatetime,
 			Fsp:      6,
 			TimeZone: nil,
-			Negative: false,
 		}
 		c.Assert(types.TimestampDiff(test.unit, t1, t2), Equals, test.expect)
 	}


### PR DESCRIPTION
Makes it easier to fit in Chunk.