### PR TITLE
plan, expression: remove FromID from Column

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -38,7 +38,7 @@ func TestT(t *testing.T) {
 	logLevel := os.Getenv("log_level")
 	logutil.InitLogger(&logutil.LogConfig{
 		Level:  logLevel,
-		Format: "highlight",
+		Format: "text",
 	})
 	TestingT(t)
 }

--- a/expression/column.go
+++ b/expression/column.go
@@ -310,6 +310,15 @@ func (col *Column) ResolveIndices(schema *Schema) {
 	col.Index = schema.ColumnIndex(col)
 	// If col's index equals to -1, it means a internal logic error happens.
 	if col.Index == -1 {
+		fmt.Printf("col.Position=%v\n", col.Position)
+		for i := range schema.Columns {
+			fmt.Printf("schema.Columns[i].Position=%v", schema.Columns[i].Position)
+			if i+1 == len(schema.Columns) {
+				fmt.Printf("\n")
+			} else {
+				fmt.Printf(", ")
+			}
+		}
 		panic(fmt.Sprintf("Column.ResolveIndices failed: col.Position=%v", col.Position))
 		log.Errorf("Can't find column %s in schema %s", col, schema)
 	}

--- a/expression/column.go
+++ b/expression/column.go
@@ -137,7 +137,6 @@ func (col *CorrelatedColumn) ResolveIndices(_ *Schema) {
 
 // Column represents a column.
 type Column struct {
-	FromID      int
 	ColName     model.CIStr
 	DBName      model.CIStr
 	OrigTblName model.CIStr
@@ -161,7 +160,7 @@ type Column struct {
 // Equal implements Expression interface.
 func (col *Column) Equal(_ sessionctx.Context, expr Expression) bool {
 	if newCol, ok := expr.(*Column); ok {
-		return newCol.FromID == col.FromID && newCol.Position == col.Position
+		return newCol.Position == col.Position
 	}
 	return false
 }
@@ -300,9 +299,8 @@ func (col *Column) HashCode(_ *stmtctx.StatementContext) []byte {
 	if len(col.hashcode) != 0 {
 		return col.hashcode
 	}
-	col.hashcode = make([]byte, 0, 17)
+	col.hashcode = make([]byte, 0, 9)
 	col.hashcode = append(col.hashcode, columnFlag)
-	col.hashcode = codec.EncodeInt(col.hashcode, int64(col.FromID))
 	col.hashcode = codec.EncodeInt(col.hashcode, int64(col.Position))
 	return col.hashcode
 }
@@ -312,6 +310,7 @@ func (col *Column) ResolveIndices(schema *Schema) {
 	col.Index = schema.ColumnIndex(col)
 	// If col's index equals to -1, it means a internal logic error happens.
 	if col.Index == -1 {
+		panic(fmt.Sprintf("Column.ResolveIndices failed: col.Position=%v", col.Position))
 		log.Errorf("Can't find column %s in schema %s", col, schema)
 	}
 }

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -248,13 +248,13 @@ func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 }
 
 // TableInfo2Schema converts table info to schema with empty DBName.
-func TableInfo2Schema(tbl *model.TableInfo) *Schema {
-	return TableInfo2SchemaWithDBName(model.CIStr{}, tbl)
+func TableInfo2Schema(ctx sessionctx.Context, tbl *model.TableInfo) *Schema {
+	return TableInfo2SchemaWithDBName(ctx, model.CIStr{}, tbl)
 }
 
 // TableInfo2SchemaWithDBName converts table info to schema.
-func TableInfo2SchemaWithDBName(dbName model.CIStr, tbl *model.TableInfo) *Schema {
-	cols := ColumnInfos2ColumnsWithDBName(dbName, tbl.Name, tbl.Columns)
+func TableInfo2SchemaWithDBName(ctx sessionctx.Context, dbName model.CIStr, tbl *model.TableInfo) *Schema {
+	cols := ColumnInfos2ColumnsWithDBName(ctx, dbName, tbl.Name, tbl.Columns)
 	keys := make([]KeyInfo, 0, len(tbl.Indices)+1)
 	for _, idx := range tbl.Indices {
 		if !idx.Unique || idx.State != model.StatePublic {
@@ -297,9 +297,9 @@ func TableInfo2SchemaWithDBName(dbName model.CIStr, tbl *model.TableInfo) *Schem
 }
 
 // ColumnInfos2ColumnsWithDBName converts a slice of ColumnInfo to a slice of Column.
-func ColumnInfos2ColumnsWithDBName(dbName, tblName model.CIStr, colInfos []*model.ColumnInfo) []*Column {
+func ColumnInfos2ColumnsWithDBName(ctx sessionctx.Context, dbName, tblName model.CIStr, colInfos []*model.ColumnInfo) []*Column {
 	columns := make([]*Column, 0, len(colInfos))
-	for i, col := range colInfos {
+	for _, col := range colInfos {
 		if col.State != model.StatePublic {
 			continue
 		}
@@ -308,7 +308,7 @@ func ColumnInfos2ColumnsWithDBName(dbName, tblName model.CIStr, colInfos []*mode
 			TblName:  tblName,
 			DBName:   dbName,
 			RetType:  &col.FieldType,
-			Position: i,
+			Position: ctx.GetSessionVars().AllocColID(),
 			Index:    col.Offset,
 		}
 		columns = append(columns, newCol)

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	log "github.com/sirupsen/logrus"
 )
 
 // KeyInfo stores the columns of one unique key or primary key.
@@ -154,7 +153,6 @@ func (s *Schema) IsUniqueKey(col *Column) bool {
 // ColumnIndex finds the index for a column.
 func (s *Schema) ColumnIndex(col *Column) int {
 	for i, c := range s.Columns {
-		log.Infof("Schema(%p).ColumnIndex: col.Position=%v, s.Columns[i].Position=%v", s, col.Position, s.Columns[i].Position)
 		if c.Position == col.Position {
 			return i
 		}

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
+	log "github.com/sirupsen/logrus"
 )
 
 // KeyInfo stores the columns of one unique key or primary key.
@@ -153,7 +154,8 @@ func (s *Schema) IsUniqueKey(col *Column) bool {
 // ColumnIndex finds the index for a column.
 func (s *Schema) ColumnIndex(col *Column) int {
 	for i, c := range s.Columns {
-		if c.FromID == col.FromID && c.Position == col.Position {
+		log.Infof("Schema(%p).ColumnIndex: col.Position=%v, s.Columns[i].Position=%v", s, col.Position, s.Columns[i].Position)
+		if c.Position == col.Position {
 			return i
 		}
 	}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -54,14 +54,13 @@ func (sr *simpleRewriter) rewriteColumn(nodeColName *ast.ColumnNameExpr) (*Colum
 	for i, col := range tblCols {
 		if col.Name.L == nodeColName.Name.Name.L {
 			return &Column{
-				FromID:      1,
 				ColName:     col.Name,
 				OrigTblName: sr.tbl.Name,
 				DBName:      model.NewCIStr(sr.ctx.GetSessionVars().CurrentDB),
 				TblName:     sr.tbl.Name,
 				RetType:     &col.FieldType,
 				ID:          col.ID,
-				Position:    col.Offset,
+				Position:    sr.ctx.GetSessionVars().AllocColID(),
 				Index:       i,
 			}, nil
 		}

--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -350,8 +350,7 @@ func (er *expressionRewriter) handleOtherComparableSubq(lexpr, rexpr expression.
 	// Create a column and append it to the schema of that aggregation.
 	colMaxOrMin := &expression.Column{
 		ColName:  model.NewCIStr("agg_Col_0"),
-		FromID:   plan4Agg.id,
-		Position: 0,
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  funcMaxOrMin.RetTp,
 	}
 	schema := expression.NewSchema(colMaxOrMin)
@@ -370,8 +369,7 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 	funcSum := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncSum, []expression.Expression{funcIsNull}, false)
 	colSum := &expression.Column{
 		ColName:  model.NewCIStr("agg_col_sum"),
-		FromID:   plan4Agg.id,
-		Position: plan4Agg.schema.Len(),
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  funcSum.RetTp,
 	}
 	plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, funcSum)
@@ -381,8 +379,7 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 		funcCount := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{funcIsNull.Clone()}, false)
 		colCount := &expression.Column{
 			ColName:  model.NewCIStr("agg_col_cnt"),
-			FromID:   plan4Agg.id,
-			Position: plan4Agg.schema.Len(),
+			Position: er.ctx.GetSessionVars().AllocColID(),
 			RetType:  funcCount.RetTp,
 		}
 		plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, funcCount)
@@ -419,9 +416,8 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 	proj.SetSchema(expression.NewSchema(joinSchema.Clone().Columns[:outerSchemaLen]...))
 	proj.Exprs = append(proj.Exprs, cond)
 	proj.schema.Append(&expression.Column{
-		FromID:      proj.id,
 		ColName:     model.NewCIStr("aux_col"),
-		Position:    proj.schema.Len(),
+		Position:    er.ctx.GetSessionVars().AllocColID(),
 		IsAggOrSubq: true,
 		RetType:     cond.GetType(),
 	})
@@ -441,14 +437,12 @@ func (er *expressionRewriter) handleNEAny(lexpr, rexpr expression.Expression, np
 	plan4Agg.SetChildren(np)
 	firstRowResultCol := &expression.Column{
 		ColName:  model.NewCIStr("col_firstRow"),
-		FromID:   plan4Agg.id,
-		Position: 0,
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  firstRowFunc.RetTp,
 	}
 	count := &expression.Column{
 		ColName:  model.NewCIStr("col_count"),
-		FromID:   plan4Agg.id,
-		Position: 1,
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  countFunc.RetTp,
 	}
 	plan4Agg.SetSchema(expression.NewSchema(firstRowResultCol, count))
@@ -469,14 +463,12 @@ func (er *expressionRewriter) handleEQAll(lexpr, rexpr expression.Expression, np
 	plan4Agg.SetChildren(np)
 	firstRowResultCol := &expression.Column{
 		ColName:  model.NewCIStr("col_firstRow"),
-		FromID:   plan4Agg.id,
-		Position: 0,
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  firstRowFunc.RetTp,
 	}
 	count := &expression.Column{
 		ColName:  model.NewCIStr("col_count"),
-		FromID:   plan4Agg.id,
-		Position: 1,
+		Position: er.ctx.GetSessionVars().AllocColID(),
 		RetType:  countFunc.RetTp,
 	}
 	plan4Agg.SetSchema(expression.NewSchema(firstRowResultCol, count))

--- a/plan/find_best_task.go
+++ b/plan/find_best_task.go
@@ -451,7 +451,7 @@ func (is *PhysicalIndexScan) initSchema(ds *DataSource, isDoubleRead bool) {
 			if !exists {
 				colPosition = is.ctx.GetSessionVars().AllocColID()
 			}
-			is.schema.Append(&expression.Column{ID: col.ID, Position: colPosition})
+			is.schema.Append(&expression.Column{ID: model.ExtraHandleID, Position: colPosition})
 			setHandle = true
 			break
 		}

--- a/plan/find_best_task.go
+++ b/plan/find_best_task.go
@@ -431,13 +431,13 @@ func (ds *DataSource) convertToIndexScan(prop *requiredProp, path *accessPath) (
 
 func (is *PhysicalIndexScan) initSchema(id int, idx *model.IndexInfo, isDoubleRead bool) {
 	indexCols := make([]*expression.Column, 0, len(idx.Columns))
-	for _, col := range idx.Columns {
-		indexCols = append(indexCols, &expression.Column{FromID: id, Position: col.Offset})
+	for _ = range idx.Columns {
+		indexCols = append(indexCols, &expression.Column{Position: is.ctx.GetSessionVars().AllocColID()})
 	}
 	setHandle := false
 	for _, col := range is.Columns {
 		if (mysql.HasPriKeyFlag(col.Flag) && is.Table.PKIsHandle) || col.ID == model.ExtraHandleID {
-			indexCols = append(indexCols, &expression.Column{FromID: id, ID: col.ID, Position: col.Offset})
+			indexCols = append(indexCols, &expression.Column{ID: col.ID, Position: is.ctx.GetSessionVars().AllocColID()})
 			setHandle = true
 			break
 		}
@@ -445,7 +445,7 @@ func (is *PhysicalIndexScan) initSchema(id int, idx *model.IndexInfo, isDoubleRe
 	// If it's double read case, the first index must return handle. So we should add extra handle column
 	// if there isn't a handle column.
 	if isDoubleRead && !setHandle {
-		indexCols = append(indexCols, &expression.Column{FromID: id, ID: model.ExtraHandleID, Position: -1})
+		indexCols = append(indexCols, &expression.Column{ID: model.ExtraHandleID, Position: is.ctx.GetSessionVars().AllocColID()})
 	}
 	is.SetSchema(expression.NewSchema(indexCols...))
 }

--- a/plan/initialize.go
+++ b/plan/initialize.go
@@ -13,6 +13,7 @@
 
 package plan
 
+import "fmt"
 import "github.com/pingcap/tidb/sessionctx"
 
 const (
@@ -345,6 +346,9 @@ func (p PhysicalIndexReader) init(ctx sessionctx.Context) *PhysicalIndexReader {
 		p.schema = is.dataSourceSchema
 	}
 	p.OutputColumns = p.schema.Clone().Columns
+	for i, outputCol := range p.OutputColumns {
+		fmt.Printf("outputCol.Position=%v, p.schema.Columns[i].Position=%v\n", outputCol.Position, p.schema.Columns[i].Position)
+	}
 	return &p
 }
 

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -104,9 +104,8 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 			aggIndexMap[i] = position
 			plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, newFunc)
 			schema4Agg.Append(&expression.Column{
-				FromID:      plan4Agg.id,
 				ColName:     model.NewCIStr(fmt.Sprintf("%d_col_%d", plan4Agg.id, position)),
-				Position:    position,
+				Position:    b.ctx.GetSessionVars().AllocColID(),
 				IsAggOrSubq: true,
 				RetType:     newFunc.RetTp})
 		}
@@ -551,8 +550,7 @@ func (b *planBuilder) buildProjectionField(id, position int, field *ast.SelectFi
 		colName = b.buildProjectionFieldNameFromExpressions(field)
 	}
 	return &expression.Column{
-		FromID:      id,
-		Position:    position,
+		Position:    b.ctx.GetSessionVars().AllocColID(),
 		TblName:     tblName,
 		OrigTblName: origTblName,
 		ColName:     colName,
@@ -655,11 +653,6 @@ func (b *planBuilder) buildProjection4Union(u *LogicalUnionAll) {
 		if _, isProj := child.(*LogicalProjection); needProjection || !isProj {
 			b.optFlag |= flagEliminateProjection
 			proj := LogicalProjection{Exprs: exprs}.init(b.ctx)
-			if childID == 0 {
-				for _, col := range unionSchema.Columns {
-					col.FromID = proj.ID()
-				}
-			}
 			proj.SetChildren(child)
 			u.children[childID] = proj
 		}
@@ -1631,9 +1624,6 @@ func (b *planBuilder) buildSelect(sel *ast.SelectStmt) LogicalPlan {
 		proj := LogicalProjection{Exprs: expression.Column2Exprs(p.Schema().Columns[:oldLen])}.init(b.ctx)
 		proj.SetChildren(p)
 		schema := expression.NewSchema(p.Schema().Clone().Columns[:oldLen]...)
-		for _, col := range schema.Columns {
-			col.FromID = proj.ID()
-		}
 		proj.SetSchema(schema)
 		return proj
 	}
@@ -1648,12 +1638,11 @@ func (b *planBuilder) buildTableDual() LogicalPlan {
 
 func (ds *DataSource) newExtraHandleSchemaCol() *expression.Column {
 	return &expression.Column{
-		FromID:   ds.id,
 		DBName:   ds.DBName,
 		TblName:  ds.tableInfo.Name,
 		ColName:  model.ExtraHandleName,
 		RetType:  types.NewFieldType(mysql.TypeLonglong),
-		Position: len(ds.tableInfo.Columns), // set a unique position
+		Position: ds.ctx.GetSessionVars().AllocColID(), // set a unique position
 		ID:       model.ExtraHandleID,
 	}
 }
@@ -1736,8 +1725,7 @@ func (b *planBuilder) buildDataSource(tn *ast.TableName) LogicalPlan {
 	for i, col := range columns {
 		ds.Columns = append(ds.Columns, col.ToInfo())
 		schema.Append(&expression.Column{
-			FromID:   ds.id,
-			Position: i,
+			Position: ds.ctx.GetSessionVars().AllocColID(),
 			DBName:   dbName,
 			TblName:  tableInfo.Name,
 			ColName:  col.Name,
@@ -1878,9 +1866,10 @@ out:
 	exists := LogicalExists{}.init(b.ctx)
 	exists.SetChildren(p)
 	newCol := &expression.Column{
-		FromID:  exists.id,
-		RetType: types.NewFieldType(mysql.TypeTiny),
-		ColName: model.NewCIStr("exists_col")}
+		Position: exists.ctx.GetSessionVars().AllocColID(),
+		RetType:  types.NewFieldType(mysql.TypeTiny),
+		ColName:  model.NewCIStr("exists_col"),
+	}
 	exists.SetSchema(expression.NewSchema(newCol))
 	return exists
 }
@@ -1901,7 +1890,7 @@ func (b *planBuilder) buildSemiJoin(outerPlan, innerPlan LogicalPlan, onConditio
 	if asScalar {
 		newSchema := outerPlan.Schema().Clone()
 		newSchema.Append(&expression.Column{
-			FromID:      joinPlan.id,
+			Position:    b.ctx.GetSessionVars().AllocColID(),
 			ColName:     model.NewCIStr(fmt.Sprintf("%d_aux_0", joinPlan.id)),
 			RetType:     types.NewFieldType(mysql.TypeTiny),
 			IsAggOrSubq: true,

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -58,6 +58,7 @@ type logicalOptRule interface {
 // The node must be prepared first.
 func Optimize(ctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (Plan, error) {
 	ctx.GetSessionVars().PlanID = 0
+	ctx.GetSessionVars().ColID = 0
 	builder := &planBuilder{
 		ctx:       ctx,
 		is:        is,
@@ -89,6 +90,7 @@ func Optimize(ctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (
 // BuildLogicalPlan used to build logical plan from ast.Node.
 func BuildLogicalPlan(ctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (Plan, error) {
 	ctx.GetSessionVars().PlanID = 0
+	ctx.GetSessionVars().ColID = 0
 	builder := &planBuilder{
 		ctx:       ctx,
 		is:        is,
@@ -118,6 +120,7 @@ func doOptimize(flag uint64, logic LogicalPlan) (PhysicalPlan, error) {
 	if !AllowCartesianProduct && existsCartesianProduct(logic) {
 		return nil, errors.Trace(ErrCartesianProductUnsupported)
 	}
+	printLogicalPlanSchema(logic, "")
 	physical, err := physicalOptimize(logic)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -163,6 +166,7 @@ func physicalOptimize(logic LogicalPlan) (PhysicalPlan, error) {
 		return nil, ErrInternal.GenByArgs("Can't find a proper physical plan for this query")
 	}
 
+	printPhysicalPlanSchema(t.plan(), "")
 	t.plan().ResolveIndices()
 	return t.plan(), nil
 }

--- a/plan/plan_to_pb.go
+++ b/plan/plan_to_pb.go
@@ -117,16 +117,17 @@ func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.Range) bool {
 // ToPB implements PhysicalPlan ToPB interface.
 func (p *PhysicalIndexScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error) {
 	columns := make([]*model.ColumnInfo, 0, p.schema.Len())
-	tableColumns := p.Table.Cols()
-	for i, col := range p.schema.Columns {
-		if col.ID == model.ExtraHandleID {
-			columns = append(columns, &model.ColumnInfo{
-				ID:   model.ExtraHandleID,
-				Name: model.ExtraHandleName,
-			})
-		} else {
-			columns = append(columns, tableColumns[i])
+	tableColumns, idxInSchema := p.Table.Cols(), 0
+	for _, col := range p.schema.Columns {
+		if col.ID != model.ExtraHandleID {
+			columns = append(columns, tableColumns[idxInSchema])
+			idxInSchema++
+			continue
 		}
+		columns = append(columns, &model.ColumnInfo{
+			ID:   model.ExtraHandleID,
+			Name: model.ExtraHandleName,
+		})
 	}
 	idxExec := &tipb.IndexScan{
 		TableId: p.Table.ID,

--- a/plan/plan_to_pb.go
+++ b/plan/plan_to_pb.go
@@ -118,14 +118,14 @@ func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.Range) bool {
 func (p *PhysicalIndexScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error) {
 	columns := make([]*model.ColumnInfo, 0, p.schema.Len())
 	tableColumns := p.Table.Cols()
-	for _, col := range p.schema.Columns {
+	for i, col := range p.schema.Columns {
 		if col.ID == model.ExtraHandleID {
 			columns = append(columns, &model.ColumnInfo{
 				ID:   model.ExtraHandleID,
 				Name: model.ExtraHandleName,
 			})
 		} else {
-			columns = append(columns, tableColumns[col.Position])
+			columns = append(columns, tableColumns[i])
 		}
 	}
 	idxExec := &tipb.IndexScan{

--- a/plan/rule_aggregation_push_down.go
+++ b/plan/rule_aggregation_push_down.go
@@ -169,14 +169,13 @@ func (a *aggregationOptimizer) checkValidJoin(join *LogicalJoin) bool {
 
 // decompose splits an aggregate function to two parts: a final mode function and a partial mode function. Currently
 // there are no differences between partial mode and complete mode, so we can confuse them.
-func (a *aggregationOptimizer) decompose(aggFunc *aggregation.AggFuncDesc, schema *expression.Schema, id int) ([]*aggregation.AggFuncDesc, *expression.Schema) {
+func (a *aggregationOptimizer) decompose(sctx sessionctx.Context, aggFunc *aggregation.AggFuncDesc, schema *expression.Schema, id int) ([]*aggregation.AggFuncDesc, *expression.Schema) {
 	// Result is a slice because avg should be decomposed to sum and count. Currently we don't process this case.
 	result := []*aggregation.AggFuncDesc{aggFunc.Clone()}
 	for _, aggFunc := range result {
 		schema.Append(&expression.Column{
 			ColName:  model.NewCIStr(fmt.Sprintf("join_agg_%d", schema.Len())), // useless but for debug
-			FromID:   id,
-			Position: schema.Len(),
+			Position: sctx.GetSessionVars().AllocColID(),
 			RetType:  aggFunc.RetTp,
 		})
 	}
@@ -262,7 +261,7 @@ func (a *aggregationOptimizer) makeNewAgg(ctx sessionctx.Context, aggFuncs []*ag
 	schema := expression.NewSchema(make([]*expression.Column, 0, aggLen)...)
 	for _, aggFunc := range aggFuncs {
 		var newFuncs []*aggregation.AggFuncDesc
-		newFuncs, schema = a.decompose(aggFunc, schema, agg.ID())
+		newFuncs, schema = a.decompose(ctx, aggFunc, schema, agg.ID())
 		newAggFuncDescs = append(newAggFuncDescs, newFuncs...)
 	}
 	for _, gbyCol := range gbyCols {

--- a/plan/rule_join_reorder.go
+++ b/plan/rule_join_reorder.go
@@ -78,7 +78,7 @@ func findColumnIndexByGroup(groups []LogicalPlan, col *expression.Column) int {
 			return i
 		}
 	}
-	log.Errorf("Unknown columns %s, from id %v, position %d", col, col.FromID, col.Position)
+	log.Errorf("Unknown columns %s, position %d", col, col.Position)
 	return -1
 }
 

--- a/plan/rule_predicate_push_down.go
+++ b/plan/rule_predicate_push_down.go
@@ -199,10 +199,8 @@ func (p *LogicalProjection) appendExpr(expr expression.Expression) *expression.C
 	expr = expression.ColumnSubstitute(expr, p.schema, p.Exprs)
 	p.Exprs = append(p.Exprs, expr)
 
-	newPosition := p.schema.Columns[p.schema.Len()-1].Position + 1
 	col := &expression.Column{
-		FromID:   p.id,
-		Position: newPosition,
+		Position: p.ctx.GetSessionVars().AllocColID(),
 		ColName:  model.NewCIStr(expr.String()),
 		RetType:  expr.GetType(),
 	}

--- a/plan/task.go
+++ b/plan/task.go
@@ -407,8 +407,7 @@ func (p *basePhysicalAgg) newPartialAggregate() (partial, final PhysicalPlan) {
 			ft := types.NewFieldType(mysql.TypeLonglong)
 			ft.Flen, ft.Charset, ft.Collate = 21, charset.CharsetBin, charset.CollationBin
 			partialSchema.Append(&expression.Column{
-				FromID:   p.ID(),
-				Position: partialCursor,
+				Position: p.ctx.GetSessionVars().AllocColID(),
 				ColName:  model.NewCIStr(fmt.Sprintf("col_%d", partialCursor)),
 				RetType:  ft,
 			})
@@ -417,8 +416,7 @@ func (p *basePhysicalAgg) newPartialAggregate() (partial, final PhysicalPlan) {
 		}
 		if needValue(finalAggFunc) {
 			partialSchema.Append(&expression.Column{
-				FromID:   p.ID(),
-				Position: partialCursor,
+				Position: p.ctx.GetSessionVars().AllocColID(),
 				ColName:  model.NewCIStr(fmt.Sprintf("col_%d", partialCursor)),
 				RetType:  finalSchema.Columns[i].GetType(),
 			})
@@ -435,8 +433,7 @@ func (p *basePhysicalAgg) newPartialAggregate() (partial, final PhysicalPlan) {
 	groupByItems := make([]expression.Expression, 0, len(p.GroupByItems))
 	for i, gbyExpr := range p.GroupByItems {
 		gbyCol := &expression.Column{
-			FromID:   p.ID(),
-			Position: partialCursor + i,
+			Position: p.ctx.GetSessionVars().AllocColID(),
 			ColName:  model.NewCIStr(fmt.Sprintf("col_%d", partialCursor+i)),
 			RetType:  gbyExpr.GetType(),
 		}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -205,6 +205,9 @@ type SessionVars struct {
 	// PlanID is the unique id of logical and physical plan.
 	PlanID int
 
+	// ColID is the unique id of columns in the schema of logical and physical plan.
+	ColID int
+
 	// PlanCacheEnabled stores the global config "plan-cache-enabled", and it will be only updated in tests.
 	PlanCacheEnabled bool
 
@@ -284,6 +287,12 @@ type SessionVars struct {
 	EnableStreaming bool
 
 	writeStmtBufs WriteStmtBufs
+}
+
+func (sv *SessionVars) AllocColID() int {
+	colId := sv.ColID
+	sv.ColID++
+	return colId
 }
 
 // NewSessionVars creates a session vars object.


### PR DESCRIPTION
## What have you changed? (mandatory)

For now we use `FromID` and `Position` to identify a column, this is a little complicated and error prone.

A simpler way to identify a column is to allocate a unique id for every column and use it to identify that column, thus we can remove `FromID` and no need to maintain `FromID` and `Position` for every column during plan building and optimizing.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

Have not tested yet, **WIP**

## Does this PR affect documentation (docs/docs-cn) update? (optional)

No

