### PR TITLE
server: do not log on handshake error

### DIFF
--- a/metrics/server.go
+++ b/metrics/server.go
@@ -102,6 +102,15 @@ var (
 			Name:      "plan_cache_total",
 			Help:      "Counter of query using plan cache.",
 		}, []string{LblType})
+
+	HandShakeErrorCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "handshake_error_total",
+			Help:      "Counter of hand shake error.",
+		},
+	)
 )
 
 func init() {
@@ -114,6 +123,7 @@ func init() {
 	prometheus.MustRegister(TimeJumpBackCounter)
 	prometheus.MustRegister(KeepAliveCounter)
 	prometheus.MustRegister(PlanCacheCounter)
+	prometheus.MustRegister(HandShakeErrorCounter)
 }
 
 // ExecuteErrorToLabel converts an execute error to label.

--- a/server/server.go
+++ b/server/server.go
@@ -111,7 +111,6 @@ func (s *Server) releaseToken(token *Token) {
 // It allocates a connection ID and random salt data for authentication.
 func (s *Server) newConn(conn net.Conn) *clientConn {
 	cc := newClientConn(s)
-	log.Infof("[%d] new connection %s", cc.connectionID, conn.RemoteAddr().String())
 	if s.cfg.Performance.TCPKeepAlive {
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
 			if err := tcpConn.SetKeepAlive(true); err != nil {
@@ -293,19 +292,18 @@ func (s *Server) Close() {
 // onConn runs in its own goroutine, handles queries from this connection.
 func (s *Server) onConn(c net.Conn) {
 	conn := s.newConn(c)
-	defer func() {
-		log.Infof("[%d] close connection", conn.connectionID)
-	}()
-
 	if err := conn.handshake(); err != nil {
 		// Some keep alive services will send request to TiDB and disconnect immediately.
-		// So we use info log level.
-		log.Infof("handshake error %s", errors.ErrorStack(err))
+		// So we only record metrics.
+		metrics.HandShakeErrorCounter.Inc()
 		err = c.Close()
 		terror.Log(errors.Trace(err))
 		return
 	}
-
+	log.Infof("[%d] new connection %s", conn.connectionID, c.RemoteAddr().String())
+	defer func() {
+		log.Infof("[%d] close connection", conn.connectionID)
+	}()
 	s.rwlock.Lock()
 	s.clients[conn.connectionID] = conn
 	connections := len(s.clients)

--- a/terror/terror.go
+++ b/terror/terror.go
@@ -278,7 +278,7 @@ func (e *Error) getMySQLErrorCode() uint16 {
 	}
 	code, ok := codeMap[e.code]
 	if !ok {
-		log.Warnf("Unknown error class: %v code: %v", e.class, e.code)
+		log.Debugf("Unknown error class: %v code: %v", e.class, e.code)
 		return defaultMySQLErrorCode
 	}
 	return code


### PR DESCRIPTION
Load balancers connects to TiDB server and close immediately, we don't need to log them.