### PR TITLE
executor: close source executor when CheckIndexExec closed

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -229,7 +229,7 @@ func (b *executorBuilder) buildCheckIndex(v *plan.CheckIndex) Executor {
 	readerExec.isCheckOp = true
 
 	e := &CheckIndexExec{
-		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
+		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), readerExec),
 		dbName:       v.DBName,
 		tableName:    readerExec.table.Meta().Name.L,
 		idxName:      v.IdxName,


### PR DESCRIPTION
We will not close `CheckIndexExec.src` when `CheckIndexExec.Close()` is called, which will further cause goroutine leak or data race in some cases.

This PR makes `CheckIndexExec.src` as a child of `CheckIndexExec` to insure that `CheckIndexExec.src` is closed when `CheckIndexExec.Close` called.