### PR TITLE
store/tikv: set ScanDetail to true

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -599,6 +599,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 			Priority:       kvPriorityToCommandPri(worker.req.Priority),
 			NotFillCache:   worker.req.NotFillCache,
 			HandleTime:     true,
+			ScanDetail:     true,
 		},
 	}
 	startTime := time.Now()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Improve the SLOW_QUERY log, make sure it includes all scan details, so the sum will be accurate.

### What is changed and how it works?
Currently `ScanDetail` is returned only when the scan takes more than one second, set this field to true will make sure the detail always returned.

Before the change, `total_keys` and `processed_keys` is missing.
```
2018/08/21 09:59:11.817 adapter.go:363: [warning] [SLOW_QUERY] cost_time:1.688710205s 
process_time:5.95s wait_time:6.312s request_count:13 succ:true con:1 user:root@127.0.0.1 
txn_start_ts:402343002133495809 database:test table_ids:[31],
sql:select count(c) from sbtest1
```

After the change, `total_keys` and `processed_keys` is present.
```
2018/08/21 10:00:16.495 adapter.go:363: [warning] [SLOW_QUERY] cost_time:1.397274785s 
process_time:5.278s wait_time:6.254s request_count:13 total_keys:3000187 
processed_keys:3000000 succ:true con:1 user:root@127.0.0.1 
txn_start_ts:402343019173117957 database:test table_ids:[31],
sql:select count(c) from sbtest1
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)

1. start a single instance pd/tikv/tidb.
2. import 3 million records.
3. query `select count(c) from sbtest1`.
4. observe the SLOW_QUERY log.

Side effects

 - Possible performance regression
TiKV need to allocate memory to marshal the scan detail information in the response. but the impact is very small.
