### PR TITLE
expression: tiny change on  to extend its ability

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -312,6 +312,7 @@ func ColumnInfos2ColumnsWithDBName(ctx sessionctx.Context, dbName, tblName model
 			TblName:  tblName,
 			DBName:   dbName,
 			RetType:  &col.FieldType,
+			ID:       col.ID,
 			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),
 			Index:    col.Offset,
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`SimpleRewriter` holds a `*TableInfo` before. Not easy to use it in test.

### What is changed and how it works?

Now just holds a `*Schema`. So it can be used without the `*TableInfo`
Make it easy to use it in test.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Existing tests.

Code changes

 - Struct internal change.

