### PR TITLE
table,plan,executor: support delete operation for table partition

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1606,6 +1606,10 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plan.PhysicalIndexLook
 		idxPlans:          v.IndexPlans,
 		tblPlans:          v.TablePlans,
 	}
+	if isPartition, partitionID := ts.IsPartition(); isPartition {
+		e.tableID = partitionID
+	}
+
 	if containsLimit(indexReq.Executors) {
 		e.feedback = statistics.NewQueryFeedback(0, nil, 0, is.Desc)
 	} else {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1028,6 +1028,53 @@ func (s *testSuite) TestDelete(c *C) {
 	tk.CheckExecResult(1, 0)
 }
 
+func (s *testSuite) TestPartitionedTableDelete(c *C) {
+	createTable := `CREATE TABLE test.t (id int not null default 1, name varchar(255), index(id))
+PARTITION BY RANGE ( id ) (
+		PARTITION p0 VALUES LESS THAN (6),
+		PARTITION p1 VALUES LESS THAN (11),
+		PARTITION p2 VALUES LESS THAN (16),
+		PARTITION p3 VALUES LESS THAN (21)
+)`
+
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set @@session.tidb_enable_table_partition=1")
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(createTable)
+	for i := 1; i < 21; i++ {
+		tk.MustExec(fmt.Sprintf(`insert into t values (%d, "hello")`, i))
+	}
+
+	tk.MustExec(`delete from t where id = 2 limit 1;`)
+	tk.CheckExecResult(1, 0)
+
+	// Test delete with false condition
+	tk.MustExec(`delete from t where 0;`)
+	tk.CheckExecResult(0, 0)
+
+	tk.MustExec("insert into t values (2, 'abc')")
+	tk.MustExec(`delete from t where t.id = 2 limit 1`)
+	tk.CheckExecResult(1, 0)
+
+	// Test delete ignore
+	tk.MustExec("insert into t values (2, 'abc')")
+	_, err := tk.Exec("delete from t where id = (select '2a')")
+	c.Assert(err, NotNil)
+	_, err = tk.Exec("delete ignore from t where id = (select '2a')")
+	c.Assert(err, IsNil)
+	tk.CheckExecResult(1, 0)
+	r := tk.MustQuery("SHOW WARNINGS;")
+	r.Check(testkit.Rows("Warning 1265 Data Truncated", "Warning 1265 Data Truncated"))
+
+	// Test delete without using index, involve multiple partitions.
+	tk.MustExec("delete from t ignore index(id) where id >= 13 and id <= 17")
+	tk.CheckExecResult(5, 0)
+
+	tk.MustExec("admin check table t")
+	tk.MustExec(`delete from t ;`)
+}
+
 func (s *testSuite) fillDataMultiTable(tk *testkit.TestKit) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1, t2, t3")

--- a/plan/find_best_task.go
+++ b/plan/find_best_task.go
@@ -343,7 +343,12 @@ func (ds *DataSource) convertToIndexScan(prop *requiredProp, path *accessPath) (
 			return invalidTask, nil
 		}
 		// On this way, it's double read case.
-		ts := PhysicalTableScan{Columns: ds.Columns, Table: is.Table}.init(ds.ctx)
+		ts := PhysicalTableScan{
+			Columns:     ds.Columns,
+			Table:       is.Table,
+			isPartition: ds.isPartition,
+			partitionID: ds.partitionID,
+		}.init(ds.ctx)
 		ts.SetSchema(ds.schema.Clone())
 		cop.tablePlan = ts
 	} else if prop.taskTp == copDoubleReadTaskType {

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -185,3 +185,15 @@ func (t *PartitionedTable) AddRecord(ctx sessionctx.Context, r []types.Datum, sk
 	tbl := t.GetPartition(pid)
 	return tbl.AddRecord(ctx, r, skipHandleCheck)
 }
+
+// RemoveRecord implements table.Table RemoveRecord interface.
+func (t *PartitionedTable) RemoveRecord(ctx sessionctx.Context, h int64, r []types.Datum) error {
+	partitionInfo := t.meta.GetPartitionInfo()
+	pid, err := t.locatePartition(ctx, partitionInfo, r)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tbl := t.GetPartition(pid)
+	return tbl.RemoveRecord(ctx, h, r)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (mandatory)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Separately describe each logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume reviewers understand the original issue
-->

Implement `RemoveRecord` for `PartitionedTable`, so delete operation on partitioned  table would work.
Fix IndexLookupReader table ID is not changed to partition ID when the  table is a partition.

## What is the type of the changes? (mandatory)

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

unit  test

<!--
Please describe the tests that you ran to verify your changes.
Have you finished unit tests, integration tests, or manual tests?
What additional tests would give you greater confidence in this change?
-->

PTAL @coocood @winoros 