### PR TITLE
server: add USR1 signal handler to dump goroutine

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -441,6 +441,7 @@ func setupSignalHandler() {
 			if sig == syscall.SIGUSR1 {
 				stackLen := runtime.Stack(buf, true)
 				log.Printf("=== Got signal [%s] to goroutine dump===\n*** goroutine dump...\n%s\n*** end\n", sig, buf[:stackLen])
+				continue
 			}
 		}
 	}()

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -48,7 +48,7 @@ import (
 	"github.com/pingcap/tidb/util/printer"
 	"github.com/pingcap/tidb/util/systimemon"
 	"github.com/pingcap/tidb/x-server"
-	"github.com/pingcap/tipb/go-binlog"
+	binlog "github.com/pingcap/tipb/go-binlog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	log "github.com/sirupsen/logrus"

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -432,16 +432,8 @@ func createServer() {
 }
 
 func setupSignalHandler() {
-	closeSignalChan := make(chan os.Signal, 1)
-	signal.Notify(closeSignalChan,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM,
-		syscall.SIGQUIT)
-
 	dumpSignalChan := make(chan os.Signal, 1)
 	signal.Notify(dumpSignalChan, syscall.SIGUSR1)
-
 	go func() {
 		buf := make([]byte, 1<<16)
 		for {
@@ -454,6 +446,12 @@ func setupSignalHandler() {
 		}
 	}()
 
+	closeSignalChan := make(chan os.Signal, 1)
+	signal.Notify(closeSignalChan,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT)
 	go func() {
 		sig := <-closeSignalChan
 		log.Infof("Got signal [%s] to exit.", sig)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -445,11 +445,11 @@ func setupSignalHandler(ctx context.Context) {
 
 	go func() {
 		quited := false
+		buf := make([]byte, 1<<20)
 		for {
 			select {
 			case sig := <-sc:
 				if sig == syscall.SIGUSR1 {
-					buf := make([]byte, 1<<20)
 					stackLen := runtime.Stack(buf, true)
 					log.Printf("=== Got signal [%s] to goroutine dump===\n*** goroutine dump...\n%s\n*** end\n", sig, buf[:stackLen])
 					continue

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -445,7 +445,7 @@ func setupSignalHandler(ctx context.Context) {
 
 	go func() {
 		quited := false
-		buf := make([]byte, 1<<20)
+		buf := make([]byte, 1<<16)
 		for {
 			select {
 			case sig := <-sc:

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -432,16 +432,15 @@ func createServer() {
 }
 
 func setupSignalHandler() {
-	dumpSignalChan := make(chan os.Signal, 1)
-	signal.Notify(dumpSignalChan, syscall.SIGUSR1)
+	usrDefSignalChan := make(chan os.Signal, 1)
+	signal.Notify(usrDefSignalChan, syscall.SIGUSR1)
 	go func() {
 		buf := make([]byte, 1<<16)
 		for {
-			sig := <-dumpSignalChan
+			sig := <-usrDefSignalChan
 			if sig == syscall.SIGUSR1 {
 				stackLen := runtime.Stack(buf, true)
-				log.Printf("=== Got signal [%s] to goroutine dump===\n*** goroutine dump...\n%s\n*** end\n", sig, buf[:stackLen])
-				continue
+				log.Printf("\n=== Got signal [%s] to dump goroutine stack. ===\n%s\n=== Finished dumping goroutine stack. ===\n", sig, buf[:stackLen])
 			}
 		}
 	}()

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -441,7 +441,6 @@ func setupSignalHandler() {
 			if sig == syscall.SIGUSR1 {
 				stackLen := runtime.Stack(buf, true)
 				log.Printf("=== Got signal [%s] to goroutine dump===\n*** goroutine dump...\n%s\n*** end\n", sig, buf[:stackLen])
-				continue
 			}
 		}
 	}()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

relate to #7558, we add USR1 signal handler to dump goroutine stack into stdout.

### What is changed and how it works?

- doesn't exit signal handler goroutine until cleanup down
- handle USR1 signal and dump groutine into stdout

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

1) `pkill -USR1 tidb-server` to send signal and check stdout see

```
2018/09/03 11:20:06.150  [info] === Got signal [user defined signal 1] to thread dump===
*** goroutine dump...
goroutine 107 [running]:
main.setupSignalHandler.func1(0xc4200f8e40, 0x14cdd80, 0xc4200dfec0)
	/home/robi/Code/go/src/github.com/pingcap/tidb/tidb-server/main.go:453 +0x2d8
created by main.setupSignalHandler
	/home/robi/Code/go/src/github.com/pingcap/tidb/tidb-server/main.go:446 +0x12e

goroutine 1 [sleep, 10 minutes]:
time.Sleep(0x1176592e000)
	/home/robi/go1.10/src/runtime/time.go:102 +0x166
main.cleanup()
	/home/robi/Code/go/src/github.com/pingcap/tidb/tidb-server/main.go:526 +0x3b
main.main()
	/home/robi/Code/go/src/github.com/pingcap/tidb/tidb-server/main.go:147 +0xbc

goroutine 18 [syscall]:
os/signal.signal_recv(0x14c2840)
	/home/robi/go1.10/src/runtime/sigqueue.go:139 +0xa6
os/signal.loop()
	/home/robi/go1.10/src/os/signal/signal_unix.go:22 +0x22
created by os/signal.init.0
	/home/robi/go1.10/src/os/signal/signal_unix.go:28 +0x41

goroutine 114 [chan receive]:
github.com/pingcap/tidb/util/systimemon.StartMonitor(0x1410138, 0x140f6a8, 0xc420038f20)
	/home/robi/Code/go/src/github.com/pingcap/tidb/util/systimemon/systime_mon.go:30 +0x154
created by main.setupMetrics
	/home/robi/Code/go/src/github.com/pingcap/tidb/tidb-server/main.go:493 +0xb5
......
``` 

2) temporal add `Sleep(time.Mintue*20) in cleanup(main.go).` 
3) `pkill -QUIT tidb-server` to shutdown tidb-server
4) `pkill -USR1 tidb-server` again and got dump output too

Code changes

 - signal handler change

Side effects

 - no

Related changes

 - no

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7587)
<!-- Reviewable:end -->
