### PR TITLE
util/charset: Add utf8mb4 as alias for utf8

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -877,7 +877,7 @@ func (s *testIntegrationSuite) TestStringBuiltin(c *C) {
 
 	// for convert
 	result = tk.MustQuery(`select convert("123" using "866"), convert("123" using "binary"), convert("中文" using "binary"), convert("中文" using "utf8"), convert("中文" using "utf8mb4"), convert(cast("中文" as binary) using "utf8");`)
-	result.Check(testkit.Rows("123 123 中文 中文 中文"))
+	result.Check(testkit.Rows("123 123 中文 中文 中文 中文"))
 
 	// for insert
 	result = tk.MustQuery(`select insert("中文", 1, 1, cast("aaa" as binary)), insert("ba", -1, 1, "aaa"), insert("ba", 1, 100, "aaa"), insert("ba", 100, 1, "aaa");`)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -876,7 +876,7 @@ func (s *testIntegrationSuite) TestStringBuiltin(c *C) {
 	result.Check(testkit.Rows("'121' '0' '中文' <nil>"))
 
 	// for convert
-	result = tk.MustQuery(`select convert("123" using "866"), convert("123" using "binary"), convert("中文" using "binary"), convert("中文" using "utf8"), convert(cast("中文" as binary) using "utf8");`)
+	result = tk.MustQuery(`select convert("123" using "866"), convert("123" using "binary"), convert("中文" using "binary"), convert("中文" using "utf8"), convert("中文" using "utf8mb4"), convert(cast("中文" as binary) using "utf8");`)
 	result.Check(testkit.Rows("123 123 中文 中文 中文"))
 
 	// for insert

--- a/util/charset/encoding_table.go
+++ b/util/charset/encoding_table.go
@@ -42,6 +42,7 @@ var encodings = map[string]struct {
 	"unicode-1-1-utf-8":   {encoding.Nop, "utf-8"},
 	"utf-8":               {encoding.Nop, "utf-8"},
 	"utf8":                {encoding.Nop, "utf-8"},
+	"utf8mb4":             {encoding.Nop, "utf-8"},
 	"binary":              {encoding.Nop, "binary"},
 	"866":                 {charmap.CodePage866, "ibm866"},
 	"cp866":               {charmap.CodePage866, "ibm866"},


### PR DESCRIPTION
Supports applications which directly change to utf8mb4 charset.
Safe for TiDB to treat both as the same.
Fixes #7267

## What have you changed? (mandatory)

Added an alias for utf8mb4 as a character set. It is treated the same as utf8.

## What is the type of the changes? (mandatory)

Bug fix/compatibility improvement.

## How has this PR been tested? (mandatory)
Manual testing:

```
mysql> SELECT CONVERT( CONVERT( 'xxx' USING ascii ) USING utf8mb4 ) AS xxx;
+------+
| xxx  |
+------+
| xxx  |
+------+
1 row in set (0.00 sec)
```

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)

```
Release note: Compatibility fix: utf8mb4 has been added as an alias for utf8.
```

## Refer to a related PR or issue link (optional)

Fixes #7267

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)