### PR TITLE
Add `advertise-address` to config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,19 +40,20 @@ var (
 
 // Config contains configuration options.
 type Config struct {
-	Host            string          `toml:"host" json:"host"`
-	Port            uint            `toml:"port" json:"port"`
-	Store           string          `toml:"store" json:"store"`
-	Path            string          `toml:"path" json:"path"`
-	Socket          string          `toml:"socket" json:"socket"`
-	Lease           string          `toml:"lease" json:"lease"`
-	RunDDL          bool            `toml:"run-ddl" json:"run-ddl"`
-	SplitTable      bool            `toml:"split-table" json:"split-table"`
-	TokenLimit      uint            `toml:"token-limit" json:"token-limit"`
-	OOMAction       string          `toml:"oom-action" json:"oom-action"`
-	MemQuotaQuery   int64           `toml:"mem-quota-query" json:"mem-quota-query"`
-	EnableStreaming bool            `toml:"enable-streaming" json:"enable-streaming"`
-	TxnLocalLatches TxnLocalLatches `toml:"txn-local-latches" json:"txn-local-latches"`
+	Host             string          `toml:"host" json:"host"`
+	AdvertiseAddress string          `toml:"advertise-address" json:"advertise-address"`
+	Port             uint            `toml:"port" json:"port"`
+	Store            string          `toml:"store" json:"store"`
+	Path             string          `toml:"path" json:"path"`
+	Socket           string          `toml:"socket" json:"socket"`
+	Lease            string          `toml:"lease" json:"lease"`
+	RunDDL           bool            `toml:"run-ddl" json:"run-ddl"`
+	SplitTable       bool            `toml:"split-table" json:"split-table"`
+	TokenLimit       uint            `toml:"token-limit" json:"token-limit"`
+	OOMAction        string          `toml:"oom-action" json:"oom-action"`
+	MemQuotaQuery    int64           `toml:"mem-quota-query" json:"mem-quota-query"`
+	EnableStreaming  bool            `toml:"enable-streaming" json:"enable-streaming"`
+	TxnLocalLatches  TxnLocalLatches `toml:"txn-local-latches" json:"txn-local-latches"`
 	// Set sys variable lower-case-table-names, ref: https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html.
 	// TODO: We actually only support mode 2, which keeps the original case, but the comparison is case-insensitive.
 	LowerCaseTableNames int `toml:"lower-case-table-names" json:"lower-case-table-names"`
@@ -236,17 +237,18 @@ type Binlog struct {
 }
 
 var defaultConf = Config{
-	Host:            "0.0.0.0",
-	Port:            4000,
-	Store:           "mocktikv",
-	Path:            "/tmp/tidb",
-	RunDDL:          true,
-	SplitTable:      true,
-	Lease:           "45s",
-	TokenLimit:      1000,
-	OOMAction:       "log",
-	MemQuotaQuery:   32 << 30,
-	EnableStreaming: false,
+	Host:             "0.0.0.0",
+	AdvertiseAddress: "",
+	Port:             4000,
+	Store:            "mocktikv",
+	Path:             "/tmp/tidb",
+	RunDDL:           true,
+	SplitTable:       true,
+	Lease:            "45s",
+	TokenLimit:       1000,
+	OOMAction:        "log",
+	MemQuotaQuery:    32 << 30,
+	EnableStreaming:  false,
 	TxnLocalLatches: TxnLocalLatches{
 		Enabled:  false,
 		Capacity: 10240000,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -3,6 +3,9 @@
 # TiDB server host.
 host = "0.0.0.0"
 
+# tidb server advertise IP
+advertise-ip = ""
+
 # TiDB server port.
 port = 4000
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -4,7 +4,7 @@
 host = "0.0.0.0"
 
 # tidb server advertise IP.
-advertise-ip = ""
+advertise-address = ""
 
 # TiDB server port.
 port = 4000

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -57,24 +57,25 @@ import (
 
 // Flag Names
 const (
-	nmVersion         = "V"
-	nmConfig          = "config"
-	nmStore           = "store"
-	nmStorePath       = "path"
-	nmHost            = "host"
-	nmPort            = "P"
-	nmSocket          = "socket"
-	nmBinlogSocket    = "binlog-socket"
-	nmRunDDL          = "run-ddl"
-	nmLogLevel        = "L"
-	nmLogFile         = "log-file"
-	nmLogSlowQuery    = "log-slow-query"
-	nmReportStatus    = "report-status"
-	nmStatusPort      = "status"
-	nmMetricsAddr     = "metrics-addr"
-	nmMetricsInterval = "metrics-interval"
-	nmDdlLease        = "lease"
-	nmTokenLimit      = "token-limit"
+	nmVersion          = "V"
+	nmConfig           = "config"
+	nmStore            = "store"
+	nmStorePath        = "path"
+	nmHost             = "host"
+	nmAdvertiseAddress = "advertise-address"
+	nmPort             = "P"
+	nmSocket           = "socket"
+	nmBinlogSocket     = "binlog-socket"
+	nmRunDDL           = "run-ddl"
+	nmLogLevel         = "L"
+	nmLogFile          = "log-file"
+	nmLogSlowQuery     = "log-slow-query"
+	nmReportStatus     = "report-status"
+	nmStatusPort       = "status"
+	nmMetricsAddr      = "metrics-addr"
+	nmMetricsInterval  = "metrics-interval"
+	nmDdlLease         = "lease"
+	nmTokenLimit       = "token-limit"
 
 	nmProxyProtocolNetworks      = "proxy-protocol-networks"
 	nmProxyProtocolHeaderTimeout = "proxy-protocol-header-timeout"
@@ -85,15 +86,16 @@ var (
 	configPath = flag.String(nmConfig, "", "config file path")
 
 	// Base
-	store        = flag.String(nmStore, "mocktikv", "registered store name, [tikv, mocktikv]")
-	storePath    = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
-	host         = flag.String(nmHost, "0.0.0.0", "tidb server host")
-	port         = flag.String(nmPort, "4000", "tidb server port")
-	socket       = flag.String(nmSocket, "", "The socket file to use for connection.")
-	binlogSocket = flag.String(nmBinlogSocket, "", "socket file to write binlog")
-	runDDL       = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
-	ddlLease     = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
-	tokenLimit   = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
+	store            = flag.String(nmStore, "mocktikv", "registered store name, [tikv, mocktikv]")
+	storePath        = flag.String(nmStorePath, "/tmp/tidb", "tidb storage path")
+	host             = flag.String(nmHost, "0.0.0.0", "tidb server host")
+	advertiseAddress = flag.String(nmAdvertiseAddress, "", "tidb server advertise IP")
+	port             = flag.String(nmPort, "4000", "tidb server port")
+	socket           = flag.String(nmSocket, "", "The socket file to use for connection.")
+	binlogSocket     = flag.String(nmBinlogSocket, "", "socket file to write binlog")
+	runDDL           = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
+	ddlLease         = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
+	tokenLimit       = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
 
 	// Log
 	logLevel     = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
@@ -261,6 +263,9 @@ func overrideConfig() {
 	// Base
 	if actualFlags[nmHost] {
 		cfg.Host = *host
+	}
+	if actualFlags[nmAdvertiseAddress] {
+		cfg.AdvertiseAddress = *advertiseAddress
 	}
 	var err error
 	if actualFlags[nmPort] {


### PR DESCRIPTION
## What have you changed? (mandatory)

* This PR add `advertise-address` configuration to config.
* `advertise-address` is the current TiDB server IP. We need put some information such as IP to PD.This is for issue[#6961](https://github.com/pingcap/tidb/issues/6961)
* Why do not use `host` of the config directly? Because the `host` Maybe "0.0.0.0"


## What is the type of the changes? (mandatory)

## How has this PR been tested? (mandatory)

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
Yes.

## Does this PR affect tidb-ansible update? (mandatory)
Yes.

## Does this PR need to be added to the release notes? (mandatory)

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

