### PR TITLE
binloginfo: fix CI in unit test TestMaxRecvSize

### DIFF
--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -84,8 +84,12 @@ func DisableSkipBinlogFlag() {
 
 // SetIgnoreError sets the ignoreError flag, this function called when TiDB start
 // up and find config.Binlog.IgnoreError is true.
-func SetIgnoreError() {
-	atomic.StoreUint32(&ignoreError, 1)
+func SetIgnoreError(on bool) {
+	if on {
+		atomic.StoreUint32(&ignoreError, 1)
+	} else {
+		atomic.StoreUint32(&ignoreError, 0)
+	}
 }
 
 // WriteBinlog writes a binlog to Pump.

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -376,14 +376,12 @@ func (s *testBinlogSuite) TestIgnoreError(c *C) {
 	tk.MustExec("drop table if exists ignore_error")
 	tk.MustExec("create table t (id int)")
 
+	binloginfo.SetIgnoreError(true)
 	s.pump.mu.Lock()
 	s.pump.mu.mockFail = true
 	s.pump.mu.Unlock()
 
-	_, err := tk.Exec("insert into t values (1)")
-	c.Assert(err, NotNil)
-
-	binloginfo.SetIgnoreError()
+	tk.MustExec("insert into t values (1)")
 	tk.MustExec("insert into t values (1)")
 
 	// Clean up.
@@ -391,4 +389,5 @@ func (s *testBinlogSuite) TestIgnoreError(c *C) {
 	s.pump.mu.mockFail = false
 	s.pump.mu.Unlock()
 	binloginfo.DisableSkipBinlogFlag()
+	binloginfo.SetIgnoreError(false)
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -174,7 +174,7 @@ func setupBinlogClient() {
 	clientConn, err := session.DialPumpClientWithRetry(cfg.Binlog.BinlogSocket, util.DefaultMaxRetries, dialerOpt)
 	terror.MustNil(err)
 	if cfg.Binlog.IgnoreError {
-		binloginfo.SetIgnoreError()
+		binloginfo.SetIgnoreError(true)
 	}
 	binloginfo.SetPumpClient(binlog.NewPumpClient(clientConn))
 	log.Infof("created binlog client at %s, ignore error %v", cfg.Binlog.BinlogSocket, cfg.Binlog.IgnoreError)


### PR DESCRIPTION
`TestMaxRecvSize` failed because of some unexpected concurrency logic.
I adjust the test `TestIgnoreError` to avoid it.

```
Exec("insert...")   ...  it fails because we mock fail   @1

// our test begin
setIgnoreError()
MustExec("insert...")   ....  

// test finish, clean up
binloginfo.DisableSkipBinlogFlag()

// Well, there is a background 2pc clean up goroutine asynchronously, left by @1
// it set skipBinlog again !!
// Then TestMaxRecvSize fails
```