### PR TITLE
 ddl: make testleak be more stable.

### DIFF
--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -16,7 +16,6 @@ package ddl
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/util/testleak"
 	"golang.org/x/net/context"
 )
 

--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -61,7 +61,6 @@ func (tc *TestDDLCallback) OnWatched(ctx context.Context) {
 }
 
 func (s *testDDLSuite) TestCallback(c *C) {
-	defer testleak.AfterTest(c)()
 	cb := &BaseCallback{}
 	c.Assert(cb.OnChanged(nil), IsNil)
 	cb.OnJobRunBefore(nil)

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -41,6 +41,7 @@ type testColumnChangeSuite struct {
 }
 
 func (s *testColumnChangeSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_column_change")
 	s.dbInfo = &model.DBInfo{
 		Name: model.NewCIStr("test_column_change"),
@@ -53,8 +54,12 @@ func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (s *testColumnChangeSuite) TearDownSuite(c *C) {
+	s.store.Close()
+	testleak.AfterTest(c)()
+}
+
 func (s *testColumnChangeSuite) TestColumnChange(c *C) {
-	defer testleak.AfterTest(c)()
 	d := testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 	defer d.Stop()
 	// create table t (c1 int, c2 int);

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -44,6 +44,7 @@ type testColumnSuite struct {
 }
 
 func (s *testColumnSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_column")
 	s.d = testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 
@@ -57,6 +58,7 @@ func (s *testColumnSuite) TearDownSuite(c *C) {
 
 	err := s.store.Close()
 	c.Assert(err, IsNil)
+	testleak.AfterTest(c)()
 }
 
 func testCreateColumn(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo,
@@ -105,7 +107,6 @@ func testDropColumn(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, 
 }
 
 func (s *testColumnSuite) TestColumn(c *C) {
-	defer testleak.AfterTest(c)()
 	tblInfo := testTableInfo(c, s.d, "t1", 3)
 	ctx := testNewContext(s.d)
 
@@ -736,7 +737,6 @@ func (s *testColumnSuite) testGetColumn(t table.Table, name string, isExist bool
 }
 
 func (s *testColumnSuite) TestAddColumn(c *C) {
-	defer testleak.AfterTest(c)()
 	d := testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 3)
 	ctx := testNewContext(d)
@@ -822,7 +822,6 @@ func (s *testColumnSuite) TestAddColumn(c *C) {
 }
 
 func (s *testColumnSuite) TestDropColumn(c *C) {
-	defer testleak.AfterTest(c)()
 	d := testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 	tblInfo := testTableInfo(c, d, "t", 4)
 	ctx := testNewContext(d)

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -47,6 +47,7 @@ type testStateChangeSuite struct {
 }
 
 func (s *testStateChangeSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	s.lease = 200 * time.Millisecond
 	var err error
 	s.store, err = mockstore.NewMockTikvStore()
@@ -68,6 +69,7 @@ func (s *testStateChangeSuite) TearDownSuite(c *C) {
 	s.se.Close()
 	s.dom.Close()
 	s.store.Close()
+	testleak.AfterTest(c)()
 }
 
 func (s *testStateChangeSuite) TestTwoStates(c *C) {
@@ -103,7 +105,6 @@ func (s *testStateChangeSuite) TestTwoStates(c *C) {
 }
 
 func (s *testStateChangeSuite) test(c *C, tableName, alterTableSQL string, testInfo *testExecInfo) {
-	defer testleak.AfterTest(c)()
 	_, err := s.se.Execute(context.Background(), `create table t (
 		c1 int,
 		c2 varchar(64),
@@ -312,7 +313,6 @@ func (s *testStateChangeSuite) TestDeleteOnly(c *C) {
 
 func (s *testStateChangeSuite) runTestInSchemaState(c *C, state model.SchemaState, tableName, alterTableSQL string,
 	sqlWithErrs []sqlWithErr) {
-	defer testleak.AfterTest(c)()
 	_, err := s.se.Execute(context.Background(), `create table t (
 		c1 varchar(64),
 		c2 enum('N','Y') not null default 'N',
@@ -390,7 +390,6 @@ func (s *testStateChangeSuite) CheckResult(tk *testkit.TestKit, sql string, args
 }
 
 func (s *testStateChangeSuite) TestShowIndex(c *C) {
-	defer testleak.AfterTest(c)()
 	_, err := s.se.Execute(context.Background(), `create table t(c1 int primary key, c2 int)`)
 	c.Assert(err, IsNil)
 	defer s.se.Execute(context.Background(), "drop table t")

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -38,12 +38,16 @@ type testDDLSuite struct{}
 const testLease = 5 * time.Millisecond
 
 func (s *testDDLSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	// set ReorgWaitTimeout to small value, make test to be faster.
 	ReorgWaitTimeout = 50 * time.Millisecond
 }
 
+func (s *testDDLSuite) TearDownSuite(c *C) {
+	testleak.AfterTest(c)()
+}
+
 func (s *testDDLSuite) TestCheckOwner(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_owner")
 	defer store.Close()
 
@@ -59,7 +63,6 @@ func (s *testDDLSuite) TestCheckOwner(c *C) {
 
 // TestRunWorker tests no job is handled when the value of RunWorker is false.
 func (s *testDDLSuite) TestRunWorker(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_run_worker")
 	defer store.Close()
 
@@ -106,7 +109,6 @@ func (s *testDDLSuite) TestRunWorker(c *C) {
 }
 
 func (s *testDDLSuite) TestSchemaError(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_schema_error")
 	defer store.Close()
 
@@ -118,7 +120,6 @@ func (s *testDDLSuite) TestSchemaError(c *C) {
 }
 
 func (s *testDDLSuite) TestTableError(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_table_error")
 	defer store.Close()
 
@@ -160,7 +161,6 @@ func (s *testDDLSuite) TestTableError(c *C) {
 }
 
 func (s *testDDLSuite) TestForeignKeyError(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_foreign_key_error")
 	defer store.Close()
 
@@ -179,7 +179,6 @@ func (s *testDDLSuite) TestForeignKeyError(c *C) {
 }
 
 func (s *testDDLSuite) TestIndexError(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_index_error")
 	defer store.Close()
 
@@ -216,7 +215,6 @@ func (s *testDDLSuite) TestIndexError(c *C) {
 }
 
 func (s *testDDLSuite) TestColumnError(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_column_error")
 	defer store.Close()
 	d := testNewDDL(context.Background(), nil, store, nil, nil, testLease)
@@ -358,7 +356,6 @@ func buildCancelJobTests(firstID int64) []testCancelJob {
 }
 
 func (s *testDDLSuite) TestCancelJob(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_cancel_job")
 	defer store.Close()
 	d := testNewDDL(context.Background(), nil, store, nil, nil, testLease)

--- a/ddl/fail_test.go
+++ b/ddl/fail_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func (s *testColumnChangeSuite) TestFailBeforeDecodeArgs(c *C) {
-	defer testleak.AfterTest(c)()
 	d := testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 	defer d.Stop()
 	// create table t_fail (c1 int, c2 int);

--- a/ddl/fail_test.go
+++ b/ddl/fail_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/testleak"
 	"golang.org/x/net/context"
 )
 

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -35,6 +35,7 @@ type testIndexChangeSuite struct {
 }
 
 func (s *testIndexChangeSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_index_change")
 	s.dbInfo = &model.DBInfo{
 		Name: model.NewCIStr("test_index_change"),
@@ -47,8 +48,12 @@ func (s *testIndexChangeSuite) SetUpSuite(c *C) {
 	c.Check(err, IsNil, Commentf("err %v", errors.ErrorStack(err)))
 }
 
+func (s *testIndexChangeSuite) TearDownSuite(c *C) {
+	s.store.Close()
+	testleak.AfterTest(c)()
+}
+
 func (s *testIndexChangeSuite) TestIndexChange(c *C) {
-	defer testleak.AfterTest(c)()
 	d := testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 	defer d.Stop()
 	// create table t (c1 int primary key, c2 int);

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -34,7 +34,6 @@ func (k testCtxKeyType) String() string {
 const testCtxKey testCtxKeyType = 0
 
 func (s *testDDLSuite) TestReorg(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_reorg")
 	defer store.Close()
 
@@ -142,7 +141,6 @@ func (s *testDDLSuite) TestReorg(c *C) {
 }
 
 func (s *testDDLSuite) TestReorgOwner(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_reorg_owner")
 	defer store.Close()
 

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/testleak"
 	"golang.org/x/net/context"
 )
 

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -33,6 +33,14 @@ var _ = Suite(&testSchemaSuite{})
 
 type testSchemaSuite struct{}
 
+func (s *testSchemaSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
+}
+
+func (s *testSchemaSuite) TearDownSuite(c *C) {
+	testleak.AfterTest(c)()
+}
+
 func testSchemaInfo(c *C, d *ddl, name string) *model.DBInfo {
 	var err error
 	dbInfo := &model.DBInfo{
@@ -115,7 +123,6 @@ func testCheckSchemaState(c *C, d *ddl, dbInfo *model.DBInfo, state model.Schema
 }
 
 func (s *testSchemaSuite) TestSchema(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_schema")
 	defer store.Close()
 	d := testNewDDL(context.Background(), nil, store, nil, nil, testLease)
@@ -176,7 +183,6 @@ func (s *testSchemaSuite) TestSchema(c *C) {
 }
 
 func (s *testSchemaSuite) TestSchemaWaitJob(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_schema_wait")
 	defer store.Close()
 
@@ -229,7 +235,6 @@ LOOP:
 }
 
 func (s *testSchemaSuite) TestSchemaResume(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_schema_resume")
 	defer store.Close()
 

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -28,6 +28,14 @@ var _ = Suite(&testStatSuite{})
 type testStatSuite struct {
 }
 
+func (s *testStatSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
+}
+
+func (s *testStatSuite) TearDownSuite(c *C) {
+	testleak.AfterTest(c)()
+}
+
 func (s *testStatSuite) getDDLSchemaVer(c *C, d *ddl) int64 {
 	m, err := d.Stats(nil)
 	c.Assert(err, IsNil)
@@ -36,7 +44,6 @@ func (s *testStatSuite) getDDLSchemaVer(c *C, d *ddl) int64 {
 }
 
 func (s *testStatSuite) TestStat(c *C) {
-	defer testleak.AfterTest(c)()
 	store := testCreateStore(c, "test_stat")
 	defer store.Close()
 

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -186,6 +186,7 @@ func testGetTableWithError(d *ddl, schemaID, tableID int64) (table.Table, error)
 }
 
 func (s *testTableSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_table")
 	s.d = testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 
@@ -197,10 +198,10 @@ func (s *testTableSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(s.d), s.d, s.dbInfo)
 	s.d.Stop()
 	s.store.Close()
+	testleak.AfterTest(c)()
 }
 
 func (s *testTableSuite) TestTable(c *C) {
-	defer testleak.AfterTest(c)()
 	d := s.d
 
 	ctx := testNewContext(d)
@@ -242,7 +243,6 @@ func (s *testTableSuite) TestTable(c *C) {
 }
 
 func (s *testTableSuite) TestTableResume(c *C) {
-	defer testleak.AfterTest(c)()
 	d := s.d
 
 	testCheckOwner(c, d, true)


### PR DESCRIPTION
We detected goroutine leak in testStateChangeSuite.test, but it was not a real leak, because we are not correctly setup the `testleak.beforeTestGorountines`,  so I call the `testleak.BeforeTest()` in SetupSuite and call `testleak.AfterTest(c)()` in TearDownSuite, after we close the store and the domain.
```
FAIL: ddl_db_change_test.go:73: testStateChangeSuite.TestTwoStates

ddl_db_change_test.go:101:
    s.test(c, "", alterTableSQL, testInfo)
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:111:
    c.Errorf("Test appears to have leaked: %v", g)
... Error: Test appears to have leaked: github.com/pingcap/tidb/domain.(*Domain).loadSchemaInLoop(0xc420370e60, 0xbebc200)
	/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:335 +0x26a
created by github.com/pingcap/tidb/domain.(*Domain).Init
	/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:506 +0x2e8
```