### PR TITLE
executor: support insert ignore on duplicate update

### DIFF
--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -447,13 +447,13 @@ func (s *testStateChangeSuite) TestParallelDDL(c *C) {
 			return
 		}
 		var qLen int64
-		var err error
+		var err1 error
 		for {
 			kv.RunInNewTxn(s.store, false, func(txn kv.Transaction) error {
 				m := meta.NewMeta(txn)
-				qLen, err = m.DDLJobQueueLen()
-				if err != nil {
-					return err
+				qLen, err1 = m.DDLJobQueueLen()
+				if err1 != nil {
+					return err1
 				}
 				return nil
 			})

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -537,6 +537,26 @@ commit;`
 	r.Check(testkit.Rows("1 1"))
 }
 
+func (s *testSuite) TestInsertIgnoreOnDup(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	testSQL := `drop table if exists t;
+    create table t (i int not null primary key, j int unique key);`
+	tk.MustExec(testSQL)
+	testSQL = `insert into t values (1, 1), (2, 2);`
+	tk.MustExec(testSQL)
+	testSQL = `insert ignore into t values(1, 1) on duplicate key update i = 2;`
+	tk.MustExec(testSQL)
+	testSQL = `select * from t;`
+	r := tk.MustQuery(testSQL)
+	r.Check(testkit.Rows("1 1", "2 2"))
+	testSQL = `insert ignore into t values(1, 1) on duplicate key update j = 2;`
+	tk.MustExec(testSQL)
+	testSQL = `select * from t;`
+	r = tk.MustQuery(testSQL)
+	r.Check(testkit.Rows("1 1", "2 2"))
+}
+
 func (s *testSuite) TestReplace(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
It seems TiDB has never supported `ignore` combine with `on duplicate key update` together in `insert` statement.
PTAL @coocood 