### PR TITLE
plan: Fix the empty result of join

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -260,6 +260,11 @@ func (s *testSuite) TestJoin(c *C) {
 	tk.MustExec("create table user(id int, name varchar(20))")
 	tk.MustExec("insert into user values(1, 'a'), (2, 'b')")
 	tk.MustQuery("select user.id,user.name from user left join aa on aa.id = user.id left join bb on aa.id = bb.id where bb.id < 10;").Check(testkit.Rows("1 a"))
+
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t (a bigint);`)
+	tk.MustExec(`insert into t values (1);`)
+	tk.MustQuery(`select t2.a, t1.a from t t1 inner join (select "1" as a) t2 on t2.a = t1.a;`).Check(testkit.Rows("1 1"))
 }
 
 func (s *testSuite) TestJoinCast(c *C) {

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -265,6 +265,7 @@ func (s *testSuite) TestJoin(c *C) {
 	tk.MustExec(`create table t (a bigint);`)
 	tk.MustExec(`insert into t values (1);`)
 	tk.MustQuery(`select t2.a, t1.a from t t1 inner join (select "1" as a) t2 on t2.a = t1.a;`).Check(testkit.Rows("1 1"))
+	tk.MustQuery(`select t2.a, t1.a from t t1 inner join (select "2" as b, "1" as a) t2 on t2.a = t1.a;`).Check(testkit.Rows("1 1"))
 }
 
 func (s *testSuite) TestJoinCast(c *C) {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -568,7 +568,7 @@ func (b *planBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 	proj := LogicalProjection{Exprs: make([]expression.Expression, 0, len(fields))}.init(b.ctx)
 	schema := expression.NewSchema(make([]*expression.Column, 0, len(fields))...)
 	oldLen := 0
-	for i, field := range fields {
+	for _, field := range fields {
 		newExpr, np, err := b.rewrite(field.Expr, p, mapper, true)
 		if err != nil {
 			b.err = errors.Trace(err)
@@ -577,7 +577,7 @@ func (b *planBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 		p = np
 		proj.Exprs = append(proj.Exprs, newExpr)
 
-		col := b.buildProjectionField(proj.id, i, field, newExpr)
+		col := b.buildProjectionField(proj.id, schema.Len()+1, field, newExpr)
 		schema.Append(col)
 
 		if !field.Auxiliary {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -568,7 +568,7 @@ func (b *planBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 	proj := LogicalProjection{Exprs: make([]expression.Expression, 0, len(fields))}.init(b.ctx)
 	schema := expression.NewSchema(make([]*expression.Column, 0, len(fields))...)
 	oldLen := 0
-	for _, field := range fields {
+	for i, field := range fields {
 		newExpr, np, err := b.rewrite(field.Expr, p, mapper, true)
 		if err != nil {
 			b.err = errors.Trace(err)
@@ -577,7 +577,7 @@ func (b *planBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 		p = np
 		proj.Exprs = append(proj.Exprs, newExpr)
 
-		col := b.buildProjectionField(proj.id, schema.Len()+1, field, newExpr)
+		col := b.buildProjectionField(proj.id, i, field, newExpr)
 		schema.Append(col)
 
 		if !field.Auxiliary {

--- a/plan/rule_predicate_push_down.go
+++ b/plan/rule_predicate_push_down.go
@@ -198,9 +198,11 @@ func (p *LogicalProjection) appendExpr(expr expression.Expression) *expression.C
 	}
 	expr = expression.ColumnSubstitute(expr, p.schema, p.Exprs)
 	p.Exprs = append(p.Exprs, expr)
+
+	newPosition := p.schema.Columns[p.schema.Len()-1].Position + 1
 	col := &expression.Column{
 		FromID:   p.id,
-		Position: p.schema.Len(),
+		Position: newPosition,
 		ColName:  model.NewCIStr(expr.String()),
 		RetType:  expr.GetType(),
 	}


### PR DESCRIPTION
## Brief Intro 
Let's say we have the following table:
```sql
drop table if exists t;
create table t (a bigint);
insert into t values (1);
```

Before this PR:
```sql
TiDB(localhost:4000) > select t2.a, t1.a from t t1 inner join (select "1" as a) t2 on t2.a = t1.a;
Empty set (0.00 sec)
```

After this PR:
```sql
TiDB(localhost:4000) > select t2.a, t1.a from t t1 inner join (select "1" as a) t2 on t2.a = t1.a;
+------+------+
| a    | a    |
+------+------+
| 1    |    1 |
+------+------+
1 row in set (0.00 sec)
```
## What is the root cause of this issue

The execution plan of this sql is:
```sql
TiDB(localhost:4000) > desc select t2.a, t1.a from t t1 inner join (select "1" as a) t2 on t2.a = t1.a;
+----------------+----------------+-----------------------------+------+------------------------------------------------------------------+----------+
| id             | parents        | children                    | task | operator info                                                    | count    |
+----------------+----------------+-----------------------------+------+------------------------------------------------------------------+----------+
| TableScan_11   |                |                             | cop  | table:t1, range:[-inf,+inf], keep order:false                    | 10000.00 |
| TableReader_12 | Projection_10  |                             | root | data:TableScan_11                                                | 10000.00 |
| Projection_10  | HashLeftJoin_8 | TableReader_12              | root | t1.a, cast(t1.a)                                                 | 10000.00 |
| TableDual_14   | Projection_13  |                             | root | rows:1                                                           | 1.00     |
| Projection_13  | HashLeftJoin_8 | TableDual_14                | root | 1, cast(1)                                                       | 1.00     |
| HashLeftJoin_8 | Projection_7   | Projection_10,Projection_13 | root | inner join, inner:Projection_13, equal:[eq(cast(t1.a), cast(1))] | 1.25     |
| Projection_7   |                | HashLeftJoin_8              | root | t2.a, t1.a                                                       | 1.25     |
+----------------+----------------+-----------------------------+------+------------------------------------------------------------------+----------+
7 rows in set (0.00 sec)
```

NOTE:
For `Projection_13`, the expressions are `1` and `cast(1)`:
- `1` is built in: https://github.com/pingcap/tidb/pull/6669/files#diff-638d8be162d442ef3a5c423ff0c735d4R580
- `cast(1)` is built in: https://github.com/pingcap/tidb/blob/master/plan/rule_predicate_push_down.go#L200

before this PR, these two expressions have the same `FromID`, and `Position` in the schema of `Projection_13`, which cause the wrong join key chosen, and further cause the empty join result.