### PR TITLE
config: set min auto-analyze-ratio to 0.3

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,9 +143,10 @@ query-feedback-limit = 1024
 # row count in statistics of a table is greater than it.
 pseudo-estimate-ratio = 0.7
 
-# Auto analyze will run if the ratio between the modify count and
-# the row count of a table is greater than it. It should be a positive
-# float number. Setting this to 0.0 can disable auto analyze.
+# Auto analyze will run if (table modify count)/(table row count) is greater than this value.
+# The minimum allowed ratio value is 0.3.
+# The suggested ratio value is 0.5.
+# Setting the value to 0.0 disables auto-analyze.
 auto-analyze-ratio = 0.0
 
 [proxy-protocol]

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -325,6 +325,8 @@ func overrideConfig() {
 	}
 }
 
+const minAutoAnalyzeRatio = 0.3
+
 func validateConfig() {
 	if cfg.Security.SkipGrantTable && !hasRootPrivilege() {
 		log.Error("TiDB run with skip-grant-table need root privilege.")
@@ -354,6 +356,9 @@ func validateConfig() {
 	if cfg.LowerCaseTableNames < 0 || cfg.LowerCaseTableNames > 2 {
 		log.Errorf("lower-case-table-names should be 0 or 1 or 2.")
 		os.Exit(-1)
+	}
+	if cfg.Performance.AutoAnalyzeRatio > 0 && cfg.Performance.AutoAnalyzeRatio < minAutoAnalyzeRatio {
+		cfg.Performance.AutoAnalyzeRatio = minAutoAnalyzeRatio
 	}
 }
 


### PR DESCRIPTION
Prevent accidentally set this value to low, cause cluster overload.
And update the config comment.