### PR TITLE
parser: support SUBPARTITION grammar for table partition

### DIFF
--- a/parser/misc.go
+++ b/parser/misc.go
@@ -444,6 +444,8 @@ var tokenMap = map[string]int{
 	"STORED":                   stored,
 	"STRAIGHT_JOIN":            straightJoin,
 	"SUBDATE":                  subDate,
+	"SUBPARTITION":             subpartition,
+	"SUBPARTITIONS":            subpartitions,
 	"SUBSTR":                   substring,
 	"SUBSTRING":                substring,
 	"SUM":                      sum,

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -376,6 +376,8 @@ import (
 	start		"START"
 	statsPersistent	"STATS_PERSISTENT"
 	status		"STATUS"
+	subpartition	"SUBPARTITION"
+	subpartitions	"SUBPARTITIONS"
 	super		"SUPER"
 	some 		"SOME"
 	global		"GLOBAL"
@@ -721,6 +723,8 @@ import (
 	StatsPersistentVal		"stats_persistent value"
 	StringName			"string literal or identifier"
 	StringList 			"string list"
+	SubPartitionOpt			"SubPartition option"
+	SubPartitionNumOpt		"SubPartition NUM option"
 	Symbol				"Constraint Symbol"
 	TableAsName			"table alias name"
 	TableAsNameOpt 			"table alias name optional"
@@ -1796,11 +1800,11 @@ PartitionOpt:
 	{
 		$$ = nil
 	}
-|	"PARTITION" "BY" "RANGE" '(' Expression ')' PartitionNumOpt  PartitionDefinitionListOpt
+|	"PARTITION" "BY" "RANGE" '(' Expression ')' PartitionNumOpt SubPartitionOpt PartitionDefinitionListOpt
 	{
 		var defs []*ast.PartitionDefinition
-		if $8 != nil {
-			defs = $8.([]*ast.PartitionDefinition)
+		if $9 != nil {
+			defs = $9.([]*ast.PartitionDefinition)
 		}
 		$$ = &ast.PartitionOptions{
 			Tp:		model.PartitionTypeRange,
@@ -1820,6 +1824,18 @@ PartitionOpt:
 			Definitions:	defs,
 		}
 	}
+
+SubPartitionOpt:
+	{}
+|	"SUBPARTITION" "BY" "HASH" '(' Expression ')' SubPartitionNumOpt
+	{}
+|	"SUBPARTITION" "BY" "KEY" '(' ColumnNameList ')' SubPartitionNumOpt
+	{}
+
+SubPartitionNumOpt:
+	{}
+|	"SUBPARTITIONS" NUM
+	{}
 
 PartitionNumOpt:
 	{}
@@ -2780,8 +2796,8 @@ UnReservedKeyword:
 | "COLUMNS" | "COMMIT" | "COMPACT" | "COMPRESSED" | "CONSISTENT" | "DATA" | "DATE" %prec lowerThanStringLitToken| "DATETIME" | "DAY" | "DEALLOCATE" | "DO" | "DUPLICATE"
 | "DYNAMIC"| "END" | "ENGINE" | "ENGINES" | "ENUM" | "ERRORS" | "ESCAPE" | "EXECUTE" | "FIELDS" | "FIRST" | "FIXED" | "FLUSH" | "FORMAT" | "FULL" |"GLOBAL"
 | "HASH" | "HOUR" | "LESS" | "LOCAL" | "NAMES" | "OFFSET" | "PASSWORD" %prec lowerThanEq | "PREPARE" | "QUICK" | "REDUNDANT"
-| "ROLLBACK" | "SESSION" | "SIGNED" | "SNAPSHOT" | "START" | "STATUS" | "TABLES" | "TABLESPACE" | "TEXT" | "THAN" | "TIME" %prec lowerThanStringLitToken | "TIMESTAMP" %prec lowerThanStringLitToken
-| "TRACE" | "TRANSACTION" | "TRUNCATE" | "UNKNOWN" | "VALUE" | "WARNINGS" | "YEAR" | "MODE"  | "WEEK"  | "ANY" | "SOME" | "USER" | "IDENTIFIED"
+| "ROLLBACK" | "SESSION" | "SIGNED" | "SNAPSHOT" | "START" | "STATUS" | "SUBPARTITIONS" | "SUBPARTITION" | "TABLES" | "TABLESPACE" | "TEXT" | "THAN" | "TIME" %prec lowerThanStringLitToken 
+| "TIMESTAMP" %prec lowerThanStringLitToken | "TRACE" | "TRANSACTION" | "TRUNCATE" | "UNKNOWN" | "VALUE" | "WARNINGS" | "YEAR" | "MODE"  | "WEEK"  | "ANY" | "SOME" | "USER" | "IDENTIFIED"
 | "COLLATION" | "COMMENT" | "AVG_ROW_LENGTH" | "CONNECTION" | "CHECKSUM" | "COMPRESSION" | "KEY_BLOCK_SIZE" | "MASTER" | "MAX_ROWS"
 | "MIN_ROWS" | "NATIONAL" | "ROW" | "ROW_FORMAT" | "QUARTER" | "GRANTS" | "TRIGGERS" | "DELAY_KEY_WRITE" | "ISOLATION" | "JSON"
 | "REPEATABLE" | "COMMITTED" | "UNCOMMITTED" | "ONLY" | "SERIALIZABLE" | "LEVEL" | "VARIABLES" | "SQL_CACHE" | "INDEXES" | "PROCESSLIST"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -87,7 +87,7 @@ func (s *testParserSuite) TestSimple(c *C) {
 		"date", "datediff", "datetime", "deallocate", "do", "from_days", "end", "engine", "engines", "execute", "first", "full",
 		"local", "names", "offset", "password", "prepare", "quick", "rollback", "session", "signed",
 		"start", "global", "tables", "tablespace", "text", "time", "timestamp", "tidb", "transaction", "truncate", "unknown",
-		"value", "warnings", "year", "now", "substr", "substring", "mode", "any", "some", "user", "identified",
+		"value", "warnings", "year", "now", "substr", "subpartition", "subpartitions", "substring", "mode", "any", "some", "user", "identified",
 		"collation", "comment", "avg_row_length", "checksum", "compression", "connection", "key_block_size",
 		"max_rows", "min_rows", "national", "row", "quarter", "escape", "grants", "status", "fields", "triggers",
 		"delay_key_write", "isolation", "partitions", "repeatable", "committed", "uncommitted", "only", "serializable", "level",
@@ -2390,6 +2390,14 @@ func (s *testParserSuite) TestTablePartition(c *C) {
 		{`create table t1 (a int) partition by range (a)
 		  (PARTITION p0 VALUES LESS THAN (63340531200) COMMENT 'xxx' ENGINE = MyISAM ,
 		   PARTITION p1 VALUES LESS THAN (63342604800) ENGINE = MyISAM)`, true},
+		{`create table t (id int)
+		    partition by range (id)
+		    subpartition by key (id) subpartitions 2
+		    (partition p0 values less than (42))`, true},
+		{`create table t (id int)
+		    partition by range (id)
+		    subpartition by hash (id)
+		    (partition p0 values less than (42))`, true},
 	}
 	s.RunTest(c, table)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


There are many test cases in mysql-test use `subpartition`.
If we parse the `subpartition` grammar, it would be more convenient for us to use the test cases. 

```
CREATE TABLE t1 (
    ID int(11) NOT NULL,
    `aaaa,aaaaa` tinyint(3) UNSIGNED NOT NULL DEFAULT '0',
    ddddddddd int(11) NOT NULL DEFAULT '0',
    new_field0 varchar(50),
    PRIMARY KEY(ID, `aaaa,aaaaa`, ddddddddd))
PARTITION BY RANGE(ID)
PARTITIONS 3
SUBPARTITION BY LINEAR KEY(ID,`aaaa,aaaaa`)
SUBPARTITIONS 2 (
    PARTITION p01 VALUES LESS THAN(100),
    PARTITION p11 VALUES LESS THAN(200),
    PARTITION p21 VALUES LESS THAN MAXVALUE);
```

### What is changed and how it works?

Parser will parse `create table ... partition by range ... subpartition ...` 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - update parser.y add the rules
 - add "subpartition" and "subpartitions" to lexer
 - add test

@coocood @zhexuany @winkyao 
