### PR TITLE
server: fix CI nil pointer panic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -289,7 +289,7 @@ func (s *Server) Close() {
 		s.listener = nil
 	}
 	if s.statusServer != nil {
-		err := s.statusServer.Shutdown(nil)
+		err := s.statusServer.Close()
 		terror.Log(errors.Trace(err))
 		s.statusServer = nil
 	}


### PR DESCRIPTION
server.ShutDown(ctx), it would panic if ctx is nil, because http package
calls <-ctx.Done()

replace ShutDown() with Close()

@fipped @winkyao @coocood 