### PR TITLE
ddl: fix create partition table not suport bit and year column type

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1675,6 +1675,9 @@ func (s *testDBSuite) TestCreateTableWithPartition(c *C) {
 		partition p1 values less than (6)
 	);`)
 	c.Assert(err, IsNil)
+
+	s.tk.MustExec(`create TABLE t20 (c1 int,c2 bit(10)) partition by range(c2) (partition p0 values less than (10));`)
+	s.tk.MustExec(`create TABLE t21 (c1 int,c2 year) partition by range( c2 ) (partition p0 values less than (2000));`)
 }
 
 func (s *testDBSuite) TestTableDDLWithFloatType(c *C) {

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -23,9 +23,9 @@ import (
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/model"
-	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/types"
 )
 
 const (
@@ -148,8 +148,8 @@ func checkCreatePartitionValue(pi *model.PartitionInfo) error {
 
 // validRangePartitionType checks the type supported by the range partitioning key.
 func validRangePartitionType(col *table.Column) bool {
-	switch col.Tp {
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+	switch col.FieldType.EvalType() {
+	case types.ETInt:
 		return true
 	default:
 		return false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
TiDB
```SQL
mysql:test> create TABLE t20 (c1 int,c2 bit(10)) partition by range(c2) (partition p0 values less than (10));
(1105, "Field '`c2`' is of a not allowed type for this type of partitioning")
mysql:test> create TABLE t21 (c1 int,c2 year) partition by range( c2 ) (partition p0 values less than (2000));
(1105, "Field '`c2`' is of a not allowed type for this type of partitioning")
```
MySQL 
```SQL
mysql:test> create TABLE t20 (c1 int,c2 bit(10)) partition by range(c2) (partition p0 values less than (10));
Query OK, 0 rows affected
Time: 0.014s
mysql:test> create TABLE t21 (c1 int,c2 year) partition by range( c2 ) (partition p0 values less than (2000));
Query OK, 0 rows affected
Time: 0.014s
```

## What is the type of the changes? (mandatory)

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

Unit Test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No
## Does this PR need to be added to the release notes? (mandatory)
No
<!--
If this PR needs to be added to the release notes, please:
1. add the "**release-note**" label for this PR
2. write your release note in the below block
3. if the PR requires additional action from users switching to the new
   release, describe the concrete action that users need to take in detail.

An example:
```
release note:
// put your release notes for this PR here.

action required:
// put your required action in detail here.
```
-->


## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

