### PR TITLE
parser: fix a bug lexer.Reset() doesn't reset to the initial state

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -94,6 +94,7 @@ func (s *Scanner) reset(sql string) {
 	s.buf.Reset()
 	s.errs = s.errs[:0]
 	s.stmtStartPos = 0
+	s.specialComment = nil
 }
 
 func (s *Scanner) stmtText() string {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2204,3 +2204,14 @@ func (s *testParserSuite) TestSetTransaction(c *C) {
 		c.Assert(vars.Value.GetValue(), Equals, t.value)
 	}
 }
+
+func (s *testParserSuite) TestSideEffect(c *C) {
+	// This test cover a bug that parse an error SQL doesn't leave the parser in a
+	// clean state, cause the following SQL parse fail.
+	parser := New()
+	_, err := parser.ParseOneStmt("create table t /*!50100 'abc', 'abc' */;", "", "")
+	c.Assert(err, NotNil)
+
+	_, err = parser.ParseOneStmt("show tables;", "", "")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
```
create table t /*!50100 'abc', 'abc' */;
show tables;
```

Parse second SQL statement failed because lexer leave some dirty state
during parsing the first statement.

@shenli @jackysp 