### PR TITLE
store/mockstore: Add raw delete range to mock store

### DIFF
--- a/store/mockstore/mocktikv/mvcc.go
+++ b/store/mockstore/mocktikv/mvcc.go
@@ -435,6 +435,7 @@ type RawKV interface {
 	RawScan(startKey, endKey []byte, limit int) []Pair
 	RawPut(key, value []byte)
 	RawDelete(key []byte)
+	RawDeleteRange(startKey, endKey []byte)
 }
 
 // MVCCDebugger is for debugging.
@@ -778,6 +779,23 @@ func (s *MvccStore) RawDelete(key []byte) {
 	s.Lock()
 	defer s.Unlock()
 	s.rawkv.Delete(newRawEntry(key))
+}
+
+// RawDeleteRange deletes all key-value pairs in a given range
+func (s *MvccStore) RawDeleteRange(startKey, endKey []byte) {
+	s.Lock()
+	defer s.Unlock()
+
+	var entriesToDelete []*rawEntry
+	iterator := func(item btree.Item) bool {
+		entriesToDelete = append(entriesToDelete, item.(*rawEntry))
+		return true
+	}
+	s.rawkv.AscendRange(newRawEntry(startKey), newRawEntry(endKey), iterator)
+
+	for _, entry := range entriesToDelete {
+		s.rawkv.Delete(entry)
+	}
 }
 
 // RawScan reads up to a limited number of rawkv Pairs.


### PR DESCRIPTION
It's required to test raw delete range API, which will be added to ticlient