### PR TITLE
[DNM] store/tikv:avoid random error when check leader in gc

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -643,6 +643,9 @@ func (w *GCWorker) checkLeader() (bool, error) {
 		return true, nil
 	}
 
+	_, err = session.Execute(goCtx, "ROLLBACK")
+	terror.Log(errors.Trace(err))
+
 	_, err = session.Execute(goCtx, "BEGIN")
 	if err != nil {
 		return false, errors.Trace(err)


### PR DESCRIPTION
if gc worker on many different tidb servers begin to check leader together, leader of gc worker may get  
```
gc_worker.go:267: [warning] [gc worker] check leader err: [0] can not retry select for update statement
```
It is necessary and will abort the gc in this time, to avoid it, rollback the statement if this worker is not leader.