### PR TITLE
expression: update wording in comments

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1090,7 +1090,7 @@ func RefineComparedConstant(ctx sessionctx.Context, isUnsigned bool, con *Consta
 		}
 	case opcode.NullEQ, opcode.EQ:
 		switch con.RetType.EvalType() {
-		// An integer value equal or not equal to a float value which contains
+		// An integer value equal or NULL-safe equal to a float value which contains
 		// non-zero decimal digits is definitely false.
 		// e.g.,
 		//   1. "integer  =  1.1" is definitely false.

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1090,17 +1090,17 @@ func RefineComparedConstant(ctx sessionctx.Context, isUnsigned bool, con *Consta
 		}
 	case opcode.NullEQ, opcode.EQ:
 		switch con.RetType.EvalType() {
-		// An integer value equals or null-equals to a float value contains
-		// non-zero decimal digits is definite false.
-		// e.g:
-		//   1. "integer  =  1.1" is definite false.
-		//   2. "integer <=> 1.1" is definite false.
+		// An integer value equal or not equal to a float value which contains
+		// non-zero decimal digits is definitely false.
+		// e.g.,
+		//   1. "integer  =  1.1" is definitely false.
+		//   2. "integer <=> 1.1" is definitely false.
 		case types.ETReal, types.ETDecimal:
 			return con, true
 		case types.ETString:
-			// We try to convert the string constant to double,
-			// if the double result equals to the int result, we can return the int result,
-			// otherwise, the compare function must be false.
+			// We try to convert the string constant to double.
+			// If the double result equals the int result, we can return the int result;
+			// otherwise, the compare function will be false.
 			var doubleDatum types.Datum
 			doubleDatum, err = dt.ConvertTo(sc, types.NewFieldType(mysql.TypeDouble))
 			if err != nil {
@@ -1122,8 +1122,8 @@ func RefineComparedConstant(ctx sessionctx.Context, isUnsigned bool, con *Consta
 	return con, false
 }
 
-// refineArgs rewrite the arguments if the compare expression is `int column <cmp> non-int constant` or
-// `non-int constant <cmp> int column`. e.g. `a < 1.1` will be rewritten to `a < 2`.
+// refineArgs will rewrite the arguments if the compare expression is `int column <cmp> non-int constant` or
+// `non-int constant <cmp> int column`. E.g., `a < 1.1` will be rewritten to `a < 2`.
 func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Expression) []Expression {
 	arg0Type, arg1Type := args[0].GetType(), args[1].GetType()
 	arg0IsInt := arg0Type.EvalType() == types.ETInt

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -64,7 +64,7 @@ func (s *testEvaluatorSuite) TestCompareFunctionWithRefine(c *C) {
 		{"'123456789123456711111189' = a", "0"},
 		{"123456789123456789.12345 = a", "0"},
 		// This cast can not be eliminated,
-		// since convert "aaaa" to int will cause DataTruncate error.
+		// since converting "aaaa" to an int will cause DataTruncate error.
 		{"'aaaa'=a", "eq(cast(aaaa), cast(a))"},
 	}
 


### PR DESCRIPTION
## What have you changed? (mandatory)

The code comments. 

## What is the type of the changes? (mandatory)

Improvement 

## How has this PR been tested? (mandatory)


## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.

## Does this PR affect tidb-ansible update? (mandatory)

No.

## Does this PR need to be added to the release notes? (mandatory)

No.

@XuHuaiyu @zz-jason PTAL Via https://github.com/pingcap/tidb/pull/7108

Notes:

- When "equal" is used as an adjective, you can say "A **is equal to** B".
- When ''equal'' is used as a verb, you can say "A **equals** B".
- "definite" and "false" are both adjectives. An adjective cannot modify another adjective; only an adverb can modify an adjective.
