### PR TITLE
plan, executor: fix check index bug

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2483,6 +2483,9 @@ func (s *testSuite) TestCheckIndex(c *C) {
 	idx := tb.Indices()[0]
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 
+	_, err = se.Execute(context.Background(), "admin check index t idx_inexistent")
+	c.Assert(strings.Contains(err.Error(), "not exist"), IsTrue)
+
 	// set data to:
 	// index     data (handle, data): (1, 10), (2, 20), (3, 30)
 	// table     data (handle, data): (1, 10), (2, 20), (4, 40)

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -482,6 +482,9 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 	case ast.AdminCheckIndex:
 		dbName := as.Tables[0].Schema
 		readerPlan := b.buildCheckIndex(dbName, as)
+		if b.err != nil {
+			return ret
+		}
 		ret = &CheckIndex{
 			DBName:            dbName.L,
 			IdxName:           as.Index,


### PR DESCRIPTION
Check a non-existent index