### PR TITLE
parser: add 'IDENTIFIED WITH' option on create user statement

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6565,6 +6565,19 @@ AuthOption:
 	{
 		$$ = nil
 	}
+|	"IDENTIFIED" "WITH" StringName "BY" AuthString
+	{
+		$$ = &ast.AuthOption {
+			AuthString: $5.(string),
+			ByAuthString: true,
+		}
+	}
+|	"IDENTIFIED" "WITH" StringName "AS" HashString
+	{
+		$$ = &ast.AuthOption{
+			HashString: $5.(string),
+		}
+	}
 |	"IDENTIFIED" "BY" "PASSWORD" HashString
 	{
 		$$ = &ast.AuthOption{

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6561,6 +6561,10 @@ AuthOption:
 			ByAuthString: true,
 		}
 	}
+|	"IDENTIFIED" "WITH" StringName
+	{
+		$$ = nil
+	}
 |	"IDENTIFIED" "BY" "PASSWORD" HashString
 	{
 		$$ = &ast.AuthOption{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1853,6 +1853,8 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 		{"CREATE USER 'uesr1'@`localhost`", true},
 		{"CREATE USER `uesr1`@'localhost'", true},
 		{"create user 'bug19354014user'@'%' identified WITH mysql_native_password", true},
+		{"create user 'bug19354014user'@'%' identified WITH mysql_native_password by 'new-password'", true},
+		{"create user 'bug19354014user'@'%' identified WITH mysql_native_password as 'hashstring'", true},
 		{`CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD 'hashstring'`, true},

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1852,6 +1852,7 @@ func (s *testParserSuite) TestPrivilege(c *C) {
 		{"CREATE USER 'uesr1'@'localhost'", true},
 		{"CREATE USER 'uesr1'@`localhost`", true},
 		{"CREATE USER `uesr1`@'localhost'", true},
+		{"create user 'bug19354014user'@'%' identified WITH mysql_native_password", true},
 		{`CREATE USER IF NOT EXISTS 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY 'new-password'`, true},
 		{`CREATE USER 'root'@'localhost' IDENTIFIED BY PASSWORD 'hashstring'`, true},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #7295 to make JDBC test happy.

### What is changed and how it works?
An CNF grammar rule is added to support `IDENTIFIED WITH` in `CREATE USER`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects
no

Related changes

