### PR TITLE
tikv: remove a useless metric

### DIFF
--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -404,7 +404,6 @@ func (s *tikvStore) getTimestampWithRetry(bo *Backoffer) (uint64, error) {
 }
 
 func (s *tikvStore) GetClient() kv.Client {
-	metrics.TiKVTxnCmdCounter.WithLabelValues("get_client").Inc()
 	return &CopClient{
 		store: s,
 	}


### PR DESCRIPTION
The metric of "get_client" is useless, and it's not a real "KV" command. So i removed it.