### PR TITLE
store/tikv: rollback all keys when prewrite fails.

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -73,13 +73,13 @@ type twoPhaseCommitter struct {
 	commitTS  uint64
 	mu        struct {
 		sync.RWMutex
-		writtenKeys     [][]byte
 		committed       bool
 		undeterminedErr error // undeterminedErr saves the rpc error we encounter when commit primary key.
 	}
 	priority pb.CommandPri
 	syncLog  bool
 	connID   uint64 // connID is used for log.
+	cleanWg  sync.WaitGroup
 }
 
 // newTwoPhaseCommitter creates a twoPhaseCommitter.
@@ -362,18 +362,6 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 		}
 		keyErrs := prewriteResp.GetErrors()
 		if len(keyErrs) == 0 {
-			// We need to cleanup all written keys if transaction aborts.
-			c.mu.Lock()
-			defer c.mu.Unlock()
-			// Primary key should always been in the front since in `cleanup` we
-			// would check whether the `writtenKeys`'s first key is primary key.
-			if bytes.Equal(batch.keys[0], c.primary()) {
-				tmpKeys := make([][]byte, 0, len(batch.keys)+len(c.mu.writtenKeys))
-				tmpKeys = append(tmpKeys, batch.keys...)
-				c.mu.writtenKeys = append(tmpKeys, c.mu.writtenKeys...)
-			} else {
-				c.mu.writtenKeys = append(c.mu.writtenKeys, batch.keys...)
-			}
 			return nil
 		}
 		var locks []*Lock
@@ -568,19 +556,20 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) error {
 	defer func() {
 		// Always clean up all written keys if the txn does not commit.
 		c.mu.RLock()
-		writtenKeys := c.mu.writtenKeys
 		committed := c.mu.committed
 		undetermined := c.mu.undeterminedErr != nil
 		c.mu.RUnlock()
 		if !committed && !undetermined {
+			c.cleanWg.Add(1)
 			twoPhaseCommitGP.Go(func() {
-				err := c.cleanupKeys(NewBackoffer(context.Background(), cleanupMaxBackoff), writtenKeys)
+				err := c.cleanupKeys(NewBackoffer(context.Background(), cleanupMaxBackoff), c.keys)
 				if err != nil {
 					metrics.TiKVSecondaryLockCleanupFailureCounter.WithLabelValues("rollback").Inc()
 					log.Infof("[%d] 2PC cleanup err: %v, tid: %d", c.connID, err, c.startTS)
 				} else {
 					log.Infof("[%d] 2PC clean up done, tid: %d", c.connID, c.startTS)
 				}
+				c.cleanWg.Done()
 			})
 		}
 	}()

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -379,3 +379,35 @@ func (s *testCommitterSuite) TestPrewritePrimaryKeyFailed(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("a3"))
 }
+
+func (s *testCommitterSuite) TestWrittenKeysOnConflict(c *C) {
+	// This test checks that when there is a write conflict, written keys is collected,
+	// so we can use it to clean up keys.
+	region, _ := s.cluster.GetRegionByKey([]byte("x"))
+	newRegionID := s.cluster.AllocID()
+	newPeerID := s.cluster.AllocID()
+	s.cluster.Split(region.Id, newRegionID, []byte("y"), []uint64{newPeerID}, newPeerID)
+	var totalTime time.Duration
+	for i := 0; i < 10; i++ {
+		txn1 := s.begin(c)
+		txn2 := s.begin(c)
+		txn2.Set([]byte("x1"), []byte("1"))
+		commiter2, err := newTwoPhaseCommitter(txn2, 2)
+		c.Assert(err, IsNil)
+		err = commiter2.execute(context.Background())
+		c.Assert(err, IsNil)
+		txn1.Set([]byte("x1"), []byte("1"))
+		txn1.Set([]byte("y1"), []byte("2"))
+		commiter1, err := newTwoPhaseCommitter(txn1, 2)
+		c.Assert(err, IsNil)
+		err = commiter1.execute(context.Background())
+		c.Assert(err, NotNil)
+		commiter1.cleanWg.Wait()
+		txn3 := s.begin(c)
+		start := time.Now()
+		txn3.Get([]byte("y1"))
+		totalTime += time.Since(start)
+		txn3.Commit(context.Background())
+	}
+	c.Assert(totalTime, Less, time.Millisecond*200)
+}


### PR DESCRIPTION
The old implementation only rollbacks keys that are successfully written.
If we cancel the context, we will not get the response, we will not know if keys are written, so
we can not later clean up them.