### PR TITLE
parser: support drop column cascade syntax, parse it and ignore it.

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -948,7 +948,7 @@ AlterTableSpec:
 			Constraint: constraint,
 		}
 	}
-|	"DROP" ColumnKeywordOpt ColumnName
+|	"DROP" ColumnKeywordOpt ColumnName RestrictOrCascadeOpt
 	{
 		$$ = &ast.AlterTableSpec{
 			Tp: ast.AlterTableDropColumn,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1633,6 +1633,8 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"ALTER TABLE t CONVERT TO CHARSET utf8 COLLATE utf8_bin;", true},
 		{"ALTER TABLE t FORCE", true},
 		{"ALTER TABLE t DROP INDEX;", false},
+		{"ALTER TABLE t DROP COLUMN a CASCADE", true},
+
 		// For #6405
 		{"ALTER TABLE t RENAME KEY a TO b;", true},
 		{"ALTER TABLE t RENAME INDEX a TO b;", true},


### PR DESCRIPTION
## What have you changed? (mandatory)

Support `alter table drop column cascade` syntax.

## What are the type of the changes (mandatory)?

- New feature (non-breaking change which adds functionality)

## How has this PR been tested (mandatory)?

unit tests


