### PR TITLE
plan: fix a bug in `rebuildRange` when enabling prepare-plan-cache.

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -26,6 +26,10 @@ import (
 func (s *testSuite) TestPrepared(c *C) {
 	orgEnable := plan.PreparedPlanCacheEnabled
 	orgCapacity := plan.PreparedPlanCacheCapacity
+	defer func() {
+		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.PreparedPlanCacheCapacity = orgCapacity
+	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
@@ -177,13 +181,15 @@ func (s *testSuite) TestPrepared(c *C) {
 		exec.Next(ctx, nil)
 		exec.Close()
 	}
-	plan.PreparedPlanCacheEnabled = orgEnable
-	plan.PreparedPlanCacheCapacity = orgCapacity
 }
 
 func (s *testSuite) TestPreparedLimitOffset(c *C) {
 	orgEnable := plan.PreparedPlanCacheEnabled
 	orgCapacity := plan.PreparedPlanCacheCapacity
+	defer func() {
+		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.PreparedPlanCacheCapacity = orgCapacity
+	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
@@ -211,13 +217,15 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, 1)
 		c.Assert(err, IsNil)
 	}
-	plan.PreparedPlanCacheEnabled = orgEnable
-	plan.PreparedPlanCacheCapacity = orgCapacity
 }
 
 func (s *testSuite) TestPreparedNullParam(c *C) {
 	orgEnable := plan.PreparedPlanCacheEnabled
 	orgCapacity := plan.PreparedPlanCacheCapacity
+	defer func() {
+		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.PreparedPlanCacheCapacity = orgCapacity
+	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
 		plan.PreparedPlanCacheEnabled = flag
@@ -245,8 +253,6 @@ func (s *testSuite) TestPreparedNullParam(c *C) {
 		r = tk.MustQuery(`execute stmt using @id;`)
 		r.Check(testkit.Rows("1"))
 	}
-	plan.PreparedPlanCacheEnabled = orgEnable
-	plan.PreparedPlanCacheCapacity = orgCapacity
 }
 
 func (s *testSuite) TestPreparedNameResolver(c *C) {

--- a/plan/common_plans.go
+++ b/plan/common_plans.go
@@ -208,11 +208,10 @@ func (e *Execute) rebuildRange(p Plan) error {
 	switch x := p.(type) {
 	case *PhysicalTableReader:
 		ts := x.TablePlans[0].(*PhysicalTableScan)
-		cols := expression.ColumnInfos2ColumnsWithDBName(ts.DBName, ts.Table.Name, ts.Columns)
 		var pkCol *expression.Column
 		if ts.Table.PKIsHandle {
 			if pkColInfo := ts.Table.GetPkColInfo(); pkColInfo != nil {
-				pkCol = expression.ColInfo2Col(cols, pkColInfo)
+				pkCol = expression.ColInfo2Col(x.schema.Columns, pkColInfo)
 			}
 		}
 		if pkCol != nil {
@@ -227,14 +226,14 @@ func (e *Execute) rebuildRange(p Plan) error {
 	case *PhysicalIndexReader:
 		is := x.IndexPlans[0].(*PhysicalIndexScan)
 		var err error
-		is.Ranges, err = e.buildRangeForIndexScan(sctx, is)
+		is.Ranges, err = e.buildRangeForIndexScan(sctx, is, x.schema)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	case *PhysicalIndexLookUpReader:
 		is := x.IndexPlans[0].(*PhysicalIndexScan)
 		var err error
-		is.Ranges, err = e.buildRangeForIndexScan(sctx, is)
+		is.Ranges, err = e.buildRangeForIndexScan(sctx, is, x.schema)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -250,9 +249,8 @@ func (e *Execute) rebuildRange(p Plan) error {
 	return nil
 }
 
-func (e *Execute) buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan) ([]*ranger.Range, error) {
-	cols := expression.ColumnInfos2ColumnsWithDBName(is.DBName, is.Table.Name, is.Columns)
-	idxCols, colLengths := expression.IndexInfo2Cols(cols, is.Index)
+func (e *Execute) buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan, schema *expression.Schema) ([]*ranger.Range, error) {
+	idxCols, colLengths := expression.IndexInfo2Cols(schema.Columns, is.Index)
 	ranges := ranger.FullRange()
 	if len(idxCols) > 0 {
 		var err error


### PR DESCRIPTION
It cannot build range successfully if the plan is an index plan.
PTAL @lamxTyler @zz-jason @XuHuaiyu @jackysp 