### PR TITLE
parser: support drop column cascade syntax, parse it and ignore it. (#6791)

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -924,7 +924,7 @@ AlterTableSpec:
 			Constraint: constraint,
 		}
 	}
-|	"DROP" ColumnKeywordOpt ColumnName
+|	"DROP" ColumnKeywordOpt ColumnName RestrictOrCascadeOpt
 	{
 		$$ = &ast.AlterTableSpec{
 			Tp: ast.AlterTableDropColumn,

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1605,6 +1605,7 @@ func (s *testParserSuite) TestDDL(c *C) {
 		{"ALTER TABLE `hello-world@dev`.`User` ADD COLUMN `name` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL , ALGORITHM = INPLACE;", true},
 		{"ALTER TABLE `hello-world@dev`.`User` ADD COLUMN `name` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL , ALGORITHM = COPY;", true},
 		{"ALTER TABLE t DROP INDEX;", false},
+		{"ALTER TABLE t DROP COLUMN a CASCADE", true},
 
 		// For create index statement
 		{"CREATE INDEX idx ON t (a)", true},


### PR DESCRIPTION
cherry-pick from #6791 