### PR TITLE
infoschema: add missing columns in collations_information_applicability

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -243,7 +243,7 @@ func (s *testSuite) TestAggregation(c *C) {
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
 	// When adding new memory table in information_schema, please update this variable.
-	columnCountOfAllInformationSchemaTables := "743"
+	columnCountOfAllInformationSchemaTables := "745"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 
 	tk.MustExec("drop table if exists t1")

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -243,7 +243,7 @@ func (s *testSuite) TestAggregation(c *C) {
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
 	// When adding new memory columns in information_schema, please update this variable.
-	columnCountOfAllInformationSchemaTables := "745"
+	columnCountOfAllInformationSchemaTables := "736"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 
 	tk.MustExec("drop table if exists t1")

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -242,7 +242,7 @@ func (s *testSuite) TestAggregation(c *C) {
 	result.Check(testkit.Rows("<nil>", "<nil>"))
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
-	// When adding new memory table in information_schema, please update this variable.
+	// When adding new memory columns in information_schema, please update this variable.
 	columnCountOfAllInformationSchemaTables := "745"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -508,6 +508,8 @@ var tableTableSpacesCols = []columnInfo{
 }
 
 var tableCollationCharacterSetApplicabilityCols = []columnInfo{
+	{"COLLATION_NAME", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
+	{"CHARACTER_SET_NAME", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
 	{"TABLESPACE_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"ENGINE", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"TABLESPACE_TYPE", mysql.TypeVarchar, 64, 0, nil, nil},

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -510,15 +510,6 @@ var tableTableSpacesCols = []columnInfo{
 var tableCollationCharacterSetApplicabilityCols = []columnInfo{
 	{"COLLATION_NAME", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
 	{"CHARACTER_SET_NAME", mysql.TypeVarchar, 32, mysql.NotNullFlag, nil, nil},
-	{"TABLESPACE_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"ENGINE", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"TABLESPACE_TYPE", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"LOGFILE_GROUP_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"EXTENT_SIZE", mysql.TypeLong, 21, 0, nil, nil},
-	{"AUTOEXTEND_SIZE", mysql.TypeLong, 21, 0, nil, nil},
-	{"MAXIMUM_SIZE", mysql.TypeLong, 21, 0, nil, nil},
-	{"NODEGROUP_ID", mysql.TypeLong, 21, 0, nil, nil},
-	{"TABLESPACE_COMMENT", mysql.TypeVarchar, 2048, 0, nil, nil},
 }
 
 func dataForCharacterSets() (records [][]types.Datum) {
@@ -539,6 +530,17 @@ func dataForColltions() (records [][]types.Datum) {
 		types.MakeDatums("latin1_swedish_ci", "latin1", 3, "Yes", "Yes", 1),
 		types.MakeDatums("utf8_general_ci", "utf8", 4, "Yes", "Yes", 1),
 		types.MakeDatums("utf8mb4_general_ci", "utf8mb4", 5, "Yes", "Yes", 1),
+	)
+	return records
+}
+
+func dataForCollationCharacterSetApplicability() (records [][]types.Datum) {
+	records = append(records,
+		types.MakeDatums("ascii_general_ci", "ascii"),
+		types.MakeDatums("binary", "binary"),
+		types.MakeDatums("latin1_swedish_ci", "latin1"),
+		types.MakeDatums("utf8_general_ci", "utf8"),
+		types.MakeDatums("utf8mb4_general_ci", "utf8mb4"),
 	)
 	return records
 }
@@ -1088,6 +1090,7 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 	case tableOptimizerTrace:
 	case tableTableSpaces:
 	case tableCollationCharacterSetApplicability:
+		fullRows = dataForCollationCharacterSetApplicability()
 	}
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
In mysql, the output is the following:

```
show create table COLLATION_CHARACTER_SET_APPLICABILITY;
+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table                                 | Create Table                                                                                                                                                                                                     |
+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| COLLATION_CHARACTER_SET_APPLICABILITY | CREATE TEMPORARY TABLE `COLLATION_CHARACTER_SET_APPLICABILITY` (
  `COLLATION_NAME` varchar(32) NOT NULL DEFAULT '',
  `CHARACTER_SET_NAME` varchar(32) NOT NULL DEFAULT ''
) ENGINE=MEMORY DEFAULT CHARSET=utf8 |
+---------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

In tidb, the output is the following:
```
mysql> show create table COLLATION_CHARACTER_SET_APPLICABILITY;
+---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table |
+---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| COLLATION_CHARACTER_SET_APPLICABILITY | CREATE TABLE `COLLATION_CHARACTER_SET_APPLICABILITY` (
 `TABLESPACE_NAME` varchar(64) DEFAULT NULL,
 `ENGINE` varchar(64) DEFAULT NULL,
 `TABLESPACE_TYPE` varchar(64) DEFAULT NULL,
 `LOGFILE_GROUP_NAME` varchar(64) DEFAULT NULL,
 `EXTENT_SIZE` int(21) UNSIGNED DEFAULT NULL,
 `AUTOEXTEND_SIZE` int(21) UNSIGNED DEFAULT NULL,
 `MAXIMUM_SIZE` int(21) UNSIGNED DEFAULT NULL,
 `NODEGROUP_ID` int(21) UNSIGNED DEFAULT NULL,
 `TABLESPACE_COMMENT` varchar(2048) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+---------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

This PR fixed inconsistent behavior.  I am not sure how to test this change since I did not find any related test protocol for similar code pattern. 
@tiancaiamao @zz-jason PTAL