### PR TITLE
tidb-server: don't bind graceful shutdown to SIGTERM

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -435,7 +435,7 @@ func setupSignalHandler() {
 	go func() {
 		sig := <-sc
 		log.Infof("Got signal [%s] to exit.", sig)
-		if sig == syscall.SIGTERM {
+		if sig == syscall.SIGQUIT {
 			graceful = true
 		}
 


### PR DESCRIPTION
SIGTERM is the default kill command signal, it's better to bind it
with normal exit rather than graceful shutdown.

@winkyao @shenli @coocood 