### PR TITLE
expression: set pb code for builtinArithmeticDivideDecimalSig

### DIFF
--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -583,6 +583,7 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDecimal, types.ETDecimal, types.ETDecimal)
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
 	sig := &builtinArithmeticDivideDecimalSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DivideDecimal)
 	return sig, nil
 }
 


### PR DESCRIPTION
## Main Modification

set pb code `ScalarFuncSig_DivideDecimal` for `builtinArithmeticDivideDecimalSig`


```sql
drop table if exists t;
create table t(a decimal(10, 2), b bigint);
insert into t values(1.3, 1);
```

To fix this panic in TiKV/mocktikv:
```sql
TiDB(localhost:4000) > select * from t where a/1 > 1;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```