### PR TITLE
Add admin checksum table command

### DIFF
--- a/ast/misc.go
+++ b/ast/misc.go
@@ -593,6 +593,7 @@ const (
 	AdminRecoverIndex
 	AdminCheckIndexRange
 	AdminShowDDLJobQueries
+	AdminChecksumTable
 )
 
 // HandleRange represents a range where handle value >= Begin and < End.

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -344,6 +344,22 @@ func Analyze(ctx context.Context, client kv.Client, kvReq *kv.Request) (SelectRe
 	return result, nil
 }
 
+// Checksum sends a checksum request.
+func Checksum(ctx context.Context, client kv.Client, kvReq *kv.Request) (SelectResult, error) {
+	resp := client.Send(ctx, kvReq)
+	if resp == nil {
+		return nil, errors.New("client returns nil response")
+	}
+	result := &selectResult{
+		label:    "checksum",
+		resp:     resp,
+		results:  make(chan resultWithErr, kvReq.Concurrency),
+		closed:   make(chan struct{}),
+		feedback: statistics.NewQueryFeedback(0, nil, 0, false),
+	}
+	return result, nil
+}
+
 // XAPI error codes.
 const (
 	codeInvalidResp = 1

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -93,6 +93,19 @@ func (builder *RequestBuilder) SetAnalyzeRequest(ana *tipb.AnalyzeReq) *RequestB
 	return builder
 }
 
