### PR TITLE
chunk:  reduce chunk's iterator function call

### DIFF
--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -106,13 +106,13 @@ func NewIterator4Chunk(chk *Chunk) *Iterator4Chunk {
 // Iterator4Chunk is used to iterate rows inside a chunk.
 type Iterator4Chunk struct {
 	chk     *Chunk
-	cursor  int
-	numRows int
+	cursor  int32
+	numRows int32
 }
 
 // Begin implements the Iterator interface.
 func (it *Iterator4Chunk) Begin() Row {
-	it.numRows = it.chk.NumRows()
+	it.numRows = int32(it.chk.NumRows())
 	if it.numRows == 0 {
 		return it.End()
 	}
@@ -126,17 +126,17 @@ func (it *Iterator4Chunk) Next() Row {
 		it.cursor = it.numRows + 1
 		return it.End()
 	}
-	row := it.chk.GetRow(it.cursor)
+	row := it.chk.GetRow(int(it.cursor))
 	it.cursor++
 	return row
 }
 
 // Current implements the Iterator interface.
 func (it *Iterator4Chunk) Current() Row {
-	if it.cursor == 0 || it.cursor > it.Len() {
+	if it.cursor == 0 || int(it.cursor) > it.Len() {
 		return it.End()
 	}
-	return it.chk.GetRow(it.cursor - 1)
+	return it.chk.GetRow(int(it.cursor) - 1)
 }
 
 // End implements the Iterator interface.
@@ -146,7 +146,7 @@ func (it *Iterator4Chunk) End() Row {
 
 // ReachEnd implements the Iterator interface.
 func (it *Iterator4Chunk) ReachEnd() {
-	it.cursor = it.Len() + 1
+	it.cursor = int32(it.Len() + 1)
 }
 
 // Len implements the Iterator interface

--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -105,13 +105,15 @@ func NewIterator4Chunk(chk *Chunk) *Iterator4Chunk {
 
 // Iterator4Chunk is used to iterate rows inside a chunk.
 type Iterator4Chunk struct {
-	chk    *Chunk
-	cursor int
+	chk     *Chunk
+	cursor  int
+	numRows int
 }
 
 // Begin implements the Iterator interface.
 func (it *Iterator4Chunk) Begin() Row {
-	if it.chk.NumRows() == 0 {
+	it.numRows = it.chk.NumRows()
+	if it.numRows == 0 {
 		return it.End()
 	}
 	it.cursor = 1
@@ -120,8 +122,8 @@ func (it *Iterator4Chunk) Begin() Row {
 
 // Next implements the Iterator interface.
 func (it *Iterator4Chunk) Next() Row {
-	if it.cursor >= it.chk.NumRows() {
-		it.cursor = it.chk.NumRows() + 1
+	if it.cursor >= it.numRows {
+		it.cursor = it.numRows + 1
 		return it.End()
 	}
 	row := it.chk.GetRow(it.cursor)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 Reduce chunk's iterator function call.

### What is changed and how it works?
Add `numRows int` to Iterator4Chunk.

Below is a benchmark
```go
func BenchmarkIterator4Chunk_Next(b *testing.B) {
        // 1024 rows
	chk := getChks()
	it := NewIterator4Chunk(chk)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		for row := it.Begin(); row != it.End(); row = it.Next() {
			_ = row
		}
	}
}
```
old:
```
BenchmarkIterator4Chunk_Next     2000000              2712 ns/op
BenchmarkIterator4Chunk_Next     2000000              2711 ns/op
BenchmarkIterator4Chunk_Next     2000000              2704 ns/op
```
this branch 
```
BenchmarkIterator4Chunk_Next     3000000              1412 ns/op
BenchmarkIterator4Chunk_Next     3000000              1411 ns/op
BenchmarkIterator4Chunk_Next     3000000              1410 ns/op
```
