### PR TITLE
tidb-server: remove useless metric

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -114,14 +114,6 @@ var (
 			Name:      "time_jump_back_total",
 			Help:      "Counter of system time jumps backward.",
 		})
-
-	keepAliveCounter = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Namespace: "tidb",
-			Subsystem: "monitor",
-			Name:      "keep_alive_total",
-			Help:      "Counter of TiDB keep alive.",
-		})
 )
 
 var (
@@ -429,7 +421,6 @@ func setupMetrics() {
 		timeJumpBackCounter.Inc()
 	}
 	sucessCallBack := func() {
-		keepAliveCounter.Inc()
 	}
 	go systimemon.StartMonitor(time.Now, systimeErrHandler, sucessCallBack)
 


### PR DESCRIPTION
We should not use keepalive counter to detect if the tidb server is alive. We just care about the time jumping back event, so i remove the useless metric.