### PR TITLE
stats: auto analyze on certain period of a day

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -623,6 +623,8 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBOptAggPushDown, boolToIntStr(DefOptAggPushDown)},
 	{ScopeGlobal | ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},
 	{ScopeGlobal, TiDBAutoAnalyzeRatio, strconv.FormatFloat(DefAutoAnalyzeRatio, 'f', -1, 64)},
+	{ScopeGlobal, TiDBAutoAnalyzeStartTime, DefAutoAnalyzeStartTime},
+	{ScopeGlobal, TiDBAutoAnalyzeEndTime, DefAutoAnalyzeEndTime},
 	{ScopeSession, TiDBChecksumTableConcurrency, strconv.Itoa(DefChecksumTableConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBDistSQLScanConcurrency, strconv.Itoa(DefDistSQLScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBOptInSubqUnFolding, boolToIntStr(DefOptInSubqUnfolding)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -38,6 +38,10 @@ const (
 	// Auto analyze will run if (table modify count)/(table row count) is greater than this value.
 	TiDBAutoAnalyzeRatio = "tidb_auto_analyze_ratio"
 
+	// Auto analyze will run if current time is within start time and end time.
+	TiDBAutoAnalyzeStartTime = "tidb_auto_analyze_start_time"
+	TiDBAutoAnalyzeEndTime   = "tidb_auto_analyze_end_time"
+
 	// tidb_checksum_table_concurrency is used to speed up the ADMIN CHECKSUM TABLE
 	// statement, when a table has multiple indices, those indices can be
 	// scanned concurrently, with the cost of higher system performance impact.
@@ -189,6 +193,8 @@ const (
 	DefDistSQLScanConcurrency        = 15
 	DefBuildStatsConcurrency         = 4
 	DefAutoAnalyzeRatio              = 0.5
+	DefAutoAnalyzeStartTime          = "00:00 UTC"
+	DefAutoAnalyzeEndTime            = "23:59 UTC"
 	DefChecksumTableConcurrency      = 4
 	DefSkipUTF8Check                 = false
 	DefOptAggPushDown                = false

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -193,8 +193,8 @@ const (
 	DefDistSQLScanConcurrency        = 15
 	DefBuildStatsConcurrency         = 4
 	DefAutoAnalyzeRatio              = 0.5
-	DefAutoAnalyzeStartTime          = "00:00 UTC"
-	DefAutoAnalyzeEndTime            = "23:59 UTC"
+	DefAutoAnalyzeStartTime          = "00:00 +0000"
+	DefAutoAnalyzeEndTime            = "23:59 +0000"
 	DefChecksumTableConcurrency      = 4
 	DefSkipUTF8Check                 = false
 	DefOptAggPushDown                = false

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -618,7 +618,7 @@ func withinTimePeriod(start, end, now time.Time) bool {
 
 // NeedAnalyzeTable checks if we need to analyze the table:
 // 1. If the table has never been analyzed, we need to analyze it when it has
-//    not been modified for a time.
+//    not been modified for a while.
 // 2. If the table had been analyzed before, we need to analyze it when
 //    "tbl.ModifyCount/tbl.Count > autoAnalyzeRatio".
 // 3. The current time is between `start` and `end`.

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -932,7 +932,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 		now    string
 		result bool
 	}{
-		// table never analyzed and has reach the limit
+		// table was never analyzed and has reach the limit
 		{
 			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
 			limit:  0,
@@ -942,7 +942,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:00 CST",
 			result: true,
 		},
-		// table never analyzed but has not reach the limit
+		// table was never analyzed but has not reach the limit
 		{
 			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
 			limit:  time.Hour,
@@ -952,7 +952,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:00 CST",
 			result: false,
 		},
-		// table already analyzed but auto analyze is disabled
+		// table was already analyzed but auto analyze is disabled
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
 			limit:  0,
@@ -962,7 +962,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:00 CST",
 			result: false,
 		},
-		// table already analyzed and but modify count is small
+		// table was already analyzed and but modify count is small
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 0, Count: 1}},
 			limit:  0,
@@ -972,7 +972,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:00 CST",
 			result: false,
 		},
-		// table already analyzed and but not within time period
+		// table was already analyzed and but not within time period
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
 			limit:  0,
@@ -982,7 +982,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:02 CST",
 			result: false,
 		},
-		// table already analyzed and but not within time period
+		// table was already analyzed and but not within time period
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
 			limit:  0,
@@ -992,7 +992,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "10:00 CST",
 			result: false,
 		},
-		// table already analyzed and within time period
+		// table was already analyzed and within time period
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
 			limit:  0,
@@ -1002,7 +1002,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 			now:    "00:00 CST",
 			result: true,
 		},
