### PR TITLE
plan: resolve indices for apply schema

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1602,8 +1602,6 @@ func (s *testSuite) TestUpdateSelect(c *C) {
 	tk.MustExec("insert msg values ('abc', 1, 1)")
 	tk.MustExec("create table detail (id varchar(8), start varchar(8), status int, index idx_start(start))")
 	tk.MustExec("insert detail values ('abc', '123', 2)")
-	tk.MustExec(`
-UPDATE msg SET msg.status = (SELECT detail.status FROM detail WHERE detail.start = '123' AND msg.id = detail.id)
-WHERE EXISTS (SELECT 1 FROM detail d WHERE  d.start = '123' AND msg.id = d.id)`)
+	tk.MustExec("UPDATE msg SET msg.status = (SELECT detail.status FROM detail WHERE msg.id = detail.id)")
 	tk.MustExec("admin check table msg")
 }

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1594,3 +1594,16 @@ func (s *testSuite) TestDataTooLongErrMsg(c *C) {
 	c.Assert(types.ErrDataTooLong.Equal(err), IsTrue)
 	c.Assert(err.Error(), Equals, "[types:1406]Data too long for column 'a' at row 1")
 }
+
+func (s *testSuite) TestUpdateSelect(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table msg (id varchar(8), b int, status int, primary key (id, b))")
+	tk.MustExec("insert msg values ('abc', 1, 1)")
+	tk.MustExec("create table detail (id varchar(8), start varchar(8), status int, index idx_start(start))")
+	tk.MustExec("insert detail values ('abc', '123', 2)")
+	tk.MustExec(`
+UPDATE msg SET msg.status = (SELECT detail.status FROM detail WHERE detail.start = '123' AND msg.id = detail.id)
+WHERE EXISTS (SELECT 1 FROM detail d WHERE  d.start = '123' AND msg.id = d.id)`)
+	tk.MustExec("admin check table msg")
+}

--- a/plan/resolve_indices.go
+++ b/plan/resolve_indices.go
@@ -159,6 +159,9 @@ func (p *PhysicalTopN) ResolveIndices() {
 // ResolveIndices implements Plan interface.
 func (p *PhysicalApply) ResolveIndices() {
 	p.PhysicalJoin.ResolveIndices()
+	for _, col := range p.schema.Columns {
+		col.ResolveIndices(p.PhysicalJoin.schema)
+	}
 	for _, col := range p.OuterSchema {
 		col.Column.ResolveIndices(p.children[0].Schema())
 	}


### PR DESCRIPTION
If the apply schema is not resolved, the handle will be lost, then update will update the row with 0 handle.