### PR TITLE
chunk/codec: adjust decoding offsets in chunk

### DIFF
--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -128,7 +128,7 @@ func (c *Codec) decodeColumn(buffer []byte, col *column, ordinal int) (remained 
 	numDataBytes := numFixedBytes * col.length
 	if numFixedBytes == -1 {
 		numOffsetBytes := (col.length + 1) * 4
-		col.offsets = append(col.offsets[:0], c.bytesToI32Slice(buffer)...)
+		col.offsets = append(col.offsets[:0], c.bytesToI32Slice(buffer[:numOffsetBytes])...)
 		buffer = buffer[numOffsetBytes:]
 		numDataBytes = int(col.offsets[col.length])
 	} else if cap(col.elemBuf) < numFixedBytes {


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR adjust the behavior in decoding offsets in chunk.

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

no

## Refer to a related PR or issue link (optional)

https://github.com/pingcap/tidb/pull/7006

## Benchmark result if necessary (optional)

before:
```
go test -bench BenchmarkDecodeToChunkWithVariableType -run xx -count 5 --benchmem
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/util/chunk
BenchmarkDecodeToChunkWithVariableType-8          200000              7320 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          200000              7001 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          200000              7394 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          200000              7329 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          200000              7352 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/util/chunk      7.678s

```

after

```
go test -bench BenchmarkDecodeToChunkWithVariableType -run xx -count 5 --benchmem
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/util/chunk
BenchmarkDecodeToChunkWithVariableType-8          500000              2751 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          500000              2701 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          500000              2745 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          500000              2705 ns/op               0 B/op          0 allocs/op
BenchmarkDecodeToChunkWithVariableType-8          500000              2715 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/util/chunk      6.976s

```
@zz-jason @coocood PTAL
