### PR TITLE
ddl: partition by range value should accept constant expression

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1729,12 +1729,12 @@ func (s *testDBSuite) TestCreateTableWithPartition(c *C) {
 
 	// 'Less than' in partition expression could be a constant expression, notice that
 	// the SHOW result changed.
-	s.tk.MustExec(`create table t1 (a date)
+	s.tk.MustExec(`create table t26 (a date)
 			  partition by range(to_seconds(a))(
 			  partition p0 values less than (to_seconds('2004-01-01')),
 			  partition p1 values less than (to_seconds('2005-01-01')));`)
-	s.tk.MustQuery("show create table t1").Check(
-		testkit.Rows("t1 CREATE TABLE `t1` (\n  `a` date DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin\nPARTITION BY RANGE ( to_seconds(`a`) ) (\n  PARTITION p0 VALUES LESS THAN (63240134400),\n  PARTITION p1 VALUES LESS THAN (63271756800)\n)"))
+	s.tk.MustQuery("show create table t26").Check(
+		testkit.Rows("t26 CREATE TABLE `t26` (\n  `a` date DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin\nPARTITION BY RANGE ( to_seconds(`a`) ) (\n  PARTITION p0 VALUES LESS THAN (63240134400),\n  PARTITION p1 VALUES LESS THAN (63271756800)\n)"))
 }
 
 func (s *testDBSuite) TestTableDDLWithFloatType(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -904,7 +904,7 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 			return errors.Trace(err)
 		}
 
-		if err = checkCreatePartitionValue(pi); err != nil {
+		if err = checkCreatePartitionValue(ctx, tbInfo, pi); err != nil {
 			return errors.Trace(err)
 		}
 

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
 )
 
 const (
@@ -160,7 +161,8 @@ func checkPartitionFuncType(ctx sessionctx.Context, s *ast.CreateTableStmt, cols
 }
 
 // checkCreatePartitionValue checks whether `less than value` is strictly increasing for each partition.
-func checkCreatePartitionValue(pi *model.PartitionInfo) error {
+// Side effect: it may simplify the partition range definition from a constant expression to an integer.
+func checkCreatePartitionValue(ctx sessionctx.Context, tblInfo *model.TableInfo, pi *model.PartitionInfo) error {
 	defs := pi.Definitions
 	if len(defs) <= 1 {
 		return nil
@@ -169,15 +171,19 @@ func checkCreatePartitionValue(pi *model.PartitionInfo) error {
 	if strings.EqualFold(defs[len(defs)-1].LessThan[0], partitionMaxValue) {
 		defs = defs[:len(defs)-1]
 	}
-	var prevRangeValue int
+	var prevRangeValue int64
 	for i := 0; i < len(defs); i++ {
 		if strings.EqualFold(defs[i].LessThan[0], partitionMaxValue) {
 			return errors.Trace(ErrPartitionMaxvalue)
 		}
 
-		currentRangeValue, err := strconv.Atoi(defs[i].LessThan[0])
+		currentRangeValue, fromExpr, err := getRangeValue(ctx, tblInfo, defs[i].LessThan[0])
 		if err != nil {
-			return ErrNotAllowedTypeInPartition.GenByArgs(defs[i].LessThan[0])
+			return errors.Trace(err)
+		}
+		if fromExpr {
+			// Constant fold the expression.
+			defs[i].LessThan[0] = fmt.Sprintf("%d", currentRangeValue)
 		}
 
 		if i == 0 {
@@ -191,6 +197,28 @@ func checkCreatePartitionValue(pi *model.PartitionInfo) error {
 		prevRangeValue = currentRangeValue
 	}
 	return nil
+}
+
+// getRangeValue gets an integer from the range value string.
+// The returned boolean value indicates whether the input string is a constant expression.
+func getRangeValue(ctx sessionctx.Context, tblInfo *model.TableInfo, str string) (int64, bool, error) {
+
+	if value, err := strconv.ParseInt(str, 10, 64); err == nil {
+		return value, false, nil
+	}
+
+	// The range value maybe not an integer, it could be a constant expression.
+	// For example, the following two cases are the same:
+	// PARTITION p0 VALUES LESS THAN (TO_SECONDS('2004-01-01'))
+	// PARTITION p0 VALUES LESS THAN (63340531200)
+	if e, err1 := expression.ParseSimpleExprWithTableInfo(ctx, str, tblInfo); err1 == nil {
+		res, isNull, err2 := e.EvalInt(ctx, chunk.Row{})
+		if err2 == nil && isNull == false {
+			return res, true, nil
+		}
+	}
+
+	return 0, false, ErrNotAllowedTypeInPartition.GenByArgs(str)
 }
 
 // validRangePartitionType checks the type supported by the range partitioning key.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -46,11 +46,6 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	}
 
 	if tbInfo.Partition != nil {
-		err = checkCreatePartitionValue(tbInfo.Partition)
-		if err != nil {
-			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
-		}
 		err = checkAddPartitionTooManyPartitions(len(tbInfo.Partition.Definitions))
 		if err != nil {
 			job.State = model.JobStateCancelled

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -170,9 +170,8 @@ func (h *rpcHandler) buildDAGExecutor(req *coprocessor.Request) (*dagContext, ex
 func constructTimeZone(name string, offset int) (*time.Location, error) {
 	if name != "" {
 		return LocCache.getLoc(name)
-	} else {
-		return time.FixedZone("", offset), nil
 	}
+	return time.FixedZone("", offset), nil
 }
 
 func (h *rpcHandler) handleCopStream(ctx context.Context, req *coprocessor.Request) (tikvpb.Tikv_CoprocessorStreamClient, error) {


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In partitioned table definition, the range value maybe not an integer, it could be a constant expression.
For example, the following two cases are the same:
	PARTITION p0 VALUES LESS THAN (TO_SECONDS('2004-01-01'))
	PARTITION p0 VALUES LESS THAN (63340531200)

### What is changed and how it works?

Add a `getRangeValue` function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

The `model.PartitionInfo`  may be modified.

@ciscoxll  @coocood 