### PR TITLE
*: add tidb_hashagg_partial/final_concurrency

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -45,9 +45,6 @@ type HashAggExec struct {
 	GroupByItems  []expression.Expression
 	groupKey      []byte
 	groupVals     [][]byte
-
-	partialConcurrency int
-	finalConcurrency   int
 }
 
 // Close implements the Executor Close interface.

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -45,6 +45,9 @@ type HashAggExec struct {
 	GroupByItems  []expression.Expression
 	groupKey      []byte
 	groupVals     [][]byte
+
+	partialConcurrency int
+	finalConcurrency   int
 }
 
 // Close implements the Executor Close interface.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -826,11 +826,14 @@ func (b *executorBuilder) buildHashAgg(v *plan.PhysicalHashAgg) Executor {
 		b.err = errors.Trace(b.err)
 		return nil
 	}
+	sessionVars := b.ctx.GetSessionVars()
 	e := &HashAggExec{
-		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
-		sc:           b.ctx.GetSessionVars().StmtCtx,
-		AggFuncs:     make([]aggregation.Aggregation, 0, len(v.AggFuncs)),
-		GroupByItems: v.GroupByItems,
+		baseExecutor:       newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
+		sc:                 sessionVars.StmtCtx,
+		AggFuncs:           make([]aggregation.Aggregation, 0, len(v.AggFuncs)),
+		GroupByItems:       v.GroupByItems,
+		partialConcurrency: sessionVars.HashAggPartialConcurrency,
+		finalConcurrency:   sessionVars.HashAggFinalConcurrency,
 	}
 	for _, aggDesc := range v.AggFuncs {
 		e.AggFuncs = append(e.AggFuncs, aggDesc.GetAggFunc())

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -828,10 +828,10 @@ func (b *executorBuilder) buildHashAgg(v *plan.PhysicalHashAgg) Executor {
 	}
 	sessionVars := b.ctx.GetSessionVars()
 	e := &HashAggExec{
-		baseExecutor:       newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
-		sc:                 sessionVars.StmtCtx,
-		AggFuncs:           make([]aggregation.Aggregation, 0, len(v.AggFuncs)),
-		GroupByItems:       v.GroupByItems,
+		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
+		sc:           sessionVars.StmtCtx,
+		AggFuncs:     make([]aggregation.Aggregation, 0, len(v.AggFuncs)),
+		GroupByItems: v.GroupByItems,
 	}
 	for _, aggDesc := range v.AggFuncs {
 		e.AggFuncs = append(e.AggFuncs, aggDesc.GetAggFunc())

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -832,8 +832,6 @@ func (b *executorBuilder) buildHashAgg(v *plan.PhysicalHashAgg) Executor {
 		sc:                 sessionVars.StmtCtx,
 		AggFuncs:           make([]aggregation.Aggregation, 0, len(v.AggFuncs)),
 		GroupByItems:       v.GroupByItems,
-		partialConcurrency: sessionVars.HashAggPartialConcurrency,
-		finalConcurrency:   sessionVars.HashAggFinalConcurrency,
 	}
 	for _, aggDesc := range v.AggFuncs {
 		e.AggFuncs = append(e.AggFuncs, aggDesc.GetAggFunc())

--- a/session/session.go
+++ b/session/session.go
@@ -1289,6 +1289,8 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.TiDBIndexSerialScanConcurrency + quoteCommaQuote +
 	variable.TiDBHashJoinConcurrency + quoteCommaQuote +
 	variable.TiDBProjectionConcurrency + quoteCommaQuote +
+	variable.TiDBHashAggPartialConcurrency + quoteCommaQuote +
+	variable.TiDBHashAggFinalConcurrency + quoteCommaQuote +
 	variable.TiDBBackoffLockFast + quoteCommaQuote +
 	variable.TiDBOptInSubqUnFolding + quoteCommaQuote +
 	variable.TiDBDistSQLScanConcurrency + quoteCommaQuote +

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -311,6 +311,8 @@ func NewSessionVars() *SessionVars {
 		HashJoinConcurrency:        DefTiDBHashJoinConcurrency,
 		ProjectionConcurrency:      DefTiDBProjectionConcurrency,
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
+		HashAggPartialConcurrency:  DefTiDBHashAggPartialConcurrency,
+		HashAggFinalConcurrency:    DefTiDBHashAggFinalConcurrency,
 	}
 	vars.MemQuota = MemQuota{
 		MemQuotaQuery:             config.GetGlobalConfig().MemQuotaQuery,
@@ -493,6 +495,10 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.HashJoinConcurrency = tidbOptPositiveInt32(val, DefTiDBHashJoinConcurrency)
 	case TiDBProjectionConcurrency:
 		s.ProjectionConcurrency = tidbOptInt64(val, DefTiDBProjectionConcurrency)
+	case TiDBHashAggPartialConcurrency:
+		s.HashAggPartialConcurrency = tidbOptPositiveInt32(val, DefTiDBHashAggPartialConcurrency)
+	case TiDBHashAggFinalConcurrency:
+		s.HashAggFinalConcurrency = tidbOptPositiveInt32(val, DefTiDBHashAggFinalConcurrency)
 	case TiDBDistSQLScanConcurrency:
 		s.DistSQLScanConcurrency = tidbOptPositiveInt32(val, DefDistSQLScanConcurrency)
 	case TiDBIndexSerialScanConcurrency:
@@ -572,6 +578,12 @@ type Concurrency struct {
 
 	// ProjectionConcurrency is the number of concurrent projection worker.
 	ProjectionConcurrency int64
+
+	// HashAggPartialConcurrency is the number of concurrent hash aggregation partial worker.
+	HashAggPartialConcurrency int
+
+	// HashAggPartialConcurrency is the number of concurrent hash aggregation final worker.
+	HashAggFinalConcurrency int
 
 	// IndexSerialScanConcurrency is the number of concurrent index serial scan worker.
 	IndexSerialScanConcurrency int

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -638,6 +638,8 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TxnIsolationOneShot, ""},
 	{ScopeGlobal | ScopeSession, TiDBHashJoinConcurrency, strconv.Itoa(DefTiDBHashJoinConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBProjectionConcurrency, strconv.Itoa(DefTiDBProjectionConcurrency)},
+	{ScopeGlobal | ScopeSession, TiDBHashAggPartialConcurrency, strconv.Itoa(DefTiDBHashAggPartialConcurrency)},
+	{ScopeGlobal | ScopeSession, TiDBHashAggFinalConcurrency, strconv.Itoa(DefTiDBHashAggFinalConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBBackoffLockFast, strconv.Itoa(kv.DefBackoffLockFast)},
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -158,6 +158,14 @@ const (
 	// This variable controls the worker number of projection operator.
 	TiDBProjectionConcurrency = "tidb_projection_concurrency"
 
+	// tidb_hashagg_partial_concurrency is used for hash agg executor.
+	// The hash agg executor starts multiple concurrent partial workers to do partial aggregate works.
+	TiDBHashAggPartialConcurrency = "tidb_hashagg_partial_concurrency"
+
+	// tidb_hashagg_final_concurrency is used for hash agg executor.
+	// The hash agg executor starts multiple concurrent final workers to do final aggregate works.
+	TiDBHashAggFinalConcurrency = "tidb_hashagg_final_concurrency"
+
 	// tidb_backoff_lock_fast is used for tikv backoff base time in milliseconds.
 	TiDBBackoffLockFast = "tidb_backoff_lock_fast"
 )
@@ -193,6 +201,8 @@ const (
 	DefTiDBHashJoinConcurrency       = 5
 	DefTiDBProjectionConcurrency     = 4
 	DefTiDBOptimizerSelectivityLevel = 0
+	DefTiDBHashAggPartialConcurrency = 4
+	DefTiDBHashAggFinalConcurrency   = 4
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -64,6 +64,8 @@ func (s *testVarsutilSuite) TestNewSessionVars(c *C) {
 	c.Assert(vars.IndexLookupJoinConcurrency, Equals, DefIndexLookupJoinConcurrency)
 	c.Assert(vars.HashJoinConcurrency, Equals, DefTiDBHashJoinConcurrency)
 	c.Assert(vars.ProjectionConcurrency, Equals, int64(DefTiDBProjectionConcurrency))
+	c.Assert(vars.HashAggPartialConcurrency, Equals, DefTiDBHashAggPartialConcurrency)
+	c.Assert(vars.HashAggFinalConcurrency, Equals, DefTiDBHashAggFinalConcurrency)
 	c.Assert(vars.DistSQLScanConcurrency, Equals, DefDistSQLScanConcurrency)
 	c.Assert(vars.MaxChunkSize, Equals, DefMaxChunkSize)
 	c.Assert(vars.DMLBatchSize, Equals, DefDMLBatchSize)


### PR DESCRIPTION
Thank you for working on TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.

## What have you changed? (mandatory)

This commit adds 2 system variables:
- tidb_hashagg_partial_concurrency: control the number of hash agg partial workers
- tidb_hashagg_final_concurrency: control the number of hash agg final workers

## What are the type of the changes (mandatory)?

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- New feature (non-breaking change which adds functionality)

## How has this PR been tested (mandatory)?

unit-test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) and [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.

## Refer to a related PR or issue link (optional)
#6658 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

