### PR TITLE
plan: change the logic of converting to inner join

### DIFF
--- a/expression/util.go
+++ b/expression/util.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/cznic/mathutil"
 	"github.com/juju/errors"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/mysql"
@@ -448,4 +449,20 @@ func (s *exprStack) push(expr Expression) {
 // len returns the length of th stack.
 func (s *exprStack) len() int {
 	return len(s.stack)
+}
+
+// ColumnSliceIntersect intersects two column slice.
+// You need to make sure that at least each element in s2 is unique.
+func ColumnSliceIntersect(s1, s2 []*Column) []*Column {
+	intSet := map[int]struct{}{}
+	for _, col := range s1 {
+		intSet[col.UniqueID] = struct{}{}
+	}
+	result := make([]*Column, 0, mathutil.Min(len(s1), len(s2)))
+	for _, col := range s2 {
+		if _, ok := intSet[col.UniqueID]; ok {
+			result = append(result, col)
+		}
+	}
+	return result
 }

--- a/plan/exhaust_physical_plans.go
+++ b/plan/exhaust_physical_plans.go
@@ -518,7 +518,7 @@ func (p *LogicalJoin) buildRangeForIndexJoin(indexInfo *model.IndexInfo, innerPl
 		return nil, nil, nil
 	}
 
-	conds, eqConds, keyOff2IdxOff := p.buildFakeEqCondsForIndexJoin(innerJoinKeys, idxCols, colLengths, innerPlan)
+	access, eqConds, remained, keyOff2IdxOff := p.buildFakeEqCondsForIndexJoin(innerJoinKeys, idxCols, colLengths, innerPlan.pushedDownConds)
 
 	if len(keyOff2IdxOff) == 0 {
 		return nil, nil, nil
@@ -527,7 +527,7 @@ func (p *LogicalJoin) buildRangeForIndexJoin(indexInfo *model.IndexInfo, innerPl
 	// After constant propagation, there won'be cases that t1.a=t2.a and t2.a=1 occur in the same time.
 	// And if there're cases like t1.a=t2.a and t1.a > 1, we can also guarantee that t1.a > 1 won't be chosen as access condition.
 	// So DetachCondAndBuildRangeForIndex won't miss the equal conditions we generate.
-	ranges, accesses, remained, _, err := ranger.DetachCondAndBuildRangeForIndex(p.ctx, conds, idxCols, colLengths)
+	ranges, accesses, moreRemained, _, err := ranger.DetachCondAndBuildRangeForIndex(p.ctx, access, idxCols, colLengths)
 	if err != nil {
 		terror.Log(errors.Trace(err))
 		return nil, nil, nil
@@ -540,27 +540,30 @@ func (p *LogicalJoin) buildRangeForIndexJoin(indexInfo *model.IndexInfo, innerPl
 		}
 	}
 
-	return ranges, remained, keyOff2IdxOff
+	return ranges, append(remained, moreRemained...), keyOff2IdxOff
 }
 
 func (p *LogicalJoin) buildFakeEqCondsForIndexJoin(keys, idxCols []*expression.Column, colLengths []int,
-	innerPlan *DataSource) (accesses, eqConds []expression.Expression, keyOff2IdxOff []int) {
+	innerFilters []expression.Expression) (accesses, eqConds, remained []expression.Expression, keyOff2IdxOff []int) {
 	// Check whether all join keys match one column from index.
 	keyOff2IdxOff = joinKeysMatchIndex(keys, idxCols, colLengths)
 	if keyOff2IdxOff == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
+
+	usableKeys := make([]*expression.Column, 0, len(keys))
 
 	// After predicate push down, the one side conditions of join must be the conditions that cannot be pushed down and
 	// cannot calculate range either. So we only need the innerPlan.pushedDownConds and the eq conditions that we generate.
 	// TODO: There may be a selection that block the index join.
-	conds := make([]expression.Expression, 0, len(keys)+len(innerPlan.pushedDownConds))
+	conds := make([]expression.Expression, 0, len(keys)+len(innerFilters))
 	eqConds = make([]expression.Expression, 0, len(keys))
 	// Construct a fake equal expression for calculating the range.
 	for i, key := range keys {
 		if keyOff2IdxOff[i] < 0 {
 			continue
 		}
+		usableKeys = append(usableKeys, key)
 		// Int datum 1 can convert to all column's type(numeric type, string type, json, time type, enum, set) safely.
 		fakeConstant := &expression.Constant{Value: types.NewIntDatum(1), RetType: key.GetType()}
 		eqFunc := expression.NewFunctionInternal(p.ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), key, fakeConstant)
@@ -568,8 +571,17 @@ func (p *LogicalJoin) buildFakeEqCondsForIndexJoin(keys, idxCols []*expression.C
 		eqConds = append(eqConds, eqFunc)
 	}
 
-	conds = append(conds, innerPlan.pushedDownConds...)
-	return conds, eqConds, keyOff2IdxOff
+	remained = make([]expression.Expression, 0, len(innerFilters))
+	for _, filter := range innerFilters {
+		affectedCols := expression.ExtractColumns(filter)
+		if len(expression.ColumnSliceIntersect(affectedCols, usableKeys)) > 0 {
+			remained = append(remained, filter)
+			continue
+		}
+		conds = append(conds, filter)
+	}
+
+	return conds, eqConds, remained, keyOff2IdxOff
 }
 
 // tryToGetIndexJoin will get index join by hints. If we can generate a valid index join by hint, the second return value

--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -407,6 +407,10 @@ func (s *testPlanSuite) TestDAGPlanBuilderJoin(c *C) {
 			sql:  "select /*+ TIDB_INLJ(t1) */ * from t t1 join t t2 where t1.f=t2.f and t1.a=t2.a",
 			best: "IndexJoin{TableReader(Table(t))->TableReader(Table(t))}(t1.a,t2.a)",
 		},
+		{
+			sql:  "select /*+ TIDB_INLJ(t1) */ * from t t1 join t t2 where t1.a=t2.a and t1.a in(1, 2) and t2.a in (1, 2)",
+			best: "IndexJoin{TableReader(Table(t))->TableReader(Table(t)->Sel([in(t2.a, 1, 2)]))}(t1.a,t2.a)",
+		},
 	}
 	for i, tt := range tests {
 		comment := Commentf("case:%v sql:%s", i, tt.sql)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Race occurs in race test. It's caused by the sql added in the unit-test.
Original sql is optimized to that one after https://github.com/pingcap/tidb/pull/7276

In such case, the index join may just be as well as hash join, not better than it. And even worse since it has redundant expression evaluation.
This pr mainly to make **the hint** work in this case.

### What is changed and how it works?

Make the filters that index join uses to build range more strict.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
