### PR TITLE
table: Add a new interface in table.Table

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1277,6 +1277,10 @@ func (it *infoschemaTable) Meta() *model.TableInfo {
 	return it.meta
 }
 
+func (it *infoschemaTable) GetID() int64 {
+	return it.meta.ID
+}
+
 // Seek is the first method called for table scan, we lazy initialize it here.
 func (it *infoschemaTable) Seek(ctx sessionctx.Context, h int64) (int64, bool, error) {
 	return 0, false, table.ErrUnsupportedOp

--- a/table/table.go
+++ b/table/table.go
@@ -138,6 +138,11 @@ type Table interface {
 	// Meta returns TableInfo.
 	Meta() *model.TableInfo
 
+	// GetID returns the ID of the table.
+	// If it is not a partition, the ID would be the tableID.
+	// If it is a partition, the ID would be the partitionID.
+	GetID() int64
+
 	// Seek returns the handle greater or equal to h.
 	Seek(ctx sessionctx.Context, h int64) (handle int64, found bool, err error)
 

--- a/table/tables/memory_tables.go
+++ b/table/tables/memory_tables.go
@@ -139,6 +139,11 @@ func (t *MemoryTable) Meta() *model.TableInfo {
 	return t.meta
 }
 
+// GetID implements table.Table GetID interface.
+func (t *MemoryTable) GetID() int64 {
+	return t.meta.ID
+}
+
 // Cols implements table.Table Cols interface.
 func (t *MemoryTable) Cols() []*table.Column {
 	return t.Columns

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -47,6 +47,12 @@ var _ table.PartitionedTable = &PartitionedTable{}
 // Partition also implements the table.Table interface.
 type Partition struct {
 	tableCommon
+	ID int64
+}
+
+// GetID implements table.Table GetID interface.
+func (p *Partition) GetID() int64 {
+	return p.ID
 }
 
 // PartitionedTable implements the table.PartitionedTable interface.
@@ -71,6 +77,7 @@ func newPartitionedTable(tbl *Table, tblInfo *model.TableInfo) (table.Table, err
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		t.ID = p.ID
 		partitions[p.ID] = &t
 	}
 

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -59,7 +59,7 @@ type tableCommon struct {
 	meta            *model.TableInfo
 	alloc           autoid.Allocator
 
-	// Both of them are generated using partitionID.
+	// recordPrefix and indexPrefix are generated using partitionID.
 	recordPrefix kv.Key
 	indexPrefix  kv.Key
 }
@@ -203,6 +203,11 @@ func (t *tableCommon) DeletableIndices() []table.Index {
 // Meta implements table.Table Meta interface.
 func (t *tableCommon) Meta() *model.TableInfo {
 	return t.meta
+}
+
+// GetID implements table.Table GetID interface.
+func (t *tableCommon) GetID() int64 {
+	return t.meta.ID
 }
 
 // Cols implements table.Table Cols interface.

--- a/table/tables/virtual_tables.go
+++ b/table/tables/virtual_tables.go
@@ -158,6 +158,11 @@ func (vt *VirtualTable) Meta() *model.TableInfo {
 	return vt.dataSource.Meta()
 }
 
+// GetID implements table.Table GetID interface.
+func (vt *VirtualTable) GetID() int64 {
+	return vt.dataSource.Meta().ID
+}
+
 // Seek implements table.Table Type interface.
 func (vt *VirtualTable) Seek(ctx sessionctx.Context, h int64) (int64, bool, error) {
 	return 0, false, table.ErrUnsupportedOp


### PR DESCRIPTION
In some cases, We need to get the PartitionID instead of the TableID. So
we should call GetID() instead of Meta().ID.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

Add a new interface named GetID() in table.Table.
There are a lot of codes need get the PartitionID instead of TableID. PR #6814 for example. With the GetID() interface, we could avoid passing an extra argument to some functions. This could make our code more clear. 
The following function call looks weird to me:
> +	maxID, emptyTable, err := d.GetTableMaxRowID(curVer.Ver, tbl.Meta(), tbl.Meta().ID)

## What is the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)


## How has this PR been tested? (mandatory)
Unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No

## Does this PR affect tidb-ansible update? (mandatory)
No

## Does this PR need to be added to the release notes? (mandatory)
No

## Refer to a related PR or issue link (optional)
No

## Benchmark result if necessary (optional)
No

## Add a few positive/negative examples (optional)
No
