### PR TITLE
Support showing currently running jobs when executing "admin show ddl"

### DIFF
--- a/ddl/stat.go
+++ b/ddl/stat.go
@@ -65,23 +65,26 @@ func (d *ddl) Stats(vars *variable.SessionVars) (map[string]interface{}, error) 
 
 	m[ddlSchemaVersion] = ddlInfo.SchemaVer
 	// TODO: Get the owner information.
-	if ddlInfo.Job != nil {
-		m[ddlJobID] = ddlInfo.Job.ID
-		m[ddlJobAction] = ddlInfo.Job.Type.String()
-		m[ddlJobStartTS] = ddlInfo.Job.StartTS / 1e9 // unit: second
-		m[ddlJobState] = ddlInfo.Job.State.String()
-		m[ddlJobRows] = ddlInfo.Job.RowCount
-		if ddlInfo.Job.Error == nil {
-			m[ddlJobError] = ""
-		} else {
-			m[ddlJobError] = ddlInfo.Job.Error.Error()
-		}
-		m[ddlJobSchemaState] = ddlInfo.Job.SchemaState.String()
-		m[ddlJobSchemaID] = ddlInfo.Job.SchemaID
-		m[ddlJobTableID] = ddlInfo.Job.TableID
-		m[ddlJobSnapshotVer] = ddlInfo.Job.SnapshotVer
-		m[ddlJobReorgHandle] = ddlInfo.ReorgHandle
-		m[ddlJobArgs] = ddlInfo.Job.Args
+	if len(ddlInfo.Jobs) == 0 {
+		return m, nil
 	}
+	// TODO: Add all job infromation if needed.
+	job := ddlInfo.Jobs[0]
+	m[ddlJobID] = job.ID
+	m[ddlJobAction] = job.Type.String()
+	m[ddlJobStartTS] = job.StartTS / 1e9 // unit: second
+	m[ddlJobState] = job.State.String()
+	m[ddlJobRows] = job.RowCount
+	if job.Error == nil {
+		m[ddlJobError] = ""
+	} else {
+		m[ddlJobError] = job.Error.Error()
+	}
+	m[ddlJobSchemaState] = job.SchemaState.String()
+	m[ddlJobSchemaID] = job.SchemaID
+	m[ddlJobTableID] = job.TableID
+	m[ddlJobSnapshotVer] = job.SnapshotVer
+	m[ddlJobReorgHandle] = ddlInfo.ReorgHandle
+	m[ddlJobArgs] = job.Args
 	return m, nil
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -199,13 +199,17 @@ func (e *ShowDDLExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return nil
 	}
 
-	ddlJob := ""
-	if e.ddlInfo.Job != nil {
-		ddlJob = e.ddlInfo.Job.String()
+	ddlJobs := ""
+	l := len(e.ddlInfo.Jobs)
+	for i, job := range e.ddlInfo.Jobs {
+		ddlJobs += job.String()
+		if i != l-1 {
+			ddlJobs += "\n"
+		}
 	}
 	chk.AppendInt64(0, e.ddlInfo.SchemaVer)
 	chk.AppendString(1, e.ddlOwnerID)
-	chk.AppendString(2, ddlJob)
+	chk.AppendString(2, ddlJobs)
 	chk.AppendString(3, e.selfID)
 	e.done = true
 	return nil

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -463,7 +463,7 @@ var (
 type JobListKeyType []byte
 
 var (
-	// DefaultJobListKey keeps all actions of DDL jobs.
+	// DefaultJobListKey keeps all actions of DDL jobs except "add index".
 	DefaultJobListKey JobListKeyType = mDDLJobListKey
 	// AddIndexJobListKey only keeps the action of adding index.
 	AddIndexJobListKey JobListKeyType = mDDLJobAddIdxList

--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -639,7 +639,7 @@ func buildShowDDLFields() *expression.Schema {
 	schema := expression.NewSchema(make([]*expression.Column, 0, 4)...)
 	schema.Append(buildColumn("", "SCHEMA_VER", mysql.TypeLonglong, 4))
 	schema.Append(buildColumn("", "OWNER", mysql.TypeVarchar, 64))
-	schema.Append(buildColumn("", "JOB", mysql.TypeVarchar, 128))
+	schema.Append(buildColumn("", "RUNNING_JOBS", mysql.TypeVarchar, 256))
 	schema.Append(buildColumn("", "SELF_ID", mysql.TypeVarchar, 64))
 
 	return schema

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -37,8 +37,8 @@ import (
 // DDLInfo is for DDL information.
 type DDLInfo struct {
 	SchemaVer   int64
-	ReorgHandle int64 // it's only used for DDL information.
-	Job         *model.Job
+	ReorgHandle int64        // It's only used for DDL information.
+	Jobs        []*model.Job // It's the currently running jobs.
 }
 
 // GetDDLInfo returns DDL information.
@@ -47,19 +47,31 @@ func GetDDLInfo(txn kv.Transaction) (*DDLInfo, error) {
 	info := &DDLInfo{}
 	t := meta.NewMeta(txn)
 
-	info.Job, err = t.GetDDLJobByIdx(0)
+	info.Jobs = make([]*model.Job, 0, 2)
+	job, err := t.GetDDLJobByIdx(0)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	if job != nil {
+		info.Jobs = append(info.Jobs, job)
+	}
+	addIdxJob, err := t.GetDDLJobByIdx(0, meta.AddIndexJobListKey)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if addIdxJob != nil {
+		info.Jobs = append(info.Jobs, addIdxJob)
+	}
+
 	info.SchemaVer, err = t.GetSchemaVersion()
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if info.Job == nil {
+	if addIdxJob == nil {
 		return info, nil
 	}
 
-	info.ReorgHandle, _, _, err = t.GetDDLReorgHandle(info.Job)
+	info.ReorgHandle, _, _, err = t.GetDDLReorgHandle(addIdxJob)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## What have you changed? (mandatory)
After merging the PR of "preliminary support for the parallel DDL operation", the SQL that "admin show ddl" only can show the general jobs(except "add index" job). 
This PR can also support showing "add index" jobs. Fix #7273.

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

Yes
## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No.
## Does this PR affect tidb-ansible update? (mandatory)

No.
## Does this PR need to be added to the release notes? (mandatory)

No.

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

