### PR TITLE
session: check if the user variable is nil while logging a statement

### DIFF
--- a/session.go
+++ b/session.go
@@ -1383,9 +1383,17 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 		*ast.DropDatabaseStmt, *ast.DropIndexStmt, *ast.DropTableStmt, *ast.RenameTableStmt, *ast.TruncateTableStmt:
 		user := vars.User
 		if ss, ok := node.(ast.SensitiveStmtNode); ok {
-			log.Infof("[CRUCIAL OPERATION] %s (by %s).", ss.SecureText(), user)
+			if user == nil {
+				log.Infof("[CRUCIAL OPERATION] %s.", ss.SecureText())
+			} else {
+				log.Infof("[CRUCIAL OPERATION] %s (by %s).", ss.SecureText(), user)
+			}
 		} else {
-			log.Infof("[CRUCIAL OPERATION] %s (by %s).", stmt.Text(), user)
+			if user == nil {
+				log.Infof("[CRUCIAL OPERATION] %s.", stmt.Text())
+			} else {
+				log.Infof("[CRUCIAL OPERATION] %s (by %s).", stmt.Text(), user)
+			}
 		}
 	default:
 		logQuery(node.Text(), vars)


### PR DESCRIPTION
While calling `session.logStmt` to log statements, we should check if the user variable is nil before passing it to `log.Infof` as the argument. Otherwise, it will cause segmentation fault while accessing its members `Username` and `Hostname` in its `String()` method.