### PR TITLE
expression: push builtin function `IS TRUE`/`IS FALSE` to TiKV

### DIFF
--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -289,6 +289,8 @@ func (pc PbConverter) canFuncBePushed(sf *ScalarFunction) bool {
 		ast.In,
 		ast.IsNull,
 		ast.Like,
+		ast.IsTruth,
+		ast.IsFalsity,
 
 		// arithmetical functions.
 		ast.Plus,


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

Push builtin function `IS TRUE` and `IS FALSE` to TiKV, before this PR:
```sql
TiDB(localhost:4000) > desc select * from t where a is true;
+---------------+-------------+---------------+------+----------------------------------------------+----------+
| id            | parents     | children      | task | operator info                                | count    |
+---------------+-------------+---------------+------+----------------------------------------------+----------+
| TableScan_6   |             |               | cop  | table:t, range:[-inf,+inf], keep order:false | 10000.00 |
| TableReader_7 | Selection_5 |               | root | data:TableScan_6                             | 10000.00 |
| Selection_5   |             | TableReader_7 | root | istrue(test.t.a)                             | 8000.00  |
+---------------+-------------+---------------+------+----------------------------------------------+----------+
3 rows in set (0.00 sec)
```

After this PR:
```sql
TiDB(localhost:4000) > desc select * from t where a is true;
+---------------+-------------+-------------+------+----------------------------------------------+----------+
| id            | parents     | children    | task | operator info                                | count    |
+---------------+-------------+-------------+------+----------------------------------------------+----------+
| TableScan_5   | Selection_6 |             | cop  | table:t, range:[-inf,+inf], keep order:false | 10000.00 |
| Selection_6   |             | TableScan_5 | cop  | istrue(test.t.a)                             | 6656.67  |
| TableReader_7 |             |             | root | data:Selection_6                             | 6656.67  |
+---------------+-------------+-------------+------+----------------------------------------------+----------+
3 rows in set (0.00 sec)
```
## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

No