+// SetChecksumRequest sets the request type to "ReqTypeChecksum" and construct request data.
+func (builder *RequestBuilder) SetChecksumRequest(checksum *tipb.ChecksumRequest) *RequestBuilder {
+	if builder.err != nil {
+		return builder
+	}
+
+	builder.Request.Tp = kv.ReqTypeChecksum
+	builder.Request.StartTs = checksum.StartTs
+	builder.Request.Data, builder.err = checksum.Marshal()
+	builder.Request.NotFillCache = true
+	return builder
+}
+
 // SetKeyRanges sets "KeyRanges" for "kv.Request".
 func (builder *RequestBuilder) SetKeyRanges(keyRanges []kv.KeyRange) *RequestBuilder {
 	builder.Request.KeyRanges = keyRanges
@@ -137,6 +150,12 @@ func (builder *RequestBuilder) SetPriority(priority int) *RequestBuilder {
 // SetStreaming sets "Streaming" flag for "kv.Request".
 func (builder *RequestBuilder) SetStreaming(streaming bool) *RequestBuilder {
 	builder.Request.Streaming = streaming
+	return builder
+}
+
+// SetConcurrency sets "Concurrency" for "kv.Request".
+func (builder *RequestBuilder) SetConcurrency(concurrency int) *RequestBuilder {
+	builder.Request.Concurrency = concurrency
 	return builder
 }
 

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -510,3 +510,37 @@ func (s *testSuite) TestRequestBuilder5(c *C) {
 	}
 	c.Assert(actual, DeepEquals, expect)
 }
+
+func (s *testSuite) TestRequestBuilder6(c *C) {
+	keyRanges := []kv.KeyRange{
+		{
+			StartKey: kv.Key{0x00, 0x01},
+			EndKey:   kv.Key{0x02, 0x03},
+		},
+	}
+
+	concurrency := 10
+
+	actual, err := (&RequestBuilder{}).SetKeyRanges(keyRanges).
+		SetChecksumRequest(&tipb.ChecksumRequest{}).
+		SetConcurrency(concurrency).
+		Build()
+	c.Assert(err, IsNil)
+
+	expect := &kv.Request{
+		Tp:             105,
+		StartTs:        0x0,
+		Data:           []uint8{0x8, 0x0, 0x10, 0x0, 0x18, 0x0},
+		KeyRanges:      keyRanges,
+		KeepOrder:      false,
+		Desc:           false,
+		Concurrency:    concurrency,
+		IsolationLevel: 0,
+		Priority:       0,
+		NotFillCache:   true,
+		SyncLog:        false,
+		Streaming:      false,
+	}
+
+	c.Assert(actual, DeepEquals, expect)
+}

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -1,0 +1,288 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"strconv"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/distsql"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/ranger"
+	tipb "github.com/pingcap/tipb/go-tipb"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+var _ Executor = &ChecksumTableExec{}
+
+// ChecksumTableExec represents ChecksumTable executor.
+type ChecksumTableExec struct {
+	baseExecutor
+
+	tables map[int64]*checksumContext
+	done   bool
+}
+
+// Open implements the Executor Open interface.
+func (e *ChecksumTableExec) Open(ctx context.Context) error {
+	if err := e.baseExecutor.Open(ctx); err != nil {
+		return errors.Trace(err)
+	}
+
+	concurrency, err := getChecksumTableConcurrency(e.ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tasks, err := e.buildTasks()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	taskCh := make(chan *checksumTask, len(tasks))
+	resultCh := make(chan *checksumResult, len(tasks))
+	for i := 0; i < concurrency; i++ {
+		go e.checksumWorker(taskCh, resultCh)
+	}
+
+	for _, task := range tasks {
+		taskCh <- task
+	}
+	close(taskCh)
+
+	for i := 0; i < len(tasks); i++ {
+		result := <-resultCh
+		if result.Error != nil {
+			err = result.Error
+			log.Error(errors.ErrorStack(err))
+			continue
+		}
+		e.handleResult(result)
+	}
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return nil
+}
+
+// NextChunk implements the Executor NextChunk interface.
+func (e *ChecksumTableExec) NextChunk(ctx context.Context, chk *chunk.Chunk) error {
+	chk.Reset()
+	if e.done {
+		return nil
+	}
+	for _, t := range e.tables {
+		chk.AppendString(0, t.DBInfo.Name.O)
+		chk.AppendString(1, t.TableInfo.Name.O)
+		chk.AppendUint64(2, t.Response.Checksum)
+		chk.AppendUint64(3, t.Response.TotalKvs)
+		chk.AppendUint64(4, t.Response.TotalBytes)
+	}
+	e.done = true
+	return nil
+}
+
+func (e *ChecksumTableExec) buildTasks() ([]*checksumTask, error) {
+	var tasks []*checksumTask
+	for id, t := range e.tables {
+		reqs, err := t.BuildRequests(e.ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		for _, req := range reqs {
+			tasks = append(tasks, &checksumTask{id, req})
+		}
+	}
+	return tasks, nil
+}
+
+func (e *ChecksumTableExec) handleResult(result *checksumResult) {
+	table := e.tables[result.TableID]
+	table.HandleResponse(result.Response)
+}
+
+func (e *ChecksumTableExec) checksumWorker(taskCh <-chan *checksumTask, resultCh chan<- *checksumResult) {
+	for task := range taskCh {
+		result := &checksumResult{TableID: task.TableID}
+		result.Response, result.Error = e.handleChecksumRequest(task.Request)
+		resultCh <- result
+	}
+}
+
+func (e *ChecksumTableExec) handleChecksumRequest(req *kv.Request) (resp *tipb.ChecksumResponse, err error) {
+	ctx := context.TODO()
+	res, err := distsql.Checksum(ctx, e.ctx.GetClient(), req)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	res.Fetch(ctx)
+	defer func() {
+		if err1 := res.Close(); err1 != nil {
+			err = errors.Trace(err1)
+		}
+	}()
+
+	resp = &tipb.ChecksumResponse{}
+
+	for {
+		data, err := res.NextRaw(ctx)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if data == nil {
+			break
+		}
+		checksum := &tipb.ChecksumResponse{}
+		if err = checksum.Unmarshal(data); err != nil {
+			return nil, errors.Trace(err)
+		}
+		updateChecksumResponse(resp, checksum)
+	}
+
+	return resp, nil
+}
+
+type checksumTask struct {
+	TableID int64
+	Request *kv.Request
+}
+
+type checksumResult struct {
+	Error    error
+	TableID  int64
+	Response *tipb.ChecksumResponse
+}
+
+type checksumContext struct {
+	DBInfo    *model.DBInfo
+	TableInfo *model.TableInfo
+	StartTs   uint64
+	Response  *tipb.ChecksumResponse
+}
+
+func newChecksumContext(db *model.DBInfo, table *model.TableInfo, startTs uint64) *checksumContext {
+	return &checksumContext{
+		DBInfo:    db,
+		TableInfo: table,
+		StartTs:   startTs,
+		Response:  &tipb.ChecksumResponse{},
+	}
+}
+
+func (c *checksumContext) BuildRequests(ctx sessionctx.Context) ([]*kv.Request, error) {
+	reqs, err := c.buildTableRequest(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	for _, indexInfo := range c.TableInfo.Indices {
+		if indexInfo.State != model.StatePublic {
+			continue
+		}
+		req, err := c.buildIndexRequest(ctx, indexInfo)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		reqs = append(reqs, req)
+	}
+
+	return reqs, nil
+}
+
+func (c *checksumContext) buildTableRequest(ctx sessionctx.Context) ([]*kv.Request, error) {
+	checksum := &tipb.ChecksumRequest{
+		StartTs:   c.StartTs,
+		ScanOn:    tipb.ChecksumScanOn_Table,
+		Algorithm: tipb.ChecksumAlgorithm_Crc64_Xor,
+	}
+
+	var ranges []*ranger.NewRange
+	if c.TableInfo.PKIsHandle {
+		pkInfo := c.TableInfo.GetPkColInfo()
+		ranges = ranger.FullIntNewRange(mysql.HasUnsignedFlag(pkInfo.Flag))
+	} else {
+		ranges = ranger.FullIntNewRange(false)
+	}
+
+	var reqs []*kv.Request
+
+	ranges1, ranges2 := splitRanges(ranges, false)
+	if len(ranges1) > 0 {
+		var builder distsql.RequestBuilder
+		req, err := builder.SetTableRanges(c.TableInfo.ID, ranges1, nil).
+			SetChecksumRequest(checksum).
+			SetConcurrency(ctx.GetSessionVars().DistSQLScanConcurrency).
+			Build()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		reqs = append(reqs, req)
+	}
+	if len(ranges2) > 0 {
+		var builder distsql.RequestBuilder
+		req, err := builder.SetTableRanges(c.TableInfo.ID, ranges2, nil).
+			SetChecksumRequest(checksum).
+			SetConcurrency(ctx.GetSessionVars().DistSQLScanConcurrency).
+			Build()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		reqs = append(reqs, req)
+	}
+
+	return reqs, nil
+}
+
+func (c *checksumContext) buildIndexRequest(ctx sessionctx.Context, indexInfo *model.IndexInfo) (*kv.Request, error) {
+	checksum := &tipb.ChecksumRequest{
+		StartTs:   c.StartTs,
+		ScanOn:    tipb.ChecksumScanOn_Index,
+		Algorithm: tipb.ChecksumAlgorithm_Crc64_Xor,
+	}
+
+	ranges := ranger.FullNewRange()
+
+	var builder distsql.RequestBuilder
+	return builder.SetIndexRanges(ctx.GetSessionVars().StmtCtx, c.TableInfo.ID, indexInfo.ID, ranges).
+		SetChecksumRequest(checksum).
+		SetConcurrency(ctx.GetSessionVars().DistSQLScanConcurrency).
+		Build()
+}
+
+func (c *checksumContext) HandleResponse(update *tipb.ChecksumResponse) {
+	updateChecksumResponse(c.Response, update)
+}
+
+func getChecksumTableConcurrency(ctx sessionctx.Context) (int, error) {
+	sessionVars := ctx.GetSessionVars()
+	concurrency, err := variable.GetSessionSystemVar(sessionVars, variable.TiDBChecksumTableConcurrency)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	c, err := strconv.ParseInt(concurrency, 10, 64)
+	return int(c), errors.Trace(err)
+}
+
+func updateChecksumResponse(resp, update *tipb.ChecksumResponse) {
+	resp.Checksum ^= update.Checksum
+	resp.TotalKvs += update.TotalKvs
+	resp.TotalBytes += update.TotalBytes
+}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -157,10 +157,11 @@ type Client interface {
 
 // ReqTypes.
 const (
-	ReqTypeSelect  = 101
-	ReqTypeIndex   = 102
-	ReqTypeDAG     = 103
-	ReqTypeAnalyze = 104
+	ReqTypeSelect   = 101
+	ReqTypeIndex    = 102
+	ReqTypeDAG      = 103
+	ReqTypeAnalyze  = 104
+	ReqTypeChecksum = 105
 
 	ReqSubTypeBasic      = 0
 	ReqSubTypeDesc       = 10000

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4791,6 +4791,13 @@ AdminStmt:
 			HandleRanges: $6.([]ast.HandleRange),
 		}
 	}
+|	"ADMIN" "CHECKSUM" "TABLE" TableNameList
+	{
+		$$ = &ast.AdminStmt{
+			Tp: ast.AdminChecksumTable,
+			Tables: $4.([]*ast.TableName),
+		}
+	}
 |	"ADMIN" "CANCEL" "DDL" "JOBS" NumList
 	{
 		$$ = &ast.AdminStmt{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -408,6 +408,7 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"admin check table t1, t2;", true},
 		{"admin check index tableName idxName;", true},
 		{"admin check index tableName idxName (1, 2), (4, 5);", true},
+		{"admin checksum table t1, t2;", true},
 		{"admin cancel ddl jobs 1", true},
 		{"admin cancel ddl jobs 1, 2", true},
 		{"admin recover index t1 idx_a", true},

--- a/plan/common_plans.go
+++ b/plan/common_plans.go
@@ -84,6 +84,13 @@ type CheckIndexRange struct {
 	HandleRanges []ast.HandleRange
 }
 
+// ChecksumTable is used for calculating table checksum, built from the `admin checksum table` statement.
+type ChecksumTable struct {
+	baseSchemaProducer
+
+	Tables []*ast.TableName
+}
+
 // CancelDDLJobs represents a cancel DDL jobs plan.
 type CancelDDLJobs struct {
 	baseSchemaProducer

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -487,6 +487,10 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 		p := &RecoverIndex{Table: as.Tables[0], IndexName: as.Index}
 		p.SetSchema(buildRecoverIndexFields())
 		ret = p
+	case ast.AdminChecksumTable:
+		p := &ChecksumTable{Tables: as.Tables}
+		p.SetSchema(buildChecksumTableSchema())
+		ret = p
 	case ast.AdminShowDDL:
 		p := &ShowDDL{}
 		p.SetSchema(buildShowDDLFields())
@@ -1398,5 +1402,15 @@ func buildShowSchema(s *ast.ShowStmt) (schema *expression.Schema) {
 		col.RetType = fieldType
 		schema.Append(col)
 	}
+	return schema
+}
+
+func buildChecksumTableSchema() *expression.Schema {
+	schema := expression.NewSchema(make([]*expression.Column, 0, 5)...)
+	schema.Append(buildColumn("", "Db_name", mysql.TypeVarchar, 128))
+	schema.Append(buildColumn("", "Table_name", mysql.TypeVarchar, 128))
+	schema.Append(buildColumn("", "Checksum_crc64_xor", mysql.TypeLonglong, 22))
+	schema.Append(buildColumn("", "Total_kvs", mysql.TypeLonglong, 22))
+	schema.Append(buildColumn("", "Total_bytes", mysql.TypeLonglong, 22))
 	return schema
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -610,6 +610,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBOptAggPushDown, boolToIntStr(DefOptAggPushDown)},
 	{ScopeSession, TiDBOptInSubqUnFolding, boolToIntStr(DefOptInSubqUnfolding)},
 	{ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},
+	{ScopeSession, TiDBChecksumTableConcurrency, strconv.Itoa(DefChecksumTableConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBDistSQLScanConcurrency, strconv.Itoa(DefDistSQLScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBIndexJoinBatchSize, strconv.Itoa(DefIndexJoinBatchSize)},
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupSize, strconv.Itoa(DefIndexLookupSize)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -48,6 +48,11 @@ const (
 	// those indices can be scanned concurrently, with the cost of higher system performance impact.
 	TiDBBuildStatsConcurrency = "tidb_build_stats_concurrency"
 
+	// tidb_checksum_table_concurrency is used to speed up the ADMIN CHECKSUM TABLE
+	// statement, when a table has multiple indices, those indices can be
+	// scanned concurrently, with the cost of higher system performance impact.
+	TiDBChecksumTableConcurrency = "tidb_checksum_table_concurrency"
+
 	// TiDBCurrentTS is used to get the current transaction timestamp.
 	// It is read-only.
 	TiDBCurrentTS = "tidb_current_ts"
@@ -135,6 +140,7 @@ const (
 	DefIndexLookupSize               = 20000
 	DefDistSQLScanConcurrency        = 15
 	DefBuildStatsConcurrency         = 4
+	DefChecksumTableConcurrency      = 4
 	DefSkipUTF8Check                 = false
 	DefOptAggPushDown                = false
 	DefOptInSubqUnfolding            = false

--- a/store/mockstore/mocktikv/checksum.go
+++ b/store/mockstore/mocktikv/checksum.go
@@ -1,0 +1,34 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mocktikv
+
+import (
+	"fmt"
+
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	tipb "github.com/pingcap/tipb/go-tipb"
+)
+
+func (h *rpcHandler) handleCopChecksumRequest(req *coprocessor.Request) *coprocessor.Response {
+	resp := &tipb.ChecksumResponse{
+		Checksum:   1,
+		TotalKvs:   1,
+		TotalBytes: 1,
+	}
+	data, err := resp.Marshal()
+	if err != nil {
+		panic(fmt.Sprintf("marshal checksum response error: %v", err))
+	}
+	return &coprocessor.Response{Data: data}
+}

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -15,6 +15,7 @@ package mocktikv
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/golang/protobuf/proto"
@@ -612,10 +613,15 @@ func (c *RPCClient) SendReq(ctx context.Context, addr string, req *tikvrpc.Reque
 		handler.rawStartKey = MvccKey(handler.startKey).Raw()
 		handler.rawEndKey = MvccKey(handler.endKey).Raw()
 		var res *coprocessor.Response
-		if r.GetTp() == kv.ReqTypeDAG {
+		switch r.GetTp() {
+		case kv.ReqTypeDAG:
 			res = handler.handleCopDAGRequest(r)
-		} else {
+		case kv.ReqTypeAnalyze:
 			res = handler.handleCopAnalyzeRequest(r)
+		case kv.ReqTypeChecksum:
+			res = handler.handleCopChecksumRequest(r)
+		default:
+			panic(fmt.Sprintf("unknown coprocessor request type: %v", r.GetTp()))
 		}
 		resp.Cop = res
 	case tikvrpc.CmdCopStream:


### PR DESCRIPTION
Support a new command `ADMIN CHECKSUM TABLE tablename` in TiDB.
The result of this command is a 64bit checksum, calculated from all key-values in a table, including records and indices.
This command will be implemented like the `ANALYZE table` command and will be pushed down to TiKV.
The corresponding TiKV PR is here: https://github.com/pingcap/tikv/pull/2822.

The current implementation use this checksum algorithm:
1. For every key-value in a table, including records and indices, calculate a CRC64 from (key + value).
2. For every CRC64 from every key-value, accumulate the checksum by XOR them together.