### PR TITLE
executor, plan: convert Limit to TableDual when meet `limit 0`

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2488,6 +2488,14 @@ func (s *testSuite) TestIssue5666(c *C) {
 	tk.MustQuery("SELECT QUERY_ID, SUM(DURATION) AS SUM_DURATION FROM INFORMATION_SCHEMA.PROFILING GROUP BY QUERY_ID;").Check(testkit.Rows("0 0"))
 }
 
+func (s *testSuite) TestIssue5341(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop table if exists test.t")
+	tk.MustExec("create table test.t(a char)")
+	tk.MustExec("insert into test.t value('a')")
+	tk.MustQuery("select * from test.t where a < 1 order by a limit 0;").Check(testkit.Rows())
+}
+
 func (s *testSuite) TestCheckIndex(c *C) {
 	s.ctx = mock.NewContext()
 	s.ctx.Store = s.store

--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -324,7 +324,7 @@ func (s *testAnalyzeSuite) TestEmptyTable(c *C) {
 		},
 		{
 			sql:  "select * from t limit 0",
-			best: "TableReader(Table(t)->Limit)->Limit",
+			best: "Dual",
 		},
 	}
 	for _, tt := range tests {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -788,6 +788,11 @@ func (b *planBuilder) buildLimit(src LogicalPlan, limit *ast.Limit) LogicalPlan 
 	if count > math.MaxUint64-offset {
 		count = math.MaxUint64 - offset
 	}
+	if offset+count == 0 {
+		tableDual := LogicalTableDual{RowCount: 0}.init(b.ctx)
+		tableDual.schema = src.Schema()
+		return tableDual
+	}
 	li := LogicalLimit{
 		Offset: offset,
 		Count:  count,

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -604,11 +604,6 @@ func (s *testPlanSuite) TestPlanBuilder(c *C) {
 			sql:  "select * from t t1 natural join t t2",
 			plan: "Join{DataScan(t1)->DataScan(t2)}->Projection",
 		},
-		// issue #5341
-		{
-			sql:  "select * from t limit 0",
-			plan: "Dual",
-		},
 	}
 	for _, ca := range tests {
 		comment := Commentf("for %s", ca.sql)

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -604,6 +604,11 @@ func (s *testPlanSuite) TestPlanBuilder(c *C) {
 			sql:  "select * from t t1 natural join t t2",
 			plan: "Join{DataScan(t1)->DataScan(t2)}->Projection",
 		},
+		// issue #5341
+		{
+			sql:  "select * from t limit 0",
+			plan: "Dual",
+		},
 	}
 	for _, ca := range tests {
 		comment := Commentf("for %s", ca.sql)


### PR DESCRIPTION
Fix #5341 
Before this PR: 
``` sql
create table t(a char);
insert into t value('a');
select * from test.t where a < 1 order by a limit 0;
```
``` sql
+----------------+--------------+----------------+------+----------------------------------------------+-------+
| id             | parents      | children       | task | operator info                                | count |
+----------------+--------------+----------------+------+----------------------------------------------+-------+
| TableScan_15   |              |                | cop  | table:t, range:[-inf,+inf], keep order:false | 1.00  |
| TableReader_16 | Selection_14 |                | root | data:TableScan_15                            | 1.00  |
| Selection_14   | TopN_10      | TableReader_16 | root | lt(cast(test.t.a), 1)                        | 0.80  |
| TopN_10        |              | Selection_14   | root | test.t.a:asc, offset:0, count:0              | 0.00  |
+----------------+--------------+----------------+------+----------------------------------------------+-------+
```
This sql will get panic message as #5341 shows,
cause TopN cannot be pushed down, and the check [here](https://github.com/pingcap/tidb/blob/master/executor/sort.go#L401) will be true.

PTAL @coocood @zz-jason 