### PR TITLE
tidb-server: check `run-ddl` is false when using mocktikv

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -344,6 +344,10 @@ func validateConfig() {
 		log.Errorf("\"store\" should be in [%s] only", strings.Join(nameList, ", "))
 		os.Exit(-1)
 	}
+	if cfg.Store == "mocktikv" && cfg.RunDDL == false {
+		log.Errorf("can't disable DDL on mocktikv")
+		os.Exit(-1)
+	}
 	if cfg.Log.File.MaxSize > config.MaxLogFileSize {
 		log.Errorf("log max-size should not be larger than %d MB", config.MaxLogFileSize)
 		os.Exit(-1)


### PR DESCRIPTION
If `-run-ddl` is false on mocktikv, 

```
./tidb-server -run-ddl=false -store=mocktikv
```

TiDB can't bootstrap and print those message forever:

```
2018/06/07 20:14:58.991 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 372.808µs
2018/06/07 20:14:58.991 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.041 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 325.993µs
2018/06/07 20:14:59.041 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.091 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 330.413µs
2018/06/07 20:14:59.091 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.142 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 1.492201ms
2018/06/07 20:14:59.142 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.191 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 286.144µs
2018/06/07 20:14:59.191 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.241 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 285.693µs
2018/06/07 20:14:59.241 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.291 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 286.802µs
2018/06/07 20:14:59.291 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.341 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 285.581µs
2018/06/07 20:14:59.341 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.391 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 301.906µs
2018/06/07 20:14:59.391 domain.go:309: [info] [ddl] full load and reset schema validator.
2018/06/07 20:14:59.441 domain.go:117: [info] [ddl] full load InfoSchema from version 0 to 0, in 348.285µs
```

After this PR:

```
➜  bin git:(localstore-ddl) ✗ ./tidb-server -run-ddl=false                
ERRO[0000] can't disable DDL on mocktikv
```


@zimulala @jackysp 