### PR TITLE
expression: support simple expression rewriter

### DIFF
--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -28,60 +27,43 @@ import (
 
 func (s *testEvaluatorSuite) TestCompareFunctionWithRefine(c *C) {
 	defer testleak.AfterTest(c)()
-
-	colInt := &Column{
-		ColName: model.NewCIStr("a"),
-		RetType: types.NewFieldType(mysql.TypeLong),
-	}
-
-	conOne := &Constant{
-		Value:   types.NewFloat64Datum(1.0),
-		RetType: types.NewFieldType(mysql.TypeDouble),
-	}
-
-	conOnePointOne := &Constant{
-		Value:   types.NewFloat64Datum(1.1),
-		RetType: types.NewFieldType(mysql.TypeDouble),
-	}
-
+	tblInfo := newTestTableBuilder("").add("a", mysql.TypeLong).build()
 	tests := []struct {
-		arg0     Expression
-		arg1     Expression
-		funcName string
-		result   string
+		exprStr string
+		result  string
 	}{
-		{colInt, conOne, ast.LT, "lt(a, 1)"},
-		{colInt, conOne, ast.LE, "le(a, 1)"},
-		{colInt, conOne, ast.GT, "gt(a, 1)"},
-		{colInt, conOne, ast.GE, "ge(a, 1)"},
-		{colInt, conOne, ast.EQ, "eq(a, 1)"},
-		{colInt, conOne, ast.NullEQ, "nulleq(a, 1)"},
-		{colInt, conOne, ast.NE, "ne(a, 1)"},
-		{colInt, conOnePointOne, ast.LT, "lt(a, 2)"},
-		{colInt, conOnePointOne, ast.LE, "le(a, 1)"},
-		{colInt, conOnePointOne, ast.GT, "gt(a, 1)"},
-		{colInt, conOnePointOne, ast.GE, "ge(a, 2)"},
-		{colInt, conOnePointOne, ast.EQ, "eq(cast(a), 1.1)"},
-		{colInt, conOnePointOne, ast.NullEQ, "nulleq(cast(a), 1.1)"},
-		{colInt, conOnePointOne, ast.NE, "ne(cast(a), 1.1)"},
-		{conOne, colInt, ast.LT, "lt(1, a)"},
-		{conOne, colInt, ast.LE, "le(1, a)"},
-		{conOne, colInt, ast.GT, "gt(1, a)"},
-		{conOne, colInt, ast.GE, "ge(1, a)"},
-		{conOne, colInt, ast.EQ, "eq(1, a)"},
-		{conOne, colInt, ast.NullEQ, "nulleq(1, a)"},
-		{conOne, colInt, ast.NE, "ne(1, a)"},
-		{conOnePointOne, colInt, ast.LT, "lt(1, a)"},
-		{conOnePointOne, colInt, ast.LE, "le(2, a)"},
-		{conOnePointOne, colInt, ast.GT, "gt(2, a)"},
-		{conOnePointOne, colInt, ast.GE, "ge(1, a)"},
-		{conOnePointOne, colInt, ast.EQ, "eq(1.1, cast(a))"},
-		{conOnePointOne, colInt, ast.NullEQ, "nulleq(1.1, cast(a))"},
-		{conOnePointOne, colInt, ast.NE, "ne(1.1, cast(a))"},
+		{"a < '1.0'", "lt(a, 1)"},
+		{"a <= '1.0'", "le(a, 1)"},
+		{"a > '1'", "gt(a, 1)"},
+		{"a >= '1'", "ge(a, 1)"},
+		{"a = '1'", "eq(a, 1)"},
+		{"a <=> '1'", "nulleq(a, 1)"},
+		{"a != '1'", "ne(a, 1)"},
+		{"a < '1.1'", "lt(a, 2)"},
+		{"a <= '1.1'", "le(a, 1)"},
+		{"a > 1.1", "gt(a, 1)"},
+		{"a >= '1.1'", "ge(a, 2)"},
+		{"a = '1.1'", "eq(cast(a), 1.1)"},
+		{"a <=> '1.1'", "nulleq(cast(a), 1.1)"},
+		{"a != '1.1'", "ne(cast(a), 1.1)"},
+		{"'1' < a", "lt(1, a)"},
+		{"'1' <= a", "le(1, a)"},
+		{"'1' > a", "gt(1, a)"},
+		{"'1' >= a", "ge(1, a)"},
+		{"'1' = a", "eq(1, a)"},
+		{"'1' <=> a", "nulleq(1, a)"},
+		{"'1' != a", "ne(1, a)"},
+		{"'1.1' < a", "lt(1, a)"},
+		{"'1.1' <= a", "le(2, a)"},
+		{"'1.1' > a", "gt(2, a)"},
+		{"'1.1' >= a", "ge(1, a)"},
+		{"'1.1' = a", "eq(1.1, cast(a))"},
+		{"'1.1' <=> a", "nulleq(1.1, cast(a))"},
+		{"'1.1' != a", "ne(1.1, cast(a))"},
 	}
 
 	for _, t := range tests {
-		f, err := NewFunction(s.ctx, t.funcName, types.NewFieldType(mysql.TypeUnspecified), t.arg0, t.arg1)
+		f, err := ParseSimpleExpr(s.ctx, t.exprStr, tblInfo)
 		c.Assert(err, IsNil)
 		c.Assert(f.String(), Equals, t.result)
 	}

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -31,6 +31,8 @@ var (
 	errUnknownCharacterSet           = terror.ClassExpression.New(mysql.ErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
 	errDefaultValue                  = terror.ClassExpression.New(mysql.ErrInvalidDefault, "invalid default value")
 	errDeprecatedSyntaxNoReplacement = terror.ClassExpression.New(mysql.ErrWarnDeprecatedSyntaxNoReplacement, mysql.MySQLErrName[mysql.ErrWarnDeprecatedSyntaxNoReplacement])
+	errBadField                      = terror.ClassExpression.New(mysql.ErrBadField, mysql.MySQLErrName[mysql.ErrBadField])
+	ErrOperandColumns                = terror.ClassExpression.New(mysql.ErrOperandColumns, mysql.MySQLErrName[mysql.ErrOperandColumns])
 )
 
 func init() {
@@ -43,6 +45,8 @@ func init() {
 		mysql.ErrUnknownCharacterSet:               mysql.ErrUnknownCharacterSet,
 		mysql.ErrInvalidDefault:                    mysql.ErrInvalidDefault,
 		mysql.ErrWarnDeprecatedSyntaxNoReplacement: mysql.ErrWarnDeprecatedSyntaxNoReplacement,
+		mysql.ErrWrongColumnName:                   mysql.ErrWrongColumnName,
+		mysql.ErrOperandColumns:                    mysql.ErrOperandColumns,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassExpression] = expressionMySQLErrCodes
 }

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -1,0 +1,442 @@
+package expression
+
+import (
+	"fmt"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/parser"
+	"github.com/pingcap/tidb/parser/opcode"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+)
+
+type simpleRewriter struct {
+	tbl *model.TableInfo
+
+	stack *ExprStack
+	err   error
+	ctx   sessionctx.Context
+}
+
+// ParseSimpleExpr parses simple expression string to Expression.
+// The expression string must only reference the column in table Info.
+func ParseSimpleExpr(ctx sessionctx.Context, exprStr string, tableInfo *model.TableInfo) (Expression, error) {
+	exprStr = fmt.Sprintf("select %s", exprStr)
+	stmts, err := parser.New().Parse(exprStr, "", "")
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	expr := stmts[0].(*ast.SelectStmt).Fields.Fields[0].Expr
+	rewriter := &simpleRewriter{tbl: tableInfo, ctx: ctx, stack: new(ExprStack)}
+	expr.Accept(rewriter)
+	if rewriter.err != nil {
+		return nil, errors.Trace(rewriter.err)
+	}
+	return rewriter.stack.Pop(), nil
+}
+
+func (sr *simpleRewriter) rewriteColumn(cn *ast.ColumnNameExpr) (*Column, error) {
+	cols := sr.tbl.Columns
+	for i, col := range cols {
+		if col.Name.L == cn.Name.Name.L {
+			eCol := &Column{
+				FromID:      1,
+				ColName:     col.Name,
+				OrigTblName: sr.tbl.Name,
+				DBName:      model.NewCIStr(sr.ctx.GetSessionVars().CurrentDB),
+				TblName:     sr.tbl.Name,
+				RetType:     &col.FieldType,
+				ID:          col.ID,
+				Position:    col.Offset,
+				Index:       i,
+			}
+			return eCol, nil
+		}
+	}
+	return nil, errBadField.Gen(cn.Name.Name.O, "expression")
+}
+
+func (sr *simpleRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
+	return inNode, false
+}
+
+func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok bool) {
+	switch v := originInNode.(type) {
+	case *ast.ColumnNameExpr:
+		column, err := sr.rewriteColumn(v)
+		if err != nil {
+			sr.err = err
+			return originInNode, false
+		}
+		sr.stack.Push(column)
+	case *ast.ValueExpr:
+		value := &Constant{Value: v.Datum, RetType: &v.Type}
+		sr.stack.Push(value)
+	case *ast.FuncCallExpr:
+		sr.funcCallToExpression(v)
+	case *ast.FuncCastExpr:
+		arg := sr.stack.Pop()
+		sr.err = CheckArgsOneColumn(arg)
+		if sr.err != nil {
+			return retNode, false
+		}
+		sr.stack.Push(BuildCastFunction(sr.ctx, arg, v.Tp))
+	case *ast.BinaryOperationExpr:
+		sr.binaryOpToExpression(v)
+	case *ast.UnaryOperationExpr:
+		sr.unaryOpToExpression(v)
+	case *ast.BetweenExpr:
+		sr.betweenToExpression(v)
+	case *ast.IsNullExpr:
+		sr.isNullToExpression(v)
+	case *ast.IsTruthExpr:
+		sr.isTrueToScalarFunc(v)
+	case *ast.PatternLikeExpr:
+		sr.likeToScalarFunc(v)
+	case *ast.PatternRegexpExpr:
+		sr.regexpToScalarFunc(v)
+	case *ast.PatternInExpr:
+		if v.Sel == nil {
+			sr.inToExpression(len(v.List), v.Not, &v.Type)
+		}
+	case *ast.RowExpr:
+		sr.rowToScalarFunc(v)
+	case *ast.ParenthesesExpr:
+	case *ast.ColumnName:
+	default:
+		sr.err = errors.Errorf("UnknownType: %T", v)
+		return retNode, false
+	}
+	if sr.err != nil {
+		return retNode, false
+	}
+	return originInNode, true
+}
+
+func (sr *simpleRewriter) binaryOpToExpression(v *ast.BinaryOperationExpr) {
+	right := sr.stack.Pop()
+	left := sr.stack.Pop()
+	var function Expression
+	switch v.Op {
+	case opcode.EQ, opcode.NE, opcode.NullEQ, opcode.GT, opcode.GE, opcode.LT, opcode.LE:
+		function, sr.err = sr.constructBinaryOpFunction(left, right,
+			v.Op.String())
+	default:
+		lLen := GetFuncArgLen(left)
+		rLen := GetFuncArgLen(right)
+		if lLen != 1 || rLen != 1 {
+			sr.err = ErrOperandColumns.GenByArgs(1)
+			return
+		}
+		function, sr.err = NewFunction(sr.ctx, v.Op.String(), types.NewFieldType(mysql.TypeUnspecified), left, right)
+	}
+	if sr.err != nil {
+		sr.err = errors.Trace(sr.err)
+		return
+	}
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
+	args := sr.stack.PopN(len(v.Args))
+	sr.err = CheckArgsOneColumn(args...)
+	if sr.err != nil {
+		return
+	}
+	if sr.rewriteFuncCall(v) {
+		return
+	}
+	var function Expression
+	function, sr.err = NewFunction(sr.ctx, v.FnName.L, &v.Type, args...)
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
+	switch v.FnName.L {
+	case ast.Nullif:
+		if len(v.Args) != 2 {
+			sr.err = ErrIncorrectParameterCount.GenByArgs(v.FnName.O)
+			return true
+		}
+		param2 := sr.stack.Pop()
+		param1 := sr.stack.Pop()
+		// param1 = param2
+		funcCompare, err := sr.constructBinaryOpFunction(param1, param2, ast.EQ)
+		if err != nil {
+			sr.err = err
+			return true
+		}
+		// NULL
+		nullTp := types.NewFieldType(mysql.TypeNull)
+		nullTp.Flen, nullTp.Decimal = mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeNull)
+		paramNull := &Constant{
+			Value:   types.NewDatum(nil),
+			RetType: nullTp,
+		}
+		// if(param1 = param2, NULL, param1)
+		funcIf, err := NewFunction(sr.ctx, ast.If, &v.Type, funcCompare, paramNull, param1)
+		if err != nil {
+			sr.err = err
+			return true
+		}
+		sr.stack.Push(funcIf)
+		return true
+	default:
+		return false
+	}
+}
+
+// 1. If op are EQ or NE or NullEQ, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to (a0 op b0) and (a1 op b1) and (a2 op b2)
+// 2. If op are LE or GE, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to
+// `IF( (a0 op b0) EQ 0, 0,
+//      IF ( (a1 op b1) EQ 0, 0, a2 op b2))`
+// 3. If op are LT or GT, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to
+// `IF( a0 NE b0, a0 op b0,
+//      IF( a1 NE b1,
+//          a1 op b1,
+//          a2 op b2)
+// )`
+func (sr *simpleRewriter) constructBinaryOpFunction(l Expression, r Expression, op string) (Expression, error) {
+	lLen, rLen := GetFuncArgLen(l), GetFuncArgLen(r)
+	if lLen == 1 && rLen == 1 {
+		return NewFunction(sr.ctx, op, types.NewFieldType(mysql.TypeTiny), l, r)
+	} else if rLen != lLen {
+		return nil, ErrOperandColumns.GenByArgs(lLen)
+	}
+	switch op {
+	case ast.EQ, ast.NE, ast.NullEQ:
+		funcs := make([]Expression, lLen)
+		for i := 0; i < lLen; i++ {
+			var err error
+			funcs[i], err = sr.constructBinaryOpFunction(GetFuncArg(l, i), GetFuncArg(r, i), op)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		return ComposeCNFCondition(sr.ctx, funcs...), nil
+	default:
+		larg0, rarg0 := GetFuncArg(l, 0), GetFuncArg(r, 0)
+		var expr1, expr2, expr3 Expression
+		if op == ast.LE || op == ast.GE {
+			expr1 = NewFunctionInternal(sr.ctx, op, types.NewFieldType(mysql.TypeTiny), larg0, rarg0)
+			expr1 = NewFunctionInternal(sr.ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), expr1, Zero)
+			expr2 = Zero
+		} else if op == ast.LT || op == ast.GT {
+			expr1 = NewFunctionInternal(sr.ctx, ast.NE, types.NewFieldType(mysql.TypeTiny), larg0, rarg0)
+			expr2 = NewFunctionInternal(sr.ctx, op, types.NewFieldType(mysql.TypeTiny), larg0, rarg0)
+		}
+		var err error
+		l, err = PopFuncFirstArg(sr.ctx, l)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		r, err = PopFuncFirstArg(sr.ctx, r)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		expr3, err = sr.constructBinaryOpFunction(l, r, op)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return NewFunction(sr.ctx, ast.If, types.NewFieldType(mysql.TypeTiny), expr1, expr2, expr3)
+	}
+}
+
+func (sr *simpleRewriter) unaryOpToExpression(v *ast.UnaryOperationExpr) {
+	var op string
+	switch v.Op {
+	case opcode.Plus:
+		// expression (+ a) is equal to a
+		return
+	case opcode.Minus:
+		op = ast.UnaryMinus
+	case opcode.BitNeg:
+		op = ast.BitNeg
+	case opcode.Not:
+		op = ast.UnaryNot
+	default:
+		sr.err = errors.Errorf("Unknown Unary Op %T", v.Op)
+		return
+	}
+	expr := sr.stack.Pop()
+	if GetFuncArgLen(expr) != 1 {
+		sr.err = ErrOperandColumns.GenByArgs(1)
+		return
+	}
+	newExpr, err := NewFunction(sr.ctx, op, &v.Type, expr)
+	sr.err = err
+	sr.stack.Push(newExpr)
+}
+
+func (sr *simpleRewriter) likeToScalarFunc(v *ast.PatternLikeExpr) {
+	pattern := sr.stack.Pop()
+	expr := sr.stack.Pop()
+	sr.err = CheckArgsOneColumn(expr, pattern)
+	if sr.err != nil {
+		return
+	}
+	escapeTp := &types.FieldType{}
+	types.DefaultTypeForValue(int(v.Escape), escapeTp)
+	function := sr.notToExpression(v.Not, ast.Like, &v.Type,
+		expr, pattern, &Constant{Value: types.NewIntDatum(int64(v.Escape)), RetType: escapeTp})
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) regexpToScalarFunc(v *ast.PatternRegexpExpr) {
+	parttern := sr.stack.Pop()
+	expr := sr.stack.Pop()
+	sr.err = CheckArgsOneColumn(expr, parttern)
+	if sr.err != nil {
+		return
+	}
+	function := sr.notToExpression(v.Not, ast.Regexp, &v.Type, expr, parttern)
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) rowToScalarFunc(v *ast.RowExpr) {
+	elems := sr.stack.PopN(len(v.Values))
+	function, err := NewFunction(sr.ctx, ast.RowFunc, elems[0].GetType(), elems...)
+	if err != nil {
+		sr.err = errors.Trace(err)
+		return
+	}
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) betweenToExpression(v *ast.BetweenExpr) {
+	right := sr.stack.Pop()
+	left := sr.stack.Pop()
+	expr := sr.stack.Pop()
+	sr.err = CheckArgsOneColumn(expr)
+	if sr.err != nil {
+		return
+	}
+	var l, r Expression
+	l, sr.err = NewFunction(sr.ctx, ast.GE, &v.Type, expr, left)
+	if sr.err == nil {
+		r, sr.err = NewFunction(sr.ctx, ast.LE, &v.Type, expr, right)
+	}
+	if sr.err != nil {
+		sr.err = errors.Trace(sr.err)
+		return
+	}
+	function, err := NewFunction(sr.ctx, ast.LogicAnd, &v.Type, l, r)
+	if err != nil {
+		sr.err = errors.Trace(err)
+		return
+	}
+	if v.Not {
+		function, err = NewFunction(sr.ctx, ast.UnaryNot, &v.Type, function)
+		if err != nil {
+			sr.err = errors.Trace(err)
+			return
+		}
+	}
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) isNullToExpression(v *ast.IsNullExpr) {
+	arg := sr.stack.Pop()
+	if GetFuncArgLen(arg) != 1 {
+		sr.err = ErrOperandColumns.GenByArgs(1)
+		return
+	}
+	function := sr.notToExpression(v.Not, ast.IsNull, &v.Type, arg)
+	sr.stack.Push(function)
+}
+
+func (sr *simpleRewriter) notToExpression(hasNot bool, op string, tp *types.FieldType,
+	args ...Expression) Expression {
+	opFunc, err := NewFunction(sr.ctx, op, tp, args...)
+	if err != nil {
+		sr.err = errors.Trace(err)
+		return nil
+	}
+	if !hasNot {
+		return opFunc
+	}
+
+	opFunc, err = NewFunction(sr.ctx, ast.UnaryNot, tp, opFunc)
+	if err != nil {
+		sr.err = errors.Trace(err)
+		return nil
+	}
+	return opFunc
+}
+
+func (sr *simpleRewriter) isTrueToScalarFunc(v *ast.IsTruthExpr) {
+	arg := sr.stack.Pop()
+	op := ast.IsTruth
+	if v.True == 0 {
+		op = ast.IsFalsity
+	}
+	if GetFuncArgLen(arg) != 1 {
+		sr.err = ErrOperandColumns.GenByArgs(1)
+		return
+	}
+	function := sr.notToExpression(v.Not, op, &v.Type, arg)
+	sr.stack.Push(function)
+}
+
+// inToExpression converts in expression to a scalar function. The argument lLen means the length of in list.
+// The argument not means if the expression is not in. The tp stands for the expression type, which is always bool.
+// a in (b, c, d) will be rewritten as `(a = b) or (a = c) or (a = d)`.
+func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType) {
+	exprs := sr.stack.PopN(lLen + 1)
+	leftExpr := exprs[0]
+	elems := exprs[1:]
+	l := GetFuncArgLen(leftExpr)
+	for i := 0; i < lLen; i++ {
+		if l != GetFuncArgLen(elems[i]) {
+			sr.err = ErrOperandColumns.GenByArgs(l)
+			return
+		}
+	}
+	leftIsNull := leftExpr.GetType().Tp == mysql.TypeNull
+	if leftIsNull {
+		sr.stack.Push(Null.Clone())
+		return
+	}
+	leftEt := leftExpr.GetType().EvalType()
+	if leftEt == types.ETInt {
+		for i := 0; i < len(elems); i++ {
+			if c, ok := elems[i].(*Constant); ok {
+				elems[i] = RefineConstantArg(sr.ctx, c, opcode.EQ)
+			}
+		}
+	}
+	allSameType := true
+	for _, elem := range elems {
+		if elem.GetType().Tp != mysql.TypeNull && GetAccurateCmpType(leftExpr, elem) != leftEt {
+			allSameType = false
+			break
+		}
+	}
+	var function Expression
+	if allSameType && l == 1 {
+		function = sr.notToExpression(not, ast.In, tp, exprs...)
+	} else {
+		eqFunctions := make([]Expression, 0, lLen)
+		for i := 0; i < len(elems); i++ {
+			expr, err := sr.constructBinaryOpFunction(leftExpr, elems[i], ast.EQ)
+			if err != nil {
+				sr.err = err
+				return
+			}
+			eqFunctions = append(eqFunctions, expr)
+		}
+		function = ComposeDNFCondition(sr.ctx, eqFunctions...)
+		if not {
+			var err error
+			function, err = NewFunction(sr.ctx, ast.UnaryNot, tp, function)
+			if err != nil {
+				sr.err = err
+				return
+			}
+		}
+	}
+	sr.stack.Push(function)
+}

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -100,8 +100,9 @@ func (b *planBuilder) rewriteWithPreprocess(expr ast.ExprNode, p LogicalPlan, ag
 	if len(rewriter.ctxStack) != 1 {
 		return nil, nil, errors.Errorf("context len %v is invalid", len(rewriter.ctxStack))
 	}
-	if getRowLen(rewriter.ctxStack[0]) != 1 {
-		return nil, nil, ErrOperandColumns.GenByArgs(1)
+	rewriter.err = expression.CheckArgsOneColumn(rewriter.ctxStack[0])
+	if rewriter.err != nil {
+		return nil, nil, errors.Trace(rewriter.err)
 	}
 	b.rewriterCounter--
 	return rewriter.ctxStack[0], rewriter.p, nil
@@ -122,34 +123,6 @@ type expressionRewriter struct {
 	preprocess func(ast.Node) ast.Node
 }
 
-func getRowLen(e expression.Expression) int {
-	if f, ok := e.(*expression.ScalarFunction); ok && f.FuncName.L == ast.RowFunc {
-		return len(f.GetArgs())
-	}
-	return 1
-}
-
-func getRowArg(e expression.Expression, idx int) expression.Expression {
-	if f, ok := e.(*expression.ScalarFunction); ok {
-		return f.GetArgs()[idx]
-	}
-	return nil
-}
-
-// popRowArg pops the first element and return the rest of row.
-// e.g. After this function (1, 2, 3) becomes (2, 3).
-func popRowArg(ctx sessionctx.Context, e expression.Expression) (ret expression.Expression, err error) {
-	if f, ok := e.(*expression.ScalarFunction); ok {
-		args := f.GetArgs()
-		if len(args) == 2 {
-			return args[1].Clone(), nil
-		}
-		ret, err = expression.NewFunction(ctx, f.FuncName.L, f.GetType(), args[1:]...)
-		return ret, errors.Trace(err)
-	}
-	return
-}
-
 // 1. If op are EQ or NE or NullEQ, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to (a0 op b0) and (a1 op b1) and (a2 op b2)
 // 2. If op are LE or GE, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to
 // `IF( (a0 op b0) EQ 0, 0,
@@ -161,7 +134,7 @@ func popRowArg(ctx sessionctx.Context, e expression.Expression) (ret expression.
 //          a2 op b2)
 // )`
 func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression, r expression.Expression, op string) (expression.Expression, error) {
-	lLen, rLen := getRowLen(l), getRowLen(r)
+	lLen, rLen := expression.GetFuncArgLen(l), expression.GetFuncArgLen(r)
 	if lLen == 1 && rLen == 1 {
 		return expression.NewFunction(er.ctx, op, types.NewFieldType(mysql.TypeTiny), l, r)
 	} else if rLen != lLen {
@@ -172,14 +145,14 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 		funcs := make([]expression.Expression, lLen)
 		for i := 0; i < lLen; i++ {
 			var err error
-			funcs[i], err = er.constructBinaryOpFunction(getRowArg(l, i), getRowArg(r, i), op)
+			funcs[i], err = er.constructBinaryOpFunction(expression.GetFuncArg(l, i), expression.GetFuncArg(r, i), op)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
 		}
 		return expression.ComposeCNFCondition(er.ctx, funcs...), nil
 	default:
-		larg0, rarg0 := getRowArg(l, 0), getRowArg(r, 0)
+		larg0, rarg0 := expression.GetFuncArg(l, 0), expression.GetFuncArg(r, 0)
 		var expr1, expr2, expr3 expression.Expression
 		if op == ast.LE || op == ast.GE {
 			expr1 = expression.NewFunctionInternal(er.ctx, op, types.NewFieldType(mysql.TypeTiny), larg0, rarg0)
@@ -190,11 +163,11 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 			expr2 = expression.NewFunctionInternal(er.ctx, op, types.NewFieldType(mysql.TypeTiny), larg0, rarg0)
 		}
 		var err error
-		l, err = popRowArg(er.ctx, l)
+		l, err = expression.PopFuncFirstArg(er.ctx, l)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		r, err = popRowArg(er.ctx, r)
+		r, err = expression.PopFuncFirstArg(er.ctx, r)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -300,11 +273,11 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 	}
 	// Only (a,b,c) = any (...) and (a,b,c) != all (...) can use row expression.
 	canMultiCol := (!v.All && v.Op == opcode.EQ) || (v.All && v.Op == opcode.NE)
-	if !canMultiCol && (getRowLen(lexpr) != 1 || np.Schema().Len() != 1) {
+	if !canMultiCol && (expression.GetFuncArgLen(lexpr) != 1 || np.Schema().Len() != 1) {
 		er.err = ErrOperandColumns.GenByArgs(1)
 		return v, true
 	}
-	lLen := getRowLen(lexpr)
+	lLen := expression.GetFuncArgLen(lexpr)
 	if lLen != np.Schema().Len() {
 		er.err = ErrOperandColumns.GenByArgs(lLen)
 		return v, true
@@ -565,7 +538,7 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 	if er.err != nil {
 		return v, true
 	}
-	lLen := getRowLen(lexpr)
+	lLen := expression.GetFuncArgLen(lexpr)
 	if lLen != np.Schema().Len() {
 		er.err = ErrOperandColumns.GenByArgs(lLen)
 		return v, true
@@ -728,7 +701,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		er.caseToExpression(v)
 	case *ast.FuncCastExpr:
 		arg := er.ctxStack[len(er.ctxStack)-1]
-		er.checkArgsOneColumn(arg)
+		er.err = expression.CheckArgsOneColumn(arg)
 		if er.err != nil {
 			return retNode, false
 		}
@@ -840,7 +813,7 @@ func (er *expressionRewriter) unaryOpToExpression(v *ast.UnaryOperationExpr) {
 		er.err = errors.Errorf("Unknown Unary Op %T", v.Op)
 		return
 	}
-	if getRowLen(er.ctxStack[stkLen-1]) != 1 {
+	if expression.GetFuncArgLen(er.ctxStack[stkLen-1]) != 1 {
 		er.err = ErrOperandColumns.GenByArgs(1)
 		return
 	}
@@ -855,8 +828,8 @@ func (er *expressionRewriter) binaryOpToExpression(v *ast.BinaryOperationExpr) {
 		function, er.err = er.constructBinaryOpFunction(er.ctxStack[stkLen-2], er.ctxStack[stkLen-1],
 			v.Op.String())
 	default:
-		lLen := getRowLen(er.ctxStack[stkLen-2])
-		rLen := getRowLen(er.ctxStack[stkLen-1])
+		lLen := expression.GetFuncArgLen(er.ctxStack[stkLen-2])
+		rLen := expression.GetFuncArgLen(er.ctxStack[stkLen-1])
 		if lLen != 1 || rLen != 1 {
 			er.err = ErrOperandColumns.GenByArgs(1)
 			return
@@ -892,7 +865,7 @@ func (er *expressionRewriter) notToExpression(hasNot bool, op string, tp *types.
 
 func (er *expressionRewriter) isNullToExpression(v *ast.IsNullExpr) {
 	stkLen := len(er.ctxStack)
-	if getRowLen(er.ctxStack[stkLen-1]) != 1 {
+	if expression.GetFuncArgLen(er.ctxStack[stkLen-1]) != 1 {
 		er.err = ErrOperandColumns.GenByArgs(1)
 		return
 	}
@@ -915,7 +888,7 @@ func (er *expressionRewriter) isTrueToScalarFunc(v *ast.IsTruthExpr) {
 	if v.True == 0 {
 		op = ast.IsFalsity
 	}
-	if getRowLen(er.ctxStack[stkLen-1]) != 1 {
+	if expression.GetFuncArgLen(er.ctxStack[stkLen-1]) != 1 {
 		er.err = ErrOperandColumns.GenByArgs(1)
 		return
 	}
@@ -929,9 +902,9 @@ func (er *expressionRewriter) isTrueToScalarFunc(v *ast.IsTruthExpr) {
 // a in (b, c, d) will be rewritten as `(a = b) or (a = c) or (a = d)`.
 func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.FieldType) {
 	stkLen := len(er.ctxStack)
-	l := getRowLen(er.ctxStack[stkLen-lLen-1])
+	l := expression.GetFuncArgLen(er.ctxStack[stkLen-lLen-1])
 	for i := 0; i < lLen; i++ {
-		if l != getRowLen(er.ctxStack[stkLen-lLen+i]) {
+		if l != expression.GetFuncArgLen(er.ctxStack[stkLen-lLen+i]) {
 			er.err = ErrOperandColumns.GenByArgs(l)
 			return
 		}
@@ -990,7 +963,7 @@ func (er *expressionRewriter) caseToExpression(v *ast.CaseExpr) {
 	if v.ElseClause != nil {
 		argsLen++
 	}
-	er.checkArgsOneColumn(er.ctxStack[stkLen-argsLen:]...)
+	er.err = expression.CheckArgsOneColumn(er.ctxStack[stkLen-argsLen:]...)
 	if er.err != nil {
 		return
 	}
@@ -1037,7 +1010,7 @@ func (er *expressionRewriter) caseToExpression(v *ast.CaseExpr) {
 
 func (er *expressionRewriter) likeToScalarFunc(v *ast.PatternLikeExpr) {
 	l := len(er.ctxStack)
-	er.checkArgsOneColumn(er.ctxStack[l-2:]...)
+	er.err = expression.CheckArgsOneColumn(er.ctxStack[l-2:]...)
 	if er.err != nil {
 		return
 	}
@@ -1051,7 +1024,7 @@ func (er *expressionRewriter) likeToScalarFunc(v *ast.PatternLikeExpr) {
 
 func (er *expressionRewriter) regexpToScalarFunc(v *ast.PatternRegexpExpr) {
 	l := len(er.ctxStack)
-	er.checkArgsOneColumn(er.ctxStack[l-2:]...)
+	er.err = expression.CheckArgsOneColumn(er.ctxStack[l-2:]...)
 	if er.err != nil {
 		return
 	}
@@ -1078,7 +1051,7 @@ func (er *expressionRewriter) rowToScalarFunc(v *ast.RowExpr) {
 
 func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 	stkLen := len(er.ctxStack)
-	er.checkArgsOneColumn(er.ctxStack[stkLen-3:]...)
+	er.err = expression.CheckArgsOneColumn(er.ctxStack[stkLen-3:]...)
 	if er.err != nil {
 		return
 	}
@@ -1107,15 +1080,6 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 	}
 	er.ctxStack = er.ctxStack[:stkLen-3]
 	er.ctxStack = append(er.ctxStack, function)
-}
-
-func (er *expressionRewriter) checkArgsOneColumn(args ...expression.Expression) {
-	for _, arg := range args {
-		if getRowLen(arg) != 1 {
-			er.err = ErrOperandColumns.GenByArgs(1)
-			return
-		}
-	}
 }
 
 // rewriteFuncCall handles a FuncCallExpr and generates a customized function.
@@ -1161,7 +1125,7 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 	stackLen := len(er.ctxStack)
 	args := er.ctxStack[stackLen-len(v.Args):]
-	er.checkArgsOneColumn(args...)
+	er.err = expression.CheckArgsOneColumn(args...)
 	if er.err != nil {
 		return
 	}


### PR DESCRIPTION
So the partition expression can be parsed and rewrite to `expression.Expression` and be evaluable.