### PR TITLE
server: fix ComStmtSendLongData when data length is 0 (#7485)

### DIFF
--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -83,7 +83,12 @@ func (ts *TiDBStatement) AppendParam(paramID int, data []byte) error {
 	if paramID >= len(ts.boundParams) {
 		return mysql.NewErr(mysql.ErrWrongArguments, "stmt_send_longdata")
 	}
-	ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+	// If len(data) is 0, append an empty byte slice to the end to distinguish no data and no parameter.
+	if len(data) == 0 {
+		ts.boundParams[paramID] = []byte{}
+	} else {
+		ts.boundParams[paramID] = append(ts.boundParams[paramID], data...)
+	}
 	return nil
 }
 


### PR DESCRIPTION
(cherry picked from commit 09fb68ae3bd5d93f5d8c2c4d3efc50575769338c)

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry-pick #7485 to release 2.0.

### What is changed and how it works?
Append an empty slice instead of nil when appending a parameter.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to be included in the release note
