### PR TITLE
stats: fix bug when estimating row count for outdated histograms

### DIFF
--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -362,6 +362,36 @@ func (s *testAnalyzeSuite) TestAnalyze(c *C) {
 	}
 }
 
+func (s *testAnalyzeSuite) TestOutdatedAnalyze(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	testKit := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (a int, b int, index idx(a))")
+	for i := 0; i < 10; i++ {
+		testKit.MustExec(fmt.Sprintf("insert into t values (%d,%d)", i, i))
+	}
+	h := dom.StatsHandle()
+	h.DumpStatsDeltaToKV()
+	testKit.MustExec("analyze table t")
+	testKit.MustExec("insert into t select * from t")
+	testKit.MustExec("insert into t select * from t")
+	testKit.MustExec("insert into t select * from t")
+	h.DumpStatsDeltaToKV()
+	c.Assert(h.Update(dom.InfoSchema()), IsNil)
+	// FIXME: The count for table scan is wrong.
+	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
+		"TableScan_5 Selection_6  cop table:t, range:(-inf,+inf), keep order:false 28.799999999999997",
+		"Selection_6  TableScan_5 cop le(test.t.a, 5), le(test.t.b, 5) 28.799999999999997",
+		"TableReader_7   root data:Selection_6 28.799999999999997",
+	))
+}
+
 func (s *testAnalyzeSuite) TestPreparedNullParam(c *C) {
 	defer testleak.AfterTest(c)()
 	store, dom, err := newStoreWithBootstrap()

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -478,14 +478,13 @@ func (c *Column) equalRowCount(sc *stmtctx.StatementContext, val types.Datum) (f
 }
 
 // getIntColumnRowCount estimates the row count by a slice of IntColumnRange.
-func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []ranger.IntColumnRange,
-	totalRowCount float64) (float64, error) {
+func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []ranger.IntColumnRange) (float64, error) {
 	var rowCount float64
 	for _, rg := range intRanges {
 		var cnt float64
 		var err error
 		if rg.LowVal == math.MinInt64 && rg.HighVal == math.MaxInt64 {
-			cnt = totalRowCount
+			cnt = c.totalRowCount()
 		} else if rg.LowVal == math.MinInt64 {
 			cnt, err = c.lessAndEqRowCount(sc, types.NewIntDatum(rg.HighVal))
 		} else if rg.HighVal == math.MaxInt64 {
@@ -505,8 +504,8 @@ func (c *Column) getIntColumnRowCount(sc *stmtctx.StatementContext, intRanges []
 		}
 		rowCount += cnt
 	}
-	if rowCount > totalRowCount {
-		rowCount = totalRowCount
+	if rowCount > c.totalRowCount() {
+		rowCount = c.totalRowCount()
 	}
 	return rowCount, nil
 }

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -190,6 +190,12 @@ func (s *testSelectivitySuite) TestSelectivity(c *C) {
 		ratio, err := statsTbl.Selectivity(ctx, p.Children()[0].(*plan.LogicalSelection).Conditions)
 		c.Assert(err, IsNil, comment)
 		c.Assert(math.Abs(ratio-tt.selectivity) < eps, IsTrue, Commentf("for %s, needed: %v, got: %v", tt.exprs, tt.selectivity, ratio))
+
+		statsTbl.Count *= 10
+		ratio, err = statsTbl.Selectivity(ctx, p.Children()[0].(*plan.LogicalSelection).Conditions)
+		c.Assert(err, IsNil, comment)
+		c.Assert(math.Abs(ratio-tt.selectivity) < eps, IsTrue, Commentf("for %s, needed: %v, got: %v", tt.exprs, tt.selectivity, ratio))
+		statsTbl.Count /= 10
 	}
 }
 

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -580,6 +580,11 @@ func (s *testStatisticsSuite) TestIntColumnRanges(c *C) {
 	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
 	c.Assert(err, IsNil)
 	c.Assert(int(count), Equals, 1)
+
+	tbl.Count *= 10
+	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
+	c.Assert(err, IsNil)
+	c.Assert(int(count), Equals, 10)
 }
 
 func (s *testStatisticsSuite) TestIndexRanges(c *C) {

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -307,7 +307,9 @@ func (t *Table) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID
 		return getPseudoRowCountByIntRanges(intRanges, float64(t.Count)), nil
 	}
 	c := t.Columns[colID]
-	return c.getIntColumnRowCount(sc, intRanges, float64(t.Count))
+	result, err := c.getIntColumnRowCount(sc, intRanges)
+	result *= c.getIncreaseFactor(t.Count)
+	return result, errors.Trace(err)
 }
 
 // GetRowCountByColumnRanges estimates the row count by a slice of NewRange.
@@ -316,7 +318,9 @@ func (t *Table) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID in
 		return getPseudoRowCountByColumnRanges(sc, float64(t.Count), colRanges, 0)
 	}
 	c := t.Columns[colID]
-	return c.getColumnRowCount(sc, colRanges)
+	result, err := c.getColumnRowCount(sc, colRanges)
+	result *= c.getIncreaseFactor(t.Count)
+	return result, errors.Trace(err)
 }
 
 // GetRowCountByIndexRanges estimates the row count by a slice of NewRange.


### PR DESCRIPTION
When estimating row count for out of date histograms, we should multiply an increase factor.
  