### PR TITLE
Makefile: fix 'errcheck' after github.com/kisielk/errcheck is updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ goword:
 errcheck:
 	go get github.com/kisielk/errcheck
 	@echo "errcheck"
-	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -vE "_test\.go|Fprint" | awk '{print} END{if(NR>0) {exit 1}}'
+	@ GOPATH=$(GOPATH) errcheck  -ignore 'fmt:[FS]?[Pp]rint*' -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
 	go get golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ goword:
 errcheck:
 	go get github.com/kisielk/errcheck
 	@echo "errcheck"
-	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
+	@ GOPATH=$(GOPATH) errcheck -blank $(PACKAGES) | grep -vE "_test\.go|Fprint" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
 	go get golang.org/x/lint/golint

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ goword:
 errcheck:
 	go get github.com/kisielk/errcheck
 	@echo "errcheck"
-	@ GOPATH=$(GOPATH) errcheck  -ignore 'fmt:[FS]?[Pp]rint*' -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
+	@ GOPATH=$(GOPATH) errcheck -exclude errcheck_excludes.txt -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
 	go get golang.org/x/lint/golint

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,2 @@
+fmt.Fprintf
+fmt.Fprint

--- a/types/time.go
+++ b/types/time.go
@@ -630,7 +630,8 @@ func parseDatetime(str string, fsp int, isFloat bool) (Time, error) {
 				// 20170118.123423 => 2017-01-18 00:00:00
 			} else {
 				// '20170118.123423' => 2017-01-18 12:34:23.234
-				_, err = fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
+				_, err1 := fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
+				terror.Log(err1)
 			}
 		}
 	case 3:

--- a/types/time.go
+++ b/types/time.go
@@ -630,7 +630,7 @@ func parseDatetime(str string, fsp int, isFloat bool) (Time, error) {
 				// 20170118.123423 => 2017-01-18 00:00:00
 			} else {
 				// '20170118.123423' => 2017-01-18 12:34:23.234
-				fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
+				_, err = fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
 			}
 		}
 	case 3:


### PR DESCRIPTION
After the update of package `github.com/kisielk/errcheck` , CI would fail and complain:

```
explaintest end
gofmt (simplify)
go get github.com/kisielk/errcheck
errcheck
ast/expressions.go:98:12:	fmt.Fprint(w, s)
ast/expressions.go:149:12:	fmt.Fprint(w, " BETWEEN ")
ast/expressions.go:151:12:	fmt.Fprint(w, " AND ")
ast/expressions.go:198:12:	fmt.Fprint(w, " ")
ast/expressions.go:200:12:	fmt.Fprint(w, " ")
ast/expressions.go:271:12:	fmt.Fprint(w, "CASE ")
ast/expressions.go:273:12:	fmt.Fprint(w, " ")
ast/expressions.go:275:13:	fmt.Fprint(w, "WHEN ")
ast/expressions.go:277:13:	fmt.Fprint(w, " THEN ")
ast/expressions.go:281:13:	fmt.Fprint(w, " ELSE ")
ast/expressions.go:284:12:	fmt.Fprint(w, " END")
ast/expressions.go:468:13:	fmt.Fprintf(w, "`%s`", name)
ast/expressions.go:559:12:	fmt.Fprint(w, " IN (")
ast/expressions.go:563:14:	fmt.Fprint(w, ",")
ast/expressions.go:566:12:	fmt.Fprint(w, ")")
ast/expressions.go:611:13:	fmt.Fprint(w, " IS NOT NULL")
ast/expressions.go:614:12:	fmt.Fprint(w, " IS NULL")
ast/expressions.go:647:13:	fmt.Fprint(w, " IS NOT")
ast/expressions.go:649:13:	fmt.Fprint(w, " IS")
ast/expressions.go:652:13:	fmt.Fprint(w, " TRUE")
ast/expressions.go:654:13:	fmt.Fprint(w, " FALSE")
ast/expressions.go:692:12:	fmt.Fprint(w, " LIKE ")
ast/expressions.go:695:13:	fmt.Fprint(w, " ESCAPE ")
ast/expressions.go:696:14:	fmt.Fprintf(w, "'%c'", n.Escape)
ast/expressions.go:756:12:	fmt.Fprint(w, "(")
ast/expressions.go:758:12:	fmt.Fprint(w, ")")
```

I ignore the check of `Fprint` in the Makefile to fix this.

@coocood @zhexuany 