### PR TITLE
aggregation: handle non-integer input for bit related aggregate functions

### DIFF
--- a/expression/aggregation/aggregation_test.go
+++ b/expression/aggregation/aggregation_test.go
@@ -234,6 +234,51 @@ func (s *testAggFuncSuit) TestBitOr(c *C) {
 	c.Assert(result.GetUint64(), Equals, uint64(3))
 	partialResult := bitOrFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetUint64(), Equals, uint64(3))
+
+	// test bit_or( decimal )
+	col.RetType = types.NewFieldType(mysql.TypeNewDecimal)
+	bitOrFunc.ResetContext(s.ctx.GetSessionVars().StmtCtx, evalCtx)
+
+	result = bitOrFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(0))
+
+	var dec types.MyDecimal
+	err = dec.FromString([]byte("12.234"))
+	c.Assert(err, IsNil)
+
+	row = types.MakeDatums(&dec)
+	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitOrFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(12))
+
+	err = dec.FromString([]byte("1.012"))
+	c.Assert(err, IsNil)
+
+	row = types.MakeDatums(&dec)
+	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitOrFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(13))
+
+	err = dec.FromString([]byte("15.12345678"))
+	c.Assert(err, IsNil)
+
+	row = types.MakeDatums(&dec)
+	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitOrFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(15))
+
+	err = dec.FromString([]byte("16.00"))
+	c.Assert(err, IsNil)
+
+	row = types.MakeDatums(&dec)
+	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitOrFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(31))
+
 }
 
 func (s *testAggFuncSuit) TestBitXor(c *C) {

--- a/expression/aggregation/aggregation_test.go
+++ b/expression/aggregation/aggregation_test.go
@@ -191,6 +191,38 @@ func (s *testAggFuncSuit) TestBitAnd(c *C) {
 	c.Assert(result.GetUint64(), Equals, uint64(0))
 	partialResult := bitAndFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetUint64(), Equals, uint64(0))
+
+	// test bit_and( decimal )
+	col.RetType = types.NewFieldType(mysql.TypeNewDecimal)
+	bitAndFunc.ResetContext(s.ctx.GetSessionVars().StmtCtx, evalCtx)
+
+	result = bitAndFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(math.MaxUint64))
+
+	var dec types.MyDecimal
+	err = dec.FromString([]byte("1.234"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitAndFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitAndFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(1))
+
+	err = dec.FromString([]byte("3.012"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitAndFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitAndFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(1))
+
+	err = dec.FromString([]byte("2.12345678"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitAndFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitAndFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(0))
 }
 
 func (s *testAggFuncSuit) TestBitOr(c *C) {
@@ -245,7 +277,6 @@ func (s *testAggFuncSuit) TestBitOr(c *C) {
 	var dec types.MyDecimal
 	err = dec.FromString([]byte("12.234"))
 	c.Assert(err, IsNil)
-
 	row = types.MakeDatums(&dec)
 	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
 	c.Assert(err, IsNil)
@@ -254,13 +285,11 @@ func (s *testAggFuncSuit) TestBitOr(c *C) {
 
 	err = dec.FromString([]byte("1.012"))
 	c.Assert(err, IsNil)
-
 	row = types.MakeDatums(&dec)
 	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
 	c.Assert(err, IsNil)
 	result = bitOrFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(13))
-
 	err = dec.FromString([]byte("15.12345678"))
 	c.Assert(err, IsNil)
 
@@ -272,13 +301,11 @@ func (s *testAggFuncSuit) TestBitOr(c *C) {
 
 	err = dec.FromString([]byte("16.00"))
 	c.Assert(err, IsNil)
-
 	row = types.MakeDatums(&dec)
 	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
 	c.Assert(err, IsNil)
 	result = bitOrFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(31))
-
 }
 
 func (s *testAggFuncSuit) TestBitXor(c *C) {
@@ -322,6 +349,38 @@ func (s *testAggFuncSuit) TestBitXor(c *C) {
 	c.Assert(result.GetUint64(), Equals, uint64(1))
 	partialResult := bitXorFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetUint64(), Equals, uint64(1))
+
+	// test bit_xor( decimal )
+	col.RetType = types.NewFieldType(mysql.TypeNewDecimal)
+	bitXorFunc.ResetContext(s.ctx.GetSessionVars().StmtCtx, evalCtx)
+
+	result = bitXorFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(0))
+
+	var dec types.MyDecimal
+	err = dec.FromString([]byte("1.234"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitXorFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitXorFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(1))
+
+	err = dec.FromString([]byte("1.012"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitXorFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitXorFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(0))
+
+	err = dec.FromString([]byte("2.12345678"))
+	c.Assert(err, IsNil)
+	row = types.MakeDatums(&dec)
+	err = bitXorFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, types.DatumRow(row))
+	c.Assert(err, IsNil)
+	result = bitXorFunc.GetResult(evalCtx)
+	c.Assert(result.GetUint64(), Equals, uint64(2))
 }
 
 func (s *testAggFuncSuit) TestCount(c *C) {

--- a/expression/aggregation/bit_and.go
+++ b/expression/aggregation/bit_and.go
@@ -43,7 +43,15 @@ func (bf *bitAndFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		return errors.Trace(err)
 	}
 	if !value.IsNull() {
-		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() & value.GetUint64())
+		if value.Kind() == types.KindUint64 {
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() & value.GetUint64())
+		} else {
+			int64Value, err := value.ToInt64(sc)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() & uint64(int64Value))
+		}
 	}
 	return nil
 }

--- a/expression/aggregation/bit_or.go
+++ b/expression/aggregation/bit_or.go
@@ -41,7 +41,15 @@ func (bf *bitOrFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 		return errors.Trace(err)
 	}
 	if !value.IsNull() {
-		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() | value.GetUint64())
+		if value.Kind() == types.KindUint64 {
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() | value.GetUint64())
+		} else {
+			int64Value, err := value.ToInt64(sc)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() | uint64(int64Value))
+		}
 	}
 	return nil
 }

--- a/expression/aggregation/bit_xor.go
+++ b/expression/aggregation/bit_xor.go
@@ -41,7 +41,15 @@ func (bf *bitXorFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		return errors.Trace(err)
 	}
 	if !value.IsNull() {
-		evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() ^ value.GetUint64())
+		if value.Kind() == types.KindUint64 {
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() ^ value.GetUint64())
+		} else {
+			int64Value, err := value.ToInt64(sc)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() ^ uint64(int64Value))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## What have you changed? (mandatory)
fix [issue#6987](https://github.com/pingcap/tidb/issues/6987#event-1717221272)
bit_or doesn't handle decimal

## What are the type of the changes (mandatory)?
Bug fix

## How has this PR been tested (mandatory)?

## Does this PR affect documentation (docs/docs-cn) update? (optional)
No.