### PR TITLE
[cherry-pick]stats: support auto analyze table when modify/count is too high (#6294)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -151,6 +151,7 @@ type Performance struct {
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
 	QueryFeedbackLimit  uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
 	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
+	AutoAnalyzeRatio    float64 `toml:"auto-analyze-ratio" json:"auto-analyze-ratio"`
 }
 
 // XProtocol is the XProtocol section of the config.
@@ -258,6 +259,7 @@ var defaultConf = Config{
 		FeedbackProbability: 0,
 		QueryFeedbackLimit:  1024,
 		PseudoEstimateRatio: 0.7,
+		AutoAnalyzeRatio:    0,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,6 +143,11 @@ query-feedback-limit = 1024
 # row count in statistics of a table is greater than it.
 pseudo-estimate-ratio = 0.7
 
+# Auto analyze will run if the ratio between the modify count and
+# the row count of a table is greater than it. It should be a positive
+# float number. Setting this to 0.0 can disable auto analyze.
+auto-analyze-ratio = 0.0
+
 [proxy-protocol]
 # PROXY protocol acceptable client networks.
 # Empty string means disable PROXY protocol, * means all networks.

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -366,6 +366,9 @@ const (
 // AutoAnalyzeMinCnt means if the count of table is less than this value, we needn't do auto analyze.
 var AutoAnalyzeMinCnt int64 = 1000
 
+// AutoAnalyzeRatio is the ratio which auto analyze will run when modify_count/count is greater than.
+var AutoAnalyzeRatio float64
+
 func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	if tbl.ModifyCount == 0 || tbl.Count < AutoAnalyzeMinCnt {
 		return false
@@ -373,6 +376,9 @@ func needAnalyzeTable(tbl *Table, limit time.Duration) bool {
 	t := time.Unix(0, oracle.ExtractPhysical(tbl.Version)*int64(time.Millisecond))
 	if time.Since(t) < limit {
 		return false
+	}
+	if AutoAnalyzeRatio > 0 && float64(tbl.ModifyCount)/float64(tbl.Count) > AutoAnalyzeRatio {
+		return true
 	}
 	for _, col := range tbl.Columns {
 		if col.Count > 0 {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -366,6 +366,7 @@ func setGlobalVars() {
 	domain.RunAutoAnalyze = cfg.Performance.RunAutoAnalyze
 	statistics.FeedbackProbability = cfg.Performance.FeedbackProbability
 	statistics.MaxQueryFeedbackCount = int(cfg.Performance.QueryFeedbackLimit)
+	statistics.AutoAnalyzeRatio = cfg.Performance.AutoAnalyzeRatio
 	plan.RatioOfPseudoEstimate = cfg.Performance.PseudoEstimateRatio
 	ddl.RunWorker = cfg.RunDDL
 	ddl.EnableSplitTableRegion = cfg.SplitTable


### PR DESCRIPTION
This PR supports analyze table automatically when modify/count is greater than auto-analyze-ratio which set in the configuration. If auto-analyze-ratio is not set or set to a negative number, auto analyze won't run.