### PR TITLE
update default analyze ratio and pseudo estimate ratio

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -266,7 +266,7 @@ var defaultConf = Config{
 		StmtCountLimit:      5000,
 		FeedbackProbability: 0.05,
 		QueryFeedbackLimit:  1024,
-		PseudoEstimateRatio: 0.7,
+		PseudoEstimateRatio: 0.8,
 	},
 	XProtocol: XProtocol{
 		XHost: "",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -138,7 +138,7 @@ query-feedback-limit = 1024
 
 # Pseudo stats will be used if the ratio between the modify count and
 # row count in statistics of a table is greater than it.
-pseudo-estimate-ratio = 0.7
+pseudo-estimate-ratio = 0.8
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -167,7 +167,7 @@ const (
 	DefIndexLookupSize               = 20000
 	DefDistSQLScanConcurrency        = 15
 	DefBuildStatsConcurrency         = 4
-	DefAutoAnalyzeRatio              = 0.7
+	DefAutoAnalyzeRatio              = 0.5
 	DefChecksumTableConcurrency      = 4
 	DefSkipUTF8Check                 = false
 	DefOptAggPushDown                = false


### PR DESCRIPTION
If pseudo estimate ratio is greater or equal to analyze ratio, there would be a gap time the
table use pseudo stats to build plan.