### PR TITLE
server: fix column length when convert column info for tinyint

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -338,10 +338,10 @@ func convertColumnInfo(fld *ast.ResultField) (ci *ColumnInfo) {
 			// Consider the decimal point.
 			ci.ColumnLength++
 		}
-	} else if fld.Column.Tp != mysql.TypeBit {
+	} else if fld.Column.Tp != mysql.TypeBit && fld.Column.Tp != mysql.TypeTiny {
 		// Fix issue #4540.
 		// The flen is a hint, not a precise value, so most client will not use the value.
-		// But we found in race MySQL client, like Navicat for MySQL(version before 12) will truncate
+		// But we found in rare MySQL client, like Navicat for MySQL(version before 12) will truncate
 		// the `show create table` result. To fix this case, we must use a large enough flen to prevent
 		// the truncation, in MySQL, it will multiply bytes length by a multiple based on character set.
 		// For examples:

--- a/server/driver_tidb_test.go
+++ b/server/driver_tidb_test.go
@@ -60,4 +60,38 @@ func (ts tidbResultSetTestSuite) TestConvertColumnInfo(c *C) {
 	c.Assert(colInfo.Type, Equals, mysql.TypeBit)
 	c.Assert(colInfo.DefaultValueLength, Equals, uint64(0))
 	c.Assert(colInfo.DefaultValue, IsNil)
+
+	// Test "mysql.TypeTiny", for: https://github.com/pingcap/tidb/issues/5405.
+	resultField = ast.ResultField{
+		Column: &model.ColumnInfo{
+			Name:   model.NewCIStr("a"),
+			ID:     0,
+			Offset: 0,
+			FieldType: types.FieldType{
+				Tp:      mysql.TypeTiny,
+				Flag:    mysql.UnsignedFlag,
+				Flen:    1,
+				Decimal: 0,
+				Charset: charset.CharsetUTF8,
+				Collate: charset.CollationUTF8,
+			},
+			Comment: "column a is the first column in table dual",
+		},
+		ColumnAsName: model.NewCIStr("a"),
+		TableAsName:  model.NewCIStr("dual"),
+		DBName:       model.NewCIStr("test"),
+	}
+	colInfo = convertColumnInfo(&resultField)
+	c.Assert(colInfo.Schema, Equals, "test")
+	c.Assert(colInfo.Table, Equals, "dual")
+	c.Assert(colInfo.OrgTable, Equals, "")
+	c.Assert(colInfo.Name, Equals, "a")
+	c.Assert(colInfo.OrgName, Equals, "a")
+	c.Assert(colInfo.ColumnLength, Equals, uint32(1))
+	c.Assert(colInfo.Charset, Equals, uint16(mysql.CharsetIDs[charset.CharsetUTF8]))
+	c.Assert(colInfo.Flag, Equals, uint16(mysql.UnsignedFlag))
+	c.Assert(colInfo.Decimal, Equals, uint8(0))
+	c.Assert(colInfo.Type, Equals, mysql.TypeTiny)
+	c.Assert(colInfo.DefaultValueLength, Equals, uint64(0))
+	c.Assert(colInfo.DefaultValue, IsNil)
 }

--- a/server/driver_tidb_test.go
+++ b/server/driver_tidb_test.go
@@ -26,6 +26,22 @@ type tidbResultSetTestSuite struct{}
 
 var _ = Suite(tidbResultSetTestSuite{})
 
+func createColumnByTypeAndLen(tp byte, len uint32) *ColumnInfo {
+	return &ColumnInfo{
+		Schema:             "test",
+		Table:              "dual",
+		OrgTable:           "",
+		Name:               "a",
+		OrgName:            "a",
+		ColumnLength:       len,
+		Charset:            uint16(mysql.CharsetIDs[charset.CharsetUTF8]),
+		Flag:               uint16(mysql.UnsignedFlag),
+		Decimal:            uint8(0),
+		Type:               tp,
+		DefaultValueLength: uint64(0),
+		DefaultValue:       nil,
+	}
+}
 func (ts tidbResultSetTestSuite) TestConvertColumnInfo(c *C) {
 	// Test "mysql.TypeBit", for: https://github.com/pingcap/tidb/issues/5405.
 	resultField := ast.ResultField{
@@ -48,18 +64,7 @@ func (ts tidbResultSetTestSuite) TestConvertColumnInfo(c *C) {
 		DBName:       model.NewCIStr("test"),
 	}
 	colInfo := convertColumnInfo(&resultField)
-	c.Assert(colInfo.Schema, Equals, "test")
-	c.Assert(colInfo.Table, Equals, "dual")
-	c.Assert(colInfo.OrgTable, Equals, "")
-	c.Assert(colInfo.Name, Equals, "a")
-	c.Assert(colInfo.OrgName, Equals, "a")
-	c.Assert(colInfo.ColumnLength, Equals, uint32(1))
-	c.Assert(colInfo.Charset, Equals, uint16(mysql.CharsetIDs[charset.CharsetUTF8]))
-	c.Assert(colInfo.Flag, Equals, uint16(mysql.UnsignedFlag))
-	c.Assert(colInfo.Decimal, Equals, uint8(0))
-	c.Assert(colInfo.Type, Equals, mysql.TypeBit)
-	c.Assert(colInfo.DefaultValueLength, Equals, uint64(0))
-	c.Assert(colInfo.DefaultValue, IsNil)
+	c.Assert(colInfo, DeepEquals, createColumnByTypeAndLen(mysql.TypeBit, 1))
 
 	// Test "mysql.TypeTiny", for: https://github.com/pingcap/tidb/issues/5405.
 	resultField = ast.ResultField{
@@ -82,16 +87,5 @@ func (ts tidbResultSetTestSuite) TestConvertColumnInfo(c *C) {
 		DBName:       model.NewCIStr("test"),
 	}
 	colInfo = convertColumnInfo(&resultField)
-	c.Assert(colInfo.Schema, Equals, "test")
-	c.Assert(colInfo.Table, Equals, "dual")
-	c.Assert(colInfo.OrgTable, Equals, "")
-	c.Assert(colInfo.Name, Equals, "a")
-	c.Assert(colInfo.OrgName, Equals, "a")
-	c.Assert(colInfo.ColumnLength, Equals, uint32(1))
-	c.Assert(colInfo.Charset, Equals, uint16(mysql.CharsetIDs[charset.CharsetUTF8]))
-	c.Assert(colInfo.Flag, Equals, uint16(mysql.UnsignedFlag))
-	c.Assert(colInfo.Decimal, Equals, uint8(0))
-	c.Assert(colInfo.Type, Equals, mysql.TypeTiny)
-	c.Assert(colInfo.DefaultValueLength, Equals, uint64(0))
-	c.Assert(colInfo.DefaultValue, IsNil)
+	c.Assert(colInfo, DeepEquals, createColumnByTypeAndLen(mysql.TypeTiny, 1))
 }


### PR DESCRIPTION
When column type is `tinyint`, [ao](https://sourcegraph.com/github.com/Kast0rTr0y/ao@189a44ab341e5d613ae9db0e98365688b80162ed/-/blob/activeobjects-core/src/net/java/ao/types/TypeManager.java#L258) checks both jdbc type and its precision in qualifiers. It needs precision in qualifiers to be 1 but tidb returned column's precision is 4(here precision is just column length). This PR fixes this. 

@zz-jason @XuHuaiyu PTAL and please check whether navicat has same behavior.  