### PR TITLE
stats: support auto analyze table when modify/count is too high

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ var defaultConf = Config{
 		FeedbackProbability: 0,
 		QueryFeedbackLimit:  1024,
 		PseudoEstimateRatio: 0.7,
-		AutoAnalyzeRatio:    1e100,
+		AutoAnalyzeRatio:    0,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,7 @@ type Performance struct {
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
 	QueryFeedbackLimit  uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
 	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
+	AutoAnalyzeRatio    float64 `toml:"auto-analyze-ratio" json:"auto-analyze-ratio"`
 }
 
 // XProtocol is the XProtocol section of the config.
@@ -258,6 +259,7 @@ var defaultConf = Config{
 		FeedbackProbability: 0,
 		QueryFeedbackLimit:  1024,
 		PseudoEstimateRatio: 0.7,
+		AutoAnalyzeRatio:    -1.0,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ var defaultConf = Config{
 		FeedbackProbability: 0,
 		QueryFeedbackLimit:  1024,
 		PseudoEstimateRatio: 0.7,
-		AutoAnalyzeRatio:    -1.0,
+		AutoAnalyzeRatio:    1e100,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -145,7 +145,7 @@ pseudo-estimate-ratio = 0.7
 
 # Auto analyze will run if the ratio between the modify count and
 # the row count of a table is greater than it. It should be a positive
-# float number, otherwise auto analyze won't run.
+# float number. Setting this to 0.0 can disable auto analyze.
 auto-analyze-ratio = 0.0
 
 [proxy-protocol]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -145,8 +145,8 @@ pseudo-estimate-ratio = 0.7
 
 # Auto analyze will run if the ratio between the modify count and
 # the row count of a table is greater than it. It should be a positive
-# number.
-auto-analyze-ratio = 1e100
+# float number, otherwise auto analyze won't run.
+auto-analyze-ratio = 0.0
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -144,9 +144,9 @@ query-feedback-limit = 1024
 pseudo-estimate-ratio = 0.7
 
 # Auto analyze will run if the ratio between the modify count and
-# the row count of a table is greater than it. If set it to a negative
-# number, auto analyze won't run.
-auto-analyze-ratio = -1.0
+# the row count of a table is greater than it. It should be a positive
+# number.
+auto-analyze-ratio = 1e100
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,6 +143,11 @@ query-feedback-limit = 1024
 # row count in statistics of a table is greater than it.
 pseudo-estimate-ratio = 0.7
 
+# Auto analyze will run if the ratio between the modify count and
+# the row count of a table is greater than it. If set it to a negative
+# number, auto analyze won't run.
+auto-analyze-ratio = -1.0
+
 [proxy-protocol]
 # PROXY protocol acceptable client networks.
 # Empty string means disable PROXY protocol, * means all networks.

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -367,7 +367,7 @@ const (
 var AutoAnalyzeMinCnt int64 = 1000
 
 // AutoAnalyzeRatio is the ratio which auto analyze will run when modify_count/count is greater than.
-var AutoAnalyzeRatio = 1e100
+var AutoAnalyzeRatio float64
 
 func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	if tbl.ModifyCount == 0 || tbl.Count < AutoAnalyzeMinCnt {

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -366,6 +366,8 @@ const (
 // AutoAnalyzeMinCnt means if the count of table is less than this value, we needn't do auto analyze.
 var AutoAnalyzeMinCnt int64 = 1000
 
+var AutoAnalyzeRatio = -1.0
+
 func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	if tbl.ModifyCount == 0 || tbl.Count < AutoAnalyzeMinCnt {
 		return false
@@ -373,6 +375,9 @@ func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	t := time.Unix(0, oracle.ExtractPhysical(tbl.Version)*int64(time.Millisecond))
 	if time.Since(t) < limit {
 		return false
+	}
+	if AutoAnalyzeRatio >= 0 && float64(tbl.ModifyCount)/float64(tbl.Count) > AutoAnalyzeRatio {
+		return true
 	}
 	for _, col := range tbl.Columns {
 		if col.Count > 0 {

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -366,7 +366,8 @@ const (
 // AutoAnalyzeMinCnt means if the count of table is less than this value, we needn't do auto analyze.
 var AutoAnalyzeMinCnt int64 = 1000
 
-var AutoAnalyzeRatio = -1.0
+// AutoAnalyzeRatio is the ratio which auto analyze will run when modify_count/count is greater than.
+var AutoAnalyzeRatio = 1e100
 
 func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	if tbl.ModifyCount == 0 || tbl.Count < AutoAnalyzeMinCnt {
@@ -376,7 +377,7 @@ func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	if time.Since(t) < limit {
 		return false
 	}
-	if AutoAnalyzeRatio >= 0 && float64(tbl.ModifyCount)/float64(tbl.Count) > AutoAnalyzeRatio {
+	if AutoAnalyzeRatio > 0 && float64(tbl.ModifyCount)/float64(tbl.Count) > AutoAnalyzeRatio {
 		return true
 	}
 	for _, col := range tbl.Columns {

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -277,8 +277,10 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	testKit.MustExec("create table t (a varchar(20))")
 
 	statistics.AutoAnalyzeMinCnt = 0
+	statistics.AutoAnalyzeRatio = 0.6
 	defer func() {
 		statistics.AutoAnalyzeMinCnt = 1000
+		statistics.AutoAnalyzeRatio = -1.0
 	}()
 
 	do := s.do
@@ -309,6 +311,28 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 		break
 	}
 
+	_, err = testKit.Exec("insert into t values ('fff')")
+	c.Assert(err, IsNil)
+	c.Assert(h.DumpStatsDeltaToKV(), IsNil)
+	c.Assert(h.Update(is), IsNil)
+	err = h.HandleAutoAnalyze(is)
+	c.Assert(err, IsNil)
+	h.Update(is)
+	stats = h.GetTableStats(tableInfo)
+	c.Assert(stats.Count, Equals, int64(2))
+	c.Assert(stats.ModifyCount, Equals, int64(1))
+
+	_, err = testKit.Exec("insert into t values ('fff')")
+	c.Assert(err, IsNil)
+	c.Assert(h.DumpStatsDeltaToKV(), IsNil)
+	c.Assert(h.Update(is), IsNil)
+	err = h.HandleAutoAnalyze(is)
+	c.Assert(err, IsNil)
+	h.Update(is)
+	stats = h.GetTableStats(tableInfo)
+	c.Assert(stats.Count, Equals, int64(3))
+	c.Assert(stats.ModifyCount, Equals, int64(0))
+
 	_, err = testKit.Exec("insert into t values ('eee')")
 	c.Assert(err, IsNil)
 	h.DumpStatsDeltaToKV()
@@ -321,12 +345,12 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	c.Assert(err, IsNil)
 	h.Update(is)
 	stats = h.GetTableStats(tableInfo)
-	c.Assert(stats.Count, Equals, int64(2))
+	c.Assert(stats.Count, Equals, int64(4))
 	// Modify count is non-zero means that we do not analyze the table.
 	c.Assert(stats.ModifyCount, Equals, int64(1))
 	for _, item := range stats.Columns {
 		// TotColSize = 6, because the table has not been analyzed, and insert statement will add 3(length of 'eee') to TotColSize.
-		c.Assert(item.TotColSize, Equals, int64(6))
+		c.Assert(item.TotColSize, Equals, int64(14))
 		break
 	}
 
@@ -339,12 +363,12 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	h.HandleAutoAnalyze(is)
 	h.Update(is)
 	stats = h.GetTableStats(tableInfo)
-	c.Assert(stats.Count, Equals, int64(2))
+	c.Assert(stats.Count, Equals, int64(4))
 	c.Assert(stats.ModifyCount, Equals, int64(0))
 	hg, ok := stats.Indices[tableInfo.Indices[0].ID]
 	c.Assert(ok, IsTrue)
-	c.Assert(hg.NDV, Equals, int64(2))
-	c.Assert(hg.Len(), Equals, 2)
+	c.Assert(hg.NDV, Equals, int64(3))
+	c.Assert(hg.Len(), Equals, 3)
 }
 
 func appendBucket(h *statistics.Histogram, l, r int64) {

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -280,7 +280,7 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	statistics.AutoAnalyzeRatio = 0.6
 	defer func() {
 		statistics.AutoAnalyzeMinCnt = 1000
-		statistics.AutoAnalyzeRatio = -1.0
+		statistics.AutoAnalyzeRatio = 0.0
 	}()
 
 	do := s.do

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -366,6 +366,7 @@ func setGlobalVars() {
 	domain.RunAutoAnalyze = cfg.Performance.RunAutoAnalyze
 	statistics.FeedbackProbability = cfg.Performance.FeedbackProbability
 	statistics.MaxQueryFeedbackCount = int(cfg.Performance.QueryFeedbackLimit)
+	statistics.AutoAnalyzeRatio = cfg.Performance.AutoAnalyzeRatio
 	plan.RatioOfPseudoEstimate = cfg.Performance.PseudoEstimateRatio
 	ddl.RunWorker = cfg.RunDDL
 	ddl.EnableSplitTableRegion = cfg.SplitTable


### PR DESCRIPTION
This PR supports analyze table automatically when `modify/count` is greater than `auto-analyze-ratio` which set in the configuration. If `auto-analyze-ratio` is not set or set to a negative number, auto analyze won't run.
PTAL @coocood @lamxTyler 