### PR TITLE
executor: increase index join's batch size in boot.

### DIFF
--- a/executor/index_join.go
+++ b/executor/index_join.go
@@ -73,7 +73,7 @@ type IndexLookUpJoin struct {
 
 // Open implements the Executor Open interface.
 func (e *IndexLookUpJoin) Open() error {
-	e.curBatchSize = 32
+	e.curBatchSize = e.ctx.GetSessionVars().InitialIndexJoinBatchSize
 	e.cursor = 0
 	e.exhausted = false
 	return errors.Trace(e.children[0].Open())

--- a/session.go
+++ b/session.go
@@ -1147,6 +1147,7 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.TiDBIndexLookupConcurrency + quoteCommaQuote +
 	variable.TiDBIndexSerialScanConcurrency + quoteCommaQuote +
 	variable.TiDBMaxRowCountForINLJ + quoteCommaQuote +
+	variable.TiDBInitialIndexJoinBatchSize +
 	variable.TiDBDistSQLScanConcurrency + "')"
 
 // loadCommonGlobalVariablesIfNeeded loads and applies commonly used global variables for the session.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -229,6 +229,9 @@ type SessionVars struct {
 
 	// MaxRowCountForINLJ defines max row count that the outer table of index nested loop join could be without force hint.
 	MaxRowCountForINLJ int
+
+	// InitialIndexJoinBatchSize defines the initial index join batch size.
+	InitialIndexJoinBatchSize int
 }
 
 // NewSessionVars creates a session vars object.
@@ -252,6 +255,7 @@ func NewSessionVars() *SessionVars {
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
 		MaxRowCountForINLJ:         DefMaxRowCountForINLJ,
 		DMLBatchSize:               DefDMLBatchSize,
+		InitialIndexJoinBatchSize:  DefInitialIndexJoinBatchSize,
 	}
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -615,6 +615,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupConcurrency, strconv.Itoa(DefIndexLookupConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBIndexSerialScanConcurrency, strconv.Itoa(DefIndexSerialScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBMaxRowCountForINLJ, strconv.Itoa(DefMaxRowCountForINLJ)},
+	{ScopeGlobal | ScopeSession, TiDBInitialIndexJoinBatchSize, strconv.Itoa(DefInitialIndexJoinBatchSize)},
 	{ScopeGlobal | ScopeSession, TiDBSkipUTF8Check, boolToIntStr(DefSkipUTF8Check)},
 	{ScopeSession, TiDBBatchInsert, boolToIntStr(DefBatchInsert)},
 	{ScopeSession, TiDBBatchDelete, boolToIntStr(DefBatchDelete)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -106,6 +106,8 @@ const (
 	// It controls the max row count of outer table when do index nested loop join without hint.
 	// After the row count of the inner table is accurate, this variable will be removed.
 	TiDBMaxRowCountForINLJ = "tidb_max_row_count_for_inlj"
+
+	TiDBInitialIndexJoinBatchSize = "tidb_initial_index_join_batch_size"
 )
 
 // Default TiDB system variable values.
@@ -124,4 +126,5 @@ const (
 	DefBatchDelete                = false
 	DefCurretTS                   = 0
 	DefDMLBatchSize               = 20000
+	DefInitialIndexJoinBatchSize  = 2048
 )

--- a/sessionctx/varsutil/varsutil.go
+++ b/sessionctx/varsutil/varsutil.go
@@ -167,6 +167,8 @@ func SetSessionSystemVar(vars *variable.SessionVars, name string, value types.Da
 		vars.MaxRowCountForINLJ = tidbOptPositiveInt(sVal, variable.DefMaxRowCountForINLJ)
 	case variable.TiDBCurrentTS:
 		return variable.ErrReadOnly
+	case variable.TiDBInitialIndexJoinBatchSize:
+		vars.InitialIndexJoinBatchSize = tidbOptPositiveInt(sVal, variable.DefInitialIndexJoinBatchSize)
 	}
 	vars.Systems[name] = sVal
 	return nil

--- a/sessionctx/varsutil/varsutil_test.go
+++ b/sessionctx/varsutil/varsutil_test.go
@@ -161,6 +161,11 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(v.MaxRowCountForINLJ, Equals, 128)
 	SetSessionSystemVar(v, variable.TiDBMaxRowCountForINLJ, types.NewStringDatum("127"))
 	c.Assert(v.MaxRowCountForINLJ, Equals, 127)
+
+	// Test case for tidb_initial_index_join_batch_size
+	c.Assert(v.InitialIndexJoinBatchSize, Equals, 2048)
+	SetSessionSystemVar(v, variable.TiDBInitialIndexJoinBatchSize, types.NewStringDatum("10000"))
+	c.Assert(v.InitialIndexJoinBatchSize, Equals, 10000)
 }
 
 type mockGlobalAccessor struct {


### PR DESCRIPTION
increase it and make it controlable
