### PR TITLE
table: refine utf8 error message.

### DIFF
--- a/table/column.go
+++ b/table/column.go
@@ -163,11 +163,11 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 			if strings.HasPrefix(str[i:], string(utf8.RuneError)) {
 				continue
 			}
-			log.Errorf("[%d] incorrect utf8 value: %x for column %s",
-				ctx.GetSessionVars().ConnectionID, []byte(str), col.Name)
+			err = ErrTruncateWrongValue.FastGen("incorrect utf8 value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
+			log.Errorf("[%d] %v", err)
 			// Truncate to valid utf8 string.
 			casted = types.NewStringDatum(str[:i])
-			err = sc.HandleTruncate(ErrTruncateWrongValue)
+			err = sc.HandleTruncate(err)
 			break
 		}
 	}

--- a/table/column.go
+++ b/table/column.go
@@ -164,7 +164,7 @@ func CastValue(ctx context.Context, val types.Datum, col *model.ColumnInfo) (cas
 				continue
 			}
 			err = ErrTruncateWrongValue.FastGen("incorrect utf8 value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
-			log.Errorf("[%d] %v", err)
+			log.Errorf("[%d] %v", ctx.GetSessionVars().ConnectionID, err)
 			// Truncate to valid utf8 string.
 			casted = types.NewStringDatum(str[:i])
 			err = sc.HandleTruncate(err)


### PR DESCRIPTION
Make the error message includes hex value and original string and column name.