### PR TITLE
expression: fix wrong result of floor

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -702,7 +702,14 @@ func (b *builtinFloorIntToDecSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_floor
 func (b *builtinFloorIntToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
-	return types.NewDecFromUint(uint64(val)), isNull, errors.Trace(err)
+	if isNull || err != nil {
+		return nil, true, errors.Trace(err)
+	}
+
+	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) || val >= 0 {
+		return types.NewDecFromUint(uint64(val)), false, nil
+	}
+	return types.NewDecFromInt(val), false, nil
 }
 
 type builtinFloorDecToIntSig struct {
@@ -747,20 +754,22 @@ func (b *builtinFloorDecToDecSig) Clone() builtinFunc {
 func (b *builtinFloorDecToDecSig) evalDecimal(row types.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
-	}
-	if val.GetDigitsFrac() > 0 && val.IsNegative() {
-		err = types.DecimalSub(val, types.NewDecFromInt(1), val)
-		if err != nil {
-			return nil, true, errors.Trace(err)
-		}
-	}
-	res := new(types.MyDecimal)
-	err = val.Round(res, 0, types.ModeTruncate)
-	if err != nil {
 		return nil, true, errors.Trace(err)
 	}
-	return res, false, nil
+
+	res := new(types.MyDecimal)
+	if !val.IsNegative() {
+		err = val.Round(res, 0, types.ModeTruncate)
+		return res, err != nil, errors.Trace(err)
+	}
+
+	err = val.Round(res, 0, types.ModeTruncate)
+	if err != nil || res.Compare(val) == 0 {
+		return res, err != nil, errors.Trace(err)
+	}
+
+	err = types.DecimalSub(res, types.NewDecFromInt(1), res)
+	return res, err != nil, errors.Trace(err)
 }
 
 type logFunctionClass struct {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -383,6 +383,9 @@ func (s *testIntegrationSuite) TestMathBuiltin(c *C) {
 	tk.MustQuery("select a, ceil(a) from t where ceil(a) > 1;").Check(testkit.Rows("2.99999999900000000000 3", "12.00000000000000000000 12"))
 	tk.MustQuery("select a, ceil(a) from t;").Check(testkit.Rows("2.99999999900000000000 3", "12.00000000000000000000 12", "0.00000000000000000000 0"))
 	tk.MustQuery("select ceil(-29464);").Check(testkit.Rows("-29464"))
+	tk.MustQuery("select a, floor(a) from t where floor(a) > 1;").Check(testkit.Rows("2.99999999900000000000 2", "12.00000000000000000000 12"))
+	tk.MustQuery("select a, floor(a) from t;").Check(testkit.Rows("2.99999999900000000000 2", "12.00000000000000000000 12", "0.00000000000000000000 0"))
+	tk.MustQuery("select floor(-29464);").Check(testkit.Rows("-29464"))
 
 	// for cot
 	result = tk.MustQuery("select cot(1), cot(-1), cot(NULL)")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -387,6 +387,12 @@ func (s *testIntegrationSuite) TestMathBuiltin(c *C) {
 	tk.MustQuery("select a, floor(a) from t;").Check(testkit.Rows("2.99999999900000000000 2", "12.00000000000000000000 12", "0.00000000000000000000 0"))
 	tk.MustQuery("select floor(-29464);").Check(testkit.Rows("-29464"))
 
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t(a decimal(40,20), b bigint);`)
+	tk.MustExec(`insert into t values(-2.99999990000000000000, -1);`)
+	tk.MustQuery(`select floor(a), floor(a), floor(a) from t;`).Check(testkit.Rows(`-3 -3 -3`))
+	tk.MustQuery(`select b, floor(b) from t;`).Check(testkit.Rows(`-1 -1`))
+
 	// for cot
 	result = tk.MustQuery("select cot(1), cot(-1), cot(NULL)")
 	result.Check(testkit.Rows("0.6420926159343308 -0.6420926159343308 <nil>"))


### PR DESCRIPTION
fix #6595 

```sql
drop table if exists t;
create table t(a decimal(40,20), b bigint);
insert into t values(-2.99999990000000000000, -1);
```

Before this PR:
```sql
TiDB(localhost:4000) > select floor(a), floor(a), floor(a) from t;
+----------+----------+----------+
| floor(a) | floor(a) | floor(a) |
+----------+----------+----------+
|       -3 |       -4 |       -5 |
+----------+----------+----------+
1 row in set (0.00 sec)

TiDB(localhost:4000) > select b, floor(b) from t;
+------+----------------------+
| b    | floor(b)             |
+------+----------------------+
|   -1 | 18446744073709551615 |
+------+----------------------+
1 row in set (0.00 sec)
```

After this PR:
```sql
TiDB(localhost:4000) > select floor(a), floor(a), floor(a) from t;
+----------+----------+----------+
| floor(a) | floor(a) | floor(a) |
+----------+----------+----------+
|       -3 |       -3 |       -3 |
+----------+----------+----------+
1 row in set (0.01 sec)

TiDB(localhost:4000) > select b, floor(b) from t;
+------+----------+
| b    | floor(b) |
+------+----------+
|   -1 |       -1 |
+------+----------+
1 row in set (0.00 sec)
```