### PR TITLE
executor: fix update join result when join table order changed

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1228,7 +1228,7 @@ func (b *executorBuilder) buildUpdate(v *plan.Update) Executor {
 		b.err = errors.Trace(b.err)
 		return nil
 	}
-	columns2Handle := buildColumns2Handle(v.Schema(), tblID2table)
+	columns2Handle := buildColumns2Handle(v.SelectPlan.Schema(), tblID2table)
 	updateExec := &UpdateExec{
 		baseExecutor:   newBaseExecutor(b.ctx, nil, v.ExplainID(), selExec),
 		SelectExec:     selExec,

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3024,7 +3024,7 @@ func (s *testSuite) TestUnionAutoSignedCast(c *C) {
 func (s *testSuite) TestUpdateJoin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1, t2, t3, t4, t5")
+	tk.MustExec("drop table if exists t1, t2, t3, t4, t5, t6, t7")
 	tk.MustExec("create table t1(k int, v int)")
 	tk.MustExec("create table t2(k int, v int)")
 	tk.MustExec("create table t3(id int auto_increment, k int, v int, primary key(id))")
@@ -3032,6 +3032,8 @@ func (s *testSuite) TestUpdateJoin(c *C) {
 	tk.MustExec("create table t5(v int, k int, primary key(k))")
 	tk.MustExec("insert into t1 values (1, 1)")
 	tk.MustExec("insert into t4 values (3, 3)")
+	tk.MustExec("create table t6 (id int, v longtext)")
+	tk.MustExec("create table t7 (x int, id int, v longtext, primary key(id))")
 
 	// test the normal case that update one row for a single table.
 	tk.MustExec("update t1 set v = 0 where k = 1")
@@ -3086,6 +3088,10 @@ func (s *testSuite) TestUpdateJoin(c *C) {
 	tk.MustQuery("select k, v from t1").Check(testkit.Rows("<nil> 2"))
 	tk.MustQuery("select k, v from t5").Check(testkit.Rows("0 0"))
 
+	tk.MustExec("insert into t6 values (1, NULL)")
+	tk.MustExec("insert into t7 values (5, 1, 'a')")
+	tk.MustExec("update t6, t7 set t6.v = t7.v where t6.id = t7.id and t7.x = 5")
+	tk.MustQuery("select v from t6").Check(testkit.Rows("a"))
 }
 
 func (s *testSuite) TestMaxOneRow(c *C) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

this question is introduced by #7177 

create two simple table and one of them have primary key.

```
create table t6 (id int, v longtext);
create table t7 (x int, id int, v longtext, primary key(id);
insert into t6 values (1, NULL);
insert into t7 values (5, 1, 'a')
```

execute this

```
update t6, t7 set t6.v = t7.v where t6.id = t7.id
```
will make `t6.v`  be `a`.

but with 

```
update t6, t7 set t6.v = t7.v where t6.id = t7.id and t7.x = 5;
```

will update nothing.

because added `t7.x = 5` will change plan from `t6 join t7` to `t7 join t6` and in update there are no projection stage like select stmt. 

one of new added code doesn't take care about it and use `updateExec.schema` to build handle identity map, but use `update.selectExec.schema` to query map, so meet error.

### What is changed and how it works?

build identity map using `update.SelectPlan` instead of `updatePlan`, oneline change.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - bug fix

Side effects

 - no

Related changes

 - no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7571)
<!-- Reviewable:end -->
