### PR TITLE
makefile,store/tikv: allow golint check context.Context in 'make check'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check: errcheck
 	@ go tool vet -all -shadow $(TOPDIRS) 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 	@ go tool vet -all -shadow *.go 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 	@echo "golint"
-	@ golint ./... 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
+	@ golint -set_exit_status $(PACKAGES)
 	@echo "gofmt (simplify)"
 	@ gofmt -s -l -w $(FILES) 2>&1 | grep -v "vendor|parser/parser.go" | awk '{print} END{if(NR>0) {exit 1}}'
 

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ check: errcheck
 	@ go tool vet -all -shadow $(TOPDIRS) 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 	@ go tool vet -all -shadow *.go 2>&1 | awk '{print} END{if(NR>0) {exit 1}}'
 	@echo "golint"
-	@ golint ./... 2>&1 | grep -vE 'vendor|context\.Context|LastInsertId|NewLexer|\.pb\.go' | awk '{print} END{if(NR>0) {exit 1}}'
+	@ golint ./... 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
 	@echo "gofmt (simplify)"
 	@ gofmt -s -l -w $(FILES) 2>&1 | grep -v "vendor|parser/parser.go" | awk '{print} END{if(NR>0) {exit 1}}'
 

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -47,7 +47,7 @@ func (s *testDDLTableSplitSuite) TestTableSplit(c *C) {
 		GetRegionCache() *tikv.RegionCache
 	}
 	cache := store.(kvStore).GetRegionCache()
-	loc, err := cache.LocateKey(tikv.NewBackoffer(5000, context.Background()), regionStartKey)
+	loc, err := cache.LocateKey(tikv.NewBackoffer(context.Background(), 5000), regionStartKey)
 	c.Assert(err, IsNil)
 	c.Assert(loc.StartKey, BytesEquals, []byte(regionStartKey))
 }

