### PR TITLE
 *: fix bug when init HTTP stats handler

### DIFF
--- a/server/statistics_handler.go
+++ b/server/statistics_handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/tidb"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/model"
-	log "github.com/sirupsen/logrus"
 )
 
 // StatsHandler is the handler for dump statistics.
@@ -33,10 +32,10 @@ func (s *Server) newStatsHandler() *StatsHandler {
 	if !ok {
 		panic("Illegal driver")
 	}
-	do, err := tidb.BootstrapSession(store.store)
+
+	do, err := tidb.GetDomain(store.store)
 	if err != nil {
-		log.Error("Failed to bootstrap session", err)
-		return nil
+		panic("Failed to get domain")
 	}
 	return &StatsHandler{do}
 }

--- a/session.go
+++ b/session.go
@@ -1037,6 +1037,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	return dom, errors.Trace(err)
 }
 
+// GetDomain gets the associated domain for store.
 func GetDomain(store kv.Storage) (*domain.Domain, error) {
 	return domap.Get(store)
 }

--- a/session.go
+++ b/session.go
@@ -1037,6 +1037,10 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	return dom, errors.Trace(err)
 }
 
+func GetDomain(store kv.Storage) (*domain.Domain, error) {
+	return domap.Get(store)
+}
+
 // runInBootstrapSession create a special session for boostrap to run.
 // If no bootstrap and storage is remote, we must use a little lease time to
 // bootstrap quickly, after bootstrapped, we will reset the lease time.


### PR DESCRIPTION
When init HTTP stats handler, we should not call `BootstrapSession`, it will init stats two times. 