### PR TITLE
executor: drop partition information in 'show create table'

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -592,19 +592,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	// add partition info here.
 	partitionInfo := tb.Meta().Partition
 	if partitionInfo != nil {
-		buf.WriteString(fmt.Sprintf("\nPARTITION BY %s ( %s ) (\n", partitionInfo.Type.String(), partitionInfo.Expr))
-		for i, def := range partitionInfo.Definitions {
-			if i < len(partitionInfo.Definitions)-1 {
-				buf.WriteString(fmt.Sprintf("  PARTITION %s VALUES LESS THAN %s,\n", def.Name, def.LessThan[0]))
-			} else {
-				if def.MaxValue {
-					buf.WriteString(fmt.Sprintf("  PARTITION %s VALUES LESS THAN %s\n", def.Name, "MAXVALUE"))
-				} else {
-					buf.WriteString(fmt.Sprintf("  PARTITION %s VALUES LESS THAN %s\n", def.Name, def.LessThan[0]))
-				}
-			}
-		}
-		buf.WriteString(")")
+		// Partition info is truncated in release-2.0 branch.
 	}
 
 	if hasAutoIncID {

--- a/executor/show.go
+++ b/executor/show.go
@@ -589,11 +589,9 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(fmt.Sprintf(" DEFAULT CHARSET=%s COLLATE=%s", charsetName, collate))
 	}
 
-	// add partition info here.
-	partitionInfo := tb.Meta().Partition
-	if partitionInfo != nil {
-		// Partition info is truncated in release-2.0 branch.
-	}
+	// Partition info is truncated in release-2.0 branch.
+	// create table t (id int) partition by ... will become
+	// create table t (id int)
 
 	if hasAutoIncID {
 		autoIncID, err := tb.Allocator(e.ctx).NextGlobalAutoID(tb.Meta().ID)

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -330,8 +330,7 @@ func (s *testSuite) TestShow(c *C) {
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		"t CREATE TABLE `t` (\n"+
 			"  `a` int(11) DEFAULT NULL\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"+"\nPARTITION BY RANGE ( `a` ) (\n  PARTITION p0 VALUES LESS THAN 10,\n  PARTITION p1 VALUES LESS THAN 20,\n  PARTITION p2 VALUES LESS THAN MAXVALUE\n)",
-	))
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"))
 }
 
 func (s *testSuite) TestShowVisibility(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix `show create table` in release 2.0

Before this change, create a table like this:
```
CREATE TABLE t (a int) PARTITION BY RANGE(a) (
 	PARTITION p0 VALUES LESS THAN (10),
 	PARTITION p1 VALUES LESS THAN (20),
 	PARTITION p2 VALUES LESS THAN (MAXVALUE))
```
`show create table` results in:

```
CREATE TABLE t (a int) PARTITION BY RANGE(a) (
 	PARTITION p0 VALUES LESS THAN 10,
 	PARTITION p1 VALUES LESS THAN 20,
 	PARTITION p2 VALUES LESS THAN (MAXVALUE))
```
It's a illegal SQL and would make syncer broken.

### What is changed and how it works?

https://github.com/pingcap/tidb/pull/6630 fix it in the master branch, but it's hard to cherry-pick.
There is a related fix in `show create table` like https://github.com/pingcap/tidb/pull/6332
And also this one https://github.com/pingcap/tidb/pull/7379
And also some parser related changes for the cherry-pick.

**In one word, it's fixed so many times, but never got right.**

In this PR, I just drop the partition information, no code, not bug.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

`show create table` in release 2.0 branch  will not display table partition any more.

@shenli @zhexuany @winkyao 