### PR TITLE
expression, util: handle err instead of panic in EncodeDecimal

### DIFF
--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
+	log "github.com/sirupsen/logrus"
 )
 
 var _ = Suite(&testEvalSuite{})
@@ -134,7 +135,11 @@ func datumExpr(d types.Datum) *tipb.Expr {
 		expr.Val = codec.EncodeInt(nil, int64(d.GetMysqlDuration().Duration))
 	case types.KindMysqlDecimal:
 		expr.Tp = tipb.ExprType_MysqlDecimal
-		expr.Val = codec.EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
+		var err error
+		expr.Val, err = codec.EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
+		if err != nil {
+			log.Warnf("err happened when EncodeDecimal in datumExpr:%s", err.Error())
+		}
 	default:
 		expr.Tp = tipb.ExprType_Null
 	}

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -148,7 +148,12 @@ func (pc *PbConverter) encodeDatum(d types.Datum) (tipb.ExprType, []byte, bool) 
 		val = codec.EncodeInt(nil, int64(d.GetMysqlDuration().Duration))
 	case types.KindMysqlDecimal:
 		tp = tipb.ExprType_MysqlDecimal
-		val = codec.EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
+		var err error
+		val, err = codec.EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
+		if err != nil {
+			log.Errorf("Fail to encode value, err: %s", err.Error())
+			return tp, nil, false
+		}
 	case types.KindMysqlTime:
 		if pc.client.IsRequestTypeSupported(kv.ReqTypeDAG, int64(tipb.ExprType_MysqlTime)) {
 			tp = tipb.ExprType_MysqlTime

--- a/util/codec/bench_test.go
+++ b/util/codec/bench_test.go
@@ -67,7 +67,7 @@ func BenchmarkDecodeDecimal(b *testing.B) {
 	dec := &types.MyDecimal{}
 	dec.FromFloat64(1211.1211113)
 	precision, frac := dec.PrecisionAndFrac()
-	raw := EncodeDecimal([]byte{}, dec, precision, frac)
+	raw, _ := EncodeDecimal([]byte{}, dec, precision, frac)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		DecodeDecimal(raw)

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -44,7 +44,7 @@ const (
 
 // encode will encode a datum and append it to a byte slice. If comparable is true, the encoded bytes can be sorted as it's original order.
 // If hash is true, the encoded bytes can be checked equal as it's original value.
-func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparable bool, hash bool) ([]byte, error) {
+func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparable bool, hash bool) (_ []byte, err error) {
 	for i, length := 0, len(vals); i < length; i++ {
 		switch vals[i].Kind() {
 		case types.KindInt64:
@@ -71,7 +71,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 			// Encoding timestamp need to consider timezone.
 			// If it's not in UTC, transform to UTC first.
 			if t.Type == mysql.TypeTimestamp && sc.TimeZone != time.UTC {
-				err := t.ConvertTimeZone(sc.TimeZone, time.UTC)
+				err = t.ConvertTimeZone(sc.TimeZone, time.UTC)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -97,7 +97,12 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 				}
 				b = append(b, bin...)
 			} else {
-				b = EncodeDecimal(b, vals[i].GetMysqlDecimal(), vals[i].Length(), vals[i].Frac())
+				b, err = EncodeDecimal(b, vals[i].GetMysqlDecimal(), vals[i].Length(), vals[i].Frac())
+				if terror.ErrorEqual(err, types.ErrTruncated) {
+					err = sc.HandleTruncate(err)
+				} else if terror.ErrorEqual(err, types.ErrOverflow) {
+					err = sc.HandleOverflow(err, err)
+				}
 			}
 		case types.KindMysqlEnum:
 			b = encodeUnsignedInt(b, uint64(vals[i].GetMysqlEnum().ToNumber()), comparable)
@@ -124,7 +129,7 @@ func encode(sc *stmtctx.StatementContext, b []byte, vals []types.Datum, comparab
 		}
 	}
 
-	return b, nil
+	return b, errors.Trace(err)
 }
 
 func encodeBytes(b []byte, v []byte, comparable bool) []byte {
@@ -173,7 +178,7 @@ func EncodeValue(sc *stmtctx.StatementContext, b []byte, v ...types.Datum) ([]by
 	return encode(sc, b, v, false, false)
 }
 
-func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTypes []*types.FieldType, colIdx []int, comparable, hash bool) ([]byte, error) {
+func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTypes []*types.FieldType, colIdx []int, comparable, hash bool) (_ []byte, err error) {
 	for _, i := range colIdx {
 		if row.IsNull(i) {
 			b = append(b, NilFlag)
@@ -210,7 +215,7 @@ func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTy
 			// Encoding timestamp need to consider timezone.
 			// If it's not in UTC, transform to UTC first.
 			if t.Type == mysql.TypeTimestamp && sc.TimeZone != time.UTC {
-				err := t.ConvertTimeZone(sc.TimeZone, time.UTC)
+				err = t.ConvertTimeZone(sc.TimeZone, time.UTC)
 				if err != nil {
 					return nil, errors.Trace(err)
 				}
@@ -236,7 +241,10 @@ func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTy
 				}
 				b = append(b, bin...)
 			} else {
-				b = EncodeDecimal(b, row.GetMyDecimal(i), allTypes[i].Flen, allTypes[i].Decimal)
+				b, err = EncodeDecimal(b, row.GetMyDecimal(i), allTypes[i].Flen, allTypes[i].Decimal)
+				if terror.ErrorEqual(err, types.ErrTruncated) {
+					err = sc.HandleTruncate(err)
+				}
 			}
 		case mysql.TypeEnum:
 			b = encodeUnsignedInt(b, uint64(row.GetEnum(i).ToNumber()), comparable)
@@ -256,7 +264,7 @@ func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTy
 			return nil, errors.Errorf("unsupport column type for encode %d", allTypes[i].Tp)
 		}
 	}
-	return b, nil
+	return b, errors.Trace(err)
 }
 
 // HashValues appends the encoded values to byte slice b, returning the appended

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -743,10 +743,22 @@ func (s *testCodecSuite) TestDecimal(c *C) {
 
 	d := types.NewDecFromStringForTest("-123.123456789")
 	_, err := EncodeDecimal(nil, d, 20, 5)
-
 	c.Assert(terror.ErrorEqual(err, types.ErrTruncated), IsTrue)
 	_, err = EncodeDecimal(nil, d, 12, 10)
 	c.Assert(terror.ErrorEqual(err, types.ErrOverflow), IsTrue)
+
+	sc.IgnoreTruncate = true
+	decimalDatum := types.NewDatum(d)
+	decimalDatum.SetLength(20)
+	decimalDatum.SetFrac(5)
+	_, err = EncodeValue(sc, nil, decimalDatum)
+	c.Assert(err, IsNil)
+
+	sc.OverflowAsWarning = true
+	decimalDatum.SetLength(12)
+	decimalDatum.SetFrac(10)
+	_, err = EncodeValue(sc, nil, decimalDatum)
+	c.Assert(err, IsNil)
 }
 
 func (s *testCodecSuite) TestJSON(c *C) {

--- a/util/codec/decimal.go
+++ b/util/codec/decimal.go
@@ -14,24 +14,19 @@
 package codec
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/types"
 )
 
 // EncodeDecimal encodes a decimal into a byte slice which can be sorted lexicographically later.
-func EncodeDecimal(b []byte, dec *types.MyDecimal, precision, frac int) []byte {
+func EncodeDecimal(b []byte, dec *types.MyDecimal, precision, frac int) ([]byte, error) {
 	if precision == 0 {
 		precision, frac = dec.PrecisionAndFrac()
 	}
 	b = append(b, byte(precision), byte(frac))
 	bin, err := dec.ToBin(precision, frac)
-	if err != nil {
-		panic(fmt.Sprintf("should not happen, precision %d, frac %d %v", precision, frac, err))
-	}
 	b = append(b, bin...)
-	return b
+	return b, errors.Trace(err)
 }
 
 // DecodeDecimal decodes bytes to decimal.

--- a/util/codec/decimal_test.go
+++ b/util/codec/decimal_test.go
@@ -47,7 +47,8 @@ func (s *testDecimalSuite) TestDecimalCodec(c *C) {
 	for _, input := range inputs {
 		v := types.NewDecFromFloatForTest(input.Input)
 		datum := types.NewDatum(v)
-		b := EncodeDecimal([]byte{}, datum.GetMysqlDecimal(), datum.Length(), datum.Frac())
+		b, err := EncodeDecimal([]byte{}, datum.GetMysqlDecimal(), datum.Length(), datum.Frac())
+		c.Assert(err, IsNil)
 		_, d, err := DecodeDecimal(b)
 		c.Assert(err, IsNil)
 		c.Assert(v.Compare(d), Equals, 0)
@@ -70,7 +71,8 @@ func (s *testDecimalSuite) TestFrac(c *C) {
 func testFrac(c *C, v *types.MyDecimal) {
 	var d1 types.Datum
 	d1.SetMysqlDecimal(v)
-	b := EncodeDecimal([]byte{}, d1.GetMysqlDecimal(), d1.Length(), d1.Frac())
+	b, err := EncodeDecimal([]byte{}, d1.GetMysqlDecimal(), d1.Length(), d1.Frac())
+	c.Assert(err, IsNil)
 	_, dec, err := DecodeDecimal(b)
 	c.Assert(err, IsNil)
 	c.Assert(dec.String(), Equals, v.String())


### PR DESCRIPTION
PTAL @zz-jason @coocood 
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)
Before this commit, we `panic` when meets error in EncodeDecimal.
This commit handle the error instead of panic.

## What are the type of the changes (mandatory)?
- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested (mandatory)?

unit test

## Does this PR affect documentation (docs/docs-cn) update? (optional)
no

## Refer to a related PR or issue link (optional)
split from #6658 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

