### PR TITLE
executor: close hashjoin goroutines as soon as possible to avoid unexpected error

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -104,12 +104,12 @@ type hashJoinBuffer struct {
 
 // Close implements the Executor Close interface.
 func (e *HashJoinExec) Close() error {
+	close(e.closeCh)
 	e.finished.Store(true)
 	if err := e.baseExecutor.Close(); err != nil {
 		return errors.Trace(err)
 	}
 
-	close(e.closeCh)
 	if e.prepared {
 		if e.resultBufferCh != nil {
 			for range e.resultBufferCh {
@@ -598,6 +598,8 @@ func (e *HashJoinExec) runJoinWorker4Chunk(workerID int) {
 			break
 		}
 		select {
+		case <-e.closeCh:
+			return
 		case outerResult, ok = <-e.outerResultChs[workerID]:
 		}
 		if !ok {


### PR DESCRIPTION
If there is a Limit upon HashJoin, 
the main thread may invoke Executor.Close() 
**while the join worker goroutines are still working**.

**Before** this commit, the resource of children may be destroyed 
before the join worker goroutines are closed, this may cause unexpected error.

This commit tries to close the join goroutines
**as soon as possible** to avoid this problem.

PTAL @zz-jason @lamxTyler 