### PR TITLE
plan: check error encountered in the function "buildResultSetNode"

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2953,6 +2953,14 @@ func (s *testIntegrationSuite) TestIssue4954(c *C) {
 	r.Check(testkit.Rows("F6"))
 }
 
+func (s *testIntegrationSuite) TestUnsupportedUDF(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	defer s.cleanEnv(c)
+	_, err := tk.Exec("select * from (select udf_xx(1) as a) t1 join (select udf_xx(2) as a) t2 on t1.a=t2.a;")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[expression:1305]FUNCTION udf_xx does not exist")
+}
+
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := tikv.NewMockTikvStore()
 	if err != nil {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -225,7 +225,15 @@ func (b *planBuilder) buildJoin(join *ast.Join) LogicalPlan {
 	}
 	b.optFlag = b.optFlag | flagPredicatePushDown
 	leftPlan := b.buildResultSetNode(join.Left)
+	if b.err != nil {
+		b.err = errors.Trace(b.err)
+		return nil
+	}
 	rightPlan := b.buildResultSetNode(join.Right)
+	if b.err != nil {
+		b.err = errors.Trace(b.err)
+		return nil
+	}
 	leftAlias := extractTableAlias(leftPlan)
 	rightAlias := extractTableAlias(rightPlan)
 


### PR DESCRIPTION
before this PR, executing the following sql will cause a panic in tidb-server:
```sql
select * from (select udf_xx(1) as a) t1 join (select udf_xx(2) as a) t2 on t1.a=t2.a;
```

This PR fixes this by handle the error after calling `buildResultSetNode`