### PR TITLE
execute: set TableAsName and ColumnAsName for prepared statement

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -152,6 +152,14 @@ func (e *PrepareExec) DoPrepare() {
 	}
 	if result, ok := stmt.(ast.ResultSetNode); ok {
 		e.Fields = result.GetResultFields()
+		for _, fields := range e.Fields {
+			if fields.TableAsName.O == "" {
+				fields.TableAsName = fields.Table.Name
+			}
+			if fields.ColumnAsName.O == "" {
+				fields.ColumnAsName = fields.Column.Name
+			}
+		}
 	}
 
 	// The parameter markers are appended in visiting order, which may not

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -97,6 +97,37 @@ func (s *testSuite) TestPrepared(c *C) {
 	_, err = tk.Exec("execute stmt")
 	c.Assert(err, NotNil)
 
+	_, _, fields, err := tk.Se.PrepareStmt("select a from prepare3")
+	c.Assert(err, IsNil)
+	c.Assert(fields[0].DBName.L, Equals, "test")
+	c.Assert(fields[0].TableAsName.L, Equals, "prepare3")
+	c.Assert(fields[0].ColumnAsName.L, Equals, "a")
+
+	_, _, fields, err = tk.Se.PrepareStmt("select a from prepare3 where ?")
+	c.Assert(err, IsNil)
+	c.Assert(fields[0].DBName.L, Equals, "test")
+	c.Assert(fields[0].TableAsName.L, Equals, "prepare3")
+	c.Assert(fields[0].ColumnAsName.L, Equals, "a")
+
+	_, _, fields, err = tk.Se.PrepareStmt("select (1,1) in (select 1,1)")
+	c.Assert(err, IsNil)
+	c.Assert(fields[0].DBName.L, Equals, "")
+	c.Assert(fields[0].TableAsName.L, Equals, "")
+	c.Assert(fields[0].ColumnAsName.L, Equals, "(1,1) in (select 1,1)")
+
+	_, _, fields, err = tk.Se.PrepareStmt("select * from prepare3 as t1 join prepare3 as t2")
+	c.Assert(err, IsNil)
+	c.Assert(fields[0].DBName.L, Equals, "test")
+	c.Assert(fields[0].TableAsName.L, Equals, "t1")
+	c.Assert(fields[0].ColumnAsName.L, Equals, "a")
+	c.Assert(fields[1].DBName.L, Equals, "test")
+	c.Assert(fields[1].TableAsName.L, Equals, "t2")
+	c.Assert(fields[1].ColumnAsName.L, Equals, "a")
+
+	_, _, fields, err = tk.Se.PrepareStmt("update prepare3 set a = ?")
+	c.Assert(err, IsNil)
+	c.Assert(len(fields), Equals, 0)
+
 	// Coverage.
 	exec := &executor.ExecuteExec{}
 	exec.Next()


### PR DESCRIPTION
This C++ code will panic in v1.0.7 because TiDB returns wrong column information for prepared statement.

```
#include <stdlib.h>
#include <iostream>
#include "mysql_connection.h"

#include <cppconn/driver.h>
#include <cppconn/exception.h>
#include <cppconn/resultset.h>
#include <cppconn/statement.h>
#include <cppconn/prepared_statement.h>

int main() {
	sql::Driver* driver = get_driver_instance();
	sql::Connection *conn = driver->connect("127.0.0.1:4000", "root", "");
	conn->setSchema("test");
	conn->setClientOption("libmysql_debug", "d:t:0,client.trace");
	int on_off = 1;
	conn->setClientOption("clientTrace", &on_off);
	sql::PreparedStatement *stmt = conn->prepareStatement("select * from test limit ?");
	stmt->setInt(1, 2);
	stmt->execute();

	sql::ResultSet *res = stmt->executeQuery();
	std::cout << "00" << std::endl;
	while (res->next()) {
		std::cout << res->getInt64("a") << std::endl;
		std::cout << "22" << std::endl;
	}

	delete stmt;
	delete conn;
}
```

Set TableAsName and ColumnAsName for prepared statement will fix it.

PTAL @XuHuaiyu @coocood @shenli 