### PR TITLE
expression: fix a test case that use inconsistent time zone

### DIFF
--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -230,7 +230,7 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 	originIgnoreTruncate := sc.IgnoreTruncate
 	originTZ := sc.TimeZone
 	sc.IgnoreTruncate = true
-	sc.TimeZone = time.Local
+	sc.TimeZone = time.UTC
 	defer func() {
 		sc.IgnoreTruncate = originIgnoreTruncate
 		sc.TimeZone = originTZ


### PR DESCRIPTION
In TestCastFuncSig function, the test use Local time zone,
but the result expect UTC

Here https://github.com/pingcap/tidb/compare/master...tiancaiamao:fix-test-zone?expand=1#diff-f61679ca72a49e11a31f02251a3317e0L184

Fix CI for https://github.com/pingcap/tidb/pull/5852

B.T.W, this function is too long, I'll split it into small functions later.
@XuHuaiyu @shenli 