### PR TITLE
*: rename `NewRange` to `Range`.

### DIFF
--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -113,7 +113,7 @@ func (s *testSuite) TestTableHandlesToKVRanges(c *C) {
 }
 
 func (s *testSuite) TestTableRangesToKVRanges(c *C) {
-	ranges := []*ranger.NewRange{
+	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
 			HighVal: []types.Datum{types.NewIntDatum(2)},
@@ -170,7 +170,7 @@ func (s *testSuite) TestTableRangesToKVRanges(c *C) {
 }
 
 func (s *testSuite) TestIndexRangesToKVRanges(c *C) {
-	ranges := []*ranger.NewRange{
+	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
 			HighVal: []types.Datum{types.NewIntDatum(2)},
@@ -229,7 +229,7 @@ func (s *testSuite) TestIndexRangesToKVRanges(c *C) {
 }
 
 func (s *testSuite) TestRequestBuilder1(c *C) {
-	ranges := []*ranger.NewRange{
+	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
 			HighVal: []types.Datum{types.NewIntDatum(2)},
@@ -303,7 +303,7 @@ func (s *testSuite) TestRequestBuilder1(c *C) {
 }
 
 func (s *testSuite) TestRequestBuilder2(c *C) {
-	ranges := []*ranger.NewRange{
+	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
 			HighVal: []types.Datum{types.NewIntDatum(2)},

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -104,7 +104,7 @@ func (e *CheckIndexRangeExec) Open(ctx context.Context) error {
 	}
 	sc := e.ctx.GetSessionVars().StmtCtx
 	var builder distsql.RequestBuilder
-	kvReq, err := builder.SetIndexRanges(sc, e.table.ID, e.index.ID, ranger.FullNewRange()).
+	kvReq, err := builder.SetIndexRanges(sc, e.table.ID, e.index.ID, ranger.FullRange()).
 		SetDAGRequest(dagPB).
 		SetKeepOrder(true).
 		SetFromSessionVars(e.ctx.GetSessionVars()).
@@ -247,7 +247,7 @@ func (e *RecoverIndexExec) buildTableScan(ctx context.Context, txn kv.Transactio
 		return nil, errors.Trace(err)
 	}
 	tblInfo := e.table.Meta()
-	ranges := []*ranger.NewRange{{LowVal: []types.Datum{types.NewIntDatum(startHandle)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}}}
+	ranges := []*ranger.Range{{LowVal: []types.Datum{types.NewIntDatum(startHandle)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}}}
 	var builder distsql.RequestBuilder
 	kvReq, err := builder.SetTableRanges(tblInfo.ID, ranges, nil).
 		SetDAGRequest(dagPB).
@@ -609,7 +609,7 @@ func (e *CleanupIndexExec) buildIndexScan(ctx context.Context, txn kv.Transactio
 	}
 	sc := e.ctx.GetSessionVars().StmtCtx
 	var builder distsql.RequestBuilder
-	ranges := ranger.FullNewRange()
+	ranges := ranger.FullRange()
 	kvReq, err := builder.SetIndexRanges(sc, e.table.Meta().ID, e.index.Meta().ID, ranges).
 		SetDAGRequest(dagPB).
 		SetKeepOrder(true).

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -176,7 +176,7 @@ type AnalyzeIndexExec struct {
 
 func (e *AnalyzeIndexExec) open() error {
 	var builder distsql.RequestBuilder
-	kvReq, err := builder.SetIndexRanges(e.ctx.GetSessionVars().StmtCtx, e.tblInfo.ID, e.idxInfo.ID, ranger.FullNewRange()).
+	kvReq, err := builder.SetIndexRanges(e.ctx.GetSessionVars().StmtCtx, e.tblInfo.ID, e.idxInfo.ID, ranger.FullRange()).
 		SetAnalyzeRequest(e.analyzePB).
 		SetKeepOrder(true).
 		Build()
@@ -264,11 +264,11 @@ type AnalyzeColumnsExec struct {
 }
 
 func (e *AnalyzeColumnsExec) open() error {
-	var ranges []*ranger.NewRange
+	var ranges []*ranger.Range
 	if e.pkInfo != nil {
-		ranges = ranger.FullIntNewRange(mysql.HasUnsignedFlag(e.pkInfo.Flag))
+		ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(e.pkInfo.Flag))
 	} else {
-		ranges = ranger.FullIntNewRange(false)
+		ranges = ranger.FullIntRange(false)
 	}
 	e.resultHandler = &tableResultHandler{}
 	firstPartRanges, secondPartRanges := splitRanges(ranges, e.keepOrder)
@@ -290,7 +290,7 @@ func (e *AnalyzeColumnsExec) open() error {
 	return nil
 }
 
-func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.NewRange) (distsql.SelectResult, error) {
+func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectResult, error) {
 	var builder distsql.RequestBuilder
 	kvReq, err := builder.SetTableRanges(e.tblInfo.ID, ranges, nil).
 		SetAnalyzeRequest(e.analyzePB).

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -224,7 +224,7 @@ func (b *executorBuilder) buildCheckIndex(v *plan.CheckIndex) Executor {
 		b.err = errors.Trace(err)
 		return nil
 	}
-	readerExec.ranges = ranger.FullNewRange()
+	readerExec.ranges = ranger.FullRange()
 	readerExec.isCheckOp = true
 
 	e := &CheckIndexExec{
@@ -1446,7 +1446,7 @@ type dataReaderBuilder struct {
 }
 
 func (builder *dataReaderBuilder) buildExecutorForIndexJoin(ctx context.Context, datums [][]types.Datum,
-	IndexRanges []*ranger.NewRange, keyOff2IdxOff []int) (Executor, error) {
+	IndexRanges []*ranger.Range, keyOff2IdxOff []int) (Executor, error) {
 	switch v := builder.Plan.(type) {
 	case *plan.PhysicalTableReader:
 		return builder.buildTableReaderForIndexJoin(ctx, v, datums)
@@ -1494,7 +1494,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Contex
 }
 
 func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Context, v *plan.PhysicalIndexReader,
-	values [][]types.Datum, indexRanges []*ranger.NewRange, keyOff2IdxOff []int) (Executor, error) {
+	values [][]types.Datum, indexRanges []*ranger.Range, keyOff2IdxOff []int) (Executor, error) {
 	e, err := buildNoRangeIndexReader(builder.executorBuilder, v)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1508,7 +1508,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 }
 
 func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context.Context, v *plan.PhysicalIndexLookUpReader,
-	values [][]types.Datum, indexRanges []*ranger.NewRange, keyOff2IdxOff []int) (Executor, error) {
+	values [][]types.Datum, indexRanges []*ranger.Range, keyOff2IdxOff []int) (Executor, error) {
 	e, err := buildNoRangeIndexLookUpReader(builder.executorBuilder, v)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1522,7 +1522,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 }
 
 // buildKvRangesForIndexJoin builds kv ranges for index join when the inner plan is index scan plan.
-func buildKvRangesForIndexJoin(sc *stmtctx.StatementContext, tableID, indexID int64, keyDatums [][]types.Datum, indexRanges []*ranger.NewRange, keyOff2IdxOff []int) ([]kv.KeyRange, error) {
+func buildKvRangesForIndexJoin(sc *stmtctx.StatementContext, tableID, indexID int64, keyDatums [][]types.Datum, indexRanges []*ranger.Range, keyOff2IdxOff []int) ([]kv.KeyRange, error) {
 	kvRanges := make([]kv.KeyRange, 0, len(indexRanges)*len(keyDatums))
 	for _, val := range keyDatums {
 		for _, ran := range indexRanges {

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -216,7 +216,7 @@ func (c *checksumContext) buildTableRequest(ctx sessionctx.Context) (*kv.Request
 		Algorithm: tipb.ChecksumAlgorithm_Crc64_Xor,
 	}
 
-	ranges := ranger.FullIntNewRange(false)
+	ranges := ranger.FullIntRange(false)
 
 	var builder distsql.RequestBuilder
 	return builder.SetTableRanges(c.TableInfo.ID, ranges, nil).
@@ -232,7 +232,7 @@ func (c *checksumContext) buildIndexRequest(ctx sessionctx.Context, indexInfo *m
 		Algorithm: tipb.ChecksumAlgorithm_Crc64_Xor,
 	}
 
-	ranges := ranger.FullNewRange()
+	ranges := ranger.FullRange()
 
 	var builder distsql.RequestBuilder
 	return builder.SetIndexRanges(ctx.GetSessionVars().StmtCtx, c.TableInfo.ID, indexInfo.ID, ranges).

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -123,7 +123,7 @@ func buildSchema(names []string, ftypes []byte) *expression.Schema {
 }
 
 func (s *testExecSuite) TestBuildKvRangesForIndexJoin(c *C) {
-	indexRanges := make([]*ranger.NewRange, 0, 6)
+	indexRanges := make([]*ranger.Range, 0, 6)
 	indexRanges = append(indexRanges, generateIndexRange(1, 1, 1, 1, 1))
 	indexRanges = append(indexRanges, generateIndexRange(1, 1, 2, 1, 1))
 	indexRanges = append(indexRanges, generateIndexRange(1, 1, 2, 1, 2))
@@ -151,11 +151,11 @@ func (s *testExecSuite) TestBuildKvRangesForIndexJoin(c *C) {
 	}
 }
 
-func generateIndexRange(vals ...int64) *ranger.NewRange {
+func generateIndexRange(vals ...int64) *ranger.Range {
 	lowDatums := generateDatumSlice(vals...)
 	highDatums := make([]types.Datum, len(vals))
 	copy(highDatums, lowDatums)
-	return &ranger.NewRange{LowVal: lowDatums, HighVal: highDatums}
+	return &ranger.Range{LowVal: lowDatums, HighVal: highDatums}
 }
 
 func generateDatumSlice(vals ...int64) []types.Datum {

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -62,7 +62,7 @@ type IndexLookUpJoin struct {
 
 	resultGenerator joinResultGenerator
 
-	indexRanges   []*ranger.NewRange
+	indexRanges   []*ranger.Range
 	keyOff2IdxOff []int
 	innerPtrBytes [][]byte
 
@@ -121,7 +121,7 @@ type innerWorker struct {
 	ctx         sessionctx.Context
 	executorChk *chunk.Chunk
 
-	indexRanges   []*ranger.NewRange
+	indexRanges   []*ranger.Range
 	keyOff2IdxOff []int
 }
 
@@ -170,7 +170,7 @@ func (e *IndexLookUpJoin) newOuterWorker(resultCh, innerCh chan *lookUpJoinTask)
 
 func (e *IndexLookUpJoin) newInnerWorker(taskCh chan *lookUpJoinTask) *innerWorker {
 	// Since multiple inner workers run concurrently, we should copy join's indexRanges for every worker to avoid data race.
-	copiedRanges := make([]*ranger.NewRange, 0, len(e.indexRanges))
+	copiedRanges := make([]*ranger.Range, 0, len(e.indexRanges))
 	for _, ran := range e.indexRanges {
 		copiedRanges = append(copiedRanges, ran.Clone())
 	}

--- a/plan/common_plans.go
+++ b/plan/common_plans.go
@@ -222,7 +222,7 @@ func (e *Execute) rebuildRange(p Plan) error {
 				return errors.Trace(err)
 			}
 		} else {
-			ts.Ranges = ranger.FullIntNewRange(false)
+			ts.Ranges = ranger.FullIntRange(false)
 		}
 	case *PhysicalIndexReader:
 		is := x.IndexPlans[0].(*PhysicalIndexScan)
@@ -250,10 +250,10 @@ func (e *Execute) rebuildRange(p Plan) error {
 	return nil
 }
 
-func (e *Execute) buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan) ([]*ranger.NewRange, error) {
+func (e *Execute) buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan) ([]*ranger.Range, error) {
 	cols := expression.ColumnInfos2ColumnsWithDBName(is.DBName, is.Table.Name, is.Columns)
 	idxCols, colLengths := expression.IndexInfo2Cols(cols, is.Index)
-	ranges := ranger.FullNewRange()
+	ranges := ranger.FullRange()
 	if len(idxCols) > 0 {
 		var err error
 		ranges, _, _, _, err = ranger.DetachCondAndBuildRangeForIndex(sctx, is.conditions, idxCols, colLengths)

--- a/plan/gen_physical_plans.go
+++ b/plan/gen_physical_plans.go
@@ -209,7 +209,7 @@ func joinKeyMatchIndexCol(key *expression.Column, indexCols []*expression.Column
 
 // When inner plan is TableReader, the last two parameter will be nil
 func (p *LogicalJoin) constructIndexJoin(prop *requiredProp, innerJoinKeys, outerJoinKeys []*expression.Column, outerIdx int,
-	innerPlan PhysicalPlan, ranges []*ranger.NewRange, keyOff2IdxOff []int) []PhysicalPlan {
+	innerPlan PhysicalPlan, ranges []*ranger.Range, keyOff2IdxOff []int) []PhysicalPlan {
 	joinType := p.JoinType
 	outerSchema := p.children[outerIdx].Schema()
 	// If the order by columns are not all from outer child, index join cannot promise the order.
@@ -267,7 +267,7 @@ func (p *LogicalJoin) getIndexJoinByOuterIdx(prop *requiredProp, outerIdx int) [
 	}
 	var (
 		bestIndexInfo  *model.IndexInfo
-		rangesOfBest   []*ranger.NewRange
+		rangesOfBest   []*ranger.Range
 		maxUsedCols    int
 		remainedOfBest []expression.Expression
 		keyOff2IdxOff  []int
@@ -295,7 +295,7 @@ func (p *LogicalJoin) getIndexJoinByOuterIdx(prop *requiredProp, outerIdx int) [
 // buildRangeForIndexJoin checks whether this index can be used for building index join and return the range if this index is ok.
 // If this index is invalid, just return nil range.
 func (p *LogicalJoin) buildRangeForIndexJoin(indexInfo *model.IndexInfo, innerPlan *DataSource, innerJoinKeys []*expression.Column) (
-	[]*ranger.NewRange, []expression.Expression, []int) {
+	[]*ranger.Range, []expression.Expression, []int) {
 	idxCols, colLengths := expression.IndexInfo2Cols(innerPlan.Schema().Columns, indexInfo)
 	if len(idxCols) == 0 {
 		return nil, nil, nil

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -260,7 +260,7 @@ func (ds *DataSource) forceToIndexScan(idx *model.IndexInfo, remainedConds []exp
 		Columns:          ds.Columns,
 		Index:            idx,
 		dataSourceSchema: ds.schema,
-		Ranges:           ranger.FullNewRange(),
+		Ranges:           ranger.FullRange(),
 		KeepOrder:        false,
 	}.init(ds.ctx)
 	is.filterCondition = remainedConds
@@ -309,7 +309,7 @@ func (ds *DataSource) convertToIndexScan(prop *requiredProp, idx *model.IndexInf
 	rowCount := float64(statsTbl.Count)
 	sc := ds.ctx.GetSessionVars().StmtCtx
 	idxCols, colLengths := expression.IndexInfo2Cols(ds.Schema().Columns, idx)
-	is.Ranges = ranger.FullNewRange()
+	is.Ranges = ranger.FullRange()
 	eqCount := 0
 	if len(ds.pushedDownConds) > 0 {
 		is.conditions = ds.pushedDownConds
@@ -497,11 +497,11 @@ func checkIndexCondition(condition expression.Expression, indexColumns []*model.
 }
 
 func (ds *DataSource) forceToTableScan(pk *expression.Column) PhysicalPlan {
-	var ranges []*ranger.NewRange
+	var ranges []*ranger.Range
 	if pk != nil {
-		ranges = ranger.FullIntNewRange(mysql.HasUnsignedFlag(pk.RetType.Flag))
+		ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(pk.RetType.Flag))
 	} else {
-		ranges = ranger.FullIntNewRange(false)
+		ranges = ranger.FullIntRange(false)
 	}
 	ts := PhysicalTableScan{
 		Table:       ds.tableInfo,
@@ -547,9 +547,9 @@ func (ds *DataSource) convertToTableScan(prop *requiredProp) (task task, err err
 		}
 	}
 	if pkCol != nil {
-		ts.Ranges = ranger.FullIntNewRange(mysql.HasUnsignedFlag(pkCol.RetType.Flag))
+		ts.Ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(pkCol.RetType.Flag))
 	} else {
-		ts.Ranges = ranger.FullIntNewRange(false)
+		ts.Ranges = ranger.FullIntRange(false)
 	}
 	statsTbl := ds.statisticTable
 	rowCount := float64(statsTbl.Count)

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -95,7 +95,7 @@ type PhysicalIndexScan struct {
 
 	Table     *model.TableInfo
 	Index     *model.IndexInfo
-	Ranges    []*ranger.NewRange
+	Ranges    []*ranger.Range
 	Columns   []*model.ColumnInfo
 	DBName    model.CIStr
 	Desc      bool
@@ -147,7 +147,7 @@ type PhysicalTableScan struct {
 	Columns []*model.ColumnInfo
 	DBName  model.CIStr
 	Desc    bool
-	Ranges  []*ranger.NewRange
+	Ranges  []*ranger.Range
 	pkCol   *expression.Column
 
 	TableAsName *model.CIStr
@@ -226,7 +226,7 @@ type PhysicalIndexJoin struct {
 	DefaultValues []types.Datum
 
 	// Ranges stores the IndexRanges when the inner plan is index scan.
-	Ranges []*ranger.NewRange
+	Ranges []*ranger.Range
 	// KeyOff2IdxOff maps the offsets in join key to the offsets in the index.
 	KeyOff2IdxOff []int
 }

--- a/plan/plan_to_pb.go
+++ b/plan/plan_to_pb.go
@@ -102,7 +102,7 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 
 // checkCoverIndex checks whether we can pass unique info to TiKV. We should push it if and only if the length of
 // range and index are equal.
-func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.NewRange) bool {
+func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.Range) bool {
 	// If the index is (c1, c2) but the query range only contains c1, it is not a unique get.
 	if !idx.Unique {
 		return false

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -453,7 +453,7 @@ func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) Pla
 		Columns:          columns,
 		Index:            idx,
 		dataSourceSchema: schema,
-		Ranges:           ranger.FullNewRange(),
+		Ranges:           ranger.FullRange(),
 		KeepOrder:        false,
 	}.init(b.ctx)
 	is.stats = &statsInfo{}

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -92,7 +92,7 @@ func (q *QueryFeedback) CollectFeedback(numOfRanges int) bool {
 }
 
 // StoreRanges stores the ranges for update.
-func (q *QueryFeedback) StoreRanges(ranges []*ranger.NewRange) {
+func (q *QueryFeedback) StoreRanges(ranges []*ranger.Range) {
 	q.feedback = make([]feedback, 0, len(ranges))
 	for _, ran := range ranges {
 		q.feedback = append(q.feedback, feedback{&ran.LowVal[0], &ran.HighVal[0], 0, 0})

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -34,7 +34,7 @@ type exprSet struct {
 	// mask is a bit pattern whose ith bit will indicate whether the ith expression is covered by this index/column.
 	mask int64
 	// ranges contains all the ranges we got.
-	ranges []*ranger.NewRange
+	ranges []*ranger.Range
 }
 
 // The type of the exprSet.
@@ -194,7 +194,7 @@ func (t *Table) Selectivity(ctx sessionctx.Context, exprs []expression.Expressio
 }
 
 func getMaskAndRanges(ctx sessionctx.Context, exprs []expression.Expression, rangeType ranger.RangeType,
-	lengths []int, cols ...*expression.Column) (mask int64, ranges []*ranger.NewRange, err error) {
+	lengths []int, cols ...*expression.Column) (mask int64, ranges []*ranger.Range, err error) {
 	sc := ctx.GetSessionVars().StmtCtx
 	var accessConds []expression.Expression
 	switch rangeType {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -458,7 +458,7 @@ func (s *testStatisticsSuite) TestColumnRange(c *C) {
 		Count:   int64(col.totalRowCount()),
 		Columns: make(map[int64]*Column),
 	}
-	ran := []*ranger.NewRange{{
+	ran := []*ranger.Range{{
 		LowVal:  []types.Datum{{}},
 		HighVal: []types.Datum{types.MaxValueDatum()},
 	}}
@@ -525,7 +525,7 @@ func (s *testStatisticsSuite) TestIntColumnRanges(c *C) {
 		Count:   int64(col.totalRowCount()),
 		Columns: make(map[int64]*Column),
 	}
-	ran := []*ranger.NewRange{{
+	ran := []*ranger.Range{{
 		LowVal:  []types.Datum{types.NewIntDatum(math.MinInt64)},
 		HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)},
 	}}
@@ -548,7 +548,7 @@ func (s *testStatisticsSuite) TestIntColumnRanges(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(int(count), Equals, 1)
 
-	ran = []*ranger.NewRange{{
+	ran = []*ranger.Range{{
 		LowVal:  []types.Datum{types.NewUintDatum(0)},
 		HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 	}}
@@ -615,7 +615,7 @@ func (s *testStatisticsSuite) TestIndexRanges(c *C) {
 		Count:   int64(idx.totalRowCount()),
 		Indices: make(map[int64]*Index),
 	}
-	ran := []*ranger.NewRange{{
+	ran := []*ranger.Range{{
 		LowVal:  []types.Datum{types.MinNotNullDatum()},
 		HighVal: []types.Datum{types.MaxValueDatum()},
 	}}

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -316,7 +316,7 @@ func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Da
 }
 
 // GetRowCountByIntColumnRanges estimates the row count by a slice of IntColumnRange.
-func (t *Table) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID int64, intRanges []*ranger.NewRange) (float64, error) {
+func (t *Table) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID int64, intRanges []*ranger.Range) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		if len(intRanges) == 0 {
 			return float64(t.Count), nil
@@ -332,8 +332,8 @@ func (t *Table) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID
 	return result, errors.Trace(err)
 }
 
-// GetRowCountByColumnRanges estimates the row count by a slice of NewRange.
-func (t *Table) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID int64, colRanges []*ranger.NewRange) (float64, error) {
+// GetRowCountByColumnRanges estimates the row count by a slice of Range.
+func (t *Table) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID int64, colRanges []*ranger.Range) (float64, error) {
 	if t.ColumnIsInvalid(sc, colID) {
 		return getPseudoRowCountByColumnRanges(sc, float64(t.Count), colRanges, 0)
 	}
@@ -343,8 +343,8 @@ func (t *Table) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID in
 	return result, errors.Trace(err)
 }
 
-// GetRowCountByIndexRanges estimates the row count by a slice of NewRange.
-func (t *Table) GetRowCountByIndexRanges(sc *stmtctx.StatementContext, idxID int64, indexRanges []*ranger.NewRange) (float64, error) {
+// GetRowCountByIndexRanges estimates the row count by a slice of Range.
+func (t *Table) GetRowCountByIndexRanges(sc *stmtctx.StatementContext, idxID int64, indexRanges []*ranger.Range) (float64, error) {
 	idx := t.Indices[idxID]
 	if t.Pseudo || idx == nil || idx.Len() == 0 {
 		colsLen := -1
@@ -381,7 +381,7 @@ func PseudoTable(tblInfo *model.TableInfo) *Table {
 	return t
 }
 
-func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []*ranger.NewRange,
+func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []*ranger.Range,
 	tableRowCount float64, colsLen int) (float64, error) {
 	if tableRowCount == 0 {
 		return 0, nil
@@ -400,7 +400,7 @@ func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []
 		if i >= len(indexRange.LowVal) {
 			i = len(indexRange.LowVal) - 1
 		}
-		rowCount, err := getPseudoRowCountByColumnRanges(sc, tableRowCount, []*ranger.NewRange{indexRange}, i)
+		rowCount, err := getPseudoRowCountByColumnRanges(sc, tableRowCount, []*ranger.Range{indexRange}, i)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
@@ -418,7 +418,7 @@ func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []
 	return totalCount, nil
 }
 
-func getPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount float64, columnRanges []*ranger.NewRange, colIdx int) (float64, error) {
+func getPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount float64, columnRanges []*ranger.Range, colIdx int) (float64, error) {
 	var rowCount float64
 	var err error
 	for _, ran := range columnRanges {
@@ -456,7 +456,7 @@ func getPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount
 	return rowCount, nil
 }
 
-func getPseudoRowCountBySignedIntRanges(intRanges []*ranger.NewRange, tableRowCount float64) float64 {
+func getPseudoRowCountBySignedIntRanges(intRanges []*ranger.Range, tableRowCount float64) float64 {
 	var rowCount float64
 	for _, rg := range intRanges {
 		var cnt float64
@@ -486,7 +486,7 @@ func getPseudoRowCountBySignedIntRanges(intRanges []*ranger.NewRange, tableRowCo
 	return rowCount
 }
 
-func getPseudoRowCountByUnsignedIntRanges(intRanges []*ranger.NewRange, tableRowCount float64) float64 {
+func getPseudoRowCountByUnsignedIntRanges(intRanges []*ranger.Range, tableRowCount float64) float64 {
 	var rowCount float64
 	for _, rg := range intRanges {
 		var cnt float64

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -412,9 +412,9 @@ func (s *testStatsUpdateSuite) TestSplitRange(c *C) {
 		},
 	}
 	for _, t := range tests {
-		ranges := make([]*ranger.NewRange, 0, len(t.points)/2)
+		ranges := make([]*ranger.Range, 0, len(t.points)/2)
 		for i := 0; i < len(t.points); i += 2 {
-			ranges = append(ranges, &ranger.NewRange{
+			ranges = append(ranges, &ranger.Range{
 				LowVal:      []types.Datum{types.NewIntDatum(t.points[i])},
 				LowExclude:  t.exclude[i],
 				HighVal:     []types.Datum{types.NewIntDatum(t.points[i+1])},

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -123,18 +123,18 @@ var fullRange = []point{
 	{value: types.MaxValueDatum()},
 }
 
-// FullIntNewRange is used for table range. Since table range cannot accept MaxValueDatum as the max value.
+// FullIntRange is used for table range. Since table range cannot accept MaxValueDatum as the max value.
 // So we need to set it to MaxInt64.
-func FullIntNewRange(isUnsigned bool) []*NewRange {
+func FullIntRange(isUnsigned bool) []*Range {
 	if isUnsigned {
-		return []*NewRange{{LowVal: []types.Datum{types.NewUintDatum(0)}, HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)}}}
+		return []*Range{{LowVal: []types.Datum{types.NewUintDatum(0)}, HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)}}}
 	}
-	return []*NewRange{{LowVal: []types.Datum{types.NewIntDatum(math.MinInt64)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}}}
+	return []*Range{{LowVal: []types.Datum{types.NewIntDatum(math.MinInt64)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}}}
 }
 
-// FullNewRange is (-∞, +∞) for NewRange.
-func FullNewRange() []*NewRange {
-	return []*NewRange{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}
+// FullRange is (-∞, +∞) for Range.
+func FullRange() []*Range {
+	return []*Range{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}
 }
 
 // builder is the range builder struct.

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -46,10 +46,10 @@ func validInterval(sc *stmtctx.StatementContext, low, high point) (bool, error) 
 	return bytes.Compare(l, r) < 0, nil
 }
 
-// points2NewRanges build index ranges from range points.
-// Only one column is built there. If there're multiple columns, use appendPoints2NewRanges.
-func points2NewRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.FieldType) ([]*NewRange, error) {
-	ranges := make([]*NewRange, 0, len(rangePoints)/2)
+// points2Ranges build index ranges from range points.
+// Only one column is built there. If there're multiple columns, use appendPoints2Ranges.
+func points2Ranges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.FieldType) ([]*Range, error) {
+	ranges := make([]*Range, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
 		startPoint, err := convertPoint(sc, rangePoints[i], tp)
 		if err != nil {
@@ -70,7 +70,7 @@ func points2NewRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *typ
 		if mysql.HasNotNullFlag(tp.Flag) && endPoint.value.Kind() == types.KindNull {
 			continue
 		}
-		ran := &NewRange{
+		ran := &Range{
 			LowVal:      []types.Datum{startPoint.value},
 			LowExclude:  startPoint.excl,
 			HighVal:     []types.Datum{endPoint.value},
@@ -126,13 +126,13 @@ func convertPoint(sc *stmtctx.StatementContext, point point, tp *types.FieldType
 	return point, nil
 }
 
-// appendPoints2NewRanges appends additional column ranges for multi-column index.
+// appendPoints2Ranges appends additional column ranges for multi-column index.
 // The additional column ranges can only be appended to point ranges.
 // for example we have an index (a, b), if the condition is (a > 1 and b = 2)
 // then we can not build a conjunctive ranges for this index.
-func appendPoints2NewRanges(sc *stmtctx.StatementContext, origin []*NewRange, rangePoints []point,
-	ft *types.FieldType) ([]*NewRange, error) {
-	var newIndexRanges []*NewRange
+func appendPoints2Ranges(sc *stmtctx.StatementContext, origin []*Range, rangePoints []point,
+	ft *types.FieldType) ([]*Range, error) {
+	var newIndexRanges []*Range
 	for i := 0; i < len(origin); i++ {
 		oRange := origin[i]
 		if !oRange.IsPoint(sc) {
@@ -148,9 +148,9 @@ func appendPoints2NewRanges(sc *stmtctx.StatementContext, origin []*NewRange, ra
 	return newIndexRanges, nil
 }
 
-func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *NewRange, rangePoints []point,
-	ft *types.FieldType) ([]*NewRange, error) {
-	newRanges := make([]*NewRange, 0, len(rangePoints)/2)
+func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *Range, rangePoints []point,
+	ft *types.FieldType) ([]*Range, error) {
+	newRanges := make([]*Range, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
 		startPoint, err := convertPoint(sc, rangePoints[i], ft)
 		if err != nil {
@@ -176,7 +176,7 @@ func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *NewRange, ran
 		copy(highVal, origin.HighVal)
 		highVal[len(origin.HighVal)] = endPoint.value
 
-		ir := &NewRange{
+		ir := &Range{
 			LowVal:      lowVal,
 			LowExclude:  startPoint.excl,
 			HighVal:     highVal,
@@ -189,8 +189,8 @@ func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *NewRange, ran
 
 // points2TableRanges build ranges for table scan from range points.
 // It will remove the nil and convert MinNotNull and MaxValue to MinInt64 or MinUint64 and MaxInt64 or MaxUint64.
-func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.FieldType) ([]*NewRange, error) {
-	ranges := make([]*NewRange, 0, len(rangePoints)/2)
+func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.FieldType) ([]*Range, error) {
+	ranges := make([]*Range, 0, len(rangePoints)/2)
 	var minValueDatum, maxValueDatum types.Datum
 	// Currently, table's kv range cannot accept encoded value of MaxValueDatum. we need to convert it.
 	if mysql.HasUnsignedFlag(tp.Flag) {
@@ -227,7 +227,7 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *t
 		if !less {
 			continue
 		}
-		ran := &NewRange{
+		ran := &Range{
 			LowVal:      []types.Datum{startPoint.value},
 			LowExclude:  startPoint.excl,
 			HighVal:     []types.Datum{endPoint.value},
@@ -239,7 +239,7 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []point, tp *t
 }
 
 // BuildTableRange will build range of pk for PhysicalTableScan
-func BuildTableRange(accessConditions []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*NewRange, error) {
+func BuildTableRange(accessConditions []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*Range, error) {
 	rb := builder{sc: sc}
 	rangePoints := fullRange
 	for _, cond := range accessConditions {
@@ -257,9 +257,9 @@ func BuildTableRange(accessConditions []expression.Expression, sc *stmtctx.State
 }
 
 // BuildColumnRange builds the range for sampling histogram to calculate the row count.
-func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*NewRange, error) {
+func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*Range, error) {
 	if len(conds) == 0 {
-		return []*NewRange{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}, nil
+		return []*Range{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}, nil
 	}
 
 	rb := builder{sc: sc}
@@ -271,7 +271,7 @@ func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContex
 		}
 	}
 	newTp := newFieldType(tp)
-	ranges, err := points2NewRanges(sc, rangePoints, newTp)
+	ranges, err := points2Ranges(sc, rangePoints, newTp)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -280,10 +280,10 @@ func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContex
 
 // buildCNFIndexRange builds the range for index where the top layer is CNF.
 func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, newTp []*types.FieldType, lengths []int,
-	eqAndInCount int, accessCondition []expression.Expression) ([]*NewRange, error) {
+	eqAndInCount int, accessCondition []expression.Expression) ([]*Range, error) {
 	rb := builder{sc: sc}
 	var (
-		ranges []*NewRange
+		ranges []*Range
 		err    error
 	)
 	for _, col := range cols {
@@ -299,9 +299,9 @@ func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column,
 			return nil, errors.Trace(rb.err)
 		}
 		if i == 0 {
-			ranges, err = points2NewRanges(sc, point, newTp[i])
+			ranges, err = points2Ranges(sc, point, newTp[i])
 		} else {
-			ranges, err = appendPoints2NewRanges(sc, ranges, point, newTp[i])
+			ranges, err = appendPoints2Ranges(sc, ranges, point, newTp[i])
 		}
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -316,9 +316,9 @@ func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column,
 		}
 	}
 	if eqAndInCount == 0 {
-		ranges, err = points2NewRanges(sc, rangePoints, newTp[0])
+		ranges, err = points2Ranges(sc, rangePoints, newTp[0])
 	} else if eqAndInCount < len(accessCondition) {
-		ranges, err = appendPoints2NewRanges(sc, ranges, rangePoints, newTp[eqAndInCount])
+		ranges, err = appendPoints2Ranges(sc, ranges, rangePoints, newTp[eqAndInCount])
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -349,12 +349,12 @@ func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column,
 }
 
 type sortRange struct {
-	originalValue *NewRange
+	originalValue *Range
 	encodedStart  []byte
 	encodedEnd    []byte
 }
 
-func unionNewRanges(sc *stmtctx.StatementContext, ranges []*NewRange) ([]*NewRange, error) {
+func unionRanges(sc *stmtctx.StatementContext, ranges []*Range) ([]*Range, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -409,7 +409,7 @@ func hasPrefix(lengths []int) bool {
 	return false
 }
 
-func fixPrefixColRange(ranges []*NewRange, lengths []int) {
+func fixPrefixColRange(ranges []*Range, lengths []int) {
 	for _, ran := range ranges {
 		for i := 0; i < len(ran.LowVal); i++ {
 			fixRangeDatum(&ran.LowVal[i], lengths[i])

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -23,8 +23,8 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
-// NewRange represents a range generated in physical plan building phase.
-type NewRange struct {
+// Range represents a range generated in physical plan building phase.
+type Range struct {
 	LowVal  []types.Datum
 	HighVal []types.Datum
 
@@ -32,9 +32,9 @@ type NewRange struct {
 	HighExclude bool // High value is exclusive.
 }
 
-// Clone clones a NewRange.
-func (ran *NewRange) Clone() *NewRange {
-	newRange := &NewRange{
+// Clone clones a Range.
+func (ran *Range) Clone() *Range {
+	newRange := &Range{
 		LowVal:      make([]types.Datum, 0, len(ran.LowVal)),
 		HighVal:     make([]types.Datum, 0, len(ran.HighVal)),
 		LowExclude:  ran.LowExclude,
@@ -50,7 +50,7 @@ func (ran *NewRange) Clone() *NewRange {
 }
 
 // IsPoint returns if the range is a point.
-func (ran *NewRange) IsPoint(sc *stmtctx.StatementContext) bool {
+func (ran *Range) IsPoint(sc *stmtctx.StatementContext) bool {
 	if len(ran.LowVal) != len(ran.HighVal) {
 		return false
 	}
@@ -71,8 +71,8 @@ func (ran *NewRange) IsPoint(sc *stmtctx.StatementContext) bool {
 	return !ran.LowExclude && !ran.HighExclude
 }
 
-// Convert2NewRange implements the Convert2NewRange interface.
-func (ran *NewRange) String() string {
+// String implements the Stringer interface.
+func (ran *Range) String() string {
 	lowStrs := make([]string, 0, len(ran.LowVal))
 	for _, d := range ran.LowVal {
 		lowStrs = append(lowStrs, formatDatum(d, true))
@@ -93,7 +93,7 @@ func (ran *NewRange) String() string {
 
 // PrefixEqualLen tells you how long the prefix of the range is a point.
 // e.g. If this range is (1 2 3, 1 2 +inf), then the return value is 2.
-func (ran *NewRange) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) {
+func (ran *Range) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) {
 	// Here, len(ran.LowVal) always equal to len(ran.HighVal)
 	for i := 0; i < len(ran.LowVal); i++ {
 		cmp, err := ran.LowVal[i].CompareDatum(sc, &ran.HighVal[i])

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -27,18 +27,18 @@ type testRangeSuite struct {
 
 func (s *testRangeSuite) TestRange(c *C) {
 	simpleTests := []struct {
-		ran ranger.NewRange
+		ran ranger.Range
 		str string
 	}{
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewIntDatum(1)},
 			},
 			str: "[1,1]",
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:      []types.Datum{types.NewIntDatum(1)},
 				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
@@ -46,7 +46,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			str: "[1,1)",
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:      []types.Datum{types.NewIntDatum(1)},
 				HighVal:     []types.Datum{types.NewIntDatum(2)},
 				LowExclude:  true,
@@ -55,7 +55,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			str: "(1,2)",
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:      []types.Datum{types.NewFloat64Datum(1.1)},
 				HighVal:     []types.Datum{types.NewFloat64Datum(1.9)},
 				HighExclude: true,
@@ -63,7 +63,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			str: "[1.1,1.9)",
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:      []types.Datum{types.MinNotNullDatum()},
 				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
@@ -76,32 +76,32 @@ func (s *testRangeSuite) TestRange(c *C) {
 	}
 
 	isPointTests := []struct {
-		ran     ranger.NewRange
+		ran     ranger.Range
 		isPoint bool
 	}{
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewIntDatum(1)},
 			},
 			isPoint: true,
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewStringDatum("abc")},
 				HighVal: []types.Datum{types.NewStringDatum("abc")},
 			},
 			isPoint: true,
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewIntDatum(1), types.NewIntDatum(1)},
 			},
 			isPoint: false,
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:     []types.Datum{types.NewIntDatum(1)},
 				HighVal:    []types.Datum{types.NewIntDatum(1)},
 				LowExclude: true,
@@ -109,7 +109,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			isPoint: false,
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:      []types.Datum{types.NewIntDatum(1)},
 				HighVal:     []types.Datum{types.NewIntDatum(1)},
 				HighExclude: true,
@@ -117,7 +117,7 @@ func (s *testRangeSuite) TestRange(c *C) {
 			isPoint: false,
 		},
 		{
-			ran: ranger.NewRange{
+			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewIntDatum(2)},
 			},


### PR DESCRIPTION
Now only one type of range exists.
PTAL @zz-jason @XuHuaiyu @lamxTyler 