### PR TITLE
variable: modify default max chunk size to 32

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -196,7 +196,7 @@ const (
 	DefBatchInsert                   = false
 	DefBatchDelete                   = false
 	DefCurretTS                      = 0
-	DefMaxChunkSize                  = 1024
+	DefMaxChunkSize                  = 32
 	DefDMLBatchSize                  = 20000
 	DefTiDBMemQuotaHashJoin          = 32 << 30 // 32GB.
 	DefTiDBMemQuotaMergeJoin         = 32 << 30 // 32GB.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -171,7 +171,7 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	SetSessionSystemVar(v, TiDBBatchInsert, types.NewStringDatum("1"))
 	c.Assert(v.BatchInsert, IsTrue)
 
-	c.Assert(v.MaxChunkSize, Equals, 1024)
+	c.Assert(v.MaxChunkSize, Equals, 32)
 	SetSessionSystemVar(v, TiDBMaxChunkSize, types.NewStringDatum("2"))
 	c.Assert(v.MaxChunkSize, Equals, 2)
 


### PR DESCRIPTION
### What problem does this PR solve? 

~~OLTP user often uses the small chunk size configuration, so we change the default value.~~
In OLTP scenario, small chunk size is more suitable. Becasue it could save a lot of memory allocation and gc work. Especially when the throughput is high. 
In this PR, we change the default chunk size from 1024 to 32. So the default configuration fits the OLTP scenario better.

### What is changed and how it works?

modify default value

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
Code changes

- default value

Side effects

 - Possible performance regression in OLAP scenario

Related changes

 - Need to update the documentation: maybe or not(only in master)
 - Need to be included in the release note: maybe or not(but now only in master)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7358)
<!-- Reviewable:end -->
