### PR TITLE
*: add a session variable for table partition, tiny update

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -840,10 +840,8 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 	}
 	if s.Partition != nil {
 		pi := &model.PartitionInfo{
-			Type: s.Partition.Tp,
-		}
-		if ctx.GetSessionVars().EnableTablePartition {
-			pi.Enable = true
+			Type:   s.Partition.Tp,
+			Enable: ctx.GetSessionVars().EnableTablePartition,
 		}
 		if s.Partition.Expr != nil {
 			buf := new(bytes.Buffer)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -842,6 +842,9 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 		pi := &model.PartitionInfo{
 			Type: s.Partition.Tp,
 		}
+		if ctx.GetSessionVars().EnableTablePartition {
+			pi.Enable = true
+		}
 		if s.Partition.Expr != nil {
 			buf := new(bytes.Buffer)
 			s.Partition.Expr.Format(buf)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -280,6 +280,9 @@ type SessionVars struct {
 	// OptimizerSelectivityLevel defines the level of the selectivity estimation in planner.
 	OptimizerSelectivityLevel int
 
+	// EnableTablePartition enables table partition feature.
+	EnableTablePartition bool
+
 	// EnableStreaming indicates whether the coprocessor request can use streaming API.
 	// TODO: remove this after tidb-server configuration "enable-streaming' removed.
 	EnableStreaming bool
@@ -543,6 +546,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.EnableStreaming = TiDBOptOn(val)
 	case TiDBOptimizerSelectivityLevel:
 		s.OptimizerSelectivityLevel = tidbOptPositiveInt32(val, DefTiDBOptimizerSelectivityLevel)
+	case TiDBEnableTablePartition:
+		s.EnableTablePartition = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -636,6 +636,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TIDBMemQuotaNestedLoopApply, strconv.FormatInt(DefTiDBMemQuotaNestedLoopApply, 10)},
 	{ScopeSession, TiDBEnableStreaming, "0"},
 	{ScopeSession, TxnIsolationOneShot, ""},
+	{ScopeSession, TiDBEnableTablePartition, "0"},
 	{ScopeGlobal | ScopeSession, TiDBHashJoinConcurrency, strconv.Itoa(DefTiDBHashJoinConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBProjectionConcurrency, strconv.Itoa(DefTiDBProjectionConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBHashAggPartialConcurrency, strconv.Itoa(DefTiDBHashAggPartialConcurrency)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -100,6 +100,9 @@ const (
 
 	// tidb_optimizer_selectivity_level is used to control the selectivity estimation level.
 	TiDBOptimizerSelectivityLevel = "tidb_optimizer_selectivity_level"
+
+	// tidb_enable_table_partition is used to enable table partition feature.
+	TiDBEnableTablePartition = "tidb_enable_table_partition"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -225,6 +225,14 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "3")
 	c.Assert(v.RetryLimit, Equals, int64(3))
+
+	c.Assert(v.EnableTablePartition, IsFalse)
+	err = SetSessionSystemVar(v, TiDBEnableTablePartition, types.NewStringDatum("1"))
+	c.Assert(err, IsNil)
+	val, err = GetSessionSystemVar(v, TiDBEnableTablePartition)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "1")
+	c.Assert(v.EnableTablePartition, IsTrue)
 }
 
 type mockGlobalAccessor struct {

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -447,15 +447,6 @@ func (t *Table) getRollbackableMemStore(ctx sessionctx.Context) kv.RetrieverMuta
 
 // locatePartition returns the partition ID of the input record.
 func (t *Table) locatePartition(ctx sessionctx.Context, pi *model.PartitionInfo, r []types.Datum) (int64, error) {
-	// TODO: Remove this later, when we have better way to TestPartitionAddRecord.
-	if t.partitionExpr == nil {
-		partitionExpr, err := generatePartitionExpr(t.meta)
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-		t.partitionExpr = partitionExpr
-	}
-
 	var err error
 	partitionExprs := t.partitionExpr.Locate
 	idx := sort.Search(len(partitionExprs), func(i int) bool {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -344,7 +344,6 @@ PARTITION BY RANGE ( id ) (
 	c.Assert(err, IsNil)
 	tb, err := ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
 	tbInfo := tb.Meta()
-	tbInfo.Partition.Enable = true
 	p0 := tbInfo.Partition.Definitions[0]
 	c.Assert(p0.Name, Equals, "p0")
 
@@ -352,7 +351,7 @@ PARTITION BY RANGE ( id ) (
 	rid, err := tb.AddRecord(ts.se, types.MakeDatums(1), false)
 	c.Assert(err, IsNil)
 
-	// Check the add record is write to the partition, rather than table.
+	// Check that add record writes to the partition, rather than the table.
 	txn := ts.se.Txn()
 	val, err := txn.Get(tables.PartitionRecordKey(p0.ID, rid))
 	c.Assert(err, IsNil)
@@ -383,7 +382,6 @@ PARTITION BY RANGE ( id ) (
 	c.Assert(ts.se.NewTxn(), IsNil)
 	tb, err = ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t2"))
 	tbInfo = tb.Meta()
-	tbInfo.Partition.Enable = true
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(22), false)
 	c.Assert(err, IsNil) // Insert into maxvalue partition.
 }

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -338,7 +338,9 @@ PARTITION BY RANGE ( id ) (
 		PARTITION p3 VALUES LESS THAN (21)
 )`
 
-	_, err := ts.se.Execute(context.Background(), createTable1)
+	_, err := ts.se.Execute(context.Background(), "set @@session.tidb_enable_table_partition=1")
+	c.Assert(err, IsNil)
+	_, err = ts.se.Execute(context.Background(), createTable1)
 	c.Assert(err, IsNil)
 	tb, err := ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
 	tbInfo := tb.Meta()


### PR DESCRIPTION
## What have you changed? (mandatory)

- add a 'tidb_enable_table_partition' session variable
- update a TODO

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

unit test

## Does this PR affect documentation (docs/docs-cn) update? (optional)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)


@winoros @coocood @XuHuaiyu 