### PR TITLE
importer: support varchar for set

### DIFF
--- a/cmd/importer/README.md
+++ b/cmd/importer/README.md
@@ -129,7 +129,7 @@ mysql> select * from t;
 ```
 Support Type [can only be used in none unique index]: 
 
-tinyint | smallint | int | bigint | float | double | decimal.
+tinyint | smallint | int | bigint | float | double | decimal | varchar.
 
 ## License
 Apache 2.0 license. See the [LICENSE](../LICENSE) file for details.

--- a/cmd/importer/db.go
+++ b/cmd/importer/db.go
@@ -44,6 +44,14 @@ func intRangeValue(column *column, min int64, max int64) (int64, int64) {
 	return min, max
 }
 
+func randStringValue(column *column, n int) string {
+	if len(column.set) > 0 {
+		idx := randInt(0, len(column.set)-1)
+		return column.set[idx]
+	}
+	return randString(randInt(1, n))
+}
+
 func randInt64Value(column *column, min int64, max int64) int64 {
 	if len(column.set) > 0 {
 		idx := randInt(0, len(column.set)-1)
@@ -152,7 +160,7 @@ func genColumnData(table *table, column *column) (string, error) {
 		if isUnique {
 			data = append(data, []byte(column.data.uniqString(tp.Flen))...)
 		} else {
-			data = append(data, []byte(randString(randInt(1, tp.Flen)))...)
+			data = append(data, []byte(randStringValue(column, tp.Flen))...)
 		}
 
 		data = append(data, '\'')


### PR DESCRIPTION
This PR enables generating varchar type in set like this:
```
./importer -t "create table t(a varchar(10) comment '[[set=ios,android]]');" -P 4000 -c 1 -n 10
```
@hanfei1991 @lamxTyler PTAL