### PR TITLE
plan, parser: fix wrong `LIMIT`/`ORDER BY` check of the `UNION` statement

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -478,6 +478,8 @@ type SelectStmt struct {
 	TableHints []*TableOptimizerHint
 	// IsAfterUnionDistinct indicates whether it's a stmt after "union distinct".
 	IsAfterUnionDistinct bool
+	// IsInBraces indicate whether it's a stmt in brace.
+	IsInBraces bool
 }
 
 // Accept implements Node Accept interface.

--- a/ast/dml.go
+++ b/ast/dml.go
@@ -478,7 +478,7 @@ type SelectStmt struct {
 	TableHints []*TableOptimizerHint
 	// IsAfterUnionDistinct indicates whether it's a stmt after "union distinct".
 	IsAfterUnionDistinct bool
-	// IsInBraces indicate whether it's a stmt in brace.
+	// IsInBraces indicates whether it's a stmt in brace.
 	IsInBraces bool
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -964,6 +964,25 @@ func (s *testSuite) TestUnion(c *C) {
 	terr = errors.Trace(err).(*errors.Err).Cause().(*terror.Error)
 	c.Assert(terr.Code(), Equals, terror.ErrCode(mysql.ErrWrongUsage))
 
+	_, err = tk.Exec("(select a from t order by a) union all select a from t limit 1 union all select a from t limit 1")
+	c.Assert(err, NotNil)
+	terr = errors.Trace(err).(*errors.Err).Cause().(*terror.Error)
+	c.Assert(terr.Code(), Equals, terror.ErrCode(mysql.ErrWrongUsage))
+
+	_, err = tk.Exec("(select a from t limit 1) union all select a from t limit 1")
+	c.Assert(err, IsNil)
+	_, err = tk.Exec("(select a from t order by a) union all select a from t order by a")
+	c.Assert(err, IsNil)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t value(1),(2),(3)")
+
+	tk.MustQuery("(select a from t order by a limit 2) union all (select a from t order by a desc limit 2) order by a desc limit 1,2").Check(testkit.Rows("2", "2"))
+	tk.MustQuery("select a from t union all select a from t order by a desc limit 5").Check(testkit.Rows("3", "3", "2", "2", "1"))
+	tk.MustQuery("(select a from t order by a desc limit 2) union all select a from t group by a order by a").Check(testkit.Rows("1", "2", "2", "3", "3"))
+	tk.MustQuery("(select a from t order by a desc limit 2) union all select 33 as a order by a desc limit 2").Check(testkit.Rows("33", "3"))
+
 	tk.MustQuery("select 1 union select 1 union all select 1").Check(testkit.Rows("1", "1"))
 	tk.MustQuery("select 1 union all select 1 union select 1").Check(testkit.Rows("1"))
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -965,9 +965,7 @@ func (s *testSuite) TestUnion(c *C) {
 	c.Assert(terr.Code(), Equals, terror.ErrCode(mysql.ErrWrongUsage))
 
 	_, err = tk.Exec("(select a from t order by a) union all select a from t limit 1 union all select a from t limit 1")
-	c.Assert(err, NotNil)
-	terr = errors.Trace(err).(*errors.Err).Cause().(*terror.Error)
-	c.Assert(terr.Code(), Equals, terror.ErrCode(mysql.ErrWrongUsage))
+	c.Assert(terror.ErrorEqual(err, plan.ErrWrongUsage), IsTrue)
 
 	_, err = tk.Exec("(select a from t limit 1) union all select a from t limit 1")
 	c.Assert(err, IsNil)

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4685,6 +4685,7 @@ UnionStmt:
 		endOffset := parser.endOffset(&yyS[yypt-6])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
 		st := $5.(*ast.SelectStmt)
+		st.IsInBraces = true
 		st.IsAfterUnionDistinct = $3.(bool)
 		endOffset = parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(st, endOffset)
@@ -4726,6 +4727,7 @@ UnionSelect:
 |	'(' SelectStmt ')'
 	{
 		st := $2.(*ast.SelectStmt)
+		st.IsInBraces = true
 		endOffset := parser.endOffset(&yyS[yypt])
 		parser.setLastSelectFieldText(st, endOffset)
 		$$ = $2

--- a/plan/preprocess.go
+++ b/plan/preprocess.go
@@ -223,14 +223,21 @@ func (p *preprocessor) checkAutoIncrement(stmt *ast.CreateTableStmt) {
 	}
 }
 
+// checkUnionSelectList check union's selectList.
+// refer: https://dev.mysql.com/doc/refman/5.7/en/union.html
+// "To apply ORDER BY or LIMIT to an individual SELECT, place the clause inside the parentheses that enclose the SELECT."
 func (p *preprocessor) checkUnionSelectList(stmt *ast.UnionSelectList) {
-	for idx, sel := range stmt.Selects {
-		if idx != len(stmt.Selects)-1 {
-			if sel.OrderBy != nil {
-				p.err = ErrWrongUsage.GenByArgs("UNION", "ORDER BY")
-			} else if sel.Limit != nil {
-				p.err = ErrWrongUsage.GenByArgs("UNION", "LIMIT")
-			}
+	for _, sel := range stmt.Selects[:len(stmt.Selects)-1] {
+		if sel.IsInBraces {
+			continue
+		}
+		if sel.Limit != nil {
+			p.err = ErrWrongUsage.GenByArgs("UNION", "LIMIT")
+			return
+		}
+		if sel.OrderBy != nil {
+			p.err = ErrWrongUsage.GenByArgs("UNION", "ORDER BY")
+			return
 		}
 	}
 }

--- a/plan/preprocess.go
+++ b/plan/preprocess.go
@@ -223,7 +223,7 @@ func (p *preprocessor) checkAutoIncrement(stmt *ast.CreateTableStmt) {
 	}
 }
 
-// checkUnionSelectList check union's selectList.
+// checkUnionSelectList checks union's selectList.
 // refer: https://dev.mysql.com/doc/refman/5.7/en/union.html
 // "To apply ORDER BY or LIMIT to an individual SELECT, place the clause inside the parentheses that enclose the SELECT."
 func (p *preprocessor) checkUnionSelectList(stmt *ast.UnionSelectList) {


### PR DESCRIPTION
check union's `select limit / order by` follow [mysql](https://dev.mysql.com/doc/refman/5.7/en/union.html)'s logic.

- last `limit`/`order by` affect to whole `union` statement
- to apply `limit`/`order by` to an individual `select`, must place the clause  in braces

## What have you changed? (mandatory)

- add ` IsInBraces` to `SelectStmt`
- modify parser to set `IsInBraces`  to `true` when in `select` place in braces within `union`
- modify `preprocessor.checkUnionSelectList` to check select stmt except last one must in braces or without `limit`/`order by`

## What are the type of the changes (mandatory)?

- Bug fix

## How has this PR been tested (mandatory)?

- unit tests: in executor_test.go
- manual test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

pending...

## Add a few positive/negative examples (optional)

expect:

```
mysql> (select 1 from t limit 1) union (select 2 from t limit 1) limit 2;
Empty set (0.00 sec)
```
but got:

```
mysql> (select 1 from t limit 1) union (select 2 from t limit 1) limit 2;
ERROR 1221 (HY000): Incorrect usage of UNION and LIMIT
```