### PR TITLE
parser: fix "insert into t1 (select * from t)"

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2586,6 +2586,10 @@ InsertValues:
 	{
 		$$ = &ast.InsertStmt{Lists:  $2.([][]ast.ExprNode)}
 	}
+|	'(' SelectStmt ')'
+	{
+		$$ = &ast.InsertStmt{Select: $2.(*ast.SelectStmt)}
+	}
 |	SelectStmt
 	{
 		$$ = &ast.InsertStmt{Select: $1.(*ast.SelectStmt)}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -273,6 +273,7 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{";", true},
 		{"INSERT INTO foo VALUES (1234)", true},
 		{"INSERT INTO foo VALUES (1234, 5678)", true},
+		{"INSERT INTO t1 (SELECT * FROM t2)", true},
 		// 15
 		{"INSERT INTO foo VALUES (1 || 2)", true},
 		{"INSERT INTO foo VALUES (1 | 2)", true},


### PR DESCRIPTION
we support
```
insert into t1 select * from t
```
but not
```
insert into t1 (select * from t)
```

This is a fix for issue https://github.com/pingcap/tidb/issues/6038