### PR TITLE
ddl: wait for 2*lease when finishing delete-reorg in a rollback operation

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -236,7 +236,9 @@ func (d *ddl) handleDDLJobQueue() error {
 
 			if job.IsDone() {
 				binloginfo.SetDDLBinlog(d.workerVars.BinlogClient, txn, job.ID, job.Query)
-				job.State = model.JobStateSynced
+				if !job.IsRollbackDone() {
+					job.State = model.JobStateSynced
+				}
 				err = d.finishDDLJob(t, job)
 				return errors.Trace(err)
 			}

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -274,7 +274,7 @@ func testCheckJobCancelled(c *C, d *ddl, job *model.Job, state *model.SchemaStat
 		t := meta.NewMeta(txn)
 		historyJob, err := t.GetHistoryDDLJob(job.ID)
 		c.Assert(err, IsNil)
-		c.Assert(historyJob.IsCancelled(), IsTrue, Commentf("histroy job %s", historyJob))
+		c.Assert(historyJob.IsCancelled() || historyJob.IsRollbackDone(), IsTrue, Commentf("histroy job %s", historyJob))
 		if state != nil {
 			c.Assert(historyJob.SchemaState, Equals, *state)
 		}

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -237,7 +237,10 @@ func insertJobIntoDeleteRangeTable(ctx sessionctx.Context, job *model.Job) error
 	// ActionAddIndex needs do it, because it needs to be rolled back when it's canceled.
 	case model.ActionAddIndex:
 		tableID := job.TableID
-		indexID := job.Args[1].(int64)
+		var indexID int64
+		if err := job.DecodeArgs(&indexID); err != nil {
+			return errors.Trace(err)
+		}
 		startKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID)
 		endKey := tablecodec.EncodeTableIndexPrefix(tableID, indexID+1)
 		return doInsert(s, job.ID, indexID, startKey, endKey, now)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -391,10 +391,11 @@ func (d *ddl) onDropIndex(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		// Finish this job.
 		if job.IsRollingback() {
 			job.FinishTableJob(model.JobStateRollbackDone, model.StateNone, ver, tblInfo)
+			job.Args[0] = indexInfo.ID
 		} else {
 			job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
+			job.Args = append(job.Args, indexInfo.ID)
 		}
-		job.Args = append(job.Args, indexInfo.ID)
 	default:
 		err = ErrInvalidTableState.Gen("invalid table state %v", tblInfo.State)
 	}

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -246,7 +246,7 @@ func (job *Job) IsSynced() bool {
 
 // IsDone returns whether job is done.
 func (job *Job) IsDone() bool {
-	return job.State == JobStateDone || job.State == JobStateRollbackDone
+	return job.State == JobStateDone
 }
 
 // IsRunning returns whether job is still running or not.

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -221,7 +221,12 @@ func (job *Job) IsFinished() bool {
 
 // IsCancelled returns whether the job is cancelled or not.
 func (job *Job) IsCancelled() bool {
-	return job.State == JobStateCancelled || job.State == JobStateRollbackDone
+	return job.State == JobStateCancelled
+}
+
+// IsRollbackDone returns whether the job is rolled back or not.
+func (job *Job) IsRollbackDone() bool {
+	return job.State == JobStateRollbackDone
 }
 
 // IsRollingback returns whether the job is rolling back or not.
@@ -241,7 +246,7 @@ func (job *Job) IsSynced() bool {
 
 // IsDone returns whether job is done.
 func (job *Job) IsDone() bool {
-	return job.State == JobStateDone
+	return job.State == JobStateDone || job.State == JobStateRollbackDone
 }
 
 // IsRunning returns whether job is still running or not.

--- a/model/model_test.go
+++ b/model/model_test.go
@@ -195,6 +195,7 @@ func (*testModelSuite) TestJobCodec(c *C) {
 	c.Assert(job.IsFinished(), IsTrue)
 	c.Assert(job.IsRunning(), IsFalse)
 	c.Assert(job.IsSynced(), IsFalse)
+	c.Assert(job.IsRollbackDone(), IsFalse)
 	job.SetRowCount(3)
 	c.Assert(job.GetRowCount(), Equals, int64(3))
 }

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -95,7 +95,7 @@ func CancelJobs(txn kv.Transaction, ids []int64) ([]error, error) {
 				continue
 			}
 			// If the state is rolling back, it means the work is cleaning the data after cancelling the job.
-			if job.IsCancelled() || job.IsRollingback() {
+			if job.IsCancelled() || job.IsRollingback() || job.IsRollbackDone() {
 				continue
 			}
 			job.State = model.JobStateCancelling


### PR DESCRIPTION
We encounter the `write conflict` error when doing the delete-range operation. So `TestCancelAddIndex` failed.
When the index in `delete reorg` state we can do the `delete` statement,  and we do the delete-range operation in this state.  So `write conflict` may occur.
This PR fix it.
