### PR TITLE
*: support warnings when using coprocessor streaming

### DIFF
--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
@@ -78,6 +79,9 @@ func (r *streamResult) readDataFromResponse(ctx context.Context, resp kv.Respons
 	}
 	if stream.Error != nil {
 		return false, errors.Errorf("stream response error: [%d]%s\n", stream.Error.Code, stream.Error.Msg)
+	}
+	for _, warning := range stream.Warnings {
+		r.ctx.GetSessionVars().StmtCtx.AppendWarning(terror.ClassTiKV.New(terror.ErrCode(warning.Code), warning.Msg))
 	}
 
 	// TODO: Check stream.GetEncodeType() here if we support tipb.EncodeType_TypeArrow some day.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2763,3 +2763,16 @@ func (s *testSuite) TestLimit(c *C) {
 		"6 6",
 	))
 }
+
+func (s *testSuite) TestCoprocessorStreamingWarning(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a double)")
+	tk.MustExec("insert into t value(1.2)")
+	tk.MustExec("set @@session.tidb_enable_streaming = 1")
+
+	result := tk.MustQuery("select * from t where a/0 > 1")
+	result.Check(testkit.Rows())
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|Division by 0"))
+}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2530,10 +2530,7 @@ func (s *testIntegrationSuite) TestArithmeticBuiltin(c *C) {
 	tk.MustExec("insert into t value(1.2)")
 	result = tk.MustQuery("select * from t where a/0 > 1")
 	result.Check(testkit.Rows())
-	// TODO: tipb.StreamResponse should encode the warning fields, fix here.
-	if !tk.Se.GetSessionVars().EnableStreaming {
-		tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|Division by 0"))
-	}
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|Division by 0"))
 }
 
 func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -114,15 +114,16 @@ func (h *rpcHandler) buildDAGExecutor(req *coprocessor.Request) (*dagContext, ex
 }
 
 func (h *rpcHandler) handleCopStream(ctx context.Context, req *coprocessor.Request) (tikvpb.Tikv_CoprocessorStreamClient, error) {
-	_, e, dagReq, err := h.buildDAGExecutor(req)
+	dagCtx, e, dagReq, err := h.buildDAGExecutor(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	return &mockCopStreamClient{
-		exec: e,
-		req:  dagReq,
-		ctx:  ctx,
+		exec:   e,
+		req:    dagReq,
+		ctx:    ctx,
+		dagCtx: dagCtx,
 	}, nil
 }
 
@@ -427,6 +428,7 @@ type mockCopStreamClient struct {
 	req      *tipb.DAGRequest
 	exec     executor
 	ctx      context.Context
+	dagCtx   *dagContext
 	finished bool
 }
 
@@ -459,7 +461,7 @@ func (mock *mockCopStreamClient) Recv() (*coprocessor.Response, error) {
 
 	var resp coprocessor.Response
 	counts := make([]int64, len(mock.req.Executors))
-	chunk, finish, ran, counts, err := mock.readBlockFromExecutor()
+	chunk, finish, ran, counts, warnings, err := mock.readBlockFromExecutor()
 	resp.Range = ran
 	if err != nil {
 		if locked, ok := errors.Cause(err).(*ErrLocked); ok {
@@ -484,10 +486,18 @@ func (mock *mockCopStreamClient) Recv() (*coprocessor.Response, error) {
 		resp.OtherError = err.Error()
 		return &resp, nil
 	}
+	var Warnings []*tipb.Error
+	if len(warnings) > 0 {
+		Warnings = make([]*tipb.Error, 0, len(warnings))
+		for i := range warnings {
+			Warnings = append(Warnings, toPBError(warnings[i]))
+		}
+	}
 	streamResponse := tipb.StreamResponse{
 		Error:      toPBError(err),
 		EncodeType: tipb.EncodeType_TypeDefault,
 		Data:       data,
+		Warnings:   Warnings,
 	}
 	// The counts was the output count of each executor, but now it is the scan count of each range,
 	// so we need a flag to tell them apart.
@@ -503,7 +513,7 @@ func (mock *mockCopStreamClient) Recv() (*coprocessor.Response, error) {
 	return &resp, nil
 }
 
-func (mock *mockCopStreamClient) readBlockFromExecutor() (tipb.Chunk, bool, *coprocessor.KeyRange, []int64, error) {
+func (mock *mockCopStreamClient) readBlockFromExecutor() (tipb.Chunk, bool, *coprocessor.KeyRange, []int64, []error, error) {
 	var chunk tipb.Chunk
 	var ran coprocessor.KeyRange
 	var finish bool
@@ -514,7 +524,7 @@ func (mock *mockCopStreamClient) readBlockFromExecutor() (tipb.Chunk, bool, *cop
 		row, err := mock.exec.Next(mock.ctx)
 		if err != nil {
 			ran.End, _ = mock.exec.Cursor()
-			return chunk, false, &ran, nil, errors.Trace(err)
+			return chunk, false, &ran, nil, nil, errors.Trace(err)
 		}
 		if row == nil {
 			finish = true
@@ -529,7 +539,9 @@ func (mock *mockCopStreamClient) readBlockFromExecutor() (tipb.Chunk, bool, *cop
 	if desc {
 		ran.Start, ran.End = ran.End, ran.Start
 	}
-	return chunk, finish, &ran, mock.exec.Counts(), nil
+	warnings := mock.dagCtx.evalCtx.sc.GetWarnings()
+	mock.dagCtx.evalCtx.sc.SetWarnings(nil)
+	return chunk, finish, &ran, mock.exec.Counts(), warnings, nil
 }
 
 func buildResp(chunks []tipb.Chunk, counts []int64, err error, warnings []error) *coprocessor.Response {


### PR DESCRIPTION
When using coprocessor streaming API, `warnings` field is not set in  `StreamResponse`.
This PR fix it.

@lamxTyler @zz-jason 