### PR TITLE
executor: fix panic on Stream Aggregate

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -832,12 +832,6 @@ func (e *StreamAggExec) consumeOneGroup(ctx context.Context, chk *chunk.Chunk) e
 				return nil
 			}
 		}
-		if e.newAggFuncs != nil {
-			err := e.consumeGroupRows()
-			if err != nil {
-				return errors.Trace(err)
-			}
-		}
 	}
 	return nil
 }
@@ -860,6 +854,14 @@ func (e *StreamAggExec) consumeGroupRows() error {
 func (e *StreamAggExec) fetchChildIfNecessary(ctx context.Context, chk *chunk.Chunk) error {
 	if e.inputRow != e.inputIter.End() {
 		return nil
+	}
+
+	// Before fetching a new batch of input, we should consume the last group.
+	if e.newAggFuncs != nil {
+		err := e.consumeGroupRows()
+		if err != nil {
+			return errors.Trace(err)
+		}
 	}
 
 	err := e.children[0].Next(ctx, e.childrenResults[0])


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR fix #6983.

For stream aggregate, if the last group in a `Chunk` only contains the last row of that `Chunk`, and there is no more data to be fetched from child, we reset the `Chunk` in `fetchChildIfNecessary` and got panic in `consumeGroupRows`.

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (mandatory)?

- unit test
- explain test
- randgen test

