### PR TITLE
chunk:imporve append bytes in chunk

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -407,7 +407,17 @@ func (c *column) appendString(str string) {
 }
 
 func (c *column) appendBytes(b []byte) {
-	c.data = append(c.data, b...)
+	m := len(c.data)
+	n := m + len(b)
+	if n > cap(c.data) { // if necessary, reallocate
+		// allocate double what's needed, for futher growth
+		newData := make([]byte, (n+1)*128)
+		copy(newData, c.data)
+		c.data = newData
+	}
+	c.data = c.data[0:n]
+	copy(c.data[m:n], b)
+	// c.data = append(c.data, b...)
 	c.finishAppendVar()
 }
 

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -410,14 +410,13 @@ func (c *column) appendBytes(b []byte) {
 	m := len(c.data)
 	n := m + len(b)
 	if n > cap(c.data) { // if necessary, reallocate
-		// allocate double what's needed, for futher growth
+		// allocate 128 times larger than what's needed, for futher growth
 		newData := make([]byte, (n+1)*128)
 		copy(newData, c.data)
 		c.data = newData
 	}
 	c.data = c.data[0:n]
 	copy(c.data[m:n], b)
-	// c.data = append(c.data, b...)
 	c.finishAppendVar()
 }
 

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -501,6 +501,20 @@ func appendRow(chk *Chunk, row Row) {
 	}
 }
 
+func BenchmarkAppendBytes(b *testing.B) {
+	chk := NewChunk([]*types.FieldType{types.NewFieldType(mysql.TypeString)})
+	var bs = make([]byte, 1, 1000)
+	for i := 0; i < b.N; i++ {
+		appendBytes(chk, bs)
+	}
+}
+
+func appendBytes(chk *Chunk, bs []byte) {
+	for i := 0; i < 1000; i++ {
+		chk.AppendBytes(0, bs)
+	}
+}
+
 func BenchmarkAccess(b *testing.B) {
 	b.StopTimer()
 	rowChk := newChunk(8)


### PR DESCRIPTION
We took some cpu samples when whole system is at its limit. Specifically, idle cpu is only 16%.  From these samples, we generated a flame graph. 

From flame graph, we can tell `readRowsDAta` in `selectResult` consumes around 11 % cpu time and 90% of them are consumed by `growSlice` in `chunk`'s `appednBytes`.  This implies we need a complete control of growth of slice which resulting in this PR. 

Below is benchmarks:

```
benchmark                       old ns/op     new ns/op     delta
BenchmarkAppendInt-8            11342         11185         -1.38%
BenchmarkAppendString-8         9198          8916          -3.07%
BenchmarkAppendRow-8            53320         50795         -4.74%
BenchmarkAppendBytes-8          23076         19949         -13.55%
BenchmarkMutRowSetRow-8         21.0          19.7          -6.19%
BenchmarkMutRowSetDatums-8      35.1          32.9          -6.27%
BenchmarkMutRowSetValues-8      25.6          27.6          +7.81%
BenchmarkMutRowFromTypes-8      316           314           -0.63%
BenchmarkMutRowFromDatums-8     380           358           -5.79%
BenchmarkMutRowFromValues-8     119           106           -10.92%

benchmark                       old allocs     new allocs     delta
BenchmarkAppendInt-8            0              0              +0.00%
BenchmarkAppendString-8         0              0              +0.00%
BenchmarkAppendRow-8            0              0              +0.00%
BenchmarkMutRowSetRow-8         0              0              +0.00%
BenchmarkMutRowSetDatums-8      0              0              +0.00%
BenchmarkMutRowSetValues-8      0              0              +0.00%
BenchmarkMutRowFromTypes-8      8              8              +0.00%
BenchmarkMutRowFromDatums-8     10             10             +0.00%
BenchmarkMutRowFromValues-8     3              3              +0.00%

benchmark                       old bytes     new bytes     delta
BenchmarkAppendInt-8            0             0             +0.00%
BenchmarkAppendString-8         0             0             +0.00%
BenchmarkAppendRow-8            4             4             +0.00%
BenchmarkMutRowSetRow-8         0             0             +0.00%
BenchmarkMutRowSetDatums-8      0             0             +0.00%
BenchmarkMutRowSetValues-8      0             0             +0.00%
BenchmarkMutRowFromTypes-8      312           312           +0.00%
BenchmarkMutRowFromDatums-8     328           328           +0.00%
BenchmarkMutRowFromValues-8     72            72            +0.00%
```