### PR TITLE
plan: remove planBuilder.err

### DIFF
--- a/plan/expression_rewriter.go
+++ b/plan/expression_rewriter.go
@@ -224,20 +224,18 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 	}
 }
 
-func (er *expressionRewriter) buildSubquery(subq *ast.SubqueryExpr) LogicalPlan {
+func (er *expressionRewriter) buildSubquery(subq *ast.SubqueryExpr) (LogicalPlan, error) {
 	if er.schema != nil {
 		outerSchema := er.schema.Clone()
 		er.b.outerSchemas = append(er.b.outerSchemas, outerSchema)
+		defer func() { er.b.outerSchemas = er.b.outerSchemas[0 : len(er.b.outerSchemas)-1] }()
 	}
-	np := er.b.buildResultSetNode(subq.Query)
-	if er.schema != nil {
-		er.b.outerSchemas = er.b.outerSchemas[0 : len(er.b.outerSchemas)-1]
+
+	np, err := er.b.buildResultSetNode(subq.Query)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
-	if er.b.err != nil {
-		er.err = errors.Trace(er.b.err)
-		return nil
-	}
-	return np
+	return np, nil
 }
 
 // Enter implements Visitor interface.
@@ -323,8 +321,9 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 		er.err = errors.Errorf("Unknown compare type %T.", v.R)
 		return v, true
 	}
-	np := er.buildSubquery(subq)
-	if er.err != nil {
+	np, err := er.buildSubquery(subq)
+	if err != nil {
+		er.err = errors.Trace(err)
 		return v, true
 	}
 	// Only (a,b,c) = any (...) and (a,b,c) != all (...) can use row expression.
@@ -365,11 +364,11 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 			if v.All {
 				er.handleEQAll(lexpr, rexpr, np)
 			} else {
-				er.p = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, false)
+				er.p, er.err = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, false)
 			}
 		} else if v.Op == opcode.NE {
 			if v.All {
-				er.p = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, true)
+				er.p, er.err = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, true)
 			} else {
 				er.handleNEAny(lexpr, rexpr, np)
 			}
@@ -459,7 +458,7 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 	// plan4Agg.buildProjectionIfNecessary()
 	if !er.asScalar {
 		// For Semi LogicalApply without aux column, the result is no matter false or null. So we can add it to join predicate.
-		er.p = er.b.buildSemiApply(er.p, plan4Agg, []expression.Expression{cond}, false, false)
+		er.p, er.err = er.b.buildSemiApply(er.p, plan4Agg, []expression.Expression{cond}, false, false)
 		return
 	}
 	// If we treat the result as a scalar value, we will add a projection with a extra column to output true, false or null.
@@ -540,14 +539,15 @@ func (er *expressionRewriter) handleExistSubquery(v *ast.ExistsSubqueryExpr) (as
 		er.err = errors.Errorf("Unknown exists type %T.", v.Sel)
 		return v, true
 	}
