### PR TITLE
executor: skip inner rows when the join keys contains NULL (#7255)

### DIFF
--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -532,6 +532,10 @@ func (iw *innerWorker) buildLookUpMap(task *lookUpJoinTask) error {
 		chk := task.innerResult.GetChunk(i)
 		for j := 0; j < chk.NumRows(); j++ {
 			innerRow := chk.GetRow(j)
+			if iw.hasNullInJoinKey(innerRow) {
+				continue
+			}
+
 			keyBuf = keyBuf[:0]
 			for _, keyCol := range iw.keyCols {
 				d := innerRow.GetDatum(keyCol, iw.rowTypes[keyCol])
@@ -547,6 +551,15 @@ func (iw *innerWorker) buildLookUpMap(task *lookUpJoinTask) error {
 		}
 	}
 	return nil
+}
+
+func (iw *innerWorker) hasNullInJoinKey(row chunk.Row) bool {
+	for _, ordinal := range iw.keyCols {
+		if row.IsNull(ordinal) {
+			return true
+		}
+	}
+	return false
 }
 
 // Close implements the Executor interface.


### PR DESCRIPTION
## What have you changed? (mandatory)

cherry-pick #7255 to release-2.0

## What is the type of the changes? (mandatory)

- Bug fix (non-breaking change which fixes an issue)

## How has this PR been tested? (mandatory)

- existing test
- newly add UT

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)



An example:
```
release note:
Fix the wrong behavior of `Merge Join` and `Index Join` in a special scenario.
```

