### PR TITLE
stats: Use feedback in time

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -694,6 +694,10 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			if !owner.IsOwner() {
 				continue
 			}
+			err = statsHandle.UpdateStatsByLocalFeedback(do.InfoSchema())
+			if err != nil {
+				log.Debug("[stats] update stats using local feedback fail: ", errors.ErrorStack(err))
+			}
 			err = statsHandle.HandleUpdateStats(do.InfoSchema())
 			if err != nil {
 				log.Debug("[stats] update stats using feedback fail: ", errors.ErrorStack(err))

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -63,6 +63,7 @@ func (h *Handle) Clear() {
 	h.statsCache.Store(statsCache{})
 	h.LastVersion = 0
 	h.PrevLastVersion = 0
+	h.feedback = h.feedback[:0]
 	for len(h.ddlEventCh) > 0 {
 		<-h.ddlEventCh
 	}


### PR DESCRIPTION
This PR update statistic tables by local feedback periodically. 
Currently, we dump the feedback with the period of 10 min, so it takes 10 min for an feedback to take effect.  However, we can use the feedback locally, so it could be used more timely.
PTAL @lamxTyler @coocood 