### PR TITLE
*: cherry pick 5547 and 5548 to fix time_zone bug

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1683,7 +1683,9 @@ func (b *builtinSysDateWithFspSig) evalTime(row []types.Datum) (d types.Time, is
 		return types.Time{}, isNull, errors.Trace(err)
 	}
 
-	result, err := convertTimeToMysqlTime(time.Now(), int(fsp))
+	tz := b.ctx.GetSessionVars().GetTimeZone()
+	now := time.Now().In(tz)
+	result, err := convertTimeToMysqlTime(now, int(fsp))
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -1697,7 +1699,9 @@ type builtinSysDateWithoutFspSig struct {
 // evalTime evals SYSDATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sysdate
 func (b *builtinSysDateWithoutFspSig) evalTime(row []types.Datum) (d types.Time, isNull bool, err error) {
-	result, err := convertTimeToMysqlTime(time.Now(), 0)
+	tz := b.ctx.GetSessionVars().GetTimeZone()
+	now := time.Now().In(tz)
+	result, err := convertTimeToMysqlTime(now, 0)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -1725,7 +1729,8 @@ type builtinCurrentDateSig struct {
 // evalTime evals CURDATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curdate
 func (b *builtinCurrentDateSig) evalTime(row []types.Datum) (d types.Time, isNull bool, err error) {
-	year, month, day := time.Now().Date()
+	tz := b.ctx.GetSessionVars().GetTimeZone()
+	year, month, day := time.Now().In(tz).Date()
 	result := types.Time{
 		Time: types.FromDate(year, int(month), day, 0, 0, 0, 0),
 		Type: mysql.TypeDate,
@@ -1773,7 +1778,9 @@ type builtinCurrentTime0ArgSig struct {
 }
 
 func (b *builtinCurrentTime0ArgSig) evalDuration(row []types.Datum) (types.Duration, bool, error) {
-	res, err := types.ParseDuration(time.Now().Format(types.TimeFormat), types.MinFsp)
+	tz := b.ctx.GetSessionVars().GetTimeZone()
+	dur := time.Now().In(tz).Format(types.TimeFormat)
+	res, err := types.ParseDuration(dur, types.MinFsp)
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
 	}
@@ -1790,7 +1797,9 @@ func (b *builtinCurrentTime1ArgSig) evalDuration(row []types.Datum) (types.Durat
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
 	}
-	res, err := types.ParseDuration(time.Now().Format(types.TimeFSPFormat), int(fsp))
+	tz := b.ctx.GetSessionVars().GetTimeZone()
+	dur := time.Now().In(tz).Format(types.TimeFSPFormat)
+	res, err := types.ParseDuration(dur, int(fsp))
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
 	}

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -2208,3 +2208,44 @@ func (s *testEvaluatorSuite) TestLastDay(c *C) {
 		c.Assert(d.IsNull(), IsTrue)
 	}
 }
+
+func (s *testEvaluatorSuite) TestWithTimeZone(c *C) {
+	sv := s.ctx.GetSessionVars()
+	originTZ := sv.GetTimeZone()
+	sv.TimeZone, _ = time.LoadLocation("Asia/Tokyo")
+	defer func() {
+		sv.TimeZone = originTZ
+	}()
+
+	timeToGoTime := func(d types.Datum, loc *time.Location) time.Time {
+		result, _ := d.GetMysqlTime().Time.GoTime(loc)
+		return result
+	}
+	durationToGoTime := func(d types.Datum, loc *time.Location) time.Time {
+		t, _ := d.GetMysqlDuration().ConvertToTime(mysql.TypeDatetime)
+		result, _ := t.Time.GoTime(sv.TimeZone)
+		return result
+	}
+
+	tests := []struct {
+		method        string
+		Input         []types.Datum
+		convertToTime func(types.Datum, *time.Location) time.Time
+	}{
+		{ast.Sysdate, makeDatums(2), timeToGoTime},
+		{ast.Sysdate, nil, timeToGoTime},
+		{ast.Curdate, nil, timeToGoTime},
+		{ast.CurrentTime, makeDatums(2), durationToGoTime},
+		{ast.CurrentTime, nil, durationToGoTime},
+		{ast.Curtime, nil, durationToGoTime},
+	}
+
+	for _, t := range tests {
+		now := time.Now().In(sv.TimeZone)
+		f, err := funcs[t.method].getFunction(s.ctx, s.datumsToConstants(t.Input))
+		d, err := evalBuiltinFunc(f, nil)
+		c.Assert(err, IsNil)
+		result := t.convertToTime(d, sv.TimeZone)
+		c.Assert(result.Sub(now), LessEqual, 2*time.Second)
+	}
+}


### PR DESCRIPTION
* tidb: move loadCommonGlobalVariablesIfNeeded to Execute (#5547)
* expression: consider time zone for builtin function curtime/sysdate/curdate (#5548)
