### PR TITLE
session: add session variable to log query string.

### DIFF
--- a/session.go
+++ b/session.go
@@ -1342,7 +1342,7 @@ func (s *session) ShowProcess() util.ProcessInfo {
 }
 
 // logStmt logs some crucial SQL including: CREATE USER/GRANT PRIVILEGE/CHANGE PASSWORD/DDL etc and normal SQL
-// if variable.ProcessLogQuery is set.
+// if variable.ProcessGeneralLog is set.
 func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 	switch stmt := node.(type) {
 	case *ast.CreateUserStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.SetPwdStmt, *ast.GrantStmt,
@@ -1360,7 +1360,7 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 }
 
 func logQuery(query string, vars *variable.SessionVars) {
-	if atomic.LoadUint32(&variable.ProcessLogQuery) != 0 && !vars.InRestrictedSQL {
+	if atomic.LoadUint32(&variable.ProcessGeneralLog) != 0 && !vars.InRestrictedSQL {
 		log.Infof("[%d] %s", vars.ConnectionID, query)
 	}
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -620,6 +620,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBDMLBatchSize, strconv.Itoa(DefDMLBatchSize)},
 	{ScopeSession, TiDBCurrentTS, strconv.Itoa(DefCurretTS)},
 	{ScopeSession, TiDBMaxChunkSize, strconv.Itoa(DefMaxChunkSize)},
+	{ScopeSession, TiDBLogQuery, strconv.Itoa(DefLogQuery)},
 }
 
 // SetNamesVariables is the system variable names related to set names statements.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -621,7 +621,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBCurrentTS, strconv.Itoa(DefCurretTS)},
 	{ScopeSession, TiDBMaxChunkSize, strconv.Itoa(DefMaxChunkSize)},
 	/* The following variable is defined as session scope but is actually server scope. */
-	{ScopeSession, TiDBLogQuery, strconv.Itoa(DefLogQuery)},
+	{ScopeSession, TiDBGeneralLog, strconv.Itoa(DefTiDBGeneralLog)},
 }
 
 // SetNamesVariables is the system variable names related to set names statements.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -620,6 +620,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBDMLBatchSize, strconv.Itoa(DefDMLBatchSize)},
 	{ScopeSession, TiDBCurrentTS, strconv.Itoa(DefCurretTS)},
 	{ScopeSession, TiDBMaxChunkSize, strconv.Itoa(DefMaxChunkSize)},
+	/* The following variable is defined as session scope but is actually server scope. */
 	{ScopeSession, TiDBLogQuery, strconv.Itoa(DefLogQuery)},
 }
 

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -105,8 +105,8 @@ const (
 	// tidb_max_chunk_capacity is used to control the max chunk size during query execution.
 	TiDBMaxChunkSize = "tidb_max_chunk_size"
 
-	// tidb_log_query is used to log every query in info level.
-	TiDBLogQuery = "tidb_log_query"
+	// tidb_general_log is used to log every query in the server in info level.
+	TiDBGeneralLog = "tidb_general_log"
 )
 
 // Default TiDB system variable values.
@@ -125,10 +125,10 @@ const (
 	DefCurretTS                   = 0
 	DefMaxChunkSize               = 1024
 	DefDMLBatchSize               = 20000
-	DefLogQuery                   = 0
+	DefTiDBGeneralLog             = 0
 )
 
 // Process global variables.
 var (
-	ProcessLogQuery uint32
+	ProcessGeneralLog uint32
 )

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -104,6 +104,9 @@ const (
 
 	// tidb_max_chunk_capacity is used to control the max chunk size during query execution.
 	TiDBMaxChunkSize = "tidb_max_chunk_size"
+
+	// tidb_log_query is used to log every query in info level.
+	TiDBLogQuery = "tidb_log_query"
 )
 
 // Default TiDB system variable values.
@@ -122,4 +125,10 @@ const (
 	DefCurretTS                   = 0
 	DefMaxChunkSize               = 1024
 	DefDMLBatchSize               = 20000
+	DefLogQuery                   = 0
+)
+
+// Process global variables.
+var (
+	ProcessLogQuery uint32
 )

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -54,8 +54,8 @@ func GetSessionOnlySysVars(s *variable.SessionVars, key string) (string, bool, e
 	switch sysVar.Name {
 	case variable.TiDBCurrentTS:
 		return fmt.Sprintf("%d", s.TxnCtx.StartTS), true, nil
-	case variable.TiDBLogQuery:
-		return fmt.Sprintf("%d", atomic.LoadUint32(&variable.ProcessLogQuery)), true, nil
+	case variable.TiDBGeneralLog:
+		return fmt.Sprintf("%d", atomic.LoadUint32(&variable.ProcessGeneralLog)), true, nil
 	}
 	sVal, ok := s.Systems[key]
 	if ok {
@@ -171,8 +171,8 @@ func SetSessionSystemVar(vars *variable.SessionVars, name string, value types.Da
 		return variable.ErrReadOnly
 	case variable.TiDBMaxChunkSize:
 		vars.MaxChunkSize = tidbOptPositiveInt(sVal, variable.DefMaxChunkSize)
-	case variable.TiDBLogQuery:
-		atomic.StoreUint32(&variable.ProcessLogQuery, uint32(tidbOptPositiveInt(sVal, variable.DefLogQuery)))
+	case variable.TiDBGeneralLog:
+		atomic.StoreUint32(&variable.ProcessGeneralLog, uint32(tidbOptPositiveInt(sVal, variable.DefTiDBGeneralLog)))
 	}
 	vars.Systems[name] = sVal
 	return nil


### PR DESCRIPTION
Use an atomic global variable to control the switch to log query.
And the query is logged before execution.