### PR TITLE
expression: refine compare timestamp col with string constant

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -962,6 +962,9 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 			cmpType = lhsFieldType.EvalType()
 		} else {
 			cmpType = types.ETDatetime
+			if lhsFieldType.EvalType() == types.ETTimestamp || rhsFieldType.EvalType() == types.ETTimestamp {
+				cmpType = types.ETTimestamp
+			}
 		}
 	} else if lhsFieldType.Tp == mysql.TypeDuration && rhsFieldType.Tp == mysql.TypeDuration {
 		// duration <cmp> duration

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2705,6 +2705,12 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec("create table t(a bigint unsigned)")
 	tk.MustExec("insert into t value(17666000000000000000)")
 	tk.MustQuery("select * from t where a = 17666000000000000000").Check(testkit.Rows("17666000000000000000"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a timestamp)")
+	tk.MustExec("insert into t value('1991-05-06 04:59:28')")
+	tk.MustExec("delete from t where a = '1991-05-06 04:59:28'")
+	tk.MustQuery("select * from t").Check(testkit.Rows())
 }
 
 func (s *testIntegrationSuite) TestAggregationBuiltin(c *C) {


### PR DESCRIPTION
When comparing a timestamp column with a non-time constant,
they should be compared as timestamp rather than datetime since
timezone should be considered.

PTAL @winkyao @zz-jason 