### PR TITLE
ddl/reorg: enlarge runDDLJob wait timeout

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -66,7 +66,7 @@ func newContext(store kv.Storage) sessionctx.Context {
 const defaultWaitReorgTimeout = 10 * time.Second
 
 // ReorgWaitTimeout is the timeout that wait ddl in write reorganization stage.
-var ReorgWaitTimeout = 1 * time.Second
+var ReorgWaitTimeout = 5 * time.Second
 
 func (rc *reorgCtx) notifyReorgCancel() {
 	atomic.StoreInt32(&rc.notifyCancelReorgJob, 1)


### PR DESCRIPTION
## What have you changed? (mandatory)

Enlarge ReorgWaitTimeout to avoid too many useless log

## What are the type of the changes (mandatory)?

The currently defined types are listed below, please pick one of the types for this PR by removing the others:
- Improvement (non-breaking change which is an improvement to an existing feature)

