### PR TITLE
Makefile: workaround fetch issue of golint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,9 @@ errcheck:
 	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
-	go get github.com/golang/lint/golint
+	mkdir -p $(GOPATH)/src/golang.org/x 
+	git clone --depth=1 https://github.com/golang/lint.git $(GOPATH)/src/golang.org/x/lint
+	go get -u golang.org/x/lint/golint
 	@echo "golint"
 	@ golint -set_exit_status $(PACKAGES)
 


### PR DESCRIPTION
As golint repo does not return metadata for go get to work correctly, circle ci fails. 
This commit installs golint without using go get until it's fixed.

See also https://github.com/golang/lint/issues/397
