### PR TITLE
ddl:In non-strict SQL mode, fix column type is text /blob/json default value null not processed.

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -386,7 +386,7 @@ func ignoreNullDefaultValuesForColumns(ctx sessionctx.Context, col *table.Column
 		if col.Tp == mysql.TypeBlob || col.Tp == mysql.TypeLongBlob && value == "" {
 			hasDefaultValue = false
 		}
-		// In non-strict SQL mode, the json default value is empty, and then initialize it as an empty array.
+		// In non-strict SQL mode, if the column type is json and the default value is null, it is initialized to an empty array.
 		if col.Tp == mysql.TypeJSON && value == "" {
 			col.DefaultValue = `null`
 			hasDefaultValue = true


### PR DESCRIPTION
## What have you changed? (mandatory)
In non-strict SQL mode, we can ignore that the default value of a text /blob column is an empty string.
In non-strict SQL mode, if the column type is json and the default value is null, it is initialized to an empty array.
  *  Fix issue#7158

## What is the type of the changes? (mandatory)

 Improvement
- New feature (non-breaking change which adds functionality)
- Improvement (non-breaking change which is an improvement to an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this PR been tested? (mandatory)
 No

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)
No



