### PR TITLE
stats: fix zero column size update error

### DIFF
--- a/statistics/update.go
+++ b/statistics/update.go
@@ -230,6 +230,10 @@ func (h *Handle) dumpTableStatColSizeToKV(id int64, delta variable.TableDelta) e
 		}
 		values = append(values, fmt.Sprintf("(%d, 0, %d, 0, %d, %d)", id, histID, deltaColSize, version))
 	}
+	if len(values) == 0 {
+		_, err = h.ctx.(sqlexec.SQLExecutor).Execute(ctx, "rollback")
+		return errors.Trace(err)
+	}
 	sql := fmt.Sprintf("insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, tot_col_size, version) "+
 		"values %s on duplicate key update tot_col_size = tot_col_size + values(tot_col_size), version = values(version)", strings.Join(values, ","))
 	_, err = h.ctx.(sqlexec.SQLExecutor).Execute(ctx, sql)

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -393,6 +393,18 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	c.Assert(hg.Len(), Equals, 3)
 }
 
+func (s *testStatsUpdateSuite) TestZeroColSizeUpdate(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	testKit := testkit.NewTestKit(c, s.store)
+	testKit.MustExec("use test")
+	testKit.MustExec("create table t (a varchar(20))")
+	testKit.MustExec("analyze table t")
+	testKit.MustExec("insert into t values ('ss')")
+	testKit.MustExec("delete from t")
+	h := s.do.StatsHandle()
+	c.Assert(h.DumpStatsDeltaToKV(), IsNil)
+}
+
 func appendBucket(h *statistics.Histogram, l, r int64) {
 	lower, upper := types.NewIntDatum(l), types.NewIntDatum(r)
 	h.AppendBucket(&lower, &upper, 0, 0)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When all the column size delta is zero, there would be parse error for the insert statement.

### What is changed and how it works?

Skip the update when the column size delta is zero.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - None

PTAL @coocood @zz-jason @winoros 