### PR TITLE
http: support change log level.

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -103,6 +103,13 @@ timezone.*
     curl -x POST -d "tidb_general_log=0" http://{TiDBIP}:10080/settings
     ```
 
+1. Change TiDB server log level
+
+    ```shell
+    curl -x POST -d "log_level=debug" http://{TiDBIP}:10080/settings
+    curl -x POST -d "log_level=info" http://{TiDBIP}:10080/settings
+    ```
+
 1. Get the column value by an encoded row and some information that can be obtained from a column of the table schema information. 
 
     Argument example: rowBin=base64_encoded_row_value

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -530,6 +530,15 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			writeError(w, err)
 			return
 		}
+		if levelStr := req.Form.Get("log_level"); levelStr != "" {
+			l, err1 := log.ParseLevel(levelStr)
+			if err1 != nil {
+				writeError(w, err1)
+				return
+			}
+			log.SetLevel(l)
+			config.GetGlobalConfig().Log.Level = levelStr
+		}
 		if generalLog := req.Form.Get("tidb_general_log"); generalLog != "" {
 			switch generalLog {
 			case "0":

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	log "github.com/sirupsen/logrus"
 )
 
 type HTTPHandlerTestSuite struct {
@@ -591,15 +592,21 @@ func (ts *HTTPHandlerTestSuite) TestPostSettings(c *C) {
 	ts.prepareData(c)
 	defer ts.stopServer(c)
 	form := make(url.Values)
+	form.Set("log_level", "error")
 	form.Set("tidb_general_log", "1")
 	resp, err := http.PostForm("http://127.0.0.1:10090/settings", form)
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	c.Assert(log.GetLevel(), Equals, log.ErrorLevel)
+	c.Assert(config.GetGlobalConfig().Log.Level, Equals, "error")
 	c.Assert(atomic.LoadUint32(&variable.ProcessGeneralLog), Equals, uint32(1))
 	form = make(url.Values)
+	form.Set("log_level", "info")
 	form.Set("tidb_general_log", "0")
 	resp, err = http.PostForm("http://127.0.0.1:10090/settings", form)
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	c.Assert(atomic.LoadUint32(&variable.ProcessGeneralLog), Equals, uint32(0))
+	c.Assert(log.GetLevel(), Equals, log.InfoLevel)
+	c.Assert(config.GetGlobalConfig().Log.Level, Equals, "info")
 }


### PR DESCRIPTION
So we don't need to restart the server to change the log level, useful for debug.