### PR TITLE
types: handle `NULL datum` if we need convert it to string.

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -622,7 +622,7 @@ func (e *InsertValues) getKeysNeedCheck(rows []types.DatumRow) ([][]keyWithDupEr
 			if !distinct {
 				continue
 			}
-			colValStr, err1 := types.DatumsToString(colVals)
+			colValStr, err1 := types.DatumsToString(colVals, false)
 			if err1 != nil {
 				return nil, errors.Trace(err1)
 			}

--- a/executor/show_stats_test.go
+++ b/executor/show_stats_test.go
@@ -88,3 +88,12 @@ func (s *testSuite) TestShowStatsHealthy(c *C) {
 	do.StatsHandle().Update(do.InfoSchema())
 	tk.MustQuery("show stats_healthy").Check(testkit.Rows("test t 0"))
 }
+
+func (s *testSuite) TestShowStatsHasNullValue(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, index idx(a))")
+	tk.MustExec("insert into t values(NULL)")
+	tk.MustExec("analyze table t")
+	tk.MustQuery("show stats_buckets").Check(testkit.Rows("test t idx 1 0 1 1 NULL NULL"))
+}

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -411,7 +411,7 @@ func (ts *HTTPHandlerTestSuite) TestDecodeColumnValue(c *C) {
 		var data interface{}
 		err = decoder.Decode(&data)
 		c.Assert(err, IsNil, Commentf("url:%v\ndata%v", url, data))
-		colVal, err := types.DatumsToString([]types.Datum{row[col.id-1]})
+		colVal, err := types.DatumsToString([]types.Datum{row[col.id-1]}, false)
 		c.Assert(err, IsNil)
 		c.Assert(data, Equals, colVal, Commentf("url:%v", url))
 	}

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -324,7 +324,7 @@ func ValueToString(value *types.Datum, idxCols int) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
-	str, err := types.DatumsToString(decodedVals)
+	str, err := types.DatumsToString(decodedVals, true)
 	if err != nil {
 		return "", errors.Trace(err)
 	}

--- a/types/datum.go
+++ b/types/datum.go
@@ -1807,9 +1807,13 @@ func handleTruncateError(sc *stmtctx.StatementContext) error {
 }
 
 // DatumsToString converts several datums to formatted string.
-func DatumsToString(datums []Datum) (string, error) {
+func DatumsToString(datums []Datum, handleNULL bool) (string, error) {
 	var strs []string
 	for _, datum := range datums {
+		if datum.Kind() == KindNull && handleNULL {
+			strs = append(strs, "NULL")
+			continue
+		}
 		str, err := datum.ToString()
 		if err != nil {
 			return "", errors.Trace(err)


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

Statistics may contain `NULL` values, and this will make `DatumsToString` fail.
So we may meet error if we run `show stats` or `dump stats`.

## What are the type of the changes (mandatory)?
Bug fix

## How has this PR been tested (mandatory)?

~~I don't know how to generate a good case for this test. @lamxTyler any good suggestion?~~

added one in unit-test.

PTAL @coocood @lamxTyler @zz-jason 