### PR TITLE
util: make list.MemoryUsage() be more efficient

### DIFF
--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -301,7 +301,7 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 	if er.err != nil {
 		return v, true
 	}
-	// Only (a,b,c) = all (...) and (a,b,c) != any () can use row expression.
+	// Only (a,b,c) = any (...) and (a,b,c) != all (...) can use row expression.
 	canMultiCol := (!v.All && v.Op == opcode.EQ) || (v.All && v.Op == opcode.NE)
 	if !canMultiCol && (getRowLen(lexpr) != 1 || np.Schema().Len() != 1) {
 		er.err = ErrOperandColumns.GenByArgs(1)

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -14,13 +14,14 @@
 package chunk
 
 import (
+	"math"
+	"testing"
+	"time"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
-	"math"
-	"testing"
-	"time"
 )
 
 func (s *testChunkSuite) TestList(c *check.C) {


### PR DESCRIPTION
fix #5722
After this commit, we only calculate the memory usage of `list.chunks[len(list.chunks)-1]`
when call list.MemoryUsage() every time.

PTAL @zz-jason