### PR TITLE
config, variable: add memory quota config for a query

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,7 @@ type Config struct {
 	SplitTable      bool            `toml:"split-table" json:"split-table"`
 	TokenLimit      uint            `toml:"token-limit" json:"token-limit"`
 	OOMAction       string          `toml:"oom-action" json:"oom-action"`
+	MemQuotaQuery   int64           `toml:"mem-quota-query" json:"mem-quota-query"`
 	EnableStreaming bool            `toml:"enable-streaming" json:"enable-streaming"`
 	TxnLocalLatches TxnLocalLatches `toml:"txn-local-latches" json:"txn-local-latches"`
 	// Set sys variable lower-case-table-names, ref: https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html.
@@ -245,6 +246,7 @@ var defaultConf = Config{
 	Lease:           "45s",
 	TokenLimit:      1000,
 	OOMAction:       "log",
+	MemQuotaQuery:   5 << 30,
 	EnableStreaming: false,
 	TxnLocalLatches: TxnLocalLatches{
 		Enabled:  false,

--- a/config/config.go
+++ b/config/config.go
@@ -246,7 +246,7 @@ var defaultConf = Config{
 	Lease:           "45s",
 	TokenLimit:      1000,
 	OOMAction:       "log",
-	MemQuotaQuery:   5 << 30,
+	MemQuotaQuery:   32 << 30,
 	EnableStreaming: false,
 	TxnLocalLatches: TxnLocalLatches{
 		Enabled:  false,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -32,8 +32,8 @@ token-limit = 1000
 # Valid options: ["log", "cancel"]
 oom-action = "log"
 
-# Set the memory quota for a query in bytes. Default: 5GB
-mem-quota-query = 5368709120
+# Set the memory quota for a query in bytes. Default: 32GB
+mem-quota-query = 34359738368
 
 # Enable coprocessor streaming.
 enable-streaming = false

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -32,6 +32,9 @@ token-limit = 1000
 # Valid options: ["log", "cancel"]
 oom-action = "log"
 
+# Set the memory quota for a query in bytes. Default: 5GB
+mem-quota-query = 5368709120
+
 # Enable coprocessor streaming.
 enable-streaming = false
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -313,7 +313,7 @@ func NewSessionVars() *SessionVars {
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
 	}
 	vars.MemQuota = MemQuota{
-		MemQuotaQuery:             DefTiDBMemQuotaQuery,
+		MemQuotaQuery:             config.GetGlobalConfig().MemQuotaQuery,
 		MemQuotaHashJoin:          DefTiDBMemQuotaHashJoin,
 		MemQuotaMergeJoin:         DefTiDBMemQuotaMergeJoin,
 		MemQuotaSort:              DefTiDBMemQuotaSort,
@@ -510,7 +510,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	case TiDBMaxChunkSize:
 		s.MaxChunkSize = tidbOptPositiveInt32(val, DefMaxChunkSize)
 	case TIDBMemQuotaQuery:
-		s.MemQuotaQuery = tidbOptInt64(val, DefTiDBMemQuotaQuery)
+		s.MemQuotaQuery = tidbOptInt64(val, config.GetGlobalConfig().MemQuotaQuery)
 	case TIDBMemQuotaHashJoin:
 		s.MemQuotaHashJoin = tidbOptInt64(val, DefTiDBMemQuotaHashJoin)
 	case TIDBMemQuotaMergeJoin:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
@@ -625,7 +626,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBDMLBatchSize, strconv.Itoa(DefDMLBatchSize)},
 	{ScopeSession, TiDBCurrentTS, strconv.Itoa(DefCurretTS)},
 	{ScopeGlobal | ScopeSession, TiDBMaxChunkSize, strconv.Itoa(DefMaxChunkSize)},
-	{ScopeSession, TIDBMemQuotaQuery, strconv.FormatInt(DefTiDBMemQuotaQuery, 10)},
+	{ScopeSession, TIDBMemQuotaQuery, strconv.FormatInt(config.GetGlobalConfig().MemQuotaQuery, 10)},
 	{ScopeSession, TIDBMemQuotaHashJoin, strconv.FormatInt(DefTiDBMemQuotaHashJoin, 10)},
 	{ScopeSession, TIDBMemQuotaMergeJoin, strconv.FormatInt(DefTiDBMemQuotaMergeJoin, 10)},
 	{ScopeSession, TIDBMemQuotaSort, strconv.FormatInt(DefTiDBMemQuotaSort, 10)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -181,7 +181,6 @@ const (
 	DefCurretTS                      = 0
 	DefMaxChunkSize                  = 1024
 	DefDMLBatchSize                  = 20000
-	DefTiDBMemQuotaQuery             = 32 << 30 // 32GB.
 	DefTiDBMemQuotaHashJoin          = 32 << 30 // 32GB.
 	DefTiDBMemQuotaMergeJoin         = 32 << 30 // 32GB.
 	DefTiDBMemQuotaSort              = 32 << 30 // 32GB.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -67,7 +67,7 @@ func (s *testVarsutilSuite) TestNewSessionVars(c *C) {
 	c.Assert(vars.DistSQLScanConcurrency, Equals, DefDistSQLScanConcurrency)
 	c.Assert(vars.MaxChunkSize, Equals, DefMaxChunkSize)
 	c.Assert(vars.DMLBatchSize, Equals, DefDMLBatchSize)
-	c.Assert(vars.MemQuotaQuery, Equals, int64(DefTiDBMemQuotaQuery))
+	c.Assert(vars.MemQuotaQuery, Equals, int64(config.GetGlobalConfig().MemQuotaQuery))
 	c.Assert(vars.MemQuotaHashJoin, Equals, int64(DefTiDBMemQuotaHashJoin))
 	c.Assert(vars.MemQuotaMergeJoin, Equals, int64(DefTiDBMemQuotaMergeJoin))
 	c.Assert(vars.MemQuotaSort, Equals, int64(DefTiDBMemQuotaSort))


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

Before this PR, the default memory quota for a query is 32GB and can not be configured, this PR:
1. add a config entry named **mem-quota-query** to config the default memory quota for a query.
2. set the default memory quota for a query from 32GB to 5GB
3. we can still change the session variable **tidb_mem_quota_query** to control the memory quota for a query

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

Yes

## Refer to a related PR or issue link (optional)

