### PR TITLE
executor: make chunk fetch size be tunable in stmt level

### DIFF
--- a/cmd/benchfilesort/main.go
+++ b/cmd/benchfilesort/main.go
@@ -77,7 +77,7 @@ func encodeRow(b []byte, row *comparableRow) ([]byte, error) {
 		head = make([]byte, 8)
 		body []byte
 	)
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	body, err = codec.EncodeKey(sc, body, row.key...)
 	if err != nil {
 		return b, errors.Trace(err)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1432,7 +1432,7 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
 
-	if err := checkPointTypeColumn(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
+	if err = checkPointTypeColumn(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -232,6 +232,8 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 		return a.handleNoDelayExecutor(ctx, sctx, e, pi)
 	}
 
+	a.Ctx.GetSessionVars().StmtCtx.FetchChunkSize = estimateChunkSize(a.Ctx, a.Plan)
+
 	return &recordSet{
 		executor:    e,
 		stmt:        a,

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -224,12 +224,12 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 	}
 	// If the executor doesn't return any result to the client, we execute it without delay.
 	if e.Schema().Len() == 0 {
-		return a.handleNoDelayExecutor(ctx, sctx, e, pi)
+		return a.handleNoDelayExecutor(ctx, sctx, e, pi, chunk.VoidChunk)
 	} else if proj, ok := e.(*ProjectionExec); ok && proj.calculateNoDelay {
 		// Currently this is only for the "DO" statement. Take "DO 1, @a=2;" as an example:
 		// the Projection has two expressions and two columns in the schema, but we should
 		// not return the result of the two expressions.
-		return a.handleNoDelayExecutor(ctx, sctx, e, pi)
+		return a.handleNoDelayExecutor(ctx, sctx, e, pi, e.newChunk())
 	}
 
 	a.Ctx.GetSessionVars().StmtCtx.FetchChunkSize = estimateChunkSize(a.Ctx, a.Plan)
@@ -242,7 +242,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 	}, nil
 }
 
