### PR TITLE
clean up abandoned storage engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Evolve TiDB schemas as your requirement changes. You can add new columns and ind
 
 - __Multiple storage engine support__
 
-Power TiDB with your most favorite engines. TiDB supports local storage engines such as GolevelDB and BoltDB, as well as [TiKV](https://github.com/pingcap/tikv), a distributed storage engine.
+Power TiDB with your most favorite engines. TiDB supports local storage engines such as GolevelDB, as well as [TiKV](https://github.com/pingcap/tikv), a distributed storage engine.
 
 For more details, see [How we build TiDB](https://pingcap.github.io/blog/2016/10/17/how-we-build-tidb/).
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -6,7 +6,7 @@ host = "0.0.0.0"
 # TiDB server port.
 port = 4000
 
-# Registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]
+# Registered store name, [tikv, mocktikv]
 store = "mocktikv"
 
 # TiDB storage path.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -93,10 +93,6 @@ func (s *testSuite) SetUpSuite(c *C) {
 		s.store = store
 		tidb.SetSchemaLease(0)
 		tidb.SetStatsLease(0)
-	} else {
-		store, err := tidb.NewStore("memory://test/test")
-		c.Assert(err, IsNil)
-		s.store = store
 	}
 	_, err := tidb.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/mysql/const_test.go
+++ b/mysql/const_test.go
@@ -61,10 +61,6 @@ func (s *testMySQLConstSuite) SetUpSuite(c *C) {
 		s.store = store
 		tidb.SetSchemaLease(0)
 		tidb.SetStatsLease(0)
-	} else {
-		store, err := tidb.NewStore("memory://test/test")
-		c.Assert(err, IsNil)
-		s.store = store
 	}
 	_, err := tidb.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -81,7 +81,7 @@ var (
 	configPath = flag.String(nmConfig, "", "config file path")
 
 	// Base
-	store        = flag.String(nmStore, "mocktikv", "registered store name, [memory, goleveldb, boltdb, tikv, mocktikv]")
+	store        = flag.String(nmStore, "mocktikv", "registered store name, [tikv, mocktikv]")
 	storePath    = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
 	host         = flag.String(nmHost, "0.0.0.0", "tidb server host")
 	port         = flag.String(nmPort, "4000", "tidb server port")


### PR DESCRIPTION
The `memory`, `goleveldb`(renamed to mocktikv), `boltdb` is not supported anymore, so remove them from command line flags.

P.S. I don't know whether I should change the roadmap file which contains boltdb word.

@coocood  @tiancaiamao  @shenli  PTAL