### PR TITLE
mocktikv: tiny update ScanLock and ResolveLock function

### DIFF
--- a/store/mockstore/mocktikv/mock_tikv_test.go
+++ b/store/mockstore/mocktikv/mock_tikv_test.go
@@ -349,6 +349,14 @@ func (s *testMockTiKVSuite) TestScanLock(c *C) {
 	s.mustPrewriteOK(c, putMutations("p1", "v5", "s1", "v5"), "p1", 5)
 	s.mustPrewriteOK(c, putMutations("p2", "v10", "s2", "v10"), "p2", 10)
 	s.mustPrewriteOK(c, putMutations("p3", "v20", "s3", "v20"), "p3", 20)
+
+	locks, err := s.store.ScanLock([]byte("a"), []byte("r"), 12)
+	c.Assert(err, IsNil)
+	c.Assert(locks, DeepEquals, []*kvrpcpb.LockInfo{
+		lock("p1", "p1", 5),
+		lock("p2", "p2", 10),
+	})
+
 	s.mustScanLock(c, 10, []*kvrpcpb.LockInfo{
 		lock("p1", "p1", 5),
 		lock("p2", "p2", 10),

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -800,10 +800,6 @@ func (mvcc *MVCCLevelDB) ResolveLock(startKey, endKey []byte, startTS, commitTS 
 	mvcc.mu.Lock()
 	defer mvcc.mu.Unlock()
 
-	// startKey and endKey are MvccKey type actually, take out the raw key here.
-	startKey = MvccKey(startKey).Raw()
-	endKey = MvccKey(endKey).Raw()
-
 	iter, currKey, err := newScanIterator(mvcc.db, startKey, endKey)
 	defer iter.Release()
 	if err != nil {

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -326,7 +326,9 @@ func (h *rpcHandler) handleKvBatchRollback(req *kvrpcpb.BatchRollbackRequest) *k
 }
 
 func (h *rpcHandler) handleKvScanLock(req *kvrpcpb.ScanLockRequest) *kvrpcpb.ScanLockResponse {
-	locks, err := h.mvccStore.ScanLock(h.startKey, h.endKey, req.GetMaxVersion())
+	startKey := MvccKey(h.startKey).Raw()
+	endKey := MvccKey(h.endKey).Raw()
+	locks, err := h.mvccStore.ScanLock(startKey, endKey, req.GetMaxVersion())
 	if err != nil {
 		return &kvrpcpb.ScanLockResponse{
 			Error: convertToKeyError(err),
@@ -338,7 +340,9 @@ func (h *rpcHandler) handleKvScanLock(req *kvrpcpb.ScanLockRequest) *kvrpcpb.Sca
 }
 
 func (h *rpcHandler) handleKvResolveLock(req *kvrpcpb.ResolveLockRequest) *kvrpcpb.ResolveLockResponse {
-	err := h.mvccStore.ResolveLock(h.startKey, h.endKey, req.GetStartVersion(), req.GetCommitVersion())
+	startKey := MvccKey(h.startKey).Raw()
+	endKey := MvccKey(h.endKey).Raw()
+	err := h.mvccStore.ResolveLock(startKey, endKey, req.GetStartVersion(), req.GetCommitVersion())
 	if err != nil {
 		return &kvrpcpb.ResolveLockResponse{
 			Error: convertToKeyError(err),


### PR DESCRIPTION
Make the semantics more clear for MVCCStore, it handles raw key (tableID + PK)
it encode the key to MvccKey in the storage layer.

@disksing @MyonKeminta 