### PR TITLE
expression: fix test cases in TestWrapWithCastAsTime and TestCompareBuiltin

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2603,7 +2603,7 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec(`insert into t2 values(1, 1.1, "2017-08-01 12:01:01", "12:01:01", "abcdef", 0b10101)`)
 
 	result = tk.MustQuery("select coalesce(NULL, a), coalesce(NULL, b, a), coalesce(c, NULL, a, b), coalesce(d, NULL), coalesce(d, c), coalesce(NULL, NULL, e, 1), coalesce(f), coalesce(1, a, b, c, d, e, f) from t2")
-	result.Check(testkit.Rows(fmt.Sprintf("1 1.1 2017-08-01 12:01:01 12:01:01 %s 12:01:01 abcdef 21 1", time.Now().In(time.UTC).Format("2006-01-02"))))
+	result.Check(testkit.Rows(fmt.Sprintf("1 1.1 2017-08-01 12:01:01 12:01:01 %s 12:01:01 abcdef 21 1", time.Now().In(tk.Se.GetSessionVars().GetTimeZone()).Format("2006-01-02"))))
 
 	// nullif
 	result = tk.MustQuery(`SELECT NULLIF(NULL, 1), NULLIF(1, NULL), NULLIF(1, 1), NULLIF(NULL, NULL);`)


### PR DESCRIPTION
```
FAIL: integration_test.go:2508: testIntegrationSuite.TestCompareBuiltin

integration_test.go:2606:
    result.Check(testkit.Rows(fmt.Sprintf("1 1.1 2017-08-01 12:01:01 12:01:01 %s 12:01:01 abcdef 21 1", time.Now().In(time.UTC).Format("2006-01-02"))))
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:48:
    res.c.Assert(got, check.Equals, need, res.comment)
... obtained string = "[[1 1.1 2017-08-01 12:01:01 12:01:01 2018-03-12 12:01:01 abcdef 21 1]]"
... expected string = "[[1 1.1 2017-08-01 12:01:01 12:01:01 2018-03-11 12:01:01 abcdef 21 1]]"
... sql:select coalesce(NULL, a), coalesce(NULL, b, a), coalesce(c, NULL, a, b), coalesce(d, NULL), coalesce(d, c), coalesce(NULL, NULL, e, 1), coalesce(f), coalesce(1, a, b, c, d, e, f) from t2, args:[]

FAIL: builtin_cast_test.go:1153: testEvaluatorSuite.TestWrapWithCastAsTime

builtin_cast_test.go:1197:
    c.Assert(res.Compare(t.res), Equals, 0)
... obtained int = 1
... expected int = 0
```

@XuHuaiyu @coocood 

Those test cases use wrong timezone, they will fail when TimeZone set to Tokyo
and time.Now() is 01:04