### PR TITLE
store: move backoff logic to a separate function. 

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -222,7 +222,8 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 	b.types = append(b.types, typ)
 
 	log.Debugf("%v, retry later(totalSleep %dms, maxSleep %dms)", err, b.totalSleep, b.maxSleep)
-	b.errors = append(b.errors, err)
+
+	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
 	if b.maxSleep > 0 && b.totalSleep >= b.maxSleep {
 		errMsg := fmt.Sprintf("backoffer.maxSleep %dms is exceeded, errors:", b.maxSleep)
 		for i, err := range b.errors {


### PR DESCRIPTION
Original code:
```
select {
        case <-b.ctx.Done():
	         return errors.Trace(err)
	default:
	}
```
It may be confused and buggy. I moved backoff logic to a function and calling it in `default` case of `select` statement. 