### PR TITLE
plan, parser: fix the wrong result of the `UNION` statement

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -476,6 +476,8 @@ type SelectStmt struct {
 	LockTp SelectLockType
 	// TableHints represents the table level Optimizer Hint for join type
 	TableHints []*TableOptimizerHint
+	// UnionDistinct is mark flag that previous union is distinct
+	UnionDistinct bool
 }
 
 // Accept implements Node Accept interface.
@@ -561,7 +563,8 @@ func (n *SelectStmt) Accept(v Visitor) (Node, bool) {
 type UnionSelectList struct {
 	node
 
-	Selects []*SelectStmt
+	Selects  []*SelectStmt
+	Distinct bool
 }
 
 // Accept implements Node Accept interface.

--- a/ast/dml.go
+++ b/ast/dml.go
@@ -476,8 +476,8 @@ type SelectStmt struct {
 	LockTp SelectLockType
 	// TableHints represents the table level Optimizer Hint for join type
 	TableHints []*TableOptimizerHint
-	// UnionDistinct is mark flag that previous union is distinct
-	UnionDistinct bool
+	// IsAfterUnionDistinct indicates whether it's a stmt after "union distinct".
+	IsAfterUnionDistinct bool
 }
 
 // Accept implements Node Accept interface.
@@ -563,8 +563,7 @@ func (n *SelectStmt) Accept(v Visitor) (Node, bool) {
 type UnionSelectList struct {
 	node
 
-	Selects  []*SelectStmt
-	Distinct bool
+	Selects []*SelectStmt
 }
 
 // Accept implements Node Accept interface.
@@ -590,7 +589,6 @@ type UnionStmt struct {
 	dmlNode
 	resultSetNode
 
-	Distinct   bool
 	SelectList *UnionSelectList
 	OrderBy    *OrderByClause
 	Limit      *Limit

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -151,6 +151,37 @@ explain select if(10, t1.c1, t1.c2) from t1;
 id	parents	children	task	operator info	count
 TableScan_4			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 TableReader_5			root	data:TableScan_4	10000.00
+explain select c1 from t2 union select c1 from t2 union all select c1 from t2;
+id	parents	children	task	operator info	count
+TableScan_16			cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+TableReader_17	Union_14		root	data:TableScan_16	10000.00
+IndexScan_34	StreamAgg_26		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+StreamAgg_26		IndexScan_34	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+IndexReader_36	StreamAgg_35		root	index:StreamAgg_26	8000.00
+StreamAgg_35	Union_22	IndexReader_36	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+IndexScan_51	StreamAgg_43		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+StreamAgg_43		IndexScan_51	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+IndexReader_53	StreamAgg_52		root	index:StreamAgg_43	8000.00
+StreamAgg_52	Union_22	IndexReader_53	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+Union_22	HashAgg_21	StreamAgg_35,StreamAgg_52	root		16000.00
+HashAgg_21	Union_14	Union_22	root	group by:t2.c1, funcs:firstrow(join_agg_0)	16000.00
+Union_14		TableReader_17,HashAgg_21	root		26000.00
+explain select c1 from t2 union all select c1 from t2 union select c1 from t2;
+id	parents	children	task	operator info	count
+IndexScan_28	StreamAgg_20		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+StreamAgg_20		IndexScan_28	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+IndexReader_30	StreamAgg_29		root	index:StreamAgg_20	8000.00
+StreamAgg_29	Union_16	IndexReader_30	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+IndexScan_45	StreamAgg_37		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+StreamAgg_37		IndexScan_45	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+IndexReader_47	StreamAgg_46		root	index:StreamAgg_37	8000.00
+StreamAgg_46	Union_16	IndexReader_47	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+IndexScan_62	StreamAgg_54		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+StreamAgg_54		IndexScan_62	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+IndexReader_64	StreamAgg_63		root	index:StreamAgg_54	8000.00
+StreamAgg_63	Union_16	IndexReader_64	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+Union_16	HashAgg_15	StreamAgg_29,StreamAgg_46,StreamAgg_63	root		24000.00
+HashAgg_15		Union_16	root	group by:t2.c1, funcs:firstrow(join_agg_0)	24000.00
 set @@session.tidb_opt_insubquery_unfold = 0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	parents	children	task	operator info	count

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -32,6 +32,8 @@ explain select * from t4 use index(idx) where a > 1 and b > 1 and c > 1 limit 1;
 explain select * from t4 where a > 1 and c > 1 limit 1;
 explain select ifnull(null, t1.c1) from t1;
 explain select if(10, t1.c1, t1.c2) from t1;
+explain select c1 from t2 union select c1 from t2 union all select c1 from t2;
+explain select c1 from t2 union all select c1 from t2 union select c1 from t2;
 
 set @@session.tidb_opt_insubquery_unfold = 0;
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -963,6 +963,9 @@ func (s *testSuite) TestUnion(c *C) {
 	c.Assert(err, NotNil)
 	terr = errors.Trace(err).(*errors.Err).Cause().(*terror.Error)
 	c.Assert(terr.Code(), Equals, terror.ErrCode(mysql.ErrWrongUsage))
+
+	tk.MustQuery("select 1 union select 1 union all select 1").Check(testkit.Rows("1", "1"))
+	tk.MustQuery("select 1 union all select 1 union select 1").Check(testkit.Rows("1"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4625,8 +4625,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
-		st.UnionDistinct = $3.(bool)
-		union.Distinct = union.Distinct || $3.(bool)
+		st.IsAfterUnionDistinct = $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-5])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
@@ -4646,8 +4645,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
-		st.UnionDistinct = $3.(bool)
-		union.Distinct = union.Distinct || $3.(bool)
+		st.IsAfterUnionDistinct = $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-4])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
@@ -4664,8 +4662,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
-		st.UnionDistinct = $3.(bool)
-		union.Distinct = union.Distinct || $3.(bool)
+		st.IsAfterUnionDistinct = $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-5])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
@@ -4684,12 +4681,11 @@ UnionStmt:
 |	UnionClauseList "UNION" UnionOpt '(' SelectStmt ')' OrderByOptional SelectStmtLimit
 	{
 		union := $1.(*ast.UnionStmt)
-		union.Distinct = union.Distinct || $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-6])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
 		st := $5.(*ast.SelectStmt)
