### PR TITLE
model: adding a variable to aovid compatible issue

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -265,7 +265,7 @@ type PartitionInfo struct {
 type PartitionDefinition struct {
 	ID       int64    `json:"id"`
 	Name     string   `json:"name"`
-	LessThan []string `json:"lessthan"`
+	LessThan []string `json:"less_than"`
 	Comment  string   `json:"comment,omit_empty"`
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -121,7 +121,7 @@ type TableInfo struct {
 	// ShardRowIDBits specify if the implicit row ID is sharded.
 	ShardRowIDBits uint64
 
-	Partition *PartitionInfo
+	Partition *PartitionInfo `json:"partition"`
 }
 
 // GetUpdateTime gets the table's updating time.

--- a/model/model.go
+++ b/model/model.go
@@ -249,16 +249,16 @@ func (p PartitionType) String() string {
 
 // PartitionInfo provides table partition info.
 type PartitionInfo struct {
-	Type    PartitionType
-	Expr    string
-	Columns []CIStr
+	Type    PartitionType `json:"type"`
+	Expr    string        `json:"expr"`
+	Columns []CIStr       `json:"columns"`
 
 	// User may already creates table with partition but table partition is not
 	// yet supported back then. When Enable is true, write/read need use tid
 	// rather than pid.
-	Enable bool
+	Enable bool `json:"enable"`
 
-	Definitions []PartitionDefinition
+	Definitions []PartitionDefinition `json:"definitions"`
 }
 
 // PartitionDefinition defines a single partition.

--- a/model/model.go
+++ b/model/model.go
@@ -266,7 +266,7 @@ type PartitionDefinition struct {
 	ID       int64    `json:"id"`
 	Name     string   `json:"name"`
 	LessThan []string `json:"less_than"`
-	Comment  string   `json:"comment,omit_empty"`
+	Comment  string   `json:"comment,omitempty"`
 }
 
 // IndexColumn provides index column info.

--- a/model/model.go
+++ b/model/model.go
@@ -253,6 +253,11 @@ type PartitionInfo struct {
 	Expr    string
 	Columns []CIStr
 
+	// User may already creates table with partition but table partition is not
+	// yet supported back then. When UsedTID is true, write/read need use tid
+	// rather than pid.
+	UsedTID bool
+
 	Definitions []PartitionDefinition
 }
 

--- a/model/model.go
+++ b/model/model.go
@@ -254,9 +254,9 @@ type PartitionInfo struct {
 	Columns []CIStr
 
 	// User may already creates table with partition but table partition is not
-	// yet supported back then. When UsedTID is true, write/read need use tid
+	// yet supported back then. When Enable is true, write/read need use tid
 	// rather than pid.
-	UsedTID bool
+	Enable bool
 
 	Definitions []PartitionDefinition
 }

--- a/model/model.go
+++ b/model/model.go
@@ -266,7 +266,7 @@ type PartitionDefinition struct {
 	ID       int64    `json:"id"`
 	Name     string   `json:"name"`
 	LessThan []string `json:"lessthan"`
-	Comment  string   `json:"omit_empty"`
+	Comment  string   `json:"comment,omit_empty"`
 }
 
 // IndexColumn provides index column info.

--- a/model/model.go
+++ b/model/model.go
@@ -263,10 +263,10 @@ type PartitionInfo struct {
 
 // PartitionDefinition defines a single partition.
 type PartitionDefinition struct {
-	ID       int64
-	Name     string
-	LessThan []string
-	Comment  string `json:"omit_empty"`
+	ID       int64    `json:"id"`
+	Name     string   `json:"name"`
+	LessThan []string `json:"lessthan"`
+	Comment  string   `json:"omit_empty"`
 }
 
 // IndexColumn provides index column info.


### PR DESCRIPTION
Currently, table partition is not used.
Users may have created tables with partition info already.
If we start to write/read data with partition ID, the data in old table will be lost.
We need to find a way to make sure old table keeps read/write data with table ID,
Only new table use partition ID to read/write data.

By adding a bool value in `PartitionInfo`, we can force read/write operations use `tid` rather than `pid`. 