### PR TITLE
Executor: fix affected rows count when update

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -165,7 +165,10 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 	if onDup {
 		sc.AddAffectedRows(2)
 	} else {
-		sc.AddAffectedRows(1)
+		// if handleChanged == true, the `affectedRows` is calculated when add new record.
+		if !handleChanged {
+			sc.AddAffectedRows(1)
+		}
 	}
 	colSize := make(map[int64]int64)
 	for id, col := range t.Cols() {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1611,3 +1611,20 @@ func (s *testSuite) TestUpdateSelect(c *C) {
 	tk.MustExec("UPDATE msg SET msg.status = (SELECT detail.status FROM detail WHERE msg.id = detail.id)")
 	tk.MustExec("admin check table msg")
 }
+
+func (s *testSuite) TestUpdateAffectRowCnt(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table a(id int auto_increment, a int default null, primary key(id))")
+	tk.MustExec("insert into a values (1, 1001), (2, 1001), (10001, 1), (3, 1)")
+	tk.MustExec("update a set id = id*10 where a = 1001")
+	ctx := tk.Se.(sessionctx.Context)
+	c.Assert(ctx.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(2))
+
+	tk.MustExec("drop table a")
+	tk.MustExec("create table a ( a bigint, b bigint)")
+	tk.MustExec("insert into a values (1, 1001), (2, 1001), (10001, 1), (3, 1)")
+	tk.MustExec("update a set a = a*10 where b = 1001")
+	ctx = tk.Se.(sessionctx.Context)
+	c.Assert(ctx.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(2))
+}


### PR DESCRIPTION
Fix #6640 