### PR TITLE
tidb-server:Remove the override of GOMAXPROCS

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"os/signal"
-	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -130,8 +129,6 @@ func main() {
 		printer.PrintRawTiDBInfo()
 		os.Exit(0)
 	}
-
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	registerStores()
 	loadConfig()


### PR DESCRIPTION
From Go 1.5, the default setting of GOMAXPROCS is the number of CPUs available, and we need 1.9 or above now. we might as well remove this so people can set GOMAXPROCS to a custom value using environment variables.
https://golang.org/doc/go1.5#runtime