### PR TITLE
plan: refine the result of `EXPLAIN` statement

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -157,7 +157,7 @@ IndexScan_14			cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:fals
 TableScan_15	Selection_16		cop	table:rr, keep order:false	10000.00
 Selection_16		TableScan_15	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	3.33
 IndexLookUp_17	IndexJoin_18		root	index:IndexScan_14, table:Selection_16	3.33
-IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	outer:TableReader_42, inner join, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
+IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
 Limit_12	Projection_9	IndexJoin_18	root	offset:0, count:2000	0.00
 Projection_9		Limit_12	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	0.00
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -163,7 +163,7 @@ IndexScan_14			cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:fals
 TableScan_15	Selection_16		cop	table:rr, keep order:false	2000.00
 Selection_16		TableScan_15	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	970.00
 IndexLookUp_17	IndexJoin_18		root	index:IndexScan_14, table:Selection_16	970.00
-IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	outer:TableReader_42, inner join, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
+IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
 Limit_12	Projection_9	IndexJoin_18	root	offset:0, count:2000	428.32
 Projection_9		Limit_12	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	428.32
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -13,9 +13,9 @@ TableScan_16			cop	table:t3, range:[-inf,+inf], keep order:false	10000.00
 TableReader_17	Projection_15		root	data:TableScan_16	10000.00
 Projection_15	HashLeftJoin_14	TableReader_17	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	10000.00
 TableScan_29	StreamAgg_22		cop	table:s, range:[-inf,+inf], keep order:false	10000.00
-StreamAgg_22		TableScan_29	cop	, funcs:sum(s.a)	1.00
+StreamAgg_22		TableScan_29	cop	funcs:sum(s.a)	1.00
 TableReader_31	StreamAgg_30		root	data:StreamAgg_22	1.00
-StreamAgg_30	HashLeftJoin_14	TableReader_31	root	, funcs:sum(col_0)	1.00
+StreamAgg_30	HashLeftJoin_14	TableReader_31	root	funcs:sum(col_0)	1.00
 HashLeftJoin_14	Projection_13	Projection_15,StreamAgg_30	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	8000.00
 Projection_13		HashLeftJoin_14	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	8000.00
 explain select * from t1;
@@ -47,7 +47,7 @@ TableReader_23	IndexJoin_11		root	data:TableScan_22	3333.33
 IndexScan_8			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:false	10000.00
 TableScan_9			cop	table:t2, keep order:false	10000.00
 IndexLookUp_10	IndexJoin_11		root	index:IndexScan_8, table:TableScan_9	10000.00
-IndexJoin_11		TableReader_23,IndexLookUp_10	root	outer:TableReader_23, left outer join, outer key:test.t1.c2, inner key:test.t2.c1	4166.67
+IndexJoin_11		TableReader_23,IndexLookUp_10	root	left outer join, inner:IndexLookUp_10, outer key:test.t1.c2, inner key:test.t2.c1	4166.67
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	parents	children	task	operator info	count
 TableScan_4			cop	table:t1, range:[1,1], keep order:false	1.00
@@ -65,7 +65,7 @@ TableScan_20	HashAgg_17		cop	table:b, range:[-inf,+inf], keep order:false	10000.
 HashAgg_17		TableScan_20	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	8000.00
 TableReader_22	HashAgg_21		root	data:HashAgg_17	8000.00
 HashAgg_21	IndexJoin_14	TableReader_22	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	8000.00
-IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	outer:HashAgg_21, inner join, outer key:b.c2, inner key:a.c1	10000.00
+IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	10000.00
 Projection_11		IndexJoin_14	root	cast(join_agg_0)	10000.00
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	parents	children	task	operator info	count
@@ -88,9 +88,9 @@ TableReader_7			root	data:Selection_6	0.33
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	parents	children	task	operator info	count
 TableScan_20	StreamAgg_13		cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-StreamAgg_13		TableScan_20	cop	, funcs:sum(in(test.t1.c1, 1, 2))	1.00
+StreamAgg_13		TableScan_20	cop	funcs:sum(in(test.t1.c1, 1, 2))	1.00
 TableReader_22	StreamAgg_21		root	data:StreamAgg_13	1.00
