### PR TITLE
expression/agg: add `ResetContext()` for stream aggregation.

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -347,7 +347,7 @@ func (e *StreamAggExec) fetchChildIfNecessary(ctx context.Context, chk *chunk.Ch
 }
 
 // appendResult2Chunk appends result of all the aggregation functions to the
-// result chunk, and realloc the evaluation context for each aggregation.
+// result chunk, and reset the evaluation context for each aggregation.
 func (e *StreamAggExec) appendResult2Chunk(chk *chunk.Chunk) {
 	e.rowBuffer = e.rowBuffer[:0]
 	for i, af := range e.AggFuncs {

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -352,7 +352,7 @@ func (e *StreamAggExec) appendResult2Chunk(chk *chunk.Chunk) {
 	e.rowBuffer = e.rowBuffer[:0]
 	for i, af := range e.AggFuncs {
 		e.rowBuffer = append(e.rowBuffer, af.GetResult(e.aggCtxs[i]))
-		e.aggCtxs[i] = af.CreateContext(e.ctx.GetSessionVars().StmtCtx)
+		af.ResetContext(e.ctx.GetSessionVars().StmtCtx, e.aggCtxs[i])
 	}
 	e.mutableRow.SetDatums(e.rowBuffer...)
 	chk.AppendRow(e.mutableRow.ToRow())

--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -38,6 +38,8 @@ type Aggregation interface {
 
 	// Create a new AggEvaluateContext for the aggregation function.
 	CreateContext(sc *stmtctx.StatementContext) *AggEvaluateContext
+
+	ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext)
 }
 
 // NewDistAggFunc creates new Aggregate function for mock tikv.
@@ -113,6 +115,13 @@ func (af *aggFunction) CreateContext(sc *stmtctx.StatementContext) *AggEvaluateC
 		evalCtx.DistinctChecker = createDistinctChecker(sc)
 	}
 	return evalCtx
+}
+
+func (af *aggFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	if af.HasDistinct {
+		evalCtx.DistinctChecker = createDistinctChecker(sc)
+	}
+	evalCtx.Value.SetNull()
 }
 
 func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext, row types.Row) error {

--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -39,6 +39,7 @@ type Aggregation interface {
 	// Create a new AggEvaluateContext for the aggregation function.
 	CreateContext(sc *stmtctx.StatementContext) *AggEvaluateContext
 
+	// Reset the content of the evaluate context.
 	ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext)
 }
 

--- a/expression/aggregation/avg.go
+++ b/expression/aggregation/avg.go
@@ -46,6 +46,14 @@ func (af *avgFunction) updateAvg(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 	return nil
 }
 
+func (af *avgFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	if af.HasDistinct {
+		evalCtx.DistinctChecker = createDistinctChecker(sc)
+	}
+	evalCtx.Value.SetNull()
+	evalCtx.Count = 0
+}
+
 // Update implements Aggregation interface.
 func (af *avgFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	if af.Mode == FinalMode {

--- a/expression/aggregation/bench_test.go
+++ b/expression/aggregation/bench_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+func BenchmarkCreateContext(b *testing.B) {
+	col := &expression.Column{
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false).GetAggFunc()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		fun.CreateContext(ctx.GetSessionVars().StmtCtx)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkResetContext(b *testing.B) {
+	col := &expression.Column{
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false).GetAggFunc()
+	evalCtx := fun.CreateContext(ctx.GetSessionVars().StmtCtx)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		fun.ResetContext(ctx.GetSessionVars().StmtCtx, evalCtx)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkCreateDistinctContext(b *testing.B) {
+	col := &expression.Column{
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true).GetAggFunc()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		fun.CreateContext(ctx.GetSessionVars().StmtCtx)
+	}
+	b.ReportAllocs()
+}
+
+func BenchmarkResetDistinctContext(b *testing.B) {
+	col := &expression.Column{
+		Index:   0,
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	ctx := mock.NewContext()
+	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true).GetAggFunc()
+	evalCtx := fun.CreateContext(ctx.GetSessionVars().StmtCtx)
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		fun.ResetContext(ctx.GetSessionVars().StmtCtx, evalCtx)
+	}
+	b.ReportAllocs()
+}

--- a/expression/aggregation/bit_and.go
+++ b/expression/aggregation/bit_and.go
@@ -31,6 +31,10 @@ func (bf *bitAndFunction) CreateContext(sc *stmtctx.StatementContext) *AggEvalua
 	return evalCtx
 }
 
+func (bf bitAndFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	evalCtx.Value.SetUint64(math.MaxUint64)
+}
+
 // Update implements Aggregation interface.
 func (bf *bitAndFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]

--- a/expression/aggregation/bit_or.go
+++ b/expression/aggregation/bit_or.go
@@ -29,6 +29,10 @@ func (bf *bitOrFunction) CreateContext(sc *stmtctx.StatementContext) *AggEvaluat
 	return evalCtx
 }
 
