### PR TITLE
*: avoid the generation of mysql.TypeNewDate

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -896,6 +896,13 @@ func (s *testSuite) TestUnion(c *C) {
 	// If set unspecified column flen to 0, it will cause bug in union.
 	// This test is used to prevent the bug reappear.
 	tk.MustQuery("select c from t1 union (select c from t2) order by c").Check(testkit.Rows("73", "930"))
+
+	// issue 5703
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a date)")
+	tk.MustExec("insert into t value ('2017-01-01'), ('2017-01-02')")
+	r = tk.MustQuery("(select a from t where a < 0) union (select a from t where a > 0) order by a")
+	r.Check(testkit.Rows("2017-01-01", "2017-01-02"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -1395,7 +1395,7 @@ func WrapWithCastAsTime(ctx context.Context, expr Expression, tp *types.FieldTyp
 		return expr
 	}
 	switch x := expr.GetType(); x.Tp {
-	case mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeNewDate, mysql.TypeDate, mysql.TypeDuration:
+	case mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeDate, mysql.TypeDuration:
 		tp.Decimal = x.Decimal
 	default:
 		tp.Decimal = types.MaxFsp
@@ -1422,7 +1422,7 @@ func WrapWithCastAsDuration(ctx context.Context, expr Expression) Expression {
 	}
 	tp := types.NewFieldType(mysql.TypeDuration)
 	switch x := expr.GetType(); x.Tp {
-	case mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeNewDate, mysql.TypeDate:
+	case mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeDate:
 		tp.Decimal = x.Decimal
 	default:
 		tp.Decimal = types.MaxFsp

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -191,7 +191,7 @@ func (s *testEvaluatorSuite) TestCoalesce(c *C) {
 		{[]interface{}{1, types.NewDecFromFloatForTest(123.456)}, types.NewDecFromInt(1), false, false},
 		{[]interface{}{nil, duration}, duration, false, false},
 		{[]interface{}{nil, tm, nil}, tm, false, false},
-		{[]interface{}{nil, dt, nil}, dt.String(), false, false},
+		{[]interface{}{nil, dt, nil}, dt, false, false},
 		{[]interface{}{tm, dt}, tm, false, false},
 	}
 

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2920,7 +2920,7 @@ type timestampFunctionClass struct {
 
 func (c *timestampFunctionClass) getDefaultFsp(tp *types.FieldType) int {
 	if tp.Tp == mysql.TypeDatetime || tp.Tp == mysql.TypeDate || tp.Tp == mysql.TypeDuration ||
-		tp.Tp == mysql.TypeTimestamp || tp.Tp == mysql.TypeNewDate {
+		tp.Tp == mysql.TypeTimestamp {
 		return tp.Decimal
 	}
 	switch cls := tp.EvalType(); cls {

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -215,7 +215,6 @@ func (s *testEvaluatorSuite) TestColumn2Pb(c *C) {
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeDuration, 11))
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeDatetime, 12))
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeYear, 13))
-	colExprs = append(colExprs, dg.genColumn(mysql.TypeNewDate, 14))
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeVarchar, 15))
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeJSON, 16))
 	colExprs = append(colExprs, dg.genColumn(mysql.TypeNewDecimal, 17))
