### PR TITLE
[release-1.0]ddl: update the column's offset when we do modify column

### DIFF
--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -23,13 +23,18 @@ import (
 type TestDDLCallback struct {
 	*BaseCallback
 
-	onJobRunBefore       func(*model.Job)
-	onJobUpdated         func(*model.Job)
-	OnJobUpdatedExported func(*model.Job)
-	onWatched            func(ctx goctx.Context)
+	onJobRunBefore         func(*model.Job)
+	OnJobRunBeforeExported func(*model.Job)
+	onJobUpdated           func(*model.Job)
+	OnJobUpdatedExported   func(*model.Job)
+	onWatched              func(ctx goctx.Context)
 }
 
 func (tc *TestDDLCallback) OnJobRunBefore(job *model.Job) {
+	if tc.OnJobRunBeforeExported != nil {
+		tc.OnJobRunBeforeExported(job)
+		return
+	}
 	if tc.onJobRunBefore != nil {
 		tc.onJobRunBefore(job)
 		return

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -450,6 +450,8 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo
 		return ver, infoschema.ErrColumnNotExists.GenByArgs(oldName, tblInfo.Name)
 	}
 
+	col.Offset = oldCol.Offset
+	col.State = oldCol.State
 	// Calculate column's new position.
 	oldPos, newPos := oldCol.Offset, oldCol.Offset
 	if pos.Tp == ast.ColumnPositionAfter {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -438,7 +438,7 @@ func (d *ddl) onModifyColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) 
 }
 
 // doModifyColumn updates the column information and reorders all columns.
-func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo, oldName *model.CIStr, pos *ast.ColumnPosition) (ver int64, _ error) {
+func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, newCol *model.ColumnInfo, oldName *model.CIStr, pos *ast.ColumnPosition) (ver int64, _ error) {
 	tblInfo, err := getTableInfo(t, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -450,8 +450,9 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo
 		return ver, infoschema.ErrColumnNotExists.GenByArgs(oldName, tblInfo.Name)
 	}
 
-	col.Offset = oldCol.Offset
-	col.State = oldCol.State
+	// We need the latest column's offset and state. This information can be obtained from the store.
+	newCol.Offset = oldCol.Offset
+	newCol.State = oldCol.State
 	// Calculate column's new position.
 	oldPos, newPos := oldCol.Offset, oldCol.Offset
 	if pos.Tp == ast.ColumnPositionAfter {
@@ -477,10 +478,10 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo
 	}
 
 	columnChanged := make(map[string]*model.ColumnInfo)
-	columnChanged[oldName.L] = col
+	columnChanged[oldName.L] = newCol
 
 	if newPos == oldPos {
-		tblInfo.Columns[newPos] = col
+		tblInfo.Columns[newPos] = newCol
 	} else {
 		cols := tblInfo.Columns
 
@@ -490,7 +491,7 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo
 		} else {
 			copy(cols[oldPos:], cols[oldPos+1:newPos+1])
 		}
-		cols[newPos] = col
+		cols[newPos] = newCol
 
 		for i, col := range tblInfo.Columns {
 			if col.Offset != i {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1259,8 +1259,7 @@ func (d *ddl) getModifiableColumnJob(ctx context.Context, ident ast.Ident, origi
 	}
 
 	newCol := table.ToColumn(&model.ColumnInfo{
-		ID: col.ID,
-		// TODO: Determine if we need to set it in the file of column.go.
+		ID:                 col.ID,
 		OriginDefaultValue: col.OriginDefaultValue,
 		FieldType:          *spec.NewColumn.Tp,
 		Name:               spec.NewColumn.Name.Name,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1259,9 +1259,8 @@ func (d *ddl) getModifiableColumnJob(ctx context.Context, ident ast.Ident, origi
 	}
 
 	newCol := table.ToColumn(&model.ColumnInfo{
-		ID:                 col.ID,
-		Offset:             col.Offset,
-		State:              col.State,
+		ID: col.ID,
+		// TODO: Determine if we need to set it in the file of column.go.
 		OriginDefaultValue: col.OriginDefaultValue,
 		FieldType:          *spec.NewColumn.Tp,
 		Name:               spec.NewColumn.Name.Name,

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -14,7 +14,9 @@
 package ddl_test
 
 import (
+	"github.com/pingcap/tidb/meta"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -354,6 +356,76 @@ func (s *testStateChangeSuite) runTestInSchemaState(c *C, state model.SchemaStat
 	_, err = s.se.Execute(alterTableSQL)
 	c.Assert(err, IsNil)
 	c.Assert(errors.ErrorStack(checkErr), Equals, "")
+	callback = &ddl.TestDDLCallback{}
+	d.SetHook(callback)
+}
+
+func (s *testStateChangeSuite) TestParallelDDL(c *C) {
+	defer testleak.AfterTest(c)()
+	_, err := s.se.Execute("use test_db_state")
+	c.Assert(err, IsNil)
+	_, err = s.se.Execute("create table t(a int, b int, c int)")
+	c.Assert(err, IsNil)
+	defer s.se.Execute("drop table t")
+
+	callback := &ddl.TestDDLCallback{}
+	times := 0
+	callback.OnJobUpdatedExported = func(job *model.Job) {
+		if times != 0 {
+			return
+		}
+		var qLen int64
+		var err error
+		for {
+			kv.RunInNewTxn(s.store, false, func(txn kv.Transaction) error {
+				m := meta.NewMeta(txn)
+				qLen, err = m.DDLJobQueueLen()
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			if qLen == 2 {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		times++
+	}
+	d := s.dom.DDL()
+	d.SetHook(callback)
+
+	wg := sync.WaitGroup{}
+	var err1 error
+	var err2 error
+	se, err := tidb.CreateSession(s.store)
+	c.Assert(err, IsNil)
+	_, err = se.Execute("use test_db_state")
+	c.Assert(err, IsNil)
+	se1, err := tidb.CreateSession(s.store)
+	c.Assert(err, IsNil)
+	_, err = se1.Execute("use test_db_state")
+	c.Assert(err, IsNil)
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		_, err1 = se.Execute("ALTER TABLE t MODIFY COLUMN b int FIRST;")
+	}()
+
+	go func() {
+		wg.Add(1)
+		defer wg.Done()
+		_, err2 = se1.Execute("ALTER TABLE t MODIFY COLUMN b int FIRST;")
+	}()
+
+	time.Sleep(1 * time.Second)
+	wg.Wait()
+	c.Assert(err1, IsNil)
+	c.Assert(err2, IsNil)
+
+	_, err = s.se.Execute("select * from t")
+	c.Assert(err, IsNil)
+
 	callback = &ddl.TestDDLCallback{}
 	d.SetHook(callback)
 }

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -424,7 +424,7 @@ func (s *testStateChangeSuite) TestParallelDDL(c *C) {
 	c.Assert(err2, IsNil)
 
 	_, err = s.se.Execute("select * from t")
-	c.Assert(err, IsNil)
+	c.Assert(err, IsNil, Commentf("err:%v", errors.ErrorStack(err)))
 
 	callback = &ddl.TestDDLCallback{}
 	d.SetHook(callback)


### PR DESCRIPTION
We should get the latest offset from the store when we do modify the column.