### PR TITLE
executor: add more information in error message of replace statement

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1838,7 +1838,7 @@ func (e *ReplaceExec) exec(ctx context.Context, rows [][]types.Datum) (types.Dat
 		}
 		oldRow, err1 := e.Table.Row(e.ctx, h)
 		if err1 != nil {
-			return nil, errors.Trace(err1)
+			return nil, errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d", idx+1, rowsLen, h)
 		}
 		rowUnchanged, err1 := types.EqualDatums(sc, oldRow, row)
 		if err1 != nil {

--- a/executor/write.go
+++ b/executor/write.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
@@ -1839,7 +1840,9 @@ func (e *ReplaceExec) exec(ctx context.Context, rows [][]types.Datum) (types.Dat
 		oldRow, err1 := e.Table.Row(e.ctx, h)
 		if err1 != nil {
 			rErr := errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d", idx+1, rowsLen, h)
-			log.Errorf("%s, row: %v", rErr.Error(), row)
+			rowStr, err := types.DatumsToString(row, true)
+			terror.Log(err)
+			log.Errorf("%s, row: %v", rErr.Error(), rowStr)
 			return nil, rErr
 		}
 		rowUnchanged, err1 := types.EqualDatums(sc, oldRow, row)

--- a/executor/write.go
+++ b/executor/write.go
@@ -1839,11 +1839,9 @@ func (e *ReplaceExec) exec(ctx context.Context, rows [][]types.Datum) (types.Dat
 		}
 		oldRow, err1 := e.Table.Row(e.ctx, h)
 		if err1 != nil {
-			rErr := errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d", idx+1, rowsLen, h)
 			rowStr, err := types.DatumsToString(row, true)
 			terror.Log(err)
-			log.Errorf("%s, row: %v", rErr.Error(), rowStr)
-			return nil, rErr
+			return nil, errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d, row: %s", idx+1, rowsLen, h, rowStr)
 		}
 		rowUnchanged, err1 := types.EqualDatums(sc, oldRow, row)
 		if err1 != nil {

--- a/executor/write.go
+++ b/executor/write.go
@@ -1838,7 +1838,9 @@ func (e *ReplaceExec) exec(ctx context.Context, rows [][]types.Datum) (types.Dat
 		}
 		oldRow, err1 := e.Table.Row(e.ctx, h)
 		if err1 != nil {
-			return nil, errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d", idx+1, rowsLen, h)
+			rErr := errors.Annotatef(err1, "[replace] the %dth of total %d rows, handle %d", idx+1, rowsLen, h)
+			log.Errorf("%s, row: %v", rErr.Error(), row)
+			return nil, rErr
 		}
 		rowUnchanged, err1 := types.EqualDatums(sc, oldRow, row)
 		if err1 != nil {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -763,7 +763,7 @@ func (s *testSuite) TestReplaceLog(c *C) {
 
 	_, err = tk.Exec(`replace into testLog values (0, 0), (1, 1);`)
 	c.Assert(err, NotNil)
-	expErr := errors.New(`[replace] the 2th of total 2 rows, handle 1: [kv:2]Error: key not exist`)
+	expErr := errors.New(`[replace] the 2th of total 2 rows, handle 1, row: (1, 1): [kv:2]Error: key not exist`)
 	c.Assert(expErr.Error() == err.Error(), IsTrue, Commentf("obtained error: (%s)\nexpected error: (%s)", err.Error(), expErr.Error()))
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add more information in error message of replace statement. e.g. number of rows, the index of all rows, string format of error row datum.

### What is changed and how it works?
User will get an error message like,
```
[replace] the 2th of total 2 rows, handle 1: [kv:2]Error: key not exist
```
and the error log will look like,
```
2018/08/15 20:26:52.580 write.go:1842: [error] [replace] the 2th of total 2 rows, handle 1: [kv:2]Error: key not exist, row: [{1 0 0 0 1 [] <nil>} {1 0 0 0 1 [] <nil>}]
2018/08/15 20:26:52.580 tidb.go:183: [info] RollbackTxn for ddl/autocommit error.
2018/08/15 20:26:52.581 session.go:753: [warning] con:1 session error:
[kv:2]Error: key not exist
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/kv/union_store.go:186: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/store/tikv/txn.go:90: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/session/txn.go:144: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/table/tables/tables.go:520: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/table/tables/tables.go:577: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/write.go:1841: [replace] the 2th of total 2 rows, handle 1
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/write.go:1893: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/adapter.go:268: 
/Users/yusp/work/goprojects/src/github.com/pingcap/tidb/session/tidb.go:200: 
{
  "currDBName": "test",
  "id": 1,
  "status": 2,
  "strictMode": true,
  "user": null
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

PTAL @shenli @coocood 