### PR TITLE
Add keyonly support for seek

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -46,6 +46,8 @@ const (
 	// BypassLatch option tells 2PC commit to bypass latches, it would be true when the
 	// transaction is not conflict-retryable, for example: 'select for update', 'load data'.
 	BypassLatch
+	// KeyOnly retrieve only keys, it can be used in scan now
+	KeyOnly
 )
 
 // Priority value for transaction priority.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -46,7 +46,7 @@ const (
 	// BypassLatch option tells 2PC commit to bypass latches, it would be true when the
 	// transaction is not conflict-retryable, for example: 'select for update', 'load data'.
 	BypassLatch
-	// KeyOnly retrieve only keys, it can be used in scan now
+	// KeyOnly retrieve only keys, it can be used in scan now.
 	KeyOnly
 )
 

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -126,6 +126,22 @@ func (s *testLockSuite) TestScanLockResolveWithSeek(c *C) {
 	}
 }
 
+func (s *testLockSuite) TestScanLockResolveWithSeekKeyOnly(c *C) {
+	s.putAlphabets(c)
+	s.prepareAlphabetLocks(c)
+
+	txn, err := s.store.Begin()
+	c.Assert(err, IsNil)
+	txn.SetOption(kv.KeyOnly, true)
+	iter, err := txn.Seek([]byte("a"))
+	c.Assert(err, IsNil)
+	for ch := byte('a'); ch <= byte('z'); ch++ {
+		c.Assert(iter.Valid(), IsTrue)
+		c.Assert([]byte(iter.Key()), BytesEquals, []byte{ch})
+		c.Assert(iter.Next(), IsNil)
+	}
+}
+
 func (s *testLockSuite) TestScanLockResolveWithBatchGet(c *C) {
 	s.putAlphabets(c)
 	s.prepareAlphabetLocks(c)

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -100,6 +100,11 @@ func (s *Scanner) Next() error {
 			s.Close()
 			return errors.Trace(err)
 		}
+
+		if len(s.Value()) == 0 && !s.keyOnly {
+			// nil stands for NotExist, go to next KV pair.
+			continue
+		}
 		return nil
 	}
 }

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -27,14 +27,13 @@ type Scanner struct {
 	snapshot     *tikvSnapshot
 	batchSize    int
 	valid        bool
-	keyOnly      bool
 	cache        []*pb.KvPair
 	idx          int
 	nextStartKey []byte
 	eof          bool
 }
 
