### PR TITLE
store, kvencoder: add a options to disable txn local latches in mockTikvStore, which may cause lightning to be oom.

### DIFF
--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -41,11 +41,12 @@ func (d MockDriver) Open(path string) (kv.Storage, error) {
 }
 
 type mockOptions struct {
-	cluster        *mocktikv.Cluster
-	mvccStore      mocktikv.MVCCStore
-	clientHijack   func(tikv.Client) tikv.Client
-	pdClientHijack func(pd.Client) pd.Client
-	path           string
+	cluster                *mocktikv.Cluster
+	mvccStore              mocktikv.MVCCStore
+	clientHijack           func(tikv.Client) tikv.Client
+	pdClientHijack         func(pd.Client) pd.Client
+	path                   string
+	disableTxnLocalLatches bool
 }
 
 // MockTiKVStoreOption is used to control some behavior of mock tikv.
@@ -80,6 +81,13 @@ func WithPath(path string) MockTiKVStoreOption {
 	}
 }
 
+// WithTxnLocalLatches enable or disble txnLocalLatches.
+func WithTxnLocalLatches(enable bool) MockTiKVStoreOption {
+	return func(c *mockOptions) {
+		c.disableTxnLocalLatches = !enable
+	}
+}
+
 // NewMockTikvStore creates a mocked tikv store, the path is the file path to store the data.
 // If path is an empty string, a memory storage will be created.
 func NewMockTikvStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
@@ -93,5 +101,5 @@ func NewMockTikvStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 		return nil, errors.Trace(err)
 	}
 
-	return tikv.NewTestTiKVStore(client, pdClient, opt.clientHijack, opt.pdClientHijack)
+	return tikv.NewTestTiKVStore(client, pdClient, opt.clientHijack, opt.pdClientHijack, opt.disableTxnLocalLatches)
 }

--- a/store/tikv/delete_range_test.go
+++ b/store/tikv/delete_range_test.go
@@ -37,7 +37,7 @@ func (s *testDeleteRangeSuite) SetUpTest(c *C) {
 	client, pdClient, err := mocktikv.NewTestClient(s.cluster, nil, "")
 	c.Assert(err, IsNil)
 
-	store, err := NewTestTiKVStore(client, pdClient, nil, nil)
+	store, err := NewTestTiKVStore(client, pdClient, nil, nil, false)
 	c.Check(err, IsNil)
 	s.store = store.(*tikvStore)
 }

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -35,7 +35,7 @@ func (s *testSplitSuite) SetUpTest(c *C) {
 	client, pdClient, err := mocktikv.NewTestClient(s.cluster, nil, "")
 	c.Assert(err, IsNil)
 
-	store, err := NewTestTiKVStore(client, pdClient, nil, nil)
+	store, err := NewTestTiKVStore(client, pdClient, nil, nil, false)
 	c.Check(err, IsNil)
 	s.store = store.(*tikvStore)
 	s.bo = NewBackoffer(context.Background(), 5000)

--- a/store/tikv/test_util.go
+++ b/store/tikv/test_util.go
@@ -21,7 +21,7 @@ import (
 )
 
 // NewTestTiKVStore creates a test store with Option
-func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client) (kv.Storage, error) {
+func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, disableTxnLocalLatches bool) (kv.Storage, error) {
 	if clientHijack != nil {
 		client = clientHijack(client)
 	}
@@ -35,7 +35,11 @@ func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Clien
 	uid := uuid.NewV4().String()
 	spkv := NewMockSafePointKV()
 	tikvStore, err := newTikvStore(uid, pdCli, spkv, client, false)
-	tikvStore.EnableTxnLocalLatches(1024000)
+
+	if !disableTxnLocalLatches {
+		tikvStore.EnableTxnLocalLatches(1024000)
+	}
+
 	tikvStore.mock = true
 	return tikvStore, errors.Trace(err)
 }

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -51,7 +51,7 @@ func NewTestStore(c *C) kv.Storage {
 	client, pdClient, err := mocktikv.NewTestClient(nil, nil, "")
 	c.Assert(err, IsNil)
 
-	store, err := NewTestTiKVStore(client, pdClient, nil, nil)
+	store, err := NewTestTiKVStore(client, pdClient, nil, nil, false)
 	c.Assert(err, IsNil)
 	return store
 }

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -192,7 +192,7 @@ func (e *kvEncoder) GetSystemVariable(name string) (string, bool) {
 }
 
 func newMockTikvWithBootstrap() (kv.Storage, *domain.Domain, error) {
-	store, err := mockstore.NewMockTikvStore()
+	store, err := mockstore.NewMockTikvStore(mockstore.WithTxnLocalLatches(false))
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Lightning use mockTikvStore to convert sql to kv pairs, it is newed by NewTestTiKVStore:

```
// NewTestTiKVStore creates a test store with Option
func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, disableTxnLocalLatches bool) (kv.Storage, error) {
	if clientHijack != nil {
		client = clientHijack(client)
	}

	pdCli := pd.Client(&codecPDClient{pdClient})
	if pdClientHijack != nil {
		pdCli = pdClientHijack(pdCli)
	}

	// Make sure the uuid is unique.
	uid := uuid.NewV4().String()
	spkv := NewMockSafePointKV()
	tikvStore, err := newTikvStore(uid, pdCli, spkv, client, false)
	tikvStore.EnableTxnLocalLatches(1024000)

	tikvStore.mock = true
	return tikvStore, errors.Trace(err)
}
```

NewTestTiKVStore will definitely new a 100mb txn local latches, which is useless in lightning, and will lead lightning to oom. So we add an option to disable it in kvencoder.

@holys @huachaohuang PTAL
