### PR TITLE
executor: get the correct result of "show create table" when running "add index"

### DIFF
--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -75,6 +75,41 @@ func (s *testStateChangeSuite) TearDownSuite(c *C) {
 	testleak.AfterTest(c)()
 }
 
+// TestShowCreateTable tests the result of "show create table" when we are running "add index" or "add column".
+func (s *testStateChangeSuite) TestShowCreateTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int, index idx (id))")
+
+	var checkErr error
+	prevState := model.StateNone
+	callback := &ddl.TestDDLCallback{}
+	callback.OnJobUpdatedExported = func(job *model.Job) {
+		if job.SchemaState == prevState || checkErr != nil {
+			return
+		}
+		if job.SchemaState != model.StatePublic {
+			result := tk.MustQuery("show create table t")
+			got := result.Rows()[0][1]
+			var expected string
+			if job.Type == model.ActionAddIndex {
+				expected = "CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
+			} else if job.Type == model.ActionAddColumn {
+				expected = "CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`),\n  KEY `idx1` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
+			}
+			if got != expected {
+				checkErr = errors.Errorf("got %s, expected %s", got, expected)
+			}
+		}
+	}
+	d := s.dom.DDL()
+	d.(ddl.DDLForTest).SetHook(callback)
+	tk.MustExec("alter table t add index idx1(id)")
+	c.Assert(checkErr, IsNil)
+	tk.MustExec("alter table t add column c int")
+	c.Assert(checkErr, IsNil)
+}
+
 func (s *testStateChangeSuite) TestTwoStates(c *C) {
 	cnt := 5
 	// New the testExecInfo.

--- a/executor/show.go
+++ b/executor/show.go
@@ -478,9 +478,6 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	var pkCol *table.Column
 	var hasAutoIncID bool
 	for i, col := range tb.Cols() {
-		if col.State != model.StatePublic {
-			continue
-		}
 		buf.WriteString(fmt.Sprintf("  `%s` %s", col.Name.O, col.GetTypeDesc()))
 		if col.IsGenerated() {
 			// It's a generated column.
@@ -544,11 +541,14 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(",\n")
 	}
 
-	for i, idx := range tb.Indices() {
-		idxInfo := idx.Meta()
-		if idxInfo.State != model.StatePublic {
-			continue
+	publicIndices := make([]table.Index, 0, len(tb.Indices()))
+	for _, idx := range tb.Indices() {
+		if idx.Meta().State == model.StatePublic {
+			publicIndices = append(publicIndices, idx)
 		}
+	}
+	for i, idx := range publicIndices {
+		idxInfo := idx.Meta()
 		if idxInfo.Primary {
 			buf.WriteString("  PRIMARY KEY ")
 		} else if idxInfo.Unique {
@@ -566,7 +566,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 			cols = append(cols, colInfo)
 		}
 		buf.WriteString(fmt.Sprintf("(%s)", strings.Join(cols, ",")))
-		if i != len(tb.Indices())-1 {
+		if i != len(publicIndices)-1 {
 			buf.WriteString(",\n")
 		}
 	}


### PR DESCRIPTION
## What have you changed? (mandatory)

Get the correct result of "show create table" when executing "add index".
Fix #6991 

## What are the type of the changes (mandatory)?

- Improvement 

## How has this PR been tested (mandatory)?

unit test
