### PR TITLE
executor: improve the sort efficiency on "lookupTableTask.rows"

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -57,6 +57,7 @@ var LookupTableTaskChannelSize int32 = 50
 // contains the handles in those index keys.
 type lookupTableTask struct {
 	handles []int64
+	rowIdx  []int // rowIdx represents the handle index for every row. Only used when keep order.
 	rows    []chunk.Row
 	cursor  int
 
@@ -67,6 +68,19 @@ type lookupTableTask struct {
 	// The handles fetched from index is originally ordered by index, but we need handles to be ordered by itself
 	// to do table request.
 	indexOrder map[int64]int
+}
+
+func (task *lookupTableTask) Len() int {
+	return len(task.rows)
+}
+
+func (task *lookupTableTask) Less(i, j int) bool {
+	return task.rowIdx[i] < task.rowIdx[j]
+}
+
+func (task *lookupTableTask) Swap(i, j int) {
+	task.rowIdx[i], task.rowIdx[j] = task.rowIdx[j], task.rowIdx[i]
+	task.rows[i], task.rows[j] = task.rows[j], task.rows[i]
 }
 
 func (task *lookupTableTask) getRow(schema *expression.Schema) (Row, error) {
@@ -813,11 +827,12 @@ func (w *tableWorker) executeTask(goCtx goctx.Context, task *lookupTableTask) {
 		}
 	}
 	if w.keepOrder {
-		sort.Slice(task.rows, func(i, j int) bool {
-			hI := task.rows[i].GetInt64(w.handleIdx)
-			hJ := task.rows[j].GetInt64(w.handleIdx)
-			return task.indexOrder[hI] < task.indexOrder[hJ]
-		})
+		task.rowIdx = make([]int, 0, len(task.rows))
+		for i := range task.rows {
+			handle := task.rows[i].GetInt64(w.handleIdx)
+			task.rowIdx = append(task.rowIdx, task.indexOrder[handle])
+		}
+		sort.Sort(task)
 	}
 }
 


### PR DESCRIPTION

<img width="1210" alt="2018-01-18 17 33 51" src="https://user-images.githubusercontent.com/5268763/35090821-d05e7d8e-fc75-11e7-8e9f-97187beaea49.png">

The old sort mechanism spends too much time in map access, this PR removes the map access during comparing two rows.

For a simple query `select L_ORDERKEY, L_PARTKEY from lineitem where L_ORDERKEY > 0 order by L_ORDERKEY;`:

```sql
mysql> desc select L_ORDERKEY, L_PARTKEY from lineitem where L_ORDERKEY > 0 order by L_ORDERKEY;
+----------------+---------------+----------------+------+---------------------------------------------------------------------------------+---------+
| id             | parents       | children       | task | operator info                                                                   | count   |
+----------------+---------------+----------------+------+---------------------------------------------------------------------------------+---------+
| IndexScan_16   |               |                | cop  | table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range:(0,+inf], keep order:true | 6001215 |
| TableScan_17   |               |                | cop  | table:lineitem, keep order:false                                                | 6001215 |
| IndexLookUp_18 | Projection_14 |                | root | index:IndexScan_16, table:TableScan_17                                          | 6001215 |
| Projection_14  |               | IndexLookUp_18 | root | tpch.lineitem.l_orderkey, tpch.lineitem.l_partkey                               | 6001215 |
+----------------+---------------+----------------+------+---------------------------------------------------------------------------------+---------+
4 rows in set (0.00 sec)
```

the execution time is reduced from 12.4458720684s to 8.71774888039s, performance gain is about 43%