### PR TITLE
*: kill one's own connection doesn't require SUPER privilege (#6954)

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -41,8 +41,12 @@ type mockSessionManager struct {
 }
 
 // ShowProcessList implements the SessionManager.ShowProcessList interface.
-func (msm *mockSessionManager) ShowProcessList() []util.ProcessInfo {
-	return msm.PS
+func (msm *mockSessionManager) ShowProcessList() map[uint64]util.ProcessInfo {
+	ret := make(map[uint64]util.ProcessInfo)
+	for _, item := range msm.PS {
+		ret[item.ID] = item
+	}
+	return ret
 }
 
 // Kill implements the SessionManager.Kill interface.

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -386,8 +386,9 @@ type mockSessionManager struct {
 }
 
 // ShowProcessList implements the SessionManager.ShowProcessList interface.
-func (msm *mockSessionManager) ShowProcessList() []util.ProcessInfo {
-	return []util.ProcessInfo{msm.ShowProcess()}
+func (msm *mockSessionManager) ShowProcessList() map[uint64]util.ProcessInfo {
+	ps := msm.ShowProcess()
+	return map[uint64]util.ProcessInfo{ps.ID: ps}
 }
 
 // Kill implements the SessionManager.Kill interface.

--- a/server/server.go
+++ b/server/server.go
@@ -314,14 +314,15 @@ func (s *Server) onConn(c net.Conn) {
 }
 
 // ShowProcessList implements the SessionManager interface.
-func (s *Server) ShowProcessList() []util.ProcessInfo {
-	var rs []util.ProcessInfo
+func (s *Server) ShowProcessList() map[uint64]util.ProcessInfo {
 	s.rwlock.RLock()
+	rs := make(map[uint64]util.ProcessInfo, len(s.clients))
 	for _, client := range s.clients {
 		if atomic.LoadInt32(&client.status) == connStatusWaitShutdown {
 			continue
 		}
-		rs = append(rs, client.ctx.ShowProcess())
+		pi := client.ctx.ShowProcess()
+		rs[pi.ID] = pi
 	}
 	s.rwlock.RUnlock()
 	return rs

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -33,6 +33,7 @@ type ProcessInfo struct {
 // SessionManager is an interface for session manage. Show processlist and
 // kill statement rely on this interface.
 type SessionManager interface {
-	ShowProcessList() []ProcessInfo
+	// ShowProcessList returns map[connectionID]ProcessInfo
+	ShowProcessList() map[uint64]ProcessInfo
 	Kill(connectionID uint64, query bool)
 }

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -33,7 +33,7 @@ type ProcessInfo struct {
 // SessionManager is an interface for session manage. Show processlist and
 // kill statement rely on this interface.
 type SessionManager interface {
-	// ShowProcessList returns map[connectionID]ProcessInfo
+	// ShowProcessList returns map[connectionID]ProcessInfo.
 	ShowProcessList() map[uint64]ProcessInfo
 	Kill(connectionID uint64, query bool)
 }


### PR DESCRIPTION
## What have you changed? (mandatory)

cherry pick from https://github.com/pingcap/tidb/pull/6954

    `kill tidb connID`, if the user is the owner of that connection, there
    is no need to check the SUPER privilege.
    SessionManager interface is slightly modified.

## What are the type of the changes (mandatory)?

- Bug fix (non-breaking change which fixes an issue)