+func (bf *bitOrFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	evalCtx.Value.SetUint64(0)
+}
+
 // Update implements Aggregation interface.
 func (bf *bitOrFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]

--- a/expression/aggregation/bit_xor.go
+++ b/expression/aggregation/bit_xor.go
@@ -29,6 +29,10 @@ func (bf *bitXorFunction) CreateContext(sc *stmtctx.StatementContext) *AggEvalua
 	return evalCtx
 }
 
+func (bf *bitXorFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	evalCtx.Value.SetUint64(0)
+}
+
 // Update implements Aggregation interface.
 func (bf *bitXorFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.StatementContext, row types.Row) error {
 	a := bf.Args[0]

--- a/expression/aggregation/concat.go
+++ b/expression/aggregation/concat.go
@@ -102,6 +102,13 @@ func (cf *concatFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum)
 	return d
 }
 
+func (cf *concatFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	if cf.HasDistinct {
+		evalCtx.DistinctChecker = createDistinctChecker(sc)
+	}
+	evalCtx.Buffer = nil
+}
+
 // GetPartialResult implements Aggregation interface.
 func (cf *concatFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
 	return []types.Datum{cf.GetResult(evalCtx)}

--- a/expression/aggregation/count.go
+++ b/expression/aggregation/count.go
@@ -59,6 +59,13 @@ func (cf *countFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 	return nil
 }
 
+func (cf *countFunction) ResetContext(sc *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	if cf.HasDistinct {
+		evalCtx.DistinctChecker = createDistinctChecker(sc)
+	}
+	evalCtx.Count = 0
+}
+
 // GetResult implements Aggregation interface.
 func (cf *countFunction) GetResult(evalCtx *AggEvaluateContext) (d types.Datum) {
 	d.SetInt64(evalCtx.Count)

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -45,6 +45,10 @@ func (ff *firstRowFunction) GetResult(evalCtx *AggEvaluateContext) types.Datum {
 	return evalCtx.Value
 }
 
+func (ff *firstRowFunction) ResetContext(_ *stmtctx.StatementContext, evalCtx *AggEvaluateContext) {
+	evalCtx.GotFirstRow = false
+}
+
 // GetPartialResult implements Aggregation interface.
 func (ff *firstRowFunction) GetPartialResult(evalCtx *AggEvaluateContext) []types.Datum {
 	return []types.Datum{ff.GetResult(evalCtx)}


### PR DESCRIPTION
Benchmark result for `CreateContext` and `ResetContext`:
```
➜  aggregation git:(reset-context) ✗ go test . -bench=BenchmarkCreateContext
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression/aggregation
BenchmarkCreateContext-8   	20000000	        63.1 ns/op	      96 B/op	       1 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression/aggregation	1.388s
```

```
➜  aggregation git:(reset-context) ✗ go test . -bench=BenchmarkResetContext
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression/aggregation
BenchmarkResetContext-8   	300000000	         5.21 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression/aggregation	2.135s
```

```
➜  aggregation git:(reset-context) ✗ go test . -bench=BenchmarkCreateDistinctContext
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression/aggregation
BenchmarkCreateDistinctContext-8   	 1000000	      1171 ns/op	    2912 B/op	       8 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression/aggregation	1.235s
```

```
➜  aggregation git:(reset-context) ✗ go test . -bench=BenchmarkResetDistinctContext
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression/aggregation
BenchmarkResetDistinctContext-8   	 1000000	      1166 ns/op	    2816 B/op	       7 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression/aggregation	1.227s
```