### PR TITLE
ticlient: Add keep alive

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -217,6 +217,12 @@ type TiKVClient struct {
 	// GrpcConnectionCount is the max gRPC connections that will be established
 	// with each tikv-server.
 	GrpcConnectionCount uint `toml:"grpc-connection-count" json:"grpc-connection-count"`
+	// After a duration of this time in seconds if the client doesn't see any activity it pings
+	// the server to see if the transport is still alive.
+	GrpcKeepAliveTime uint `toml:"grpc-keepalive-time" json:"grpc-keepalive-time"`
+	// After having pinged for keepalive check, the client waits for a duration of Timeout in seconds
+	// and if no activity is seen even after that the connection is closed.
+	GrpcKeepAliveTimeout uint `toml:"grpc-keepalive-timeout" json:"grpc-keepalive-timeout"`
 	// CommitTimeout is the max time which command 'commit' will wait.
 	CommitTimeout string `toml:"commit-timeout" json:"commit-timeout"`
 }
@@ -296,8 +302,10 @@ var defaultConf = Config{
 		Reporter: OpenTracingReporter{},
 	},
 	TiKVClient: TiKVClient{
-		GrpcConnectionCount: 16,
-		CommitTimeout:       "41s",
+		GrpcConnectionCount:  16,
+		GrpcKeepAliveTime:    10,
+		GrpcKeepAliveTimeout: 3,
+		CommitTimeout:        "41s",
 	},
 	Binlog: Binlog{
 		WriteTimeout: "15s",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -215,6 +215,14 @@ local-agent-host-port = ""
 # Max gRPC connections that will be established with each tikv-server.
 grpc-connection-count = 16
 
+# After a duration of this time in seconds if the client doesn't see any activity it pings
+# the server to see if the transport is still alive.
+grpc-keepalive-time = 10
+
+# After having pinged for keepalive check, the client waits for a duration of Timeout in seconds
+# and if no activity is seen even after that the connection is closed.
+grpc-keepalive-timeout = 3
+
 # max time for commit command, must be twice bigger than raft election timeout.
 commit-timeout = "41s"
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -389,6 +389,8 @@ func setGlobalVars() {
 	if cfg.TiKVClient.GrpcConnectionCount > 0 {
 		tikv.MaxConnectionCount = cfg.TiKVClient.GrpcConnectionCount
 	}
+	tikv.GrpcKeepAliveTime = time.Duration(cfg.TiKVClient.GrpcKeepAliveTime) * time.Second
+	tikv.GrpcKeepAliveTimeout = time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout) * time.Second
 
 	// set lower_case_table_names
 	variable.SysVars["lower_case_table_names"].Value = strconv.Itoa(cfg.LowerCaseTableNames)


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR adds keep alive settings for ticlient, using the same configuration as TiKV's (time = 10s, timeout = 3s).

By adding keep alive, we can avoid firewall dropping our inactive connections, which will cause SQL queries to fail.

Since the client meets issue on our release-2.0 branch, this fix is proposed over release-2.0 branch instead of master. It will be cherry picked to master later.

## What is the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

To test whether this fix is effective, we first need to reproduce the issue in our own environment.

Since I don't have such firewalls, so I tried to simulate this firewall by using the following scripts:

```bash
echo "*filter" > rule
echo ":INPUT ACCEPT [549:776388]" >> rule
echo ":FORWARD ACCEPT [0:0]" >> rule
echo ":OUTPUT ACCEPT [596:577866]" >> rule
netstat -anp | grep tidb | grep ESTABLISHED | grep tcp | grep 20160 | awk '{ print $4 }' | awk -F':' '{ print $2 }' | sort | uniq | awk '{ print "-A INPUT -p tcp --dport " $1 " -j DROP"; print "-A OUTPUT -p tcp --sport " $1 " -j DROP" }' >> rule
echo "COMMIT" >> rule
cat rule | tee /etc/sysconfig/iptables
service iptables restart
```

This script captures all alive source ports of established connections between current host's TiDB and other TiKVs. These source ports will be added it to iptables' rule (drop packet). After execution, all future packets in these ports (connection) will be dropped, just like the firewall.

### For the current TiDB master as well as release-2.0 branch

For TiDB, after dropping start working, existing gRPC connections were still used to send requests (and will never receive response) so all queries from this TiDB took a very long time and its QPS is 0:

![image](https://user-images.githubusercontent.com/1916485/42895820-933b6820-8aed-11e8-9546-e5ce263d4f88.png)

![image](https://user-images.githubusercontent.com/1916485/42895803-8a5dfce0-8aed-11e8-8e7d-c60495acb5c5.png)

Sysbench will fail:

![image](https://user-images.githubusercontent.com/1916485/42895839-a359db7e-8aed-11e8-9f22-8344a55e80df.png)

According to netstat, these dead connections were kept for more than 15 minutes since we started another sysbench after dropping them. After that, they were destroyed and new connections were established, so that everything backed to normal again.

### For this fixed version (Test 1)

I started a sysbench immediately after these connections are dropped by iptables:

![image](https://user-images.githubusercontent.com/1916485/42895894-cacfbd90-8aed-11e8-9177-0e65710c1eea.png)

![image](https://user-images.githubusercontent.com/1916485/42895902-d0537022-8aed-11e8-9e9b-2a39501379c4.png)

We can see that initially QPS was affected (notice that we deployed multiple TiDBs and only 1 is affected). After about 30 seconds it was recovered. This is far better than the 15-minute-recovery previously. Also sysbench did not fail.

### For this fixed version (Test 2)

I started a sysbench 1 minute after these connections are dropped by iptables:

![image](https://user-images.githubusercontent.com/1916485/42895923-e8aa6bd0-8aed-11e8-81e4-71b45b31877c.png)

We can see that QPS was not affected totally.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

https://github.com/pingcap/tidb-ansible/pull/469

## Does this PR need to be added to the release notes? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)
