### PR TITLE
executor: gather all the error definitions together

### DIFF
--- a/executor/errors.go
+++ b/executor/errors.go
@@ -1,0 +1,57 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/terror"
+)
+
+// Error codes that are not mapping to mysql error codes.
+const (
+	codeUnknownPlan = iota
+	codePrepareMulti
+	codePrepareDDL
+	codeResultIsEmpty
+	codeErrBuildExec
+	codeBatchInsertFail
+)
+
+// Error instances.
+var (
+	ErrUnknownPlan     = terror.ClassExecutor.New(codeUnknownPlan, "Unknown plan")
+	ErrPrepareMulti    = terror.ClassExecutor.New(codePrepareMulti, "Can not prepare multiple statements")
+	ErrPrepareDDL      = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements")
+	ErrResultIsEmpty   = terror.ClassExecutor.New(codeResultIsEmpty, "result is empty")
+	ErrBuildExecutor   = terror.ClassExecutor.New(codeErrBuildExec, "Failed to build executor")
+	ErrBatchInsertFail = terror.ClassExecutor.New(codeBatchInsertFail, "Batch insert failed, please clean the table and try again.")
+
+	ErrPasswordNoMatch             = terror.ClassExecutor.New(mysql.ErrPasswordNoMatch, mysql.MySQLErrName[mysql.ErrPasswordNoMatch])
+	ErrCannotUser                  = terror.ClassExecutor.New(mysql.ErrCannotUser, mysql.MySQLErrName[mysql.ErrCannotUser])
+	ErrWrongValueCountOnRow        = terror.ClassExecutor.New(mysql.ErrWrongValueCountOnRow, mysql.MySQLErrName[mysql.ErrWrongValueCountOnRow])
+	ErrPasswordFormat              = terror.ClassExecutor.New(mysql.ErrPasswordFormat, mysql.MySQLErrName[mysql.ErrPasswordFormat])
+	ErrCantChangeTxCharacteristics = terror.ClassExecutor.New(mysql.ErrCantChangeTxCharacteristics, mysql.MySQLErrName[mysql.ErrCantChangeTxCharacteristics])
+)
+
+func init() {
+	// Map error codes to mysql error codes.
+	tableMySQLErrCodes := map[terror.ErrCode]uint16{
+		mysql.ErrPasswordNoMatch:             mysql.ErrPasswordNoMatch,
+		mysql.ErrCannotUser:                  mysql.ErrCannotUser,
+		mysql.ErrWrongValueCountOnRow:        mysql.ErrWrongValueCountOnRow,
+		mysql.ErrPasswordFormat:              mysql.ErrPasswordFormat,
+		mysql.ErrCantChangeTxCharacteristics: mysql.ErrCantChangeTxCharacteristics,
+	}
+	terror.ErrClassToMySQLCodes[terror.ClassExecutor] = tableMySQLErrCodes
+}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
@@ -61,35 +60,6 @@ var (
 	_ Executor = &HashJoinExec{}
 	_ Executor = &IndexLookUpExecutor{}
 	_ Executor = &MergeJoinExec{}
-)
-
-// Error instances.
-var (
-	ErrUnknownPlan                 = terror.ClassExecutor.New(codeUnknownPlan, "Unknown plan")
-	ErrPrepareMulti                = terror.ClassExecutor.New(codePrepareMulti, "Can not prepare multiple statements")
-	ErrPrepareDDL                  = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements")
-	ErrPasswordNoMatch             = terror.ClassExecutor.New(CodePasswordNoMatch, "Can't find any matching row in the user table")
-	ErrResultIsEmpty               = terror.ClassExecutor.New(codeResultIsEmpty, "result is empty")
-	ErrBuildExecutor               = terror.ClassExecutor.New(codeErrBuildExec, "Failed to build executor")
-	ErrBatchInsertFail             = terror.ClassExecutor.New(codeBatchInsertFail, "Batch insert failed, please clean the table and try again.")
-	ErrWrongValueCountOnRow        = terror.ClassExecutor.New(codeWrongValueCountOnRow, "Column count doesn't match value count at row %d")
-	ErrPasswordFormat              = terror.ClassExecutor.New(codePasswordFormat, "The password hash doesn't have the expected format. Check if the correct password algorithm is being used with the PASSWORD() function.")
-	ErrCantChangeTxCharacteristics = terror.ClassExecutor.New(codeErrCantChangeTxCharacteristics, "Transaction characteristics can't be changed while a transaction is in progress")
-)
-
-// Error codes.
-const (
-	codeUnknownPlan                    terror.ErrCode = 1
-	codePrepareMulti                   terror.ErrCode = 2
-	codePrepareDDL                     terror.ErrCode = 7
-	codeResultIsEmpty                  terror.ErrCode = 8
-	codeErrBuildExec                   terror.ErrCode = 9
-	codeBatchInsertFail                terror.ErrCode = 10
-	CodePasswordNoMatch                terror.ErrCode = 1133 // MySQL error code
-	CodeCannotUser                     terror.ErrCode = 1396 // MySQL error code
-	codeWrongValueCountOnRow           terror.ErrCode = 1136 // MySQL error code
-	codePasswordFormat                 terror.ErrCode = 1827 // MySQL error code
-	codeErrCantChangeTxCharacteristics terror.ErrCode = 1568
 )
 
 type baseExecutor struct {
@@ -636,14 +606,6 @@ func init() {
 			}
 		}
 	}
-	tableMySQLErrCodes := map[terror.ErrCode]uint16{
-		CodeCannotUser:                     mysql.ErrCannotUser,
-		CodePasswordNoMatch:                mysql.ErrPasswordNoMatch,
-		codeWrongValueCountOnRow:           mysql.ErrWrongValueCountOnRow,
-		codePasswordFormat:                 mysql.ErrPasswordFormat,
-		codeErrCantChangeTxCharacteristics: mysql.ErrCantChangeTxCharacteristics,
-	}
-	terror.ErrClassToMySQLCodes[terror.ClassExecutor] = tableMySQLErrCodes
 }
 
 // ProjectionExec represents a select fields executor.

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -210,8 +210,7 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		errMsg := "Operation ALTER USER failed for " + strings.Join(failedUsers, ",")
-		return terror.ClassExecutor.New(CodeCannotUser, errMsg)
+		return ErrCannotUser.GenByArgs("ALTER USER", strings.Join(failedUsers, ","))
 	}
 	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
 	return nil
@@ -242,8 +241,7 @@ func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		errMsg := "Operation DROP USER failed for " + strings.Join(failedUsers, ",")
-		return terror.ClassExecutor.New(CodeCannotUser, errMsg)
+		return ErrCannotUser.GenByArgs("DROP USER", strings.Join(failedUsers, ","))
 	}
 	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
 	return nil


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

- Move all the error definitions in package `executor` into a file named **errors.go**. 
- Remove some duplicated error messages, use `mysql.MySQLErrName[code]` instead

## What are the type of the changes (mandatory)?


- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

No

