### PR TITLE
*: AddIndex skip checking unique constraint when TiDB is importing data.

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -690,7 +690,7 @@ func (w *worker) doBackfillIndexTaskInTxn(t table.Table, txn kv.Transaction, col
 		}
 
 		// Create the index.
-		handle, err := w.index.Create(txn, idxRecord.vals, idxRecord.handle)
+		handle, err := w.index.Create(w.ctx, txn, idxRecord.vals, idxRecord.handle)
 		if err != nil {
 			if kv.ErrKeyExists.Equal(err) && idxRecord.handle == handle {
 				// Index already exists, skip it.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"flag"
 	"fmt"
+	"github.com/pingcap/tidb/util/mock"
 	"os"
 	"sync"
 	"testing"
@@ -182,7 +183,7 @@ func (s *testSuite) TestAdmin(c *C) {
 	tb, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("admin_test"))
 	c.Assert(err, IsNil)
 	c.Assert(tb.Indices(), HasLen, 1)
-	_, err = tb.Indices()[0].Create(txn, types.MakeDatums(int64(10)), 1)
+	_, err = tb.Indices()[0].Create(mock.NewContext(), txn, types.MakeDatums(int64(10)), 1)
 	c.Assert(err, IsNil)
 	err = txn.Commit(goctx.Background())
 	c.Assert(err, IsNil)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -16,7 +16,6 @@ package executor_test
 import (
 	"flag"
 	"fmt"
-	"github.com/pingcap/tidb/util/mock"
 	"os"
 	"sync"
 	"testing"
@@ -42,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -124,11 +124,11 @@ func (s *testSuite) TestSetVar(c *C) {
 
 	tk.MustExec("set @@character_set_results = NULL")
 
-	c.Assert(vars.SkipConstraintCheck, IsFalse)
+	c.Assert(vars.ImportingData, IsFalse)
 	tk.MustExec("set @@tidb_skip_constraint_check = '1'")
-	c.Assert(vars.SkipConstraintCheck, IsTrue)
+	c.Assert(vars.ImportingData, IsTrue)
 	tk.MustExec("set @@tidb_skip_constraint_check = '0'")
-	c.Assert(vars.SkipConstraintCheck, IsFalse)
+	c.Assert(vars.ImportingData, IsFalse)
 
 	// Test set transaction isolation level, which is equivalent to setting variable "tx_isolation".
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -125,9 +125,9 @@ func (s *testSuite) TestSetVar(c *C) {
 	tk.MustExec("set @@character_set_results = NULL")
 
 	c.Assert(vars.ImportingData, IsFalse)
-	tk.MustExec("set @@tidb_skip_constraint_check = '1'")
+	tk.MustExec("set @@tidb_import_data = '1'")
 	c.Assert(vars.ImportingData, IsTrue)
-	tk.MustExec("set @@tidb_skip_constraint_check = '0'")
+	tk.MustExec("set @@tidb_import_data = '0'")
 	c.Assert(vars.ImportingData, IsFalse)
 
 	// Test set transaction isolation level, which is equivalent to setting variable "tx_isolation".

--- a/kv/buffer_store.go
+++ b/kv/buffer_store.go
@@ -47,7 +47,7 @@ func (s *BufferStore) Get(k Key) ([]byte, error) {
 		return nil, errors.Trace(err)
 	}
 	if len(val) == 0 {
-		return nil, errors.Trace(ErrNotExist)
+		return nil, ErrNotExist
 	}
 	return val, nil
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -200,8 +200,8 @@ type SessionVars struct {
 
 	/* TiDB system variables */
 
-	// SkipConstraintCheck is true when importing data.
-	SkipConstraintCheck bool
+	// ImportingData is true when importing data.
+	ImportingData bool
 
 	// SkipUTF8Check check on input value.
 	SkipUTF8Check bool

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -605,7 +605,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_online_alter_log_max_size", "134217728"},
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
-	{ScopeSession, TiDBSkipConstraintCheck, "0"},
+	{ScopeSession, TiDBImportingData, "0"},
 	{ScopeSession, TiDBOptAggPushDown, boolToIntStr(DefOptAggPushDown)},
 	{ScopeSession, TiDBOptInSubqUnFolding, boolToIntStr(DefOptInSubqUnfolding)},
 	{ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -34,9 +34,9 @@ const (
 	// When the value is set to a datetime string like '2017-11-11 20:20:20', the session reads history data of that time.
 	TiDBSnapshot = "tidb_snapshot"
 
-	// tidb_skip_constraint_check is used for loading data from a dump file, to speed up the loading process.
+	// tidb_import_data is used for loading data from a dump file, to speed up the loading process.
 	// When the value is set to true, unique index constraint is not checked.
-	TiDBSkipConstraintCheck = "tidb_skip_constraint_check"
+	TiDBImportingData = "tidb_import_data"
 
 	// tidb_opt_agg_push_down is used to endable/disable the optimizer rule of aggregation push down.
 	TiDBOptAggPushDown = "tidb_opt_agg_push_down"

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -140,8 +140,8 @@ func SetSessionSystemVar(vars *variable.SessionVars, name string, value types.Da
 		if isAutocommit {
 			vars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 		}
-	case variable.TiDBSkipConstraintCheck:
-		vars.SkipConstraintCheck = tidbOptOn(sVal)
+	case variable.TiDBImportingData:
+		vars.ImportingData = tidbOptOn(sVal)
 	case variable.TiDBSkipUTF8Check:
 		vars.SkipUTF8Check = tidbOptOn(sVal)
 	case variable.TiDBOptAggPushDown:

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -83,23 +83,23 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 
 	c.Assert(SetSessionSystemVar(v, "character_set_results", types.Datum{}), IsNil)
 
-	// Test case for get TiDBSkipConstraintCheck session variable.
-	val, err = GetSessionSystemVar(v, variable.TiDBSkipConstraintCheck)
+	// Test case for get TiDBImportingData session variable.
+	val, err = GetSessionSystemVar(v, variable.TiDBImportingData)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 
 	// Test case for tidb_skip_constraint_check
-	c.Assert(v.SkipConstraintCheck, IsFalse)
-	SetSessionSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
-	c.Assert(v.SkipConstraintCheck, IsFalse)
-	SetSessionSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
-	c.Assert(v.SkipConstraintCheck, IsTrue)
-	SetSessionSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("0"))
-	c.Assert(v.SkipConstraintCheck, IsFalse)
+	c.Assert(v.ImportingData, IsFalse)
+	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("0"))
+	c.Assert(v.ImportingData, IsFalse)
+	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("1"))
+	c.Assert(v.ImportingData, IsTrue)
+	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("0"))
+	c.Assert(v.ImportingData, IsFalse)
 
-	// Test case for change TiDBSkipConstraintCheck session variable.
-	SetSessionSystemVar(v, variable.TiDBSkipConstraintCheck, types.NewStringDatum("1"))
-	val, err = GetSessionSystemVar(v, variable.TiDBSkipConstraintCheck)
+	// Test case for change TiDBImportingData session variable.
+	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("1"))
+	val, err = GetSessionSystemVar(v, variable.TiDBImportingData)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "1")
 

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -88,7 +88,7 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 
-	// Test case for tidb_skip_constraint_check
+	// Test case for tidb_import_data
 	c.Assert(v.ImportingData, IsFalse)
 	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("0"))
 	c.Assert(v.ImportingData, IsFalse)

--- a/table/index.go
+++ b/table/index.go
@@ -14,6 +14,7 @@
 package table
 
 import (
+	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/types"
@@ -30,7 +31,7 @@ type Index interface {
 	// Meta returns IndexInfo.
 	Meta() *model.IndexInfo
 	// Create supports insert into statement.
-	Create(rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (int64, error)
+	Create(ctx context.Context, rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (int64, error)
 	// Delete supports delete from statement.
 	Delete(m kv.Mutator, indexedValues []types.Datum, h int64) error
 	// Drop supports drop table, drop index statements.

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -179,7 +179,7 @@ func (c *index) GenIndexKey(indexedValues []types.Datum, h int64) (key []byte, d
 // If the index is unique and there is an existing entry with the same key,
 // Create will return the existing entry's handle as the first return value, ErrKeyExists as the second return value.
 func (c *index) Create(ctx context.Context, rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (int64, error) {
-	skipCheck := ctx.GetSessionVars().SkipConstraintCheck
+	importData := ctx.GetSessionVars().ImportingData
 	key, distinct, err := c.GenIndexKey(indexedValues, h)
 	if err != nil {
 		return 0, errors.Trace(err)
@@ -191,11 +191,11 @@ func (c *index) Create(ctx context.Context, rm kv.RetrieverMutator, indexedValue
 	}
 
 	var value []byte
-	if !skipCheck {
+	if !importData {
 		value, err = rm.Get(key)
 	}
 
-	if skipCheck || kv.IsErrNotFound(err) {
+	if importData || kv.IsErrNotFound(err) {
 		err = rm.Set(key, encodeHandle(h))
 		return 0, errors.Trace(err)
 	}

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -14,6 +14,7 @@
 package tables_test
 
 import (
+	"github.com/pingcap/tidb/util/mock"
 	"io"
 
 	. "github.com/pingcap/check"
@@ -67,7 +68,8 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(err, IsNil)
 
 	values := types.MakeDatums(1, 2)
-	_, err = index.Create(txn, values, 1)
+	mockCtx := mock.NewContext()
+	_, err = index.Create(mockCtx, txn, values, 1)
 	c.Assert(err, IsNil)
 
 	it, err := index.SeekFirst(txn)
@@ -99,7 +101,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(terror.ErrorEqual(err, io.EOF), IsTrue)
 	it.Close()
 
-	_, err = index.Create(txn, values, 0)
+	_, err = index.Create(mockCtx, txn, values, 0)
 	c.Assert(err, IsNil)
 
 	_, err = index.SeekFirst(txn)
@@ -150,10 +152,10 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	txn, err = s.s.Begin()
 	c.Assert(err, IsNil)
 
-	_, err = index.Create(txn, values, 1)
+	_, err = index.Create(mockCtx, txn, values, 1)
 	c.Assert(err, IsNil)
 
-	_, err = index.Create(txn, values, 2)
+	_, err = index.Create(mockCtx, txn, values, 2)
 	c.Assert(err, NotNil)
 
 	it, err = index.SeekFirst(txn)
@@ -203,8 +205,9 @@ func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 	txn, err := s.s.Begin()
 	c.Assert(err, IsNil)
 
+	mockCtx := mock.NewContext()
 	values := types.MakeDatums("abc", "def")
-	_, err = index.Create(txn, values, 1)
+	_, err = index.Create(mockCtx, txn, values, 1)
 	c.Assert(err, IsNil)
 
 	index2 := tables.NewIndex(tblInfo, tblInfo.Indices[0])

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -14,7 +14,6 @@
 package tables_test
 
 import (
-	"github.com/pingcap/tidb/util/mock"
 	"io"
 
 	. "github.com/pingcap/check"
@@ -24,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	goctx "golang.org/x/net/context"
 )

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -215,7 +215,7 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData, newData []ty
 	bs := kv.NewBufferStore(txn)
 
 	// rebuild index
-	err := t.rebuildIndices(bs, h, touched, oldData, newData)
+	err := t.rebuildIndices(ctx, bs, h, touched, oldData, newData)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -271,7 +271,7 @@ func (t *Table) UpdateRecord(ctx context.Context, h int64, oldData, newData []ty
 	return nil
 }
 
-func (t *Table) rebuildIndices(rm kv.RetrieverMutator, h int64, touched []bool, oldData []types.Datum, newData []types.Datum) error {
+func (t *Table) rebuildIndices(ctx context.Context, rm kv.RetrieverMutator, h int64, touched []bool, oldData []types.Datum, newData []types.Datum) error {
 	for _, idx := range t.DeletableIndices() {
 		for _, ic := range idx.Meta().Columns {
 			if !touched[ic.Offset] {
@@ -296,7 +296,7 @@ func (t *Table) rebuildIndices(rm kv.RetrieverMutator, h int64, touched []bool, 
 			if err != nil {
 				return errors.Trace(err)
 			}
-			if err := t.buildIndexForRow(rm, h, newVs, idx); err != nil {
+			if err := t.buildIndexForRow(ctx, rm, h, newVs, idx); err != nil {
 				return errors.Trace(err)
 			}
 			break
@@ -427,7 +427,7 @@ func (t *Table) addIndices(ctx context.Context, recordID int64, r []types.Datum,
 			dupKeyErr = kv.ErrKeyExists.FastGen("Duplicate entry '%s' for key '%s'", entryKey, v.Meta().Name)
 			txn.SetOption(kv.PresumeKeyNotExistsError, dupKeyErr)
 		}
-		if dupHandle, err := v.Create(bs, colVals, recordID); err != nil {
+		if dupHandle, err := v.Create(ctx, bs, colVals, recordID); err != nil {
 			if kv.ErrKeyExists.Equal(err) {
 				return dupHandle, errors.Trace(dupKeyErr)
 			}
@@ -599,8 +599,8 @@ func (t *Table) removeRowIndex(rm kv.RetrieverMutator, h int64, vals []types.Dat
 }
 
 // buildIndexForRow implements table.Table BuildIndexForRow interface.
-func (t *Table) buildIndexForRow(rm kv.RetrieverMutator, h int64, vals []types.Datum, idx table.Index) error {
-	if _, err := idx.Create(rm, vals, h); err != nil {
+func (t *Table) buildIndexForRow(ctx context.Context, rm kv.RetrieverMutator, h int64, vals []types.Datum, idx table.Index) error {
+	if _, err := idx.Create(ctx, rm, vals, h); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -404,10 +404,11 @@ func (s *testSuite) testIndex(c *C, tb table.Table, idx table.Index) {
 	c.Assert(err, IsNil)
 	c.Assert(cnt, Equals, int64(2))
 
+	mockCtx := mock.NewContext()
 	// set data to:
 	// index     data (handle, data): (1, 10), (2, 20), (3, 30)
 	// table     data (handle, data): (1, 10), (2, 20), (4, 40)
-	_, err = idx.Create(txn, types.MakeDatums(int64(30)), 3)
+	_, err = idx.Create(mockCtx, txn, types.MakeDatums(int64(30)), 3)
 	c.Assert(err, IsNil)
 	key := tablecodec.EncodeRowKey(tb.Meta().ID, codec.EncodeInt(nil, 4))
 	setColValue(c, txn, key, types.NewDatum(int64(40)))
@@ -425,7 +426,7 @@ func (s *testSuite) testIndex(c *C, tb table.Table, idx table.Index) {
 	// set data to:
 	// index     data (handle, data): (1, 10), (2, 20), (3, 30), (4, 40)
 	// table     data (handle, data): (1, 10), (2, 20), (4, 40), (3, 31)
-	_, err = idx.Create(txn, types.MakeDatums(int64(40)), 4)
+	_, err = idx.Create(mockCtx, txn, types.MakeDatums(int64(40)), 4)
 	c.Assert(err, IsNil)
 	key = tablecodec.EncodeRowKey(tb.Meta().ID, codec.EncodeInt(nil, 3))
 	setColValue(c, txn, key, types.NewDatum(int64(31)))

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -225,7 +225,7 @@ func (e *kvEncoder) initial(dbName string, idAlloc autoid.Allocator) (err error)
 	}
 
 	se.GetSessionVars().IDAllocator = idAlloc
-	se.GetSessionVars().SkipConstraintCheck = true
+	se.GetSessionVars().ImportingData = true
 	e.se = se
 	e.store = store
 	e.dom = dom


### PR DESCRIPTION
In my mac book, run kvencoder bench, got below results:

```
this pr:
[direct] kv num = 12288000 / kv size = 1362432000
[direct] cost avg = 39.035 sec

master:
[direct] kv num = 12288000 / kv size = 1362432000
[direct] cost avg = 43.753 sec
```

about 10% improvement.

@shenli @coocood PTAL