### PR TITLE
executor: fix index lookup join hang

### DIFF
--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -392,9 +392,6 @@ func (iw *innerWorker) run(ctx context.Context, wg *sync.WaitGroup) {
 
 		err := iw.handleTask(ctx, task)
 		task.doneCh <- errors.Trace(err)
-		if err != nil {
-			return
-		}
 	}
 }
 

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -1,0 +1,39 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package executor_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+	"context"
+)
+
+func (s *testSuite) TestIndexLookupJoinHang(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table idxJoinOuter (a int unsigned)")
+	tk.MustExec("create table idxJoinInner (a int unsigned unique)")
+	tk.MustExec("insert idxJoinOuter values (1), (1), (1), (1), (1)")
+	tk.MustExec("insert idxJoinInner values (1)")
+	tk.Se.GetSessionVars().IndexJoinBatchSize = 1
+	tk.Se.GetSessionVars().IndexLookupJoinConcurrency = 1
+
+	rs, err := tk.Exec("select /*+ TIDB_INLJ(o, i)*/ * from idxJoinOuter o left join idxJoinInner i on o.a = i.a where o.a in (1, 2) and (i.a - 3) > 0")
+	c.Assert(err, IsNil)
+	chk := rs.NewChunk()
+	for i := 0; i < 5; i++ {
+		rs.Next(context.Background(), chk)
+	}
+	rs.Close()
+}

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package executor_test
 
 import (
+	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/testkit"
-	"context"
 )
 
 func (s *testSuite) TestIndexLookupJoinHang(c *C) {


### PR DESCRIPTION
The index lookup join inner worker should keep consuming the task channel and should not return on error,
or the task channel maybe full and blocks forever.