### PR TITLE
expression: fix type infer for binary literal

### DIFF
--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -67,6 +67,9 @@ func numericContextResultType(ft *types.FieldType) types.EvalType {
 		}
 		return types.ETInt
 	}
+	if types.IsBinaryStr(ft) {
+		return types.ETInt
+	}
 	evalTp4Ft := types.ETReal
 	if !ft.Hybrid() {
 		evalTp4Ft = ft.EvalType()

--- a/expression/builtin_arithmetic_test.go
+++ b/expression/builtin_arithmetic_test.go
@@ -148,6 +148,22 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(isNull, IsTrue)
 	c.Assert(realResult, Equals, float64(0))
+
+	// case 5
+	hexStr, err := types.ParseHexStr("0x20000000000000")
+	c.Assert(err, IsNil)
+	args = []interface{}{hexStr, int64(1)}
+
+	bf, err = funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
+	c.Assert(err, IsNil)
+	c.Assert(bf, NotNil)
+	intSig, ok = bf.(*builtinArithmeticPlusIntSig)
+	c.Assert(ok, IsTrue)
+	c.Assert(intSig, NotNil)
+
+	intResult, _, err = intSig.evalInt(nil)
+	c.Assert(err, IsNil)
+	c.Assert(intResult, Equals, int64(9007199254740993))
 }
 
 func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
@@ -85,6 +86,8 @@ func (s *testEvaluatorSuite) kindToFieldType(kind byte) types.FieldType {
 		ft.Tp = mysql.TypeDatetime
 	case types.KindBinaryLiteral:
 		ft.Tp = mysql.TypeVarString
+		ft.Charset = charset.CharsetBin
+		ft.Collate = charset.CollationBin
 	case types.KindMysqlBit:
 		ft.Tp = mysql.TypeBit
 	}


### PR DESCRIPTION
`numericContextResultType` should be `types.EInt`.

The result type of `0x20000000000000 + 1` should be BIGINT instead of DOUBLE.