### PR TITLE
executor: fix a bug of duplicate key update

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1225,12 +1225,11 @@ func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*
 
 // fillBackKeys fills the updated key-value pair to the dupKeyValues for further check.
 func (e *InsertExec) fillBackKeys(fillBackKeysInRow []keyWithDupError, handle int64) {
-	filled := false
+	if len(fillBackKeysInRow) == 0 {
+		return
+	}
+	e.dupOldRowValues[string(e.Table.RecordKey(handle))] = fillBackKeysInRow[0].newRowValue
 	for _, insert := range fillBackKeysInRow {
-		if !filled {
-			e.dupOldRowValues[string(e.Table.RecordKey(handle))] = insert.newRowValue
-			filled = true
-		}
 		if insert.isRecordKey {
 			e.dupKeyValues[string(e.Table.RecordKey(handle))] = insert.newRowValue
 		} else {

--- a/executor/write.go
+++ b/executor/write.go
@@ -1225,8 +1225,12 @@ func (e *InsertExec) batchUpdateDupRows(newRows [][]types.Datum, onDuplicate []*
 
 // fillBackKeys fills the updated key-value pair to the dupKeyValues for further check.
 func (e *InsertExec) fillBackKeys(fillBackKeysInRow []keyWithDupError, handle int64) {
-	e.dupOldRowValues[string(e.Table.RecordKey(handle))] = fillBackKeysInRow[0].newRowValue
+	filled := false
 	for _, insert := range fillBackKeysInRow {
+		if !filled {
+			e.dupOldRowValues[string(e.Table.RecordKey(handle))] = insert.newRowValue
+			filled = true
+		}
 		if insert.isRecordKey {
 			e.dupKeyValues[string(e.Table.RecordKey(handle))] = insert.newRowValue
 		} else {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -576,6 +576,12 @@ commit;`
 	testSQL = `SELECT LAST_INSERT_ID();`
 	r = tk.MustQuery(testSQL)
 	r.Check(testkit.Rows("1"))
+
+	testSQL = `DROP TABLE IF EXISTS t1;
+	CREATE TABLE t1 (f1 INT);
+	INSERT t1 VALUES (1) ON DUPLICATE KEY UPDATE f1 = 1;`
+	tk.MustExec(testSQL)
+	tk.MustQuery(`SELECT * FROM t1;`).Check(testkit.Rows("1"))
 }
 
 func (s *testSuite) TestInsertIgnoreOnDup(c *C) {


### PR DESCRIPTION
When insert a row with on-duplicate-key update statement into a table which does not have any unique keys, the batch update operation miss a not-nil check.
PTAL @coocood @zz-jason 