### PR TITLE
infoschema: set collate and charset to null for non-varchar column type

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1751,7 +1751,7 @@ func (s *testDBSuite) TestCharacterSetInColumns(c *C) {
 	s.tk.MustExec("create database varchar_test;")
 	s.tk.MustExec("use varchar_test")
 	s.tk.MustExec("drop table if exists t")
-	s.tk.MustExec("create table t (c1 int, s1 varchar(10))")
+	s.tk.MustExec("create table t (c1 int, s1 varchar(10), s2 text)")
 	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name != 'utf8'").Check(testkit.Rows("0"))
-	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name = 'utf8'").Check(testkit.Rows("1"))
+	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name = 'utf8'").Check(testkit.Rows("2"))
 }

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1744,3 +1744,14 @@ func (s *testDBSuite) TestRebaseAutoID(c *C) {
 	s.tk.MustExec("create table tidb.test2 (a int);")
 	s.testErrorCode(c, "alter table tidb.test2 add column b int auto_increment key, auto_increment=10;", tmysql.ErrUnknown)
 }
+
+func (s *testDBSuite) TestCharacterSetInColumns(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("drop database if exists varchar_test;")
+	s.tk.MustExec("create database varchar_test;")
+	s.tk.MustExec("use varchar_test")
+	s.tk.MustExec("drop table if exists t")
+	s.tk.MustExec("create table t (c1 int, s1 varchar(10))")
+	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name != 'utf8'").Check(testkit.Rows("0"))
+	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name = 'utf8'").Check(testkit.Rows("1"))
+}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -728,7 +728,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
 		// In mysql, 'character_set_name' and 'collation_name' are setted to null when column type is non-varchar in information_schema.
-		if col.Tp != mysql.TypeVarchar {
+		if col.Tp != mysql.TypeVarchar && col.Tp != mysql.TypeBlob {
 			record[13].SetNull()
 			record[14].SetNull()
 		}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -727,7 +727,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
-		// In mysql, 'character_set_name' and 'collation_name' are setted to null when column type is non-varchar in information_schema.
+		// In mysql, 'character_set_name' and 'collation_name' are setted to null when column type is non-varchar or non-blob in information_schema.
 		if col.Tp != mysql.TypeVarchar && col.Tp != mysql.TypeBlob {
 			record[13].SetNull()
 			record[14].SetNull()

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -693,7 +693,6 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 	for i, col := range tbl.Columns {
 		colLen, decimal := col.Flen, col.Decimal
 		defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(col.Tp)
-
 		if colLen == types.UnspecifiedLength {
 			colLen = defaultFlen
 		}
@@ -728,7 +727,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
-		// in mysql, character set is setted to null when column type is non-varchar
+		// In mysql, 'character set' is setted to null when column type is non-varchar.
 		if col.Tp != mysql.TypeVarchar {
 			record[13].SetNull()
 			record[14].SetNull()

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -693,6 +693,11 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 	for i, col := range tbl.Columns {
 		colLen, decimal := col.Flen, col.Decimal
 		defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(col.Tp)
+		if col.Tp != mysql.TypeVarchar {
+			col.Collate = "NULL"
+			col.Charset = "NULL"
+		}
+
 		if colLen == types.UnspecifiedLength {
 			colLen = defaultFlen
 		}
@@ -727,6 +732,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
+
 		rows = append(rows, record)
 	}
 	return rows

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -693,10 +693,6 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 	for i, col := range tbl.Columns {
 		colLen, decimal := col.Flen, col.Decimal
 		defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(col.Tp)
-		if col.Tp != mysql.TypeVarchar {
-			col.Collate = "NULL"
-			col.Charset = "NULL"
-		}
 
 		if colLen == types.UnspecifiedLength {
 			colLen = defaultFlen
@@ -732,6 +728,11 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
+		// in mysql, character set is setted to null when column type is non-varchar
+		if col.Tp != mysql.TypeVarchar {
+			record[13].SetNull()
+			record[14].SetNull()
+		}
 
 		rows = append(rows, record)
 	}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -727,7 +727,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
 		)
-		// In mysql, 'character set' is setted to null when column type is non-varchar.
+		// In mysql, 'character_set_name' and 'collation_name' are setted to null when column type is non-varchar in information_schema.
 		if col.Tp != mysql.TypeVarchar {
 			record[13].SetNull()
 			record[14].SetNull()


### PR DESCRIPTION
TiDB's behavior is inconsistent with mysql. Below is a reproduce guide.

```
use test;
create table t (c1 int, s1 varchar(10));
select table_name, column_name, column_type, character_set_name FROM information_schema.COLUMNS WHERE table_schema = 'test';
```
In TiDB, it returns:
```
+------------+-------------+-------------+--------------------+
| table_name | column_name | column_type | character_set_name |
+------------+-------------+-------------+--------------------+
| t          | c1          | int(11)     | binary              |
| t          | s1          | varchar(10) | utf8               |
+------------+-------------+-------------+--------------------+
2 rows in set (0.00 sec)
```
In mysql, it returns:
```
+------------+-------------+-------------+--------------------+
| table_name | column_name | column_type | character_set_name |
+------------+-------------+-------------+--------------------+
| t          | c1          | int(11)     | NULL               |
| t          | s1          | varchar(10) | utf8               |
+------------+-------------+-------------+--------------------+
2 rows in set (0.00 sec)
```