### PR TITLE
plan: draw relation bewteen operators with indent

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -104,70 +104,70 @@ CREATE TABLE `rr` (
 PRIMARY KEY (`aid`,`dic`)
 );
 explain SELECT `ds`, `p1`, `p2`, `p3`, `p4`, `p5`, `p6_md5`, `p7_md5`, count(dic) as install_device FROM `dt` use index (cmi) WHERE (`ds` >= '2016-09-01') AND (`ds` <= '2016-11-03') AND (`cm` IN ('1062', '1086', '1423', '1424', '1425', '1426', '1427', '1428', '1429', '1430', '1431', '1432', '1433', '1434', '1435', '1436', '1437', '1438', '1439', '1440', '1441', '1442', '1443', '1444', '1445', '1446', '1447', '1448', '1449', '1450', '1451', '1452', '1488', '1489', '1490', '1491', '1492', '1493', '1494', '1495', '1496', '1497', '1550', '1551', '1552', '1553', '1554', '1555', '1556', '1557', '1558', '1559', '1597', '1598', '1599', '1600', '1601', '1602', '1603', '1604', '1605', '1606', '1607', '1608', '1609', '1610', '1611', '1612', '1613', '1614', '1615', '1616', '1623', '1624', '1625', '1626', '1627', '1628', '1629', '1630', '1631', '1632', '1709', '1719', '1720', '1843', '2813', '2814', '2815', '2816', '2817', '2818', '2819', '2820', '2821', '2822', '2823', '2824', '2825', '2826', '2827', '2828', '2829', '2830', '2831', '2832', '2833', '2834', '2835', '2836', '2837', '2838', '2839', '2840', '2841', '2842', '2843', '2844', '2845', '2846', '2847', '2848', '2849', '2850', '2851', '2852', '2853', '2854', '2855', '2856', '2857', '2858', '2859', '2860', '2861', '2862', '2863', '2864', '2865', '2866', '2867', '2868', '2869', '2870', '2871', '2872', '3139', '3140', '3141', '3142', '3143', '3144', '3145', '3146', '3147', '3148', '3149', '3150', '3151', '3152', '3153', '3154', '3155', '3156', '3157', '3158', '3386', '3387', '3388', '3389', '3390', '3391', '3392', '3393', '3394', '3395', '3664', '3665', '3666', '3667', '3668', '3670', '3671', '3672', '3673', '3674', '3676', '3677', '3678', '3679', '3680', '3681', '3682', '3683', '3684', '3685', '3686', '3687', '3688', '3689', '3690', '3691', '3692', '3693', '3694', '3695', '3696', '3697', '3698', '3699', '3700', '3701', '3702', '3703', '3704', '3705', '3706', '3707', '3708', '3709', '3710', '3711', '3712', '3713', '3714', '3715', '3960', '3961', '3962', '3963', '3964', '3965', '3966', '3967', '3968', '3978', '3979', '3980', '3981', '3982', '3983', '3984', '3985', '3986', '3987', '4208', '4209', '4210', '4211', '4212', '4304', '4305', '4306', '4307', '4308', '4866', '4867', '4868', '4869', '4870', '4871', '4872', '4873', '4874', '4875')) GROUP BY `ds`, `p1`, `p2`, `p3`, `p4`, `p5`, `p6_md5`, `p7_md5` ORDER BY `ds2` DESC;
-id	parents	children	task	operator info	count
-IndexScan_14			cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	2650.00
-TableScan_15	Selection_16		cop	table:dt, keep order:false	2650.00
-Selection_16	HashAgg_11	TableScan_15	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	66.25
-HashAgg_11		Selection_16	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	53.00
-IndexLookUp_18	HashAgg_17		root	index:IndexScan_14, table:HashAgg_11	53.00
-HashAgg_17	Sort_8	IndexLookUp_18	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	53.00
-Sort_8	Projection_7	HashAgg_17	root	test.dt.ds2:desc	53.00
-Projection_7		Sort_8	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	53.00
+id	task	operator info	count
+Projection_7	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	53.00
+  Sort_8	root	test.dt.ds2:desc	53.00
+    HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	53.00
+      IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	53.00
+        IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	2650.00
+        HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	53.00
+          Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	66.25
+            TableScan_15	cop	table:dt, keep order:false	2650.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.bm = 0 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
-id	parents	children	task	operator info	count
-IndexScan_29			cop	table:gad, index:t, range:(1478143908,+inf], keep order:false	3333.33
-TableScan_30	Selection_31		cop	table:st, keep order:false	3333.33
-Selection_31		TableScan_30	cop	eq(gad.bm, 0), eq(gad.pt, android)	0.00
-IndexLookUp_32	IndexJoin_23		root	index:IndexScan_29, table:Selection_31	0.00
-IndexScan_19			cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-TableScan_20	Selection_21		cop	table:dd, keep order:false	10000.00
-Selection_21		TableScan_20	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	0.00
-IndexLookUp_22	IndexJoin_23		root	index:IndexScan_19, table:Selection_21	0.00
-IndexJoin_23	HashAgg_18	IndexLookUp_32,IndexLookUp_22	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	0.00
-HashAgg_18	Limit_15	IndexJoin_23	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	1.00
-Limit_15	Projection_12	HashAgg_18	root	offset:0, count:2500	1.00
-Projection_12		Limit_15	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	1.00
+id	task	operator info	count
+Projection_12	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	1.00
+  Limit_15	root	offset:0, count:2500	1.00
+    HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	1.00
+      IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	0.00
+        IndexLookUp_32	root	index:IndexScan_29, table:Selection_31	0.00
+          IndexScan_29	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false	3333.33
+          Selection_31	cop	eq(gad.bm, 0), eq(gad.pt, android)	0.00
+            TableScan_30	cop	table:st, keep order:false	3333.33
+        IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	0.00
+          IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+          Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	0.00
+            TableScan_20	cop	table:dd, keep order:false	10000.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
-id	parents	children	task	operator info	count
-IndexScan_23			cop	table:gad, index:t, range:(1477971479,+inf], keep order:false	3333.33
-TableScan_24	Selection_25		cop	table:st, keep order:false	3333.33
-Selection_25		TableScan_24	cop	eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	0.00
-IndexLookUp_26	IndexJoin_17		root	index:IndexScan_23, table:Selection_25	0.00
-IndexScan_13			cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-TableScan_14	Selection_15		cop	table:dd, keep order:false	10000.00
-Selection_15		TableScan_14	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	0.00
-IndexLookUp_16	IndexJoin_17		root	index:IndexScan_13, table:Selection_15	0.00
-IndexJoin_17	Limit_12	IndexLookUp_26,IndexLookUp_16	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	0.00
-Limit_12	Projection_9	IndexJoin_17	root	offset:0, count:3000	0.00
-Projection_9		Limit_12	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	0.00
+id	task	operator info	count
+Projection_9	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	0.00
+  Limit_12	root	offset:0, count:3000	0.00
+    IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	0.00
+      IndexLookUp_26	root	index:IndexScan_23, table:Selection_25	0.00
+        IndexScan_23	cop	table:gad, index:t, range:(1477971479,+inf], keep order:false	3333.33
+        Selection_25	cop	eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	0.00
+          TableScan_24	cop	table:st, keep order:false	3333.33
+      IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
+        IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+        Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	0.00
+          TableScan_14	cop	table:dd, keep order:false	10000.00
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
-id	parents	children	task	operator info	count
-IndexScan_13			cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	250.00
-TableScan_14	Selection_15		cop	table:st, keep order:false	250.00
-Selection_15		TableScan_14	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	0.00
-IndexLookUp_16	HashAgg_7		root	index:IndexScan_13, table:Selection_15	0.00
-HashAgg_7	Projection_5	IndexLookUp_16	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	1.00
-Projection_5		HashAgg_7	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	1.00
+id	task	operator info	count
+Projection_5	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	1.00
+  HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	1.00
+    IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
+      IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	250.00
+      Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	0.00
+        TableScan_14	cop	table:st, keep order:false	250.00
 explain select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as cm, rr.gid as gid, rr.acd as acd, rr.t as t,dt.p1 as p1, dt.p2 as p2, dt.p3 as p3, dt.p4 as p4, dt.p5 as p5, dt.p6_md5 as p6, dt.p7_md5 as p7 from dt dt join rr rr on (rr.pt = 'ios' and rr.t > 1478185592 and dt.aid = rr.aid and dt.dic = rr.dic) where dt.pt = 'ios' and dt.t > 1478185592 and dt.bm = 0 limit 2000;
-id	parents	children	task	operator info	count
-TableScan_40	Selection_41		cop	table:dt, range:[0,+inf], keep order:false	10000.00
-Selection_41		TableScan_40	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	0.00
-TableReader_42	IndexJoin_18		root	data:Selection_41	0.00
-IndexScan_14			cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-TableScan_15	Selection_16		cop	table:rr, keep order:false	10000.00
-Selection_16		TableScan_15	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	3.33
-IndexLookUp_17	IndexJoin_18		root	index:IndexScan_14, table:Selection_16	3.33
-IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
-Limit_12	Projection_9	IndexJoin_18	root	offset:0, count:2000	0.00
-Projection_9		Limit_12	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	0.00
+id	task	operator info	count
+Projection_9	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	0.00
+  Limit_12	root	offset:0, count:2000	0.00
+    IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
+      TableReader_42	root	data:Selection_41	0.00
+        Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	0.00
+          TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	10000.00
+      IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	3.33
+        IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+        Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	3.33
+          TableScan_15	cop	table:rr, keep order:false	10000.00
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
-id	parents	children	task	operator info	count
-IndexScan_25			cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false	0.40
-TableScan_26	Selection_27		cop	table:pp, keep order:false	0.40
-Selection_27		TableScan_26	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)	0.00
-IndexLookUp_28	HashAgg_7		root	index:IndexScan_25, table:Selection_27	0.00
-HashAgg_7	Projection_5	IndexLookUp_28	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	1.00
-Projection_5		HashAgg_7	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	1.00
+id	task	operator info	count
+Projection_5	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	1.00
+  HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	1.00
+    IndexLookUp_28	root	index:IndexScan_25, table:Selection_27	0.00
+      IndexScan_25	cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false	0.40
+      Selection_27	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)	0.00
+        TableScan_26	cop	table:pp, keep order:false	0.40
 CREATE TABLE `tbl_001` (`a` int, `b` int);
 CREATE TABLE `tbl_002` (`a` int, `b` int);
 CREATE TABLE `tbl_003` (`a` int, `b` int);
@@ -178,24 +178,24 @@ CREATE TABLE `tbl_007` (`a` int, `b` int);
 CREATE TABLE `tbl_008` (`a` int, `b` int);
 CREATE TABLE `tbl_009` (`a` int, `b` int);
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
-id	parents	children	task	operator info	count
-TableScan_28			cop	table:tbl_001, range:[-inf,+inf], keep order:false	10000.00
-TableReader_29	Union_26		root	data:TableScan_28	10000.00
-TableScan_31			cop	table:tbl_002, range:[-inf,+inf], keep order:false	10000.00
-TableReader_32	Union_26		root	data:TableScan_31	10000.00
-TableScan_34			cop	table:tbl_003, range:[-inf,+inf], keep order:false	10000.00
-TableReader_35	Union_26		root	data:TableScan_34	10000.00
-TableScan_37			cop	table:tbl_004, range:[-inf,+inf], keep order:false	10000.00
-TableReader_38	Union_26		root	data:TableScan_37	10000.00
-TableScan_40			cop	table:tbl_005, range:[-inf,+inf], keep order:false	10000.00
-TableReader_41	Union_26		root	data:TableScan_40	10000.00
-TableScan_43			cop	table:tbl_006, range:[-inf,+inf], keep order:false	10000.00
-TableReader_44	Union_26		root	data:TableScan_43	10000.00
-TableScan_46			cop	table:tbl_007, range:[-inf,+inf], keep order:false	10000.00
-TableReader_47	Union_26		root	data:TableScan_46	10000.00
-TableScan_49			cop	table:tbl_008, range:[-inf,+inf], keep order:false	10000.00
-TableReader_50	Union_26		root	data:TableScan_49	10000.00
-TableScan_52			cop	table:tbl_009, range:[-inf,+inf], keep order:false	10000.00
-TableReader_53	Union_26		root	data:TableScan_52	10000.00
-Union_26	HashAgg_25	TableReader_29,TableReader_32,TableReader_35,TableReader_38,TableReader_41,TableReader_44,TableReader_47,TableReader_50,TableReader_53	root		90000.00
-HashAgg_25		Union_26	root	group by:x.b, funcs:sum(x.a)	72000.00
+id	task	operator info	count
+HashAgg_25	root	group by:x.b, funcs:sum(x.a)	72000.00
+  Union_26	root		90000.00
+    TableReader_29	root	data:TableScan_28	10000.00
+      TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_32	root	data:TableScan_31	10000.00
+      TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_35	root	data:TableScan_34	10000.00
+      TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_38	root	data:TableScan_37	10000.00
+      TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_41	root	data:TableScan_40	10000.00
+      TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_44	root	data:TableScan_43	10000.00
+      TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_47	root	data:TableScan_46	10000.00
+      TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_50	root	data:TableScan_49	10000.00
+      TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_53	root	data:TableScan_52	10000.00
+      TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	10000.00

--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -106,68 +106,68 @@ PRIMARY KEY (`aid`,`dic`)
 explain SELECT `ds`, `p1`, `p2`, `p3`, `p4`, `p5`, `p6_md5`, `p7_md5`, count(dic) as install_device FROM `dt` use index (cmi) WHERE (`ds` >= '2016-09-01') AND (`ds` <= '2016-11-03') AND (`cm` IN ('1062', '1086', '1423', '1424', '1425', '1426', '1427', '1428', '1429', '1430', '1431', '1432', '1433', '1434', '1435', '1436', '1437', '1438', '1439', '1440', '1441', '1442', '1443', '1444', '1445', '1446', '1447', '1448', '1449', '1450', '1451', '1452', '1488', '1489', '1490', '1491', '1492', '1493', '1494', '1495', '1496', '1497', '1550', '1551', '1552', '1553', '1554', '1555', '1556', '1557', '1558', '1559', '1597', '1598', '1599', '1600', '1601', '1602', '1603', '1604', '1605', '1606', '1607', '1608', '1609', '1610', '1611', '1612', '1613', '1614', '1615', '1616', '1623', '1624', '1625', '1626', '1627', '1628', '1629', '1630', '1631', '1632', '1709', '1719', '1720', '1843', '2813', '2814', '2815', '2816', '2817', '2818', '2819', '2820', '2821', '2822', '2823', '2824', '2825', '2826', '2827', '2828', '2829', '2830', '2831', '2832', '2833', '2834', '2835', '2836', '2837', '2838', '2839', '2840', '2841', '2842', '2843', '2844', '2845', '2846', '2847', '2848', '2849', '2850', '2851', '2852', '2853', '2854', '2855', '2856', '2857', '2858', '2859', '2860', '2861', '2862', '2863', '2864', '2865', '2866', '2867', '2868', '2869', '2870', '2871', '2872', '3139', '3140', '3141', '3142', '3143', '3144', '3145', '3146', '3147', '3148', '3149', '3150', '3151', '3152', '3153', '3154', '3155', '3156', '3157', '3158', '3386', '3387', '3388', '3389', '3390', '3391', '3392', '3393', '3394', '3395', '3664', '3665', '3666', '3667', '3668', '3670', '3671', '3672', '3673', '3674', '3676', '3677', '3678', '3679', '3680', '3681', '3682', '3683', '3684', '3685', '3686', '3687', '3688', '3689', '3690', '3691', '3692', '3693', '3694', '3695', '3696', '3697', '3698', '3699', '3700', '3701', '3702', '3703', '3704', '3705', '3706', '3707', '3708', '3709', '3710', '3711', '3712', '3713', '3714', '3715', '3960', '3961', '3962', '3963', '3964', '3965', '3966', '3967', '3968', '3978', '3979', '3980', '3981', '3982', '3983', '3984', '3985', '3986', '3987', '4208', '4209', '4210', '4211', '4212', '4304', '4305', '4306', '4307', '4308', '4866', '4867', '4868', '4869', '4870', '4871', '4872', '4873', '4874', '4875')) GROUP BY `ds`, `p1`, `p2`, `p3`, `p4`, `p5`, `p6_md5`, `p7_md5` ORDER BY `ds2` DESC;
 id	task	operator info	count
 Projection_7	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	53.00
-  Sort_8	root	test.dt.ds2:desc	53.00
-    HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	53.00
-      IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	53.00
-        IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	2650.00
-        HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	53.00
-          Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	66.25
-            TableScan_15	cop	table:dt, keep order:false	2650.00
+└─Sort_8	root	test.dt.ds2:desc	53.00
+  └─HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	53.00
+    └─IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	53.00
+      ├─IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	2650.00
+      └─HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	53.00
+        └─Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	66.25
+          └─TableScan_15	cop	table:dt, keep order:false	2650.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.bm = 0 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
 id	task	operator info	count
 Projection_12	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	1.00
-  Limit_15	root	offset:0, count:2500	1.00
-    HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	1.00
-      IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	0.00
-        IndexLookUp_32	root	index:IndexScan_29, table:Selection_31	0.00
-          IndexScan_29	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false	3333.33
-          Selection_31	cop	eq(gad.bm, 0), eq(gad.pt, android)	0.00
-            TableScan_30	cop	table:st, keep order:false	3333.33
-        IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	0.00
-          IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-          Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	0.00
-            TableScan_20	cop	table:dd, keep order:false	10000.00
+└─Limit_15	root	offset:0, count:2500	1.00
+  └─HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	1.00
+    └─IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	0.00
+      ├─IndexLookUp_32	root	index:IndexScan_29, table:Selection_31	0.00
+      │ ├─IndexScan_29	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false	3333.33
+      │ └─Selection_31	cop	eq(gad.bm, 0), eq(gad.pt, android)	0.00
+      │   └─TableScan_30	cop	table:st, keep order:false	3333.33
+      └─IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	0.00
+        ├─IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+        └─Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	0.00
+          └─TableScan_20	cop	table:dd, keep order:false	10000.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	task	operator info	count
 Projection_9	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	0.00
-  Limit_12	root	offset:0, count:3000	0.00
-    IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	0.00
-      IndexLookUp_26	root	index:IndexScan_23, table:Selection_25	0.00
-        IndexScan_23	cop	table:gad, index:t, range:(1477971479,+inf], keep order:false	3333.33
-        Selection_25	cop	eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	0.00
-          TableScan_24	cop	table:st, keep order:false	3333.33
-      IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
-        IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-        Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	0.00
-          TableScan_14	cop	table:dd, keep order:false	10000.00
+└─Limit_12	root	offset:0, count:3000	0.00
+  └─IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	0.00
+    ├─IndexLookUp_26	root	index:IndexScan_23, table:Selection_25	0.00
+    │ ├─IndexScan_23	cop	table:gad, index:t, range:(1477971479,+inf], keep order:false	3333.33
+    │ └─Selection_25	cop	eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	0.00
+    │   └─TableScan_24	cop	table:st, keep order:false	3333.33
+    └─IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
+      ├─IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+      └─Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	0.00
+        └─TableScan_14	cop	table:dd, keep order:false	10000.00
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	task	operator info	count
 Projection_5	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	1.00