-StreamAgg_21		TableReader_22	root	, funcs:sum(col_0)	1.00
+StreamAgg_21		TableReader_22	root	funcs:sum(col_0)	1.00
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	parents	children	task	operator info	count
 TableScan_10			cop	table:t1, range:[0,0], [1,1], keep order:false	2.00
@@ -119,7 +119,7 @@ Limit_35		Selection_34	cop	offset:0, count:1	1.00
 TableScan_33			cop	table:t2, keep order:false	1.00
 IndexLookUp_36	Limit_21		root	index:Limit_35, table:TableScan_33	1.00
 Limit_21	Apply_14	IndexLookUp_36	root	offset:0, count:1	1.00
-Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21, right:Limit_21	10000.00
+Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21	10000.00
 Projection_12		Apply_14	root	eq(test.t1.c2, test.t2.c2)	10000.00
 explain select * from t1 order by c1 desc limit 1;
 id	parents	children	task	operator info	count
@@ -151,7 +151,7 @@ TableReader_19	MergeJoin_28		root	data:TableScan_18	10000.00
 IndexScan_22			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 IndexReader_23	MergeJoin_28		root	index:IndexScan_22	10000.00
 MergeJoin_28	StreamAgg_12	TableReader_19,IndexReader_23	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
-StreamAgg_12		MergeJoin_28	root	, funcs:sum(5_aux_0)	1.00
+StreamAgg_12		MergeJoin_28	root	funcs:sum(5_aux_0)	1.00
 explain select 1 in (select c2 from t2) from t1;
 id	parents	children	task	operator info	count
 TableScan_8			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
@@ -169,7 +169,7 @@ TableScan_16	Selection_17		cop	table:t2, range:[-inf,+inf], keep order:false	100
 Selection_17		TableScan_16	cop	eq(6, test.t2.c2)	10.00
 TableReader_18	HashLeftJoin_19		root	data:Selection_17	10.00
 HashLeftJoin_19	StreamAgg_12	TableReader_21,TableReader_18	root	left outer semi join, inner:TableReader_18	10000.00
-StreamAgg_12		HashLeftJoin_19	root	, funcs:sum(5_aux_0)	1.00
+StreamAgg_12		HashLeftJoin_19	root	funcs:sum(5_aux_0)	1.00
 explain format="dot" select sum(t1.c1 in (select c1 from t2)) from t1;
 dot contents
 

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -14,9 +14,9 @@ TableScan_16			cop	table:t3, range:[-inf,+inf], keep order:false	2000.00
 TableReader_17	Projection_15		root	data:TableScan_16	2000.00
 Projection_15	HashLeftJoin_14	TableReader_17	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	2000.00
 TableScan_29	StreamAgg_22		cop	table:s, range:[-inf,+inf], keep order:false	2000.00
-StreamAgg_22		TableScan_29	cop	, funcs:sum(s.a)	1.00
+StreamAgg_22		TableScan_29	cop	funcs:sum(s.a)	1.00
 TableReader_31	StreamAgg_30		root	data:StreamAgg_22	1.00
-StreamAgg_30	HashLeftJoin_14	TableReader_31	root	, funcs:sum(col_0)	1.00
+StreamAgg_30	HashLeftJoin_14	TableReader_31	root	funcs:sum(col_0)	1.00
 HashLeftJoin_14	Projection_13	Projection_15,StreamAgg_30	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	1600.00
 Projection_13		HashLeftJoin_14	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	1600.00
 explain select * from t1;
@@ -69,7 +69,7 @@ TableScan_20	HashAgg_17		cop	table:b, range:[-inf,+inf], keep order:false	1985.0
 HashAgg_17		TableScan_20	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	1985.00
 TableReader_22	HashAgg_21		root	data:HashAgg_17	1985.00
 HashAgg_21	IndexJoin_14	TableReader_22	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	1985.00
-IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	outer:HashAgg_21, inner join, outer key:b.c2, inner key:a.c1	1985.00
+IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	1985.00
 Projection_11		IndexJoin_14	root	cast(join_agg_0)	1985.00
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	parents	children	task	operator info	count
@@ -106,7 +106,7 @@ Limit_35		Selection_34	cop	offset:0, count:1	1.00
 TableScan_33			cop	table:t2, keep order:false	1.00
 IndexLookUp_36	Limit_21		root	index:Limit_35, table:TableScan_33	1.00
 Limit_21	Apply_14	IndexLookUp_36	root	offset:0, count:1	1.00
-Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21, right:Limit_21	1999.00
+Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21	1999.00
 Projection_12		Apply_14	root	eq(test.t1.c2, test.t2.c2)	1999.00
 explain select * from t1 order by c1 desc limit 1;
 id	parents	children	task	operator info	count

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -176,10 +176,10 @@ IndexScan_30			cop	table:te, index:trade_id, range:[<nil>,+inf], keep order:fals
 TableScan_31	Selection_32		cop	table:te, keep order:false	10000.00
 Selection_32		TableScan_31	cop	ge(te.expect_time, 2018-04-23 00:00:00.000000), le(te.expect_time, 2018-04-23 23:59:59.000000)	250.00
 IndexLookUp_33	IndexJoin_34		root	index:IndexScan_30, table:Selection_32	250.00
-IndexJoin_34	TopN_139	IndexLookUp_104,IndexLookUp_33	root	outer:IndexLookUp_104, inner join, outer key:tr.id, inner key:te.trade_id	0.00
+IndexJoin_34	TopN_139	IndexLookUp_104,IndexLookUp_33	root	inner join, inner:IndexLookUp_33, outer key:tr.id, inner key:te.trade_id	0.00
 TopN_139	IndexJoin_136	IndexJoin_34	root	te.expect_time:asc, offset:0, count:5	0.00
 IndexScan_134			cop	table:p, index:relate_id, range:[<nil>,+inf], keep order:false	10000.00
 IndexReader_135	IndexJoin_136		root	index:IndexScan_134	10000.00
-IndexJoin_136	Limit_18	TopN_139,IndexReader_135	root	outer:TopN_139, left outer join, outer key:tr.id, inner key:p.relate_id	0.00
+IndexJoin_136	Limit_18	TopN_139,IndexReader_135	root	left outer join, inner:IndexReader_135, outer key:tr.id, inner key:p.relate_id	0.00
 Limit_18	Projection_12	IndexJoin_136	root	offset:0, count:5	0.00
 Projection_12		Limit_18	root	te.expect_time	0.00

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -846,7 +846,7 @@ func (s *testSuite) TestMergejoinOrder(c *C) {
 		"TableReader_11 MergeJoin_15  root data:TableScan_10 10000.00",
 		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
 		"TableReader_13 MergeJoin_15  root data:TableScan_12 10000.00",
-		"MergeJoin_15  TableReader_11,TableReader_13 root left outer join, left cond:[ne(test.t1.a, 3)], left key:test.t1.a, right key:test.t2.a 12500.00",
+		"MergeJoin_15  TableReader_11,TableReader_13 root left outer join, left key:test.t1.a, right key:test.t2.a, left cond:[ne(test.t1.a, 3)] 12500.00",
 	))
 
 	tk.MustExec("set @@tidb_max_chunk_size=1")

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -33,7 +33,7 @@ func (p *PhysicalIndexScan) ExplainInfo() string {
 	if p.TableAsName != nil && p.TableAsName.O != "" {
 		tblName = p.TableAsName.O
 	}
-	buffer.WriteString(fmt.Sprintf("table:%s", tblName))
+	fmt.Fprintf(buffer, "table:%s", tblName)
 	if len(p.Index.Columns) > 0 {
 		buffer.WriteString(", index:")
 		for i, idxCol := range p.Index.Columns {
@@ -52,7 +52,7 @@ func (p *PhysicalIndexScan) ExplainInfo() string {
 			}
 		}
 	}
-	buffer.WriteString(fmt.Sprintf(", keep order:%v", p.KeepOrder))
+	fmt.Fprintf(buffer, ", keep order:%v", p.KeepOrder)
 	if p.Desc {
 		buffer.WriteString(", desc")
 	}
@@ -66,9 +66,9 @@ func (p *PhysicalTableScan) ExplainInfo() string {
 	if p.TableAsName != nil && p.TableAsName.O != "" {
 		tblName = p.TableAsName.O
 	}
-	buffer.WriteString(fmt.Sprintf("table:%s", tblName))
+	fmt.Fprintf(buffer, "table:%s", tblName)
 	if p.pkCol != nil {
-		buffer.WriteString(fmt.Sprintf(", pk col:%s", p.pkCol.ExplainInfo()))
+		fmt.Fprintf(buffer, ", pk col:%s", p.pkCol.ExplainInfo())
 	}
 	if len(p.Ranges) > 0 {
 		buffer.WriteString(", range:")
@@ -79,7 +79,7 @@ func (p *PhysicalTableScan) ExplainInfo() string {
 			}
 		}
 	}
-	buffer.WriteString(fmt.Sprintf(", keep order:%v", p.KeepOrder))
+	fmt.Fprintf(buffer, ", keep order:%v", p.KeepOrder)
 	if p.Desc {
 		buffer.WriteString(", desc")
 	}
@@ -88,12 +88,12 @@ func (p *PhysicalTableScan) ExplainInfo() string {
 
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalTableReader) ExplainInfo() string {
-	return fmt.Sprintf("data:%s", p.tablePlan.ExplainID())
+	return "data:" + p.tablePlan.ExplainID()
 }
 
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalIndexReader) ExplainInfo() string {
-	return fmt.Sprintf("index:%s", p.indexPlan.ExplainID())
+	return "index:" + p.indexPlan.ExplainID()
 }
 
 // ExplainInfo implements PhysicalPlan interface.
