### PR TITLE
plan: move `StatsInfo` from `PhysicalPlan` to `Plan`

### DIFF
--- a/plan/plan.go
+++ b/plan/plan.go
@@ -39,6 +39,9 @@ type Plan interface {
 	replaceExprColumns(replace map[string]*expression.Column)
 
 	context() sessionctx.Context
+
+	// StatsInfo will return the statsInfo for this plan.
+	StatsInfo() *statsInfo
 }
 
 // taskType is the type of execution task.
@@ -226,9 +229,6 @@ type PhysicalPlan interface {
 	// getChildReqProps gets the required property by child index.
 	getChildReqProps(idx int) *requiredProp
 
-	// StatsInfo will return the statsInfo for this plan.
-	StatsInfo() *statsInfo
-
 	// Get all the children.
 	Children() []PhysicalPlan
 
@@ -347,6 +347,11 @@ func (p *basePlan) replaceExprColumns(replace map[string]*expression.Column) {
 // ID implements Plan ID interface.
 func (p *basePlan) ID() int {
 	return p.id
+}
+
+// StatsInfo implements the Plan interface.
+func (p *basePlan) StatsInfo() *statsInfo {
+	return p.stats
 }
 
 func (p *basePlan) ExplainID() string {

--- a/plan/stats.go
+++ b/plan/stats.go
@@ -59,10 +59,6 @@ func (s *statsInfo) scaleByExpectCnt(expectCnt float64) *statsInfo {
 	return s
 }
 
-func (p *basePhysicalPlan) StatsInfo() *statsInfo {
-	return p.stats
-}
-
 func (p *LogicalTableDual) deriveStats() (*statsInfo, error) {
 	profile := &statsInfo{
 		count:       float64(p.RowCount),
@@ -95,6 +91,12 @@ func (p *baseLogicalPlan) deriveStats() (*statsInfo, error) {
 	}
 	p.stats = profile
 	return profile, nil
+}
+
+// StatsInfo implements the Plan interface.
+// TODO: merge `ds.statsAfterSelect`, just use `ds.stats`.
+func (ds *DataSource) StatsInfo() *statsInfo {
+	return ds.statsAfterSelect
 }
 
 func (ds *DataSource) getStatsByFilter(conds expression.CNFExprs) *statsInfo {


### PR DESCRIPTION
## What have you changed? (mandatory)

LogicalPlan may call `StatsInfo` too, so move it to `Plan` interface.

## What is the type of the changes? (mandatory)

tiny refactor.

## How has this PR been tested? (mandatory)

existing tests.

