### PR TITLE
tidb-server: enable mutex profiling

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -455,6 +455,8 @@ func setupSignalHandler() {
 }
 
 func setupMetrics() {
+	// Enable the mutex profile, 1/10 of mutex blocking event sampling.
+	runtime.SetMutexProfileFraction(10)
 	systimeErrHandler := func() {
 		metrics.TimeJumpBackCounter.Inc()
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes the performance bottleneck is due to mutex contention, this can be detected by mutex profiling.

By default, mutex blocking event is not sampled, to enable it, we need to call `runtime.SetMutexProfileFraction`.

### What is changed and how it works?
Adding a line `runtime.SetMutexProfileFraction(10)` in `tidb-server/main.go`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

1. run `tidb-server`
2. run some working load, `sysbench` for example.
3. visit `http://localhost:10080/debug/pprof/mutex?debug=1`

Side effects

 - Possible performance regression

Theoretically, there will be some perfromance regression, but I tested `sysbench` update-index and point-select on a 10000000 records table when the rate is set to 1，no noticeable performance decrease, so it is safe to set it to 10.

