### PR TITLE
util/mock: optimize mock.NewContext

### DIFF
--- a/sessionctx/variable/mock_globalaccessor.go
+++ b/sessionctx/variable/mock_globalaccessor.go
@@ -15,32 +15,28 @@ package variable
 
 // MockGlobalAccessor implements GlobalVarAccessor interface. it's used in tests
 type MockGlobalAccessor struct {
-	vars map[string]string
 }
 
 // NewMockGlobalAccessor implements GlobalVarAccessor interface.
 func NewMockGlobalAccessor() *MockGlobalAccessor {
-	m := &MockGlobalAccessor{
-		vars: make(map[string]string),
-	}
-	for name, val := range SysVars {
-		m.vars[name] = val.Value
-	}
-	return m
+	return new(MockGlobalAccessor)
 }
 
 // GetGlobalSysVar implements GlobalVarAccessor.GetGlobalSysVar interface.
 func (m *MockGlobalAccessor) GetGlobalSysVar(name string) (string, error) {
-	return m.vars[name], nil
+	v, ok := SysVars[name]
+	if ok {
+		return v.Value, nil
+	}
+	return "", nil
 }
 
 // SetGlobalSysVar implements GlobalVarAccessor.SetGlobalSysVar interface.
 func (m *MockGlobalAccessor) SetGlobalSysVar(name string, value string) error {
-	m.vars[name] = value
-	return nil
+	panic("not supported")
 }
 
 // GetAllSysVars implements GlobalVarAccessor.GetAllSysVars interface.
 func (m *MockGlobalAccessor) GetAllSysVars() (map[string]string, error) {
-	return m.vars, nil
+	panic("not supported")
 }

--- a/util/mock/mock_test.go
+++ b/util/mock/mock_test.go
@@ -50,3 +50,10 @@ func (s *testMockSuite) TestContext(c *C) {
 	v = ctx.Value(contextKey)
 	c.Assert(v, IsNil)
 }
+
+func BenchmarkNewContext(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		NewContext()
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This function takes 6.5% of the CPU usage in faketikv in sysbench index update workload.
This PR optimize the performance of `mock.NewContext`. It can also speed up unit-test.

Performance improvement is 77x:

From
20000	     75189 ns/op	   85596 B/op	      42 allocs/op

To
2000000	       972 ns/op	    2016 B/op	      15 allocs/op

### What is changed and how it works?
Do not create a map and set every global variable to that map.
We never need to set the global variable with mock context.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
