### PR TITLE
plan, executor, cmd: remove equal conditions in PhysicalMergeJoin

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -103,7 +103,7 @@ TableScan_22			cop	table:s, range:[-inf,+inf], keep order:true	10000.00
 TableReader_23	Projection_21		root	data:TableScan_22	10000.00
 Projection_21	Selection_20	TableReader_23	root	1, s.c1	10000.00
 Selection_20	MergeJoin_15	Projection_21	root	ne(k, 0)	8000.00
-MergeJoin_15	Projection_14	TableReader_18,Selection_20	root	left outer join, equal:[eq(test.t1.c1, s.c1)], left key:test.t1.c1, right key:s.c1	10000.00
+MergeJoin_15	Projection_14	TableReader_18,Selection_20	root	left outer join, left key:test.t1.c1, right key:s.c1	10000.00
 Projection_14	Projection_13	MergeJoin_15	root	test.t1.c1, ifnull(5_col_0, 0)	10000.00
 Projection_13		Projection_14	root	k	10000.00
 explain select * from information_schema.columns;
@@ -150,7 +150,7 @@ TableScan_18			cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
 TableReader_19	MergeJoin_28		root	data:TableScan_18	10000.00
 IndexScan_22			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 IndexReader_23	MergeJoin_28		root	index:IndexScan_22	10000.00
-MergeJoin_28	StreamAgg_12	TableReader_19,IndexReader_23	root	left outer semi join, equal:[eq(test.t1.c1, test.t2.c1)], left key:test.t1.c1, right key:test.t2.c1	10000.00
+MergeJoin_28	StreamAgg_12	TableReader_19,IndexReader_23	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
 StreamAgg_12		MergeJoin_28	root	, funcs:sum(5_aux_0)	1.00
 explain select 1 in (select c2 from t2) from t1;
 id	parents	children	task	operator info	count

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -50,7 +50,7 @@ IndexLookUp_17	MergeJoin_7		root	index:Selection_16, table:TableScan_15	1998.00
 IndexScan_19			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1985.00
 TableScan_20			cop	table:t2, keep order:false	1985.00
 IndexLookUp_21	MergeJoin_7		root	index:IndexScan_19, table:TableScan_20	1985.00
-MergeJoin_7	Projection_6	IndexLookUp_17,IndexLookUp_21	root	left outer join, equal:[eq(test.t1.c2, test.t2.c1)], left key:test.t1.c2, right key:test.t2.c1	2481.25
+MergeJoin_7	Projection_6	IndexLookUp_17,IndexLookUp_21	root	left outer join, left key:test.t1.c2, right key:test.t2.c1	2481.25
 Projection_6		MergeJoin_7	root	test.t1.c1, test.t1.c2, test.t1.c3, test.t2.c1, test.t2.c2	2481.25
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	parents	children	task	operator info	count

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -714,26 +714,8 @@ func (b *executorBuilder) buildMergeJoin(v *plan.PhysicalMergeJoin) Executor {
 			leftExec.retTypes(), rightExec.retTypes()),
 	}
 
-	leftKeys := make([]*expression.Column, 0, len(v.EqualConditions))
-	rightKeys := make([]*expression.Column, 0, len(v.EqualConditions))
-	for _, eqCond := range v.EqualConditions {
-		if len(eqCond.GetArgs()) != 2 {
-			b.err = errors.Annotate(ErrBuildExecutor, "invalid join key for equal condition")
-			return nil
-		}
-		leftKey, ok := eqCond.GetArgs()[0].(*expression.Column)
-		if !ok {
-			b.err = errors.Annotate(ErrBuildExecutor, "left side of join key must be column for merge join")
-			return nil
-		}
-		rightKey, ok := eqCond.GetArgs()[1].(*expression.Column)
-		if !ok {
-			b.err = errors.Annotate(ErrBuildExecutor, "right side of join key must be column for merge join")
-			return nil
-		}
-		leftKeys = append(leftKeys, leftKey)
-		rightKeys = append(rightKeys, rightKey)
-	}
+	leftKeys := v.LeftKeys
+	rightKeys := v.RightKeys
 
 	e.outerIdx = 0
 	innerFilter := v.RightConditions

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -846,7 +846,7 @@ func (s *testSuite) TestMergejoinOrder(c *C) {
 		"TableReader_11 MergeJoin_15  root data:TableScan_10 10000.00",
 		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
 		"TableReader_13 MergeJoin_15  root data:TableScan_12 10000.00",
-		"MergeJoin_15  TableReader_11,TableReader_13 root left outer join, equal:[eq(test.t1.a, test.t2.a)], left cond:[ne(test.t1.a, 3)], left key:test.t1.a, right key:test.t2.a 12500.00",
+		"MergeJoin_15  TableReader_11,TableReader_13 root left outer join, left cond:[ne(test.t1.a, 3)], left key:test.t1.a, right key:test.t2.a 12500.00",
 	))
 
 	tk.MustExec("set @@tidb_max_chunk_size=1")