@@ -129,7 +129,7 @@ func (p *PhysicalSort) ExplainInfo() string {
 		if item.Desc {
 			order = "desc"
 		}
-		buffer.WriteString(fmt.Sprintf("%s:%s", item.Expr.ExplainInfo(), order))
+		fmt.Fprintf(buffer, "%s:%s", item.Expr.ExplainInfo(), order)
 		if i+1 < len(p.ByItems) {
 			buffer.WriteString(", ")
 		}
@@ -146,10 +146,10 @@ func (p *PhysicalLimit) ExplainInfo() string {
 func (p *basePhysicalAgg) ExplainInfo() string {
 	buffer := bytes.NewBufferString("")
 	if len(p.GroupByItems) > 0 {
-		buffer.WriteString(fmt.Sprintf("group by:%s",
-			expression.ExplainExpressionList(p.GroupByItems)))
+		fmt.Fprintf(buffer, "group by:%s, ",
+			expression.ExplainExpressionList(p.GroupByItems))
 	}
-	buffer.WriteString(", funcs:")
+	buffer.WriteString("funcs:")
 	for i, agg := range p.AggFuncs {
 		buffer.WriteString(aggregation.ExplainAggFunc(agg))
 		if i+1 < len(p.AggFuncs) {
@@ -162,34 +162,32 @@ func (p *basePhysicalAgg) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalApply) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.PhysicalJoin.ExplainInfo())
-	buffer.WriteString(fmt.Sprintf(", right:%s", p.Children()[1].ExplainID()))
 	return buffer.String()
 }
 
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalIndexJoin) ExplainInfo() string {
-	var buffer bytes.Buffer
-	fmt.Fprintf(&buffer, "outer:%s", p.Children()[p.OuterIndex].ExplainID())
-	buffer.WriteString(fmt.Sprintf(", %s", p.JoinType))
+	buffer := bytes.NewBufferString(p.JoinType.String())
+	fmt.Fprintf(buffer, ", outer:%s", p.Children()[p.OuterIndex].ExplainID())
 	if len(p.OuterJoinKeys) > 0 {
-		buffer.WriteString(fmt.Sprintf(", outer key:%s",
-			expression.ExplainColumnList(p.OuterJoinKeys)))
+		fmt.Fprintf(buffer, ", outer key:%s",
+			expression.ExplainColumnList(p.OuterJoinKeys))
 	}
 	if len(p.InnerJoinKeys) > 0 {
-		buffer.WriteString(fmt.Sprintf(", inner key:%s",
-			expression.ExplainColumnList(p.InnerJoinKeys)))
+		fmt.Fprintf(buffer, ", inner key:%s",
+			expression.ExplainColumnList(p.InnerJoinKeys))
 	}
 	if len(p.LeftConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", left cond:%s",
-			expression.ExplainExpressionList(p.LeftConditions)))
+		fmt.Fprintf(buffer, ", left cond:%s",
+			expression.ExplainExpressionList(p.LeftConditions))
 	}
 	if len(p.RightConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", right cond:%s",
-			expression.ExplainExpressionList(p.RightConditions)))
+		fmt.Fprintf(buffer, ", right cond:%s",
+			expression.ExplainExpressionList(p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", other cond:%s",
-			expression.ExplainExpressionList(p.OtherConditions)))
+		fmt.Fprintf(buffer, ", other cond:%s",
+			expression.ExplainExpressionList(p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -197,20 +195,20 @@ func (p *PhysicalIndexJoin) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalHashJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
-	buffer.WriteString(fmt.Sprintf(", inner:%s", p.Children()[p.InnerChildIdx].ExplainID()))
+	fmt.Fprintf(buffer, ", outer:%s", p.Children()[1-p.InnerChildIdx].ExplainID())
 	if len(p.EqualConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", equal:%s", p.EqualConditions))
+		fmt.Fprintf(buffer, ", equal:%s", p.EqualConditions)
 	}
 	if len(p.LeftConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", left cond:%s", p.LeftConditions))
