### PR TITLE
planner: Fix index name check when build plan for 'ADMIN CHECK INDEX' syntax (#6477)

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2541,6 +2541,12 @@ func (s *testSuite) TestCheckIndex(c *C) {
 	tb, err := tables.TableFromMeta(alloc, tbInfo)
 	c.Assert(err, IsNil)
 
+	_, err = se.Execute(context.Background(), "admin check index t c")
+	c.Assert(err, IsNil)
+
+	_, err = se.Execute(context.Background(), "admin check index t C")
+	c.Assert(err, IsNil)
+
 	// set data to:
 	// index     data (handle, data): (1, 10), (2, 20)
 	// table     data (handle, data): (1, 10), (2, 20)

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -417,7 +417,7 @@ func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) Pla
 	// get index information
 	var idx *model.IndexInfo
 	for _, index := range tblInfo.Indices {
-		if index.Name.L == as.Index {
+		if index.Name.L == strings.ToLower(as.Index) {
 			idx = index
 			break
 		}


### PR DESCRIPTION
cherry pick #6477 to release 2.0