-  HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	1.00
-    IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
-      IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	250.00
-      Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	0.00
-        TableScan_14	cop	table:st, keep order:false	250.00
+└─HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	1.00
+  └─IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	0.00
+    ├─IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	250.00
+    └─Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	0.00
+      └─TableScan_14	cop	table:st, keep order:false	250.00
 explain select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as cm, rr.gid as gid, rr.acd as acd, rr.t as t,dt.p1 as p1, dt.p2 as p2, dt.p3 as p3, dt.p4 as p4, dt.p5 as p5, dt.p6_md5 as p6, dt.p7_md5 as p7 from dt dt join rr rr on (rr.pt = 'ios' and rr.t > 1478185592 and dt.aid = rr.aid and dt.dic = rr.dic) where dt.pt = 'ios' and dt.t > 1478185592 and dt.bm = 0 limit 2000;
 id	task	operator info	count
 Projection_9	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	0.00
-  Limit_12	root	offset:0, count:2000	0.00
-    IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
-      TableReader_42	root	data:Selection_41	0.00
-        Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	0.00
-          TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	10000.00
-      IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	3.33
-        IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
-        Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	3.33
-          TableScan_15	cop	table:rr, keep order:false	10000.00
+└─Limit_12	root	offset:0, count:2000	0.00
+  └─IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	0.00
+    ├─TableReader_42	root	data:Selection_41	0.00
+    │ └─Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	0.00
+    │   └─TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	10000.00
+    └─IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	3.33
+      ├─IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	10000.00
+      └─Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	3.33
+        └─TableScan_15	cop	table:rr, keep order:false	10000.00
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	task	operator info	count
 Projection_5	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	1.00
-  HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	1.00
-    IndexLookUp_28	root	index:IndexScan_25, table:Selection_27	0.00
-      IndexScan_25	cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false	0.40
-      Selection_27	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)	0.00
-        TableScan_26	cop	table:pp, keep order:false	0.40
+└─HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	1.00
+  └─IndexLookUp_28	root	index:IndexScan_25, table:Selection_27	0.00
+    ├─IndexScan_25	cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false	0.40
+    └─Selection_27	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)	0.00
+      └─TableScan_26	cop	table:pp, keep order:false	0.40
 CREATE TABLE `tbl_001` (`a` int, `b` int);
 CREATE TABLE `tbl_002` (`a` int, `b` int);
 CREATE TABLE `tbl_003` (`a` int, `b` int);
@@ -180,22 +180,22 @@ CREATE TABLE `tbl_009` (`a` int, `b` int);
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	task	operator info	count
 HashAgg_25	root	group by:x.b, funcs:sum(x.a)	72000.00
-  Union_26	root		90000.00
-    TableReader_29	root	data:TableScan_28	10000.00
-      TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_32	root	data:TableScan_31	10000.00
-      TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_35	root	data:TableScan_34	10000.00
-      TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_38	root	data:TableScan_37	10000.00
-      TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_41	root	data:TableScan_40	10000.00
-      TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_44	root	data:TableScan_43	10000.00
-      TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_47	root	data:TableScan_46	10000.00
-      TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_50	root	data:TableScan_49	10000.00
-      TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_53	root	data:TableScan_52	10000.00
-      TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	10000.00
+└─Union_26	root		90000.00
+  ├─TableReader_29	root	data:TableScan_28	10000.00
+  │ └─TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_32	root	data:TableScan_31	10000.00
+  │ └─TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_35	root	data:TableScan_34	10000.00
+  │ └─TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_38	root	data:TableScan_37	10000.00
+  │ └─TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_41	root	data:TableScan_40	10000.00
+  │ └─TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_44	root	data:TableScan_43	10000.00
+  │ └─TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_47	root	data:TableScan_46	10000.00
+  │ └─TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	10000.00
+  ├─TableReader_50	root	data:TableScan_49	10000.00
+  │ └─TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	10000.00
+  └─TableReader_53	root	data:TableScan_52	10000.00
+    └─TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	10000.00

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -114,68 +114,68 @@ PRIMARY KEY (aid,dic)
 );
 load stats 's/explain_complex_stats_rr.json';
 explain SELECT ds, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(dic) as install_device FROM dt use index (cm) WHERE (ds >= '2016-09-01') AND (ds <= '2016-11-03') AND (cm IN ('1062', '1086', '1423', '1424', '1425', '1426', '1427', '1428', '1429', '1430', '1431', '1432', '1433', '1434', '1435', '1436', '1437', '1438', '1439', '1440', '1441', '1442', '1443', '1444', '1445', '1446', '1447', '1448', '1449', '1450', '1451', '1452', '1488', '1489', '1490', '1491', '1492', '1493', '1494', '1495', '1496', '1497', '1550', '1551', '1552', '1553', '1554', '1555', '1556', '1557', '1558', '1559', '1597', '1598', '1599', '1600', '1601', '1602', '1603', '1604', '1605', '1606', '1607', '1608', '1609', '1610', '1611', '1612', '1613', '1614', '1615', '1616', '1623', '1624', '1625', '1626', '1627', '1628', '1629', '1630', '1631', '1632', '1709', '1719', '1720', '1843', '2813', '2814', '2815', '2816', '2817', '2818', '2819', '2820', '2821', '2822', '2823', '2824', '2825', '2826', '2827', '2828', '2829', '2830', '2831', '2832', '2833', '2834', '2835', '2836', '2837', '2838', '2839', '2840', '2841', '2842', '2843', '2844', '2845', '2846', '2847', '2848', '2849', '2850', '2851', '2852', '2853', '2854', '2855', '2856', '2857', '2858', '2859', '2860', '2861', '2862', '2863', '2864', '2865', '2866', '2867', '2868', '2869', '2870', '2871', '2872', '3139', '3140', '3141', '3142', '3143', '3144', '3145', '3146', '3147', '3148', '3149', '3150', '3151', '3152', '3153', '3154', '3155', '3156', '3157', '3158', '3386', '3387', '3388', '3389', '3390', '3391', '3392', '3393', '3394', '3395', '3664', '3665', '3666', '3667', '3668', '3670', '3671', '3672', '3673', '3674', '3676', '3677', '3678', '3679', '3680', '3681', '3682', '3683', '3684', '3685', '3686', '3687', '3688', '3689', '3690', '3691', '3692', '3693', '3694', '3695', '3696', '3697', '3698', '3699', '3700', '3701', '3702', '3703', '3704', '3705', '3706', '3707', '3708', '3709', '3710', '3711', '3712', '3713', '3714', '3715', '3960', '3961', '3962', '3963', '3964', '3965', '3966', '3967', '3968', '3978', '3979', '3980', '3981', '3982', '3983', '3984', '3985', '3986', '3987', '4208', '4209', '4210', '4211', '4212', '4304', '4305', '4306', '4307', '4308', '4866', '4867', '4868', '4869', '4870', '4871', '4872', '4873', '4874', '4875')) GROUP BY ds, p1, p2, p3, p4, p5, p6_md5, p7_md5 ORDER BY ds2 DESC;
-id	parents	children	task	operator info	count
-IndexScan_14			cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	128.32
-TableScan_15	Selection_16		cop	table:dt, keep order:false	128.32
-Selection_16	HashAgg_11	TableScan_15	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	21.43
-HashAgg_11		Selection_16	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	21.40
-IndexLookUp_18	HashAgg_17		root	index:IndexScan_14, table:HashAgg_11	21.40
-HashAgg_17	Sort_8	IndexLookUp_18	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	21.40
-Sort_8	Projection_7	HashAgg_17	root	test.dt.ds2:desc	21.40
-Projection_7		Sort_8	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	21.40
+id	task	operator info	count
+Projection_7	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	21.40
+  Sort_8	root	test.dt.ds2:desc	21.40
+    HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	21.40
+      IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	21.40
+        IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	128.32
+        HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	21.40
+          Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	21.43
+            TableScan_15	cop	table:dt, keep order:false	128.32
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.bm = 0 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
-id	parents	children	task	operator info	count
-TableScan_26	Selection_27		cop	table:gad, range:[0,+inf], keep order:false	1999.00
-Selection_27		TableScan_26	cop	gt(gad.t, 1478143908), eq(gad.bm, 0), eq(gad.pt, android)	424.00
-TableReader_28	IndexJoin_23		root	data:Selection_27	424.00
-IndexScan_19			cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-TableScan_20	Selection_21		cop	table:dd, keep order:false	2000.00
-Selection_21		TableScan_20	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	455.80
-IndexLookUp_22	IndexJoin_23		root	index:IndexScan_19, table:Selection_21	455.80
-IndexJoin_23	HashAgg_18	TableReader_28,IndexLookUp_22	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	424.00
-HashAgg_18	Limit_15	IndexJoin_23	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	424.00
-Limit_15	Projection_12	HashAgg_18	root	offset:0, count:2500	424.00
-Projection_12		Limit_15	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	424.00
+id	task	operator info	count
+Projection_12	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	424.00
+  Limit_15	root	offset:0, count:2500	424.00
+    HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	424.00
+      IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	424.00
+        TableReader_28	root	data:Selection_27	424.00
+          Selection_27	cop	gt(gad.t, 1478143908), eq(gad.bm, 0), eq(gad.pt, android)	424.00
+            TableScan_26	cop	table:gad, range:[0,+inf], keep order:false	1999.00
+        IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	455.80
+          IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+          Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	455.80
+            TableScan_20	cop	table:dd, keep order:false	2000.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
-id	parents	children	task	operator info	count
-TableScan_20	Selection_21		cop	table:gad, range:[0,+inf], keep order:false	1999.00
-Selection_21		TableScan_20	cop	gt(gad.t, 1477971479), eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	170.34
-TableReader_22	IndexJoin_17		root	data:Selection_21	170.34
-IndexScan_13			cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-TableScan_14	Selection_15		cop	table:dd, keep order:false	2000.00
-Selection_15		TableScan_14	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	509.04
-IndexLookUp_16	IndexJoin_17		root	index:IndexScan_13, table:Selection_15	509.04
-IndexJoin_17	Limit_12	TableReader_22,IndexLookUp_16	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	170.34
-Limit_12	Projection_9	IndexJoin_17	root	offset:0, count:3000	170.34
-Projection_9		Limit_12	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	170.34
+id	task	operator info	count
+Projection_9	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	170.34
+  Limit_12	root	offset:0, count:3000	170.34
+    IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	170.34
+      TableReader_22	root	data:Selection_21	170.34
+        Selection_21	cop	gt(gad.t, 1477971479), eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	170.34
+          TableScan_20	cop	table:gad, range:[0,+inf], keep order:false	1999.00
+      IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	509.04
+        IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+        Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	509.04
+          TableScan_14	cop	table:dd, keep order:false	2000.00
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
-id	parents	children	task	operator info	count
-IndexScan_13			cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	160.23
-TableScan_14	Selection_15		cop	table:st, keep order:false	160.23
-Selection_15		TableScan_14	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	39.38
-IndexLookUp_16	HashAgg_7		root	index:IndexScan_13, table:Selection_15	39.38
-HashAgg_7	Projection_5	IndexLookUp_16	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	39.28
-Projection_5		HashAgg_7	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	39.28
+id	task	operator info	count
+Projection_5	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	39.28
+  HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	39.28
+    IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	39.38
+      IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	160.23
+      Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	39.38
+        TableScan_14	cop	table:st, keep order:false	160.23
 explain select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as cm, rr.gid as gid, rr.acd as acd, rr.t as t,dt.p1 as p1, dt.p2 as p2, dt.p3 as p3, dt.p4 as p4, dt.p5 as p5, dt.p6_md5 as p6, dt.p7_md5 as p7 from dt dt join rr rr on (rr.pt = 'ios' and rr.t > 1478185592 and dt.aid = rr.aid and dt.dic = rr.dic) where dt.pt = 'ios' and dt.t > 1478185592 and dt.bm = 0 limit 2000;
-id	parents	children	task	operator info	count
-TableScan_40	Selection_41		cop	table:dt, range:[0,+inf], keep order:false	2000.00
-Selection_41		TableScan_40	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	428.32
-TableReader_42	IndexJoin_18		root	data:Selection_41	428.32
-IndexScan_14			cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-TableScan_15	Selection_16		cop	table:rr, keep order:false	2000.00
-Selection_16		TableScan_15	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	970.00
-IndexLookUp_17	IndexJoin_18		root	index:IndexScan_14, table:Selection_16	970.00
-IndexJoin_18	Limit_12	TableReader_42,IndexLookUp_17	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
-Limit_12	Projection_9	IndexJoin_18	root	offset:0, count:2000	428.32
-Projection_9		Limit_12	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	428.32
+id	task	operator info	count
+Projection_9	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	428.32
+  Limit_12	root	offset:0, count:2000	428.32
+    IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
+      TableReader_42	root	data:Selection_41	428.32
+        Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	428.32
+          TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	2000.00
+      IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	970.00
+        IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+        Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	970.00
+          TableScan_15	cop	table:rr, keep order:false	2000.00
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
-id	parents	children	task	operator info	count
-IndexScan_22			cop	table:pp, index:ps, range:[2,2], keep order:false	627.00
-TableScan_23	Selection_24		cop	table:pp, keep order:false	627.00
-Selection_24		TableScan_23	cop	ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780)	207.86
-IndexLookUp_28	HashAgg_7		root	index:IndexScan_22, table:Selection_24	207.86
-HashAgg_7	Projection_5	IndexLookUp_28	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	207.86
-Projection_5		HashAgg_7	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	207.86
+id	task	operator info	count
+Projection_5	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	207.86
+  HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	207.86
+    IndexLookUp_28	root	index:IndexScan_22, table:Selection_24	207.86
+      IndexScan_22	cop	table:pp, index:ps, range:[2,2], keep order:false	627.00
+      Selection_24	cop	ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780)	207.86
+        TableScan_23	cop	table:pp, keep order:false	627.00
 drop table if exists tbl_001;
 CREATE TABLE tbl_001 (a int, b int);
 load stats 's/explain_complex_stats_tbl_001.json';
@@ -204,24 +204,24 @@ drop table if exists tbl_009;
 CREATE TABLE tbl_009 (a int, b int);
 load stats 's/explain_complex_stats_tbl_009.json';
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
-id	parents	children	task	operator info	count
-TableScan_28			cop	table:tbl_001, range:[-inf,+inf], keep order:false	2000.00
-TableReader_29	Union_26		root	data:TableScan_28	2000.00
-TableScan_31			cop	table:tbl_002, range:[-inf,+inf], keep order:false	2000.00
-TableReader_32	Union_26		root	data:TableScan_31	2000.00
-TableScan_34			cop	table:tbl_003, range:[-inf,+inf], keep order:false	2000.00
-TableReader_35	Union_26		root	data:TableScan_34	2000.00
-TableScan_37			cop	table:tbl_004, range:[-inf,+inf], keep order:false	2000.00
-TableReader_38	Union_26		root	data:TableScan_37	2000.00
-TableScan_40			cop	table:tbl_005, range:[-inf,+inf], keep order:false	2000.00
-TableReader_41	Union_26		root	data:TableScan_40	2000.00
-TableScan_43			cop	table:tbl_006, range:[-inf,+inf], keep order:false	2000.00
-TableReader_44	Union_26		root	data:TableScan_43	2000.00
-TableScan_46			cop	table:tbl_007, range:[-inf,+inf], keep order:false	2000.00
-TableReader_47	Union_26		root	data:TableScan_46	2000.00
-TableScan_49			cop	table:tbl_008, range:[-inf,+inf], keep order:false	2000.00
-TableReader_50	Union_26		root	data:TableScan_49	2000.00
-TableScan_52			cop	table:tbl_009, range:[-inf,+inf], keep order:false	2000.00
-TableReader_53	Union_26		root	data:TableScan_52	2000.00
-Union_26	HashAgg_25	TableReader_29,TableReader_32,TableReader_35,TableReader_38,TableReader_41,TableReader_44,TableReader_47,TableReader_50,TableReader_53	root		18000.00
-HashAgg_25		Union_26	root	group by:x.b, funcs:sum(x.a)	18000.00
+id	task	operator info	count
+HashAgg_25	root	group by:x.b, funcs:sum(x.a)	18000.00
+  Union_26	root		18000.00
+    TableReader_29	root	data:TableScan_28	2000.00
+      TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_32	root	data:TableScan_31	2000.00
+      TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_35	root	data:TableScan_34	2000.00
+      TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_38	root	data:TableScan_37	2000.00
+      TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_41	root	data:TableScan_40	2000.00
+      TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_44	root	data:TableScan_43	2000.00
+      TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_47	root	data:TableScan_46	2000.00
+      TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_50	root	data:TableScan_49	2000.00
+      TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	2000.00
+    TableReader_53	root	data:TableScan_52	2000.00
+      TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	2000.00

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -116,66 +116,66 @@ load stats 's/explain_complex_stats_rr.json';
 explain SELECT ds, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(dic) as install_device FROM dt use index (cm) WHERE (ds >= '2016-09-01') AND (ds <= '2016-11-03') AND (cm IN ('1062', '1086', '1423', '1424', '1425', '1426', '1427', '1428', '1429', '1430', '1431', '1432', '1433', '1434', '1435', '1436', '1437', '1438', '1439', '1440', '1441', '1442', '1443', '1444', '1445', '1446', '1447', '1448', '1449', '1450', '1451', '1452', '1488', '1489', '1490', '1491', '1492', '1493', '1494', '1495', '1496', '1497', '1550', '1551', '1552', '1553', '1554', '1555', '1556', '1557', '1558', '1559', '1597', '1598', '1599', '1600', '1601', '1602', '1603', '1604', '1605', '1606', '1607', '1608', '1609', '1610', '1611', '1612', '1613', '1614', '1615', '1616', '1623', '1624', '1625', '1626', '1627', '1628', '1629', '1630', '1631', '1632', '1709', '1719', '1720', '1843', '2813', '2814', '2815', '2816', '2817', '2818', '2819', '2820', '2821', '2822', '2823', '2824', '2825', '2826', '2827', '2828', '2829', '2830', '2831', '2832', '2833', '2834', '2835', '2836', '2837', '2838', '2839', '2840', '2841', '2842', '2843', '2844', '2845', '2846', '2847', '2848', '2849', '2850', '2851', '2852', '2853', '2854', '2855', '2856', '2857', '2858', '2859', '2860', '2861', '2862', '2863', '2864', '2865', '2866', '2867', '2868', '2869', '2870', '2871', '2872', '3139', '3140', '3141', '3142', '3143', '3144', '3145', '3146', '3147', '3148', '3149', '3150', '3151', '3152', '3153', '3154', '3155', '3156', '3157', '3158', '3386', '3387', '3388', '3389', '3390', '3391', '3392', '3393', '3394', '3395', '3664', '3665', '3666', '3667', '3668', '3670', '3671', '3672', '3673', '3674', '3676', '3677', '3678', '3679', '3680', '3681', '3682', '3683', '3684', '3685', '3686', '3687', '3688', '3689', '3690', '3691', '3692', '3693', '3694', '3695', '3696', '3697', '3698', '3699', '3700', '3701', '3702', '3703', '3704', '3705', '3706', '3707', '3708', '3709', '3710', '3711', '3712', '3713', '3714', '3715', '3960', '3961', '3962', '3963', '3964', '3965', '3966', '3967', '3968', '3978', '3979', '3980', '3981', '3982', '3983', '3984', '3985', '3986', '3987', '4208', '4209', '4210', '4211', '4212', '4304', '4305', '4306', '4307', '4308', '4866', '4867', '4868', '4869', '4870', '4871', '4872', '4873', '4874', '4875')) GROUP BY ds, p1, p2, p3, p4, p5, p6_md5, p7_md5 ORDER BY ds2 DESC;
 id	task	operator info	count
 Projection_7	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device	21.40
