### PR TITLE
parser/opcode: fix format function for mod opcode

### DIFF
--- a/parser/opcode/opcode.go
+++ b/parser/opcode/opcode.go
@@ -134,5 +134,5 @@ var opsLiteral = map[Op]string{
 
 // Format the ExprNode into a Writer.
 func (o Op) Format(w io.Writer) {
-	fmt.Fprintf(w, opsLiteral[o])
+	fmt.Fprintf(w, "%s", opsLiteral[o])
 }

--- a/parser/opcode/opcode_test.go
+++ b/parser/opcode/opcode_test.go
@@ -13,12 +13,27 @@
 
 package opcode
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 func TestT(t *testing.T) {
 	op := Plus
 	if op.String() != "plus" {
 		t.Fatalf("invalid op code")
+	}
+
+	if len(Ops) != len(opsLiteral) {
+		t.Error("inconsistent count ops and opsliteral")
+	}
+	var buf bytes.Buffer
+	for op := range Ops {
+		op.Format(&buf)
+		if buf.String() != opsLiteral[op] {
+			t.Error("format op fail", op)
+		}
+		buf.Reset()
 	}
 
 	// Test invalid opcode


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before this fix, format `Mod` opcode will get `%!(NOVERB)`

### What is changed and how it works?

Use fmt.Printf correctly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


@lysu @jackysp 