### PR TITLE
*: remove GetSessionVars() in expression evaluation

### DIFF
--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -27,17 +27,17 @@ import (
 // Aggregation stands for aggregate functions.
 type Aggregation interface {
 	// Update during executing.
-	Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error
+	Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error
 
 	// GetPartialResult will called by coprocessor to get partial results. For avg function, partial results will return
 	// sum and count values at the same time.
-	GetPartialResult(ctx *AggEvaluateContext) []types.Datum
+	GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum
 
 	// GetResult will be called when all data have been processed.
-	GetResult(ctx *AggEvaluateContext) types.Datum
+	GetResult(evalCtx *AggEvaluateContext) types.Datum
 
 	// Create a new AggEvaluateContext for the aggregation function.
-	CreateContext() *AggEvaluateContext
+	CreateContext(sc *stmtctx.StatementContext) *AggEvaluateContext
 }
 
 // NewDistAggFunc creates new Aggregate function for mock tikv.
@@ -107,15 +107,15 @@ func newAggFunc(funcName string, args []expression.Expression, hasDistinct bool)
 }
 
 // CreateContext implements Aggregation interface.
-func (af *aggFunction) CreateContext() *AggEvaluateContext {
-	ctx := &AggEvaluateContext{}
+func (af *aggFunction) CreateContext(sc *stmtctx.StatementContext) *AggEvaluateContext {
+	evalCtx := &AggEvaluateContext{}
 	if af.HasDistinct {
-		ctx.DistinctChecker = createDistinctChecker()
+		evalCtx.DistinctChecker = createDistinctChecker(sc)
 	}
-	return ctx
+	return evalCtx
 }
 
-func (af *aggFunction) updateSum(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext, row types.Row) error {
 	a := af.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
@@ -125,7 +125,7 @@ func (af *aggFunction) updateSum(ctx *AggEvaluateContext, sc *stmtctx.StatementC
 		return nil
 	}
 	if af.HasDistinct {
-		d, err1 := ctx.DistinctChecker.Check(sc, []types.Datum{value})
+		d, err1 := evalCtx.DistinctChecker.Check([]types.Datum{value})
 		if err1 != nil {
 			return errors.Trace(err1)
 		}
@@ -133,10 +133,10 @@ func (af *aggFunction) updateSum(ctx *AggEvaluateContext, sc *stmtctx.StatementC
 			return nil
 		}
 	}
-	ctx.Value, err = calculateSum(sc, ctx.Value, value)
+	evalCtx.Value, err = calculateSum(sc, evalCtx.Value, value)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ctx.Count++
+	evalCtx.Count++
 	return nil
 }

--- a/expression/aggregation/bit_and.go
+++ b/expression/aggregation/bit_and.go
@@ -26,27 +26,27 @@ type bitAndFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (bf *bitAndFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (bf *bitAndFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ctx.Value.IsNull() {
-		ctx.Value.SetUint64(math.MaxUint64)
+	if evalCtx.Value.IsNull() {
+		evalCtx.Value.SetUint64(math.MaxUint64)
 	}
 	if !value.IsNull() {
-		ctx.Value.SetUint64(ctx.Value.GetUint64() & value.GetUint64())
+		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() & value.GetUint64())
 	}
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (bf *bitAndFunction) GetResult(ctx *AggEvaluateContext) types.Datum {
-	return ctx.Value
+func (bf *bitAndFunction) GetResult(evalCtx *AggEvaluateContext) types.Datum {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (bf *bitAndFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{bf.GetResult(ctx)}
+func (bf *bitAndFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{bf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/bit_or.go
+++ b/expression/aggregation/bit_or.go
@@ -24,27 +24,27 @@ type bitOrFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (bf *bitOrFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (bf *bitOrFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ctx.Value.IsNull() {
-		ctx.Value.SetUint64(0)
+	if evalCtx.Value.IsNull() {
+		evalCtx.Value.SetUint64(0)
 	}
 	if !value.IsNull() {
-		ctx.Value.SetUint64(ctx.Value.GetUint64() | value.GetUint64())
+		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() | value.GetUint64())
 	}
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (bf *bitOrFunction) GetResult(ctx *AggEvaluateContext) types.Datum {
-	return ctx.Value
+func (bf *bitOrFunction) GetResult(evalCtx *AggEvaluateContext) types.Datum {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (bf *bitOrFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{bf.GetResult(ctx)}
+func (bf *bitOrFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{bf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/bit_xor.go
+++ b/expression/aggregation/bit_xor.go
@@ -24,27 +24,27 @@ type bitXorFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (bf *bitXorFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (bf *bitXorFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ctx.Value.IsNull() {
-		ctx.Value.SetUint64(0)
+	if evalCtx.Value.IsNull() {
+		evalCtx.Value.SetUint64(0)
 	}
 	if !value.IsNull() {
-		ctx.Value.SetUint64(ctx.Value.GetUint64() ^ value.GetUint64())
+		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() ^ value.GetUint64())
 	}
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (bf *bitXorFunction) GetResult(ctx *AggEvaluateContext) types.Datum {
-	return ctx.Value
+func (bf *bitXorFunction) GetResult(evalCtx *AggEvaluateContext) types.Datum {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (bf *bitXorFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{bf.GetResult(ctx)}
+func (bf *bitXorFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{bf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/concat.go
+++ b/expression/aggregation/concat.go
@@ -28,29 +28,29 @@ type concatFunction struct {
 	sepInited bool
 }
 
-func (cf *concatFunction) writeValue(ctx *AggEvaluateContext, val types.Datum) {
+func (cf *concatFunction) writeValue(evalCtx *AggEvaluateContext, val types.Datum) {
 	if val.Kind() == types.KindBytes {
-		ctx.Buffer.Write(val.GetBytes())
+		evalCtx.Buffer.Write(val.GetBytes())
 	} else {
-		ctx.Buffer.WriteString(fmt.Sprintf("%v", val.GetValue()))
+		evalCtx.Buffer.WriteString(fmt.Sprintf("%v", val.GetValue()))
 	}
 }
 
 func (cf *concatFunction) initSeparator(sc *stmtctx.StatementContext, row types.Row) error {
 	sepArg := cf.Args[len(cf.Args)-1]
-	sep, isNull, err := sepArg.EvalString(row, sc)
+	sepDatum, err := sepArg.Eval(row)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if isNull {
+	if sepDatum.IsNull() {
 		return errors.Errorf("Invalid separator argument.")
 	}
-	cf.separator = sep
-	return nil
+	cf.separator, err = sepDatum.ToString()
+	return errors.Trace(err)
 }
 
 // Update implements Aggregation interface.
-func (cf *concatFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	datumBuf := make([]types.Datum, 0, len(cf.Args))
 	if !cf.sepInited {
 		err := cf.initSeparator(sc, row)
@@ -72,7 +72,7 @@ func (cf *concatFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementC
 		datumBuf = append(datumBuf, value)
 	}
 	if cf.HasDistinct {
-		d, err := ctx.DistinctChecker.Check(sc, datumBuf)
+		d, err := evalCtx.DistinctChecker.Check(datumBuf)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -80,22 +80,22 @@ func (cf *concatFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementC
 			return nil
 		}
 	}
-	if ctx.Buffer == nil {
-		ctx.Buffer = &bytes.Buffer{}
+	if evalCtx.Buffer == nil {
+		evalCtx.Buffer = &bytes.Buffer{}
 	} else {
-		ctx.Buffer.WriteString(cf.separator)
+		evalCtx.Buffer.WriteString(cf.separator)
 	}
 	for _, val := range datumBuf {
-		cf.writeValue(ctx, val)
+		cf.writeValue(evalCtx, val)
 	}
 	// TODO: if total length is greater than global var group_concat_max_len, truncate it.
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (cf *concatFunction) GetResult(ctx *AggEvaluateContext) (d types.Datum) {
-	if ctx.Buffer != nil {
-		d.SetString(ctx.Buffer.String())
+func (cf *concatFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum) {
+	if evalCtx.Buffer != nil {
+		d.SetString(evalCtx.Buffer.String())
 	} else {
 		d.SetNull()
 	}
@@ -103,6 +103,6 @@ func (cf *concatFunction) GetResult(ctx *AggEvaluateContext) (d types.Datum) {
 }
 
 // GetPartialResult implements Aggregation interface.
-func (cf *concatFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{cf.GetResult(ctx)}
+func (cf *concatFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{cf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/count.go
+++ b/expression/aggregation/count.go
@@ -24,7 +24,7 @@ type countFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (cf *countFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (cf *countFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	var datumBuf []types.Datum
 	if cf.HasDistinct {
 		datumBuf = make([]types.Datum, 0, len(cf.Args))
@@ -38,14 +38,14 @@ func (cf *countFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementCo
 			return nil
 		}
 		if cf.Mode == FinalMode {
-			ctx.Count += value.GetInt64()
+			evalCtx.Count += value.GetInt64()
 		}
 		if cf.HasDistinct {
 			datumBuf = append(datumBuf, value)
 		}
 	}
 	if cf.HasDistinct {
-		d, err := ctx.DistinctChecker.Check(sc, datumBuf)
+		d, err := evalCtx.DistinctChecker.Check(datumBuf)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -54,18 +54,18 @@ func (cf *countFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementCo
 		}
 	}
 	if cf.Mode == CompleteMode {
-		ctx.Count++
+		evalCtx.Count++
 	}
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (cf *countFunction) GetResult(ctx *AggEvaluateContext) (d types.Datum) {
-	d.SetInt64(ctx.Count)
+func (cf *countFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum) {
+	d.SetInt64(evalCtx.Count)
 	return d
 }
 
 // GetPartialResult implements Aggregation interface.
-func (cf *countFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{cf.GetResult(ctx)}
+func (cf *countFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{cf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -24,8 +24,8 @@ type firstRowFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (ff *firstRowFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
-	if ctx.GotFirstRow {
+func (ff *firstRowFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+	if evalCtx.GotFirstRow {
 		return nil
 	}
 	if len(ff.Args) != 1 {
@@ -35,17 +35,17 @@ func (ff *firstRowFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.Statemen
 	if err != nil {
 		return errors.Trace(err)
 	}
-	ctx.Value = types.CopyDatum(value)
-	ctx.GotFirstRow = true
+	evalCtx.Value = types.CopyDatum(value)
+	evalCtx.GotFirstRow = true
 	return nil
 }
 
 // GetResult implements Aggregation interface.
-func (ff *firstRowFunction) GetResult(ctx *AggEvaluateContext) types.Datum {
-	return ctx.Value
+func (ff *firstRowFunction) GetResult(evalCtx *AggEvaluateContext) types.Datum {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (ff *firstRowFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{ff.GetResult(ctx)}
+func (ff *firstRowFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{ff.GetResult(evalCtx)}
 }

--- a/expression/aggregation/max_min.go
+++ b/expression/aggregation/max_min.go
@@ -25,35 +25,35 @@ type maxMinFunction struct {
 }
 
 // GetResult implements Aggregation interface.
-func (mmf *maxMinFunction) GetResult(ctx *AggEvaluateContext) (d types.Datum) {
-	return ctx.Value
+func (mmf *maxMinFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum) {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (mmf *maxMinFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{mmf.GetResult(ctx)}
+func (mmf *maxMinFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{mmf.GetResult(evalCtx)}
 }
 
 // Update implements Aggregation interface.
-func (mmf *maxMinFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := mmf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ctx.Value.IsNull() {
-		ctx.Value = value
+	if evalCtx.Value.IsNull() {
+		evalCtx.Value = value
 	}
 	if value.IsNull() {
 		return nil
 	}
 	var c int
-	c, err = ctx.Value.CompareDatum(sc, &value)
+	c, err = evalCtx.Value.CompareDatum(sc, &value)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if (mmf.isMax && c == -1) || (!mmf.isMax && c == 1) {
-		ctx.Value = value
+		evalCtx.Value = value
 	}
 	return nil
 }

--- a/expression/aggregation/sum.go
+++ b/expression/aggregation/sum.go
@@ -23,16 +23,16 @@ type sumFunction struct {
 }
 
 // Update implements Aggregation interface.
-func (sf *sumFunction) Update(ctx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
-	return sf.updateSum(ctx, sc, row)
+func (sf *sumFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
+	return sf.updateSum(sc, evalCtx, row)
 }
 
 // GetResult implements Aggregation interface.
-func (sf *sumFunction) GetResult(ctx *AggEvaluateContext) (d types.Datum) {
-	return ctx.Value
+func (sf *sumFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum) {
+	return evalCtx.Value
 }
 
 // GetPartialResult implements Aggregation interface.
-func (sf *sumFunction) GetPartialResult(ctx *AggEvaluateContext) []types.Datum {
-	return []types.Datum{sf.GetResult(ctx)}
+func (sf *sumFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
+	return []types.Datum{sf.GetResult(evalCtx)}
 }

--- a/expression/aggregation/util.go
+++ b/expression/aggregation/util.go
@@ -1,3 +1,16 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package aggregation
 
 import (
@@ -13,20 +26,22 @@ type distinctChecker struct {
 	existingKeys *mvmap.MVMap
 	key          []byte
 	vals         [][]byte
+	sc           *stmtctx.StatementContext
 }
 
 // createDistinctChecker creates a new distinct checker.
-func createDistinctChecker() *distinctChecker {
+func createDistinctChecker(sc *stmtctx.StatementContext) *distinctChecker {
 	return &distinctChecker{
 		existingKeys: mvmap.NewMVMap(),
+		sc:           sc,
 	}
 }
 
 // Check checks if values is distinct.
-func (d *distinctChecker) Check(sc *stmtctx.StatementContext, values []types.Datum) (bool, error) {
+func (d *distinctChecker) Check(values []types.Datum) (bool, error) {
 	d.key = d.key[:0]
 	var err error
-	d.key, err = codec.EncodeValue(sc, d.key, values...)
+	d.key, err = codec.EncodeValue(d.sc, d.key, values...)
 	if err != nil {
 		return false, errors.Trace(err)
 	}

--- a/expression/aggregation/util_test.go
+++ b/expression/aggregation/util_test.go
@@ -16,7 +16,8 @@ type testUtilSuite struct {
 
 func (s *testUtilSuite) TestDistinct(c *check.C) {
 	defer testleak.AfterTest(c)()
-	dc := createDistinctChecker()
+	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	dc := createDistinctChecker(sc)
 	tests := []struct {
 		vals   []interface{}
 		expect bool
@@ -28,9 +29,8 @@ func (s *testUtilSuite) TestDistinct(c *check.C) {
 		{[]interface{}{1, nil}, true},
 		{[]interface{}{1, nil}, false},
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	for _, tt := range tests {
-		d, err := dc.Check(sc, types.MakeDatums(tt.vals...))
+		d, err := dc.Check(types.MakeDatums(tt.vals...))
 		c.Assert(err, check.IsNil)
 		c.Assert(d, check.Equals, tt.expect)
 	}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -178,14 +178,12 @@ type builtinArithmeticPlusIntSig struct {
 }
 
 func (s *builtinArithmeticPlusIntSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -226,12 +224,11 @@ type builtinArithmeticPlusDecimalSig struct {
 }
 
 func (s *builtinArithmeticPlusDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -248,12 +245,11 @@ type builtinArithmeticPlusRealSig struct {
 }
 
 func (s *builtinArithmeticPlusRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalReal(row, sc)
+	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalReal(row, sc)
+	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -303,12 +299,11 @@ type builtinArithmeticMinusRealSig struct {
 }
 
 func (s *builtinArithmeticMinusRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalReal(row, sc)
+	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalReal(row, sc)
+	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -323,12 +318,11 @@ type builtinArithmeticMinusDecimalSig struct {
 }
 
 func (s *builtinArithmeticMinusDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -345,14 +339,12 @@ type builtinArithmeticMinusIntSig struct {
 }
 
 func (s *builtinArithmeticMinusIntSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -439,12 +431,11 @@ type builtinArithmeticMultiplyIntUnsignedSig struct{ baseBuiltinFunc }
 type builtinArithmeticMultiplyIntSig struct{ baseBuiltinFunc }
 
 func (s *builtinArithmeticMultiplyRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalReal(row, sc)
+	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalReal(row, sc)
+	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -456,12 +447,11 @@ func (s *builtinArithmeticMultiplyRealSig) evalReal(row types.Row) (float64, boo
 }
 
 func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -474,13 +464,12 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(row types.Row) (*types
 }
 
 func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 	unsignedA := uint64(a)
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -493,12 +482,11 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(row types.Row) (val in
 }
 
 func (s *builtinArithmeticMultiplyIntSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -536,12 +524,11 @@ type builtinArithmeticDivideRealSig struct{ baseBuiltinFunc }
 type builtinArithmeticDivideDecimalSig struct{ baseBuiltinFunc }
 
 func (s *builtinArithmeticDivideRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalReal(row, sc)
+	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalReal(row, sc)
+	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -556,13 +543,12 @@ func (s *builtinArithmeticDivideRealSig) evalReal(row types.Row) (float64, bool,
 }
 
 func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
 
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -606,8 +592,7 @@ type builtinArithmeticIntDivideIntSig struct{ baseBuiltinFunc }
 type builtinArithmeticIntDivideDecimalSig struct{ baseBuiltinFunc }
 
 func (s *builtinArithmeticIntDivideIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -616,7 +601,7 @@ func (s *builtinArithmeticIntDivideIntSig) evalInt(row types.Row) (int64, bool, 
 		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
 	}
 
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -645,13 +630,12 @@ func (s *builtinArithmeticIntDivideIntSig) evalInt(row types.Row) (int64, bool, 
 }
 
 func (s *builtinArithmeticIntDivideDecimalSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -736,8 +720,7 @@ type builtinArithmeticModRealSig struct {
 }
 
 func (s *builtinArithmeticModRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	b, isNull, err := s.args[1].EvalReal(row, sc)
+	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -746,7 +729,7 @@ func (s *builtinArithmeticModRealSig) evalReal(row types.Row) (float64, bool, er
 		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
 	}
 
-	a, isNull, err := s.args[0].EvalReal(row, sc)
+	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -759,12 +742,11 @@ type builtinArithmeticModDecimalSig struct {
 }
 
 func (s *builtinArithmeticModDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	a, isNull, err := s.args[0].EvalDecimal(row, sc)
+	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
-	b, isNull, err := s.args[1].EvalDecimal(row, sc)
+	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -781,9 +763,7 @@ type builtinArithmeticModIntSig struct {
 }
 
 func (s *builtinArithmeticModIntSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-
-	b, isNull, err := s.args[1].EvalInt(row, sc)
+	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -792,7 +772,7 @@ func (s *builtinArithmeticModIntSig) evalInt(row types.Row) (val int64, isNull b
 		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
 	}
 
-	a, isNull, err := s.args[0].EvalInt(row, sc)
+	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -429,7 +429,7 @@ type builtinCastIntAsIntSig struct {
 }
 
 func (b *builtinCastIntAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	return b.args[0].EvalInt(row, b.getCtx().GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinCastIntAsRealSig struct {
@@ -437,7 +437,7 @@ type builtinCastIntAsRealSig struct {
 }
 
 func (b *builtinCastIntAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -456,8 +456,7 @@ type builtinCastIntAsDecimalSig struct {
 }
 
 func (b *builtinCastIntAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalInt(row, sc)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -471,7 +470,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDe
 		}
 		res = types.NewDecFromUint(uVal)
 	}
-	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
+	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, isNull, errors.Trace(err)
 }
 
@@ -480,8 +479,7 @@ type builtinCastIntAsStringSig struct {
 }
 
 func (b *builtinCastIntAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalInt(row, sc)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -495,7 +493,7 @@ func (b *builtinCastIntAsStringSig) evalString(row types.Row) (res string, isNul
 		}
 		res = strconv.FormatUint(uVal, 10)
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, sc)
+	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, false, errors.Trace(err)
 }
 
@@ -504,12 +502,11 @@ type builtinCastIntAsTimeSig struct {
 }
 
 func (b *builtinCastIntAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalInt(row, sc)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
-	res, err = types.ParseTimeFromNum(sc, val, b.tp.Tp, b.tp.Decimal)
+	res, err = types.ParseTimeFromNum(b.ctx.GetSessionVars().StmtCtx, val, b.tp.Tp, b.tp.Decimal)
 	if err != nil {
 		return res, true, errors.Trace(err)
 	}
@@ -525,15 +522,14 @@ type builtinCastIntAsDurationSig struct {
 }
 
 func (b *builtinCastIntAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalInt(row, sc)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	dur, err := types.NumberToDuration(val, b.tp.Decimal)
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
-			err = sc.HandleOverflow(err, err)
+			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 		}
 		return res, true, errors.Trace(err)
 	}
@@ -545,7 +541,7 @@ type builtinCastIntAsJSONSig struct {
 }
 
 func (b *builtinCastIntAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -564,7 +560,7 @@ type builtinCastRealAsJSONSig struct {
 }
 
 func (b *builtinCastRealAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	// FIXME: `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
 	return json.CreateBinary(val), isNull, errors.Trace(err)
 }
@@ -574,7 +570,7 @@ type builtinCastDecimalAsJSONSig struct {
 }
 
 func (b *builtinCastDecimalAsJSONSig) evalJSON(row types.Row) (json.BinaryJSON, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return json.BinaryJSON{}, true, errors.Trace(err)
 	}
@@ -591,7 +587,7 @@ type builtinCastStringAsJSONSig struct {
 }
 
 func (b *builtinCastStringAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -608,7 +604,7 @@ type builtinCastDurationAsJSONSig struct {
 }
 
 func (b *builtinCastDurationAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -621,7 +617,7 @@ type builtinCastTimeAsJSONSig struct {
 }
 
 func (b *builtinCastTimeAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -636,7 +632,7 @@ type builtinCastRealAsRealSig struct {
 }
 
 func (b *builtinCastRealAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	return b.args[0].EvalReal(row, b.getCtx().GetSessionVars().StmtCtx)
+	return b.args[0].EvalReal(b.ctx, row)
 }
 
 type builtinCastRealAsIntSig struct {
@@ -644,16 +640,15 @@ type builtinCastRealAsIntSig struct {
 }
 
 func (b *builtinCastRealAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
-	sc := b.ctx.GetSessionVars().StmtCtx
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
-		res, err = types.ConvertFloatToInt(sc, val, types.SignedLowerBound[mysql.TypeLonglong], types.SignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
+		res, err = types.ConvertFloatToInt(val, types.SignedLowerBound[mysql.TypeLonglong], types.SignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
 	} else {
 		var uintVal uint64
-		uintVal, err = types.ConvertFloatToUint(sc, val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
+		uintVal, err = types.ConvertFloatToUint(val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
 		res = int64(uintVal)
 	}
 	return res, isNull, errors.Trace(err)
@@ -664,8 +659,7 @@ type builtinCastRealAsDecimalSig struct {
 }
 
 func (b *builtinCastRealAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalReal(row, sc)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -674,7 +668,7 @@ func (b *builtinCastRealAsDecimalSig) evalDecimal(row types.Row) (res *types.MyD
 	if err != nil {
 		return res, false, errors.Trace(err)
 	}
-	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
+	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, false, errors.Trace(err)
 }
 
@@ -683,12 +677,11 @@ type builtinCastRealAsStringSig struct {
 }
 
 func (b *builtinCastRealAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalReal(row, sc)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, 64), b.tp, sc)
+	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, 64), b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, isNull, errors.Trace(err)
 }
 
@@ -697,11 +690,11 @@ type builtinCastRealAsTimeSig struct {
 }
 
 func (b *builtinCastRealAsTimeSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalReal(row, sc)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err := types.ParseTime(sc, strconv.FormatFloat(val, 'f', -1, 64), b.tp.Tp, b.tp.Decimal)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
@@ -718,8 +711,7 @@ type builtinCastRealAsDurationSig struct {
 }
 
 func (b *builtinCastRealAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalReal(row, sc)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -732,11 +724,11 @@ type builtinCastDecimalAsDecimalSig struct {
 }
 
 func (b *builtinCastDecimalAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalDecimal(row, sc)
+	res, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -746,8 +738,7 @@ type builtinCastDecimalAsIntSig struct {
 }
 
 func (b *builtinCastDecimalAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDecimal(row, sc)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -769,7 +760,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(row types.Row) (res int64, isNull b
 
 	if types.ErrOverflow.Equal(err) {
 		warnErr := types.ErrTruncatedWrongVal.GenByArgs("DECIMAL", val)
-		err = sc.HandleOverflow(err, warnErr)
+		err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 	}
 
 	return res, false, errors.Trace(err)
@@ -780,11 +771,11 @@ type builtinCastDecimalAsStringSig struct {
 }
 
 func (b *builtinCastDecimalAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDecimal(row, sc)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -794,7 +785,7 @@ type builtinCastDecimalAsRealSig struct {
 }
 
 func (b *builtinCastDecimalAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -807,11 +798,11 @@ type builtinCastDecimalAsTimeSig struct {
 }
 
 func (b *builtinCastDecimalAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDecimal(row, sc)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc, string(val.ToString()), b.tp.Tp, b.tp.Decimal)
 	if err != nil {
 		return res, false, errors.Trace(err)
@@ -828,14 +819,13 @@ type builtinCastDecimalAsDurationSig struct {
 }
 
 func (b *builtinCastDecimalAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDecimal(row, sc)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return res, false, errors.Trace(err)
 	}
 	res, err = types.ParseDuration(string(val.ToString()), b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
-		err = sc.HandleTruncate(err)
+		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 		// ZeroDuration of error ErrTruncatedWrongVal needs to be considered NULL.
 		if res == types.ZeroDuration {
 			return res, true, errors.Trace(err)
@@ -849,11 +839,11 @@ type builtinCastStringAsStringSig struct {
 }
 
 func (b *builtinCastStringAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalString(row, sc)
+	res, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -872,7 +862,7 @@ func (b *builtinCastStringAsIntSig) handleOverflow(origRes int64, origStr string
 		return
 	}
 
-	sc := b.getCtx().GetSessionVars().StmtCtx
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if sc.InSelectStmt && types.ErrOverflow.Equal(origErr) {
 		if isNegative {
 			res = math.MinInt64
@@ -887,11 +877,10 @@ func (b *builtinCastStringAsIntSig) handleOverflow(origRes int64, origStr string
 }
 
 func (b *builtinCastStringAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	if b.args[0].GetType().Hybrid() || IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalInt(row, sc)
+		return b.args[0].EvalInt(b.ctx, row)
 	}
-	val, isNull, err := b.args[0].EvalString(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -903,6 +892,7 @@ func (b *builtinCastStringAsIntSig) evalInt(row types.Row) (res int64, isNull bo
 	}
 
 	var ures uint64
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if isNegative {
 		res, err = types.StrToInt(sc, val)
 		if err == nil {
@@ -927,14 +917,14 @@ type builtinCastStringAsRealSig struct {
 }
 
 func (b *builtinCastStringAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalReal(row, sc)
+		return b.args[0].EvalReal(b.ctx, row)
 	}
-	val, isNull, err := b.args[0].EvalString(row, sc)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.StrToFloat(sc, val)
 	if err != nil {
 		return 0, false, errors.Trace(err)
@@ -948,15 +938,15 @@ type builtinCastStringAsDecimalSig struct {
 }
 
 func (b *builtinCastStringAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	if IsBinaryLiteral(b.args[0]) {
-		return b.args[0].EvalDecimal(row, sc)
+		return b.args[0].EvalDecimal(b.ctx, row)
 	}
-	val, isNull, err := b.args[0].EvalString(row, sc)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	res = new(types.MyDecimal)
+	sc := b.ctx.GetSessionVars().StmtCtx
 	err = sc.HandleTruncate(res.FromString([]byte(val)))
 	if err != nil {
 		return res, false, errors.Trace(err)
@@ -970,11 +960,11 @@ type builtinCastStringAsTimeSig struct {
 }
 
 func (b *builtinCastStringAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalString(row, sc)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc, val, b.tp.Tp, b.tp.Decimal)
 	if err != nil {
 		return res, false, errors.Trace(err)
@@ -991,13 +981,13 @@ type builtinCastStringAsDurationSig struct {
 }
 
 func (b *builtinCastStringAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalString(row, sc)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	res, err = types.ParseDuration(val, b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
+		sc := b.ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 		// ZeroDuration of error ErrTruncatedWrongVal needs to be considered NULL.
 		if res == types.ZeroDuration {
@@ -1012,12 +1002,12 @@ type builtinCastTimeAsTimeSig struct {
 }
 
 func (b *builtinCastTimeAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalTime(row, sc)
+	res, isNull, err = b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if res, err = res.Convert(sc, b.tp.Tp); err != nil {
 		return res, true, errors.Trace(err)
 	}
@@ -1035,11 +1025,11 @@ type builtinCastTimeAsIntSig struct {
 }
 
 func (b *builtinCastTimeAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalTime(row, sc)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	t, err := val.RoundFrac(sc, types.DefaultFsp)
 	if err != nil {
 		return res, false, errors.Trace(err)
@@ -1053,7 +1043,7 @@ type builtinCastTimeAsRealSig struct {
 }
 
 func (b *builtinCastTimeAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1066,11 +1056,11 @@ type builtinCastTimeAsDecimalSig struct {
 }
 
 func (b *builtinCastTimeAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalTime(row, sc)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(val.ToNumber(), b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -1080,11 +1070,11 @@ type builtinCastTimeAsStringSig struct {
 }
 
 func (b *builtinCastTimeAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalTime(row, sc)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -1094,7 +1084,7 @@ type builtinCastTimeAsDurationSig struct {
 }
 
 func (b *builtinCastTimeAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1111,7 +1101,7 @@ type builtinCastDurationAsDurationSig struct {
 }
 
 func (b *builtinCastDurationAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	res, isNull, err = b.args[0].EvalDuration(row, b.getCtx().GetSessionVars().StmtCtx)
+	res, isNull, err = b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1124,7 +1114,7 @@ type builtinCastDurationAsIntSig struct {
 }
 
 func (b *builtinCastDurationAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1141,7 +1131,7 @@ type builtinCastDurationAsRealSig struct {
 }
 
 func (b *builtinCastDurationAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	val, isNull, err := b.args[0].EvalDuration(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1154,11 +1144,11 @@ type builtinCastDurationAsDecimalSig struct {
 }
 
 func (b *builtinCastDurationAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDuration(row, sc)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(val.ToNumber(), b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -1168,11 +1158,11 @@ type builtinCastDurationAsStringSig struct {
 }
 
 func (b *builtinCastDurationAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDuration(row, sc)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc)
 	return res, false, errors.Trace(err)
 }
@@ -1182,8 +1172,7 @@ type builtinCastDurationAsTimeSig struct {
 }
 
 func (b *builtinCastDurationAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalDuration(row, sc)
+	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1191,6 +1180,7 @@ func (b *builtinCastDurationAsTimeSig) evalTime(row types.Row) (res types.Time, 
 	if err != nil {
 		return res, false, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = res.RoundFrac(sc, b.tp.Decimal)
 	return res, false, errors.Trace(err)
 }
@@ -1200,7 +1190,7 @@ type builtinCastJSONAsJSONSig struct {
 }
 
 func (b *builtinCastJSONAsJSONSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	return b.args[0].EvalJSON(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalJSON(b.ctx, row)
 }
 
 type builtinCastJSONAsIntSig struct {
@@ -1208,11 +1198,11 @@ type builtinCastJSONAsIntSig struct {
 }
 
 func (b *builtinCastJSONAsIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToInt(sc, val, mysql.HasUnsignedFlag(b.tp.Flag))
 	return
 }
@@ -1222,11 +1212,11 @@ type builtinCastJSONAsRealSig struct {
 }
 
 func (b *builtinCastJSONAsRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToFloat(sc, val)
 	return
 }
@@ -1236,11 +1226,11 @@ type builtinCastJSONAsDecimalSig struct {
 }
 
 func (b *builtinCastJSONAsDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	f64, err := types.ConvertJSONToFloat(sc, val)
 	if err == nil {
 		res = new(types.MyDecimal)
@@ -1254,8 +1244,7 @@ type builtinCastJSONAsStringSig struct {
 }
 
 func (b *builtinCastJSONAsStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1267,8 +1256,7 @@ type builtinCastJSONAsTimeSig struct {
 }
 
 func (b *builtinCastJSONAsTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1276,6 +1264,7 @@ func (b *builtinCastJSONAsTimeSig) evalTime(row types.Row) (res types.Time, isNu
 	if err != nil {
 		return res, false, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc, s, b.tp.Tp, b.tp.Decimal)
 	if err != nil {
 		return res, false, errors.Trace(err)
@@ -1292,8 +1281,7 @@ type builtinCastJSONAsDurationSig struct {
 }
 
 func (b *builtinCastJSONAsDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalJSON(row, sc)
+	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1303,6 +1291,7 @@ func (b *builtinCastJSONAsDurationSig) evalDuration(row types.Row) (res types.Du
 	}
 	res, err = types.ParseDuration(s, b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
+		sc := b.ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 	}
 	return

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser/opcode"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tipb/go-tipb"
@@ -208,9 +207,8 @@ type builtinCoalesceIntSig struct {
 }
 
 func (b *builtinCoalesceIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalInt(row, sc)
+		res, isNull, err = a.EvalInt(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -225,9 +223,8 @@ type builtinCoalesceRealSig struct {
 }
 
 func (b *builtinCoalesceRealSig) evalReal(row types.Row) (res float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalReal(row, sc)
+		res, isNull, err = a.EvalReal(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -242,9 +239,8 @@ type builtinCoalesceDecimalSig struct {
 }
 
 func (b *builtinCoalesceDecimalSig) evalDecimal(row types.Row) (res *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalDecimal(row, sc)
+		res, isNull, err = a.EvalDecimal(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -259,9 +255,8 @@ type builtinCoalesceStringSig struct {
 }
 
 func (b *builtinCoalesceStringSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalString(row, sc)
+		res, isNull, err = a.EvalString(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -276,9 +271,8 @@ type builtinCoalesceTimeSig struct {
 }
 
 func (b *builtinCoalesceTimeSig) evalTime(row types.Row) (res types.Time, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalTime(row, sc)
+		res, isNull, err = a.EvalTime(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -293,9 +287,8 @@ type builtinCoalesceDurationSig struct {
 }
 
 func (b *builtinCoalesceDurationSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for _, a := range b.getArgs() {
-		res, isNull, err = a.EvalDuration(row, sc)
+		res, isNull, err = a.EvalDuration(b.ctx, row)
 		if err != nil || !isNull {
 			break
 		}
@@ -395,14 +388,13 @@ type builtinGreatestIntSig struct {
 // evalInt evals a builtinGreatestIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestIntSig) evalInt(row types.Row) (max int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	max, isNull, err = b.args[0].EvalInt(row, sc)
+	max, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return max, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
-		v, isNull, err = b.args[i].EvalInt(row, sc)
+		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
 		if isNull || err != nil {
 			return max, isNull, errors.Trace(err)
 		}
@@ -420,14 +412,13 @@ type builtinGreatestRealSig struct {
 // evalReal evals a builtinGreatestRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestRealSig) evalReal(row types.Row) (max float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	max, isNull, err = b.args[0].EvalReal(row, sc)
+	max, isNull, err = b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return max, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
-		v, isNull, err = b.args[i].EvalReal(row, sc)
+		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
 		if isNull || err != nil {
 			return max, isNull, errors.Trace(err)
 		}
@@ -445,14 +436,13 @@ type builtinGreatestDecimalSig struct {
 // evalDecimal evals a builtinGreatestDecimalSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestDecimalSig) evalDecimal(row types.Row) (max *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	max, isNull, err = b.args[0].EvalDecimal(row, sc)
+	max, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return max, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
-		v, isNull, err = b.args[i].EvalDecimal(row, sc)
+		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
 		if isNull || err != nil {
 			return max, isNull, errors.Trace(err)
 		}
@@ -470,14 +460,13 @@ type builtinGreatestStringSig struct {
 // evalString evals a builtinGreatestStringSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestStringSig) evalString(row types.Row) (max string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	max, isNull, err = b.args[0].EvalString(row, sc)
+	max, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return max, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
-		v, isNull, err = b.args[i].EvalString(row, sc)
+		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return max, isNull, errors.Trace(err)
 		}
@@ -495,14 +484,14 @@ type builtinGreatestTimeSig struct {
 // evalString evals a builtinGreatestTimeSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_greatest
 func (b *builtinGreatestTimeSig) evalString(row types.Row) (_ string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var (
 		v string
 		t types.Time
 	)
 	max := types.ZeroDatetime
+	sc := b.ctx.GetSessionVars().StmtCtx
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err = b.args[i].EvalString(row, sc)
+		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return "", true, errors.Trace(err)
 		}
@@ -563,14 +552,13 @@ type builtinLeastIntSig struct {
 // evalInt evals a builtinLeastIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastIntSig) evalInt(row types.Row) (min int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	min, isNull, err = b.args[0].EvalInt(row, sc)
+	min, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return min, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
-		v, isNull, err = b.args[i].EvalInt(row, sc)
+		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
 		if isNull || err != nil {
 			return min, isNull, errors.Trace(err)
 		}
@@ -588,14 +576,13 @@ type builtinLeastRealSig struct {
 // evalReal evals a builtinLeastRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastRealSig) evalReal(row types.Row) (min float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	min, isNull, err = b.args[0].EvalReal(row, sc)
+	min, isNull, err = b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return min, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
-		v, isNull, err = b.args[i].EvalReal(row, sc)
+		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
 		if isNull || err != nil {
 			return min, isNull, errors.Trace(err)
 		}
@@ -613,14 +600,13 @@ type builtinLeastDecimalSig struct {
 // evalDecimal evals a builtinLeastDecimalSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastDecimalSig) evalDecimal(row types.Row) (min *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	min, isNull, err = b.args[0].EvalDecimal(row, sc)
+	min, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return min, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
-		v, isNull, err = b.args[i].EvalDecimal(row, sc)
+		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
 		if isNull || err != nil {
 			return min, isNull, errors.Trace(err)
 		}
@@ -638,14 +624,13 @@ type builtinLeastStringSig struct {
 // evalString evals a builtinLeastStringSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastStringSig) evalString(row types.Row) (min string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	min, isNull, err = b.args[0].EvalString(row, sc)
+	min, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return min, isNull, errors.Trace(err)
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
-		v, isNull, err = b.args[i].EvalString(row, sc)
+		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return min, isNull, errors.Trace(err)
 		}
@@ -663,7 +648,6 @@ type builtinLeastTimeSig struct {
 // evalString evals a builtinLeastTimeSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#functionleast
 func (b *builtinLeastTimeSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var (
 		v string
 		t types.Time
@@ -674,8 +658,9 @@ func (b *builtinLeastTimeSig) evalString(row types.Row) (res string, isNull bool
 		Fsp:  types.MaxFsp,
 	}
 	findInvalidTime := false
+	sc := b.ctx.GetSessionVars().StmtCtx
 	for i := 0; i < len(b.args); i++ {
-		v, isNull, err = b.args[i].EvalString(row, sc)
+		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return "", true, errors.Trace(err)
 		}
@@ -738,15 +723,14 @@ type builtinIntervalIntSig struct {
 // evalInt evals a builtinIntervalIntSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_interval
 func (b *builtinIntervalIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	args0, isNull, err := b.args[0].EvalInt(row, sc)
+	args0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
 	if isNull {
 		return -1, false, nil
 	}
-	idx, err := b.binSearch(sc, args0, mysql.HasUnsignedFlag(b.args[0].GetType().Flag), b.args[1:], row)
+	idx, err := b.binSearch(args0, mysql.HasUnsignedFlag(b.args[0].GetType().Flag), b.args[1:], row)
 	return int64(idx), err != nil, errors.Trace(err)
 }
 
@@ -754,11 +738,11 @@ func (b *builtinIntervalIntSig) evalInt(row types.Row) (int64, bool, error) {
 // All arguments are treated as integers.
 // It is required that arg[0] < args[1] < args[2] < ... < args[n] for this function to work correctly.
 // This is because a binary search is used (very fast).
-func (b *builtinIntervalIntSig) binSearch(sc *stmtctx.StatementContext, target int64, isUint1 bool, args []Expression, row types.Row) (_ int, err error) {
+func (b *builtinIntervalIntSig) binSearch(target int64, isUint1 bool, args []Expression, row types.Row) (_ int, err error) {
 	i, j, cmp := 0, len(args), false
 	for i < j {
 		mid := i + (j-i)/2
-		v, isNull, err1 := args[mid].EvalInt(row, sc)
+		v, isNull, err1 := args[mid].EvalInt(b.ctx, row)
 		if err1 != nil {
 			err = err1
 			break
@@ -793,23 +777,22 @@ type builtinIntervalRealSig struct {
 // evalInt evals a builtinIntervalRealSig.
 // See http://dev.mysql.com/doc/refman/5.7/en/comparison-operators.html#function_interval
 func (b *builtinIntervalRealSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	args0, isNull, err := b.args[0].EvalReal(row, sc)
+	args0, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
 	if isNull {
 		return -1, false, nil
 	}
-	idx, err := b.binSearch(sc, args0, b.args[1:], row)
+	idx, err := b.binSearch(args0, b.args[1:], row)
 	return int64(idx), err != nil, errors.Trace(err)
 }
 
-func (b *builtinIntervalRealSig) binSearch(sc *stmtctx.StatementContext, target float64, args []Expression, row types.Row) (_ int, err error) {
+func (b *builtinIntervalRealSig) binSearch(target float64, args []Expression, row types.Row) (_ int, err error) {
 	i, j := 0, len(args)
 	for i < j {
 		mid := i + (j-i)/2
-		v, isNull, err1 := args[mid].EvalReal(row, sc)
+		v, isNull, err1 := args[mid].EvalReal(b.ctx, row)
 		if err != nil {
 			err = err1
 			break
@@ -930,11 +913,11 @@ func tryToConvertConstantInt(ctx context.Context, con *Constant) *Constant {
 	if con.GetType().EvalType() == types.ETInt {
 		return con
 	}
-	sc := ctx.GetSessionVars().StmtCtx
 	dt, err := con.Eval(nil)
 	if err != nil {
 		return con
 	}
+	sc := ctx.GetSessionVars().StmtCtx
 	i64, err := dt.ToInt64(sc)
 	if err != nil {
 		return con
@@ -948,11 +931,11 @@ func tryToConvertConstantInt(ctx context.Context, con *Constant) *Constant {
 
 // RefineConstantArg changes the constant argument to it's ceiling or flooring result by the given op.
 func RefineConstantArg(ctx context.Context, con *Constant, op opcode.Op) *Constant {
-	sc := ctx.GetSessionVars().StmtCtx
 	dt, err := con.Eval(nil)
 	if err != nil {
 		return con
 	}
+	sc := ctx.GetSessionVars().StmtCtx
 	i64, err := dt.ToInt64(sc)
 	if err != nil {
 		return con
@@ -1540,12 +1523,11 @@ type builtinNullEQIntSig struct {
 }
 
 func (s *builtinNullEQIntSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := s.args[0].EvalInt(s.ctx, row)
 	if err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalInt(row, sc)
+	arg1, isNull1, err := s.args[1].EvalInt(s.ctx, row)
 	if err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1583,12 +1565,11 @@ type builtinNullEQRealSig struct {
 }
 
 func (s *builtinNullEQRealSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalReal(row, sc)
+	arg0, isNull0, err := s.args[0].EvalReal(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalReal(row, sc)
+	arg1, isNull1, err := s.args[1].EvalReal(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1609,12 +1590,11 @@ type builtinNullEQDecimalSig struct {
 }
 
 func (s *builtinNullEQDecimalSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalDecimal(row, sc)
+	arg0, isNull0, err := s.args[0].EvalDecimal(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalDecimal(row, sc)
+	arg1, isNull1, err := s.args[1].EvalDecimal(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1635,12 +1615,11 @@ type builtinNullEQStringSig struct {
 }
 
 func (s *builtinNullEQStringSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalString(row, sc)
+	arg0, isNull0, err := s.args[0].EvalString(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalString(row, sc)
+	arg1, isNull1, err := s.args[1].EvalString(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1661,12 +1640,11 @@ type builtinNullEQDurationSig struct {
 }
 
 func (s *builtinNullEQDurationSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalDuration(row, sc)
+	arg0, isNull0, err := s.args[0].EvalDuration(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalDuration(row, sc)
+	arg1, isNull1, err := s.args[1].EvalDuration(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1687,12 +1665,11 @@ type builtinNullEQTimeSig struct {
 }
 
 func (s *builtinNullEQTimeSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalTime(row, sc)
+	arg0, isNull0, err := s.args[0].EvalTime(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalTime(row, sc)
+	arg1, isNull1, err := s.args[1].EvalTime(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1713,12 +1690,11 @@ type builtinNullEQJSONSig struct {
 }
 
 func (s *builtinNullEQJSONSig) evalInt(row types.Row) (val int64, isNull bool, err error) {
-	sc := s.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := s.args[0].EvalJSON(row, sc)
+	arg0, isNull0, err := s.args[0].EvalJSON(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := s.args[1].EvalJSON(row, sc)
+	arg1, isNull1, err := s.args[1].EvalJSON(s.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1810,12 +1786,11 @@ func resOfNE(val int64, isNull bool, err error) (int64, bool, error) {
 }
 
 func compareInt(args []Expression, row types.Row, ctx context.Context) (val int64, isNull bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalInt(row, sc)
+	arg0, isNull0, err := args[0].EvalInt(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalInt(row, sc)
+	arg1, isNull1, err := args[1].EvalInt(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1843,12 +1818,11 @@ func compareInt(args []Expression, row types.Row, ctx context.Context) (val int6
 }
 
 func compareString(args []Expression, row types.Row, ctx context.Context) (val int64, isNull bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalString(row, sc)
+	arg0, isNull0, err := args[0].EvalString(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalString(row, sc)
+	arg1, isNull1, err := args[1].EvalString(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1856,12 +1830,11 @@ func compareString(args []Expression, row types.Row, ctx context.Context) (val i
 }
 
 func compareReal(args []Expression, row types.Row, ctx context.Context) (val int64, isNull bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalReal(row, sc)
+	arg0, isNull0, err := args[0].EvalReal(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalReal(row, sc)
+	arg1, isNull1, err := args[1].EvalReal(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1869,12 +1842,11 @@ func compareReal(args []Expression, row types.Row, ctx context.Context) (val int
 }
 
 func compareDecimal(args []Expression, row types.Row, ctx context.Context) (val int64, isNull bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalDecimal(row, sc)
+	arg0, isNull0, err := args[0].EvalDecimal(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalDecimal(row, sc)
+	arg1, isNull1, err := args[1].EvalDecimal(ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1885,12 +1857,11 @@ func compareDecimal(args []Expression, row types.Row, ctx context.Context) (val 
 }
 
 func compareTime(args []Expression, row types.Row, ctx context.Context) (int64, bool, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalTime(row, sc)
+	arg0, isNull0, err := args[0].EvalTime(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalTime(row, sc)
+	arg1, isNull1, err := args[1].EvalTime(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1898,12 +1869,11 @@ func compareTime(args []Expression, row types.Row, ctx context.Context) (int64, 
 }
 
 func compareDuration(args []Expression, row types.Row, ctx context.Context) (int64, bool, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalDuration(row, sc)
+	arg0, isNull0, err := args[0].EvalDuration(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalDuration(row, sc)
+	arg1, isNull1, err := args[1].EvalDuration(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}
@@ -1911,12 +1881,11 @@ func compareDuration(args []Expression, row types.Row, ctx context.Context) (int
 }
 
 func compareJSON(args []Expression, row types.Row, ctx context.Context) (int64, bool, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := args[0].EvalJSON(row, sc)
+	arg0, isNull0, err := args[0].EvalJSON(ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	arg1, isNull1, err := args[1].EvalJSON(row, sc)
+	arg1, isNull1, err := args[1].EvalJSON(ctx, row)
 	if isNull1 || err != nil {
 		return 0, isNull1, errors.Trace(err)
 	}

--- a/expression/builtin_control.go
+++ b/expression/builtin_control.go
@@ -210,25 +210,24 @@ type builtinCaseWhenIntSig struct {
 // evalInt evals a builtinCaseWhenIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenIntSig) evalInt(row types.Row) (ret int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return 0, isNull, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalInt(row, sc)
+		ret, isNull, err = args[i+1].EvalInt(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalInt(row, sc)
+		ret, isNull, err = args[l-1].EvalInt(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -241,25 +240,24 @@ type builtinCaseWhenRealSig struct {
 // evalReal evals a builtinCaseWhenRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenRealSig) evalReal(row types.Row) (ret float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return 0, isNull, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalReal(row, sc)
+		ret, isNull, err = args[i+1].EvalReal(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalReal(row, sc)
+		ret, isNull, err = args[l-1].EvalReal(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -272,25 +270,24 @@ type builtinCaseWhenDecimalSig struct {
 // evalDecimal evals a builtinCaseWhenDecimalSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenDecimalSig) evalDecimal(row types.Row) (ret *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return nil, isNull, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalDecimal(row, sc)
+		ret, isNull, err = args[i+1].EvalDecimal(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalDecimal(row, sc)
+		ret, isNull, err = args[l-1].EvalDecimal(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -303,25 +300,24 @@ type builtinCaseWhenStringSig struct {
 // evalString evals a builtinCaseWhenStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenStringSig) evalString(row types.Row) (ret string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return "", isNull, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalString(row, sc)
+		ret, isNull, err = args[i+1].EvalString(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalString(row, sc)
+		ret, isNull, err = args[l-1].EvalString(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -334,25 +330,24 @@ type builtinCaseWhenTimeSig struct {
 // evalTime evals a builtinCaseWhenTimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenTimeSig) evalTime(row types.Row) (ret types.Time, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return ret, isNull, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalTime(row, sc)
+		ret, isNull, err = args[i+1].EvalTime(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalTime(row, sc)
+		ret, isNull, err = args[l-1].EvalTime(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -365,25 +360,24 @@ type builtinCaseWhenDurationSig struct {
 // evalDuration evals a builtinCaseWhenDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/case.html
 func (b *builtinCaseWhenDurationSig) evalDuration(row types.Row) (ret types.Duration, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var condition int64
 	args, l := b.getArgs(), len(b.getArgs())
 	for i := 0; i < l-1; i += 2 {
-		condition, isNull, err = args[i].EvalInt(row, sc)
+		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return ret, true, errors.Trace(err)
 		}
 		if isNull || condition == 0 {
 			continue
 		}
-		ret, isNull, err = args[i+1].EvalDuration(row, sc)
+		ret, isNull, err = args[i+1].EvalDuration(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
-		ret, isNull, err = args[l-1].EvalDuration(row, sc)
+		ret, isNull, err = args[l-1].EvalDuration(b.ctx, row)
 		return ret, isNull, errors.Trace(err)
 	}
 	return ret, true, nil
@@ -433,16 +427,15 @@ type builtinIfIntSig struct {
 }
 
 func (b *builtinIfIntSig) evalInt(row types.Row) (ret int64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalInt(row, sc)
+	arg2, isNull2, err := b.args[2].EvalInt(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -451,16 +444,15 @@ type builtinIfRealSig struct {
 }
 
 func (b *builtinIfRealSig) evalReal(row types.Row) (ret float64, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalReal(row, sc)
+	arg1, isNull1, err := b.args[1].EvalReal(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalReal(row, sc)
+	arg2, isNull2, err := b.args[2].EvalReal(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -469,16 +461,15 @@ type builtinIfDecimalSig struct {
 }
 
 func (b *builtinIfDecimalSig) evalDecimal(row types.Row) (ret *types.MyDecimal, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return nil, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalDecimal(row, sc)
+	arg1, isNull1, err := b.args[1].EvalDecimal(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalDecimal(row, sc)
+	arg2, isNull2, err := b.args[2].EvalDecimal(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -487,16 +478,15 @@ type builtinIfStringSig struct {
 }
 
 func (b *builtinIfStringSig) evalString(row types.Row) (ret string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return "", true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalString(row, sc)
+	arg1, isNull1, err := b.args[1].EvalString(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalString(row, sc)
+	arg2, isNull2, err := b.args[2].EvalString(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -505,16 +495,15 @@ type builtinIfTimeSig struct {
 }
 
 func (b *builtinIfTimeSig) evalTime(row types.Row) (ret types.Time, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return ret, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalTime(row, sc)
+	arg1, isNull1, err := b.args[1].EvalTime(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalTime(row, sc)
+	arg2, isNull2, err := b.args[2].EvalTime(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -523,16 +512,15 @@ type builtinIfDurationSig struct {
 }
 
 func (b *builtinIfDurationSig) evalDuration(row types.Row) (ret types.Duration, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return ret, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull1, err := b.args[1].EvalDuration(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
 		return arg1, isNull1, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalDuration(row, sc)
+	arg2, isNull2, err := b.args[2].EvalDuration(b.ctx, row)
 	return arg2, isNull2, errors.Trace(err)
 }
 
@@ -541,16 +529,15 @@ type builtinIfJSONSig struct {
 }
 
 func (b *builtinIfJSONSig) evalJSON(row types.Row) (ret json.BinaryJSON, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return ret, true, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalJSON(row, sc)
+	arg1, isNull1, err := b.args[1].EvalJSON(b.ctx, row)
 	if err != nil {
 		return ret, true, errors.Trace(err)
 	}
-	arg2, isNull2, err := b.args[2].EvalJSON(row, sc)
+	arg2, isNull2, err := b.args[2].EvalJSON(b.ctx, row)
 	if err != nil {
 		return ret, true, errors.Trace(err)
 	}
@@ -613,12 +600,11 @@ type builtinIfNullIntSig struct {
 }
 
 func (b *builtinIfNullIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -627,12 +613,11 @@ type builtinIfNullRealSig struct {
 }
 
 func (b *builtinIfNullRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalReal(row, sc)
+	arg0, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalReal(row, sc)
+	arg1, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -641,12 +626,11 @@ type builtinIfNullDecimalSig struct {
 }
 
 func (b *builtinIfNullDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDecimal(row, sc)
+	arg0, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDecimal(row, sc)
+	arg1, isNull, err := b.args[1].EvalDecimal(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -655,12 +639,11 @@ type builtinIfNullStringSig struct {
 }
 
 func (b *builtinIfNullStringSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalString(row, sc)
+	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalString(row, sc)
+	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -669,12 +652,11 @@ type builtinIfNullTimeSig struct {
 }
 
 func (b *builtinIfNullTimeSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalTime(row, sc)
+	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalTime(row, sc)
+	arg1, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -683,12 +665,11 @@ type builtinIfNullDurationSig struct {
 }
 
 func (b *builtinIfNullDurationSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if !isNull || err != nil {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }
 
@@ -697,11 +678,10 @@ type builtinIfNullJSONSig struct {
 }
 
 func (b *builtinIfNullJSONSig) evalJSON(row types.Row) (json.BinaryJSON, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalJSON(row, sc)
+	arg0, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if !isNull {
 		return arg0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalJSON(row, sc)
+	arg1, isNull, err := b.args[1].EvalJSON(b.ctx, row)
 	return arg1, isNull || err != nil, errors.Trace(err)
 }

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -95,12 +95,12 @@ type builtinAesDecryptSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesDecryptSig) evalString(row types.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	cryptStr, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	cryptStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	keyStr, isNull, err := b.args[1].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -137,12 +137,12 @@ type builtinAesEncryptSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_aes-decrypt
 func (b *builtinAesEncryptSig) evalString(row types.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	keyStr, isNull, err := b.args[1].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -225,8 +225,7 @@ type builtinPasswordSig struct {
 // evalString evals a builtinPasswordSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
 func (b *builtinPasswordSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	pass, isNull, err := b.args[0].EvalString(row, sc)
+	pass, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", err != nil, errors.Trace(err)
 	}
@@ -260,7 +259,7 @@ type builtinRandomBytesSig struct {
 // evalString evals RANDOM_BYTES(len).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_random-bytes
 func (b *builtinRandomBytesSig) evalString(row types.Row) (string, bool, error) {
-	len, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	len, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -297,7 +296,7 @@ type builtinMD5Sig struct {
 // evalString evals a builtinMD5Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_md5
 func (b *builtinMD5Sig) evalString(row types.Row) (string, bool, error) {
-	arg, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -328,7 +327,7 @@ type builtinSHA1Sig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_sha1
 // The value is returned as a string of 40 hexadecimal digits, or NULL if the argument was NULL.
 func (b *builtinSHA1Sig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -370,11 +369,11 @@ const (
 // evalString evals SHA2(str, hash_length).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_sha2
 func (b *builtinSHA2Sig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	hashLength, isNull, err := b.args[1].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	hashLength, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -455,7 +454,7 @@ type builtinCompressSig struct {
 // evalString evals COMPRESS(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_compress
 func (b *builtinCompressSig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -512,7 +511,7 @@ type builtinUncompressSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_uncompress
 func (b *builtinUncompressSig) evalString(row types.Row) (string, bool, error) {
 	sc := b.ctx.GetSessionVars().StmtCtx
-	payload, isNull, err := b.args[0].EvalString(row, sc)
+	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -554,7 +553,7 @@ type builtinUncompressedLengthSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_uncompressed-length
 func (b *builtinUncompressedLengthSig) evalInt(row types.Row) (int64, bool, error) {
 	sc := b.ctx.GetSessionVars().StmtCtx
-	payload, isNull, err := b.args[0].EvalString(row, sc)
+	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -235,8 +235,7 @@ type builtinLastInsertIDWithIDSig struct {
 // evalInt evals LAST_INSERT_ID(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_last-insert-id.
 func (b *builtinLastInsertIDWithIDSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalInt(row, sc)
+	res, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tipb/go-tipb"
@@ -95,7 +94,7 @@ func (c *jsonTypeFunctionClass) getFunction(ctx context.Context, args []Expressi
 
 func (b *builtinJSONTypeSig) evalString(row types.Row) (res string, isNull bool, err error) {
 	var j json.BinaryJSON
-	j, isNull, err = b.args[0].EvalJSON(row, b.getCtx().GetSessionVars().StmtCtx)
+	j, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -126,15 +125,14 @@ func (c *jsonExtractFunctionClass) getFunction(ctx context.Context, args []Expre
 }
 
 func (b *builtinJSONExtractSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalJSON(row, sc)
+	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return
 	}
 	pathExprs := make([]json.PathExpression, 0, len(b.args)-1)
 	for _, arg := range b.args[1:] {
 		var s string
-		s, isNull, err = arg.EvalString(row, sc)
+		s, isNull, err = arg.EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return res, isNull, errors.Trace(err)
 		}
@@ -172,7 +170,7 @@ func (c *jsonUnquoteFunctionClass) getFunction(ctx context.Context, args []Expre
 
 func (b *builtinJSONUnquoteSig) evalString(row types.Row) (res string, isNull bool, err error) {
 	var j json.BinaryJSON
-	j, isNull, err = b.args[0].EvalJSON(row, b.getCtx().GetSessionVars().StmtCtx)
+	j, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -210,8 +208,7 @@ func (c *jsonSetFunctionClass) getFunction(ctx context.Context, args []Expressio
 }
 
 func (b *builtinJSONSetSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = jsonModify(b.args, row, json.ModifySet, sc)
+	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifySet)
 	return res, isNull, errors.Trace(err)
 }
 
@@ -245,8 +242,7 @@ func (c *jsonInsertFunctionClass) getFunction(ctx context.Context, args []Expres
 }
 
 func (b *builtinJSONInsertSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = jsonModify(b.args, row, json.ModifyInsert, sc)
+	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifyInsert)
 	return res, isNull, errors.Trace(err)
 }
 
@@ -280,8 +276,7 @@ func (c *jsonReplaceFunctionClass) getFunction(ctx context.Context, args []Expre
 }
 
 func (b *builtinJSONReplaceSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = jsonModify(b.args, row, json.ModifyReplace, sc)
+	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifyReplace)
 	return res, isNull, errors.Trace(err)
 }
 
@@ -309,15 +304,14 @@ func (c *jsonRemoveFunctionClass) getFunction(ctx context.Context, args []Expres
 }
 
 func (b *builtinJSONRemoveSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	res, isNull, err = b.args[0].EvalJSON(row, sc)
+	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	pathExprs := make([]json.PathExpression, 0, len(b.args)-1)
 	for _, arg := range b.args[1:] {
 		var s string
-		s, isNull, err = arg.EvalString(row, sc)
+		s, isNull, err = arg.EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return res, isNull, errors.Trace(err)
 		}
@@ -358,11 +352,10 @@ func (c *jsonMergeFunctionClass) getFunction(ctx context.Context, args []Express
 }
 
 func (b *builtinJSONMergeSig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	values := make([]json.BinaryJSON, 0, len(b.args))
 	for _, arg := range b.args {
 		var value json.BinaryJSON
-		value, isNull, err = arg.EvalJSON(row, sc)
+		value, isNull, err = arg.EvalJSON(b.ctx, row)
 		if isNull || err != nil {
 			return res, isNull, errors.Trace(err)
 		}
@@ -405,13 +398,12 @@ func (b *builtinJSONObjectSig) evalJSON(row types.Row) (res json.BinaryJSON, isN
 		err = ErrIncorrectParameterCount.GenByArgs(ast.JSONObject)
 		return res, true, errors.Trace(err)
 	}
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	jsons := make(map[string]interface{}, len(b.args)>>1)
 	var key string
 	var value json.BinaryJSON
 	for i, arg := range b.args {
 		if i&1 == 0 {
-			key, isNull, err = arg.EvalString(row, sc)
+			key, isNull, err = arg.EvalString(b.ctx, row)
 			if err != nil {
 				return res, true, errors.Trace(err)
 			}
@@ -420,7 +412,7 @@ func (b *builtinJSONObjectSig) evalJSON(row types.Row) (res json.BinaryJSON, isN
 				return res, true, errors.Trace(err)
 			}
 		} else {
-			value, isNull, err = arg.EvalJSON(row, sc)
+			value, isNull, err = arg.EvalJSON(b.ctx, row)
 			if err != nil {
 				return res, true, errors.Trace(err)
 			}
@@ -461,7 +453,7 @@ func (c *jsonArrayFunctionClass) getFunction(ctx context.Context, args []Express
 func (b *builtinJSONArraySig) evalJSON(row types.Row) (res json.BinaryJSON, isNull bool, err error) {
 	jsons := make([]interface{}, 0, len(b.args))
 	for _, arg := range b.args {
-		j, isNull, err := arg.EvalJSON(row, b.getCtx().GetSessionVars().StmtCtx)
+		j, isNull, err := arg.EvalJSON(b.ctx, row)
 		if err != nil {
 			return res, true, errors.Trace(err)
 		}
@@ -473,8 +465,8 @@ func (b *builtinJSONArraySig) evalJSON(row types.Row) (res json.BinaryJSON, isNu
 	return json.CreateBinary(jsons), false, nil
 }
 
-func jsonModify(args []Expression, row types.Row, mt json.ModifyType, sc *stmtctx.StatementContext) (res json.BinaryJSON, isNull bool, err error) {
-	res, isNull, err = args[0].EvalJSON(row, sc)
+func jsonModify(ctx context.Context, args []Expression, row types.Row, mt json.ModifyType) (res json.BinaryJSON, isNull bool, err error) {
+	res, isNull, err = args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -482,7 +474,7 @@ func jsonModify(args []Expression, row types.Row, mt json.ModifyType, sc *stmtct
 	for i := 1; i < len(args); i += 2 {
 		// TODO: We can cache pathExprs if args are constants.
 		var s string
-		s, isNull, err = args[i].EvalString(row, sc)
+		s, isNull, err = args[i].EvalString(ctx, row)
 		if isNull || err != nil {
 			return res, isNull, errors.Trace(err)
 		}
@@ -496,7 +488,7 @@ func jsonModify(args []Expression, row types.Row, mt json.ModifyType, sc *stmtct
 	values := make([]json.BinaryJSON, 0, (len(args)-1)/2+1)
 	for i := 2; i < len(args); i += 2 {
 		var value json.BinaryJSON
-		value, isNull, err = args[i].EvalJSON(row, sc)
+		value, isNull, err = args[i].EvalJSON(ctx, row)
 		if err != nil {
 			return res, true, errors.Trace(err)
 		}

--- a/expression/builtin_like.go
+++ b/expression/builtin_like.go
@@ -58,18 +58,17 @@ type builtinLikeSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-comparison-functions.html#operator_like
 // NOTE: Currently tikv's like function is case sensitive, so we keep its behavior here.
 func (b *builtinLikeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	valStr, isNull, err := b.args[0].EvalString(row, sc)
+	valStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
 	// TODO: We don't need to compile pattern if it has been compiled or it is static.
-	patternStr, isNull, err := b.args[1].EvalString(row, sc)
+	patternStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	val, isNull, err := b.args[2].EvalInt(row, sc)
+	val, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -103,14 +102,12 @@ type builtinRegexpBinarySig struct {
 }
 
 func (b *builtinRegexpBinarySig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	expr, isNull, err := b.args[0].EvalString(row, sc)
+	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
 
-	pat, isNull, err := b.args[1].EvalString(row, sc)
+	pat, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -130,14 +127,12 @@ type builtinRegexpSig struct {
 // evalInt evals `expr REGEXP pat`, or `expr RLIKE pat`.
 // See https://dev.mysql.com/doc/refman/5.7/en/regexp.html#operator_regexp
 func (b *builtinRegexpSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	expr, isNull, err := b.args[0].EvalString(row, sc)
+	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
 
-	pat, isNull, err := b.args[1].EvalString(row, sc)
+	pat, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -29,7 +29,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -164,7 +163,7 @@ type builtinAbsRealSig struct {
 // evalReal evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsRealSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -178,7 +177,7 @@ type builtinAbsIntSig struct {
 // evalInt evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsIntSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -198,7 +197,7 @@ type builtinAbsUIntSig struct {
 // evalInt evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsUIntSig) evalInt(row types.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinAbsDecSig struct {
@@ -208,7 +207,7 @@ type builtinAbsDecSig struct {
 // evalDecimal evals ABS(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_abs
 func (b *builtinAbsDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -276,7 +275,7 @@ type builtinRoundRealSig struct {
 // evalReal evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundRealSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -290,7 +289,7 @@ type builtinRoundIntSig struct {
 // evalInt evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundIntSig) evalInt(row types.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinRoundDecSig struct {
@@ -300,7 +299,7 @@ type builtinRoundDecSig struct {
 // evalDecimal evals ROUND(value).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -318,11 +317,11 @@ type builtinRoundWithFracRealSig struct {
 // evalReal evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracRealSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	frac, isNull, err := b.args[1].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -336,11 +335,11 @@ type builtinRoundWithFracIntSig struct {
 // evalInt evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracIntSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	frac, isNull, err := b.args[1].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -354,11 +353,11 @@ type builtinRoundWithFracDecSig struct {
 // evalDecimal evals ROUND(value, frac).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_round
 func (b *builtinRoundWithFracDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
-	frac, isNull, err := b.args[1].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -415,7 +414,7 @@ type builtinCeilRealSig struct {
 // evalReal evals a builtinCeilRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_ceil
 func (b *builtinCeilRealSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -429,7 +428,7 @@ type builtinCeilIntToIntSig struct {
 // evalInt evals a builtinCeilIntToIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_ceil
 func (b *builtinCeilIntToIntSig) evalInt(row types.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinCeilIntToDecSig struct {
@@ -439,7 +438,7 @@ type builtinCeilIntToDecSig struct {
 // evalDec evals a builtinCeilIntToDecSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_Ceil
 func (b *builtinCeilIntToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	return types.NewDecFromUint(uint64(val)), isNull, errors.Trace(err)
 }
 
@@ -450,7 +449,7 @@ type builtinCeilDecToIntSig struct {
 // evalInt evals a builtinCeilDecToIntSig.
 // Ceil receives
 func (b *builtinCeilDecToIntSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -471,7 +470,7 @@ type builtinCeilDecToDecSig struct {
 
 // evalDec evals a builtinCeilDecToDecSig.
 func (b *builtinCeilDecToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -561,7 +560,7 @@ type builtinFloorRealSig struct {
 // evalReal evals a builtinFloorRealSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorRealSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -575,7 +574,7 @@ type builtinFloorIntToIntSig struct {
 // evalInt evals a builtinFloorIntToIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorIntToIntSig) evalInt(row types.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinFloorIntToDecSig struct {
@@ -585,7 +584,7 @@ type builtinFloorIntToDecSig struct {
 // evalDec evals a builtinFloorIntToDecSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorIntToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	return types.NewDecFromUint(uint64(val)), isNull, errors.Trace(err)
 }
 
@@ -596,7 +595,7 @@ type builtinFloorDecToIntSig struct {
 // evalInt evals a builtinFloorDecToIntSig.
 // floor receives
 func (b *builtinFloorDecToIntSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -617,7 +616,7 @@ type builtinFloorDecToDecSig struct {
 
 // evalDec evals a builtinFloorDecToDecSig.
 func (b *builtinFloorDecToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -671,7 +670,7 @@ type builtinLog1ArgSig struct {
 // evalReal evals a builtinLog1ArgSig, corresponding to log(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log
 func (b *builtinLog1ArgSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -688,14 +687,12 @@ type builtinLog2ArgsSig struct {
 // evalReal evals a builtinLog2ArgsSig, corresponding to log(b, x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log
 func (b *builtinLog2ArgsSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	val1, isNull, err := b.args[0].EvalReal(row, sc)
+	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	val2, isNull, err := b.args[1].EvalReal(row, sc)
+	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -727,7 +724,7 @@ type builtinLog2Sig struct {
 // evalReal evals a builtinLog2Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log2
 func (b *builtinLog2Sig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -757,7 +754,7 @@ type builtinLog10Sig struct {
 // evalReal evals a builtinLog10Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_log10
 func (b *builtinLog10Sig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -812,7 +809,7 @@ type builtinRandWithSeedSig struct {
 // evalReal evals RAND(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_rand
 func (b *builtinRandWithSeedSig) evalReal(row types.Row) (float64, bool, error) {
-	seed, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	seed, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -847,12 +844,11 @@ type builtinPowSig struct {
 // evalReal evals POW(x, y).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_pow
 func (b *builtinPowSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	x, isNull, err := b.args[0].EvalReal(row, sc)
+	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	y, isNull, err := b.args[1].EvalReal(row, sc)
+	y, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -889,18 +885,17 @@ type builtinConvSig struct {
 // evalString evals CONV(N,from_base,to_base).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_conv.
 func (b *builtinConvSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	n, isNull, err := b.args[0].EvalString(row, sc)
+	n, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 
-	fromBase, isNull, err := b.args[1].EvalInt(row, sc)
+	fromBase, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 
-	toBase, isNull, err := b.args[2].EvalInt(row, sc)
+	toBase, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -989,7 +984,7 @@ type builtinCRC32Sig struct {
 // evalInt evals a CRC32(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_crc32
 func (b *builtinCRC32Sig) evalInt(row types.Row) (int64, bool, error) {
-	x, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1017,7 +1012,7 @@ type builtinSignSig struct {
 // evalInt evals SIGN(v).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sign
 func (b *builtinSignSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1050,7 +1045,7 @@ type builtinSqrtSig struct {
 // evalReal evals a SQRT(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sqrt
 func (b *builtinSqrtSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1080,7 +1075,7 @@ type builtinAcosSig struct {
 // evalReal evals a builtinAcosSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_acos
 func (b *builtinAcosSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1111,7 +1106,7 @@ type builtinAsinSig struct {
 // evalReal evals a builtinAsinSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_asin
 func (b *builtinAsinSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1159,7 +1154,7 @@ type builtinAtan1ArgSig struct {
 // evalReal evals a builtinAtan1ArgSig, corresponding to atan(x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_atan
 func (b *builtinAtan1ArgSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1174,13 +1169,12 @@ type builtinAtan2ArgsSig struct {
 // evalReal evals a builtinAtan1ArgSig, corresponding to atan(y, x).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_atan
 func (b *builtinAtan2ArgsSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val1, isNull, err := b.args[0].EvalReal(row, sc)
+	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	val2, isNull, err := b.args[1].EvalReal(row, sc)
+	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1208,7 +1202,7 @@ type builtinCosSig struct {
 // evalReal evals a builtinCosSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_cos
 func (b *builtinCosSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1235,7 +1229,7 @@ type builtinCotSig struct {
 // evalReal evals a builtinCotSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_cot
 func (b *builtinCotSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1270,7 +1264,7 @@ type builtinDegreesSig struct {
 // evalReal evals a builtinDegreesSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_degrees
 func (b *builtinDegreesSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1298,7 +1292,7 @@ type builtinExpSig struct {
 // evalReal evals a builtinExpSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_exp
 func (b *builtinExpSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1360,7 +1354,7 @@ type builtinRadiansSig struct {
 // evalReal evals RADIANS(X).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_radians
 func (b *builtinRadiansSig) evalReal(row types.Row) (float64, bool, error) {
-	x, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1387,7 +1381,7 @@ type builtinSinSig struct {
 // evalreal evals a builtinSinSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_sin
 func (b *builtinSinSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1414,7 +1408,7 @@ type builtinTanSig struct {
 // eval evals a builtinTanSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_tan
 func (b *builtinTanSig) evalReal(row types.Row) (float64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1426,9 +1420,9 @@ type truncateFunctionClass struct {
 }
 
 // getDecimal returns the `Decimal` value of return type for function `TRUNCATE`.
-func (c *truncateFunctionClass) getDecimal(sc *stmtctx.StatementContext, arg Expression) int {
+func (c *truncateFunctionClass) getDecimal(ctx context.Context, arg Expression) int {
 	if constant, ok := arg.(*Constant); ok {
-		decimal, isNull, err := constant.EvalInt(nil, sc)
+		decimal, isNull, err := constant.EvalInt(ctx, nil)
 		if isNull || err != nil {
 			return 0
 		} else if decimal > 30 {
@@ -1456,7 +1450,7 @@ func (c *truncateFunctionClass) getFunction(ctx context.Context, args []Expressi
 	if argTp == types.ETInt {
 		bf.tp.Decimal = 0
 	} else {
-		bf.tp.Decimal = c.getDecimal(bf.ctx.GetSessionVars().StmtCtx, args[1])
+		bf.tp.Decimal = c.getDecimal(bf.ctx, args[1])
 	}
 	bf.tp.Flen = args[0].GetType().Flen - args[0].GetType().Decimal + bf.tp.Decimal
 	bf.tp.Flag |= args[0].GetType().Flag
@@ -1481,14 +1475,12 @@ type builtinTruncateDecimalSig struct {
 // evalDecimal evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	x, isNull, err := b.args[0].EvalDecimal(row, sc)
+	x, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
 
-	d, isNull, err := b.args[1].EvalInt(row, sc)
+	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return nil, isNull, errors.Trace(err)
 	}
@@ -1507,14 +1499,12 @@ type builtinTruncateRealSig struct {
 // evalReal evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	x, isNull, err := b.args[0].EvalReal(row, sc)
+	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	d, isNull, err := b.args[1].EvalInt(row, sc)
+	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1529,14 +1519,12 @@ type builtinTruncateIntSig struct {
 // evalInt evals a TRUNCATE(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_truncate
 func (b *builtinTruncateIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	x, isNull, err := b.args[0].EvalInt(row, sc)
+	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	d, isNull, err := b.args[1].EvalInt(row, sc)
+	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -96,7 +96,7 @@ type builtinSleepSig struct {
 // evalInt evals a builtinSleepSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_sleep
 func (b *builtinSleepSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -222,7 +222,7 @@ type builtinDecimalAnyValueSig struct {
 // evalDecimal evals a builtinDecimalAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinDecimalAnyValueSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	return b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalDecimal(b.ctx, row)
 }
 
 type builtinDurationAnyValueSig struct {
@@ -232,7 +232,7 @@ type builtinDurationAnyValueSig struct {
 // evalDuration evals a builtinDurationAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinDurationAnyValueSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	return b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalDuration(b.ctx, row)
 }
 
 type builtinIntAnyValueSig struct {
@@ -242,7 +242,7 @@ type builtinIntAnyValueSig struct {
 // evalInt evals a builtinIntAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinIntAnyValueSig) evalInt(row types.Row) (int64, bool, error) {
-	return b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalInt(b.ctx, row)
 }
 
 type builtinJSONAnyValueSig struct {
@@ -252,7 +252,7 @@ type builtinJSONAnyValueSig struct {
 // evalJSON evals a builtinJSONAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinJSONAnyValueSig) evalJSON(row types.Row) (json.BinaryJSON, bool, error) {
-	return b.args[0].EvalJSON(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalJSON(b.ctx, row)
 }
 
 type builtinRealAnyValueSig struct {
@@ -262,7 +262,7 @@ type builtinRealAnyValueSig struct {
 // evalReal evals a builtinRealAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinRealAnyValueSig) evalReal(row types.Row) (float64, bool, error) {
-	return b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalReal(b.ctx, row)
 }
 
 type builtinStringAnyValueSig struct {
@@ -272,7 +272,7 @@ type builtinStringAnyValueSig struct {
 // evalString evals a builtinStringAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinStringAnyValueSig) evalString(row types.Row) (string, bool, error) {
-	return b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalString(b.ctx, row)
 }
 
 type builtinTimeAnyValueSig struct {
@@ -282,7 +282,7 @@ type builtinTimeAnyValueSig struct {
 // evalTime evals a builtinTimeAnyValueSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_any-value
 func (b *builtinTimeAnyValueSig) evalTime(row types.Row) (types.Time, bool, error) {
-	return b.args[0].EvalTime(row, b.ctx.GetSessionVars().StmtCtx)
+	return b.args[0].EvalTime(b.ctx, row)
 }
 
 type defaultFunctionClass struct {
@@ -315,7 +315,7 @@ type builtinInetAtonSig struct {
 // evalInt evals a builtinInetAtonSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-aton
 func (b *builtinInetAtonSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return 0, true, errors.Trace(err)
 	}
@@ -382,7 +382,7 @@ type builtinInetNtoaSig struct {
 // evalString evals a builtinInetNtoaSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet-ntoa
 func (b *builtinInetNtoaSig) evalString(row types.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil || isNull {
 		return "", true, errors.Trace(err)
 	}
@@ -425,7 +425,7 @@ type builtinInet6AtonSig struct {
 // evalString evals a builtinInet6AtonSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-aton
 func (b *builtinInet6AtonSig) evalString(row types.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return "", true, errors.Trace(err)
 	}
@@ -487,7 +487,7 @@ type builtinInet6NtoaSig struct {
 // evalString evals a builtinInet6NtoaSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_inet6-ntoa
 func (b *builtinInet6NtoaSig) evalString(row types.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return "", true, errors.Trace(err)
 	}
@@ -532,7 +532,7 @@ type builtinIsIPv4Sig struct {
 // evalInt evals a builtinIsIPv4Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4
 func (b *builtinIsIPv4Sig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, errors.Trace(err)
 	}
@@ -590,7 +590,7 @@ type builtinIsIPv4CompatSig struct {
 // evalInt evals Is_IPv4_Compat
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4-compat
 func (b *builtinIsIPv4CompatSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, errors.Trace(err)
 	}
@@ -629,7 +629,7 @@ type builtinIsIPv4MappedSig struct {
 // evalInt evals Is_IPv4_Mapped
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv4-mapped
 func (b *builtinIsIPv4MappedSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, errors.Trace(err)
 	}
@@ -668,7 +668,7 @@ type builtinIsIPv6Sig struct {
 // evalInt evals a builtinIsIPv6Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_is-ipv6
 func (b *builtinIsIPv6Sig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return 0, err != nil, errors.Trace(err)
 	}

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -76,12 +76,11 @@ type builtinLogicAndSig struct {
 }
 
 func (b *builtinLogicAndSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil || (!isNull0 && arg0 == 0) {
 		return 0, err != nil, errors.Trace(err)
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil || (!isNull1 && arg1 == 0) {
 		return 0, err != nil, errors.Trace(err)
 	}
@@ -112,15 +111,14 @@ type builtinLogicOrSig struct {
 }
 
 func (b *builtinLogicOrSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull0, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
 	if !isNull0 && arg0 != 0 {
 		return 1, false, nil
 	}
-	arg1, isNull1, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -154,12 +152,11 @@ type builtinLogicXorSig struct {
 }
 
 func (b *builtinLogicXorSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -190,12 +187,11 @@ type builtinBitAndSig struct {
 }
 
 func (b *builtinBitAndSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -223,12 +219,11 @@ type builtinBitOrSig struct {
 }
 
 func (b *builtinBitOrSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -256,12 +251,11 @@ type builtinBitXorSig struct {
 }
 
 func (b *builtinBitXorSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -288,12 +282,11 @@ type builtinLeftShiftSig struct {
 }
 
 func (b *builtinLeftShiftSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -320,12 +313,11 @@ type builtinRightShiftSig struct {
 }
 
 func (b *builtinRightShiftSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalInt(row, sc)
+	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalInt(row, sc)
+	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -385,7 +377,7 @@ type builtinRealIsTrueSig struct {
 }
 
 func (b *builtinRealIsTrueSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -400,7 +392,7 @@ type builtinDecimalIsTrueSig struct {
 }
 
 func (b *builtinDecimalIsTrueSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -415,7 +407,7 @@ type builtinIntIsTrueSig struct {
 }
 
 func (b *builtinIntIsTrueSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -430,7 +422,7 @@ type builtinRealIsFalseSig struct {
 }
 
 func (b *builtinRealIsFalseSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -445,7 +437,7 @@ type builtinDecimalIsFalseSig struct {
 }
 
 func (b *builtinDecimalIsFalseSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -460,7 +452,7 @@ type builtinIntIsFalseSig struct {
 }
 
 func (b *builtinIntIsFalseSig) evalInt(row types.Row) (int64, bool, error) {
-	input, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -490,8 +482,7 @@ type builtinBitNegSig struct {
 }
 
 func (b *builtinBitNegSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalInt(row, sc)
+	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -520,8 +511,7 @@ type builtinUnaryNotSig struct {
 }
 
 func (b *builtinUnaryNotSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalInt(row, sc)
+	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -565,8 +555,7 @@ func (c *unaryMinusFunctionClass) typeInfer(argExpr Expression, ctx context.Cont
 	sc := ctx.GetSessionVars().StmtCtx
 	overflow := false
 	// TODO: Handle float overflow.
-	if arg, ok := argExpr.(*Constant); sc.InSelectStmt && ok &&
-		tp == types.ETInt {
+	if arg, ok := argExpr.(*Constant); sc.InSelectStmt && ok && tp == types.ETInt {
 		overflow = c.handleIntOverflow(arg)
 		if overflow {
 			tp = types.ETDecimal
@@ -627,7 +616,7 @@ type builtinUnaryMinusIntSig struct {
 
 func (b *builtinUnaryMinusIntSig) evalInt(row types.Row) (res int64, isNull bool, err error) {
 	var val int64
-	val, isNull, err = b.args[0].EvalInt(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if err != nil || isNull {
 		return val, isNull, errors.Trace(err)
 	}
@@ -652,10 +641,8 @@ type builtinUnaryMinusDecimalSig struct {
 }
 
 func (b *builtinUnaryMinusDecimalSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-
 	var dec *types.MyDecimal
-	dec, isNull, err := b.args[0].EvalDecimal(row, sc)
+	dec, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil || isNull {
 		return dec, isNull, errors.Trace(err)
 	}
@@ -670,8 +657,7 @@ type builtinUnaryMinusRealSig struct {
 }
 
 func (b *builtinUnaryMinusRealSig) evalReal(row types.Row) (float64, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalReal(row, sc)
+	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	return -val, isNull, errors.Trace(err)
 }
 
@@ -732,7 +718,7 @@ func evalIsNull(isNull bool, err error) (int64, bool, error) {
 }
 
 func (b *builtinDecimalIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalDecimal(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -741,7 +727,7 @@ type builtinDurationIsNullSig struct {
 }
 
 func (b *builtinDurationIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -750,7 +736,7 @@ type builtinIntIsNullSig struct {
 }
 
 func (b *builtinIntIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -759,7 +745,7 @@ type builtinRealIsNullSig struct {
 }
 
 func (b *builtinRealIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalReal(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -768,7 +754,7 @@ type builtinStringIsNullSig struct {
 }
 
 func (b *builtinStringIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalString(b.ctx, row)
 	return evalIsNull(isNull, err)
 }
 
@@ -777,6 +763,6 @@ type builtinTimeIsNullSig struct {
 }
 
 func (b *builtinTimeIsNullSig) evalInt(row types.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalTime(row, b.ctx.GetSessionVars().StmtCtx)
+	_, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	return evalIsNull(isNull, err)
 }

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -107,15 +107,14 @@ type builtinInIntSig struct {
 }
 
 func (b *builtinInIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalInt(row, sc)
+	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
-	isUnsigned0 := mysql.HasUnsignedFlag(args[0].GetType().Flag)
+	isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalInt(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalInt(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -151,14 +150,13 @@ type builtinInStringSig struct {
 }
 
 func (b *builtinInStringSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalString(row, sc)
+	arg0, isNull0, err := b.args[0].EvalString(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalString(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalString(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -179,14 +177,13 @@ type builtinInRealSig struct {
 }
 
 func (b *builtinInRealSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalReal(row, sc)
+	arg0, isNull0, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalReal(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalReal(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -207,14 +204,13 @@ type builtinInDecimalSig struct {
 }
 
 func (b *builtinInDecimalSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalDecimal(row, sc)
+	arg0, isNull0, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalDecimal(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalDecimal(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -235,14 +231,13 @@ type builtinInTimeSig struct {
 }
 
 func (b *builtinInTimeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalTime(row, sc)
+	arg0, isNull0, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalTime(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalTime(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -263,14 +258,13 @@ type builtinInDurationSig struct {
 }
 
 func (b *builtinInDurationSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalDuration(row, sc)
+	arg0, isNull0, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalDuration(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalDuration(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -291,14 +285,13 @@ type builtinInJSONSig struct {
 }
 
 func (b *builtinInJSONSig) evalInt(row types.Row) (int64, bool, error) {
-	sc, args := b.ctx.GetSessionVars().StmtCtx, b.getArgs()
-	arg0, isNull0, err := args[0].EvalJSON(row, sc)
+	arg0, isNull0, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull0 || err != nil {
 		return 0, isNull0, errors.Trace(err)
 	}
 	var hasNull bool
-	for _, arg := range args[1:] {
-		evaledArg, isNull, err := arg.EvalJSON(row, sc)
+	for _, arg := range b.args[1:] {
+		evaledArg, isNull, err := arg.EvalJSON(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -362,12 +355,11 @@ type builtinSetVarSig struct {
 func (b *builtinSetVarSig) evalString(row types.Row) (res string, isNull bool, err error) {
 	var varName string
 	sessionVars := b.ctx.GetSessionVars()
-	sc := sessionVars.StmtCtx
-	varName, isNull, err = b.args[0].EvalString(row, sc)
+	varName, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	res, isNull, err = b.args[1].EvalString(row, sc)
+	res, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -399,8 +391,7 @@ type builtinGetVarSig struct {
 
 func (b *builtinGetVarSig) evalString(row types.Row) (string, bool, error) {
 	sessionVars := b.ctx.GetSessionVars()
-	sc := sessionVars.StmtCtx
-	varName, isNull, err := b.args[0].EvalString(row, sc)
+	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -627,9 +618,7 @@ type builtinBitCountSig struct {
 // evalInt evals BIT_COUNT(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/bit-functions.html#function_bit-count
 func (b *builtinBitCountSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	n, isNull, err := b.args[0].EvalInt(row, sc)
+	n, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil || isNull {
 		if err != nil && types.ErrOverflow.Equal(err) {
 			return 64, false, nil
@@ -667,8 +656,7 @@ type builtinGetParamStringSig struct {
 
 func (b *builtinGetParamStringSig) evalString(row types.Row) (string, bool, error) {
 	sessionVars := b.ctx.GetSessionVars()
-	sc := sessionVars.StmtCtx
-	idx, isNull, err := b.args[0].EvalInt(row, sc)
+	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
@@ -194,7 +193,7 @@ type builtinLengthSig struct {
 // evalInt evaluates a builtinLengthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html
 func (b *builtinLengthSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -222,7 +221,7 @@ type builtinASCIISig struct {
 // eval evals a builtinASCIISig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ascii
 func (b *builtinASCIISig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -270,7 +269,7 @@ type builtinConcatSig struct {
 func (b *builtinConcatSig) evalString(row types.Row) (d string, isNull bool, err error) {
 	var s []byte
 	for _, a := range b.getArgs() {
-		d, isNull, err = a.EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+		d, isNull, err = a.EvalString(b.ctx, row)
 		if isNull || err != nil {
 			return d, isNull, errors.Trace(err)
 		}
@@ -331,7 +330,7 @@ func (b *builtinConcatWSSig) evalString(row types.Row) (string, bool, error) {
 	strs := make([]string, 0, len(args))
 	var sep string
 	for i, arg := range args {
-		val, isNull, err := arg.EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+		val, isNull, err := arg.EvalString(b.ctx, row)
 		if err != nil {
 			return val, isNull, errors.Trace(err)
 		}
@@ -384,12 +383,11 @@ type builtinLeftBinarySig struct {
 // evalString evals LEFT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_left
 func (b *builtinLeftBinarySig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	left, isNull, err := b.args[1].EvalInt(row, sc)
+	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -409,12 +407,11 @@ type builtinLeftSig struct {
 // evalString evals LEFT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_left
 func (b *builtinLeftSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	left, isNull, err := b.args[1].EvalInt(row, sc)
+	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -454,12 +451,11 @@ type builtinRightBinarySig struct {
 // evalString evals RIGHT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_right
 func (b *builtinRightBinarySig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	right, isNull, err := b.args[1].EvalInt(row, sc)
+	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -479,12 +475,11 @@ type builtinRightSig struct {
 // evalString evals RIGHT(str,len).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_right
 func (b *builtinRightSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	right, isNull, err := b.args[1].EvalInt(row, sc)
+	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -520,13 +515,12 @@ type builtinRepeatSig struct {
 // eval evals a builtinRepeatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_repeat
 func (b *builtinRepeatSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
 
-	num, isNull, err := b.args[1].EvalInt(row, sc)
+	num, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -566,7 +560,7 @@ type builtinLowerSig struct {
 // evalString evals a builtinLowerSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lower
 func (b *builtinLowerSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -607,7 +601,7 @@ type builtinReverseBinarySig struct {
 // evalString evals a REVERSE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_reverse
 func (b *builtinReverseBinarySig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -622,7 +616,7 @@ type builtinReverseSig struct {
 // evalString evals a REVERSE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_reverse
 func (b *builtinReverseSig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -653,7 +647,7 @@ type builtinSpaceSig struct {
 func (b *builtinSpaceSig) evalString(row types.Row) (d string, isNull bool, err error) {
 	var x int64
 
-	x, isNull, err = b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	x, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -689,7 +683,7 @@ type builtinUpperSig struct {
 // evalString evals a builtinUpperSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_upper
 func (b *builtinUpperSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -729,12 +723,11 @@ func (b *builtinStrcmpSig) evalInt(row types.Row) (int64, bool, error) {
 		err         error
 	)
 
-	sc := b.ctx.GetSessionVars().StmtCtx
-	left, isNull, err = b.args[0].EvalString(row, sc)
+	left, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	right, isNull, err = b.args[1].EvalString(row, sc)
+	right, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -779,16 +772,15 @@ type builtinReplaceSig struct {
 func (b *builtinReplaceSig) evalString(row types.Row) (d string, isNull bool, err error) {
 	var str, oldStr, newStr string
 
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err = b.args[0].EvalString(row, sc)
+	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	oldStr, isNull, err = b.args[1].EvalString(row, sc)
+	oldStr, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	newStr, isNull, err = b.args[2].EvalString(row, sc)
+	newStr, isNull, err = b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -822,14 +814,12 @@ type builtinConvertSig struct {
 // evalString evals CONVERT(expr USING transcoding_name).
 // See https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#function_convert
 func (b *builtinConvertSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	expr, isNull, err := b.args[0].EvalString(row, sc)
+	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	charsetName, isNull, err := b.args[1].EvalString(row, sc)
+	charsetName, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -885,12 +875,11 @@ type builtinSubstringBinary2ArgsSig struct {
 // evalString evals SUBSTR(str,pos), SUBSTR(str FROM pos), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstringBinary2ArgsSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -913,12 +902,11 @@ type builtinSubstring2ArgsSig struct {
 // evalString evals SUBSTR(str,pos), SUBSTR(str FROM pos), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring2ArgsSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -942,16 +930,15 @@ type builtinSubstringBinary3ArgsSig struct {
 // evalString evals SUBSTR(str,pos,len), SUBSTR(str FROM pos FOR len), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstringBinary3ArgsSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	length, isNull, err := b.args[2].EvalInt(row, sc)
+	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -980,16 +967,15 @@ type builtinSubstring3ArgsSig struct {
 // evalString evals SUBSTR(str,pos,len), SUBSTR(str FROM pos FOR len), SUBSTR() is a synonym for SUBSTRING().
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_substr
 func (b *builtinSubstring3ArgsSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
-	length, isNull, err := b.args[2].EvalInt(row, sc)
+	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1039,16 +1025,15 @@ func (b *builtinSubstringIndexSig) evalString(row types.Row) (d string, isNull b
 		str, delim string
 		count      int64
 	)
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err = b.args[0].EvalString(row, sc)
+	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	delim, isNull, err = b.args[1].EvalString(row, sc)
+	delim, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	count, isNull, err = b.args[2].EvalInt(row, sc)
+	count, isNull, err = b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1110,12 +1095,11 @@ type builtinLocateBinary2ArgsSig struct {
 // evalInt evals LOCATE(substr,str), case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocateBinary2ArgsSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	subStr, isNull, err := b.args[0].EvalString(row, sc)
+	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	str, isNull, err := b.args[1].EvalString(row, sc)
+	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1137,12 +1121,11 @@ type builtinLocate2ArgsSig struct {
 // evalInt evals LOCATE(substr,str), non case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate2ArgsSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	subStr, isNull, err := b.args[0].EvalString(row, sc)
+	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	str, isNull, err := b.args[1].EvalString(row, sc)
+	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1164,16 +1147,15 @@ type builtinLocateBinary3ArgsSig struct {
 // evalInt evals LOCATE(substr,str,pos), case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocateBinary3ArgsSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	subStr, isNull, err := b.args[0].EvalString(row, sc)
+	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	str, isNull, err := b.args[1].EvalString(row, sc)
+	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[2].EvalInt(row, sc)
+	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
@@ -1200,16 +1182,15 @@ type builtinLocate3ArgsSig struct {
 // evalInt evals LOCATE(substr,str,pos), non case-sensitive.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_locate
 func (b *builtinLocate3ArgsSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	subStr, isNull, err := b.args[0].EvalString(row, sc)
+	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	str, isNull, err := b.args[1].EvalString(row, sc)
+	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	pos, isNull, err := b.args[2].EvalInt(row, sc)
+	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
@@ -1263,7 +1244,7 @@ type builtinHexStrArgSig struct {
 // evalString evals a builtinHexStrArgSig, corresponding to hex(str)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
 func (b *builtinHexStrArgSig) evalString(row types.Row) (string, bool, error) {
-	d, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1277,7 +1258,7 @@ type builtinHexIntArgSig struct {
 // evalString evals a builtinHexIntArgSig, corresponding to hex(N)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_hex
 func (b *builtinHexIntArgSig) evalString(row types.Row) (string, bool, error) {
-	x, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -1326,7 +1307,7 @@ type builtinUnHexSig struct {
 func (b *builtinUnHexSig) evalString(row types.Row) (string, bool, error) {
 	var bs []byte
 
-	d, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1390,7 +1371,7 @@ type builtinTrim1ArgSig struct {
 // evalString evals a builtinTrim1ArgSig, corresponding to trim(str)
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_trim
 func (b *builtinTrim1ArgSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1406,12 +1387,11 @@ type builtinTrim2ArgsSig struct {
 func (b *builtinTrim2ArgsSig) evalString(row types.Row) (d string, isNull bool, err error) {
 	var str, remstr string
 
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err = b.args[0].EvalString(row, sc)
+	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	remstr, isNull, err = b.args[1].EvalString(row, sc)
+	remstr, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1433,16 +1413,15 @@ func (b *builtinTrim3ArgsSig) evalString(row types.Row) (d string, isNull bool, 
 		direction    ast.TrimDirectionType
 		isRemStrNull bool
 	)
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err = b.args[0].EvalString(row, sc)
+	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	remstr, isRemStrNull, err = b.args[1].EvalString(row, sc)
+	remstr, isRemStrNull, err = b.args[1].EvalString(b.ctx, row)
 	if err != nil {
 		return d, isNull, errors.Trace(err)
 	}
-	x, isNull, err = b.args[2].EvalInt(row, sc)
+	x, isNull, err = b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1493,7 +1472,7 @@ type builtinLTrimSig struct {
 // evalString evals a builtinLTrimSig
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ltrim
 func (b *builtinLTrimSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1523,7 +1502,7 @@ type builtinRTrimSig struct {
 // evalString evals a builtinRTrimSig
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rtrim
 func (b *builtinRTrimSig) evalString(row types.Row) (d string, isNull bool, err error) {
-	d, isNull, err = b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
@@ -1550,9 +1529,9 @@ func trimRight(str, remstr string) string {
 	}
 }
 
-func getFlen4LpadAndRpad(sc *stmtctx.StatementContext, arg Expression) int {
+func getFlen4LpadAndRpad(ctx context.Context, arg Expression) int {
 	if constant, ok := arg.(*Constant); ok {
-		length, isNull, err := constant.EvalInt(nil, sc)
+		length, isNull, err := constant.EvalInt(ctx, nil)
 		if err != nil {
 			log.Errorf("getFlen4LpadAndRpad with error: %v", err.Error())
 		}
@@ -1573,7 +1552,7 @@ func (c *lpadFunctionClass) getFunction(ctx context.Context, args []Expression) 
 		return nil, errors.Trace(err)
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETString)
-	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx.GetSessionVars().StmtCtx, args[1])
+	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx, args[1])
 	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
 	SetBinFlagOrBinStr(args[2].GetType(), bf.tp)
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
@@ -1594,21 +1573,19 @@ type builtinLpadBinarySig struct {
 // evalString evals LPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadBinarySig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	byteLength := len(str)
 
-	length, isNull, err := b.args[1].EvalInt(row, sc)
+	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	targetLength := int(length)
 
-	padStr, isNull, err := b.args[2].EvalString(row, sc)
+	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1632,21 +1609,19 @@ type builtinLpadSig struct {
 // evalString evals LPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_lpad
 func (b *builtinLpadSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	runeLength := len([]rune(str))
 
-	length, isNull, err := b.args[1].EvalInt(row, sc)
+	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	targetLength := int(length)
 
-	padStr, isNull, err := b.args[2].EvalString(row, sc)
+	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1672,7 +1647,7 @@ func (c *rpadFunctionClass) getFunction(ctx context.Context, args []Expression) 
 		return nil, errors.Trace(err)
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETString)
-	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx.GetSessionVars().StmtCtx, args[1])
+	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx, args[1])
 	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
 	SetBinFlagOrBinStr(args[2].GetType(), bf.tp)
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
@@ -1693,21 +1668,19 @@ type builtinRpadBinarySig struct {
 // evalString evals RPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadBinarySig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	byteLength := len(str)
 
-	length, isNull, err := b.args[1].EvalInt(row, sc)
+	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	targetLength := int(length)
 
-	padStr, isNull, err := b.args[2].EvalString(row, sc)
+	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1731,21 +1704,19 @@ type builtinRpadSig struct {
 // evalString evals RPAD(str,len,padstr).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_rpad
 func (b *builtinRpadSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	runeLength := len([]rune(str))
 
-	length, isNull, err := b.args[1].EvalInt(row, sc)
+	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	targetLength := int(length)
 
-	padStr, isNull, err := b.args[2].EvalString(row, sc)
+	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1783,7 +1754,7 @@ type builtinBitLengthSig struct {
 // evalInt evaluates a builtinBitLengthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_bit-length
 func (b *builtinBitLengthSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1834,9 +1805,8 @@ func (b *builtinCharSig) convertToBytes(ints []int64) []byte {
 func (b *builtinCharSig) evalString(row types.Row) (string, bool, error) {
 	bigints := make([]int64, 0, len(b.args)-1)
 
-	sc := b.ctx.GetSessionVars().StmtCtx
 	for i := 0; i < len(b.args)-1; i++ {
-		val, IsNull, err := b.args[i].EvalInt(row, sc)
+		val, IsNull, err := b.args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return "", true, errors.Trace(err)
 		}
@@ -1847,7 +1817,7 @@ func (b *builtinCharSig) evalString(row types.Row) (string, bool, error) {
 	}
 	// The last argument represents the charset name after "using".
 	// Use default charset utf8 if it is nil.
-	argCharset, IsNull, err := b.args[len(b.args)-1].EvalString(row, sc)
+	argCharset, IsNull, err := b.args[len(b.args)-1].EvalString(b.ctx, row)
 	if err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1892,7 +1862,7 @@ type builtinCharLengthSig struct {
 // evalInt evals a builtinCharLengthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_char-length
 func (b *builtinCharLengthSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1922,14 +1892,12 @@ type builtinFindInSetSig struct {
 // TODO: This function can be optimized by using bit arithmetic when the first argument is
 // a constant string and the second is a column of type SET.
 func (b *builtinFindInSetSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	strlist, isNull, err := b.args[1].EvalString(row, sc)
+	strlist, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1992,13 +1960,12 @@ type builtinFieldIntSig struct {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldIntSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalInt(row, sc)
+	str, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, errors.Trace(err)
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalInt(row, sc)
+		stri, isNull, err := b.args[i].EvalInt(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -2016,13 +1983,12 @@ type builtinFieldRealSig struct {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldRealSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalReal(row, sc)
+	str, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, errors.Trace(err)
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalReal(row, sc)
+		stri, isNull, err := b.args[i].EvalReal(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -2040,13 +2006,12 @@ type builtinFieldStringSig struct {
 // evalInt evals FIELD(str,str1,str2,str3,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_field
 func (b *builtinFieldStringSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, err != nil, errors.Trace(err)
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
-		stri, isNull, err := b.args[i].EvalString(row, sc)
+		stri, isNull, err := b.args[i].EvalString(b.ctx, row)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -2061,10 +2026,10 @@ type makeSetFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *makeSetFunctionClass) getFlen(sc *stmtctx.StatementContext, args []Expression) int {
+func (c *makeSetFunctionClass) getFlen(ctx context.Context, args []Expression) int {
 	flen, count := 0, 0
 	if constant, ok := args[0].(*Constant); ok {
-		bits, isNull, err := constant.EvalInt(nil, sc)
+		bits, isNull, err := constant.EvalInt(ctx, nil)
 		if err == nil && !isNull {
 			for i, length := 1, len(args); i < length; i++ {
 				if (bits & (1 << uint(i-1))) != 0 {
@@ -2097,7 +2062,7 @@ func (c *makeSetFunctionClass) getFunction(ctx context.Context, args []Expressio
 	for i, length := 0, len(args); i < length; i++ {
 		SetBinFlagOrBinStr(args[i].GetType(), bf.tp)
 	}
-	bf.tp.Flen = c.getFlen(bf.ctx.GetSessionVars().StmtCtx, args)
+	bf.tp.Flen = c.getFlen(bf.ctx, args)
 	if bf.tp.Flen > mysql.MaxBlobWidth {
 		bf.tp.Flen = mysql.MaxBlobWidth
 	}
@@ -2112,9 +2077,7 @@ type builtinMakeSetSig struct {
 // evalString evals MAKE_SET(bits,str1,str2,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_make-set
 func (b *builtinMakeSetSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	bits, isNull, err := b.args[0].EvalInt(row, sc)
+	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2124,7 +2087,7 @@ func (b *builtinMakeSetSig) evalString(row types.Row) (string, bool, error) {
 		if (bits & (1 << uint(i-1))) == 0 {
 			continue
 		}
-		str, isNull, err := b.args[i].EvalString(row, sc)
+		str, isNull, err := b.args[i].EvalString(b.ctx, row)
 		if err != nil {
 			return "", true, errors.Trace(err)
 		}
@@ -2165,7 +2128,7 @@ type builtinOctIntSig struct {
 // evalString evals OCT(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_oct
 func (b *builtinOctIntSig) evalString(row types.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -2180,8 +2143,7 @@ type builtinOctStringSig struct {
 // // evalString evals OCT(N).
 // // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_oct
 func (b *builtinOctStringSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	val, isNull, err := b.args[0].EvalString(row, sc)
+	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -2230,7 +2192,7 @@ type builtinOrdSig struct {
 // evalInt evals a builtinOrdSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_ord
 func (b *builtinOrdSig) evalInt(row types.Row) (int64, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -2275,9 +2237,7 @@ type builtinQuoteSig struct {
 // evalString evals QUOTE(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_quote
 func (b *builtinQuoteSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2326,7 +2286,7 @@ type builtinBinSig struct {
 // evalString evals BIN(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_bin
 func (b *builtinBinSig) evalString(row types.Row) (string, bool, error) {
-	val, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2367,14 +2327,14 @@ type builtinEltSig struct {
 // evalString evals a builtinEltSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_elt
 func (b *builtinEltSig) evalString(row types.Row) (string, bool, error) {
-	idx, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	if idx < 1 || idx >= int64(len(b.args)) {
 		return "", true, nil
 	}
-	arg, isNull, err := b.args[idx].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[idx].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2434,19 +2394,17 @@ type builtinExportSet3ArgSig struct {
 // evalString evals EXPORT_SET(bits,on,off).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet3ArgSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	bits, isNull, err := b.args[0].EvalInt(row, sc)
+	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	on, isNull, err := b.args[1].EvalString(row, sc)
+	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	off, isNull, err := b.args[2].EvalString(row, sc)
+	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2461,24 +2419,22 @@ type builtinExportSet4ArgSig struct {
 // evalString evals EXPORT_SET(bits,on,off,separator).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet4ArgSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	bits, isNull, err := b.args[0].EvalInt(row, sc)
+	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	on, isNull, err := b.args[1].EvalString(row, sc)
+	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	off, isNull, err := b.args[2].EvalString(row, sc)
+	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	separator, isNull, err := b.args[3].EvalString(row, sc)
+	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2493,29 +2449,27 @@ type builtinExportSet5ArgSig struct {
 // evalString evals EXPORT_SET(bits,on,off,separator,number_of_bits).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_export-set
 func (b *builtinExportSet5ArgSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	bits, isNull, err := b.args[0].EvalInt(row, sc)
+	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	on, isNull, err := b.args[1].EvalString(row, sc)
+	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	off, isNull, err := b.args[2].EvalString(row, sc)
+	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	separator, isNull, err := b.args[3].EvalString(row, sc)
+	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	numberOfBits, isNull, err := b.args[4].EvalInt(row, sc)
+	numberOfBits, isNull, err := b.args[4].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2557,19 +2511,17 @@ type builtinFormatWithLocaleSig struct {
 // evalString evals FORMAT(X,D,locale).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_format
 func (b *builtinFormatWithLocaleSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	x, isNull, err := b.args[0].EvalString(row, sc)
+	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	d, isNull, err := b.args[1].EvalString(row, sc)
+	d, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	locale, isNull, err := b.args[2].EvalString(row, sc)
+	locale, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2585,14 +2537,12 @@ type builtinFormatSig struct {
 // evalString evals FORMAT(X,D).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_format
 func (b *builtinFormatSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	x, isNull, err := b.args[0].EvalString(row, sc)
+	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	d, isNull, err := b.args[1].EvalString(row, sc)
+	d, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2623,7 +2573,7 @@ type builtinFromBase64Sig struct {
 // evalString evals FROM_BASE64(str).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_from-base64
 func (b *builtinFromBase64Sig) evalString(row types.Row) (string, bool, error) {
-	str, isNull, err := b.args[0].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2681,8 +2631,7 @@ func base64NeededEncodedLength(n int) int {
 // evalString evals a builtinToBase64Sig.
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_to-base64
 func (b *builtinToBase64Sig) evalString(row types.Row) (d string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -2742,15 +2691,13 @@ type builtinInsertBinarySig struct {
 // evalString evals INSERT(str,pos,len,newstr).
 // See https://dev.mysql.com/doc/refman/5.6/en/string-functions.html#function_insert
 func (b *builtinInsertBinarySig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	strLength := int64(len(str))
 
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2758,12 +2705,12 @@ func (b *builtinInsertBinarySig) evalString(row types.Row) (string, bool, error)
 		return str, false, nil
 	}
 
-	length, isNull, err := b.args[2].EvalInt(row, sc)
+	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	newstr, isNull, err := b.args[3].EvalString(row, sc)
+	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2781,16 +2728,14 @@ type builtinInsertSig struct {
 // evalString evals INSERT(str,pos,len,newstr).
 // See https://dev.mysql.com/doc/refman/5.6/en/string-functions.html#function_insert
 func (b *builtinInsertSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, isNull, err := b.args[0].EvalString(row, sc)
+	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 	runes := []rune(str)
 	runeLength := int64(len(runes))
 
-	pos, isNull, err := b.args[1].EvalInt(row, sc)
+	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2798,12 +2743,12 @@ func (b *builtinInsertSig) evalString(row types.Row) (string, bool, error) {
 		return str, false, nil
 	}
 
-	length, isNull, err := b.args[2].EvalInt(row, sc)
+	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
 
-	newstr, isNull, err := b.args[3].EvalString(row, sc)
+	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2838,15 +2783,13 @@ type builtinInstrBinarySig struct{ baseBuiltinFunc }
 // evalInt evals INSTR(str,substr), case insensitive
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_instr
 func (b *builtinInstrSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, IsNull, err := b.args[0].EvalString(row, sc)
+	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
 	if IsNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
 	str = strings.ToLower(str)
 
-	substr, IsNull, err := b.args[1].EvalString(row, sc)
+	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
 	if IsNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -2862,14 +2805,12 @@ func (b *builtinInstrSig) evalInt(row types.Row) (int64, bool, error) {
 // evalInt evals INSTR(str,substr), case sensitive
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_instr
 func (b *builtinInstrBinarySig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	str, IsNull, err := b.args[0].EvalString(row, sc)
+	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
 	if IsNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
 
-	substr, IsNull, err := b.args[1].EvalString(row, sc)
+	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
 	if IsNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -258,9 +258,7 @@ type builtinDateSig struct {
 // evalTime evals DATE(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date
 func (b *builtinDateSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	expr, isNull, err := b.args[0].EvalTime(row, sc)
+	expr, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -312,7 +310,7 @@ type builtinDateLiteralSig struct {
 // evalTime evals DATE 'stringLit'.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-literals.html
 func (b *builtinDateLiteralSig) evalTime(row types.Row) (types.Time, bool, error) {
-	mode := b.getCtx().GetSessionVars().SQLMode
+	mode := b.ctx.GetSessionVars().SQLMode
 	if mode.HasNoZeroDateMode() && b.literal.IsZero() {
 		return b.literal, true, types.ErrIncorrectDatetimeValue.GenByArgs(b.literal.String())
 	}
@@ -342,12 +340,11 @@ type builtinDateDiffSig struct {
 // evalInt evals a builtinDateDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_datediff
 func (b *builtinDateDiffSig) evalInt(row types.Row) (int64, bool, error) {
-	ctx := b.ctx.GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalTime(row, ctx)
+	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
-	rhs, isNull, err := b.args[1].EvalTime(row, ctx)
+	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -430,18 +427,17 @@ type builtinDurationDurationTimeDiffSig struct {
 // evalDuration evals a builtinDurationDurationTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinDurationDurationTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalDuration(row, sc)
+	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhs, isNull, err := b.args[1].EvalDuration(row, sc)
+	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(sc, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
 	return d, isNull, errors.Trace(err)
 }
 
@@ -452,17 +448,17 @@ type builtinTimeTimeTimeDiffSig struct {
 // evalDuration evals a builtinTimeTimeTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinTimeTimeTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalTime(row, sc)
+	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhs, isNull, err := b.args[1].EvalTime(row, sc)
+	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	d, isNull, err = calculateTimeDiff(sc, lhs, rhs)
 	return d, isNull, errors.Trace(err)
 }
@@ -474,23 +470,23 @@ type builtinDurationStringTimeDiffSig struct {
 // evalDuration evals a builtinDurationStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinDurationStringTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalDuration(row, sc)
+	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhsStr, isNull, err := b.args[1].EvalString(row, sc)
+	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	rhs, _, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.Decimal)
 	if err != nil || !isDuration {
 		return d, true, errors.Trace(err)
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(sc, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
 	return d, isNull, errors.Trace(err)
 }
 
@@ -501,23 +497,23 @@ type builtinStringDurationTimeDiffSig struct {
 // evalDuration evals a builtinStringDurationTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringDurationTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhsStr, isNull, err := b.args[0].EvalString(row, sc)
+	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhs, isNull, err := b.args[1].EvalDuration(row, sc)
+	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	lhs, _, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.Decimal)
 	if err != nil || !isDuration {
 		return d, true, errors.Trace(err)
 	}
 
-	d, isNull, err = calculateDurationTimeDiff(sc, lhs, rhs)
+	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
 	return d, isNull, errors.Trace(err)
 }
 
@@ -532,7 +528,7 @@ func calculateTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Time) (d typ
 }
 
 // calculateTimeDiff calculates interval difference of two types.Duration.
-func calculateDurationTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Duration) (d types.Duration, isNull bool, err error) {
+func calculateDurationTimeDiff(ctx context.Context, lhs, rhs types.Duration) (d types.Duration, isNull bool, err error) {
 	d, err = lhs.Sub(rhs)
 	if err != nil {
 		return d, true, errors.Trace(err)
@@ -540,6 +536,7 @@ func calculateDurationTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Dura
 
 	d.Duration, err = types.TruncateOverflowMySQLTime(d.Duration)
 	if types.ErrTruncatedWrongVal.Equal(err) {
+		sc := ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 	}
 	return d, err != nil, errors.Trace(err)
@@ -552,17 +549,17 @@ type builtinTimeStringTimeDiffSig struct {
 // evalDuration evals a builtinTimeStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinTimeStringTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalTime(row, sc)
+	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhsStr, isNull, err := b.args[1].EvalString(row, sc)
+	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	_, rhs, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.Decimal)
 	if err != nil || isDuration {
 		return d, true, errors.Trace(err)
@@ -579,17 +576,17 @@ type builtinStringTimeTimeDiffSig struct {
 // evalDuration evals a builtinStringTimeTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringTimeTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhsStr, isNull, err := b.args[0].EvalString(row, sc)
+	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhs, isNull, err := b.args[1].EvalTime(row, sc)
+	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	_, lhs, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.Decimal)
 	if err != nil || isDuration {
 		return d, true, errors.Trace(err)
@@ -606,17 +603,17 @@ type builtinStringStringTimeDiffSig struct {
 // evalDuration evals a builtinStringStringTimeDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timediff
 func (b *builtinStringStringTimeDiffSig) evalDuration(row types.Row) (d types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	lhs, isNull, err := b.args[0].EvalString(row, sc)
+	lhs, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
-	rhs, isNull, err := b.args[1].EvalString(row, sc)
+	rhs, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return d, isNull, errors.Trace(err)
 	}
 
+	sc := b.ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.Decimal
 	lhsDur, lhsTime, lhsIsDuration, err := convertStringToDuration(sc, lhs, fsp)
 	if err != nil {
@@ -633,7 +630,7 @@ func (b *builtinStringStringTimeDiffSig) evalDuration(row types.Row) (d types.Du
 	}
 
 	if lhsIsDuration {
-		d, isNull, err = calculateDurationTimeDiff(sc, lhsDur, rhsDur)
+		d, isNull, err = calculateDurationTimeDiff(b.ctx, lhsDur, rhsDur)
 	} else {
 		d, isNull, err = calculateTimeDiff(sc, lhsTime, rhsTime)
 	}
@@ -687,15 +684,14 @@ type builtinDateFormatSig struct {
 // evalString evals a builtinDateFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format
 func (b *builtinDateFormatSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	t, isNull, err := b.args[0].EvalTime(row, sc)
+	t, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
 	if t.InvalidZero() {
 		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(t.String())))
 	}
-	formatMask, isNull, err := b.args[1].EvalString(row, sc)
+	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -725,9 +721,7 @@ type builtinFromDaysSig struct {
 // evalTime evals FROM_DAYS(N).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_from-days
 func (b *builtinFromDaysSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-
-	n, isNull, err := b.args[0].EvalInt(row, sc)
+	n, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -756,7 +750,7 @@ type builtinHourSig struct {
 // evalInt evals HOUR(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_hour
 func (b *builtinHourSig) evalInt(row types.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -785,7 +779,7 @@ type builtinMinuteSig struct {
 // evalInt evals MINUTE(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_minute
 func (b *builtinMinuteSig) evalInt(row types.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -814,7 +808,7 @@ type builtinSecondSig struct {
 // evalInt evals SECOND(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_second
 func (b *builtinSecondSig) evalInt(row types.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -843,7 +837,7 @@ type builtinMicroSecondSig struct {
 // evalInt evals MICROSECOND(expr).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_microsecond
 func (b *builtinMicroSecondSig) evalInt(row types.Row) (int64, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// ignore error and return NULL
 	if isNull || err != nil {
 		return 0, true, nil
@@ -872,8 +866,7 @@ type builtinMonthSig struct {
 // evalInt evals MONTH(date).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_month
 func (b *builtinMonthSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -906,8 +899,7 @@ type builtinMonthNameSig struct {
 }
 
 func (b *builtinMonthNameSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalTime(row, sc)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -941,7 +933,7 @@ type builtinDayNameSig struct {
 // evalString evals a builtinDayNameSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayname
 func (b *builtinDayNameSig) evalString(row types.Row) (string, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(row, b.ctx.GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -976,7 +968,7 @@ type builtinDayOfMonthSig struct {
 // evalInt evals a builtinDayOfMonthSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofmonth
 func (b *builtinDayOfMonthSig) evalInt(row types.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(row, b.ctx.GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1007,8 +999,7 @@ type builtinDayOfWeekSig struct {
 // evalInt evals a builtinDayOfWeekSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofweek
 func (b *builtinDayOfWeekSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalTime(row, sc)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1040,7 +1031,7 @@ type builtinDayOfYearSig struct {
 // evalInt evals a builtinDayOfYearSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_dayofyear
 func (b *builtinDayOfYearSig) evalInt(row types.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(row, b.ctx.GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1085,8 +1076,7 @@ type builtinWeekWithModeSig struct {
 // evalInt evals WEEK(date, mode).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_week
 func (b *builtinWeekWithModeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -1096,7 +1086,7 @@ func (b *builtinWeekWithModeSig) evalInt(row types.Row) (int64, bool, error) {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(date.String())))
 	}
 
-	mode, isNull, err := b.args[1].EvalInt(row, sc)
+	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -1112,8 +1102,7 @@ type builtinWeekWithoutModeSig struct {
 // evalInt evals WEEK(date).
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_week
 func (b *builtinWeekWithoutModeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -1149,9 +1138,7 @@ type builtinWeekDaySig struct {
 
 // evalInt evals WEEKDAY(date).
 func (b *builtinWeekDaySig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1184,8 +1171,7 @@ type builtinWeekOfYearSig struct {
 // evalInt evals WEEKOFYEAR(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_weekofyear
 func (b *builtinWeekOfYearSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -1220,8 +1206,7 @@ type builtinYearSig struct {
 // evalInt evals YEAR(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_year
 func (b *builtinYearSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -1267,9 +1252,7 @@ type builtinYearWeekWithModeSig struct {
 // evalInt evals YEARWEEK(date,mode).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithModeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1277,7 +1260,7 @@ func (b *builtinYearWeekWithModeSig) evalInt(row types.Row) (int64, bool, error)
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(date.String())))
 	}
 
-	mode, isNull, err := b.args[1].EvalInt(row, sc)
+	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -1300,9 +1283,7 @@ type builtinYearWeekWithoutModeSig struct {
 // evalInt evals YEARWEEK(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithoutModeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -1342,7 +1323,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx context.Context, args []Expr
 		if isArg0Str {
 			bf.tp.Decimal = types.MaxFsp
 		} else if isArg0Con {
-			arg0, _, err1 := args[0].EvalDecimal(nil, ctx.GetSessionVars().StmtCtx)
+			arg0, _, err1 := args[0].EvalDecimal(ctx, nil)
 			if err1 != nil {
 				return sig, errors.Trace(err1)
 			}
@@ -1361,8 +1342,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx context.Context, args []Expr
 }
 
 func evalFromUnixTime(ctx context.Context, fsp int, row types.Row, arg Expression) (res types.Time, isNull bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	unixTimeStamp, isNull, err := arg.EvalDecimal(row, sc)
+	unixTimeStamp, isNull, err := arg.EvalDecimal(ctx, row)
 	if err != nil || isNull {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1406,6 +1386,7 @@ func evalFromUnixTime(ctx context.Context, fsp int, row types.Row, arg Expressio
 		fsp = types.MaxFsp
 	}
 
+	sc := ctx.GetSessionVars().StmtCtx
 	tmp := time.Unix(integralPart, fractionalPart).In(sc.TimeZone)
 	t, err := convertTimeToMysqlTime(tmp, fsp)
 	if err != nil {
@@ -1431,8 +1412,7 @@ type builtinFromUnixTime2ArgSig struct {
 // evalString evals a builtinFromUnixTime2ArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_from-unixtime
 func (b *builtinFromUnixTime2ArgSig) evalString(row types.Row) (res string, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	format, isNull, err := b.args[1].EvalString(row, sc)
+	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -1465,12 +1445,11 @@ type builtinGetFormatSig struct {
 // evalString evals a builtinGetFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_get-format
 func (b *builtinGetFormatSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	t, isNull, err := b.args[0].EvalString(row, sc)
+	t, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	l, isNull, err := b.args[1].EvalString(row, sc)
+	l, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -1531,7 +1510,7 @@ func (c *strToDateFunctionClass) getRetTp(arg Expression, ctx context.Context) (
 		return tp, types.MaxFsp
 	}
 	strArg := WrapWithCastAsString(ctx, arg)
-	format, isNull, err := strArg.EvalString(nil, ctx.GetSessionVars().StmtCtx)
+	format, isNull, err := strArg.EvalString(ctx, nil)
 	if err != nil || isNull {
 		return
 	}
@@ -1583,16 +1562,16 @@ type builtinStrToDateDateSig struct {
 }
 
 func (b *builtinStrToDateDateSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalString(row, sc)
+	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
-	format, isNull, err := b.args[1].EvalString(row, sc)
+	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
 	var t types.Time
+	sc := b.ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc, date, format)
 	if !succ {
 		return types.Time{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(t.String()))
@@ -1606,16 +1585,16 @@ type builtinStrToDateDatetimeSig struct {
 }
 
 func (b *builtinStrToDateDatetimeSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalString(row, sc)
+	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
-	format, isNull, err := b.args[1].EvalString(row, sc)
+	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
 	var t types.Time
+	sc := b.ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc, date, format)
 	if !succ {
 		return types.Time{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(t.String()))
@@ -1631,16 +1610,16 @@ type builtinStrToDateDurationSig struct {
 // TODO: If the NO_ZERO_DATE or NO_ZERO_IN_DATE SQL mode is enabled, zero dates or part of dates are disallowed.
 // In that case, STR_TO_DATE() returns NULL and generates a warning.
 func (b *builtinStrToDateDurationSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	date, isNull, err := b.args[0].EvalString(row, sc)
+	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, errors.Trace(err)
 	}
-	format, isNull, err := b.args[1].EvalString(row, sc)
+	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, errors.Trace(err)
 	}
 	var t types.Time
+	sc := b.ctx.GetSessionVars().StmtCtx
 	succ := t.StrToDate(sc, date, format)
 	if !succ {
 		return types.Duration{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenByArgs(t.String()))
@@ -1681,9 +1660,7 @@ type builtinSysDateWithFspSig struct {
 // evalTime evals SYSDATE(fsp).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sysdate
 func (b *builtinSysDateWithFspSig) evalTime(row types.Row) (d types.Time, isNull bool, err error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	fsp, isNull, err := b.args[0].EvalInt(row, sc)
+	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
@@ -1762,7 +1739,7 @@ func (c *currentTimeFunctionClass) getFunction(ctx context.Context, args []Expre
 	_, ok := args[0].(*Constant)
 	fsp := int64(types.MaxFsp)
 	if ok {
-		fsp, _, err = args[0].EvalInt(nil, ctx.GetSessionVars().StmtCtx)
+		fsp, _, err = args[0].EvalInt(ctx, nil)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1797,8 +1774,7 @@ type builtinCurrentTime1ArgSig struct {
 }
 
 func (b *builtinCurrentTime1ArgSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	fsp, _, err := b.args[0].EvalInt(row, sc)
+	fsp, _, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
 	}
@@ -1831,8 +1807,7 @@ type builtinTimeSig struct {
 // evalDuration evals a builtinTimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time.
 func (b *builtinTimeSig) evalDuration(row types.Row) (res types.Duration, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	expr, isNull, err := b.args[0].EvalString(row, sc)
+	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -1848,6 +1823,7 @@ func (b *builtinTimeSig) evalDuration(row types.Row) (res types.Duration, isNull
 
 	res, err = types.ParseDuration(expr, fsp)
 	if types.ErrTruncatedWrongVal.Equal(err) {
+		sc := b.ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 	}
 	return res, isNull, errors.Trace(err)
@@ -1930,9 +1906,9 @@ type utcTimestampFunctionClass struct {
 	baseFunctionClass
 }
 
-func getFlenAndDecimal4UTCTimestampAndNow(sc *stmtctx.StatementContext, arg Expression) (flen, decimal int) {
+func getFlenAndDecimal4UTCTimestampAndNow(ctx context.Context, arg Expression) (flen, decimal int) {
 	if constant, ok := arg.(*Constant); ok {
-		fsp, isNull, err := constant.EvalInt(nil, sc)
+		fsp, isNull, err := constant.EvalInt(ctx, nil)
 		if isNull || err != nil || fsp > int64(types.MaxFsp) {
 			decimal = types.MaxFsp
 		} else if fsp < int64(types.MinFsp) {
@@ -1960,7 +1936,7 @@ func (c *utcTimestampFunctionClass) getFunction(ctx context.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, argTps...)
 
 	if len(args) == 1 {
-		bf.tp.Flen, bf.tp.Decimal = getFlenAndDecimal4UTCTimestampAndNow(bf.ctx.GetSessionVars().StmtCtx, args[0])
+		bf.tp.Flen, bf.tp.Decimal = getFlenAndDecimal4UTCTimestampAndNow(bf.ctx, args[0])
 	} else {
 		bf.tp.Flen, bf.tp.Decimal = 19, 0
 	}
@@ -1989,7 +1965,7 @@ type builtinUTCTimestampWithArgSig struct {
 // evalTime evals UTC_TIMESTAMP(fsp).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithArgSig) evalTime(row types.Row) (types.Time, bool, error) {
-	num, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	num, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2031,7 +2007,7 @@ func (c *nowFunctionClass) getFunction(ctx context.Context, args []Expression) (
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, argTps...)
 
 	if len(args) == 1 {
-		bf.tp.Flen, bf.tp.Decimal = getFlenAndDecimal4UTCTimestampAndNow(bf.ctx.GetSessionVars().StmtCtx, args[0])
+		bf.tp.Flen, bf.tp.Decimal = getFlenAndDecimal4UTCTimestampAndNow(bf.ctx, args[0])
 	} else {
 		bf.tp.Flen, bf.tp.Decimal = 19, 0
 	}
@@ -2071,7 +2047,7 @@ type builtinNowWithArgSig struct {
 // evalTime evals NOW(fsp)
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_now
 func (b *builtinNowWithArgSig) evalTime(row types.Row) (types.Time, bool, error) {
-	fsp, isNull, err := b.args[0].EvalInt(row, b.ctx.GetSessionVars().StmtCtx)
+	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
@@ -2124,7 +2100,7 @@ func (c *extractFunctionClass) getFunction(ctx context.Context, args []Expressio
 	isDatetimeUnit := true
 	args[0] = WrapWithCastAsString(ctx, args[0])
 	if _, isCon := args[0].(*Constant); isCon {
-		unit, _, err1 := args[0].EvalString(nil, ctx.GetSessionVars().StmtCtx)
+		unit, _, err1 := args[0].EvalString(ctx, nil)
 		if err1 != nil {
 			return nil, errors.Trace(err1)
 		}
@@ -2148,12 +2124,11 @@ type builtinExtractDatetimeSig struct {
 // evalInt evals a builtinExtractDatetimeSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 func (b *builtinExtractDatetimeSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	unit, isNull, err := b.args[0].EvalString(row, sc)
+	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	dt, isNull, err := b.args[1].EvalTime(row, sc)
+	dt, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -2168,12 +2143,11 @@ type builtinExtractDurationSig struct {
 // evalInt evals a builtinExtractDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_extract
 func (b *builtinExtractDurationSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	unit, isNull, err := b.args[0].EvalString(row, sc)
+	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	dur, isNull, err := b.args[1].EvalDuration(row, sc)
+	dur, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -2195,8 +2169,7 @@ func newDateArighmeticalUtil() baseDateArithmitical {
 }
 
 func (du *baseDateArithmitical) getDateFromString(ctx context.Context, args []Expression, row types.Row, unit string) (types.Time, bool, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	dateStr, isNull, err := args[0].EvalString(row, sc)
+	dateStr, isNull, err := args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2206,17 +2179,18 @@ func (du *baseDateArithmitical) getDateFromString(ctx context.Context, args []Ex
 		dateTp = mysql.TypeDatetime
 	}
 
+	sc := ctx.GetSessionVars().StmtCtx
 	date, err := types.ParseTime(sc, dateStr, dateTp, types.MaxFsp)
 	return date, err != nil, errors.Trace(handleInvalidTimeError(ctx, err))
 }
 
 func (du *baseDateArithmitical) getDateFromInt(ctx context.Context, args []Expression, row types.Row, unit string) (types.Time, bool, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	dateInt, isNull, err := args[0].EvalInt(row, sc)
+	dateInt, isNull, err := args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
 
+	sc := ctx.GetSessionVars().StmtCtx
 	date, err := types.ParseTimeFromInt64(sc, dateInt)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(handleInvalidTimeError(ctx, err))
@@ -2231,7 +2205,7 @@ func (du *baseDateArithmitical) getDateFromInt(ctx context.Context, args []Expre
 }
 
 func (du *baseDateArithmitical) getDateFromDatetime(ctx context.Context, args []Expression, row types.Row, unit string) (types.Time, bool, error) {
-	date, isNull, err := args[0].EvalTime(row, ctx.GetSessionVars().StmtCtx)
+	date, isNull, err := args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2245,7 +2219,7 @@ func (du *baseDateArithmitical) getDateFromDatetime(ctx context.Context, args []
 }
 
 func (du *baseDateArithmitical) getIntervalFromString(ctx context.Context, args []Expression, row types.Row, unit string) (string, bool, error) {
-	interval, isNull, err := args[1].EvalString(row, ctx.GetSessionVars().StmtCtx)
+	interval, isNull, err := args[1].EvalString(ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2263,7 +2237,7 @@ func (du *baseDateArithmitical) getIntervalFromString(ctx context.Context, args 
 }
 
 func (du *baseDateArithmitical) getIntervalFromInt(ctx context.Context, args []Expression, row types.Row, unit string) (string, bool, error) {
-	interval, isNull, err := args[1].EvalInt(row, ctx.GetSessionVars().StmtCtx)
+	interval, isNull, err := args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
 		return "", true, errors.Trace(err)
 	}
@@ -2381,9 +2355,7 @@ type builtinAddDateStringStringSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateStringStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2410,9 +2382,7 @@ type builtinAddDateStringIntSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateStringIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2439,9 +2409,7 @@ type builtinAddDateIntStringSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateIntStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2468,9 +2436,7 @@ type builtinAddDateIntIntSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateIntIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2497,9 +2463,7 @@ type builtinAddDateDatetimeStringSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateDatetimeStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2526,9 +2490,7 @@ type builtinAddDateDatetimeIntSig struct {
 // evalTime evals ADDDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_adddate
 func (b *builtinAddDateDatetimeIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2613,9 +2575,7 @@ type builtinSubDateStringStringSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateStringStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2642,9 +2602,7 @@ type builtinSubDateStringIntSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateStringIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2671,9 +2629,7 @@ type builtinSubDateIntStringSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateIntStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2700,9 +2656,7 @@ type builtinSubDateIntIntSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateIntIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2729,9 +2683,7 @@ type builtinSubDateDatetimeStringSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateDatetimeStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2758,9 +2710,7 @@ type builtinSubDateDatetimeIntSig struct {
 // evalTime evals SUBDATE(date,INTERVAL expr unit).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subdate
 func (b *builtinSubDateDatetimeIntSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	unit, isNull, err := b.args[2].EvalString(row, sc)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -2799,18 +2749,17 @@ type builtinTimestampDiffSig struct {
 // evalInt evals a builtinTimestampDiffSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampdiff
 func (b *builtinTimestampDiffSig) evalInt(row types.Row) (int64, bool, error) {
-	ctx := b.getCtx().GetSessionVars().StmtCtx
-	unit, isNull, err := b.args[0].EvalString(row, ctx)
+	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
-	lhs, isNull, err := b.args[1].EvalTime(row, ctx)
+	lhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.getCtx(), err))
+		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
-	rhs, isNull, err := b.args[2].EvalTime(row, ctx)
+	rhs, isNull, err := b.args[2].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.getCtx(), err))
+		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
 	if invalidLHS, invalidRHS := lhs.InvalidZero(), rhs.InvalidZero(); invalidLHS || invalidRHS {
 		if invalidLHS {
@@ -2924,7 +2873,7 @@ type builtinUnixTimestampIntSig struct {
 // evalInt evals a UNIX_TIMESTAMP(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampIntSig) evalInt(row types.Row) (int64, bool, error) {
-	val, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if err != nil && terror.ErrorEqual(types.ErrInvalidTimeFormat, err) {
 		// Return 0 for invalid date time.
 		return 0, false, nil
@@ -2932,7 +2881,7 @@ func (b *builtinUnixTimestampIntSig) evalInt(row types.Row) (int64, bool, error)
 	if isNull {
 		return 0, true, nil
 	}
-	t, err := val.Time.GoTime(getTimeZone(b.getCtx()))
+	t, err := val.Time.GoTime(getTimeZone(b.ctx))
 	if err != nil {
 		return 0, false, nil
 	}
@@ -2952,12 +2901,12 @@ type builtinUnixTimestampDecSig struct {
 // evalDecimal evals a UNIX_TIMESTAMP(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
-	val, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		// Return 0 for invalid date time.
 		return new(types.MyDecimal), isNull, nil
 	}
-	t, err := val.Time.GoTime(getTimeZone(b.getCtx()))
+	t, err := val.Time.GoTime(getTimeZone(b.ctx))
 	if err != nil {
 		return new(types.MyDecimal), false, nil
 	}
@@ -3028,12 +2977,12 @@ type builtinTimestamp1ArgSig struct {
 // evalTime evals a builtinTimestamp1ArgSig.
 // See https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_timestamp
 func (b *builtinTimestamp1ArgSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	s, isNull, err := b.args[0].EvalString(row, sc)
+	s, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
 	var tm types.Time
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if b.isFloat {
 		tm, err = types.ParseTimeFromFloatString(sc, s, mysql.TypeDatetime, getFsp(s))
 	} else {
@@ -3054,12 +3003,12 @@ type builtinTimestamp2ArgsSig struct {
 // evalTime evals a builtinTimestamp2ArgsSig.
 // See https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_timestamp
 func (b *builtinTimestamp2ArgsSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalString(row, sc)
+	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
 	var tm types.Time
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if b.isFloat {
 		tm, err = types.ParseTimeFromFloatString(sc, arg0, mysql.TypeDatetime, getFsp(arg0))
 	} else {
@@ -3068,7 +3017,7 @@ func (b *builtinTimestamp2ArgsSig) evalTime(row types.Row) (types.Time, bool, er
 	if err != nil {
 		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
-	arg1, isNull, err := b.args[1].EvalString(row, sc)
+	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, isNull, errors.Trace(err)
 	}
@@ -3343,12 +3292,11 @@ type builtinAddDatetimeAndDurationSig struct {
 // evalTime evals a builtinAddDatetimeAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDatetimeAndDurationSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalTime(row, sc)
+	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
@@ -3363,12 +3311,11 @@ type builtinAddDatetimeAndStringSig struct {
 // evalTime evals a builtinAddDatetimeAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDatetimeAndStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalTime(row, sc)
+	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
@@ -3400,12 +3347,11 @@ type builtinAddDurationAndDurationSig struct {
 // evalDuration evals a builtinAddDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDurationAndDurationSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
@@ -3423,12 +3369,11 @@ type builtinAddDurationAndStringSig struct {
 // evalDuration evals a builtinAddDurationAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDurationAndStringSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
@@ -3463,19 +3408,19 @@ type builtinAddStringAndDurationSig struct {
 // evalString evals a builtinAddStringAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddStringAndDurationSig) evalString(row types.Row) (result string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	var (
 		arg0 string
 		arg1 types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(row, sc)
+	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg1, isNull, err = b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)
 		if err != nil {
@@ -3494,16 +3439,15 @@ type builtinAddStringAndStringSig struct {
 // evalString evals a builtinAddStringAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddStringAndStringSig) evalString(row types.Row) (result string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	var (
 		arg0, arg1Str string
 		arg1          types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(row, sc)
+	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg1Str, isNull, err = b.args[1].EvalString(row, sc)
+	arg1Str, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -3511,6 +3455,7 @@ func (b *builtinAddStringAndStringSig) evalString(row types.Row) (result string,
 	if err != nil {
 		return "", true, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)
 		if err != nil {
@@ -3529,12 +3474,11 @@ type builtinAddDateAndDurationSig struct {
 // evalString evals a builtinAddDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDateAndDurationSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -3549,12 +3493,11 @@ type builtinAddDateAndStringSig struct {
 // evalString evals a builtinAddDateAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_addtime
 func (b *builtinAddDateAndStringSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -3582,7 +3525,7 @@ func (c *convertTzFunctionClass) getDecimal(ctx context.Context, arg Expression)
 		case types.ETReal, types.ETDecimal:
 			decimal = arg.GetType().Decimal
 		case types.ETString:
-			str, isNull, err := dt.EvalString(nil, ctx.GetSessionVars().StmtCtx)
+			str, isNull, err := dt.EvalString(ctx, nil)
 			if err == nil && !isNull {
 				decimal = types.DateFSP(str)
 			}
@@ -3625,19 +3568,17 @@ type builtinConvertTzSig struct {
 // evalTime evals CONVERT_TZ(dt,from_tz,to_tz).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_convert-tz
 func (b *builtinConvertTzSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	dt, isNull, err := b.args[0].EvalTime(row, sc)
+	dt, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
 
-	fromTzStr, isNull, err := b.args[1].EvalString(row, sc)
+	fromTzStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
 
-	toTzStr, isNull, err := b.args[2].EvalString(row, sc)
+	toTzStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -3705,13 +3646,12 @@ type builtinMakeDateSig struct {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_makedate
 func (b *builtinMakeDateSig) evalTime(row types.Row) (d types.Time, isNull bool, err error) {
 	args := b.getArgs()
-	sc := b.ctx.GetSessionVars().StmtCtx
 	var year, dayOfYear int64
-	year, isNull, err = args[0].EvalInt(row, sc)
+	year, isNull, err = args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return d, true, errors.Trace(err)
 	}
-	dayOfYear, isNull, err = args[1].EvalInt(row, sc)
+	dayOfYear, isNull, err = args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return d, true, errors.Trace(err)
 	}
@@ -3774,20 +3714,20 @@ type builtinMakeTimeSig struct {
 // evalDuration evals a builtinMakeTimeIntSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_maketime
 func (b *builtinMakeTimeSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc, dur := b.ctx.GetSessionVars().StmtCtx, types.ZeroDuration
+	dur := types.ZeroDuration
 	dur.Fsp = types.MaxFsp
-	hour, isNull, err := b.args[0].EvalInt(row, sc)
+	hour, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
-	minute, isNull, err := b.args[1].EvalInt(row, sc)
+	minute, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
 	if minute < 0 || minute >= 60 {
 		return dur, true, nil
 	}
-	second, isNull, err := b.args[2].EvalReal(row, sc)
+	second, isNull, err := b.args[2].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return dur, isNull, errors.Trace(err)
 	}
@@ -3876,9 +3816,7 @@ type builtinPeriodAddSig struct {
 // evalInt evals PERIOD_ADD(P,N).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-add
 func (b *builtinPeriodAddSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	p, isNull, err := b.args[0].EvalInt(row, sc)
+	p, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -3887,7 +3825,7 @@ func (b *builtinPeriodAddSig) evalInt(row types.Row) (int64, bool, error) {
 		return 0, false, nil
 	}
 
-	n, isNull, err := b.args[1].EvalInt(row, sc)
+	n, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -3917,14 +3855,12 @@ type builtinPeriodDiffSig struct {
 // evalInt evals PERIOD_DIFF(P1,P2).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_period-diff
 func (b *builtinPeriodDiffSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	p1, isNull, err := b.args[0].EvalInt(row, sc)
+	p1, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
 
-	p2, isNull, err := b.args[1].EvalInt(row, sc)
+	p2, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -3955,9 +3891,7 @@ type builtinQuarterSig struct {
 // evalInt evals QUARTER(date).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_quarter
 func (b *builtinQuarterSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-
-	date, isNull, err := b.args[0].EvalTime(row, sc)
+	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -4007,8 +3941,7 @@ type builtinSecToTimeSig struct {
 // evalDuration evals SEC_TO_TIME(seconds).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sec-to-time
 func (b *builtinSecToTimeSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	secondsFloat, isNull, err := b.args[0].EvalReal(row, sc)
+	secondsFloat, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, errors.Trace(err)
 	}
@@ -4104,12 +4037,11 @@ type builtinSubDatetimeAndDurationSig struct {
 // evalTime evals a builtinSubDatetimeAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDatetimeAndDurationSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalTime(row, sc)
+	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
@@ -4117,6 +4049,7 @@ func (b *builtinSubDatetimeAndDurationSig) evalTime(row types.Row) (types.Time, 
 	if err != nil {
 		return arg1time, true, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	tmpDuration := arg0.Sub(sc, &arg1time)
 	result, err := tmpDuration.ConvertToTime(arg0.Type)
 	return result, err != nil, errors.Trace(err)
@@ -4129,12 +4062,11 @@ type builtinSubDatetimeAndStringSig struct {
 // evalTime evals a builtinSubDatetimeAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDatetimeAndStringSig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalTime(row, sc)
+	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDatetime, isNull, errors.Trace(err)
 	}
@@ -4152,6 +4084,7 @@ func (b *builtinSubDatetimeAndStringSig) evalTime(row types.Row) (types.Time, bo
 	if err != nil {
 		return types.ZeroDatetime, true, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	tmpDuration := arg0.Sub(sc, &arg1time)
 	result, err := tmpDuration.ConvertToTime(mysql.TypeDatetime)
 	return result, err != nil, errors.Trace(err)
@@ -4174,19 +4107,19 @@ type builtinSubStringAndDurationSig struct {
 // evalString evals a builtinSubStringAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubStringAndDurationSig) evalString(row types.Row) (result string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	var (
 		arg0 string
 		arg1 types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(row, sc)
+	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg1, isNull, err = b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationSubDuration(sc, arg0, arg1)
 		if err != nil {
@@ -4205,16 +4138,15 @@ type builtinSubStringAndStringSig struct {
 // evalString evals a builtinAddStringAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubStringAndStringSig) evalString(row types.Row) (result string, isNull bool, err error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
 	var (
 		s, arg0 string
 		arg1    types.Duration
 	)
-	arg0, isNull, err = b.args[0].EvalString(row, sc)
+	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	s, isNull, err = b.args[1].EvalString(row, sc)
+	s, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -4222,6 +4154,7 @@ func (b *builtinSubStringAndStringSig) evalString(row types.Row) (result string,
 	if err != nil {
 		return "", true, errors.Trace(err)
 	}
+	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationSubDuration(sc, arg0, arg1)
 		if err != nil {
@@ -4250,12 +4183,11 @@ type builtinSubDurationAndDurationSig struct {
 // evalDuration evals a builtinAddDurationAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDurationAndDurationSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
@@ -4273,12 +4205,11 @@ type builtinSubDurationAndStringSig struct {
 // evalDuration evals a builtinAddDurationAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDurationAndStringSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return types.ZeroDuration, isNull, errors.Trace(err)
 	}
@@ -4310,12 +4241,11 @@ type builtinSubDateAndDurationSig struct {
 // evalString evals a builtinAddDateAndDurationSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDateAndDurationSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg1, isNull, err := b.args[1].EvalDuration(row, sc)
+	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -4330,12 +4260,11 @@ type builtinSubDateAndStringSig struct {
 // evalString evals a builtinAddDateAndStringSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_subtime
 func (b *builtinSubDateAndStringSig) evalString(row types.Row) (string, bool, error) {
-	sc := b.getCtx().GetSessionVars().StmtCtx
-	arg0, isNull, err := b.args[0].EvalDuration(row, sc)
+	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	s, isNull, err := b.args[1].EvalString(row, sc)
+	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -4375,7 +4304,7 @@ type builtinTimeFormatSig struct {
 // evalString evals a builtinTimeFormatSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-format
 func (b *builtinTimeFormatSig) evalString(row types.Row) (string, bool, error) {
-	dur, isNull, err := b.args[0].EvalDuration(row, b.ctx.GetSessionVars().StmtCtx)
+	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// if err != nil, then dur is ZeroDuration, outputs 00:00:00 in this case which follows the behavior of mysql.
 	if err != nil {
 		log.Warnf("Expression.EvalDuration() in time_format() failed, due to %s", err.Error())
@@ -4383,7 +4312,7 @@ func (b *builtinTimeFormatSig) evalString(row types.Row) (string, bool, error) {
 	if isNull {
 		return "", isNull, errors.Trace(err)
 	}
-	formatMask, isNull, err := b.args[1].EvalString(row, b.ctx.GetSessionVars().StmtCtx)
+	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if err != nil || isNull {
 		return "", isNull, errors.Trace(err)
 	}
@@ -4422,8 +4351,7 @@ type builtinTimeToSecSig struct {
 // evalInt evals TIME_TO_SEC(time).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-to-sec
 func (b *builtinTimeToSecSig) evalInt(row types.Row) (int64, bool, error) {
-	ctx := b.getCtx().GetSessionVars().StmtCtx
-	duration, isNull, err := b.args[0].EvalDuration(row, ctx)
+	duration, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, errors.Trace(err)
 	}
@@ -4458,16 +4386,15 @@ type builtinTimestampAddSig struct {
 // evalString evals a builtinTimestampAddSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_timestampadd
 func (b *builtinTimestampAddSig) evalString(row types.Row) (string, bool, error) {
-	ctx := b.getCtx().GetSessionVars().StmtCtx
-	unit, isNull, err := b.args[0].EvalString(row, ctx)
+	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	v, isNull, err := b.args[1].EvalInt(row, ctx)
+	v, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
-	arg, isNull, err := b.args[2].EvalTime(row, ctx)
+	arg, isNull, err := b.args[2].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return "", isNull, errors.Trace(err)
 	}
@@ -4527,8 +4454,7 @@ type builtinToDaysSig struct {
 // evalInt evals a builtinToDaysSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-days
 func (b *builtinToDaysSig) evalInt(row types.Row) (int64, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalTime(row, sc)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
@@ -4560,7 +4486,7 @@ type builtinToSecondsSig struct {
 // evalInt evals a builtinToSecondsSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_to-seconds
 func (b *builtinToSecondsSig) evalInt(row types.Row) (int64, bool, error) {
-	arg, isNull, err := b.args[0].EvalTime(row, b.getCtx().GetSessionVars().StmtCtx)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}
@@ -4575,13 +4501,13 @@ type utcTimeFunctionClass struct {
 	baseFunctionClass
 }
 
-func (c *utcTimeFunctionClass) getFlenAndDecimal4UTCTime(sc *stmtctx.StatementContext, args []Expression) (flen, decimal int) {
+func (c *utcTimeFunctionClass) getFlenAndDecimal4UTCTime(ctx context.Context, args []Expression) (flen, decimal int) {
 	if len(args) == 0 {
 		flen, decimal = 8, 0
 		return
 	}
 	if constant, ok := args[0].(*Constant); ok {
-		fsp, isNull, err := constant.EvalInt(nil, sc)
+		fsp, isNull, err := constant.EvalInt(ctx, nil)
 		if isNull || err != nil || fsp > int64(types.MaxFsp) {
 			decimal = types.MaxFsp
 		} else if fsp < int64(types.MinFsp) {
@@ -4607,7 +4533,7 @@ func (c *utcTimeFunctionClass) getFunction(ctx context.Context, args []Expressio
 		argTps = append(argTps, types.ETInt)
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, argTps...)
-	bf.tp.Flen, bf.tp.Decimal = c.getFlenAndDecimal4UTCTime(bf.ctx.GetSessionVars().StmtCtx, args)
+	bf.tp.Flen, bf.tp.Decimal = c.getFlenAndDecimal4UTCTime(bf.ctx, args)
 
 	var sig builtinFunc
 	if len(args) == 1 {
@@ -4636,8 +4562,7 @@ type builtinUTCTimeWithArgSig struct {
 // evalDuration evals a builtinUTCTimeWithArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithArgSig) evalDuration(row types.Row) (types.Duration, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	fsp, isNull, err := b.args[0].EvalInt(row, sc)
+	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
 		return types.Duration{}, isNull, errors.Trace(err)
 	}
@@ -4672,8 +4597,7 @@ type builtinLastDaySig struct {
 // evalTime evals a builtinLastDaySig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_last-day
 func (b *builtinLastDaySig) evalTime(row types.Row) (types.Time, bool, error) {
-	sc := b.ctx.GetSessionVars().StmtCtx
-	arg, isNull, err := b.args[0].EvalTime(row, sc)
+	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
 	}

--- a/expression/chunk_executor.go
+++ b/expression/chunk_executor.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -54,9 +53,8 @@ func hasUnVectorizableFunc(expr Expression) bool {
 
 // VectorizedExecute evaluates a list of expressions column by column and append their results to "output" Chunk.
 func VectorizedExecute(ctx context.Context, exprs []Expression, input, output *chunk.Chunk) error {
-	sc := ctx.GetSessionVars().StmtCtx
 	for colID, expr := range exprs {
-		err := evalOneColumn(sc, expr, input, output, colID)
+		err := evalOneColumn(ctx, expr, input, output, colID)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -64,35 +62,35 @@ func VectorizedExecute(ctx context.Context, exprs []Expression, input, output *c
 	return nil
 }
 
-func evalOneColumn(sc *stmtctx.StatementContext, expr Expression, input, output *chunk.Chunk, colID int) (err error) {
+func evalOneColumn(ctx context.Context, expr Expression, input, output *chunk.Chunk, colID int) (err error) {
 	switch fieldType, evalType := expr.GetType(), expr.GetType().EvalType(); evalType {
 	case types.ETInt:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToInt(sc, expr, fieldType, row, output, colID)
+			err = executeToInt(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETReal:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToReal(sc, expr, fieldType, row, output, colID)
+			err = executeToReal(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETDecimal:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToDecimal(sc, expr, fieldType, row, output, colID)
+			err = executeToDecimal(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETDatetime, types.ETTimestamp:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToDatetime(sc, expr, fieldType, row, output, colID)
+			err = executeToDatetime(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETDuration:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToDuration(sc, expr, fieldType, row, output, colID)
+			err = executeToDuration(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETJson:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToJSON(sc, expr, fieldType, row, output, colID)
+			err = executeToJSON(ctx, expr, fieldType, row, output, colID)
 		}
 	case types.ETString:
 		for row := input.Begin(); err == nil && row != input.End(); row = row.Next() {
-			err = executeToString(sc, expr, fieldType, row, output, colID)
+			err = executeToString(ctx, expr, fieldType, row, output, colID)
 		}
 	}
 	return errors.Trace(err)
@@ -100,10 +98,9 @@ func evalOneColumn(sc *stmtctx.StatementContext, expr Expression, input, output 
 
 // UnVectorizedExecute evaluates a list of expressions row by row and append their results to "output" Chunk.
 func UnVectorizedExecute(ctx context.Context, exprs []Expression, input, output *chunk.Chunk) error {
-	sc := ctx.GetSessionVars().StmtCtx
 	for row := input.Begin(); row != input.End(); row = row.Next() {
 		for colID, expr := range exprs {
-			err := evalOneCell(sc, expr, row, output, colID)
+			err := evalOneCell(ctx, expr, row, output, colID)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -112,28 +109,28 @@ func UnVectorizedExecute(ctx context.Context, exprs []Expression, input, output 
 	return nil
 }
 
-func evalOneCell(sc *stmtctx.StatementContext, expr Expression, row chunk.Row, output *chunk.Chunk, colID int) (err error) {
+func evalOneCell(ctx context.Context, expr Expression, row chunk.Row, output *chunk.Chunk, colID int) (err error) {
 	switch fieldType, evalType := expr.GetType(), expr.GetType().EvalType(); evalType {
 	case types.ETInt:
-		err = executeToInt(sc, expr, fieldType, row, output, colID)
+		err = executeToInt(ctx, expr, fieldType, row, output, colID)
 	case types.ETReal:
-		err = executeToReal(sc, expr, fieldType, row, output, colID)
+		err = executeToReal(ctx, expr, fieldType, row, output, colID)
 	case types.ETDecimal:
-		err = executeToDecimal(sc, expr, fieldType, row, output, colID)
+		err = executeToDecimal(ctx, expr, fieldType, row, output, colID)
 	case types.ETDatetime, types.ETTimestamp:
-		err = executeToDatetime(sc, expr, fieldType, row, output, colID)
+		err = executeToDatetime(ctx, expr, fieldType, row, output, colID)
 	case types.ETDuration:
-		err = executeToDuration(sc, expr, fieldType, row, output, colID)
+		err = executeToDuration(ctx, expr, fieldType, row, output, colID)
 	case types.ETJson:
-		err = executeToJSON(sc, expr, fieldType, row, output, colID)
+		err = executeToJSON(ctx, expr, fieldType, row, output, colID)
 	case types.ETString:
-		err = executeToString(sc, expr, fieldType, row, output, colID)
+		err = executeToString(ctx, expr, fieldType, row, output, colID)
 	}
 	return errors.Trace(err)
 }
 
-func executeToInt(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalInt(row, sc)
+func executeToInt(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalInt(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -149,8 +146,8 @@ func executeToInt(sc *stmtctx.StatementContext, expr Expression, fieldType *type
 	return nil
 }
 
-func executeToReal(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalReal(row, sc)
+func executeToReal(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalReal(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -164,8 +161,8 @@ func executeToReal(sc *stmtctx.StatementContext, expr Expression, fieldType *typ
 	return nil
 }
 
-func executeToDecimal(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalDecimal(row, sc)
+func executeToDecimal(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalDecimal(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -177,8 +174,8 @@ func executeToDecimal(sc *stmtctx.StatementContext, expr Expression, fieldType *
 	return nil
 }
 
-func executeToDatetime(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalTime(row, sc)
+func executeToDatetime(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalTime(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -190,8 +187,8 @@ func executeToDatetime(sc *stmtctx.StatementContext, expr Expression, fieldType 
 	return nil
 }
 
-func executeToDuration(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalDuration(row, sc)
+func executeToDuration(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalDuration(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -203,8 +200,8 @@ func executeToDuration(sc *stmtctx.StatementContext, expr Expression, fieldType 
 	return nil
 }
 
-func executeToJSON(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalJSON(row, sc)
+func executeToJSON(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalJSON(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -216,8 +213,8 @@ func executeToJSON(sc *stmtctx.StatementContext, expr Expression, fieldType *typ
 	return nil
 }
 
-func executeToString(sc *stmtctx.StatementContext, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
-	res, isNull, err := expr.EvalString(row, sc)
+func executeToString(ctx context.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
+	res, isNull, err := expr.EvalString(ctx, row)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -253,7 +250,7 @@ func VectorizedFilter(ctx context.Context, filters []Expression, input *chunk.Ch
 				continue
 			}
 			if isIntType {
-				filterResult, isNull, err := filter.EvalInt(row, ctx.GetSessionVars().StmtCtx)
+				filterResult, isNull, err := filter.EvalInt(ctx, row)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -24,8 +24,6 @@ import (
 func (s *testEvaluatorSuite) TestColumn(c *C) {
 	defer testleak.AfterTest(c)()
 
-	sc := s.ctx.GetSessionVars().StmtCtx
-
 	col := &Column{RetType: types.NewFieldType(mysql.TypeLonglong), FromID: 0, Position: 0}
 	c.Assert(col.Equal(col, nil), IsTrue)
 	c.Assert(col.Equal(&Column{FromID: 1}, nil), IsFalse)
@@ -48,7 +46,7 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 
 	intCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeLonglong)},
 		Data: &intDatum}
-	intVal, isNull, err := intCorCol.EvalInt(nil, sc)
+	intVal, isNull, err := intCorCol.EvalInt(s.ctx, nil)
 	c.Assert(intVal, Equals, int64(1))
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)
@@ -56,7 +54,7 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 	realDatum := types.NewFloat64Datum(1.2)
 	realCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeDouble)},
 		Data: &realDatum}
-	realVal, isNull, err := realCorCol.EvalReal(nil, sc)
+	realVal, isNull, err := realCorCol.EvalReal(s.ctx, nil)
 	c.Assert(realVal, Equals, float64(1.2))
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)
@@ -64,7 +62,7 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 	decimalDatum := types.NewDecimalDatum(types.NewDecFromStringForTest("1.2"))
 	decimalCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeNewDecimal)},
 		Data: &decimalDatum}
-	decVal, isNull, err := decimalCorCol.EvalDecimal(nil, sc)
+	decVal, isNull, err := decimalCorCol.EvalDecimal(s.ctx, nil)
 	c.Assert(decVal.Compare(types.NewDecFromStringForTest("1.2")), Equals, 0)
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)
@@ -72,14 +70,14 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 	stringDatum := types.NewStringDatum("abc")
 	stringCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeVarchar)},
 		Data: &stringDatum}
-	strVal, isNull, err := stringCorCol.EvalString(nil, sc)
+	strVal, isNull, err := stringCorCol.EvalString(s.ctx, nil)
 	c.Assert(strVal, Equals, "abc")
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)
 
 	durationCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeDuration)},
 		Data: &durationDatum}
-	durationVal, isNull, err := durationCorCol.EvalDuration(nil, sc)
+	durationVal, isNull, err := durationCorCol.EvalDuration(s.ctx, nil)
 	c.Assert(durationVal.Compare(duration), Equals, 0)
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)
@@ -87,7 +85,7 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 	timeDatum := types.NewTimeDatum(tm)
 	timeCorCol := &CorrelatedColumn{Column: Column{RetType: types.NewFieldType(mysql.TypeDatetime)},
 		Data: &timeDatum}
-	timeVal, isNull, err := timeCorCol.EvalTime(nil, sc)
+	timeVal, isNull, err := timeCorCol.EvalTime(s.ctx, nil)
 	c.Assert(timeVal.Compare(tm), Equals, 0)
 	c.Assert(isNull, IsFalse)
 	c.Assert(err, IsNil)

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	log "github.com/sirupsen/logrus"
@@ -110,7 +109,7 @@ func (c *Constant) Eval(_ types.Row) (types.Datum, error) {
 }
 
 // EvalInt returns int representation of Constant.
-func (c *Constant) EvalInt(_ types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
+func (c *Constant) EvalInt(ctx context.Context, _ types.Row) (int64, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -119,7 +118,7 @@ func (c *Constant) EvalInt(_ types.Row, sc *stmtctx.StatementContext) (int64, bo
 		if dt.IsNull() {
 			return 0, true, nil
 		}
-		val, err := dt.ToInt64(sc)
+		val, err := dt.ToInt64(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -130,14 +129,14 @@ func (c *Constant) EvalInt(_ types.Row, sc *stmtctx.StatementContext) (int64, bo
 		}
 	}
 	if c.GetType().Hybrid() || c.Value.Kind() == types.KindBinaryLiteral || c.Value.Kind() == types.KindString {
-		res, err := c.Value.ToInt64(sc)
+		res, err := c.Value.ToInt64(ctx.GetSessionVars().StmtCtx)
 		return res, err != nil, errors.Trace(err)
 	}
 	return c.Value.GetInt64(), false, nil
 }
 
 // EvalReal returns real representation of Constant.
-func (c *Constant) EvalReal(_ types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
+func (c *Constant) EvalReal(ctx context.Context, _ types.Row) (float64, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -146,7 +145,7 @@ func (c *Constant) EvalReal(_ types.Row, sc *stmtctx.StatementContext) (float64,
 		if dt.IsNull() {
 			return 0, true, nil
 		}
-		val, err := dt.ToFloat64(sc)
+		val, err := dt.ToFloat64(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
 			return 0, true, errors.Trace(err)
 		}
@@ -157,14 +156,14 @@ func (c *Constant) EvalReal(_ types.Row, sc *stmtctx.StatementContext) (float64,
 		}
 	}
 	if c.GetType().Hybrid() || c.Value.Kind() == types.KindBinaryLiteral || c.Value.Kind() == types.KindString {
-		res, err := c.Value.ToFloat64(sc)
+		res, err := c.Value.ToFloat64(ctx.GetSessionVars().StmtCtx)
 		return res, err != nil, errors.Trace(err)
 	}
 	return c.Value.GetFloat64(), false, nil
 }
 
 // EvalString returns string representation of Constant.
-func (c *Constant) EvalString(_ types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
+func (c *Constant) EvalString(ctx context.Context, _ types.Row) (string, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -188,7 +187,7 @@ func (c *Constant) EvalString(_ types.Row, sc *stmtctx.StatementContext) (string
 }
 
 // EvalDecimal returns decimal representation of Constant.
-func (c *Constant) EvalDecimal(_ types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
+func (c *Constant) EvalDecimal(ctx context.Context, _ types.Row) (*types.MyDecimal, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -203,12 +202,12 @@ func (c *Constant) EvalDecimal(_ types.Row, sc *stmtctx.StatementContext) (*type
 			return nil, true, nil
 		}
 	}
-	res, err := c.Value.ToDecimal(sc)
+	res, err := c.Value.ToDecimal(ctx.GetSessionVars().StmtCtx)
 	return res, err != nil, errors.Trace(err)
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.
-func (c *Constant) EvalTime(_ types.Row, sc *stmtctx.StatementContext) (val types.Time, isNull bool, err error) {
+func (c *Constant) EvalTime(ctx context.Context, _ types.Row) (val types.Time, isNull bool, err error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -221,7 +220,7 @@ func (c *Constant) EvalTime(_ types.Row, sc *stmtctx.StatementContext) (val type
 		if err != nil {
 			return types.Time{}, true, errors.Trace(err)
 		}
-		tim, err := types.ParseDatetime(sc, val)
+		tim, err := types.ParseDatetime(ctx.GetSessionVars().StmtCtx, val)
 		if err != nil {
 			return types.Time{}, true, errors.Trace(err)
 		}
@@ -235,7 +234,7 @@ func (c *Constant) EvalTime(_ types.Row, sc *stmtctx.StatementContext) (val type
 }
 
 // EvalDuration returns Duration representation of Constant.
-func (c *Constant) EvalDuration(_ types.Row, sc *stmtctx.StatementContext) (val types.Duration, isNull bool, err error) {
+func (c *Constant) EvalDuration(ctx context.Context, _ types.Row) (val types.Duration, isNull bool, err error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -262,7 +261,7 @@ func (c *Constant) EvalDuration(_ types.Row, sc *stmtctx.StatementContext) (val 
 }
 
 // EvalJSON returns JSON representation of Constant.
-func (c *Constant) EvalJSON(_ types.Row, sc *stmtctx.StatementContext) (json.BinaryJSON, bool, error) {
+func (c *Constant) EvalJSON(ctx context.Context, _ types.Row) (json.BinaryJSON, bool, error) {
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(nil)
 		if err != nil {
@@ -271,7 +270,7 @@ func (c *Constant) EvalJSON(_ types.Row, sc *stmtctx.StatementContext) (json.Bin
 		if dt.IsNull() {
 			return json.BinaryJSON{}, true, nil
 		}
-		val, err := dt.ConvertTo(sc, types.NewFieldType(mysql.TypeJSON))
+		val, err := dt.ConvertTo(ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeJSON))
 		if err != nil {
 			return json.BinaryJSON{}, true, errors.Trace(err)
 		}

--- a/expression/evaluator.go
+++ b/expression/evaluator.go
@@ -42,10 +42,9 @@ type defaultEvaluator struct {
 }
 
 func (e *defaultEvaluator) run(ctx context.Context, input, output *chunk.Chunk) error {
-	sc := ctx.GetSessionVars().StmtCtx
 	if e.vectorizable {
 		for i := range e.outputIdxes {
-			err := evalOneColumn(sc, e.exprs[i], input, output, e.outputIdxes[i])
+			err := evalOneColumn(ctx, e.exprs[i], input, output, e.outputIdxes[i])
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -55,7 +54,7 @@ func (e *defaultEvaluator) run(ctx context.Context, input, output *chunk.Chunk) 
 
 	for row := input.Begin(); row != input.End(); row = row.Next() {
 		for i := range e.outputIdxes {
-			err := evalOneCell(sc, e.exprs[i], row, output, e.outputIdxes[i])
+			err := evalOneCell(ctx, e.exprs[i], row, output, e.outputIdxes[i])
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -40,25 +39,25 @@ type Expression interface {
 	Eval(row types.Row) (types.Datum, error)
 
 	// EvalInt returns the int64 representation of expression.
-	EvalInt(row types.Row, sc *stmtctx.StatementContext) (val int64, isNull bool, err error)
+	EvalInt(ctx context.Context, row types.Row) (val int64, isNull bool, err error)
 
 	// EvalReal returns the float64 representation of expression.
-	EvalReal(row types.Row, sc *stmtctx.StatementContext) (val float64, isNull bool, err error)
+	EvalReal(ctx context.Context, row types.Row) (val float64, isNull bool, err error)
 
 	// EvalString returns the string representation of expression.
-	EvalString(row types.Row, sc *stmtctx.StatementContext) (val string, isNull bool, err error)
+	EvalString(ctx context.Context, row types.Row) (val string, isNull bool, err error)
 
 	// EvalDecimal returns the decimal representation of expression.
-	EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (val *types.MyDecimal, isNull bool, err error)
+	EvalDecimal(ctx context.Context, row types.Row) (val *types.MyDecimal, isNull bool, err error)
 
 	// EvalTime returns the DATE/DATETIME/TIMESTAMP representation of expression.
-	EvalTime(row types.Row, sc *stmtctx.StatementContext) (val types.Time, isNull bool, err error)
+	EvalTime(ctx context.Context, row types.Row) (val types.Time, isNull bool, err error)
 
 	// EvalDuration returns the duration representation of expression.
-	EvalDuration(row types.Row, sc *stmtctx.StatementContext) (val types.Duration, isNull bool, err error)
+	EvalDuration(ctx context.Context, row types.Row) (val types.Duration, isNull bool, err error)
 
 	// EvalJSON returns the JSON representation of expression.
-	EvalJSON(row types.Row, sc *stmtctx.StatementContext) (val json.BinaryJSON, isNull bool, err error)
+	EvalJSON(ctx context.Context, row types.Row) (val json.BinaryJSON, isNull bool, err error)
 
 	// GetType gets the type that the expression returns.
 	GetType() *types.FieldType

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -181,7 +180,6 @@ func (sf *ScalarFunction) Decorrelate(schema *Schema) Expression {
 
 // Eval implements Expression interface.
 func (sf *ScalarFunction) Eval(row types.Row) (d types.Datum, err error) {
-	sc := sf.GetCtx().GetSessionVars().StmtCtx
 	var (
 		res    interface{}
 		isNull bool
@@ -189,24 +187,24 @@ func (sf *ScalarFunction) Eval(row types.Row) (d types.Datum, err error) {
 	switch tp, evalType := sf.GetType(), sf.GetType().EvalType(); evalType {
 	case types.ETInt:
 		var intRes int64
-		intRes, isNull, err = sf.EvalInt(row, sc)
+		intRes, isNull, err = sf.EvalInt(sf.GetCtx(), row)
 		if mysql.HasUnsignedFlag(tp.Flag) {
 			res = uint64(intRes)
 		} else {
 			res = intRes
 		}
 	case types.ETReal:
-		res, isNull, err = sf.EvalReal(row, sc)
+		res, isNull, err = sf.EvalReal(sf.GetCtx(), row)
 	case types.ETDecimal:
-		res, isNull, err = sf.EvalDecimal(row, sc)
+		res, isNull, err = sf.EvalDecimal(sf.GetCtx(), row)
 	case types.ETDatetime, types.ETTimestamp:
-		res, isNull, err = sf.EvalTime(row, sc)
+		res, isNull, err = sf.EvalTime(sf.GetCtx(), row)
 	case types.ETDuration:
-		res, isNull, err = sf.EvalDuration(row, sc)
+		res, isNull, err = sf.EvalDuration(sf.GetCtx(), row)
 	case types.ETJson:
-		res, isNull, err = sf.EvalJSON(row, sc)
+		res, isNull, err = sf.EvalJSON(sf.GetCtx(), row)
 	case types.ETString:
-		res, isNull, err = sf.EvalString(row, sc)
+		res, isNull, err = sf.EvalString(sf.GetCtx(), row)
 	}
 
 	if isNull || err != nil {
@@ -218,37 +216,37 @@ func (sf *ScalarFunction) Eval(row types.Row) (d types.Datum, err error) {
 }
 
 // EvalInt implements Expression interface.
-func (sf *ScalarFunction) EvalInt(row types.Row, sc *stmtctx.StatementContext) (int64, bool, error) {
+func (sf *ScalarFunction) EvalInt(ctx context.Context, row types.Row) (int64, bool, error) {
 	return sf.Function.evalInt(row)
 }
 
 // EvalReal implements Expression interface.
-func (sf *ScalarFunction) EvalReal(row types.Row, sc *stmtctx.StatementContext) (float64, bool, error) {
+func (sf *ScalarFunction) EvalReal(ctx context.Context, row types.Row) (float64, bool, error) {
 	return sf.Function.evalReal(row)
 }
 
 // EvalDecimal implements Expression interface.
-func (sf *ScalarFunction) EvalDecimal(row types.Row, sc *stmtctx.StatementContext) (*types.MyDecimal, bool, error) {
+func (sf *ScalarFunction) EvalDecimal(ctx context.Context, row types.Row) (*types.MyDecimal, bool, error) {
 	return sf.Function.evalDecimal(row)
 }
 
 // EvalString implements Expression interface.
-func (sf *ScalarFunction) EvalString(row types.Row, sc *stmtctx.StatementContext) (string, bool, error) {
+func (sf *ScalarFunction) EvalString(ctx context.Context, row types.Row) (string, bool, error) {
 	return sf.Function.evalString(row)
 }
 
 // EvalTime implements Expression interface.
-func (sf *ScalarFunction) EvalTime(row types.Row, sc *stmtctx.StatementContext) (types.Time, bool, error) {
+func (sf *ScalarFunction) EvalTime(ctx context.Context, row types.Row) (types.Time, bool, error) {
 	return sf.Function.evalTime(row)
 }
 
 // EvalDuration implements Expression interface.
-func (sf *ScalarFunction) EvalDuration(row types.Row, sc *stmtctx.StatementContext) (types.Duration, bool, error) {
+func (sf *ScalarFunction) EvalDuration(ctx context.Context, row types.Row) (types.Duration, bool, error) {
 	return sf.Function.evalDuration(row)
 }
 
 // EvalJSON implements Expression interface.
-func (sf *ScalarFunction) EvalJSON(row types.Row, sc *stmtctx.StatementContext) (json.BinaryJSON, bool, error) {
+func (sf *ScalarFunction) EvalJSON(ctx context.Context, row types.Row) (json.BinaryJSON, bool, error) {
 	return sf.Function.evalJSON(row)
 }
 

--- a/store/tikv/mocktikv/aggregate.go
+++ b/store/tikv/mocktikv/aggregate.go
@@ -172,7 +172,7 @@ func (e *hashAggExec) getContexts(groupKey []byte) []*aggregation.AggEvaluateCon
 	if !ok {
 		aggCtxs = make([]*aggregation.AggEvaluateContext, 0, len(e.aggExprs))
 		for _, agg := range e.aggExprs {
-			aggCtxs = append(aggCtxs, agg.CreateContext())
+			aggCtxs = append(aggCtxs, agg.CreateContext(e.evalCtx.sc))
 		}
 		e.aggCtxsMap[groupKeyString] = aggCtxs
 	}
@@ -221,7 +221,7 @@ func (e *streamAggExec) getPartialResult() ([][]byte, error) {
 			value = append(value, data)
 		}
 		// Clear the aggregate context.
-		e.aggCtxs[i] = agg.CreateContext()
+		e.aggCtxs[i] = agg.CreateContext(e.evalCtx.sc)
 	}
 	e.currGroupByValues = e.currGroupByValues[:0]
 	for _, d := range e.currGroupByRow {

--- a/store/tikv/mocktikv/cop_handler_dag.go
+++ b/store/tikv/mocktikv/cop_handler_dag.go
@@ -290,7 +290,7 @@ func (h *rpcHandler) buildStreamAgg(ctx *dagContext, executor *tipb.Executor) (*
 	}
 	aggCtxs := make([]*aggregation.AggEvaluateContext, 0, len(aggs))
 	for _, agg := range aggs {
-		aggCtxs = append(aggCtxs, agg.CreateContext())
+		aggCtxs = append(aggCtxs, agg.CreateContext(ctx.evalCtx.sc))
 	}
 
 	return &streamAggExec{

--- a/types/convert.go
+++ b/types/convert.go
@@ -68,7 +68,7 @@ var SignedLowerBound = map[byte]int64{
 }
 
 // ConvertFloatToInt converts a float64 value to a int value.
-func ConvertFloatToInt(sc *stmtctx.StatementContext, fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
+func ConvertFloatToInt(fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
 	val := RoundFloat(fval)
 	if val < float64(lowerBound) {
 		return lowerBound, overflow(val, tp)
@@ -124,7 +124,7 @@ func ConvertUintToUint(val uint64, upperBound uint64, tp byte) (uint64, error) {
 }
 
 // ConvertFloatToUint converts a float value to an uint value.
-func ConvertFloatToUint(sc *stmtctx.StatementContext, fval float64, upperBound uint64, tp byte) (uint64, error) {
+func ConvertFloatToUint(fval float64, upperBound uint64, tp byte) (uint64, error) {
 	val := RoundFloat(fval)
 	if val < 0 {
 		return uint64(int64(val)), overflow(val, tp)
@@ -340,10 +340,10 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 		if !unsigned {
 			lBound := SignedLowerBound[mysql.TypeLonglong]
 			uBound := SignedUpperBound[mysql.TypeLonglong]
-			return ConvertFloatToInt(sc, f, lBound, uBound, mysql.TypeDouble)
+			return ConvertFloatToInt(f, lBound, uBound, mysql.TypeDouble)
 		}
 		bound := UnsignedUpperBound[mysql.TypeLonglong]
-		u, err := ConvertFloatToUint(sc, f, bound, mysql.TypeDouble)
+		u, err := ConvertFloatToUint(f, bound, mysql.TypeDouble)
 		return int64(u), errors.Trace(err)
 	case json.TypeCodeString:
 		return StrToInt(sc, hack.String(j.GetString()))

--- a/types/datum.go
+++ b/types/datum.go
@@ -849,7 +849,7 @@ func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (
 	case KindUint64:
 		val, err = ConvertUintToUint(d.GetUint64(), upperBound, tp)
 	case KindFloat32, KindFloat64:
-		val, err = ConvertFloatToUint(sc, d.GetFloat64(), upperBound, tp)
+		val, err = ConvertFloatToUint(d.GetFloat64(), upperBound, tp)
 	case KindString, KindBytes:
 		val, err = StrToUint(sc, d.GetString())
 		if err != nil {
@@ -880,14 +880,14 @@ func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (
 		}
 	case KindMysqlDecimal:
 		fval, err1 := d.GetMysqlDecimal().ToFloat64()
-		val, err = ConvertFloatToUint(sc, fval, upperBound, tp)
+		val, err = ConvertFloatToUint(fval, upperBound, tp)
 		if err == nil {
 			err = err1
 		}
 	case KindMysqlEnum:
-		val, err = ConvertFloatToUint(sc, d.GetMysqlEnum().ToNumber(), upperBound, tp)
+		val, err = ConvertFloatToUint(d.GetMysqlEnum().ToNumber(), upperBound, tp)
 	case KindMysqlSet:
-		val, err = ConvertFloatToUint(sc, d.GetMysqlSet().ToNumber(), upperBound, tp)
+		val, err = ConvertFloatToUint(d.GetMysqlSet().ToNumber(), upperBound, tp)
 	case KindBinaryLiteral, KindMysqlBit:
 		val, err = d.GetBinaryLiteral().ToInt()
 	case KindMysqlJSON:
@@ -1348,9 +1348,9 @@ func (d *Datum) toSignedInteger(sc *stmtctx.StatementContext, tp byte) (int64, e
 	case KindUint64:
 		return ConvertUintToInt(d.GetUint64(), upperBound, tp)
 	case KindFloat32:
-		return ConvertFloatToInt(sc, float64(d.GetFloat32()), lowerBound, upperBound, tp)
+		return ConvertFloatToInt(float64(d.GetFloat32()), lowerBound, upperBound, tp)
 	case KindFloat64:
-		return ConvertFloatToInt(sc, d.GetFloat64(), lowerBound, upperBound, tp)
+		return ConvertFloatToInt(d.GetFloat64(), lowerBound, upperBound, tp)
 	case KindString, KindBytes:
 		iVal, err := StrToInt(sc, d.GetString())
 		iVal, err2 := ConvertIntToInt(iVal, lowerBound, upperBound, tp)
@@ -1398,10 +1398,10 @@ func (d *Datum) toSignedInteger(sc *stmtctx.StatementContext, tp byte) (int64, e
 		return ival, err
 	case KindMysqlEnum:
 		fval := d.GetMysqlEnum().ToNumber()
-		return ConvertFloatToInt(sc, fval, lowerBound, upperBound, tp)
+		return ConvertFloatToInt(fval, lowerBound, upperBound, tp)
 	case KindMysqlSet:
 		fval := d.GetMysqlSet().ToNumber()
-		return ConvertFloatToInt(sc, fval, lowerBound, upperBound, tp)
+		return ConvertFloatToInt(fval, lowerBound, upperBound, tp)
 	case KindMysqlJSON:
 		return ConvertJSONToInt(sc, d.GetMysqlJSON(), false)
 	case KindBinaryLiteral, KindMysqlBit:


### PR DESCRIPTION
removes a lot of redundant `ctx.GetSessionVars()` function calls.