-		// table already analyzed and within time period
+		// table was already analyzed and within time period
 		{
 			tbl:    &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
 			limit:  0,

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/ranger"
@@ -916,5 +917,91 @@ func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
 		s.hook.results = ""
 		testKit.MustQuery(t.sql)
 		c.Assert(s.hook.results, Equals, t.result)
+	}
+}
+
+func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
+	columns := map[int64]*statistics.Column{}
+	columns[1] = &statistics.Column{Count: 1}
+	tests := []struct {
+		tbl     *statistics.Table
+		ratio   float64
+		limit   time.Duration
+		timeStr []string
+		result  bool
+	}{
+		// table never analyzed and has reach the limit
+		{
+			tbl:     &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
+			limit:   0,
+			ratio:   0,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:00 CST"},
+			result:  true,
+		},
+		// table never analyzed but has not reach the limit
+		{
+			tbl:     &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
+			limit:   time.Hour,
+			ratio:   0,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:00 CST"},
+			result:  false,
+		},
+		// table already analyzed but auto analyze is disabled
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			limit:   0,
+			ratio:   0,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:00 CST"},
+			result:  false,
+		},
+		// table already analyzed and but modify count is small
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 0, Count: 1}},
+			limit:   0,
+			ratio:   0.3,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:00 CST"},
+			result:  false,
+		},
+		// table already analyzed and but not within time period
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			limit:   0,
+			ratio:   0.3,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:02 CST"},
+			result:  false,
+		},
+		// table already analyzed and but not within time period
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			limit:   0,
+			ratio:   0.3,
+			timeStr: []string{"22:00 CST", "06:00 CST", "10:02 CST"},
+			result:  false,
+		},
+		// table already analyzed and within time period
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			limit:   0,
+			ratio:   0.3,
+			timeStr: []string{"00:00 CST", "00:01 CST", "00:00 CST"},
+			result:  true,
+		},
+		// table already analyzed and within time period
+		{
+			tbl:     &statistics.Table{HistColl: statistics.HistColl{Columns: columns, ModifyCount: 1, Count: 1}},
+			limit:   0,
+			ratio:   0.3,
+			timeStr: []string{"22:00 CST", "06:00 CST", "23:00 CST"},
+			result:  true,
+		},
+	}
+	for _, test := range tests {
+		ts := make([]time.Time, 0, 3)
+		for _, s := range test.timeStr {
+			t, err := time.ParseInLocation(statistics.TimeFormat, s, time.UTC)
+			c.Assert(err, IsNil)
+			ts = append(ts, t)
+		}
+		c.Assert(statistics.NeedAnalyzeTable(test.tbl, test.limit, test.ratio, ts[0], ts[1], ts[2]), Equals, test.result)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some application doesn't want auto-analyze to be executed in the hours when the cluster is busy, we need to provide an option to only execute auto-analyze in idle hours.
Fix #7072 

### What is changed and how it works?

Add two global variables to control the analyze start time and end time. But when the table is never analyzed, the time limit is ignored.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - None

Related changes

 - Need to update the documentation

PTAL @coocood @zz-jason @winoros 