### PR TITLE
set gcScanLockLimit appropriately 

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -104,7 +104,8 @@ const (
 	gcDefaultLifeTime        = time.Minute * 10
 	gcSafePointKey           = "tikv_gc_safe_point"
 	gcSafePointCacheInterval = tikv.GcSafePointCacheInterval
-	gcScanLockLimit          = 1000
+	// We don't want gc to sweep out the cached info belong to other processes, like coprocessor.
+	gcScanLockLimit = tikv.ResolvedCacheSize / 2
 )
 
 var gcVariableComments = map[string]string{

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -28,7 +28,8 @@ import (
 	goctx "golang.org/x/net/context"
 )
 
-const resolvedCacheSize = 512
+// ResolvedCacheSize is max number of cached txn status.
+const ResolvedCacheSize = 2048
 
 // LockResolver resolves locks and also caches resolved txn status.
 type LockResolver struct {
@@ -132,7 +133,7 @@ func (lr *LockResolver) saveResolved(txnID uint64, status TxnStatus) {
 	}
 	lr.mu.resolved[txnID] = status
 	lr.mu.recentResolved.PushBack(txnID)
-	if len(lr.mu.resolved) > resolvedCacheSize {
+	if len(lr.mu.resolved) > ResolvedCacheSize {
 		front := lr.mu.recentResolved.Front()
 		delete(lr.mu.resolved, front.Value.(uint64))
 		lr.mu.recentResolved.Remove(front)


### PR DESCRIPTION
To avoid gc worker fill the resolved lock cache full.
