### PR TITLE
tidb-server: move "setupMetrics" to the front of "createStoreAndDomain"

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -137,10 +137,10 @@ func main() {
 	setupTracing() // Should before createServer and after setup config.
 	printInfo()
 	setupBinlogClient()
+	setupMetrics()
 	createStoreAndDomain()
 	createServer()
 	setupSignalHandler()
-	setupMetrics()
 	runServer()
 	cleanup()
 	os.Exit(0)


### PR DESCRIPTION
## What have you changed? (mandatory)
Move "setupMetrics" to the front of "createStoreAndDomain".
Make sure that the metric works when we do the operation of `bootstrap`.

## What are the type of the changes (mandatory)?

- Improvement 

## How has this PR been tested (mandatory)?
test in local