-  Sort_8	root	test.dt.ds2:desc	21.40
-    HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	21.40
-      IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	21.40
-        IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	128.32
-        HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	21.40
-          Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	21.43
-            TableScan_15	cop	table:dt, keep order:false	128.32
+└─Sort_8	root	test.dt.ds2:desc	21.40
+  └─HashAgg_17	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7), firstrow(col_8), firstrow(col_9)	21.40
+    └─IndexLookUp_18	root	index:IndexScan_14, table:HashAgg_11	21.40
+      ├─IndexScan_14	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false	128.32
+      └─HashAgg_11	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds), firstrow(test.dt.ds2), firstrow(test.dt.p1), firstrow(test.dt.p2), firstrow(test.dt.p3), firstrow(test.dt.p4), firstrow(test.dt.p5), firstrow(test.dt.p6_md5), firstrow(test.dt.p7_md5)	21.40
+        └─Selection_16	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)	21.43
+          └─TableScan_15	cop	table:dt, keep order:false	128.32
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.bm = 0 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
 id	task	operator info	count
 Projection_12	root	gad.id, test.dd.id, gad.aid, gad.cm, test.dd.dic, test.dd.ip, test.dd.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext, gad.t	424.00
-  Limit_15	root	offset:0, count:2500	424.00
-    HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	424.00
-      IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	424.00
-        TableReader_28	root	data:Selection_27	424.00
-          Selection_27	cop	gt(gad.t, 1478143908), eq(gad.bm, 0), eq(gad.pt, android)	424.00
-            TableScan_26	cop	table:gad, range:[0,+inf], keep order:false	1999.00
-        IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	455.80
-          IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-          Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	455.80
-            TableScan_20	cop	table:dd, keep order:false	2000.00
+└─Limit_15	root	offset:0, count:2500	424.00
+  └─HashAgg_18	root	group by:gad.aid, test.dd.dic, funcs:firstrow(gad.id), firstrow(gad.aid), firstrow(gad.cm), firstrow(gad.p1), firstrow(gad.p2), firstrow(gad.p3), firstrow(gad.p4), firstrow(gad.p5), firstrow(gad.p6_md5), firstrow(gad.p7_md5), firstrow(gad.ext), firstrow(gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)	424.00
+    └─IndexJoin_23	root	inner join, inner:IndexLookUp_22, outer key:gad.aid, inner key:test.dd.aid, other cond:eq(gad.ip, test.dd.ip)	424.00
+      ├─TableReader_28	root	data:Selection_27	424.00
+      │ └─Selection_27	cop	gt(gad.t, 1478143908), eq(gad.bm, 0), eq(gad.pt, android)	424.00
+      │   └─TableScan_26	cop	table:gad, range:[0,+inf], keep order:false	1999.00
+      └─IndexLookUp_22	root	index:IndexScan_19, table:Selection_21	455.80
+        ├─IndexScan_19	cop	table:dd, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+        └─Selection_21	cop	eq(test.dd.pt, android), eq(test.dd.bm, 0), gt(test.dd.t, 1478143908)	455.80
+          └─TableScan_20	cop	table:dd, keep order:false	2000.00
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	task	operator info	count
 Projection_9	root	gad.id, sdk.id, gad.aid, gad.cm, sdk.dic, sdk.ip, sdk.t, gad.p1, gad.p2, gad.p3, gad.p4, gad.p5, gad.p6_md5, gad.p7_md5, gad.ext	170.34
-  Limit_12	root	offset:0, count:3000	170.34
-    IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	170.34
-      TableReader_22	root	data:Selection_21	170.34
-        Selection_21	cop	gt(gad.t, 1477971479), eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	170.34
-          TableScan_20	cop	table:gad, range:[0,+inf], keep order:false	1999.00
-      IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	509.04
-        IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-        Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	509.04
-          TableScan_14	cop	table:dd, keep order:false	2000.00
+└─Limit_12	root	offset:0, count:3000	170.34
+  └─IndexJoin_17	root	inner join, inner:IndexLookUp_16, outer key:gad.aid, inner key:sdk.aid, other cond:eq(gad.dic, sdk.mac)	170.34
+    ├─TableReader_22	root	data:Selection_21	170.34
+    │ └─Selection_21	cop	gt(gad.t, 1477971479), eq(gad.bm, 0), eq(gad.pt, ios), eq(gad.dit, mac)	170.34
+    │   └─TableScan_20	cop	table:gad, range:[0,+inf], keep order:false	1999.00
+    └─IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	509.04
+      ├─IndexScan_13	cop	table:sdk, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+      └─Selection_15	cop	gt(sdk.t, 1477971479), eq(sdk.bm, 0), eq(sdk.pt, ios)	509.04
+        └─TableScan_14	cop	table:dd, keep order:false	2000.00
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	task	operator info	count
 Projection_5	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1	39.28
-  HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	39.28
-    IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	39.38
-      IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	160.23
-      Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	39.38
-        TableScan_14	cop	table:st, keep order:false	160.23
+└─HashAgg_7	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)	39.28
+  └─IndexLookUp_16	root	index:IndexScan_13, table:Selection_15	39.38
+    ├─IndexScan_13	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false	160.23
+    └─Selection_15	cop	eq(test.st.aid, cn.sbkcq), eq(test.st.pt, android)	39.38
+      └─TableScan_14	cop	table:st, keep order:false	160.23
 explain select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as cm, rr.gid as gid, rr.acd as acd, rr.t as t,dt.p1 as p1, dt.p2 as p2, dt.p3 as p3, dt.p4 as p4, dt.p5 as p5, dt.p6_md5 as p6, dt.p7_md5 as p7 from dt dt join rr rr on (rr.pt = 'ios' and rr.t > 1478185592 and dt.aid = rr.aid and dt.dic = rr.dic) where dt.pt = 'ios' and dt.t > 1478185592 and dt.bm = 0 limit 2000;
 id	task	operator info	count
 Projection_9	root	dt.id, dt.aid, dt.pt, dt.dic, dt.cm, rr.gid, rr.acd, rr.t, dt.p1, dt.p2, dt.p3, dt.p4, dt.p5, dt.p6_md5, dt.p7_md5	428.32
-  Limit_12	root	offset:0, count:2000	428.32
-    IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
-      TableReader_42	root	data:Selection_41	428.32
-        Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	428.32
-          TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	2000.00
-      IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	970.00
-        IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
-        Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	970.00
-          TableScan_15	cop	table:rr, keep order:false	2000.00
+└─Limit_12	root	offset:0, count:2000	428.32
+  └─IndexJoin_18	root	inner join, inner:IndexLookUp_17, outer key:dt.aid, dt.dic, inner key:rr.aid, rr.dic	428.32
+    ├─TableReader_42	root	data:Selection_41	428.32
+    │ └─Selection_41	cop	eq(dt.pt, ios), gt(dt.t, 1478185592), eq(dt.bm, 0)	428.32
+    │   └─TableScan_40	cop	table:dt, range:[0,+inf], keep order:false	2000.00
+    └─IndexLookUp_17	root	index:IndexScan_14, table:Selection_16	970.00
+      ├─IndexScan_14	cop	table:rr, index:aid, dic, range:[<nil>,+inf], keep order:false	2000.00
+      └─Selection_16	cop	eq(rr.pt, ios), gt(rr.t, 1478185592)	970.00
+        └─TableScan_15	cop	table:rr, keep order:false	2000.00
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	task	operator info	count
 Projection_5	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2	207.86
-  HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	207.86
-    IndexLookUp_28	root	index:IndexScan_22, table:Selection_24	207.86
-      IndexScan_22	cop	table:pp, index:ps, range:[2,2], keep order:false	627.00
-      Selection_24	cop	ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780)	207.86
-        TableScan_23	cop	table:pp, keep order:false	627.00
+└─HashAgg_7	root	group by:test.pp.pc, test.pp.cr, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)	207.86
+  └─IndexLookUp_28	root	index:IndexScan_22, table:Selection_24	207.86
+    ├─IndexScan_22	cop	table:pp, index:ps, range:[2,2], keep order:false	627.00
+    └─Selection_24	cop	ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780)	207.86
+      └─TableScan_23	cop	table:pp, keep order:false	627.00
 drop table if exists tbl_001;
 CREATE TABLE tbl_001 (a int, b int);
 load stats 's/explain_complex_stats_tbl_001.json';
@@ -206,22 +206,22 @@ load stats 's/explain_complex_stats_tbl_009.json';
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	task	operator info	count
 HashAgg_25	root	group by:x.b, funcs:sum(x.a)	18000.00
-  Union_26	root		18000.00
-    TableReader_29	root	data:TableScan_28	2000.00
-      TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_32	root	data:TableScan_31	2000.00
-      TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_35	root	data:TableScan_34	2000.00
-      TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_38	root	data:TableScan_37	2000.00
-      TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_41	root	data:TableScan_40	2000.00
-      TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_44	root	data:TableScan_43	2000.00
-      TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_47	root	data:TableScan_46	2000.00
-      TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_50	root	data:TableScan_49	2000.00
-      TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	2000.00
-    TableReader_53	root	data:TableScan_52	2000.00
-      TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	2000.00
+└─Union_26	root		18000.00
+  ├─TableReader_29	root	data:TableScan_28	2000.00
+  │ └─TableScan_28	cop	table:tbl_001, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_32	root	data:TableScan_31	2000.00
+  │ └─TableScan_31	cop	table:tbl_002, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_35	root	data:TableScan_34	2000.00
+  │ └─TableScan_34	cop	table:tbl_003, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_38	root	data:TableScan_37	2000.00
+  │ └─TableScan_37	cop	table:tbl_004, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_41	root	data:TableScan_40	2000.00
+  │ └─TableScan_40	cop	table:tbl_005, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_44	root	data:TableScan_43	2000.00
+  │ └─TableScan_43	cop	table:tbl_006, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_47	root	data:TableScan_46	2000.00
+  │ └─TableScan_46	cop	table:tbl_007, range:[-inf,+inf], keep order:false	2000.00
+  ├─TableReader_50	root	data:TableScan_49	2000.00
+  │ └─TableScan_49	cop	table:tbl_008, range:[-inf,+inf], keep order:false	2000.00
+  └─TableReader_53	root	data:TableScan_52	2000.00
+    └─TableScan_52	cop	table:tbl_009, range:[-inf,+inf], keep order:false	2000.00

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -8,207 +8,207 @@ create table t4 (a int, b int, c int, index idx(a, b), primary key(a));
 set @@session.tidb_opt_insubquery_unfold = 1;
 set @@session.tidb_opt_agg_push_down = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
-id	parents	children	task	operator info	count
-TableScan_16			cop	table:t3, range:[-inf,+inf], keep order:false	10000.00
-TableReader_17	Projection_15		root	data:TableScan_16	10000.00
-Projection_15	HashLeftJoin_14	TableReader_17	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	10000.00
-TableScan_29	StreamAgg_22		cop	table:s, range:[-inf,+inf], keep order:false	10000.00
-StreamAgg_22		TableScan_29	cop	funcs:sum(s.a)	1.00
-TableReader_31	StreamAgg_30		root	data:StreamAgg_22	1.00
-StreamAgg_30	HashLeftJoin_14	TableReader_31	root	funcs:sum(col_0)	1.00
-HashLeftJoin_14	Projection_13	Projection_15,StreamAgg_30	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	8000.00
-Projection_13		HashLeftJoin_14	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	8000.00
+id	task	operator info	count
+Projection_13	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	8000.00
+  HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	8000.00
+    Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	10000.00
+      TableReader_17	root	data:TableScan_16	10000.00
+        TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	10000.00
+    StreamAgg_30	root	funcs:sum(col_0)	1.00
+      TableReader_31	root	data:StreamAgg_22	1.00
+        StreamAgg_22	cop	funcs:sum(s.a)	1.00
+          TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_5			root	data:TableScan_4	10000.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	10000.00
+  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 order by c2;
-id	parents	children	task	operator info	count
-IndexScan_11			cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	10000.00
-TableScan_12			cop	table:t1, keep order:false	10000.00
-IndexLookUp_13			root	index:IndexScan_11, table:TableScan_12	10000.00
+id	task	operator info	count
+IndexLookUp_13	root	index:IndexScan_11, table:TableScan_12	10000.00
+  IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	10000.00
+  TableScan_12	cop	table:t1, keep order:false	10000.00
 explain select * from t2 order by c2;
-id	parents	children	task	operator info	count
-TableScan_7			cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-TableReader_8	Sort_4		root	data:TableScan_7	10000.00
-Sort_4		TableReader_8	root	test.t2.c2:asc	10000.00
+id	task	operator info	count
+Sort_4	root	test.t2.c2:asc	10000.00
+  TableReader_8	root	data:TableScan_7	10000.00
+    TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 where t1.c1 > 0;
-id	parents	children	task	operator info	count
-TableScan_5			cop	table:t1, range:(0,+inf], keep order:false	3333.33
-TableReader_6			root	data:TableScan_5	3333.33
+id	task	operator info	count
+TableReader_6	root	data:TableScan_5	3333.33
+  TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	3333.33
 explain select t1.c1, t1.c2 from t1 where t1.c2 = 1;
-id	parents	children	task	operator info	count
-IndexScan_8			cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
-IndexReader_9			root	index:IndexScan_8	10.00
+id	task	operator info	count
+IndexReader_9	root	index:IndexScan_8	10.00
+  IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
 explain select * from t1 left join t2 on t1.c2 = t2.c1 where t1.c1 > 1;
-id	parents	children	task	operator info	count
-TableScan_22			cop	table:t1, range:(1,+inf], keep order:false	3333.33
-TableReader_23	IndexJoin_11		root	data:TableScan_22	3333.33
-IndexScan_8			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:false	10000.00
-TableScan_9			cop	table:t2, keep order:false	10000.00
-IndexLookUp_10	IndexJoin_11		root	index:IndexScan_8, table:TableScan_9	10000.00
-IndexJoin_11		TableReader_23,IndexLookUp_10	root	left outer join, inner:IndexLookUp_10, outer key:test.t1.c2, inner key:test.t2.c1	4166.67
+id	task	operator info	count
+IndexJoin_11	root	left outer join, inner:IndexLookUp_10, outer key:test.t1.c2, inner key:test.t2.c1	4166.67
+  TableReader_23	root	data:TableScan_22	3333.33
+    TableScan_22	cop	table:t1, range:(1,+inf], keep order:false	3333.33
+  IndexLookUp_10	root	index:IndexScan_8, table:TableScan_9	10000.00
+    IndexScan_8	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:false	10000.00
+    TableScan_9	cop	table:t2, keep order:false	10000.00
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[1,1], keep order:false	1.00
-TableReader_5			root	data:TableScan_4	1.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	1.00
+  TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
 explain delete from t1 where t1.c2 = 1;
-id	parents	children	task	operator info	count
-IndexScan_7			cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
-TableScan_8			cop	table:t1, keep order:false	10.00
-IndexLookUp_9			root	index:IndexScan_7, table:TableScan_8	10.00
+id	task	operator info	count
+IndexLookUp_9	root	index:IndexScan_7, table:TableScan_8	10.00
+  IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
+  TableScan_8	cop	table:t1, keep order:false	10.00
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
-id	parents	children	task	operator info	count
-TableScan_12			cop	table:a, range:[-inf,+inf], keep order:false	10000.00
-TableReader_13	IndexJoin_14		root	data:TableScan_12	10000.00
-TableScan_20	HashAgg_17		cop	table:b, range:[-inf,+inf], keep order:false	10000.00
-HashAgg_17		TableScan_20	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	8000.00
-TableReader_22	HashAgg_21		root	data:HashAgg_17	8000.00
-HashAgg_21	IndexJoin_14	TableReader_22	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	8000.00
-IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	10000.00
-Projection_11		IndexJoin_14	root	cast(join_agg_0)	10000.00
+id	task	operator info	count
+Projection_11	root	cast(join_agg_0)	10000.00
+  IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	10000.00
+    TableReader_13	root	data:TableScan_12	10000.00
+      TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	10000.00
+    HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	8000.00
+      TableReader_22	root	data:HashAgg_17	8000.00
+        HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	8000.00
+          TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t2 order by t2.c2 limit 0, 1;
-id	parents	children	task	operator info	count
-TableScan_13	TopN_14		cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-TopN_14		TableScan_13	cop	test.t2.c2:asc, offset:0, count:1	1.00
-TableReader_15	TopN_7		root	data:TopN_14	1.00
-TopN_7		TableReader_15	root	test.t2.c2:asc, offset:0, count:1	1.00
+id	task	operator info	count
+TopN_7	root	test.t2.c2:asc, offset:0, count:1	1.00
+  TableReader_15	root	data:TopN_14	1.00
+    TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
+      TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 where c1 > 1 and c2 = 1 and c3 < 1;
-id	parents	children	task	operator info	count
-IndexScan_8	Selection_10		cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
-Selection_10		IndexScan_8	cop	gt(test.t1.c1, 1)	3.33
-TableScan_9	Selection_11		cop	table:t1, keep order:false	3.33
-Selection_11		TableScan_9	cop	lt(test.t1.c3, 1)	1.11
-IndexLookUp_12			root	index:Selection_10, table:Selection_11	1.11
+id	task	operator info	count
+IndexLookUp_12	root	index:Selection_10, table:Selection_11	1.11
+  Selection_10	cop	gt(test.t1.c1, 1)	3.33
+    IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
+  Selection_11	cop	lt(test.t1.c3, 1)	1.11
+    TableScan_9	cop	table:t1, keep order:false	3.33
 explain select * from t1 where c1 = 1 and c2 > 1;
