### PR TITLE
plan, executor: remove the duplicate function of setPBColumnsDefaultValue

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1013,7 +1013,7 @@ func (b *executorBuilder) buildAnalyzeColumnsPushdown(task plan.AnalyzeColumnsTa
 		CmsketchDepth: &depth,
 		CmsketchWidth: &width,
 	}
-	b.err = errors.Trace(setPBColumnsDefaultValue(b.ctx, e.analyzePB.ColReq.ColumnsInfo, cols))
+	b.err = errors.Trace(plan.SetPBColumnsDefaultValue(b.ctx, e.analyzePB.ColReq.ColumnsInfo, cols))
 	return e
 }
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -163,29 +163,6 @@ func statementContextToFlags(sc *stmtctx.StatementContext) uint64 {
 	return flags
 }
 
-func setPBColumnsDefaultValue(ctx sessionctx.Context, pbColumns []*tipb.ColumnInfo, columns []*model.ColumnInfo) error {
-	for i, c := range columns {
-		if c.OriginDefaultValue == nil {
-			continue
-		}
-
-		sessVars := ctx.GetSessionVars()
-		originStrict := sessVars.StrictSQLMode
-		sessVars.StrictSQLMode = false
-		d, err := table.GetColOriginDefaultValue(ctx, c)
-		sessVars.StrictSQLMode = originStrict
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		pbColumns[i].DefaultVal, err = tablecodec.EncodeValue(ctx.GetSessionVars().StmtCtx, d)
-		if err != nil {
-			return errors.Trace(err)
-		}
-	}
-	return nil
-}
-
 // handleIsExtra checks whether this column is a extra handle column generated during plan building phase.
 func handleIsExtra(col *expression.Column) bool {
 	if col != nil && col.ID == model.ExtraHandleID {

--- a/plan/plan_to_pb.go
+++ b/plan/plan_to_pb.go
@@ -96,7 +96,7 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 		Columns: ColumnsToProto(columns, p.Table.PKIsHandle),
 		Desc:    p.Desc,
 	}
-	err := setPBColumnsDefaultValue(ctx, tsExec.Columns, p.Columns)
+	err := SetPBColumnsDefaultValue(ctx, tsExec.Columns, p.Columns)
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tsExec}, errors.Trace(err)
 }
 
@@ -140,7 +140,8 @@ func (p *PhysicalIndexScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 	return &tipb.Executor{Tp: tipb.ExecType_TypeIndexScan, IdxScan: idxExec}, nil
 }
 
-func setPBColumnsDefaultValue(ctx sessionctx.Context, pbColumns []*tipb.ColumnInfo, columns []*model.ColumnInfo) error {
+// SetPBColumnsDefaultValue sets the default values of tipb.ColumnInfos.
+func SetPBColumnsDefaultValue(ctx sessionctx.Context, pbColumns []*tipb.ColumnInfo, columns []*model.ColumnInfo) error {
 	for i, c := range columns {
 		if c.OriginDefaultValue == nil {
 			continue

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -480,10 +480,7 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 		p := &CheckTable{Tables: as.Tables}
 		ret = p
 	case ast.AdminCheckIndex:
-		dbName := model.NewCIStr(b.ctx.GetSessionVars().CurrentDB)
-		if as.Tables[0].DBInfo != nil {
-			dbName = as.Tables[0].DBInfo.Name
-		}
+		dbName := as.Tables[0].Schema
 		readerPlan := b.buildCheckIndex(dbName, as)
 		ret = &CheckIndex{
 			DBName:            dbName.L,


### PR DESCRIPTION
Remove the duplicate function of setPBColumnsDefaultValue.
plan/planbuilder.go: remove the useless code.