### PR TITLE
*: fix data race in the file of prepare_test.go

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -152,7 +152,7 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		Params:        sorter.markers,
 		SchemaVersion: e.is.SchemaMetaVersion(),
 	}
-	prepared.UseCache = plan.PreparedPlanCacheEnabled && (vars.ImportingData || plan.Cacheable(stmt))
+	prepared.UseCache = plan.PreparedPlanCacheEnabled() && (vars.ImportingData || plan.Cacheable(stmt))
 
 	// We try to build the real statement of preparedStmt.
 	for i := range prepared.Params {

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -287,15 +287,15 @@ func (s *testSuite) TestPrepareMaxParamCountCheck(c *C) {
 }
 
 func (s *testSuite) TestPrepareWithAggregation(c *C) {
-	orgEnable := plan.PreparedPlanCacheEnabled
+	orgEnable := plan.PreparedPlanCacheEnabled()
 	orgCapacity := plan.PreparedPlanCacheCapacity
 	defer func() {
-		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.SetPreparedPlanCache(orgEnable)
 		plan.PreparedPlanCacheCapacity = orgCapacity
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		plan.PreparedPlanCacheEnabled = flag
+		plan.SetPreparedPlanCache(flag)
 		plan.PreparedPlanCacheCapacity = 100
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -27,16 +27,16 @@ import (
 )
 
 func (s *testSuite) TestPrepared(c *C) {
-	orgEnable := plan.PreparedPlanCacheEnabled
+	orgEnable := plan.PreparedPlanCacheEnabled()
 	orgCapacity := plan.PreparedPlanCacheCapacity
 	defer func() {
-		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.SetPreparedPlanCache(orgEnable)
 		plan.PreparedPlanCacheCapacity = orgCapacity
 	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
-		plan.PreparedPlanCacheEnabled = flag
+		plan.SetPreparedPlanCache(flag)
 		plan.PreparedPlanCacheCapacity = 100
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -187,16 +187,16 @@ func (s *testSuite) TestPrepared(c *C) {
 }
 
 func (s *testSuite) TestPreparedLimitOffset(c *C) {
-	orgEnable := plan.PreparedPlanCacheEnabled
+	orgEnable := plan.PreparedPlanCacheEnabled()
 	orgCapacity := plan.PreparedPlanCacheCapacity
 	defer func() {
-		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.SetPreparedPlanCache(orgEnable)
 		plan.PreparedPlanCacheCapacity = orgCapacity
 	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
-		plan.PreparedPlanCacheEnabled = flag
+		plan.SetPreparedPlanCache(flag)
 		plan.PreparedPlanCacheCapacity = 100
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -223,15 +223,15 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 }
 
 func (s *testSuite) TestPreparedNullParam(c *C) {
-	orgEnable := plan.PreparedPlanCacheEnabled
+	orgEnable := plan.PreparedPlanCacheEnabled()
 	orgCapacity := plan.PreparedPlanCacheCapacity
 	defer func() {
-		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.SetPreparedPlanCache(orgEnable)
 		plan.PreparedPlanCacheCapacity = orgCapacity
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		plan.PreparedPlanCacheEnabled = flag
+		plan.SetPreparedPlanCache(flag)
 		plan.PreparedPlanCacheCapacity = 100
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -114,7 +114,7 @@ func (p *PointGetPlan) SetChildren(...PhysicalPlan) {}
 func (p *PointGetPlan) ResolveIndices() {}
 
 func tryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
-	if PreparedPlanCacheEnabled {
+	if PreparedPlanCacheEnabled() {
 		// Do not support plan cache.
 		return nil
 	}

--- a/plan/prepare_test.go
+++ b/plan/prepare_test.go
@@ -30,15 +30,15 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
-	orgEnable := plan.PreparedPlanCacheEnabled
+	orgEnable := plan.PreparedPlanCacheEnabled()
 	orgCapacity := plan.PreparedPlanCacheCapacity
 	defer func() {
 		dom.Close()
 		store.Close()
-		plan.PreparedPlanCacheEnabled = orgEnable
+		plan.SetPreparedPlanCache(orgEnable)
 		plan.PreparedPlanCacheCapacity = orgCapacity
 	}()
-	plan.PreparedPlanCacheEnabled = true
+	plan.SetPreparedPlanCache(true)
 	plan.PreparedPlanCacheCapacity = 100
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/session/session.go
+++ b/session/session.go
@@ -1161,7 +1161,7 @@ func createSession(store kv.Storage) (*session, error) {
 		sessionVars:     variable.NewSessionVars(),
 		ddlOwnerChecker: dom.DDL().OwnerManager(),
 	}
-	if plan.PreparedPlanCacheEnabled {
+	if plan.PreparedPlanCacheEnabled() {
 		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plan.PreparedPlanCacheCapacity)
 	}
 	s.mu.values = make(map[fmt.Stringer]interface{})
@@ -1183,7 +1183,7 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 		parser:      parser.New(),
 		sessionVars: variable.NewSessionVars(),
 	}
-	if plan.PreparedPlanCacheEnabled {
+	if plan.PreparedPlanCacheEnabled() {
 		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plan.PreparedPlanCacheCapacity)
 	}
 	s.mu.values = make(map[fmt.Stringer]interface{})

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -384,8 +384,8 @@ func setGlobalVars() {
 	plan.AllowCartesianProduct = cfg.Performance.CrossJoin
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
 
-	plan.PreparedPlanCacheEnabled = cfg.PreparedPlanCache.Enabled
-	if plan.PreparedPlanCacheEnabled {
+	plan.SetPreparedPlanCache(cfg.PreparedPlanCache.Enabled)
+	if plan.PreparedPlanCacheEnabled() {
 		plan.PreparedPlanCacheCapacity = cfg.PreparedPlanCache.Capacity
 	}
 


### PR DESCRIPTION
## What have you changed? (mandatory)
Fix data race in the file of prepare_test.go
```
Read at 0x0000028eb742 by goroutine 35:
  github.com/pingcap/tidb/plan.tryFastPlan()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/plan/point_get_plan.go:117 +0x3e
  github.com/pingcap/tidb/plan.Optimize()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/plan/optimizer.go:62 +0x77
  github.com/pingcap/tidb/executor.(*Compiler).Compile()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:48 +0x221
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:807 +0x80f
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:765 +0x79
  github.com/pingcap/tidb/ddl/util.CompleteDeleteRange()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/util/util.go:94 +0x1f9
  github.com/pingcap/tidb/ddl.(*delRange).doTask()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:200 +0x432
  github.com/pingcap/tidb/ddl.(*delRange).doDelRangeWork()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:151 +0x541
  github.com/pingcap/tidb/ddl.(*delRange).doTask()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:200 +0x432
  github.com/pingcap/tidb/ddl.(*delRange).doDelRangeWork()
...

Previous write at 0x0000028eb742 by goroutine 749:
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:229 +0x3a
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:259 +0x5d3
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:256 +0x544
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:253 +0x4ee
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:250 +0x43b
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/prepared_test.go:249 +0x404
  github.com/pingcap/tidb/executor_test.(*testSuite).TestPreparedNullParam()
    
```

## What is the type of the changes? (mandatory)
- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
Yes.

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No.
## Does this PR affect tidb-ansible update? (mandatory)
No.

## Does this PR need to be added to the release notes? (mandatory)
No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

