### PR TITLE
*: remove varsutil package, make Systems a private member of SessionVars

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -201,15 +201,15 @@ func (a *ExecStmt) Exec(goCtx goctx.Context) (ast.RecordSet, error) {
 		oriScan := ctx.GetSessionVars().DistSQLScanConcurrency
 		oriIndex := ctx.GetSessionVars().IndexSerialScanConcurrency
 		oriIso, _ := ctx.GetSessionVars().GetSystemVar(variable.TxnIsolation)
-		terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, "1"))
+		terror.Log(errors.Trace(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, "1")))
 		ctx.GetSessionVars().DistSQLScanConcurrency = 1
 		ctx.GetSessionVars().IndexSerialScanConcurrency = 1
-		terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, ast.ReadCommitted))
+		terror.Log(errors.Trace(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, ast.ReadCommitted)))
 		defer func() {
-			terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, oriStats))
+			terror.Log(errors.Trace(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, oriStats)))
 			ctx.GetSessionVars().DistSQLScanConcurrency = oriScan
 			ctx.GetSessionVars().IndexSerialScanConcurrency = oriIndex
-			terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, oriIso))
+			terror.Log(errors.Trace(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, oriIso)))
 		}()
 	}
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -197,19 +197,19 @@ func (a *ExecStmt) Exec(goCtx goctx.Context) (ast.RecordSet, error) {
 	a.startTime = time.Now()
 	ctx := a.Ctx
 	if _, ok := a.Plan.(*plan.Analyze); ok && ctx.GetSessionVars().InRestrictedSQL {
-		oriStats := ctx.GetSessionVars().Systems[variable.TiDBBuildStatsConcurrency]
+		oriStats, _ := ctx.GetSessionVars().GetSystemVar(variable.TiDBBuildStatsConcurrency)
 		oriScan := ctx.GetSessionVars().DistSQLScanConcurrency
 		oriIndex := ctx.GetSessionVars().IndexSerialScanConcurrency
-		oriIso := ctx.GetSessionVars().Systems[variable.TxnIsolation]
-		ctx.GetSessionVars().Systems[variable.TiDBBuildStatsConcurrency] = "1"
+		oriIso, _ := ctx.GetSessionVars().GetSystemVar(variable.TxnIsolation)
+		terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, "1"))
 		ctx.GetSessionVars().DistSQLScanConcurrency = 1
 		ctx.GetSessionVars().IndexSerialScanConcurrency = 1
-		ctx.GetSessionVars().Systems[variable.TxnIsolation] = ast.ReadCommitted
+		terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, ast.ReadCommitted))
 		defer func() {
-			ctx.GetSessionVars().Systems[variable.TiDBBuildStatsConcurrency] = oriStats
+			terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, oriStats))
 			ctx.GetSessionVars().DistSQLScanConcurrency = oriScan
 			ctx.GetSessionVars().IndexSerialScanConcurrency = oriIndex