-func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Context, e Executor, pi processinfoSetter) (ast.RecordSet, error) {
+func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Context, e Executor, pi processinfoSetter, chunk *chunk.Chunk) (ast.RecordSet, error) {
 	// Check if "tidb_snapshot" is set for the write executors.
 	// In history read mode, we can not do write operations.
 	switch e.(type) {
@@ -266,7 +266,7 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 		a.logSlowQuery(txnTS, err == nil)
 	}()
 
-	err = e.Next(ctx, e.newChunk())
+	err = e.Next(ctx, chunk)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -192,7 +192,7 @@ func (e *RecoverIndexExec) Open(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
-	e.srcChunk = chunk.NewChunkWithCapacity(e.columnsTypes(), e.maxChunkSize)
+	e.srcChunk = chunk.NewChunkWithCapacity(e.columnsTypes(), e.chunkRowsPerFetch())
 	e.batchSize = 2048
 	e.recoverRows = make([]recoverRows, 0, e.batchSize)
 	e.idxValsBufs = make([][]types.Datum, e.batchSize)
@@ -630,7 +630,7 @@ func (e *CleanupIndexExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	e.idxChunk = chunk.NewChunkWithCapacity(e.getIdxColTypes(), e.maxChunkSize)
+	e.idxChunk = chunk.NewChunkWithCapacity(e.getIdxColTypes(), e.chunkRowsPerFetch())
 	e.idxValues = make(map[int64][]types.Datum, e.batchSize)
 	e.batchKeys = make([]kv.Key, 0, e.batchSize)
 	e.idxValsBufs = make([][]types.Datum, e.batchSize)

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -110,7 +110,7 @@ func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		}
 		e.mutableRow.SetDatums(e.rowBuffer...)
 		chk.AppendRow(e.mutableRow.ToRow())
-		if chk.NumRows() == e.maxChunkSize {
+		if chk.NumRows() == e.chunkRowsPerFetch() {
 			return nil
 		}
 	}
@@ -243,7 +243,7 @@ func (e *StreamAggExec) Close() error {
 func (e *StreamAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 
-	for !e.executed && chk.NumRows() < e.maxChunkSize {
+	for !e.executed && chk.NumRows() < e.chunkRowsPerFetch() {
 		err := e.consumeOneGroup(ctx, chk)
 		if err != nil {
 			e.executed = true

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -595,12 +595,12 @@ func (b *executorBuilder) buildGrant(grant *ast.GrantStmt) Executor {
 
 func (b *executorBuilder) buildRevoke(revoke *ast.RevokeStmt) Executor {
 	e := &RevokeExec{
-		ctx:        b.ctx,
-		Privs:      revoke.Privs,
-		ObjectType: revoke.ObjectType,
-		Level:      revoke.Level,
-		Users:      revoke.Users,
-		is:         b.is,
+		baseExecutor: newBaseExecutor(b.ctx, nil, "RevokeStmt"),
+		Privs:        revoke.Privs,
+		ObjectType:   revoke.ObjectType,
+		Level:        revoke.Level,
+		Users:        revoke.Users,
+		is:           b.is,
 	}
 	return e
 }

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -511,9 +511,9 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		finished:     e.finished,
 		resultCh:     e.resultCh,
 		keepOrder:    e.keepOrder,
-		batchSize:    e.maxChunkSize,
+		batchSize:    e.chunkRowsPerFetch(),
 		maxBatchSize: e.ctx.GetSessionVars().IndexLookupSize,
-		maxChunkSize: e.maxChunkSize,
+		maxChunkSize: e.chunkRowsPerFetch(),
 	}
 	if worker.batchSize > worker.maxBatchSize {
 		worker.batchSize = worker.maxBatchSize
@@ -612,7 +612,7 @@ func (e *IndexLookUpExecutor) Next(ctx context.Context, chk *chunk.Chunk) error 
 		for resultTask.cursor < len(resultTask.rows) {
 			chk.AppendRow(resultTask.rows[resultTask.cursor])
 			resultTask.cursor++
-			if chk.NumRows() >= e.maxChunkSize {
+			if chk.NumRows() >= e.chunkRowsPerFetch() {
 				return nil
 			}
 		}

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -139,7 +139,7 @@ func (s *testExecSuite) TestBuildKvRangesForIndexJoin(c *C) {
 	joinKeyRows = append(joinKeyRows, generateDatumSlice(2, 3))
 
 	keyOff2IdxOff := []int{1, 3}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	kvRanges, err := buildKvRangesForIndexJoin(sc, 0, 0, joinKeyRows, indexRanges, keyOff2IdxOff)
 	c.Assert(err, IsNil)
 	// Check the kvRanges is in order.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2619,7 +2619,7 @@ func (s *testSuite) TestCheckIndex(c *C) {
 
 	mockCtx := mock.NewContext()
 	idx := tb.Indices()[0]
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 
 	_, err = se.Execute(context.Background(), "admin check index t idx_inexistent")
 	c.Assert(strings.Contains(err.Error(), "not exist"), IsTrue)
@@ -2674,7 +2674,7 @@ func (s *testSuite) TestCheckIndex(c *C) {
 func setColValue(c *C, txn kv.Transaction, key kv.Key, v types.Datum) {
 	row := []types.Datum{v, {}}
 	colIDs := []int64{2, 3}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	value, err := tablecodec.EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	err = txn.Set(key, value)

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -40,7 +40,7 @@ func (e *ExplainExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return nil
 	}
 
-	numCurRows := mathutil.Min(e.maxChunkSize, len(e.rows)-e.cursor)
+	numCurRows := mathutil.Min(e.chunkRowsPerFetch(), len(e.rows)-e.cursor)
 	for i := e.cursor; i < e.cursor+numCurRows; i++ {
 		for j := range e.rows[i] {
 			chk.AppendString(j, e.rows[i][j])

--- a/executor/join.go
+++ b/executor/join.go
@@ -385,7 +385,7 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 			return false, joinResult
 		}
 		nr := joinResult.chk.NumRows()
-		fr := e.chunkRowsPerFetch()
+		fr := e.ctx.GetSessionVars().MaxChunkSize
 		if nr == fr {
 			ok := true
 			e.joinResultCh <- joinResult

--- a/executor/join_result_generators.go
+++ b/executor/join_result_generators.go
@@ -56,12 +56,12 @@ func newJoinResultGenerator(ctx sessionctx.Context, joinType plan.JoinType,
 		ctx:          ctx,
 		conditions:   filter,
 		outerIsRight: outerIsRight,
-		maxChunkSize: ctx.GetSessionVars().MaxChunkSize,
+		maxChunkSize: ctx.GetSessionVars().ChunkRowsPerFetch(),
 	}
 	colTypes := make([]*types.FieldType, 0, len(lhsColTypes)+len(rhsColTypes))
 	colTypes = append(colTypes, lhsColTypes...)
 	colTypes = append(colTypes, rhsColTypes...)
-	base.chk = chunk.NewChunkWithCapacity(colTypes, ctx.GetSessionVars().MaxChunkSize)
+	base.chk = chunk.NewChunkWithCapacity(colTypes, ctx.GetSessionVars().ChunkRowsPerFetch())
 	base.selected = make([]bool, 0, chunk.InitialCapacity)
 	if joinType == plan.LeftOuterJoin || joinType == plan.RightOuterJoin {
 		innerColTypes := lhsColTypes

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -29,7 +29,7 @@ type MockExec struct {
 func (m *MockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	colTypes := m.retTypes()
-	for ; m.curRowIdx < len(m.Rows) && chk.NumRows() < m.maxChunkSize; m.curRowIdx++ {
+	for ; m.curRowIdx < len(m.Rows) && chk.NumRows() < m.chunkRowsPerFetch(); m.curRowIdx++ {
 		curRow := m.Rows[m.curRowIdx]
 		for i := 0; i < len(curRow); i++ {
 			curDatum := curRow.GetDatum(i, colTypes[i])
@@ -91,7 +91,7 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		innerFilter:     []expression.Expression{innerFilter},
 		resultGenerator: generator,
 	}
-	join.innerList = chunk.NewList(innerExec.retTypes(), innerExec.maxChunkSize)
+	join.innerList = chunk.NewList(innerExec.retTypes(), innerExec.chunkRowsPerFetch())
 	join.innerChunk = innerExec.newChunk()
 	join.outerChunk = outerExec.newChunk()
 	joinChk := join.newChunk()

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -262,6 +262,8 @@ func ResetStmtCtx(ctx sessionctx.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
 	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = sessVars.GetTimeZone()
+	sc.DefaultFetchChunkSize = ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize
+	sc.FetchChunkSize = ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize
 	sc.MemTracker = memory.NewTracker(s.Text(), sessVars.MemQuotaQuery)
 	switch config.GetGlobalConfig().OOMAction {
 	case config.OOMActionCancel:

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -262,8 +262,7 @@ func ResetStmtCtx(ctx sessionctx.Context, s ast.StmtNode) {
 	sessVars := ctx.GetSessionVars()
 	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = sessVars.GetTimeZone()
-	sc.DefaultFetchChunkSize = ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize
-	sc.FetchChunkSize = ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize
+	sc.FetchChunkSize = ctx.GetSessionVars().DefaultFetchChunkSize
 	sc.MemTracker = memory.NewTracker(s.Text(), sessVars.MemQuotaQuery)
 	switch config.GetGlobalConfig().OOMAction {
 	case config.OOMActionCancel:

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -56,6 +56,8 @@ type ProjectionExec struct {
 	fetcher    projectionInputFetcher
 	numWorkers int64
 	workers    []*projectionWorker
+
+	childResult *chunk.Chunk
 }
 
 // Open implements the Executor Open interface.
@@ -143,11 +145,14 @@ func (e *ProjectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 }
 
 func (e *ProjectionExec) unParallelExecute(ctx context.Context, chk *chunk.Chunk) error {
-	err := e.children[0].Next(ctx, e.childrenResults[0])
+	if e.childResult == nil {
+		e.childResult = e.children[0].newChunk()
+	}
+	err := e.children[0].Next(ctx, e.childResult)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = e.evaluatorSuit.Run(e.ctx, e.childrenResults[0], chk)
+	err = e.evaluatorSuit.Run(e.ctx, e.childResult, chk)
 	return errors.Trace(err)
 }
 
@@ -216,6 +221,9 @@ func (e *ProjectionExec) prepare(ctx context.Context) {
 
 // Close implements the Executor Close interface.
 func (e *ProjectionExec) Close() error {
+	if e.childResult != nil {
+		e.childResult = nil
+	}
 	if e.outputCh != nil {
 		close(e.finishCh)
 		// Wait for "projectionInputFetcher" to finish and exit.

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/mysql"
-	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -45,7 +44,6 @@ type RevokeExec struct {
 	Level      *ast.GrantLevel
 	Users      []*ast.UserSpec
 
-	ctx  sessionctx.Context
 	is   infoschema.InfoSchema
 	done bool
 }

--- a/executor/show.go
+++ b/executor/show.go
@@ -86,7 +86,7 @@ func (e *ShowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if e.cursor >= e.result.NumRows() {
 		return nil
 	}
-	numCurBatch := mathutil.Min(e.maxChunkSize, e.result.NumRows()-e.cursor)
+	numCurBatch := mathutil.Min(e.chunkRowsPerFetch(), e.result.NumRows()-e.cursor)
 	chk.Append(e.result, e.cursor, e.cursor+numCurBatch)
 	e.cursor += numCurBatch
 	return nil

--- a/expression/aggregation/util_test.go
+++ b/expression/aggregation/util_test.go
@@ -16,7 +16,7 @@ type testUtilSuite struct {
 
 func (s *testUtilSuite) TestDistinct(c *check.C) {
 	defer testleak.AfterTest(c)()
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	dc := createDistinctChecker(sc)
 	tests := []struct {
 		vals   []interface{}

--- a/expression/evaluator.go
+++ b/expression/evaluator.go
@@ -80,7 +80,7 @@ func NewEvaluatorSuit(exprs []Expression) *EvaluatorSuit {
 		switch x := expr.(type) {
 		case *Column:
 			if e.columnEvaluator == nil {
-				e.columnEvaluator = &columnEvaluator{inputIdxToOutputIdxes: make(map[int][]int)}
+				e.columnEvaluator = &columnEvaluator{inputIdxToOutputIdxes: make(map[int][]int, len(exprs))}
 			}
 			inputIdx, outputIdx := x.Index, i
 			e.columnEvaluator.inputIdxToOutputIdxes[inputIdx] = append(e.columnEvaluator.inputIdxToOutputIdxes[inputIdx], outputIdx)

--- a/expression/evaluator.go
+++ b/expression/evaluator.go
@@ -80,7 +80,7 @@ func NewEvaluatorSuit(exprs []Expression) *EvaluatorSuit {
 		switch x := expr.(type) {
 		case *Column:
 			if e.columnEvaluator == nil {
-				e.columnEvaluator = &columnEvaluator{inputIdxToOutputIdxes: make(map[int][]int, len(exprs))}
+				e.columnEvaluator = &columnEvaluator{inputIdxToOutputIdxes: make(map[int][]int)}
 			}
 			inputIdx, outputIdx := x.Index, i
 			e.columnEvaluator.inputIdxToOutputIdxes[inputIdx] = append(e.columnEvaluator.inputIdxToOutputIdxes[inputIdx], outputIdx)

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -55,7 +55,7 @@ func (s *testEvaluatorSuite) TestEvaluateExprWithNull(c *C) {
 func (s *testEvaluatorSuite) TestConstant(c *C) {
 	defer testleak.AfterTest(c)()
 
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	c.Assert(Zero.IsCorrelated(), IsFalse)
 	c.Assert(Zero.Decorrelate(nil).Equal(s.ctx, Zero), IsTrue)
 	c.Assert(Zero.HashCode(sc), DeepEquals, []byte{0x0, 0x8, 0x0})

--- a/expression/scalar_function_test.go
+++ b/expression/scalar_function_test.go
@@ -35,7 +35,7 @@ func (s *testEvaluatorSuite) TestScalarFunction(c *C) {
 		ColName:  model.NewCIStr("han"),
 		RetType:  types.NewFieldType(mysql.TypeDouble),
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	sf := newFunction(ast.LT, a, One)
 	res, err := sf.MarshalJSON()
 	c.Assert(err, IsNil)

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -31,7 +31,7 @@ type testKeySuite struct {
 
 func (s *testKeySuite) TestPartialNext(c *C) {
 	defer testleak.AfterTest(c)()
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	// keyA represents a multi column index.
 	keyA, err := codec.EncodeValue(sc, nil, types.NewDatum("abc"), types.NewDatum("def"))
 	c.Check(err, IsNil)

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
-	"fmt"
 )
 
 // AllowCartesianProduct means whether tidb allows cartesian join without equal conditions.
@@ -147,15 +146,9 @@ func logicalOptimize(flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 func physicalOptimize(logic LogicalPlan) (PhysicalPlan, error) {
 	logic.preparePossibleProperties()
 
-	var (
-		stats *statsInfo
-		err error
-	)
-	if stats, err = logic.deriveStats(); err != nil {
+	if _, err := logic.deriveStats(); err != nil {
 		return nil, errors.Trace(err)
 	}
-
-	fmt.Println(stats)
 
 	prop := &requiredProp{
 		taskTp:      rootTaskType,

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
+	"fmt"
 )
 
 // AllowCartesianProduct means whether tidb allows cartesian join without equal conditions.
@@ -146,9 +147,15 @@ func logicalOptimize(flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 func physicalOptimize(logic LogicalPlan) (PhysicalPlan, error) {
 	logic.preparePossibleProperties()
 
-	if _, err := logic.deriveStats(); err != nil {
+	var (
+		stats *statsInfo
+		err error
+	)
+	if stats, err = logic.deriveStats(); err != nil {
 		return nil, errors.Trace(err)
 	}
+
+	fmt.Println(stats)
 
 	prop := &requiredProp{
 		taskTp:      rootTaskType,

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -76,7 +76,7 @@ func (ts *HTTPHandlerTestSuite) TestRegionIndexRange(c *C) {
 		}
 		expectIndexValues = append(expectIndexValues, str)
 	}
-	encodedValue, err := codec.EncodeKey(&stmtctx.StatementContext{TimeZone: time.Local}, nil, indexValues...)
+	encodedValue, err := codec.EncodeKey(stmtctx.NewStatementContext(time.Local), nil, indexValues...)
 	c.Assert(err, IsNil)
 
 	startKey := tablecodec.EncodeIndexSeekKey(sTableID, sIndex, encodedValue)
@@ -407,7 +407,7 @@ func (ts *HTTPHandlerTestSuite) TestDecodeColumnValue(c *C) {
 	for _, col := range cols {
 		colIDs = append(colIDs, col.id)
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	bs, err := tablecodec.EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(bs, NotNil)

--- a/session/session.go
+++ b/session/session.go
@@ -1085,6 +1085,8 @@ func CreateSession4Test(store kv.Storage) (Session, error) {
 	if err == nil {
 		// initialize session variables for test.
 		s.GetSessionVars().MaxChunkSize = 2
+		s.GetSessionVars().StmtCtx.FetchChunkSize = 2
+		s.GetSessionVars().StmtCtx.DefaultFetchChunkSize = 2
 	}
 	return s, errors.Trace(err)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1085,8 +1085,8 @@ func CreateSession4Test(store kv.Storage) (Session, error) {
 	if err == nil {
 		// initialize session variables for test.
 		s.GetSessionVars().MaxChunkSize = 2
+		s.GetSessionVars().DefaultFetchChunkSize = 2
 		s.GetSessionVars().StmtCtx.FetchChunkSize = 2
-		s.GetSessionVars().StmtCtx.DefaultFetchChunkSize = 2
 	}
 	return s, errors.Trace(err)
 }

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -58,25 +58,23 @@ type StatementContext struct {
 	}
 
 	// Copied from SessionVars.TimeZone.
-	TimeZone              *time.Location
-	Priority              mysql.PriorityEnum
-	NotFillCache          bool
-	MemTracker            *memory.Tracker
-	TableIDs              []int64
-	IndexIDs              []int64
-	FetchChunkSize        int
-	DefaultFetchChunkSize int
+	TimeZone       *time.Location
+	Priority       mysql.PriorityEnum
+	NotFillCache   bool
+	MemTracker     *memory.Tracker
+	TableIDs       []int64
+	IndexIDs       []int64
+	FetchChunkSize int
 }
 
-// DefaultFetchChunkSize is default value for StatementContext#FetchChunkSize.
-const DefaultFetchChunkSize = 1024
+// DefFetchChunkSize is default value for StatementContext#FetchChunkSize.
+const DefFetchChunkSize = 1024
 
 // NewStatementContext creates new statementContext with timeZone and default chunk capacity
 func NewStatementContext(timezone *time.Location) *StatementContext {
 	return &StatementContext{
-		TimeZone:              timezone,
-		FetchChunkSize:        DefaultFetchChunkSize,
-		DefaultFetchChunkSize: DefaultFetchChunkSize,
+		TimeZone:       timezone,
+		FetchChunkSize: DefFetchChunkSize,
 	}
 }
 

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -58,12 +58,26 @@ type StatementContext struct {
 	}
 
 	// Copied from SessionVars.TimeZone.
-	TimeZone     *time.Location
-	Priority     mysql.PriorityEnum
-	NotFillCache bool
-	MemTracker   *memory.Tracker
-	TableIDs     []int64
-	IndexIDs     []int64
+	TimeZone              *time.Location
+	Priority              mysql.PriorityEnum
+	NotFillCache          bool
+	MemTracker            *memory.Tracker
+	TableIDs              []int64
+	IndexIDs              []int64
+	FetchChunkSize        int
+	DefaultFetchChunkSize int
+}
+
+// DefaultFetchChunkSize is default value for StatementContext#FetchChunkSize.
+const DefaultFetchChunkSize = 1024
+
+// NewStatementContext creates new statementContext with timeZone and default chunk capacity
+func NewStatementContext(timezone *time.Location) *StatementContext {
+	return &StatementContext{
+		TimeZone:              timezone,
+		FetchChunkSize:        DefaultFetchChunkSize,
+		DefaultFetchChunkSize: DefaultFetchChunkSize,
+	}
 }
 
 // AddAffectedRows adds affected rows.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -286,6 +286,15 @@ type SessionVars struct {
 	writeStmtBufs WriteStmtBufs
 }
 
+// ChunkRowsPerFetch returns chunkRows capacity for next fetch.
+func (s *SessionVars) ChunkRowsPerFetch() int {
+	chunkRows := s.StmtCtx.FetchChunkSize
+	if chunkRows > s.MaxChunkSize {
+		return s.MaxChunkSize
+	}
+	return chunkRows
+}
+
 // NewSessionVars creates a session vars object.
 func NewSessionVars() *SessionVars {
 	vars := &SessionVars{
@@ -304,6 +313,8 @@ func NewSessionVars() *SessionVars {
 		OptimizerSelectivityLevel: DefTiDBOptimizerSelectivityLevel,
 		RetryLimit:                DefTiDBRetryLimit,
 	}
+	vars.StmtCtx.DefaultFetchChunkSize = stmtctx.DefaultFetchChunkSize
+	vars.StmtCtx.FetchChunkSize = vars.StmtCtx.DefaultFetchChunkSize
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,
 		IndexSerialScanConcurrency: DefIndexSerialScanConcurrency,

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 )
 
@@ -626,6 +627,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBDMLBatchSize, strconv.Itoa(DefDMLBatchSize)},
 	{ScopeSession, TiDBCurrentTS, strconv.Itoa(DefCurretTS)},
 	{ScopeGlobal | ScopeSession, TiDBMaxChunkSize, strconv.Itoa(DefMaxChunkSize)},
+	{ScopeGlobal | ScopeSession, TiDBDefaultFetchChunkSize, strconv.Itoa(stmtctx.DefFetchChunkSize)},
 	{ScopeSession, TIDBMemQuotaQuery, strconv.FormatInt(config.GetGlobalConfig().MemQuotaQuery, 10)},
 	{ScopeSession, TIDBMemQuotaHashJoin, strconv.FormatInt(DefTiDBMemQuotaHashJoin, 10)},
 	{ScopeSession, TIDBMemQuotaMergeJoin, strconv.FormatInt(DefTiDBMemQuotaMergeJoin, 10)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -146,6 +146,9 @@ const (
 	// tidb_max_chunk_capacity is used to control the max chunk size during query execution.
 	TiDBMaxChunkSize = "tidb_max_chunk_size"
 
+	// tidb_default_fetch_chunk_size is used to control default fetch chunk size in session level.
+	TiDBDefaultFetchChunkSize = "tidb_default_fetch_chunk_size"
+
 	// tidb_skip_utf8_check skips the UTF8 validate process, validate UTF8 has performance cost, if we can make sure
 	// the input string values are valid, we can skip the check.
 	TiDBSkipUTF8Check = "tidb_skip_utf8_check"

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -50,7 +50,7 @@ func buildCMSketchAndMap(d, w int32, seed int64, total, imax uint64, s float64) 
 }
 
 func averageAbsoluteError(cms *CMSketch, mp map[int64]uint32) (uint64, error) {
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	var total uint64
 	for num, count := range mp {
 		estimate, err := cms.queryValue(sc, types.NewIntDatum(num))

--- a/statistics/dump.go
+++ b/statistics/dump.go
@@ -75,7 +75,7 @@ func (h *Handle) DumpStatsToJSON(dbName string, tableInfo *model.TableInfo) (*JS
 	}
 
 	for _, col := range tbl.Columns {
-		sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+		sc := stmtctx.NewStatementContext(time.UTC)
 		hist, err := col.ConvertTo(sc, types.NewFieldType(mysql.TypeBlob))
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -189,7 +189,7 @@ func (h *Handle) LoadStatsFromJSONToTable(tableInfo *model.TableInfo, jsonTbl *J
 			}
 			hist := HistogramFromProto(jsonCol.Histogram)
 			count := int64(hist.totalRowCount())
-			sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+			sc := stmtctx.NewStatementContext(time.UTC)
 			hist, err := hist.ConvertTo(sc, &colInfo.FieldType)
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/statistics/fmsketch_test.go
+++ b/statistics/fmsketch_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func (s *testStatisticsSuite) TestSketch(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	maxSize := 1000
 	sampleSketch, ndv, err := buildFMSketch(sc, s.samples, maxSize)
 	c.Check(err, IsNil)
@@ -49,7 +49,7 @@ func (s *testStatisticsSuite) TestSketch(c *C) {
 }
 
 func (s *testStatisticsSuite) TestSketchProtoConversion(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	maxSize := 1000
 	sampleSketch, ndv, err := buildFMSketch(sc, s.samples, maxSize)
 	c.Check(err, IsNil)

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -70,8 +70,8 @@ func (h *Handle) Clear() {
 		<-h.analyzeResultCh
 	}
 	h.ctx.GetSessionVars().MaxChunkSize = 1
+	h.ctx.GetSessionVars().DefaultFetchChunkSize = 1
 	h.ctx.GetSessionVars().StmtCtx.FetchChunkSize = 1
-	h.ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize = 1
 	h.listHead = &SessionStatsCollector{mapper: make(tableDeltaMap)}
 	h.globalMap = make(tableDeltaMap)
 }

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -70,6 +70,8 @@ func (h *Handle) Clear() {
 		<-h.analyzeResultCh
 	}
 	h.ctx.GetSessionVars().MaxChunkSize = 1
+	h.ctx.GetSessionVars().StmtCtx.FetchChunkSize = 1
+	h.ctx.GetSessionVars().StmtCtx.DefaultFetchChunkSize = 1
 	h.listHead = &SessionStatsCollector{mapper: make(tableDeltaMap)}
 	h.globalMap = make(tableDeltaMap)
 }

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -88,7 +88,7 @@ func (s *testSampleSuite) TestMergeSampleCollector(c *C) {
 		CMSketchDepth:   8,
 	}
 	s.rs.Close()
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	collectors, pkBuilder, err := builder.CollectColumnStats()
 	c.Assert(err, IsNil)
 	c.Assert(pkBuilder, IsNil)

--- a/statistics/scalar.go
+++ b/statistics/scalar.go
@@ -68,7 +68,7 @@ func convertDatumToScalar(value *types.Datum, commonPfxLen int) float64 {
 		case mysql.TypeTimestamp:
 			minTime = types.MinTimestamp
 		}
-		sc := &stmtctx.StatementContext{TimeZone: types.BoundTimezone}
+		sc := stmtctx.NewStatementContext(types.BoundTimezone)
 		return float64(valueTime.Sub(sc, &minTime).Duration)
 	case types.KindString, types.KindBytes:
 		bytes := value.GetBytes()

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -66,7 +66,7 @@ func (s *testSelectivitySuite) generateIntDatum(dimension, num int) ([]types.Dat
 			ret[i] = types.NewIntDatum(int64(i))
 		}
 	} else {
-		sc := &stmtctx.StatementContext{TimeZone: time.Local}
+		sc := stmtctx.NewStatementContext(time.Local)
 		// In this way, we can guarantee the datum is in order.
 		for i := 0; i < length; i++ {
 			data := make([]types.Datum, dimension)

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -164,7 +164,7 @@ func (s *testStatisticsSuite) SetUpSuite(c *C) {
 }
 
 func encodeKey(key types.Datum) types.Datum {
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	buf, _ := codec.EncodeKey(sc, nil, key)
 	return types.NewBytesDatum(buf)
 }

--- a/store/mockstore/mocktikv/cluster_test.go
+++ b/store/mockstore/mocktikv/cluster_test.go
@@ -55,7 +55,7 @@ func (s *testClusterSuite) TestClusterSplit(c *C) {
 	idxID := int64(2)
 	colID := int64(3)
 	handle := int64(1)
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	for i := 0; i < 1000; i++ {
 		rowKey := tablecodec.EncodeRowKeyWithHandle(tblID, handle)
 		colValue := types.NewStringDatum(strconv.Itoa(int(handle)))

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -84,7 +84,7 @@ func (s *testIndexSuite) TestIndex(c *C) {
 	c.Assert(getValues[1].GetInt64(), Equals, int64(2))
 	c.Assert(h, Equals, int64(1))
 	it.Close()
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	exist, _, err := index.Exist(sc, txn, values, 100)
 	c.Assert(err, IsNil)
 	c.Assert(exist, IsFalse)
@@ -227,7 +227,7 @@ func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 	c.Assert(err, IsNil)
 
 	index2 := tables.NewIndex(tblInfo, tblInfo.Indices[0])
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	iter, hit, err := index2.Seek(sc, txn, types.MakeDatums("abc", nil))
 	c.Assert(err, IsNil)
 	defer iter.Close()

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -73,7 +73,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	for _, col := range cols {
 		colIDs = append(colIDs, col.id)
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	bs, err := EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(bs, NotNil)
@@ -151,7 +151,7 @@ func (s *testTableCodecSuite) TestTimeCodec(c *C) {
 	row := make([]types.Datum, colLen)
 	row[0] = types.NewIntDatum(100)
 	row[1] = types.NewBytesDatum([]byte("abc"))
-	ts, err := types.ParseTimestamp(&stmtctx.StatementContext{TimeZone: time.UTC},
+	ts, err := types.ParseTimestamp(stmtctx.NewStatementContext(time.UTC),
 		"2016-06-23 11:30:45")
 	c.Assert(err, IsNil)
 	row[2] = types.NewDatum(ts)
@@ -164,7 +164,7 @@ func (s *testTableCodecSuite) TestTimeCodec(c *C) {
 	for _, col := range cols {
 		colIDs = append(colIDs, col.id)
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	bs, err := EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(bs, NotNil)
@@ -202,7 +202,7 @@ func (s *testTableCodecSuite) TestCutRow(c *C) {
 	row[1] = types.NewBytesDatum([]byte("abc"))
 	row[2] = types.NewDecimalDatum(types.NewDecFromInt(1))
 
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	data := make([][]byte, 3)
 	data[0], err = EncodeValue(sc, row[0])
 	c.Assert(err, IsNil)
@@ -238,7 +238,7 @@ func (s *testTableCodecSuite) TestCutKeyNew(c *C) {
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
 	handle := types.NewIntDatum(100)
 	values = append(values, handle)
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	encodedValue, err := codec.EncodeKey(sc, nil, values...)
 	c.Assert(err, IsNil)
 	tableID := int64(4)
@@ -261,7 +261,7 @@ func (s *testTableCodecSuite) TestCutKey(c *C) {
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
 	handle := types.NewIntDatum(100)
 	values = append(values, handle)
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	encodedValue, err := codec.EncodeKey(sc, nil, values...)
 	c.Assert(err, IsNil)
 	tableID := int64(4)
@@ -348,7 +348,7 @@ func (s *testTableCodecSuite) TestDecodeIndexKey(c *C) {
 		}
 		valueStrs = append(valueStrs, str)
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	encodedValue, err := codec.EncodeKey(sc, nil, values...)
 	c.Assert(err, IsNil)
 	indexKey := EncodeIndexSeekKey(tableID, indexID, encodedValue)

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -163,7 +163,7 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v.(Duration).String(), Equals, "10:11:11.1")
 
-	vt, err := ParseTime(&stmtctx.StatementContext{TimeZone: time.UTC}, "2010-10-10 10:11:11.12345", mysql.TypeTimestamp, 2)
+	vt, err := ParseTime(stmtctx.NewStatementContext(time.UTC), "2010-10-10 10:11:11.12345", mysql.TypeTimestamp, 2)
 	c.Assert(vt.String(), Equals, "2010-10-10 10:11:11.12")
 	c.Assert(err, IsNil)
 	v, err = Convert(vt, ft)
@@ -330,7 +330,7 @@ func (s *testTypeConvertSuite) TestConvertToString(c *C) {
 	testToString(c, Enum{Name: "a", Value: 1}, "a")
 	testToString(c, Set{Name: "a", Value: 1}, "a")
 
-	t, err := ParseTime(&stmtctx.StatementContext{TimeZone: time.UTC},
+	t, err := ParseTime(stmtctx.NewStatementContext(time.UTC),
 		"2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 6)
 	c.Assert(err, IsNil)
 	testToString(c, t, "2011-11-10 11:11:11.999999")
@@ -701,9 +701,7 @@ func (s *testTypeConvertSuite) TestConvertTime(c *C) {
 	}
 
 	for _, timezone := range timezones {
-		sc := &stmtctx.StatementContext{
-			TimeZone: timezone,
-		}
+		sc := stmtctx.NewStatementContext(timezone)
 		testConvertTimeTimeZone(c, sc)
 	}
 }

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -68,7 +68,7 @@ func (ts *testDatumSuite) TestToBool(c *C) {
 	testDatumToBool(c, Enum{Name: "a", Value: 1}, 1)
 	testDatumToBool(c, Set{Name: "a", Value: 1}, 1)
 
-	t, err := ParseTime(&stmtctx.StatementContext{TimeZone: time.UTC}, "2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 6)
+	t, err := ParseTime(stmtctx.NewStatementContext(time.UTC), "2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 6)
 	c.Assert(err, IsNil)
 	testDatumToBool(c, t, 1)
 
@@ -145,9 +145,7 @@ func (ts *testTypeConvertSuite) TestToInt64(c *C) {
 	testDatumToInt64(c, Set{Name: "a", Value: 1}, int64(1))
 	testDatumToInt64(c, json.CreateBinary(int64(3)), int64(3))
 
-	t, err := ParseTime(&stmtctx.StatementContext{
-		TimeZone: time.UTC,
-	}, "2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 0)
+	t, err := ParseTime(stmtctx.NewStatementContext(time.UTC), "2011-11-10 11:11:11.999999", mysql.TypeTimestamp, 0)
 	c.Assert(err, IsNil)
 	testDatumToInt64(c, t, int64(20111110111112))
 
@@ -194,7 +192,7 @@ func (ts *testTypeConvertSuite) TestToFloat32(c *C) {
 
 // mustParseTimeIntoDatum is similar to ParseTime but panic if any error occurs.
 func mustParseTimeIntoDatum(s string, tp byte, fsp int) (d Datum) {
-	t, err := ParseTime(&stmtctx.StatementContext{TimeZone: time.UTC}, s, tp, fsp)
+	t, err := ParseTime(stmtctx.NewStatementContext(time.UTC), s, tp, fsp)
 	if err != nil {
 		panic("ParseTime fail")
 	}
@@ -385,7 +383,7 @@ func mustParseDurationDatum(str string, fsp int) Datum {
 }
 
 func (ts *testDatumSuite) TestCoerceArithmetic(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		input  Datum
 		expect Datum
@@ -416,7 +414,7 @@ func (ts *testDatumSuite) TestCoerceArithmetic(c *C) {
 }
 
 func (ts *testDatumSuite) TestComputePlusAndMinus(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		a      Datum
 		b      Datum
@@ -450,7 +448,7 @@ func (ts *testDatumSuite) TestComputePlusAndMinus(c *C) {
 }
 
 func (ts *testDatumSuite) TestComputeMul(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		a      Datum
 		b      Datum
@@ -477,7 +475,7 @@ func (ts *testDatumSuite) TestComputeMul(c *C) {
 }
 
 func (ts *testDatumSuite) TestComputeDiv(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		a      Datum
 		b      Datum
@@ -506,7 +504,7 @@ func (ts *testDatumSuite) TestComputeDiv(c *C) {
 }
 
 func (ts *testDatumSuite) TestComputeMod(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		a      Datum
 		b      Datum
@@ -540,7 +538,7 @@ func (ts *testDatumSuite) TestComputeMod(c *C) {
 }
 
 func (ts *testDatumSuite) TestComputeIntDiv(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := stmtctx.NewStatementContext(time.UTC)
 	tests := []struct {
 		a      Datum
 		b      Datum

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -657,7 +657,7 @@ func (s *testTimeSuite) TestRoundFrac(c *C) {
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	sc.TimeZone = time.UTC
-	sc.FetchChunkSize = stmtctx.DefaultFetchChunkSize
+	sc.FetchChunkSize = stmtctx.DefFetchChunkSize
 	defer testleak.AfterTest(c)()
 	tbl := []struct {
 		Input  string
@@ -741,7 +741,7 @@ func (s *testTimeSuite) TestConvert(c *C) {
 
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.TimeZone = time.UTC
-	sc.FetchChunkSize = stmtctx.DefaultFetchChunkSize
+	sc.FetchChunkSize = stmtctx.DefFetchChunkSize
 	for _, t := range tblDuration {
 		v, err := types.ParseDuration(t.Input, t.Fsp)
 		c.Assert(err, IsNil)

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -260,7 +260,7 @@ func (s *testSuite) TestScan(c *C) {
 	idxRow1 := &RecordData{Handle: int64(1), Values: types.MakeDatums(int64(10))}
 	idxRow2 := &RecordData{Handle: int64(2), Values: types.MakeDatums(int64(20))}
 	kvIndex := tables.NewIndex(tb.Meta(), indices[0].Meta())
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	idxRows, nextVals, err := ScanIndexData(sc, txn, kvIndex, idxRow1.Values, 2)
 	c.Assert(err, IsNil)
 	c.Assert(idxRows, DeepEquals, []*RecordData{idxRow1, idxRow2})
@@ -347,7 +347,7 @@ func (s *testSuite) testTableData(c *C, tb table.Table, rs []*RecordData) {
 func (s *testSuite) testIndex(c *C, ctx sessionctx.Context, dbName string, tb table.Table, idx table.Index) {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	err = CompareIndexData(ctx, txn, tb, idx)
 	c.Assert(err, IsNil)
 
@@ -460,7 +460,7 @@ func (s *testSuite) testIndex(c *C, ctx sessionctx.Context, dbName string, tb ta
 func setColValue(c *C, txn kv.Transaction, key kv.Key, v types.Datum) {
 	row := []types.Datum{v, {}}
 	colIDs := []int64{2, 3}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	value, err := tablecodec.EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	err = txn.Set(key, value)

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -25,6 +25,14 @@ import (
 
 var _ types.Row = Row{}
 
+// VoidChunk is a void chunk.
+// just like `void` for programmer
+// it's mainly used in NoDelayExecutor for OLTP situation.
+var VoidChunk = &Chunk{
+	columns:        make([]*column, 0),
+	numVirtualRows: 0,
+}
+
 // Chunk stores multiple rows of data in Apache Arrow format.
 // See https://arrow.apache.org/docs/memory_layout.html
 // Values are appended in compact format and can be directly accessed without decoding.

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -79,7 +79,7 @@ func (s *testCodecSuite) TestCodecKey(c *C) {
 			types.MakeDatums(uint64(1), uint64(1)),
 		},
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for i, t := range table {
 		comment := Commentf("%d %v", i, t)
 		b, err := EncodeKey(sc, nil, t.Input...)
@@ -194,7 +194,7 @@ func (s *testCodecSuite) TestCodecKeyCompare(c *C) {
 			-1,
 		},
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for _, t := range table {
 		b1, err := EncodeKey(sc, nil, t.Left...)
 		c.Assert(err, IsNil)
@@ -525,7 +525,7 @@ func (s *testCodecSuite) TestTime(c *C) {
 		"2011-01-01 00:00:00",
 		"0001-01-01 00:00:00",
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for _, t := range tbl {
 		m := types.NewDatum(parseTime(c, t))
 
@@ -570,7 +570,7 @@ func (s *testCodecSuite) TestDuration(c *C) {
 		"00:00:00",
 		"1 11:11:11",
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for _, t := range tbl {
 		m := parseDuration(c, t)
 
@@ -624,7 +624,7 @@ func (s *testCodecSuite) TestDecimal(c *C) {
 		"-12.340",
 		"-0.1234",
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for _, t := range tbl {
 		dec := new(types.MyDecimal)
 		err := dec.FromString([]byte(t))
@@ -839,7 +839,7 @@ func (s *testCodecSuite) TestCut(c *C) {
 			types.MakeDatums(types.NewDecFromInt(0), types.NewDecFromFloatForTest(-1.3)),
 		},
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for i, t := range table {
 		comment := Commentf("%d %v", i, t)
 		b, err := EncodeKey(sc, nil, t.Input...)
@@ -873,7 +873,7 @@ func (s *testCodecSuite) TestCut(c *C) {
 }
 
 func (s *testCodecSuite) TestSetRawValues(c *C) {
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))
 	rowData, err := EncodeValue(sc, nil, datums...)
 	c.Assert(err, IsNil)
@@ -923,7 +923,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		{json.CreateBinary("abc"), types.NewFieldType(mysql.TypeJSON)},
 		{int64(1), types.NewFieldType(mysql.TypeYear)},
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 
 	datums := make([]types.Datum, 0, len(table))
 	tps := make([]*types.FieldType, 0, len(table))

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -581,7 +581,7 @@ func (w *Worker) flushToFile() {
 		return
 	}
 	defer terror.Call(outputFile.Close)
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	for _, row := range w.buf {
 		prevLen = len(outputByte)
 		outputByte = append(outputByte, w.head...)

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -494,7 +494,7 @@ func (s *testKvEncoderSuite) TestSimpleKeyEncode(c *C) {
 	handle := int64(1)
 	expectRecordKey := tablecodec.EncodeRecordKey(tablePrefix, handle)
 
-	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	sc := stmtctx.NewStatementContext(time.Local)
 	indexPrefix := tablecodec.EncodeTableIndexPrefix(tableID, indexID)
 	expectIdxKey := make([]byte, 0)
 	expectIdxKey = append(expectIdxKey, []byte(indexPrefix)...)

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -224,8 +224,8 @@ func NewContext() *Context {
 		cancel:      cancel,
 	}
 	sctx.sessionVars.MaxChunkSize = 2
+	sctx.sessionVars.DefaultFetchChunkSize = 2
 	sctx.sessionVars.StmtCtx.FetchChunkSize = 2
-	sctx.sessionVars.StmtCtx.DefaultFetchChunkSize = 2
 	sctx.sessionVars.StmtCtx.TimeZone = time.UTC
 	return sctx
 }

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -224,6 +224,8 @@ func NewContext() *Context {
 		cancel:      cancel,
 	}
 	sctx.sessionVars.MaxChunkSize = 2
+	sctx.sessionVars.StmtCtx.FetchChunkSize = 2
+	sctx.sessionVars.StmtCtx.DefaultFetchChunkSize = 2
 	sctx.sessionVars.StmtCtx.TimeZone = time.UTC
 	return sctx
 }


### PR DESCRIPTION
## What have you changed? (mandatory)

### Goal
- decrease OLTP chunk memory usage
- Be able to control one `next` call return result size.

but this pr does not realsolve:
- OLAP chunk usage chunk memory improve.

### what the changes:

There will be 2~3 commits in this pr

- [x]  remove `childrenResult` from `baseExecutor` and push down them to real implements if they real need children chunk. (first commit)
- [x]  remove `maxChunkSize` from `baseExecutor` and add `fetchChunkSize` in `stmtCtx` level to control chunk init capacity and max fetch rows. `maxChunkSize` in sessionVars still work to control max chunk size if `fetchChunkSize > maxChunkSize` (second commit)
- [x]  use plan result to determin `fetchChunkSize` for each stmts.
 
### why they are needed:
- not all executor that has children need allocate children chunk, so move them to real implements
- `maxChunkSize` in `baseExecutor` make us hard to control chunk cap/return-rows in stmt level, e.g. https://github.com/pingcap/tidb/pull/6648 will be more effective after this pr, and then we can control chunk memory in stmt level base on plan.

because stmtCtx struct initialization is in everywhere(special for test case), so 2nd commit modifies many files...

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

just refactor and regression test base on old unit/integration test.

## Does this PR affect documentation (docs/docs-cn) update? (optional)

Yes, we have add a new `tidb_default_fetch_chunk_size` session variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/6849)
<!-- Reviewable:end -->
