### PR TITLE
tables: fix prefix index, when the charset is utf8, truncate it from runes (#7109)

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -123,6 +123,7 @@ func buildIndexColumns(columns []*model.ColumnInfo, idxColNames []*ast.IndexColN
 			Name:   col.Name,
 			Offset: col.Offset,
 			Length: ic.Length,
+			Tp:     &col.FieldType,
 		})
 	}
 

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3352,3 +3352,17 @@ func (s *testIntegrationSuite) TestTwoDecimalAssignTruncate(c *C) {
 	res := tk.MustQuery("select a, b from t1")
 	res.Check(testkit.Rows("123.12345 123.1"))
 }
+
+func (s *testIntegrationSuite) TestPrefixIndex(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	defer s.cleanEnv(c)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t1 (
+  			name varchar(12) DEFAULT NULL,
+  			KEY pname (name(12))
+		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci`)
+
+	tk.MustExec("insert into t1 values('借款策略集_网页');")
+	res := tk.MustQuery("select * from t1 where name = '借款策略集_网页';")
+	res.Check(testkit.Rows("借款策略集_网页"))
+}

--- a/model/model.go
+++ b/model/model.go
@@ -285,6 +285,8 @@ type IndexColumn struct {
 	// for indexing;
 	// UnspecifedLength if not using prefix indexing
 	Length int `json:"length"`
+	// Tp is the index column field type.
+	Tp *types.FieldType
 }
 
 // Clone clones IndexColumn.

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -210,8 +210,8 @@ func (s *testIndexSuite) TestCombineIndexSeek(c *C) {
 				ID:   2,
 				Name: model.NewCIStr("test"),
 				Columns: []*model.IndexColumn{
-					{},
-					{},
+					{Tp: &types.FieldType{}},
+					{Tp: &types.FieldType{}},
 				},
 			},
 		},


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Cherry-pick from #7109 

## What is the type of the changes? (mandatory)

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->

- Bug fix (non-breaking change which fixes an issue)


## How has this PR been tested? (mandatory)

UT

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

NO

## Does this PR affect tidb-ansible update? (mandatory)

NO

## Does this PR need to be added to the release notes? (mandatory)

YES, `fix prefix index, when the charset is utf8 or utf8mb4, truncate it from runes.`


## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

