### PR TITLE
plan: always chose the smaller child as outer for IndexJoin

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -323,6 +323,13 @@ type basePlan struct {
 	stats *statsInfo
 }
 
+func (p *DataSource) cardinality() float64 {
+	if p.statsAfterSelect == nil {
+		return math.MaxFloat64
+	}
+	return p.statsAfterSelect.count
+}
+
 func (p *basePlan) cardinality() float64 {
 	if p.stats == nil {
 		return math.MaxFloat64

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -15,6 +15,7 @@ package plan
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
@@ -162,6 +163,8 @@ type LogicalPlan interface {
 
 	// deriveStats derives statistic info between plans.
 	deriveStats() (*statsInfo, error)
+
+	cardinality() float64
 
 	// preparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.
@@ -318,6 +321,13 @@ type basePlan struct {
 	id    int
 	ctx   sessionctx.Context
 	stats *statsInfo
+}
+
+func (p *basePlan) cardinality() float64 {
+	if p.stats == nil {
+		return math.MaxFloat64
+	}
+	return p.stats.count
 }
 
 func (p *basePlan) replaceExprColumns(replace map[string]*expression.Column) {


### PR DESCRIPTION
## What have you changed? (mandatory)

Always chose the smaller child as the outer one for `IndexJoin` if possible.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- unit test
- explain test


