### PR TITLE
 executor: fix group_concat when chunk size is set to 1

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -275,6 +275,10 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk.MustQuery("select 10 from idx_agg group by b").Check(testkit.Rows("10", "10"))
 	tk.MustQuery("select 11 from idx_agg group by a").Check(testkit.Rows("11", "11"))
 
+	tk.MustExec("set @@tidb_max_chunk_size=1;")
+	tk.MustQuery("select group_concat(b) from idx_agg group by b;").Check(testkit.Rows("1", "2,2"))
+	tk.MustExec("set @@tidb_max_chunk_size=2;")
+
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int(11), b decimal(15,2))")
 	tk.MustExec("insert into t values(1,771.64),(2,378.49),(3,920.92),(4,113.97)")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
Before this PR, the following sql would return wrong result.
``` sql
create table idx_agg (a int, b int, index (b));
insert idx_agg values (1, 1), (1, 2), (2, 2);
set @@tidb_max_chunk_size=1;
tidb> select group_concat(b) from idx_agg group by b;
+-----------------+
| group_concat(b) |
+-----------------+
| 1              |
| 22            |
+-----------------+
```
The PR fix the problem:
``` sql
tidb> select group_concat(b) from idx_agg group by b;
+-----------------+
| group_concat(b) |
+-----------------+
| 1             |
| 2,2         |
+-----------------+
2 rows in set (0.00 sec)
```
How does this bug occur？

This bug is caused by [this line](https://github.com/pingcap/tidb/blob/master/executor/aggfuncs/func_group_concat.go#L107).
When max_chunk_size is set to 1, [rowInGroup](https://github.com/pingcap/tidb/blob/master/executor/aggfuncs/func_group_concat.go#L83) pass into the function
contains only 1 row every time. As we can see, separator be appended
 [here](https://github.com/pingcap/tidb/blob/master/executor/aggfuncs/func_group_concat.go#L102-L104) would be truncated out of the loop.

How does this bug be fixed?

This commit first check whether `p.buffer != nil`, which means we've 
got part of the result for a group, if it's true, we'll append separator at 
the end of p.buffer. Through this, we can avoid truncating separator 
wrongly. Then we append the string be consist of the values. If 
this string is null, we'll truncated the separator which is appended at 
the first.


<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (mandatory)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Separately describe each logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume reviewers understand the original issue
-->

## What is the type of the changes? (mandatory)
Bug-fix

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->

## How has this PR been tested? (mandatory)
unit test

<!--
Please describe the tests that you ran to verify your changes.
Have you finished unit tests, integration tests, or manual tests?
What additional tests would give you greater confidence in this change?
-->

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) or [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->

## Does this PR affect tidb-ansible update? (mandatory)
no
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->

## Does this PR need to be added to the release notes? (mandatory)
no
<!--
If this PR needs to be added to the release notes, please:
1. add the "**release-note**" label for this PR
2. write your release note in the below block
3. if the PR requires additional action from users switching to the new
   release, describe the concrete action that users need to take in detail.

An example:
```
release note:
// put your release notes for this PR here.

action required:
// put your required action in detail here.
```
-->


## Refer to a related PR or issue link (optional)

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

