### PR TITLE
executor: only rebase auto increment ID when needed

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -73,26 +73,26 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 				return false, handleChanged, newHandle, 0, errors.Trace(err)
 			}
 		}
-		// Rebase auto increment id if the field is changed.
-		if mysql.HasAutoIncrementFlag(col.Flag) {
-			if newData[i].IsNull() {
-				return false, handleChanged, newHandle, 0, table.ErrColumnCantNull.GenByArgs(col.Name)
-			}
-			val, errTI := newData[i].ToInt64(sc)
-			if errTI != nil {
-				return false, handleChanged, newHandle, 0, errors.Trace(errTI)
-			}
-			lastInsertID = uint64(val)
-			err := t.RebaseAutoID(ctx, val, true)
-			if err != nil {
-				return false, handleChanged, newHandle, 0, errors.Trace(err)
-			}
-		}
 		cmp, err := newData[i].CompareDatum(sc, &oldData[i])
 		if err != nil {
 			return false, handleChanged, newHandle, 0, errors.Trace(err)
 		}
 		if cmp != 0 {
+			// Rebase auto increment id if the field is changed.
+			if mysql.HasAutoIncrementFlag(col.Flag) {
+				if newData[i].IsNull() {
+					return false, handleChanged, newHandle, 0, table.ErrColumnCantNull.GenByArgs(col.Name)
+				}
+				val, errTI := newData[i].ToInt64(sc)
+				if errTI != nil {
+					return false, handleChanged, newHandle, 0, errors.Trace(errTI)
+				}
+				lastInsertID = uint64(val)
+				err := t.RebaseAutoID(ctx, val, true)
+				if err != nil {
+					return false, handleChanged, newHandle, 0, errors.Trace(err)
+				}
+			}
 			changed = true
 			modified[i] = true
 			if col.IsPKHandleColumn(t.Meta()) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #7422 . It is better to compare the value of the auto-increment ID before rebasing it in `updateRecord`. Update an old value which was inserted from another TiDB when the auto-increment column has no change does not need to rebase its ID. After this PR, the increasing speed of the auto-increment ID value will be slower than before.

### What is changed and how it works?
Compare the values before rebasing the ID. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
The same SQL in #7422 

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to be included in the release note

PTAL @zimulala @coocood 