### PR TITLE
types:check correctness of decimal's exponent part

### DIFF
--- a/types/helper.go
+++ b/types/helper.go
@@ -128,12 +128,17 @@ func myMinInt8(a, b int8) int8 {
 	return b
 }
 
+const (
+	maxUint    = uint64(math.MaxUint64)
+	uintCutOff = maxUint/uint64(10) + 1
+	intCutOff  = uint64(math.MaxInt64) + 1
+)
+
 // strToInt converts a string to an integer in best effort.
-// TODO: handle overflow and add unittest.
 func strToInt(str string) (int64, error) {
 	str = strings.TrimSpace(str)
 	if len(str) == 0 {
-		return 0, nil
+		return 0, ErrTruncated
 	}
 	negative := false
 	i := 0
@@ -143,16 +148,47 @@ func strToInt(str string) (int64, error) {
 	} else if str[i] == '+' {
 		i++
 	}
-	r := int64(0)
+
+	var (
+		err    error
+		hasNum = false
+	)
+	r := uint64(0)
 	for ; i < len(str); i++ {
 		if !unicode.IsDigit(rune(str[i])) {
+			err = ErrTruncated
 			break
 		}
-		r = r*10 + int64(str[i]-'0')
+		hasNum = true
+		if r >= uintCutOff {
+			r = 0
+			err = ErrBadNumber
+			break
+		}
+		r = r * uint64(10)
+
+		r1 := r + uint64(str[i]-'0')
+		if r1 < r || r1 > maxUint {
+			r = 0
+			err = ErrBadNumber
+			break
+		}
+		r = r1
 	}
+	if !hasNum {
+		err = ErrTruncated
+	}
+
+	if !negative && r >= intCutOff {
+		return math.MaxInt64, ErrBadNumber
+	}
+
+	if negative && r > intCutOff {
+		return math.MinInt64, ErrBadNumber
+	}
+
 	if negative {
 		r = -r
 	}
-	// TODO: if i < len(str), we should return an error.
-	return r, nil
+	return int64(r), err
 }