-id	parents	children	task	operator info	count
-TableScan_5	Selection_6		cop	table:t1, range:[1,1], keep order:false	1.00
-Selection_6		TableScan_5	cop	gt(test.t1.c2, 1)	0.33
-TableReader_7			root	data:Selection_6	0.33
+id	task	operator info	count
+TableReader_7	root	data:Selection_6	0.33
+  Selection_6	cop	gt(test.t1.c2, 1)	0.33
+    TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
-id	parents	children	task	operator info	count
-TableScan_20	StreamAgg_13		cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-StreamAgg_13		TableScan_20	cop	funcs:sum(in(test.t1.c1, 1, 2))	1.00
-TableReader_22	StreamAgg_21		root	data:StreamAgg_13	1.00
-StreamAgg_21		TableReader_22	root	funcs:sum(col_0)	1.00
+id	task	operator info	count
+StreamAgg_21	root	funcs:sum(col_0)	1.00
+  TableReader_22	root	data:StreamAgg_13	1.00
+    StreamAgg_13	cop	funcs:sum(in(test.t1.c1, 1, 2))	1.00
+      TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select c1 from t1 where c1 in (select c2 from t2);
-id	parents	children	task	operator info	count
-TableScan_10			cop	table:t1, range:[0,0], [1,1], keep order:false	2.00
-TableReader_11			root	data:TableScan_10	2.00
+id	task	operator info	count
+TableReader_11	root	data:TableScan_10	2.00
+  TableScan_10	cop	table:t1, range:[0,0], [1,1], keep order:false	2.00
 explain select (select count(1) k from t1 s where s.c1 = t1.c1 having k != 0) from t1;
-id	parents	children	task	operator info	count
-TableScan_17			cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
-TableReader_18	MergeJoin_15		root	data:TableScan_17	10000.00
-TableScan_22			cop	table:s, range:[-inf,+inf], keep order:true	10000.00
-TableReader_23	Projection_21		root	data:TableScan_22	10000.00
-Projection_21	Selection_20	TableReader_23	root	1, s.c1	10000.00
-Selection_20	MergeJoin_15	Projection_21	root	ne(k, 0)	8000.00
-MergeJoin_15	Projection_14	TableReader_18,Selection_20	root	left outer join, left key:test.t1.c1, right key:s.c1	10000.00
-Projection_14	Projection_13	MergeJoin_15	root	test.t1.c1, ifnull(5_col_0, 0)	10000.00
-Projection_13		Projection_14	root	k	10000.00
+id	task	operator info	count
+Projection_13	root	k	10000.00
+  Projection_14	root	test.t1.c1, ifnull(5_col_0, 0)	10000.00
+    MergeJoin_15	root	left outer join, left key:test.t1.c1, right key:s.c1	10000.00
+      TableReader_18	root	data:TableScan_17	10000.00
+        TableScan_17	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
+      Selection_20	root	ne(k, 0)	8000.00
+        Projection_21	root	1, s.c1	10000.00
+          TableReader_23	root	data:TableScan_22	10000.00
+            TableScan_22	cop	table:s, range:[-inf,+inf], keep order:true	10000.00
 explain select * from information_schema.columns;
-id	parents	children	task	operator info	count
-MemTableScan_4			root		10000.00
+id	task	operator info	count
+MemTableScan_4	root		10000.00
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
-id	parents	children	task	operator info	count
-TableScan_15			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_16	Apply_14		root	data:TableScan_15	10000.00
-IndexScan_32	Selection_34		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
-Selection_34	Limit_35	IndexScan_32	cop	eq(test.t1.c1, test.t2.c1)	1.00
-Limit_35		Selection_34	cop	offset:0, count:1	1.00
-TableScan_33			cop	table:t2, keep order:false	1.00
-IndexLookUp_36	Limit_21		root	index:Limit_35, table:TableScan_33	1.00
-Limit_21	Apply_14	IndexLookUp_36	root	offset:0, count:1	1.00
-Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21	10000.00
-Projection_12		Apply_14	root	eq(test.t1.c2, test.t2.c2)	10000.00
+id	task	operator info	count
+Projection_12	root	eq(test.t1.c2, test.t2.c2)	10000.00
+  Apply_14	root	left outer join, inner:Limit_21	10000.00
+    TableReader_16	root	data:TableScan_15	10000.00
+      TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+    Limit_21	root	offset:0, count:1	1.00
+      IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
+        Limit_35	cop	offset:0, count:1	1.00
+          Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
+            IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
+        TableScan_33	cop	table:t2, keep order:false	1.00
 explain select * from t1 order by c1 desc limit 1;
-id	parents	children	task	operator info	count
-TableScan_18	Limit_20		cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
-Limit_20		TableScan_18	cop	offset:0, count:1	1.00
-TableReader_21	Limit_10		root	data:Limit_20	1.00
-Limit_10		TableReader_21	root	offset:0, count:1	1.00
+id	task	operator info	count
+Limit_10	root	offset:0, count:1	1.00
+  TableReader_21	root	data:Limit_20	1.00
+    Limit_20	cop	offset:0, count:1	1.00
+      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
 explain select * from t4 use index(idx) where a > 1 and b > 1 and c > 1 limit 1;
-id	parents	children	task	operator info	count
-IndexScan_12	Selection_14		cop	table:t4, index:a, b, range:(1 +inf,+inf +inf], keep order:false	9.00
-Selection_14		IndexScan_12	cop	gt(test.t4.b, 1)	3.00
-TableScan_13	Selection_15		cop	table:t4, keep order:false	3.00
-Selection_15	Limit_16	TableScan_13	cop	gt(test.t4.c, 1)	1.00
-Limit_16		Selection_15	cop	offset:0, count:1	1.00
-IndexLookUp_17	Limit_9		root	index:Selection_14, table:Limit_16	1.00
-Limit_9		IndexLookUp_17	root	offset:0, count:1	1.00
+id	task	operator info	count
+Limit_9	root	offset:0, count:1	1.00
+  IndexLookUp_17	root	index:Selection_14, table:Limit_16	1.00
+    Selection_14	cop	gt(test.t4.b, 1)	3.00
+      IndexScan_12	cop	table:t4, index:a, b, range:(1 +inf,+inf +inf], keep order:false	9.00
+    Limit_16	cop	offset:0, count:1	1.00
+      Selection_15	cop	gt(test.t4.c, 1)	1.00
+        TableScan_13	cop	table:t4, keep order:false	3.00
 explain select * from t4 where a > 1 and c > 1 limit 1;
-id	parents	children	task	operator info	count
-TableScan_11	Selection_12		cop	table:t4, range:(1,+inf], keep order:false	3.00
-Selection_12	Limit_14	TableScan_11	cop	gt(test.t4.c, 1)	1.00
-Limit_14		Selection_12	cop	offset:0, count:1	1.00
-TableReader_15	Limit_8		root	data:Limit_14	1.00
-Limit_8		TableReader_15	root	offset:0, count:1	1.00
+id	task	operator info	count
+Limit_8	root	offset:0, count:1	1.00
+  TableReader_15	root	data:Limit_14	1.00
+    Limit_14	cop	offset:0, count:1	1.00
+      Selection_12	cop	gt(test.t4.c, 1)	1.00
+        TableScan_11	cop	table:t4, range:(1,+inf], keep order:false	3.00
 explain select ifnull(null, t1.c1) from t1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_5			root	data:TableScan_4	10000.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	10000.00
+  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select if(10, t1.c1, t1.c2) from t1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_5			root	data:TableScan_4	10000.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	10000.00
+  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select c1 from t2 union select c1 from t2 union all select c1 from t2;
-id	parents	children	task	operator info	count
-TableScan_16			cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-TableReader_17	Union_14		root	data:TableScan_16	10000.00
-IndexScan_34	StreamAgg_26		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-StreamAgg_26		IndexScan_34	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-IndexReader_36	StreamAgg_35		root	index:StreamAgg_26	8000.00
-StreamAgg_35	Union_22	IndexReader_36	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-IndexScan_51	StreamAgg_43		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-StreamAgg_43		IndexScan_51	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-IndexReader_53	StreamAgg_52		root	index:StreamAgg_43	8000.00
-StreamAgg_52	Union_22	IndexReader_53	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-Union_22	HashAgg_21	StreamAgg_35,StreamAgg_52	root		16000.00
-HashAgg_21	Union_14	Union_22	root	group by:t2.c1, funcs:firstrow(join_agg_0)	16000.00
-Union_14		TableReader_17,HashAgg_21	root		26000.00
+id	task	operator info	count
+Union_14	root		26000.00
+  TableReader_17	root	data:TableScan_16	10000.00
+    TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+  HashAgg_21	root	group by:t2.c1, funcs:firstrow(join_agg_0)	16000.00
+    Union_22	root		16000.00
+      StreamAgg_35	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+        IndexReader_36	root	index:StreamAgg_26	8000.00
+          StreamAgg_26	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+            IndexScan_34	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+      StreamAgg_52	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+        IndexReader_53	root	index:StreamAgg_43	8000.00
+          StreamAgg_43	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+            IndexScan_51	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 explain select c1 from t2 union all select c1 from t2 union select c1 from t2;
-id	parents	children	task	operator info	count
-IndexScan_28	StreamAgg_20		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-StreamAgg_20		IndexScan_28	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-IndexReader_30	StreamAgg_29		root	index:StreamAgg_20	8000.00
-StreamAgg_29	Union_16	IndexReader_30	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-IndexScan_45	StreamAgg_37		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-StreamAgg_37		IndexScan_45	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-IndexReader_47	StreamAgg_46		root	index:StreamAgg_37	8000.00
-StreamAgg_46	Union_16	IndexReader_47	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-IndexScan_62	StreamAgg_54		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-StreamAgg_54		IndexScan_62	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-IndexReader_64	StreamAgg_63		root	index:StreamAgg_54	8000.00
-StreamAgg_63	Union_16	IndexReader_64	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-Union_16	HashAgg_15	StreamAgg_29,StreamAgg_46,StreamAgg_63	root		24000.00
-HashAgg_15		Union_16	root	group by:t2.c1, funcs:firstrow(join_agg_0)	24000.00
+id	task	operator info	count
+HashAgg_15	root	group by:t2.c1, funcs:firstrow(join_agg_0)	24000.00
+  Union_16	root		24000.00
+    StreamAgg_29	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+      IndexReader_30	root	index:StreamAgg_20	8000.00
+        StreamAgg_20	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+          IndexScan_28	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+    StreamAgg_46	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+      IndexReader_47	root	index:StreamAgg_37	8000.00
+        StreamAgg_37	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+          IndexScan_45	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+    StreamAgg_63	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+      IndexReader_64	root	index:StreamAgg_54	8000.00
+        StreamAgg_54	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+          IndexScan_62	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 set @@session.tidb_opt_insubquery_unfold = 0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
-id	parents	children	task	operator info	count
-TableScan_18			cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
-TableReader_19	MergeJoin_28		root	data:TableScan_18	10000.00
-IndexScan_22			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-IndexReader_23	MergeJoin_28		root	index:IndexScan_22	10000.00
-MergeJoin_28	StreamAgg_12	TableReader_19,IndexReader_23	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
-StreamAgg_12		MergeJoin_28	root	funcs:sum(5_aux_0)	1.00
+id	task	operator info	count
+StreamAgg_12	root	funcs:sum(5_aux_0)	1.00
+  MergeJoin_28	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
+    TableReader_19	root	data:TableScan_18	10000.00
+      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
+    IndexReader_23	root	index:IndexScan_22	10000.00
+      IndexScan_22	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 explain select 1 in (select c2 from t2) from t1;
-id	parents	children	task	operator info	count
-TableScan_8			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_9	HashLeftJoin_7		root	data:TableScan_8	10000.00
-TableScan_10	Selection_11		cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-Selection_11		TableScan_10	cop	eq(1, test.t2.c2)	10.00
-TableReader_12	HashLeftJoin_7		root	data:Selection_11	10.00
-HashLeftJoin_7	Projection_6	TableReader_9,TableReader_12	root	left outer semi join, inner:TableReader_12	10000.00
-Projection_6		HashLeftJoin_7	root	5_aux_0	10000.00
+id	task	operator info	count
+Projection_6	root	5_aux_0	10000.00
+  HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	10000.00
+    TableReader_9	root	data:TableScan_8	10000.00
+      TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_12	root	data:Selection_11	10.00
+      Selection_11	cop	eq(1, test.t2.c2)	10.00
+        TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select sum(6 in (select c2 from t2)) from t1;
-id	parents	children	task	operator info	count
-TableScan_20			cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-TableReader_21	HashLeftJoin_19		root	data:TableScan_20	10000.00
-TableScan_16	Selection_17		cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-Selection_17		TableScan_16	cop	eq(6, test.t2.c2)	10.00
-TableReader_18	HashLeftJoin_19		root	data:Selection_17	10.00
-HashLeftJoin_19	StreamAgg_12	TableReader_21,TableReader_18	root	left outer semi join, inner:TableReader_18	10000.00
-StreamAgg_12		HashLeftJoin_19	root	funcs:sum(5_aux_0)	1.00
+id	task	operator info	count
+StreamAgg_12	root	funcs:sum(5_aux_0)	1.00
+  HashLeftJoin_19	root	left outer semi join, inner:TableReader_18	10000.00
+    TableReader_21	root	data:TableScan_20	10000.00
+      TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+    TableReader_18	root	data:Selection_17	10.00
+      Selection_17	cop	eq(6, test.t2.c2)	10.00
+        TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain format="dot" select sum(t1.c1 in (select c1 from t2)) from t1;
 dot contents
 

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -10,205 +10,205 @@ set @@session.tidb_opt_agg_push_down = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
 id	task	operator info	count
 Projection_13	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	8000.00
-  HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	8000.00
-    Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	10000.00
-      TableReader_17	root	data:TableScan_16	10000.00
-        TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	10000.00
-    StreamAgg_30	root	funcs:sum(col_0)	1.00
-      TableReader_31	root	data:StreamAgg_22	1.00
-        StreamAgg_22	cop	funcs:sum(s.a)	1.00
-          TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	10000.00
+└─HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	8000.00
+  ├─Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	10000.00
+  │ └─TableReader_17	root	data:TableScan_16	10000.00
+  │   └─TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	10000.00
+  └─StreamAgg_30	root	funcs:sum(col_0)	1.00
+    └─TableReader_31	root	data:StreamAgg_22	1.00
+      └─StreamAgg_22	cop	funcs:sum(s.a)	1.00
+        └─TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	10000.00
-  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+└─TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 order by c2;
 id	task	operator info	count
 IndexLookUp_13	root	index:IndexScan_11, table:TableScan_12	10000.00
-  IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	10000.00
-  TableScan_12	cop	table:t1, keep order:false	10000.00
+├─IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	10000.00
+└─TableScan_12	cop	table:t1, keep order:false	10000.00
 explain select * from t2 order by c2;
 id	task	operator info	count
 Sort_4	root	test.t2.c2:asc	10000.00
-  TableReader_8	root	data:TableScan_7	10000.00
-    TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+└─TableReader_8	root	data:TableScan_7	10000.00
+  └─TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 where t1.c1 > 0;
 id	task	operator info	count
 TableReader_6	root	data:TableScan_5	3333.33
-  TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	3333.33
+└─TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	3333.33
 explain select t1.c1, t1.c2 from t1 where t1.c2 = 1;
 id	task	operator info	count
 IndexReader_9	root	index:IndexScan_8	10.00
-  IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
+└─IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
 explain select * from t1 left join t2 on t1.c2 = t2.c1 where t1.c1 > 1;
 id	task	operator info	count
 IndexJoin_11	root	left outer join, inner:IndexLookUp_10, outer key:test.t1.c2, inner key:test.t2.c1	4166.67
-  TableReader_23	root	data:TableScan_22	3333.33
-    TableScan_22	cop	table:t1, range:(1,+inf], keep order:false	3333.33
-  IndexLookUp_10	root	index:IndexScan_8, table:TableScan_9	10000.00
-    IndexScan_8	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:false	10000.00
-    TableScan_9	cop	table:t2, keep order:false	10000.00
+├─TableReader_23	root	data:TableScan_22	3333.33
+│ └─TableScan_22	cop	table:t1, range:(1,+inf], keep order:false	3333.33
+└─IndexLookUp_10	root	index:IndexScan_8, table:TableScan_9	10000.00
+  ├─IndexScan_8	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:false	10000.00
+  └─TableScan_9	cop	table:t2, keep order:false	10000.00
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	1.00
-  TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
+└─TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
 explain delete from t1 where t1.c2 = 1;
 id	task	operator info	count
 IndexLookUp_9	root	index:IndexScan_7, table:TableScan_8	10.00
-  IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
-  TableScan_8	cop	table:t1, keep order:false	10.00
+├─IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
+└─TableScan_8	cop	table:t1, keep order:false	10.00
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	task	operator info	count
 Projection_11	root	cast(join_agg_0)	10000.00
-  IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	10000.00
-    TableReader_13	root	data:TableScan_12	10000.00
-      TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	10000.00
-    HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	8000.00
-      TableReader_22	root	data:HashAgg_17	8000.00
-        HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	8000.00
-          TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	10000.00
+└─IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	10000.00
+  ├─TableReader_13	root	data:TableScan_12	10000.00
+  │ └─TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	10000.00
+  └─HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	8000.00
+    └─TableReader_22	root	data:HashAgg_17	8000.00
+      └─HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	8000.00
+        └─TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	task	operator info	count
 TopN_7	root	test.t2.c2:asc, offset:0, count:1	1.00
-  TableReader_15	root	data:TopN_14	1.00
-    TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
-      TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+└─TableReader_15	root	data:TopN_14	1.00
+  └─TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
+    └─TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select * from t1 where c1 > 1 and c2 = 1 and c3 < 1;
 id	task	operator info	count
 IndexLookUp_12	root	index:Selection_10, table:Selection_11	1.11
-  Selection_10	cop	gt(test.t1.c1, 1)	3.33
-    IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
-  Selection_11	cop	lt(test.t1.c3, 1)	1.11
-    TableScan_9	cop	table:t1, keep order:false	3.33
+├─Selection_10	cop	gt(test.t1.c1, 1)	3.33
+│ └─IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	10.00
+└─Selection_11	cop	lt(test.t1.c3, 1)	1.11
+  └─TableScan_9	cop	table:t1, keep order:false	3.33
 explain select * from t1 where c1 = 1 and c2 > 1;
 id	task	operator info	count
 TableReader_7	root	data:Selection_6	0.33
-  Selection_6	cop	gt(test.t1.c2, 1)	0.33
-    TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
+└─Selection_6	cop	gt(test.t1.c2, 1)	0.33
+  └─TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	task	operator info	count
 StreamAgg_21	root	funcs:sum(col_0)	1.00
