### PR TITLE
use sync.Pool to reduce gc presure on hot path

### DIFF
--- a/ast/flag_test.go
+++ b/ast/flag_test.go
@@ -33,7 +33,7 @@ type testFlagSuite struct {
 }
 
 func (ts *testFlagSuite) SetUpSuite(c *C) {
-	ts.Parser = parser.New()
+	ts.Parser = parser.NewParser()
 }
 
 func (ts *testFlagSuite) TestHasAggFlag(c *C) {

--- a/ast/format_test.go
+++ b/ast/format_test.go
@@ -84,7 +84,7 @@ func (ts *testAstFormatSuite) TestAstFormat(c *C) {
 	for _, tt := range testcases {
 		expr := fmt.Sprintf("select %s", tt.input)
 		charset, collation := getDefaultCharsetAndCollate()
-		stmts, err := parser.New().Parse(expr, charset, collation)
+		stmts, err := parser.NewParser().Parse(expr, charset, collation)
 		node := stmts[0].(*ast.SelectStmt).Fields.Fields[0].Expr
 		c.Assert(err, IsNil)
 

--- a/ast/misc_test.go
+++ b/ast/misc_test.go
@@ -97,7 +97,7 @@ jobAbbr char(4) not null,
 constraint foreign key (jobabbr) references ffxi_jobtype (jobabbr) on delete cascade on update cascade
 );
 `
-	parse := parser.New()
+	parse := parser.NewParser()
 	stmts, err := parse.Parse(sql, "", "")
 	c.Assert(err, IsNil)
 	for _, stmt := range stmts {
@@ -116,7 +116,7 @@ update t1 set col1 = col1 + 1, col2 = col1;
 show create table t;
 load data infile '/tmp/t.csv' into table t fields terminated by 'ab' enclosed by 'b';`
 
-	p := parser.New()
+	p := parser.NewParser()
 	stmts, err := p.Parse(sql, "", "")
 	c.Assert(err, IsNil)
 	for _, stmt := range stmts {

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -115,7 +115,7 @@ func globalVarsCount() int64 {
 func (s *testBootstrapSuite) bootstrapWithOnlyDDLWork(store kv.Storage, c *C) {
 	ss := &session{
 		store:       store,
-		parser:      parser.New(),
+		parser:      parser.NewParser(),
 		sessionVars: variable.NewSessionVars(),
 	}
 	ss.mu.values = make(map[fmt.Stringer]interface{})

--- a/cmd/importer/parser.go
+++ b/cmd/importer/parser.go
@@ -219,7 +219,7 @@ func parseTable(t *table, stmt *ast.CreateTableStmt) error {
 }
 
 func parseTableSQL(table *table, sql string) error {
-	stmt, err := parser.New().ParseOneStmt(sql, "", "")
+	stmt, err := parser.NewParser().ParseOneStmt(sql, "", "")
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -256,7 +256,7 @@ func parseIndexSQL(table *table, sql string) error {
 		return nil
 	}
 
-	stmt, err := parser.New().ParseOneStmt(sql, "", "")
+	stmt, err := parser.NewParser().ParseOneStmt(sql, "", "")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -926,7 +926,7 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 
 func (s *testColumnSuite) colDefStrToFieldType(c *C, str string) *types.FieldType {
 	sqlA := "alter table t modify column a " + str
-	stmt, err := parser.New().ParseOneStmt(sqlA, "", "")
+	stmt, err := parser.NewParser().ParseOneStmt(sqlA, "", "")
 	c.Assert(err, IsNil)
 	colDef := stmt.(*ast.AlterTableStmt).Specs[0].NewColumns[0]
 	col, _, err := buildColumnAndConstraint(nil, 0, colDef)

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -57,7 +57,7 @@ func (s *testStateChangeSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	_, err = s.se.Execute(goctx.Background(), "use test_db_state")
 	c.Assert(err, IsNil)
-	s.p = parser.New()
+	s.p = parser.NewParser()
 }
 
 func (s *testStateChangeSuite) TearDownSuite(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -78,7 +78,7 @@ var mockTikv = flag.Bool("mockTikv", true, "use mock tikv store in executor test
 func (s *testSuite) SetUpSuite(c *C) {
 	s.autoIDStep = autoid.GetStep()
 	autoid.SetStep(5000)
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 	flag.Lookup("mockTikv")
 	useMockTikv := *mockTikv
 	if useMockTikv {

--- a/executor/metrics_test.go
+++ b/executor/metrics_test.go
@@ -58,7 +58,7 @@ func (s *testSuite) TestStmtLabel(c *C) {
 	}
 	var ignore bool
 	for _, tt := range tests {
-		stmtNode, err := parser.New().ParseOneStmt(tt.sql, "", "")
+		stmtNode, err := parser.NewParser().ParseOneStmt(tt.sql, "", "")
 		c.Check(err, IsNil)
 		is := executor.GetInfoSchema(tk.Se)
 		err = plan.Preprocess(tk.Se.(context.Context), stmtNode, is, false)

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -120,7 +120,7 @@ func (e *PrepareExec) DoPrepare() error {
 	if sqlParser, ok := e.ctx.(sqlexec.SQLParser); ok {
 		stmts, err = sqlParser.ParseSQL(e.sqlText, charset, collation)
 	} else {
-		stmts, err = parser.New().Parse(e.sqlText, charset, collation)
+		stmts, err = parser.NewParser().Parse(e.sqlText, charset, collation)
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/expression/aggregation/agg_to_pb_test.go
+++ b/expression/aggregation/agg_to_pb_test.go
@@ -106,7 +106,7 @@ type testEvaluatorSuite struct {
 }
 
 func (s *testEvaluatorSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 	s.ctx = mock.NewContext()
 }
 

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -41,7 +41,7 @@ type testEvaluatorSuite struct {
 }
 
 func (s *testEvaluatorSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 	s.ctx = mock.NewContext()
 	s.ctx.GetSessionVars().StmtCtx.TimeZone = time.Local
 }

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -52,7 +52,7 @@ type testInferTypeSuite struct {
 }
 
 func (s *testInferTypeSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 }
 
 func (s *testInferTypeSuite) TearDownSuite(c *C) {

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -46,7 +46,7 @@ type testMySQLConstSuite struct {
 var mockTikv = flag.Bool("mockTikv", true, "use mock tikv store in executor test")
 
 func (s *testMySQLConstSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 	flag.Lookup("mockTikv")
 	useMockTikv := *mockTikv
 	if useMockTikv {

--- a/new_session_test.go
+++ b/new_session_test.go
@@ -339,7 +339,7 @@ func (s *testSessionSuite) TestRetryCleanTxn(c *C) {
 
 	// Hijack retry history, add a statement that returns error.
 	history := tidb.GetHistory(tk.Se)
-	stmtNode, err := parser.New().ParseOneStmt("insert retrytxn values (2, 'a')", "", "")
+	stmtNode, err := parser.NewParser().ParseOneStmt("insert retrytxn values (2, 'a')", "", "")
 	c.Assert(err, IsNil)
 	stmt, _ := tidb.Compile(goctx.TODO(), tk.Se, stmtNode)
 	executor.ResetStmtCtx(tk.Se, stmtNode)

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -32,7 +32,22 @@ func BenchmarkSysbenchSelect(b *testing.B) {
 	b.ReportAllocs()
 }
 
-func BenchmarkParse(b *testing.B) {
+func BenchmarkParseDecimal(b *testing.B) {
+	var sql = "select 1234567890123456789012345678901230947.0;"
+	parser := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 10240; j++ {
+			_, err := parser.Parse(sql, "", "")
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkParseInt(b *testing.B) {
 	var table = []string{
 		"insert into t values (1), (2), (3)",
 		"insert into t values (4), (5), (6), (7)",

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -27,7 +27,7 @@ func sysebchSelect(parser *Parser, sql string, num int, b *testing.B) {
 }
 
 func BenchmarkSysbenchSelect1024(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -37,7 +37,7 @@ func BenchmarkSysbenchSelect1024(b *testing.B) {
 }
 
 func BenchmarkSysbenchSelect256(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -47,7 +47,7 @@ func BenchmarkSysbenchSelect256(b *testing.B) {
 }
 
 func BenchmarkSysbenchSelect128(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -57,7 +57,7 @@ func BenchmarkSysbenchSelect128(b *testing.B) {
 }
 
 func BenchmarkParseInt4096(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, v := range table {
@@ -68,7 +68,7 @@ func BenchmarkParseInt4096(b *testing.B) {
 }
 
 func BenchmarkParseInt1024(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, v := range table {
@@ -86,7 +86,7 @@ var table = []string{
 }
 
 func BenchmarkParseInt512(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, v := range table {
@@ -107,7 +107,7 @@ func parseInt(parser *Parser, sql string, num int, b *testing.B) {
 }
 
 func BenchmarkParseInt256(b *testing.B) {
-	parser := New()
+	parser := NewParser()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, v := range table {

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -17,53 +17,103 @@ import (
 	"testing"
 )
 
-func BenchmarkSysbenchSelect(b *testing.B) {
+func sysebchSelect(parser *Parser, sql string, num int, b *testing.B) {
+	for i := 0; i < num; i++ {
+		_, err := parser.Parse(sql, "", "")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSysbenchSelect1024(b *testing.B) {
 	parser := New()
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10240; j++ {
-			_, err := parser.Parse(sql, "", "")
-			if err != nil {
-				b.Fatal(err)
-			}
+		sysebchSelect(parser, sql, 1024, b)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkSysbenchSelect256(b *testing.B) {
+	parser := New()
+	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sysebchSelect(parser, sql, 256, b)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkSysbenchSelect128(b *testing.B) {
+	parser := New()
+	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sysebchSelect(parser, sql, 128, b)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkParseInt4096(b *testing.B) {
+	parser := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, v := range table {
+			parseInt(parser, v, 4096, b)
 		}
 	}
 	b.ReportAllocs()
 }
 
-func BenchmarkParseDecimal(b *testing.B) {
-	var sql = "select 1234567890123456789012345678901230947.0;"
+func BenchmarkParseInt1024(b *testing.B) {
 	parser := New()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10240; j++ {
-			_, err := parser.Parse(sql, "", "")
-			if err != nil {
-				b.Fatal(err)
-			}
+		for _, v := range table {
+			parseInt(parser, v, 1024, b)
 		}
 	}
 	b.ReportAllocs()
 }
 
-func BenchmarkParseInt(b *testing.B) {
-	var table = []string{
-		"insert into t values (1), (2), (3)",
-		"insert into t values (4), (5), (6), (7)",
-		"select c from t where c > 2",
-	}
+var table = []string{
+	"insert into t values (1), (2), (3)",
+	"insert into t values (4), (5), (6), (7)",
+	"select c from t where c > 2",
+	"select c from t where c > 1234567890123456789012345678901234567890.0;",
+}
+
+func BenchmarkParseInt512(b *testing.B) {
 	parser := New()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 10240; j++ {
-			for _, v := range table {
-				_, err := parser.Parse(v, "", "")
-				if err != nil {
-					b.Fatal(err)
-				}
-			}
+		for _, v := range table {
+			parseInt(parser, v, 512, b)
 		}
+
+	}
+	b.ReportAllocs()
+}
+
+func parseInt(parser *Parser, sql string, num int, b *testing.B) {
+	for i := 0; i < num; i++ {
+		_, err := parser.Parse(sql, "", "")
+		if err != nil {
+			b.Failed()
+		}
+	}
+}
+
+func BenchmarkParseInt256(b *testing.B) {
+	parser := New()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, v := range table {
+			parseInt(parser, v, 256, b)
+		}
+
 	}
 	b.ReportAllocs()
 }

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkSysbenchSelect(b *testing.B) {
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 1024; j++ {
+		for j := 0; j < 10240; j++ {
 			_, err := parser.Parse(sql, "", "")
 			if err != nil {
 				b.Fatal(err)
@@ -41,7 +41,7 @@ func BenchmarkParse(b *testing.B) {
 	parser := New()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < 1024; j++ {
+		for j := 0; j < 10240; j++ {
 			for _, v := range table {
 				_, err := parser.Parse(v, "", "")
 				if err != nil {

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -22,9 +22,11 @@ func BenchmarkSysbenchSelect(b *testing.B) {
 	sql := "SELECT pad FROM sbtest1 WHERE id=1;"
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := parser.Parse(sql, "", "")
-		if err != nil {
-			b.Fatal(err)
+		for j := 0; j < 1024; j++ {
+			_, err := parser.Parse(sql, "", "")
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	}
 	b.ReportAllocs()
@@ -39,10 +41,12 @@ func BenchmarkParse(b *testing.B) {
 	parser := New()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _, v := range table {
-			_, err := parser.Parse(v, "", "")
-			if err != nil {
-				b.Failed()
+		for j := 0; j < 1024; j++ {
+			for _, v := range table {
+				_, err := parser.Parse(v, "", "")
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		}
 	}

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -97,7 +97,8 @@ func (s *Scanner) reset(sql string) {
 }
 
 func (s *Scanner) stmtText() string {
-	endPos := s.r.pos().Offset
+	var endPos int
+	endPos = s.r.pos().Offset
 	if s.r.s[endPos-1] == '\n' {
 		endPos = endPos - 1 // trim new line
 	}
@@ -134,9 +135,8 @@ func (s *Scanner) Lex(v *yySymType) int {
 	v.ident = lit
 	if tok == identifier {
 		tok = handleIdent(v)
-	}
-	if tok == identifier {
-		if tok1 := s.isTokenIdentifier(lit, pos.Offset); tok1 != 0 {
+		var tok1 int
+		if tok1 = s.isTokenIdentifier(lit, pos.Offset); tok1 != 0 {
 			tok = tok1
 		}
 	}

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -76,8 +76,8 @@ type stmtTexter interface {
 	stmtText() string
 }
 
-// New returns a Parser object.
-func New() *Parser {
+// NewParser returns a Parser object.
+func NewParser() *Parser {
 	return &Parser{
 		cache: make([]yySymType, 200),
 	}

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -185,11 +185,14 @@ func toInt(l yyLexer, lval *yySymType, str string) int {
 	default:
 		lval.item = n
 	}
+	if d, ok := lval.item.(*types.MyDecimal); ok {
+		d.Free()
+	}
 	return intLit
 }
 
 func toDecimal(l yyLexer, lval *yySymType, str string) int {
-	dec := new(types.MyDecimal)
+	dec := types.NewMyDecimal()
 	err := dec.FromString(hack.Slice(str))
 	if err != nil {
 		l.Errorf("decimal literal: %v", err)

--- a/plan/expression_test.go
+++ b/plan/expression_test.go
@@ -36,7 +36,7 @@ type testExpressionSuite struct {
 }
 
 func (s *testExpressionSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 	s.ctx = mock.NewContext()
 }
 

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -52,7 +52,7 @@ type testPlanSuite struct {
 func (s *testPlanSuite) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{MockTable()})
 	s.ctx = mockContext()
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 }
 
 func newLongType() types.FieldType {

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -36,7 +36,7 @@ type testPlanSuite struct {
 
 func (s *testPlanSuite) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{plan.MockTable()})
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 }
 
 func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {

--- a/session.go
+++ b/session.go
@@ -1259,7 +1259,7 @@ func createSession(store kv.Storage) (*session, error) {
 	}
 	s := &session{
 		store:       store,
-		parser:      parser.New(),
+		parser:      parser.NewParser(),
 		sessionVars: variable.NewSessionVars(),
 	}
 	if plan.PreparedPlanCacheEnabled {
@@ -1282,7 +1282,7 @@ func createSession(store kv.Storage) (*session, error) {
 func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, error) {
 	s := &session{
 		store:       store,
-		parser:      parser.New(),
+		parser:      parser.NewParser(),
 		sessionVars: variable.NewSessionVars(),
 	}
 	if plan.PreparedPlanCacheEnabled {

--- a/table/tables/gen_expr.go
+++ b/table/tables/gen_expr.go
@@ -65,7 +65,7 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 func parseExpression(expr string) (node ast.ExprNode, err error) {
 	expr = fmt.Sprintf("select %s", expr)
 	charset, collation := getDefaultCharsetAndCollate()
-	stmts, err := parser.New().Parse(expr, charset, collation)
+	stmts, err := parser.NewParser().Parse(expr, charset, collation)
 	if err == nil {
 		node = stmts[0].(*ast.SelectStmt).Fields.Fields[0].Expr
 	}

--- a/tidb.go
+++ b/tidb.go
@@ -136,7 +136,7 @@ func SetCommitRetryLimit(limit int) {
 func Parse(ctx context.Context, src string) ([]ast.StmtNode, error) {
 	log.Debug("compiling", src)
 	charset, collation := ctx.GetSessionVars().GetCharsetInfo()
-	p := parser.New()
+	p := parser.NewParser()
 	p.SetSQLMode(ctx.GetSessionVars().SQLMode)
 	stmts, err := p.Parse(src, charset, collation)
 	if err != nil {

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -45,7 +45,7 @@ type testRangerSuite struct {
 }
 
 func (s *testRangerSuite) SetUpSuite(c *C) {
-	s.Parser = parser.New()
+	s.Parser = parser.NewParser()
 }
 
 func newStoreWithBootstrap(c *C) (kv.Storage, error) {


### PR DESCRIPTION
Below is the benchmark, I am not sure why the ~~~memory usage does not decrease.~~~ (we just reuse the object. Memory allocation is still original. Using sync.Pool can only reduce gc pressure. )
I am inverstigating this. In additon, I will add different workload benchmark test later.
```
name              old time/op    new time/op    delta
SysbenchSelect-8    46.8ms ± 1%    46.5ms ± 5%  -0.55%  (p=0.044 n=18+20)
Parse-8              147ms ± 3%     145ms ± 2%  -1.61%  (p=0.000 n=20+17)

name              old alloc/op   new alloc/op   delta
SysbenchSelect-8    18.4MB ± 0%    18.4MB ± 0%    ~     (p=0.057 n=17+18)
Parse-8             51.7MB ± 0%    51.7MB ± 0%    ~     (p=0.072 n=19+20)

name              old allocs/op  new allocs/op  delta
SysbenchSelect-8      184k ± 0%      184k ± 0%    ~     (all equal)
Parse-8               707k ± 0%      707k ± 0%    ~     (all equal)
```