### PR TITLE
tidb-server -V print out admin check status.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,16 @@ ifeq ("$(WITH_RACE)", "1")
 	GOBUILD   = GOPATH=$(GOPATH) CGO_ENABLED=1 $(GO) build
 endif
 
+CHECK_FLAG = 
+ifeq ("$(WITH_CHECK)", "1")
+	CHECK_FLAG = $(TEST_LDFLAGS)
+endif
+
 server: parserlib
 ifeq ($(TARGET), "")
-	$(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS)' -o bin/tidb-server tidb-server/main.go
+	$(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o bin/tidb-server tidb-server/main.go
 else
-	$(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS)' -o '$(TARGET)' tidb-server/main.go
+	$(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)' tidb-server/main.go
 endif
 
 server_check: parserlib

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -60,14 +60,16 @@ func GetTiDBInfo() string {
 		"UTC Build Time: %s\n"+
 		"GoVersion: %s\n"+
 		"Race Enabled: %v\n"+
-		"TiKV Min Version: %s",
+		"TiKV Min Version: %s\n"+
+		"Check Table Before Drop: %v",
 		mysql.TiDBReleaseVersion,
 		TiDBGitHash,
 		TiDBGitBranch,
 		TiDBBuildTS,
 		GoVersion,
 		israce.RaceEnabled,
-		TiKVMinVersion)
+		TiKVMinVersion,
+		config.CheckTableBeforeDrop)
 }
 
 // checkValidity checks whether cols and every data have the same length.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
+ add print `Check Table Before Drop` message when execute `bin/tidb-server -V`
```shell
Release Version: v2.1.0-beta-257-gd56777007-dirty
Git Commit Hash: d567770076f118d2b5d886d54e1f811d5b6df978
Git Branch: add-print
UTC Build Time: 2018-08-20 10:32:32
GoVersion: go version go1.10.3 darwin/amd64
Race Enabled: false
TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
Check Table Before Drop: false
```
+ add os env `WITH CHECK` when make to enable check table before drop.
```shell
# now `WITH_CHECK=1 make` = `make server-admin-check`
~/code/goread/src/github.com/pingcap/tidb (add-print ✔) ᐅ WITH_CHECK=1 make
CGO_ENABLED=0 go build   -ldflags '-X "github.com/pingcap/tidb/mysql.TiDBReleaseVersion=v2.1.0-beta-259-ge9761518e" -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=2018-08-20 12:48:31" -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=e9761518e1a3191f39f691af9974d0357b40bcd1" -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=add-print" -X "github.com/pingcap/tidb/util/printer.GoVersion=go version go1.10.3 darwin/amd64" -X "github.com/pingcap/tidb/config.checkBeforeDropLDFlag=1"' -o bin/tidb-server tidb-server/main.go
Build TiDB Server successfully!
~/code/goread/src/github.com/pingcap/tidb (add-print ✔) ᐅ bin/tidb-server -V
Release Version: v2.1.0-beta-259-ge9761518e
Git Commit Hash: e9761518e1a3191f39f691af9974d0357b40bcd1
Git Branch: add-print
UTC Build Time: 2018-08-20 12:48:31
GoVersion: go version go1.10.3 darwin/amd64
Race Enabled: false
TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
Check Table Before Drop: true
```