### PR TITLE
config: increase the default lease.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -226,7 +226,7 @@ var defaultConf = Config{
 	Path:                "/tmp/tidb",
 	RunDDL:              true,
 	SplitTable:          true,
-	Lease:               "10s",
+	Lease:               "60s",
 	TokenLimit:          1000,
 	OOMAction:           "log",
 	EnableStreaming:     false,

--- a/config/config.go
+++ b/config/config.go
@@ -226,7 +226,7 @@ var defaultConf = Config{
 	Path:                "/tmp/tidb",
 	RunDDL:              true,
 	SplitTable:          true,
-	Lease:               "60s",
+	Lease:               "45s",
 	TokenLimit:          1000,
 	OOMAction:           "log",
 	EnableStreaming:     false,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -22,7 +22,7 @@ binlog-socket = ""
 run-ddl = true
 
 # Schema lease duration, very dangerous to change only if you know what you do.
-lease = "60s"
+lease = "45s"
 
 # When create table, split a separated region for it. It is recommended to
 # turn off this option if there will be a large number of tables created.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -22,7 +22,7 @@ binlog-socket = ""
 run-ddl = true
 
 # Schema lease duration, very dangerous to change only if you know what you do.
-lease = "10s"
+lease = "60s"
 
 # When create table, split a separated region for it. It is recommended to
 # turn off this option if there will be a large number of tables created.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -93,7 +93,7 @@ var (
 	socket       = flag.String(nmSocket, "", "The socket file to use for connection.")
 	binlogSocket = flag.String(nmBinlogSocket, "", "socket file to write binlog")
 	runDDL       = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
-	ddlLease     = flag.String(nmDdlLease, "60s", "schema lease duration, very dangerous to change only if you know what you do")
+	ddlLease     = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
 	tokenLimit   = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
 
 	// Log

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -93,7 +93,7 @@ var (
 	socket       = flag.String(nmSocket, "", "The socket file to use for connection.")
 	binlogSocket = flag.String(nmBinlogSocket, "", "socket file to write binlog")
 	runDDL       = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
-	ddlLease     = flag.String(nmDdlLease, "10s", "schema lease duration, very dangerous to change only if you know what you do")
+	ddlLease     = flag.String(nmDdlLease, "60s", "schema lease duration, very dangerous to change only if you know what you do")
 	tokenLimit   = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
 
 	// Log


### PR DESCRIPTION
Reduce the risk of `schema out of date` error.