-  TableReader_22	root	data:StreamAgg_13	1.00
-    StreamAgg_13	cop	funcs:sum(in(test.t1.c1, 1, 2))	1.00
-      TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+└─TableReader_22	root	data:StreamAgg_13	1.00
+  └─StreamAgg_13	cop	funcs:sum(in(test.t1.c1, 1, 2))	1.00
+    └─TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	task	operator info	count
 TableReader_11	root	data:TableScan_10	2.00
-  TableScan_10	cop	table:t1, range:[0,0], [1,1], keep order:false	2.00
+└─TableScan_10	cop	table:t1, range:[0,0], [1,1], keep order:false	2.00
 explain select (select count(1) k from t1 s where s.c1 = t1.c1 having k != 0) from t1;
 id	task	operator info	count
 Projection_13	root	k	10000.00
-  Projection_14	root	test.t1.c1, ifnull(5_col_0, 0)	10000.00
-    MergeJoin_15	root	left outer join, left key:test.t1.c1, right key:s.c1	10000.00
-      TableReader_18	root	data:TableScan_17	10000.00
-        TableScan_17	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
-      Selection_20	root	ne(k, 0)	8000.00
-        Projection_21	root	1, s.c1	10000.00
-          TableReader_23	root	data:TableScan_22	10000.00
-            TableScan_22	cop	table:s, range:[-inf,+inf], keep order:true	10000.00
+└─Projection_14	root	test.t1.c1, ifnull(5_col_0, 0)	10000.00
+  └─MergeJoin_15	root	left outer join, left key:test.t1.c1, right key:s.c1	10000.00
+    ├─TableReader_18	root	data:TableScan_17	10000.00
+    │ └─TableScan_17	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
+    └─Selection_20	root	ne(k, 0)	8000.00
+      └─Projection_21	root	1, s.c1	10000.00
+        └─TableReader_23	root	data:TableScan_22	10000.00
+          └─TableScan_22	cop	table:s, range:[-inf,+inf], keep order:true	10000.00
 explain select * from information_schema.columns;
 id	task	operator info	count
 MemTableScan_4	root		10000.00
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	task	operator info	count
 Projection_12	root	eq(test.t1.c2, test.t2.c2)	10000.00
-  Apply_14	root	left outer join, inner:Limit_21	10000.00
-    TableReader_16	root	data:TableScan_15	10000.00
-      TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-    Limit_21	root	offset:0, count:1	1.00
-      IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
-        Limit_35	cop	offset:0, count:1	1.00
-          Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
-            IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
-        TableScan_33	cop	table:t2, keep order:false	1.00
+└─Apply_14	root	left outer join, inner:Limit_21	10000.00
+  ├─TableReader_16	root	data:TableScan_15	10000.00
+  │ └─TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+  └─Limit_21	root	offset:0, count:1	1.00
+    └─IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
+      ├─Limit_35	cop	offset:0, count:1	1.00
+      │ └─Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
+      │   └─IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
+      └─TableScan_33	cop	table:t2, keep order:false	1.00
 explain select * from t1 order by c1 desc limit 1;
 id	task	operator info	count
 Limit_10	root	offset:0, count:1	1.00
-  TableReader_21	root	data:Limit_20	1.00
-    Limit_20	cop	offset:0, count:1	1.00
-      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
+└─TableReader_21	root	data:Limit_20	1.00
+  └─Limit_20	cop	offset:0, count:1	1.00
+    └─TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
 explain select * from t4 use index(idx) where a > 1 and b > 1 and c > 1 limit 1;
 id	task	operator info	count
 Limit_9	root	offset:0, count:1	1.00
-  IndexLookUp_17	root	index:Selection_14, table:Limit_16	1.00
-    Selection_14	cop	gt(test.t4.b, 1)	3.00
-      IndexScan_12	cop	table:t4, index:a, b, range:(1 +inf,+inf +inf], keep order:false	9.00
-    Limit_16	cop	offset:0, count:1	1.00
-      Selection_15	cop	gt(test.t4.c, 1)	1.00
-        TableScan_13	cop	table:t4, keep order:false	3.00
+└─IndexLookUp_17	root	index:Selection_14, table:Limit_16	1.00
+  ├─Selection_14	cop	gt(test.t4.b, 1)	3.00
+  │ └─IndexScan_12	cop	table:t4, index:a, b, range:(1 +inf,+inf +inf], keep order:false	9.00
+  └─Limit_16	cop	offset:0, count:1	1.00
+    └─Selection_15	cop	gt(test.t4.c, 1)	1.00
+      └─TableScan_13	cop	table:t4, keep order:false	3.00
 explain select * from t4 where a > 1 and c > 1 limit 1;
 id	task	operator info	count
 Limit_8	root	offset:0, count:1	1.00
-  TableReader_15	root	data:Limit_14	1.00
-    Limit_14	cop	offset:0, count:1	1.00
-      Selection_12	cop	gt(test.t4.c, 1)	1.00
-        TableScan_11	cop	table:t4, range:(1,+inf], keep order:false	3.00
+└─TableReader_15	root	data:Limit_14	1.00
+  └─Limit_14	cop	offset:0, count:1	1.00
+    └─Selection_12	cop	gt(test.t4.c, 1)	1.00
+      └─TableScan_11	cop	table:t4, range:(1,+inf], keep order:false	3.00
 explain select ifnull(null, t1.c1) from t1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	10000.00
-  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+└─TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select if(10, t1.c1, t1.c2) from t1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	10000.00
-  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+└─TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
 explain select c1 from t2 union select c1 from t2 union all select c1 from t2;
 id	task	operator info	count
 Union_14	root		26000.00
-  TableReader_17	root	data:TableScan_16	10000.00
-    TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
-  HashAgg_21	root	group by:t2.c1, funcs:firstrow(join_agg_0)	16000.00
-    Union_22	root		16000.00
-      StreamAgg_35	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-        IndexReader_36	root	index:StreamAgg_26	8000.00
-          StreamAgg_26	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-            IndexScan_34	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-      StreamAgg_52	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-        IndexReader_53	root	index:StreamAgg_43	8000.00
-          StreamAgg_43	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-            IndexScan_51	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+├─TableReader_17	root	data:TableScan_16	10000.00
+│ └─TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+└─HashAgg_21	root	group by:t2.c1, funcs:firstrow(join_agg_0)	16000.00
+  └─Union_22	root		16000.00
+    ├─StreamAgg_35	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+    │ └─IndexReader_36	root	index:StreamAgg_26	8000.00
+    │   └─StreamAgg_26	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+    │     └─IndexScan_34	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+    └─StreamAgg_52	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+      └─IndexReader_53	root	index:StreamAgg_43	8000.00
+        └─StreamAgg_43	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+          └─IndexScan_51	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 explain select c1 from t2 union all select c1 from t2 union select c1 from t2;
 id	task	operator info	count
 HashAgg_15	root	group by:t2.c1, funcs:firstrow(join_agg_0)	24000.00
-  Union_16	root		24000.00
-    StreamAgg_29	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-      IndexReader_30	root	index:StreamAgg_20	8000.00
-        StreamAgg_20	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-          IndexScan_28	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-    StreamAgg_46	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-      IndexReader_47	root	index:StreamAgg_37	8000.00
-        StreamAgg_37	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-          IndexScan_45	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
-    StreamAgg_63	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
-      IndexReader_64	root	index:StreamAgg_54	8000.00
-        StreamAgg_54	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
-          IndexScan_62	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+└─Union_16	root		24000.00
+  ├─StreamAgg_29	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+  │ └─IndexReader_30	root	index:StreamAgg_20	8000.00
+  │   └─StreamAgg_20	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+  │     └─IndexScan_28	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+  ├─StreamAgg_46	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+  │ └─IndexReader_47	root	index:StreamAgg_37	8000.00
+  │   └─StreamAgg_37	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+  │     └─IndexScan_45	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+  └─StreamAgg_63	root	group by:col_2, funcs:firstrow(col_0), firstrow(col_1)	8000.00
+    └─IndexReader_64	root	index:StreamAgg_54	8000.00
+      └─StreamAgg_54	cop	group by:test.t2.c1, funcs:firstrow(test.t2.c1), firstrow(test.t2.c1)	8000.00
+        └─IndexScan_62	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 set @@session.tidb_opt_insubquery_unfold = 0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	task	operator info	count
 StreamAgg_12	root	funcs:sum(5_aux_0)	1.00
-  MergeJoin_28	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
-    TableReader_19	root	data:TableScan_18	10000.00
-      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
-    IndexReader_23	root	index:IndexScan_22	10000.00
-      IndexScan_22	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
+└─MergeJoin_28	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1	10000.00
+  ├─TableReader_19	root	data:TableScan_18	10000.00
+  │ └─TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true	10000.00
+  └─IndexReader_23	root	index:IndexScan_22	10000.00
+    └─IndexScan_22	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	10000.00
 explain select 1 in (select c2 from t2) from t1;
 id	task	operator info	count
 Projection_6	root	5_aux_0	10000.00
-  HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	10000.00
-    TableReader_9	root	data:TableScan_8	10000.00
-      TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_12	root	data:Selection_11	10.00
-      Selection_11	cop	eq(1, test.t2.c2)	10.00
-        TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+└─HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	10000.00
+  ├─TableReader_9	root	data:TableScan_8	10000.00
+  │ └─TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+  └─TableReader_12	root	data:Selection_11	10.00
+    └─Selection_11	cop	eq(1, test.t2.c2)	10.00
+      └─TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain select sum(6 in (select c2 from t2)) from t1;
 id	task	operator info	count
 StreamAgg_12	root	funcs:sum(5_aux_0)	1.00
-  HashLeftJoin_19	root	left outer semi join, inner:TableReader_18	10000.00
-    TableReader_21	root	data:TableScan_20	10000.00
-      TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
-    TableReader_18	root	data:Selection_17	10.00
-      Selection_17	cop	eq(6, test.t2.c2)	10.00
-        TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
+└─HashLeftJoin_19	root	left outer semi join, inner:TableReader_18	10000.00
+  ├─TableReader_21	root	data:TableScan_20	10000.00
+  │ └─TableScan_20	cop	table:t1, range:[-inf,+inf], keep order:false	10000.00
+  └─TableReader_18	root	data:Selection_17	10.00
+    └─Selection_17	cop	eq(6, test.t2.c2)	10.00
+      └─TableScan_16	cop	table:t2, range:[-inf,+inf], keep order:false	10000.00
 explain format="dot" select sum(t1.c1 in (select c1 from t2)) from t1;
 dot contents
 

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -9,121 +9,121 @@ load stats 's/explain_easy_stats_t3.json';
 set @@session.tidb_opt_insubquery_unfold = 1;
 set @@session.tidb_opt_agg_push_down = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
-id	parents	children	task	operator info	count
-TableScan_16			cop	table:t3, range:[-inf,+inf], keep order:false	2000.00
-TableReader_17	Projection_15		root	data:TableScan_16	2000.00
-Projection_15	HashLeftJoin_14	TableReader_17	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	2000.00
-TableScan_29	StreamAgg_22		cop	table:s, range:[-inf,+inf], keep order:false	2000.00
-StreamAgg_22		TableScan_29	cop	funcs:sum(s.a)	1.00
-TableReader_31	StreamAgg_30		root	data:StreamAgg_22	1.00
-StreamAgg_30	HashLeftJoin_14	TableReader_31	root	funcs:sum(col_0)	1.00
-HashLeftJoin_14	Projection_13	Projection_15,StreamAgg_30	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	1600.00
-Projection_13		HashLeftJoin_14	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	1600.00
+id	task	operator info	count
+Projection_13	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	1600.00
+  HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	1600.00
+    Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	2000.00
+      TableReader_17	root	data:TableScan_16	2000.00
+        TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	2000.00
+    StreamAgg_30	root	funcs:sum(col_0)	1.00
+      TableReader_31	root	data:StreamAgg_22	1.00
+        StreamAgg_22	cop	funcs:sum(s.a)	1.00
+          TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	2000.00
 explain select * from t1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
-TableReader_5			root	data:TableScan_4	1999.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	1999.00
+  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
 explain select * from t1 order by c2;
-id	parents	children	task	operator info	count
-IndexScan_11			cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
-TableScan_12			cop	table:t1, keep order:false	1999.00
-IndexLookUp_13			root	index:IndexScan_11, table:TableScan_12	1999.00
+id	task	operator info	count
+IndexLookUp_13	root	index:IndexScan_11, table:TableScan_12	1999.00
+  IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
+  TableScan_12	cop	table:t1, keep order:false	1999.00
 explain select * from t2 order by c2;
-id	parents	children	task	operator info	count
-TableScan_7			cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
-TableReader_8	Sort_4		root	data:TableScan_7	1985.00
-Sort_4		TableReader_8	root	test.t2.c2:asc	1985.00
+id	task	operator info	count
+Sort_4	root	test.t2.c2:asc	1985.00
+  TableReader_8	root	data:TableScan_7	1985.00
+    TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t1 where t1.c1 > 0;
-id	parents	children	task	operator info	count
-TableScan_5			cop	table:t1, range:(0,+inf], keep order:false	1999.00
-TableReader_6			root	data:TableScan_5	1999.00
+id	task	operator info	count
+TableReader_6	root	data:TableScan_5	1999.00
+  TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	1999.00
 explain select t1.c1, t1.c2 from t1 where t1.c2 = 1;
-id	parents	children	task	operator info	count
-IndexScan_8			cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
-IndexReader_9			root	index:IndexScan_8	0.00
+id	task	operator info	count
+IndexReader_9	root	index:IndexScan_8	0.00
+  IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
 explain select * from t1 left join t2 on t1.c2 = t2.c1 where t1.c1 > 1;
-id	parents	children	task	operator info	count
-IndexScan_14	Selection_16		cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
-Selection_16		IndexScan_14	cop	gt(test.t1.c1, 1)	1998.00
-TableScan_15			cop	table:t1, keep order:false	1998.00
-IndexLookUp_17	MergeJoin_7		root	index:Selection_16, table:TableScan_15	1998.00
-IndexScan_19			cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1985.00
-TableScan_20			cop	table:t2, keep order:false	1985.00
-IndexLookUp_21	MergeJoin_7		root	index:IndexScan_19, table:TableScan_20	1985.00
-MergeJoin_7	Projection_6	IndexLookUp_17,IndexLookUp_21	root	left outer join, left key:test.t1.c2, right key:test.t2.c1	2481.25
-Projection_6		MergeJoin_7	root	test.t1.c1, test.t1.c2, test.t1.c3, test.t2.c1, test.t2.c2	2481.25
+id	task	operator info	count
+Projection_6	root	test.t1.c1, test.t1.c2, test.t1.c3, test.t2.c1, test.t2.c2	2481.25
+  MergeJoin_7	root	left outer join, left key:test.t1.c2, right key:test.t2.c1	2481.25
+    IndexLookUp_17	root	index:Selection_16, table:TableScan_15	1998.00
+      Selection_16	cop	gt(test.t1.c1, 1)	1998.00
+        IndexScan_14	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
+      TableScan_15	cop	table:t1, keep order:false	1998.00
+    IndexLookUp_21	root	index:IndexScan_19, table:TableScan_20	1985.00
+      IndexScan_19	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1985.00
+      TableScan_20	cop	table:t2, keep order:false	1985.00
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
-id	parents	children	task	operator info	count
-TableScan_4			cop	table:t1, range:[1,1], keep order:false	1.00
-TableReader_5			root	data:TableScan_4	1.00
+id	task	operator info	count
+TableReader_5	root	data:TableScan_4	1.00
+  TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
 explain delete from t1 where t1.c2 = 1;
-id	parents	children	task	operator info	count
-IndexScan_7			cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
-TableScan_8			cop	table:t1, keep order:false	0.00
-IndexLookUp_9			root	index:IndexScan_7, table:TableScan_8	0.00
+id	task	operator info	count
+IndexLookUp_9	root	index:IndexScan_7, table:TableScan_8	0.00
+  IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
+  TableScan_8	cop	table:t1, keep order:false	0.00
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
-id	parents	children	task	operator info	count
-TableScan_12			cop	table:a, range:[-inf,+inf], keep order:false	1999.00
-TableReader_13	IndexJoin_14		root	data:TableScan_12	1999.00
-TableScan_20	HashAgg_17		cop	table:b, range:[-inf,+inf], keep order:false	1985.00
-HashAgg_17		TableScan_20	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	1985.00
-TableReader_22	HashAgg_21		root	data:HashAgg_17	1985.00
-HashAgg_21	IndexJoin_14	TableReader_22	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	1985.00
-IndexJoin_14	Projection_11	TableReader_13,HashAgg_21	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	1985.00
-Projection_11		IndexJoin_14	root	cast(join_agg_0)	1985.00
+id	task	operator info	count
+Projection_11	root	cast(join_agg_0)	1985.00
+  IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	1985.00
+    TableReader_13	root	data:TableScan_12	1999.00
+      TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	1999.00
+    HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	1985.00
+      TableReader_22	root	data:HashAgg_17	1985.00
+        HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	1985.00
+          TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t2 order by t2.c2 limit 0, 1;
-id	parents	children	task	operator info	count
-TableScan_13	TopN_14		cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
-TopN_14		TableScan_13	cop	test.t2.c2:asc, offset:0, count:1	1.00
-TableReader_15	TopN_7		root	data:TopN_14	1.00
-TopN_7		TableReader_15	root	test.t2.c2:asc, offset:0, count:1	1.00
+id	task	operator info	count
+TopN_7	root	test.t2.c2:asc, offset:0, count:1	1.00
+  TableReader_15	root	data:TopN_14	1.00
+    TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
+      TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t1 where c1 > 1 and c2 = 1 and c3 < 1;
-id	parents	children	task	operator info	count
-IndexScan_8	Selection_10		cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
-Selection_10		IndexScan_8	cop	gt(test.t1.c1, 1)	0.00
-TableScan_9	Selection_11		cop	table:t1, keep order:false	0.00
-Selection_11		TableScan_9	cop	lt(test.t1.c3, 1)	0.00
-IndexLookUp_12			root	index:Selection_10, table:Selection_11	0.00
+id	task	operator info	count
+IndexLookUp_12	root	index:Selection_10, table:Selection_11	0.00
+  Selection_10	cop	gt(test.t1.c1, 1)	0.00
+    IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
+  Selection_11	cop	lt(test.t1.c3, 1)	0.00
+    TableScan_9	cop	table:t1, keep order:false	0.00
 explain select * from t1 where c1 = 1 and c2 > 1;
-id	parents	children	task	operator info	count
-TableScan_5	Selection_6		cop	table:t1, range:[1,1], keep order:false	1.00
-Selection_6		TableScan_5	cop	gt(test.t1.c2, 1)	0.50
-TableReader_7			root	data:Selection_6	0.50
+id	task	operator info	count
+TableReader_7	root	data:Selection_6	0.50
+  Selection_6	cop	gt(test.t1.c2, 1)	0.50
+    TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
 explain select c1 from t1 where c1 in (select c2 from t2);
