### PR TITLE
expression: Add deprecation warning for builtin function PASSWORD

### DIFF
--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -234,7 +234,7 @@ func (b *builtinPasswordSig) evalString(row types.Row) (d string, isNull bool, e
 		return "", false, nil
 	}
 
-	// Generate warning as the password function is deprecated as of MySQL 5.7.6
+	// We should append a warning here because function "PASSWORD" is deprecated since MySQL 5.7.6.
 	// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
 	b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenByArgs("PASSWORD"))
 

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -234,7 +234,8 @@ func (b *builtinPasswordSig) evalString(row types.Row) (d string, isNull bool, e
 		return "", false, nil
 	}
 
-	// Generate warning as password is deprecated as of MySQL 5.7.6
+	// Generate warning as the password function is deprecated as of MySQL 5.7.6
+	// See https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
 	b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenByArgs("PASSWORD"))
 
 	return auth.EncodePassword(pass), false, nil

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -234,6 +234,9 @@ func (b *builtinPasswordSig) evalString(row types.Row) (d string, isNull bool, e
 		return "", false, nil
 	}
 
+	// Generate warning as password is deprecated as of MySQL 5.7.6
+	b.ctx.GetSessionVars().StmtCtx.AppendWarning(errDeprecatedSyntaxNoReplacement.GenByArgs("PASSWORD"))
+
 	return auth.EncodePassword(pass), false, nil
 }
 

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -360,10 +360,12 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 		}
 
 		warnings := s.ctx.GetSessionVars().StmtCtx.GetWarnings()
-		lastWarn := warnings[len(warnings)-1]
 		if t.getWarn {
 			c.Assert(len(warnings), Equals, warnCount+1)
+
+			lastWarn := warnings[len(warnings)-1]
 			c.Assert(terror.ErrorEqual(errDeprecatedSyntaxNoReplacement, lastWarn), IsTrue)
+
 			warnCount = len(warnings)
 		} else {
 			c.Assert(len(warnings), Equals, warnCount)

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -362,11 +362,11 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 		warnings := s.ctx.GetSessionVars().StmtCtx.GetWarnings()
 		lastWarn := warnings[len(warnings)-1]
 		if t.getWarn {
-			c.Assert(len(warnings) == warnCount+1, IsTrue)
+			c.Assert(len(warnings), Equals, warnCount+1)
 			c.Assert(terror.ErrorEqual(errDeprecatedSyntaxNoReplacement, lastWarn), IsTrue)
 			warnCount = len(warnings)
 		} else {
-			c.Assert(len(warnings) == warnCount, IsTrue)
+			c.Assert(len(warnings), Equals, warnCount)
 		}
 	}
 

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/testleak"
@@ -336,15 +337,17 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 		expected string
 		isNil    bool
 		getErr   bool
+		getWarn  bool
 	}{
-		{nil, "", false, false},
-		{"", "", false, false},
-		{"abc", "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E", false, false},
-		{123, "*23AE809DDACAF96AF0FD78ED04B6A265E05AA257", false, false},
-		{1.23, "*A589EEBA8D3F9E1A34A7EE518FAC4566BFAD5BB6", false, false},
-		{types.NewDecFromFloatForTest(123.123), "*B15B84262DB34BFB2C817A45A55C405DC7C52BB1", false, false},
+		{nil, "", false, false, false},
+		{"", "", false, false, false},
+		{"abc", "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E", false, false, true},
+		{123, "*23AE809DDACAF96AF0FD78ED04B6A265E05AA257", false, false, true},
+		{1.23, "*A589EEBA8D3F9E1A34A7EE518FAC4566BFAD5BB6", false, false, true},
+		{types.NewDecFromFloatForTest(123.123), "*B15B84262DB34BFB2C817A45A55C405DC7C52BB1", false, false, true},
 	}
 
+	warnCount := len(s.ctx.GetSessionVars().StmtCtx.GetWarnings())
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.PasswordFunc, s.primitiveValsToConstants([]interface{}{t.args})...)
 		c.Assert(err, IsNil)
