### PR TITLE
expression: fix comparation between uint and int

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1800,13 +1800,13 @@ func compareInt(ctx sessionctx.Context, args []Expression, row types.Row) (val i
 	case isUnsigned0 && isUnsigned1:
 		res = types.CompareUint64(uint64(arg0), uint64(arg1))
 	case isUnsigned0 && !isUnsigned1:
-		if arg1 < 0 || arg0 > math.MaxInt64 {
+		if arg1 < 0 || uint64(arg0) > math.MaxInt64 {
 			res = 1
 		} else {
 			res = types.CompareInt64(arg0, arg1)
 		}
 	case !isUnsigned0 && isUnsigned1:
-		if arg0 < 0 || arg1 > math.MaxInt64 {
+		if arg0 < 0 || uint64(arg1) > math.MaxInt64 {
 			res = -1
 		} else {
 			res = types.CompareInt64(arg0, arg1)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2665,6 +2665,8 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	result = tk.MustQuery(`select least(cast("2017-01-01" as datetime), "123", "234", cast("2018-01-01" as date)), least(cast("2017-01-01" as date), "123", null)`)
 	result.Check(testkit.Rows("123 <nil>"))
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|invalid time format", "Warning|1105|invalid time format", "Warning|1105|invalid time format"))
+
+	tk.MustQuery(`select 1 < 17666000000000000000, 1 > 17666000000000000000, 1 = 17666000000000000000`).Check(testkit.Rows("1 0 0"))
 }
 
 func (s *testIntegrationSuite) TestAggregationBuiltin(c *C) {


### PR DESCRIPTION
Before this commit, this sql returns 1;
```sql
select 1 > 17666000000000000000
```
PTAL @winoros @zz-jason 