### PR TITLE
executor: remove unused code

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -127,12 +127,6 @@ func (e *baseExecutor) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements interface Executor.
-// To be removed in near future.
-func (e *baseExecutor) Next(context.Context) (Row, error) {
-	return nil, nil
-}
-
 // Close closes all executors and release all resources.
 func (e *baseExecutor) Close() error {
 	for _, child := range e.children {
@@ -188,7 +182,6 @@ func newBaseExecutor(ctx sessionctx.Context, schema *expression.Schema, id strin
 
 // Executor executes a query.
 type Executor interface {
-	Next(context.Context) (Row, error)
 	Close() error
 	Open(context.Context) error
 	Schema() *expression.Schema
@@ -1009,7 +1002,6 @@ type UnionExec struct {
 	baseExecutor
 
 	stopFetchData atomic.Value
-	cursor        int
 	wg            sync.WaitGroup
 
 	finished      chan struct{}

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -82,19 +82,24 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 	}
 
 	ctx := context.Background()
+	err := e.Open(ctx)
+	c.Assert(err, IsNil)
+
+	chk := e.newChunk()
+	it := chunk.NewIterator4Chunk(chk)
 	// Run test and check results.
 	for _, p := range ps {
-		chk := e.newChunk()
-		err := e.NextChunk(context.Background(), chk)
+		err = e.NextChunk(context.Background(), chk)
 		c.Assert(err, IsNil)
-		it := chunk.NewIterator4Chunk(chk)
 		for row := it.Begin(); row != it.End(); row = it.Next() {
 			c.Assert(row.GetUint64(0), Equals, p.ID)
 		}
 	}
-	r, err := e.Next(ctx)
+	err = e.NextChunk(context.Background(), chk)
 	c.Assert(err, IsNil)
-	c.Assert(r, IsNil)
+	c.Assert(chk.NumRows(), Equals, 0)
+	err = e.Close()
+	c.Assert(err, IsNil)
 }
 
 func buildSchema(names []string, ftypes []byte) *expression.Schema {

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -22,7 +22,6 @@ type pkgTestSuite struct {
 type MockExec struct {
 	baseExecutor
 
-	fields    []*ast.ResultField
 	Rows      []Row
 	curRowIdx int
 }


### PR DESCRIPTION
Remove all the unused code in package "executor".  We can rename `NextChunk` to `Next` in next PR.