### PR TITLE
ddl: check if the column name already exists when we rename the column name

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -451,6 +451,13 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, col *model.ColumnInfo
 		job.State = model.JobStateCancelled
 		return ver, infoschema.ErrColumnNotExists.GenByArgs(oldName, tblInfo.Name)
 	}
+	// If we want to rename the column name, we need to check whether it already exists.
+	if col.Name.L != oldName.L {
+		c := findCol(tblInfo.Columns, col.Name.L)
+		if c != nil {
+			return ver, infoschema.ErrColumnExists.GenByArgs(col.Name)
+		}
+	}
 
 	// Calculate column's new position.
 	oldPos, newPos := oldCol.Offset, oldCol.Offset

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -452,10 +452,11 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, newCol *model.ColumnI
 		return ver, infoschema.ErrColumnNotExists.GenByArgs(oldName, tblInfo.Name)
 	}
 	// If we want to rename the column name, we need to check whether it already exists.
-	if col.Name.L != oldName.L {
-		c := findCol(tblInfo.Columns, col.Name.L)
+	if newCol.Name.L != oldName.L {
+		c := findCol(tblInfo.Columns, newCol.Name.L)
 		if c != nil {
-			return ver, infoschema.ErrColumnExists.GenByArgs(col.Name)
+			job.State = model.JobStateCancelled
+			return ver, infoschema.ErrColumnExists.GenByArgs(newCol.Name)
 		}
 	}
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1306,6 +1306,14 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 	if col == nil {
 		return nil, infoschema.ErrColumnNotExists.GenByArgs(originalColName, ident.Name)
 	}
+	newColName := specNewColumn.Name.Name
+	// If we want to rename the column name, we need to check whether it already exists.
+	if newColName.L != originalColName.L {
+		c := table.FindCol(t.Cols(), newColName.L)
+		if c != nil {
+			return nil, infoschema.ErrColumnExists.GenByArgs(newColName)
+		}
+	}
 
 	// Constraints in the new column means adding new constraints. Errors should thrown,
 	// which will be done by `setDefaultAndComment` later.
@@ -1320,7 +1328,7 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		State:              col.State,
 		OriginDefaultValue: col.OriginDefaultValue,
 		FieldType:          *specNewColumn.Tp,
-		Name:               specNewColumn.Name.Name,
+		Name:               newColName,
 	})
 
 	err = setCharsetCollationFlenDecimal(&newCol.FieldType)

--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -512,10 +512,10 @@ func (s *testStateChangeSuite) TestParallelChangeColumnName(c *C) {
 	callback := &ddl.TestDDLCallback{}
 	once := sync.Once{}
 	callback.OnJobUpdatedExported = func(job *model.Job) {
+		// Make sure the both DDL statements have entered the DDL queue before running the DDL jobs.
 		once.Do(func() {
 			var qLen int64
 			var err error
-			// Make sure the both DDL statements have entered the DDL queue before running the DDL jobs.
 			for {
 				kv.RunInNewTxn(s.store, false, func(txn kv.Transaction) error {
 					m := meta.NewMeta(txn)

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1145,6 +1145,9 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
 	sql = "alter table t3 modify en enum('a', 'z', 'b', 'c') not null default 'a'"
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
+	s.mustExec(c, "alter table t3 add column a bigint")
+	sql = "alter table t3 change aa a bigint"
+	s.testErrorCode(c, sql, tmysql.ErrDupFieldName)
 
 	s.tk.MustExec("drop table t3")
 }

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1145,6 +1145,7 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
 	sql = "alter table t3 modify en enum('a', 'z', 'b', 'c') not null default 'a'"
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
+	// Test renamed to an existing column.
 	s.mustExec(c, "alter table t3 add column a bigint")
 	sql = "alter table t3 change aa a bigint"
 	s.testErrorCode(c, sql, tmysql.ErrDupFieldName)

--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -1145,7 +1145,7 @@ func (s *testDBSuite) TestChangeColumn(c *C) {
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
 	sql = "alter table t3 modify en enum('a', 'z', 'b', 'c') not null default 'a'"
 	s.testErrorCode(c, sql, tmysql.ErrUnknown)
-	// Test renamed to an existing column.
+	// Rename to an existing column.
 	s.mustExec(c, "alter table t3 add column a bigint")
 	sql = "alter table t3 change aa a bigint"
 	s.testErrorCode(c, sql, tmysql.ErrDupFieldName)


### PR DESCRIPTION
If we want to rename the column name, we need to check whether it already exists.