### PR TITLE
variable: fix `NewSessionVars`

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -337,6 +337,7 @@ func NewSessionVars() *SessionVars {
 		IndexLookupSize:            DefIndexLookupSize,
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,
 		IndexSerialScanConcurrency: DefIndexSerialScanConcurrency,
+		IndexLookupJoinConcurrency: DefIndexLookupJoinConcurrency,
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
 		MaxChunkSize:               DefMaxChunkSize,
 		DMLBatchSize:               DefDMLBatchSize,


### PR DESCRIPTION
Set IndexLookupJoinConcurrency to the default value.
If this value is inited as 0, index lookup join will hang forever.

This issue occurs when we upgrade `tidb-server` on an existing cluster, the old cluster doesn't have global variable `index_lookup_join_concurrency`, so the 0 value is not overwritten to 4.