-id	parents	children	task	operator info	count
-TableDual_11	Projection_10		root	rows:0	0.00
-Projection_10		TableDual_11	root	test.t1.c1	0.00
+id	task	operator info	count
+Projection_10	root	test.t1.c1	0.00
+  TableDual_11	root	rows:0	0.00
 explain select * from information_schema.columns;
-id	parents	children	task	operator info	count
-MemTableScan_4			root		10000.00
+id	task	operator info	count
+MemTableScan_4	root		10000.00
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
-id	parents	children	task	operator info	count
-TableScan_15			cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
-TableReader_16	Apply_14		root	data:TableScan_15	1999.00
-IndexScan_32	Selection_34		cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
-Selection_34	Limit_35	IndexScan_32	cop	eq(test.t1.c1, test.t2.c1)	1.00
-Limit_35		Selection_34	cop	offset:0, count:1	1.00
-TableScan_33			cop	table:t2, keep order:false	1.00
-IndexLookUp_36	Limit_21		root	index:Limit_35, table:TableScan_33	1.00
-Limit_21	Apply_14	IndexLookUp_36	root	offset:0, count:1	1.00
-Apply_14	Projection_12	TableReader_16,Limit_21	root	left outer join, inner:Limit_21	1999.00
-Projection_12		Apply_14	root	eq(test.t1.c2, test.t2.c2)	1999.00
+id	task	operator info	count
+Projection_12	root	eq(test.t1.c2, test.t2.c2)	1999.00
+  Apply_14	root	left outer join, inner:Limit_21	1999.00
+    TableReader_16	root	data:TableScan_15	1999.00
+      TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
+    Limit_21	root	offset:0, count:1	1.00
+      IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
+        Limit_35	cop	offset:0, count:1	1.00
+          Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
+            IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
+        TableScan_33	cop	table:t2, keep order:false	1.00
 explain select * from t1 order by c1 desc limit 1;
-id	parents	children	task	operator info	count
-TableScan_18	Limit_20		cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
-Limit_20		TableScan_18	cop	offset:0, count:1	1.00
-TableReader_21	Limit_10		root	data:Limit_20	1.00
-Limit_10		TableReader_21	root	offset:0, count:1	1.00
+id	task	operator info	count
+Limit_10	root	offset:0, count:1	1.00
+  TableReader_21	root	data:Limit_20	1.00
+    Limit_20	cop	offset:0, count:1	1.00
+      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
 set @@session.tidb_opt_insubquery_unfold = 0;
 explain select 1 in (select c2 from t2) from t1;
-id	parents	children	task	operator info	count
-TableScan_8			cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
-TableReader_9	HashLeftJoin_7		root	data:TableScan_8	1999.00
-TableScan_10	Selection_11		cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
-Selection_11		TableScan_10	cop	eq(1, test.t2.c2)	0.00
-TableReader_12	HashLeftJoin_7		root	data:Selection_11	0.00
-HashLeftJoin_7	Projection_6	TableReader_9,TableReader_12	root	left outer semi join, inner:TableReader_12	1999.00
-Projection_6		HashLeftJoin_7	root	5_aux_0	1999.00
+id	task	operator info	count
+Projection_6	root	5_aux_0	1999.00
+  HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	1999.00
+    TableReader_9	root	data:TableScan_8	1999.00
+      TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
+    TableReader_12	root	data:Selection_11	0.00
+      Selection_11	cop	eq(1, test.t2.c2)	0.00
+        TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain format="dot" select 1 in (select c2 from t2) from t1;
 dot contents
 

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -11,119 +11,119 @@ set @@session.tidb_opt_agg_push_down = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
 id	task	operator info	count
 Projection_13	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d	1600.00
-  HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	1600.00
-    Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	2000.00
-      TableReader_17	root	data:TableScan_16	2000.00
-        TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	2000.00
-    StreamAgg_30	root	funcs:sum(col_0)	1.00
-      TableReader_31	root	data:StreamAgg_22	1.00
-        StreamAgg_22	cop	funcs:sum(s.a)	1.00
-          TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	2000.00
+└─HashLeftJoin_14	root	semi join, inner:StreamAgg_30, equal:[eq(cast(test.t3.a), sel_agg_1)]	1600.00
+  ├─Projection_15	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)	2000.00
+  │ └─TableReader_17	root	data:TableScan_16	2000.00
+  │   └─TableScan_16	cop	table:t3, range:[-inf,+inf], keep order:false	2000.00
+  └─StreamAgg_30	root	funcs:sum(col_0)	1.00
+    └─TableReader_31	root	data:StreamAgg_22	1.00
+      └─StreamAgg_22	cop	funcs:sum(s.a)	1.00
+        └─TableScan_29	cop	table:s, range:[-inf,+inf], keep order:false	2000.00
 explain select * from t1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	1999.00
-  TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
+└─TableScan_4	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
 explain select * from t1 order by c2;
 id	task	operator info	count
 IndexLookUp_13	root	index:IndexScan_11, table:TableScan_12	1999.00
-  IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
-  TableScan_12	cop	table:t1, keep order:false	1999.00
+├─IndexScan_11	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
+└─TableScan_12	cop	table:t1, keep order:false	1999.00
 explain select * from t2 order by c2;
 id	task	operator info	count
 Sort_4	root	test.t2.c2:asc	1985.00
-  TableReader_8	root	data:TableScan_7	1985.00
-    TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
+└─TableReader_8	root	data:TableScan_7	1985.00
+  └─TableScan_7	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t1 where t1.c1 > 0;
 id	task	operator info	count
 TableReader_6	root	data:TableScan_5	1999.00
-  TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	1999.00
+└─TableScan_5	cop	table:t1, range:(0,+inf], keep order:false	1999.00
 explain select t1.c1, t1.c2 from t1 where t1.c2 = 1;
 id	task	operator info	count
 IndexReader_9	root	index:IndexScan_8	0.00
-  IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
+└─IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
 explain select * from t1 left join t2 on t1.c2 = t2.c1 where t1.c1 > 1;
 id	task	operator info	count
 Projection_6	root	test.t1.c1, test.t1.c2, test.t1.c3, test.t2.c1, test.t2.c2	2481.25
-  MergeJoin_7	root	left outer join, left key:test.t1.c2, right key:test.t2.c1	2481.25
-    IndexLookUp_17	root	index:Selection_16, table:TableScan_15	1998.00
-      Selection_16	cop	gt(test.t1.c1, 1)	1998.00
-        IndexScan_14	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
-      TableScan_15	cop	table:t1, keep order:false	1998.00
-    IndexLookUp_21	root	index:IndexScan_19, table:TableScan_20	1985.00
-      IndexScan_19	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1985.00
-      TableScan_20	cop	table:t2, keep order:false	1985.00
+└─MergeJoin_7	root	left outer join, left key:test.t1.c2, right key:test.t2.c1	2481.25
+  ├─IndexLookUp_17	root	index:Selection_16, table:TableScan_15	1998.00
+  │ ├─Selection_16	cop	gt(test.t1.c1, 1)	1998.00
+  │ │ └─IndexScan_14	cop	table:t1, index:c2, range:[<nil>,+inf], keep order:true	1999.00
+  │ └─TableScan_15	cop	table:t1, keep order:false	1998.00
+  └─IndexLookUp_21	root	index:IndexScan_19, table:TableScan_20	1985.00
+    ├─IndexScan_19	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1985.00
+    └─TableScan_20	cop	table:t2, keep order:false	1985.00
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	task	operator info	count
 TableReader_5	root	data:TableScan_4	1.00
-  TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
+└─TableScan_4	cop	table:t1, range:[1,1], keep order:false	1.00
 explain delete from t1 where t1.c2 = 1;
 id	task	operator info	count
 IndexLookUp_9	root	index:IndexScan_7, table:TableScan_8	0.00
-  IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
-  TableScan_8	cop	table:t1, keep order:false	0.00
+├─IndexScan_7	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
+└─TableScan_8	cop	table:t1, keep order:false	0.00
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	task	operator info	count
 Projection_11	root	cast(join_agg_0)	1985.00
-  IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	1985.00
-    TableReader_13	root	data:TableScan_12	1999.00
-      TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	1999.00
-    HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	1985.00
-      TableReader_22	root	data:HashAgg_17	1985.00
-        HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	1985.00
-          TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	1985.00
+└─IndexJoin_14	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1	1985.00
+  ├─TableReader_13	root	data:TableScan_12	1999.00
+  │ └─TableScan_12	cop	table:a, range:[-inf,+inf], keep order:false	1999.00
+  └─HashAgg_21	root	group by:col_2, funcs:count(col_0), firstrow(col_1)	1985.00
+    └─TableReader_22	root	data:HashAgg_17	1985.00
+      └─HashAgg_17	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)	1985.00
+        └─TableScan_20	cop	table:b, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	task	operator info	count
 TopN_7	root	test.t2.c2:asc, offset:0, count:1	1.00
-  TableReader_15	root	data:TopN_14	1.00
-    TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
-      TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
+└─TableReader_15	root	data:TopN_14	1.00
+  └─TopN_14	cop	test.t2.c2:asc, offset:0, count:1	1.00
+    └─TableScan_13	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain select * from t1 where c1 > 1 and c2 = 1 and c3 < 1;
 id	task	operator info	count
 IndexLookUp_12	root	index:Selection_10, table:Selection_11	0.00
-  Selection_10	cop	gt(test.t1.c1, 1)	0.00
-    IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
-  Selection_11	cop	lt(test.t1.c3, 1)	0.00
-    TableScan_9	cop	table:t1, keep order:false	0.00
+├─Selection_10	cop	gt(test.t1.c1, 1)	0.00
+│ └─IndexScan_8	cop	table:t1, index:c2, range:[1,1], keep order:false	0.00
+└─Selection_11	cop	lt(test.t1.c3, 1)	0.00
+  └─TableScan_9	cop	table:t1, keep order:false	0.00
 explain select * from t1 where c1 = 1 and c2 > 1;
 id	task	operator info	count
 TableReader_7	root	data:Selection_6	0.50
-  Selection_6	cop	gt(test.t1.c2, 1)	0.50
-    TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
+└─Selection_6	cop	gt(test.t1.c2, 1)	0.50
+  └─TableScan_5	cop	table:t1, range:[1,1], keep order:false	1.00
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	task	operator info	count
 Projection_10	root	test.t1.c1	0.00
-  TableDual_11	root	rows:0	0.00
+└─TableDual_11	root	rows:0	0.00
 explain select * from information_schema.columns;
 id	task	operator info	count
 MemTableScan_4	root		10000.00
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	task	operator info	count
 Projection_12	root	eq(test.t1.c2, test.t2.c2)	1999.00
-  Apply_14	root	left outer join, inner:Limit_21	1999.00
-    TableReader_16	root	data:TableScan_15	1999.00
-      TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
-    Limit_21	root	offset:0, count:1	1.00
-      IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
-        Limit_35	cop	offset:0, count:1	1.00
-          Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
-            IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
-        TableScan_33	cop	table:t2, keep order:false	1.00
+└─Apply_14	root	left outer join, inner:Limit_21	1999.00
+  ├─TableReader_16	root	data:TableScan_15	1999.00
+  │ └─TableScan_15	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
+  └─Limit_21	root	offset:0, count:1	1.00
+    └─IndexLookUp_36	root	index:Limit_35, table:TableScan_33	1.00
+      ├─Limit_35	cop	offset:0, count:1	1.00
+      │ └─Selection_34	cop	eq(test.t1.c1, test.t2.c1)	1.00
+      │   └─IndexScan_32	cop	table:t2, index:c1, range:[<nil>,+inf], keep order:true	1.25
+      └─TableScan_33	cop	table:t2, keep order:false	1.00
 explain select * from t1 order by c1 desc limit 1;
 id	task	operator info	count
 Limit_10	root	offset:0, count:1	1.00
-  TableReader_21	root	data:Limit_20	1.00
-    Limit_20	cop	offset:0, count:1	1.00
-      TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
+└─TableReader_21	root	data:Limit_20	1.00
+  └─Limit_20	cop	offset:0, count:1	1.00
+    └─TableScan_18	cop	table:t1, range:[-inf,+inf], keep order:true, desc	1.00
 set @@session.tidb_opt_insubquery_unfold = 0;
 explain select 1 in (select c2 from t2) from t1;
 id	task	operator info	count
 Projection_6	root	5_aux_0	1999.00
-  HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	1999.00
-    TableReader_9	root	data:TableScan_8	1999.00
-      TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
-    TableReader_12	root	data:Selection_11	0.00
-      Selection_11	cop	eq(1, test.t2.c2)	0.00
-        TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
+└─HashLeftJoin_7	root	left outer semi join, inner:TableReader_12	1999.00
+  ├─TableReader_9	root	data:TableScan_8	1999.00
+  │ └─TableScan_8	cop	table:t1, range:[-inf,+inf], keep order:false	1999.00
+  └─TableReader_12	root	data:Selection_11	0.00
+    └─Selection_11	cop	eq(1, test.t2.c2)	0.00
+      └─TableScan_10	cop	table:t2, range:[-inf,+inf], keep order:false	1985.00
 explain format="dot" select 1 in (select c2 from t2) from t1;
 dot contents
 

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -166,20 +166,20 @@ tr.trade_type IN (1) AND
 te.expect_time BETWEEN '2018-04-23 00:00:00.0' AND '2018-04-23 23:59:59.0'
 ORDER BY te.expect_time asc
 LIMIT 0, 5;
-id	parents	children	task	operator info	count
-IndexScan_100	Selection_102		cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false	10.00
-Selection_102		IndexScan_100	cop	eq(tr.business_type, 18), in(tr.trade_type, 1)	0.00
-TableScan_101	Selection_103		cop	table:tr, keep order:false	0.00
-Selection_103		TableScan_101	cop	eq(tr.brand_identy, 32314), eq(tr.domain_type, 2)	0.00
-IndexLookUp_104	IndexJoin_34		root	index:Selection_102, table:Selection_103	0.00
-IndexScan_30			cop	table:te, index:trade_id, range:[<nil>,+inf], keep order:false	10000.00
-TableScan_31	Selection_32		cop	table:te, keep order:false	10000.00
-Selection_32		TableScan_31	cop	ge(te.expect_time, 2018-04-23 00:00:00.000000), le(te.expect_time, 2018-04-23 23:59:59.000000)	250.00
-IndexLookUp_33	IndexJoin_34		root	index:IndexScan_30, table:Selection_32	250.00
-IndexJoin_34	TopN_139	IndexLookUp_104,IndexLookUp_33	root	inner join, inner:IndexLookUp_33, outer key:tr.id, inner key:te.trade_id	0.00
-TopN_139	IndexJoin_136	IndexJoin_34	root	te.expect_time:asc, offset:0, count:5	0.00
-IndexScan_134			cop	table:p, index:relate_id, range:[<nil>,+inf], keep order:false	10000.00
-IndexReader_135	IndexJoin_136		root	index:IndexScan_134	10000.00
-IndexJoin_136	Limit_18	TopN_139,IndexReader_135	root	left outer join, inner:IndexReader_135, outer key:tr.id, inner key:p.relate_id	0.00
-Limit_18	Projection_12	IndexJoin_136	root	offset:0, count:5	0.00
-Projection_12		Limit_18	root	te.expect_time	0.00
+id	task	operator info	count
+Projection_12	root	te.expect_time	0.00
+  Limit_18	root	offset:0, count:5	0.00
+    IndexJoin_136	root	left outer join, inner:IndexReader_135, outer key:tr.id, inner key:p.relate_id	0.00
+      TopN_139	root	te.expect_time:asc, offset:0, count:5	0.00
+        IndexJoin_34	root	inner join, inner:IndexLookUp_33, outer key:tr.id, inner key:te.trade_id	0.00
+          IndexLookUp_104	root	index:Selection_102, table:Selection_103	0.00
+            Selection_102	cop	eq(tr.business_type, 18), in(tr.trade_type, 1)	0.00
+              IndexScan_100	cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false	10.00
+            Selection_103	cop	eq(tr.brand_identy, 32314), eq(tr.domain_type, 2)	0.00
+              TableScan_101	cop	table:tr, keep order:false	0.00
+          IndexLookUp_33	root	index:IndexScan_30, table:Selection_32	250.00
+            IndexScan_30	cop	table:te, index:trade_id, range:[<nil>,+inf], keep order:false	10000.00
+            Selection_32	cop	ge(te.expect_time, 2018-04-23 00:00:00.000000), le(te.expect_time, 2018-04-23 23:59:59.000000)	250.00
+              TableScan_31	cop	table:te, keep order:false	10000.00
+      IndexReader_135	root	index:IndexScan_134	10000.00
+        IndexScan_134	cop	table:p, index:relate_id, range:[<nil>,+inf], keep order:false	10000.00

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -168,18 +168,18 @@ ORDER BY te.expect_time asc
 LIMIT 0, 5;
 id	task	operator info	count
 Projection_12	root	te.expect_time	0.00
