### PR TITLE
expression: revert pr 6621

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -962,9 +962,6 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 			cmpType = lhsFieldType.EvalType()
 		} else {
 			cmpType = types.ETDatetime
-			if lhsFieldType.EvalType() == types.ETTimestamp || rhsFieldType.EvalType() == types.ETTimestamp {
-				cmpType = types.ETTimestamp
-			}
 		}
 	} else if lhsFieldType.Tp == mysql.TypeDuration && rhsFieldType.Tp == mysql.TypeDuration {
 		// duration <cmp> duration

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2721,12 +2721,6 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec("create table t(a bigint unsigned)")
 	tk.MustExec("insert into t value(17666000000000000000)")
 	tk.MustQuery("select * from t where a = 17666000000000000000").Check(testkit.Rows("17666000000000000000"))
-
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a timestamp)")
-	tk.MustExec("insert into t value('1991-05-06 04:59:28')")
-	tk.MustExec("delete from t where a = '1991-05-06 04:59:28'")
-	tk.MustQuery("select * from t").Check(testkit.Rows())
 }
 
 func (s *testIntegrationSuite) TestAggregationBuiltin(c *C) {


### PR DESCRIPTION
https://github.com/pingcap/tidb/pull/6621 is not correct way to do it. Mysql use `datetime` to compare. The real reason is that we did not handle daylight saving time. 