-func newScanner(snapshot *tikvSnapshot, startKey []byte, batchSize int, keyOnly bool) (*Scanner, error) {
+func newScanner(snapshot *tikvSnapshot, startKey []byte, batchSize int) (*Scanner, error) {
 	// It must be > 1. Otherwise scanner won't skipFirst.
 	if batchSize <= 1 {
 		batchSize = scanBatchSize
@@ -43,7 +42,6 @@ func newScanner(snapshot *tikvSnapshot, startKey []byte, batchSize int, keyOnly 
 		snapshot:     snapshot,
 		batchSize:    batchSize,
 		valid:        true,
-		keyOnly:      keyOnly,
 		nextStartKey: startKey,
 	}
 	err := scanner.Next()
@@ -148,7 +146,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 				StartKey: s.nextStartKey,
 				Limit:    uint32(s.batchSize),
 				Version:  s.startTS(),
-				KeyOnly:  s.keyOnly,
+				KeyOnly:  s.snapshot.keyOnly,
 			},
 			Context: pb.Context{
 				Priority:     s.snapshot.priority,

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -41,7 +41,7 @@ func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
 	txn, err = store.Begin()
 	c.Assert(err, IsNil)
 	snapshot := newTiKVSnapshot(store, kv.Version{Ver: txn.StartTS()})
-	scanner, err := newScanner(snapshot, []byte("a"), 10)
+	scanner, err := newScanner(snapshot, []byte("a"), 10, false)
 	c.Assert(err, IsNil)
 	for ch := byte('a'); ch <= byte('z'); ch++ {
 		c.Assert([]byte{ch}, BytesEquals, []byte(scanner.Key()))

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -41,7 +41,7 @@ func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
 	txn, err = store.Begin()
 	c.Assert(err, IsNil)
 	snapshot := newTiKVSnapshot(store, kv.Version{Ver: txn.StartTS()})
-	scanner, err := newScanner(snapshot, []byte("a"), 10, false)
+	scanner, err := newScanner(snapshot, []byte("a"), 10)
 	c.Assert(err, IsNil)
 	for ch := byte('a'); ch <= byte('z'); ch++ {
 		c.Assert([]byte{ch}, BytesEquals, []byte(scanner.Key()))

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -109,5 +109,24 @@ func (s *testScanSuite) TestSeek(c *C) {
 		}
 		scan.Next()
 		c.Assert(scan.Valid(), IsFalse)
+
+		// Restore KeyOnly to false
+		txn3.SetOption(kv.KeyOnly, false)
+		scan, err = txn3.Seek(encodeKey(s.prefix, ""))
+		c.Assert(err, IsNil)
+
+		for i := 0; i < rowNum; i++ {
+			k := scan.Key()
+			c.Assert([]byte(k), BytesEquals, encodeKey(s.prefix, s08d("key", i)))
+			v := scan.Value()
+			c.Assert(v, BytesEquals, valueBytes(i))
+			// Because newScan return first item without calling scan.Next() just like go-hbase,
+			// for-loop count will decrease 1.
+			if i < rowNum-1 {
+				scan.Next()
+			}
+		}
+		scan.Next()
+		c.Assert(scan.Valid(), IsFalse)
 	}
 }

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/kv"
 	"golang.org/x/net/context"
 )
 
@@ -83,6 +84,23 @@ func (s *testScanSuite) TestSeek(c *C) {
 			c.Assert([]byte(k), BytesEquals, encodeKey(s.prefix, s08d("key", i)))
 			v := scan.Value()
 			c.Assert(v, BytesEquals, valueBytes(i))
+			// Because newScan return first item without calling scan.Next() just like go-hbase,
+			// for-loop count will decrease 1.
+			if i < rowNum-1 {
+				scan.Next()
+			}
+		}
+		scan.Next()
+		c.Assert(scan.Valid(), IsFalse)
+
+		txn3 := s.beginTxn(c)
+		txn3.SetOption(kv.KeyOnly, true)
+		scan, err = txn3.Seek(encodeKey(s.prefix, ""))
+		c.Assert(err, IsNil)
+
+		for i := 0; i < rowNum; i++ {
+			k := scan.Key()
+			c.Assert([]byte(k), BytesEquals, encodeKey(s.prefix, s08d("key", i)))
 			// Because newScan return first item without calling scan.Next() just like go-hbase,
 			// for-loop count will decrease 1.
 			if i < rowNum-1 {

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -47,6 +47,7 @@ type tikvSnapshot struct {
 	priority     pb.CommandPri
 	notFillCache bool
 	syncLog      bool
+	keyOnly      bool
 	vars         *kv.Variables
 }
 
@@ -282,7 +283,7 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 
 // Seek return a list of key-value pair after `k`.
 func (s *tikvSnapshot) Seek(k kv.Key) (kv.Iterator, error) {
-	scanner, err := newScanner(s, k, scanBatchSize)
+	scanner, err := newScanner(s, k, scanBatchSize, s.keyOnly)
 	return scanner, errors.Trace(err)
 }
 

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -283,7 +283,7 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 
 // Seek return a list of key-value pair after `k`.
 func (s *tikvSnapshot) Seek(k kv.Key) (kv.Iterator, error) {
-	scanner, err := newScanner(s, k, scanBatchSize, s.keyOnly)
+	scanner, err := newScanner(s, k, scanBatchSize)
 	return scanner, errors.Trace(err)
 }
 

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -150,6 +150,8 @@ func (txn *tikvTxn) SetOption(opt kv.Option, val interface{}) {
 		txn.snapshot.notFillCache = val.(bool)
 	case kv.SyncLog:
 		txn.snapshot.syncLog = val.(bool)
+	case kv.KeyOnly:
+		txn.snapshot.keyOnly = val.(bool)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Only return keys when do seek

### What is changed and how it works?
Add a new Option: KeyOnly

```go
// Before seek , set the KeyOnly option, it takes effects until you set it false in this transaction
txn.SetOption(kv.KeyOnly, true)
```
The TiKV RPC method has already supported this option, so there is nothing to change with the remote  server

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```go
    txn.SetOption(kv.KeyOnly, true)
    iter, err := txn.Seek("your key")
    if err != nil {
        return err
    }
    for iter.Valid()  {
        fmt.Println(iter.Key(), iter.Value)
        if err := iter.Next(); err != nil {
          return  err
        }
    }
```
 - No code
