### PR TITLE
infoschema: support generation_expression column in information_schema.columns

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -240,7 +240,7 @@ func (s *testSuite) TestAggregation(c *C) {
 
 	result = tk.MustQuery("select count(*) from information_schema.columns")
 	// When adding new memory columns in information_schema, please update this variable.
-	columnCountOfAllInformationSchemaTables := "748"
+	columnCountOfAllInformationSchemaTables := "749"
 	result.Check(testkit.Rows(columnCountOfAllInformationSchemaTables))
 
 	tk.MustExec("drop table if exists t1")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1353,9 +1353,12 @@ func (s *testSuite) TestGeneratedColumnRead(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec(`CREATE TABLE test_gc_read(a int primary key, b int, c int as (a+b), d int as (a*b) stored)`)
 
+	result := tk.MustQuery(`SELECT generation_expression FROM information_schema.columns WHERE table_name = 'test_gc_read' AND column_name = 'd'`)
+	result.Check(testkit.Rows("`a` * `b`"))
+
 	// Insert only column a and b, leave c and d be calculated from them.
 	tk.MustExec(`INSERT INTO test_gc_read (a, b) VALUES (0,null),(1,2),(3,4)`)
-	result := tk.MustQuery(`SELECT * FROM test_gc_read ORDER BY a`)
+	result = tk.MustQuery(`SELECT * FROM test_gc_read ORDER BY a`)
 	result.Check(testkit.Rows(`0 <nil> <nil> <nil>`, `1 2 3 2`, `3 4 7 12`))
 
 	tk.MustExec(`INSERT INTO test_gc_read SET a = 5, b = 10`)

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -168,6 +168,7 @@ var columnsCols = []columnInfo{
 	{"EXTRA", mysql.TypeVarchar, 30, 0, nil, nil},
 	{"PRIVILEGES", mysql.TypeVarchar, 80, 0, nil, nil},
 	{"COLUMN_COMMENT", mysql.TypeVarchar, 1024, 0, nil, nil},
+	{"GENERATION_EXPRESSION", mysql.TypeBlob, 589779, mysql.NotNullFlag, nil, nil},
 }
 
 var statisticsCols = []columnInfo{
@@ -758,6 +759,7 @@ func dataForColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) [][]types
 			columnDesc.Extra,                  // EXTRA
 			"select,insert,update,references", // PRIVILEGES
 			columnDesc.Comment,                // COLUMN_COMMENT
+			col.GeneratedExprString,           // GENERATION_EXPRESSION
 		)
 		// In mysql, 'character_set_name' and 'collation_name' are setted to null when column type is non-varchar or non-blob in information_schema.
 		if col.Tp != mysql.TypeVarchar && col.Tp != mysql.TypeBlob {


### PR DESCRIPTION
## What have you changed? (mandatory)

Support generation_expression column in information_schema.columns will fix https://github.com/pingcap/tidb/issues/6949

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

Unit test.

PTAL @hicqu @coocood @zz-jason 