### PR TITLE
ddl: fix shard show id bug

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -276,7 +276,7 @@ func (d *ddl) onShardRowID(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		return ver, errors.Trace(err)
 	}
 	tblInfo.ShardRowIDBits = shardRowIDBits
-	job.State = model.JobCancelled
+	job.State = model.JobDone
 	job.BinlogInfo.AddTableInfo(ver, tblInfo)
 	ver, err = updateTableInfo(t, job, tblInfo, tblInfo.State)
 	if err != nil {

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -310,4 +310,6 @@ func (s *testSuite) TestShardRowIDBits(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, 100)
 	c.Assert(hasShardedID, IsTrue)
+
+	tk.MustExec("alter table t shard_row_id_bits = 5")
 }


### PR DESCRIPTION
The master is OK, but the release 1.0 is wrong.
Because the job's state is wrong when cherry picks the operation to release 1.0
original PR #5513
cherry-pick PR #5559 