### PR TITLE
sessionctx/binloginfo: make TestMaxRecvSize more stable

### DIFF
--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -369,7 +369,9 @@ func mutationRowsToRows(c *C, mutationRows [][]byte, columnValueOffsets ...int) 
 	return rows
 }
 
-func (s *testBinlogSuite) TestIgnoreError(c *C) {
+// Sometimes this test doesn't clean up fail, let the function name begin with 'Z'
+// so it runs last and would not disrupt other tests.
+func (s *testBinlogSuite) TestZIgnoreError(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.Se.GetSessionVars().BinlogClient = s.client


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

TestIgnoreError may clean up fail, rename it to TestZIgnoreError so
even it fails, it doesn't not affect TestMaxRecvSize.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

