### PR TITLE
gcworker: reduce gcWaitTime

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -100,7 +100,7 @@ const (
 	gcLastRunTimeKey     = "tikv_gc_last_run_time"
 	gcRunIntervalKey     = "tikv_gc_run_interval"
 	gcDefaultRunInterval = time.Minute * 10
-	gcWaitTime           = time.Minute * 10
+	gcWaitTime           = time.Minute * 1
 
 	gcLifeTimeKey            = "tikv_gc_life_time"
 	gcDefaultLifeTime        = time.Minute * 10


### PR DESCRIPTION
The original value of gcWaitTime is 10 minutes.
So even if we set gc_life_time and gc_run_interval to 1 minute, the actual run interval is still 10 minutes.

Change it to one minute so the actual run interval can be reduced to 1 minute.