### PR TITLE
Use the revive linter.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,9 @@ errcheck:
 	@ GOPATH=$(GOPATH) errcheck -exclude errcheck_excludes.txt -blank $(PACKAGES) | grep -v "_test\.go" | awk '{print} END{if(NR>0) {exit 1}}'
 
 lint:
-	go get golang.org/x/lint/golint
-	@echo "golint"
-	@ golint -set_exit_status $(PACKAGES)
+	go get github.com/mgechev/revive
+	@echo "linting"
+	CGO_ENABLED=0 revive -formatter friendly -config revive.toml $(PACKAGES)
 
 vet:
 	@echo "vet"

--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -691,9 +691,8 @@ func main() {
 		tr := newTester(t)
 		if err = tr.Run(); err != nil {
 			log.Fatalf("run test [%s] err: %v", t, err)
-		} else {
-			log.Infof("run test [%s] ok", t)
 		}
+		log.Infof("run test [%s] ok", t)
 	}
 
 	println("\nGreat, All tests passed")

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -203,12 +203,11 @@ func (dr *delRange) doTask(ctx sessionctx.Context, r util.DelRangeTask) error {
 			}
 			log.Infof("[ddl] delRange emulator complete task: (%d, %d)", r.JobID, r.ElementID)
 			break
-		} else {
-			if err := util.UpdateDeleteRange(ctx, r, newStartKey, oldStartKey); err != nil {
-				log.Errorf("[ddl] delRange emulator update task fail: %s", err)
-			}
-			oldStartKey = newStartKey
 		}
+		if err := util.UpdateDeleteRange(ctx, r, newStartKey, oldStartKey); err != nil {
+			log.Errorf("[ddl] delRange emulator update task fail: %s", err)
+		}
+		oldStartKey = newStartKey
 	}
 	return nil
 }

--- a/mysql/locale_format.go
+++ b/mysql/locale_format.go
@@ -15,10 +15,9 @@ func formatENUS(number string, precision string) (string, error) {
 		for i, v := range precision {
 			if unicode.IsDigit(v) {
 				continue
-			} else {
-				precision = precision[:i]
-				break
 			}
+			precision = precision[:i]
+			break
 		}
 	} else {
 		precision = "0"

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -462,12 +462,11 @@ func (b *planBuilder) buildSelection(p LogicalPlan, where ast.ExprNode, AggMappe
 				ret, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
 				if err != nil || ret {
 					continue
-				} else {
-					// If there is condition which is always false, return dual plan directly.
-					dual := LogicalTableDual{}.init(b.ctx)
-					dual.SetSchema(p.Schema())
-					return dual
 				}
+				// If there is condition which is always false, return dual plan directly.
+				dual := LogicalTableDual{}.init(b.ctx)
+				dual.SetSchema(p.Schema())
+				return dual
 			}
 			expressions = append(expressions, item)
 		}

--- a/revive.toml
+++ b/revive.toml
@@ -1,0 +1,51 @@
+ignoreGeneratedHeader = false
+severity = "error"
+confidence = 0.8
+errorCode = 0
+warningCode = 0
+
+[rule.blank-imports]
+[rule.context-as-argument]
+[rule.dot-imports]
+[rule.error-return]
+[rule.error-strings]
+[rule.error-naming]
+[rule.exported]
+[rule.if-return]
+[rule.var-naming]
+[rule.package-comments]
+[rule.range]
+[rule.receiver-naming]
+[rule.indent-error-flow]
+[rule.superfluous-else]
+[rule.modifies-parameter]
+
+# This can be checked by other tools like megacheck
+[rule.unreachable-code]
+
+
+# Currently this makes too much noise, but should add it in
+# and perhaps ignore it in a few files
+#[rule.confusing-naming]
+#  severity = "warning"
+#[rule.confusing-results]
+#  severity = "warning"
+#[rule.unused-parameter]
+#  severity = "warning"
+#[rule.deep-exit]
+#  severity = "warning"
+#[rule.flag-parameter]
+#  severity = "warning"
+
+
+
+# Adding these will slow down the linter
+# They are already provided by megacheck
+# [rule.unexported-return]
+# [rule.time-naming]
+# [rule.errorf]
+
+# Adding these will slow down the linter
+# Not sure if they are already provided by megacheck
+# [rule.var-declaration]
+# [rule.context-keys-type]

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -268,14 +268,14 @@ func getUsableSetsByGreedy(sets []*exprSet) (newBlocks []*exprSet) {
 		}
 		if bestCount == 0 {
 			break
-		} else {
-			// update the mask, remove the bit that sets[bestID].mask has.
-			mask &^= sets[bestID].mask
-
-			newBlocks = append(newBlocks, sets[bestID])
-			// remove the chosen one
-			sets = append(sets[:bestID], sets[bestID+1:]...)
 		}
+
+		// update the mask, remove the bit that sets[bestID].mask has.
+		mask &^= sets[bestID].mask
+
+		newBlocks = append(newBlocks, sets[bestID])
+		// remove the chosen one
+		sets = append(sets[:bestID], sets[bestID+1:]...)
 	}
 	return
 }

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -67,9 +67,8 @@ func (s *testSafePointSuite) waitUntilErrorPlugIn(t uint64) {
 		if err == nil {
 			s.store.UpdateSPCache(newSafePoint, cachedTime)
 			break
-		} else {
-			time.Sleep(time.Second)
 		}
+		time.Sleep(time.Second)
 	}
 }
 

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -480,10 +480,11 @@ func (fs *FileSorter) Input(key []types.Datum, val []types.Datum, handle int64) 
 		}
 		if assigned {
 			break
-		} else {
-			// all workers are busy now, cooldown and retry
-			time.Sleep(cooldownTime)
 		}
+
+		// all workers are busy now, cooldown and retry
+		time.Sleep(cooldownTime)
+
 		if time.Since(origin) >= abortTime {
 			// weird: all workers are busy for at least 1 min
 			// choose to abort for safety


### PR DESCRIPTION
Switch to the revive linter. This linter is faster and more configurable. Rules are configurable and can be disabled on specific lines or files.

Maintainers of this project can maintain rules as they see fit. I essentially turned on as many as possible and left comments for those that I think are good to turn on but have not been.


## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

`make check && make test`

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

```
release note:
* use the configurable revive linter in place of golint
```