### PR TITLE
executor: fix insert on duplicate update

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1177,10 +1177,7 @@ func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*
 			if err != nil {
 				return errors.Trace(err)
 			}
-			e.dupOldRowValues[string(e.Table.RecordKey(newHandle))] = keysInRow[0].newRowValue
-			for _, k := range keysInRow {
-				e.dupKeyValues[string(k.key)] = k.newRowValue
-			}
+			e.fillBackKeys(keysInRow, newHandle)
 		}
 	}
 	return nil

--- a/executor/write.go
+++ b/executor/write.go
@@ -804,6 +804,23 @@ type InsertExec struct {
 	dupOldRowValues  map[string][]byte
 }
 
+func (e *InsertExec) insertOneRow(row []types.Datum) (int64, error) {
+	if err := e.checkBatchLimit(); err != nil {
+		return 0, errors.Trace(err)
+	}
+	e.ctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
+	h, err := e.Table.AddRecord(e.ctx, row, false)
+	e.ctx.Txn().DelOption(kv.PresumeKeyNotExists)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if !e.ctx.GetSessionVars().ImportingData {
+		e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
+	}
+	e.rowCount++
+	return h, nil
+}
+
 func (e *InsertExec) exec(ctx context.Context, rows [][]types.Datum) (Row, error) {
 	// If tidb_batch_insert is ON and not in a transaction, we could use BatchInsert mode.
 	sessVars := e.ctx.GetSessionVars()
@@ -817,59 +834,60 @@ func (e *InsertExec) exec(ctx context.Context, rows [][]types.Datum) (Row, error
 	// If `ON DUPLICATE KEY UPDATE` is specified, and no `IGNORE` keyword,
 	// the to-be-insert rows will be check on duplicate keys and update to the new rows.
 	if len(e.OnDuplicate) > 0 && !e.IgnoreErr {
-		var err error
-		rows, err = e.batchUpdateDupRows(rows, e.OnDuplicate)
+		err := e.batchUpdateDupRows(rows, e.OnDuplicate)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-	} else if len(e.OnDuplicate) == 0 && e.IgnoreErr {
-		// If you use the IGNORE keyword, duplicate-key error that occurs while executing the INSERT statement are ignored.
-		// For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in
-		// the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row is discarded and no error occurs.
-		// However, if the `on duplicate update` is also specified, the duplicated row will be updated.
-		// Using BatchGet in insert ignore to mark rows as duplicated before we add records to the table.
-		var err error
-		rows, err = batchMarkDupRows(e.ctx, e.Table, rows)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-	for _, row := range rows {
-		// duplicate row will be marked as nil in batchMarkDupRows if
-		// IgnoreErr is true. For IgnoreErr is false, it is a protection.
-		if row == nil {
-			continue
-		}
-		if err := e.checkBatchLimit(); err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(e.OnDuplicate) == 0 && !e.IgnoreErr {
-			e.ctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
-		}
-		h, err := e.Table.AddRecord(e.ctx, row, false)
-		e.ctx.Txn().DelOption(kv.PresumeKeyNotExists)
-		if err == nil {
-			if !sessVars.ImportingData {
-				e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
+	} else {
+		if len(e.OnDuplicate) == 0 && e.IgnoreErr {
+			// If you use the IGNORE keyword, duplicate-key error that occurs while executing the INSERT statement are ignored.
+			// For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in
+			// the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row is discarded and no error occurs.
+			// However, if the `on duplicate update` is also specified, the duplicated row will be updated.
+			// Using BatchGet in insert ignore to mark rows as duplicated before we add records to the table.
+			var err error
+			rows, err = batchMarkDupRows(e.ctx, e.Table, rows)
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
-			e.rowCount++
-			continue
 		}
-		if kv.ErrKeyExists.Equal(err) {
-			// TODO: Use batch get to speed up `insert ignore on duplicate key update`.
-			if len(e.OnDuplicate) > 0 && e.IgnoreErr {
-				data, err1 := e.Table.RowWithCols(e.ctx, h, e.Table.WritableCols())
-				if err1 != nil {
-					return nil, errors.Trace(err1)
-				}
-				if _, _, _, err = e.doDupRowUpdate(h, data, row, e.OnDuplicate); err != nil {
-					return nil, errors.Trace(err)
+		for _, row := range rows {
+			// duplicate row will be marked as nil in batchMarkDupRows if
+			// IgnoreErr is true. For IgnoreErr is false, it is a protection.
+			if row == nil {
+				continue
+			}
+			if err := e.checkBatchLimit(); err != nil {
+				return nil, errors.Trace(err)
+			}
+			if len(e.OnDuplicate) == 0 && !e.IgnoreErr {
+				e.ctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
+			}
+			h, err := e.Table.AddRecord(e.ctx, row, false)
+			e.ctx.Txn().DelOption(kv.PresumeKeyNotExists)
+			if err == nil {
+				if !sessVars.ImportingData {
+					e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
 				}
 				e.rowCount++
 				continue
 			}
+			if kv.ErrKeyExists.Equal(err) {
+				// TODO: Use batch get to speed up `insert ignore on duplicate key update`.
+				if len(e.OnDuplicate) > 0 && e.IgnoreErr {
+					data, err1 := e.Table.RowWithCols(e.ctx, h, e.Table.WritableCols())
+					if err1 != nil {
+						return nil, errors.Trace(err1)
+					}
+					if _, _, _, err = e.doDupRowUpdate(h, data, row, e.OnDuplicate); err != nil {
+						return nil, errors.Trace(err)
+					}
+					e.rowCount++
+					continue
+				}
+			}
+			return nil, errors.Trace(err)
 		}
-		return nil, errors.Trace(err)
 	}
 
 	if e.lastInsertID != 0 {
@@ -1125,17 +1143,17 @@ func (e *InsertExec) updateDupKeyValues(keys []keyWithDupError, oldHandle int64,
 }
 
 // batchUpdateDupRows updates multi-rows in batch if they are duplicate with rows in table.
-func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*expression.Assignment) ([][]types.Datum, error) {
+func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*expression.Assignment) error {
 	var err error
 	e.uniqueKeysInRows, e.dupKeyValues, err = batchGetInsertKeys(e.ctx, e.Table, newRows)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
 
 	// Batch get the to-be-updated rows in storage.
 	err = e.initDupOldRowValue(newRows)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return errors.Trace(err)
 	}
 
 	for i, keysInRow := range e.uniqueKeysInRows {
@@ -1143,7 +1161,7 @@ func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*
 			if val, found := e.dupKeyValues[string(k.key)]; found {
 				err := e.updateDupRow(keysInRow, k, val, newRows[i], e.OnDuplicate)
 				if err != nil {
-					return nil, errors.Trace(err)
+					return errors.Trace(err)
 				}
 				// Clean up row for latest add record operation.
 				newRows[i] = nil
@@ -1151,15 +1169,21 @@ func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*
 			}
 		}
 		// If row was checked with no duplicate keys,
-		// it should be add to values map for the further row check.
-		// There may be duplicate keys inside the insert statement.
-		if newRows[i] == nil {
+		// we should do insert the row,
+		// and key-values should be filled back to dupOldRowValues for the further row check,
+		// due to there may be duplicate keys inside the insert statement.
+		if newRows[i] != nil {
+			newHandle, err := e.insertOneRow(newRows[i])
+			if err != nil {
+				return errors.Trace(err)
+			}
+			e.dupOldRowValues[string(e.Table.RecordKey(newHandle))] = keysInRow[0].newRowValue
 			for _, k := range keysInRow {
 				e.dupKeyValues[string(k.key)] = k.newRowValue
 			}
 		}
 	}
-	return newRows, nil
+	return nil
 }
 
 // fillBackKeys fills the updated key-value pair to the dupKeyValues for further check.

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -525,6 +525,16 @@ commit;`
 	testSQL = `select * from test order by i;`
 	r = tk.MustQuery(testSQL)
 	r.Check(testkit.Rows("1 3"))
+
+	testSQL = `create table tmp (id int auto_increment, code int, primary key(id, code));
+	create table m (id int primary key auto_increment, code int unique);
+	insert tmp (code) values (1);
+	insert tmp (code) values (1);
+	insert m (code) select code from tmp on duplicate key update code = values(code);`
+	tk.MustExec(testSQL)
+	testSQL = `select * from m;`
+	r = tk.MustQuery(testSQL)
+	r.Check(testkit.Rows("1 1"))
 }
 
 func (s *testSuite) TestReplace(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -516,6 +516,15 @@ commit;`
 	testSQL = `select * from test order by i;`
 	r = tk.MustQuery(testSQL)
 	r.Check(testkit.Rows("-2 -2", "1 3"))
+
+	testSQL = `delete from test;
+begin;
+insert into test values (1, 3), (1, 3) on duplicate key update i = values(i), j = values(j);
+commit;`
+	tk.MustExec(testSQL)
+	testSQL = `select * from test order by i;`
+	r = tk.MustQuery(testSQL)
+	r.Check(testkit.Rows("1 3"))
 }
 
 func (s *testSuite) TestReplace(c *C) {

--- a/server/conn.go
+++ b/server/conn.go
@@ -480,6 +480,7 @@ func (cc *clientConn) Run() {
 			}
 			log.Warnf("[%d] dispatch error:\n%s\n%q\n%s",
 				cc.connectionID, cc, queryStrForLog(string(data[1:])), errStrForLog(err))
+			log.Warnf("YUSP %v", errors.ErrorStack(err))
 			err1 := cc.writeError(err)
 			terror.Log(errors.Trace(err1))
 		}

--- a/server/conn.go
+++ b/server/conn.go
@@ -480,7 +480,6 @@ func (cc *clientConn) Run() {
 			}
 			log.Warnf("[%d] dispatch error:\n%s\n%q\n%s",
 				cc.connectionID, cc, queryStrForLog(string(data[1:])), errStrForLog(err))
-			log.Warnf("YUSP %v", errors.ErrorStack(err))
 			err1 := cc.writeError(err)
 			terror.Log(errors.Trace(err1))
 		}


### PR DESCRIPTION
Do insert when check duplicate and update. It is not the same logic as `insert ignore`, because `insert ignore` only skip the duplicate rows, without doing anything.
PTAL @coocood 