### PR TITLE
kvencoder: add GetSystemVariable and SetSystemVariable to KvEncoder, to get/set system variable

### DIFF
--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -16,6 +16,7 @@ package kvenc
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"sync/atomic"
 
 	"github.com/juju/errors"
@@ -66,6 +67,12 @@ type KvEncoder interface {
 
 	// EncodeMetaAutoID encode the table meta info, autoID to coresponding key-value pair.
 	EncodeMetaAutoID(dbID, tableID, autoID int64) (KvPair, error)
+
+	// SetSystemVariable set system variable name = value.
+	SetSystemVariable(name string, value string) error
+
+	// GetSystemVariable get the system variable value of name.
+	GetSystemVariable(name string) (string, bool)
 
 	// Close cleanup the kvEncoder.
 	Close() error
@@ -166,6 +173,23 @@ func (e *kvEncoder) ExecDDLSQL(sql string) error {
 	}
 
 	return nil
+}
+
+func (e *kvEncoder) SetSystemVariable(name string, value string) error {
+	name = strings.ToLower(name)
+	if e.se != nil {
+		return e.se.GetSessionVars().SetSystemVar(name, value)
+	}
+	return errors.Errorf("e.se is nil, please new KvEncoder by kvencoder.New().")
+}
+
+func (e *kvEncoder) GetSystemVariable(name string) (string, bool) {
+	name = strings.ToLower(name)
+	if e.se == nil {
+		return "", false
+	}
+
+	return e.se.GetSessionVars().GetSystemVar(name)
 }
 
 func newMockTikvWithBootstrap() (kv.Storage, *domain.Domain, error) {

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -596,3 +596,28 @@ func (s *testKvEncoderSuite) TestEncodeMetaAutoID(c *C) {
 	c.Assert(bytes.Compare(kvPair.Key, expectKey), Equals, 0)
 	c.Assert(bytes.Compare(kvPair.Val, expectVal), Equals, 0)
 }
+
+func (s *testKvEncoderSuite) TestGetSetSystemVariable(c *C) {
+	encoder, err := New("test", nil)
+	c.Assert(err, IsNil)
+	defer encoder.Close()
+
+	err = encoder.SetSystemVariable("sql_mode", "")
+	c.Assert(err, IsNil)
+
+	val, ok := encoder.GetSystemVariable("sql_mode")
+	c.Assert(ok, IsTrue)
+	c.Assert(val, Equals, "")
+
+	sqlMode := "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
+	err = encoder.SetSystemVariable("sql_mode", sqlMode)
+	c.Assert(err, IsNil)
+
+	val, ok = encoder.GetSystemVariable("sql_mode")
+	c.Assert(ok, IsTrue)
+	c.Assert(val, Equals, sqlMode)
+
+	val, ok = encoder.GetSystemVariable("SQL_MODE")
+	c.Assert(ok, IsTrue)
+	c.Assert(val, Equals, sqlMode)
+}

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -621,3 +621,37 @@ func (s *testKvEncoderSuite) TestGetSetSystemVariable(c *C) {
 	c.Assert(ok, IsTrue)
 	c.Assert(val, Equals, sqlMode)
 }
+
+func (s *testKvEncoderSuite) TestDisableStrictSQLMode(c *C) {
+	sql := "create table `ORDER-LINE` (" +
+		"  ol_w_id         integer   not null," +
+		"  ol_d_id         integer   not null," +
+		"  ol_o_id         integer   not null," +
+		"  ol_number       integer   not null," +
+		"  ol_i_id         integer   not null," +
+		"  ol_delivery_d   timestamp DEFAULT CURRENT_TIMESTAMP," +
+		"  ol_amount       decimal(6,2)," +
+		"  ol_supply_w_id  integer," +
+		"  ol_quantity     decimal(2,0)," +
+		"  ol_dist_info    char(24)," +
+		"  primary key (ol_w_id, ol_d_id, ol_o_id, ol_number)" +
+		");"
+
+	encoder, err := New("test", nil)
+	c.Assert(err, IsNil)
+	defer encoder.Close()
+
+	err = encoder.ExecDDLSQL(sql)
+	c.Assert(err, IsNil)
+	tableID := int64(1)
+	sql = "insert into `ORDER-LINE` values(2, 1, 1, 1, 1, 'NULL', 1, 1, 1, '1');"
+	_, _, err = encoder.Encode(sql, tableID)
+	c.Assert(err, NotNil)
+
+	err = encoder.SetSystemVariable("sql_mode", "")
+	c.Assert(err, IsNil)
+
+	sql = "insert into `ORDER-LINE` values(2, 1, 1, 1, 1, 'NULL', 1, 1, 1, '1');"
+	_, _, err = encoder.Encode(sql, tableID)
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Lightning will need to set kvencoder's sql_mode, to disable strict SQL mode.

@huachaohuang @jackysp PTAL