--- a/plan/exhaust_physical_plans.go
+++ b/plan/exhaust_physical_plans.go
@@ -63,11 +63,8 @@ func findMaxPrefixLen(candidates [][]*expression.Column, keys []*expression.Colu
 	return maxLen
 }
 
-func (p *LogicalJoin) getEqAndOtherCondsByOffsets(offsets []int) ([]*expression.ScalarFunction, []expression.Expression) {
-	var (
-		eqConds    = make([]*expression.ScalarFunction, 0, len(p.EqualConditions))
-		otherConds = make([]expression.Expression, len(p.OtherConditions))
-	)
+func (p *LogicalJoin) moveEqualToOtherConditions(offsets []int) []expression.Expression {
+	otherConds := make([]expression.Expression, len(p.OtherConditions))
 	copy(otherConds, p.OtherConditions)
 	for i, eqCond := range p.EqualConditions {
 		match := false
@@ -79,17 +76,15 @@ func (p *LogicalJoin) getEqAndOtherCondsByOffsets(offsets []int) ([]*expression.
 		}
 		if !match {
 			otherConds = append(otherConds, eqCond)
-		} else {
-			eqConds = append(eqConds, eqCond)
 		}
 	}
-	return eqConds, otherConds
+	return otherConds
 }
 
 // Only if the input required prop is the prefix fo join keys, we can pass through this property.
 func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *requiredProp) ([]*requiredProp, bool) {
-	lProp := &requiredProp{taskTp: rootTaskType, cols: p.leftKeys, expectedCnt: math.MaxFloat64}
-	rProp := &requiredProp{taskTp: rootTaskType, cols: p.rightKeys, expectedCnt: math.MaxFloat64}
+	lProp := &requiredProp{taskTp: rootTaskType, cols: p.LeftKeys, expectedCnt: math.MaxFloat64}
+	rProp := &requiredProp{taskTp: rootTaskType, cols: p.RightKeys, expectedCnt: math.MaxFloat64}
 	if !prop.isEmpty() {
 		// sort merge join fits the cases of massive ordered data, so desc scan is always expensive.
 		if prop.desc {
@@ -134,11 +129,11 @@ func (p *LogicalJoin) getMergeJoin(prop *requiredProp) []PhysicalPlan {
 			LeftConditions:  p.LeftConditions,
 			RightConditions: p.RightConditions,
 			DefaultValues:   p.DefaultValues,
-			leftKeys:        leftKeys,
-			rightKeys:       rightKeys,
+			LeftKeys:        leftKeys,
+			RightKeys:       rightKeys,
 		}.init(p.ctx, p.stats.scaleByExpectCnt(prop.expectedCnt))
 		mergeJoin.SetSchema(p.schema)
-		mergeJoin.EqualConditions, mergeJoin.OtherConditions = p.getEqAndOtherCondsByOffsets(offsets)
+		mergeJoin.OtherConditions = p.moveEqualToOtherConditions(offsets)
 		if reqProps, ok := mergeJoin.tryToGetChildReqProp(prop); ok {
 			mergeJoin.childrenReqProps = reqProps
 			joins = append(joins, mergeJoin)

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -218,9 +218,6 @@ func (p *PhysicalHashJoin) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalMergeJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
-	if len(p.EqualConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", equal:%s", p.EqualConditions))
-	}
 	if len(p.LeftConditions) > 0 {
 		buffer.WriteString(fmt.Sprintf(", left cond:%s", p.LeftConditions))
 	}
@@ -232,13 +229,13 @@ func (p *PhysicalMergeJoin) ExplainInfo() string {
 		buffer.WriteString(fmt.Sprintf(", other cond:%s",
 			expression.ExplainExpressionList(p.OtherConditions)))
 	}
-	if len(p.leftKeys) > 0 {
+	if len(p.LeftKeys) > 0 {
 		buffer.WriteString(fmt.Sprintf(", left key:%s",
-			expression.ExplainColumnList(p.leftKeys)))
+			expression.ExplainColumnList(p.LeftKeys)))
 	}
-	if len(p.rightKeys) > 0 {
+	if len(p.RightKeys) > 0 {
 		buffer.WriteString(fmt.Sprintf(", right key:%s",
-			expression.ExplainColumnList(p.rightKeys)))
+			expression.ExplainColumnList(p.RightKeys)))
 	}
 	return buffer.String()
 }

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -429,7 +429,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSubquery(c *C) {
 		// Test Nested sub query.
 		{
 			sql:  "select * from t where exists (select s.a from t s where s.c in (select c from t as k where k.d = s.d) having sum(s.a) = t.a )",
-			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[<nil>,+inf]])->IndexReader(Index(t.c_d_e)[[<nil>,+inf]])}(s.d,k.d)(s.c,k.c)->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[<nil>,+inf]])->IndexReader(Index(t.c_d_e)[[<nil>,+inf]])}(s.c,k.c)(s.d,k.d)->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
 		},
 		// Test Semi Join + Order by.
 		{

--- a/plan/physical_plans.go
+++ b/plan/physical_plans.go
@@ -232,15 +232,14 @@ type PhysicalMergeJoin struct {
 
 	JoinType JoinType
 
-	EqualConditions []*expression.ScalarFunction
 	LeftConditions  []expression.Expression
 	RightConditions []expression.Expression
 	OtherConditions []expression.Expression
 
 	DefaultValues []types.Datum
 
-	leftKeys  []*expression.Column
-	rightKeys []*expression.Column
+	LeftKeys  []*expression.Column
+	RightKeys []*expression.Column
 }
 
 // PhysicalLock is the physical operator of lock, which is used for `select ... for update` clause.

--- a/plan/resolve_indices.go
+++ b/plan/resolve_indices.go
@@ -51,9 +51,11 @@ func (p *PhysicalMergeJoin) ResolveIndices() {
 	p.physicalSchemaProducer.ResolveIndices()
 	lSchema := p.children[0].Schema()
 	rSchema := p.children[1].Schema()
-	for _, fun := range p.EqualConditions {
-		fun.GetArgs()[0].ResolveIndices(lSchema)
-		fun.GetArgs()[1].ResolveIndices(rSchema)
+	for _, col := range p.LeftKeys {
+		col.ResolveIndices(lSchema)
+	}
+	for _, col := range p.RightKeys {
+		col.ResolveIndices(rSchema)
 	}
 	for _, expr := range p.LeftConditions {
 		expr.ResolveIndices(lSchema)

--- a/plan/stringer.go
+++ b/plan/stringer.go
@@ -92,9 +92,9 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 			id = "MergeInnerJoin"
 		}
 		str = id + "{" + strings.Join(children, "->") + "}"
-		for _, eq := range x.EqualConditions {
-			l := eq.GetArgs()[0].String()
-			r := eq.GetArgs()[1].String()
+		for i := range x.LeftKeys {
+			l := x.LeftKeys[i].String()
+			r := x.RightKeys[i].String()
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
 	case *LogicalApply, *PhysicalApply:


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

Remove `EqualConditions` and export `leftKeys`/`rightKeys` so that we don't need to:
- print equal conditions for merge join in the result of `EXPLAIN` statement
- rebuild equal conditions during physical plan exhausting
- build left and right join keys when constructing the merge join executor

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)
No