@@ -230,8 +229,7 @@ func (s *testEvaluatorSuite) TestColumn2Pb(c *C) {
 	c.Assert(len(remained), Equals, 0)
 	js, err := json.Marshal(pbExpr)
 	c.Assert(err, IsNil)
-	c.Assert(string(js), Equals, "{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAM=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAQ=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAU=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAY=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAc=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAg=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAk=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAo=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAs=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAw=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAA0=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAA4=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAA8=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABA=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABE=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABI=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABM=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABQ=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABU=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABY=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABc=\",\"sig\":0}],\"sig\":0}")
-
+	c.Assert(string(js), Equals, "{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":2301,\"children\":[{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAI=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAM=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAQ=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAU=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAY=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAc=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAg=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAk=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAo=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAs=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAAw=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAA0=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAAA8=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABA=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABE=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABI=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABM=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABQ=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABU=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABY=\",\"sig\":0}],\"sig\":0},{\"tp\":201,\"val\":\"gAAAAAAAABc=\",\"sig\":0}],\"sig\":0}")
 	pbExprs = ExpressionsToPBList(sc, colExprs, client)
 	jsons := []string{
 		"{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0}",
@@ -247,7 +245,6 @@ func (s *testEvaluatorSuite) TestColumn2Pb(c *C) {
 		"{\"tp\":201,\"val\":\"gAAAAAAAAAs=\",\"sig\":0}",
 		"{\"tp\":201,\"val\":\"gAAAAAAAAAw=\",\"sig\":0}",
 		"{\"tp\":201,\"val\":\"gAAAAAAAAA0=\",\"sig\":0}",
-		"{\"tp\":201,\"val\":\"gAAAAAAAAA4=\",\"sig\":0}",
 		"{\"tp\":201,\"val\":\"gAAAAAAAAA8=\",\"sig\":0}",
 		"{\"tp\":201,\"val\":\"gAAAAAAAABA=\",\"sig\":0}",
 		"{\"tp\":201,\"val\":\"gAAAAAAAABE=\",\"sig\":0}",

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -283,7 +283,7 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			mysql.TypeBit, mysql.TypeEnum, mysql.TypeSet, mysql.TypeTinyBlob,
 			mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob,
 			mysql.TypeVarString, mysql.TypeString, mysql.TypeGeometry,
-			mysql.TypeDate, mysql.TypeNewDate,
+			mysql.TypeDate,
 			mysql.TypeTimestamp, mysql.TypeDatetime, mysql.TypeDuration:
 			if len(paramValues) < (pos + 1) {
 				err = mysql.ErrMalformPacket

--- a/server/util.go
+++ b/server/util.go
@@ -209,7 +209,7 @@ func dumpBinaryDateTime(data []byte, t types.Time, loc *time.Location) ([]byte, 
 		data = dumpUint16(data, uint16(year))
 		data = append(data, byte(mon), byte(day), byte(t.Time.Hour()), byte(t.Time.Minute()), byte(t.Time.Second()))
 		data = dumpUint32(data, uint32(t.Time.Microsecond()))
-	case mysql.TypeDate, mysql.TypeNewDate:
+	case mysql.TypeDate:
 		data = append(data, 4)
 		data = dumpUint16(data, uint16(year)) //year
 		data = append(data, byte(mon), byte(day))

--- a/table/column.go
+++ b/table/column.go
@@ -370,7 +370,7 @@ func GetZeroValue(col *model.ColumnInfo) types.Datum {
 		d.SetBytes([]byte{})
 	case mysql.TypeDuration:
 		d.SetMysqlDuration(types.ZeroDuration)
-	case mysql.TypeDate, mysql.TypeNewDate:
+	case mysql.TypeDate:
 		d.SetMysqlTime(types.ZeroDate)
 	case mysql.TypeTimestamp:
 		d.SetMysqlTime(types.ZeroTimestamp)

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -174,13 +174,6 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(vv.(Time).String(), Equals, "2010-10-10 10:11:11.1")
 
-	// For mysql.TypeNewDate.
-	ft = NewFieldType(mysql.TypeNewDate)
-	ft.Decimal = 3
-	v, err = Convert("2010-10-10 10:11:11.12345", ft)
-	c.Assert(err, IsNil)
-	c.Assert(v.(Time).String(), Equals, "2010-10-10 10:11:11.123")
-
 	// For TypeLonglong
 	ft = NewFieldType(mysql.TypeLonglong)
 	v, err = Convert("100", ft)

--- a/types/datum.go
+++ b/types/datum.go
@@ -671,7 +671,7 @@ func (d *Datum) ConvertTo(sc *stmtctx.StatementContext, target *FieldType) (Datu
 		return d.convertToString(sc, target)
 	case mysql.TypeTimestamp:
 		return d.convertToMysqlTimestamp(sc, target)
-	case mysql.TypeDatetime, mysql.TypeDate, mysql.TypeNewDate:
+	case mysql.TypeDatetime, mysql.TypeDate:
 		return d.convertToMysqlTime(sc, target)
 	case mysql.TypeDuration:
 		return d.convertToMysqlDuration(sc, target)

--- a/types/etc.go
+++ b/types/etc.go
@@ -70,7 +70,7 @@ func IsTypeFractionable(tp byte) bool {
 // IsTypeTime returns a boolean indicating
 // whether the tp is time type like datetime, date or timestamp.
 func IsTypeTime(tp byte) bool {
-	return tp == mysql.TypeDatetime || tp == mysql.TypeDate || tp == mysql.TypeNewDate || tp == mysql.TypeTimestamp
+	return tp == mysql.TypeDatetime || tp == mysql.TypeDate || tp == mysql.TypeTimestamp
 }
 
 // IsTypeFloat returns a boolean indicating whether the tp is floating-point type.

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -698,7 +698,7 @@ var fieldTypeMergeRules = [fieldTypeNum][fieldTypeNum]byte{
 		//mysql.TypeLonglong     mysql.TypeInt24
 		mysql.TypeLonglong, mysql.TypeLonglong,
 		//mysql.TypeDate         mysql.TypeTime
-		mysql.TypeNewDate, mysql.TypeDuration,
+		mysql.TypeDate, mysql.TypeDuration,
 		//mysql.TypeDatetime     mysql.TypeYear
 		mysql.TypeDatetime, mysql.TypeYear,
 		//mysql.TypeNewDate      mysql.TypeVarchar
@@ -826,11 +826,11 @@ var fieldTypeMergeRules = [fieldTypeNum][fieldTypeNum]byte{
 		//mysql.TypeFloat        mysql.TypeDouble
 		mysql.TypeVarchar, mysql.TypeVarchar,
 		//mysql.TypeNull         mysql.TypeTimestamp
-		mysql.TypeNewDate, mysql.TypeDatetime,
+		mysql.TypeDate, mysql.TypeDatetime,
 		//mysql.TypeLonglong     mysql.TypeInt24
 		mysql.TypeVarchar, mysql.TypeVarchar,
 		//mysql.TypeDate         mysql.TypeTime
-		mysql.TypeNewDate, mysql.TypeDatetime,
+		mysql.TypeDate, mysql.TypeDatetime,
 		//mysql.TypeDatetime     mysql.TypeYear
 		mysql.TypeDatetime, mysql.TypeVarchar,
 		//mysql.TypeNewDate      mysql.TypeVarchar

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -239,7 +239,7 @@ func (s *testFieldTypeSuite) TestAggFieldType(c *C) {
 		aggTp = AggFieldType([]*FieldType{fts[i], fts[i]})
 		switch fts[i].Tp {
 		case mysql.TypeDate:
-			c.Assert(aggTp.Tp, Equals, mysql.TypeNewDate)
+			c.Assert(aggTp.Tp, Equals, mysql.TypeDate)
 		case mysql.TypeJSON:
 			c.Assert(aggTp.Tp, Equals, mysql.TypeJSON)
 		case mysql.TypeEnum, mysql.TypeSet, mysql.TypeVarString:


### PR DESCRIPTION
According to https://lists.mysql.com/internals/37677

`MYSQL_TYPE_NEWDATE` is an internal type of MySQL.
MySQL can handle both `MYSQL_TYPE_NEWDATE` and `MYSQL_TYPE_DATE`,
The only difference is that `MYSQL_TYPE_DATE` takes 4 bytes while
`MYSQL_TYPE_NEWDATE` takes 3 bytes to store. 

In TiDB, we only consider mysql.TypeDate,
so we should avoid the generation of mysql.TypeNewDate.

fix #5703 

PTAL @coocood @zz-jason 