### PR TITLE
tidb-server: don't bind graceful shutdown to SIGTERM (#6562)

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -436,7 +436,7 @@ func setupSignalHandler() {
 	go func() {
 		sig := <-sc
 		log.Infof("Got signal [%s] to exit.", sig)
-		if sig == syscall.SIGTERM {
+		if sig == syscall.SIGQUIT {
 			graceful = true
 		}
 


### PR DESCRIPTION
SIGTERM is the default kill command signal, it's better to bind it
with normal exit rather than graceful shutdown.

Cherry-pick to release 2.0

@winkyao @shenli 