### PR TITLE
ddl: fix data race in schema_test

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -62,7 +62,7 @@ func (d *ddl) generalWorker() *worker {
 	return d.workers[generalWorker]
 }
 
-// restartWorkers is like the function fo d.start. But it won't initialize the "workers" and create a new worker.
+// restartWorkers is like the function of d.start. But it won't initialize the "workers" and create a new worker.
 // It only starts the original workers.
 func (d *ddl) restartWorkers(ctx context.Context) {
 	d.quitCh = make(chan struct{})

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
@@ -59,6 +60,24 @@ func (d *ddl) SetInterceptoror(i Interceptor) {
 // generalWorker returns the general worker.
 func (d *ddl) generalWorker() *worker {
 	return d.workers[generalWorker]
+}
+
+// restartWorkers is like the function fo d.start. But it won't initialize the "workers" and create a new worker.
+// It only starts the original workers.
+func (d *ddl) restartWorkers(ctx context.Context) {
+	d.quitCh = make(chan struct{})
+	if !RunWorker {
+		return
+	}
+
+	err := d.ownerManager.CampaignOwner(ctx)
+	terror.Log(err)
+	for _, worker := range d.workers {
+		worker.wg.Add(1)
+		worker.quitCh = make(chan struct{})
+		go worker.start(d.ddlCtx)
+		asyncNotify(worker.ddlJobCh)
+	}
 }
 
 func TestT(t *testing.T) {

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -229,7 +229,7 @@ LOOP:
 		select {
 		case <-ticker.C:
 			d.Stop()
-			d.start(context.Background(), nil)
+			d.restartWorkers(context.Background())
 			time.Sleep(time.Millisecond * 20)
 		case err := <-done:
 			c.Assert(err, IsNil)


### PR DESCRIPTION
## What have you changed? (mandatory)
Fix data race in schema_test.
```
WARNING: DATA RACE
Read at 0x00c420af55f0 by goroutine 29:
  github.com/pingcap/tidb/ddl.(*ddl).asyncNotifyWorker()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:457 +0xf6
  github.com/pingcap/tidb/ddl.(*ddl).doDDLJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:475 +0x174
  github.com/pingcap/tidb/ddl.testRunInterruptedJob.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/schema_test.go:221 +0x5c

Previous write at 0x00c420af55f0 by goroutine 124:
  github.com/pingcap/tidb/ddl.(*ddl).start()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:359 +0x28a
  github.com/pingcap/tidb/ddl.testRunInterruptedJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/schema_test.go:232 +0x20d
 2018/07/31 10:47:04.655 ddl_worker.go:109: [info] [ddl] start DDL worker 0, tp general
  github.com/pingcap/tidb/ddl.(*testTableSuite).TestTableResume()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/table_test.go:267 +0x4d1
```
```
WARNING: DATA RACE
Read at 0x00c420c50720 by goroutine 29:
  runtime.mapaccess1()
      /usr/local/go/src/runtime/hashmap.go:343 +0x0
  github.com/pingcap/tidb/ddl.(*ddl).asyncNotifyWorker()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:457 +0x120
  github.com/pingcap/tidb/ddl.(*ddl).doDDLJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:475 +0x174
  github.com/pingcap/tidb/ddl.testRunInterruptedJob.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/schema_test.go:221 +0x5c

Previous write at 0x00c420c50720 by goroutine 124:
  runtime.mapassign()
      /usr/local/go/src/runtime/hashmap.go:505 +0x0
  github.com/pingcap/tidb/ddl.(*ddl).start()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:360 +0x355
  github.com/pingcap/tidb/ddl.testRunInterruptedJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/schema_test.go:232 +0x20d
  github.com/pingcap/tidb/ddl.(*testTableSuite).TestTableResume()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/table_test.go:267 +0x4d1
```

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
Yes.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.
## Does this PR affect tidb-ansible update? (mandatory)
No.
## Does this PR need to be added to the release notes? (mandatory)
No.


## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

