### PR TITLE
*: don't record binlog when statement rollback

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -76,8 +76,8 @@ type Context interface {
 	StmtCommit() error
 	// StmtRollback provides statement level rollback.
 	StmtRollback()
-	// GetMutation gets the binlog mutation for current statement.
-	GetMutation(int64) *binlog.TableMutation
+	// StmtGetMutation gets the binlog mutation for current statement.
+	StmtGetMutation(int64) *binlog.TableMutation
 }
 
 type basicCtxType int

--- a/context/context.go
+++ b/context/context.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
+	binlog "github.com/pingcap/tipb/go-binlog"
 	goctx "golang.org/x/net/context"
 )
 
@@ -70,6 +71,13 @@ type Context interface {
 
 	// StoreQueryFeedback stores the query feedback.
 	StoreQueryFeedback(feedback interface{})
+
+	// StmtCommit flush all changes by the statement to the underlying transaction.
+	StmtCommit() error
+	// StmtRollback provides statement level rollback.
+	StmtRollback()
+	// GetMutation gets the binlog mutation for current statement.
+	GetMutation(int64) *binlog.TableMutation
 }
 
 type basicCtxType int

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -232,7 +232,7 @@ func checkCases(tests []testCase, ld *executor.LoadDataInfo,
 			c.Assert(data, DeepEquals, tt.restData,
 				Commentf("data1:%v, data2:%v, data:%v", string(tt.data1), string(tt.data2), string(data)))
 		}
-		terror.Log(ctx.Txn().StmtCommit())
+		terror.Log(ctx.StmtCommit())
 		err1 = ctx.Txn().Commit(goctx.Background())
 		c.Assert(err1, IsNil)
 		r := tk.MustQuery(selectSQL)

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -504,7 +504,7 @@ func (iw *innerWorker) fetchInnerResults(goCtx goctx.Context, task *lookUpJoinTa
 			iw.executorChk = chunk.NewChunk(iw.innerCtx.rowTypes)
 			continue
 		}
