### PR TITLE
store/tikv/coprocessor: check nil for coprocessor stream response.

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -644,8 +644,10 @@ func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *co
 	}
 	var detail *kvrpcpb.ExecDetails
 	// CopStream can be nil if server returns io.EOF.
-	if task.cmdType == tikvrpc.CmdCopStream && resp.CopStream != nil {
-		detail = resp.CopStream.ExecDetails
+	if task.cmdType == tikvrpc.CmdCopStream {
+		if resp.CopStream != nil {
+			detail = resp.CopStream.ExecDetails
+		}
 	} else {
 		detail = resp.Cop.ExecDetails
 	}

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -643,8 +643,8 @@ func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *co
 		logStr += fmt.Sprintf(" backoff_ms:%d backoff_types:%s", bo.totalSleep, backoffTypes)
 	}
 	var detail *kvrpcpb.ExecDetails
-	// CopStream can be nil if server returns io.EOF.
 	if task.cmdType == tikvrpc.CmdCopStream {
+		// CopStream can be nil if server returns io.EOF.
 		if resp.CopStream != nil {
 			detail = resp.CopStream.ExecDetails
 		}

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -643,12 +643,9 @@ func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *co
 		logStr += fmt.Sprintf(" backoff_ms:%d backoff_types:%s", bo.totalSleep, backoffTypes)
 	}
 	var detail *kvrpcpb.ExecDetails
-	if task.cmdType == tikvrpc.CmdCopStream {
-		// CopStream can be nil if server returns io.EOF.
-		if resp.CopStream != nil {
-			detail = resp.CopStream.ExecDetails
-		}
-	} else {
+	if resp.CopStream != nil {
+		detail = resp.CopStream.ExecDetails
+	} else if resp.Cop != nil {
 		detail = resp.Cop.ExecDetails
 	}
 	if detail != nil {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -643,7 +643,8 @@ func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *co
 		logStr += fmt.Sprintf(" backoff_ms:%d backoff_types:%s", bo.totalSleep, backoffTypes)
 	}
 	var detail *kvrpcpb.ExecDetails
-	if task.cmdType == tikvrpc.CmdCopStream {
+	// CopStream can be nil if server returns io.EOF.
+	if task.cmdType == tikvrpc.CmdCopStream && resp.CopStream != nil {
 		detail = resp.CopStream.ExecDetails
 	} else {
 		detail = resp.Cop.ExecDetails

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -643,10 +643,10 @@ func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *co
 		logStr += fmt.Sprintf(" backoff_ms:%d backoff_types:%s", bo.totalSleep, backoffTypes)
 	}
 	var detail *kvrpcpb.ExecDetails
-	if resp.CopStream != nil {
-		detail = resp.CopStream.ExecDetails
-	} else if resp.Cop != nil {
+	if resp.Cop != nil {
 		detail = resp.Cop.ExecDetails
+	} else if resp.CopStream != nil {
+		detail = resp.CopStream.ExecDetails
 	}
 	if detail != nil {
 		if detail.HandleTime != nil {


### PR DESCRIPTION
When server return io.EOF, the first cop stream response is nil.