### PR TITLE
util: Fix range construction for `in` predicate (#6667)

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3245,6 +3245,29 @@ func (s *testIntegrationSuite) TestIssues(c *C) {
 	tk.MustQuery("select * from t where cast(a as binary)").Check(testkit.Rows("1"))
 }
 
+func (s *testIntegrationSuite) TestInPredicate4UnsignedInt(c *C) {
+	// for issue #6661
+	tk := testkit.NewTestKit(c, s.store)
+	defer s.cleanEnv(c)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (a bigint unsigned,key (a));")
+	tk.MustExec("INSERT INTO t VALUES (0), (4), (5), (6), (7), (8), (9223372036854775810), (18446744073709551614), (18446744073709551615);")
+	r := tk.MustQuery(`SELECT a FROM t WHERE a NOT IN (-1, -2, 18446744073709551615);`)
+	r.Check(testkit.Rows("0", "4", "5", "6", "7", "8", "9223372036854775810", "18446744073709551614"))
+	r = tk.MustQuery(`SELECT a FROM t WHERE a NOT IN (-1, -2, 4, 9223372036854775810);`)
+	r.Check(testkit.Rows("0", "5", "6", "7", "8", "18446744073709551614", "18446744073709551615"))
+	r = tk.MustQuery(`SELECT a FROM t WHERE a NOT IN (-1, -2, 0, 4, 18446744073709551614);`)
+	r.Check(testkit.Rows("5", "6", "7", "8", "9223372036854775810", "18446744073709551615"))
+
+	// for issue #4473
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t1 (some_id smallint(5) unsigned,key (some_id) )")
+	tk.MustExec("insert into t1 values (1),(2)")
+	r = tk.MustQuery(`select some_id from t1 where some_id not in(2,-1);`)
+	r.Check(testkit.Rows("1"))
+}
+
 func (s *testIntegrationSuite) TestFilterExtractFromDNF(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	defer s.cleanEnv(c)

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
@@ -426,11 +427,27 @@ func (r *builder) buildFromNot(expr *expression.ScalarFunction) []point {
 	case ast.IsFalsity:
 		return r.buildFromIsFalse(expr, 1)
 	case ast.In:
+		var (
+			isUnsignedIntCol bool
+			nonNegativePos   int
+		)
 		rangePoints, hasNull := r.buildFromIn(expr)
 		if hasNull {
 			return nil
 		}
-		retRangePoints := make([]point, 0, len(rangePoints)+2)
+		if x, ok := expr.GetArgs()[0].(*expression.Column); ok {
+			isUnsignedIntCol = mysql.HasUnsignedFlag(x.RetType.Flag) && mysql.IsIntegerType(x.RetType.Tp)
+		}
+		// negative ranges can be directly ignored for unsigned int columns.
+		if isUnsignedIntCol {
+			for nonNegativePos = 0; nonNegativePos < len(rangePoints); nonNegativePos += 2 {
+				if rangePoints[nonNegativePos].value.Kind() == types.KindUint64 || rangePoints[nonNegativePos].value.GetInt64() >= 0 {
+					break
+				}
+			}
+			rangePoints = rangePoints[nonNegativePos:]
+		}
+		retRangePoints := make([]point, 0, 2+len(rangePoints))
 		previousValue := types.Datum{}
 		for i := 0; i < len(rangePoints); i += 2 {
 			retRangePoints = append(retRangePoints, point{value: previousValue, start: true, excl: true})

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -74,7 +74,7 @@ func (s *testRangerSuite) TestTableRange(c *C) {
 	testKit := testkit.NewTestKit(c, store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
-	testKit.MustExec("create table t(a int, b int)")
+	testKit.MustExec("create table t(a int, b int, c int unsigned)")
 
 	tests := []struct {
 		exprStr     string
@@ -509,6 +509,90 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 			accessConds: "[]",
 			filterConds: "[or(gt(test.t.a, a), gt(test.t.c, 1))]",
 			resultStr:   "[[<nil>,+inf]]",
+		},
+	}
+
+	for _, tt := range tests {
+		sql := "select * from t where " + tt.exprStr
+		ctx := testKit.Se.(sessionctx.Context)
+		stmts, err := session.Parse(ctx, sql)
+		c.Assert(err, IsNil, Commentf("error %v, for expr %s", err, tt.exprStr))
+		c.Assert(stmts, HasLen, 1)
+		is := domain.GetDomain(ctx).InfoSchema()
+		err = plan.Preprocess(ctx, stmts[0], is, false)
+		c.Assert(err, IsNil, Commentf("error %v, for resolve name, expr %s", err, tt.exprStr))
+		p, err := plan.BuildLogicalPlan(ctx, stmts[0], is)
+		c.Assert(err, IsNil, Commentf("error %v, for build plan, expr %s", err, tt.exprStr))
+		selection := p.(plan.LogicalPlan).Children()[0].(*plan.LogicalSelection)
+		tbl := selection.Children()[0].(*plan.DataSource).TableInfo()
+		c.Assert(selection, NotNil, Commentf("expr:%v", tt.exprStr))
+		conds := make([]expression.Expression, 0, len(selection.Conditions))
+		for _, cond := range selection.Conditions {
+			conds = append(conds, expression.PushDownNot(ctx, cond, false))
+		}
+		cols, lengths := expression.IndexInfo2Cols(selection.Schema().Columns, tbl.Indices[tt.indexPos])
+		c.Assert(cols, NotNil)
+		ranges, conds, filter, _, err := ranger.DetachCondAndBuildRangeForIndex(ctx, conds, cols, lengths)
+		c.Assert(err, IsNil)
+		c.Assert(fmt.Sprintf("%s", conds), Equals, tt.accessConds, Commentf("wrong access conditions for expr: %s", tt.exprStr))
+		c.Assert(fmt.Sprintf("%s", filter), Equals, tt.filterConds, Commentf("wrong filter conditions for expr: %s", tt.exprStr))
+		got := fmt.Sprintf("%v", ranges)
+		c.Assert(got, Equals, tt.resultStr, Commentf("different for expr %s", tt.exprStr))
+	}
+}
+
+// for issue #6661
+func (s *testRangerSuite) TestIndexRangeForUnsignedInt(c *C) {
+	defer testleak.AfterTest(c)()
+	store, err := newStoreWithBootstrap(c)
+	defer store.Close()
+	c.Assert(err, IsNil)
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec("create table t (a smallint(5) unsigned,key (a) )")
+
+	tests := []struct {
+		indexPos    int
+		exprStr     string
+		accessConds string
+		filterConds string
+		resultStr   string
+	}{
+		{
+			indexPos:    0,
+			exprStr:     `a not in (0, 1, 2)`,
+			accessConds: "[not(in(test.t.a, 0, 1, 2))]",
+			filterConds: "[]",
+			resultStr:   `[(<nil>,0) (2,+inf]]`,
+		},
+		{
+			indexPos:    0,
+			exprStr:     `a not in (-1, 1, 2)`,
+			accessConds: "[not(in(test.t.a, -1, 1, 2))]",
+			filterConds: "[]",
+			resultStr:   `[(<nil>,1) (2,+inf]]`,
+		},
+		{
+			indexPos:    0,
+			exprStr:     `a not in (-2, -1, 1, 2)`,
+			accessConds: "[not(in(test.t.a, -2, -1, 1, 2))]",
+			filterConds: "[]",
+			resultStr:   `[(<nil>,1) (2,+inf]]`,
+		},
+		{
+			indexPos:    0,
+			exprStr:     `a not in (111)`,
+			accessConds: "[not(in(test.t.a, 111))]",
+			filterConds: "[]",
+			resultStr:   `[(<nil>,111) (111,+inf]]`,
+		},
+		{
+			indexPos:    0,
+			exprStr:     `a not in (1, 2, 9223372036854775810)`,
+			accessConds: "[not(in(test.t.a, 1, 2, 9223372036854775810))]",
+			filterConds: "[]",
+			resultStr:   `[(<nil>,1) (2,9223372036854775810) (9223372036854775810,+inf]]`,
 		},
 	}
 


### PR DESCRIPTION
cherry pick #6667 to release 2.0 