### PR TITLE
server: make long-data type no longer check nullBitmap

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -246,15 +246,14 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 	var isNull bool
 
 	for i := 0; i < len(args); i++ {
-		if nullBitmap[i>>3]&(1<<(uint(i)%8)) > 0 {
-			args[i] = nil
-			continue
-		}
 		if boundParams[i] != nil {
 			args[i] = boundParams[i]
 			continue
 		}
-
+		if nullBitmap[i>>3]&(1<<(uint(i)%8)) > 0 {
+			args[i] = nil
+			continue
+		}
 		if (i<<1)+1 >= len(paramTypes) {
 			return mysql.ErrMalformPacket
 		}

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -246,11 +246,18 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 	var isNull bool
 
 	for i := 0; i < len(args); i++ {
+		// if params had received via ComStmtSendLongData, use them directly.
+		// ref https://dev.mysql.com/doc/internals/en/com-stmt-send-long-data.html
+		// see clientConn#handleStmtSendLongData
 		if boundParams[i] != nil {
 			args[i] = boundParams[i]
 			continue
 		}
 
+		// check nullBitMap to determine the NULL arguments.
+		// ref https://dev.mysql.com/doc/internals/en/com-stmt-execute.html
+		// notice: some client(e.g. mariadb) will set nullBitMap even if data had be sent via ComStmtSendLongData,
+		// so this check need place after boundParam's check.
 		if nullBitmap[i>>3]&(1<<(uint(i)%8)) > 0 {
 			args[i] = nil
 			continue

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -250,10 +250,12 @@ func parseStmtArgs(args []interface{}, boundParams [][]byte, nullBitmap, paramTy
 			args[i] = boundParams[i]
 			continue
 		}
+
 		if nullBitmap[i>>3]&(1<<(uint(i)%8)) > 0 {
 			args[i] = nil
 			continue
 		}
+
 		if (i<<1)+1 >= len(paramTypes) {
 			return mysql.ErrMalformPacket
 		}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #7572

mariadb send none zero value in nullBitmap, tidb follow [protocol docs](https://dev.mysql.com/doc/internals/en/com-stmt-execute.html) to check nullBitmap and got nul value

but after experiment and check code, `nullBitmap` is nouse for `LONG_DATA_VALUE`(and it's NULL value seem be magic), so we need skip them, and make mariadb client user work.

### What is changed and how it works?

if param is long_data_value then skip nullBitmap check.

### Check List <!--REMOVE the items that are not applicable-->

 - Integration test by https://github.com/pingcap/tidb-test/pull/615
 - Manual test

use mariadb client can reproduce it, after this PR fixed.

Code changes

 - impl

Side effects

 - no

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7573)
<!-- Reviewable:end -->