-  Limit_18	root	offset:0, count:5	0.00
-    IndexJoin_136	root	left outer join, inner:IndexReader_135, outer key:tr.id, inner key:p.relate_id	0.00
-      TopN_139	root	te.expect_time:asc, offset:0, count:5	0.00
-        IndexJoin_34	root	inner join, inner:IndexLookUp_33, outer key:tr.id, inner key:te.trade_id	0.00
-          IndexLookUp_104	root	index:Selection_102, table:Selection_103	0.00
-            Selection_102	cop	eq(tr.business_type, 18), in(tr.trade_type, 1)	0.00
-              IndexScan_100	cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false	10.00
-            Selection_103	cop	eq(tr.brand_identy, 32314), eq(tr.domain_type, 2)	0.00
-              TableScan_101	cop	table:tr, keep order:false	0.00
-          IndexLookUp_33	root	index:IndexScan_30, table:Selection_32	250.00
-            IndexScan_30	cop	table:te, index:trade_id, range:[<nil>,+inf], keep order:false	10000.00
-            Selection_32	cop	ge(te.expect_time, 2018-04-23 00:00:00.000000), le(te.expect_time, 2018-04-23 23:59:59.000000)	250.00
-              TableScan_31	cop	table:te, keep order:false	10000.00
-      IndexReader_135	root	index:IndexScan_134	10000.00
-        IndexScan_134	cop	table:p, index:relate_id, range:[<nil>,+inf], keep order:false	10000.00
+└─Limit_18	root	offset:0, count:5	0.00
+  └─IndexJoin_136	root	left outer join, inner:IndexReader_135, outer key:tr.id, inner key:p.relate_id	0.00
+    ├─TopN_139	root	te.expect_time:asc, offset:0, count:5	0.00
+    │ └─IndexJoin_34	root	inner join, inner:IndexLookUp_33, outer key:tr.id, inner key:te.trade_id	0.00
+    │   ├─IndexLookUp_104	root	index:Selection_102, table:Selection_103	0.00
+    │   │ ├─Selection_102	cop	eq(tr.business_type, 18), in(tr.trade_type, 1)	0.00
+    │   │ │ └─IndexScan_100	cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false	10.00
+    │   │ └─Selection_103	cop	eq(tr.brand_identy, 32314), eq(tr.domain_type, 2)	0.00
+    │   │   └─TableScan_101	cop	table:tr, keep order:false	0.00
+    │   └─IndexLookUp_33	root	index:IndexScan_30, table:Selection_32	250.00
+    │     ├─IndexScan_30	cop	table:te, index:trade_id, range:[<nil>,+inf], keep order:false	10000.00
+    │     └─Selection_32	cop	ge(te.expect_time, 2018-04-23 00:00:00.000000), le(te.expect_time, 2018-04-23 23:59:59.000000)	250.00
+    │       └─TableScan_31	cop	table:te, keep order:false	10000.00
+    └─IndexReader_135	root	index:IndexScan_134	10000.00
+      └─IndexScan_134	cop	table:p, index:relate_id, range:[<nil>,+inf], keep order:false	10000.00

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -853,11 +853,11 @@ func (s *testSuite) TestMergejoinOrder(c *C) {
 	tk.MustExec("insert into t2 select a*100, b*100 from t1;")
 
 	tk.MustQuery("explain select /*+ TIDB_SMJ(t2) */ * from t1 left outer join t2 on t1.a=t2.a and t1.a!=3 order by t1.a;").Check(testkit.Rows(
-		"TableScan_10   cop table:t1, range:[-inf,+inf], keep order:true 10000.00",
-		"TableReader_11 MergeJoin_15  root data:TableScan_10 10000.00",
-		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
-		"TableReader_13 MergeJoin_15  root data:TableScan_12 10000.00",
-		"MergeJoin_15  TableReader_11,TableReader_13 root left outer join, left key:test.t1.a, right key:test.t2.a, left cond:[ne(test.t1.a, 3)] 12500.00",
+		"MergeJoin_15 root left outer join, left key:test.t1.a, right key:test.t2.a, left cond:[ne(test.t1.a, 3)] 12500.00",
+		"  TableReader_11 root data:TableScan_10 10000.00",
+		"    TableScan_10 cop table:t1, range:[-inf,+inf], keep order:true 10000.00",
+		"  TableReader_13 root data:TableScan_12 10000.00",
+		"    TableScan_12 cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
 	))
 
 	tk.MustExec("set @@tidb_max_chunk_size=1")

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -854,10 +854,10 @@ func (s *testSuite) TestMergejoinOrder(c *C) {
 
 	tk.MustQuery("explain select /*+ TIDB_SMJ(t2) */ * from t1 left outer join t2 on t1.a=t2.a and t1.a!=3 order by t1.a;").Check(testkit.Rows(
 		"MergeJoin_15 root left outer join, left key:test.t1.a, right key:test.t2.a, left cond:[ne(test.t1.a, 3)] 12500.00",
-		"  TableReader_11 root data:TableScan_10 10000.00",
-		"    TableScan_10 cop table:t1, range:[-inf,+inf], keep order:true 10000.00",
-		"  TableReader_13 root data:TableScan_12 10000.00",
-		"    TableScan_12 cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
+		"├─TableReader_11 root data:TableScan_10 10000.00",
+		"│ └─TableScan_10 cop table:t1, range:[-inf,+inf], keep order:true 10000.00",
+		"└─TableReader_13 root data:TableScan_12 10000.00",
+		"  └─TableScan_12 cop table:t2, range:[-inf,+inf], keep order:true 10000.00",
 	))
 
 	tk.MustExec("set @@tidb_max_chunk_size=1")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2688,9 +2688,11 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a date)")
 	result = tk.MustQuery("desc select a = a from t")
-	result.Check(testkit.Rows("TableScan_4   cop table:t, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_5 Projection_3  root data:TableScan_4 10000.00",
-		"Projection_3  TableReader_5 root eq(test.t.a, test.t.a) 10000.00"))
+	result.Check(testkit.Rows(
+		"Projection_3 root eq(test.t.a, test.t.a) 10000.00",
+		"  TableReader_5 root data:TableScan_4 10000.00",
+		"    TableScan_4 cop table:t, range:[-inf,+inf], keep order:false 10000.00",
+	))
 
 	// for interval
 	result = tk.MustQuery(`select interval(null, 1, 2), interval(1, 2, 3), interval(2, 1, 3)`)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2690,8 +2690,8 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	result = tk.MustQuery("desc select a = a from t")
 	result.Check(testkit.Rows(
 		"Projection_3 root eq(test.t.a, test.t.a) 10000.00",
-		"  TableReader_5 root data:TableScan_4 10000.00",
-		"    TableScan_4 cop table:t, range:[-inf,+inf], keep order:false 10000.00",
+		"└─TableReader_5 root data:TableScan_4 10000.00",
+		"  └─TableScan_4 cop table:t, range:[-inf,+inf], keep order:false 10000.00",
 	))
 
 	// for interval

--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -57,10 +57,10 @@ func (s *testAnalyzeSuite) TestCBOWithoutAnalyze(c *C) {
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t1, t2 where t1.a = t2.a").Check(testkit.Rows(
 		"HashLeftJoin_8 root inner join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)] 7.50",
-		"  TableReader_11 root data:TableScan_10 6.00",
-		"    TableScan_10 cop table:t1, range:[-inf,+inf], keep order:false 6.00",
-		"  TableReader_13 root data:TableScan_12 6.00",
-		"    TableScan_12 cop table:t2, range:[-inf,+inf], keep order:false 6.00",
+		"├─TableReader_11 root data:TableScan_10 6.00",
+		"│ └─TableScan_10 cop table:t1, range:[-inf,+inf], keep order:false 6.00",
+		"└─TableReader_13 root data:TableScan_12 6.00",
+		"  └─TableScan_12 cop table:t2, range:[-inf,+inf], keep order:false 6.00",
 	))
 }
 
@@ -82,44 +82,44 @@ func (s *testAnalyzeSuite) TestStraightJoin(c *C) {
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4").Check(testkit.Rows(
 		"HashLeftJoin_10 root inner join, inner:TableReader_23 10000000000000000.00",
-		"  HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
-		"    HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
-		"      TableReader_17 root data:TableScan_16 10000.00",
-		"        TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"      TableReader_19 root data:TableScan_18 10000.00",
-		"        TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"    TableReader_21 root data:TableScan_20 10000.00",
-		"      TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"  TableReader_23 root data:TableScan_22 10000.00",
-		"    TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
+		"├─HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
+		"│ ├─HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
+		"│ │ ├─TableReader_17 root data:TableScan_16 10000.00",
+		"│ │ │ └─TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"│ │ └─TableReader_19 root data:TableScan_18 10000.00",
+		"│ │   └─TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"│ └─TableReader_21 root data:TableScan_20 10000.00",
+		"│   └─TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"└─TableReader_23 root data:TableScan_22 10000.00",
+		"  └─TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 
 	testKit.MustQuery("explain select * from t1 straight_join t2 straight_join t3 straight_join t4").Check(testkit.Rows(
 		"HashLeftJoin_10 root inner join, inner:TableReader_23 10000000000000000.00",
-		"  HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
-		"    HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
-		"      TableReader_17 root data:TableScan_16 10000.00",
-		"        TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"      TableReader_19 root data:TableScan_18 10000.00",
-		"        TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"    TableReader_21 root data:TableScan_20 10000.00",
-		"      TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"  TableReader_23 root data:TableScan_22 10000.00",
-		"    TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
+		"├─HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
+		"│ ├─HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
+		"│ │ ├─TableReader_17 root data:TableScan_16 10000.00",
+		"│ │ │ └─TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"│ │ └─TableReader_19 root data:TableScan_18 10000.00",
+		"│ │   └─TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"│ └─TableReader_21 root data:TableScan_20 10000.00",
+		"│   └─TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"└─TableReader_23 root data:TableScan_22 10000.00",
+		"  └─TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4 where t1.a=t4.a;").Check(testkit.Rows(
 		"HashLeftJoin_11 root inner join, inner:TableReader_24, equal:[eq(test.t1.a, test.t4.a)] 1250000000000.00",
-		"  HashLeftJoin_13 root inner join, inner:TableReader_22 1000000000000.00",
-		"    HashLeftJoin_15 root inner join, inner:TableReader_20 100000000.00",
-		"      TableReader_18 root data:TableScan_17 10000.00",
-		"        TableScan_17 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"      TableReader_20 root data:TableScan_19 10000.00",
-		"        TableScan_19 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"    TableReader_22 root data:TableScan_21 10000.00",
-		"      TableScan_21 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"  TableReader_24 root data:TableScan_23 10000.00",
-		"    TableScan_23 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
+		"├─HashLeftJoin_13 root inner join, inner:TableReader_22 1000000000000.00",
+		"│ ├─HashLeftJoin_15 root inner join, inner:TableReader_20 100000000.00",
+		"│ │ ├─TableReader_18 root data:TableScan_17 10000.00",
+		"│ │ │ └─TableScan_17 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"│ │ └─TableReader_20 root data:TableScan_19 10000.00",
+		"│ │   └─TableScan_19 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"│ └─TableReader_22 root data:TableScan_21 10000.00",
+		"│   └─TableScan_21 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"└─TableReader_24 root data:TableScan_23 10000.00",
+		"  └─TableScan_23 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 }
 
@@ -144,7 +144,7 @@ func (s *testAnalyzeSuite) TestTableDual(c *C) {
 
 	testKit.MustQuery(`explain select * from t where 1 = 0`).Check(testkit.Rows(
 		`Projection_5 root test.t.a 0.00`,
-		`  TableDual_6 root rows:0 0.00`,
+		`└─TableDual_6 root rows:0 0.00`,
 	))
 
 	testKit.MustQuery(`explain select * from t where 1 = 1 limit 0`).Check(testkit.Rows(
@@ -179,9 +179,9 @@ func (s *testAnalyzeSuite) TestEstimation(c *C) {
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select count(*) from t group by a").Check(testkit.Rows(
 		"HashAgg_9 root group by:col_1, funcs:count(col_0) 2.00",
-		"  TableReader_10 root data:HashAgg_5 2.00",
-		"    HashAgg_5 cop group by:test.t.a, funcs:count(1) 2.00",
-		"      TableScan_8 cop table:t, range:[-inf,+inf], keep order:false 8.00",
+		"└─TableReader_10 root data:HashAgg_5 2.00",
+		"  └─HashAgg_5 cop group by:test.t.a, funcs:count(1) 2.00",
+		"    └─TableScan_8 cop table:t, range:[-inf,+inf], keep order:false 8.00",
 	))
 }
 
@@ -496,15 +496,15 @@ func (s *testAnalyzeSuite) TestOutdatedAnalyze(c *C) {
 	plan.RatioOfPseudoEstimate = 10.0
 	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
 		"TableReader_7 root data:Selection_6 28.80",
-		"  Selection_6 cop le(test.t.a, 5), le(test.t.b, 5) 28.80",
-		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 80.00",
+		"└─Selection_6 cop le(test.t.a, 5), le(test.t.b, 5) 28.80",
+		"  └─TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 80.00",
 	))
 	plan.RatioOfPseudoEstimate = 0.7
 	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
 		"IndexLookUp_11 root index:IndexScan_8, table:Selection_10 8.84",
-		"  IndexScan_8 cop table:t, index:a, range:[-inf,5], keep order:false 26.59",
-		"  Selection_10 cop le(test.t.b, 5) 8.84",
-		"    TableScan_9 cop table:t, keep order:false 26.59",
+		"├─IndexScan_8 cop table:t, index:a, range:[-inf,5], keep order:false 26.59",
+		"└─Selection_10 cop le(test.t.b, 5) 8.84",
+		"  └─TableScan_9 cop table:t, keep order:false 26.59",
 	))
 }
 
@@ -565,13 +565,13 @@ func (s *testAnalyzeSuite) TestNullCount(c *C) {
 	testKit.MustExec("analyze table t")
 	testKit.MustQuery("explain select * from t where a is null").Check(testkit.Rows(
 		"TableReader_7 root data:Selection_6 2.00",
-		"  Selection_6 cop isnull(test.t.a) 2.00",
-		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
+		"└─Selection_6 cop isnull(test.t.a) 2.00",
+		"  └─TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 	testKit.MustQuery("explain select * from t use index(idx) where a is null").Check(testkit.Rows(
 		"IndexLookUp_7 root index:IndexScan_5, table:TableScan_6 2.00",
-		"  IndexScan_5 cop table:t, index:a, range:[<nil>,<nil>], keep order:false 2.00",
-		"  TableScan_6 cop table:t, keep order:false 2.00",
+		"├─IndexScan_5 cop table:t, index:a, range:[<nil>,<nil>], keep order:false 2.00",
+		"└─TableScan_6 cop table:t, keep order:false 2.00",
 	))
 	h := dom.StatsHandle()
 	h.Clear()
@@ -580,13 +580,13 @@ func (s *testAnalyzeSuite) TestNullCount(c *C) {
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t where b = 1").Check(testkit.Rows(
 		"TableReader_7 root data:Selection_6 0.00",
-		"  Selection_6 cop eq(test.t.b, 1) 0.00",
-		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
+		"└─Selection_6 cop eq(test.t.b, 1) 0.00",
+		"  └─TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 	testKit.MustQuery("explain select * from t where b < 1").Check(testkit.Rows(
 		"TableReader_7 root data:Selection_6 0.00",
-		"  Selection_6 cop lt(test.t.b, 1) 0.00",
-		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
+		"└─Selection_6 cop lt(test.t.b, 1) 0.00",
+		"  └─TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 }
 

--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -605,17 +605,18 @@ func (s *testAnalyzeSuite) TestCorrelatedEstimation(c *C) {
 	tk.MustExec("insert into t values(1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5), (6,6,6), (7,7,7), (8,8,8), (9,9,9),(10,10,10)")
 	tk.MustExec("analyze table t")
 	tk.MustQuery("explain select t.c in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;").
-		Check(testkit.Rows("TableScan_14   cop table:t, range:[-inf,+inf], keep order:false 10.00",
-			"TableReader_15 Apply_13  root data:TableScan_14 10.00",
-			"TableScan_23 Selection_24  cop table:s, range:[-inf,+inf], keep order:false 10.00",
-			"Selection_24  TableScan_23 cop eq(s.a, test.t.a) 1.00",
-			"TableReader_25 HashRightJoin_22  root data:Selection_24 1.00",
-			"TableScan_26   cop table:t1, range:[-inf,+inf], keep order:false 10.00",
-			"TableReader_27 HashRightJoin_22  root data:TableScan_26 10.00",
-			"HashRightJoin_22 StreamAgg_20 TableReader_25,TableReader_27 root inner join, inner:TableReader_25, equal:[eq(s.a, t1.a)] 1.00",
-			"StreamAgg_20 Apply_13 HashRightJoin_22 root funcs:count(1) 1.00",
-			"Apply_13 Projection_11 TableReader_15,StreamAgg_20 root left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, count(*))] 10.00",
-			"Projection_11  Apply_13 root 9_aux_0 10.00",
+		Check(testkit.Rows(
+			"Projection_11 root 9_aux_0 10.00",
+			"└─Apply_13 root left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, count(*))] 10.00",
+			"  ├─TableReader_15 root data:TableScan_14 10.00",
+			"  │ └─TableScan_14 cop table:t, range:[-inf,+inf], keep order:false 10.00",
+			"  └─StreamAgg_20 root funcs:count(1) 1.00",
+			"    └─HashRightJoin_22 root inner join, inner:TableReader_25, equal:[eq(s.a, t1.a)] 1.00",
+			"      ├─TableReader_25 root data:Selection_24 1.00",
+			"      │ └─Selection_24 cop eq(s.a, test.t.a) 1.00",
+			"      │   └─TableScan_23 cop table:s, range:[-inf,+inf], keep order:false 10.00",
+			"      └─TableReader_27 root data:TableScan_26 10.00",
+			"        └─TableScan_26 cop table:t1, range:[-inf,+inf], keep order:false 10.00",
 		))
 }
 

--- a/plan/cbo_test.go
+++ b/plan/cbo_test.go
@@ -56,11 +56,11 @@ func (s *testAnalyzeSuite) TestCBOWithoutAnalyze(c *C) {
 	h.DumpStatsDeltaToKV()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t1, t2 where t1.a = t2.a").Check(testkit.Rows(
-		"TableScan_10   cop table:t1, range:[-inf,+inf], keep order:false 6.00",
-		"TableReader_11 HashLeftJoin_8  root data:TableScan_10 6.00",
-		"TableScan_12   cop table:t2, range:[-inf,+inf], keep order:false 6.00",
-		"TableReader_13 HashLeftJoin_8  root data:TableScan_12 6.00",
-		"HashLeftJoin_8  TableReader_11,TableReader_13 root inner join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)] 7.50",
+		"HashLeftJoin_8 root inner join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)] 7.50",
+		"  TableReader_11 root data:TableScan_10 6.00",
+		"    TableScan_10 cop table:t1, range:[-inf,+inf], keep order:false 6.00",
+		"  TableReader_13 root data:TableScan_12 6.00",
+		"    TableScan_12 cop table:t2, range:[-inf,+inf], keep order:false 6.00",
 	))
 }
 
@@ -81,45 +81,45 @@ func (s *testAnalyzeSuite) TestStraightJoin(c *C) {
 	}
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4").Check(testkit.Rows(
-		"TableScan_16   cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_17 HashLeftJoin_14  root data:TableScan_16 10000.00",
-		"TableScan_18   cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_19 HashLeftJoin_14  root data:TableScan_18 10000.00",
-		"HashLeftJoin_14 HashLeftJoin_12 TableReader_17,TableReader_19 root inner join, inner:TableReader_19 100000000.00",
-		"TableScan_20   cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_21 HashLeftJoin_12  root data:TableScan_20 10000.00",
-		"HashLeftJoin_12 HashLeftJoin_10 HashLeftJoin_14,TableReader_21 root inner join, inner:TableReader_21 1000000000000.00",
-		"TableScan_22   cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_23 HashLeftJoin_10  root data:TableScan_22 10000.00",
-		"HashLeftJoin_10  HashLeftJoin_12,TableReader_23 root inner join, inner:TableReader_23 10000000000000000.00",
+		"HashLeftJoin_10 root inner join, inner:TableReader_23 10000000000000000.00",
+		"  HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
+		"    HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
+		"      TableReader_17 root data:TableScan_16 10000.00",
+		"        TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"      TableReader_19 root data:TableScan_18 10000.00",
+		"        TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"    TableReader_21 root data:TableScan_20 10000.00",
+		"      TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"  TableReader_23 root data:TableScan_22 10000.00",
+		"    TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 
 	testKit.MustQuery("explain select * from t1 straight_join t2 straight_join t3 straight_join t4").Check(testkit.Rows(
-		"TableScan_16   cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_17 HashLeftJoin_14  root data:TableScan_16 10000.00",
-		"TableScan_18   cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_19 HashLeftJoin_14  root data:TableScan_18 10000.00",
-		"HashLeftJoin_14 HashLeftJoin_12 TableReader_17,TableReader_19 root inner join, inner:TableReader_19 100000000.00",
-		"TableScan_20   cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_21 HashLeftJoin_12  root data:TableScan_20 10000.00",
-		"HashLeftJoin_12 HashLeftJoin_10 HashLeftJoin_14,TableReader_21 root inner join, inner:TableReader_21 1000000000000.00",
-		"TableScan_22   cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_23 HashLeftJoin_10  root data:TableScan_22 10000.00",
-		"HashLeftJoin_10  HashLeftJoin_12,TableReader_23 root inner join, inner:TableReader_23 10000000000000000.00",
+		"HashLeftJoin_10 root inner join, inner:TableReader_23 10000000000000000.00",
+		"  HashLeftJoin_12 root inner join, inner:TableReader_21 1000000000000.00",
+		"    HashLeftJoin_14 root inner join, inner:TableReader_19 100000000.00",
+		"      TableReader_17 root data:TableScan_16 10000.00",
+		"        TableScan_16 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"      TableReader_19 root data:TableScan_18 10000.00",
+		"        TableScan_18 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"    TableReader_21 root data:TableScan_20 10000.00",
+		"      TableScan_20 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"  TableReader_23 root data:TableScan_22 10000.00",
+		"    TableScan_22 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4 where t1.a=t4.a;").Check(testkit.Rows(
-		"TableScan_17   cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_18 HashLeftJoin_15  root data:TableScan_17 10000.00",
-		"TableScan_19   cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_20 HashLeftJoin_15  root data:TableScan_19 10000.00",
-		"HashLeftJoin_15 HashLeftJoin_13 TableReader_18,TableReader_20 root inner join, inner:TableReader_20 100000000.00",
-		"TableScan_21   cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_22 HashLeftJoin_13  root data:TableScan_21 10000.00",
-		"HashLeftJoin_13 HashLeftJoin_11 HashLeftJoin_15,TableReader_22 root inner join, inner:TableReader_22 1000000000000.00",
-		"TableScan_23   cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
-		"TableReader_24 HashLeftJoin_11  root data:TableScan_23 10000.00",
-		"HashLeftJoin_11  HashLeftJoin_13,TableReader_24 root inner join, inner:TableReader_24, equal:[eq(test.t1.a, test.t4.a)] 1250000000000.00",
+		"HashLeftJoin_11 root inner join, inner:TableReader_24, equal:[eq(test.t1.a, test.t4.a)] 1250000000000.00",
+		"  HashLeftJoin_13 root inner join, inner:TableReader_22 1000000000000.00",
+		"    HashLeftJoin_15 root inner join, inner:TableReader_20 100000000.00",
+		"      TableReader_18 root data:TableScan_17 10000.00",
+		"        TableScan_17 cop table:t1, range:[-inf,+inf], keep order:false 10000.00",
+		"      TableReader_20 root data:TableScan_19 10000.00",
+		"        TableScan_19 cop table:t2, range:[-inf,+inf], keep order:false 10000.00",
+		"    TableReader_22 root data:TableScan_21 10000.00",
+		"      TableScan_21 cop table:t3, range:[-inf,+inf], keep order:false 10000.00",
+		"  TableReader_24 root data:TableScan_23 10000.00",
+		"    TableScan_23 cop table:t4, range:[-inf,+inf], keep order:false 10000.00",
 	))
 }
 
@@ -143,12 +143,12 @@ func (s *testAnalyzeSuite) TestTableDual(c *C) {
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 
 	testKit.MustQuery(`explain select * from t where 1 = 0`).Check(testkit.Rows(
-		`TableDual_6 Projection_5  root rows:0 0.00`,
-		`Projection_5  TableDual_6 root test.t.a 0.00`,
+		`Projection_5 root test.t.a 0.00`,
+		`  TableDual_6 root rows:0 0.00`,
 	))
 
 	testKit.MustQuery(`explain select * from t where 1 = 1 limit 0`).Check(testkit.Rows(
-		`TableDual_5   root rows:0 0.00`,
+		`TableDual_5 root rows:0 0.00`,
 	))
 }
 
@@ -178,10 +178,10 @@ func (s *testAnalyzeSuite) TestEstimation(c *C) {
 	h.DumpStatsDeltaToKV()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select count(*) from t group by a").Check(testkit.Rows(
-		"TableScan_8 HashAgg_5  cop table:t, range:[-inf,+inf], keep order:false 8.00",
-		"HashAgg_5  TableScan_8 cop group by:test.t.a, funcs:count(1) 2.00",
-		"TableReader_10 HashAgg_9  root data:HashAgg_5 2.00",
-		"HashAgg_9  TableReader_10 root group by:col_1, funcs:count(col_0) 2.00",
+		"HashAgg_9 root group by:col_1, funcs:count(col_0) 2.00",
+		"  TableReader_10 root data:HashAgg_5 2.00",
+		"    HashAgg_5 cop group by:test.t.a, funcs:count(1) 2.00",
+		"      TableScan_8 cop table:t, range:[-inf,+inf], keep order:false 8.00",
 	))
 }
 
@@ -495,16 +495,16 @@ func (s *testAnalyzeSuite) TestOutdatedAnalyze(c *C) {
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	plan.RatioOfPseudoEstimate = 10.0
 	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
-		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 80.00",
-		"Selection_6  TableScan_5 cop le(test.t.a, 5), le(test.t.b, 5) 28.80",
-		"TableReader_7   root data:Selection_6 28.80",
+		"TableReader_7 root data:Selection_6 28.80",
+		"  Selection_6 cop le(test.t.a, 5), le(test.t.b, 5) 28.80",
+		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 80.00",
 	))
 	plan.RatioOfPseudoEstimate = 0.7
 	testKit.MustQuery("explain select * from t where a <= 5 and b <= 5").Check(testkit.Rows(
-		"IndexScan_8   cop table:t, index:a, range:[-inf,5], keep order:false 26.59",
-		"TableScan_9 Selection_10  cop table:t, keep order:false 26.59",
-		"Selection_10  TableScan_9 cop le(test.t.b, 5) 8.84",
-		"IndexLookUp_11   root index:IndexScan_8, table:Selection_10 8.84",
+		"IndexLookUp_11 root index:IndexScan_8, table:Selection_10 8.84",
+		"  IndexScan_8 cop table:t, index:a, range:[-inf,5], keep order:false 26.59",
+		"  Selection_10 cop le(test.t.b, 5) 8.84",
+		"    TableScan_9 cop table:t, keep order:false 26.59",
 	))
 }
 
