### PR TITLE
store/tikv: make LockKeys() function thread safe

### DIFF
--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/juju/errors"
@@ -40,6 +41,7 @@ type tikvTxn struct {
 	commitTS  uint64
 	valid     bool
 	lockKeys  [][]byte
+	mu        sync.Mutex // For thread-safe LockKeys function.
 	dirty     bool
 	setCnt    int64
 	vars      *kv.Variables
@@ -221,9 +223,11 @@ func (txn *tikvTxn) Rollback() error {
 
 func (txn *tikvTxn) LockKeys(keys ...kv.Key) error {
 	metrics.TiKVTxnCmdCounter.WithLabelValues("lock_keys").Inc()
+	txn.mu.Lock()
 	for _, key := range keys {
 		txn.lockKeys = append(txn.lockKeys, key)
 	}
+	txn.mu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
A data race is found in the CI:

```
WARNING: DATA RACE
Read at 0x00c42d7b3dd0 by goroutine 136:
  github.com/pingcap/tidb/store/tikv.(*tikvTxn).LockKeys()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/txn.go:225 +0x14b
  github.com/pingcap/tidb/session.(*TxnState).LockKeys()
      <autogenerated>:1 +0x7d
  github.com/pingcap/tidb/executor.(*SelectLockExec).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:492 +0x5d9
  github.com/pingcap/tidb/executor.(*ProjectionExec).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:634 +0xf7
  github.com/pingcap/tidb/executor.(*recordSet).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:88 +0x95
  github.com/pingcap/tidb/session.GetRows4Test()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:225 +0x288
  github.com/pingcap/tidb/util/testkit.(*TestKit).ResultSetToResult()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:179 +0x142
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:173 +0x4d3
  github.com/pingcap/tidb/executor_test.(*testSuite).TestSelectForUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:1991 +0xbb3
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:130 +0x133
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:159 +0x91
  github.com/pingcap/tidb/executor_test.(*testSuite).TestSelectForUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:1945 +0x55f
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:130 +0x133
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:159 +0x91
  github.com/pingcap/tidb/executor_test.(*testSuite).TestSelectForUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:1940 +0x483
  github.com/pingcap/tidb/executor_test.(*testSuite).TestSelectForUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:1937 +0x397
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:573 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/tidb/vendor/github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/vendor/github.com/pingcap/check/check.go:798 +0x954
  github.com/pingcap/tidb/vendor/github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/vendor/github.com/pingcap/check/check.go:692 +0x89
```

The SQL input is 

```
select * from (select * from t for update) t join t1 for update
```

and generated plan:


![test](https://user-images.githubusercontent.com/1420062/39111574-34944d8c-469b-11e8-9db7-d2498ae68e51.png)

When `SelectLock` is a children of `HashLeftJoin`, its `Next()` may run concurrently,
and `txn.LockKeys()` is called in `Next()` function, so the data race happen.

@coocood @zz-jason @shenli 