### PR TITLE
executor: refactor insert_common

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -244,7 +244,7 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 	// Check if "tidb_snapshot" is set for the write executors.
 	// In history read mode, we can not do write operations.
 	switch e.(type) {
-	case *DeleteExec, *InsertExec, *UpdateExec, *ReplaceExec, *LoadData, *DDLExec:
+	case *DeleteExec, *InsertExec, *UpdateExec, *ReplaceExec, *LoadDataExec, *DDLExec:
 		snapshotTS := sctx.GetSessionVars().SnapshotTS
 		if snapshotTS != 0 {
 			return nil, errors.New("can not execute write statement when 'tidb_snapshot' is set")

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -547,7 +547,7 @@ func (b *executorBuilder) buildLoadData(v *plan.LoadData) Executor {
 		b.err = errors.Trace(err)
 		return nil
 	}
-	loadDataExec := &LoadData{
+	loadDataExec := &LoadDataExec{
 		baseExecutor: newBaseExecutor(b.ctx, nil, v.ExplainID()),
 		IsLocal:      v.IsLocal,
 		loadDataInfo: &LoadDataInfo{

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -28,6 +28,62 @@ import (
 	"golang.org/x/net/context"
 )
 
+// LoadDataExec represents a load data executor.
+type LoadDataExec struct {
+	baseExecutor
+
+	IsLocal      bool
+	loadDataInfo *LoadDataInfo
+}
+
+// NewLoadDataInfo returns a LoadDataInfo structure, and it's only used for tests now.
+func NewLoadDataInfo(ctx sessionctx.Context, row []types.Datum, tbl table.Table, cols []*table.Column) *LoadDataInfo {
+	insertVal := &InsertValues{baseExecutor: newBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
+	return &LoadDataInfo{
+		row:       row,
+		insertVal: insertVal,
+		Table:     tbl,
+		Ctx:       ctx,
+		columns:   cols,
+	}
+}
+
+// Next implements the Executor Next interface.
+func (e *LoadDataExec) Next(ctx context.Context, chk *chunk.Chunk) error {
+	chk.Reset()
+	// TODO: support load data without local field.
+	if !e.IsLocal {
+		return errors.New("Load Data: don't support load data without local field")
+	}
+	// TODO: support lines terminated is "".
+	if len(e.loadDataInfo.LinesInfo.Terminated) == 0 {
+		return errors.New("Load Data: don't support load data terminated is nil")
+	}
+
+	sctx := e.loadDataInfo.insertVal.ctx
+	val := sctx.Value(LoadDataVarKey)
+	if val != nil {
+		sctx.SetValue(LoadDataVarKey, nil)
+		return errors.New("Load Data: previous load data option isn't closed normal")
+	}
+	if e.loadDataInfo.Path == "" {
+		return errors.New("Load Data: infile path is empty")
+	}
+	sctx.SetValue(LoadDataVarKey, e.loadDataInfo)
+
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *LoadDataExec) Close() error {
+	return nil
+}
+
+// Open implements the Executor Open interface.
+func (e *LoadDataExec) Open(ctx context.Context) error {
+	return nil
+}
+
 // LoadDataInfo saves the information of loading data operation.
 type LoadDataInfo struct {
 	row       []types.Datum
@@ -180,7 +236,7 @@ func (e *LoadDataInfo) InsertData(prevData, curData []byte) ([]byte, bool, error
 			curData = nil
 		}
 
-		cols, err := GetFieldsFromLine(line, e.FieldsInfo)
+		cols, err := e.GetFieldsFromLine(line)
 		if err != nil {
 			return nil, false, errors.Trace(err)
 		}
@@ -193,7 +249,7 @@ func (e *LoadDataInfo) InsertData(prevData, curData []byte) ([]byte, bool, error
 			break
 		}
 	}
-	rows, err := batchMarkDupRows(e.Ctx, e.Table, rows)
+	rows, err := e.insertVal.batchMarkDupRows(rows)
 	if err != nil {
 		return nil, reachLimit, errors.Trace(err)
 	}
@@ -235,76 +291,20 @@ func (e *LoadDataInfo) insertData(row types.DatumRow) {
 	}
 }
 
-// LoadData represents a load data executor.
-type LoadData struct {
-	baseExecutor
-
-	IsLocal      bool
-	loadDataInfo *LoadDataInfo
-}
-
-// Next implements the Executor Next interface.
-func (e *LoadData) Next(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	// TODO: support load data without local field.
-	if !e.IsLocal {
-		return errors.New("Load Data: don't support load data without local field")
-	}
-	// TODO: support lines terminated is "".
-	if len(e.loadDataInfo.LinesInfo.Terminated) == 0 {
-		return errors.New("Load Data: don't support load data terminated is nil")
-	}
-
-	sctx := e.loadDataInfo.insertVal.ctx
-	val := sctx.Value(LoadDataVarKey)
-	if val != nil {
-		sctx.SetValue(LoadDataVarKey, nil)
-		return errors.New("Load Data: previous load data option isn't closed normal")
-	}
-	if e.loadDataInfo.Path == "" {
-		return errors.New("Load Data: infile path is empty")
-	}
-	sctx.SetValue(LoadDataVarKey, e.loadDataInfo)
-
-	return nil
-}
-
-// Close implements the Executor Close interface.
-func (e *LoadData) Close() error {
-	return nil
-}
-
-// Open implements the Executor Open interface.
-func (e *LoadData) Open(ctx context.Context) error {
-	return nil
-}
-
-// NewLoadDataInfo returns a LoadDataInfo structure, and it's only used for tests now.
-func NewLoadDataInfo(ctx sessionctx.Context, row []types.Datum, tbl table.Table, cols []*table.Column) *LoadDataInfo {
-	insertVal := &InsertValues{baseExecutor: newBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
-	return &LoadDataInfo{
-		row:       row,
-		insertVal: insertVal,
-		Table:     tbl,
-		Ctx:       ctx,
-		columns:   cols,
-	}
-}
-
 // GetFieldsFromLine splits line according to fieldsInfo, this function is exported for testing.
-func GetFieldsFromLine(line []byte, fieldsInfo *ast.FieldsClause) ([]string, error) {
+func (e *LoadDataInfo) GetFieldsFromLine(line []byte) ([]string, error) {
 	var sep []byte
-	if fieldsInfo.Enclosed != 0 {
-		if line[0] != fieldsInfo.Enclosed || line[len(line)-1] != fieldsInfo.Enclosed {
-			return nil, errors.Errorf("line %s should begin and end with %c", string(line), fieldsInfo.Enclosed)
+	if e.FieldsInfo.Enclosed != 0 {
+		if line[0] != e.FieldsInfo.Enclosed || line[len(line)-1] != e.FieldsInfo.Enclosed {
+			return nil, errors.Errorf("line %s should begin and end with %c", string(line), e.FieldsInfo.Enclosed)
 		}
 		line = line[1 : len(line)-1]
-		sep = make([]byte, 0, len(fieldsInfo.Terminated)+2)
-		sep = append(sep, fieldsInfo.Enclosed)
-		sep = append(sep, fieldsInfo.Terminated...)
-		sep = append(sep, fieldsInfo.Enclosed)
+		sep = make([]byte, 0, len(e.FieldsInfo.Terminated)+2)
+		sep = append(sep, e.FieldsInfo.Enclosed)
+		sep = append(sep, e.FieldsInfo.Terminated...)
+		sep = append(sep, e.FieldsInfo.Enclosed)
 	} else {
-		sep = []byte(fieldsInfo.Terminated)
+		sep = []byte(e.FieldsInfo.Terminated)
 	}
 	rawCols := bytes.Split(line, sep)
 	cols := escapeCols(rawCols)

--- a/executor/update.go
+++ b/executor/update.go
@@ -42,7 +42,7 @@ type UpdateExec struct {
 }
 
 func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema) (types.DatumRow, error) {
-	assignFlag, err := getUpdateColumns(e.OrderedList, schema.Len())
+	assignFlag, err := e.getUpdateColumns(schema.Len())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -183,9 +183,9 @@ func (e *UpdateExec) Open(ctx context.Context) error {
 	return e.SelectExec.Open(ctx)
 }
 
-func getUpdateColumns(assignList []*expression.Assignment, schemaLen int) ([]bool, error) {
+func (e *UpdateExec) getUpdateColumns(schemaLen int) ([]bool, error) {
 	assignFlag := make([]bool, schemaLen)
-	for _, v := range assignList {
+	for _, v := range e.OrderedList {
 		idx := v.Col.Index
 		assignFlag[idx] = true
 	}

--- a/executor/write.go
+++ b/executor/write.go
@@ -31,7 +31,16 @@ var (
 	_ Executor = &DeleteExec{}
 	_ Executor = &InsertExec{}
 	_ Executor = &ReplaceExec{}
-	_ Executor = &LoadData{}
+	_ Executor = &LoadDataExec{}
+)
+
+const (
+	// DirtyTableAddRow is the constant for dirty table operation type.
+	DirtyTableAddRow = iota
+	// DirtyTableDeleteRow is the constant for dirty table operation type.
+	DirtyTableDeleteRow
+	// DirtyTableTruncate is the constant for dirty table operation type.
+	DirtyTableTruncate
 )
 
 // updateRecord updates the row specified by the handle `h`, from `oldData` to `newData`.
@@ -172,15 +181,6 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 	ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(t.Meta().ID, 0, 1, colSize)
 	return true, handleChanged, newHandle, lastInsertID, nil
 }
-
-const (
-	// DirtyTableAddRow is the constant for dirty table operation type.
-	DirtyTableAddRow = iota
-	// DirtyTableDeleteRow is the constant for dirty table operation type.
-	DirtyTableDeleteRow
-	// DirtyTableTruncate is the constant for dirty table operation type.
-	DirtyTableTruncate
-)
 
 // resetErrDataTooLong reset ErrDataTooLong error msg.
 // types.ErrDataTooLong is produced in types.ProduceStrWithSpecifiedTp, there is no column info in there,

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1435,18 +1435,21 @@ func (s *testSuite) TestGetFieldsFromLine(c *C) {
 			[]string{string([]byte{0, '\b', '\n', '\r', '\t', 26, '\\', ' ', ' ', 'c', '\'', '"'})},
 		},
 	}
-	fieldsInfo := &ast.FieldsClause{
-		Enclosed:   '"',
-		Terminated: ",",
+
+	ldInfo := executor.LoadDataInfo{
+		FieldsInfo: &ast.FieldsClause{
+			Enclosed:   '"',
+			Terminated: ",",
+		},
 	}
 
 	for _, test := range tests {
-		got, err := executor.GetFieldsFromLine([]byte(test.input), fieldsInfo)
+		got, err := ldInfo.GetFieldsFromLine([]byte(test.input))
 		c.Assert(err, IsNil, Commentf("failed: %s", test.input))
 		assertEqualStrings(c, got, test.expected)
 	}
 
-	_, err := executor.GetFieldsFromLine([]byte(`1,a string,100.20`), fieldsInfo)
+	_, err := ldInfo.GetFieldsFromLine([]byte(`1,a string,100.20`))
 	c.Assert(err, NotNil)
 }
 


### PR DESCRIPTION
1. Move the batch-check functions as the methods of `InsertValues`, so it is only used by `insert`, `load data` and `replace`.
2. Rename `LoadData` to `LoadDataExec` to make it looks more like a executor.
3. Move all things about LoadDataExec to the beginning of the load_data.go.

PTAL @zimulala @coocood 