### PR TITLE
Add max backoff settings for tikv-client

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -114,7 +114,6 @@ func (a *connArray) Init(addr string, security config.Security) error {
 	}
 
 	for i := range a.v {
-
 		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 		conn, err := grpc.DialContext(
 			ctx,
@@ -126,6 +125,7 @@ func (a *connArray) Init(addr string, security config.Security) error {
 			grpc.WithStreamInterceptor(streamInterceptor),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallMsgSize)),
 			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(MaxSendMsgSize)),
+			grpc.WithBackoffMaxDelay(time.Second*3),
 		)
 		cancel()
 		if err != nil {


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

This PR adds MaxBackoff settings when dialing grpc in tikv-client. Note, pd-client will not be benefited since it's inside etcd's implementation.

When we have connection failures, we have our own backoff strategy, so a short time as 3 seconds is acceptable.

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (mandatory)?

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)

Fix https://github.com/pingcap/tidb/issues/6730

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)
