### PR TITLE
Makefile: fix 'errcheck' after github.com/kisielk/errcheck is updated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ goword:
 
 errcheck:
 	go get github.com/kisielk/errcheck
-	@ GOPATH=$(CURDIR)/_vendor:$(GOPATH) errcheck -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
+	@ GOPATH=$(CURDIR)/_vendor:$(GOPATH) errcheck -exclude errcheck_excludes.txt -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 clean:
 	$(GO) clean -i ./...
@@ -126,7 +126,7 @@ leak: parserlib
 tikv_integration_test: parserlib
 	$(GOTEST) ./store/tikv/. -with-tikv=true
 
-RACE_FLAG = 
+RACE_FLAG =
 ifeq ("$(WITH_RACE)", "1")
 	RACE_FLAG = -race
 	GOBUILD   = GOPATH=$(CURDIR)/_vendor:$(GOPATH) CGO_ENABLED=1 $(GO) build

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,2 @@
+fmt.Fprintf
+fmt.Fprint

--- a/util/types/time.go
+++ b/util/types/time.go
@@ -659,7 +659,8 @@ func parseDatetime(str string, fsp int, isFloat bool) (Time, error) {
 				// 20170118.123423 => 2017-01-18 00:00:00
 			} else {
 				// '20170118.123423' => 2017-01-18 12:34:23.234
-				fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
+				_, err1 := fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
+				terror.Log(err1)
 			}
 		}
 	case 3:


### PR DESCRIPTION
Since the branch "master" differs too much to the branch "release-1.0", I rewritten the code in https://github.com/pingcap/tidb/pull/6574 to "release-1.0" manually.