### PR TITLE
parser: Fix a bug in CreateView

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1772,7 +1772,7 @@ PartDefStorageOpt:
 CreateViewStmt:
     "CREATE" OrReplace ViewAlgorithm ViewDefiner ViewSQLSecurity "VIEW" ViewName ViewFieldList "AS" SelectStmt ViewCheckOption
     {
-		startOffset := parser.startOffset(&yyS[yypt])
+		startOffset := parser.startOffset(&yyS[yypt-1])
 		selStmt := $10.(*ast.SelectStmt)
 		selStmt.SetText(string(parser.src[startOffset:]))
 		x := &ast.CreateViewStmt {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2025,6 +2025,14 @@ func (s *testParserSuite) TestView(c *C) {
 		{"create or replace algorithm = merge definer = current_user view v as select * from t", false},
 	}
 	s.RunTest(c, table)
+
+	// Test case for the text of the select statement in create view statement.
+	p := New()
+	sms, err := p.Parse("create view v as select * from t", "", "")
+	c.Assert(err, IsNil)
+	v, ok := sms[0].(*ast.CreateViewStmt)
+	c.Assert(ok, IsTrue)
+	c.Assert(v.Select.Text(), Equals, "select * from t")
 }
 
 func (s *testParserSuite) TestTimestampDiffUnit(c *C) {


### PR DESCRIPTION
The index of the top item in yys Stack is yypt-1. So the text of the select statement will be wrongly set. What's worse is that when parsing a short SQL after a long SQL, it could cause index out of range.
 
Before this commit, the added test case will fail:
```
FAIL: parser_test.go:2010: testParserSuite.TestView

parser_test.go:2036:
    c.Assert(v.Select.Text(), Equals, "select * from t")
... obtained string = "create view v as select * from t"
... expected string = "select * from t"

OOPS: 0 passed, 1 FAILED
--- FAIL: TestT (0.01s)
```
@tiancaiamao PTAL