### PR TITLE
plan: remove unneeded lines of code

### DIFF
--- a/plan/column_pruning.go
+++ b/plan/column_pruning.go
@@ -165,10 +165,6 @@ func (ds *DataSource) PruneColumns(parentUsedCols []*expression.Column) {
 }
 
 // PruneColumns implements LogicalPlan interface.
-func (p *LogicalTableDual) PruneColumns(_ []*expression.Column) {
-}
-
-// PruneColumns implements LogicalPlan interface.
 func (p *LogicalExists) PruneColumns(parentUsedCols []*expression.Column) {
 	p.children[0].PruneColumns(nil)
 }


### PR DESCRIPTION
IMHO, I think the function `LogicalTableDual.PruneColumns(_ []*expression.Column)` is unneeded since it just returns nothing like what the following function does.
https://github.com/pingcap/tidb/blob/c6e14669715b5b4a5e9afd7667d3df83741ab47f/plan/plan.go#L304-L310.