### PR TITLE
ddl: fix genGlobalID function repetition RunInNewTxn

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -255,16 +255,6 @@ func (dc *ddlCtx) isOwner() bool {
 	return isOwner
 }
 
-func (dc *ddlCtx) genGlobalID() (int64, error) {
-	var globalID int64
-	err := kv.RunInNewTxn(dc.store, true, func(txn kv.Transaction) error {
-		var err error
-		globalID, err = meta.NewMeta(txn).GenGlobalID()
-		return errors.Trace(err)
-	})
-	return globalID, errors.Trace(err)
-}
-
 // RegisterEventCh registers passed channel for ddl Event.
 func (d *ddl) RegisterEventCh(ch chan<- *util.Event) {
 	d.ddlEventCh = ch
@@ -415,6 +405,16 @@ func (d *ddl) GetInformationSchema(ctx sessionctx.Context) infoschema.InfoSchema
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.mu.interceptor.OnGetInfoSchema(ctx, is)
+}
+
+func (d *ddl) genGlobalID() (int64, error) {
+	var globalID int64
+	err := kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
+		var err error
+		globalID, err = meta.NewMeta(txn).GenGlobalID()
+		return errors.Trace(err)
+	})
+	return globalID, errors.Trace(err)
 }
 
 // generalWorker returns the first worker. The ddl structure has only one worker before we implement the parallel worker.

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -440,7 +440,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionDropForeignKey:
 		ver, err = onDropForeignKey(t, job)
 	case model.ActionTruncateTable:
-		ver, err = onTruncateTable(d, t, job)
+		ver, err = onTruncateTable(t, job)
 	case model.ActionRebaseAutoID:
 		ver, err = onRebaseAutoID(d.store, t, job)
 	case model.ActionRenameTable:

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -220,7 +220,7 @@ func onTruncateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		oldPartitionIDs = getPartitionIDs(tblInfo)
 		for _, def := range tblInfo.Partition.Definitions {
 			var pid int64
-			pid, err := t.GenGlobalID()
+			pid, err = t.GenGlobalID()
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -194,7 +194,7 @@ func getTableInfo(t *meta.Meta, job *model.Job, schemaID int64) (*model.TableInf
 // onTruncateTable delete old table meta, and creates a new table identical to old table except for table ID.
 // As all the old data is encoded with old table ID, it can not be accessed any more.
 // A background job will be created to delete old data.
-func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
+func onTruncateTable(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
 	tableID := job.TableID
 	var newTableID int64
@@ -220,7 +220,7 @@ func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ erro
 		oldPartitionIDs = getPartitionIDs(tblInfo)
 		for _, def := range tblInfo.Partition.Definitions {
 			var pid int64
-			pid, err := d.genGlobalID()
+			pid, err := t.GenGlobalID()
 			if err != nil {
 				job.State = model.JobStateCancelled
 				return ver, errors.Trace(err)


### PR DESCRIPTION
## What have you changed? (mandatory)
Fix PR #7036
* In `onTruncateTable` function can directly use `t.GenGlobalID()`.
* Otherwise, it will repetition RunInNewTxn in `onTruncateTable`.
* We don't have to modify this `genGlobalID()` function.
## What is the type of the changes? (mandatory)

Improvement
- New feature (non-breaking change which adds functionality)
- Improvement (non-breaking change which is an improvement to an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this PR been tested? (mandatory)
 No

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)
No



