### PR TITLE
expression: fix binary protocol time type when it meets zero microsecond.

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -455,7 +455,13 @@ func parseBinaryTimestamp(pos int, paramValues []byte) (int, string) {
 	pos, dateTime := parseBinaryDateTime(pos, paramValues)
 	microSecond := binary.LittleEndian.Uint32(paramValues[pos : pos+4])
 	pos += 4
-	return pos, fmt.Sprintf("%s.%06d", dateTime, microSecond)
+	var str string
+	if microSecond == 0 {
+		str = fmt.Sprintf("%s", dateTime)
+	} else {
+		str = fmt.Sprintf("%s.%06d", dateTime, microSecond)
+	}
+	return pos, str
 }
 
 func parseBinaryDuration(pos int, paramValues []byte, isNegative uint8) (int, string) {
@@ -471,7 +477,14 @@ func parseBinaryDuration(pos int, paramValues []byte, isNegative uint8) (int, st
 	pos++
 	seconds := uint8(paramValues[pos])
 	pos++
-	return pos, fmt.Sprintf("%s%d %02d:%02d:%02d", sign, days, hours, minutes, seconds)
+
+	var str string
+	if days == 0 {
+		str = fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+	} else {
+		str = fmt.Sprintf("%s%d %02d:%02d:%02d", sign, days, hours, minutes, seconds)
+	}
+	return pos, str
 }
 
 func parseBinaryDurationWithMS(pos int, paramValues []byte,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When using the binary protocol, consider the following statement,
"select ?", arg "2015-01-01 10:00:00"
TiDB will get "2015-01-01 10:00:00.000000", but MySQL gets "2015-01-01 10:00:00".
When the arg is "2015-01-01 10:00:00.000000", the results are the same as before in TiDB and MySQL.
This pr fix it when parsing the arguments, but there may be another way to fix it in the expression package.
PTAL @XuHuaiyu , if it is acceptable, I'll add a case for it, then we can merge it.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
