### PR TITLE
The version of GO should be 1.10 or above.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ TiDB is written in [Go](http://golang.org).
 If you don't have a Go development environment,
 please [set one up](http://golang.org/doc/code.html).
 
-The version of GO should be **1.9** or above.
+The version of GO should be **1.10** or above.
 
 After installation, you'll need `GOPATH` defined,
 and `PATH` modified to access your Go binaries.


### PR DESCRIPTION
## What have you changed? (mandatory)

The version of GO should be 1.10 or above,because 1.9 can't support math.Round

## What are the type of the changes (mandatory)?

Bug fix

## How has this PR been tested (mandatory)?

### Use GO 1.9.4 version:
[root@zbdba tidb]# make server
make parser
make[1]: Entering directory `/data1/source_code/src/github.com/pingcap/tidb'
CGO_ENABLED=0 go build  -o bin/goyacc parser/goyacc/main.go
bin/goyacc -o /dev/null parser/parser.y
Parse table entries: 708693 of 1797400, x 16 bits == 1417386 bytes
bin/goyacc -o parser/parser.go parser/parser.y 2>&1 | egrep "(shift|reduce)/reduce" | awk '{print} END {if (NR > 0) {print "Find conflict in parser.y. Please check y.output for more information."; exit 1;}}'
rm -f y.output
make[1]: Leaving directory `/data1/source_code/src/github.com/pingcap/tidb'
CGO_ENABLED=0 go build   -ldflags '-X "github.com/pingcap/tidb/mysql.TiDBReleaseVersion=v2.1.0-beta-7-gf6ee36e" -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=2018-07-03 06:49:15" -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=f6ee36e08c3a11b9c93135f79e4ed984bee9564c" -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=master" -X "github.com/pingcap/tidb/util/printer.GoVersion=go version go1.9.4 linux/amd64"' -o bin/tidb-server tidb-server/main.go
github.com/pingcap/tidb/statistics
statistics/histogram.go:124:10: undefined: math.Round
make: *** [server] Error 2

### use GO 1.10.3 version:
make success

