### PR TITLE
parser: correct mistake on maping between tinyint and boolean.

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -38,12 +38,12 @@ func (s *testSuite) TestShow(c *C) {
 
 	testSQL := `drop table if exists show_test`
 	tk.MustExec(testSQL)
-	testSQL = `create table SHOW_test (id int PRIMARY KEY AUTO_INCREMENT, c1 int comment "c1_comment", c2 int, c3 int default 1, c4 text, key idx_wide_c4(c3, c4(10))) ENGINE=InnoDB AUTO_INCREMENT=28934 DEFAULT CHARSET=utf8 COMMENT "table_comment";`
+	testSQL = `create table SHOW_test (id int PRIMARY KEY AUTO_INCREMENT, c1 int comment "c1_comment", c2 int, c3 int default 1, c4 text, c5 boolean, key idx_wide_c4(c3, c4(10))) ENGINE=InnoDB AUTO_INCREMENT=28934 DEFAULT CHARSET=utf8 COMMENT "table_comment";`
 	tk.MustExec(testSQL)
 
 	testSQL = "show columns from show_test;"
 	result := tk.MustQuery(testSQL)
-	c.Check(result.Rows(), HasLen, 5)
+	c.Check(result.Rows(), HasLen, 6)
 
 	testSQL = "show create table show_test;"
 	result = tk.MustQuery(testSQL)
@@ -51,7 +51,7 @@ func (s *testSuite) TestShow(c *C) {
 	row := result.Rows()[0]
 	// For issue https://github.com/pingcap/tidb/issues/1061
 	expectedRow := []interface{}{
-		"SHOW_test", "CREATE TABLE `SHOW_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `c1` int(11) DEFAULT NULL COMMENT 'c1_comment',\n  `c2` int(11) DEFAULT NULL,\n  `c3` int(11) DEFAULT '1',\n  `c4` text DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_wide_c4` (`c3`,`c4`(10))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=28934 COMMENT='table_comment'"}
+		"SHOW_test", "CREATE TABLE `SHOW_test` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `c1` int(11) DEFAULT NULL COMMENT 'c1_comment',\n  `c2` int(11) DEFAULT NULL,\n  `c3` int(11) DEFAULT '1',\n  `c4` text DEFAULT NULL,\n  `c5` tinyint(1) DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  KEY `idx_wide_c4` (`c3`,`c4`(10))\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=28934 COMMENT='table_comment'"}
 	for i, r := range row {
 		c.Check(r, Equals, expectedRow[i])
 	}

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5440,7 +5440,7 @@ NumericType:
 			if o.IsZerofill {
 				x.Flag |= mysql.ZerofillFlag
 			}
-	}
+		}
 		$$ = x
 	}
 |	FixedPointType FloatOpt FieldOpts

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -5421,10 +5421,10 @@ Type:
 NumericType:
 	IntegerType OptFieldLen FieldOpts
 	{
-    // For boolean and bool, mysql maps them to tinyint(1)
-    // In tidb, tinyint has 4 bits by default. This if branch is to
-    // handle this situation.
-    var x *types.FieldType
+		// For boolean and bool, mysql maps them to tinyint(1)
+		// In tidb, tinyint has 4 bits by default. This if branch is to
+		// handle this situation.
+		var x *types.FieldType
 		if b, ok :=  $1.(*types.FieldType); ok {
 			x = b
 			x.Flen = 1


### PR DESCRIPTION
For ddl query like `create table t (c1 boolean)`
`show create table t` gives different result compared against with mysql. 
This patch will fix this issue. 

