### PR TITLE
*: rename "GetDDLJob" to "GetDDLJobByIdx"

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -205,7 +205,7 @@ func (d *ddl) getHistoryDDLJob(id int64) (*model.Job, error) {
 
 // getFirstDDLJob gets the first DDL job form DDL queue.
 func (w *worker) getFirstDDLJob(t *meta.Meta) (*model.Job, error) {
-	job, err := t.GetDDLJob(0)
+	job, err := t.GetDDLJobByIdx(0)
 	return job, errors.Trace(err)
 }
 

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -152,7 +152,7 @@ func (s *testDDLSuite) TestCleanJobs(c *C) {
 			t := meta.NewMeta(txn)
 			t.SetJobListKey(meta.AddIndexJobListKey)
 			lastJobID := int64(len(failedJobIDs) - 1)
-			job, err1 := t.GetDDLJob(lastJobID)
+			job, err1 := t.GetDDLJobByIdx(lastJobID)
 			c.Assert(err1, IsNil)
 			_, err1 = d.generalWorker().runDDLJob(d.ddlCtx, t, job)
 			c.Assert(err1, IsNil)

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -83,7 +83,7 @@ func testDropSchema(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo) 
 }
 
 func isDDLJobDone(c *C, t *meta.Meta) bool {
-	job, err := t.GetDDLJob(0)
+	job, err := t.GetDDLJobByIdx(0)
 	c.Assert(err, IsNil)
 	if job == nil {
 		return true

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -237,7 +237,7 @@ func (e *ShowDDLJobQueriesExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	jobs, err := admin.GetDDLJobs(e.ctx.Txn())
+	jobs, err := admin.GetDDLJobByIdxs(e.ctx.Txn())
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -278,7 +278,7 @@ func (e *ShowDDLJobsExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	jobs, err := admin.GetDDLJobs(e.ctx.Txn())
+	jobs, err := admin.GetDDLJobByIdxs(e.ctx.Txn())
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -504,11 +504,11 @@ func (m *Meta) getDDLJob(key []byte, index int64) (*model.Job, error) {
 	return job, errors.Trace(err)
 }
 
-// GetDDLJob returns the DDL job with index.
-func (m *Meta) GetDDLJob(index int64) (*model.Job, error) {
+// GetDDLJobByIdx returns the corresponding DDL job by the index.
+func (m *Meta) GetDDLJobByIdx(index int64) (*model.Job, error) {
 	startTime := time.Now()
 	job, err := m.getDDLJob(m.jobListKey, index)
-	metrics.MetaHistogram.WithLabelValues(metrics.GetDDLJob, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
+	metrics.MetaHistogram.WithLabelValues(metrics.GetDDLJobByIdx, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	return job, errors.Trace(err)
 }
 

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -273,10 +273,10 @@ func (s *testSuite) TestDDL(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(n, Equals, int64(1))
 
-	v, err := t.GetDDLJob(0)
+	v, err := t.GetDDLJobByIdx(0)
 	c.Assert(err, IsNil)
 	c.Assert(v, DeepEquals, job)
-	v, err = t.GetDDLJob(1)
+	v, err = t.GetDDLJobByIdx(1)
 	c.Assert(err, IsNil)
 	c.Assert(v, IsNil)
 	job.ID = 2

--- a/metrics/meta.go
+++ b/metrics/meta.go
@@ -33,7 +33,7 @@ var (
 
 	GetSchemaDiff    = "get_schema_diff"
 	SetSchemaDiff    = "set_schema_diff"
-	GetDDLJob        = "get_ddl_job"
+	GetDDLJobByIdx   = "get_ddl_job"
 	UpdateDDLJob     = "update_ddl_job"
 	GetHistoryDDLJob = "get_history_ddl_job"
 

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -47,7 +47,7 @@ func GetDDLInfo(txn kv.Transaction) (*DDLInfo, error) {
 	info := &DDLInfo{}
 	t := meta.NewMeta(txn)
 
-	info.Job, err = t.GetDDLJob(0)
+	info.Job, err = t.GetDDLJobByIdx(0)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -73,7 +73,7 @@ func CancelJobs(txn kv.Transaction, ids []int64) ([]error, error) {
 		return nil, nil
 	}
 
-	jobs, err := GetDDLJobs(txn)
+	jobs, err := GetDDLJobByIdxs(txn)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -116,8 +116,8 @@ func CancelJobs(txn kv.Transaction, ids []int64) ([]error, error) {
 	return errs, nil
 }
 
-// GetDDLJobs returns the DDL jobs and an error.
-func GetDDLJobs(txn kv.Transaction) ([]*model.Job, error) {
+// GetDDLJobByIdxs returns the DDL jobs and an error.
+func GetDDLJobByIdxs(txn kv.Transaction) ([]*model.Job, error) {
 	t := meta.NewMeta(txn)
 	cnt, err := t.DDLJobQueueLen()
 	if err != nil {
@@ -126,7 +126,7 @@ func GetDDLJobs(txn kv.Transaction) ([]*model.Job, error) {
 
 	jobs := make([]*model.Job, cnt)
 	for i := range jobs {
-		jobs[i], err = t.GetDDLJob(int64(i))
+		jobs[i], err = t.GetDDLJobByIdx(int64(i))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -90,7 +90,7 @@ func (s *testSuite) TestGetDDLInfo(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *testSuite) TestGetDDLJobs(c *C) {
+func (s *testSuite) TestGetDDLJobByIdxs(c *C) {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
 	t := meta.NewMeta(txn)
@@ -104,12 +104,12 @@ func (s *testSuite) TestGetDDLJobs(c *C) {
 		}
 		err = t.EnQueueDDLJob(jobs[i])
 		c.Assert(err, IsNil)
-		currJobs, err1 := GetDDLJobs(txn)
+		currJobs, err1 := GetDDLJobByIdxs(txn)
 		c.Assert(err1, IsNil)
 		c.Assert(currJobs, HasLen, i+1)
 	}
 
-	currJobs, err := GetDDLJobs(txn)
+	currJobs, err := GetDDLJobByIdxs(txn)
 	c.Assert(err, IsNil)
 	for i, job := range jobs {
 		c.Assert(job.ID, Equals, currJobs[i].ID)


### PR DESCRIPTION
## What have you changed? (mandatory)

`GetDDLJob` returns the corresponding DDL job by the index.
`GetHistoryDDLJob` gets the corresponding history DDL job by the ID.
I want to distinguish these two functions, so rename `GetDDLJob` to `GetDDLJobByIdx`

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested? (mandatory)

Yes

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)

No