-		st.UnionDistinct = $3.(bool)
+		st.IsAfterUnionDistinct = $3.(bool)
 		endOffset = parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(st, endOffset)
 		union.SelectList.Selects = append(union.SelectList.Selects, st)
@@ -4714,8 +4710,7 @@ UnionClauseList:
 	{
 		union := $1.(*ast.UnionStmt)
 		st := $4.(*ast.SelectStmt)
-		st.UnionDistinct = $3.(bool)
-		union.Distinct = union.Distinct || $3.(bool)
+		st.IsAfterUnionDistinct = $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(lastSelect, endOffset)

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4625,6 +4625,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
+		st.UnionDistinct = $3.(bool)
 		union.Distinct = union.Distinct || $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-5])
@@ -4645,6 +4646,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
+		st.UnionDistinct = $3.(bool)
 		union.Distinct = union.Distinct || $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-4])
@@ -4662,6 +4664,7 @@ UnionStmt:
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
+		st.UnionDistinct = $3.(bool)
 		union.Distinct = union.Distinct || $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-5])
@@ -4686,6 +4689,7 @@ UnionStmt:
 		endOffset := parser.endOffset(&yyS[yypt-6])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
 		st := $5.(*ast.SelectStmt)
+		st.UnionDistinct = $3.(bool)
 		endOffset = parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(st, endOffset)
 		union.SelectList.Selects = append(union.SelectList.Selects, st)
@@ -4709,11 +4713,13 @@ UnionClauseList:
 |	UnionClauseList "UNION" UnionOpt UnionSelect
 	{
 		union := $1.(*ast.UnionStmt)
+		st := $4.(*ast.SelectStmt)
+		st.UnionDistinct = $3.(bool)
 		union.Distinct = union.Distinct || $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
 		endOffset := parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
-		union.SelectList.Selects = append(union.SelectList.Selects, $4.(*ast.SelectStmt))
+		union.SelectList.Selects = append(union.SelectList.Selects, st)
 		$$ = union
 	}
 

