### PR TITLE
stats: fix pseudo selectivity for primary key

### DIFF
--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -161,8 +161,8 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 		},
 		// Test PK in index single read.
 		{
-			sql:  "select c from t where t.c = 1 and t.a = 1 order by t.d limit 1",
-			best: "IndexReader(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.a, 1)])->Limit)->Limit->Projection",
+			sql:  "select c from t where t.c = 1 and t.a > 1 order by t.d limit 1",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]]->Sel([gt(test.t.a, 1)])->Limit)->Limit->Projection",
 		},
 		// Test composed index.
 		// FIXME: The TopN didn't be pushed.

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -48,6 +48,7 @@ type Table struct {
 	ModifyCount int64 // Total modify count in a table.
 	Version     uint64
 	Pseudo      bool
+	PKIsHandle  bool
 }
 
 func (t *Table) copy() *Table {
@@ -360,11 +361,12 @@ func (t *Table) GetRowCountByIndexRanges(sc *stmtctx.StatementContext, idxID int
 // PseudoTable creates a pseudo table statistics.
 func PseudoTable(tblInfo *model.TableInfo) *Table {
 	t := &Table{
-		TableID: tblInfo.ID,
-		Pseudo:  true,
-		Count:   pseudoRowCount,
-		Columns: make(map[int64]*Column, len(tblInfo.Columns)),
-		Indices: make(map[int64]*Index, len(tblInfo.Indices)),
+		TableID:    tblInfo.ID,
+		Pseudo:     true,
+		Count:      pseudoRowCount,
+		PKIsHandle: tblInfo.PKIsHandle,
+		Columns:    make(map[int64]*Column, len(tblInfo.Columns)),
+		Indices:    make(map[int64]*Index, len(tblInfo.Indices)),
 	}
 	for _, col := range tblInfo.Columns {
 		if col.State == model.StatePublic {


### PR DESCRIPTION
When estimating the pseudo selectivity for primary key equal conditions, it should not exceed `1/row count`.
PTAL @coocood @winoros @zz-jason  