### PR TITLE
infoschema: fix test for table rows count field

### DIFF
--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -29,6 +29,7 @@ func (s *testSuite) TestDataForTableRowsCountField(c *C) {
 	store, err := mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
 	defer store.Close()
+	session.SetStatsLease(0)
 	do, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)
 	defer do.Close()
@@ -40,6 +41,7 @@ func (s *testSuite) TestDataForTableRowsCountField(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c int, d int)")
+	h.HandleDDLEvent(<-h.DDLEventCh())
 	tk.MustQuery("select table_rows from information_schema.tables where table_name='t'").Check(
 		testkit.Rows("0"))
 	tk.MustExec("insert into t(c, d) values(1, 2), (2, 3), (3, 4)")


### PR DESCRIPTION
## What have you changed? (mandatory)

There will be a background loop that updates the stats when the stats lease is not 0. So when we call a function that updates stats elsewhere, there will be a chance of panic because there may have a race for the only stats session context.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

unit test

PTAL @coocood @zimulala @zz-jason @winoros 