--- a/plan/errors.go
+++ b/plan/errors.go
@@ -26,26 +26,27 @@ const (
 	codeWrongParamCount                 = 5
 	codeSchemaChanged                   = 6
 
-	codeWrongUsage           = mysql.ErrWrongUsage
-	codeAmbiguous            = mysql.ErrNonUniq
-	codeUnknownColumn        = mysql.ErrBadField
-	codeUnknownTable         = mysql.ErrUnknownTable
-	codeWrongArguments       = mysql.ErrWrongArguments
-	codeBadGeneratedColumn   = mysql.ErrBadGeneratedColumn
-	codeFieldNotInGroupBy    = mysql.ErrFieldNotInGroupBy
-	codeBadTable             = mysql.ErrBadTable
-	codeKeyDoesNotExist      = mysql.ErrKeyDoesNotExist
-	codeOperandColumns       = mysql.ErrOperandColumns
-	codeInvalidWildCard      = mysql.ErrParse
-	codeInvalidGroupFuncUse  = mysql.ErrInvalidGroupFuncUse
-	codeIllegalReference     = mysql.ErrIllegalReference
-	codeNoDB                 = mysql.ErrNoDB
-	codeUnknownExplainFormat = mysql.ErrUnknownExplainFormat
-	codeWrongGroupField      = mysql.ErrWrongGroupField
-	codeDupFieldName         = mysql.ErrDupFieldName
-	codeNonUpdatableTable    = mysql.ErrNonUpdatableTable
-	codeInternal             = mysql.ErrInternal
-	codeNonUniqTable         = mysql.ErrNonuniqTable
+	codeWrongUsage                   = mysql.ErrWrongUsage
+	codeAmbiguous                    = mysql.ErrNonUniq
+	codeUnknownColumn                = mysql.ErrBadField
+	codeUnknownTable                 = mysql.ErrUnknownTable
+	codeWrongArguments               = mysql.ErrWrongArguments
+	codeWrongNumberOfColumnsInSelect = mysql.ErrWrongNumberOfColumnsInSelect
+	codeBadGeneratedColumn           = mysql.ErrBadGeneratedColumn
+	codeFieldNotInGroupBy            = mysql.ErrFieldNotInGroupBy
+	codeBadTable                     = mysql.ErrBadTable
+	codeKeyDoesNotExist              = mysql.ErrKeyDoesNotExist
+	codeOperandColumns               = mysql.ErrOperandColumns
+	codeInvalidWildCard              = mysql.ErrParse
+	codeInvalidGroupFuncUse          = mysql.ErrInvalidGroupFuncUse
+	codeIllegalReference             = mysql.ErrIllegalReference
+	codeNoDB                         = mysql.ErrNoDB
+	codeUnknownExplainFormat         = mysql.ErrUnknownExplainFormat
+	codeWrongGroupField              = mysql.ErrWrongGroupField
+	codeDupFieldName                 = mysql.ErrDupFieldName
+	codeNonUpdatableTable            = mysql.ErrNonUpdatableTable
+	codeInternal                     = mysql.ErrInternal
+	codeNonUniqTable                 = mysql.ErrNonuniqTable
 )
 
 // error definitions.
