### PR TITLE
ddl: support the rolling upgrade.

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -460,6 +460,13 @@ func (d *ddl) doModifyColumn(t *meta.Meta, job *model.Job, newCol *model.ColumnI
 		}
 	}
 
+	// gofail: var uninitializedOffsetAndState bool
+	// if uninitializedOffsetAndState {
+	// if newCol.State != model.StatePublic {
+	//      return ver, errors.New("the column state is wrong")
+	// }
+	// }
+
 	// We need the latest column's offset and state. This information can be obtained from the store.
 	newCol.Offset = oldCol.Offset
 	newCol.State = oldCol.State

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1380,7 +1380,6 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		// a new version TiDB builds the DDL job that doesn't be set the column's offset and state,
 		// and the old version TiDB is the DDL owner, it doesn't get offset and state from the store. Then it will encounter errors.
 		// So here we set offset and state to support the rolling upgrade.
-		// TODO: Remove the set offset and state operation.
 		Offset:             col.Offset,
 		State:              col.State,
 		OriginDefaultValue: col.OriginDefaultValue,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1372,7 +1372,17 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 	}
 
 	newCol := table.ToColumn(&model.ColumnInfo{
-		ID:                 col.ID,
+		ID: col.ID,
+		// We use this PR(https://github.com/pingcap/tidb/pull/6274) as the dividing line to define whether it is a new version or an old version TiDB.
+		// The old version TiDB initializes the column's offset and state here.
+		// The new version TiDB doesn't initialize the column's offset and state, and it will do the initialization in run DDL function.
+		// When we do the rolling upgrade the following may happen:
+		// a new version TiDB builds the DDL job that doesn't be set the column's offset and state,
+		// and the old version TiDB is the DDL owner, it doesn't get offset and state from the store. Then it will encounter errors.
+		// So here we set offset and state to support the rolling upgrade.
+		// TODO: Remove the set offset and state operation.
+		Offset:             col.Offset,
+		State:              col.State,
 		OriginDefaultValue: col.OriginDefaultValue,
 		FieldType:          *specNewColumn.Tp,
 		Name:               newColName,

--- a/ddl/fail_db_test.go
+++ b/ddl/fail_db_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	gofail "github.com/coreos/gofail/runtime"
+	. "github.com/pingcap/check"
+	"golang.org/x/net/context"
+)
+
+// TestInitializeOffsetAndState tests the case that the column's offset and state don't be initialized in the file of ddl_api.go when
+// doing the operation of 'modify column'.
+func (s *testStateChangeSuite) TestInitializeOffsetAndState(c *C) {
+	_, err := s.se.Execute(context.Background(), "use test_db_state")
+	c.Assert(err, IsNil)
+	_, err = s.se.Execute(context.Background(), "create table t(a int, b int, c int)")
+	c.Assert(err, IsNil)
+	defer s.se.Execute(context.Background(), "drop table t")
+
+	gofail.Enable("github.com/pingcap/tidb/ddl/uninitializedOffsetAndState", `return(true)`)
+	_, err = s.se.Execute(context.Background(), "ALTER TABLE t MODIFY COLUMN b int FIRST;")
+	c.Assert(err, IsNil)
+	gofail.Disable("github.com/pingcap/tidb/ddl/uninitializedOffsetAndState")
+}


### PR DESCRIPTION
We use this PR(https://github.com/pingcap/tidb/pull/6274) as the dividing line to define whether it is a new version or an old version TiDB.
The old version TiDB initializes the column's offset and state here.
The new version TiDB doesn't initialize the column's offset and state, and it will do the initialization in run DDL function.
When we do the rolling upgrade the following may happen:
a new version TiDB builds the DDL job that doesn't be set the column's offset and state,
and the old version TiDB is the DDL owner, it doesn't get offset and state from the store. Then it will encounter errors.
This PR will fix it.