### PR TITLE
tidb-server: close Domain and Storage before HTTP listener

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -143,7 +143,6 @@ func main() {
 	createServer()
 	setupSignalHandler()
 	runServer()
-	cleanup()
 	os.Exit(0)
 }
 
@@ -421,6 +420,7 @@ func createServer() {
 	svr, err = server.NewServer(cfg, driver)
 	// Both domain and storage have started, so we have to clean them before exiting.
 	terror.MustNil(err, closeDomainAndStorage)
+	svr.SetCleanupFunc(cleanup)
 	if cfg.XProtocol.XServer {
 		xcfg := &xserver.Config{
 			Addr:       fmt.Sprintf("%s:%d", cfg.XProtocol.XHost, cfg.XProtocol.XPort),
@@ -490,6 +490,7 @@ func runServer() {
 		err := xsvr.Run()
 		terror.MustNil(err)
 	}
+	<-closeCh
 }
 
 func closeDomainAndStorage() {
@@ -498,9 +499,12 @@ func closeDomainAndStorage() {
 	terror.Log(errors.Trace(err))
 }
 
+var closeCh = make(chan struct{})
+
 func cleanup() {
 	if graceful {
 		svr.GracefulDown()
 	}
 	closeDomainAndStorage()
+	close(closeCh)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the tidb-server failed to quit, we need to know why. 
But HTTP listener is closed before domain and storage, we can get the goroutine stack info.
It can be helpful to solve https://github.com/pingcap/tidb/issues/7545

### What is changed and how it works?
add `SetCleanupFunc` method to `Server`, call this function in `Close` before HTTP listener is closed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Add `Sleep(time.Munite)` in `cleanup`.
2. make server
3. start the server
4. kill the server.
5. try to connect the server with mysql-client, should be failed.
6. visit `http://localhost:10080/debug/pprof`, we can see the page.


Code changes

 - Has exported function/method change
