### PR TITLE
types,executor: treat decimal truncate as warning in update

### DIFF
--- a/executor/statement_context_test.go
+++ b/executor/statement_context_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
@@ -37,9 +36,7 @@ func (s *testSuite) TestStatementContext(c *C) {
 
 	tk.MustExec(strictModeSQL)
 	tk.MustQuery("select * from sc where a > cast(1.1 as decimal)").Check(testkit.Rows("2"))
-	_, err := tk.Exec(`select * from sc where a > cast(1.1 as decimal);
-		        update sc set a = 4 where a > cast(1.1 as decimal)`)
-	c.Check(terror.ErrorEqual(err, types.ErrTruncated), IsTrue)
+	tk.MustExec("update sc set a = 4 where a > cast(1.1 as decimal)")
 
 	tk.MustExec(nonStrictModeSQL)
 	tk.MustExec("update sc set a = 3 where a > cast(1.1 as decimal)")
@@ -53,7 +50,7 @@ func (s *testSuite) TestStatementContext(c *C) {
 	// Handle coprocessor flags, '1x' is an invalid int.
 	// UPDATE and DELETE do select request first which is handled by coprocessor.
 	// In strict mode we expect error.
-	_, err = tk.Exec("update sc set a = 4 where a > '1x'")
+	_, err := tk.Exec("update sc set a = 4 where a > '1x'")
 	c.Assert(err, NotNil)
 	_, err = tk.Exec("delete from sc where a < '1x'")
 	c.Assert(err, NotNil)

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -654,6 +654,7 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("insert into decimals values (201)")
 	// A warning rather than data truncated error.
 	tk.MustExec("update decimals set a = a + 1.23;")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1265 Data Truncated"))
 	r = tk.MustQuery("select * from decimals")
 	r.Check(testkit.Rows("202"))
 }

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -648,6 +648,14 @@ func (s *testSuite) TestUpdate(c *C) {
 	r1 := tk.MustQuery("select ts from tsup use index (idx);")
 	r2 := tk.MustQuery("select ts from tsup;")
 	r1.Check(r2.Rows())
+
+	// issue 5532
+	tk.MustExec("create table decimals (a decimal(20, 0) not null)")
+	tk.MustExec("insert into decimals values (201)")
+	// A warning rather than data truncated error.
+	tk.MustExec("update decimals set a = a + 1.23;")
+	r = tk.MustQuery("select * from decimals")
+	r.Check(testkit.Rows("202"))
 }
 
 // TestUpdateCastOnlyModifiedValues for issue #4514.

--- a/types/datum.go
+++ b/types/datum.go
@@ -1087,8 +1087,9 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *stmtctx.Statem
 				return nil, errors.Trace(err)
 			}
 			if !dec.IsZero() && frac > decimal && dec.Compare(&old) != 0 {
-				if sc.InInsertStmt {
+				if sc.InInsertStmt || sc.InUpdateOrDeleteStmt {
 					// fix https://github.com/pingcap/tidb/issues/3895
+					// fix https://github.com/pingcap/tidb/issues/5532
 					sc.AppendWarning(ErrTruncated)
 					err = nil
 				} else {


### PR DESCRIPTION
Fix issue https://github.com/pingcap/tidb/issues/5532

@coocood  @zimulala  @XuHuaiyu