@@ -354,6 +357,16 @@ func (s *testEvaluatorSuite) TestPassword(c *C) {
 			c.Assert(d.Kind(), Equals, types.KindNull)
 		} else {
 			c.Assert(d.GetString(), Equals, t.expected)
+		}
+
+		warnings := s.ctx.GetSessionVars().StmtCtx.GetWarnings()
+		lastWarn := warnings[len(warnings)-1]
+		if t.getWarn {
+			c.Assert(len(warnings) == warnCount+1, IsTrue)
+			c.Assert(terror.ErrorEqual(errDeprecatedSyntaxNoReplacement, lastWarn), IsTrue)
+			warnCount = len(warnings)
+		} else {
+			c.Assert(len(warnings) == warnCount, IsTrue)
 		}
 	}
 

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -25,22 +25,24 @@ var (
 	ErrIncorrectParameterCount = terror.ClassExpression.New(mysql.ErrWrongParamcountToNativeFct, mysql.MySQLErrName[mysql.ErrWrongParamcountToNativeFct])
 	ErrDivisionByZero          = terror.ClassExpression.New(mysql.ErrDivisionByZero, mysql.MySQLErrName[mysql.ErrDivisionByZero])
 
-	errFunctionNotExists   = terror.ClassExpression.New(mysql.ErrSpDoesNotExist, mysql.MySQLErrName[mysql.ErrSpDoesNotExist])
-	errZlibZData           = terror.ClassTypes.New(mysql.ErrZlibZData, mysql.MySQLErrName[mysql.ErrZlibZData])
-	errIncorrectArgs       = terror.ClassExpression.New(mysql.ErrWrongArguments, mysql.MySQLErrName[mysql.ErrWrongArguments])
-	errUnknownCharacterSet = terror.ClassExpression.New(mysql.ErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
-	errDefaultValue        = terror.ClassExpression.New(mysql.ErrInvalidDefault, "invalid default value")
+	errFunctionNotExists             = terror.ClassExpression.New(mysql.ErrSpDoesNotExist, mysql.MySQLErrName[mysql.ErrSpDoesNotExist])
+	errZlibZData                     = terror.ClassTypes.New(mysql.ErrZlibZData, mysql.MySQLErrName[mysql.ErrZlibZData])
+	errIncorrectArgs                 = terror.ClassExpression.New(mysql.ErrWrongArguments, mysql.MySQLErrName[mysql.ErrWrongArguments])
+	errUnknownCharacterSet           = terror.ClassExpression.New(mysql.ErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
+	errDefaultValue                  = terror.ClassExpression.New(mysql.ErrInvalidDefault, "invalid default value")
+	errDeprecatedSyntaxNoReplacement = terror.ClassExpression.New(mysql.ErrWarnDeprecatedSyntaxNoReplacement, mysql.MySQLErrName[mysql.ErrWarnDeprecatedSyntaxNoReplacement])
 )
 
 func init() {
 	expressionMySQLErrCodes := map[terror.ErrCode]uint16{
-		mysql.ErrWrongParamcountToNativeFct: mysql.ErrWrongParamcountToNativeFct,
-		mysql.ErrDivisionByZero:             mysql.ErrDivisionByZero,
-		mysql.ErrSpDoesNotExist:             mysql.ErrSpDoesNotExist,
-		mysql.ErrZlibZData:                  mysql.ErrZlibZData,
-		mysql.ErrWrongArguments:             mysql.ErrWrongArguments,
-		mysql.ErrUnknownCharacterSet:        mysql.ErrUnknownCharacterSet,
-		mysql.ErrInvalidDefault:             mysql.ErrInvalidDefault,
+		mysql.ErrWrongParamcountToNativeFct:        mysql.ErrWrongParamcountToNativeFct,
+		mysql.ErrDivisionByZero:                    mysql.ErrDivisionByZero,
+		mysql.ErrSpDoesNotExist:                    mysql.ErrSpDoesNotExist,
+		mysql.ErrZlibZData:                         mysql.ErrZlibZData,
+		mysql.ErrWrongArguments:                    mysql.ErrWrongArguments,
+		mysql.ErrUnknownCharacterSet:               mysql.ErrUnknownCharacterSet,
+		mysql.ErrInvalidDefault:                    mysql.ErrInvalidDefault,
+		mysql.ErrWarnDeprecatedSyntaxNoReplacement: mysql.ErrWarnDeprecatedSyntaxNoReplacement,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassExpression] = expressionMySQLErrCodes
 }


### PR DESCRIPTION
Password() is deprecated as of MySQL 5.7.6 and produces a warning.
https://dev.mysql.com/doc/refman/5.7/en/encryption-functions.html#function_password
Note the warning only appears when Password is given a parameter,
passing NULL or empty string produces no warning (tested with 5.7.20)

fix #5946 