### PR TITLE
executor: split interface Executor to a single package

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -357,7 +357,7 @@ func (a *ExecStmt) logSlowQuery(txnTS uint64, succ bool) {
 }
 
 // IsPointGetWithPKOrUniqueKeyByAutoCommit returns true when meets following conditions:
-//  1. ctx is auto commit tagged
+//  1. Sctx is auto commit tagged
 //  2. txn is nil
 //  2. plan is point get by pk or unique key
 func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p plan.Plan) bool {

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/distsql"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
@@ -37,9 +38,10 @@ import (
 )
 
 var (
-	_ Executor = &CheckIndexRangeExec{}
-	_ Executor = &RecoverIndexExec{}
-	_ Executor = &CleanupIndexExec{}
+	_ operator.Executor = &baseExecutor{}
+	_ operator.Executor = &CheckIndexRangeExec{}
+	_ operator.Executor = &RecoverIndexExec{}
+	_ operator.Executor = &CleanupIndexExec{}
 )
 
 // CheckIndexRangeExec outputs the index values which has handle between begin and end.
@@ -97,7 +99,7 @@ func (e *CheckIndexRangeExec) Open(ctx context.Context) error {
 		ID:   model.ExtraHandleID,
 		Name: model.ExtraHandleName,
 	})
-	e.srcChunk = e.newChunk()
+	e.srcChunk = e.NewChunk()
 	dagPB, err := e.buildDAGPB()
 	if err != nil {
 		return errors.Trace(err)

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/mysql"
@@ -32,7 +33,7 @@ type aggCtxsMapper map[string][]*aggregation.AggEvaluateContext
 // It is built from the Aggregate Plan. When Next() is called, it reads all the data from Src
 // and updates all the items in AggFuncs.
 type HashAggExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	executed      bool
 	sc            *stmtctx.StatementContext
@@ -49,7 +50,7 @@ type HashAggExec struct {
 
 // Close implements the Executor Close interface.
 func (e *HashAggExec) Close() error {
-	if err := e.baseExecutor.Close(); err != nil {
+	if err := e.BaseExecutor.Close(); err != nil {
 		return errors.Trace(err)
 	}
 	e.groupMap = nil
@@ -60,7 +61,7 @@ func (e *HashAggExec) Close() error {
 
 // Open implements the Executor Open interface.
 func (e *HashAggExec) Open(ctx context.Context) error {
-	if err := e.baseExecutor.Open(ctx); err != nil {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.executed = false
@@ -104,7 +105,7 @@ func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		}
 		e.mutableRow.SetDatums(e.rowBuffer...)
 		chk.AppendRow(e.mutableRow.ToRow())
-		if chk.NumRows() == e.maxChunkSize {
+		if chk.NumRows() == e.ChunkSize {
 			return nil
 		}
 	}
@@ -112,14 +113,14 @@ func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // execute fetches Chunks from src and update each aggregate function for each row in Chunk.
 func (e *HashAggExec) execute(ctx context.Context) (err error) {
-	inputIter := chunk.NewIterator4Chunk(e.childrenResults[0])
+	inputIter := chunk.NewIterator4Chunk(e.ChildrenResults[0])
 	for {
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.Children[0].Next(ctx, e.ChildrenResults[0])
 		if err != nil {
 			return errors.Trace(err)
 		}
 		// no more data.
-		if e.childrenResults[0].NumRows() == 0 {
+		if e.ChildrenResults[0].NumRows() == 0 {
 			return nil
 		}
 		for row := inputIter.Begin(); row != inputIter.End(); row = inputIter.Next() {
@@ -167,7 +168,7 @@ func (e *HashAggExec) getContexts(groupKey []byte) []*aggregation.AggEvaluateCon
 	if !ok {
 		aggCtxs = make([]*aggregation.AggEvaluateContext, 0, len(e.AggFuncs))
 		for _, af := range e.AggFuncs {
-			aggCtxs = append(aggCtxs, af.CreateContext(e.ctx.GetSessionVars().StmtCtx))
+			aggCtxs = append(aggCtxs, af.CreateContext(e.Sctx.GetSessionVars().StmtCtx))
 		}
 		e.aggCtxsMap[groupKeyString] = aggCtxs
 	}
@@ -178,7 +179,7 @@ func (e *HashAggExec) getContexts(groupKey []byte) []*aggregation.AggEvaluateCon
 // It assumes all the input data is sorted by group by key.
 // When Next() is called, it will return a result for the same group.
 type StreamAggExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	executed     bool
 	hasData      bool
@@ -198,20 +199,20 @@ type StreamAggExec struct {
 
 // Open implements the Executor Open interface.
 func (e *StreamAggExec) Open(ctx context.Context) error {
-	if err := e.baseExecutor.Open(ctx); err != nil {
+	if err := e.BaseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
 	e.executed = false
 	e.hasData = false
-	e.inputIter = chunk.NewIterator4Chunk(e.childrenResults[0])
+	e.inputIter = chunk.NewIterator4Chunk(e.ChildrenResults[0])
 	e.inputRow = e.inputIter.End()
 	e.mutableRow = chunk.MutRowFromTypes(e.RetTypes())
 	e.rowBuffer = make([]types.Datum, 0, e.Schema().Len())
 
 	e.aggCtxs = make([]*aggregation.AggEvaluateContext, 0, len(e.AggFuncs))
 	for _, agg := range e.AggFuncs {
-		e.aggCtxs = append(e.aggCtxs, agg.CreateContext(e.ctx.GetSessionVars().StmtCtx))
+		e.aggCtxs = append(e.aggCtxs, agg.CreateContext(e.Sctx.GetSessionVars().StmtCtx))
 	}
 
 	return nil
@@ -221,7 +222,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 func (e *StreamAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 
-	for !e.executed && chk.NumRows() < e.maxChunkSize {
+	for !e.executed && chk.NumRows() < e.ChunkSize {
 		err := e.consumeOneGroup(ctx, chk)
 		if err != nil {
 			e.executed = true
@@ -264,12 +265,12 @@ func (e *StreamAggExec) fetchChildIfNecessary(ctx context.Context, chk *chunk.Ch
 		return nil
 	}
 
-	err := e.children[0].Next(ctx, e.childrenResults[0])
+	err := e.Children[0].Next(ctx, e.ChildrenResults[0])
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// No more data.
-	if e.childrenResults[0].NumRows() == 0 {
+	if e.ChildrenResults[0].NumRows() == 0 {
 		if e.hasData || len(e.GroupByItems) == 0 {
 			e.appendResult2Chunk(chk)
 		}
@@ -277,7 +278,7 @@ func (e *StreamAggExec) fetchChildIfNecessary(ctx context.Context, chk *chunk.Ch
 		return nil
 	}
 
-	// Reach here, "e.childrenResults[0].NumRows() > 0" is guaranteed.
+	// Reach here, "e.ChildrenResults[0].NumRows() > 0" is guaranteed.
 	e.inputRow = e.inputIter.Begin()
 	e.hasData = true
 	return nil
@@ -289,7 +290,7 @@ func (e *StreamAggExec) appendResult2Chunk(chk *chunk.Chunk) {
 	e.rowBuffer = e.rowBuffer[:0]
 	for i, af := range e.AggFuncs {
 		e.rowBuffer = append(e.rowBuffer, af.GetResult(e.aggCtxs[i]))
-		af.ResetContext(e.ctx.GetSessionVars().StmtCtx, e.aggCtxs[i])
+		af.ResetContext(e.Sctx.GetSessionVars().StmtCtx, e.aggCtxs[i])
 	}
 	e.mutableRow.SetDatums(e.rowBuffer...)
 	chk.AppendRow(e.mutableRow.ToRow())

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -33,7 +33,7 @@ type aggCtxsMapper map[string][]*aggregation.AggEvaluateContext
 // It is built from the Aggregate Plan. When Next() is called, it reads all the data from Src
 // and updates all the items in AggFuncs.
 type HashAggExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	executed      bool
 	sc            *stmtctx.StatementContext
@@ -48,9 +48,9 @@ type HashAggExec struct {
 	groupVals     [][]byte
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *HashAggExec) Close() error {
-	if err := e.BaseExecutor.Close(); err != nil {
+	if err := e.BaseOperator.Close(); err != nil {
 		return errors.Trace(err)
 	}
 	e.groupMap = nil
@@ -59,9 +59,9 @@ func (e *HashAggExec) Close() error {
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *HashAggExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.executed = false
@@ -75,7 +75,7 @@ func (e *HashAggExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	// In this stage we consider all data from src as a single group.
 	if !e.executed {
@@ -179,7 +179,7 @@ func (e *HashAggExec) getContexts(groupKey []byte) []*aggregation.AggEvaluateCon
 // It assumes all the input data is sorted by group by key.
 // When Next() is called, it will return a result for the same group.
 type StreamAggExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	executed     bool
 	hasData      bool
@@ -197,9 +197,9 @@ type StreamAggExec struct {
 	rowBuffer  []types.Datum
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *StreamAggExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -218,7 +218,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *StreamAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -67,7 +67,7 @@ func (e *HashAggExec) Open(ctx context.Context) error {
 	e.groupMap = mvmap.NewMVMap()
 	e.groupIterator = e.groupMap.NewIterator()
 	e.aggCtxsMap = make(aggCtxsMapper, 0)
-	e.mutableRow = chunk.MutRowFromTypes(e.retTypes())
+	e.mutableRow = chunk.MutRowFromTypes(e.RetTypes())
 	e.rowBuffer = make([]types.Datum, 0, e.Schema().Len())
 	e.groupKey = make([]byte, 0, 8)
 	e.groupVals = make([][]byte, 0, 8)
@@ -206,7 +206,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 	e.hasData = false
 	e.inputIter = chunk.NewIterator4Chunk(e.childrenResults[0])
 	e.inputRow = e.inputIter.End()
-	e.mutableRow = chunk.MutRowFromTypes(e.retTypes())
+	e.mutableRow = chunk.MutRowFromTypes(e.RetTypes())
 	e.rowBuffer = make([]types.Datum, 0, e.Schema().Len())
 
 	e.aggCtxs = make([]*aggregation.AggEvaluateContext, 0, len(e.AggFuncs))

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -35,11 +35,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ operator.Executor = &AnalyzeExec{}
+var _ operator.Operator = &AnalyzeExec{}
 
 // AnalyzeExec represents Analyze executor.
 type AnalyzeExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 	tasks []*analyzeTask
 }
 
@@ -52,7 +52,7 @@ const (
 	defaultCMSketchWidth = 2048
 )
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *AnalyzeExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	concurrency, err := getBuildStatsConcurrency(e.Sctx)
 	if err != nil {

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/distsql"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -34,7 +35,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ Executor = &AnalyzeExec{}
+var _ operator.Executor = &AnalyzeExec{}
 
 // AnalyzeExec represents Analyze executor.
 type AnalyzeExec struct {

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -30,19 +30,19 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ operator.Executor = &ChecksumTableExec{}
+var _ operator.Operator = &ChecksumTableExec{}
 
 // ChecksumTableExec represents ChecksumTable executor.
 type ChecksumTableExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	tables map[int64]*checksumContext
 	done   bool
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ChecksumTableExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -83,7 +83,7 @@ func (e *ChecksumTableExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ChecksumTableExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.done {

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/distsql"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
@@ -29,7 +30,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ Executor = &ChecksumTableExec{}
+var _ operator.Executor = &ChecksumTableExec{}
 
 // ChecksumTableExec represents ChecksumTable executor.
 type ChecksumTableExec struct {

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -32,14 +32,14 @@ import (
 // DDLExec represents a DDL executor.
 // It grabs a DDL instance from Domain, calling the DDL methods to do the work.
 type DDLExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	stmt ast.StmtNode
 	is   infoschema.InfoSchema
 	done bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *DDLExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 	if e.done {
 		return nil

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -28,9 +28,9 @@ import (
 // DeleteExec represents a delete executor.
 // See https://dev.mysql.com/doc/refman/5.7/en/delete.html
 type DeleteExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
-	SelectExec operator.Executor
+	SelectExec operator.Operator
 
 	Tables       []*ast.TableName
 	IsMultiTable bool
@@ -44,7 +44,7 @@ type DeleteExec struct {
 	finished bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *DeleteExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.finished {
@@ -237,12 +237,12 @@ func (e *DeleteExec) removeRow(ctx sessionctx.Context, t table.Table, h int64, d
 	return nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *DeleteExec) Close() error {
 	return e.SelectExec.Close()
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *DeleteExec) Open(ctx context.Context) error {
 	return e.SelectExec.Open(ctx)
 }

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
@@ -29,7 +30,7 @@ import (
 type DeleteExec struct {
 	baseExecutor
 
-	SelectExec Executor
+	SelectExec operator.Executor
 
 	Tables       []*ast.TableName
 	IsMultiTable bool
@@ -103,9 +104,9 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 	// If tidb_batch_delete is ON and not in a transaction, we could use BatchDelete mode.
 	batchDelete := e.ctx.GetSessionVars().BatchDelete && !e.ctx.GetSessionVars().InTxn()
 	batchDMLSize := e.ctx.GetSessionVars().DMLBatchSize
-	fields := e.children[0].retTypes()
+	fields := e.children[0].RetTypes()
 	for {
-		chk := e.children[0].newChunk()
+		chk := e.children[0].NewChunk()
 		iter := chunk.NewIterator4Chunk(chk)
 
 		err := e.children[0].Next(ctx, chk)
@@ -183,9 +184,9 @@ func (e *DeleteExec) deleteMultiTablesByChunk(ctx context.Context) error {
 	e.initialMultiTableTblMap()
 	colPosInfos := e.getColPosInfos(e.children[0].Schema())
 	tblRowMap := make(tableRowMapType)
-	fields := e.children[0].retTypes()
+	fields := e.children[0].RetTypes()
 	for {
-		chk := e.children[0].newChunk()
+		chk := e.children[0].NewChunk()
 		iter := chunk.NewIterator4Chunk(chk)
 
 		err := e.children[0].Next(ctx, chk)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -40,39 +40,39 @@ import (
 )
 
 var (
-	_ operator.Executor = &CheckTableExec{}
-	_ operator.Executor = &ExistsExec{}
-	_ operator.Executor = &HashAggExec{}
-	_ operator.Executor = &LimitExec{}
-	_ operator.Executor = &MaxOneRowExec{}
-	_ operator.Executor = &ProjectionExec{}
-	_ operator.Executor = &SelectionExec{}
-	_ operator.Executor = &SelectLockExec{}
-	_ operator.Executor = &ShowDDLExec{}
-	_ operator.Executor = &ShowDDLJobsExec{}
-	_ operator.Executor = &ShowDDLJobQueriesExec{}
-	_ operator.Executor = &SortExec{}
-	_ operator.Executor = &StreamAggExec{}
-	_ operator.Executor = &TableDualExec{}
-	_ operator.Executor = &TableScanExec{}
-	_ operator.Executor = &TopNExec{}
-	_ operator.Executor = &UnionExec{}
-	_ operator.Executor = &CheckIndexExec{}
-	_ operator.Executor = &HashJoinExec{}
-	_ operator.Executor = &IndexLookUpExecutor{}
-	_ operator.Executor = &MergeJoinExec{}
+	_ operator.Operator = &CheckTableExec{}
+	_ operator.Operator = &ExistsExec{}
+	_ operator.Operator = &HashAggExec{}
+	_ operator.Operator = &LimitExec{}
+	_ operator.Operator = &MaxOneRowExec{}
+	_ operator.Operator = &ProjectionExec{}
+	_ operator.Operator = &SelectionExec{}
+	_ operator.Operator = &SelectLockExec{}
+	_ operator.Operator = &ShowDDLExec{}
+	_ operator.Operator = &ShowDDLJobsExec{}
+	_ operator.Operator = &ShowDDLJobQueriesExec{}
+	_ operator.Operator = &SortExec{}
+	_ operator.Operator = &StreamAggExec{}
+	_ operator.Operator = &TableDualExec{}
+	_ operator.Operator = &TableScanExec{}
+	_ operator.Operator = &TopNExec{}
+	_ operator.Operator = &UnionExec{}
+	_ operator.Operator = &CheckIndexExec{}
+	_ operator.Operator = &HashJoinExec{}
+	_ operator.Operator = &IndexLookUpExecutor{}
+	_ operator.Operator = &MergeJoinExec{}
 )
 
 // CancelDDLJobsExec represents a cancel DDL jobs executor.
 type CancelDDLJobsExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	cursor int
 	jobIDs []int64
 	errs   []error
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *CancelDDLJobsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.cursor >= len(e.jobIDs) {
@@ -93,7 +93,7 @@ func (e *CancelDDLJobsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // ShowDDLExec represents a show DDL executor.
 type ShowDDLExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	ddlOwnerID string
 	selfID     string
@@ -101,7 +101,7 @@ type ShowDDLExec struct {
 	done       bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ShowDDLExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.done {
@@ -122,7 +122,7 @@ func (e *ShowDDLExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // ShowDDLJobsExec represent a show DDL jobs executor.
 type ShowDDLJobsExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	cursor int
 	jobs   []*model.Job
@@ -133,16 +133,16 @@ type ShowDDLJobsExec struct {
 // The jobs ExplainID that is given by 'admin show ddl job queries' statement,
 // only be searched in the latest 10 history jobs
 type ShowDDLJobQueriesExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	cursor int
 	jobs   []*model.Job
 	jobIDs []int64
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ShowDDLJobQueriesExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	jobs, err := admin.GetDDLJobs(e.Sctx.Txn())
@@ -161,7 +161,7 @@ func (e *ShowDDLJobQueriesExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ShowDDLJobQueriesExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.cursor >= len(e.jobs) {
@@ -182,9 +182,9 @@ func (e *ShowDDLJobQueriesExec) Next(ctx context.Context, chk *chunk.Chunk) erro
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ShowDDLJobsExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	jobs, err := admin.GetDDLJobs(e.Sctx.Txn())
@@ -202,7 +202,7 @@ func (e *ShowDDLJobsExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ShowDDLJobsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.cursor >= len(e.jobs) {
@@ -251,23 +251,23 @@ func getTableName(is infoschema.InfoSchema, id int64) string {
 // It is built from the "admin check table" statement, and it checks if the
 // index matches the records in the table.
 type CheckTableExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	tables []*ast.TableName
 	done   bool
 	is     infoschema.InfoSchema
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *CheckTableExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.done = false
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *CheckTableExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if e.done {
 		return nil
@@ -295,7 +295,7 @@ func (e *CheckTableExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // It is built from the "admin check index" statement, and it checks
 // the consistency of the index data with the records of the table.
 type CheckIndexExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	dbName    string
 	tableName string
@@ -305,9 +305,9 @@ type CheckIndexExec struct {
 	is        infoschema.InfoSchema
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *CheckIndexExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	if err := e.src.Open(ctx); err != nil {
@@ -317,12 +317,12 @@ func (e *CheckIndexExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *CheckIndexExec) Close() error {
 	return errors.Trace(e.src.Close())
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *CheckIndexExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if e.done {
 		return nil
@@ -348,19 +348,19 @@ func (e *CheckIndexExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // SelectLockExec represents a select lock executor.
 // It is built from the "SELECT .. FOR UPDATE" or the "SELECT .. LOCK IN SHARE MODE" statement.
-// For "SELECT .. FOR UPDATE" statement, it locks every row key from source Executor.
+// For "SELECT .. FOR UPDATE" statement, it locks every row key from source Operator.
 // After the execution, the keys are buffered in transaction, and will be sent to KV
 // when doing commit. If there is any key already locked by another transaction,
 // the transaction will rollback and retry.
 type SelectLockExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Lock ast.SelectLockType
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *SelectLockExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -373,7 +373,7 @@ func (e *SelectLockExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *SelectLockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	err := e.Children[0].Next(ctx, chk)
@@ -405,7 +405,7 @@ func (e *SelectLockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // LimitExec represents limit executor
 // It ignores 'Offset' rows from src, then returns 'Count' rows at maximum.
 type LimitExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	begin  uint64
 	end    uint64
@@ -415,7 +415,7 @@ type LimitExec struct {
 	meetFirstBatch bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.cursor >= e.end {
@@ -463,9 +463,9 @@ func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *LimitExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.cursor = 0
@@ -513,20 +513,20 @@ func init() {
 
 // TableDualExec represents a dual table executor.
 type TableDualExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	// numDualRows can only be 0 or 1.
 	numDualRows int
 	numReturned int
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *TableDualExec) Open(ctx context.Context) error {
 	e.numReturned = 0
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *TableDualExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.numReturned >= e.numDualRows {
@@ -545,7 +545,7 @@ func (e *TableDualExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // SelectionExec represents a filter executor.
 type SelectionExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	batched   bool
 	filters   []expression.Expression
@@ -554,9 +554,9 @@ type SelectionExec struct {
 	inputRow  chunk.Row
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *SelectionExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.batched = expression.Vectorizable(e.filters)
@@ -570,14 +570,14 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 
 // Close implements plan.Plan Close interface.
 func (e *SelectionExec) Close() error {
-	if err := e.BaseExecutor.Close(); err != nil {
+	if err := e.BaseOperator.Close(); err != nil {
 		return errors.Trace(err)
 	}
 	e.selected = nil
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *SelectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 
@@ -641,7 +641,7 @@ func (e *SelectionExec) unBatchedNext(ctx context.Context, chk *chunk.Chunk) err
 
 // TableScanExec is a table scan executor without result fields.
 type TableScanExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	t                     table.Table
 	seekHandle            int64
@@ -652,7 +652,7 @@ type TableScanExec struct {
 	virtualTableChunkIdx  int
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *TableScanExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.isVirtualTable {
@@ -728,7 +728,7 @@ func (e *TableScanExec) getRow(handle int64) (types.DatumRow, error) {
 	return row, nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *TableScanExec) Open(ctx context.Context) error {
 	e.iter = nil
 	e.virtualTableChunkList = nil
@@ -737,21 +737,21 @@ func (e *TableScanExec) Open(ctx context.Context) error {
 
 // ExistsExec represents exists executor.
 type ExistsExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	evaluated bool
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ExistsExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.evaluated = false
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.evaluated {
@@ -772,21 +772,21 @@ func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // MaxOneRowExec checks if the number of rows that a query returns is at maximum one.
 // It's built from subquery expression.
 type MaxOneRowExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	evaluated bool
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *MaxOneRowExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.evaluated = false
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *MaxOneRowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.evaluated {
@@ -829,7 +829,7 @@ func (e *MaxOneRowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 //   |--------------------------| main thread | <---------------------+
 //                              +-------------+
 type UnionExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	stopFetchData atomic.Value
 	wg            sync.WaitGroup
@@ -855,9 +855,9 @@ func (e *UnionExec) waitAllFinished() {
 	close(e.resultPool)
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *UnionExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	e.stopFetchData.Store(false)
@@ -917,7 +917,7 @@ func (e *UnionExec) resultPuller(ctx context.Context, childID int) {
 	}
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *UnionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.initialized {
@@ -937,7 +937,7 @@ func (e *UnionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *UnionExec) Close() error {
 	close(e.finished)
 	if e.resultPool != nil {
@@ -945,5 +945,5 @@ func (e *UnionExec) Close() error {
 		}
 	}
 	e.resourcePools = nil
-	return errors.Trace(e.BaseExecutor.Close())
+	return errors.Trace(e.BaseOperator.Close())
 }

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -85,7 +85,7 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 	err := e.Open(ctx)
 	c.Assert(err, IsNil)
 
-	chk := e.newChunk()
+	chk := e.NewChunk()
 	it := chunk.NewIterator4Chunk(chk)
 	// Run test and check results.
 	for _, p := range ps {

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -78,7 +78,7 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 
 	// Compose executor.
 	e := &ShowExec{
-		BaseExecutor: operator.NewBaseExecutor(sctx, schema, ""),
+		BaseOperator: operator.NewBaseOperator(sctx, schema, ""),
 		Tp:           ast.ShowProcessList,
 	}
 

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -77,7 +78,7 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 
 	// Compose executor.
 	e := &ShowExec{
-		baseExecutor: newBaseExecutor(sctx, schema, ""),
+		BaseExecutor: operator.NewBaseExecutor(sctx, schema, ""),
 		Tp:           ast.ShowProcessList,
 	}
 

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -22,19 +22,19 @@ import (
 
 // ExplainExec represents an explain executor.
 type ExplainExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	rows   [][]string
 	cursor int
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *ExplainExec) Close() error {
 	e.rows = nil
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ExplainExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.cursor >= len(e.rows) {

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -15,13 +15,14 @@ package executor
 
 import (
 	"github.com/cznic/mathutil"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/util/chunk"
 	"golang.org/x/net/context"
 )
 
 // ExplainExec represents an explain executor.
 type ExplainExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	rows   [][]string
 	cursor int
@@ -40,7 +41,7 @@ func (e *ExplainExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return nil
 	}
 
-	numCurRows := mathutil.Min(e.maxChunkSize, len(e.rows)-e.cursor)
+	numCurRows := mathutil.Min(e.ChunkSize, len(e.rows)-e.cursor)
 	for i := e.cursor; i < e.cursor+numCurRows; i++ {
 		for j := range e.rows[i] {
 			chk.AppendString(j, e.rows[i][j])

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -35,7 +36,7 @@ import (
  * See https://dev.mysql.com/doc/refman/5.7/en/grant.html
  ************************************************************************************/
 var (
-	_ Executor = (*GrantExec)(nil)
+	_ operator.Executor = (*GrantExec)(nil)
 )
 
 // GrantExec executes GrantStmt.

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -41,7 +41,7 @@ var (
 
 // GrantExec executes GrantStmt.
 type GrantExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	Privs      []*ast.PrivElem
 	ObjectType ast.ObjectTypeType
@@ -62,12 +62,12 @@ func (e *GrantExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 	dbName := e.Level.DBName
 	if len(dbName) == 0 {
-		dbName = e.ctx.GetSessionVars().CurrentDB
+		dbName = e.Sctx.GetSessionVars().CurrentDB
 	}
 	// Grant for each user
 	for _, user := range e.Users {
 		// Check if user exists.
-		exists, err := userExists(e.ctx, user.User.Username, user.User.Hostname)
+		exists, err := userExists(e.Sctx, user.User.Username, user.User.Hostname)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -78,7 +78,7 @@ func (e *GrantExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			}
 			user := fmt.Sprintf(`("%s", "%s", "%s")`, user.User.Hostname, user.User.Username, pwd)
 			sql := fmt.Sprintf(`INSERT INTO %s.%s (Host, User, Password) VALUES %s;`, mysql.SystemDB, mysql.UserTable, user)
-			_, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+			_, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -90,12 +90,12 @@ func (e *GrantExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		// Column scope:	mysql.Columns_priv
 		switch e.Level.Level {
 		case ast.GrantLevelDB:
-			err := checkAndInitDBPriv(e.ctx, dbName, e.is, user.User.Username, user.User.Hostname)
+			err := checkAndInitDBPriv(e.Sctx, dbName, e.is, user.User.Username, user.User.Hostname)
 			if err != nil {
 				return errors.Trace(err)
 			}
 		case ast.GrantLevelTable:
-			err := checkAndInitTablePriv(e.ctx, dbName, e.Level.TableName, e.is, user.User.Username, user.User.Hostname)
+			err := checkAndInitTablePriv(e.Sctx, dbName, e.Level.TableName, e.is, user.User.Username, user.User.Hostname)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -120,7 +120,7 @@ func (e *GrantExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			}
 		}
 	}
-	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	domain.GetDomain(e.Sctx).NotifyUpdatePrivilege(e.Sctx)
 	return nil
 }
 
@@ -155,7 +155,7 @@ func checkAndInitTablePriv(ctx sessionctx.Context, dbName, tblName string, is in
 // checkAndInitColumnPriv checks if column scope privilege entry exists in mysql.Columns_priv.
 // If unexists, insert a new one.
 func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast.ColumnName) error {
-	dbName, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
+	dbName, tbl, err := getTargetSchemaAndTable(e.Sctx, e.Level.DBName, e.Level.TableName, e.is)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -164,7 +164,7 @@ func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c.Name.O)
 		}
-		ok, err := columnPrivEntryExists(e.ctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
+		ok, err := columnPrivEntryExists(e.Sctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -172,7 +172,7 @@ func (e *GrantExec) checkAndInitColumnPriv(user string, host string, cols []*ast
 			continue
 		}
 		// Entry does not exist for user-host-db-tbl-col. Insert a new entry.
-		err = initColumnPrivEntry(e.ctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
+		err = initColumnPrivEntry(e.Sctx, user, host, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -228,7 +228,7 @@ func (e *GrantExec) grantGlobalPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 		return errors.Trace(err)
 	}
 	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s"`, mysql.SystemDB, mysql.UserTable, asgns, user.User.Username, user.User.Hostname)
-	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
+	_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
 	return errors.Trace(err)
 }
 
@@ -236,14 +236,14 @@ func (e *GrantExec) grantGlobalPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 func (e *GrantExec) grantDBPriv(priv *ast.PrivElem, user *ast.UserSpec) error {
 	dbName := e.Level.DBName
 	if len(dbName) == 0 {
-		dbName = e.ctx.GetSessionVars().CurrentDB
+		dbName = e.Sctx.GetSessionVars().CurrentDB
 	}
 	asgns, err := composeDBPrivUpdate(priv.Priv, "Y")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s";`, mysql.SystemDB, mysql.DBTable, asgns, user.User.Username, user.User.Hostname, dbName)
-	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
+	_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
 	return errors.Trace(err)
 }
 
@@ -251,21 +251,21 @@ func (e *GrantExec) grantDBPriv(priv *ast.PrivElem, user *ast.UserSpec) error {
 func (e *GrantExec) grantTablePriv(priv *ast.PrivElem, user *ast.UserSpec) error {
 	dbName := e.Level.DBName
 	if len(dbName) == 0 {
-		dbName = e.ctx.GetSessionVars().CurrentDB
+		dbName = e.Sctx.GetSessionVars().CurrentDB
 	}
 	tblName := e.Level.TableName
-	asgns, err := composeTablePrivUpdateForGrant(e.ctx, priv.Priv, user.User.Username, user.User.Hostname, dbName, tblName)
+	asgns, err := composeTablePrivUpdateForGrant(e.Sctx, priv.Priv, user.User.Username, user.User.Hostname, dbName, tblName)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s";`, mysql.SystemDB, mysql.TablePrivTable, asgns, user.User.Username, user.User.Hostname, dbName, tblName)
-	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
+	_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
 	return errors.Trace(err)
 }
 
 // grantColumnPriv manipulates mysql.tables_priv table.
 func (e *GrantExec) grantColumnPriv(priv *ast.PrivElem, user *ast.UserSpec) error {
-	dbName, tbl, err := getTargetSchemaAndTable(e.ctx, e.Level.DBName, e.Level.TableName, e.is)
+	dbName, tbl, err := getTargetSchemaAndTable(e.Sctx, e.Level.DBName, e.Level.TableName, e.is)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -275,12 +275,12 @@ func (e *GrantExec) grantColumnPriv(priv *ast.PrivElem, user *ast.UserSpec) erro
 		if col == nil {
 			return errors.Errorf("Unknown column: %s", c)
 		}
-		asgns, err := composeColumnPrivUpdateForGrant(e.ctx, priv.Priv, user.User.Username, user.User.Hostname, dbName, tbl.Meta().Name.O, col.Name.O)
+		asgns, err := composeColumnPrivUpdateForGrant(e.Sctx, priv.Priv, user.User.Username, user.User.Hostname, dbName, tbl.Meta().Name.O, col.Name.O)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		sql := fmt.Sprintf(`UPDATE %s.%s SET %s WHERE User="%s" AND Host="%s" AND DB="%s" AND Table_name="%s" AND Column_name="%s";`, mysql.SystemDB, mysql.ColumnPrivTable, asgns, user.User.Username, user.User.Hostname, dbName, tbl.Meta().Name.O, col.Name.O)
-		_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
+		_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -36,12 +36,12 @@ import (
  * See https://dev.mysql.com/doc/refman/5.7/en/grant.html
  ************************************************************************************/
 var (
-	_ operator.Executor = (*GrantExec)(nil)
+	_ operator.Operator = (*GrantExec)(nil)
 )
 
 // GrantExec executes GrantStmt.
 type GrantExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Privs      []*ast.PrivElem
 	ObjectType ast.ObjectTypeType
@@ -53,7 +53,7 @@ type GrantExec struct {
 	done bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *GrantExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if e.done {
 		return nil

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -37,7 +37,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ operator.Executor = &IndexLookUpJoin{}
+var _ operator.Operator = &IndexLookUpJoin{}
 
 // IndexLookUpJoin employs one outer worker and N innerWorkers to execute concurrently.
 // It preserves the order of the outer table and support batch lookup.
@@ -48,7 +48,7 @@ var _ operator.Executor = &IndexLookUpJoin{}
 // 3. main thread receives the task, waits for inner worker finish handling the task.
 // 4. main thread join each outer row by look up the inner rows hash map in the task.
 type IndexLookUpJoin struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	resultCh   <-chan *lookUpJoinTask
 	cancelFunc context.CancelFunc
@@ -101,7 +101,7 @@ type outerWorker struct {
 	outerCtx
 
 	ctx      sessionctx.Context
-	executor operator.Executor
+	executor operator.Operator
 
 	executorChk *chunk.Chunk
 
@@ -126,7 +126,7 @@ type innerWorker struct {
 	keyOff2IdxOff []int
 }
 
-// Open implements the Executor interface.
+// Open implements the Operator interface.
 func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 	err := e.Children[0].Open(ctx)
 	if err != nil {
@@ -187,7 +187,7 @@ func (e *IndexLookUpJoin) newInnerWorker(taskCh chan *lookUpJoinTask) *innerWork
 	return iw
 }
 
-// Next implements the Executor interface.
+// Next implements the Operator interface.
 func (e *IndexLookUpJoin) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	e.joinResult.Reset()
@@ -550,7 +550,7 @@ func (iw *innerWorker) buildLookUpMap(task *lookUpJoinTask) error {
 	return nil
 }
 
-// Close implements the Executor interface.
+// Close implements the Operator interface.
 func (e *IndexLookUpJoin) Close() error {
 	if e.cancelFunc != nil {
 		e.cancelFunc()

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -47,14 +47,14 @@ func (e *InsertExec) insertOneRow(row types.DatumRow) (int64, error) {
 	if err := e.checkBatchLimit(); err != nil {
 		return 0, errors.Trace(err)
 	}
-	e.ctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
-	h, err := e.Table.AddRecord(e.ctx, row, false)
-	e.ctx.Txn().DelOption(kv.PresumeKeyNotExists)
+	e.Sctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
+	h, err := e.Table.AddRecord(e.Sctx, row, false)
+	e.Sctx.Txn().DelOption(kv.PresumeKeyNotExists)
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	if !e.ctx.GetSessionVars().ImportingData {
-		e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
+	if !e.Sctx.GetSessionVars().ImportingData {
+		e.Sctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
 	}
 	e.rowCount++
 	return h, nil
@@ -62,13 +62,13 @@ func (e *InsertExec) insertOneRow(row types.DatumRow) (int64, error) {
 
 func (e *InsertExec) exec(rows []types.DatumRow) error {
 	// If tidb_batch_insert is ON and not in a transaction, we could use BatchInsert mode.
-	sessVars := e.ctx.GetSessionVars()
+	sessVars := e.Sctx.GetSessionVars()
 	defer sessVars.CleanBuffers()
 	ignoreErr := sessVars.StmtCtx.IgnoreErr
 
 	e.rowCount = 0
 	if !sessVars.ImportingData {
-		sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.ctx.Txn(), kv.TempTxnMemBufCap)
+		sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.Sctx.Txn(), kv.TempTxnMemBufCap)
 	}
 
 	// If `ON DUPLICATE KEY UPDATE` is specified, and no `IGNORE` keyword,
@@ -101,13 +101,13 @@ func (e *InsertExec) exec(rows []types.DatumRow) error {
 				return errors.Trace(err)
 			}
 			if len(e.OnDuplicate) == 0 && !ignoreErr {
-				e.ctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
+				e.Sctx.Txn().SetOption(kv.PresumeKeyNotExists, nil)
 			}
-			h, err := e.Table.AddRecord(e.ctx, row, false)
-			e.ctx.Txn().DelOption(kv.PresumeKeyNotExists)
+			h, err := e.Table.AddRecord(e.Sctx, row, false)
+			e.Sctx.Txn().DelOption(kv.PresumeKeyNotExists)
 			if err == nil {
 				if !sessVars.ImportingData {
-					e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
+					e.Sctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
 				}
 				e.rowCount++
 				continue
@@ -115,13 +115,13 @@ func (e *InsertExec) exec(rows []types.DatumRow) error {
 			if kv.ErrKeyExists.Equal(err) {
 				// TODO: Use batch get to speed up `insert ignore on duplicate key update`.
 				if len(e.OnDuplicate) > 0 && ignoreErr {
-					data, err1 := e.Table.RowWithCols(e.ctx, h, e.Table.WritableCols())
+					data, err1 := e.Table.RowWithCols(e.Sctx, h, e.Table.WritableCols())
 					if err1 != nil {
 						return errors.Trace(err1)
 					}
 					_, _, _, err = e.doDupRowUpdate(h, data, row, e.OnDuplicate)
 					if kv.ErrKeyExists.Equal(err) {
-						e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+						e.Sctx.GetSessionVars().StmtCtx.AppendWarning(err)
 						continue
 					}
 					if err != nil {
@@ -144,18 +144,18 @@ func (e *InsertExec) exec(rows []types.DatumRow) error {
 
 // checkBatchLimit check the batchSize limitation.
 func (e *InsertExec) checkBatchLimit() error {
-	sessVars := e.ctx.GetSessionVars()
+	sessVars := e.Sctx.GetSessionVars()
 	batchInsert := sessVars.BatchInsert && !sessVars.InTxn()
 	batchSize := sessVars.DMLBatchSize
 	if batchInsert && e.rowCount >= uint64(batchSize) {
-		e.ctx.StmtCommit()
-		if err := e.ctx.NewTxn(); err != nil {
+		e.Sctx.StmtCommit()
+		if err := e.Sctx.NewTxn(); err != nil {
 			// We should return a special error for batch insert.
 			return ErrBatchInsertFail.Gen("BatchInsert failed with error: %v", err)
 		}
 		e.rowCount = 0
 		if !sessVars.ImportingData {
-			sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.ctx.Txn(), kv.TempTxnMemBufCap)
+			sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.Sctx.Txn(), kv.TempTxnMemBufCap)
 		}
 	}
 	return nil
@@ -205,7 +205,7 @@ func (e *InsertExec) updateDupRow(keys []keyWithDupError, k keyWithDupError, val
 		return errors.NotFoundf("can not be duplicated row, due to old row not found. handle %d", oldHandle)
 	}
 	cols := e.Table.WritableCols()
-	oldRow, oldRowMap, err := tables.DecodeRawRowData(e.ctx, e.Table.Meta(), oldHandle, cols, oldValue)
+	oldRow, oldRowMap, err := tables.DecodeRawRowData(e.Sctx, e.Table.Meta(), oldHandle, cols, oldValue)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -214,7 +214,7 @@ func (e *InsertExec) updateDupRow(keys []keyWithDupError, k keyWithDupError, val
 		if col.State != model.StatePublic && oldRow[col.Offset].IsNull() {
 			_, found := oldRowMap[col.ID]
 			if !found {
-				oldRow[col.Offset], err = table.GetColOriginDefaultValue(e.ctx, col.ToInfo())
+				oldRow[col.Offset], err = table.GetColOriginDefaultValue(e.Sctx, col.ToInfo())
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -314,7 +314,7 @@ func (e *InsertExec) doDupRowUpdate(handle int64, oldRow types.DatumRow, newRow 
 	cols []*expression.Assignment) (types.DatumRow, bool, int64, error) {
 	assignFlag := make([]bool, len(e.Table.WritableCols()))
 	// See http://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
-	e.ctx.GetSessionVars().CurrInsertValues = types.DatumRow(newRow)
+	e.Sctx.GetSessionVars().CurrInsertValues = types.DatumRow(newRow)
 	newData := make(types.DatumRow, len(oldRow))
 	copy(newData, oldRow)
 	for _, col := range cols {
@@ -325,7 +325,7 @@ func (e *InsertExec) doDupRowUpdate(handle int64, oldRow types.DatumRow, newRow 
 		newData[col.Col.Index] = val
 		assignFlag[col.Col.Index] = true
 	}
-	_, handleChanged, newHandle, lastInsertID, err := updateRecord(e.ctx, handle, oldRow, newData, assignFlag, e.Table, true)
+	_, handleChanged, newHandle, lastInsertID, err := updateRecord(e.Sctx, handle, oldRow, newData, assignFlag, e.Table, true)
 	if err != nil {
 		return nil, false, 0, errors.Trace(err)
 	}
@@ -351,7 +351,7 @@ func (e *InsertExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 
 	var rows []types.DatumRow
-	if len(e.children) > 0 && e.children[0] != nil {
+	if len(e.Children) > 0 && e.Children[0] != nil {
 		rows, err = e.getRowsSelectChunk(ctx, cols)
 	} else {
 		rows, err = e.getRows(cols)
@@ -365,7 +365,7 @@ func (e *InsertExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // Close implements the Executor Close interface.
 func (e *InsertExec) Close() error {
-	e.ctx.GetSessionVars().CurrInsertValues = nil
+	e.Sctx.GetSessionVars().CurrInsertValues = nil
 	if e.SelectExec != nil {
 		return e.SelectExec.Close()
 	}

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -363,7 +363,7 @@ func (e *InsertExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return errors.Trace(e.exec(rows))
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *InsertExec) Close() error {
 	e.Sctx.GetSessionVars().CurrInsertValues = nil
 	if e.SelectExec != nil {
@@ -372,7 +372,7 @@ func (e *InsertExec) Close() error {
 	return nil
 }
 
-// Open implements the Executor Close interface.
+// Open implements the Operator Close interface.
 func (e *InsertExec) Open(ctx context.Context) error {
 	if e.SelectExec != nil {
 		return e.SelectExec.Open(ctx)

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
@@ -41,7 +42,7 @@ type InsertValues struct {
 	needFillDefaultValues bool
 	hasExtraHandle        bool
 
-	SelectExec Executor
+	SelectExec operator.Executor
 
 	Table   table.Table
 	Columns []*ast.ColumnName
@@ -290,9 +291,9 @@ func (e *InsertValues) getRowsSelectChunk(ctx context.Context, cols []*table.Col
 		return nil, ErrWrongValueCountOnRow.GenByArgs(1)
 	}
 	var rows []types.DatumRow
-	fields := selectExec.retTypes()
+	fields := selectExec.RetTypes()
 	for {
-		chk := selectExec.newChunk()
+		chk := selectExec.NewChunk()
 		iter := chunk.NewIterator4Chunk(chk)
 
 		err := selectExec.Next(ctx, chk)

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -34,7 +34,7 @@ import (
 
 // InsertValues is the data to insert.
 type InsertValues struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	rowCount              uint64
 	maxRowsInBatch        uint64
@@ -42,7 +42,7 @@ type InsertValues struct {
 	needFillDefaultValues bool
 	hasExtraHandle        bool
 
-	SelectExec operator.Executor
+	SelectExec operator.Operator
 
 	Table   table.Table
 	Columns []*ast.ColumnName

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -241,7 +241,7 @@ func (s *testSuite) TestJoin(c *C) {
 	result.Check(testkit.Rows("1", "2", "3", "4", "5", "6", "7", "8", "9"))
 
 	// This case is for testing:
-	// when the main thread calls Executor.Close() while the out data fetch worker and join workers are still working,
+	// when the main thread calls Operator.Close() while the out data fetch worker and join workers are still working,
 	// we need to stop the goroutines as soon as possible to avoid unexpected error.
 	tk.MustExec("set @@tidb_hash_join_concurrency=5")
 	tk.MustExec("drop table if exists t;")

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -31,7 +31,7 @@ import (
 
 // LoadDataExec represents a load data executor.
 type LoadDataExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	IsLocal      bool
 	loadDataInfo *LoadDataInfo
@@ -39,7 +39,7 @@ type LoadDataExec struct {
 
 // NewLoadDataInfo returns a LoadDataInfo structure, and it's only used for tests now.
 func NewLoadDataInfo(ctx sessionctx.Context, row types.DatumRow, tbl table.Table, cols []*table.Column) *LoadDataInfo {
-	insertVal := &InsertValues{BaseExecutor: operator.NewBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
+	insertVal := &InsertValues{BaseOperator: operator.NewBaseOperator(ctx, nil, "InsertValues"), Table: tbl}
 	return &LoadDataInfo{
 		row:          row,
 		InsertValues: insertVal,
@@ -49,7 +49,7 @@ func NewLoadDataInfo(ctx sessionctx.Context, row types.DatumRow, tbl table.Table
 	}
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *LoadDataExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	// TODO: support load data without local field.
@@ -75,12 +75,12 @@ func (e *LoadDataExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *LoadDataExec) Close() error {
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *LoadDataExec) Open(ctx context.Context) error {
 	return nil
 }

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
@@ -30,7 +31,7 @@ import (
 
 // LoadDataExec represents a load data executor.
 type LoadDataExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	IsLocal      bool
 	loadDataInfo *LoadDataInfo
@@ -38,7 +39,7 @@ type LoadDataExec struct {
 
 // NewLoadDataInfo returns a LoadDataInfo structure, and it's only used for tests now.
 func NewLoadDataInfo(ctx sessionctx.Context, row types.DatumRow, tbl table.Table, cols []*table.Column) *LoadDataInfo {
-	insertVal := &InsertValues{baseExecutor: newBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
+	insertVal := &InsertValues{BaseExecutor: operator.NewBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
 	return &LoadDataInfo{
 		row:          row,
 		InsertValues: insertVal,
@@ -60,7 +61,7 @@ func (e *LoadDataExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return errors.New("Load Data: don't support load data terminated is nil")
 	}
 
-	sctx := e.loadDataInfo.ctx
+	sctx := e.loadDataInfo.Sctx
 	val := sctx.Value(LoadDataVarKey)
 	if val != nil {
 		sctx.SetValue(LoadDataVarKey, nil)
@@ -258,7 +259,7 @@ func (e *LoadDataInfo) InsertData(prevData, curData []byte) ([]byte, bool, error
 		e.insertData(row)
 	}
 	if e.lastInsertID != 0 {
-		e.ctx.GetSessionVars().SetLastInsertID(e.lastInsertID)
+		e.Sctx.GetSessionVars().SetLastInsertID(e.lastInsertID)
 	}
 
 	return curData, reachLimit, nil
@@ -285,7 +286,7 @@ func (e *LoadDataInfo) insertData(row types.DatumRow) {
 	if row == nil {
 		return
 	}
-	_, err := e.Table.AddRecord(e.ctx, row, false)
+	_, err := e.Table.AddRecord(e.Sctx, row, false)
 	if err != nil {
 		warnLog := fmt.Sprintf("Load Data: insert data:%v failed:%v", row, errors.ErrorStack(err))
 		e.handleLoadDataWarnings(err, warnLog)

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -18,13 +18,14 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/util/chunk"
 	"golang.org/x/net/context"
 )
 
-var _ Executor = &LoadStatsExec{}
+var _ operator.Executor = &LoadStatsExec{}
 
 // LoadStatsExec represents a load statistic executor.
 type LoadStatsExec struct {

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -29,7 +29,7 @@ var _ operator.Executor = &LoadStatsExec{}
 
 // LoadStatsExec represents a load statistic executor.
 type LoadStatsExec struct {
-	baseExecutor
+	operator.BaseExecutor
 	info *LoadStatsInfo
 }
 
@@ -56,12 +56,12 @@ func (e *LoadStatsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if len(e.info.Path) == 0 {
 		return errors.New("Load Stats: file path is empty")
 	}
-	val := e.ctx.Value(LoadStatsVarKey)
+	val := e.Sctx.Value(LoadStatsVarKey)
 	if val != nil {
-		e.ctx.SetValue(LoadStatsVarKey, nil)
+		e.Sctx.SetValue(LoadStatsVarKey, nil)
 		return errors.New("Load Stats: previous load stats option isn't closed normally")
 	}
-	e.ctx.SetValue(LoadStatsVarKey, e.info)
+	e.Sctx.SetValue(LoadStatsVarKey, e.info)
 	return nil
 }
 

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -25,11 +25,11 @@ import (
 	"golang.org/x/net/context"
 )
 
-var _ operator.Executor = &LoadStatsExec{}
+var _ operator.Operator = &LoadStatsExec{}
 
 // LoadStatsExec represents a load statistic executor.
 type LoadStatsExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 	info *LoadStatsInfo
 }
 
@@ -50,7 +50,7 @@ func (k loadStatsVarKeyType) String() string {
 // LoadStatsVarKey is a variable key for load statistic.
 const LoadStatsVarKey loadStatsVarKeyType = 0
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *LoadStatsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if len(e.info.Path) == 0 {
@@ -65,12 +65,12 @@ func (e *LoadStatsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *LoadStatsExec) Close() error {
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *LoadStatsExec) Open(ctx context.Context) error {
 	return nil
 }

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -31,7 +31,7 @@ import (
 // 2. For other cases its preferred not to use SMJ and operator
 // will throw error.
 type MergeJoinExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	stmtCtx         *stmtctx.StatementContext
 	compareFuncs    []chunk.CompareFunc
@@ -50,7 +50,7 @@ type MergeJoinExec struct {
 }
 
 type mergeJoinOuterTable struct {
-	reader operator.Executor
+	reader operator.Operator
 	filter []expression.Expression
 	keys   []*expression.Column
 
@@ -65,7 +65,7 @@ type mergeJoinOuterTable struct {
 // All the inner rows which have the same join key are returned when function
 // "rowsWithSameKey()" being called.
 type mergeJoinInnerTable struct {
-	reader   operator.Executor
+	reader   operator.Operator
 	joinKeys []*expression.Column
 	ctx      context.Context
 
@@ -175,17 +175,17 @@ func (t *mergeJoinInnerTable) reallocReaderResult() {
 	t.curResultInUse = false
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *MergeJoinExec) Close() error {
 	e.memTracker.Detach()
 	e.memTracker = nil
 
-	return errors.Trace(e.BaseExecutor.Close())
+	return errors.Trace(e.BaseOperator.Close())
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *MergeJoinExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -235,7 +235,7 @@ func (e *MergeJoinExec) prepare(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *MergeJoinExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.prepared {

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/chunk"
@@ -49,7 +50,7 @@ type MergeJoinExec struct {
 }
 
 type mergeJoinOuterTable struct {
-	reader Executor
+	reader operator.Executor
 	filter []expression.Expression
 	keys   []*expression.Column
 
@@ -64,7 +65,7 @@ type mergeJoinOuterTable struct {
 // All the inner rows which have the same join key are returned when function
 // "rowsWithSameKey()" being called.
 type mergeJoinInnerTable struct {
-	reader   Executor
+	reader   operator.Executor
 	joinKeys []*expression.Column
 	ctx      context.Context
 
@@ -160,9 +161,9 @@ func (t *mergeJoinInnerTable) reallocReaderResult() {
 	// Create a new Chunk and append it to "resourceQueue" if there is no more
 	// available chunk in "resourceQueue".
 	if len(t.resourceQueue) == 0 {
-		newChunk := t.reader.newChunk()
-		t.memTracker.Consume(newChunk.MemoryUsage())
-		t.resourceQueue = append(t.resourceQueue, newChunk)
+		NewChunk := t.reader.NewChunk()
+		t.memTracker.Consume(NewChunk.MemoryUsage())
+		t.resourceQueue = append(t.resourceQueue, NewChunk)
 	}
 
 	// NOTE: "t.curResult" is always the last element of "resultQueue".

--- a/executor/operator/operator.go
+++ b/executor/operator/operator.go
@@ -1,0 +1,122 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operator
+
+import (
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"golang.org/x/net/context"
+)
+
+// Executor is the physical implementation of a algebra operator.
+//
+// In TiDB, all algebra operators are implemented as iterators, i.e., they
+// support a simple Open-Next-Close protocol. See this paper for more details:
+//
+// "Volcano-An Extensible and Parallel Query Evaluation System"
+//
+// Different from Volcano's execution model, a "Next" function call in TiDB will
+// return a batch of rows, other than a single row in Volcano.
+// NOTE: Executors must call "chk.Reset()" before appending their results to it.
+type Executor interface {
+	Open(context.Context) error
+	Next(ctx context.Context, chk *chunk.Chunk) error
+	Close() error
+	Schema() *expression.Schema
+
+	RetTypes() []*types.FieldType
+	NewChunk() *chunk.Chunk
+}
+
+type BaseExecutor struct {
+	Sctx            sessionctx.Context
+	ExplainID       string
+	ChunkSize       int
+	Children        []Executor
+	ChildrenResults []*chunk.Chunk
+
+	schema        *expression.Schema
+	retFieldTypes []*types.FieldType
+}
+
+// Open initializes Children recursively and "ChildrenResults" according to Children's schemas.
+func (e *BaseExecutor) Open(ctx context.Context) error {
+	for _, child := range e.Children {
+		err := child.Open(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	e.ChildrenResults = make([]*chunk.Chunk, 0, len(e.Children))
+	for _, child := range e.Children {
+		e.ChildrenResults = append(e.ChildrenResults, child.NewChunk())
+	}
+	return nil
+}
+
+// Close closes all executors and release all resources.
+func (e *BaseExecutor) Close() error {
+	for _, child := range e.Children {
+		err := child.Close()
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	e.ChildrenResults = nil
+	return nil
+}
+
+// Schema returns the current BaseExecutor's schema. If it is nil, then create and return a new one.
+func (e *BaseExecutor) Schema() *expression.Schema {
+	if e.schema == nil {
+		return expression.NewSchema()
+	}
+	return e.schema
+}
+
+// NewChunk creates a new chunk to buffer current executor's result.
+func (e *BaseExecutor) NewChunk() *chunk.Chunk {
+	return chunk.NewChunkWithCapacity(e.RetTypes(), e.ChunkSize)
+}
+
+// RetTypes returns all output column types.
+func (e *BaseExecutor) RetTypes() []*types.FieldType {
+	return e.retFieldTypes
+}
+
+// Next fills mutiple rows into a chunk.
+func (e *BaseExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
+	return nil
+}
+
+func NewBaseExecutor(ctx sessionctx.Context, schema *expression.Schema, id string, children ...Executor) BaseExecutor {
+	e := BaseExecutor{
+		Children:  children,
+		Sctx:      ctx,
+		ExplainID: id,
+		schema:    schema,
+		ChunkSize: ctx.GetSessionVars().MaxChunkSize,
+	}
+	if schema != nil {
+		cols := schema.Columns
+		e.retFieldTypes = make([]*types.FieldType, len(cols))
+		for i := range cols {
+			e.retFieldTypes[i] = cols[i].RetType
+		}
+	}
+	return e
+}

--- a/executor/operator/operator.go
+++ b/executor/operator/operator.go
@@ -22,8 +22,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Executor is the physical implementation of a algebra operator.
-//
+// Operator is the physical implementation of a algebra operator.
 // In TiDB, all algebra operators are implemented as iterators, i.e., they
 // support a simple Open-Next-Close protocol. See this paper for more details:
 //
@@ -31,30 +30,79 @@ import (
 //
 // Different from Volcano's execution model, a "Next" function call in TiDB will
 // return a batch of rows, other than a single row in Volcano.
-// NOTE: Executors must call "chk.Reset()" before appending their results to it.
-type Executor interface {
+//
+// NOTE: Operator implementations should call "chk.Reset()" before appending
+// their results to it.
+type Operator interface {
+	// Open initializes this operator and its child operators recursively.
+	// For example: allocate buffers, start goroutines. It should be called
+	// before Next().
 	Open(context.Context) error
+
+	// Next returns a batch of rows stored in the input Chunk, which is the
+	// result of this operator. A Chunk with 0 rows indicates there is no more
+	// data to be returned, and Close() should be called to release the
+	// resources.
 	Next(ctx context.Context, chk *chunk.Chunk) error
+
+	// Close releases this operator and its child operators' resources
+	// recursively. It should be called when there is no more data to return
+	// or any errors encountered during the execution of Open() or Next() to
+	// release resources and clean goroutines.
 	Close() error
+
+	// Schema returns the schema of this operator.
 	Schema() *expression.Schema
 
+	// RetTypes returns the types of all the output columns, which can be found
+	// in the result of function Schema().
 	RetTypes() []*types.FieldType
+
+	// NewChunk allocates a Chunk which can store the result of this operator.
+	// A typical usage of this function is:
+	//   chk := operator.NewChunk()
+	//   err := operator.Next(ctx, chk)
 	NewChunk() *chunk.Chunk
 }
 
-type BaseExecutor struct {
+// BaseOperator is the base implementation of the Operator interface. It holds
+// the basic common resources that every operator needs, implements the Operator
+// interface in the basic way, Operator implementations should implement their
+// own methods if necessary.
+type BaseOperator struct {
 	Sctx            sessionctx.Context
 	ExplainID       string
 	ChunkSize       int
-	Children        []Executor
+	Children        []Operator
 	ChildrenResults []*chunk.Chunk
 
-	schema        *expression.Schema
-	retFieldTypes []*types.FieldType
+	schema   *expression.Schema
+	retTypes []*types.FieldType
 }
 
-// Open initializes Children recursively and "ChildrenResults" according to Children's schemas.
-func (e *BaseExecutor) Open(ctx context.Context) error {
+// NewBaseOperator creates a BaseOperator.
+func NewBaseOperator(sctx sessionctx.Context, schema *expression.Schema, id string, children ...Operator) BaseOperator {
+	e := BaseOperator{
+		Children:  children,
+		Sctx:      sctx,
+		ExplainID: id,
+		schema:    schema,
+		ChunkSize: sctx.GetSessionVars().MaxChunkSize,
+	}
+	if schema != nil {
+		cols := schema.Columns
+		e.retTypes = make([]*types.FieldType, len(cols))
+		for i := range cols {
+			e.retTypes[i] = cols[i].RetType
+		}
+	}
+	return e
+}
+
+// Open implements the Operator interface. It initializes the child operators
+// recursively, allocate and initializes "ChildrenResults" according to the
+// schema of each child operator.
+func (e *BaseOperator) Open(ctx context.Context) error {
 	for _, child := range e.Children {
 		err := child.Open(ctx)
 		if err != nil {
@@ -68,8 +116,14 @@ func (e *BaseExecutor) Open(ctx context.Context) error {
 	return nil
 }
 
-// Close closes all executors and release all resources.
-func (e *BaseExecutor) Close() error {
+// Next implements the Operator interface.
+func (e *BaseOperator) Next(ctx context.Context, chk *chunk.Chunk) error {
+	return nil
+}
+
+// Close implements the Operator interface. It closes the child operators
+// recursively, release all resources obtained.
+func (e *BaseOperator) Close() error {
 	for _, child := range e.Children {
 		err := child.Close()
 		if err != nil {
@@ -80,43 +134,21 @@ func (e *BaseExecutor) Close() error {
 	return nil
 }
 
-// Schema returns the current BaseExecutor's schema. If it is nil, then create and return a new one.
-func (e *BaseExecutor) Schema() *expression.Schema {
+// Schema returns the schema of this operator. An empty schema is returned if
+// it doesn't have one.
+func (e *BaseOperator) Schema() *expression.Schema {
 	if e.schema == nil {
 		return expression.NewSchema()
 	}
 	return e.schema
 }
 
-// NewChunk creates a new chunk to buffer current executor's result.
-func (e *BaseExecutor) NewChunk() *chunk.Chunk {
+// RetTypes returns all field types of the output columns.
+func (e *BaseOperator) RetTypes() []*types.FieldType {
+	return e.retTypes
+}
+
+// NewChunk creates a new chunk to buffer the result of this operator.
+func (e *BaseOperator) NewChunk() *chunk.Chunk {
 	return chunk.NewChunkWithCapacity(e.RetTypes(), e.ChunkSize)
-}
-
-// RetTypes returns all output column types.
-func (e *BaseExecutor) RetTypes() []*types.FieldType {
-	return e.retFieldTypes
-}
-
-// Next fills mutiple rows into a chunk.
-func (e *BaseExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	return nil
-}
-
-func NewBaseExecutor(ctx sessionctx.Context, schema *expression.Schema, id string, children ...Executor) BaseExecutor {
-	e := BaseExecutor{
-		Children:  children,
-		Sctx:      ctx,
-		ExplainID: id,
-		schema:    schema,
-		ChunkSize: ctx.GetSessionVars().MaxChunkSize,
-	}
-	if schema != nil {
-		cols := schema.Columns
-		e.retFieldTypes = make([]*types.FieldType, len(cols))
-		for i := range cols {
-			e.retFieldTypes[i] = cols[i].RetType
-		}
-	}
-	return e
 }

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
@@ -20,7 +21,7 @@ type pkgTestSuite struct {
 }
 
 type MockExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	Rows      []types.DatumRow
 	curRowIdx int
@@ -29,7 +30,7 @@ type MockExec struct {
 func (m *MockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	colTypes := m.RetTypes()
-	for ; m.curRowIdx < len(m.Rows) && chk.NumRows() < m.maxChunkSize; m.curRowIdx++ {
+	for ; m.curRowIdx < len(m.Rows) && chk.NumRows() < m.ChunkSize; m.curRowIdx++ {
 		curRow := m.Rows[m.curRowIdx]
 		for i := 0; i < len(curRow); i++ {
 			curDatum := curRow.GetDatum(i, colTypes[i])
@@ -57,7 +58,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 	con := &expression.Constant{Value: types.NewDatum(6), RetType: types.NewFieldType(mysql.TypeLong)}
 	outerSchema := expression.NewSchema(col0)
 	outerExec := &MockExec{
-		baseExecutor: newBaseExecutor(sctx, outerSchema, ""),
+		BaseExecutor: operator.NewBaseExecutor(sctx, outerSchema, ""),
 		Rows: []types.DatumRow{
 			types.MakeDatums(1),
 			types.MakeDatums(2),
@@ -68,7 +69,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		}}
 	innerSchema := expression.NewSchema(col1)
 	innerExec := &MockExec{
-		baseExecutor: newBaseExecutor(sctx, innerSchema, ""),
+		BaseExecutor: operator.NewBaseExecutor(sctx, innerSchema, ""),
 		Rows: []types.DatumRow{
 			types.MakeDatums(1),
 			types.MakeDatums(2),
@@ -84,14 +85,14 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		make([]types.Datum, innerExec.Schema().Len()), []expression.Expression{otherFilter}, outerExec.RetTypes(), innerExec.RetTypes())
 	joinSchema := expression.NewSchema(col0, col1)
 	join := &NestedLoopApplyExec{
-		baseExecutor:    newBaseExecutor(sctx, joinSchema, ""),
+		BaseExecutor:    operator.NewBaseExecutor(sctx, joinSchema, ""),
 		outerExec:       outerExec,
 		innerExec:       innerExec,
 		outerFilter:     []expression.Expression{outerFilter},
 		innerFilter:     []expression.Expression{innerFilter},
 		resultGenerator: generator,
 	}
-	join.innerList = chunk.NewList(innerExec.RetTypes(), innerExec.maxChunkSize)
+	join.innerList = chunk.NewList(innerExec.RetTypes(), innerExec.ChunkSize)
 	join.innerChunk = innerExec.NewChunk()
 	join.outerChunk = outerExec.NewChunk()
 	joinChk := join.NewChunk()

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -28,7 +28,7 @@ type MockExec struct {
 
 func (m *MockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
-	colTypes := m.retTypes()
+	colTypes := m.RetTypes()
 	for ; m.curRowIdx < len(m.Rows) && chk.NumRows() < m.maxChunkSize; m.curRowIdx++ {
 		curRow := m.Rows[m.curRowIdx]
 		for i := 0; i < len(curRow); i++ {
@@ -81,7 +81,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 	innerFilter := outerFilter.Clone()
 	otherFilter := expression.NewFunctionInternal(sctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), col0, col1)
 	generator := newJoinResultGenerator(sctx, plan.InnerJoin, false,
-		make([]types.Datum, innerExec.Schema().Len()), []expression.Expression{otherFilter}, outerExec.retTypes(), innerExec.retTypes())
+		make([]types.Datum, innerExec.Schema().Len()), []expression.Expression{otherFilter}, outerExec.RetTypes(), innerExec.RetTypes())
 	joinSchema := expression.NewSchema(col0, col1)
 	join := &NestedLoopApplyExec{
 		baseExecutor:    newBaseExecutor(sctx, joinSchema, ""),
@@ -91,10 +91,10 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		innerFilter:     []expression.Expression{innerFilter},
 		resultGenerator: generator,
 	}
-	join.innerList = chunk.NewList(innerExec.retTypes(), innerExec.maxChunkSize)
-	join.innerChunk = innerExec.newChunk()
-	join.outerChunk = outerExec.newChunk()
-	joinChk := join.newChunk()
+	join.innerList = chunk.NewList(innerExec.RetTypes(), innerExec.maxChunkSize)
+	join.innerChunk = innerExec.NewChunk()
+	join.outerChunk = outerExec.NewChunk()
+	joinChk := join.NewChunk()
 	it := chunk.NewIterator4Chunk(joinChk)
 	for rowIdx := 1; ; {
 		err := join.Next(ctx, joinChk)

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -21,7 +21,7 @@ type pkgTestSuite struct {
 }
 
 type MockExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Rows      []types.DatumRow
 	curRowIdx int
@@ -58,7 +58,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 	con := &expression.Constant{Value: types.NewDatum(6), RetType: types.NewFieldType(mysql.TypeLong)}
 	outerSchema := expression.NewSchema(col0)
 	outerExec := &MockExec{
-		BaseExecutor: operator.NewBaseExecutor(sctx, outerSchema, ""),
+		BaseOperator: operator.NewBaseOperator(sctx, outerSchema, ""),
 		Rows: []types.DatumRow{
 			types.MakeDatums(1),
 			types.MakeDatums(2),
@@ -69,7 +69,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		}}
 	innerSchema := expression.NewSchema(col1)
 	innerExec := &MockExec{
-		BaseExecutor: operator.NewBaseExecutor(sctx, innerSchema, ""),
+		BaseOperator: operator.NewBaseOperator(sctx, innerSchema, ""),
 		Rows: []types.DatumRow{
 			types.MakeDatums(1),
 			types.MakeDatums(2),
@@ -85,7 +85,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		make([]types.Datum, innerExec.Schema().Len()), []expression.Expression{otherFilter}, outerExec.RetTypes(), innerExec.RetTypes())
 	joinSchema := expression.NewSchema(col0, col1)
 	join := &NestedLoopApplyExec{
-		BaseExecutor:    operator.NewBaseExecutor(sctx, joinSchema, ""),
+		BaseOperator:    operator.NewBaseOperator(sctx, joinSchema, ""),
 		outerExec:       outerExec,
 		innerExec:       innerExec,
 		outerFilter:     []expression.Expression{outerFilter},

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -20,6 +20,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser"
@@ -34,9 +35,9 @@ import (
 )
 
 var (
-	_ Executor = &DeallocateExec{}
-	_ Executor = &ExecuteExec{}
-	_ Executor = &PrepareExec{}
+	_ operator.Executor = &DeallocateExec{}
+	_ operator.Executor = &ExecuteExec{}
+	_ operator.Executor = &PrepareExec{}
 )
 
 type paramMarkerSorter struct {
@@ -178,7 +179,7 @@ type ExecuteExec struct {
 	name      string
 	usingVars []expression.Expression
 	id        uint32
-	stmtExec  Executor
+	stmtExec  operator.Executor
 	stmt      ast.StmtNode
 	plan      plan.Plan
 }

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -35,9 +35,9 @@ import (
 )
 
 var (
-	_ operator.Executor = &DeallocateExec{}
-	_ operator.Executor = &ExecuteExec{}
-	_ operator.Executor = &PrepareExec{}
+	_ operator.Operator = &DeallocateExec{}
+	_ operator.Operator = &ExecuteExec{}
+	_ operator.Operator = &PrepareExec{}
 )
 
 type paramMarkerSorter struct {
@@ -73,7 +73,7 @@ func (e *paramMarkerExtractor) Leave(in ast.Node) (ast.Node, bool) {
 
 // PrepareExec represents a PREPARE executor.
 type PrepareExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	is      infoschema.InfoSchema
 	name    string
@@ -87,13 +87,13 @@ type PrepareExec struct {
 // NewPrepareExec creates a new PrepareExec.
 func NewPrepareExec(ctx sessionctx.Context, is infoschema.InfoSchema, sqlTxt string) *PrepareExec {
 	return &PrepareExec{
-		BaseExecutor: operator.NewBaseExecutor(ctx, nil, "PrepareStmt"),
+		BaseOperator: operator.NewBaseOperator(ctx, nil, "PrepareStmt"),
 		is:           is,
 		sqlText:      sqlTxt,
 	}
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	vars := e.Sctx.GetSessionVars()
 	if e.ID != 0 {
@@ -171,20 +171,20 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // ExecuteExec represents an EXECUTE executor.
 // It cannot be executed by itself, all it needs to do is to build
-// another Executor from a prepared statement.
+// another Operator from a prepared statement.
 type ExecuteExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	is        infoschema.InfoSchema
 	name      string
 	usingVars []expression.Expression
 	id        uint32
-	stmtExec  operator.Executor
+	stmtExec  operator.Operator
 	stmt      ast.StmtNode
 	plan      plan.Plan
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ExecuteExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	return nil
 }
@@ -215,12 +215,12 @@ func (e *ExecuteExec) Build() error {
 
 // DeallocateExec represent a DEALLOCATE executor.
 type DeallocateExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Name string
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *DeallocateExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	vars := e.Sctx.GetSessionVars()
 	id, ok := vars.PreparedStmtNameToID[e.Name]

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -46,7 +46,7 @@ type projectionOutput struct {
 // ProjectionExec implements the physical Projection Operator:
 // https://en.wikipedia.org/wiki/Projection_(relational_algebra)
 type ProjectionExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	evaluatorSuit    *expression.EvaluatorSuit
 	calculateNoDelay bool
@@ -59,9 +59,9 @@ type ProjectionExec struct {
 	workers    []*projectionWorker
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ProjectionExec) Open(ctx context.Context) error {
-	if err := e.BaseExecutor.Open(ctx); err != nil {
+	if err := e.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -77,7 +77,7 @@ func (e *ProjectionExec) Open(ctx context.Context) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 //
 // Here we explain the execution flow of the parallel projection implementation.
 // There are 3 main components:
@@ -215,7 +215,7 @@ func (e *ProjectionExec) prepare(ctx context.Context) {
 	}
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *ProjectionExec) Close() error {
 	if e.outputCh != nil {
 		close(e.finishCh)
@@ -224,11 +224,11 @@ func (e *ProjectionExec) Close() error {
 		}
 		e.outputCh = nil
 	}
-	return errors.Trace(e.BaseExecutor.Close())
+	return errors.Trace(e.BaseOperator.Close())
 }
 
 type projectionInputFetcher struct {
-	child          operator.Executor
+	child          operator.Operator
 	globalFinishCh <-chan struct{}
 	globalOutputCh chan<- *projectionOutput
 

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
@@ -198,11 +199,11 @@ func (e *ProjectionExec) prepare(ctx context.Context) {
 		})
 
 		e.fetcher.inputCh <- &projectionInput{
-			chk:          e.children[0].newChunk(),
+			chk:          e.children[0].NewChunk(),
 			targetWorker: e.workers[i],
 		}
 		e.fetcher.outputCh <- &projectionOutput{
-			chk:  e.newChunk(),
+			chk:  e.NewChunk(),
 			done: make(chan error, 1),
 		}
 	}
@@ -227,7 +228,7 @@ func (e *ProjectionExec) Close() error {
 }
 
 type projectionInputFetcher struct {
-	child          Executor
+	child          operator.Executor
 	globalFinishCh <-chan struct{}
 	globalOutputCh chan<- *projectionOutput
 

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -28,7 +28,7 @@ type ReplaceExec struct {
 	finished bool
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *ReplaceExec) Close() error {
 	if e.SelectExec != nil {
 		return e.SelectExec.Close()
@@ -36,7 +36,7 @@ func (e *ReplaceExec) Close() error {
 	return nil
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *ReplaceExec) Open(ctx context.Context) error {
 	if e.SelectExec != nil {
 		return e.SelectExec.Open(ctx)
@@ -104,7 +104,7 @@ func (e *ReplaceExec) exec(rows []types.DatumRow) error {
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ReplaceExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.finished {

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -19,6 +19,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -33,7 +34,7 @@ import (
  * See https://dev.mysql.com/doc/refman/5.7/en/revoke.html
  ************************************************************************************/
 var (
-	_ Executor = (*RevokeExec)(nil)
+	_ operator.Executor = (*RevokeExec)(nil)
 )
 
 // RevokeExec executes RevokeStmt.

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -34,12 +34,12 @@ import (
  * See https://dev.mysql.com/doc/refman/5.7/en/revoke.html
  ************************************************************************************/
 var (
-	_ operator.Executor = (*RevokeExec)(nil)
+	_ operator.Operator = (*RevokeExec)(nil)
 )
 
 // RevokeExec executes RevokeStmt.
 type RevokeExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Privs      []*ast.PrivElem
 	ObjectType ast.ObjectTypeType
@@ -51,7 +51,7 @@ type RevokeExec struct {
 	done bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *RevokeExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if e.done {
 		return nil

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -39,7 +39,7 @@ var (
 
 // RevokeExec executes RevokeStmt.
 type RevokeExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	Privs      []*ast.PrivElem
 	ObjectType ast.ObjectTypeType

--- a/executor/set.go
+++ b/executor/set.go
@@ -37,13 +37,13 @@ import (
 
 // SetExecutor executes set statement.
 type SetExecutor struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	vars []*expression.VarAssignment
 	done bool
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *SetExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.done {

--- a/executor/set.go
+++ b/executor/set.go
@@ -21,6 +21,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
@@ -36,7 +37,7 @@ import (
 
 // SetExecutor executes set statement.
 type SetExecutor struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	vars []*expression.VarAssignment
 	done bool
@@ -49,7 +50,7 @@ func (e *SetExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return nil
 	}
 	e.done = true
-	sessionVars := e.ctx.GetSessionVars()
+	sessionVars := e.Sctx.GetSessionVars()
 	for _, v := range e.vars {
 		// Variable is case insensitive, we use lower case.
 		if v.Name == ast.SetNames {
@@ -112,7 +113,7 @@ func (e *SetExecutor) getSynonyms(varName string) []string {
 }
 
 func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) error {
-	sessionVars := e.ctx.GetSessionVars()
+	sessionVars := e.Sctx.GetSessionVars()
 	sysVar := variable.GetSysVar(name)
 	if sysVar == nil {
 		return variable.UnknownSystemVar.GenByArgs(name)
@@ -159,7 +160,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 		}
 		newSnapshotIsSet := sessionVars.SnapshotTS > 0 && sessionVars.SnapshotTS != oldSnapshotTS
 		if newSnapshotIsSet {
-			err = validateSnapshot(e.ctx, sessionVars.SnapshotTS)
+			err = validateSnapshot(e.Sctx, sessionVars.SnapshotTS)
 			if err != nil {
 				sessionVars.SnapshotTS = oldSnapshotTS
 				return errors.Trace(err)
@@ -184,7 +185,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 	if name == variable.TxnIsolation {
 		isoLevel, _ := sessionVars.GetSystemVar(variable.TxnIsolation)
 		if isoLevel == ast.ReadCommitted {
-			e.ctx.Txn().SetOption(kv.IsolationLevel, kv.RC)
+			e.Sctx.Txn().SetOption(kv.IsolationLevel, kv.RC)
 		}
 	}
 
@@ -222,7 +223,7 @@ func (e *SetExecutor) setCharset(cs, co string) error {
 			return errors.Trace(err)
 		}
 	}
-	sessionVars := e.ctx.GetSessionVars()
+	sessionVars := e.Sctx.GetSessionVars()
 	for _, v := range variable.SetNamesVariables {
 		terror.Log(errors.Trace(sessionVars.SetSystemVar(v, cs)))
 	}
@@ -238,7 +239,7 @@ func (e *SetExecutor) getVarValue(v *expression.VarAssignment, sysVar *variable.
 		if sysVar != nil {
 			value = types.NewStringDatum(sysVar.Value)
 		} else {
-			s, err1 := variable.GetGlobalSystemVar(e.ctx.GetSessionVars(), v.Name)
+			s, err1 := variable.GetGlobalSystemVar(e.Sctx.GetSessionVars(), v.Name)
 			if err1 != nil {
 				return value, errors.Trace(err1)
 			}
@@ -254,13 +255,13 @@ func (e *SetExecutor) loadSnapshotInfoSchemaIfNeeded(name string) error {
 	if name != variable.TiDBSnapshot {
 		return nil
 	}
-	vars := e.ctx.GetSessionVars()
+	vars := e.Sctx.GetSessionVars()
 	if vars.SnapshotTS == 0 {
 		vars.SnapshotInfoschema = nil
 		return nil
 	}
 	log.Infof("[con:%d] loadSnapshotInfoSchema, SnapshotTS:%d", vars.ConnectionID, vars.SnapshotTS)
-	dom := domain.GetDomain(e.ctx)
+	dom := domain.GetDomain(e.Sctx)
 	snapInfo, err := dom.GetSnapshotInfoSchema(vars.SnapshotTS)
 	if err != nil {
 		return errors.Trace(err)

--- a/executor/show.go
+++ b/executor/show.go
@@ -65,7 +65,7 @@ type ShowExec struct {
 func (e *ShowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.result == nil {
-		e.result = e.newChunk()
+		e.result = e.NewChunk()
 		err := e.fetchAll()
 		if err != nil {
 			return errors.Trace(err)

--- a/executor/show.go
+++ b/executor/show.go
@@ -43,7 +43,7 @@ import (
 
 // ShowExec represents a show executor.
 type ShowExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Tp     ast.ShowStmtType // Databases/Tables/Columns/....
 	DBName model.CIStr
@@ -62,7 +62,7 @@ type ShowExec struct {
 	cursor int
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *ShowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if e.result == nil {

--- a/executor/show_stats.go
+++ b/executor/show_stats.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (e *ShowExec) fetchShowStatsMeta() error {
-	do := domain.GetDomain(e.ctx)
+	do := domain.GetDomain(e.Sctx)
 	h := do.StatsHandle()
 	dbs := do.InfoSchema().AllSchemas()
 	for _, db := range dbs {
@@ -46,7 +46,7 @@ func (e *ShowExec) fetchShowStatsMeta() error {
 }
 
 func (e *ShowExec) fetchShowStatsHistogram() error {
-	do := domain.GetDomain(e.ctx)
+	do := domain.GetDomain(e.Sctx)
 	h := do.StatsHandle()
 	dbs := do.InfoSchema().AllSchemas()
 	for _, db := range dbs {
@@ -84,7 +84,7 @@ func (e *ShowExec) versionToTime(version uint64) types.Time {
 }
 
 func (e *ShowExec) fetchShowStatsBuckets() error {
-	do := domain.GetDomain(e.ctx)
+	do := domain.GetDomain(e.Sctx)
 	h := do.StatsHandle()
 	dbs := do.InfoSchema().AllSchemas()
 	for _, db := range dbs {
@@ -141,7 +141,7 @@ func (e *ShowExec) bucketsToRows(dbName, tblName, colName string, numOfCols int,
 }
 
 func (e *ShowExec) fetchShowStatsHealthy() {
-	do := domain.GetDomain(e.ctx)
+	do := domain.GetDomain(e.Sctx)
 	h := do.StatsHandle()
 	dbs := do.InfoSchema().AllSchemas()
 	for _, db := range dbs {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -41,14 +41,14 @@ import (
 // `BeginStmt`, `CommitStmt`, `RollbackStmt`.
 // TODO: list all simple statements.
 type SimpleExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	Statement ast.StmtNode
 	done      bool
 	is        infoschema.InfoSchema
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *SimpleExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 	if e.done {
 		return nil

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
@@ -40,7 +41,7 @@ import (
 // `BeginStmt`, `CommitStmt`, `RollbackStmt`.
 // TODO: list all simple statements.
 type SimpleExec struct {
-	baseExecutor
+	operator.BaseExecutor
 
 	Statement ast.StmtNode
 	done      bool
@@ -89,11 +90,11 @@ func (e *SimpleExec) executeUse(s *ast.UseStmt) error {
 	if !exists {
 		return infoschema.ErrDatabaseNotExists.GenByArgs(dbname)
 	}
-	e.ctx.GetSessionVars().CurrentDB = dbname.O
+	e.Sctx.GetSessionVars().CurrentDB = dbname.O
 	// character_set_database is the character set used by the default database.
 	// The server sets this variable whenever the default database changes.
 	// See http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_character_set_database
-	sessionVars := e.ctx.GetSessionVars()
+	sessionVars := e.Sctx.GetSessionVars()
 	terror.Log(errors.Trace(sessionVars.SetSystemVar(variable.CharsetDatabase, dbinfo.Charset)))
 	terror.Log(errors.Trace(sessionVars.SetSystemVar(variable.CollationDatabase, dbinfo.Collate)))
 	return nil
@@ -102,9 +103,9 @@ func (e *SimpleExec) executeUse(s *ast.UseStmt) error {
 func (e *SimpleExec) executeBegin(s *ast.BeginStmt) error {
 	// If BEGIN is the first statement in TxnCtx, we can reuse the existing transaction, without the
 	// need to call NewTxn, which commits the existing transaction and begins a new one.
-	txnCtx := e.ctx.GetSessionVars().TxnCtx
+	txnCtx := e.Sctx.GetSessionVars().TxnCtx
 	if txnCtx.Histroy != nil {
-		err := e.ctx.NewTxn()
+		err := e.Sctx.NewTxn()
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -112,21 +113,21 @@ func (e *SimpleExec) executeBegin(s *ast.BeginStmt) error {
 	// With START TRANSACTION, autocommit remains disabled until you end
 	// the transaction with COMMIT or ROLLBACK. The autocommit mode then
 	// reverts to its previous state.
-	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, true)
+	e.Sctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, true)
 	return nil
 }
 
 func (e *SimpleExec) executeCommit(s *ast.CommitStmt) {
-	e.ctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
+	e.Sctx.GetSessionVars().SetStatusFlag(mysql.ServerStatusInTrans, false)
 }
 
 func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {
-	sessVars := e.ctx.GetSessionVars()
+	sessVars := e.Sctx.GetSessionVars()
 	log.Debugf("[con:%d] execute rollback statement", sessVars.ConnectionID)
 	sessVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
-	if e.ctx.Txn().Valid() {
-		e.ctx.GetSessionVars().TxnCtx.ClearDelta()
-		return e.ctx.Txn().Rollback()
+	if e.Sctx.Txn().Valid() {
+		e.Sctx.GetSessionVars().TxnCtx.ClearDelta()
+		return e.Sctx.Txn().Rollback()
 	}
 	return nil
 }
@@ -134,7 +135,7 @@ func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {
 func (e *SimpleExec) executeCreateUser(s *ast.CreateUserStmt) error {
 	users := make([]string, 0, len(s.Specs))
 	for _, spec := range s.Specs {
-		exists, err1 := userExists(e.ctx, spec.User.Username, spec.User.Hostname)
+		exists, err1 := userExists(e.Sctx, spec.User.Username, spec.User.Hostname)
 		if err1 != nil {
 			return errors.Trace(err1)
 		}
@@ -155,17 +156,17 @@ func (e *SimpleExec) executeCreateUser(s *ast.CreateUserStmt) error {
 		return nil
 	}
 	sql := fmt.Sprintf(`INSERT INTO %s.%s (Host, User, Password) VALUES %s;`, mysql.SystemDB, mysql.UserTable, strings.Join(users, ", "))
-	_, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql)
+	_, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	domain.GetDomain(e.Sctx).NotifyUpdatePrivilege(e.Sctx)
 	return errors.Trace(err)
 }
 
 func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 	if s.CurrentAuth != nil {
-		user := e.ctx.GetSessionVars().User
+		user := e.Sctx.GetSessionVars().User
 		if user == nil {
 			return errors.New("Session user is empty")
 		}
@@ -178,7 +179,7 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 
 	failedUsers := make([]string, 0, len(s.Specs))
 	for _, spec := range s.Specs {
-		exists, err := userExists(e.ctx, spec.User.Username, spec.User.Hostname)
+		exists, err := userExists(e.Sctx, spec.User.Username, spec.User.Hostname)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -199,27 +200,27 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 		}
 		sql := fmt.Sprintf(`UPDATE %s.%s SET Password = "%s" WHERE Host = "%s" and User = "%s";`,
 			mysql.SystemDB, mysql.UserTable, pwd, spec.User.Hostname, spec.User.Username)
-		_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
+		_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
 		if err != nil {
 			failedUsers = append(failedUsers, spec.User.String())
 		}
 	}
 	if len(failedUsers) > 0 {
 		// Commit the transaction even if we returns error
-		err := e.ctx.Txn().Commit(sessionctx.SetCommitCtx(context.Background(), e.ctx))
+		err := e.Sctx.Txn().Commit(sessionctx.SetCommitCtx(context.Background(), e.Sctx))
 		if err != nil {
 			return errors.Trace(err)
 		}
 		return ErrCannotUser.GenByArgs("ALTER USER", strings.Join(failedUsers, ","))
 	}
-	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	domain.GetDomain(e.Sctx).NotifyUpdatePrivilege(e.Sctx)
 	return nil
 }
 
 func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 	failedUsers := make([]string, 0, len(s.UserList))
 	for _, user := range s.UserList {
-		exists, err := userExists(e.ctx, user.Username, user.Hostname)
+		exists, err := userExists(e.Sctx, user.Username, user.Hostname)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -231,13 +232,13 @@ func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 		}
 
 		// begin a transaction to delete a user.
-		if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "begin"); err != nil {
+		if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), "begin"); err != nil {
 			return errors.Trace(err)
 		}
 		sql := fmt.Sprintf(`DELETE FROM %s.%s WHERE Host = "%s" and User = "%s";`, mysql.SystemDB, mysql.UserTable, user.Hostname, user.Username)
-		if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
+		if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
 			failedUsers = append(failedUsers, user.String())
-			if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
+			if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
 				return errors.Trace(err)
 			}
 			continue
@@ -245,9 +246,9 @@ func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 
 		// delete privileges from mysql.db
 		sql = fmt.Sprintf(`DELETE FROM %s.%s WHERE Host = "%s" and User = "%s";`, mysql.SystemDB, mysql.DBTable, user.Hostname, user.Username)
-		if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
+		if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
 			failedUsers = append(failedUsers, user.String())
-			if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
+			if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
 				return errors.Trace(err)
 			}
 			continue
@@ -255,23 +256,23 @@ func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 
 		// delete privileges from mysql.tables_priv
 		sql = fmt.Sprintf(`DELETE FROM %s.%s WHERE Host = "%s" and User = "%s";`, mysql.SystemDB, mysql.TablePrivTable, user.Hostname, user.Username)
-		if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
+		if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
 			failedUsers = append(failedUsers, user.String())
-			if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
+			if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
 				return errors.Trace(err)
 			}
 			continue
 		}
 
 		//TODO: need delete columns_priv once we implement columns_priv functionality.
-		if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "commit"); err != nil {
+		if _, err := e.Sctx.(sqlexec.SQLExecutor).Execute(context.Background(), "commit"); err != nil {
 			failedUsers = append(failedUsers, user.String())
 		}
 	}
 	if len(failedUsers) > 0 {
 		return ErrCannotUser.GenByArgs("DROP USER", strings.Join(failedUsers, ","))
 	}
-	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	domain.GetDomain(e.Sctx).NotifyUpdatePrivilege(e.Sctx)
 	return nil
 }
 
@@ -286,13 +287,13 @@ func userExists(ctx sessionctx.Context, name string, host string) (bool, error) 
 
 func (e *SimpleExec) executeSetPwd(s *ast.SetPwdStmt) error {
 	if s.User == nil {
-		vars := e.ctx.GetSessionVars()
+		vars := e.Sctx.GetSessionVars()
 		s.User = vars.User
 		if s.User == nil {
 			return errors.New("Session error is empty")
 		}
 	}
-	exists, err := userExists(e.ctx, s.User.Username, s.User.Hostname)
+	exists, err := userExists(e.Sctx, s.User.Username, s.User.Hostname)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -302,21 +303,21 @@ func (e *SimpleExec) executeSetPwd(s *ast.SetPwdStmt) error {
 
 	// update mysql.user
 	sql := fmt.Sprintf(`UPDATE %s.%s SET password="%s" WHERE User="%s" AND Host="%s";`, mysql.SystemDB, mysql.UserTable, auth.EncodePassword(s.Password), s.User.Username, s.User.Hostname)
-	_, _, err = e.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.ctx, sql)
-	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	_, _, err = e.Sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(e.Sctx, sql)
+	domain.GetDomain(e.Sctx).NotifyUpdatePrivilege(e.Sctx)
 	return errors.Trace(err)
 }
 
 func (e *SimpleExec) executeKillStmt(s *ast.KillStmt) error {
 	if s.TiDBExtension {
-		sm := e.ctx.GetSessionManager()
+		sm := e.Sctx.GetSessionManager()
 		if sm == nil {
 			return nil
 		}
 		sm.Kill(s.ConnectionID, s.Query)
 	} else {
 		err := errors.New("Invalid operation. Please use 'KILL TIDB [CONNECTION | QUERY] connectionID' instead")
-		e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
+		e.Sctx.GetSessionVars().StmtCtx.AppendWarning(err)
 	}
 	return nil
 }
@@ -326,7 +327,7 @@ func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
 	case ast.FlushTables:
 		// TODO: A dummy implement
 	case ast.FlushPrivileges:
-		dom := domain.GetDomain(e.ctx)
+		dom := domain.GetDomain(e.Sctx)
 		sysSessionPool := dom.SysSessionPool()
 		ctx, err := sysSessionPool.Get()
 		if err != nil {
@@ -340,13 +341,13 @@ func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
 }
 
 func (e *SimpleExec) executeDropStats(s *ast.DropStatsStmt) error {
-	h := domain.GetDomain(e.ctx).StatsHandle()
+	h := domain.GetDomain(e.Sctx).StatsHandle()
 	if h.Lease <= 0 {
 		err := h.DeleteTableStatsFromKV(s.Table.TableInfo.ID)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		return errors.Trace(h.Update(GetInfoSchema(e.ctx)))
+		return errors.Trace(h.Update(GetInfoSchema(e.Sctx)))
 	}
 	h.DDLEventCh() <- &util.Event{Tp: model.ActionDropTable, TableInfo: s.Table.TableInfo}
 	return nil

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -29,7 +29,7 @@ import (
 
 // SortExec represents sorting executor.
 type SortExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	ByItems []*plan.ByItems
 	Idx     int
@@ -52,14 +52,14 @@ type SortExec struct {
 	memTracker *memory.Tracker
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *SortExec) Close() error {
 	e.memTracker.Detach()
 	e.memTracker = nil
 	return errors.Trace(e.Children[0].Close())
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *SortExec) Open(ctx context.Context) error {
 	e.fetched = false
 	e.Idx = 0
@@ -72,7 +72,7 @@ func (e *SortExec) Open(ctx context.Context) error {
 	return errors.Trace(e.Children[0].Open(ctx))
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *SortExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.fetched {
@@ -288,14 +288,14 @@ func (h *topNChunkHeap) Swap(i, j int) {
 	h.rowPtrs[i], h.rowPtrs[j] = h.rowPtrs[j], h.rowPtrs[i]
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *TopNExec) Open(ctx context.Context) error {
 	e.memTracker = memory.NewTracker(e.ExplainID, e.Sctx.GetSessionVars().MemQuotaTopn)
 	e.memTracker.AttachTo(e.Sctx.GetSessionVars().StmtCtx.MemTracker)
 	return errors.Trace(e.SortExec.Open(ctx))
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *TopNExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.fetched {

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -106,12 +106,12 @@ func (e *SortExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 }
 
 func (e *SortExec) fetchRowChunks(ctx context.Context) error {
-	fields := e.retTypes()
+	fields := e.RetTypes()
 	e.rowChunks = chunk.NewList(fields, e.maxChunkSize)
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel("rowChunks")
 	for {
-		chk := e.children[0].newChunk()
+		chk := e.children[0].NewChunk()
 		err := e.children[0].Next(ctx, chk)
 		if err != nil {
 			return errors.Trace(err)
@@ -323,11 +323,11 @@ func (e *TopNExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
 	e.chkHeap = &topNChunkHeap{e}
-	e.rowChunks = chunk.NewList(e.retTypes(), e.maxChunkSize)
+	e.rowChunks = chunk.NewList(e.RetTypes(), e.maxChunkSize)
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel("rowChunks")
 	for e.rowChunks.Len() < e.totalLimit {
-		srcChk := e.children[0].newChunk()
+		srcChk := e.children[0].NewChunk()
 		err := e.children[0].Next(ctx, srcChk)
 		if err != nil {
 			return errors.Trace(err)
@@ -362,7 +362,7 @@ func (e *TopNExec) executeTopN(ctx context.Context) error {
 	if e.keyChunks != nil {
 		childKeyChk = chunk.NewChunkWithCapacity(e.keyTypes, e.maxChunkSize)
 	}
-	childRowChk := e.children[0].newChunk()
+	childRowChk := e.children[0].NewChunk()
 	for {
 		err := e.children[0].Next(ctx, childRowChk)
 		if err != nil {
@@ -425,7 +425,7 @@ func (e *TopNExec) processChildChk(childRowChk, childKeyChk *chunk.Chunk) error 
 // but we want descending top N, then we will keep all data in memory.
 // But if data is distributed randomly, this function will be called log(n) times.
 func (e *TopNExec) doCompaction() error {
-	newRowChunks := chunk.NewList(e.retTypes(), e.maxChunkSize)
+	newRowChunks := chunk.NewList(e.RetTypes(), e.maxChunkSize)
 	newRowPtrs := make([]chunk.RowPtr, 0, e.rowChunks.Len())
 	for _, rowPtr := range e.rowPtrs {
 		newRowPtr := newRowChunks.AppendRow(e.rowChunks.GetRow(rowPtr))

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -119,14 +119,14 @@ func (us *UnionScanExec) Open(ctx context.Context) error {
 	if err := us.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	us.snapshotChunkBuffer = us.newChunk()
+	us.snapshotChunkBuffer = us.NewChunk()
 	return nil
 }
 
 // Next implements the Executor Next interface.
 func (us *UnionScanExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
-	mutableRow := chunk.MutRowFromTypes(us.retTypes())
+	mutableRow := chunk.MutRowFromTypes(us.RetTypes())
 	for i, batchSize := 0, us.ctx.GetSessionVars().MaxChunkSize; i < batchSize; i++ {
 		row, err := us.getOneRow(ctx)
 		if err != nil {
@@ -207,7 +207,7 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) (types.DatumRow, er
 				// commit, but for simplicity, we don't handle it here.
 				continue
 			}
-			us.snapshotRows = append(us.snapshotRows, row.GetDatumRow(us.children[0].retTypes()))
+			us.snapshotRows = append(us.snapshotRows, row.GetDatumRow(us.children[0].RetTypes()))
 		}
 	}
 	return us.snapshotRows[0], nil

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -95,7 +95,7 @@ func GetDirtyDB(ctx sessionctx.Context) *DirtyDB {
 
 // UnionScanExec merges the rows from dirty table and the rows from XAPI request.
 type UnionScanExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
 	dirty *DirtyTable
 	// usedIndex is the column offsets of the index which Src executor has used.
@@ -115,16 +115,16 @@ type UnionScanExec struct {
 	snapshotChunkBuffer *chunk.Chunk
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (us *UnionScanExec) Open(ctx context.Context) error {
-	if err := us.BaseExecutor.Open(ctx); err != nil {
+	if err := us.BaseOperator.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
 	us.snapshotChunkBuffer = us.NewChunk()
 	return nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (us *UnionScanExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	mutableRow := chunk.MutRowFromTypes(us.RetTypes())

--- a/executor/update.go
+++ b/executor/update.go
@@ -27,9 +27,9 @@ import (
 
 // UpdateExec represents a new update executor.
 type UpdateExec struct {
-	operator.BaseExecutor
+	operator.BaseOperator
 
-	SelectExec  operator.Executor
+	SelectExec  operator.Operator
 	OrderedList []*expression.Assignment
 
 	// updatedRowKeys is a map for unique (Table, handle) pair.
@@ -93,7 +93,7 @@ func (e *UpdateExec) exec(schema *expression.Schema) (types.DatumRow, error) {
 	return types.DatumRow{}, nil
 }
 
-// Next implements the Executor Next interface.
+// Next implements the Operator Next interface.
 func (e *UpdateExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.fetched {
@@ -174,12 +174,12 @@ func (e *UpdateExec) composeNewRow(rowIdx int, oldRow types.DatumRow) (types.Dat
 	return newRowData, nil
 }
 
-// Close implements the Executor Close interface.
+// Close implements the Operator Close interface.
 func (e *UpdateExec) Close() error {
 	return e.SelectExec.Close()
 }
 
-// Open implements the Executor Open interface.
+// Open implements the Operator Open interface.
 func (e *UpdateExec) Open(ctx context.Context) error {
 	return e.SelectExec.Open(ctx)
 }

--- a/executor/update.go
+++ b/executor/update.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"github.com/juju/errors"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
@@ -28,7 +29,7 @@ import (
 type UpdateExec struct {
 	baseExecutor
 
-	SelectExec  Executor
+	SelectExec  operator.Executor
 	OrderedList []*expression.Assignment
 
 	// updatedRowKeys is a map for unique (Table, handle) pair.
@@ -120,10 +121,10 @@ func (e *UpdateExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 }
 
 func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
-	fields := e.children[0].retTypes()
+	fields := e.children[0].RetTypes()
 	globalRowIdx := 0
 	for {
-		chk := e.children[0].newChunk()
+		chk := e.children[0].NewChunk()
 		err := e.children[0].Next(ctx, chk)
 		if err != nil {
 			return errors.Trace(err)

--- a/executor/write.go
+++ b/executor/write.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/executor/operator"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -27,11 +28,11 @@ import (
 )
 
 var (
-	_ Executor = &UpdateExec{}
-	_ Executor = &DeleteExec{}
-	_ Executor = &InsertExec{}
-	_ Executor = &ReplaceExec{}
-	_ Executor = &LoadDataExec{}
+	_ operator.Executor = &UpdateExec{}
+	_ operator.Executor = &DeleteExec{}
+	_ operator.Executor = &InsertExec{}
+	_ operator.Executor = &ReplaceExec{}
+	_ operator.Executor = &LoadDataExec{}
 )
 
 const (

--- a/executor/write.go
+++ b/executor/write.go
@@ -76,7 +76,7 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData types.DatumR
 			newData[i] = v
 		}
 
-		// Rebase auto increment id if the field is changed.
+		// Rebase auto increment ExplainID if the field is changed.
 		if mysql.HasAutoIncrementFlag(col.Flag) {
 			if newData[i].IsNull() {
 				return false, handleChanged, newHandle, 0,

--- a/executor/write.go
+++ b/executor/write.go
@@ -28,11 +28,11 @@ import (
 )
 
 var (
-	_ operator.Executor = &UpdateExec{}
-	_ operator.Executor = &DeleteExec{}
-	_ operator.Executor = &InsertExec{}
-	_ operator.Executor = &ReplaceExec{}
-	_ operator.Executor = &LoadDataExec{}
+	_ operator.Operator = &UpdateExec{}
+	_ operator.Operator = &DeleteExec{}
+	_ operator.Operator = &InsertExec{}
+	_ operator.Operator = &ReplaceExec{}
+	_ operator.Operator = &LoadDataExec{}
 )
 
 const (


### PR DESCRIPTION
## What have you changed? (mandatory)

This is the first step to split the `executor` package. The `executor` package is too big, which contains a lot of source files with different functionality:
1. physical operator implementations
2. query adaptors
3. record set implementations

This pull request renames `Executor` to `Operator` and move it to a new package named `operator`. For further improvements, we can:
- make a new package named `joins` inside the `operator` package and move all the join implementations into it
- make a new package named `readers` inside the `operator` package and move all the reader implementations into it
- ...

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

