### PR TITLE
executor: break innerTable fetcher is error happend during fetching outer table

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -102,6 +102,10 @@ func (e *HashJoinExec) Close() error {
 	close(e.closeCh)
 	e.finished.Store(true)
 	if e.prepared {
+		if e.innerFinished != nil {
+			for range e.innerFinished {
+			}
+		}
 		if e.joinResultCh != nil {
 			for range e.joinResultCh {
 			}
@@ -511,6 +515,10 @@ func (e *HashJoinExec) fetchInnerAndBuildHashTable(ctx context.Context) {
 
 	if err := e.fetchInnerRows(ctx); err != nil {
 		e.innerFinished <- errors.Trace(err)
+		return
+	}
+
+	if e.finished.Load().(bool) {
 		return
 	}
 

--- a/executor/join.go
+++ b/executor/join.go
@@ -541,9 +541,6 @@ func (e *HashJoinExec) buildHashTableForList() error {
 		}
 		chk := e.innerResult.GetChunk(i)
 		for j := 0; j < chk.NumRows(); j++ {
-			if e.finished.Load().(bool) {
-				return nil
-			}
 			hasNull, keyBuf, err = e.getJoinKeyFromChkRow(false, chk.GetRow(j), keyBuf)
 			if err != nil {
 				return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Break [fetchInnerAndBuildHashTable](https://github.com/pingcap/tidb/blob/master/executor/join.go#L476) if error happened during [fetchOuterAndProbeHashTable](https://github.com/pingcap/tidb/blob/master/executor/join.go#L477).

### What is changed and how it works?
Before this PR, if any error happens during fetchOuterAndProbeHashTable,
fetchInnerAndBuildHashTable will continue running, this will cause some
unexpected situations such as DataRace which would may by closing HashJoinExec
while fetchOuterAndProbeHashTable is still running.

This PR checks HashJoinExec.finished evecy time in the loop of
fetchInnerAndBuildHashTable to exists in time if any error happens.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change


Side effects

Related changes

 - Need to cherry-pick to the release branch

