### PR TITLE
*: remove variable 'tidb_import_data' and rename SessionVars.ImportingData to LightningMode

### DIFF
--- a/executor/insert.go
+++ b/executor/insert.go
@@ -47,7 +47,7 @@ func (e *InsertExec) insertOneRow(row []types.Datum) (int64, error) {
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	if !e.ctx.GetSessionVars().ImportingData {
+	if !e.ctx.GetSessionVars().LightningMode {
 		e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
 	}
 	e.batchInsertRowCount++
@@ -60,7 +60,7 @@ func (e *InsertExec) exec(rows [][]types.Datum) error {
 	defer sessVars.CleanBuffers()
 	ignoreErr := sessVars.StmtCtx.DupKeyAsWarning
 
-	if !sessVars.ImportingData {
+	if !sessVars.LightningMode {
 		sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.ctx.Txn(), kv.TempTxnMemBufCap)
 	}
 
@@ -107,7 +107,7 @@ func (e *InsertExec) checkBatchLimit() error {
 			return ErrBatchInsertFail.Gen("BatchInsert failed with error: %v", err)
 		}
 		e.batchInsertRowCount = 0
-		if !sessVars.ImportingData {
+		if !sessVars.LightningMode {
 			sessVars.GetWriteStmtBufs().BufStore = kv.NewBufferStore(e.ctx.Txn(), kv.TempTxnMemBufCap)
 		}
 	}

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -152,7 +152,7 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		Params:        sorter.markers,
 		SchemaVersion: e.is.SchemaMetaVersion(),
 	}
-	prepared.UseCache = plan.PreparedPlanCacheEnabled() && (vars.ImportingData || plan.Cacheable(stmt))
+	prepared.UseCache = plan.PreparedPlanCacheEnabled() && (vars.LightningMode || plan.Cacheable(stmt))
 
 	// We try to build the real statement of preparedStmt.
 	for i := range prepared.Params {

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -89,7 +89,7 @@ func (e *ReplaceExec) addRow(row []types.Datum) (int64, error) {
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	if !e.ctx.GetSessionVars().ImportingData {
+	if !e.ctx.GetSessionVars().LightningMode {
 		e.ctx.StmtAddDirtyTableOP(DirtyTableAddRow, e.Table.Meta().ID, h, row)
 	}
 	return h, nil

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -135,12 +135,6 @@ func (s *testSuite) TestSetVar(c *C) {
 
 	tk.MustExec("set @@character_set_results = NULL")
 
-	c.Assert(vars.ImportingData, IsFalse)
-	tk.MustExec("set @@tidb_import_data = '1'")
-	c.Assert(vars.ImportingData, IsTrue)
-	tk.MustExec("set @@tidb_import_data = '0'")
-	c.Assert(vars.ImportingData, IsFalse)
-
 	// Test set transaction isolation level, which is equivalent to setting variable "tx_isolation".
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))

--- a/session/session.go
+++ b/session/session.go
@@ -151,7 +151,7 @@ func (s *session) DDLOwnerChecker() owner.DDLOwnerChecker {
 }
 
 func (s *session) getMembufCap() int {
-	if s.sessionVars.ImportingData {
+	if s.sessionVars.LightningMode {
 		return kv.ImportingTxnMembufCap
 	}
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -262,8 +262,8 @@ type SessionVars struct {
 
 	/* TiDB system variables */
 
-	// ImportingData is true when importing data.
-	ImportingData bool
+	// LightningMode is true when the lightning use the kvencoder to transfer sql to raw kv.
+	LightningMode bool
 
 	// SkipUTF8Check check on input value.
 	SkipUTF8Check bool
@@ -353,7 +353,7 @@ func (s *SessionVars) GetWriteStmtBufs() *WriteStmtBufs {
 
 // CleanBuffers cleans the temporary bufs
 func (s *SessionVars) CleanBuffers() {
-	if !s.ImportingData {
+	if !s.LightningMode {
 		s.GetWriteStmtBufs().clean()
 	}
 }
@@ -486,8 +486,6 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		if isAutocommit {
 			s.SetStatusFlag(mysql.ServerStatusInTrans, false)
 		}
-	case TiDBImportingData:
-		s.ImportingData = TiDBOptOn(val)
 	case TiDBSkipUTF8Check:
 		s.SkipUTF8Check = TiDBOptOn(val)
 	case TiDBOptAggPushDown:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -619,7 +619,6 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, ErrorCount, "0"},
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
-	{ScopeSession, TiDBImportingData, "0"},
 	{ScopeSession, TiDBOptAggPushDown, boolToIntStr(DefOptAggPushDown)},
 	{ScopeGlobal | ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},
 	{ScopeGlobal, TiDBAutoAnalyzeRatio, strconv.FormatFloat(DefAutoAnalyzeRatio, 'f', -1, 64)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -32,10 +32,6 @@ const (
 	// The value can be a datetime string like '2017-11-11 20:20:20' or a tso string. When this variable is set, the session reads history data of that time.
 	TiDBSnapshot = "tidb_snapshot"
 
-	// tidb_import_data is used for loading data from a dump file, to speed up the loading process.
-	// When the value is set to true, unique index constraint is not checked.
-	TiDBImportingData = "tidb_import_data"
-
 	// tidb_opt_agg_push_down is used to enable/disable the optimizer rule of aggregation push down.
 	TiDBOptAggPushDown = "tidb_opt_agg_push_down"
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -315,7 +315,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "0", nil
 		}
 		return value, ErrWrongValueForVar.GenByArgs(name, value)
-	case AutocommitVar, TiDBImportingData, TiDBSkipUTF8Check, TiDBOptAggPushDown,
+	case AutocommitVar, TiDBSkipUTF8Check, TiDBOptAggPushDown,
 		TiDBOptInSubqUnFolding, TiDBEnableTablePartition,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
 		TiDBBatchDelete:

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -117,26 +117,6 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 
 	c.Assert(SetSessionSystemVar(v, "character_set_results", types.Datum{}), IsNil)
 
-	// Test case for get TiDBImportingData session variable.
-	val, err = GetSessionSystemVar(v, TiDBImportingData)
-	c.Assert(err, IsNil)
-	c.Assert(val, Equals, "0")
-
-	// Test case for tidb_import_data
-	c.Assert(v.ImportingData, IsFalse)
-	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("0"))
-	c.Assert(v.ImportingData, IsFalse)
-	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("1"))
-	c.Assert(v.ImportingData, IsTrue)
-	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("0"))
-	c.Assert(v.ImportingData, IsFalse)
-
-	// Test case for change TiDBImportingData session variable.
-	SetSessionSystemVar(v, TiDBImportingData, types.NewStringDatum("1"))
-	val, err = GetSessionSystemVar(v, TiDBImportingData)
-	c.Assert(err, IsNil)
-	c.Assert(val, Equals, "1")
-
 	// Test case for time_zone session variable.
 	tests := []struct {
 		input        string

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -192,7 +192,7 @@ func (c *index) GenIndexKey(sc *stmtctx.StatementContext, indexedValues []types.
 // Create will return the existing entry's handle as the first return value, ErrKeyExists as the second return value.
 func (c *index) Create(ctx sessionctx.Context, rm kv.RetrieverMutator, indexedValues []types.Datum, h int64) (int64, error) {
 	writeBufs := ctx.GetSessionVars().GetWriteStmtBufs()
-	skipCheck := ctx.GetSessionVars().ImportingData || ctx.GetSessionVars().StmtCtx.BatchCheck
+	skipCheck := ctx.GetSessionVars().LightningMode || ctx.GetSessionVars().StmtCtx.BatchCheck
 	key, distinct, err := c.GenIndexKey(ctx.GetSessionVars().StmtCtx, indexedValues, h, writeBufs.IndexKeyBuf)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -243,7 +243,7 @@ func (e *kvEncoder) initial(dbName string, idAlloc autoid.Allocator) (err error)
 	}
 
 	se.GetSessionVars().IDAllocator = idAlloc
-	se.GetSessionVars().ImportingData = true
+	se.GetSessionVars().LightningMode = true
 	se.GetSessionVars().SkipUTF8Check = true
 	e.se = se
 	e.store = storeGlobal

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -156,7 +156,7 @@ func (c *Context) InitTxnWithStartTS(startTS uint64) error {
 	}
 	if c.Store != nil {
 		membufCap := kv.DefaultTxnMembufCap
-		if c.sessionVars.ImportingData {
+		if c.sessionVars.LightningMode {
 			membufCap = kv.ImportingTxnMembufCap
 		}
 		txn, err := c.Store.BeginWithStartTS(startTS)


### PR DESCRIPTION

## What have you changed? (mandatory)

Remove the dangerous, error-prone variable `tidb_import_data`. The variable is useless. And rename `SessionVars.ImportingData` to `LightningMode`, make the code more readable.

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

exists tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

yes

```
remove variable 'tidb_import_data'
```


## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

