### PR TITLE
store/tikv: copIteratorTaskSender is not initialized properly

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -91,7 +91,7 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, vars *kv.Variable
 		store:       c.store,
 		req:         req,
 		concurrency: req.Concurrency,
-		finished:    make(chan struct{}),
+		finishCh:    make(chan struct{}),
 		vars:        vars,
 	}
 	it.tasks = tasks
@@ -343,8 +343,8 @@ type copIterator struct {
 	store       *tikvStore
 	req         *kv.Request
 	concurrency int
-	finished    chan struct{}
-	// There are two cases we need to close the `finished` channel, one is when context is done, the other one is
+	finishCh    chan struct{}
+	// There are two cases we need to close the `finishCh` channel, one is when context is done, the other one is
 	// when the Close is called. we use atomic.CompareAndSwap `closed` to to make sure the channel is not closed twice.
 	closed uint32
 
@@ -366,7 +366,7 @@ type copIteratorWorker struct {
 	store    *tikvStore
 	req      *kv.Request
 	respChan chan<- copResponse
-	finished <-chan struct{}
+	finishCh <-chan struct{}
 	vars     *kv.Variables
 }
 
@@ -375,7 +375,7 @@ type copIteratorTaskSender struct {
 	taskCh   chan<- *copTask
 	wg       *sync.WaitGroup
 	tasks    []*copTask
-	finished <-chan struct{}
+	finishCh <-chan struct{}
 	respChan chan<- copResponse
 }
 
@@ -409,7 +409,7 @@ func (worker *copIteratorWorker) run(ctx context.Context) {
 		}
 		close(task.respChan)
 		select {
-		case <-worker.finished:
+		case <-worker.finishCh:
 			return
 		default:
 		}
@@ -428,7 +428,7 @@ func (it *copIterator) open(ctx context.Context) {
 			store:    it.store,
 			req:      it.req,
 			respChan: it.respChan,
-			finished: it.finished,
+			finishCh: it.finishCh,
 			vars:     it.vars,
 		}
 		copIteratorGP.Go(func() {
@@ -439,7 +439,7 @@ func (it *copIterator) open(ctx context.Context) {
 		taskCh:   taskCh,
 		wg:       &it.wg,
 		tasks:    it.tasks,
-		finished: it.finished,
+		finishCh: it.finishCh,
 	}
 	taskSender.respChan = it.respChan
 	copIteratorGP.Go(taskSender.run)
@@ -465,12 +465,12 @@ func (sender *copIteratorTaskSender) run() {
 func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan copResponse) (resp copResponse, ok bool, exit bool) {
 	select {
 	case resp, ok = <-respCh:
-	case <-it.finished:
+	case <-it.finishCh:
 		exit = true
 	case <-ctx.Done():
 		// We select the ctx.Done() in the thread of `Next` instead of in the worker to avoid the cost of `WithCancel`.
 		if atomic.CompareAndSwapUint32(&it.closed, 0, 1) {
-			close(it.finished)
+			close(it.finishCh)
 		}
 		exit = true
 	}
@@ -480,7 +480,7 @@ func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan copResp
 func (sender *copIteratorTaskSender) sendToTaskCh(t *copTask) (exit bool) {
 	select {
 	case sender.taskCh <- t:
-	case <-sender.finished:
+	case <-sender.finishCh:
 		exit = true
 	}
 	return
@@ -489,7 +489,7 @@ func (sender *copIteratorTaskSender) sendToTaskCh(t *copTask) (exit bool) {
 func (worker *copIteratorWorker) sendToRespCh(resp copResponse, respCh chan<- copResponse) (exit bool) {
 	select {
 	case respCh <- resp:
-	case <-worker.finished:
+	case <-worker.finishCh:
 		exit = true
 	}
 	return
@@ -530,7 +530,7 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 	} else {
 		for {
 			if it.curr >= len(it.tasks) {
-				// Resp will be nil if iterator is finished.
+				// Resp will be nil if iterator is finishCh.
 				return nil, nil
 			}
 			task := it.tasks[it.curr]
@@ -771,7 +771,7 @@ func (worker *copIteratorWorker) calculateRemain(ranges *copRanges, split *copro
 
 func (it *copIterator) Close() error {
 	if atomic.CompareAndSwapUint32(&it.closed, 0, 1) {
-		close(it.finished)
+		close(it.finishCh)
 	}
 	it.wg.Wait()
 	return nil

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -436,9 +436,10 @@ func (it *copIterator) open(ctx context.Context) {
 		})
 	}
 	taskSender := &copIteratorTaskSender{
-		taskCh: taskCh,
-		wg:     &it.wg,
-		tasks:  it.tasks,
+		taskCh:   taskCh,
+		wg:       &it.wg,
+		tasks:    it.tasks,
+		finished: it.finished,
 	}
 	taskSender.respChan = it.respChan
 	copIteratorGP.Go(taskSender.run)


### PR DESCRIPTION
This bug is found by our recently added schrodinger leak test:

```
[case-id: leak-1525835901395] 2018/05/09 16:01:50 main.go:106: [fatal] goroutine seems to leak:
goroutine 742864 [select, 10 minutes]:
github.com/pingcap/tidb/store/tikv.(*copIteratorTaskSender).sendToTaskCh(0xc42dcb2680, 0xc4231da400, 0xc432ebbe00)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:480 +0xdf
github.com/pingcap/tidb/store/tikv.(*copIteratorTaskSender).run(0xc42dcb2680)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:450 +0x70
github.com/pingcap/tidb/store/tikv.(*copIteratorTaskSender).(github.com/pingcap/tidb/store/tikv.run)-fm()
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:444 +0x2a
github.com/pingcap/tidb/util/goroutine_pool.(*goroutine).workLoop(0xc427d82f60, 0xc4202da9c0)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/goroutine_pool/gp.go:115 +0x171
created by github.com/pingcap/tidb/util/goroutine_pool.(*Pool).alloc
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/goroutine_pool/gp.go:90 +0x97
```

It turns out to be that `copIteratorTaskSender` is not initialized properly, `finish` is nil and it hang forever here:

```
func (sender *copIteratorTaskSender) sendToTaskCh(t *copTask) (exit bool) {
	select {
	case sender.taskCh <- t:
	case <-sender.finished:
		exit = true
	}
	return
}
```

@coocood @zimulala 