### PR TITLE
infoschema: use the unified infoschema in "select ... information_schema.tables"

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1180,7 +1180,7 @@ func (s schemasSorter) Less(i, j int) bool {
 }
 
 func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column) (fullRows [][]types.Datum, err error) {
-	is := it.handle.Get()
+	is := ctx.GetSessionVars().TxnCtx.InfoSchema.(InfoSchema)
 	dbs := is.AllSchemas()
 	sort.Sort(schemasSorter(dbs))
 	switch it.meta.Name.O {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #7421.
In the same executor, the [line](https://github.com/pingcap/tidb/compare/master...zimulala:info-tables?expand=1#diff-7a9e970fa682861b6af9689a4a8088daL1183) uses the latest infoschema to get `dbs`, but we use the transaction's infoschema to get `table` on another [line](https://github.com/pingcap/tidb/blob/master/infoschema/tables.go#L705) .
The latest and a transaction's infoschema may be different when we do a lot of DDL.

### What is changed and how it works?
Use the unified infoschema. In the same executor, we use the transaction's infoschema.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Like #7421

Side effects
This problem will appear after this #7037.
