### PR TITLE
executor: split range in `TableReader`

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -271,6 +271,8 @@ func (e *AnalyzeColumnsExec) open() error {
 		return errors.Trace(err)
 	}
 	if len(secondPartRanges) == 0 {
+		e.resultHandler.optionalResult = nil
+		e.resultHandler.result = firstResult
 		e.resultHandler.open(nil, firstResult)
 		return nil
 	}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -271,8 +271,6 @@ func (e *AnalyzeColumnsExec) open() error {
 		return errors.Trace(err)
 	}
 	if len(secondPartRanges) == 0 {
-		e.resultHandler.optionalResult = nil
-		e.resultHandler.result = firstResult
 		e.resultHandler.open(nil, firstResult)
 		return nil
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1761,13 +1761,14 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Contex
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	e.resultHandler = &tableResultHandler{}
+	handler := &tableResultHandler{}
+	e.resultHandler = handler
 	result, err := distsql.Select(ctx, builder.ctx, kvReq, e.retTypes(), e.feedback)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	result.Fetch(ctx)
-	e.resultHandler.open(nil, result)
+	handler.open(nil, result)
 	return e, nil
 }
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -154,13 +154,6 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	return result, nil
 }
 
-type buildResp func(ctx context.Context, ranges []*ranger.Range) (distsql.SelectResult, error)
-
-const (
-	rangePerRequest    = 50000
-	requestWorkerCount = 8
-)
-
 type resultHandler interface {
 	nextChunk(ctx context.Context, chk *chunk.Chunk) error
 	Close() error
@@ -172,8 +165,9 @@ type tableResultHandler struct {
 	// optionalResult handles the request whose range is in signed int range.
 	// result handles the request whose range is exceed signed int range.
 	// Otherwise, we just set optionalFinished true and the result handles the whole ranges.
-	optionalResult   distsql.SelectResult
-	result           distsql.SelectResult
+	optionalResult distsql.SelectResult
+	result         distsql.SelectResult
+
 	optionalFinished bool
 }
 
@@ -230,6 +224,13 @@ type resultWithErr struct {
 	chk *chunk.Chunk
 	err error
 }
+
+type buildResp func(ctx context.Context, ranges []*ranger.Range) (distsql.SelectResult, error)
+
+const (
+	rangePerRequest    = 50000
+	requestWorkerCount = 8
+)
 
 // multiRangeNoOrderResultHandler will handle the case that the range is too large and the we don't need to keep the order of the result.
 type multiRangeNoOrderResultHandler struct {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR aims to solve the issue that the TiKV timeout error is caused by the too large range in one request when we don't need to keep the data to be read in order.

### What is changed and how it works?

This PR implements a new type of resultHandler, which cuts the original range slice into multiple smaller ones and sends these range segments to multiple workers for consumption.

It works well compared with rewriting the Select operation involving a large range to Union {a lot of small range select}.

Currently, it is only implemented in TableReader and only works for the situation where the data to be read does not need to be in order. In the following PRs, it will be implemented in other readers and work for the situation where the data to be read is in order.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - existing unit test with set `rangePerRequest` to 1
 - New unit test is writing.

Code changes

 - Has interface methods change
