### PR TITLE
stats: fix estimation for pseudo equal row count

### DIFF
--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -172,8 +172,8 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 		},
 		// Test PK in index double read.
 		{
-			sql:  "select * from t where t.c = 1 and t.a = 1 order by t.d limit 1",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit, Table(t))->Limit",
+			sql:  "select * from t where t.c = 1 and t.a > 1 order by t.d limit 1",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([gt(test.t.a, 1)])->Limit, Table(t))->Limit",
 		},
 		// Test index filter condition push down.
 		{

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -546,7 +546,30 @@ func (s *testStatisticsSuite) TestIntColumnRanges(c *C) {
 	ran[0].HighVal[0].SetInt64(1000)
 	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
 	c.Assert(err, IsNil)
-	c.Assert(int(count), Equals, 100)
+	c.Assert(int(count), Equals, 1)
+
+	ran = []*ranger.NewRange{{
+		LowVal:  []types.Datum{types.NewUintDatum(0)},
+		HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
+	}}
+	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
+	c.Assert(err, IsNil)
+	c.Assert(int(count), Equals, 100000)
+	ran[0].LowVal[0].SetUint64(1000)
+	ran[0].HighVal[0].SetUint64(2000)
+	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
+	c.Assert(err, IsNil)
+	c.Assert(int(count), Equals, 1000)
+	ran[0].LowVal[0].SetUint64(1001)
+	ran[0].HighVal[0].SetUint64(1999)
+	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
+	c.Assert(err, IsNil)
+	c.Assert(int(count), Equals, 998)
+	ran[0].LowVal[0].SetUint64(1000)
+	ran[0].HighVal[0].SetUint64(1000)
+	count, err = tbl.GetRowCountByIntColumnRanges(sc, 0, ran)
+	c.Assert(err, IsNil)
+	c.Assert(int(count), Equals, 1)
 
 	tbl.Columns[0] = col
 	ran[0].LowVal[0].SetInt64(math.MinInt64)

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -430,7 +430,7 @@ func getPseudoRowCountBySignedIntRanges(intRanges []*ranger.NewRange, tableRowCo
 			cnt = tableRowCount / pseudoLessRate
 		} else {
 			if low == high {
-				cnt = tableRowCount / pseudoEqualRate
+				cnt = 1 // When primary key is handle, the equal row count is at most one.
 			} else {
 				cnt = tableRowCount / pseudoBetweenRate
 			}
@@ -460,7 +460,7 @@ func getPseudoRowCountByUnsignedIntRanges(intRanges []*ranger.NewRange, tableRow
 			cnt = tableRowCount / pseudoLessRate
 		} else {
 			if low == high {
-				cnt = tableRowCount / pseudoEqualRate
+				cnt = 1 // When primary key is handle, the equal row count is at most one.
 			} else {
 				cnt = tableRowCount / pseudoBetweenRate
 			}


### PR DESCRIPTION
The equal row count for primary key should be at most 1.
PTAL @coocood @winoros 