### PR TITLE
privilege: clean up privilege.Enable variable

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
-	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
@@ -342,8 +341,6 @@ func (s *testSuite) TestShow(c *C) {
 }
 
 func (s *testSuite) TestShowVisibility(c *C) {
-	save := privileges.Enable
-	privileges.Enable = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create database showdatabase")
 	tk.MustExec("use showdatabase")
@@ -381,7 +378,6 @@ func (s *testSuite) TestShowVisibility(c *C) {
 	rows := tk1.MustQuery("show databases").Rows()
 	c.Assert(len(rows), GreaterEqual, 2) // At least INFORMATION_SCHEMA and showdatabase
 
-	privileges.Enable = save
 	tk.MustExec(`drop user 'show'@'%'`)
 	tk.MustExec("drop database showdatabase")
 }

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/terror"
@@ -222,9 +221,6 @@ func (s *testSuite) TestKillStmt(c *C) {
 }
 
 func (s *testSuite) TestFlushPrivileges(c *C) {
-	// Global variables is really bad, when the test cases run concurrently.
-	save := privileges.Enable
-	privileges.Enable = true
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec(`CREATE USER 'testflush'@'localhost' IDENTIFIED BY '';`)
@@ -247,8 +243,6 @@ func (s *testSuite) TestFlushPrivileges(c *C) {
 	// After flush.
 	_, err = se.Execute(ctx, `SELECT Password FROM mysql.User WHERE User="testflush" and Host="localhost"`)
 	c.Check(err, IsNil)
-
-	privileges.Enable = save
 }
 
 func (s *testSuite) TestDropStats(c *C) {

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -30,7 +30,6 @@ type testCacheSuite struct {
 }
 
 func (s *testCacheSuite) SetUpSuite(c *C) {
-	privileges.Enable = true
 	store, err := mockstore.NewMockTikvStore()
 	session.SetSchemaLease(0)
 	session.SetStatsLease(0)
@@ -184,7 +183,6 @@ func (s *testCacheSuite) TestCaseInsensitive(c *C) {
 }
 
 func (s *testCacheSuite) TestAbnormalMySQLTable(c *C) {
-	privileges.Enable = true
 	store, err := mockstore.NewMockTikvStore()
 	session.SetSchemaLease(0)
 	session.SetStatsLease(0)

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -25,9 +25,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Enable enables the new privilege check feature.
-var Enable = true
-
 // SkipWithGrant causes the server to start without using the privilege system at all.
 var SkipWithGrant = false
 
@@ -54,7 +51,7 @@ type UserPrivileges struct {
 
 // RequestVerification implements the Manager interface.
 func (p *UserPrivileges) RequestVerification(db, table, column string, priv mysql.PrivilegeType) bool {
-	if !Enable || SkipWithGrant {
+	if SkipWithGrant {
 		return true
 	}
 
@@ -121,7 +118,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, authenticatio
 
 // DBIsVisible implements the Manager interface.
 func (p *UserPrivileges) DBIsVisible(db string) bool {
-	if !Enable || SkipWithGrant {
+	if SkipWithGrant {
 		return true
 	}
 	mysqlPriv := p.Handle.Get()

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/privilege"
-	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/mockstore"
@@ -58,7 +57,6 @@ func (s *testPrivilegeSuite) SetUpSuite(c *C) {
 }
 
 func (s *testPrivilegeSuite) SetUpTest(c *C) {
-	privileges.Enable = true
 	s.dbName = "test"
 	s.store = newStore(c, s.dbName)
 	se := newSession(c, s.store, s.dbName)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -556,10 +556,8 @@ func (s *testSessionSuite) TestSessionAuth(c *C) {
 
 func (s *testSessionSuite) TestSkipWithGrant(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	save1 := privileges.Enable
 	save2 := privileges.SkipWithGrant
 
-	privileges.Enable = true
 	privileges.SkipWithGrant = false
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "user_not_exist"}, []byte("yyy"), []byte("zzz")), IsFalse)
 
@@ -568,7 +566,6 @@ func (s *testSessionSuite) TestSkipWithGrant(c *C) {
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: `%`}, []byte(""), []byte("")), IsTrue)
 	tk.MustExec("create table t (id int)")
 
-	privileges.Enable = save1
 	privileges.SkipWithGrant = save2
 }
 


### PR DESCRIPTION
It always `true` now, we can clean up this variable.

@shenli 