### PR TITLE
ddl: notify stats worker when truncate table

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -498,7 +498,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionDropForeignKey:
 		ver, err = onDropForeignKey(t, job)
 	case model.ActionTruncateTable:
-		ver, err = onTruncateTable(t, job)
+		ver, err = onTruncateTable(d, t, job)
 	case model.ActionRebaseAutoID:
 		ver, err = onRebaseAutoID(d.store, t, job)
 	case model.ActionRenameTable:

--- a/statistics/ddl.go
+++ b/statistics/ddl.go
@@ -30,7 +30,7 @@ import (
 // HandleDDLEvent begins to process a ddl task.
 func (h *Handle) HandleDDLEvent(t *util.Event) error {
 	switch t.Tp {
-	case model.ActionCreateTable:
+	case model.ActionCreateTable, model.ActionTruncateTable:
 		return h.insertTableStats2KV(t.TableInfo)
 	case model.ActionAddColumn:
 		return h.insertColStats2KV(t.TableInfo.ID, t.ColumnInfo)

--- a/statistics/ddl_test.go
+++ b/statistics/ddl_test.go
@@ -82,6 +82,17 @@ func (s *testStatsCacheSuite) TestDDLTable(c *C) {
 	h.Update(is)
 	statsTbl = h.GetTableStats(tableInfo)
 	c.Assert(statsTbl.Pseudo, IsFalse)
+
+	testKit.MustExec("truncate table t1")
+	is = do.InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
+	c.Assert(err, IsNil)
+	tableInfo = tbl.Meta()
+	err = h.HandleDDLEvent(<-h.DDLEventCh())
+	c.Assert(err, IsNil)
+	h.Update(is)
+	statsTbl = h.GetTableStats(tableInfo)
+	c.Assert(statsTbl.Pseudo, IsFalse)
 }
 
 func (s *testStatsCacheSuite) TestDDLHistogram(c *C) {

--- a/statistics/handle_test.go
+++ b/statistics/handle_test.go
@@ -60,10 +60,10 @@ func cleanEnv(c *C, store kv.Storage, do *domain.Domain) {
 		tableName := tb[0]
 		tk.MustExec(fmt.Sprintf("drop table %v", tableName))
 	}
-	do.StatsHandle().Clear()
 	tk.MustExec("truncate table mysql.stats_meta")
 	tk.MustExec("truncate table mysql.stats_histograms")
 	tk.MustExec("truncate table mysql.stats_buckets")
+	do.StatsHandle().Clear()
 }
 
 func (s *testStatsCacheSuite) TestStatsCache(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When a table is truncated, we would not have stats for it because its table id has changed.

### What is changed and how it works?

Notify stats woker for the truncated table, so we can create new stats for it. The old stats will be garbage collected by stats worker at later time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

- None

Related changes

- None

PTAL @coocood @zz-jason @winoros @zimulala 