-			ctx.GetSessionVars().Systems[variable.TxnIsolation] = oriIso
+			terror.Log(ctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, oriIso))
 		}()
 	}
 

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -125,7 +124,7 @@ func (e *AnalyzeExec) run(goCtx goctx.Context) error {
 
 func getBuildStatsConcurrency(ctx context.Context) (int, error) {
 	sessionVars := ctx.GetSessionVars()
-	concurrency, err := varsutil.GetSessionSystemVar(sessionVars, variable.TiDBBuildStatsConcurrency)
+	concurrency, err := variable.GetSessionSystemVar(sessionVars, variable.TiDBBuildStatsConcurrency)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	goctx "golang.org/x/net/context"
@@ -171,11 +170,11 @@ func (e *DDLExec) executeDropDatabase(s *ast.DropDatabaseStmt) error {
 	sessionVars := e.ctx.GetSessionVars()
 	if err == nil && strings.ToLower(sessionVars.CurrentDB) == dbName.L {
 		sessionVars.CurrentDB = ""
-		err = varsutil.SetSessionSystemVar(sessionVars, variable.CharsetDatabase, types.NewStringDatum("utf8"))
+		err = variable.SetSessionSystemVar(sessionVars, variable.CharsetDatabase, types.NewStringDatum("utf8"))
 		if err != nil {
 			return errors.Trace(err)
 		}
-		err = varsutil.SetSessionSystemVar(sessionVars, variable.CollationDatabase, types.NewStringDatum("utf8_unicode_ci"))
+		err = variable.SetSessionSystemVar(sessionVars, variable.CollationDatabase, types.NewStringDatum("utf8_unicode_ci"))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -995,7 +995,8 @@ func (builder *requestBuilder) SetKeepOrder(order bool) *requestBuilder {
 }
 
 func getIsolationLevel(sv *variable.SessionVars) kv.IsoLevel {
-	if sv.Systems[variable.TxnIsolation] == ast.ReadCommitted {
+	isoLevel, _ := sv.GetSystemVar(variable.TxnIsolation)
+	if isoLevel == ast.ReadCommitted {
 		return kv.RC
 	}
 	return kv.SI

--- a/executor/set.go
+++ b/executor/set.go
@@ -239,9 +239,9 @@ func (e *SetExecutor) setCharset(cs, co string) error {
 	}
 	sessionVars := e.ctx.GetSessionVars()
 	for _, v := range variable.SetNamesVariables {
-		terror.Log(sessionVars.SetSystemVar(v, cs))
+		terror.Log(errors.Trace(sessionVars.SetSystemVar(v, cs)))
 	}
-	terror.Log(sessionVars.SetSystemVar(variable.CollationConnection, co))
+	terror.Log(errors.Trace(sessionVars.SetSystemVar(variable.CollationConnection, co)))
 	return nil
 }
 

--- a/executor/set.go
+++ b/executor/set.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
@@ -116,7 +115,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 			return errors.Trace(err)
 		}
 		oldSnapshotTS := sessionVars.SnapshotTS
-		err = varsutil.SetSessionSystemVar(sessionVars, name, value)
+		err = variable.SetSessionSystemVar(sessionVars, name, value)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -145,7 +144,8 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 	}
 
 	if name == variable.TxnIsolation {
-		if sessionVars.Systems[variable.TxnIsolation] == ast.ReadCommitted {
+		isoLevel, _ := sessionVars.GetSystemVar(variable.TxnIsolation)
+		if isoLevel == ast.ReadCommitted {
 			e.ctx.Txn().SetOption(kv.IsolationLevel, kv.RC)
 		}
 	}
@@ -222,7 +222,7 @@ func validateSnapshot(ctx context.Context, snapshotTS uint64) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	safePointTS := varsutil.GoTimeToTS(safePointTime)
+	safePointTS := variable.GoTimeToTS(safePointTime)
 	if safePointTS > snapshotTS {
 		return variable.ErrSnapshotTooOld.GenByArgs(safePointString)
 	}
@@ -239,9 +239,9 @@ func (e *SetExecutor) setCharset(cs, co string) error {
 	}
 	sessionVars := e.ctx.GetSessionVars()
 	for _, v := range variable.SetNamesVariables {
-		sessionVars.Systems[v] = cs
+		terror.Log(sessionVars.SetSystemVar(v, cs))
 	}
-	sessionVars.Systems[variable.CollationConnection] = co
+	terror.Log(sessionVars.SetSystemVar(variable.CollationConnection, co))
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (e *SetExecutor) getVarValue(v *expression.VarAssignment, sysVar *variable.
 		if sysVar != nil {
 			value = types.NewStringDatum(sysVar.Value)
 		} else {
-			s, err1 := varsutil.GetGlobalSystemVar(e.ctx.GetSessionVars(), v.Name)
+			s, err1 := variable.GetGlobalSystemVar(e.ctx.GetSessionVars(), v.Name)
 			if err1 != nil {
 				return value, errors.Trace(err1)
 			}

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/util/testkit"
 	goctx "golang.org/x/net/context"
 )
@@ -221,17 +220,17 @@ func (s *testSuite) TestSetCharset(c *C) {
 	ctx := tk.Se.(context.Context)
 	sessionVars := ctx.GetSessionVars()
 	for _, v := range variable.SetNamesVariables {
-		sVar, err := varsutil.GetSessionSystemVar(sessionVars, v)
+		sVar, err := variable.GetSessionSystemVar(sessionVars, v)
 		c.Assert(err, IsNil)
 		c.Assert(sVar != "utf8", IsTrue)
 	}
 	tk.MustExec(`SET NAMES utf8`)
 	for _, v := range variable.SetNamesVariables {
-		sVar, err := varsutil.GetSessionSystemVar(sessionVars, v)
+		sVar, err := variable.GetSessionSystemVar(sessionVars, v)
 		c.Assert(err, IsNil)
 		c.Assert(sVar, Equals, "utf8")
 	}
-	sVar, err := varsutil.GetSessionSystemVar(sessionVars, variable.CollationConnection)
+	sVar, err := variable.GetSessionSystemVar(sessionVars, variable.CollationConnection)
 	c.Assert(err, IsNil)
 	c.Assert(sVar, Equals, "utf8_bin")
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
@@ -403,12 +402,12 @@ func (e *ShowExec) fetchShowVariables() (err error) {
 			// 1. try to fetch value from SessionVars.Systems;
 			// 2. if this variable is session-only, fetch value from SysVars
 			//		otherwise, fetch the value from table `mysql.Global_Variables`.
-			value, ok, err = varsutil.GetSessionOnlySysVars(sessionVars, v.Name)
+			value, ok, err = variable.GetSessionOnlySysVars(sessionVars, v.Name)
 		} else {
 			// If the scope of a system variable is ScopeNone,
 			// it's a read-only variable, so we return the default value of it.
 			// Otherwise, we have to fetch the values from table `mysql.Global_Variables` for global variable names.
-			value, ok, err = varsutil.GetScopeNoneSystemVar(v.Name)
+			value, ok, err = variable.GetScopeNoneSystemVar(v.Name)
 		}
 		if err != nil {
 			return errors.Trace(err)

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -102,8 +102,8 @@ func (e *SimpleExec) executeUse(s *ast.UseStmt) error {
 	// The server sets this variable whenever the default database changes.
 	// See http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_character_set_database
 	sessionVars := e.ctx.GetSessionVars()
-	terror.Log(sessionVars.SetSystemVar(variable.CharsetDatabase, dbinfo.Charset))
-	terror.Log(sessionVars.SetSystemVar(variable.CollationDatabase, dbinfo.Collate))
+	terror.Log(errors.Trace(sessionVars.SetSystemVar(variable.CharsetDatabase, dbinfo.Charset)))
+	terror.Log(errors.Trace(sessionVars.SetSystemVar(variable.CollationDatabase, dbinfo.Collate)))
 	return nil
 }
 

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -102,8 +102,8 @@ func (e *SimpleExec) executeUse(s *ast.UseStmt) error {
 	// The server sets this variable whenever the default database changes.
 	// See http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_character_set_database
 	sessionVars := e.ctx.GetSessionVars()
-	sessionVars.Systems[variable.CharsetDatabase] = dbinfo.Charset
-	sessionVars.Systems[variable.CollationDatabase] = dbinfo.Collate
+	terror.Log(sessionVars.SetSystemVar(variable.CharsetDatabase, dbinfo.Charset))
+	terror.Log(sessionVars.SetSystemVar(variable.CollationDatabase, dbinfo.Collate))
 	return nil
 }
 

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/mock"
@@ -706,8 +706,8 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 	}
 
 	// Test that "timestamp" and "time_zone" variable may affect the result of Now() builtin function.
-	varsutil.SetSessionSystemVar(s.ctx.GetSessionVars(), "time_zone", types.NewDatum("+00:00"))
-	varsutil.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", types.NewDatum(1234))
+	variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "time_zone", types.NewDatum("+00:00"))
+	variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", types.NewDatum(1234))
 	fc := funcs[ast.Now]
 	f, err := fc.getFunction(s.ctx, s.datumsToConstants(nil))
 	c.Assert(err, IsNil)
@@ -716,8 +716,8 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 	result, err := v.ToString()
 	c.Assert(err, IsNil)
 	c.Assert(result, Equals, "1970-01-01 00:20:34")
-	varsutil.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", types.NewDatum(0))
-	varsutil.SetSessionSystemVar(s.ctx.GetSessionVars(), "time_zone", types.NewDatum("system"))
+	variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", types.NewDatum(0))
+	variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "time_zone", types.NewDatum("system"))
 }
 
 func (s *testEvaluatorSuite) TestIsDuration(c *C) {
@@ -887,7 +887,7 @@ func (s *testEvaluatorSuite) TestSysDate(c *C) {
 	timezones := []types.Datum{types.NewDatum(1234), types.NewDatum(0)}
 	for _, timezone := range timezones {
 		// sysdate() result is not affected by "timestamp" session variable.
-		varsutil.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", timezone)
+		variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", timezone)
 		f, err := fc.getFunction(s.ctx, s.datumsToConstants(nil))
 		c.Assert(err, IsNil)
 		v, err := evalBuiltinFunc(f, nil)

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 )
@@ -127,7 +127,7 @@ func getSystemTimestamp(ctx context.Context) (time.Time, error) {
 	}
 
 	sessionVars := ctx.GetSessionVars()
-	timestampStr, err := varsutil.GetSessionSystemVar(sessionVars, "timestamp")
+	timestampStr, err := variable.GetSessionSystemVar(sessionVars, "timestamp")
 	if err != nil {
 		return now, errors.Trace(err)
 	}

--- a/expression/helper_test.go
+++ b/expression/helper_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -37,7 +37,7 @@ func (s *testExpressionSuite) TestGetTimeValue(c *C) {
 	timeValue := v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 	sessionVars := ctx.GetSessionVars()
-	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum(""))
+	variable.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum(""))
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -45,7 +45,7 @@ func (s *testExpressionSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("0"))
+	variable.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("0"))
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -53,7 +53,7 @@ func (s *testExpressionSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.Datum{})
+	variable.SetSessionSystemVar(sessionVars, "timestamp", types.Datum{})
 	v, err = GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 
@@ -61,7 +61,7 @@ func (s *testExpressionSuite) TestGetTimeValue(c *C) {
 	timeValue = v.GetMysqlTime()
 	c.Assert(timeValue.String(), Equals, "2012-12-12 00:00:00")
 
-	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("1234"))
+	variable.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("1234"))
 
 	tbl := []struct {
 		Expr interface{}
@@ -120,8 +120,8 @@ func (s *testExpressionSuite) TestCurrentTimestampTimeZone(c *C) {
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 
-	varsutil.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("1234"))
-	varsutil.SetSessionSystemVar(sessionVars, "time_zone", types.NewStringDatum("+00:00"))
+	variable.SetSessionSystemVar(sessionVars, "timestamp", types.NewStringDatum("1234"))
+	variable.SetSessionSystemVar(sessionVars, "time_zone", types.NewStringDatum("+00:00"))
 	v, err := GetTimeValue(ctx, ast.CurrentTimestamp, mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 	c.Assert(v.GetMysqlTime(), DeepEquals, types.Time{
@@ -130,7 +130,7 @@ func (s *testExpressionSuite) TestCurrentTimestampTimeZone(c *C) {
 
 	// CurrentTimestamp from "timestamp" session variable is based on UTC, so change timezone
 	// would get different value.
-	varsutil.SetSessionSystemVar(sessionVars, "time_zone", types.NewStringDatum("+08:00"))
+	variable.SetSessionSystemVar(sessionVars, "time_zone", types.NewStringDatum("+08:00"))
 	v, err = GetTimeValue(ctx, ast.CurrentTimestamp, mysql.TypeTimestamp, types.MinFsp)
 	c.Assert(err, IsNil)
 	c.Assert(v.GetMysqlTime(), DeepEquals, types.Time{

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
@@ -546,7 +545,7 @@ func dataForSessionVar(ctx context.Context) (records [][]types.Datum, err error)
 	sessionVars := ctx.GetSessionVars()
 	for _, v := range variable.SysVars {
 		var value string
-		value, err = varsutil.GetSessionSystemVar(sessionVars, v.Name)
+		value, err = variable.GetSessionSystemVar(sessionVars, v.Name)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessionctx/varsutil"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -813,17 +812,17 @@ func (er *expressionRewriter) rewriteVariable(v *ast.VariableExpr) {
 	var val string
 	var err error
 	if v.IsGlobal {
-		val, err = varsutil.GetGlobalSystemVar(sessionVars, name)
+		val, err = variable.GetGlobalSystemVar(sessionVars, name)
 	} else {
-		val, err = varsutil.GetSessionSystemVar(sessionVars, name)
+		val, err = variable.GetSessionSystemVar(sessionVars, name)
 	}
 	if err != nil {
 		er.err = errors.Trace(err)
 		return
 	}
 	e := datumToConstant(types.NewStringDatum(val), mysql.TypeVarString)
-	e.RetType.Charset = er.ctx.GetSessionVars().Systems[variable.CharacterSetConnection]
-	e.RetType.Collate = er.ctx.GetSessionVars().Systems[variable.CollationConnection]
+	e.RetType.Charset, _ = er.ctx.GetSessionVars().GetSystemVar(variable.CharacterSetConnection)
+	e.RetType.Collate, _ = er.ctx.GetSessionVars().GetSystemVar(variable.CollationConnection)
 	er.ctxStack = append(er.ctxStack, e)
 }
 

--- a/session.go
+++ b/session.go
@@ -203,9 +203,9 @@ func (s *session) SetCollation(coID int) error {
 		return errors.Trace(err)
 	}
 	for _, v := range variable.SetNamesVariables {
-		terror.Log(s.sessionVars.SetSystemVar(v, cs))
+		terror.Log(errors.Trace(s.sessionVars.SetSystemVar(v, cs)))
 	}
-	terror.Log(s.sessionVars.SetSystemVar(variable.CollationConnection, co))
+	terror.Log(errors.Trace(s.sessionVars.SetSystemVar(variable.CollationConnection, co)))
 	return nil
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -142,7 +142,7 @@ type SessionVars struct {
 	UsersLock sync.RWMutex
 	// Users are user defined variables.
 	Users map[string]string
-	// system variables, don't modify it directly, use GetSystemVar/SetSystemVar method.
+	// systems variables, don't modify it directly, use GetSystemVar/SetSystemVar method.
 	systems map[string]string
 	// PreparedStmts stores prepared statement.
 	PreparedStmts        map[uint32]interface{}
@@ -402,8 +402,8 @@ func (s *SessionVars) GetSystemVar(name string) (string, bool) {
 	return val, ok
 }
 
-// DeleteSystemVar deletes a system variable.
-func (s *SessionVars) DeleteSystemVar(name string) error {
+// deleteSystemVar deletes a system variable.
+func (s *SessionVars) deleteSystemVar(name string) error {
 	if name != CharacterSetResults {
 		return ErrCantSetToNull
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -16,6 +16,7 @@ package variable
 import (
 	"crypto/tls"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/juju/errors"
@@ -468,6 +469,10 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		return ErrReadOnly
 	case TiDBMaxChunkSize:
 		s.MaxChunkSize = tidbOptPositiveInt(val, DefMaxChunkSize)
+	case TiDBMemThreshold:
+		s.MemThreshold = int64(tidbOptPositiveInt(val, DefMemThreshold))
+	case TiDBGeneralLog:
+		atomic.StoreUint32(&ProcessGeneralLog, uint32(tidbOptPositiveInt(val, DefTiDBGeneralLog)))
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -21,7 +21,7 @@ package variable
 	3. Add SysVar instance in 'defaultSysVars' slice with the default value.
 	4. Add a field in `SessionVars`.
 	5. Update the `NewSessionVars` function to set the field to its default value.
-	6. Update the `varsutil.SetSessionSystemVar` function to use the new value when SET statement is executed.
+	6. Update the `variable.SetSessionSystemVar` function to use the new value when SET statement is executed.
 	7. If it is a global variable, add it in `tidb.loadCommonGlobalVarsSQL`.
 	8. Use this variable to control the behavior in code.
 */

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -105,11 +105,7 @@ func SetSessionSystemVar(vars *SessionVars, name string, value types.Datum) erro
 		return UnknownSystemVar
 	}
 	if value.IsNull() {
-		if name != CharacterSetResults {
-			return ErrCantSetToNull
-		}
-		delete(vars.systems, name)
-		return nil
+		return vars.deleteSystemVar(name)
 	}
 	sVal, err := value.ToString()
 	if err != nil {

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -115,68 +115,7 @@ func SetSessionSystemVar(vars *SessionVars, name string, value types.Datum) erro
 	if err != nil {
 		return errors.Trace(err)
 	}
-	switch name {
-	case TimeZone:
-		vars.TimeZone, err = parseTimeZone(sVal)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	case SQLModeVar:
-		sVal = mysql.FormatSQLModeStr(sVal)
-		// Modes is a list of different modes separated by commas.
-		sqlMode, err2 := mysql.GetSQLMode(sVal)
-		if err2 != nil {
-			return errors.Trace(err2)
-		}
-		vars.StrictSQLMode = sqlMode.HasStrictMode()
-		vars.SQLMode = sqlMode
-		vars.SetStatusFlag(mysql.ServerStatusNoBackslashEscaped, sqlMode.HasNoBackslashEscapesMode())
-	case TiDBSnapshot:
-		err = setSnapshotTS(vars, sVal)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	case AutocommitVar:
-		isAutocommit := tidbOptOn(sVal)
-		vars.SetStatusFlag(mysql.ServerStatusAutocommit, isAutocommit)
-		if isAutocommit {
-			vars.SetStatusFlag(mysql.ServerStatusInTrans, false)
-		}
-	case TiDBImportingData:
-		vars.ImportingData = tidbOptOn(sVal)
-	case TiDBSkipUTF8Check:
-		vars.SkipUTF8Check = tidbOptOn(sVal)
-	case TiDBOptAggPushDown:
-		vars.AllowAggPushDown = tidbOptOn(sVal)
-	case TiDBOptInSubqUnFolding:
-		vars.AllowInSubqueryUnFolding = tidbOptOn(sVal)
-	case TiDBIndexLookupConcurrency:
-		vars.IndexLookupConcurrency = tidbOptPositiveInt(sVal, DefIndexLookupConcurrency)
-	case TiDBIndexJoinBatchSize:
-		vars.IndexJoinBatchSize = tidbOptPositiveInt(sVal, DefIndexJoinBatchSize)
-	case TiDBIndexLookupSize:
-		vars.IndexLookupSize = tidbOptPositiveInt(sVal, DefIndexLookupSize)
-	case TiDBDistSQLScanConcurrency:
-		vars.DistSQLScanConcurrency = tidbOptPositiveInt(sVal, DefDistSQLScanConcurrency)
-	case TiDBIndexSerialScanConcurrency:
-		vars.IndexSerialScanConcurrency = tidbOptPositiveInt(sVal, DefIndexSerialScanConcurrency)
-	case TiDBBatchInsert:
-		vars.BatchInsert = tidbOptOn(sVal)
-	case TiDBBatchDelete:
-		vars.BatchDelete = tidbOptOn(sVal)
-	case TiDBDMLBatchSize:
-		vars.DMLBatchSize = tidbOptPositiveInt(sVal, DefDMLBatchSize)
-	case TiDBCurrentTS:
-		return ErrReadOnly
-	case TiDBMaxChunkSize:
-		vars.MaxChunkSize = tidbOptPositiveInt(sVal, DefMaxChunkSize)
-	case TiDBMemThreshold:
-		vars.MemThreshold = int64(tidbOptPositiveInt(sVal, DefMemThreshold))
-	case TiDBGeneralLog:
-		atomic.StoreUint32(&ProcessGeneralLog, uint32(tidbOptPositiveInt(sVal, DefTiDBGeneralLog)))
-	}
-	vars.systems[name] = sVal
-	return nil
+	return vars.SetSystemVar(name, sVal)
 }
 
 // tidbOptOn could be used for all tidb session variable options, we use "ON"/1 to turn on those options.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -11,23 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package varsutil
+package variable
 
 import (
-	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
 )
-
-func TestT(t *testing.T) {
-	TestingT(t)
-}
 
 var _ = Suite(&testVarsutilSuite{})
 
@@ -58,7 +52,7 @@ func (s *testVarsutilSuite) TestTiDBOptOn(c *C) {
 
 func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	defer testleak.AfterTest(c)()
-	v := variable.NewSessionVars()
+	v := NewSessionVars()
 	v.GlobalVarsAccessor = newMockGlobalAccessor()
 
 	SetSessionSystemVar(v, "autocommit", types.NewStringDatum("1"))
@@ -84,22 +78,22 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(SetSessionSystemVar(v, "character_set_results", types.Datum{}), IsNil)
 
 	// Test case for get TiDBImportingData session variable.
-	val, err = GetSessionSystemVar(v, variable.TiDBImportingData)
+	val, err = GetSessionSystemVar(v, TiDBImportingData)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 
 	// Test case for tidb_import_data
 	c.Assert(v.ImportingData, IsFalse)
-	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("0"))
+	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("0"))
 	c.Assert(v.ImportingData, IsFalse)
-	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("1"))
+	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("1"))
 	c.Assert(v.ImportingData, IsTrue)
-	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("0"))
+	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("0"))
 	c.Assert(v.ImportingData, IsFalse)
 
 	// Test case for change TiDBImportingData session variable.
-	SetSessionSystemVar(v, variable.TiDBImportingData, types.NewStringDatum("1"))
-	val, err = GetSessionSystemVar(v, variable.TiDBImportingData)
+	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("1"))
+	val, err = GetSessionSystemVar(v, TiDBImportingData)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "1")
 
@@ -118,19 +112,19 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 		{"-6:00", "UTC", true, 6 * time.Hour},
 	}
 	for _, tt := range tests {
-		err = SetSessionSystemVar(v, variable.TimeZone, types.NewStringDatum(tt.input))
+		err = SetSessionSystemVar(v, TimeZone, types.NewStringDatum(tt.input))
 		c.Assert(err, IsNil)
 		c.Assert(v.TimeZone.String(), Equals, tt.expect)
 		if tt.compareValue {
-			SetSessionSystemVar(v, variable.TimeZone, types.NewStringDatum(tt.input))
+			SetSessionSystemVar(v, TimeZone, types.NewStringDatum(tt.input))
 			t1 := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 			t2 := time.Date(2000, 1, 1, 0, 0, 0, 0, v.TimeZone)
 			c.Assert(t2.Sub(t1), Equals, tt.diff)
 		}
 	}
-	err = SetSessionSystemVar(v, variable.TimeZone, types.NewStringDatum("6:00"))
+	err = SetSessionSystemVar(v, TimeZone, types.NewStringDatum("6:00"))
 	c.Assert(err, NotNil)
-	c.Assert(terror.ErrorEqual(err, variable.ErrUnknownTimeZone), IsTrue)
+	c.Assert(terror.ErrorEqual(err, ErrUnknownTimeZone), IsTrue)
 
 	// Test case for sql mode.
 	for str, mode := range mysql.Str2SQLMode {
@@ -149,16 +143,16 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 
 	// Test case for tidb_index_serial_scan_concurrency.
 	c.Assert(v.IndexSerialScanConcurrency, Equals, 1)
-	SetSessionSystemVar(v, variable.TiDBIndexSerialScanConcurrency, types.NewStringDatum("4"))
+	SetSessionSystemVar(v, TiDBIndexSerialScanConcurrency, types.NewStringDatum("4"))
 	c.Assert(v.IndexSerialScanConcurrency, Equals, 4)
 
 	// Test case for tidb_batch_insert.
 	c.Assert(v.BatchInsert, IsFalse)
-	SetSessionSystemVar(v, variable.TiDBBatchInsert, types.NewStringDatum("1"))
+	SetSessionSystemVar(v, TiDBBatchInsert, types.NewStringDatum("1"))
 	c.Assert(v.BatchInsert, IsTrue)
 
 	c.Assert(v.MaxChunkSize, Equals, 1024)
-	SetSessionSystemVar(v, variable.TiDBMaxChunkSize, types.NewStringDatum("2"))
+	SetSessionSystemVar(v, TiDBMaxChunkSize, types.NewStringDatum("2"))
 	c.Assert(v.MaxChunkSize, Equals, 2)
 }
 
@@ -170,7 +164,7 @@ func newMockGlobalAccessor() *mockGlobalAccessor {
 	m := &mockGlobalAccessor{
 		vars: make(map[string]string),
 	}
-	for name, val := range variable.SysVars {
+	for name, val := range SysVars {
 		m.vars[name] = val.Value
 	}
 	return m


### PR DESCRIPTION
Session system variable may bind to values in `SessionVars`, change `SessionVars.Systems` directly makes things inconsistent, so I make `Systems` a private member and wrap get/set methods around it.

@shenli @coocood 