### PR TITLE
table: fix show index for the partitioned table

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -3141,6 +3141,18 @@ func (s *testDBSuite) TestPartitionAddIndex(c *C) {
 
 	tk.MustExec("alter table partition_add_idx add index idx1 (hired)")
 	tk.MustExec("alter table partition_add_idx add index idx2 (id, hired)")
+	ctx := s.tk.Se.(sessionctx.Context)
+	is := domain.GetDomain(ctx).InfoSchema()
+	t, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("partition_add_idx"))
+	c.Assert(err, IsNil)
+	var idx1 table.Index
+	for _, pidx := range t.Indices() {
+		if pidx.Meta().Name.L == "idx1" {
+			idx1 = pidx
+			break
+		}
+	}
+	c.Assert(idx1, NotNil)
 
 	tk.MustQuery("select count(hired) from partition_add_idx use index(idx1)").Check(testkit.Rows("500"))
 	tk.MustQuery("select count(id) from partition_add_idx use index(idx2)").Check(testkit.Rows("500"))

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -81,10 +81,10 @@ func MockTableFromMeta(tblInfo *model.TableInfo) table.Table {
 
 	var t Table
 	initTableCommon(&t.tableCommon, tblInfo, tblInfo.ID, columns, nil)
+	if err := initTableIndices(&t.tableCommon); err != nil {
+		return nil
+	}
 	if tblInfo.GetPartitionInfo() == nil {
-		if err := initTableIndices(&t.tableCommon); err != nil {
-			return nil
-		}
 		return &t
 	}
 
@@ -130,10 +130,10 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 
 	var t Table
 	initTableCommon(&t.tableCommon, tblInfo, tblInfo.ID, columns, alloc)
+	if err := initTableIndices(&t.tableCommon); err != nil {
+		return nil, errors.Trace(err)
+	}
 	if tblInfo.GetPartitionInfo() == nil {
-		if err := initTableIndices(&t.tableCommon); err != nil {
-			return nil, errors.Trace(err)
-		}
 		return &t, nil
 	}
 


### PR DESCRIPTION
## What have you changed? (mandatory)
* fix show index for the partitioned table.
* Fix issue #7345

master branch
```sql
mysql> set @@tidb_enable_table_partition = 1;
Query OK, 0 rows affected (0.00 sec)

mysql> create table partition_drop_idx (
    ->         c1 int, c2 int, c3 int
    ->     )
    ->     partition by range( c1 ) (
    ->         partition p0 values less than (1990),
    ->         partition p1 values less than (1995),
    ->         partition p2 values less than (2000),
    ->         partition p3 values less than (2005),
    ->         partition p4 values less than (2010),
    ->         partition p5 values less than (2015)
    ->        );
Query OK, 0 rows affected (0.12 sec)

mysql> alter table partition_drop_idx add index idx1 (c1);
Query OK, 0 rows affected (0.04 sec)
mysql> show index from  partition_drop_idx;
Query OK, 0 rows affected (0.04 sec)
```

show-index branch

```sql
mysql> set @@tidb_enable_table_partition = 1;
Query OK, 0 rows affected (0.00 sec)

mysql> create table partition_drop_idx (
    ->         c1 int, c2 int, c3 int
    ->     )
    ->     partition by range( c1 ) (
    ->         partition p0 values less than (1990),
    ->         partition p1 values less than (1995),
    ->         partition p2 values less than (2000),
    ->         partition p3 values less than (2005),
    ->         partition p4 values less than (2010),
    ->         partition p5 values less than (2015)
    ->        );
Query OK, 0 rows affected (0.12 sec)

mysql> alter table partition_drop_idx add index idx1 (c1);
Query OK, 0 rows affected (0.04 sec)
mysql> show index from  partition_drop_idx;
+--------------------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| Table              | Non_unique | Key_name | Seq_in_index | Column_name | Collation | Cardinality | Sub_part | Packed | Null | Index_type | Comment | Index_comment |
+--------------------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
| partition_drop_idx |          1 | idx1     |            1 | c1          | A         |           0 |     NULL | NULL   | YES  | BTREE      |         |               |
+--------------------+------------+----------+--------------+-------------+-----------+-------------+----------+--------+------+------------+---------+---------------+
1 row in set (0.00 sec)
```
## What is the type of the changes? (mandatory)

Bug fix
- New feature (non-breaking change which adds functionality)
- Improvement (non-breaking change which is an improvement to an existing feature)
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this PR been tested? (mandatory)
 No

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)

No

## Does this PR affect tidb-ansible update? (mandatory)

No

## Does this PR need to be added to the release notes? (mandatory)
No



