### PR TITLE
plan: fix a bug when using correlated column as index

### DIFF
--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -485,13 +485,14 @@ func (path *accessPath) splitCorColAccessCondFromFilters() (access, remained []e
 		matched := false
 		for j, filter := range path.tableFilters {
 			if !isColEqCorColOrConstant(filter, path.idxCols[i]) {
-				break
+				continue
 			}
 			matched = true
 			access[i-path.eqCondCount] = filter
 			if path.idxColLens[i] == types.UnspecifiedLength {
 				used[j] = true
 			}
+			break
 		}
 		if !matched {
 			access = access[:i-path.eqCondCount]

--- a/plan/logical_plans.go
+++ b/plan/logical_plans.go
@@ -484,7 +484,7 @@ func (path *accessPath) splitCorColAccessCondFromFilters() (access, remained []e
 	for i := path.eqCondCount; i < len(path.idxCols); i++ {
 		matched := false
 		for j, filter := range path.tableFilters {
-			if !isColEqCorColOrConstant(filter, path.idxCols[i]) {
+			if used[j] || !isColEqCorColOrConstant(filter, path.idxCols[i]) {
 				continue
 			}
 			matched = true


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The for loop was wrongly breaked. Hence there may be case that we misjudged.

In the for loop, we check that whether this index column have corresponding equal condition which has correlated column.
So we should break once we found it. If one condition is not matched, we should continue to next condition rather than breaking the loop.

### What is changed and how it works?

Break the for loop at the correct position.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Will be added later.

Related changes

 - Need to be included in the release note

Fix the case that index may not use correlated column correctly.
