### PR TITLE
chunk: refactor `chunk.Iterator` to support iterable high-order operation(e.g. map).

### DIFF
--- a/executor/admin.go
+++ b/executor/admin.go
@@ -70,8 +70,8 @@ func (e *CheckIndexRangeExec) Next(ctx context.Context, chk *chunk.Chunk) error 
 		if e.srcChunk.NumRows() == 0 {
 			return nil
 		}
-		iter := chunk.NewIterator4Chunk(e.srcChunk)
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := e.srcChunk.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			handle := row.GetInt64(handleIdx)
 			for _, hr := range e.handleRanges {
 				if handle >= hr.Begin && handle < hr.End {
@@ -326,8 +326,8 @@ func (e *RecoverIndexExec) fetchRecoverRows(ctx context.Context, srcResult dists
 		if e.srcChunk.NumRows() == 0 {
 			break
 		}
-		iter := chunk.NewIterator4Chunk(e.srcChunk)
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := e.srcChunk.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			if result.scanRowCount >= int64(e.batchSize) {
 				return e.recoverRows, nil
 			}
@@ -544,8 +544,8 @@ func (e *CleanupIndexExec) fetchIndex(ctx context.Context, txn kv.Transaction) e
 		if e.idxChunk.NumRows() == 0 {
 			return nil
 		}
-		iter := chunk.NewIterator4Chunk(e.idxChunk)
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := e.idxChunk.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			handle := row.GetInt64(len(e.idxCols) - 1)
 			idxVals := extractIdxVals(row, e.idxValsBufs[e.scanRowCnt], e.idxColFieldTypes)
 			e.idxValsBufs[e.scanRowCnt] = idxVals

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testkit"
 	"golang.org/x/net/context"
 )
@@ -67,28 +66,28 @@ func (s *testSuite) TestCreateTable(c *C) {
 	c.Assert(err, IsNil)
 	ctx := context.Background()
 	chk := rs.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	for {
 		err1 := rs.Next(ctx, chk)
 		c.Assert(err1, IsNil)
 		if chk.NumRows() == 0 {
 			break
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			c.Assert(row.GetString(1), Equals, "float")
 		}
 	}
 	rs, err = tk.Exec(`desc issue312_2`)
 	c.Assert(err, IsNil)
 	chk = rs.NewChunk()
-	it = chunk.NewIterator4Chunk(chk)
 	for {
 		err1 := rs.Next(ctx, chk)
 		c.Assert(err1, IsNil)
 		if chk.NumRows() == 0 {
 			break
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			it.Next()
 			c.Assert(chk.GetRow(0).GetString(1), Equals, "double")
 		}
 	}

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -106,7 +106,6 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 	fields := e.children[0].retTypes()
 	for {
 		chk := e.children[0].newChunk()
-		iter := chunk.NewIterator4Chunk(chk)
 
 		err := e.children[0].Next(ctx, chk)
 		if err != nil {
@@ -116,7 +115,8 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 			break
 		}
 
-		for chunkRow := iter.Begin(); chunkRow != iter.End(); chunkRow = iter.Next() {
+		for iter := chk.Iterator(); iter.HasNext(); {
+			chunkRow := iter.Next()
 			if batchDelete && rowCount >= batchDMLSize {
 				e.ctx.StmtCommit()
 				if err = e.ctx.NewTxn(); err != nil {
@@ -186,7 +186,6 @@ func (e *DeleteExec) deleteMultiTablesByChunk(ctx context.Context) error {
 	fields := e.children[0].retTypes()
 	for {
 		chk := e.children[0].newChunk()
-		iter := chunk.NewIterator4Chunk(chk)
 
 		err := e.children[0].Next(ctx, chk)
 		if err != nil {
@@ -196,7 +195,8 @@ func (e *DeleteExec) deleteMultiTablesByChunk(ctx context.Context) error {
 			break
 		}
 
-		for joinedChunkRow := iter.Begin(); joinedChunkRow != iter.End(); joinedChunkRow = iter.Next() {
+		for iter := chk.Iterator(); iter.HasNext(); {
+			joinedChunkRow := iter.Next()
 			joinedDatumRow := joinedChunkRow.GetDatumRow(fields)
 			e.composeTblRowMap(tblRowMap, colPosInfos, joinedDatumRow)
 		}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -811,8 +811,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 		memUsage = chk.MemoryUsage()
 		task.memUsage += memUsage
 		task.memTracker.Consume(memUsage)
-		iter := chunk.NewIterator4Chunk(chk)
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := chk.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			task.rows = append(task.rows, row)
 		}
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -483,11 +483,11 @@ func (e *SelectLockExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 	txn := e.ctx.Txn()
 	keys := make([]kv.Key, 0, chk.NumRows())
-	iter := chunk.NewIterator4Chunk(chk)
 	for id, cols := range e.Schema().TblID2Handle {
 		for _, col := range cols {
 			keys = keys[:0]
-			for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+			for iter := chk.Iterator(); iter.HasNext(); {
+				row := iter.Next()
 				keys = append(keys, tablecodec.EncodeRowKeyWithHandle(id, row.GetInt64(col.Index)))
 			}
 			err = txn.LockKeys(keys...)
@@ -599,9 +599,8 @@ func init() {
 			if chk.NumRows() == 0 {
 				return rows, nil
 			}
-			iter := chunk.NewIterator4Chunk(chk)
-			for r := iter.Begin(); r != iter.End(); r = iter.Next() {
-				row := r.GetDatumRow(exec.retTypes())
+			for iter := chk.Iterator(); iter.HasNext(); {
+				row := iter.Next().GetDatumRow(exec.retTypes())
 				rows = append(rows, row)
 			}
 		}
@@ -644,11 +643,12 @@ func (e *TableDualExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 type SelectionExec struct {
 	baseExecutor
 
-	batched   bool
-	filters   []expression.Expression
-	selected  []bool
-	inputIter *chunk.Iterator4Chunk
-	inputRow  chunk.Row
+	batched       bool
+	filters       []expression.Expression
+	selected      []bool
+	inputIterable chunk.Iterable
+	inputIterator chunk.Iterator
+	inputRow      chunk.Row
 }
 
 // Open implements the Executor Open interface.
@@ -660,8 +660,9 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 	if e.batched {
 		e.selected = make([]bool, 0, chunk.InitialCapacity)
 	}
-	e.inputIter = chunk.NewIterator4Chunk(e.childrenResults[0])
-	e.inputRow = e.inputIter.End()
+	e.inputIterable = e.childrenResults[0]
+	e.inputIterator = e.inputIterable.Iterator()
+	e.inputRow = chunk.NoneRow
 	return nil
 }
 
@@ -683,7 +684,7 @@ func (e *SelectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 
 	for {
-		for ; e.inputRow != e.inputIter.End(); e.inputRow = e.inputIter.Next() {
+		for ; e.inputRow != chunk.NoneRow; e.inputRow = e.inputIterator.Next() {
 			if !e.selected[e.inputRow.Idx()] {
 				continue
 			}
@@ -700,11 +701,12 @@ func (e *SelectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		if e.childrenResults[0].NumRows() == 0 {
 			return nil
 		}
-		e.selected, err = expression.VectorizedFilter(e.ctx, e.filters, e.inputIter, e.selected)
+		e.selected, err = expression.VectorizedFilter(e.ctx, e.filters, e.inputIterable, e.selected)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		e.inputRow = e.inputIter.Begin()
+		e.inputIterator = e.inputIterable.Iterator()
+		e.inputRow = e.inputIterator.Next()
 	}
 }
 
@@ -713,14 +715,14 @@ func (e *SelectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // we have to set batch size to 1 to do the evaluation of filter and projection.
 func (e *SelectionExec) unBatchedNext(ctx context.Context, chk *chunk.Chunk) error {
 	for {
-		for ; e.inputRow != e.inputIter.End(); e.inputRow = e.inputIter.Next() {
+		for ; e.inputRow != chunk.NoneRow; e.inputRow = e.inputIterator.Next() {
 			selected, err := expression.EvalBool(e.ctx, e.filters, e.inputRow)
 			if err != nil {
 				return errors.Trace(err)
 			}
 			if selected {
 				chk.AppendRow(e.inputRow)
-				e.inputRow = e.inputIter.Next()
+				e.inputRow = e.inputIterator.Next()
 				return nil
 			}
 		}
@@ -728,7 +730,8 @@ func (e *SelectionExec) unBatchedNext(ctx context.Context, chk *chunk.Chunk) err
 		if err != nil {
 			return errors.Trace(err)
 		}
-		e.inputRow = e.inputIter.Begin()
+		e.inputIterator = e.inputIterable.Iterator()
+		e.inputRow = e.inputIterator.Next()
 		// no more data.
 		if e.childrenResults[0].NumRows() == 0 {
 			return nil

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
 	"golang.org/x/net/context"
@@ -86,12 +85,12 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 	c.Assert(err, IsNil)
 
 	chk := e.newChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	// Run test and check results.
 	for _, p := range ps {
 		err = e.Next(context.Background(), chk)
 		c.Assert(err, IsNil)
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			c.Assert(row.GetUint64(0), Equals, p.ID)
 		}
 	}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/juju/errors"
@@ -23,8 +24,8 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // InsertValues is the data to insert.
@@ -176,13 +177,13 @@ func (e *InsertValues) checkValueCount(insertValueCount, valueCount, genColsCoun
 	return nil
 }
 
-func (e *InsertValues) getRows(cols []*table.Column) (rows []types.DatumRow, err error) {
+func (e *InsertValues) getRows(cols []*table.Column) (iter chunk.IterableDatumRow, err error) {
 	// process `insert|replace ... set x=y...`
 	if err = e.fillValueList(); err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	rows = make([]types.DatumRow, len(e.Lists))
+	rows := make([]types.DatumRow, len(e.Lists))
 	length := len(e.Lists[0])
 	for i, list := range e.Lists {
 		if err = e.checkValueCount(length, len(list), len(e.GenColumns), i, cols); err != nil {
@@ -194,6 +195,7 @@ func (e *InsertValues) getRows(cols []*table.Column) (rows []types.DatumRow, err
 			return nil, errors.Trace(err)
 		}
 	}
+	iter = chunk.IterableDatumRows(rows)
 	return
 }
 
@@ -273,37 +275,38 @@ func (e *InsertValues) fillDefaultValues(row types.DatumRow, hasValue []bool) er
 	return nil
 }
 
-func (e *InsertValues) getRowsSelectChunk(ctx context.Context, cols []*table.Column) ([]types.DatumRow, error) {
+func (e *InsertValues) getRowsSelectChunk(ctx context.Context, cols []*table.Column) (chunk.IterableDatumRow, error) {
 	// process `insert|replace into ... select ... from ...`
 	selectExec := e.children[0]
 	if selectExec.Schema().Len() != len(cols) {
 		return nil, ErrWrongValueCountOnRow.GenByArgs(1)
 	}
-	var rows []types.DatumRow
+
 	fields := selectExec.retTypes()
-	for {
-		chk := selectExec.newChunk()
 
-		err := selectExec.Next(ctx, chk)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if chk.NumRows() == 0 {
-			break
-		}
+	innerChunkRowIter := MapExecutor2Iterable(ctx, selectExec)
 
-		for iter := chk.Iterator(); iter.HasNext(); {
-			innerChunkRow := iter.Next()
-			innerRow := innerChunkRow.GetDatumRow(fields)
-			e.rowCount = uint64(len(rows))
-			row, err := e.fillRowData(cols, innerRow)
-			if err != nil {
-				return nil, errors.Trace(err)
-			}
-			rows = append(rows, row)
-		}
+	mapScope := rowToDataRowScope{insertValues: e, cols: cols, fields: fields}
+
+	return chunk.MapIterable(ctx, innerChunkRowIter, mapScope.mapFunc), nil
+}
+
+type rowToDataRowScope struct {
+	insertValues *InsertValues
+	cols         []*table.Column
+	fields       []*types.FieldType
+	rowCount     uint64
+}
+
+func (s *rowToDataRowScope) mapFunc(ctx context.Context, innerChunkRow chunk.Row) (types.DatumRow, error) {
+	s.rowCount++
+	innerRow := innerChunkRow.GetDatumRow(s.fields)
+	s.insertValues.rowCount = s.rowCount
+	row, err := s.insertValues.fillRowData(s.cols, innerRow)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	return rows, nil
+	return row, nil
 }
 
 func (e *InsertValues) fillRowData(cols []*table.Column, vals types.DatumRow) (types.DatumRow, error) {

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -95,14 +95,14 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 	join.innerChunk = innerExec.newChunk()
 	join.outerChunk = outerExec.newChunk()
 	joinChk := join.newChunk()
-	it := chunk.NewIterator4Chunk(joinChk)
 	for rowIdx := 1; ; {
 		err := join.Next(ctx, joinChk)
 		c.Check(err, IsNil)
 		if joinChk.NumRows() == 0 {
 			break
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := joinChk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			correctResult := fmt.Sprintf("%v %v", rowIdx, rowIdx)
 			obtainedResult := fmt.Sprintf("%v %v", row.GetInt64(0), row.GetInt64(1))
 			c.Check(obtainedResult, Equals, correctResult)

--- a/executor/show.go
+++ b/executor/show.go
@@ -70,13 +70,13 @@ func (e *ShowExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		iter := chunk.NewIterator4Chunk(e.result)
 		for colIdx := 0; colIdx < e.Schema().Len(); colIdx++ {
 			retType := e.Schema().Columns[colIdx].RetType
 			if !types.IsTypeVarchar(retType.Tp) {
 				continue
 			}
-			for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+			for iter := e.result.Iterator(); iter.HasNext(); {
+				row := iter.Next()
 				if valLen := len(row.GetString(colIdx)); retType.Flen < valLen {
 					retType.Flen = valLen
 				}

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -177,8 +177,8 @@ func (e *SortExec) buildKeyChunks() error {
 
 	for chkIdx := 0; chkIdx < e.rowChunks.NumChunks(); chkIdx++ {
 		keyChk := chunk.NewChunkWithCapacity(e.keyTypes, e.rowChunks.GetChunk(chkIdx).NumRows())
-		childIter := chunk.NewIterator4Chunk(e.rowChunks.GetChunk(chkIdx))
-		err := expression.VectorizedExecute(e.ctx, e.keyExprs, childIter, keyChk)
+		childChk := e.rowChunks.GetChunk(chkIdx)
+		err := expression.VectorizedExecute(e.ctx, e.keyExprs, childChk, keyChk)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -393,7 +393,7 @@ func (e *TopNExec) executeTopN(ctx context.Context) error {
 func (e *TopNExec) processChildChk(childRowChk, childKeyChk *chunk.Chunk) error {
 	if childKeyChk != nil {
 		childKeyChk.Reset()
-		err := expression.VectorizedExecute(e.ctx, e.keyExprs, chunk.NewIterator4Chunk(childRowChk), childKeyChk)
+		err := expression.VectorizedExecute(e.ctx, e.keyExprs, childRowChk, childKeyChk)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -196,8 +196,8 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) (types.DatumRow, er
 		if err != nil || us.snapshotChunkBuffer.NumRows() == 0 {
 			return nil, errors.Trace(err)
 		}
-		iter := chunk.NewIterator4Chunk(us.snapshotChunkBuffer)
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := us.snapshotChunkBuffer.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			snapshotHandle := row.GetInt64(us.belowHandleIndex)
 			if _, ok := us.dirty.deletedRows[snapshotHandle]; ok {
 				continue

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -165,12 +165,11 @@ func (h *benchHelper) init() {
 func BenchmarkVectorizedExecute(b *testing.B) {
 	h := benchHelper{}
 	h.init()
-	inputIter := chunk.NewIterator4Chunk(h.inputChunk)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		h.outputChunk.Reset()
-		if err := VectorizedExecute(h.ctx, h.exprs, inputIter, h.outputChunk); err != nil {
+		if err := VectorizedExecute(h.ctx, h.exprs, h.inputChunk, h.outputChunk); err != nil {
 			panic("errors happened during \"VectorizedExecute\"")
 		}
 	}

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/stringutil"
 	log "github.com/sirupsen/logrus"
@@ -184,7 +183,6 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 
 	fs := rs.Fields()
 	chk := rs.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	for {
 		err = rs.Next(context.TODO(), chk)
 		if err != nil {
@@ -193,7 +191,8 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 		if chk.NumRows() == 0 {
 			return nil
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			err = decodeTableRow(row, fs)
 			if err != nil {
 				return errors.Trace(err)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/auth"
-	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -522,10 +521,10 @@ func upgradeToVer12(s Session) {
 	sqls := make([]string, 0, 1)
 	defer terror.Call(r.Close)
 	chk := r.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	err = r.Next(ctx, chk)
 	for err == nil && chk.NumRows() != 0 {
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			user := row.GetString(0)
 			host := row.GetString(1)
 			pass := row.GetString(2)

--- a/session/session.go
+++ b/session/session.go
@@ -53,7 +53,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/charset"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/kvcache"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
@@ -648,8 +647,8 @@ func drainRecordSet(ctx context.Context, rs ast.RecordSet) ([]types.Row, error) 
 		if err != nil || chk.NumRows() == 0 {
 			return rows, errors.Trace(err)
 		}
-		iter := chunk.NewIterator4Chunk(chk)
-		for r := iter.Begin(); r != iter.End(); r = iter.Next() {
+		for iter := chk.Iterator(); iter.HasNext(); {
+			r := iter.Next()
 			rows = append(rows, r)
 		}
 	}

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
-	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -209,7 +208,6 @@ func GetRows4Test(ctx context.Context, sctx sessionctx.Context, rs ast.RecordSet
 	for {
 		// Since we collect all the rows, we can not reuse the chunk.
 		chk := rs.NewChunk()
-		iter := chunk.NewIterator4Chunk(chk)
 
 		err := rs.Next(ctx, chk)
 		if err != nil {
@@ -219,7 +217,8 @@ func GetRows4Test(ctx context.Context, sctx sessionctx.Context, rs ast.RecordSet
 			break
 		}
 
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		for iter := chk.Iterator(); iter.HasNext(); {
+			row := iter.Next()
 			rows = append(rows, row)
 		}
 	}

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tipb/go-tipb"
 	"golang.org/x/net/context"
 )
@@ -156,7 +155,6 @@ func (s SampleBuilder) CollectColumnStats() ([]*SampleCollector, *SortedBuilder,
 	}
 	ctx := context.TODO()
 	chk := s.RecordSet.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	for {
 		err := s.RecordSet.Next(ctx, chk)
 		if err != nil {
@@ -168,7 +166,8 @@ func (s SampleBuilder) CollectColumnStats() ([]*SampleCollector, *SortedBuilder,
 		if len(s.RecordSet.Fields()) == 0 {
 			panic(fmt.Sprintf("%T", s.RecordSet))
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			datums := ast.RowToDatums(row, s.RecordSet.Fields())
 			if s.PkBuilder != nil {
 				err = s.PkBuilder.Iterate(datums[0])

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -181,8 +181,8 @@ func buildPK(sctx sessionctx.Context, numBuckets, id int64, records ast.RecordSe
 		if chk.NumRows() == 0 {
 			break
 		}
-		it := chunk.NewIterator4Chunk(chk)
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			datums := ast.RowToDatums(row, records.Fields())
 			err = b.Iterate(datums[0])
 			if err != nil {
@@ -198,7 +198,6 @@ func buildIndex(sctx sessionctx.Context, numBuckets, id int64, records ast.Recor
 	cms := NewCMSketch(8, 2048)
 	ctx := context.Background()
 	chk := records.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	for {
 		err := records.Next(ctx, chk)
 		if err != nil {
@@ -207,7 +206,8 @@ func buildIndex(sctx sessionctx.Context, numBuckets, id int64, records ast.Recor
 		if chk.NumRows() == 0 {
 			break
 		}
-		for row := it.Begin(); row != it.End(); row = it.Next() {
+		for it := chk.Iterator(); it.HasNext(); {
+			row := it.Next()
 			datums := ast.RowToDatums(row, records.Fields())
 			buf, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, datums...)
 			if err != nil {

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -312,6 +312,11 @@ func (c *Chunk) AppendDatum(colIdx int, d *types.Datum) {
 	}
 }
 
+// Iterator implements the Iterable interface.
+func (c *Chunk) Iterator() Iterator {
+	return newIterator4Chunk(c)
+}
+
 type column struct {
 	length     int
 	nullCount  int
@@ -646,4 +651,12 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 // IsNull implements the types.Row interface.
 func (r Row) IsNull(colIdx int) bool {
 	return r.c.columns[colIdx].isNull(r.idx)
+}
+
+// IterableRows is an adaptor of row array that implements Iterable interface.
+type IterableRows []Row
+
+// Iterator implements the Iterable interface.
+func (it IterableRows) Iterator() Iterator {
+	return newIterator4Slice(it)
 }

--- a/util/chunk/iterator_test.go
+++ b/util/chunk/iterator_test.go
@@ -41,74 +41,88 @@ func (s *testChunkSuite) TestIterator(c *check.C) {
 		ptrs2 = append(ptrs2, ptr2)
 	}
 
-	it := NewIterator4Slice(rows)
+	var itb Iterable = IterableRows(rows)
+	it := itb.Iterator()
 	checkIterator(c, it, expected)
-	it.Begin()
+	it = itb.Iterator()
 	for i := 0; i < 5; i++ {
-		c.Assert(it.Current(), check.Equals, rows[i])
-		it.Next()
+		c.Assert(it.Next(), check.Equals, rows[i])
 	}
 	it.ReachEnd()
-	c.Assert(it.Current(), check.Equals, it.End())
-	c.Assert(it.Begin(), check.Equals, rows[0])
+	c.Assert(it.HasNext(), check.Equals, false)
+	it = itb.Iterator()
+	c.Assert(it.Next(), check.Equals, rows[0])
 
-	it = NewIterator4Chunk(chk)
+	itb = chk
+	it = itb.Iterator()
 	checkIterator(c, it, expected)
-	it.Begin()
+	it = itb.Iterator()
 	for i := 0; i < 5; i++ {
-		c.Assert(it.Current(), check.Equals, chk.GetRow(i))
-		it.Next()
+		c.Assert(it.Next(), check.Equals, chk.GetRow(i))
 	}
 	it.ReachEnd()
-	c.Assert(it.Current(), check.Equals, it.End())
-	c.Assert(it.Begin(), check.Equals, chk.GetRow(0))
+	c.Assert(it.Next(), check.Equals, NoneRow)
+	it = itb.Iterator()
+	c.Assert(it.Next(), check.Equals, chk.GetRow(0))
 
-	it = NewIterator4List(li)
+	itb = li
+	it = itb.Iterator()
 	checkIterator(c, it, expected)
-	it.Begin()
+	it = itb.Iterator()
 	for i := 0; i < 5; i++ {
-		c.Assert(it.Current(), check.Equals, li.GetRow(ptrs[i]))
-		it.Next()
+		c.Assert(it.Next(), check.Equals, li.GetRow(ptrs[i]))
 	}
 	it.ReachEnd()
-	c.Assert(it.Current(), check.Equals, it.End())
-	c.Assert(it.Begin(), check.Equals, li.GetRow(ptrs[0]))
+	c.Assert(it.HasNext(), check.Equals, false)
+	it = itb.Iterator()
+	c.Assert(it.Next(), check.Equals, li.GetRow(ptrs[0]))
 
-	it = NewIterator4RowPtr(li, ptrs)
+	itb = Iterable4RowPtr{li, ptrs}
+	it = itb.Iterator()
 	checkIterator(c, it, expected)
-	it.Begin()
+	it = itb.Iterator()
 	for i := 0; i < 5; i++ {
-		c.Assert(it.Current(), check.Equals, li.GetRow(ptrs[i]))
-		it.Next()
+		c.Assert(it.Next(), check.Equals, li.GetRow(ptrs[i]))
 	}
 	it.ReachEnd()
-	c.Assert(it.Current(), check.Equals, it.End())
-	c.Assert(it.Begin(), check.Equals, li.GetRow(ptrs[0]))
+	c.Assert(it.HasNext(), check.Equals, false)
+	it = itb.Iterator()
+	c.Assert(it.Next(), check.Equals, li.GetRow(ptrs[0]))
 
-	it = NewIterator4RowPtr(li2, ptrs2)
+	itb = Iterable4RowPtr{li2, ptrs2}
+	it = itb.Iterator()
 	checkIterator(c, it, expected)
-	it.Begin()
+	it = itb.Iterator()
 	for i := 0; i < 5; i++ {
-		c.Assert(it.Current(), check.Equals, li2.GetRow(ptrs2[i]))
-		it.Next()
+		c.Assert(it.Next(), check.Equals, li2.GetRow(ptrs2[i]))
 	}
 	it.ReachEnd()
-	c.Assert(it.Current(), check.Equals, it.End())
-	c.Assert(it.Begin(), check.Equals, li2.GetRow(ptrs2[0]))
+	c.Assert(it.HasNext(), check.Equals, false)
+	it = itb.Iterator()
+	c.Assert(it.Next(), check.Equals, li2.GetRow(ptrs2[0]))
 
-	it = NewIterator4Slice(nil)
-	c.Assert(it.Begin(), check.Equals, it.End())
-	it = NewIterator4Chunk(new(Chunk))
-	c.Assert(it.Begin(), check.Equals, it.End())
-	it = NewIterator4List(new(List))
-	c.Assert(it.Begin(), check.Equals, it.End())
-	it = NewIterator4RowPtr(li, nil)
-	c.Assert(it.Begin(), check.Equals, it.End())
+	itb = IterableRows(nil)
+	it = itb.Iterator()
+	c.Assert(it.HasNext(), check.Equals, false)
+	c.Assert(it.Next(), check.Equals, NoneRow)
+	itb = new(Chunk)
+	it = itb.Iterator()
+	c.Assert(it.HasNext(), check.Equals, false)
+	c.Assert(it.Next(), check.Equals, NoneRow)
+	itb = new(List)
+	it = itb.Iterator()
+	c.Assert(it.HasNext(), check.Equals, false)
+	c.Assert(it.Next(), check.Equals, NoneRow)
+	itb = Iterable4RowPtr{li, nil}
+	it = itb.Iterator()
+	c.Assert(it.HasNext(), check.Equals, false)
+	c.Assert(it.Next(), check.Equals, NoneRow)
 }
 
 func checkIterator(c *check.C, it Iterator, expected []int64) {
 	var got []int64
-	for row := it.Begin(); row != it.End(); row = it.Next() {
+	for it.HasNext() {
+		row := it.Next()
 		got = append(got, row.GetInt64(0))
 	}
 	c.Assert(got, check.DeepEquals, expected)

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -152,3 +152,8 @@ func (l *List) Walk(walkFunc ListWalkFunc) error {
 	}
 	return nil
 }
+
+// Iterator implements the Iterable interface.
+func (l *List) Iterator() Iterator {
+	return newIterator4List(l)
+}


### PR DESCRIPTION
## What have you changed? (mandatory)

before this PR, we use cpp-style Iterator, it's good for the container but abstract failure for common iterate situation.

besides coding feel, current iterator is 

- hard to connect `Executor` with `Iterator`, so we often see consume executor and buffer whole temp results in memory which cause OOM
- hard  to do iterator high-order operation(iterator A ===Fn====> iterator b) which is common in functional programming(we use iterable mode instead of observe mode).

The idea is simple, we should generate new `Iterable` from `Executor` or another `Iterable` instead of generate array or slice of data; the eval of compute will be delay until we could not delay..and compute data size for each batch will be controlled by ChunkSize

It contains 2 commits.

In first commit

- remove `begin()`/`current()`/`end()`
- add `hasNext()`
- add `Iterable` interface and make chunk/list/rows implement it.

In second commit

demonstrate how to use new `Iterable` with `map` operation to suppot `insert into x select * from y`, and use less memory printfoot, and process speed is all controlled by insert side.

- add ExecutorIterable to support map a executor to Iterable and consume loop on iterable will lazy batch call executor.Next
- add MapIterable to support Iterable to Iterable transform.

....but Go has no generic support....eee....use more code..

## What are the type of the changes (mandatory)?

The currently defined types are listed below, please pick one of the types for this PR by removing the others:

- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested (mandatory)?

- unit test

## Benchmark result if necessary (optional)

pending

