### PR TITLE
ddl: limit the number of DDL job retries

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -526,15 +526,15 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 			log.Errorf("[ddl-%s] run DDL job err %v, job query %s ", w, errors.ErrorStack(err), job.Query)
 		} else {
 			log.Infof("[ddl-%s] the DDL job is normal to cancel because %v, job query %s", w, errors.ErrorStack(err), job.Query)
-			metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerCancelDDLJob, metrics.RetLabel(err)).Observe(time.Since(model.TSConvert2Time(job.StartTS)).Seconds())
+			metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerCancelDDLJob, job.Type.String(), metrics.RetLabel(err)).Observe(time.Since(model.TSConvert2Time(job.StartTS)).Seconds())
 		}
 
 		job.Error = toTError(err)
 		job.ErrorCount++
 		if job.ErrorCount > int64(variable.GetDDLErrorRetryLimit()) && job.Type != model.ActionAddIndex {
 			log.Infof("[ddl-%s] DDL job over maximum retry count is canceled because %v, job query %s", w, errors.ErrorStack(err), job.Query)
-			job.State = model.JobStateCancelled
-			metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerCancelDDLJob, metrics.RetLabel(err)).Observe(time.Since(model.TSConvert2Time(job.StartTS)).Seconds())
+			job.State = model.JobStateCancelling
+			metrics.DDLWorkerHistogram.WithLabelValues(metrics.WorkerCancelDDLJob, job.Type.String(), metrics.RetLabel(err)).Observe(time.Since(model.TSConvert2Time(job.StartTS)).Seconds())
 			return
 		}
 	}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -65,6 +65,7 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		tbInfo.UpdateTS = t.StartTS
 		err = t.CreateTable(schemaID, tbInfo)
 		if err != nil {
+			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
 		if EnableSplitTableRegion {

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -432,4 +432,10 @@ func (s *testSuite) TestSetDDLReorgWorkerCnt(c *C) {
 	tk.MustExec("set @@global.tidb_ddl_reorg_worker_cnt = 100")
 	res = tk.MustQuery("select @@global.tidb_ddl_reorg_worker_cnt")
 	res.Check(testkit.Rows("100"))
+
+	res = tk.MustQuery("select @@global.tidb_ddl_error_retry_limit")
+	res.Check(testkit.Rows(fmt.Sprintf("%v", variable.DefTiDBDDLErrorRetryLimit)))
+	tk.MustExec("set @@global.tidb_ddl_error_retry_limit = 10000")
+	res = tk.MustQuery("select @@global.tidb_ddl_error_retry_limit")
+	res.Check(testkit.Rows("10000"))
 }

--- a/metrics/ddl.go
+++ b/metrics/ddl.go
@@ -81,6 +81,7 @@ var (
 	WorkerAddDDLJob         = "add_job"
 	WorkerRunDDLJob         = "run_job"
 	WorkerFinishDDLJob      = "finish_job"
+	WorkerCancelDDLJob      = "cancel_job"
 	WorkerWaitSchemaChanged = "wait_schema_changed"
 	DDLWorkerHistogram      = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/session/session.go
+++ b/session/session.go
@@ -1267,6 +1267,7 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.TiDBDistSQLScanConcurrency + quoteCommaQuote +
 	variable.TiDBMaxChunkSize + quoteCommaQuote +
 	variable.TiDBRetryLimit + quoteCommaQuote +
+	variable.TiDBDDLErrorRetryLimit + quoteCommaQuote +
 	variable.TiDBDisableTxnAutoRetry + "')"
 
 // loadCommonGlobalVariablesIfNeeded loads and applies commonly used global variables for the session.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -575,6 +575,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		SetDDLReorgWorkerCounter(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgWorkerCount)))
 	case TiDBDDLReorgPriority:
 		s.setDDLReorgPriority(val)
+	case TiDBDDLErrorRetryLimit:
+		SetDDLErrorRetryLimit(int32(tidbOptPositiveInt32(val, DefTiDBDDLErrorRetryLimit)))
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -661,6 +661,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBConfig, ""},
 	{ScopeGlobal | ScopeSession, TiDBDDLReorgWorkerCount, strconv.Itoa(DefTiDBDDLReorgWorkerCount)},
 	{ScopeSession, TiDBDDLReorgPriority, "PRIORITY_LOW"},
+	{ScopeGlobal | ScopeSession, TiDBDDLErrorRetryLimit, strconv.Itoa(DefTiDBDDLErrorRetryLimit)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -177,6 +177,9 @@ const (
 	// tidb_ddl_reorg_priority defines the operations priority of adding indices.
 	// It can be: PRIORITY_LOW, PRIORITY_NORMAL, PRIORITY_HIGH
 	TiDBDDLReorgPriority = "tidb_ddl_reorg_priority"
+
+	// tidb_ddl_error_retry_limit is the maximum number of retries when an error occurs in ddl job.
+	TiDBDDLErrorRetryLimit = "tidb_ddl_error_retry_limit"
 )
 
 // Default TiDB system variable values.
@@ -214,6 +217,7 @@ const (
 	DefTiDBDDLReorgWorkerCount       = 16
 	DefTiDBHashAggPartialConcurrency = 4
 	DefTiDBHashAggFinalConcurrency   = 4
+	DefTiDBDDLErrorRetryLimit        = 10000
 )
 
 // Process global variables.
@@ -222,5 +226,7 @@ var (
 	ddlReorgWorkerCounter  int32 = DefTiDBDDLReorgWorkerCount
 	maxDDLReorgWorkerCount int32 = 128
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
-	DDLSlowOprThreshold uint32 = 300
+	DDLSlowOprThreshold   uint32 = 300
+	ddlErrorRetryLimit    int32  = DefTiDBDDLErrorRetryLimit
+	minDDLErrorRetryLimit int32  = 1
 )

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -45,6 +45,19 @@ func GetDDLReorgWorkerCounter() int32 {
 	return atomic.LoadInt32(&ddlReorgWorkerCounter)
 }
 
+// SetDDLErrorRetryLimit sets ddlErrorRetryLimit count.
+func SetDDLErrorRetryLimit(cnt int32) {
+	if cnt < minDDLErrorRetryLimit {
+		cnt = minDDLErrorRetryLimit
+	}
+	atomic.StoreInt32(&ddlErrorRetryLimit, cnt)
+}
+
+// GetDDLErrorRetryLimit gets ddlErrorRetryLimit.
+func GetDDLErrorRetryLimit() int32 {
+	return atomic.LoadInt32(&ddlErrorRetryLimit)
+}
+
 // GetSessionSystemVar gets a system variable.
 // If it is a session only variable, use the default value defined in code.
 // Returns error if there is no such variable.
@@ -291,7 +304,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TiDBHashAggPartialConcurrency,
 		TiDBHashAggFinalConcurrency,
 		TiDBDistSQLScanConcurrency,
-		TiDBIndexSerialScanConcurrency, TiDBDDLReorgWorkerCount,
+		TiDBIndexSerialScanConcurrency, TiDBDDLReorgWorkerCount, TiDBDDLErrorRetryLimit,
 		TiDBBackoffLockFast, TiDBMaxChunkSize,
 		TiDBDMLBatchSize, TiDBOptimizerSelectivityLevel:
 		v, err := strconv.Atoi(value)

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -223,4 +223,16 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "1")
 	c.Assert(v.EnableTablePartition, IsTrue)
+
+	c.Assert(GetDDLErrorRetryLimit(), Equals, int32(DefTiDBDDLErrorRetryLimit))
+	SetSessionSystemVar(v, TiDBDDLErrorRetryLimit, types.NewIntDatum(DefTiDBDDLErrorRetryLimit-1))
+	c.Assert(GetDDLErrorRetryLimit(), Equals, int32(DefTiDBDDLErrorRetryLimit-1))
+
+	SetSessionSystemVar(v, TiDBDDLErrorRetryLimit, types.NewIntDatum(1))
+	c.Assert(GetDDLErrorRetryLimit(), Equals, int32(minDDLErrorRetryLimit))
+
+	SetSessionSystemVar(v, TiDBDDLErrorRetryLimit, types.NewIntDatum(DefTiDBDDLErrorRetryLimit))
+	c.Assert(GetDDLErrorRetryLimit(), Equals, int32(10000))
+	SetSessionSystemVar(v, TiDBDDLErrorRetryLimit, types.NewIntDatum(10))
+	c.Assert(GetDDLErrorRetryLimit(), Equals, int32(10))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR solves the problem of infinite retry when a DDL job error occurs.

### What is changed and how it works?
* If the current DDL job fails, it will be retried indefinitely, so we need to limit the number of retries.
* Avoid error jobs blocking the entire DDL.
* Add some logging and `metrics`.
* Set the DDL job error retry number `set @@global.tidb_ddl_error_retry_limit = 10000`.
* Fix issue #7517 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

PTAL @tiancaiamao @winkyao @zimulala .