### PR TITLE
[release 2.0] executor: fix a wrong result of limit operator when offset is a multiple of MaxChunkSize (#6498)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -533,8 +533,11 @@ func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			if newCursor > e.end {
 				end = e.end - e.cursor
 			}
-			chk.Append(e.childrenResults[0], int(begin), int(end))
 			e.cursor += end
+			if begin == end {
+				break
+			}
+			chk.Append(e.childrenResults[0], int(begin), int(end))
 			return nil
 		}
 		e.cursor += batchSize


### PR DESCRIPTION
cherry pick #6498 to release 2.0