### PR TITLE
*: update errcheck rule

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1432,7 +1432,7 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
 
-	if err := checkPointTypeColumn(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
+	if err = checkPointTypeColumn(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,2 +1,3 @@
 fmt.Fprintf
 fmt.Fprint
+fmt.Sscanf

--- a/types/time.go
+++ b/types/time.go
@@ -645,8 +645,7 @@ func parseDatetime(str string, fsp int, isFloat bool) (Time, error) {
 				// 20170118.123423 => 2017-01-18 00:00:00
 			} else {
 				// '20170118.123423' => 2017-01-18 12:34:23.234
-				_, err1 := fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
-				terror.Log(err1)
+				fmt.Sscanf(fracStr, "%2d%2d%2d", &hour, &minute, &second)
 			}
 		}
 	case 3:


### PR DESCRIPTION
## What have you changed? (mandatory)

In https://github.com/pingcap/tidb/pull/6574 we log Sscanf error to pass the `errcheck` rule, but it print some unnecessary log like this:

	2018/06/21 17:24:16.927 terror.go:342: [error] EOF

This commit change the errcheck rule: ignore error check for Sscanf.

Fix issue https://github.com/pingcap/tidb/issues/6875

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tidb/issues/6875
https://github.com/pingcap/tidb/pull/6574

PTAL @coocood  @jackysp 