### PR TITLE
ddl: fix panic in drop column

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -32,41 +32,26 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// adjustColumnInfo is used to set the correct position of column info.
+// TODO: Index can't cover the add column with offset now, we may check this later.
+// adjustColumnInfoInAddColumn is used to set the correct position of column info when add column.
 // 1. The added column was append at the end of tblInfo.Columns, due to ddl state was not public then.
 //    It should be moved to the correct position when the ddl state to be changed to public.
 // 2. The offset of column should also to be set to the right value.
-func (d *ddl) adjustColumnInfo(tblInfo *model.TableInfo, offset int) {
+func (d *ddl) adjustColumnInfoInAddColumn(tblInfo *model.TableInfo, offset int) {
 	oldCols := tblInfo.Columns
 	newCols := make([]*model.ColumnInfo, 0, len(oldCols))
 	newCols = append(newCols, oldCols[:offset]...)
 	newCols = append(newCols, oldCols[len(oldCols)-1])
 	newCols = append(newCols, oldCols[offset:len(oldCols)-1]...)
-	tblInfo.Columns = newCols
 	// Adjust column offset.
-	d.adjustColumnOffset(tblInfo.Columns, tblInfo.Indices, offset, true)
-}
-
-func (d *ddl) adjustColumnOffset(columns []*model.ColumnInfo, indices []*model.IndexInfo, offset int, added bool) {
 	offsetChanged := make(map[int]int)
-	if added {
-		for i := offset + 1; i < len(columns); i++ {
-			offsetChanged[columns[i].Offset] = i
-			columns[i].Offset = i
-		}
-		columns[offset].Offset = offset
-	} else {
-		for i := offset + 1; i < len(columns); i++ {
-			offsetChanged[columns[i].Offset] = i - 1
-			columns[i].Offset = i - 1
-		}
-		columns[offset].Offset = len(columns) - 1
+	for i := offset + 1; i < len(newCols); i++ {
+		offsetChanged[newCols[i].Offset] = i
+		newCols[i].Offset = i
 	}
-
-	// TODO: Index can't cover the add/remove column with offset now, we may check this later.
-
+	newCols[offset].Offset = offset
 	// Update index column offset info.
-	for _, idx := range indices {
+	for _, idx := range tblInfo.Indices {
 		for _, col := range idx.Columns {
 			newOffset, ok := offsetChanged[col.Offset]
 			if ok {
@@ -74,6 +59,36 @@ func (d *ddl) adjustColumnOffset(columns []*model.ColumnInfo, indices []*model.I
 			}
 		}
 	}
+	tblInfo.Columns = newCols
+}
+
+// TODO: Index can't cover the remove column with offset now, we may check this later.
+// adjustColumnInfoInDropColumn is used to set the correct position of column info when drop column.
+// 1. The offset of column should to be set to the last of the columns.
+// 2. The dropped column is moved to the end of tblInfo.Columns, due to it was not public any more.
+func (d *ddl) adjustColumnInfoInDropColumn(tblInfo *model.TableInfo, offset int) {
+	oldCols := tblInfo.Columns
+	// Adjust column offset.
+	offsetChanged := make(map[int]int)
+	for i := offset + 1; i < len(oldCols); i++ {
+		offsetChanged[oldCols[i].Offset] = i - 1
+		oldCols[i].Offset = i - 1
+	}
+	oldCols[offset].Offset = len(oldCols) - 1
+	// Update index column offset info.
+	for _, idx := range tblInfo.Indices {
+		for _, col := range idx.Columns {
+			newOffset, ok := offsetChanged[col.Offset]
+			if ok {
+				col.Offset = newOffset
+			}
+		}
+	}
+	newCols := make([]*model.ColumnInfo, 0, len(oldCols))
+	newCols = append(newCols, oldCols[:offset]...)
+	newCols = append(newCols, oldCols[offset+1:]...)
+	newCols = append(newCols, oldCols[offset])
+	tblInfo.Columns = newCols
 }
 
 func (d *ddl) createColumnInfo(tblInfo *model.TableInfo, colInfo *model.ColumnInfo, pos *ast.ColumnPosition) (*model.ColumnInfo, int, error) {
@@ -169,7 +184,7 @@ func (d *ddl) onAddColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	case model.StateWriteReorganization:
 		// reorganization -> public
 		// Adjust table column offset.
-		d.adjustColumnInfo(tblInfo, offset)
+		d.adjustColumnInfoInAddColumn(tblInfo, offset)
 		columnInfo.State = model.StatePublic
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != columnInfo.State)
 		if err != nil {
@@ -217,7 +232,7 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		job.SchemaState = model.StateWriteOnly
 		colInfo.State = model.StateWriteOnly
 		// Set this column's offset to the last and reset all following columns' offsets.
-		d.adjustColumnOffset(tblInfo.Columns, tblInfo.Indices, colInfo.Offset, false)
+		d.adjustColumnInfoInDropColumn(tblInfo, colInfo.Offset)
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != colInfo.State)
 	case model.StateWriteOnly:
 		// write only -> delete only
@@ -232,13 +247,7 @@ func (d *ddl) onDropColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	case model.StateDeleteReorganization:
 		// reorganization -> absent
 		// All reorganization jobs are done, drop this column.
-		newColumns := make([]*model.ColumnInfo, 0, len(tblInfo.Columns))
-		for _, col := range tblInfo.Columns {
-			if col.Name.L != colName.L {
-				newColumns = append(newColumns, col)
-			}
-		}
-		tblInfo.Columns = newColumns
+		tblInfo.Columns = tblInfo.Columns[:len(tblInfo.Columns)-1]
 		colInfo.State = model.StateNone
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != colInfo.State)
 		if err != nil {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -32,7 +32,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// TODO: Index can't cover the add column with offset now, we may check this later.
 // adjustColumnInfoInAddColumn is used to set the correct position of column info when adding column.
 // 1. The added column was append at the end of tblInfo.Columns, due to ddl state was not public then.
 //    It should be moved to the correct position when the ddl state to be changed to public.
@@ -51,6 +50,7 @@ func (d *ddl) adjustColumnInfoInAddColumn(tblInfo *model.TableInfo, offset int) 
 	}
 	newCols[offset].Offset = offset
 	// Update index column offset info.
+	// TODO: There may be some corner cases for index column offsets, we may check this later.
 	for _, idx := range tblInfo.Indices {
 		for _, col := range idx.Columns {
 			newOffset, ok := offsetChanged[col.Offset]
@@ -62,7 +62,6 @@ func (d *ddl) adjustColumnInfoInAddColumn(tblInfo *model.TableInfo, offset int) 
 	tblInfo.Columns = newCols
 }
 
-// TODO: Index can't cover the remove column with offset now, we may check this later.
 // adjustColumnInfoInDropColumn is used to set the correct position of column info when dropping column.
 // 1. The offset of column should to be set to the last of the columns.
 // 2. The dropped column is moved to the end of tblInfo.Columns, due to it was not public any more.
@@ -76,6 +75,7 @@ func (d *ddl) adjustColumnInfoInDropColumn(tblInfo *model.TableInfo, offset int)
 	}
 	oldCols[offset].Offset = len(oldCols) - 1
 	// Update index column offset info.
+	// TODO: There may be some corner cases for index column offsets, we may check this later.
 	for _, idx := range tblInfo.Indices {
 		for _, col := range idx.Columns {
 			newOffset, ok := offsetChanged[col.Offset]

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -33,7 +33,7 @@ import (
 )
 
 // TODO: Index can't cover the add column with offset now, we may check this later.
-// adjustColumnInfoInAddColumn is used to set the correct position of column info when add column.
+// adjustColumnInfoInAddColumn is used to set the correct position of column info when adding column.
 // 1. The added column was append at the end of tblInfo.Columns, due to ddl state was not public then.
 //    It should be moved to the correct position when the ddl state to be changed to public.
 // 2. The offset of column should also to be set to the right value.
@@ -63,7 +63,7 @@ func (d *ddl) adjustColumnInfoInAddColumn(tblInfo *model.TableInfo, offset int) 
 }
 
 // TODO: Index can't cover the remove column with offset now, we may check this later.
-// adjustColumnInfoInDropColumn is used to set the correct position of column info when drop column.
+// adjustColumnInfoInDropColumn is used to set the correct position of column info when dropping column.
 // 1. The offset of column should to be set to the last of the columns.
 // 2. The dropped column is moved to the end of tblInfo.Columns, due to it was not public any more.
 func (d *ddl) adjustColumnInfoInDropColumn(tblInfo *model.TableInfo, offset int) {

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	goctx "golang.org/x/net/context"
@@ -285,24 +286,39 @@ func (t *testExecInfo) execSQL(idx int) error {
 	return nil
 }
 
-// TestUpdateOrDelete tests whether the correct columns is used in PhysicalIndexScan's ToPB function.
-func (s *testStateChangeSuite) TestWrite(c *C) {
-	sqls := make([]string, 3)
-	sqls[0] = "delete from t where c1 = 'a'"
-	sqls[1] = "update t use index(idx2) set c1 = 'c1_update' where c1 = 'a'"
-	sqls[2] = "insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1"
-	alterTableSQL := "alter table t add column a int not null default 1 first"
-	s.runTestInWriteOnly(c, "", alterTableSQL, sqls)
+type sqlWithErr struct {
+	sql       string
+	expectErr error
 }
 
-func (s *testStateChangeSuite) runTestInWriteOnly(c *C, tableName, alterTableSQL string, sqls []string) {
+// TestWriteOnly tests whether the correct columns is used in PhysicalIndexScan's ToPB function.
+func (s *testStateChangeSuite) TestWriteOnly(c *C) {
+	sqls := make([]sqlWithErr, 3)
+	sqls[0] = sqlWithErr{"delete from t where c1 = 'a'", nil}
+	sqls[1] = sqlWithErr{"update t use index(idx2) set c1 = 'c1_update' where c1 = 'a'", nil}
+	sqls[0] = sqlWithErr{"insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1", nil}
+	addColumnSQL := "alter table t add column a int not null default 1 first"
+	s.runTestInSchemaState(c, model.StateWriteOnly, "", addColumnSQL, sqls)
+}
+
+// TestDeletaOnly tests whether the correct columns is used in PhysicalIndexScan's ToPB function.
+func (s *testStateChangeSuite) TestDeleteOnly(c *C) {
+	sqls := make([]sqlWithErr, 1)
+	sqls[0] = sqlWithErr{"insert t set c1 = 'c1_insert', c3 = '2018-02-12', c4 = 1",
+		errors.Errorf("Can't find column c1")}
+	dropColumnSQL := "alter table t drop column c1"
+	s.runTestInSchemaState(c, model.StateDeleteOnly, "", dropColumnSQL, sqls)
+}
+
+func (s *testStateChangeSuite) runTestInSchemaState(c *C, state model.SchemaState, tableName, alterTableSQL string,
+	sqlWithErrs []sqlWithErr) {
 	defer testleak.AfterTest(c)()
 	_, err := s.se.Execute(goctx.Background(), `create table t (
 		c1 varchar(64),
 		c2 enum('N','Y') not null default 'N',
 		c3 timestamp on update current_timestamp,
 		c4 int primary key,
-		unique key idx2 (c1, c2, c3))`)
+		unique key idx2 (c2, c3))`)
 	c.Assert(err, IsNil)
 	defer s.se.Execute(goctx.Background(), "drop table t")
 	_, err = s.se.Execute(goctx.Background(), "insert into t values('a', 'N', '2017-07-01', 8)")
@@ -324,12 +340,12 @@ func (s *testStateChangeSuite) runTestInWriteOnly(c *C, tableName, alterTableSQL
 			return
 		}
 		times++
-		if job.SchemaState != model.StateWriteOnly {
+		if job.SchemaState != state {
 			return
 		}
-		for _, sql := range sqls {
-			_, err = se.Execute(goctx.Background(), sql)
-			if err != nil {
+		for _, sqlWithErr := range sqlWithErrs {
+			_, err = se.Execute(goctx.Background(), sqlWithErr.sql)
+			if !terror.ErrorEqual(err, sqlWithErr.expectErr) {
 				checkErr = err
 				break
 			}

--- a/session_test.go
+++ b/session_test.go
@@ -1870,7 +1870,6 @@ func (s *testSessionSuite) TestCastTimeToDate(c *C) {
 }
 
 func (s *testSessionSuite) TestSetGlobalTZ(c *C) {
-	defer testleak.AfterTest(c)()
 	goCtx := goctx.Background()
 
 	tk := testkit.NewTestKitWithInit(c, s.store)

--- a/util/arena/arena.go
+++ b/util/arena/arena.go
@@ -60,7 +60,7 @@ func NewAllocator(capacity int) *SimpleAllocator {
 // Alloc implements Allocator.AllocBytes interface.
 func (s *SimpleAllocator) Alloc(capacity int) []byte {
 	if s.off+capacity < cap(s.arena) {
-		slice := s.arena[s.off:s.off : s.off+capacity]
+		slice := s.arena[s.off : s.off : s.off+capacity]
 		s.off += capacity
 		return slice
 	}

--- a/util/arena/arena.go
+++ b/util/arena/arena.go
@@ -60,7 +60,7 @@ func NewAllocator(capacity int) *SimpleAllocator {
 // Alloc implements Allocator.AllocBytes interface.
 func (s *SimpleAllocator) Alloc(capacity int) []byte {
 	if s.off+capacity < cap(s.arena) {
-		slice := s.arena[s.off : s.off : s.off+capacity]
+		slice := s.arena[s.off:s.off : s.off+capacity]
 		s.off += capacity
 		return slice
 	}


### PR DESCRIPTION
Drop column with pk-is-handle table (t) when insert into t will cause index out of range in delete only state. PTAL @zimulala @coocood @winkyao . Back trace as below:
```
 2018/02/14 16:54:01.082 ddl_worker.go:51: [error] ddlWorker runtime error: index out of range goroutine 121 [running]:
github.com/pingcap/tidb/util.GetStack(0xc420df8f60, 0x1d09260, 0x28bd4d0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/util/misc.go:52 +0x74
github.com/pingcap/tidb/ddl.(*ddl).onDDLWorker.func1()
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:50 +0x6e
panic(0x1d09260, 0x28bd4d0)
	/usr/local/Cellar/go/1.9.3/libexec/src/runtime/panic.go:491 +0x283
github.com/pingcap/tidb/expression.TableInfo2SchemaWithDBName(0x1eb69a1, 0xd, 0x1eb69a1, 0xd, 0xc421350540, 0xc420df92c0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/expression/expression.go:277 +0xa3a
github.com/pingcap/tidb/plan.(*planBuilder).buildInsert(0xc4212ee0c0, 0xc421368140, 0x0, 0x1e30700)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/planbuilder.go:765 +0xbf
github.com/pingcap/tidb/plan.(*planBuilder).build(0xc4212ee0c0, 0x26a1aa0, 0xc421368140, 0x0, 0xc421398240)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/planbuilder.go:188 +0x26e
github.com/pingcap/tidb/plan.Optimize(0x26c8380, 0xc42126a820, 0x26a1aa0, 0xc421368140, 0x26b3c60, 0xc421366a50, 0x0, 0x0, 0x0, 0xc420df9a88)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/plan/optimizer.go:68 +0x11e
github.com/pingcap/tidb/executor.(*Compiler).Compile(0xc420df9c88, 0x41aa370, 0xc4200160c0, 0x26aa8a0, 0xc421368140, 0x0, 0x0, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/compiler.go:48 +0x1eb
github.com/pingcap/tidb.(*session).Execute(0xc42126a820, 0x41aa370, 0xc4200160c0, 0x1ee79ca, 0x38, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/session.go:807 +0xad4
github.com/pingcap/tidb/ddl_test.(*testStateChangeSuite).runTestInSchemaState.func1(0xc4212e8f20)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_db_change_test.go:339 +0x177
github.com/pingcap/tidb/ddl.(*TestDDLCallback).OnJobUpdated(0xc42126de30, 0xc4212e8f20)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/callback_test.go:43 +0x64
github.com/pingcap/tidb/ddl.(*ddl).handleDDLJobQueue(0xc420d08000, 0x1, 0x0)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:252 +0x159
github.com/pingcap/tidb/ddl.(*ddl).onDDLWorker(0xc420d08000)
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl_worker.go:64 +0x224
created by github.com/pingcap/tidb/ddl.(*ddl).start
	/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/ddl/ddl.go:318 +0x13a
```