### PR TITLE
 plan: change the value of `descScanFactor`

### DIFF
--- a/plan/find_best_task.go
+++ b/plan/find_best_task.go
@@ -29,7 +29,7 @@ const (
 	netWorkFactor      = 1.5
 	netWorkStartFactor = 20.0
 	scanFactor         = 2.0
-	descScanFactor     = 5 * scanFactor
+	descScanFactor     = 2 * scanFactor
 	memoryFactor       = 5.0
 	// 0.5 is the looking up agg context factor.
 	hashAggFactor      = 1.2 + 0.5

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -302,7 +302,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderJoin(c *C) {
 		// Test Single Merge Join + Sort + desc.
 		{
 			sql:  "select /*+ TIDB_SMJ(t1,t2)*/ * from t t1, t t2 where t1.a = t2.a order by t2.a desc",
-			best: "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(t1.a,t2.a)->Sort",
+			best: "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(t1.a,t2.a)",
 		},
 		{
 			sql:  "select /*+ TIDB_SMJ(t1,t2)*/ * from t t1, t t2 where t1.b = t2.b order by t2.b desc",

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -31,7 +31,7 @@ var (
 	TiDBGitBranch = "None"
 	GoVersion     = "None"
 	// TiKVMinVersion is the minimum version of TiKV that can be compatible with the current TiDB.
-	TiKVMinVersion = "2.1.0-alpha.1-2f291dc12b0e05d71eb8873881c3ed11d343d6e6"
+	TiKVMinVersion = "2.1.0-alpha.1-c4133d3ef0f099f8716a916c198390b26293ec00"
 )
 
 // PrintTiDBInfo prints the TiDB version information.


### PR DESCRIPTION
## What have you changed? (mandatory)

change the value of `descScanFactor` to make it compatible with tikv due to https://github.com/pingcap/tikv/pull/3124 .

Now, if each row has only one version, the reverse scan's performance is near the performance of the speed of scan.
If there's a lot of version, it will become about 1.8x than scan.
So we decrease the factor from `5` to `2`.

## What are the type of the changes (mandatory)?

- Improvement

## How has this PR been tested (mandatory)?

No test.

## Refer to a related PR or issue link (optional)
https://github.com/pingcap/tikv/pull/3124

## Benchmark result if necessary (optional)

See the related pr for details.

