### PR TITLE
stats: refactor stats mechanism

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -662,23 +662,11 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 		case <-do.exit:
 			do.wg.Done()
 			return
-			// This channel is sent only by ddl owner or the drop stats executor.
+			// This channel is sent only by ddl owner.
 		case t := <-statsHandle.DDLEventCh():
 			err = statsHandle.HandleDDLEvent(t)
 			if err != nil {
 				log.Debug("[stats] handle ddl event fail: ", errors.ErrorStack(err))
-			}
-		case t := <-statsHandle.AnalyzeResultCh():
-			for i, hg := range t.Hist {
-				err = statistics.SaveStatsToStorage(ctx, t.TableID, t.Count, t.IsIndex, hg, t.Cms[i])
-				if err != nil {
-					log.Debug("[stats] save histogram to storage fail: ", errors.ErrorStack(err))
-				}
-			}
-		case t := <-statsHandle.LoadMetaCh():
-			err = statistics.SaveMetaToStorage(ctx, t.TableID, t.Count, t.ModifyCount)
-			if err != nil {
-				log.Debug("[stats] save meta to storage fail: ", errors.ErrorStack(err))
 			}
 		case <-deltaUpdateTicker.C:
 			err = statsHandle.DumpStatsDeltaToKV()

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -15,7 +15,6 @@ package executor
 
 import (
 	"strconv"
-	"time"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/distsql"
@@ -66,50 +65,27 @@ func (e *AnalyzeExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		taskCh <- task
 	}
 	close(taskCh)
-	dom := domain.GetDomain(e.ctx)
-	lease := dom.StatsHandle().Lease
-	if lease > 0 {
-		var err1 error
-		for i := 0; i < len(e.tasks); i++ {
-			result := <-resultCh
-			if result.Err != nil {
-				err1 = result.Err
-				log.Error(errors.ErrorStack(err1))
-				continue
-			}
-			dom.StatsHandle().AnalyzeResultCh() <- &result
-		}
-		// We sleep two lease to make sure other tidb node has updated this node.
-		time.Sleep(lease * 2)
-		return errors.Trace(err1)
-	}
-	results := make([]statistics.AnalyzeResult, 0, len(e.tasks))
-	var err1 error
+	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	for i := 0; i < len(e.tasks); i++ {
 		result := <-resultCh
 		if result.Err != nil {
-			err1 = result.Err
-			log.Error(errors.ErrorStack(err1))
+			err = result.Err
+			log.Debug(errors.ErrorStack(err))
 			continue
 		}
-		results = append(results, result)
-	}
-	if err1 != nil {
-		return errors.Trace(err1)
-	}
-	for _, result := range results {
 		for i, hg := range result.Hist {
-			err = statistics.SaveStatsToStorage(e.ctx, result.TableID, result.Count, result.IsIndex, hg, result.Cms[i])
-			if err != nil {
-				return errors.Trace(err)
+			err1 := statsHandle.SaveStatsToStorage(result.TableID, result.Count, result.IsIndex, hg, result.Cms[i])
+			if err1 != nil {
+				err = err1
+				log.Debug(errors.ErrorStack(err))
+				continue
 			}
 		}
 	}
-	err = dom.StatsHandle().Update(GetInfoSchema(e.ctx))
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return nil
+	return errors.Trace(statsHandle.Update(GetInfoSchema(e.ctx)))
 }
 
 func getBuildStatsConcurrency(ctx sessionctx.Context) (int, error) {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/model"
@@ -341,13 +340,9 @@ func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
 
 func (e *SimpleExec) executeDropStats(s *ast.DropStatsStmt) error {
 	h := domain.GetDomain(e.ctx).StatsHandle()
-	if h.Lease <= 0 {
-		err := h.DeleteTableStatsFromKV(s.Table.TableInfo.ID)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		return errors.Trace(h.Update(GetInfoSchema(e.ctx)))
+	err := h.DeleteTableStatsFromKV(s.Table.TableInfo.ID)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	h.DDLEventCh() <- &util.Event{Tp: model.ActionDropTable, TableInfo: s.Table.TableInfo}
-	return nil
+	return errors.Trace(h.Update(GetInfoSchema(e.ctx)))
 }

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -290,7 +290,6 @@ func (s *testSuite) TestDropStats(c *C) {
 
 	h.Lease = 1
 	testKit.MustExec("drop stats t")
-	h.HandleDDLEvent(<-h.DDLEventCh())
 	h.Update(is)
 	statsTbl = h.GetTableStats(tableInfo)
 	c.Assert(statsTbl.Pseudo, IsTrue)

--- a/statistics/boostrap.go
+++ b/statistics/boostrap.go
@@ -51,8 +51,10 @@ func initStatsMeta4Chunk(is infoschema.InfoSchema, tables statsCache, iter *chun
 }
 
 func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (statsCache, error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	sql := "select version, table_id, modify_count, count from mysql.stats_meta"
-	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -119,8 +121,10 @@ func initStatsHistograms4Chunk(is infoschema.InfoSchema, tables statsCache, iter
 }
 
 func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, tables statsCache) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	sql := "select table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver from mysql.stats_histograms"
-	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -189,8 +193,10 @@ func initStatsBuckets4Chunk(ctx sessionctx.Context, tables statsCache, iter *chu
 }
 
 func (h *Handle) initStatsBuckets(tables statsCache) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
 	sql := "select table_id, is_index, hist_id, count, repeats, lower_bound, upper_bound from mysql.stats_buckets order by table_id, is_index, hist_id, bucket_id"
-	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -207,11 +213,11 @@ func (h *Handle) initStatsBuckets(tables statsCache) error {
 		if chk.NumRows() == 0 {
 			break
 		}
-		initStatsBuckets4Chunk(h.ctx, tables, iter)
+		initStatsBuckets4Chunk(h.mu.ctx, tables, iter)
 	}
 	for _, table := range tables {
-		if h.LastVersion < table.Version {
-			h.LastVersion = table.Version
+		if h.mu.lastVersion < table.Version {
+			h.mu.lastVersion = table.Version
 		}
 		for _, idx := range table.Indices {
 			for i := 1; i < idx.Len(); i++ {

--- a/statistics/dump.go
+++ b/statistics/dump.go
@@ -100,57 +100,19 @@ func (h *Handle) LoadStatsFromJSON(is infoschema.InfoSchema, jsonTbl *JSONTable)
 		return errors.Trace(err)
 	}
 
-	if h.Lease > 0 {
-		hists := make([]*Histogram, 0, len(tbl.Columns))
-		cms := make([]*CMSketch, 0, len(tbl.Columns))
-		for _, col := range tbl.Columns {
-			hists = append(hists, &col.Histogram)
-			cms = append(cms, col.CMSketch)
-		}
-		h.AnalyzeResultCh() <- &AnalyzeResult{
-			TableID: tbl.TableID,
-			Hist:    hists,
-			Cms:     cms,
-			Count:   tbl.Count,
-			IsIndex: 0,
-			Err:     nil,
-		}
-
-		hists = make([]*Histogram, 0, len(tbl.Indices))
-		cms = make([]*CMSketch, 0, len(tbl.Indices))
-		for _, idx := range tbl.Indices {
-			hists = append(hists, &idx.Histogram)
-			cms = append(cms, idx.CMSketch)
-		}
-		h.AnalyzeResultCh() <- &AnalyzeResult{
-			TableID: tbl.TableID,
-			Hist:    hists,
-			Cms:     cms,
-			Count:   tbl.Count,
-			IsIndex: 1,
-			Err:     nil,
-		}
-
-		h.LoadMetaCh() <- &LoadMeta{
-			TableID:     tbl.TableID,
-			Count:       tbl.Count,
-			ModifyCount: tbl.ModifyCount,
-		}
-		return errors.Trace(err)
-	}
 	for _, col := range tbl.Columns {
-		err = SaveStatsToStorage(h.ctx, tbl.TableID, tbl.Count, 0, &col.Histogram, col.CMSketch)
+		err = h.SaveStatsToStorage(tbl.TableID, tbl.Count, 0, &col.Histogram, col.CMSketch)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
 	for _, idx := range tbl.Indices {
-		err = SaveStatsToStorage(h.ctx, tbl.TableID, tbl.Count, 1, &idx.Histogram, idx.CMSketch)
+		err = h.SaveStatsToStorage(tbl.TableID, tbl.Count, 1, &idx.Histogram, idx.CMSketch)
 		if err != nil {
 			return errors.Trace(err)
 		}
 	}
-	err = SaveMetaToStorage(h.ctx, tbl.TableID, tbl.Count, tbl.ModifyCount)
+	err = h.SaveMetaToStorage(tbl.TableID, tbl.Count, tbl.ModifyCount)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -205,11 +167,4 @@ func (h *Handle) LoadStatsFromJSONToTable(tableInfo *model.TableInfo, jsonTbl *J
 		}
 	}
 	return tbl, nil
-}
-
-// LoadMeta is the statistic meta loaded from json file.
-type LoadMeta struct {
-	TableID     int64
-	Count       int64
-	ModifyCount int64
 }

--- a/statistics/gc.go
+++ b/statistics/gc.go
@@ -32,11 +32,11 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) error
 	// we only garbage collect version before 10 lease.
 	lease := mathutil.MaxInt64(int64(h.Lease), int64(ddlLease))
 	offset := oracle.ComposeTS(10*lease, 0)
-	if h.PrevLastVersion < offset {
+	if h.LastUpdateVersion() < offset {
 		return nil
 	}
-	sql := fmt.Sprintf("select table_id from mysql.stats_meta where version < %d", h.PrevLastVersion-offset)
-	rows, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, sql)
+	sql := fmt.Sprintf("select table_id from mysql.stats_meta where version < %d", h.LastUpdateVersion()-offset)
+	rows, _, err := h.restrictedExec.ExecRestrictedSQL(nil, sql)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -50,7 +50,7 @@ func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) error
 
 func (h *Handle) gcTableStats(is infoschema.InfoSchema, tableID int64) error {
 	sql := fmt.Sprintf("select is_index, hist_id from mysql.stats_histograms where table_id = %d", tableID)
-	rows, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, sql)
+	rows, _, err := h.restrictedExec.ExecRestrictedSQL(nil, sql)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -58,7 +58,7 @@ func (h *Handle) gcTableStats(is infoschema.InfoSchema, tableID int64) error {
 	// we can safely remove the meta info now.
 	if len(rows) == 0 {
 		sql := fmt.Sprintf("delete from mysql.stats_meta where table_id = %d", tableID)
-		_, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, sql)
+		_, _, err := h.restrictedExec.ExecRestrictedSQL(nil, sql)
 		return errors.Trace(err)
 	}
 	tbl, ok := is.TableByID(tableID)
@@ -95,13 +95,15 @@ func (h *Handle) gcTableStats(is infoschema.InfoSchema, tableID int64) error {
 
 // deleteHistStatsFromKV deletes all records about a column or an index and updates version.
 func (h *Handle) deleteHistStatsFromKV(tableID int64, histID int64, isIndex int) error {
-	exec := h.ctx.(sqlexec.SQLExecutor)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	exec := h.mu.ctx.(sqlexec.SQLExecutor)
 	_, err := exec.Execute(context.Background(), "begin")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// First of all, we update the version. If this table doesn't exist, it won't have any problem. Because we cannot delete anything.
-	_, err = exec.Execute(context.Background(), fmt.Sprintf("update mysql.stats_meta set version = %d where table_id = %d ", h.ctx.Txn().StartTS(), tableID))
+	_, err = exec.Execute(context.Background(), fmt.Sprintf("update mysql.stats_meta set version = %d where table_id = %d ", h.mu.ctx.Txn().StartTS(), tableID))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -121,13 +123,15 @@ func (h *Handle) deleteHistStatsFromKV(tableID int64, histID int64, isIndex int)
 
 // DeleteTableStatsFromKV deletes table statistics from kv.
 func (h *Handle) DeleteTableStatsFromKV(id int64) error {
-	exec := h.ctx.(sqlexec.SQLExecutor)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	exec := h.mu.ctx.(sqlexec.SQLExecutor)
 	_, err := exec.Execute(context.Background(), "begin")
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// We only update the version so that other tidb will know that this table is deleted.
-	sql := fmt.Sprintf("update mysql.stats_meta set version = %d where table_id = %d ", h.ctx.Txn().StartTS(), id)
+	sql := fmt.Sprintf("update mysql.stats_meta set version = %d where table_id = %d ", h.mu.ctx.Txn().StartTS(), id)
 	_, err = exec.Execute(context.Background(), sql)
 	if err != nil {
 		return errors.Trace(err)

--- a/statistics/gc_test.go
+++ b/statistics/gc_test.go
@@ -33,7 +33,7 @@ func (s *testStatsUpdateSuite) TestGCStats(c *C) {
 	testKit.MustQuery("select count(*) from mysql.stats_histograms").Check(testkit.Rows("3"))
 	testKit.MustQuery("select count(*) from mysql.stats_buckets").Check(testkit.Rows("9"))
 	h := s.do.StatsHandle()
-	h.PrevLastVersion = math.MaxUint64
+	h.SetLastUpdateVersion(math.MaxUint64)
 	ddlLease := time.Duration(0)
 	c.Assert(h.GCStats(s.do.InfoSchema(), ddlLease), IsNil)
 	testKit.MustQuery("select count(*) from mysql.stats_histograms").Check(testkit.Rows("2"))

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/ranger"
-	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -93,7 +92,7 @@ func (t *Table) buildColNameMapper() {
 
 func (h *Handle) cmSketchFromStorage(tblID int64, isIndex, histID int64) (*CMSketch, error) {
 	selSQL := fmt.Sprintf("select cm_sketch from mysql.stats_histograms where table_id = %d and is_index = %d and hist_id = %d", tblID, isIndex, histID)
-	rows, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, selSQL)
+	rows, _, err := h.restrictedExec.ExecRestrictedSQL(nil, selSQL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -114,7 +113,7 @@ func (h *Handle) indexStatsFromStorage(row types.Row, table *Table, tableInfo *m
 			continue
 		}
 		if idx == nil || idx.LastUpdateVersion < histVer {
-			hg, err := histogramFromStorage(h.ctx, tableInfo.ID, histID, types.NewFieldType(mysql.TypeBlob), distinct, 1, histVer, nullCount, 0)
+			hg, err := h.histogramFromStorage(tableInfo.ID, histID, types.NewFieldType(mysql.TypeBlob), distinct, 1, histVer, nullCount, 0)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -156,7 +155,7 @@ func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *
 			(col == nil || col.Len() == 0 && col.LastUpdateVersion < histVer) &&
 			!loadAll
 		if notNeedLoad {
-			count, err := columnCountFromStorage(h.ctx, table.TableID, histID)
+			count, err := h.columnCountFromStorage(table.TableID, histID)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -175,7 +174,7 @@ func (h *Handle) columnStatsFromStorage(row types.Row, table *Table, tableInfo *
 			break
 		}
 		if col == nil || col.LastUpdateVersion < histVer || loadAll {
-			hg, err := histogramFromStorage(h.ctx, tableInfo.ID, histID, &colInfo.FieldType, distinct, 0, histVer, nullCount, totColSize)
+			hg, err := h.histogramFromStorage(tableInfo.ID, histID, &colInfo.FieldType, distinct, 0, histVer, nullCount, totColSize)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -219,7 +218,7 @@ func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, loadAll bool)
 		table = table.copy()
 	}
 	selSQL := fmt.Sprintf("select table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver from mysql.stats_histograms where table_id = %d", tableInfo.ID)
-	rows, _, err := h.ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(h.ctx, selSQL)
+	rows, _, err := h.restrictedExec.ExecRestrictedSQL(nil, selSQL)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/statistics/update_list_test.go
+++ b/statistics/update_list_test.go
@@ -23,7 +23,7 @@ type testUpdateListSuite struct {
 }
 
 func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
-	h := NewHandle(nil, 0)
+	h := Handle{listHead: &SessionStatsCollector{mapper: make(tableDeltaMap)}}
 	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {
 		items = append(items, h.NewSessionStatsCollector())


### PR DESCRIPTION

## What have you changed? (mandatory)

In the before, we have different stats updating mechanism depends on whether the stats lease is 0:

- If it is 0, we can directly manipulate the stats table

- If not, we need to puts all the changes to a channel so it will be processed at some time. 

This PR uses a mutex to protect the stats session context so that:

- We could directly apply the change without the channel, it could lead to cleaner code, and
guarantee that when analyze or drop stats finishes, the changes have updated into kv and local cache.

- Make it clear that the stats session context could not be used concurrently.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

unit test

PTAL @coocood @zz-jason @winoros @fipped 