### PR TITLE
privilege/privileges: don't reuse chunk in loadTable function

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -183,9 +183,11 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 	defer terror.Call(rs.Close)
 
 	fs := rs.Fields()
-	chk := rs.NewChunk()
-	it := chunk.NewIterator4Chunk(chk)
 	for {
+		// WARNNING: decodeTableRow decodes data from a chunk Row, that is a shallow copy.
+		// The result will reference memory in the chunk, so the chunk must not be reused
+		// here, otherwise some werid bug will happen!
+		chk := rs.NewChunk()
 		err = rs.Next(context.TODO(), chk)
 		if err != nil {
 			return errors.Trace(err)
@@ -193,6 +195,7 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 		if chk.NumRows() == 0 {
 			return nil
 		}
+		it := chunk.NewIterator4Chunk(chk)
 		for row := it.Begin(); row != it.End(); row = it.Next() {
 			err = decodeTableRow(row, fs)
 			if err != nil {

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -184,7 +184,7 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 
 	fs := rs.Fields()
 	for {
-		// WARNNING: decodeTableRow decodes data from a chunk Row, that is a shallow copy.
+		// NOTE: decodeTableRow decodes data from a chunk Row, that is a shallow copy.
 		// The result will reference memory in the chunk, so the chunk must not be reused
 		// here, otherwise some werid bug will happen!
 		chk := rs.NewChunk()


### PR DESCRIPTION
## What have you changed? (mandatory)

Don't reuse chunk in `loadTable` function. 
The memory from the chunk is shallow copy, and `MySQLPrivilege` struct data may be overwritten sometime later, lead to weird TiDB behavior. 

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)

PTAL @XuHuaiyu @zz-jason @coocood 