### PR TITLE
executor: buffer snapshotChunk to avoid too many object memory allocation (#6312)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ errcheck:
 	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
-	go get github.com/golang/lint/golint
+	mkdir -p $(GOPATH)/src/golang.org/x 
+	git clone --depth=1 https://github.com/golang/lint.git $(GOPATH)/src/golang.org/x/lint
+	go get -u golang.org/x/lint/golint
 	@echo "golint"
 	@ golint -set_exit_status $(PACKAGES)
 


### PR DESCRIPTION
PTAL @zz-jason @coocood 