### PR TITLE
Revert "*: add a String method for Datum to make the log more friendly"

### DIFF
--- a/executor/insert.go
+++ b/executor/insert.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -179,7 +178,6 @@ func (e *InsertExec) Open(ctx context.Context) error {
 func (e *InsertExec) updateDupRow(row toBeCheckedRow, handle int64, onDuplicate []*expression.Assignment) error {
 	oldRow, err := e.getOldRow(e.ctx, e.Table, handle)
 	if err != nil {
-		log.Errorf("[insert on dup] cannot find the record whose handle is %d for the to-be-inserted row %v", handle, row.row)
 		return errors.Trace(err)
 	}
 	// Do update row.

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -53,7 +52,6 @@ func (e *ReplaceExec) removeRow(handle int64, r toBeCheckedRow) (bool, error) {
 	newRow := r.row
 	oldRow, err := e.batchChecker.getOldRow(e.ctx, r.t, handle)
 	if err != nil {
-		log.Errorf("[replace] cannot find the record whose handle is %d for the to-be-inserted row %v", handle, r.row)
 		return false, errors.Trace(err)
 	}
 	rowUnchanged, err := types.EqualDatums(e.ctx.GetSessionVars().StmtCtx, oldRow, newRow)

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -28,11 +28,8 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 type testBypassSuite struct{}
@@ -1998,36 +1995,4 @@ func (s *testSuite) TestUpdateAffectRowCnt(c *C) {
 	tk.MustExec("update a set a = a*10 where b = 1001")
 	ctx = tk.Se.(sessionctx.Context)
 	c.Assert(ctx.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(2))
-}
-
-func (s *testSuite) TestReplaceLog(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec(`create table testLog (a int not null primary key, b int unique key);`)
-
-	// Make some dangling index.
-	s.ctx = mock.NewContext()
-	s.ctx.Store = s.store
-	is := s.domain.InfoSchema()
-	dbName := model.NewCIStr("test")
-	tblName := model.NewCIStr("testLog")
-	tbl, err := is.TableByName(dbName, tblName)
-	c.Assert(err, IsNil)
-	tblInfo := tbl.Meta()
-	idxInfo := findIndexByName("b", tblInfo.Indices)
-	indexOpr := tables.NewIndex(tblInfo.ID, tblInfo, idxInfo)
-
-	txn, err := s.store.Begin()
-	c.Assert(err, IsNil)
-	_, err = indexOpr.Create(s.ctx, txn, types.MakeDatums(1), 1)
-	c.Assert(err, IsNil)
-	err = txn.Commit(context.Background())
-	c.Assert(err, IsNil)
-
-	_, err = tk.Exec(`replace into testLog values (0, 0), (1, 1);`)
-	c.Assert(err, NotNil)
-	expErr := errors.New(`can not be duplicated row, due to old row not found. handle 1 not found`)
-	c.Assert(expErr.Error() == err.Error(), IsTrue, Commentf("obtained error: (%s)\nexpected error: (%s)", err.Error(), expErr.Error()))
-
-	tk.MustQuery(`admin cleanup index testLog b;`).Check(testkit.Rows("1"))
 }

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -170,8 +170,9 @@ func (h *rpcHandler) buildDAGExecutor(req *coprocessor.Request) (*dagContext, ex
 func constructTimeZone(name string, offset int) (*time.Location, error) {
 	if name != "" {
 		return LocCache.getLoc(name)
+	} else {
+		return time.FixedZone("", offset), nil
 	}
-	return time.FixedZone("", offset), nil
 }
 
 func (h *rpcHandler) handleCopStream(ctx context.Context, req *coprocessor.Request) (tikvpb.Tikv_CoprocessorStreamClient, error) {

--- a/types/datum.go
+++ b/types/datum.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
-	log "github.com/sirupsen/logrus"
 )
 
 // Kind constants.
@@ -1871,13 +1870,4 @@ func CopyRow(dr []Datum) []Datum {
 		c[i] = *d.Copy()
 	}
 	return c
-}
-
-// String implements fmt.Stringer interface.
-func (d Datum) String() string {
-	str, err := d.ToString()
-	if err != nil {
-		log.Info(err)
-	}
-	return fmt.Sprintf("(Kind: %s, Value: %s)", kind2Str[d.k], str)
 }


### PR DESCRIPTION
Reverts pingcap/tidb#7426 to avoid to be misused with Datum.ToString.
PTAL @coocood 