### PR TITLE
expression: Fix the decimal fraction of `DIV`

### DIFF
--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -637,8 +637,10 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row types.Row) (*types.M
 	err = types.DecimalDiv(a, b, c, types.DivFracIncr)
 	if err == types.ErrDivByZero {
 		return c, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+	} else if err == nil {
+		err = c.Round(c, s.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven)
 	}
-	return c, false, err
+	return c, false, errors.Trace(err)
 }
 
 type arithmeticIntDivideFunctionClass struct {

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -638,7 +638,10 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row types.Row) (*types.M
 	if err == types.ErrDivByZero {
 		return c, true, errors.Trace(handleDivisionByZeroError(s.ctx))
 	} else if err == nil {
-		err = c.Round(c, s.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven)
+		_, frac := c.PrecisionAndFrac()
+		if frac < s.baseBuiltinFunc.tp.Decimal {
+			err = c.Round(c, s.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven)
+		}
 	}
 	return c, false, errors.Trace(err)
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2531,6 +2531,12 @@ func (s *testIntegrationSuite) TestArithmeticBuiltin(c *C) {
 	result = tk.MustQuery("select * from t where a/0 > 1")
 	result.Check(testkit.Rows())
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|Division by 0"))
+
+	tk.MustExec("USE test;")
+	tk.MustExec("DROP TABLE IF EXISTS t;")
+	tk.MustExec("CREATE TABLE t(a BIGINT, b DECIMAL(6, 2));")
+	tk.MustExec("INSERT INTO t VALUES(0, 1.12), (1, 1.21);")
+	tk.MustQuery("SELECT a/b FROM t;").Check(testkit.Rows("0.0000", "0.8264"))
 }
 
 func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {


### PR DESCRIPTION

```sql
drop table if exists t;
create table t(a bigint, b decimal(6, 2));
insert into t values(1, 1.12), (0, 1.12);
```
Before this PR:
```sql
TiDB(localhost:4000) > select a/b from t;
+--------+
| a/b    |
+--------+
| 0.8929 |
|      0 |
+--------+
2 rows in set (0.01 sec)
```
After This PR:
```sql
TiDB(localhost:4000) > select a/b from t;
+--------+
| a/b    |
+--------+
| 0.8929 |
| 0.0000 |
+--------+
2 rows in set (0.00 sec)
```

fix #6564