### PR TITLE
executor: fix statement label for `use`

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -183,7 +183,7 @@ func GetStmtLabel(stmtNode ast.StmtNode) string {
 	case *ast.PrepareStmt:
 		return "Prepare"
 	case *ast.UseStmt:
-		return "IGNORE"
+		return "Use"
 	}
 	return "other"
 }


### PR DESCRIPTION
It is confusing that only the `UseStmt` is tagged with `IGNORE`.