### PR TITLE
executor: start hash join inner/outer workers together

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -50,6 +50,7 @@ type HashJoinExec struct {
 	prepared        bool
 	concurrency     uint // concurrency is number of concurrent channels and join workers.
 	hashTable       *mvmap.MVMap
+	innerFinished   chan error
 	hashJoinBuffers []*hashJoinBuffer
 	workerWaitGroup sync.WaitGroup // workerWaitGroup is for sync multiple join workers.
 	finished        atomic.Value
@@ -196,6 +197,8 @@ func (e *HashJoinExec) fetchOuterChunks(ctx context.Context) {
 		}
 		e.workerWaitGroup.Done()
 	}()
+
+	hasWaitedForInner := false
 	for {
 		if e.finished.Load().(bool) {
 			return
@@ -218,11 +221,40 @@ func (e *HashJoinExec) fetchOuterChunks(ctx context.Context) {
 			}
 			return
 		}
+
+		if !hasWaitedForInner {
+			innerErr, jobFinished := e.wait4InnerOnce()
+			if jobFinished {
+				return
+			} else if innerErr != nil {
+				e.joinResultCh <- &hashjoinWorkerResult{
+					err: errors.Trace(err),
+				}
+				return
+			}
+			hasWaitedForInner = true
+		}
+
 		if outerResult.NumRows() == 0 {
 			return
 		}
 		outerResource.dest <- outerResult
 	}
+}
+
+func (e *HashJoinExec) wait4InnerOnce() (err error, finished bool) {
+	select {
+	case <-e.closeCh:
+		return nil, true
+	case err, _ := <-e.innerFinished:
+		if err != nil {
+			return errors.Trace(err), false
+		}
+	}
+	if e.hashTable.Len() == 0 && e.joinType == plan.InnerJoin {
+		return nil, true
+	}
+	return nil, false
 }
 
 // fetchInnerRows fetches all rows from inner executor,
@@ -276,9 +308,6 @@ func (e *HashJoinExec) initializeForProbe() {
 }
 
 func (e *HashJoinExec) fetchOuterAndProbeHashTable(ctx context.Context) {
-	if e.hashTable.Len() == 0 && e.joinType == plan.InnerJoin {
-		return
-	}
 	e.initializeForProbe()
 	e.workerWaitGroup.Add(1)
 	go e.fetchOuterChunks(ctx)
@@ -447,12 +476,8 @@ func (e *HashJoinExec) join2Chunk(workerID uint, outerChk *chunk.Chunk, joinResu
 // step 2. fetch data from outer child in a background goroutine and probe the hash table in multiple join workers.
 func (e *HashJoinExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 	if !e.prepared {
-		if err = e.fetchInnerRows(ctx); err != nil {
-			return errors.Trace(err)
-		}
-		if err = e.buildHashTableForList(); err != nil {
-			return errors.Trace(err)
-		}
+		e.innerFinished = make(chan error, 1)
+		go e.fetchInnerAndBuildHashTable(ctx)
 		e.fetchOuterAndProbeHashTable(ctx)
 		e.prepared = true
 	}
@@ -471,6 +496,29 @@ func (e *HashJoinExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 	chk.SwapColumns(result.chk)
 	result.src <- result.chk
 	return nil
+}
+
+func (e *HashJoinExec) fetchInnerAndBuildHashTable(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			buf := make([]byte, 4096)
+			stackSize := runtime.Stack(buf, false)
+			buf = buf[:stackSize]
+			log.Errorf("HashJoinExec.fetchInnerAndBuildHashTable paniced, stack is:\n%s", buf)
+			e.innerFinished <- errors.Errorf("%v", r)
+		}
+		close(e.innerFinished)
+	}()
+
+	if err := e.fetchInnerRows(ctx); err != nil {
+		e.innerFinished <- errors.Trace(err)
+		return
+	}
+
+	if err := e.buildHashTableForList(); err != nil {
+		e.innerFinished <- errors.Trace(err)
+		return
+	}
 }
 
 // buildHashTableForList builds hash table from `list`.


### PR DESCRIPTION
## What have you changed? (mandatory)

Before this PR, the execution flow of the hash join operator is:
1. fetch inner rows and build hash table based on the fetched inner rows
2. use a goroutine(`fetchOuterChunks()`) to fetch outer rows and dispatch the fetched outer rows to many hash join workers(`runJoinWorker()`), which also runs concurrently.

**NOTE**: step 2 is blocked by step 1, which means we can only get the first outer row once we have finished building the hash table based on the fetched inner rows. 

In fact we can start the inner and outer workers together, in this PR, the execution flow of `fetchOuterChunks()` is changed to:
- fetch the first batch of outer rows (stored in a `Chunk`) from the outer child
- blocked until we have finished building hash table based on the inner rows. **NOTE**: this wait and check operation should only take once.
- dispatch the fetched outer rows to the join workers, and continue fetching and dispatching outer rows.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

No

## Benchmark result if necessary (optional)

benchmarks will be provided later

