### PR TITLE
sessionctx: supports `set character_set_results = null`

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -133,7 +133,8 @@ func (s *testSuite) TestSetVar(c *C) {
 	c.Assert(charset, Equals, "utf8")
 	c.Assert(collation, Equals, "utf8_bin")
 
-	tk.MustExec("set @@character_set_results = NULL")
+	tk.MustExec("set character_set_results = NULL")
+	tk.MustQuery("select @@character_set_results").Check(testkit.Rows(""))
 
 	// Test set transaction isolation level, which is equivalent to setting variable "tx_isolation".
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -127,12 +127,11 @@ func SetSessionSystemVar(vars *SessionVars, name string, value types.Datum) erro
 	if sysVar == nil {
 		return UnknownSystemVar
 	}
-	if value.IsNull() {
-		return vars.deleteSystemVar(name)
-	}
-	var sVal string
+	sVal := ""
 	var err error
-	sVal, err = value.ToString()
+	if !value.IsNull() {
+		sVal, err = value.ToString()
+	}
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

## What have you changed? (mandatory)
When tidb executes "set character_set_results = null", it will delete "character_set_results" variable because we set it to null. (see executor/set.go:79)  

    if value.IsNull() {
        	delete(sessionVars.Users, name)
    }
This will delete "character_set_results". When we use show variable to show it, executor can not find it.
Then ShowExecutor will go to variable.SysVars to find its default value.  (see executor/show.go:434)

    varValue, ok := systemVars[varName]
    if !ok {
        varValue = variable.SysVars[varName].Value
    }
Originally, variable.SysVars["character_set_results"] is "latin1", so the return value of "show variables where variable_name='character_set_results'" is "latin1". But "character_set_results" in TiDB is always "utf8", set variable can not effect it. 

This PR just fix compatibility with mysql when execute "set character_set_results = null". 
<!--
Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
- Summarize your change (mandatory)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Separately describe each logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

Please **NOTE** that:
- Do not assume reviewers understand the original issue
-->

## What is the type of the changes? (mandatory)

<!--
The currently defined types are listed below, please pick one of the types for this PR by removing the others.
-->

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested? (mandatory)
unit test

After change:

    mysql> set character_set_results = null;
    Query OK, 0 rows affected (0.00 sec)

    mysql> show variables where variable_name='character_set_results';
    +-----------------------+-------+
    | Variable_name         | Value |
    +-----------------------+-------+
    | character_set_results |       |
    +-----------------------+-------+
    1 row in set (0.01 sec)

<!--
Please describe the tests that you ran to verify your changes.
Have you finished unit tests, integration tests, or manual tests?
What additional tests would give you greater confidence in this change?
-->

## Does this PR affect documentation (docs/docs-cn) update? (mandatory)
No
<!--
If there is document change, please file a PR in ([docs](https://github.com/pingcap/docs) or [docs-cn](https://github.com/pingcap/docs-cn)) and add the PR number here.
-->

## Does this PR affect tidb-ansible update? (mandatory)
No
<!--
If there is a configuration or metrics change, please file a PR in [tidb-ansible](https://github.com/pingcap/tidb-ansible), and add the PR number here.
-->

## Does this PR need to be added to the release notes? (mandatory)
No
<!--
If this PR needs to be added to the release notes, please:
1. add the "**release-note**" label for this PR
2. write your release note in the below block
3. if the PR requires additional action from users switching to the new
   release, describe the concrete action that users need to take in detail.

An example:
```
release note:
// put your release notes for this PR here.

action required:
// put your required action in detail here.
```
-->


## Refer to a related PR or issue link (optional)
Fix #7284 

## Benchmark result if necessary (optional)

## Add a few positive/negative examples (optional)

