### PR TITLE
domain: fix potential nil point panic for ServerInfo syncer

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -366,6 +366,7 @@ func (do *Domain) loadSchemaInLoop(lease time.Duration) {
 			}
 			do.SchemaValidator.Restart()
 		case <-do.info.Done():
+			log.Info("[ddl] reload schema in loop, server info syncer need restart")
 			do.info.Restart(context.Background())
 		case <-do.exit:
 			return

--- a/domain/info.go
+++ b/domain/info.go
@@ -160,12 +160,13 @@ func (is *InfoSyncer) newSessionAndStoreServerInfo(ctx context.Context, retryCnt
 	if is.etcdCli == nil {
 		return nil
 	}
-	var err error
 	logPrefix := fmt.Sprintf("[Info-syncer] %s", is.serverInfoPath)
-	is.session, err = owner.NewSession(ctx, logPrefix, is.etcdCli, retryCnt, InfoSessionTTL)
+	session, err := owner.NewSession(ctx, logPrefix, is.etcdCli, retryCnt, InfoSessionTTL)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	is.session = session
+
 	err = is.storeServerInfo(ctx)
 	return errors.Trace(err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
PASS: ddl_test.go:660: TestDDLSuite.TestSimpleUpdate	21.443s

2018/08/15 16:27:34.705 domain.go:766: [error] loadSchemaInLoop, runtime error: invalid memory address or nil pointer dereference, goroutine 332 [running]:
github.com/pingcap/tidb/util.GetStack(0xc420485c48, 0x10da3e0, 0x1cdf0b0)
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb/util/misc.go:52 +0x74
github.com/pingcap/tidb/domain.recoverInDomain(0x12a73e7, 0x10, 0x77359401)
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb/domain/domain.go:765 +0x62
panic(0x10da3e0, 0x1cdf0b0)
/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/coreos/etcd/clientv3/concurrency.(*Session).Done(...)
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb_gopath/src/github.com/coreos/etcd/clientv3/concurrency/session.go:85
github.com/pingcap/tidb/domain.InfoSyncer.Done(...)
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb/domain/info.go:150
github.com/pingcap/tidb/domain.(*Domain).loadSchemaInLoop(0xc420147440, 0x3b9aca00)
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb/domain/domain.go:368 +0x1bb
created by github.com/pingcap/tidb/domain.(*Domain).Init
/home/jenkins/workspace/tikv_ghpr_integration_ddl_test/go/src/github.com/pingcap/tidb/domain/domain.go:529 +0x384
```

### What is changed and how it works?
`is.session, err = owner.NewSession(ctx, logPrefix, is.etcdCli, retryCnt, InfoSessionTTL)	`
When NewSession() failed, the err will be not nil and the is.session will be set to nil. This will cause null point panic in the future. So we should not set the is.session directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 TestSimpleUpdate

