### PR TITLE
server: Add metrics for tidb-server panic

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -408,6 +408,7 @@ func (cc *clientConn) Run() {
 			stackSize := runtime.Stack(buf, false)
 			buf = buf[:stackSize]
 			log.Errorf("lastCmd %s, %v, %s", cc.lastCmd, r, buf)
+			panicCounter.Add(1)
 		}
 		if !closedOutside {
 			err := cc.Close()

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -78,6 +78,7 @@ func init() {
 	prometheus.MustRegister(queryCounter)
 	prometheus.MustRegister(connGauge)
 	prometheus.MustRegister(criticalErrorCounter)
+	prometheus.MustRegister(panicCounter)
 }
 
 func executeErrorToLabel(err error) string {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -62,6 +62,15 @@ var (
 			Name:      "critical_error",
 			Help:      "Counter of critical errors.",
 		})
+
+	// panicCounter measures the count of panics.
+	panicCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "panic",
+			Help:      "Counter of panic.",
+		})
 )
 
 func init() {


### PR DESCRIPTION
Writing panics info in log-file is not enough. We should show them in the metrics system.