--- a/types/helper.go
+++ b/types/helper.go
@@ -162,7 +162,7 @@ func strToInt(str string) (int64, error) {
 		hasNum = true
 		if r >= uintCutOff {
 			r = 0
-			err = ErrBadNumber
+			err = errors.Trace(ErrBadNumber)
 			break
 		}
 		r = r * uint64(10)
@@ -170,7 +170,7 @@ func strToInt(str string) (int64, error) {
 		r1 := r + uint64(str[i]-'0')
 		if r1 < r || r1 > maxUint {
 			r = 0
-			err = ErrBadNumber
+			err = errors.Trace(ErrBadNumber)
 			break
 		}
 		r = r1
@@ -180,11 +180,11 @@ func strToInt(str string) (int64, error) {
 	}
 
 	if !negative && r >= intCutOff {
-		return math.MaxInt64, ErrBadNumber
+		return math.MaxInt64, errors.Trace(ErrBadNumber)
 	}
 
 	if negative && r > intCutOff {
-		return math.MinInt64, ErrBadNumber
+		return math.MinInt64, errors.Trace(ErrBadNumber)
 	}
 
 	if negative {

--- a/types/helper_test.go
+++ b/types/helper_test.go
@@ -1,0 +1,45 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"strconv"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testTypeHelperSuite{})
+
+type testTypeHelperSuite struct {
+}
+
+func (s *testTypeHelperSuite) TestStrToInt(c *C) {
+	tests := []struct {
+		input  string
+		output string
+		err    error
+	}{
+		{"9223372036854775806", "9223372036854775806", nil},
+		{"9223372036854775807", "9223372036854775807", nil},
+		{"9223372036854775808", "9223372036854775807", ErrBadNumber},
+		{"-9223372036854775807", "-9223372036854775807", nil},
+		{"-9223372036854775808", "-9223372036854775808", nil},
+		{"-9223372036854775809", "-9223372036854775808", ErrBadNumber},
+	}
+	for _, tt := range tests {
+		output, err := strToInt(tt.input)
+		c.Assert(err, Equals, tt.err)
+		c.Check(strconv.FormatInt(output, 10), Equals, tt.output)
+	}
+}

--- a/types/helper_test.go
+++ b/types/helper_test.go
@@ -16,6 +16,7 @@ package types
 import (
 	"strconv"
 
+	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 )
 
@@ -39,7 +40,7 @@ func (s *testTypeHelperSuite) TestStrToInt(c *C) {
 	}
 	for _, tt := range tests {
 		output, err := strToInt(tt.input)
-		c.Assert(err, Equals, tt.err)
+		c.Assert(errors.Cause(err), Equals, tt.err)
 		c.Check(strconv.FormatInt(output, 10), Equals, tt.output)
 	}
 }

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -394,7 +394,7 @@ func (d *MyDecimal) FromString(str []byte) error {
 	if endIdx+1 <= len(str) && (str[endIdx] == 'e' || str[endIdx] == 'E') {
 		exponent, err1 := strToInt(string(str[endIdx+1:]))
 		if err1 != nil {
-			err = err1
+			err = errors.Cause(err1)
 			if err != ErrTruncated {
 				*d = zeroMyDecimal
 			}

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -391,23 +391,30 @@ func (d *MyDecimal) FromString(str []byte) error {
 	if innerIdx != 0 {
 		d.wordBuf[wordIdx] = word * powers10[digitsPerWord-innerIdx]
 	}
-	if endIdx+1 < len(str) && (str[endIdx] == 'e' || str[endIdx] == 'E') {
+	if endIdx+1 <= len(str) && (str[endIdx] == 'e' || str[endIdx] == 'E') {
 		exponent, err1 := strToInt(string(str[endIdx+1:]))
-		// TODO: need a way to check if there is at least one digit.
 		if err1 != nil {
-			*d = zeroMyDecimal
-			return ErrBadNumber
+			err = err1
+			if err != ErrTruncated {
+				*d = zeroMyDecimal
+			}
 		}
 		if exponent > math.MaxInt32/2 {
-			*d = zeroMyDecimal
-			return ErrOverflow
+			maxDecimal(wordBufLen*digitsPerWord, 0, d)
+			err = ErrOverflow
 		}
 		if exponent < math.MinInt32/2 && err != ErrOverflow {
 			*d = zeroMyDecimal
-			return ErrTruncated
+			err = ErrTruncated
 		}
 		if err != ErrOverflow {
-			err = d.Shift(int(exponent))
+			shiftErr := d.Shift(int(exponent))
+			if shiftErr != nil {
+				if shiftErr == ErrOverflow {
+					maxDecimal(wordBufLen*digitsPerWord, 0, d)
+				}
+				err = shiftErr
+			}
 		}
 	}
 	allZero := true

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -380,13 +380,21 @@ func (s *testMyDecimalSuite) TestFromString(c *C) {
 		{"1234500009876.5", "1234500009876.5", nil},
 		{"123E5", "12300000", nil},
 		{"123E-2", "1.23", nil},
+		{"1e1073741823", "999999999999999999999999999999999999999999999999999999999999999999999999999999999", ErrOverflow},
+		{"1e18446744073709551620", "0", ErrBadNumber},
+		{"1e", "1", ErrTruncated},
+		{"1e001", "10", nil},
+		{"1e00", "1", nil},
+		{"1eabc", "1", ErrTruncated},
+		{"1e 1dddd ", "10", ErrTruncated},
+		{"1e - 1", "1", ErrTruncated},
+		{"1e -1", "0.1", nil},
 	}
 	for _, ca := range tests {
 		var dec MyDecimal
 		err := dec.FromString([]byte(ca.input))
-		c.Check(err, Equals, ca.err)
+		c.Check(err, Equals, ca.err, Commentf("input: %s", ca.input))
 		result := dec.ToString()
-		c.Check(err, IsNil)
 		c.Check(string(result), Equals, ca.output, Commentf("dec:%s", dec.String()))
 	}
 	wordBufLen = 1


### PR DESCRIPTION
### fix int overflow

```
drop table if exists t1;
create table `t1` (`a` decimal(10,2));
insert into t1 values ("1e+18446744073709551616")
```

expect:
```
ERROR 1366 (HY000): Incorrect decimal value: '1e+18446744073709551616' for column 'a' at row 1
```

but got:
```
Query OK, 1 row affected (0.01 sec)

mysql> select * from t1;
+------+
| a    |
+------+
| 1.00 |
+------+
```
The issue is cause by exponent part overflow int max.

### fix empty exponent

in this issue we also will fix

```
insert into t1 values ("123.4e")
```

expect:
```
ERROR 1366 (HY000): Incorrect decimal value: '123.4e' for column 'a' at row 1
```

but got
```
Query OK, 1 row affected, 1 warning (0.01 sec)
```


