### PR TITLE
model: pass TestJobCodec

### DIFF
--- a/inspectkv/inspectkv_test.go
+++ b/inspectkv/inspectkv_test.go
@@ -155,6 +155,7 @@ func (s *testSuite) TestGetDDLInfo(c *C) {
 	c.Assert(err, IsNil)
 	info, err := GetDDLInfo(txn)
 	c.Assert(err, IsNil)
+	job.RawArgs = nil
 	c.Assert(info.Job, DeepEquals, job)
 	c.Assert(info.ReorgHandle, Equals, int64(0))
 	err = txn.Rollback()

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -276,6 +276,7 @@ func (s *testSuite) TestDDL(c *C) {
 
 	v, err := t.GetDDLJob(0)
 	c.Assert(err, IsNil)
+	job.RawArgs = nil
 	c.Assert(v, DeepEquals, job)
 	v, err = t.GetDDLJob(1)
 	c.Assert(err, IsNil)
@@ -296,12 +297,14 @@ func (s *testSuite) TestDDL(c *C) {
 
 	v, err = t.DeQueueDDLJob()
 	c.Assert(err, IsNil)
+	job.RawArgs = nil
 	c.Assert(v, DeepEquals, job)
 
 	err = t.AddHistoryDDLJob(job)
 	c.Assert(err, IsNil)
 	v, err = t.GetHistoryDDLJob(2)
 	c.Assert(err, IsNil)
+	job.RawArgs = nil
 	c.Assert(v, DeepEquals, job)
 
 	all, err := t.GetAllHistoryDDLJobs()

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -122,7 +122,6 @@ func (*testModelSuite) TestModelBasic(c *C) {
 }
 
 func (*testModelSuite) TestJobCodec(c *C) {
-	c.Skip("codec failed")
 	type A struct {
 		Name string
 	}


### PR DESCRIPTION
Change `RawArgs ` type make `TestJobCodec` pass.
Go 1.8 will correctly handle Marshalling of both a pointer and non-pointer json.RawMessage.
[Fixing commit](https://github.com/golang/go/commit/1625da24106b610f89ff7a67a11581df95f8e234)