### PR TITLE
 server: fix insert zero timestamp bug with prepared statement

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -42,6 +42,7 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/mysql"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/hack"
 	"golang.org/x/net/context"
 )
@@ -354,7 +355,7 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			pos++
 			switch length {
 			case 0:
-				args[i] = "00000000000000"
+				args[i] = types.ZeroDatetimeStr
 			case 4:
 				pos, args[i] = parseBinaryDate(pos, paramValues)
 			case 7:

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -354,7 +354,7 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			pos++
 			switch length {
 			case 0:
-				args[i] = "0"
+				args[i] = "00000000000000"
 			case 4:
 				pos, args[i] = parseBinaryDate(pos, paramValues)
 			case 7:

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/types"
 )
 
 func (ts ConnTestSuite) TestParseStmtArgs(c *C) {
@@ -120,7 +121,7 @@ func (ts ConnTestSuite) TestParseStmtArgs(c *C) {
 				[]byte{0x00},
 			},
 			nil,
-			"00000000000000",
+			types.ZeroDatetimeStr,
 		},
 		// Tests for time
 		{

--- a/server/conn_stmt_test.go
+++ b/server/conn_stmt_test.go
@@ -120,7 +120,7 @@ func (ts ConnTestSuite) TestParseStmtArgs(c *C) {
 				[]byte{0x00},
 			},
 			nil,
-			"0",
+			"00000000000000",
 		},
 		// Tests for time
 		{

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -638,7 +638,7 @@ func (s *testSessionSuite) TestPrepareZero(c *C) {
 	tk.MustExec("set @v1='0'")
 	_, rs := tk.Exec("execute s1 using @v1")
 	c.Assert(rs, NotNil)
-	tk.MustExec("set @v2='00000000000000'")
+	tk.MustExec("set @v2='" + types.ZeroDatetimeStr + "'")
 	tk.MustExec("execute s1 using @v2")
 	tk.MustQuery("select v from t").Check(testkit.Rows("0000-00-00 00:00:00"))
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -630,6 +630,19 @@ func (s *testSessionSuite) TestLastInsertID(c *C) {
 	c.Assert(lastInsertID+2, Equals, currLastInsertID)
 }
 
+func (s *testSessionSuite) TestPrepareZero(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(v timestamp)")
+	tk.MustExec("prepare s1 from 'insert into t (v) values (?)'")
+	tk.MustExec("set @v1='0'")
+	_, rs := tk.Exec("execute s1 using @v1")
+	c.Assert(rs, NotNil)
+	tk.MustExec("set @v2='00000000000000'")
+	tk.MustExec("execute s1 using @v2")
+	tk.MustQuery("select v from t").Check(testkit.Rows("0000-00-00 00:00:00"))
+}
+
 func (s *testSessionSuite) TestPrimaryKeyAutoIncrement(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("drop table if exists t")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #7501

### What is changed and how it works?

in protocol layer return `"types.ZeroDatetimeStr"` instead of `"0"` to make later `types.parseDatetime` happy.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test 

```
    mysql_stmt= mysql_stmt_init(&mysql);
    if(!mysql_stmt)
    {
        my_chk_stmt(&mysql, mysql_stmt, __LINE__);
    }

    stmt= const_cast<char *>("INSERT INTO timestamp_insert ( id, tstamp ) VALUES ( ?, ? )");
    if(mysql_stmt_prepare(mysql_stmt, stmt, strlen(stmt)))
    {
        my_chk_stmt(&mysql, mysql_stmt, __LINE__);
    }

    memset(mysql_bind_param, 0, sizeof(mysql_bind_param));
    mysql_bind_param[0].buffer_type= MYSQL_TYPE_LONG;
    mysql_bind_param[0].buffer= (char*)&id;
    mysql_bind_param[0].is_null= 0;
    mysql_bind_param[0].length= 0;
    mysql_bind_param[1].buffer_type= MYSQL_TYPE_TIMESTAMP;
    mysql_bind_param[1].buffer= &tstamp;
    mysql_bind_param[1].is_null= 0;
    mysql_bind_param[1].length= 0;
    if(mysql_stmt_bind_param(mysql_stmt, mysql_bind_param))
    {
        my_chk_stmt(&mysql, mysql_stmt, __LINE__);
    }

    tstamp.year= 0;
    tstamp.month= 0;
    tstamp.day= 0;
    tstamp.hour= 0;
    tstamp.minute= 0;
    tstamp.second= 0;
    tstamp.second_part= 0;

    if(mysql_stmt_execute(mysql_stmt))
    {
        my_chk_stmt(&mysql, mysql_stmt, __LINE__);
    }
```

Code changes

 - impl change

Side effects

 - no

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7506)
<!-- Reviewable:end -->
