### PR TITLE
session: upgrade mysql.db user column length to 32

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -71,7 +71,7 @@ const (
 	CreateDBPrivTable = `CREATE TABLE if not exists mysql.db (
 		Host			CHAR(60),
 		DB			CHAR(64),
-		User			CHAR(16),
+		User			CHAR(32),
 		Select_priv		ENUM('N','Y') Not Null DEFAULT 'N',
 		Insert_priv		ENUM('N','Y') Not Null DEFAULT 'N',
 		Update_priv		ENUM('N','Y') Not Null DEFAULT 'N',
@@ -232,6 +232,7 @@ const (
 	version16 = 16
 	version17 = 17
 	version18 = 18
+	version19 = 19
 )
 
 func checkBootstrapped(s Session) (bool, error) {
@@ -360,6 +361,10 @@ func upgrade(s Session) {
 
 	if ver < version18 {
 		upgradeToVer18(s)
+	}
+
+	if ver < version19 {
+		upgradeToVer19(s)
 	}
 
 	updateBootstrapVer(s)
@@ -576,6 +581,10 @@ func upgradeToVer17(s Session) {
 
 func upgradeToVer18(s Session) {
 	doReentrantDDL(s, "ALTER TABLE mysql.stats_histograms ADD COLUMN `tot_col_size` bigint(64) NOT NULL DEFAULT 0", infoschema.ErrColumnExists)
+}
+
+func upgradeToVer19(s Session) {
+	doReentrantDDL(s, "ALTER TABLE mysql.db MODIFY User CHAR(32)")
 }
 
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -95,8 +95,8 @@ const (
 	// CreateTablePrivTable is the SQL statement creates table scope privilege table in system db.
 	CreateTablePrivTable = `CREATE TABLE if not exists mysql.tables_priv (
 		Host		CHAR(60),
-		DB			CHAR(64),
-		User		CHAR(16),
+		DB		CHAR(64),
+		User		CHAR(32),
 		Table_name	CHAR(64),
 		Grantor		CHAR(77),
 		Timestamp	Timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -106,8 +106,8 @@ const (
 	// CreateColumnPrivTable is the SQL statement creates column scope privilege table in system db.
 	CreateColumnPrivTable = `CREATE TABLE if not exists mysql.columns_priv(
 		Host		CHAR(60),
-		DB			CHAR(64),
-		User		CHAR(16),
+		DB		CHAR(64),
+		User		CHAR(32),
 		Table_name	CHAR(64),
 		Column_name	CHAR(64),
 		Timestamp	Timestamp DEFAULT CURRENT_TIMESTAMP,
@@ -585,6 +585,8 @@ func upgradeToVer18(s Session) {
 
 func upgradeToVer19(s Session) {
 	doReentrantDDL(s, "ALTER TABLE mysql.db MODIFY User CHAR(32)")
+	doReentrantDDL(s, "ALTER TABLE mysql.tables_priv MODIFY User CHAR(32)")
+	doReentrantDDL(s, "ALTER TABLE mysql.columns_priv MODIFY User CHAR(32)")
 }
 
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.

--- a/session/session.go
+++ b/session/session.go
@@ -1197,7 +1197,7 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = 18
+	currentBootstrapVersion = 19
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1978,6 +1978,8 @@ func (s *testSessionSuite) TestRollbackOnCompileError(c *C) {
 
 func (s *testSessionSuite) TestDBUserNameLength(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table if not exists t (a int)")
 	// Test user name lengh can be longer than 16.
 	tk.MustExec(`grant all privileges on test.* to 'abcddfjakldfjaldddds'@'%' identified by ''`)
+	tk.MustExec(`grant all privileges on test.t to 'abcddfjakldfjaldddds'@'%' identified by ''`)
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1975,3 +1975,9 @@ func (s *testSessionSuite) TestRollbackOnCompileError(c *C) {
 	}
 	c.Assert(recoverErr, IsTrue)
 }
+
+func (s *testSessionSuite) TestDBUserNameLength(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	// Test user name lengh can be longer than 16.
+	tk.MustExec(`grant all privileges on test.* to 'abcddfjakldfjaldddds'@'%' identified by ''`)
+}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1979,7 +1979,7 @@ func (s *testSessionSuite) TestRollbackOnCompileError(c *C) {
 func (s *testSessionSuite) TestDBUserNameLength(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table if not exists t (a int)")
-	// Test user name lengh can be longer than 16.
+	// Test user name length can be longer than 16.
 	tk.MustExec(`grant all privileges on test.* to 'abcddfjakldfjaldddds'@'%' identified by ''`)
 	tk.MustExec(`grant all privileges on test.t to 'abcddfjakldfjaldddds'@'%' identified by ''`)
 }


### PR DESCRIPTION
To keep consistent with MySQL, so we won't meet this error:

```
tidb(127.0.0.1)> grant all privileges on test.* to 'abcddfjakldfjaldddds'@'%' identified by '';
ERROR 1406 (22001): Data too long for column 'User' at row 1
```

@XuHuaiyu @coocood 