### PR TITLE
plan, expression: refine explain count info

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2620,9 +2620,9 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a date)")
 	result = tk.MustQuery("desc select a = a from t")
-	result.Check(testkit.Rows("TableScan_4   cop table:t, range:[-inf,+inf], keep order:false 10000",
-		"TableReader_5 Projection_3  root data:TableScan_4 10000",
-		"Projection_3  TableReader_5 root eq(test.t.a, test.t.a) 8000"))
+	result.Check(testkit.Rows("TableScan_4   cop table:t, range:[-inf,+inf], keep order:false 10000.00",
+		"TableReader_5 Projection_3  root data:TableScan_4 10000.00",
+		"Projection_3  TableReader_5 root eq(test.t.a, test.t.a) 8000.00"))
 
 	// for interval
 	result = tk.MustQuery(`select interval(null, 1, 2), interval(1, 2, 3), interval(2, 1, 3)`)

--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -56,11 +56,11 @@ func (s *testAnalyzeSuite) TestCBOWithoutAnalyze(c *C) {
 	h.DumpStatsDeltaToKV()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t1, t2 where t1.a = t2.a").Check(testkit.Rows(
-		"TableScan_10   cop table:t1, range:[-inf,+inf], keep order:false 6",
-		"TableReader_11 HashLeftJoin_8  root data:TableScan_10 6",
-		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:false 6",
-		"TableReader_13 HashLeftJoin_8  root data:TableScan_12 6",
-		"HashLeftJoin_8  TableReader_11,TableReader_13 root inner join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)] 7.499999999999999",
+		"TableScan_10   cop table:t1, range:[-inf,+inf], keep order:false 6.00",
+		"TableReader_11 HashLeftJoin_8  root data:TableScan_10 6.00",
+		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:false 6.00",
+		"TableReader_13 HashLeftJoin_8  root data:TableScan_12 6.00",
+		"HashLeftJoin_8  TableReader_11,TableReader_13 root inner join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)] 7.50",
 	))
 }
 
@@ -88,10 +88,10 @@ func (s *testAnalyzeSuite) TestEstimation(c *C) {
 	h.DumpStatsDeltaToKV()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select count(*) from t group by a").Check(testkit.Rows(
-		"TableScan_8 HashAgg_5  cop table:t, range:[-inf,+inf], keep order:false 8",
-		"HashAgg_5  TableScan_8 cop group by:test.t.a, funcs:count(1) 2",
-		"TableReader_10 HashAgg_9  root data:HashAgg_5 2",
-		"HashAgg_9  TableReader_10 root group by:col_1, funcs:count(col_0) 2",
+		"TableScan_8 HashAgg_5  cop table:t, range:[-inf,+inf], keep order:false 8.00",
+		"HashAgg_5  TableScan_8 cop group by:test.t.a, funcs:count(1) 2.00",
+		"TableReader_10 HashAgg_9  root data:HashAgg_5 2.00",
+		"HashAgg_9  TableReader_10 root group by:col_1, funcs:count(col_0) 2.00",
 	))
 }
 
@@ -387,9 +387,9 @@ func (s *testAnalyzeSuite) TestOutdatedAnalyze(c *C) {
 	h.DumpStatsDeltaToKV()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
-		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 80",
-		"Selection_6  TableScan_5 cop le(test.t.a, 5), le(test.t.b, 5) 28.799999999999997",
-		"TableReader_7   root data:Selection_6 28.799999999999997",
+		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 80.00",
+		"Selection_6  TableScan_5 cop le(test.t.a, 5), le(test.t.b, 5) 28.80",
+		"TableReader_7   root data:Selection_6 28.80",
 	))
 }
 

--- a/plan/common_plans.go
+++ b/plan/common_plans.go
@@ -371,7 +371,7 @@ func (e *Explain) prepareExplainInfo4DAGTask(p PhysicalPlan, taskType string, pa
 	}
 	childrenInfo := strings.Join(childrenIDs, ",")
 	operatorInfo := p.ExplainInfo()
-	count := string(strconv.AppendFloat([]byte{}, p.StatsInfo().count, 'f', -1, 64))
+	count := string(strconv.AppendFloat([]byte{}, p.StatsInfo().count, 'f', 2, 64))
 	row := []string{p.ExplainID(), parentID, childrenInfo, taskType, operatorInfo, count}
 	e.Rows = append(e.Rows, row)
 }


### PR DESCRIPTION
The operator count info is not stable because the selectivity may process the filter expression in a different order and the floating point operation is not accurate, so here we just limit the output precision.