### PR TITLE
ddl: fix create partition table panic

### DIFF
--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -269,7 +269,7 @@ type CaseExpr struct {
 // Format the ExprNode into a Writer.
 func (n *CaseExpr) Format(w io.Writer) {
 	fmt.Fprint(w, "CASE ")
-	// Because the presence of case when syntax, Value could be nil and we need check this.
+	// Because the presence of `case when` syntax, `Value` could be nil and we need check this.
 	if n.Value != nil {
 		n.Value.Format(w)
 		fmt.Fprint(w, " ")

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -272,8 +272,8 @@ func (n *CaseExpr) Format(w io.Writer) {
 	// Because the presence of case when syntax, Value could be nil and we need check this.
 	if n.Value != nil {
 		n.Value.Format(w)
+		fmt.Fprint(w, " ")
 	}
-	fmt.Fprint(w, " ")
 	for _, clause := range n.WhenClauses {
 		fmt.Fprint(w, "WHEN ")
 		clause.Expr.Format(w)

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -269,6 +269,7 @@ type CaseExpr struct {
 // Format the ExprNode into a Writer.
 func (n *CaseExpr) Format(w io.Writer) {
 	fmt.Fprint(w, "CASE ")
+	// Because the presence of case when syntax, Value could be nil and we need check this.
 	if n.Value != nil {
 		n.Value.Format(w)
 	}

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -269,7 +269,9 @@ type CaseExpr struct {
 // Format the ExprNode into a Writer.
 func (n *CaseExpr) Format(w io.Writer) {
 	fmt.Fprint(w, "CASE ")
-	n.Value.Format(w)
+	if n.Value != nil {
+		n.Value.Format(w)
+	}
 	fmt.Fprint(w, " ")
 	for _, clause := range n.WhenClauses {
 		fmt.Fprint(w, "WHEN ")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1665,6 +1665,16 @@ func (s *testDBSuite) TestCreateTableWithPartition(c *C) {
 		partition p2 values less than maxvalue
 	);`)
 	c.Assert(ddl.ErrNotAllowedTypeInPartition.Equal(err), IsTrue)
+
+	// TODO: This SQL should return ErrPartitionFunctionIsNotAllowed: ERROR 1564 (HY000): This partition function is not allowed
+	_, err = s.tk.Exec(`create TABLE t9 (
+	col1 int
+	)
+	partition by range( case when col1 > 0 then 10 else 20 end ) (
+		partition p0 values less than (2),
+		partition p1 values less than (6)
+	);`)
+	c.Assert(err, IsNil)
 }
 
 func (s *testDBSuite) TestTableDDLWithFloatType(c *C) {


### PR DESCRIPTION
## What have you changed? (mandatory)
Execute below SQL will panic
```SQL
create TABLE t1 (col1 int) partition by range(case when col1>0 then 10 else 20 end) (partition p0 values less than (2), partition p1 values less than (6));
```
TODO:
This PR just fix the panic, This SQL should return err:` ERROR 1564 (HY000): This partition function is not allowed`, issue[#7058](https://github.com/pingcap/tidb/issues/7058)

## What is the type of the changes? (mandatory)
Bug fix

## How has this PR been tested? (mandatory)

Unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

