### PR TITLE
*: partitioned table should not use PointGetPlan

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -595,7 +595,7 @@ func (s *testDBSuite) TestAddMultiColumnsIndex(c *C) {
 func (s *testDBSuite) TestAddIndex(c *C) {
 	s.testAddIndex(c, false, "create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))")
 	s.testAddIndex(c, true, `create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))
-			      partition by range (c2) (
+			      partition by range (c1) (
 			      partition p0 values less than (3440),
 			      partition p1 values less than (61440),
 			      partition p2 values less than (122880),
@@ -606,8 +606,7 @@ func (s *testDBSuite) TestAddIndex(c *C) {
 func (s *testDBSuite) testAddIndex(c *C, testPartition bool, createTableSQL string) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
-	// TODO: Support delete operation, then uncomment here.
-	// s.tk.MustExec("set @@tidb_enable_table_partition = 1")
+	s.tk.MustExec("set @@tidb_enable_table_partition = 1")
 	s.tk.MustExec("drop table if exists test_add_index")
 	s.tk.MustExec(createTableSQL)
 
@@ -693,16 +692,16 @@ LOOP:
 	rows := s.mustQuery(c, fmt.Sprintf("select c1 from test_add_index where c3 >= %d order by c1", start))
 	matchRows(c, rows, expectedRows)
 
+	if testPartition {
+		s.tk.MustExec("admin check table test_add_index")
+		return
+	}
+
 	// test index range
 	for i := 0; i < 100; i++ {
 		index := rand.Intn(len(keys) - 3)
 		rows := s.mustQuery(c, "select c1 from test_add_index where c3 >= ? limit 3", keys[index])
 		matchRows(c, rows, [][]interface{}{{keys[index]}, {keys[index+1]}, {keys[index+2]}})
-	}
-
-	if testPartition {
-		s.tk.MustExec("admin check table test_add_index")
-		return
 	}
 
 	// TODO: Support explain in future.

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1100,6 +1100,13 @@ PARTITION BY RANGE ( id ) (
 	tk.MustExec("admin check table t")
 	tk.MustExec(`delete from t;`)
 	tk.CheckExecResult(14, 0)
+
+	// Fix that partitioned table should not use PointGetPlan.
+	tk.MustExec(`create table t1 (c1 bigint, c2 bigint, c3 bigint, primary key(c1)) partition by range (c1) (partition p0 values less than (3440))`)
+	tk.MustExec("insert into t1 values (379, 379, 379)")
+	tk.MustExec("delete from t1 where c1 = 379")
+	tk.CheckExecResult(1, 0)
+	tk.MustExec(`drop table t1;`)
 }
 
 func (s *testSuite) fillDataMultiTable(tk *testkit.TestKit) {

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -153,6 +153,10 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 	if tbl == nil {
 		return nil
 	}
+	// Do not handle partitioned table.
+	if tbl.GetPartitionInfo() != nil {
+		return nil
+	}
 	for _, col := range tbl.Columns {
 		// Do not handle generated columns.
 		if col.IsGenerated() {

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -154,6 +154,9 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 		return nil
 	}
 	// Do not handle partitioned table.
+	// Table partition implementation translates LogicalPlan from `DataSource` to
+	// `Union -> DataSource` in the logical plan optimization pass, since PointGetPlan
+	// bypass the logical plan optimization, it can't support partitioned table.
 	if tbl.GetPartitionInfo() != nil {
 		return nil
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)

If a SQL works on partitioned table, it will not generate PointGetPlan

<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (mandatory)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Separately describe each logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume reviewers understand the original issue
-->

## What is the type of the changes? (mandatory)

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->

- Bug fix (non-breaking change which fixes an issue)


## How has this PR been tested? (mandatory)

unit test
<!--
Please describe the tests that you ran to verify your changes.
Have you finished unit tests, integration tests, or manual tests?
What additional tests would give you greater confidence in this change?
-->

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
no
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) or [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->

## Does this PR affect tidb-ansible update? (mandatory)
no
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->

## Does this PR need to be added to the release notes? (mandatory)
no
<!--
If this PR needs to be added to the release notes, please:
1. add the "**release-note**" label for this PR
2. write your release note in the below block
3. if the PR requires additional action from users switching to the new
   release, describe the concrete action that users need to take in detail.

An example:
```
release note:
// put your release notes for this PR here.

action required:
// put your required action in detail here.
```
-->

@coocood @lysu 

