### PR TITLE
expression: update expr's type as ts only if one side being ts and another side being string.

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -962,9 +962,13 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 			cmpType = lhsFieldType.EvalType()
 		} else {
 			cmpType = types.ETDatetime
-			if lhsFieldType.EvalType() == types.ETTimestamp || rhsFieldType.EvalType() == types.ETTimestamp {
+			if lhsFieldType.EvalType() == types.ETTimestamp && rhsFieldType.EvalType() == types.ETString {
 				cmpType = types.ETTimestamp
 			}
+			if lhsFieldType.EvalType() == types.ETString && rhsFieldType.EvalType() == types.ETTimestamp {
+				cmpType = types.ETTimestamp
+			}
+
 		}
 	} else if lhsFieldType.Tp == mysql.TypeDuration && rhsFieldType.Tp == mysql.TypeDuration {
 		// duration <cmp> duration

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -195,17 +195,17 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinNullEQDecimalSig{base}
 
 	case tipb.ScalarFuncSig_GTTime:
-		f = &builtinGTTimeSig{base}
+		f = &builtinGTTimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_GETime:
-		f = &builtinGETimeSig{base}
+		f = &builtinGETimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_LTTime:
-		f = &builtinLTTimeSig{base}
+		f = &builtinLTTimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_LETime:
-		f = &builtinLETimeSig{base}
+		f = &builtinLETimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_EQTime:
-		f = &builtinEQTimeSig{base}
+		f = &builtinEQTimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_NETime:
-		f = &builtinNETimeSig{base}
+		f = &builtinNETimeSig{base, types.ETDatetime}
 	case tipb.ScalarFuncSig_NullEQTime:
 		f = &builtinNullEQTimeSig{base}
 


### PR DESCRIPTION
This fixes a bug bought by https://github.com/pingcap/tidb/pull/6621. As we all know, ts has max value: 2038. When we convert some datetime beyond this value to ts, a invalid time format error will be thrown. So we need use a finer coarse to update expr's type as ts. 

I will file another pr to add ts boundary related test. 