### PR TITLE
plan: make `USE INDEX(`PRIMARY`)` works on the integer primary key

### DIFF
--- a/plan/planbuilder.go
+++ b/plan/planbuilder.go
@@ -267,13 +267,25 @@ func (b *planBuilder) detectSelectAgg(sel *ast.SelectStmt) bool {
 	return false
 }
 
-func getPathByIndexName(paths []*accessPath, idxName model.CIStr) *accessPath {
+func getPathByIndexName(paths []*accessPath, idxName model.CIStr, tblInfo *model.TableInfo) *accessPath {
+	var tablePath *accessPath
 	for _, path := range paths {
+		if path.isTablePath {
+			tablePath = path
+			continue
+		}
 		if path.index.Name.L == idxName.L {
 			return path
 		}
 	}
+	if isPrimaryIndexHint(idxName) && tblInfo.PKIsHandle {
+		return tablePath
+	}
 	return nil
+}
+
+func isPrimaryIndexHint(indexName model.CIStr) bool {
+	return indexName.L == "primary"
 }
 
 func getPossibleAccessPaths(indexHints []*ast.IndexHint, tblInfo *model.TableInfo) ([]*accessPath, error) {
@@ -295,7 +307,7 @@ func getPossibleAccessPaths(indexHints []*ast.IndexHint, tblInfo *model.TableInf
 
 		hasScanHint = true
 		for _, idxName := range hint.IndexNames {
-			path := getPathByIndexName(publicPaths[1:], idxName)
+			path := getPathByIndexName(publicPaths, idxName, tblInfo)
 			if path == nil {
 				return nil, ErrKeyDoesNotExist.GenByArgs(idxName, tblInfo.Name)
 			}
@@ -316,7 +328,7 @@ func getPossibleAccessPaths(indexHints []*ast.IndexHint, tblInfo *model.TableInf
 		available = publicPaths
 	}
 
-	available = removeIgnoredPaths(available, ignored)
+	available = removeIgnoredPaths(available, ignored, tblInfo)
 
 	// If we have got "FORCE" or "USE" index hint but got no available index,
 	// we have to use table scan.
@@ -326,13 +338,13 @@ func getPossibleAccessPaths(indexHints []*ast.IndexHint, tblInfo *model.TableInf
 	return available, nil
 }
 
-func removeIgnoredPaths(paths, ignoredPaths []*accessPath) []*accessPath {
+func removeIgnoredPaths(paths, ignoredPaths []*accessPath, tblInfo *model.TableInfo) []*accessPath {
 	if len(ignoredPaths) == 0 {
 		return paths
 	}
 	remainedPaths := make([]*accessPath, 0, len(paths))
 	for _, path := range paths {
-		if path.isTablePath || getPathByIndexName(ignoredPaths, path.index.Name) == nil {
+		if path.isTablePath || getPathByIndexName(ignoredPaths, path.index.Name, tblInfo) == nil {
 			remainedPaths = append(remainedPaths, path)
 		}
 	}

--- a/plan/planbuilder_test.go
+++ b/plan/planbuilder_test.go
@@ -16,6 +16,7 @@ package plan
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/model"
 )
 
 var _ = Suite(&testPlanBuilderSuite{})
@@ -55,4 +56,35 @@ func (s *testPlanBuilderSuite) TestShow(c *C) {
 			c.Assert(col.RetType.Flen, Greater, 0)
 		}
 	}
+}
+
+func (s *testPlanBuilderSuite) TestGetPathByIndexName(c *C) {
+	tblInfo := &model.TableInfo{
+		Indices:    make([]*model.IndexInfo, 0),
+		PKIsHandle: true,
+	}
+
+	accessPath := []*accessPath{
+		&accessPath{isTablePath: true},
+		&accessPath{index: &model.IndexInfo{Name: model.NewCIStr("idx")}},
+	}
+
+	path := getPathByIndexName(accessPath, model.NewCIStr("idx"), tblInfo)
+	c.Assert(path, NotNil)
+	c.Assert(path, Equals, accessPath[1])
+
+	path = getPathByIndexName(accessPath, model.NewCIStr("primary"), tblInfo)
+	c.Assert(path, NotNil)
+	c.Assert(path, Equals, accessPath[0])
+
+	path = getPathByIndexName(accessPath, model.NewCIStr("not exists"), tblInfo)
+	c.Assert(path, IsNil)
+
+	tblInfo = &model.TableInfo{
+		Indices:    make([]*model.IndexInfo, 0),
+		PKIsHandle: false,
+	}
+
+	path = getPathByIndexName(accessPath, model.NewCIStr("primary"), tblInfo)
+	c.Assert(path, IsNil)
 }


### PR DESCRIPTION
## What have you changed? (mandatory)

Take this as an example:
```sql
TiDB(localhost:4000) > create table t(a bigint primary key);
Query OK, 0 rows affected (0.11 sec)

TiDB(localhost:4000) > select * from t use index(`primary`) where a = 1;
ERROR 1176 (42000): Key 'primary' doesn't exist in table 't'

TiDB(localhost:4000) > explain select * from t ignore index(`primary`) where a = 1;
ERROR 1176 (42000): Key 'primary' doesn't exist in table 't'
```

This PR fixes this issue, makes the `use index(primary)` works when the primary key is an integer column. After this PR:
```sql
TiDB(localhost:4000) > explain select * from t use index(`primary`) where a = 1;
+-------------------+-------+------+------------------------------------------------------+
| id                | count | task | operator info                                        |
+-------------------+-------+------+------------------------------------------------------+
| TableReader_6     | 1.00  | root | data:TableScan_5                                     |
| └─TableScan_5     | 1.00  | cop  | table:t, range:[1,1], keep order:false, stats:pseudo |
+-------------------+-------+------+------------------------------------------------------+
2 rows in set (0.01 sec)

TiDB(localhost:4000) > explain select * from t ignore index(`primary`) where a = 1;
+-------------------+-------+------+------------------------------------------------------+
| id                | count | task | operator info                                        |
+-------------------+-------+------+------------------------------------------------------+
| TableReader_6     | 1.00  | root | data:TableScan_5                                     |
| └─TableScan_5     | 1.00  | cop  | table:t, range:[1,1], keep order:false, stats:pseudo |
+-------------------+-------+------+------------------------------------------------------+
2 rows in set (0.00 sec)
```

## What is the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

- existing tests
- newly added unit test

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)

```
release note:
Fix the the primary key doesn't exist error when the primary key is the table handle.
```

## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

