### PR TITLE
distsql: let analyze use RC level and low priority

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -90,6 +90,8 @@ func (builder *RequestBuilder) SetAnalyzeRequest(ana *tipb.AnalyzeReq) *RequestB
 	builder.Request.StartTs = ana.StartTs
 	builder.Request.Data, builder.err = ana.Marshal()
 	builder.Request.NotFillCache = true
+	builder.Request.IsolationLevel = kv.RC
+	builder.Request.Priority = kv.PriorityLow
 	return builder
 }
 

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -490,13 +489,10 @@ func (s *testSuite) TestRequestBuilder5(c *C) {
 		},
 	}
 
-	sv := variable.NewSessionVars()
-	sv.StmtCtx.Priority = mysql.LowPriority
-	sv.StmtCtx.NotFillCache = true
 	actual, err := (&RequestBuilder{}).SetKeyRanges(keyRanges).
 		SetAnalyzeRequest(&tipb.AnalyzeReq{}).
 		SetKeepOrder(true).
-		SetFromSessionVars(sv).
+		SetConcurrency(15).
 		Build()
 	c.Assert(err, IsNil)
 	expect := &kv.Request{

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -174,8 +174,8 @@ func (e *AnalyzeIndexExec) open() error {
 	kvReq, err := builder.SetIndexRanges(e.ctx.GetSessionVars().StmtCtx, e.physicalTableID, e.idxInfo.ID, ranger.FullRange()).
 		SetAnalyzeRequest(e.analyzePB).
 		SetKeepOrder(true).
+		SetConcurrency(e.concurrency).
 		Build()
-	kvReq.Concurrency = e.concurrency
 	ctx := context.TODO()
 	e.result, err = distsql.Analyze(ctx, e.ctx.GetClient(), kvReq, e.ctx.GetSessionVars().KVVars)
 	if err != nil {
@@ -289,8 +289,8 @@ func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectRe
 	kvReq, err := builder.SetTableRanges(e.physicalTableID, ranges, nil).
 		SetAnalyzeRequest(e.analyzePB).
 		SetKeepOrder(e.keepOrder).
+		SetConcurrency(e.concurrency).
 		Build()
-	kvReq.Concurrency = e.concurrency
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Analyze request should use RC isolation level and low priority.

### What is changed and how it works?

Set the isolation level and priority when building analyze request.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

PTAL @coocood @zz-jason @winoros 