### PR TITLE
executor: join don't need any inner filter.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -645,7 +645,6 @@ func (b *executorBuilder) buildHashJoin(v *plan.PhysicalHashJoin) Executor {
 	if v.InnerChildIdx == 0 {
 		e.innerExec = leftExec
 		e.outerExec = rightExec
-		e.innerFilter = v.LeftConditions
 		e.outerFilter = v.RightConditions
 		e.innerKeys = leftHashKey
 		e.outerKeys = rightHashKey
@@ -655,7 +654,6 @@ func (b *executorBuilder) buildHashJoin(v *plan.PhysicalHashJoin) Executor {
 	} else {
 		e.innerExec = rightExec
 		e.outerExec = leftExec
-		e.innerFilter = v.RightConditions
 		e.outerFilter = v.LeftConditions
 		e.innerKeys = rightHashKey
 		e.outerKeys = leftHashKey
@@ -1087,7 +1085,6 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plan.PhysicalIndexJoin) Execut
 		innerCtx: innerCtx{
 			readerBuilder: &dataReaderBuilder{innerPlan, b},
 			rowTypes:      innerTypes,
-			filter:        innerFilter,
 		},
 		workerWg:        new(sync.WaitGroup),
 		resultGenerator: newJoinResultGenerator(b.ctx, v.JoinType, v.OuterIndex == 1, defaultValues, v.OtherConditions, leftTypes, rightTypes),

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -645,6 +645,7 @@ func (b *executorBuilder) buildHashJoin(v *plan.PhysicalHashJoin) Executor {
 	if v.InnerChildIdx == 0 {
 		if len(v.LeftConditions) > 0 {
 			b.err = errors.Annotate(ErrBuildExecutor, "join's inner condition should be empty")
+			return nil
 		}
 		e.innerExec = leftExec
 		e.outerExec = rightExec
@@ -657,6 +658,7 @@ func (b *executorBuilder) buildHashJoin(v *plan.PhysicalHashJoin) Executor {
 	} else {
 		if len(v.RightConditions) > 0 {
 			b.err = errors.Annotate(ErrBuildExecutor, "join's inner condition should be empty")
+			return nil
 		}
 		e.innerExec = rightExec
 		e.outerExec = leftExec
@@ -1082,12 +1084,14 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plan.PhysicalIndexJoin) Execut
 		outerFilter = v.RightConditions
 		if len(v.LeftConditions) > 0 {
 			b.err = errors.Annotate(ErrBuildExecutor, "join's inner condition should be empty")
+			return nil
 		}
 	} else {
 		leftTypes, rightTypes = outerTypes, innerTypes
 		outerFilter = v.LeftConditions
 		if len(v.RightConditions) > 0 {
 			b.err = errors.Annotate(ErrBuildExecutor, "join's inner condition should be empty")
+			return nil
 		}
 	}
 	defaultValues := v.DefaultValues

--- a/executor/join.go
+++ b/executor/join.go
@@ -324,7 +324,7 @@ func (e *HashJoinExec) fetchOuterChunks(goCtx goctx.Context) {
 	}
 }
 
-// fetchInnerRows fetches all the selected rows from inner executor,
+// fetchInnerRows fetches all rows from inner executor,
 // and append them to e.innerResult.
 func (e *HashJoinExec) fetchInnerRows(goCtx goctx.Context) (err error) {
 	innerResult := chunk.NewList(e.innerExec.retTypes(), e.maxChunkSize)

--- a/executor/join.go
+++ b/executor/join.go
@@ -44,7 +44,6 @@ type HashJoinExec struct {
 	outerExec   Executor
 	innerExec   Executor
 	outerFilter expression.CNFExprs
-	innerFilter expression.CNFExprs
 	outerKeys   []*expression.Column
 	innerKeys   []*expression.Column
 
@@ -325,32 +324,21 @@ func (e *HashJoinExec) fetchOuterChunks(goCtx goctx.Context) {
 	}
 }
 
-// fetchSelectedInnerRows fetches all the selected rows from inner executor,
+// fetchInnerRows fetches all the selected rows from inner executor,
 // and append them to e.innerResult.
-func (e *HashJoinExec) fetchSelectedInnerRows(goCtx goctx.Context) (err error) {
-	innerExecChk := e.childrenResults[e.innerIdx]
-	innerIter := chunk.NewIterator4Chunk(innerExecChk)
-	selected := make([]bool, 0, chunk.InitialCapacity)
+func (e *HashJoinExec) fetchInnerRows(goCtx goctx.Context) (err error) {
 	innerResult := chunk.NewList(e.innerExec.retTypes(), e.maxChunkSize)
 	memExceedThreshold, execMemThreshold := false, e.ctx.GetSessionVars().MemThreshold
 	for {
-		innerExecChk.Reset()
-		err = e.innerExec.NextChunk(goCtx, innerExecChk)
+		chk := e.children[e.innerIdx].newChunk()
+		err = e.innerExec.NextChunk(goCtx, chk)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if innerExecChk.NumRows() == 0 {
+		if chk.NumRows() == 0 {
 			break
 		}
-		selected, err = expression.VectorizedFilter(e.ctx, e.innerFilter, innerIter, selected)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		for idx := range selected {
-			if selected[idx] {
-				innerResult.AppendRow(innerExecChk.GetRow(idx))
-			}
-		}
+		innerResult.Add(chk)
 		innerMemUsage := innerResult.MemoryUsage()
 		if !memExceedThreshold && innerMemUsage > execMemThreshold {
 			memExceedThreshold = true
@@ -426,14 +414,6 @@ func (e *HashJoinExec) prepare4Row(goCtx goctx.Context) error {
 		}
 		if innerRow == nil {
 			break
-		}
-
-		matched, err := expression.EvalBool(e.innerFilter, innerRow, e.ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if !matched {
-			continue
 		}
 
 		hasNull, joinKey, err := getJoinKey(e.ctx.GetSessionVars().StmtCtx, e.innerKeys, innerRow, e.hashJoinBuffers[0].data, nil)
@@ -795,7 +775,7 @@ func (e *HashJoinExec) Next(goCtx goctx.Context) (Row, error) {
 // step 2. fetch data from outer child in a background goroutine and probe the hash table in multiple join workers.
 func (e *HashJoinExec) NextChunk(goCtx goctx.Context, chk *chunk.Chunk) (err error) {
 	if !e.prepared {
-		if err = e.fetchSelectedInnerRows(goCtx); err != nil {
+		if err = e.fetchInnerRows(goCtx); err != nil {
 			return errors.Trace(err)
 		}
 		if err = e.buildHashTableForList(); err != nil {


### PR DESCRIPTION
You can see detail in [predicate_push_down.go](https://github.com/pingcap/tidb/blob/master/plan/predicate_push_down.go#L109).
Join won't retain the inner conditions.
PTAL @XuHuaiyu @zz-jason 