### PR TITLE
ddl: fix a panic when add column with insert an index column

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -32,7 +32,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func (d *ddl) adjustTableColOffset(tblInfo *model.TableInfo, offset int) {
+// adjustColumnInfo is used to set the correct position of column info.
+// 1. The added column was append at the end of tblInfo.Columns, due to ddl state was not public then.
+//    It should be moved to the correct position when the ddl state to be changed to public.
+// 2. The offset of column should also to be set to the right value.
+func (d *ddl) adjustColumnInfo(tblInfo *model.TableInfo, offset int) {
 	oldCols := tblInfo.Columns
 	newCols := make([]*model.ColumnInfo, 0, len(oldCols))
 	newCols = append(newCols, oldCols[:offset]...)
@@ -165,7 +169,7 @@ func (d *ddl) onAddColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	case model.StateWriteReorganization:
 		// reorganization -> public
 		// Adjust table column offset.
-		d.adjustTableColOffset(tblInfo, offset)
+		d.adjustColumnInfo(tblInfo, offset)
 		columnInfo.State = model.StatePublic
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -96,6 +96,7 @@ func (d *ddl) createColumnInfo(tblInfo *model.TableInfo, colInfo *model.ColumnIn
 	colInfo.Offset = len(cols)
 
 	// Append the column info to the end of the tblInfo.Columns.
+	// It will reorder to the right position in "Columns" when it state change to public.
 	newCols := make([]*model.ColumnInfo, 0, len(cols)+1)
 	newCols = append(newCols, cols...)
 	newCols = append(newCols, colInfo)

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -286,10 +286,11 @@ func (t *testExecInfo) execSQL(idx int) error {
 }
 
 // TestUpdateOrDelete tests whether the correct columns is used in PhysicalIndexScan's ToPB function.
-func (s *testStateChangeSuite) TestUpdateOrDelete(c *C) {
-	sqls := make([]string, 2)
-	sqls[0] = "delete from t where c2 = 'a'"
-	sqls[1] = "update t use index(c2) set c2 = 'c2_update' where c2 = 'a'"
+func (s *testStateChangeSuite) TestWrite(c *C) {
+	sqls := make([]string, 3)
+	sqls[0] = "delete from t where c1 = 'a'"
+	sqls[1] = "update t use index(idx2) set c1 = 'c1_update' where c1 = 'a'"
+	sqls[2] = "insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1"
 	alterTableSQL := "alter table t add column a int not null default 1 first"
 	s.runTestInWriteOnly(c, "", alterTableSQL, sqls)
 }
@@ -297,14 +298,14 @@ func (s *testStateChangeSuite) TestUpdateOrDelete(c *C) {
 func (s *testStateChangeSuite) runTestInWriteOnly(c *C, tableName, alterTableSQL string, sqls []string) {
 	defer testleak.AfterTest(c)()
 	_, err := s.se.Execute(goctx.Background(), `create table t (
-		c1 int primary key,
-		c2 varchar(64),
-		c3 enum('N','Y') not null default 'N',
-		c4 timestamp on update current_timestamp,
-		unique key(c2))`)
+		c1 varchar(64),
+		c2 enum('N','Y') not null default 'N',
+		c3 timestamp on update current_timestamp,
+		c4 int primary key,
+		unique key idx2 (c1, c2, c3))`)
 	c.Assert(err, IsNil)
 	defer s.se.Execute(goctx.Background(), "drop table t")
-	_, err = s.se.Execute(goctx.Background(), "insert into t values(8, 'a', 'N', '2017-07-01')")
+	_, err = s.se.Execute(goctx.Background(), "insert into t values('a', 'N', '2017-07-01', 8)")
 	c.Assert(err, IsNil)
 	// Make sure these sqls use the the plan of index scan.
 	_, err = s.se.Execute(goctx.Background(), "drop stats t")


### PR DESCRIPTION
PTAL @coocood @zimulala  back trace list below.
```
 2018/02/12 19:52:33.466 ddl_worker.go:51: [error] ddlWorker runtime error: index out of range goroutine 133 [running]:
github.com/pingcap/tidb/util.GetStack(0xc42038ef98, 0x1d08ac0, 0x28bd4d0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/util/misc.go:52 +0x74
github.com/pingcap/tidb/ddl.(*ddl).onDDLWorker.func1()
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:50 +0x6e
panic(0x1d08ac0, 0x28bd4d0)
	/usr/local/Cellar/go/1.9.3/libexec/src/runtime/panic.go:491 +0x283
github.com/pingcap/tidb/expression.TableInfo2SchemaWithDBName(0x1eb617c, 0xd, 0x1eb617c, 0xd, 0xc420a86700, 0xc4200c64d0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/expression/expression.go:274 +0x8fe
github.com/pingcap/tidb/plan.(*planBuilder).buildInsert(0xc420170300, 0xc420a8e1e0, 0x0, 0x1e2ff00)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/planbuilder.go:765 +0xbf
github.com/pingcap/tidb/plan.(*planBuilder).build(0xc420170300, 0x26a1aa0, 0xc420a8e1e0, 0x0, 0xc420d3f950)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/planbuilder.go:188 +0x26e
github.com/pingcap/tidb/plan.Optimize(0x26c8380, 0xc421390dd0, 0x26a1aa0, 0xc420a8e1e0, 0x26b3c60, 0xc420d9d8c0, 0xc42038fa00, 0x0, 0x0, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/optimizer.go:68 +0x11e
github.com/pingcap/tidb/executor.(*Compiler).Compile(0xc42038fc88, 0x3972578, 0xc420086048, 0x26aa8a0, 0xc420a8e1e0, 0x0, 0x0, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/compiler.go:48 +0x1eb
github.com/pingcap/tidb.(*session).Execute(0xc421390dd0, 0x3972578, 0xc420086048, 0x1ee7134, 0x38, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/session.go:805 +0xad4
github.com/pingcap/tidb/ddl_test.(*testStateChangeSuite).runTestInWriteOnly.func1(0xc420995340)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_db_change_test.go:331 +0x171
github.com/pingcap/tidb/ddl.(*TestDDLCallback).OnJobUpdated(0xc4213993b0, 0xc420995340)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/callback_test.go:43 +0x64
github.com/pingcap/tidb/ddl.(*ddl).handleDDLJobQueue(0xc420a86000, 0x1, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:252 +0x159
github.com/pingcap/tidb/ddl.(*ddl).onDDLWorker(0xc420a86000)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:64 +0x224
created by github.com/pingcap/tidb/ddl.(*ddl).start
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl.go:318 +0x13a
```