### PR TITLE
executor: add placeholder count check in prepare stage (#7162)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -76,6 +76,7 @@ var (
 	ErrWrongValueCountOnRow        = terror.ClassExecutor.New(codeWrongValueCountOnRow, "Column count doesn't match value count at row %d")
 	ErrPasswordFormat              = terror.ClassExecutor.New(codePasswordFormat, "The password hash doesn't have the expected format. Check if the correct password algorithm is being used with the PASSWORD() function.")
 	ErrCantChangeTxCharacteristics = terror.ClassExecutor.New(codeErrCantChangeTxCharacteristics, "Transaction characteristics can't be changed while a transaction is in progress")
+	ErrPsManyParam                 = terror.ClassExecutor.New(mysql.ErrPsManyParam, mysql.MySQLErrName[mysql.ErrPsManyParam])
 )
 
 // Error codes.
@@ -91,6 +92,7 @@ const (
 	codeWrongValueCountOnRow           terror.ErrCode = 1136 // MySQL error code
 	codePasswordFormat                 terror.ErrCode = 1827 // MySQL error code
 	codeErrCantChangeTxCharacteristics terror.ErrCode = 1568
+	codeErrPsManyParam                 terror.ErrCode = 1390
 )
 
 type baseExecutor struct {
@@ -611,6 +613,7 @@ func init() {
 		codeWrongValueCountOnRow:           mysql.ErrWrongValueCountOnRow,
 		codePasswordFormat:                 mysql.ErrPasswordFormat,
 		codeErrCantChangeTxCharacteristics: mysql.ErrCantChangeTxCharacteristics,
+		codeErrPsManyParam:                 mysql.ErrPsManyParam,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassExecutor] = tableMySQLErrCodes
 }

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -126,6 +126,13 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 	var extractor paramMarkerExtractor
 	stmt.Accept(&extractor)
+
+	// Prepare parameters should NOT over 2 bytes(MaxUint16)
+	// https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html#packet-COM_STMT_PREPARE_OK.
+	if len(extractor.markers) > math.MaxUint16 {
+		return ErrPsManyParam
+	}
+
 	err = plan.Preprocess(e.ctx, stmt, e.is, true)
 	if err != nil {
 		return errors.Trace(err)

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -14,6 +14,9 @@
 package executor_test
 
 import (
+	"math"
+	"strings"
+
 	"github.com/juju/errors"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/executor"
@@ -266,4 +269,29 @@ func (s *testSuite) TestPreparedNameResolver(c *C) {
 
 	_, err = tk.Exec("prepare stmt from '(select * FROM t) union all (select * FROM t) order by a limit ?'")
 	c.Assert(err.Error(), Equals, "[planner:1054]Unknown column 'a' in 'order clause'")
+}
+
+func (s *testSuite) TestPrepareMaxParamCountCheck(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (v int)")
+	normalSQL, normalParams := generateBatchSQL(math.MaxUint16)
+	_, err := tk.Exec(normalSQL, normalParams...)
+	c.Assert(err, IsNil)
+
+	bigSQL, bigParams := generateBatchSQL(math.MaxUint16 + 2)
+	_, err = tk.Exec(bigSQL, bigParams...)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[executor:1390]Prepared statement contains too many placeholders")
+}
+
+func generateBatchSQL(paramCount int) (sql string, paramSlice []interface{}) {
+	params := make([]interface{}, 0, paramCount)
+	placeholders := make([]string, 0, paramCount)
+	for i := 0; i < paramCount; i++ {
+		params = append(params, i)
+		placeholders = append(placeholders, "(?)")
+	}
+	return "insert into t values " + strings.Join(placeholders, ","), params
 }


### PR DESCRIPTION
## What have you changed? (mandatory)

cherry-pick #7162

Now, client will meet error when input parameter placeholder count > 65535 in exec stage
this PR add placeholder num check in prepare stage to return error more quick and more evident and make it compatible with mysql.

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

- uint tests
-  manual tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

no

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

run

```
package main

import "database/sql"

import (
	"bytes"
	"fmt"
	_ "github.com/go-sql-driver/mysql"
)

func main() {
	db, err := sql.Open("mysql", "root:root@tcp(127.0.0.1:3306)/test")
	if err != nil {
		panic(err)
	}
	defer db.Close()

	_, err = db.Exec("drop table if exists t")
	if err != nil {
		panic(err)
	}

	_, err = db.Exec("create table t (v int)")
	if err != nil {
		panic(err)
	}

	const pc = 65535 + 2

	var param [pc]interface{}
	param[0] = 0
	var sqlBuilder bytes.Buffer
	sqlBuilder.WriteString("insert into t values (?)")
	for i := 0; i < pc-1; i++ {
		sqlBuilder.WriteString(",(?)")
		param[i+1] = i
	}

	stmt, err := db.Prepare(sqlBuilder.String())
	if err != nil {
		panic(err)
	}

	result, err := stmt.Exec(param[:]...)
	if err != nil {
		panic(err)
	}

	fmt.Println(result)

}
```

expect:

```
panic: Error 1390: Prepared statement contains too many placeholders

goroutine 1 [running]:
main.main()
	test/main.go:41 +0x3d2
```

but got:

```
panic: sql: expected 1 arguments, got 65537

goroutine 1 [running]:
main.main()
	test/main.go:46 +0x3c2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7162)
<!-- Reviewable:end -->