### PR TITLE
store/tikv: fix CI for tikv_integration_test

### DIFF
--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/terror"
 	"golang.org/x/net/context"
 )
@@ -28,7 +27,6 @@ import (
 type testSafePointSuite struct {
 	OneByOneSuite
 	store  *tikvStore
-	oracle *mockoracle.MockOracle
 	prefix string
 }
 
@@ -37,8 +35,6 @@ var _ = Suite(&testSafePointSuite{})
 func (s *testSafePointSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
-	s.oracle = &mockoracle.MockOracle{}
-	s.store.oracle = s.oracle
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
 }
 


### PR DESCRIPTION
When -with-tikv flag is true, tikv_integration_test run with TiKV.
The tests are run one by one, and NewTestStore() will clear storage data first,
so each test will not make the storage dirty and disturb other tests.

But safepoint_test.go use a local timestamp oracle, it can't work with PD's timestamp,
cause its data not cleared, then the following TestScanMultipleRegions fail.