--- a/server/region_handler.go
+++ b/server/region_handler.go
@@ -127,7 +127,7 @@ func (s *Server) newRegionHandler() (hanler *regionHandler) {
 	regionCache := tikvStore.GetRegionCache()
 
 	// init backOffer && infoSchema.
-	backOffer := tikv.NewBackoffer(500, goctx.Background())
+	backOffer := tikv.NewBackoffer(goctx.Background(), 500)
 
 	tool := &regionHandlerTool{
 		regionCache: regionCache,

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -169,7 +169,7 @@ type Backoffer struct {
 }
 
 // NewBackoffer creates a Backoffer with maximum sleep time(in ms).
-func NewBackoffer(maxSleep int, ctx goctx.Context) *Backoffer {
+func NewBackoffer(ctx goctx.Context, maxSleep int) *Backoffer {
 	return &Backoffer{
 		Context:  ctx,
 		maxSleep: maxSleep,

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -112,7 +112,7 @@ func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
 func (c *CopClient) Send(ctx goctx.Context, req *kv.Request) kv.Response {
 	metrics.TiKVCoprocessorCounter.WithLabelValues("send").Inc()
 
-	bo := NewBackoffer(copBuildTaskMaxBackoff, ctx)
+	bo := NewBackoffer(ctx, copBuildTaskMaxBackoff)
 	tasks, err := buildCopTasks(bo, c.store.regionCache, &copRanges{mid: req.KeyRanges}, req.Desc, req.Streaming)
 	if err != nil {
 		return copErrorResponse{err}
@@ -382,7 +382,7 @@ func (it *copIterator) work(goCtx goctx.Context, taskCh <-chan *copTask) {
 			ch = task.respChan
 		}
 
-		bo := NewBackoffer(copNextMaxBackoff, ctx1)
+		bo := NewBackoffer(ctx1, copNextMaxBackoff)
 		startTime := time.Now()
 		it.handleTask(bo, task, ch)
 		costTime := time.Since(startTime)

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -33,7 +33,7 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	cache := NewRegionCache(pdCli)
 
-	bo := NewBackoffer(3000, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), 3000)
 
 	tasks, err := buildCopTasks(bo, cache, buildKeyRanges("a", "c"), false, false)
 	c.Assert(err, IsNil)
@@ -94,7 +94,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	storeID, regionIDs, peerIDs := mocktikv.BootstrapWithMultiRegions(cluster, []byte("m"))
 	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	cache := NewRegionCache(pdCli)
-	bo := NewBackoffer(3000, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), 3000)
 
 	tasks, err := buildCopTasks(bo, cache, buildKeyRanges("a", "z"), false, false)
 	c.Assert(err, IsNil)

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -345,7 +345,7 @@ func (w *GCWorker) deleteRanges(ctx goctx.Context, safePoint uint64) error {
 		return errors.Trace(err)
 	}
 
-	bo := tikv.NewBackoffer(tikv.GcDeleteRangeMaxBackoff, ctx)
+	bo := tikv.NewBackoffer(ctx, tikv.GcDeleteRangeMaxBackoff)
 	log.Infof("[gc worker] %s start delete %v ranges", w.uuid, len(ranges))
 	startTime := time.Now()
 	regions := 0
@@ -458,7 +458,7 @@ func (w *GCWorker) resolveLocks(ctx goctx.Context, safePoint uint64) error {
 			Limit:      gcScanLockLimit,
 		},
 	}
-	bo := tikv.NewBackoffer(tikv.GcResolveLockMaxBackoff, ctx)
+	bo := tikv.NewBackoffer(ctx, tikv.GcResolveLockMaxBackoff)
 
 	log.Infof("[gc worker] %s start resolve locks, safePoint: %v.", w.uuid, safePoint)
 	startTime := time.Now()
@@ -584,7 +584,7 @@ func (w *gcTaskWorker) doGCForRange(startKey []byte, endKey []byte, safePoint ui
 	}()
 	key := startKey
 	for {
-		bo := tikv.NewBackoffer(tikv.GcOneRegionMaxBackoff, goctx.Background())
+		bo := tikv.NewBackoffer(goctx.Background(), tikv.GcOneRegionMaxBackoff)
 		loc, err := w.store.GetRegionCache().LocateKey(bo, key)
 		if err != nil {
 			return errors.Trace(err)
@@ -717,7 +717,7 @@ func (w *GCWorker) doGC(ctx goctx.Context, safePoint uint64) error {
 		default:
 		}
 
-		bo := tikv.NewBackoffer(tikv.GcOneRegionMaxBackoff, ctx)
+		bo := tikv.NewBackoffer(ctx, tikv.GcOneRegionMaxBackoff)
 		task, err := w.genNextGCTask(bo, safePoint, key)
 		if err != nil {
 			return errors.Trace(err)

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -155,7 +155,7 @@ func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
 	taskWorker := newGCTaskWorker(s.store, nil, nil, s.gcWorker.uuid, &successRegions, &failedRegions)
 
 	ctx := goctx.Background()
-	bo := tikv.NewBackoffer(tikv.GcOneRegionMaxBackoff, ctx)
+	bo := tikv.NewBackoffer(ctx, tikv.GcOneRegionMaxBackoff)
 	loc, err := s.store.GetRegionCache().LocateKey(bo, []byte(""))
 	c.Assert(err, IsNil)
 	var regionErr *errorpb.Error

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -283,7 +283,7 @@ func (s *tikvStore) UUID() string {
 }
 
 func (s *tikvStore) CurrentVersion() (kv.Version, error) {
-	bo := NewBackoffer(tsoMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), tsoMaxBackoff)
 	startTS, err := s.getTimestampWithRetry(bo)
 	if err != nil {
 		return kv.NewVersion(0), errors.Trace(err)

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -205,7 +205,7 @@ func (lr *LockResolver) ResolveLocks(bo *Backoffer, locks []*Lock) (ok bool, err
 // To avoid unnecessarily aborting too many txns, it is wiser to wait a few
 // seconds before calling it after Prewrite.
 func (lr *LockResolver) GetTxnStatus(txnID uint64, primary []byte) (TxnStatus, error) {
-	bo := NewBackoffer(cleanupMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), cleanupMaxBackoff)
 	status, err := lr.getTxnStatus(bo, txnID, primary)
 	return status, errors.Trace(err)
 }

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -194,7 +194,7 @@ func (c *RawKVClient) Scan(startKey []byte, limit int) (keys [][]byte, values []
 }
 
 func (c *RawKVClient) sendReq(key []byte, req *tikvrpc.Request) (*tikvrpc.Response, *KeyLocation, error) {
-	bo := NewBackoffer(rawkvMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), rawkvMaxBackoff)
 	sender := NewRegionRequestSender(c.regionCache, c.rpcClient)
 	for {
 		loc, err := c.regionCache.LocateKey(bo, key)

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -37,7 +37,7 @@ func (s *testRawKVSuite) SetUpTest(c *C) {
 		pdClient:    pdClient,
 		rpcClient:   mocktikv.NewRPCClient(s.cluster, mocktikv.NewMvccStore()),
 	}
-	s.bo = NewBackoffer(5000, goctx.Background())
+	s.bo = NewBackoffer(goctx.Background(), 5000)
 }
 
 func (s *testRawKVSuite) TearDownTest(c *C) {

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -46,7 +46,7 @@ func (s *testRegionCacheSuite) SetUpTest(c *C) {
 	s.peer2 = peerIDs[1]
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	s.cache = NewRegionCache(pdCli)
-	s.bo = NewBackoffer(5000, goctx.Background())
+	s.bo = NewBackoffer(goctx.Background(), 5000)
 }
 
 func (s *testRegionCacheSuite) storeAddr(id uint64) string {
@@ -90,7 +90,7 @@ func (s *testRegionCacheSuite) TestSimple(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestDropStore(c *C) {
-	bo := NewBackoffer(100, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), 100)
 	s.cluster.RemoveStore(s.store1)
 	loc, err := s.cache.LocateKey(bo, []byte("a"))
 	c.Assert(err, IsNil)

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -49,7 +49,7 @@ func (s *testRegionRequestSuite) SetUpTest(c *C) {
 	s.store, s.peer, s.region = mocktikv.BootstrapWithSingleStore(s.cluster)
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	s.cache = NewRegionCache(pdCli)
-	s.bo = NewBackoffer(1, goctx.Background())
+	s.bo = NewBackoffer(goctx.Background(), 1)
 	s.mvccStore = mocktikv.NewMvccStore()
 	client := mocktikv.NewRPCClient(s.cluster, s.mvccStore)
 	s.regionRequestSender = NewRegionRequestSender(s.cache, client)

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -74,7 +74,7 @@ func (s *Scanner) Value() []byte {
 
 // Next return next element.
 func (s *Scanner) Next() error {
-	bo := NewBackoffer(scannerNextMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), scannerNextMaxBackoff)
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")
 	}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -68,7 +68,7 @@ func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 
 	// We want [][]byte instead of []kv.Key, use some magic to save memory.
 	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
-	bo := NewBackoffer(batchGetMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), batchGetMaxBackoff)
 
 	// Create a map to collect key-values from region servers.
 	var mu sync.Mutex
@@ -204,7 +204,7 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 
 // Get gets the value for key k from snapshot.
 func (s *tikvSnapshot) Get(k kv.Key) ([]byte, error) {
-	val, err := s.get(NewBackoffer(getMaxBackoff, goctx.Background()), k)
+	val, err := s.get(NewBackoffer(goctx.Background(), getMaxBackoff), k)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -28,7 +28,7 @@ import (
 // splitKey) and [splitKey, end).
 func (s *tikvStore) SplitRegion(splitKey kv.Key) error {
 	log.Infof("start split_region at %q", splitKey)
-	bo := NewBackoffer(splitRegionBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), splitRegionBackoff)
 	sender := NewRegionRequestSender(s.regionCache, s.client)
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdSplitRegion,

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -38,7 +38,7 @@ func (s *testSplitSuite) SetUpTest(c *C) {
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil)
 	c.Check(err, IsNil)
 	s.store = store.(*tikvStore)
-	s.bo = NewBackoffer(5000, context.Background())
+	s.bo = NewBackoffer(context.Background(), 5000)
 }
 
 func (s *testSplitSuite) begin(c *C) *tikvTxn {

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -60,9 +60,9 @@ func (s *testStoreSuite) TestOracle(c *C) {
 	s.store.oracle = o
 
 	ctx := goctx.Background()
-	t1, err := s.store.getTimestampWithRetry(NewBackoffer(100, ctx))
+	t1, err := s.store.getTimestampWithRetry(NewBackoffer(ctx, 100))
 	c.Assert(err, IsNil)
-	t2, err := s.store.getTimestampWithRetry(NewBackoffer(100, ctx))
+	t2, err := s.store.getTimestampWithRetry(NewBackoffer(ctx, 100))
 	c.Assert(err, IsNil)
 	c.Assert(t1, Less, t2)
 
@@ -79,7 +79,7 @@ func (s *testStoreSuite) TestOracle(c *C) {
 
 	go func() {
 		defer wg.Done()
-		t3, err := s.store.getTimestampWithRetry(NewBackoffer(tsoMaxBackoff, ctx))
+		t3, err := s.store.getTimestampWithRetry(NewBackoffer(ctx, tsoMaxBackoff))
 		c.Assert(err, IsNil)
 		c.Assert(t2, Less, t3)
 		expired := s.store.oracle.IsExpired(t2, 50)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -44,7 +44,7 @@ type tikvTxn struct {
 }
 
 func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
-	bo := NewBackoffer(tsoMaxBackoff, goctx.Background())
+	bo := NewBackoffer(goctx.Background(), tsoMaxBackoff)
 	startTS, err := store.getTimestampWithRetry(bo)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
Since `context.Context` is the first parameter now, we can turn on the golint check in `make check`

@coocood @zhexuany 