### PR TITLE
executor: fix inconsistent behavior for insert

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -893,8 +893,9 @@ func (e *InsertExec) exec(ctx context.Context, rows [][]types.Datum) (Row, error
 	// If you use the IGNORE keyword, duplicate-key error that occurs while executing the INSERT statement are ignored.
 	// For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in
 	// the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row is discarded and no error occurs.
+	// However, if the `on duplicate update` is also specified, the duplicated row will be updated.
 	// Using BatchGet in insert ignore to mark rows as duplicated before we add records to the table.
-	if e.IgnoreErr {
+	if e.IgnoreErr && len(e.OnDuplicate) == 0 {
 		var err error
 		rows, err = batchMarkDupRows(e.ctx, e.Table, rows)
 		if err != nil {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -117,6 +117,13 @@ func (s *testSuite) TestInsert(c *C) {
 	rowStr = fmt.Sprintf("%v %v %v %v", "1", "1", "10", "6")
 	r.Check(testkit.Rows(rowStr))
 
+	// for on duplicate key with ignore
+	insertSQL = `INSERT IGNORE INTO insert_test (id, c3) VALUES (1, 2) ON DUPLICATE KEY UPDATE c3=values(c3)+c3+3;`
+	tk.MustExec(insertSQL)
+	r = tk.MustQuery("select * from insert_test where id = 1;")
+	rowStr = fmt.Sprintf("%v %v %v %v", "1", "1", "10", "11")
+	r.Check(testkit.Rows(rowStr))
+
 	tk.MustExec("create table insert_err (id int, c1 varchar(8))")
 	_, err = tk.Exec("insert insert_err values (1, 'abcdabcdabcd')")
 	c.Assert(types.ErrDataTooLong.Equal(err), IsTrue)


### PR DESCRIPTION
For `insert ignore...on duplicate update`, it should update the duplicated row.
PTAL @coocood @zz-jason 