### PR TITLE
*: fix data race

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -527,15 +527,13 @@ func (s *testSuite) TestAggEliminator(c *C) {
 
 func (s *testSuite) TestIssue5663(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-
 	plan.GlobalPlanCache = kvcache.NewShardedLRUCache(2, 1)
-	if plan.GlobalPlanCache != nil {
-		plan.PlanCacheEnabled = true
-		defer func() {
-			plan.PlanCacheEnabled = false
-		}()
-	}
+	planCahche := tk.Se.GetSessionVars().PlanCacheEnabled
+	defer func() {
+		tk.Se.GetSessionVars().PlanCacheEnabled = planCahche
+	}()
 
+	tk.Se.GetSessionVars().PlanCacheEnabled = true
 	tk.MustExec("drop table if exists t1;")
 	tk.MustExec("create table t1 (i int unsigned, primary key(i));")
 	tk.MustExec("insert into t1 values (1),(2),(3);")

--- a/plan/cache.go
+++ b/plan/cache.go
@@ -25,12 +25,6 @@ import (
 )
 
 var (
-	// PlanCacheEnabled stores the global config "plan-cache-enabled".
-	PlanCacheEnabled bool
-	// PlanCacheShards stores the global config "plan-cache-shards".
-	PlanCacheShards uint
-	// PlanCacheCapacity stores the global config "plan-cache-capacity".
-	PlanCacheCapacity uint
 	// GlobalPlanCache stores the global plan cache for every session in a tidb-server.
 	GlobalPlanCache *kvcache.ShardedLRUCache
 

--- a/session/session.go
+++ b/session/session.go
@@ -765,7 +765,7 @@ func (s *session) Execute(ctx context.Context, sql string) (recordSets []ast.Rec
 		cacheValue       kvcache.Value
 		hitCache         = false
 		connID           = s.sessionVars.ConnectionID
-		planCacheEnabled = plan.PlanCacheEnabled // Read global configuration only once.
+		planCacheEnabled = s.sessionVars.PlanCacheEnabled // Its value is read from the global configuration, and it will be only updated in tests.
 	)
 
 	if planCacheEnabled {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -111,18 +111,18 @@ func (p *mockBinlogPump) PullBinlogs(ctx context.Context, in *binlog.PullBinlogR
 }
 
 func (s *testSessionSuite) TestForCoverage(c *C) {
-	planCache := plan.PlanCacheEnabled
 	plan.GlobalPlanCache = kvcache.NewShardedLRUCache(2, 1)
-	defer func() {
-		plan.PlanCacheEnabled = planCache
-	}()
 
 	// Just for test coverage.
 	tk := testkit.NewTestKitWithInit(c, s.store)
+	planCache := tk.Se.GetSessionVars().PlanCacheEnabled
+	defer func() {
+		tk.Se.GetSessionVars().PlanCacheEnabled = planCache
+	}()
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int auto_increment, v int, index (id))")
 	tk.MustExec("insert t values ()")
-	plan.PlanCacheEnabled = true
+	tk.Se.GetSessionVars().PlanCacheEnabled = true
 	tk.MustExec("insert t values ()")
 	tk.MustExec("insert t values ()")
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -192,6 +192,9 @@ type SessionVars struct {
 	// PlanID is the unique id of logical and physical plan.
 	PlanID int
 
+	// PlanCacheEnabled stores the global config "plan-cache-enabled", and it will be only updated in tests.
+	PlanCacheEnabled bool
+
 	// User is the user identity with which the session login.
 	User *auth.UserIdentity
 
@@ -349,6 +352,7 @@ func NewSessionVars() *SessionVars {
 	} else {
 		enableStreaming = "0"
 	}
+	vars.PlanCacheEnabled = config.GetGlobalConfig().PlanCache.Enabled
 	terror.Log(vars.SetSystemVar(TiDBEnableStreaming, enableStreaming))
 	return vars
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -372,11 +372,8 @@ func setGlobalVars() {
 	plan.AllowCartesianProduct = cfg.Performance.CrossJoin
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
 
-	plan.PlanCacheEnabled = cfg.PlanCache.Enabled
-	if plan.PlanCacheEnabled {
-		plan.PlanCacheCapacity = cfg.PlanCache.Capacity
-		plan.PlanCacheShards = cfg.PlanCache.Shards
-		plan.GlobalPlanCache = kvcache.NewShardedLRUCache(plan.PlanCacheCapacity, plan.PlanCacheShards)
+	if cfg.PlanCache.Enabled {
+		plan.GlobalPlanCache = kvcache.NewShardedLRUCache(cfg.PlanCache.Capacity, cfg.PlanCache.Shards)
 	}
 
 	plan.PreparedPlanCacheEnabled = cfg.PreparedPlanCache.Enabled


### PR DESCRIPTION
Fix data race and tiny clean up.
Make `PlanCacheEnabled ` as a session variable to fix data race.
```
WARNING: DATA RACE
Write at 0x00000268917e by goroutine 411:
github.com/pingcap/tidb/executor_test.(*testSuite).TestIssue5663()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/aggregate_test.go:533 +0x303
runtime.call32()
/usr/local/go/src/runtime/asm_amd64.s:573 +0x3a
reflect.Value.Call()
/usr/local/go/src/reflect/value.go:308 +0xc0
github.com/pingcap/tidb/vendor/github.com/pingcap/check.(*suiteRunner).forkTest.func1()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/vendor/github.com/pingcap/check/check.go:798 +0x954
github.com/pingcap/tidb/vendor/github.com/pingcap/check.(*suiteRunner).forkCall.func1()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/vendor/github.com/pingcap/check/check.go:692 +0x89

Previous read at 0x00000268917e by goroutine 28:
github.com/pingcap/tidb/session.(*session).Execute()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:757 +0x140
github.com/pingcap/tidb/ddl/util.CompleteDeleteRange()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/util/util.go:93 +0x1f9
github.com/pingcap/tidb/ddl.(*delRange).doTask()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:193 +0x44e
github.com/pingcap/tidb/ddl.(*delRange).doDelRangeWork()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:144 +0x538
github.com/pingcap/tidb/ddl.(*delRange).startEmulator()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:121 +0xc6
```