-	np := er.buildSubquery(subq)
-	if er.err != nil {
+	np, err := er.buildSubquery(subq)
+	if err != nil {
+		er.err = errors.Trace(err)
 		return v, true
 	}
 	np = er.b.buildExists(np)
 	if len(np.extractCorrelatedCols()) > 0 {
-		er.p = er.b.buildSemiApply(er.p, np.Children()[0], nil, er.asScalar, false)
-		if !er.asScalar {
+		er.p, er.err = er.b.buildSemiApply(er.p, np.Children()[0], nil, er.asScalar, false)
+		if er.err != nil || !er.asScalar {
 			return v, true
 		}
 		er.ctxStack = append(er.ctxStack, er.p.Schema().Columns[er.p.Schema().Len()-1])
@@ -582,8 +582,9 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 		er.err = errors.Errorf("Unknown compare type %T.", v.Sel)
 		return v, true
 	}
-	np := er.buildSubquery(subq)
-	if er.err != nil {
+	np, err := er.buildSubquery(subq)
+	if err != nil {
+		er.err = errors.Trace(err)
 		return v, true
 	}
 	lLen := expression.GetRowLen(lexpr)
@@ -595,14 +596,14 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 	// TODO: Now we cannot add it to CBO framework. Instead, user can set a session variable to open this optimization.
 	// We will improve our CBO framework in future.
 	if lLen == 1 && er.ctx.GetSessionVars().AllowInSubqueryUnFolding && len(np.extractCorrelatedCols()) == 0 {
-		physicalPlan, err := doOptimize(er.b.optFlag, np)
-		if err != nil {
-			er.err = errors.Trace(err)
+		physicalPlan, err1 := doOptimize(er.b.optFlag, np)
+		if err1 != nil {
+			er.err = errors.Trace(err1)
 			return v, true
 		}
-		rows, err := EvalSubquery(physicalPlan, er.b.is, er.b.ctx)
-		if err != nil {
-			er.err = errors.Trace(err)
+		rows, err1 := EvalSubquery(physicalPlan, er.b.is, er.b.ctx)
+		if err1 != nil {
+			er.err = errors.Trace(err1)
 			return v, true
 		}
 		for _, row := range rows {
@@ -644,7 +645,11 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 		er.err = errors.Trace(err)
 		return v, true
 	}
-	er.p = er.b.buildSemiApply(er.p, np, expression.SplitCNFItems(checkCondition), asScalar, v.Not)
+	er.p, er.err = er.b.buildSemiApply(er.p, np, expression.SplitCNFItems(checkCondition), asScalar, v.Not)
+	if er.err != nil {
+		return v, true
+	}
+
 	if asScalar {
 		col := er.p.Schema().Columns[er.p.Schema().Len()-1]
 		er.ctxStack[len(er.ctxStack)-1] = col
@@ -655,8 +660,9 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 }
 
 func (er *expressionRewriter) handleScalarSubquery(v *ast.SubqueryExpr) (ast.Node, bool) {
-	np := er.buildSubquery(v)
-	if er.err != nil {
+	np, err := er.buildSubquery(v)
+	if err != nil {
+		er.err = errors.Trace(err)
 		return v, true
 	}
 	np = er.b.buildMaxOneRow(np)
@@ -667,9 +673,9 @@ func (er *expressionRewriter) handleScalarSubquery(v *ast.SubqueryExpr) (ast.Nod
 			for _, col := range np.Schema().Columns {
 				newCols = append(newCols, col)
 			}
-			expr, err := expression.NewFunction(er.ctx, ast.RowFunc, newCols[0].GetType(), newCols...)
-			if err != nil {
-				er.err = errors.Trace(err)
+			expr, err1 := expression.NewFunction(er.ctx, ast.RowFunc, newCols[0].GetType(), newCols...)
+			if err1 != nil {
+				er.err = errors.Trace(err1)
 				return v, true
 			}
 			er.ctxStack = append(er.ctxStack, expr)

--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -1485,8 +1485,8 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 			is:        s.is,
 		}
 		builder.ctx.GetSessionVars().HashJoinConcurrency = 1
-		builder.build(stmt)
-		c.Assert(builder.err, IsNil, comment)
+		_, err = builder.build(stmt)
+		c.Assert(err, IsNil, comment)
 
 		checkVisitInfo(c, builder.visitInfo, tt.ans, comment)
 	}
@@ -1588,13 +1588,12 @@ func (s *testPlanSuite) TestUnion(c *C) {
 			is:        s.is,
 			colMapper: make(map[*ast.ColumnNameExpr]int),
 		}
-		c.Assert(builder.err, IsNil)
-		plan := builder.build(stmt)
+		plan, err := builder.build(stmt)
 		if tt.err {
-			c.Assert(builder.err, NotNil)
+			c.Assert(err, NotNil)
 			return
 		}
-		c.Assert(builder.err, IsNil)
+		c.Assert(err, IsNil)
 		p := plan.(LogicalPlan)
 		p, err = logicalOptimize(builder.optFlag, p.(LogicalPlan))
 		c.Assert(err, IsNil)
@@ -1716,8 +1715,8 @@ func (s *testPlanSuite) TestTopNPushDown(c *C) {
 			is:        s.is,
 			colMapper: make(map[*ast.ColumnNameExpr]int),
 		}
-		c.Assert(builder.err, IsNil)
-		p := builder.build(stmt).(LogicalPlan)
+		p, err := builder.build(stmt)
+		c.Assert(err, IsNil)
 		p, err = logicalOptimize(builder.optFlag, p.(LogicalPlan))
 		c.Assert(err, IsNil)
 		c.Assert(ToString(p), Equals, tt.best, comment)

--- a/plan/optimizer.go
+++ b/plan/optimizer.go
@@ -70,9 +70,9 @@ func Optimize(ctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (
 		is:        is,
 		colMapper: make(map[*ast.ColumnNameExpr]int),
 	}
-	p := builder.build(node)
-	if builder.err != nil {
-		return nil, errors.Trace(builder.err)
+	p, err := builder.build(node)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	// Maybe it's better to move this to Preprocess, but check privilege need table
@@ -102,9 +102,9 @@ func BuildLogicalPlan(ctx sessionctx.Context, node ast.Node, is infoschema.InfoS
 		is:        is,
 		colMapper: make(map[*ast.ColumnNameExpr]int),
 	}
-	p := builder.build(node)
-	if builder.err != nil {
-		return nil, errors.Trace(builder.err)
+	p, err := builder.build(node)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	return p, nil
 }

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -105,7 +105,6 @@ var clauseMsg = map[clauseCode]string{
 // planBuilder builds Plan from an ast.Node.
 // It just builds the ast node straightforwardly.
 type planBuilder struct {
-	err          error
 	ctx          sessionctx.Context
 	is           infoschema.InfoSchema
 	outerSchemas []*expression.Schema
@@ -129,13 +128,13 @@ type planBuilder struct {
 	inStraightJoin bool
 }
 
-func (b *planBuilder) build(node ast.Node) Plan {
+func (b *planBuilder) build(node ast.Node) (Plan, error) {
 	b.optFlag = flagPrunColumns
 	switch x := node.(type) {
 	case *ast.AdminStmt:
 		return b.buildAdmin(x)
 	case *ast.DeallocateStmt:
-		return &Deallocate{Name: x.Name}
+		return &Deallocate{Name: x.Name}, nil
 	case *ast.DeleteStmt:
 		return b.buildDelete(x)
 	case *ast.ExecuteStmt:
@@ -147,9 +146,9 @@ func (b *planBuilder) build(node ast.Node) Plan {
 	case *ast.LoadDataStmt:
 		return b.buildLoadData(x)
 	case *ast.LoadStatsStmt:
-		return b.buildLoadStats(x)
+		return b.buildLoadStats(x), nil
 	case *ast.PrepareStmt:
-		return b.buildPrepare(x)
+		return b.buildPrepare(x), nil
 	case *ast.SelectStmt:
 		return b.buildSelect(x)
 	case *ast.UnionStmt:
@@ -167,28 +166,27 @@ func (b *planBuilder) build(node ast.Node) Plan {
 	case *ast.BinlogStmt, *ast.FlushStmt, *ast.UseStmt,
 		*ast.BeginStmt, *ast.CommitStmt, *ast.RollbackStmt, *ast.CreateUserStmt, *ast.SetPwdStmt,
 		*ast.GrantStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.RevokeStmt, *ast.KillStmt, *ast.DropStatsStmt:
-		return b.buildSimple(node.(ast.StmtNode))
+		return b.buildSimple(node.(ast.StmtNode)), nil
 	case ast.DDLNode:
-		return b.buildDDL(x)
+		return b.buildDDL(x), nil
 	}
-	b.err = ErrUnsupportedType.Gen("Unsupported type %T", node)
-	return nil
+	return nil, ErrUnsupportedType.Gen("Unsupported type %T", node)
 }
 
-func (b *planBuilder) buildExecute(v *ast.ExecuteStmt) Plan {
+func (b *planBuilder) buildExecute(v *ast.ExecuteStmt) (Plan, error) {
 	vars := make([]expression.Expression, 0, len(v.UsingVars))
 	for _, expr := range v.UsingVars {
 		newExpr, _, err := b.rewrite(expr, nil, nil, true)
 		if err != nil {
-			b.err = errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 		vars = append(vars, newExpr)
 	}
 	exe := &Execute{Name: v.Name, UsingVars: vars, ExecID: v.ExecID}
-	return exe
+	return exe, nil
 }
 
-func (b *planBuilder) buildDo(v *ast.DoStmt) Plan {
+func (b *planBuilder) buildDo(v *ast.DoStmt) (Plan, error) {
 	dual := LogicalTableDual{RowCount: 1}.init(b.ctx)
 
 	p := LogicalProjection{Exprs: make([]expression.Expression, 0, len(v.Exprs))}.init(b.ctx)
@@ -196,8 +194,7 @@ func (b *planBuilder) buildDo(v *ast.DoStmt) Plan {
 	for _, astExpr := range v.Exprs {
 		expr, _, err := b.rewrite(astExpr, dual, nil, true)
 		if err != nil {
-			b.err = errors.Trace(err)
-			return nil
+			return nil, errors.Trace(err)
 		}
 		p.Exprs = append(p.Exprs, expr)
 		schema.Append(&expression.Column{
@@ -209,10 +206,10 @@ func (b *planBuilder) buildDo(v *ast.DoStmt) Plan {
 	p.self = p
 	p.SetSchema(schema)
 	p.calculateNoDelay = true
-	return p
+	return p, nil
 }
 
-func (b *planBuilder) buildSet(v *ast.SetStmt) Plan {
+func (b *planBuilder) buildSet(v *ast.SetStmt) (Plan, error) {
 	p := &Set{}
 	for _, vars := range v.Variables {
 		assign := &expression.VarAssignment{
@@ -226,9 +223,10 @@ func (b *planBuilder) buildSet(v *ast.SetStmt) Plan {
 				vars.Value = ast.NewValueExpr(cn.Name.Name.O)
 			}
 			mockTablePlan := LogicalTableDual{}.init(b.ctx)
-			assign.Expr, _, b.err = b.rewrite(vars.Value, mockTablePlan, nil, true)
-			if b.err != nil {
-				return nil
+			var err error
+			assign.Expr, _, err = b.rewrite(vars.Value, mockTablePlan, nil, true)
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
 		} else {
 			assign.IsDefault = true
@@ -241,7 +239,7 @@ func (b *planBuilder) buildSet(v *ast.SetStmt) Plan {
 		}
 		p.VarAssigns = append(p.VarAssigns, assign)
 	}
-	return p
+	return p, nil
 }
 
 // Detect aggregate function or groupby clause.
@@ -368,12 +366,11 @@ func (b *planBuilder) buildPrepare(x *ast.PrepareStmt) Plan {
 	return p
 }
 
-func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) Plan {
+func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) (Plan, error) {
 	tblName := as.Tables[0]
 	tbl, err := b.is.TableByName(dbName, tblName.Name)
 	if err != nil {
-		b.err = errors.Trace(err)
-		return nil
+		return nil, errors.Trace(err)
 	}
 	tblInfo := tbl.Meta()
 
@@ -386,12 +383,10 @@ func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) Pla
 		}
 	}
 	if idx == nil {
-		b.err = errors.Errorf("index %s do not exist", as.Index)
-		return nil
+		return nil, errors.Errorf("index %s do not exist", as.Index)
 	}
 	if idx.State != model.StatePublic {
-		b.err = errors.Errorf("index %s state %s isn't public", as.Index, idx.State)
-		return nil
+		return nil, errors.Errorf("index %s state %s isn't public", as.Index, idx.State)
 	}
 
 	id := 1
@@ -428,10 +423,10 @@ func (b *planBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) Pla
 	t := finishCopTask(b.ctx, cop)
 
 	rootT := t.(*rootTask)
-	return rootT.p
+	return rootT.p, nil
 }
 
-func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
+func (b *planBuilder) buildAdmin(as *ast.AdminStmt) (Plan, error) {
 	var ret Plan
 
 	switch as.Tp {
@@ -440,10 +435,11 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 		ret = p
 	case ast.AdminCheckIndex:
 		dbName := as.Tables[0].Schema
-		readerPlan := b.buildCheckIndex(dbName, as)
-		if b.err != nil {
-			return ret
+		readerPlan, err := b.buildCheckIndex(dbName, as)
+		if err != nil {
+			return ret, errors.Trace(err)
 		}
+
 		ret = &CheckIndex{
 			DBName:            dbName.L,
 			IdxName:           as.Index,
@@ -474,12 +470,12 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 		p.SetSchema(buildCancelDDLJobsFields())
 		ret = p
 	case ast.AdminCheckIndexRange:
-		p := &CheckIndexRange{Table: as.Tables[0], IndexName: as.Index, HandleRanges: as.HandleRanges}
-		schema := b.buildCheckIndexSchema(as.Tables[0], as.Index)
-		if b.err != nil {
-			b.err = errors.Trace(b.err)
-			break
+		schema, err := b.buildCheckIndexSchema(as.Tables[0], as.Index)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
+
+		p := &CheckIndexRange{Table: as.Tables[0], IndexName: as.Index, HandleRanges: as.HandleRanges}
 		p.SetSchema(schema)
 		ret = p
 	case ast.AdminShowDDLJobQueries:
@@ -487,12 +483,12 @@ func (b *planBuilder) buildAdmin(as *ast.AdminStmt) Plan {
 		p.SetSchema(buildShowDDLJobQueriesFields())
 		ret = p
 	default:
-		b.err = ErrUnsupportedType.Gen("Unsupported type %T", as)
+		return nil, ErrUnsupportedType.Gen("Unsupported ast.AdminStmt(%T) for buildAdmin", as)
 	}
-	return ret
+	return ret, nil
 }
 
-func (b *planBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string) *expression.Schema {
+func (b *planBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string) (*expression.Schema, error) {
 	schema := expression.NewSchema()
 	indexName = strings.ToLower(indexName)
 	indicesInfo := tn.TableInfo.Indices
@@ -521,10 +517,9 @@ func (b *planBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string)
 		})
 	}
 	if schema.Len() == 0 {
-		b.err = errors.Errorf("index %s not found", indexName)
-		return nil
+		return nil, errors.Errorf("index %s not found", indexName)
 	}
-	return schema
+	return schema, nil
 }
 
 // getColsInfo returns the info of index columns, normal columns and primary key.
@@ -594,21 +589,20 @@ func (b *planBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt) Plan {
 	return p
 }
 
-func (b *planBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt) Plan {
+func (b *planBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt) (Plan, error) {
 	p := &Analyze{}
 	tblInfo := as.TableNames[0].TableInfo
 	physicalIDs := getPhysicalIDs(tblInfo)
 	for _, idxName := range as.IndexNames {
 		idx := findIndexByName(tblInfo.Indices, idxName)
 		if idx == nil || idx.State != model.StatePublic {
-			b.err = ErrAnalyzeMissIndex.GenByArgs(idxName.O, tblInfo.Name.O)
-			break
+			return nil, ErrAnalyzeMissIndex.GenByArgs(idxName.O, tblInfo.Name.O)
 		}
 		for _, id := range physicalIDs {
 			p.IdxTasks = append(p.IdxTasks, AnalyzeIndexTask{PhysicalID: id, IndexInfo: idx})
 		}
 	}
-	return p
+	return p, nil
 }
 
 func (b *planBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt) Plan {
@@ -625,14 +619,14 @@ func (b *planBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt) Plan {
 	return p
 }
 
-func (b *planBuilder) buildAnalyze(as *ast.AnalyzeTableStmt) Plan {
+func (b *planBuilder) buildAnalyze(as *ast.AnalyzeTableStmt) (Plan, error) {
 	if as.IndexFlag {
 		if len(as.IndexNames) == 0 {
-			return b.buildAnalyzeAllIndex(as)
+			return b.buildAnalyzeAllIndex(as), nil
 		}
 		return b.buildAnalyzeIndex(as)
 	}
-	return b.buildAnalyzeTable(as)
+	return b.buildAnalyzeTable(as), nil
 }
 
 func buildShowDDLFields() *expression.Schema {
@@ -731,7 +725,7 @@ func splitWhere(where ast.ExprNode) []ast.ExprNode {
 	return conditions
 }
 
-func (b *planBuilder) buildShow(show *ast.ShowStmt) Plan {
+func (b *planBuilder) buildShow(show *ast.ShowStmt) (Plan, error) {
 	p := Show{
 		Tp:          show.Tp,
 		DBName:      show.DBName,
@@ -755,8 +749,7 @@ func (b *planBuilder) buildShow(show *ast.ShowStmt) Plan {
 		switch showTp {
 		case ast.ShowTables, ast.ShowTableStatus:
 			if p.DBName == "" {
-				b.err = ErrNoDB
-				return nil
+				return nil, ErrNoDB
 			}
 		case ast.ShowCreateTable:
 			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.AllPrivMask, show.Table.Schema.L, show.Table.Name.L, "")
@@ -774,8 +767,7 @@ func (b *planBuilder) buildShow(show *ast.ShowStmt) Plan {
 		}
 		expr, _, err := b.rewrite(show.Pattern, mockTablePlan, nil, false)
 		if err != nil {
-			b.err = errors.Trace(err)
-			return nil
+			return nil, errors.Trace(err)
 		}
 		p.Conditions = append(p.Conditions, expr)
 	}
@@ -784,14 +776,13 @@ func (b *planBuilder) buildShow(show *ast.ShowStmt) Plan {
 		for _, cond := range conds {
 			expr, _, err := b.rewrite(cond, mockTablePlan, nil, false)
 			if err != nil {
-				b.err = errors.Trace(err)
-				return nil
+				return nil, errors.Trace(err)
 			}
 			p.Conditions = append(p.Conditions, expr)
 		}
 		p.ResolveIndices()
 	}
-	return p
+	return p, nil
 }
 
 func (b *planBuilder) buildSimple(node ast.StmtNode) Plan {
@@ -870,7 +861,7 @@ func (b *planBuilder) findDefaultValue(cols []*table.Column, name *ast.ColumnNam
 
 // resolveGeneratedColumns resolves generated columns with their generation
 // expressions respectively. onDups indicates which columns are in on-duplicate list.
-func (b *planBuilder) resolveGeneratedColumns(columns []*table.Column, onDups map[string]struct{}, mockPlan LogicalPlan) (igc InsertGeneratedColumns) {
+func (b *planBuilder) resolveGeneratedColumns(columns []*table.Column, onDups map[string]struct{}, mockPlan LogicalPlan) (igc InsertGeneratedColumns, err error) {
 	for _, column := range columns {
 		if !column.IsGenerated() {
 			continue
@@ -880,14 +871,12 @@ func (b *planBuilder) resolveGeneratedColumns(columns []*table.Column, onDups ma
 
 		colExpr, _, err := mockPlan.findColumn(columnName)
 		if err != nil {
-			b.err = errors.Trace(err)
-			return
+			return igc, errors.Trace(err)
 		}
 
 		expr, _, err := b.rewrite(column.GeneratedExpr, mockPlan, nil, true)
 		if err != nil {
-			b.err = errors.Trace(err)
-			return
+			return igc, errors.Trace(err)
 		}
 		expr = expression.BuildCastFunction(b.ctx, expr, colExpr.GetType())
 
@@ -904,27 +893,24 @@ func (b *planBuilder) resolveGeneratedColumns(columns []*table.Column, onDups ma
 			}
 		}
 	}
-	return
+	return igc, nil
 }
 
-func (b *planBuilder) buildInsert(insert *ast.InsertStmt) Plan {
+func (b *planBuilder) buildInsert(insert *ast.InsertStmt) (Plan, error) {
 	ts, ok := insert.Table.TableRefs.Left.(*ast.TableSource)
 	if !ok {
-		b.err = infoschema.ErrTableNotExists.GenByArgs()
-		return nil
+		return nil, infoschema.ErrTableNotExists.GenByArgs()
 	}
 	tn, ok := ts.Source.(*ast.TableName)
 	if !ok {
-		b.err = infoschema.ErrTableNotExists.GenByArgs()
-		return nil
+		return nil, infoschema.ErrTableNotExists.GenByArgs()
 	}
 	tableInfo := tn.TableInfo
 	// Build Schema with DBName otherwise ColumnRef with DBName cannot match any Column in Schema.
 	schema := expression.TableInfo2SchemaWithDBName(b.ctx, tn.Schema, tableInfo)
 	tableInPlan, ok := b.is.TableByID(tableInfo.ID)
 	if !ok {
-		b.err = errors.Errorf("Can't get table %s.", tableInfo.Name.O)
-		return nil
+		return nil, errors.Errorf("Can't get table %s.", tableInfo.Name.O)
 	}
 
 	insertPlan := Insert{
@@ -956,21 +942,21 @@ func (b *planBuilder) buildInsert(insert *ast.InsertStmt) Plan {
 
 	if len(insert.Setlist) > 0 {
 		// Branch for `INSERT ... SET ...`.
-		b.buildSetValuesOfInsert(insert, insertPlan, mockTablePlan, checkRefColumn)
-		if b.err != nil {
-			return nil
+		err := b.buildSetValuesOfInsert(insert, insertPlan, mockTablePlan, checkRefColumn)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	} else if len(insert.Lists) > 0 {
 		// Branch for `INSERT ... VALUES ...`.
-		b.buildValuesListOfInsert(insert, insertPlan, mockTablePlan, checkRefColumn)
-		if b.err != nil {
-			return nil
+		err := b.buildValuesListOfInsert(insert, insertPlan, mockTablePlan, checkRefColumn)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	} else {
 		// Branch for `INSERT ... SELECT ...`.
-		b.buildSelectPlanOfInsert(insert, insertPlan)
-		if b.err != nil {
-			return nil
+		err := b.buildSelectPlanOfInsert(insert, insertPlan)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 	}
 
@@ -981,15 +967,13 @@ func (b *planBuilder) buildInsert(insert *ast.InsertStmt) Plan {
 	}
 	onDupColSet, dupCols, err := insertPlan.validateOnDup(insert.OnDuplicate, columnByName, tableInfo)
 	if err != nil {
-		b.err = errors.Trace(err)
-		return nil
+		return nil, errors.Trace(err)
 	}
 	for i, assign := range insert.OnDuplicate {
 		// Construct the function which calculates the assign value of the column.
-		expr, err := b.rewriteInsertOnDuplicateUpdate(assign.Expr, mockTablePlan, insertPlan)
-		if err != nil {
-			b.err = errors.Trace(err)
-			return nil
+		expr, err1 := b.rewriteInsertOnDuplicateUpdate(assign.Expr, mockTablePlan, insertPlan)
+		if err1 != nil {
+			return nil, errors.Trace(err1)
 		}
 
 		insertPlan.OnDuplicate = append(insertPlan.OnDuplicate, &expression.Assignment{
@@ -1000,14 +984,13 @@ func (b *planBuilder) buildInsert(insert *ast.InsertStmt) Plan {
 
 	// Calculate generated columns.
 	mockTablePlan.schema = insertPlan.tableSchema
-	insertPlan.GenCols = b.resolveGeneratedColumns(insertPlan.Table.Cols(), onDupColSet, mockTablePlan)
-	if b.err != nil {
-		b.err = errors.Trace(b.err)
-		return nil
+	insertPlan.GenCols, err = b.resolveGeneratedColumns(insertPlan.Table.Cols(), onDupColSet, mockTablePlan)
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 
 	insertPlan.ResolveIndices()
-	return insertPlan
+	return insertPlan, nil
 }
 
 func (p *Insert) validateOnDup(onDup []*ast.Assignment, colMap map[string]*table.Column, tblInfo *model.TableInfo) (map[string]struct{}, []*expression.Column, error) {
@@ -1033,7 +1016,7 @@ func (p *Insert) validateOnDup(onDup []*ast.Assignment, colMap map[string]*table
 	return onDupColSet, dupCols, nil
 }
 
-func (b *planBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *Insert) (affectedValuesCols []*table.Column) {
+func (b *planBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *Insert) (affectedValuesCols []*table.Column, err error) {
 	if len(insertStmt.Columns) > 0 {
 		// This branch is for the following scenarios:
 		// 1. `INSERT INTO tbl_name (col_name [, col_name] ...) {VALUES | VALUE} (value_list) [, (value_list)] ...`,
@@ -1042,10 +1025,9 @@ func (b *planBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *Inse
 		for _, col := range insertStmt.Columns {
 			colName = append(colName, col.Name.O)
 		}
-		affectedValuesCols, b.err = table.FindCols(insertPlan.Table.Cols(), colName, insertPlan.Table.Meta().PKIsHandle)
-		if b.err != nil {
-			b.err = errors.Trace(b.err)
-			return
+		affectedValuesCols, err = table.FindCols(insertPlan.Table.Cols(), colName, insertPlan.Table.Meta().PKIsHandle)
+		if err != nil {
+			return nil, errors.Trace(err)
 		}
 
 	} else if len(insertStmt.Setlist) == 0 {
@@ -1054,23 +1036,20 @@ func (b *planBuilder) getAffectCols(insertStmt *ast.InsertStmt, insertPlan *Inse
 		// 2. `INSERT INTO tbl_name SELECT ...`.
 		affectedValuesCols = insertPlan.Table.Cols()
 	}
-	return
+	return affectedValuesCols, nil
 }
 
-func (b *planBuilder) buildSetValuesOfInsert(insert *ast.InsertStmt, insertPlan *Insert, mockTablePlan *LogicalTableDual,
-	checkRefColumn func(n ast.Node) ast.Node) {
+func (b *planBuilder) buildSetValuesOfInsert(insert *ast.InsertStmt, insertPlan *Insert, mockTablePlan *LogicalTableDual, checkRefColumn func(n ast.Node) ast.Node) error {
 	tableInfo := insertPlan.Table.Meta()
 	colNames := make([]string, 0, len(insert.Setlist))
 	exprCols := make([]*expression.Column, 0, len(insert.Setlist))
 	for _, assign := range insert.Setlist {
 		exprCol, err := insertPlan.tableSchema.FindColumn(assign.Column)
 		if err != nil {
-			b.err = errors.Trace(err)
-			return
+			return errors.Trace(err)
 		}
 		if exprCol == nil {
-			b.err = errors.Errorf("Can't find column %s", assign.Column)
-			return
+			return errors.Errorf("Can't find column %s", assign.Column)
 		}
 		colNames = append(colNames, assign.Column.Name.L)
 		exprCols = append(exprCols, exprCol)
@@ -1079,20 +1058,18 @@ func (b *planBuilder) buildSetValuesOfInsert(insert *ast.InsertStmt, insertPlan 
 	// Check whether the column to be updated is the generated column.
 	tCols, err := table.FindCols(insertPlan.Table.Cols(), colNames, tableInfo.PKIsHandle)
 	if err != nil {
-		b.err = errors.Trace(err)
-		return
+		return errors.Trace(err)
 	}
 	for _, tCol := range tCols {
 		if tCol.IsGenerated() {
-			b.err = ErrBadGeneratedColumn.GenByArgs(tCol.Name.O, tableInfo.Name.O)
-			return
+			return ErrBadGeneratedColumn.GenByArgs(tCol.Name.O, tableInfo.Name.O)
 		}
 	}
 
 	for i, assign := range insert.Setlist {
 		expr, _, err := b.rewriteWithPreprocess(assign.Expr, mockTablePlan, nil, true, checkRefColumn)
 		if err != nil {
-			b.err = errors.Trace(err)
+			return errors.Trace(err)
 		}
 		insertPlan.SetList = append(insertPlan.SetList, &expression.Assignment{
 			Col:  exprCols[i],
@@ -1100,14 +1077,13 @@ func (b *planBuilder) buildSetValuesOfInsert(insert *ast.InsertStmt, insertPlan 
 		})
 	}
 	insertPlan.Schema4OnDuplicate = insertPlan.tableSchema
+	return nil
 }
 
-func (b *planBuilder) buildValuesListOfInsert(insert *ast.InsertStmt, insertPlan *Insert, mockTablePlan *LogicalTableDual,
-	checkRefColumn func(n ast.Node) ast.Node) {
-	affectedValuesCols := b.getAffectCols(insert, insertPlan)
-	if b.err != nil {
-		b.err = errors.Trace(b.err)
-		return
+func (b *planBuilder) buildValuesListOfInsert(insert *ast.InsertStmt, insertPlan *Insert, mockTablePlan *LogicalTableDual, checkRefColumn func(n ast.Node) ast.Node) error {
+	affectedValuesCols, err := b.getAffectCols(insert, insertPlan)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	// If value_list and col_list are empty and we have a generated column, we can still write data to this table.
@@ -1115,14 +1091,12 @@ func (b *planBuilder) buildValuesListOfInsert(insert *ast.InsertStmt, insertPlan
 	if len(insert.Columns) > 0 || len(insert.Lists[0]) > 0 {
 		// If value_list or col_list is not empty, the length of value_list should be the same with that of col_list.
 		if len(insert.Lists[0]) != len(affectedValuesCols) {
-			b.err = ErrWrongValueCountOnRow.GenByArgs(1)
-			return
+			return ErrWrongValueCountOnRow.GenByArgs(1)
 		}
 		// No generated column is allowed.
 		for _, col := range affectedValuesCols {
 			if col.IsGenerated() {
-				b.err = ErrBadGeneratedColumn.GenByArgs(col.Name.O, insertPlan.Table.Meta().Name.O)
-				return
+				return ErrBadGeneratedColumn.GenByArgs(col.Name.O, insertPlan.Table.Meta().Name.O)
 			}
 		}
 	}
@@ -1135,8 +1109,7 @@ func (b *planBuilder) buildValuesListOfInsert(insert *ast.InsertStmt, insertPlan
 		// "insert into t values (1), ()" is not valid.
 		// "insert into t values (1,2), (1)" is not valid.
 		if i > 0 && len(insert.Lists[i-1]) != len(insert.Lists[i]) {
-			b.err = ErrWrongValueCountOnRow.GenByArgs(i + 1)
-			return
+			return ErrWrongValueCountOnRow.GenByArgs(i + 1)
 		}
 		exprList := make([]expression.Expression, 0, len(valuesItem))
 		for j, valueItem := range valuesItem {
@@ -1158,30 +1131,29 @@ func (b *planBuilder) buildValuesListOfInsert(insert *ast.InsertStmt, insertPlan
 				expr, _, err = b.rewriteWithPreprocess(valueItem, mockTablePlan, nil, true, checkRefColumn)
 			}
 			if err != nil {
-				b.err = errors.Trace(err)
+				return errors.Trace(err)
 			}
 			exprList = append(exprList, expr)
 		}
 		insertPlan.Lists = append(insertPlan.Lists, exprList)
 	}
 	insertPlan.Schema4OnDuplicate = insertPlan.tableSchema
+	return nil
 }
 
-func (b *planBuilder) buildSelectPlanOfInsert(insert *ast.InsertStmt, insertPlan *Insert) {
-	affectedValuesCols := b.getAffectCols(insert, insertPlan)
-	if b.err != nil {
-		b.err = errors.Trace(b.err)
-		return
+func (b *planBuilder) buildSelectPlanOfInsert(insert *ast.InsertStmt, insertPlan *Insert) error {
+	affectedValuesCols, err := b.getAffectCols(insert, insertPlan)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	selectPlan := b.build(insert.Select)
-	if b.err != nil {
-		return
+	selectPlan, err := b.build(insert.Select)
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	// Check to guarantee that the length of the row returned by select is equal to that of affectedValuesCols.
 	if selectPlan.Schema().Len() != len(affectedValuesCols) {
-		b.err = ErrWrongValueCountOnRow.GenByArgs(1)
-		return
+		return ErrWrongValueCountOnRow.GenByArgs(1)
 	}
 
 	// Check to guarantee that there's no generated column.
@@ -1193,20 +1165,20 @@ func (b *planBuilder) buildSelectPlanOfInsert(insert *ast.InsertStmt, insertPlan
 	// that there's a generated column in the column list.
 	for _, col := range affectedValuesCols {
 		if col.IsGenerated() {
-			b.err = ErrBadGeneratedColumn.GenByArgs(col.Name.O, insertPlan.Table.Meta().Name.O)
-			return
+			return ErrBadGeneratedColumn.GenByArgs(col.Name.O, insertPlan.Table.Meta().Name.O)
 		}
 	}
 
-	insertPlan.SelectPlan, b.err = doOptimize(b.optFlag, selectPlan.(LogicalPlan))
-	if b.err != nil {
-		return
+	insertPlan.SelectPlan, err = doOptimize(b.optFlag, selectPlan.(LogicalPlan))
+	if err != nil {
+		return errors.Trace(err)
 	}
 
 	insertPlan.Schema4OnDuplicate = expression.MergeSchema(insertPlan.tableSchema, insertPlan.SelectPlan.Schema())
+	return nil
 }
 
-func (b *planBuilder) buildLoadData(ld *ast.LoadDataStmt) Plan {
+func (b *planBuilder) buildLoadData(ld *ast.LoadDataStmt) (Plan, error) {
 	p := &LoadData{
 		IsLocal:    ld.IsLocal,
 		Path:       ld.Path,
@@ -1219,14 +1191,18 @@ func (b *planBuilder) buildLoadData(ld *ast.LoadDataStmt) Plan {
 	tableInPlan, ok := b.is.TableByID(tableInfo.ID)
 	if !ok {
 		db := b.ctx.GetSessionVars().CurrentDB
-		b.err = infoschema.ErrTableNotExists.GenByArgs(db, tableInfo.Name.O)
-		return nil
+		return nil, infoschema.ErrTableNotExists.GenByArgs(db, tableInfo.Name.O)
 	}
 	schema := expression.TableInfo2Schema(b.ctx, tableInfo)
 	mockTablePlan := LogicalTableDual{}.init(b.ctx)
 	mockTablePlan.SetSchema(schema)
-	p.GenCols = b.resolveGeneratedColumns(tableInPlan.Cols(), nil, mockTablePlan)
-	return p
+
+	var err error
+	p.GenCols, err = b.resolveGeneratedColumns(tableInPlan.Cols(), nil, mockTablePlan)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return p, nil
 }
 
 func (b *planBuilder) buildLoadStats(ld *ast.LoadStatsStmt) Plan {
@@ -1308,15 +1284,15 @@ func (b *planBuilder) buildDDL(node ast.DDLNode) Plan {
 	return p
 }
 
-func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
+func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) (Plan, error) {
 	if show, ok := explain.Stmt.(*ast.ShowStmt); ok {
 		return b.buildShow(show)
 	}
 	targetPlan, err := Optimize(b.ctx, explain.Stmt, b.is)
 	if err != nil {
-		b.err = errors.Trace(err)
-		return nil
+		return nil, errors.Trace(err)
 	}
+
 	pp, ok := targetPlan.(PhysicalPlan)
 	if !ok {
 		switch x := targetPlan.(type) {
@@ -1330,8 +1306,7 @@ func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
 			}
 		}
 		if pp == nil {
-			b.err = ErrUnsupportedType.GenByArgs(targetPlan)
-			return nil
+			return nil, ErrUnsupportedType.GenByArgs(targetPlan)
 		}
 	}
 	p := &Explain{StmtPlan: pp}
@@ -1354,9 +1329,9 @@ func (b *planBuilder) buildExplain(explain *ast.ExplainStmt) Plan {
 		p.SetSchema(schema)
 		p.prepareDotInfo(p.StmtPlan.(PhysicalPlan))
 	default:
-		b.err = errors.Errorf("explain format '%s' is not supported now", explain.Format)
+		return nil, errors.Errorf("explain format '%s' is not supported now", explain.Format)
 	}
-	return p
+	return p, nil
 }
 
 func buildShowProcedureSchema() *expression.Schema {


### PR DESCRIPTION
## What have you changed? (mandatory)

This PR removes the `error` field inside the `planBuilder` struct, to:
- force to check the `error` returned by the function of `planBuilder`.
- avoid some potential panic, we didn't check `b.err` in some scenario in the before.


## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

- unit test
- explain test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)

No


