### PR TITLE
Makefile: use go get golint again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,7 @@ errcheck:
 	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
-	mkdir -p $(GOPATH)/src/golang.org/x 
-	git clone --depth=1 https://github.com/golang/lint.git $(GOPATH)/src/golang.org/x/lint
-	go get -u golang.org/x/lint/golint
+	go get golang.org/x/lint/golint
 	@echo "golint"
 	@ golint -set_exit_status $(PACKAGES)
 


### PR DESCRIPTION
The golint problem has been fixed as https://github.com/golang/lint/issues/397#issuecomment-384001884 says.

PTAL @coocood @shenli 