### PR TITLE
ddl: Clean log

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -417,7 +417,7 @@ func (d *ddl) doDDLJob(ctx context.Context, job *model.Job) error {
 
 	// Notice worker that we push a new job and wait the job done.
 	asyncNotify(d.ddlJobCh)
-	log.Infof("[ddl] start DDL job %s, Query:\n%s", job, job.Query)
+	log.Infof("[ddl] start DDL job %s, Query:%s", job, job.Query)
 
 	var historyJob *model.Job
 	jobID := job.ID


### PR DESCRIPTION
The `\n` will make the result of `grep` hard to read. We need to make the whole log in a single line.