### PR TITLE
server: do not log write error during hand shake. (#6605)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -124,7 +124,9 @@ func (cc *clientConn) handshake() error {
 	}
 	if err := cc.readOptionalSSLRequestAndHandshakeResponse(); err != nil {
 		err1 := cc.writeError(err)
-		terror.Log(errors.Trace(err1))
+		if err1 != nil {
+			log.Debug(err1)
+		}
 		return errors.Trace(err)
 	}
 	data := cc.alloc.AllocWithLen(4, 32)


### PR DESCRIPTION
If the handshake failed, we write error message to the connection, if the write returns error, we don't need to log it.