### PR TITLE
add growStack hack to reduce morestack in ParseSQL

### DIFF
--- a/session.go
+++ b/session.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/charset"
+	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
@@ -657,6 +658,7 @@ func (s *session) ParseSQL(goCtx goctx.Context, sql, charset, collation string) 
 		defer span1.Finish()
 	}
 	s.parser.SetSQLMode(s.sessionVars.SQLMode)
+	hack.GrowStack()
 	return s.parser.Parse(sql, charset, collation)
 }
 

--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -41,3 +41,14 @@ func Slice(s string) (b []byte) {
 	pbytes.Cap = pstring.Len
 	return
 }
+
+//
+//go:noinline
+func GrowStack() {
+	// when a goroutine was created, go will allocate inital stack size for it.
+	// Usually, the initial value is 2kb. By placing this 16kb array at beginning, we can force go allocate 32kb stack frame size for underlying goroutine.
+	var buf [16 << 10]byte
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+}

--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -49,6 +49,6 @@ func GrowStack() {
 	// Usually, the initial value is 2kb. By placing this 16kb array at beginning, we can force go allocate 32kb stack frame size for underlying goroutine.
 	var buf [16 << 10]byte
 	for i := range buf {
-		buf[i] = byte(i)
+		buf[i] = byte(0)
 	}
 }


### PR DESCRIPTION
According to flame graph, we have `morestack` present when we call `ParseSQL`.  By adding a 16kb at the beginning, we can hack go compiler allocate 32kb stack frame size for a goroutine. 