### PR TITLE
util: refine Row.GetDatum when tp is MyDecimal

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -278,6 +278,11 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk.MustExec("create table t(a int(11), b decimal(15,2))")
 	tk.MustExec("insert into t values(1,771.64),(2,378.49),(3,920.92),(4,113.97)")
 	tk.MustQuery("select a, max(b) from t group by a limit 2").Check(testkit.Rows("1 771.64", "2 378.49"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int(11), b char(15))")
+	tk.MustExec("insert into t values(1,771.64),(2,378.49),(3,920.92),(4,113.97)")
+	tk.MustQuery("select a, max(b) from t group by a limit 2").Check(testkit.Rows("1 771.64", "2 378.49"))
 }
 
 func (s *testSuite) TestStreamAggPushDown(c *C) {

--- a/expression/aggregation/max_min.go
+++ b/expression/aggregation/max_min.go
@@ -42,7 +42,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 		return errors.Trace(err)
 	}
 	if evalCtx.Value.IsNull() {
-		evalCtx.Value = value
+		evalCtx.Value = *(&value).Copy()
 	}
 	if value.IsNull() {
 		return nil
@@ -53,7 +53,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 		return errors.Trace(err)
 	}
 	if (mmf.isMax && c == -1) || (!mmf.isMax && c == 1) {
-		evalCtx.Value = value
+		evalCtx.Value = *(&value).Copy()
 	}
 	return nil
 }

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -619,8 +619,7 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 		}
 	case mysql.TypeNewDecimal:
 		if !r.IsNull(colIdx) {
-			dec := *r.GetMyDecimal(colIdx)
-			d.SetMysqlDecimal(&dec)
+			d.SetMysqlDecimal(r.GetMyDecimal(colIdx))
 			d.SetLength(tp.Flen)
 			d.SetFrac(tp.Decimal)
 		}

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -562,8 +562,7 @@ func (r Row) GetSet(colIdx int) types.Set {
 // GetMyDecimal returns the MyDecimal value with the colIdx.
 func (r Row) GetMyDecimal(colIdx int) *types.MyDecimal {
 	col := r.c.columns[colIdx]
-	dec := *(*types.MyDecimal)(unsafe.Pointer(&col.data[r.idx*types.MyDecimalStructSize]))
-	return &dec
+	return (*types.MyDecimal)(unsafe.Pointer(&col.data[r.idx*types.MyDecimalStructSize]))
 }
 
 // GetJSON returns the JSON value with the colIdx.
@@ -620,7 +619,8 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 		}
 	case mysql.TypeNewDecimal:
 		if !r.IsNull(colIdx) {
-			d.SetMysqlDecimal(r.GetMyDecimal(colIdx))
+			dec := *r.GetMyDecimal(colIdx)
+			d.SetMysqlDecimal(&dec)
 			d.SetLength(tp.Flen)
 			d.SetFrac(tp.Decimal)
 		}


### PR DESCRIPTION
Refer #6077 
This commit moves the dereference of *MyDecimal from 
Row.GetDecimal to Row.GetDatum to avoid the copy of MyDecimal
when calling Row.GetMyDecimal.

PTAL @coocood @zz-jason 