### PR TITLE
config: make pseudo estimate ratio configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,7 @@ type Performance struct {
 	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
+	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
 }
 
 // XProtocol is the XProtocol section of the config.
@@ -256,6 +257,7 @@ var defaultConf = Config{
 		RunAutoAnalyze:      true,
 		StmtCountLimit:      5000,
 		FeedbackProbability: 0,
+		PseudoEstimateRatio: 0.7,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -139,7 +139,8 @@ run-auto-analyze = true
 # Probability to use the query feedback to update stats, 0 or 1 for always false/true.
 feedback-probability = 0.0
 
-# Pseudo stats will be used if the ratio between the modify count and row count of a table is greater than it.
+# Pseudo stats will be used if the ratio between the modify count and
+# row count in statistics of a table is greater than it.
 pseudo-estimate-ratio = 0.7
 
 [proxy-protocol]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -139,6 +139,9 @@ run-auto-analyze = true
 # Probability to use the query feedback to update stats, 0 or 1 for always false/true.
 feedback-probability = 0.0
 
+# Pseudo stats will be used if the ratio between the modify count and row count of a table is greater than it.
+pseudo-estimate-ratio = 0.7
+
 [proxy-protocol]
 # PROXY protocol acceptable client networks.
 # Empty string means disable PROXY protocol, * means all networks.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -365,6 +365,7 @@ func setGlobalVars() {
 	session.SetStatsLease(statsLeaseDuration)
 	domain.RunAutoAnalyze = cfg.Performance.RunAutoAnalyze
 	statistics.FeedbackProbability = cfg.Performance.FeedbackProbability
+	plan.RatioOfPseudoEstimate = cfg.Performance.PseudoEstimateRatio
 	ddl.RunWorker = cfg.RunDDL
 	ddl.EnableSplitTableRegion = cfg.SplitTable
 	session.SetCommitRetryLimit(cfg.Performance.RetryLimit)


### PR DESCRIPTION
If the pseudo stats is used, there won't be any dynamic update, so this PR make it configurable.
PTAL @coocood @winoros 