### PR TITLE
binlog: fix bug in load data

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -814,7 +814,7 @@ func (cc *clientConn) handleLoadData(ctx context.Context, loadDataInfo *executor
 		}
 		return errors.Trace(err)
 	}
-	return errors.Trace(txn.Commit(sessionctx.SetConnID2Ctx(ctx, loadDataInfo.Ctx)))
+	return errors.Trace(cc.ctx.CommitTxn(sessionctx.SetConnID2Ctx(ctx, loadDataInfo.Ctx)))
 }
 
 // handleLoadStats does the additional work after processing the 'load stats' query.

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -679,6 +679,7 @@ func (c *twoPhaseCommitter) writeFinishBinlog(tp binlog.BinlogType, commitTS int
 	binInfo := c.txn.us.GetOption(kv.BinlogInfo).(*binloginfo.BinlogInfo)
 	binInfo.Data.Tp = tp
 	binInfo.Data.CommitTs = commitTS
+	binInfo.Data.PrewriteValue = nil
 	go func() {
 		err := binInfo.WriteBinlog(c.store.clusterID)
 		if err != nil {


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/7074

## What have you changed?
1. some tiny fix when commit txn for load data
2. remove prewritevalue in commit binlog

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (mandatory)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Separately describe each logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume reviewers understand the original issue
-->

## What is the type of the changes? 
<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->
Bug fix
1. when data is less than 20000 line, load data will not generate binlog
2. commit binlog shouldn't have prewritevalue
3. the binlog size will be bigger than the last time when load data, and may cause oom, should reset the binlog.

## How has this PR been tested? 

load data less than 20000 line.

## Refer to a related  issue link

https://github.com/pingcap/tidb/issues/7035