@@ -564,14 +564,14 @@ func (s *testAnalyzeSuite) TestNullCount(c *C) {
 	testKit.MustExec("insert into t values (null, null), (null, null)")
 	testKit.MustExec("analyze table t")
 	testKit.MustQuery("explain select * from t where a is null").Check(testkit.Rows(
-		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 2.00",
-		"Selection_6  TableScan_5 cop isnull(test.t.a) 2.00",
-		"TableReader_7   root data:Selection_6 2.00",
+		"TableReader_7 root data:Selection_6 2.00",
+		"  Selection_6 cop isnull(test.t.a) 2.00",
+		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 	testKit.MustQuery("explain select * from t use index(idx) where a is null").Check(testkit.Rows(
-		"IndexScan_5   cop table:t, index:a, range:[<nil>,<nil>], keep order:false 2.00",
-		"TableScan_6   cop table:t, keep order:false 2.00",
-		"IndexLookUp_7   root index:IndexScan_5, table:TableScan_6 2.00",
+		"IndexLookUp_7 root index:IndexScan_5, table:TableScan_6 2.00",
+		"  IndexScan_5 cop table:t, index:a, range:[<nil>,<nil>], keep order:false 2.00",
+		"  TableScan_6 cop table:t, keep order:false 2.00",
 	))
 	h := dom.StatsHandle()
 	h.Clear()
@@ -579,14 +579,14 @@ func (s *testAnalyzeSuite) TestNullCount(c *C) {
 	defer func() { h.Lease = 0 }()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t where b = 1").Check(testkit.Rows(
-		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 2.00",
-		"Selection_6  TableScan_5 cop eq(test.t.b, 1) 0.00",
-		"TableReader_7   root data:Selection_6 0.00",
+		"TableReader_7 root data:Selection_6 0.00",
+		"  Selection_6 cop eq(test.t.b, 1) 0.00",
+		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 	testKit.MustQuery("explain select * from t where b < 1").Check(testkit.Rows(
-		"TableScan_5 Selection_6  cop table:t, range:[-inf,+inf], keep order:false 2.00",
-		"Selection_6  TableScan_5 cop lt(test.t.b, 1) 0.00",
-		"TableReader_7   root data:Selection_6 0.00",
+		"TableReader_7 root data:Selection_6 0.00",
+		"  Selection_6 cop lt(test.t.b, 1) 0.00",
+		"    TableScan_5 cop table:t, range:[-inf,+inf], keep order:false 2.00",
 	))
 }
 

--- a/plan/explain.go
+++ b/plan/explain.go
@@ -149,11 +149,13 @@ func (p *basePhysicalAgg) ExplainInfo() string {
 		fmt.Fprintf(buffer, "group by:%s, ",
 			expression.ExplainExpressionList(p.GroupByItems))
 	}
-	buffer.WriteString("funcs:")
-	for i, agg := range p.AggFuncs {
-		buffer.WriteString(aggregation.ExplainAggFunc(agg))
-		if i+1 < len(p.AggFuncs) {
-			buffer.WriteString(", ")
+	if len(p.AggFuncs) > 0 {
+		buffer.WriteString("funcs:")
+		for i, agg := range p.AggFuncs {
+			buffer.WriteString(aggregation.ExplainAggFunc(agg))
+			if i+1 < len(p.AggFuncs) {
+				buffer.WriteString(", ")
+			}
 		}
 	}
 	return buffer.String()

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -1214,7 +1214,7 @@ func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
 		}
 		p.SetSchema(schema)
 		p.explainedPlans = map[int]bool{}
-		p.prepareRootTaskInfo(p.StmtPlan.(PhysicalPlan), "")
+		p.prepareRootTaskInfo(p.StmtPlan.(PhysicalPlan), "", true)
 	case ast.ExplainFormatDOT:
 		retFields := []string{"dot contents"}
 		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -1207,7 +1207,7 @@ func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
 	p := &Explain{StmtPlan: pp}
 	switch strings.ToLower(explain.Format) {
 	case ast.ExplainFormatROW:
-		retFields := []string{"id", "parents", "children", "task", "operator info", "count"}
+		retFields := []string{"id", "task", "operator info", "count"}
 		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
 		for _, fieldName := range retFields {
 			schema.Append(buildColumn("", fieldName, mysql.TypeString, mysql.MaxBlobWidth))

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -1214,7 +1214,7 @@ func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
 		}
 		p.SetSchema(schema)
 		p.explainedPlans = map[int]bool{}
-		p.prepareRootTaskInfo(p.StmtPlan.(PhysicalPlan), "", true)
+		p.explainPlanInRowFormat(p.StmtPlan.(PhysicalPlan), "root", "", true)
 	case ast.ExplainFormatDOT:
 		retFields := []string{"dot contents"}
 		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -205,14 +205,14 @@ func (s *testSelectivitySuite) TestPseudoSelectivity(c *C) {
 	testKit.MustExec("drop table if exists t, t1")
 	testKit.MustExec("create table t(a int, b int, unique key idx(a,b))")
 	testKit.MustQuery("explain select * from t where a = 1 and b = 1").Check(testkit.Rows(
-		"IndexScan_8   cop table:t, index:a, b, range:[1 1,1 1], keep order:false 1.00",
-		"IndexReader_9   root index:IndexScan_8 1.00"))
+		"IndexReader_9 root index:IndexScan_8 1.00",
+		"  IndexScan_8 cop table:t, index:a, b, range:[1 1,1 1], keep order:false 1.00"))
 
 	testKit.MustExec("create table t1(a int, b int, primary key(a))")
 	testKit.MustQuery("explain select b from t1 where a = 1").Check(testkit.Rows(
-		"TableScan_5   cop table:t1, range:[1,1], keep order:false 1.00",
-		"TableReader_6 Projection_4  root data:TableScan_5 1.00",
-		"Projection_4  TableReader_6 root test.t1.b 1.00"))
+		"Projection_4 root test.t1.b 1.00",
+		"  TableReader_6 root data:TableScan_5 1.00",
+		"    TableScan_5 cop table:t1, range:[1,1], keep order:false 1.00"))
 }
 
 // TestDiscreteDistribution tests the estimation for discrete data distribution. This is more common when the index
@@ -230,8 +230,8 @@ func (s *testSelectivitySuite) TestDiscreteDistribution(c *C) {
 	}
 	testKit.MustExec("analyze table t")
 	testKit.MustQuery("explain select * from t where a = 'tw' and b < 0").Check(testkit.Rows(
-		"IndexScan_8   cop table:t, index:a, b, range:[tw -inf,tw 0), keep order:false 0.00",
-		"IndexReader_9   root index:IndexScan_8 0.00"))
+		"IndexReader_9 root index:IndexScan_8 0.00",
+		"  IndexScan_8 cop table:t, index:a, b, range:[tw -inf,tw 0), keep order:false 0.00"))
 }
 
 func BenchmarkSelectivity(b *testing.B) {

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -206,13 +206,13 @@ func (s *testSelectivitySuite) TestPseudoSelectivity(c *C) {
 	testKit.MustExec("create table t(a int, b int, unique key idx(a,b))")
 	testKit.MustQuery("explain select * from t where a = 1 and b = 1").Check(testkit.Rows(
 		"IndexReader_9 root index:IndexScan_8 1.00",
-		"  IndexScan_8 cop table:t, index:a, b, range:[1 1,1 1], keep order:false 1.00"))
+		"└─IndexScan_8 cop table:t, index:a, b, range:[1 1,1 1], keep order:false 1.00"))
 
 	testKit.MustExec("create table t1(a int, b int, primary key(a))")
 	testKit.MustQuery("explain select b from t1 where a = 1").Check(testkit.Rows(
 		"Projection_4 root test.t1.b 1.00",
-		"  TableReader_6 root data:TableScan_5 1.00",
-		"    TableScan_5 cop table:t1, range:[1,1], keep order:false 1.00"))
+		"└─TableReader_6 root data:TableScan_5 1.00",
+		"  └─TableScan_5 cop table:t1, range:[1,1], keep order:false 1.00"))
 }
 
 // TestDiscreteDistribution tests the estimation for discrete data distribution. This is more common when the index
@@ -231,7 +231,7 @@ func (s *testSelectivitySuite) TestDiscreteDistribution(c *C) {
 	testKit.MustExec("analyze table t")
 	testKit.MustQuery("explain select * from t where a = 'tw' and b < 0").Check(testkit.Rows(
 		"IndexReader_9 root index:IndexScan_8 0.00",
-		"  IndexScan_8 cop table:t, index:a, b, range:[tw -inf,tw 0), keep order:false 0.00"))
+		"└─IndexScan_8 cop table:t, index:a, b, range:[tw -inf,tw 0), keep order:false 0.00"))
 }
 
 func BenchmarkSelectivity(b *testing.B) {


### PR DESCRIPTION
## What have you changed? (mandatory)
Fix #6893

The current result of `explain` is kind of confusion and hard to find the relationship between operators:
```sql
TiDB(localhost:4000) > desc select count(*) from t1 left outer join t2 on t1.a=t2.a and t1.b>10 and t2.b>20 group by t1.a;
+-----------------+-----------------+-------------------------------+------+--------------------------------------------------------------------------------------------------------+----------+
| id              | parents         | children                      | task | operator info                                                                                          | count    |
+-----------------+-----------------+-------------------------------+------+--------------------------------------------------------------------------------------------------------+----------+
| TableScan_11    |                 |                               | cop  | table:t1, range:[-inf,+inf], keep order:false                                                          | 10000.00 |
| TableReader_12  | HashLeftJoin_10 |                               | root | data:TableScan_11                                                                                      | 10000.00 |
| TableScan_13    | Selection_14    |                               | cop  | table:t2, range:[-inf,+inf], keep order:false                                                          | 10000.00 |
| Selection_14    |                 | TableScan_13                  | cop  | gt(test.t2.b, 20)                                                                                      | 3333.33  |
| TableReader_15  | HashLeftJoin_10 |                               | root | data:Selection_14                                                                                      | 3333.33  |
| HashLeftJoin_10 | HashAgg_9       | TableReader_12,TableReader_15 | root | left outer join, inner:TableReader_15, equal:[eq(test.t1.a, test.t2.a)], left cond:[gt(test.t1.b, 10)] | 10000.00 |
| HashAgg_9       |                 | HashLeftJoin_10               | root | group by:test.t1.a, funcs:count(1)                                                                     | 8000.00  |
+-----------------+-----------------+-------------------------------+------+--------------------------------------------------------------------------------------------------------+----------+
7 rows in set (0.00 sec)
```

Actually we can draw the relationship between operators by indent, after this PR:
```sql
TiDB(localhost:4000) > desc select count(*) from t1 left outer join t2 on t1.a=t2.a and t1.b>10 and t2.b>20 group by t1.a;
+--------------------------+------+-----------------------------------------------------------------------------------------------+----------+
| id                       | task | operator info                                                                                 | count    |
+--------------------------+------+-----------------------------------------------------------------------------------------------+----------+
| StreamAgg_12             | root | group by:test.t1.a, funcs:count(1)                                                            | 8000.00  |
| └─MergeJoin_29           | root | left outer join, left key:test.t1.a, right key:test.t2.a, left cond:[gt(cast(test.t1.b), 10)] | 10000.00 |
|   ├─IndexLookUp_18       | root | index:IndexScan_16, table:TableScan_17                                                        | 10000.00 |
|   │ ├─IndexScan_16       | cop  | table:t1, index:a, range:[<nil>,+inf], keep order:true                                        | 10000.00 |
|   │ └─TableScan_17       | cop  | table:t1, keep order:false                                                                    | 10000.00 |
|   └─Selection_19         | root | gt(cast(test.t2.b), 20)                                                                       | 8000.00  |
|     └─IndexLookUp_23     | root | index:IndexScan_21, table:TableScan_22                                                        | 10000.00 |
|       ├─IndexScan_21     | cop  | table:t2, index:a, range:[<nil>,+inf], keep order:true                                        | 10000.00 |
|       └─TableScan_22     | cop  | table:t2, keep order:false                                                                    | 10000.00 |
+--------------------------+------+-----------------------------------------------------------------------------------------------+----------+
9 rows in set (0.00 sec)
```

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

Yes 


