### PR TITLE
 plan: fix a bug in `topn_push_down` rule.

### DIFF
--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -1696,6 +1696,11 @@ func (s *testPlanSuite) TestTopNPushDown(c *C) {
 			sql:  "select * from t union all (select * from t s order by a) limit 5",
 			best: "UnionAll{DataScan(t)->Limit->Projection->DataScan(s)->TopN([s.a],0,5)->Projection}->Limit",
 		},
+		// Test `ByItem` containing column from both sides.
+		{
+			sql:  "select ifnull(t1.b, t2.a) from t t1 left join t t2 on t1.e=t2.e order by ifnull(t1.b, t2.a) limit 5",
+			best: "Join{DataScan(t1)->DataScan(t2)}(t1.e,t2.e)->TopN([ifnull(t1.b, t2.a)],0,5)->Projection->Projection",
+		},
 	}
 	for i, tt := range tests {
 		comment := Commentf("case:%v sql:%s", i, tt.sql)

--- a/plan/rule_topn_push_down.go
+++ b/plan/rule_topn_push_down.go
@@ -109,8 +109,10 @@ func (p *LogicalJoin) pushDownTopNToChild(topN *LogicalTopN, idx int) LogicalPla
 
 	for _, by := range topN.ByItems {
 		cols := expression.ExtractColumns(by.Expr)
-		if len(p.children[1-idx].Schema().ColumnsIndices(cols)) != 0 {
-			return p.children[idx].pushDownTopN(nil)
+		for _, col := range cols {
+			if p.children[1-idx].Schema().Contains(col) {
+				return p.children[idx].pushDownTopN(nil)
+			}
 		}
 	}
 


### PR DESCRIPTION
## What have you changed? (mandatory)

`ColumnIndices` will return `nil` if not all column in the schema.
So here will perform wrong action if the by item contains column from both sides.

## What are the type of the changes (mandatory)?

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Bug fix

## How has this PR been tested (mandatory)?

unit test.

## Refer to a related PR or issue link (optional)

fix #6864 

