### PR TITLE
distsql: make behavior of `TableHandlesToKVRanges` correct.

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -224,23 +224,17 @@ func TableHandlesToKVRanges(tid int64, handles []int64) []kv.KeyRange {
 	krs := make([]kv.KeyRange, 0, len(handles))
 	i := 0
 	for i < len(handles) {
-		h := handles[i]
-		if h == math.MaxInt64 {
-			// We can't convert MaxInt64 into an left closed, right open range.
-			i++
-			continue
-		}
 		j := i + 1
-		endHandle := h + 1
-		for ; j < len(handles); j++ {
-			if handles[j] == endHandle {
-				endHandle = handles[j] + 1
-				continue
+		for ; j < len(handles) && handles[j-1] != math.MaxInt64; j++ {
+			if handles[j] != handles[j-1]+1 {
+				break
 			}
-			break
 		}
-		startKey := tablecodec.EncodeRowKeyWithHandle(tid, h)
-		endKey := tablecodec.EncodeRowKeyWithHandle(tid, endHandle)
+		low := codec.EncodeInt(nil, handles[i])
+		high := codec.EncodeInt(nil, handles[j-1])
+		high = []byte(kv.Key(high).PrefixNext())
+		startKey := tablecodec.EncodeRowKey(tid, low)
+		endKey := tablecodec.EncodeRowKey(tid, high)
 		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 		i = j
 	}

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
@@ -83,22 +84,26 @@ type handleRange struct {
 func (s *testSuite) getExpectedRanges(tid int64, hrs []*handleRange) []kv.KeyRange {
 	krs := make([]kv.KeyRange, 0, len(hrs))
 	for _, hr := range hrs {
-		startKey := tablecodec.EncodeRowKeyWithHandle(tid, hr.start)
-		endKey := tablecodec.EncodeRowKeyWithHandle(tid, hr.end)
+		low := codec.EncodeInt(nil, hr.start)
+		high := codec.EncodeInt(nil, hr.end)
+		high = []byte(kv.Key(high).PrefixNext())
+		startKey := tablecodec.EncodeRowKey(tid, low)
+		endKey := tablecodec.EncodeRowKey(tid, high)
 		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 	}
 	return krs
 }
 
 func (s *testSuite) TestTableHandlesToKVRanges(c *C) {
-	handles := []int64{0, 2, 3, 4, 5, 10, 11, 100}
+	handles := []int64{0, 2, 3, 4, 5, 10, 11, 100, 9223372036854775806, 9223372036854775807}
 
 	// Build expected key ranges.
 	hrs := make([]*handleRange, 0, len(handles))
-	hrs = append(hrs, &handleRange{start: 0, end: 1})
-	hrs = append(hrs, &handleRange{start: 2, end: 6})
-	hrs = append(hrs, &handleRange{start: 10, end: 12})
-	hrs = append(hrs, &handleRange{start: 100, end: 101})
+	hrs = append(hrs, &handleRange{start: 0, end: 0})
+	hrs = append(hrs, &handleRange{start: 2, end: 5})
+	hrs = append(hrs, &handleRange{start: 10, end: 11})
+	hrs = append(hrs, &handleRange{start: 100, end: 100})
+	hrs = append(hrs, &handleRange{start: 9223372036854775806, end: 9223372036854775807})
 
 	// Build key ranges.
 	expect := s.getExpectedRanges(1, hrs)

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -159,3 +159,11 @@ func (s *testSuite) TestGetLackHandles(c *C) {
 	diffHandles = executor.GetLackHandles(expectedHandles, handlesMap)
 	c.Assert(retHandles, DeepEquals, diffHandles)
 }
+
+func (s *testSuite) TestBigIntPK(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a bigint unsigned primary key, b int, c int, index idx(a, b))")
+	tk.MustExec("insert into t values(1, 1, 1), (9223372036854775807, 2, 2)")
+	tk.MustQuery("select * from t use index(idx) order by a").Check(testkit.Rows("1 1 1", "9223372036854775807 2 2"))
+}


### PR DESCRIPTION
current master cannot pass the added test.
PTAL @zz-jason @lamxTyler @XuHuaiyu 