### PR TITLE
store: use first backoff error rather than last backoff error to generate mysql error

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -233,8 +233,8 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 			}
 		}
 		log.Warn(errMsg)
-		// Use the last backoff type to generate a MySQL error.
-		return typ.TError()
+		// Use the first backoff type to generate a MySQL error.
+		return b.types[0].TError()
 	}
 	return nil
 }


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

When backoff excceds its max sleep time, backoff need return a mysql error. Originally, we generate mysql error using last backoff type. It turns out old way is not quite useful when we want to know what is the first reason caused the following backoff operation. 
So I changed generating mysql error logic from printing last backoff type to first backoff type.

Improvement

No need to add test since just one line change.

No. Backoff only is used internally.

This PR solves https://github.com/pingcap/tidb/issues/6793