### PR TITLE
executor: init builder startTS in `buildTableDual`

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -897,6 +897,8 @@ func (b *executorBuilder) buildTableDual(v *plan.PhysicalTableDual) Executor {
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 		numDualRows:  v.RowCount,
 	}
+	// Init the startTS for later use.
+	b.getStartTS()
 	return e
 }
 
@@ -907,7 +909,7 @@ func (b *executorBuilder) getStartTS() uint64 {
 	}
 
 	startTS := b.ctx.GetSessionVars().SnapshotTS
-	if startTS == 0 {
+	if startTS == 0 && b.ctx.Txn() != nil {
 		startTS = b.ctx.Txn().StartTS()
 	}
 	b.startTS = startTS

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2814,3 +2814,13 @@ func (s *testSuite) TestForSelectScopeInUnion(c *C) {
 	_, err = tk1.Exec("commit")
 	c.Assert(err, IsNil)
 }
+
+func (s *testSuite) TestIndexJoinTableDualPanic(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table a (f1 int, f2 varchar(32), primary key (f1))")
+	tk.MustExec("insert into a (f1,f2) values (1,'a'), (2,'b'), (3,'c')")
+	tk.MustQuery("select a.* from a inner join (select 1 as k1,'k2-1' as k2) as k on a.f1=k.k1;").
+		Check(testkit.Rows("1 a"))
+}


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/6830

## What have you changed? (mandatory)

When we build an index join executor with outer table is table dual, we never call `b.getStartTS` during build time.
But later when we execute the query, we use the builder to build inner table which needs `startTS`, but by then, the transaction is set to invalid, then we panic.

This PR init the startTS in `executorBuilder.buildTableDual` to fix the panic issue.

## What are the type of the changes (mandatory)?
- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested (mandatory)?
- unit-test

