### PR TITLE
executor: remove childrenResult from baseExecutor

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -804,10 +804,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 // Close implements the Executor Close interface.
 func (e *StreamAggExec) Close() error {
 	e.childResult = nil
-	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
-		return err
-	}
-	return nil
+	return errors.Trace(e.baseExecutor.Close())
 }
 
 // Next implements the Executor Next interface.

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -804,7 +804,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 // Close implements the Executor Close interface.
 func (e *StreamAggExec) Close() error {
 	e.childResult = nil
-	if err := e.baseExecutor.Close(); err != nil {
+	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
 		return err
 	}
 	return nil

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -803,10 +803,10 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 
 // Close implements the Executor Close interface.
 func (e *StreamAggExec) Close() error {
+	e.childResult = nil
 	if err := e.baseExecutor.Close(); err != nil {
 		return err
 	}
-	e.childResult = nil
 	return nil
 }
 

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -159,6 +159,8 @@ type HashAggExec struct {
 	defaultVal       *chunk.Chunk
 	// isChildReturnEmpty indicates whether the child executor only returns an empty input.
 	isChildReturnEmpty bool
+
+	childResult *chunk.Chunk
 }
 
 // HashAggInput indicates the input of hash agg exec.
@@ -201,6 +203,7 @@ func (d *HashAggIntermData) ToRows(sc *stmtctx.StatementContext, rows []types.Da
 // Close implements the Executor Close interface.
 func (e *HashAggExec) Close() error {
 	if e.isUnparallelExec {
+		e.childResult = nil
 		e.groupMap = nil
 		e.groupIterator = nil
 		e.aggCtxsMap = nil
@@ -247,6 +250,7 @@ func (e *HashAggExec) initForUnparallelExec() {
 	e.rowBuffer = make([]types.Datum, 0, e.Schema().Len())
 	e.groupKey = make([]byte, 0, 8)
 	e.groupVals = make([][]byte, 0, 8)
+	e.childResult = e.children[0].newChunk()
 }
 
 func (e *HashAggExec) initForParallelExec() {
@@ -676,14 +680,14 @@ func (e *HashAggExec) unparallelExec(ctx context.Context, chk *chunk.Chunk) erro
 
 // execute fetches Chunks from src and update each aggregate function for each row in Chunk.
 func (e *HashAggExec) execute(ctx context.Context) (err error) {
-	inputIter := chunk.NewIterator4Chunk(e.childrenResults[0])
+	inputIter := chunk.NewIterator4Chunk(e.childResult)
 	for {
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.children[0].Next(ctx, e.childResult)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		// no more data.
-		if e.childrenResults[0].NumRows() == 0 {
+		if e.childResult.NumRows() == 0 {
 			return nil
 		}
 		for row := inputIter.Begin(); row != inputIter.End(); row = inputIter.Next() {
@@ -765,6 +769,8 @@ type StreamAggExec struct {
 	newAggFuncs    []aggfuncs.AggFunc
 	partialResults []aggfuncs.PartialResult
 	groupRows      []chunk.Row
+
+	childResult *chunk.Chunk
 }
 
 // Open implements the Executor Open interface.
@@ -772,10 +778,10 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-
+	e.childResult = e.children[0].newChunk()
 	e.executed = false
 	e.isChildReturnEmpty = true
-	e.inputIter = chunk.NewIterator4Chunk(e.childrenResults[0])
+	e.inputIter = chunk.NewIterator4Chunk(e.childResult)
 	e.inputRow = e.inputIter.End()
 	e.mutableRow = chunk.MutRowFromTypes(e.retTypes())
 	e.rowBuffer = make([]types.Datum, 0, e.Schema().Len())
@@ -792,6 +798,15 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *StreamAggExec) Close() error {
+	if err := e.baseExecutor.Close(); err != nil {
+		return err
+	}
+	e.childResult = nil
 	return nil
 }
 
@@ -876,13 +891,13 @@ func (e *StreamAggExec) fetchChildIfNecessary(ctx context.Context, chk *chunk.Ch
 		}
 	}
 
-	err = e.children[0].Next(ctx, e.childrenResults[0])
+	err = e.children[0].Next(ctx, e.childResult)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	// No more data.
-	if e.childrenResults[0].NumRows() == 0 {
+	if e.childResult.NumRows() == 0 {
 		if !e.isChildReturnEmpty {
 			err = e.appendResult2Chunk(chk)
 		} else if e.defaultVal != nil {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -63,13 +63,12 @@ var (
 )
 
 type baseExecutor struct {
-	ctx             sessionctx.Context
-	id              string
-	schema          *expression.Schema
-	maxChunkSize    int
-	children        []Executor
-	childrenResults []*chunk.Chunk
-	retFieldTypes   []*types.FieldType
+	ctx           sessionctx.Context
+	id            string
+	schema        *expression.Schema
+	maxChunkSize  int
+	children      []Executor
+	retFieldTypes []*types.FieldType
 }
 
 // Open initializes children recursively and "childrenResults" according to children's schemas.
@@ -79,10 +78,6 @@ func (e *baseExecutor) Open(ctx context.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-	}
-	e.childrenResults = make([]*chunk.Chunk, 0, len(e.children))
-	for _, child := range e.children {
-		e.childrenResults = append(e.childrenResults, child.newChunk())
 	}
 	return nil
 }
@@ -95,7 +90,6 @@ func (e *baseExecutor) Close() error {
 			return errors.Trace(err)
 		}
 	}
-	e.childrenResults = nil
 	return nil
 }
 
@@ -512,6 +506,8 @@ type LimitExec struct {
 
 	// meetFirstBatch represents whether we have met the first valid Chunk from child.
 	meetFirstBatch bool
+
+	childResult *chunk.Chunk
 }
 
 // Next implements the Executor Next interface.
@@ -521,11 +517,11 @@ func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return nil
 	}
 	for !e.meetFirstBatch {
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.children[0].Next(ctx, e.childResult)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		batchSize := uint64(e.childrenResults[0].NumRows())
+		batchSize := uint64(e.childResult.NumRows())
 		// no more data.
 		if batchSize == 0 {
 			return nil
@@ -540,7 +536,7 @@ func (e *LimitExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			if begin == end {
 				break
 			}
-			chk.Append(e.childrenResults[0], int(begin), int(end))
+			chk.Append(e.childResult, int(begin), int(end))
 			return nil
 		}
 		e.cursor += batchSize
@@ -567,8 +563,18 @@ func (e *LimitExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
+	e.childResult = e.children[0].newChunk()
 	e.cursor = 0
 	e.meetFirstBatch = e.begin == 0
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *LimitExec) Close() error {
+	if err := e.baseExecutor.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	e.childResult = nil
 	return nil
 }
 
@@ -646,11 +652,12 @@ func (e *TableDualExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 type SelectionExec struct {
 	baseExecutor
 
-	batched   bool
-	filters   []expression.Expression
-	selected  []bool
-	inputIter *chunk.Iterator4Chunk
-	inputRow  chunk.Row
+	batched     bool
+	filters     []expression.Expression
+	selected    []bool
+	inputIter   *chunk.Iterator4Chunk
+	inputRow    chunk.Row
+	childResult *chunk.Chunk
 }
 
 // Open implements the Executor Open interface.
@@ -658,11 +665,12 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
+	e.childResult = e.children[0].newChunk()
 	e.batched = expression.Vectorizable(e.filters)
 	if e.batched {
 		e.selected = make([]bool, 0, chunk.InitialCapacity)
 	}
-	e.inputIter = chunk.NewIterator4Chunk(e.childrenResults[0])
+	e.inputIter = chunk.NewIterator4Chunk(e.childResult)
 	e.inputRow = e.inputIter.End()
 	return nil
 }
@@ -672,6 +680,7 @@ func (e *SelectionExec) Close() error {
 	if err := e.baseExecutor.Close(); err != nil {
 		return errors.Trace(err)
 	}
+	e.childResult = nil
 	e.selected = nil
 	return nil
 }
@@ -694,12 +703,12 @@ func (e *SelectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			}
 			chk.AppendRow(e.inputRow)
 		}
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.children[0].Next(ctx, e.childResult)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		// no more data.
-		if e.childrenResults[0].NumRows() == 0 {
+		if e.childResult.NumRows() == 0 {
 			return nil
 		}
 		e.selected, err = expression.VectorizedFilter(e.ctx, e.filters, e.inputIter, e.selected)
@@ -726,13 +735,13 @@ func (e *SelectionExec) unBatchedNext(ctx context.Context, chk *chunk.Chunk) err
 				return nil
 			}
 		}
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.children[0].Next(ctx, e.childResult)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		e.inputRow = e.inputIter.Begin()
 		// no more data.
-		if e.childrenResults[0].NumRows() == 0 {
+		if e.childResult.NumRows() == 0 {
 			return nil
 		}
 	}
@@ -838,7 +847,8 @@ func (e *TableScanExec) Open(ctx context.Context) error {
 type ExistsExec struct {
 	baseExecutor
 
-	evaluated bool
+	evaluated   bool
+	childResult *chunk.Chunk
 }
 
 // Open implements the Executor Open interface.
@@ -846,6 +856,7 @@ func (e *ExistsExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
+	e.childResult = e.children[0].newChunk()
 	e.evaluated = false
 	return nil
 }
@@ -855,16 +866,25 @@ func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	if !e.evaluated {
 		e.evaluated = true
-		err := e.children[0].Next(ctx, e.childrenResults[0])
+		err := e.children[0].Next(ctx, e.childResult)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if e.childrenResults[0].NumRows() > 0 {
+		if e.childResult.NumRows() > 0 {
 			chk.AppendInt64(0, 1)
 		} else {
 			chk.AppendInt64(0, 0)
 		}
 	}
+	return nil
+}
+
+// Close implements the Executor Close interface.
+func (e *ExistsExec) Close() error {
+	if err := e.baseExecutor.Close(); err != nil {
+		return errors.Trace(err)
+	}
+	e.childResult = nil
 	return nil
 }
 
@@ -937,6 +957,8 @@ type UnionExec struct {
 	resourcePools []chan *chunk.Chunk
 	resultPool    chan *unionWorkerResult
 	initialized   bool
+
+	childrenResults []*chunk.Chunk
 }
 
 // unionWorkerResult stores the result for a union worker.
@@ -958,6 +980,9 @@ func (e *UnionExec) waitAllFinished() {
 func (e *UnionExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
+	}
+	for _, child := range e.children {
+		e.childrenResults = append(e.childrenResults, child.newChunk())
 	}
 	e.stopFetchData.Store(false)
 	e.initialized = false
@@ -1039,6 +1064,7 @@ func (e *UnionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // Close implements the Executor Close interface.
 func (e *UnionExec) Close() error {
 	close(e.finished)
+	e.childrenResults = nil
 	if e.resultPool != nil {
 		for range e.resultPool {
 		}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -572,10 +572,7 @@ func (e *LimitExec) Open(ctx context.Context) error {
 // Close implements the Executor Close interface.
 func (e *LimitExec) Close() error {
 	e.childResult = nil
-	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
-		return err
-	}
-	return nil
+	return errors.Trace(e.baseExecutor.Close())
 }
 
 func init() {
@@ -677,12 +674,9 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 
 // Close implements plan.Plan Close interface.
 func (e *SelectionExec) Close() error {
-	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
-		return err
-	}
 	e.childResult = nil
 	e.selected = nil
-	return nil
+	return errors.Trace(e.baseExecutor.Close())
 }
 
 // Next implements the Executor Next interface.
@@ -882,10 +876,7 @@ func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // Close implements the Executor Close interface.
 func (e *ExistsExec) Close() error {
 	e.childResult = nil
-	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
-		return err
-	}
-	return nil
+	return errors.Trace(e.baseExecutor.Close())
 }
 
 // MaxOneRowExec checks if the number of rows that a query returns is at maximum one.

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -572,8 +572,8 @@ func (e *LimitExec) Open(ctx context.Context) error {
 // Close implements the Executor Close interface.
 func (e *LimitExec) Close() error {
 	e.childResult = nil
-	if err := e.baseExecutor.Close(); err != nil {
-		return errors.Trace(err)
+	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
+		return err
 	}
 	return nil
 }
@@ -677,8 +677,8 @@ func (e *SelectionExec) Open(ctx context.Context) error {
 
 // Close implements plan.Plan Close interface.
 func (e *SelectionExec) Close() error {
-	if err := e.baseExecutor.Close(); err != nil {
-		return errors.Trace(err)
+	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
+		return err
 	}
 	e.childResult = nil
 	e.selected = nil
@@ -882,8 +882,8 @@ func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 // Close implements the Executor Close interface.
 func (e *ExistsExec) Close() error {
 	e.childResult = nil
-	if err := e.baseExecutor.Close(); err != nil {
-		return errors.Trace(err)
+	if err := errors.Trace(e.baseExecutor.Close()); err != nil {
+		return err
 	}
 	return nil
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -571,10 +571,10 @@ func (e *LimitExec) Open(ctx context.Context) error {
 
 // Close implements the Executor Close interface.
 func (e *LimitExec) Close() error {
+	e.childResult = nil
 	if err := e.baseExecutor.Close(); err != nil {
 		return errors.Trace(err)
 	}
-	e.childResult = nil
 	return nil
 }
 
@@ -881,10 +881,10 @@ func (e *ExistsExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // Close implements the Executor Close interface.
 func (e *ExistsExec) Close() error {
+	e.childResult = nil
 	if err := e.baseExecutor.Close(); err != nil {
 		return errors.Trace(err)
 	}
-	e.childResult = nil
 	return nil
 }
 


### PR DESCRIPTION
## What have you changed? (mandatory)

This is 1 of 3 PRs of "reduce chunk capacity". issue ref #7077

In this PR, we remove `childrenResult` from `baseExecutor` and push down them to real implements 

only create result chunk for children only when it's really needed, and try create single chunk if no needed to use more than one.


## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature), only code refactor.

## How has this PR been tested? (mandatory)

- unit tests
- integration tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7076)
<!-- Reviewable:end -->
