### PR TITLE
ddl, metrics: Add metrics for ddl worker.

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -90,9 +90,10 @@ func (d *ddl) isOwner() bool {
 
 // addDDLJob gets a global job ID and puts the DDL job in the DDL queue.
 func (d *ddl) addDDLJob(ctx context.Context, job *model.Job) error {
+	startTime := time.Now()
 	job.Version = currentVersion
 	job.Query, _ = ctx.Value(context.QueryString).(string)
-	return kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
+	err := kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
 		var err error
 		job.ID, err = t.GenGlobalID()
@@ -103,6 +104,8 @@ func (d *ddl) addDDLJob(ctx context.Context, job *model.Job) error {
 		err = t.EnQueueDDLJob(job)
 		return errors.Trace(err)
 	})
+	metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerAddDDLJob, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
+	return errors.Trace(err)
 }
 
 // getFirstDDLJob gets the first DDL job form DDL queue.
@@ -144,6 +147,10 @@ func (d *ddl) updateDDLJob(t *meta.Meta, job *model.Job, meetErr bool) error {
 // finishDDLJob deletes the finished DDL job in the ddl queue and puts it to history queue.
 // If the DDL job need to handle in background, it will prepare a background job.
 func (d *ddl) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
+	startTime := time.Now()
+	defer func() {
+		metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerFinishDDLJob, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
+	}()
 	switch job.Type {
 	case model.ActionDropSchema, model.ActionDropTable, model.ActionTruncateTable, model.ActionDropIndex:
 		if job.Version <= currentVersion {
@@ -358,6 +365,10 @@ func (d *ddl) waitSchemaChanged(ctx goctx.Context, waitTime time.Duration, lates
 	}
 
 	timeStart := time.Now()
+	var err error
+	defer func() {
+		metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerWaitSchemaChanged, metrics.RetLabel(err)).Observe(time.Since(timeStart).Seconds())
+	}()
 	// TODO: Do we need to wait for a while?
 	if latestSchemaVersion == 0 {
 		log.Infof("[ddl] schema version doesn't change")
@@ -369,7 +380,7 @@ func (d *ddl) waitSchemaChanged(ctx goctx.Context, waitTime time.Duration, lates
 		ctx, cancelFunc = goctx.WithTimeout(goctx.Background(), waitTime)
 		defer cancelFunc()
 	}
-	err := d.schemaSyncer.OwnerUpdateGlobalVersion(ctx, latestSchemaVersion)
+	err = d.schemaSyncer.OwnerUpdateGlobalVersion(ctx, latestSchemaVersion)
 	if err != nil {
 		log.Infof("[ddl] update latest schema version %d failed %v", latestSchemaVersion, err)
 		if terror.ErrorEqual(err, goctx.DeadlineExceeded) {

--- a/metrics/ddl.go
+++ b/metrics/ddl.go
@@ -76,6 +76,19 @@ var (
 			Help:      "Bucketed histogram of processing time (s) of handle syncer",
 			Buckets:   prometheus.ExponentialBuckets(0.01, 2, 20),
 		}, []string{"op", "result_state"})
+
+	// Metrics for ddl_worker.go.
+	WorkerAddDDLJob         = "add_ddl_job"
+	WorkerFinishDDLJob      = "finish_ddl_job"
+	WorkerWaitSchemaChanged = "wait_schema_changed"
+	DDLWorkerHistogram      = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "ddl",
+			Name:      "ddl_worker_operation",
+			Help:      "Bucketed histogram of processing time (s) of ddl worker operations",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20),
+		}, []string{"op", "result_state"})
 )
 
 func init() {
@@ -85,4 +98,5 @@ func init() {
 	prometheus.MustRegister(DeploySyncerHistogram)
 	prometheus.MustRegister(UpdateSelfVersionHistogram)
 	prometheus.MustRegister(OwnerHandleSyncerHistogram)
+	prometheus.MustRegister(DDLWorkerHistogram)
 }


### PR DESCRIPTION
Metrics for ddl worker operation duration:
* Add ddl job.
* Finish ddl job.
* Waiting schema version syncronized to all servers.

The metrics for update ddl job is already in meta.go.