### PR TITLE
tidb: fix benchmark go test -test.bench=. -test.run=^XXX

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -62,6 +62,10 @@ func prepareSortBenchData(se Session, colType string, valueFormat string, valueC
 	mustExecute(se, "begin")
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < valueCount; i++ {
+		if i%1000 == 0 {
+			mustExecute(se, "commit")
+			mustExecute(se, "begin")
+		}
 		mustExecute(se, "insert t (col) values ("+fmt.Sprintf(valueFormat, r.Intn(valueCount))+")")
 	}
 	mustExecute(se, "commit")
@@ -93,7 +97,9 @@ func readResult(goCtx goctx.Context, rs ast.RecordSet, count int) {
 
 func BenchmarkBasic(b *testing.B) {
 	goCtx := goctx.Background()
+	b.StopTimer()
 	se := prepareBenchSession()
+	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		rs, err := se.Execute(goCtx, "select 1")
 		if err != nil {


### PR DESCRIPTION
1. BenchmarkBasic is a magnitude slower than others.

```
BenchmarkBasic-4                    	       1	1319074066 ns/op
BenchmarkTableScan-4                	    2000	    840275 ns/op
BenchmarkExplainTableScan-4         	   50000	     29682 ns/op
BenchmarkTableLookup-4              	   20000	     91850 ns/op
BenchmarkExplainTableLookup-4       	   30000	     46362 ns/op
```
2.  Fix a panic.

```
goroutine 11105 [running]:
runtime/debug.Stack(0x1, 0xc4352c5d48, 0x410858)
	/media/genius/OS/project/go/src/runtime/debug/stack.go:24 +0xa7
runtime/debug.PrintStack()
	/media/genius/OS/project/go/src/runtime/debug/stack.go:16 +0x22
github.com/pingcap/tidb.mustExecute(0x1a6e3c0, 0xc43e9b5d40, 0xc42686d880, 0x1c)
	/media/genius/OS/project/src/github.com/pingcap/tidb/bootstrap.go:661 +0xb9
github.com/pingcap/tidb.prepareSortBenchData(0x1a6e3c0, 0xc43e9b5d40, 0x1260094, 0x3, 0x125fa8a, 0x2, 0x2710)
	/media/genius/OS/project/src/github.com/pingcap/tidb/bench_test.go:65 +0x38f
github.com/pingcap/tidb.BenchmarkSort(0xc428e65080)
	/media/genius/OS/project/src/github.com/pingcap/tidb/bench_test.go:297 +0xd2
testing.(*B).runN(0xc428e65080, 0x1)
	/media/genius/OS/project/go/src/testing/benchmark.go:141 +0xb2
testing.(*B).run1.func1(0xc428e65080)
	/media/genius/OS/project/go/src/testing/benchmark.go:214 +0x5a
created by testing.(*B).run1
	/media/genius/OS/project/go/src/testing/benchmark.go:207 +0x80
FATA[0101] statement count 5001 exceeds the transaction limitation, autocommit = true 
```
