### PR TITLE
*: use tidb_index_lookup_join_currency to control the number of IndexLookupJoin inner workers

### DIFF
--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -139,7 +139,7 @@ func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 }
 
 func (e *IndexLookUpJoin) startWorkers(ctx context.Context) {
-	concurrency := e.ctx.GetSessionVars().IndexLookupConcurrency
+	concurrency := e.ctx.GetSessionVars().IndexLookupJoinConcurrency
 	resultCh := make(chan *lookUpJoinTask, concurrency)
 	e.resultCh = resultCh
 	workerCtx, cancelFunc := context.WithCancel(ctx)

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -37,6 +37,13 @@ func (s *testSuite) TestJoinPanic(c *C) {
 
 func (s *testSuite) TestJoin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("set @@tidb_index_lookup_join_concurrency = 200")
+	c.Assert(tk.Se.GetSessionVars().IndexLookupJoinConcurrency, Equals, 200)
+
+	tk.MustExec("set @@tidb_index_lookup_join_concurrency = 4")
+	c.Assert(tk.Se.GetSessionVars().IndexLookupJoinConcurrency, Equals, 4)
+
 	tk.MustExec("set @@tidb_index_lookup_size = 2")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/session/session.go
+++ b/session/session.go
@@ -1267,6 +1267,7 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.TiDBIndexJoinBatchSize + quoteCommaQuote +
 	variable.TiDBIndexLookupSize + quoteCommaQuote +
 	variable.TiDBIndexLookupConcurrency + quoteCommaQuote +
+	variable.TiDBIndexLookupJoinConcurrency + quoteCommaQuote +
 	variable.TiDBIndexSerialScanConcurrency + quoteCommaQuote +
 	variable.TiDBDistSQLScanConcurrency + "')"
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -265,6 +265,9 @@ type SessionVars struct {
 	// IndexLookupConcurrency is the number of concurrent index lookup worker.
 	IndexLookupConcurrency int
 
+	// IndexLookupJoinConcurrency is the number of concurrent index lookup join inner worker.
+	IndexLookupJoinConcurrency int
+
 	// DistSQLScanConcurrency is the number of concurrent dist SQL scan worker.
 	DistSQLScanConcurrency int
 
@@ -501,6 +504,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.AllowInSubqueryUnFolding = TiDBOptOn(val)
 	case TiDBIndexLookupConcurrency:
 		s.IndexLookupConcurrency = tidbOptPositiveInt(val, DefIndexLookupConcurrency)
+	case TiDBIndexLookupJoinConcurrency:
+		s.IndexLookupJoinConcurrency = tidbOptPositiveInt(val, DefIndexLookupJoinConcurrency)
 	case TiDBIndexJoinBatchSize:
 		s.IndexJoinBatchSize = tidbOptPositiveInt(val, DefIndexJoinBatchSize)
 	case TiDBIndexLookupSize:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -615,6 +615,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBIndexJoinBatchSize, strconv.Itoa(DefIndexJoinBatchSize)},
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupSize, strconv.Itoa(DefIndexLookupSize)},
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupConcurrency, strconv.Itoa(DefIndexLookupConcurrency)},
+	{ScopeGlobal | ScopeSession, TiDBIndexLookupJoinConcurrency, strconv.Itoa(DefIndexLookupJoinConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBIndexSerialScanConcurrency, strconv.Itoa(DefIndexSerialScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBSkipUTF8Check, boolToIntStr(DefSkipUTF8Check)},
 	{ScopeSession, TiDBBatchInsert, boolToIntStr(DefBatchInsert)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -88,6 +88,11 @@ const (
 	// Set this value higher may reduce the latency but consumes more system resource.
 	TiDBIndexLookupConcurrency = "tidb_index_lookup_concurrency"
 
+	// tidb_index_lookup_join_concurrency is used for index lookup join executor.
+	// IndexLookUpJoin starts "tidb_index_lookup_join_concurrency" inner workers
+	// to fetch inner rows and join the matched (outer, inner) row pairs.
+	TiDBIndexLookupJoinConcurrency = "tidb_index_lookup_join_concurrency"
+
 	// tidb_index_serial_scan_concurrency is used for controlling the concurrency of index scan operation
 	// when we need to keep the data output order the same as the order of index data.
 	TiDBIndexSerialScanConcurrency = "tidb_index_serial_scan_concurrency"
@@ -141,6 +146,7 @@ const (
 // Default TiDB system variable values.
 const (
 	DefIndexLookupConcurrency        = 4
+	DefIndexLookupJoinConcurrency    = 4
 	DefIndexSerialScanConcurrency    = 1
 	DefIndexJoinBatchSize            = 25000
 	DefIndexLookupSize               = 20000


### PR DESCRIPTION
before this PR, we use `tidb_index_lookup_currency` to control the currency of index lookup reader and index lookup join, after this PR:

| session variable | effect |
|-----------------|-------|
| tidb_index_lookup_currency | control the currency of index lookup reader |
| tidb_index_lookup_join_currency | control the currency of index lookup join |