### PR TITLE
plan: prepare candidate index

### DIFF
--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -289,7 +289,7 @@ type DataSource struct {
 
 	statisticTable *statistics.Table
 
-	// availableIndices is used for storing result of avalableIndices function.
+	// availableIndices is used for storing result of availableIndices function.
 	availableIndices *avalableIndices
 }
 

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -282,7 +282,8 @@ type DataSource struct {
 	// pushedDownConds are the conditions that will be pushed down to coprocessor.
 	pushedDownConds []expression.Expression
 
-	validIndices []bool
+	// relevantIndices means the indices match the push down conditions
+	relevantIndices []bool
 
 	// statsAfterSelect is the statsInfo for dataSource and selection.
 	statsAfterSelect *statsInfo

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -282,6 +282,8 @@ type DataSource struct {
 	// pushedDownConds are the conditions that will be pushed down to coprocessor.
 	pushedDownConds []expression.Expression
 
+	validIndices []bool
+
 	// statsAfterSelect is the statsInfo for dataSource and selection.
 	statsAfterSelect *statsInfo
 

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -212,6 +212,7 @@ func (ds *DataSource) convert2PhysicalPlan(prop *requiredProp) (task, error) {
 	}
 	if !includeTableScan || len(ds.pushedDownConds) > 0 || len(prop.cols) > 0 {
 		for i, idx := range indices {
+			// TODO: We can also check if the prop matches the index columns.
 			if !ds.validIndices[i] && len(prop.cols) == 0 {
 				continue
 			}

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -201,7 +201,6 @@ func (ds *DataSource) convert2PhysicalPlan(prop *requiredProp) (task, error) {
 		return t, nil
 	}
 
-	// TODO: We have not checked if this table has a predicate. If not, we can only consider table scan.
 	indices := ds.availableIndices.indices
 	includeTableScan := ds.availableIndices.includeTableScan
 	t = invalidTask
@@ -212,7 +211,10 @@ func (ds *DataSource) convert2PhysicalPlan(prop *requiredProp) (task, error) {
 		}
 	}
 	if !includeTableScan || len(ds.pushedDownConds) > 0 || len(prop.cols) > 0 {
-		for _, idx := range indices {
+		for i, idx := range indices {
+			if !ds.validIndices[i] && len(prop.cols) == 0 {
+				continue
+			}
 			idxTask, err := ds.convertToIndexScan(prop, idx)
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -213,7 +213,7 @@ func (ds *DataSource) convert2PhysicalPlan(prop *requiredProp) (task, error) {
 	if !includeTableScan || len(ds.pushedDownConds) > 0 || len(prop.cols) > 0 {
 		for i, idx := range indices {
 			// TODO: We can also check if the prop matches the index columns.
-			if !ds.validIndices[i] && len(prop.cols) == 0 {
+			if !ds.relevantIndices[i] && len(prop.cols) == 0 {
 				continue
 			}
 			idxTask, err := ds.convertToIndexScan(prop, idx)

--- a/plan/property_cols_prune.go
+++ b/plan/property_cols_prune.go
@@ -25,6 +25,20 @@ func (ds *DataSource) preparePossibleProperties() (result [][]*expression.Column
 		if col != nil {
 			result = append(result, []*expression.Column{col})
 		}
+		cols := expression.ExtractColumnsFromExpressions(make([]*expression.Column, 0, 10), ds.pushedDownConds, nil)
+		ds.validIndices = make([]bool, len(indices))
+		for _, col := range cols {
+			for i, idx := range indices {
+				if !ds.validIndices[i] && col.ColName.L == idx.Columns[0].Name.L {
+					ds.validIndices[i] = true
+				}
+			}
+		}
+	} else {
+		ds.validIndices = make([]bool, len(indices))
+		for i := range ds.validIndices {
+			ds.validIndices[i] = true
+		}
 	}
 	for _, idx := range indices {
 		cols, _ := expression.IndexInfo2Cols(ds.schema.Columns, idx)

--- a/plan/property_cols_prune.go
+++ b/plan/property_cols_prune.go
@@ -20,7 +20,7 @@ import (
 func (ds *DataSource) preparePossibleProperties() (result [][]*expression.Column) {
 	indices := ds.availableIndices.indices
 	includeTS := ds.availableIndices.includeTableScan
-	ds.validIndices = make([]bool, len(indices))
+	ds.relevantIndices = make([]bool, len(indices))
 	if includeTS {
 		col := ds.getPKIsHandleCol()
 		if col != nil {
@@ -30,14 +30,14 @@ func (ds *DataSource) preparePossibleProperties() (result [][]*expression.Column
 		for i, idx := range indices {
 			for _, col := range cols {
 				if col.ColName.L == idx.Columns[0].Name.L {
-					ds.validIndices[i] = true
+					ds.relevantIndices[i] = true
 					break
 				}
 			}
 		}
 	} else {
-		for i := range ds.validIndices {
-			ds.validIndices[i] = true
+		for i := range ds.relevantIndices {
+			ds.relevantIndices[i] = true
 		}
 	}
 	for _, idx := range indices {

--- a/plan/property_cols_prune.go
+++ b/plan/property_cols_prune.go
@@ -54,10 +54,8 @@ func (p *LogicalSelection) preparePossibleProperties() (result [][]*expression.C
 }
 
 func (p *baseLogicalPlan) preparePossibleProperties() [][]*expression.Column {
-	if len(p.children) > 0 {
-		for _, ch := range p.children {
-			ch.preparePossibleProperties()
-		}
+	for _, ch := range p.children {
+		ch.preparePossibleProperties()
 	}
 	return nil
 }


### PR DESCRIPTION
bench result:

##After Optimize

```
BenchmarkOptimize/select_count(*)_from_t_group_by_e-4         	   		   30000	     48895 ns/op	   37488 B/op	     500 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_10_group_by_e-4         	   20000	     80996 ns/op	   50384 B/op	     706 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_50-4                    	   20000	     63905 ns/op	   35976 B/op	     539 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_c_>_'1'_group_by_b-4         	   20000	     91814 ns/op	   54489 B/op	     785 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_=_1_group_by_b-4           	   20000	     92382 ns/op	   58753 B/op	     832 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_>_1_group_by_b-4           	   20000	     97526 ns/op	   61809 B/op	     849 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_20-4                  	   10000	    112347 ns/op	   65465 B/op	     896 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_30-4                  	   10000	    114111 ns/op	   65465 B/op	     896 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_40-4                  	   10000	    104327 ns/op	   65465 B/op	     896 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_50-4                  	   10000	    110050 ns/op	   65464 B/op	     896 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_40-4                         	   30000	     41771 ns/op	   26784 B/op	     339 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_50-4                         	   30000	     44342 ns/op	   26784 B/op	     339 allocs/op
BenchmarkOptimize/select_*_from_t_where_1_and_t.b_<=_50-4                   	   30000	     42178 ns/op	   26960 B/op	     344 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_100_order_by_t.a_limit_1-4   	   10000	    166690 ns/op	  117057 B/op	    1409 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_1_order_by_t.a_limit_10-4    	   10000	    174259 ns/op	  117057 B/op	    1409 allocs/op
BenchmarkOptimize/select_*_from_t_use_index(b)_where_b_=_1_order_by_a-4     	   30000	     37150 ns/op	   24012 B/op	     328 allocs/op
BenchmarkOptimize/select_*_from_t_where_d_<_cast('1991-09-05'_as_datetime)-4       30000	     43064 ns/op	   21352 B/op	     302 allocs/op
BenchmarkOptimize/select_*_from_t_where_ts_<_'1991-09-05'-4                        30000	     45540 ns/op	   21256 B/op	     300 allocs/op
```

##Before Optimize

```
BenchmarkOptimize/select_count(*)_from_t_group_by_e-4         	   		   30000	     48797 ns/op	   37400 B/op	     498 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_10_group_by_e-4         	   10000	    106669 ns/op	   76353 B/op	    1012 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_<=_50-4                    	   10000	    126501 ns/op	   76537 B/op	    1008 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_c_>_'1'_group_by_b-4         	   10000	    149736 ns/op	   93513 B/op	    1318 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_=_1_group_by_b-4           	   10000	    129332 ns/op	   88089 B/op	    1206 allocs/op
BenchmarkOptimize/select_count(*)_from_t_where_e_>_1_group_by_b-4           	   10000	    134646 ns/op	   91178 B/op	    1223 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_20-4                  	   10000	    153472 ns/op	   99865 B/op	    1317 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_30-4                  	   10000	    162345 ns/op	   99865 B/op	    1317 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_40-4                  	   10000	    150311 ns/op	   99865 B/op	    1317 allocs/op
BenchmarkOptimize/select_count(e)_from_t_where_t.b_<=_50-4                  	   10000	    143586 ns/op	   99865 B/op	    1317 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_40-4                         	   30000	     60781 ns/op	   39456 B/op	     486 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_50-4                         	   20000	     60306 ns/op	   39456 B/op	     486 allocs/op
BenchmarkOptimize/select_*_from_t_where_1_and_t.b_<=_50-4                   	   20000	     59609 ns/op	   39632 B/op	     491 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_100_order_by_t.a_limit_1-4   	   10000	    219389 ns/op	  150401 B/op	    1797 allocs/op
BenchmarkOptimize/select_*_from_t_where_t.b_<=_1_order_by_t.a_limit_10-4    	   10000	    207552 ns/op	  150401 B/op	    1797 allocs/op
BenchmarkOptimize/select_*_from_t_use_index(b)_where_b_=_1_order_by_a-4     	   50000	     40125 ns/op	   23992 B/op	     327 allocs/op
BenchmarkOptimize/select_*_from_t_where_d_<_cast('1991-09-05'_as_datetime)-4       20000	     67813 ns/op	   39088 B/op	     505 allocs/op
BenchmarkOptimize/select_*_from_t_where_ts_<_'1991-09-05'-4                        20000	     70438 ns/op	   38992 B/op	     503 allocs/op
```