### PR TITLE
parser: Support the ODBC syntax of time/date/timestamp literal

### DIFF
--- a/parser/misc.go
+++ b/parser/misc.go
@@ -102,6 +102,8 @@ func init() {
 	initTokenByte('\\', int('\\'))
 	initTokenByte('?', paramMarker)
 	initTokenByte('=', eq)
+	initTokenByte('{', int('{'))
+	initTokenByte('}', int('}'))
 
 	initTokenString("||", pipes)
 	initTokenString("&&", andand)

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -3219,6 +3219,22 @@ FunctionCallKeyword:
 	{
 		$$ = &ast.FuncCallExpr{FnName:model.NewCIStr(ast.PasswordFunc), Args: $3.([]ast.ExprNode)}
 	}
+|	'{' Identifier stringLit '}'
+	{
+		// This is ODBC syntax.
+		// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
+		expr := ast.NewValueExpr($3)
+		tp := $2
+		if tp == "ts" {
+			$$ = &ast.FuncCallExpr{FnName: model.NewCIStr(ast.TimestampLiteral), Args: []ast.ExprNode{expr}}
+		} else if tp == "t" {
+			$$ = &ast.FuncCallExpr{FnName: model.NewCIStr(ast.TimeLiteral), Args: []ast.ExprNode{expr}}
+		} else if tp == "d" {
+			$$ = &ast.FuncCallExpr{FnName: model.NewCIStr(ast.DateLiteral), Args: []ast.ExprNode{expr}}
+		} else {
+			$$ = expr
+		}
+	}
 
 FunctionCallNonKeyword:
 	builtinCurTime '(' FuncDatetimePrecListOpt ')'

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -624,7 +624,6 @@ func (s *testParserSuite) TestExpression(c *C) {
 		{"select {ts '1989-09-10 11:11:11'}", true},
 		{"select {d '1989-09-10'}", true},
 		{"select {t '00:00:00.111'}", true},
-		{"select {ts '1989-09-10 11:11:11'}", true},
 		// If the identifier is not in (t, d, ts), we just ignore it and consider the following expression as a string literal.
 		// This is the same behavior with MySQL.
 		{"select {ts123 '1989-09-10 11:11:11'}", true},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -627,7 +627,7 @@ func (s *testParserSuite) TestExpression(c *C) {
 		{"select {ts '1989-09-10 11:11:11'}", true},
 		// If the identifier is not in (t, d, ts), we just ignore it and consider the following expression as a string literal.
 		// This is the same behavior with MySQL.
-		{"select {ts '1989-09-10 11:11:11'}", true},
+		{"select {ts123 '1989-09-10 11:11:11'}", true},
 	}
 	s.RunTest(c, table)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -618,6 +618,16 @@ func (s *testParserSuite) TestExpression(c *C) {
 		// for timestamp literal
 		{"select timestamp '1989-09-10 11:11:11'", true},
 		{"select timestamp 19890910", false},
+
+		// The ODBC syntax for time/date/timestamp literal.
+		// See: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
+		{"select {ts '1989-09-10 11:11:11'}", true},
+		{"select {d '1989-09-10'}", true},
+		{"select {t '00:00:00.111'}", true},
+		{"select {ts '1989-09-10 11:11:11'}", true},
+		// If the identifier is not in (t, d, ts), we just ignore it and consider the following expression as a string literal.
+		// This is the same behavior with MySQL.
+		{"select {ts '1989-09-10 11:11:11'}", true},
 	}
 	s.RunTest(c, table)
 }


### PR DESCRIPTION
Fix the issue in tidb user google group.
https://groups.google.com/forum/#!topic/tidb-user/wB_U4NDw_90