### PR TITLE
plan, parser: fix wrong `LIMIT`/`ORDER BY` check of the `UNION` (#6783)

### DIFF
--- a/ast/dml.go
+++ b/ast/dml.go
@@ -478,6 +478,8 @@ type SelectStmt struct {
 	TableHints []*TableOptimizerHint
 	// IsAfterUnionDistinct indicates whether it's a stmt after "union distinct".
 	IsAfterUnionDistinct bool
+	// IsInBraces indicates whether it's a stmt in brace.
+	IsInBraces bool
 }
 
 // Accept implements Node Accept interface.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -4584,6 +4584,7 @@ UnionStmt:
 		endOffset := parser.endOffset(&yyS[yypt-6])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
 		st := $5.(*ast.SelectStmt)
+		st.IsInBraces = true
 		st.IsAfterUnionDistinct = $3.(bool)
 		endOffset = parser.endOffset(&yyS[yypt-2])
 		parser.setLastSelectFieldText(st, endOffset)
@@ -4625,6 +4626,7 @@ UnionSelect:
 |	'(' SelectStmt ')'
 	{
 		st := $2.(*ast.SelectStmt)
+		st.IsInBraces = true
 		endOffset := parser.endOffset(&yyS[yypt])
 		parser.setLastSelectFieldText(st, endOffset)
 		$$ = $2


### PR DESCRIPTION
## What have you changed? (mandatory)

Cherry pick #6783 to release 2.0

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality if user depends on bug)

## How has this PR been tested (mandatory)?

- unit test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

Maybe Yes.

## Refer to a related PR or issue link (optional)

#6783