-		selected, err := expression.VectorizedFilter(iw.ctx, iw.filter, innerIter, selected)
+		selected, err = expression.VectorizedFilter(iw.ctx, iw.filter, innerIter, selected)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/executor/write.go
+++ b/executor/write.go
@@ -280,7 +280,7 @@ func (e *DeleteExec) deleteSingleTable(goCtx goctx.Context) error {
 	batchSize := e.ctx.GetSessionVars().DMLBatchSize
 	for {
 		if batchDelete && rowCount >= batchSize {
-			terror.Log(e.ctx.Txn().StmtCommit())
+			terror.Log(e.ctx.StmtCommit())
 			if err := e.ctx.NewTxn(); err != nil {
 				// We should return a special error for batch insert.
 				return ErrBatchInsertFail.Gen("BatchDelete failed with error: %v", err)
@@ -348,7 +348,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(goCtx goctx.Context) error {
 
 		for chunkRow := iter.Begin(); chunkRow != iter.End(); chunkRow = iter.Next() {
 			if batchDelete && rowCount >= batchDMLSize {
-				terror.Log(e.ctx.Txn().StmtCommit())
+				terror.Log(e.ctx.StmtCommit())
 				if err = e.ctx.NewTxn(); err != nil {
 					// We should return a special error for batch insert.
 					return ErrBatchInsertFail.Gen("BatchDelete failed with error: %v", err)
@@ -901,7 +901,7 @@ func (e *InsertExec) exec(goCtx goctx.Context, rows [][]types.Datum) (Row, error
 			continue
 		}
 		if batchInsert && rowCount >= batchSize {
-			terror.Log(e.ctx.Txn().StmtCommit())
+			terror.Log(e.ctx.StmtCommit())
 			if err := e.ctx.NewTxn(); err != nil {
 				// We should return a special error for batch insert.
 				return nil, ErrBatchInsertFail.Gen("BatchInsert failed with error: %v", err)

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -884,11 +884,13 @@ func (s *testEvaluatorSuite) TestSysDate(c *C) {
 	defer testleak.AfterTest(c)()
 	fc := funcs[ast.Sysdate]
 
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().StmtCtx.TimeZone = time.Local
 	timezones := []types.Datum{types.NewDatum(1234), types.NewDatum(0)}
 	for _, timezone := range timezones {
 		// sysdate() result is not affected by "timestamp" session variable.
-		variable.SetSessionSystemVar(s.ctx.GetSessionVars(), "timestamp", timezone)
-		f, err := fc.getFunction(s.ctx, s.datumsToConstants(nil))
+		variable.SetSessionSystemVar(ctx.GetSessionVars(), "timestamp", timezone)
+		f, err := fc.getFunction(ctx, s.datumsToConstants(nil))
 		c.Assert(err, IsNil)
 		v, err := evalBuiltinFunc(f, nil)
 		last := time.Now()
@@ -898,14 +900,14 @@ func (s *testEvaluatorSuite) TestSysDate(c *C) {
 	}
 
 	last := time.Now()
-	f, err := fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(6)))
+	f, err := fc.getFunction(ctx, s.datumsToConstants(types.MakeDatums(6)))
 	c.Assert(err, IsNil)
 	v, err := evalBuiltinFunc(f, nil)
 	c.Assert(err, IsNil)
 	n := v.GetMysqlTime()
 	c.Assert(n.String(), GreaterEqual, last.Format(types.TimeFormat))
 
-	f, err = fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(-2)))
+	f, err = fc.getFunction(ctx, s.datumsToConstants(types.MakeDatums(-2)))
 	c.Assert(err, IsNil)
 	_, err = evalBuiltinFunc(f, nil)
 	c.Assert(err, NotNil)

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -144,11 +144,6 @@ type Transaction interface {
 	GetMemBuffer() MemBuffer
 	// GetSnapshot returns the snapshot of this transaction.
 	GetSnapshot() Snapshot
-
-	// StmtCommit flush all changes by the statement to the underlying transaction.
-	StmtCommit() error
-	// StmtRollback provides statement level rollback.
-	StmtRollback()
 }
 
 // Client is used to send request to KV layer.

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -35,14 +35,6 @@ func (t *mockTxn) Rollback() error {
 	return nil
 }
 
-func (t *mockTxn) StmtCommit() error {
-	return nil
-}
-
-func (t *mockTxn) StmtRollback() {
-	return
-}
-
 func (t *mockTxn) String() string {
 	return ""
 }

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -698,7 +698,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderUnionScan(c *C) {
 		c.Assert(err, IsNil)
 		// Make txn not read only.
 		se.Txn().Set(kv.Key("AAA"), []byte("BBB"))
-		se.Txn().StmtCommit()
+		se.StmtCommit()
 		p, err := plan.Optimize(se, stmt, s.is)
 		c.Assert(err, IsNil)
 		c.Assert(plan.ToString(p), Equals, tt.best, Commentf("for %s", tt.sql))

--- a/server/conn.go
+++ b/server/conn.go
@@ -786,7 +786,7 @@ func (cc *clientConn) handleLoadData(goCtx goctx.Context, loadDataInfo *executor
 	}
 
 	txn := loadDataInfo.Ctx.Txn()
-	terror.Log(txn.StmtCommit())
+	terror.Log(loadDataInfo.Ctx.StmtCommit())
 	if err != nil {
 		if txn != nil && txn.Valid() {
 			if err1 := txn.Rollback(); err1 != nil {

--- a/session.go
+++ b/session.go
@@ -992,10 +992,10 @@ func (s *session) StmtCommit() error {
 	})
 
 	// Need to flush binlog.
-	for key, value := range st.mutations {
-		mutation := getBinlogMutation(s, key)
+	for tableID, delta := range st.mutations {
+		mutation := getBinlogMutation(s, tableID)
 		if err == nil {
-			mergeToMutation(mutation, value)
+			mergeToMutation(mutation, delta)
 		}
 	}
 	return errors.Trace(err)
@@ -1029,9 +1029,6 @@ func getBinlogMutation(ctx context.Context, tableID int64) *binlog.TableMutation
 }
 
 func mergeToMutation(m1, m2 *binlog.TableMutation) {
-	if m1.TableId != m2.TableId {
-		log.Fatal("m1.TableId must equal to m2.TableId")
-	}
 	m1.InsertedRows = append(m1.InsertedRows, m2.InsertedRows...)
 	m1.UpdatedRows = append(m1.UpdatedRows, m2.UpdatedRows...)
 	m1.DeletedIds = append(m1.DeletedIds, m2.DeletedIds...)

--- a/session.go
+++ b/session.go
@@ -1005,8 +1005,8 @@ func (s *session) StmtRollback() {
 	return
 }
 
-// GetMutation implements the context.Context interface.
-func (s *session) GetMutation(tableID int64) *binlog.TableMutation {
+// StmtGetMutation implements the context.Context interface.
+func (s *session) StmtGetMutation(tableID int64) *binlog.TableMutation {
 	st := &s.StmtTxn
 	if _, ok := st.mutations[tableID]; !ok {
 		st.mutations[tableID] = &binlog.TableMutation{TableId: tableID}

--- a/session.go
+++ b/session.go
@@ -984,11 +984,13 @@ func (s *session) StmtCommit() error {
 	})
 	st.buf.Reset()
 
-	// Need to flush binlog.
-	for key, value := range st.mutations {
-		mutation := getBinlogMutation(s, key)
-		mergeToMutation(mutation, value)
-		delete(st.mutations, key)
+	if err == nil {
+		// Need to flush binlog.
+		for key, value := range st.mutations {
+			mutation := getBinlogMutation(s, key)
+			mergeToMutation(mutation, value)
+			delete(st.mutations, key)
+		}
 	}
 	return errors.Trace(err)
 }

--- a/session.go
+++ b/session.go
@@ -984,13 +984,13 @@ func (s *session) StmtCommit() error {
 	})
 	st.buf.Reset()
 
-	if err == nil {
-		// Need to flush binlog.
-		for key, value := range st.mutations {
-			mutation := getBinlogMutation(s, key)
+	// Need to flush binlog.
+	for key, value := range st.mutations {
+		mutation := getBinlogMutation(s, key)
+		if err == nil {
 			mergeToMutation(mutation, value)
-			delete(st.mutations, key)
 		}
+		delete(st.mutations, key)
 	}
 	return errors.Trace(err)
 }

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -94,13 +94,6 @@ func (txn *tikvTxn) Get(k kv.Key) ([]byte, error) {
 	return ret, nil
 }
 
-func (txn *tikvTxn) StmtCommit() error {
-	return nil
-}
-
-func (txn *tikvTxn) StmtRollback() {
-}
-
 func (txn *tikvTxn) Set(k kv.Key, v []byte) error {
 	txn.setCnt++
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
@@ -812,15 +811,7 @@ func shouldWriteBinlog(ctx context.Context) bool {
 }
 
 func (t *Table) getMutation(ctx context.Context) *binlog.TableMutation {
-	bin := binloginfo.GetPrewriteValue(ctx, true)
-	for i := range bin.Mutations {
-		if bin.Mutations[i].TableId == t.ID {
-			return &bin.Mutations[i]
-		}
-	}
-	idx := len(bin.Mutations)
-	bin.Mutations = append(bin.Mutations, binlog.TableMutation{TableId: t.ID})
-	return &bin.Mutations[idx]
+	return ctx.GetMutation(t.ID)
 }
 
 // canSkip is for these cases, we can skip the columns in encoded row:

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -811,7 +811,7 @@ func shouldWriteBinlog(ctx context.Context) bool {
 }
 
 func (t *Table) getMutation(ctx context.Context) *binlog.TableMutation {
-	return ctx.GetMutation(t.ID)
+	return ctx.StmtGetMutation(t.ID)
 }
 
 // canSkip is for these cases, we can skip the columns in encoded row:

--- a/tidb.go
+++ b/tidb.go
@@ -169,9 +169,9 @@ func runStmt(goCtx goctx.Context, ctx context.Context, s ast.Statement) (ast.Rec
 		GetHistory(ctx).Add(0, s, se.sessionVars.StmtCtx)
 		if txn := ctx.Txn(); txn != nil {
 			if err != nil {
-				txn.StmtRollback()
+				ctx.StmtRollback()
 			} else {
-				terror.Log(txn.StmtCommit())
+				terror.Log(ctx.StmtCommit())
 			}
 		}
 	}

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
+	binlog "github.com/pingcap/tipb/go-binlog"
 	goctx "golang.org/x/net/context"
 )
 
@@ -187,6 +188,20 @@ func (c *Context) GoCtx() goctx.Context {
 
 // StoreQueryFeedback stores the query feedback.
 func (c *Context) StoreQueryFeedback(_ interface{}) {}
+
+// StmtCommit implements the context.Context interface.
+func (c *Context) StmtCommit() error {
+	return nil
+}
+
+// StmtRollback implements the context.Context interface.
+func (c *Context) StmtRollback() {
+}
+
+// GetMutation implements the context.Context interface.
+func (c *Context) GetMutation(tableID int64) *binlog.TableMutation {
+	return nil
+}
 
 // NewContext creates a new mocked context.Context.
 func NewContext() *Context {

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -198,8 +198,8 @@ func (c *Context) StmtCommit() error {
 func (c *Context) StmtRollback() {
 }
 
-// GetMutation implements the context.Context interface.
-func (c *Context) GetMutation(tableID int64) *binlog.TableMutation {
+// StmtGetMutation implements the context.Context interface.
+func (c *Context) StmtGetMutation(tableID int64) *binlog.TableMutation {
 	return nil
 }
 


### PR DESCRIPTION
Binlog mutations will be cached in StmtTxn, and flush when StmtCommit, or discard when StmtRollback.

StmtCommit/StmtRollback is moved from kv.Transaction interface to context.Context, because they involves binlog mutations which are not accessible via kv.Transaction.

@coocood @jackysp @shenli @wentaoxu 