### PR TITLE
sessionctx: set explicit_defaults_for_timestamp to ON

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -492,7 +492,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "have_symlink", "YES"},
 	{ScopeGlobal | ScopeSession, "storage_engine", "InnoDB"},
 	{ScopeGlobal | ScopeSession, "sql_log_off", "OFF"},
-	{ScopeNone, "explicit_defaults_for_timestamp", "OFF"},
+	{ScopeNone, "explicit_defaults_for_timestamp", "ON"},
 	{ScopeNone, "performance_schema_events_waits_history_size", "10"},
 	{ScopeGlobal, "log_syslog_tag", ""},
 	{ScopeGlobal | ScopeSession, "tx_read_only", "0"},

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -35,4 +35,8 @@ func (*testSysVarSuite) TestSysVar(c *C) {
 
 	f = GetSysVar("wrong-var-name")
 	c.Assert(f, IsNil)
+
+	f = GetSysVar("explicit_defaults_for_timestamp")
+	c.Assert(f, NotNil)
+	c.Assert(f.Value, Equals, "ON")
 }


### PR DESCRIPTION
Set the read-only system variable to ON by default to be consistent with TiDB timestamp behavior.
This PR relates to https://github.com/pingcap/tidb/issues/6047 and https://github.com/pingcap/tidb/issues/6065 , not fix them.
PTAL @coocood 