### PR TITLE
server: fix COM_FIELD_LIST response bug that make mariadb-client crash during `use db` (#6918)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -895,9 +895,15 @@ func (cc *clientConn) handleFieldList(sql string) (err error) {
 		return errors.Trace(err)
 	}
 	data := make([]byte, 4, 1024)
-	for _, v := range columns {
+	for _, column := range columns {
+		// Current we doesn't output defaultValue but reserve defaultValue length byte to make mariadb client happy.
+		// https://dev.mysql.com/doc/internals/en/com-query-response.html#column-definition
+		// TODO: fill the right DefaultValues.
+		column.DefaultValueLength = 0
+		column.DefaultValue = []byte{}
+
 		data = data[0:4]
-		data = v.Dump(data)
+		data = column.Dump(data)
 		if err := cc.writePacket(data); err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
## What have you changed? (mandatory)

cherry-pic #6918

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (mandatory)?

- unit tests,
- integration tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/6929)
<!-- Reviewable:end -->
