### PR TITLE
ddl, model: add finished TS when a DDL job is finished

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -95,6 +95,7 @@ func checkHistoryJobArgs(c *C, ctx sessionctx.Context, id int64, args *historyJo
 	t := meta.NewMeta(ctx.Txn())
 	historyJob, err := t.GetHistoryDDLJob(id)
 	c.Assert(err, IsNil)
+	c.Assert(historyJob.BinlogInfo.FinishedTS, Greater, uint64(0))
 
 	if args.tbl != nil {
 		c.Assert(historyJob.BinlogInfo.SchemaVersion, Equals, args.ver)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -171,6 +171,7 @@ func (d *ddl) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
 		return errors.Trace(err)
 	}
 
+	job.BinlogInfo.FinishedTS = t.StartTS
 	log.Infof("[ddl] finish DDL job %v", job)
 	err = t.AddHistoryDDLJob(job)
 	return errors.Trace(err)

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -79,6 +79,7 @@ type HistoryInfo struct {
 	SchemaVersion int64
 	DBInfo        *DBInfo
 	TableInfo     *TableInfo
+	FinishedTS    uint64
 }
 
 // AddDBInfo adds schema version and schema information that are used for binlog.


### PR DESCRIPTION
It's used for binlog

