### PR TITLE
store: enable builtin aggregation function 'bit_and', 'bit_or', 'bit_or'

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -87,7 +87,7 @@ func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
 		return true
 	// aggregate functions.
 	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg,
-        tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr:
+		tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr:
 		return true
 	// json functions.
 	case tipb.ExprType_JsonType, tipb.ExprType_JsonExtract, tipb.ExprType_JsonUnquote,

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -86,7 +86,8 @@ func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
 	case tipb.ExprType_Case, tipb.ExprType_If, tipb.ExprType_IfNull, tipb.ExprType_Coalesce:
 		return true
 	// aggregate functions.
-	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg:
+	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg,
+        tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr:
 		return true
 	// json functions.
 	case tipb.ExprType_JsonType, tipb.ExprType_JsonExtract, tipb.ExprType_JsonUnquote,


### PR DESCRIPTION
In https://github.com/pingcap/tikv/pull/2510 , builtin aggregation functions `bit_and`, `bit_or`, `bit_xor` are supported in `TiKV`. Now we can push them down to `TiKV`