### PR TITLE
executor: fix a wrong result of limit operator when offset is a multiple of MaxChunkSize

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -563,8 +563,11 @@ func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			if newCursor > e.end {
 				end = e.end - e.cursor
 			}
-			chk.Append(e.childrenResults[0], int(begin), int(end))
 			e.cursor += end
+			if begin == end {
+				break
+			}
+			chk.Append(e.childrenResults[0], int(begin), int(end))
 			return nil
 		}
 		e.cursor += batchSize

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2699,3 +2699,48 @@ func (s *testSuite) TestCoprocessorStreamingFlag(c *C) {
 		rs[0].Close()
 	}
 }
+
+func (s *testSuite) TestLimit(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test;`)
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t(a bigint, b bigint);`)
+	tk.MustExec(`insert into t values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);`)
+	tk.MustQuery(`select * from t order by a limit 1, 1;`).Check(testkit.Rows(
+		"2 2",
+	))
+	tk.MustQuery(`select * from t order by a limit 1, 2;`).Check(testkit.Rows(
+		"2 2",
+		"3 3",
+	))
+	tk.MustQuery(`select * from t order by a limit 1, 3;`).Check(testkit.Rows(
+		"2 2",
+		"3 3",
+		"4 4",
+	))
+	tk.MustQuery(`select * from t order by a limit 1, 4;`).Check(testkit.Rows(
+		"2 2",
+		"3 3",
+		"4 4",
+		"5 5",
+	))
+	tk.MustExec(`set @@tidb_max_chunk_size=2;`)
+	tk.MustQuery(`select * from t order by a limit 2, 1;`).Check(testkit.Rows(
+		"3 3",
+	))
+	tk.MustQuery(`select * from t order by a limit 2, 2;`).Check(testkit.Rows(
+		"3 3",
+		"4 4",
+	))
+	tk.MustQuery(`select * from t order by a limit 2, 3;`).Check(testkit.Rows(
+		"3 3",
+		"4 4",
+		"5 5",
+	))
+	tk.MustQuery(`select * from t order by a limit 2, 4;`).Check(testkit.Rows(
+		"3 3",
+		"4 4",
+		"5 5",
+		"6 6",
+	))
+}


### PR DESCRIPTION
If the offset of the `Limit` clause is a multiple of the global session variable `tidb_max_chunk_size`, the limit operator implementation returns 0 row to its parent as the first batch, which is not correct since we use a batch with 0 row to indicate no more data.

Consider the following table:
```sql
drop table if exists t;
create table t(a bigint, b bigint);
insert into t values(1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6);

```

Before this PR:
```sql
TiDB(localhost:4000) > set @@tidb_max_chunk_size=2;
Query OK, 0 rows affected (0.00 sec)

TiDB(localhost:4000) > select * from t limit 2, 1;
Empty set (0.00 sec)

```

After this PR:
```sql
TiDB(localhost:4000) > set @@tidb_max_chunk_size=2;
Query OK, 0 rows affected (0.00 sec)

TiDB(localhost:4000) > select * from t limit 2, 1;
+------+------+
| a    | b    |
+------+------+
|    3 |    3 |
+------+------+
1 row in set (0.00 sec)

```