### PR TITLE
expression: push CEIL down to TiKV

### DIFF
--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -288,6 +288,8 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinCeilIntToDecSig{base}
 	case tipb.ScalarFuncSig_CeilDecToInt:
 		f = &builtinCeilDecToIntSig{base}
+	case tipb.ScalarFuncSig_CeilDecToDec:
+		f = &builtinCeilDecToDecSig{base}
 	case tipb.ScalarFuncSig_CeilReal:
 		f = &builtinCeilRealSig{base}
 	case tipb.ScalarFuncSig_FloorIntToInt:

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -295,6 +295,8 @@ func (pc PbConverter) canFuncBePushed(sf *ScalarFunction) bool {
 		ast.Minus,
 		ast.Mul,
 		ast.Div,
+		ast.Ceil,
+		ast.Ceiling,
 
 		// control flow functions.
 		ast.Case,


### PR DESCRIPTION
before this PR:
```sql
TiDB(localhost:4000) > desc select * from t where ceil(a) > 10;
+---------------+-------------+---------------+------+----------------------------------------------+----------+
| id            | parents     | children      | task | operator info                                | count    |
+---------------+-------------+---------------+------+----------------------------------------------+----------+
| TableScan_6   |             |               | cop  | table:t, range:[-inf,+inf], keep order:false | 10000.00 |
| TableReader_7 | Selection_5 |               | root | data:TableScan_6                             | 10000.00 |
| Selection_5   |             | TableReader_7 | root | gt(ceil(test.t.a), 10)                       | 8000.00  |
+---------------+-------------+---------------+------+----------------------------------------------+----------+
3 rows in set (0.00 sec)
```

after this PR:
```sql
TiDB(localhost:4000) > desc select * from t where ceil(a) > 10;
+---------------+-------------+-------------+------+----------------------------------------------+----------+
| id            | parents     | children    | task | operator info                                | count    |
+---------------+-------------+-------------+------+----------------------------------------------+----------+
| TableScan_5   | Selection_6 |             | cop  | table:t, range:[-inf,+inf], keep order:false | 10000.00 |
| Selection_6   |             | TableScan_5 | cop  | gt(ceil(test.t.a), 10)                       | 8000.00  |
| TableReader_7 |             |             | root | data:Selection_6                             | 8000.00  |
+---------------+-------------+-------------+------+----------------------------------------------+----------+
3 rows in set (0.00 sec)
```