### PR TITLE
stats: fix estimation for between row count

### DIFF
--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -419,9 +419,11 @@ func (hg *Histogram) betweenRowCount(a, b types.Datum) float64 {
 	lessCountA := hg.lessRowCount(a)
 	lessCountB := hg.lessRowCount(b)
 	// If lessCountA is not less than lessCountB, it may be that they fall to the same bucket and we cannot estimate
-	// the fraction, so we use `totalCount / NDV` to estimate the row count, but the result should not greater than lessCountB.
+	// the fraction, so we use `totalCount / NDV` to estimate the row count, but the result should not greater than
+	// lessCountB or totalRowCount-lessCountA.
 	if lessCountA >= lessCountB && hg.NDV > 0 {
-		return math.Min(lessCountB, hg.totalRowCount()/float64(hg.NDV))
+		result := math.Min(lessCountB, hg.totalRowCount()-lessCountA)
+		return math.Min(result, hg.totalRowCount()/float64(hg.NDV))
 	}
 	return lessCountB - lessCountA
 }

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -172,7 +172,7 @@ func (s *testSelectivitySuite) TestSelectivity(c *C) {
 		},
 		{
 			exprs:       "a > 1 and b < 2 and c > 3 and d < 4 and e > 5",
-			selectivity: 0.00352249826,
+			selectivity: 0,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When estimating the row count for value in the range [a, b), the result should not greater than the row count in the range [a, +inf).
PTAL @coocood @winoros @fipped 