### PR TITLE
store: use MVCCLevelDB in 2pc_test.go testCommitterSuite

### DIFF
--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -789,6 +789,10 @@ func (mvcc *MVCCLevelDB) ResolveLock(startKey, endKey []byte, startTS, commitTS 
 	mvcc.mu.Lock()
 	defer mvcc.mu.Unlock()
 
+	// startKey and endKey are MvccKey type actually, take out the raw key here.
+	startKey = MvccKey(startKey).Raw()
+	endKey = MvccKey(endKey).Raw()
+
 	iter, currKey, err := newScanIterator(mvcc.db, startKey, endKey)
 	defer iter.Release()
 	if err != nil {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -38,7 +38,8 @@ var _ = Suite(&testCommitterSuite{})
 func (s *testCommitterSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster()
 	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("a"), []byte("b"), []byte("c"))
-	mvccStore := mocktikv.NewMvccStore()
+	mvccStore, err := mocktikv.NewMVCCLevelDB("")
+	c.Assert(err, IsNil)
 	client := mocktikv.NewRPCClient(s.cluster, mvccStore)
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	spkv := NewMockSafePointKV()


### PR DESCRIPTION
* MVCCLevelDB is the default MVCCStore used by mocktikv, and the de facto
local store implementation, so test code should use this one.
* Fix ResolveLock method in MVCCLevelDB

@disksing @coocood 