### PR TITLE
ddl: add fsp checking for time/timestamp/datetime column definition

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1739,6 +1739,26 @@ func (s *testDBSuite) TestTableDDLWithFloatType(c *C) {
 	s.mustExec(c, "drop table t")
 }
 
+func (s *testDBSuite) TestTableDDLWithTimeType(c *C) {
+	s.tk.MustExec("use test")
+	s.tk.MustExec("drop table if exists t")
+	s.testErrorCode(c, "create table t (a time(7))", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "create table t (a datetime(7))", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "create table t (a timestamp(7))", tmysql.ErrTooBigPrecision)
+	s.mustExec(c, "create table t (a datetime)")
+	s.testErrorCode(c, "alter table t add column b time(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t add column b datetime(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t add column b timestamp(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t modify column a time(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t modify column a datetime(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t modify column a timestamp(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t change column a aa time(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t change column a aa datetime(7)", tmysql.ErrTooBigPrecision)
+	s.testErrorCode(c, "alter table t change column a aa timestamp(7)", tmysql.ErrTooBigPrecision)
+	s.mustExec(c, "alter table t change column a aa timestamp(0)")
+	s.mustExec(c, "drop table t")
+}
+
 func (s *testDBSuite) TestTruncateTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1745,6 +1745,8 @@ func (s *testDBSuite) TestTableDDLWithTimeType(c *C) {
 	s.testErrorCode(c, "create table t (a time(7))", tmysql.ErrTooBigPrecision)
 	s.testErrorCode(c, "create table t (a datetime(7))", tmysql.ErrTooBigPrecision)
 	s.testErrorCode(c, "create table t (a timestamp(7))", tmysql.ErrTooBigPrecision)
+	_, err := s.tk.Exec("create table t (a time(-1))")
+	c.Assert(err, NotNil)
 	s.mustExec(c, "create table t (a datetime)")
 	s.testErrorCode(c, "alter table t add column b time(7)", tmysql.ErrTooBigPrecision)
 	s.testErrorCode(c, "alter table t add column b datetime(7)", tmysql.ErrTooBigPrecision)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -597,22 +597,26 @@ func checkTooManyColumns(colDefs []*ast.ColumnDef) error {
 	return nil
 }
 
-// checkPointTypeColumns checks multiple decimal/float/double columns.
-func checkPointTypeColumns(colDefs []*ast.ColumnDef) error {
+// checkColumnsAttributes checks attributes for multiple columns.
+func checkColumnsAttributes(colDefs []*ast.ColumnDef) error {
 	for _, colDef := range colDefs {
-		if err := checkPointTypeColumn(colDef.Name.OrigColName(), colDef.Tp); err != nil {
+		if err := checkColumnAttribute(colDef.Name.OrigColName(), colDef.Tp); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-// checkPointTypeColumn checks a decimal/float/double column.
-func checkPointTypeColumn(colName string, tp *types.FieldType) error {
+// checkColumnAttribute check attributes for single column.
+func checkColumnAttribute(colName string, tp *types.FieldType) error {
 	switch tp.Tp {
 	case mysql.TypeNewDecimal, mysql.TypeDouble, mysql.TypeFloat:
 		if tp.Flen < tp.Decimal {
 			return types.ErrMBiggerThanD.GenByArgs(colName)
+		}
+	case mysql.TypeDatetime, mysql.TypeDuration, mysql.TypeTimestamp:
+		if tp.Decimal != types.UnspecifiedFsp && (tp.Decimal < types.MinFsp || tp.Decimal > types.MaxFsp) {
+			return types.ErrTooBigPrecision.GenByArgs(tp.Decimal, colName, types.MaxFsp)
 		}
 	}
 	return nil
@@ -871,7 +875,7 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 		return errors.Trace(err)
 	}
 
-	if err = checkPointTypeColumns(colDefs); err != nil {
+	if err = checkColumnsAttributes(colDefs); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1193,7 +1197,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 	}
 
 	colName := specNewColumn.Name.Name.O
-	if err = checkPointTypeColumn(colName, specNewColumn.Tp); err != nil {
+	if err = checkColumnAttribute(colName, specNewColumn.Tp); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1569,7 +1573,7 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
 
-	if err = checkPointTypeColumn(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
+	if err = checkColumnAttribute(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -600,15 +600,15 @@ func checkTooManyColumns(colDefs []*ast.ColumnDef) error {
 // checkColumnsAttributes checks attributes for multiple columns.
 func checkColumnsAttributes(colDefs []*ast.ColumnDef) error {
 	for _, colDef := range colDefs {
-		if err := checkColumnAttribute(colDef.Name.OrigColName(), colDef.Tp); err != nil {
+		if err := checkColumnAttributes(colDef.Name.OrigColName(), colDef.Tp); err != nil {
 			return errors.Trace(err)
 		}
 	}
 	return nil
 }
 
-// checkColumnAttribute check attributes for single column.
-func checkColumnAttribute(colName string, tp *types.FieldType) error {
+// checkColumnAttributes check attributes for single column.
+func checkColumnAttributes(colName string, tp *types.FieldType) error {
 	switch tp.Tp {
 	case mysql.TypeNewDecimal, mysql.TypeDouble, mysql.TypeFloat:
 		if tp.Flen < tp.Decimal {
@@ -1197,7 +1197,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 	}
 
 	colName := specNewColumn.Name.Name.O
-	if err = checkColumnAttribute(colName, specNewColumn.Tp); err != nil {
+	if err = checkColumnAttributes(colName, specNewColumn.Tp); err != nil {
 		return errors.Trace(err)
 	}
 
@@ -1573,7 +1573,7 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 		return nil, errors.Trace(errUnsupportedModifyColumn)
 	}
 
-	if err = checkColumnAttribute(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
+	if err = checkColumnAttributes(specNewColumn.Name.OrigColName(), specNewColumn.Tp); err != nil {
 		return nil, errors.Trace(err)
 	}
 


### PR DESCRIPTION
## What have you changed? (mandatory)

- rename `checkPointTypeColumn` to `checkColumnAttribute`
- add fsp check for time/datetime/timestamp in `checkColumnAttribute`

## What is the type of the changes? (mandatory)

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)

- unit tests
- integration tests

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

no

## Does this PR affect tidb-ansible update? (mandatory)

no

## Does this PR need to be added to the release notes? (mandatory)

```
add fsp checking for time/timestamp/datetime column definition
```
-->

## Add a few positive/negative examples (optional)

```
create table pa(d time(7));
```
expect:

```
ERROR 1426 (42000): Too-big precision 7 specified for 'd'. Maximum is 6.
```
but got:

```
Query OK, 0 rows affected(0.12 sec)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7294)
<!-- Reviewable:end -->
