### PR TITLE
plan,table: fix select null value for table partition

### DIFF
--- a/plan/logical_plan_test.go
+++ b/plan/logical_plan_test.go
@@ -538,6 +538,17 @@ func (s *testPlanSuite) TestTablePartition(c *C) {
 			best: "Dual->Projection",
 			is:   is1,
 		},
+		{
+			// NULL will be located in the first partition.
+			sql:  "select * from t where t.h is null",
+			best: "Partition(41)->Projection",
+			is:   is,
+		},
+		{
+			sql:  "select * from t where t.h is null or t.h > 70",
+			best: "UnionAll{Partition(41)->Partition(44)}->Projection",
+			is:   is1,
+		},
 	}
 	for _, ca := range tests {
 		comment := Commentf("for %s", ca.sql)

--- a/plan/rule_partition_processor.go
+++ b/plan/rule_partition_processor.go
@@ -14,7 +14,6 @@ package plan
 
 import (
 	"github.com/juju/errors"
-	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table/tables"
@@ -76,8 +75,10 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 	}
 
 	var partitionExprs []expression.Expression
+	var col *expression.Column
 	if table, ok := ds.table.(partitionTable); ok {
 		partitionExprs = table.PartitionExpr().Ranges
+		col = table.PartitionExpr().Column
 	}
 	if len(partitionExprs) == 0 {
 		return nil, errors.New("partition expression missing")
@@ -86,8 +87,6 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 	// Rewrite data source to union all partitions, during which we may prune some
 	// partitions according to the filter conditions pushed to the DataSource.
 	children := make([]LogicalPlan, 0, len(pi.Definitions))
-
-	col := partitionExprAccessColumn(partitionExprs[0])
 	for i, expr := range partitionExprs {
 		if col != nil {
 			// If the selection condition would never be satisified, prune that partition.
@@ -142,22 +141,4 @@ func (s *partitionProcessor) canBePrune(ctx sessionctx.Context, col *expression.
 		return false, errors.Trace(err)
 	}
 	return len(r) == 0, nil
-}
-
-// partitionExprAccessColumn extracts the column which is used by the partition expression.
-// If the partition expression is not a simple operation on one column, return nil.
-func partitionExprAccessColumn(expr expression.Expression) *expression.Column {
-	lt, ok := expr.(*expression.ScalarFunction)
-	if !ok || lt.FuncName.L != ast.LT {
-		// The partition expression is constructed by us, its format should always be
-		// expr < value, such as "id < 42", "timestamp(id) < maxvalue"
-		log.Warnf("illegal partition expr:%s", expr.String())
-		return nil
-	}
-	tmp := lt.GetArgs()[0]
-	col, ok := tmp.(*expression.Column)
-	if !ok {
-		return nil
-	}
-	return col
 }

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -101,6 +101,7 @@ func newPartitionedTable(tbl *Table, tblInfo *model.TableInfo) (table.Table, err
 // Ranges: (x < y1 or x is null); (y1 <= x < y2); (y2 <= x < y3)
 // UpperBounds: (x < y1); (x < y2); (x < y3)
 type PartitionExpr struct {
+	// Column is the column appeared in the by range expression, partition pruning need this to work.
 	Column      *expression.Column
 	Ranges      []expression.Expression
 	UpperBounds []expression.Expression
@@ -132,7 +133,7 @@ func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 		if i > 0 {
 			fmt.Fprintf(&buf, " and ((%s) >= (%s))", pi.Expr, pi.Definitions[i-1].LessThan[0])
 		} else {
-			// NULL will locates in the first partition, so its expression is (expr < value or expr is null).
+			// NULL will locate in the first partition, so its expression is (expr < value or expr is null).
 			fmt.Fprintf(&buf, " or ((%s) is null)", pi.Expr)
 
 			// Extracts the column of the partition expression, it will be used by partition prunning.

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -98,14 +98,16 @@ func newPartitionedTable(tbl *Table, tblInfo *model.TableInfo) (table.Table, err
 //      p1 values less than (y1)
 //      p2 values less than (y2)
 //      p3 values less than (y3))
-// Ranges: (x < y1); (y1 <= x < y2); (y2 <= x < y3)
+// Ranges: (x < y1 or x is null); (y1 <= x < y2); (y2 <= x < y3)
 // UpperBounds: (x < y1); (x < y2); (x < y3)
 type PartitionExpr struct {
+	Column      *expression.Column
 	Ranges      []expression.Expression
 	UpperBounds []expression.Expression
 }
 
 func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
+	var column *expression.Column
 	// The caller should assure partition info is not nil.
 	pi := tblInfo.GetPartitionInfo()
 	ctx := mock.NewContext()
@@ -129,6 +131,19 @@ func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 
 		if i > 0 {
 			fmt.Fprintf(&buf, " and ((%s) >= (%s))", pi.Expr, pi.Definitions[i-1].LessThan[0])
+		} else {
+			// NULL will locates in the first partition, so its expression is (expr < value or expr is null).
+			fmt.Fprintf(&buf, " or ((%s) is null)", pi.Expr)
+
+			// Extracts the column of the partition expression, it will be used by partition prunning.
+			if tmp, err1 := expression.ParseSimpleExprWithTableInfo(ctx, pi.Expr, tblInfo); err1 == nil {
+				if col, ok := tmp.(*expression.Column); ok {
+					column = col
+				}
+			}
+			if column == nil {
+				log.Warnf("partition pruning won't work on this expr:%s", pi.Expr)
+			}
 		}
 
 		expr, err = expression.ParseSimpleExprWithTableInfo(ctx, buf.String(), tblInfo)
@@ -141,6 +156,7 @@ func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 		buf.Reset()
 	}
 	return &PartitionExpr{
+		Column:      column,
 		Ranges:      partitionPruneExprs,
 		UpperBounds: locateExprs,
 	}, nil

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -341,6 +341,8 @@ PARTITION BY RANGE ( id ) (
 
 	_, err := ts.se.Execute(context.Background(), "set @@session.tidb_enable_table_partition=1")
 	c.Assert(err, IsNil)
+	_, err = ts.se.Execute(context.Background(), "drop table if exists t1;")
+	c.Assert(err, IsNil)
 	_, err = ts.se.Execute(context.Background(), createTable1)
 	c.Assert(err, IsNil)
 	tb, err := ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
@@ -428,7 +430,7 @@ func (ts *testSuite) TestGeneratePartitionExpr(c *C) {
 	c.Assert(err, IsNil)
 	_, err = ts.se.Execute(context.Background(), "set @@session.tidb_enable_table_partition=1")
 	c.Assert(err, IsNil)
-	_, err = ts.se.Execute(context.Background(), "drop table if exists test.t1;")
+	_, err = ts.se.Execute(context.Background(), "drop table if exists t1;")
 	c.Assert(err, IsNil)
 	_, err = ts.se.Execute(context.Background(), `create table t1 (id int)
 							partition by range (id) (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
set @@session.tidb_enable_table_partition = 1;
create table t1 (a int unsigned) partition by range (a)
(partition pnull values less than (0),
 partition p0 values less than (1),
 partition p1 values less than(2));

insert into t1 values (null),(0),(1);

select * from t1 where a is null;
```

should get 

```
mysql> select * from t1 where a is null;
+------+
| a    |
+------+
| NULL |
```

But we get an empty result.

```
mysql> select * from t1 where a is null;
Empty set (0.00 sec)
```

The reason is that partition pruning works incorrectly, it prunes all the partitions.


### What is changed and how it works?

The partition pruning condition of partition[0] is changed from

`expr < value` 

to

`expr < value or expr is null`

Before this change, the partition pruning conditions in the failed example are: 
```
a < 0 and a is null
0 < a < 1 and a is null
1 < a < 2 and a is null
```

The pruning result is an empty set.

After this change, the partition pruning conditions are:

```
(a < 0 or a is null) and a is null
0 < a < 1 and a is null
1 < a < 2 and a is null
```

The first partition remains, so we get the correct result.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

@zz-jason @coocood 