@@ -57,50 +58,52 @@ var (
 	ErrWrongParamCount             = terror.ClassOptimizer.New(codeWrongParamCount, "Wrong parameter count")
 	ErrSchemaChanged               = terror.ClassOptimizer.New(codeSchemaChanged, "Schema has changed")
 
-	ErrWrongUsage           = terror.ClassOptimizer.New(codeWrongUsage, mysql.MySQLErrName[mysql.ErrWrongUsage])
-	ErrAmbiguous            = terror.ClassOptimizer.New(codeAmbiguous, mysql.MySQLErrName[mysql.ErrNonUniq])
-	ErrUnknownColumn        = terror.ClassOptimizer.New(codeUnknownColumn, mysql.MySQLErrName[mysql.ErrBadField])
-	ErrUnknownTable         = terror.ClassOptimizer.New(codeUnknownTable, mysql.MySQLErrName[mysql.ErrUnknownTable])
-	ErrWrongArguments       = terror.ClassOptimizer.New(codeWrongArguments, mysql.MySQLErrName[mysql.ErrWrongArguments])
-	ErrBadGeneratedColumn   = terror.ClassOptimizer.New(codeBadGeneratedColumn, mysql.MySQLErrName[mysql.ErrBadGeneratedColumn])
-	ErrFieldNotInGroupBy    = terror.ClassOptimizer.New(codeFieldNotInGroupBy, mysql.MySQLErrName[mysql.ErrFieldNotInGroupBy])
-	ErrBadTable             = terror.ClassOptimizer.New(codeBadTable, mysql.MySQLErrName[mysql.ErrBadTable])
-	ErrKeyDoesNotExist      = terror.ClassOptimizer.New(codeKeyDoesNotExist, mysql.MySQLErrName[mysql.ErrKeyDoesNotExist])
-	ErrOperandColumns       = terror.ClassOptimizer.New(codeOperandColumns, mysql.MySQLErrName[mysql.ErrOperandColumns])
-	ErrInvalidWildCard      = terror.ClassOptimizer.New(codeInvalidWildCard, "Wildcard fields without any table name appears in wrong place")
-	ErrInvalidGroupFuncUse  = terror.ClassOptimizer.New(codeInvalidGroupFuncUse, mysql.MySQLErrName[mysql.ErrInvalidGroupFuncUse])
-	ErrIllegalReference     = terror.ClassOptimizer.New(codeIllegalReference, mysql.MySQLErrName[mysql.ErrIllegalReference])
-	ErrNoDB                 = terror.ClassOptimizer.New(codeNoDB, mysql.MySQLErrName[mysql.ErrNoDB])
-	ErrUnknownExplainFormat = terror.ClassOptimizer.New(codeUnknownExplainFormat, mysql.MySQLErrName[mysql.ErrUnknownExplainFormat])
-	ErrWrongGroupField      = terror.ClassOptimizer.New(codeWrongGroupField, mysql.MySQLErrName[mysql.ErrWrongGroupField])
-	ErrDupFieldName         = terror.ClassOptimizer.New(codeDupFieldName, mysql.MySQLErrName[mysql.ErrDupFieldName])
-	ErrNonUpdatableTable    = terror.ClassOptimizer.New(codeNonUpdatableTable, mysql.MySQLErrName[mysql.ErrNonUpdatableTable])
-	ErrInternal             = terror.ClassOptimizer.New(codeInternal, mysql.MySQLErrName[mysql.ErrInternal])
-	ErrNonUniqTable         = terror.ClassOptimizer.New(codeNonUniqTable, mysql.MySQLErrName[mysql.ErrNonuniqTable])
+	ErrWrongUsage                   = terror.ClassOptimizer.New(codeWrongUsage, mysql.MySQLErrName[mysql.ErrWrongUsage])
+	ErrAmbiguous                    = terror.ClassOptimizer.New(codeAmbiguous, mysql.MySQLErrName[mysql.ErrNonUniq])
+	ErrUnknownColumn                = terror.ClassOptimizer.New(codeUnknownColumn, mysql.MySQLErrName[mysql.ErrBadField])
+	ErrUnknownTable                 = terror.ClassOptimizer.New(codeUnknownTable, mysql.MySQLErrName[mysql.ErrUnknownTable])
+	ErrWrongArguments               = terror.ClassOptimizer.New(codeWrongArguments, mysql.MySQLErrName[mysql.ErrWrongArguments])
+	ErrWrongNumberOfColumnsInSelect = terror.ClassOptimizer.New(codeWrongNumberOfColumnsInSelect, mysql.MySQLErrName[mysql.ErrWrongNumberOfColumnsInSelect])
+	ErrBadGeneratedColumn           = terror.ClassOptimizer.New(codeBadGeneratedColumn, mysql.MySQLErrName[mysql.ErrBadGeneratedColumn])
+	ErrFieldNotInGroupBy            = terror.ClassOptimizer.New(codeFieldNotInGroupBy, mysql.MySQLErrName[mysql.ErrFieldNotInGroupBy])
+	ErrBadTable                     = terror.ClassOptimizer.New(codeBadTable, mysql.MySQLErrName[mysql.ErrBadTable])
+	ErrKeyDoesNotExist              = terror.ClassOptimizer.New(codeKeyDoesNotExist, mysql.MySQLErrName[mysql.ErrKeyDoesNotExist])
+	ErrOperandColumns               = terror.ClassOptimizer.New(codeOperandColumns, mysql.MySQLErrName[mysql.ErrOperandColumns])
+	ErrInvalidWildCard              = terror.ClassOptimizer.New(codeInvalidWildCard, "Wildcard fields without any table name appears in wrong place")
+	ErrInvalidGroupFuncUse          = terror.ClassOptimizer.New(codeInvalidGroupFuncUse, mysql.MySQLErrName[mysql.ErrInvalidGroupFuncUse])
+	ErrIllegalReference             = terror.ClassOptimizer.New(codeIllegalReference, mysql.MySQLErrName[mysql.ErrIllegalReference])
+	ErrNoDB                         = terror.ClassOptimizer.New(codeNoDB, mysql.MySQLErrName[mysql.ErrNoDB])
+	ErrUnknownExplainFormat         = terror.ClassOptimizer.New(codeUnknownExplainFormat, mysql.MySQLErrName[mysql.ErrUnknownExplainFormat])
+	ErrWrongGroupField              = terror.ClassOptimizer.New(codeWrongGroupField, mysql.MySQLErrName[mysql.ErrWrongGroupField])
+	ErrDupFieldName                 = terror.ClassOptimizer.New(codeDupFieldName, mysql.MySQLErrName[mysql.ErrDupFieldName])
+	ErrNonUpdatableTable            = terror.ClassOptimizer.New(codeNonUpdatableTable, mysql.MySQLErrName[mysql.ErrNonUpdatableTable])
+	ErrInternal                     = terror.ClassOptimizer.New(codeInternal, mysql.MySQLErrName[mysql.ErrInternal])
+	ErrNonUniqTable                 = terror.ClassOptimizer.New(codeNonUniqTable, mysql.MySQLErrName[mysql.ErrNonuniqTable])
 )
 
 func init() {
 	mysqlErrCodeMap := map[terror.ErrCode]uint16{
-		codeWrongUsage:           mysql.ErrWrongUsage,
-		codeAmbiguous:            mysql.ErrNonUniq,
-		codeUnknownColumn:        mysql.ErrBadField,
-		codeUnknownTable:         mysql.ErrBadTable,
-		codeWrongArguments:       mysql.ErrWrongArguments,
-		codeBadGeneratedColumn:   mysql.ErrBadGeneratedColumn,
-		codeFieldNotInGroupBy:    mysql.ErrFieldNotInGroupBy,
-		codeBadTable:             mysql.ErrBadTable,
-		codeKeyDoesNotExist:      mysql.ErrKeyDoesNotExist,
-		codeOperandColumns:       mysql.ErrOperandColumns,
-		codeInvalidWildCard:      mysql.ErrParse,
-		codeInvalidGroupFuncUse:  mysql.ErrInvalidGroupFuncUse,
-		codeIllegalReference:     mysql.ErrIllegalReference,
-		codeNoDB:                 mysql.ErrNoDB,
-		codeUnknownExplainFormat: mysql.ErrUnknownExplainFormat,
-		codeWrongGroupField:      mysql.ErrWrongGroupField,
-		codeDupFieldName:         mysql.ErrDupFieldName,
-		codeNonUpdatableTable:    mysql.ErrUnknownTable,
-		codeInternal:             mysql.ErrInternal,
-		codeNonUniqTable:         mysql.ErrNonuniqTable,
+		codeWrongUsage:                   mysql.ErrWrongUsage,
+		codeAmbiguous:                    mysql.ErrNonUniq,
+		codeUnknownColumn:                mysql.ErrBadField,
+		codeUnknownTable:                 mysql.ErrBadTable,
+		codeWrongArguments:               mysql.ErrWrongArguments,
+		codeWrongNumberOfColumnsInSelect: mysql.ErrWrongNumberOfColumnsInSelect,
+		codeBadGeneratedColumn:           mysql.ErrBadGeneratedColumn,
+		codeFieldNotInGroupBy:            mysql.ErrFieldNotInGroupBy,
+		codeBadTable:                     mysql.ErrBadTable,
+		codeKeyDoesNotExist:              mysql.ErrKeyDoesNotExist,
+		codeOperandColumns:               mysql.ErrOperandColumns,
+		codeInvalidWildCard:              mysql.ErrParse,
+		codeInvalidGroupFuncUse:          mysql.ErrInvalidGroupFuncUse,
+		codeIllegalReference:             mysql.ErrIllegalReference,
+		codeNoDB:                         mysql.ErrNoDB,
+		codeUnknownExplainFormat:         mysql.ErrUnknownExplainFormat,
+		codeWrongGroupField:              mysql.ErrWrongGroupField,
+		codeDupFieldName:                 mysql.ErrDupFieldName,
+		codeNonUpdatableTable:            mysql.ErrUnknownTable,
+		codeInternal:                     mysql.ErrInternal,
+		codeNonUniqTable:                 mysql.ErrNonuniqTable,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassOptimizer] = mysqlErrCodeMap
 }

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -670,23 +670,26 @@ func (b *planBuilder) buildProjection4Union(u *LogicalUnionAll) {
 func (b *planBuilder) buildUnion(union *ast.UnionStmt) LogicalPlan {
 	distinctSelectPlans, allSelectPlans := b.divideUnionSelectPlans(union.SelectList.Selects)
 	if b.err != nil {
+		b.err = errors.Trace(b.err)
 		return nil
 	}
 
 	unionDistinctPlan := b.buildSubUnion(distinctSelectPlans)
 	if b.err != nil {
+		b.err = errors.Trace(b.err)
 		return nil
 	}
 
 	if unionDistinctPlan != nil {
 		unionDistinctPlan = b.buildDistinct(unionDistinctPlan, unionDistinctPlan.Schema().Len())
-		if allSelectPlans != nil && len(allSelectPlans) != 0 {
+		if len(allSelectPlans) != 0 {
 			allSelectPlans = append(allSelectPlans, unionDistinctPlan)
 		}
 	}
 
 	unionAllPlan := b.buildSubUnion(allSelectPlans)
 	if b.err != nil {
+		b.err = errors.Trace(b.err)
 		return nil
 	}
 
@@ -719,6 +722,7 @@ func (b *planBuilder) divideUnionSelectPlans(selects []*ast.SelectStmt) (distinc
 		}
 		selectPlan := b.buildSelect(stmt)
 		if b.err != nil {
+			b.err = errors.Trace(b.err)
 			return nil, nil
 		}
 		if columnNums == -1 {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -682,7 +682,7 @@ func (b *planBuilder) buildUnion(union *ast.UnionStmt) LogicalPlan {
 
 	if unionDistinctPlan != nil {
 		unionDistinctPlan = b.buildDistinct(unionDistinctPlan, unionDistinctPlan.Schema().Len())
-		if len(allSelectPlans) != 0 {
+		if len(allSelectPlans) > 0 {
 			allSelectPlans = append(allSelectPlans, unionDistinctPlan)
 		}
 	}


### PR DESCRIPTION
tidb diff result with mysql when mix use union and union-all

fix #6731

## What have you changed? (mandatory)

- modify parser to tag every selectStmt under unionStmt with `UnionDistinct` flag 
- let plan builder to last last union-distinct as pivot
- build a distinct plan use element before pivot, and make it as child of no distinct plan use element after pivot

so, it will work like https://dev.mysql.com/doc/refman/5.7/en/union.html

> You can mix UNION ALL and UNION DISTINCT in the same query. Mixed UNION types are treated such that a DISTINCT union overrides any ALL union to its left. A DISTINCT union can be produced explicitly by using UNION DISTINCT or implicitly by using UNION with no following DISTINCT or ALL keyword.

## What are the type of the changes (mandatory)?

Bug Fix

## How has this PR been tested (mandatory)?

- manual tested
- unit test in logical_plan_test.go
- integration test in executor_test.go

## Does this PR affect documentation (docs/docs-cn) update? (optional)

No, it make behaviour like mysql

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tidb/issues/6731

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

see #6731 