+		fmt.Fprintf(buffer, ", left cond:%s", p.LeftConditions)
 	}
 	if len(p.RightConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", right cond:%s",
-			expression.ExplainExpressionList(p.RightConditions)))
+		fmt.Fprintf(buffer, ", right cond:%s",
+			expression.ExplainExpressionList(p.RightConditions))
 	}
 	if len(p.OtherConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", other cond:%s",
-			expression.ExplainExpressionList(p.OtherConditions)))
+		fmt.Fprintf(buffer, ", other cond:%s",
+			expression.ExplainExpressionList(p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -218,27 +216,24 @@ func (p *PhysicalHashJoin) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalMergeJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
-	if len(p.EqualConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", equal:%s", p.EqualConditions))
-	}
-	if len(p.LeftConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", left cond:%s", p.LeftConditions))
-	}
-	if len(p.RightConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", right cond:%s",
-			expression.ExplainExpressionList(p.RightConditions)))
-	}
-	if len(p.OtherConditions) > 0 {
-		buffer.WriteString(fmt.Sprintf(", other cond:%s",
-			expression.ExplainExpressionList(p.OtherConditions)))
-	}
 	if len(p.leftKeys) > 0 {
-		buffer.WriteString(fmt.Sprintf(", left key:%s",
-			expression.ExplainColumnList(p.leftKeys)))
+		fmt.Fprintf(buffer, ", left key:%s",
+			expression.ExplainColumnList(p.leftKeys))
 	}
 	if len(p.rightKeys) > 0 {
-		buffer.WriteString(fmt.Sprintf(", right key:%s",
-			expression.ExplainColumnList(p.rightKeys)))
+		fmt.Fprintf(buffer, ", right key:%s",
+			expression.ExplainColumnList(p.rightKeys))
+	}
+	if len(p.LeftConditions) > 0 {
+		fmt.Fprintf(buffer, ", left cond:%s", p.LeftConditions)
+	}
+	if len(p.RightConditions) > 0 {
+		fmt.Fprintf(buffer, ", right cond:%s",
+			expression.ExplainExpressionList(p.RightConditions))
+	}
+	if len(p.OtherConditions) > 0 {
+		fmt.Fprintf(buffer, ", other cond:%s",
+			expression.ExplainExpressionList(p.OtherConditions))
 	}
 	return buffer.String()
 }
@@ -251,11 +246,11 @@ func (p *PhysicalTopN) ExplainInfo() string {
 		if item.Desc {
 			order = "desc"
 		}
-		buffer.WriteString(fmt.Sprintf("%s:%s", item.Expr.ExplainInfo(), order))
+		fmt.Fprintf(buffer, "%s:%s", item.Expr.ExplainInfo(), order)
 		if i+1 < len(p.ByItems) {
 			buffer.WriteString(", ")
 		}
 	}
-	buffer.WriteString(fmt.Sprintf(", offset:%v, count:%v", p.Offset, p.Count))
+	fmt.Fprintf(buffer, ", offset:%v, count:%v", p.Offset, p.Count)
 	return buffer.String()
 }


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

Before this PR:
- we use `buffer.WriteString(fmt.Sprintf(...))` to construct the explain result
- there is a redundant "," in the result of the aggregate operator if the group by clause is empty
- we output the information of `outer` table for index join, `inner` table for hash join, which is confusing and non-uniform
- for apply, we output the `right` table, which is confusing as well

In this PR, we fix the above issues by:
- use `fmt.Fprintf` instead
- remove the redundant "," when group by key is empty
- output `inner` table information for all join algorithms

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test