### PR TITLE
parser: Support alter convert to syntax

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -906,7 +906,7 @@ AlterTableSpec:
 	{
 		op := &ast.AlterTableSpec{
 			Tp: ast.AlterTableOption,
-			Options:[]*ast.TableOption { &ast.TableOption{Tp: ast.TableOptionCharset, StrValue: $4.(string)}},
+			Options:[]*ast.TableOption{{Tp: ast.TableOptionCharset, StrValue: $4.(string)}},
 		}
 		if $5 != "" {
 			op.Options = append(op.Options, &ast.TableOption{Tp: ast.TableOptionCollate, StrValue: $5.(string)})

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -902,6 +902,17 @@ AlterTableSpec:
 			Options:$1.([]*ast.TableOption),
 		}
 	}
+|	"CONVERT" "TO" CharsetKw CharsetName OptCollate
+	{
+		op := &ast.AlterTableSpec{
+			Tp: ast.AlterTableOption,
+			Options:[]*ast.TableOption { &ast.TableOption{Tp: ast.TableOptionCharset, StrValue: $4.(string)}},
+		}
+		if $5 != "" {
+			op.Options = append(op.Options, &ast.TableOption{Tp: ast.TableOptionCollate, StrValue: $5.(string)})
+		}
+		$$ = op
+	}
 |	"ADD" ColumnKeywordOpt ColumnDef ColumnPosition
 	{
 		$$ = &ast.AlterTableSpec{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1594,6 +1594,10 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"ALTER TABLE `hello-world@dev`.`User` ADD COLUMN `name` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL , ALGORITHM = DEFAULT;", true},
 		{"ALTER TABLE `hello-world@dev`.`User` ADD COLUMN `name` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL , ALGORITHM = INPLACE;", true},
 		{"ALTER TABLE `hello-world@dev`.`User` ADD COLUMN `name` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL , ALGORITHM = COPY;", true},
+		{"ALTER TABLE t CONVERT TO CHARACTER SET utf8;", true},
+		{"ALTER TABLE t CONVERT TO CHARSET utf8;", true},
+		{"ALTER TABLE t CONVERT TO CHARACTER SET utf8 COLLATE utf8_bin;", true},
+		{"ALTER TABLE t CONVERT TO CHARSET utf8 COLLATE utf8_bin;", true},
 
 		// For create index statement
 		{"CREATE INDEX idx ON t (a)", true},


### PR DESCRIPTION
for #6394.
This PR support the `ALTER TABLE CONVERT TO CHARACTER SET charset_name [COLLATE collation_name] ` syntax, but not actually change the charset or collation. That's because for now, nothing is done when change `character set` or `collation` in `ALTER TABLE` statements in TiDB, the related `TableOption` are ignored in function `AlterTable` in ddl/ddl_api.go.
For example:
In MySQL
```sql
mysql> create table t1 (a tinytext character set latin1);                                                                                    
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t1;
+-------+---------------------------------------------------------------------------+
| Table | Create Table                                                              |
+-------+---------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext
) ENGINE=InnoDB DEFAULT CHARSET=latin1 |
+-------+---------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> alter table t1 default character set utf8;
Query OK, 0 rows affected (0.03 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> show create table t1;                                                                                                                 
+-------+----------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                 |
+-------+----------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext CHARACTER SET latin1
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |
+-------+----------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> alter table t1 default collate latin1_bin;
Query OK, 0 rows affected (0.01 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> show create table t1;                                                                                                                 
+-------+-------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                      |
+-------+-------------------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext CHARACTER SET latin1
) ENGINE=InnoDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin |
+-------+-------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

In TiDB:
```sql
tidb> create table t1 (a tinytext character set latin1);
Query OK, 0 rows affected (0.01 sec)

tidb> show create table t1;                                                                                                                  +-------+-------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                          |
+-------+-------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

tidb>                                                                                                                                        tidb> alter table t1 default character set latin1;
Query OK, 0 rows affected (0.00 sec)

tidb> show create table t1;                                                                                                                  +-------+-------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                          |
+-------+-------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

tidb> alter table t1 default collate latin1_bin;
Query OK, 0 rows affected (0.00 sec)

tidb> show create table t1;                                                                                                                  
+-------+-------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                          |
+-------+-------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `a` tinytext DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

Maybe we should fix this in another PR.