### PR TITLE
[WIP] ddl: implement reorganize for table partition when adding index

### DIFF
--- a/model/ddl.go
+++ b/model/ddl.go
@@ -112,7 +112,8 @@ func (h *HistoryInfo) Clean() {
 type DDLReorgMeta struct {
 	// EndHandle is the last handle of the adding indices table.
 	// We should only backfill indices in the range [startHandle, EndHandle].
-	EndHandle int64 `json:"end_handle"`
+	EndHandle   int64 `json:"end_handle"`
+	PartitionID int64 `json:"partition_id"`
 }
 
 // NewDDLReorgMeta new a DDLReorgMeta.


### PR DESCRIPTION
This is still WIP but I prefer to push it, because today I just make a mistake on git and lost a lot of work. 

## What have you changed? (mandatory)

- Add a partition ID to reorgInfo, this new field would be persistent
- Handle reorganize for table partitions one by one

## What are the type of the changes (mandatory)?

- New feature (non-breaking change which adds functionality)

## How has this PR been tested (mandatory)?

## Add a few positive/negative examples (optional)

