### PR TITLE
plan: make the cost more resonable.

### DIFF
--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -264,7 +264,11 @@ func (s *testAnalyzeSuite) TestIndexRead(c *C) {
 		},
 		{
 			sql:  "select count(e) from t where t.b <= 50",
-			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)])->StreamAgg)->StreamAgg",
+			best: "IndexLookUp(Index(t.b)[[-inf,50]], Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(e) from t where t.b <= 100000000000",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 100000000000)])->StreamAgg)->StreamAgg",
 		},
 		{
 			sql:  "select * from t where t.b <= 40",
@@ -272,12 +276,16 @@ func (s *testAnalyzeSuite) TestIndexRead(c *C) {
 		},
 		{
 			sql:  "select * from t where t.b <= 50",
-			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)]))",
+			best: "IndexLookUp(Index(t.b)[[-inf,50]], Table(t))",
+		},
+		{
+			sql:  "select * from t where t.b <= 10000000000",
+			best: "TableReader(Table(t)->Sel([le(test.t.b, 10000000000)]))",
 		},
 		// test panic
 		{
 			sql:  "select * from t where 1 and t.b <= 50",
-			best: "TableReader(Table(t)->Sel([le(test.t.b, 50)]))",
+			best: "IndexLookUp(Index(t.b)[[-inf,50]], Table(t))",
 		},
 		{
 			sql:  "select * from t where t.b <= 100 order by t.a limit 1",

--- a/plan/physical_plan_builder.go
+++ b/plan/physical_plan_builder.go
@@ -403,19 +403,19 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	// Add filter condition to table plan now.
 	indexConds, tableConds := path.indexFilters, path.tableFilters
 	if indexConds != nil {
+		copTask.cst += copTask.count() * cpuFactor
 		stats := &statsInfo{count: path.countAfterIndex}
 		indexSel := PhysicalSelection{Conditions: indexConds}.init(is.ctx,
 			stats.scaleByExpectCnt(expectedCnt))
 		indexSel.SetChildren(is)
 		copTask.indexPlan = indexSel
-		copTask.cst += copTask.count() * cpuFactor
 	}
 	if tableConds != nil {
 		copTask.finishIndexPlan()
+		copTask.cst += copTask.count() * cpuFactor
 		tableSel := PhysicalSelection{Conditions: tableConds}.init(is.ctx, p.statsAfterSelect.scaleByExpectCnt(expectedCnt))
 		tableSel.SetChildren(copTask.tablePlan)
 		copTask.tablePlan = tableSel
-		copTask.cst += copTask.count() * cpuFactor
 	}
 }
 
@@ -567,10 +567,9 @@ func (ds *DataSource) convertToTableScan(prop *requiredProp, path *accessPath) (
 func (ts *PhysicalTableScan) addPushedDownSelection(copTask *copTask, stats *statsInfo) {
 	// Add filter condition to table plan now.
 	if len(ts.filterCondition) > 0 {
+		copTask.cst += copTask.count() * cpuFactor
 		sel := PhysicalSelection{Conditions: ts.filterCondition}.init(ts.ctx, stats)
 		sel.SetChildren(ts)
 		copTask.tablePlan = sel
-		// FIXME: It seems wrong...
-		copTask.cst += copTask.count() * cpuFactor
 	}
 }


### PR DESCRIPTION
The cost of `Selection` should be `row count before selection` * `cpuFactor`. Instead of `row count after selection` * `cpuFactor`.
PTAL @zz-jason @XuHuaiyu @lamxTyler 