### PR TITLE
tidb,config: limit statement count in a transaction

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -130,6 +130,7 @@ type Performance struct {
 	CrossJoin       bool   `toml:"cross-join" json:"cross-join"`
 	StatsLease      string `toml:"stats-lease" json:"stats-lease"`
 	RunAutoAnalyze  bool   `toml:"run-auto-analyze" json:"run-auto-analyze"`
+	StmtCountLimit  int    `toml:"stmt-count-limit" json:"stmt-count-limit"`
 }
 
 // XProtocol is the XProtocol section of the config.
@@ -228,6 +229,7 @@ var defaultConf = Config{
 		CrossJoin:       true,
 		StatsLease:      "3s",
 		RunAutoAnalyze:  true,
+		StmtCountLimit:  1000,
 	},
 	XProtocol: XProtocol{
 		XHost: "0.0.0.0",

--- a/config/config.go
+++ b/config/config.go
@@ -229,7 +229,7 @@ var defaultConf = Config{
 		CrossJoin:       true,
 		StatsLease:      "3s",
 		RunAutoAnalyze:  true,
-		StmtCountLimit:  1000,
+		StmtCountLimit:  5000,
 	},
 	XProtocol: XProtocol{
 		XHost: "0.0.0.0",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -105,6 +105,8 @@ metrics-interval = 15
 [performance]
 # Max CPUs to use, 0 use number of CPUs in the machine.
 max-procs = 0
+# StmtCountLimit limits the max count of statement inside a transaction.
+stmt-count-limit = 1000
 
 # Set keep alive option for tcp connection.
 tcp-keep-alive = true

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -106,7 +106,7 @@ metrics-interval = 15
 # Max CPUs to use, 0 use number of CPUs in the machine.
 max-procs = 0
 # StmtCountLimit limits the max count of statement inside a transaction.
-stmt-count-limit = 1000
+stmt-count-limit = 5000
 
 # Set keep alive option for tcp connection.
 tcp-keep-alive = true

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -709,7 +709,7 @@ func (s *testSuite) TestJoinLeak(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (d int)")
 	tk.MustExec("begin")
-	for i := 0; i < 998; i++ {
+	for i := 0; i < 1002; i++ {
 		tk.MustExec("insert t values (1)")
 	}
 	tk.MustExec("commit")

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -709,7 +709,7 @@ func (s *testSuite) TestJoinLeak(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (d int)")
 	tk.MustExec("begin")
-	for i := 0; i < 1002; i++ {
+	for i := 0; i < 998; i++ {
 		tk.MustExec("insert t values (1)")
 	}
 	tk.MustExec("commit")

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/context"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -1833,4 +1834,26 @@ func (s *testSessionSuite) TestStatementErrorInTransaction(c *C) {
 	tk.MustExec("update test set b = 11 where a = 1 and b = 2;")
 	tk.MustExec("rollback")
 	tk.MustQuery("select * from test where a = 1 and b = 11").Check(testkit.Rows())
+}
+
+func (s *testSessionSuite) TestStatementCountLimit(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table stmt_count_limit (id int)")
+	config.GetGlobalConfig().Performance.StmtCountLimit = 3
+	defer func() {
+		config.GetGlobalConfig().Performance.StmtCountLimit = 1000
+	}()
+	tk.MustExec("begin")
+	tk.MustExec("insert into stmt_count_limit values (1)")
+	tk.MustExec("insert into stmt_count_limit values (2)")
+	_, err := tk.Exec("insert into stmt_count_limit values (3)")
+	c.Assert(err, NotNil)
+
+	// begin is counted into history but this one is not.
+	tk.MustExec("SET SESSION autocommit = false")
+	tk.MustExec("insert into stmt_count_limit values (1)")
+	tk.MustExec("insert into stmt_count_limit values (2)")
+	tk.MustExec("insert into stmt_count_limit values (3)")
+	_, err = tk.Exec("insert into stmt_count_limit values (4)")
+	c.Assert(err, NotNil)
 }

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -1839,9 +1839,10 @@ func (s *testSessionSuite) TestStatementErrorInTransaction(c *C) {
 func (s *testSessionSuite) TestStatementCountLimit(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table stmt_count_limit (id int)")
+	saved := config.GetGlobalConfig().Performance.StmtCountLimit
 	config.GetGlobalConfig().Performance.StmtCountLimit = 3
 	defer func() {
-		config.GetGlobalConfig().Performance.StmtCountLimit = 1000
+		config.GetGlobalConfig().Performance.StmtCountLimit = saved
 	}()
 	tk.MustExec("begin")
 	tk.MustExec("insert into stmt_count_limit values (1)")


### PR DESCRIPTION
If the user insert, insert, insert... but never commit, TiDB would OOM.
So we limit the statement count in a transaction.

@shenli @coocood 