### PR TITLE
ddl: update ddl add index progress timely

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -94,11 +94,14 @@ func (rc *reorgCtx) clean() {
 	rc.doneCh = nil
 }
 
-func (d *ddl) runReorgJob(t *meta.Meta, job *model.Job, f func() error) error {
+func (d *ddl) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, f func() error) error {
+	job := reorgInfo.Job
 	if d.reorgCtx.doneCh == nil {
 		// start a reorganization job
 		d.wait.Add(1)
 		d.reorgCtx.doneCh = make(chan error, 1)
+		// initial reorgCtx
+		d.reorgCtx.setRowCountAndHandle(job.GetRowCount(), reorgInfo.Handle)
 		go func() {
 			defer d.wait.Done()
 			d.reorgCtx.doneCh <- f()

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -70,6 +70,14 @@ func (rc *reorgCtx) isReorgCanceled() bool {
 	return atomic.LoadInt32(&rc.notifyCancelReorgJob) == 1
 }
 
+func (rc *reorgCtx) setNextHandle(doneHandle int64) {
+	atomic.StoreInt64(&rc.doneHandle, doneHandle)
+}
+
+func (rc *reorgCtx) increaseRowCount(count int64) {
+	atomic.AddInt64(&rc.rowCount, count)
+}
+
 func (rc *reorgCtx) setRowCountAndHandle(count, doneHandle int64) {
 	atomic.StoreInt64(&rc.rowCount, count)
 	atomic.StoreInt64(&rc.doneHandle, doneHandle)

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -130,7 +130,8 @@ func (d *ddl) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, f func() error) er
 		return errors.Trace(err)
 	case <-d.quitCh:
 		log.Info("[ddl] run reorg job ddl quit")
-		d.reorgCtx.setRowCountAndHandle(0, 0)
+		d.reorgCtx.setNextHandle(0)
+		d.reorgCtx.setRowCount(0)
 		// We return errWaitReorgTimeout here too, so that outer loop will break.
 		return errWaitReorgTimeout
 	case <-time.After(waitTimeout):

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -73,13 +73,16 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	err = ctx.NewTxn()
 	c.Assert(err, IsNil)
 	m := meta.NewMeta(ctx.Txn())
-	err = d.runReorgJob(m, job, f)
+	rInfo := &reorgInfo{
+		Job: job,
+	}
+	err = d.runReorgJob(m, rInfo, f)
 	c.Assert(err, NotNil)
 
 	// The longest to wait for 5 seconds to make sure the function of f is returned.
 	for i := 0; i < 1000; i++ {
 		time.Sleep(5 * time.Millisecond)
-		err = d.runReorgJob(m, job, f)
+		err = d.runReorgJob(m, rInfo, f)
 		if err == nil {
 			c.Assert(job.RowCount, Equals, rowCount)
 			c.Assert(d.reorgCtx.rowCount, Equals, int64(0))
@@ -100,7 +103,7 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	c.Assert(err, IsNil)
 
 	d.Stop()
-	err = d.runReorgJob(m, job, func() error {
+	err = d.runReorgJob(m, rInfo, func() error {
 		time.Sleep(4 * testLease)
 		return nil
 	})

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -62,7 +62,8 @@ func (s *testDDLSuite) TestReorg(c *C) {
 	rowCount := int64(10)
 	handle := int64(100)
 	f := func() error {
-		d.reorgCtx.setRowCountAndHandle(rowCount, handle)
+		d.reorgCtx.setRowCount(rowCount)
+		d.reorgCtx.setNextHandle(handle)
 		time.Sleep(1*ReorgWaitTimeout + 100*time.Millisecond)
 		return nil
 	}


### PR DESCRIPTION
Before this PR, we update the rowCount in `admin show ddl` when we finished batch tasks, which may confuse the user. This PR update the rowCount immediately after the indices added.