### PR TITLE
expression: fix wrong result of CEIL integer

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -521,7 +521,7 @@ func (b *builtinCeilIntToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, b
 		return nil, true, errors.Trace(err)
 	}
 
-	if mysql.HasUnsignedFlag(b.baseBuiltinFunc.tp.Flag) {
+	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) || val >= 0 {
 		return types.NewDecFromUint(uint64(val)), false, nil
 	}
 	return types.NewDecFromInt(val), false, nil

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -517,7 +517,14 @@ func (b *builtinCeilIntToDecSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_Ceil
 func (b *builtinCeilIntToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
-	return types.NewDecFromUint(uint64(val)), isNull, errors.Trace(err)
+	if isNull || err != nil {
+		return nil, true, errors.Trace(err)
+	}
+
+	if mysql.HasUnsignedFlag(b.baseBuiltinFunc.tp.Flag) {
+		return types.NewDecFromUint(uint64(val)), false, nil
+	}
+	return types.NewDecFromInt(val), false, nil
 }
 
 type builtinCeilDecToIntSig struct {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -382,6 +382,7 @@ func (s *testIntegrationSuite) TestMathBuiltin(c *C) {
 	tk.MustExec("insert into t values(2.99999999900000000000), (12), (0);")
 	tk.MustQuery("select a, ceil(a) from t where ceil(a) > 1;").Check(testkit.Rows("2.99999999900000000000 3", "12.00000000000000000000 12"))
 	tk.MustQuery("select a, ceil(a) from t;").Check(testkit.Rows("2.99999999900000000000 3", "12.00000000000000000000 12", "0.00000000000000000000 0"))
+	tk.MustQuery("select ceil(-29464);").Check(testkit.Rows("-29464"))
 
 	// for cot
 	result = tk.MustQuery("select cot(1), cot(-1), cot(NULL)")


### PR DESCRIPTION
before this PR:
```sql
TiDB(localhost:4000) > select ceil(-29464);
Field   1:  `ceil(-29464)`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       NEWDECIMAL
Collation:  binary (63)
Length:     7
Max_length: 20
Decimals:   0
Flags:      BINARY NUM


+----------------------+
| ceil(-29464)         |
+----------------------+
| 18446744073709522152 |
+----------------------+
1 row in set (0.00 sec)
```

after this PR:
```sql
TiDB(localhost:4000) > select ceil(-29464);
Field   1:  `ceil(-29464)`
Catalog:    `def`
Database:   ``
Table:      ``
Org_table:  ``
Type:       NEWDECIMAL
Collation:  binary (63)
Length:     7
Max_length: 6
Decimals:   0
Flags:      BINARY NUM


+--------------+
| ceil(-29464) |
+--------------+
|       -29464 |
+--------------+
1 row in set (0.01 sec)
```