### PR TITLE
ddl, tables: remove useless NewIndexWithBuffer

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -443,7 +443,7 @@ type addIndexResult struct {
 }
 
 func newAddIndexWorker(sessCtx sessionctx.Context, d *ddl, id int, t table.Table, indexInfo *model.IndexInfo, colFieldMap map[int64]*types.FieldType) *addIndexWorker {
-	index := tables.NewIndexWithBuffer(t.Meta(), indexInfo)
+	index := tables.NewIndex(t.Meta(), indexInfo)
 	return &addIndexWorker{
 		id:          id,
 		d:           d,

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -88,7 +88,7 @@ func (s *testSuite) TestAdminRecoverIndex(c *C) {
 
 	tblInfo := tbl.Meta()
 	idxInfo := findIndexByName("c2", tblInfo.Indices)
-	indexOpr := tables.NewIndexWithBuffer(tblInfo, idxInfo)
+	indexOpr := tables.NewIndex(tblInfo, idxInfo)
 	sc := s.ctx.GetSessionVars().StmtCtx
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
@@ -184,7 +184,7 @@ func (s *testSuite) TestAdminRecoverIndex1(c *C) {
 	tblInfo := tbl.Meta()
 	idxInfo := findIndexByName("primary", tblInfo.Indices)
 	c.Assert(idxInfo, NotNil)
-	indexOpr := tables.NewIndexWithBuffer(tblInfo, idxInfo)
+	indexOpr := tables.NewIndex(tblInfo, idxInfo)
 
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -99,22 +99,6 @@ type index struct {
 	tblInfo *model.TableInfo
 	idxInfo *model.IndexInfo
 	prefix  kv.Key
-
-	// ddlReorgBuffer is used reduce the number of new slice when multiple index keys are created.
-	// It is not thread-safe, is only used in ddl index reorganization stage, please don't use it in other case.
-	ddlReorgBuffer []byte
-}
-
-// NewIndexWithBuffer builds a new Index object whit the buffer.
-func NewIndexWithBuffer(tableInfo *model.TableInfo, indexInfo *model.IndexInfo) table.Index {
-	idxPrefix := tablecodec.EncodeTableIndexPrefix(tableInfo.ID, indexInfo.ID)
-	index := &index{
-		tblInfo:        tableInfo,
-		idxInfo:        indexInfo,
-		prefix:         idxPrefix,
-		ddlReorgBuffer: make([]byte, 0, len(idxPrefix)+len(indexInfo.Columns)*9+9),
-	}
-	return index
 }
 
 // NewIndex builds a new Index object.
@@ -135,10 +119,6 @@ func (c *index) Meta() *model.IndexInfo {
 func (c *index) getIndexKeyBuf(buf []byte, defaultCap int) []byte {
 	if buf != nil {
 		return buf[:0]
-	}
-
-	if c.ddlReorgBuffer != nil {
-		return c.ddlReorgBuffer[:0]
 	}
 
 	return make([]byte, 0, defaultCap)


### PR DESCRIPTION
tables.NewIndexWithBuffer is useless and confused, because the creating index key buffer can be reused in ctx.GetSessionVars().WriteStmtBufs. 