### PR TITLE
stats, plan: return row count 0 for empty range on handle

### DIFF
--- a/statistics/table.go
+++ b/statistics/table.go
@@ -403,7 +403,7 @@ func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Da
 func (coll *HistColl) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID int64, intRanges []*ranger.Range) (float64, error) {
 	if coll.ColumnIsInvalid(sc, colID) {
 		if len(intRanges) == 0 {
-			return float64(coll.Count), nil
+			return 0, nil
 		}
 		if intRanges[0].LowVal[0].Kind() == types.KindInt64 {
 			return getPseudoRowCountBySignedIntRanges(intRanges, float64(coll.Count)), nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

to solve https://github.com/pingcap/tidb/issues/7582

### What is changed and how it works?

after this PR:
```
mysql> create table t1(a int primary key);
Query OK, 0 rows affected (0.11 sec)

mysql> explain select * from t1 where a = 1 and a = 2;
+-------------------+-------+------+------------------------------------------+
| id                | count | task | operator info                            |
+-------------------+-------+------+------------------------------------------+
| TableReader_6     | 0.00  | root | data:TableScan_5                         |
| └─TableScan_5     | 0.00  | cop  | table:t1, keep order:false, stats:pseudo |
+-------------------+-------+------+------------------------------------------+
2 rows in set (0.00 sec)

mysql> analyze table t1;
Query OK, 0 rows affected (0.00 sec)

mysql> explain select * from t1 where a = 1 and a = 2;
+-------------------+-------+------+------------------------------------------+
| id                | count | task | operator info                            |
+-------------------+-------+------+------------------------------------------+
| TableReader_6     | 0.00  | root | data:TableScan_5                         |
| └─TableScan_5     | 0.00  | cop  | table:t1, keep order:false, stats:pseudo |
+-------------------+-------+------+------------------------------------------+
2 rows in set (0.00 sec)

mysql> insert into t1 values(1);
Query OK, 1 row affected (0.00 sec)

mysql> explain select * from t1 where a = 1 and a = 2;
+-------------------+-------+------+------------------------------------------+
| id                | count | task | operator info                            |
+-------------------+-------+------+------------------------------------------+
| TableReader_6     | 0.00  | root | data:TableScan_5                         |
| └─TableScan_5     | 0.00  | cop  | table:t1, keep order:false, stats:pseudo |
+-------------------+-------+------+------------------------------------------+
2 rows in set (0.00 sec)

mysql> analyze table t1;
Query OK, 0 rows affected (0.01 sec)

mysql> explain select * from t1 where a = 1 and a = 2;
+-------------------+-------+------+----------------------------+
| id                | count | task | operator info              |
+-------------------+-------+------+----------------------------+
| TableReader_6     | 0.00  | root | data:TableScan_5           |
| └─TableScan_5     | 0.00  | cop  | table:t1, keep order:false |
+-------------------+-------+------+----------------------------+
2 rows in set (0.00 sec)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test: explain test of https://github.com/pingcap/tidb/pull/7577 would cover this code change

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note: `return row count zero in explain for table scan with empty range`
