### PR TITLE
util:check character set capitalization when creating a table

### DIFF
--- a/ddl/ddl_db_test.go
+++ b/ddl/ddl_db_test.go
@@ -2007,6 +2007,28 @@ func (s *testDBSuite) TestCharacterSetInColumns(c *C) {
 	s.tk.MustExec("create table t (c1 int, s1 varchar(10), s2 text)")
 	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name != 'utf8'").Check(testkit.Rows("0"))
 	s.tk.MustQuery("select count(*) from information_schema.columns where table_schema = 'varchar_test' and character_set_name = 'utf8'").Check(testkit.Rows("2"))
+
+	s.tk.MustExec("drop table if exists t5")
+	s.tk.MustExec("create table t5(id int) charset=UTF8;")
+	s.tk.MustExec("drop table if exists t5")
+	s.tk.MustExec("create table t5(id int) charset=BINARY;")
+	s.tk.MustExec("drop table if exists t5")
+	s.tk.MustExec("create table t5(id int) charset=LATIN1;")
+	s.tk.MustExec("drop table if exists t5")
+	s.tk.MustExec("create table t5(id int) charset=ASCII;")
+	s.tk.MustExec("drop table if exists t5")
+	s.tk.MustExec("create table t5(id int) charset=UTF8MB4;")
+
+	s.tk.MustExec("drop table if exists t6")
+	s.tk.MustExec("create table t6(id int) charset=utf8;")
+	s.tk.MustExec("drop table if exists t6")
+	s.tk.MustExec("create table t6(id int) charset=binary;")
+	s.tk.MustExec("drop table if exists t6")
+	s.tk.MustExec("create table t6(id int) charset=latin1;")
+	s.tk.MustExec("drop table if exists t6")
+	s.tk.MustExec("create table t6(id int) charset=ascii;")
+	s.tk.MustExec("drop table if exists t6")
+	s.tk.MustExec("create table t6(id int) charset=utf8mb4;")
 }
 
 func (s *testDBSuite) TestAddNotNullColumnWhileInsertOnDupUpdate(c *C) {

--- a/util/charset/charset.go
+++ b/util/charset/charset.go
@@ -85,7 +85,7 @@ func ValidCharsetAndCollation(cs string, co string) bool {
 	if cs == "" {
 		cs = "utf8"
 	}
-
+	cs = strings.ToLower(cs)
 	c, ok := charsets[cs]
 	if !ok {
 		return false


### PR DESCRIPTION
## What have you changed? (mandatory)
This pr fix problem check character set capitalization when creating a table.
```
MySQL [ltest]> create table t5(id int) charset=UTF8;
ERROR 1115 (42000): Unknown character set: 'UTF8'

MySQL [ltest]> create table t5(id int) charset=utf8;
Query OK, 0 rows affected (0.13 sec)
```



## What are the type of the changes (mandatory)?

Bug fix.

## How has this PR been tested (mandatory)?

Unit tests.