### PR TITLE
Switch checks to use retool. Fix goword and errcheck

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ y.output
 profile.coverprofile
 explain_test
 cmd/explaintest/explain-test.out
+_tools/

--- a/ast/functions_test.go
+++ b/ast/functions_test.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ast_test
 
 import (

--- a/tools.json
+++ b/tools.json
@@ -1,0 +1,41 @@
+{
+  "Tools": [
+    {
+      "Repository": "gopkg.in/alecthomas/gometalinter.v2",
+      "Commit": "46cc1ea3778b247666c2949669a3333c532fa9c6"
+    },
+    {
+      "Repository": "github.com/client9/misspell/cmd/misspell",
+      "Commit": "7888c6b6ce89353cd98e196bce3c3f9e4cdf31f6"
+    },
+    {
+      "Repository": "github.com/chzchzchz/goword",
+      "Commit": "a9744cb52b033fe5c269df48eeef2c954526cd79"
+    },
+    {
+      "Repository": "github.com/gordonklaus/ineffassign",
+      "Commit": "7bae11eba15a3285c75e388f77eb6357a2d73ee2"
+    },
+    {
+      "Repository": "honnef.co/go/tools/cmd/megacheck",
+      "Commit": "88497007e8588ea5b6baee991f74a1607e809487"
+    },
+    {
+      "Repository": "github.com/dnephin/govet",
+      "Commit": "4a96d43e39d340b63daa8bc5576985aa599885f6"
+    },
+    {
+      "Repository": "github.com/securego/gosec/cmd/gosec",
+      "Commit": "5fb530cda357c16175f2c049577d2030de735b28"
+    },
+    {
+      "Repository": "github.com/kisielk/errcheck",
+      "Commit": "55d8f507faff4d6eddd0c41a3e713e2567fca4e5"
+    },
+    {
+      "Repository": "github.com/mgechev/revive",
+      "Commit": "7773f47324c2bf1c8f7a5500aff2b6c01d3ed73b"
+    }
+  ],
+  "RetoolVersion": "1.3.7"
+}


### PR DESCRIPTION
## What have you changed? (mandatory)

Switch checks to use retool. retool vendors check tools local to the project.
Note that you can also add other tools such as code generators to the retool setup.

Fix goword and errcheck: these were not being run correctly.These are now under the `check-fail` task.

I would recommend creating an issue to fix the check-fail task. This can be time boxed to some amount of time per week, but will probably take more than one day total. `errcheck` in particular is of great importance: unhandled errors are almost guaranteed to result in bugs. I can show you how I handle collecting errors in defer statements.


## What is the type of the changes? (mandatory)

Improvement/New Feature for static analysis

## How has this PR been tested? (mandatory)

`make check`

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

Switch static checks to use retool.