### PR TITLE
stats: fix panic when log detailed stats info

### DIFF
--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -844,16 +844,20 @@ func logForIndex(prefix string, t *Table, idx *Index, ranges []*ranger.Range, ac
 		}
 		colName := idx.Info.Columns[rangePosition].Name.L
 		// prefer index stats over column stats
-		if idxHist := t.indexStartWithColumnForDebugLog(colName); idxHist != nil {
+		if idxHist := t.indexStartWithColumnForDebugLog(colName); idxHist != nil && idxHist.Histogram.Len() > 0 {
 			rangeString := logForIndexRange(idxHist, &rang, -1, factor)
 			log.Debugf("%s index: %s, actual: %d, equality: %s, expected equality: %d, %s", prefix, idx.Info.Name.O,
 				actual[i], equalityString, equalityCount, rangeString)
-		} else if colHist := t.columnByNameForDebugLog(colName); colHist != nil {
+		} else if colHist := t.columnByNameForDebugLog(colName); colHist != nil && colHist.Histogram.Len() > 0 {
 			rangeString := colRangeToStr(colHist, &rang, -1, factor)
 			log.Debugf("%s index: %s, actual: %d, equality: %s, expected equality: %d, %s", prefix, idx.Info.Name.O,
 				actual[i], equalityString, equalityCount, rangeString)
 		} else {
-			return
+			count, err := getPseudoRowCountByColumnRanges(sc, float64(t.Count), []*ranger.Range{&rang}, 0)
+			if err == nil {
+				log.Debugf("%s index: %s, actual: %d, equality: %s, expected equality: %d, range: %s, pseudo count: %.0f", prefix, idx.Info.Name.O,
+					actual[i], equalityString, equalityCount, rang.String(), count)
+			}
 		}
 	}
 }

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -910,7 +910,7 @@ func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
 			result: "[stats-feedback] test.t, index: idx_ba, actual: 1, equality: 1, expected equality: 1, range: [-inf,6], actual: -1, expected: 6, buckets: {num: 8 lower_bound: 0 upper_bound: 7 repeats: 1}",
 		},
 		{
-			sql: "select b from t use index(idx_bc) where b = 1 and c <= 5",
+			sql:    "select b from t use index(idx_bc) where b = 1 and c <= 5",
 			result: "[stats-feedback] test.t, index: idx_bc, actual: 1, equality: 1, expected equality: 1, range: [-inf,6], pseudo count: 7",
 		},
 		{

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -869,23 +869,26 @@ func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
 	oriMinError := statistics.MinLogErrorRate
 	oriLevel := log.GetLevel()
 	oriBucketNum := executor.GetMaxBucketSizeForTest()
+	oriLease := s.do.StatsHandle().Lease
 	defer func() {
 		statistics.FeedbackProbability = oriProbability
 		statistics.MinLogScanCount = oriMinLogCount
 		statistics.MinLogErrorRate = oriMinError
 		executor.SetMaxBucketSizeForTest(oriBucketNum)
+		s.do.StatsHandle().Lease = oriLease
 		log.SetLevel(oriLevel)
 	}()
 	executor.SetMaxBucketSizeForTest(4)
 	statistics.FeedbackProbability = 1
 	statistics.MinLogScanCount = 0
 	statistics.MinLogErrorRate = 0
+	s.do.StatsHandle().Lease = 1
 
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
-	testKit.MustExec("create table t (a bigint(64), b bigint(64), primary key(a), index idx(b), index idx_ba(b,a))")
+	testKit.MustExec("create table t (a bigint(64), b bigint(64), c bigint(64), primary key(a), index idx(b), index idx_ba(b,a), index idx_bc(b,c))")
 	for i := 0; i < 20; i++ {
-		testKit.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i, i))
+		testKit.MustExec(fmt.Sprintf("insert into t values (%d, %d, %d)", i, i, i))
 	}
 	testKit.MustExec("analyze table t")
 	tests := []struct {
@@ -905,6 +908,10 @@ func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
 		{
 			sql:    "select b from t use index(idx_ba) where b = 1 and a <= 5",
 			result: "[stats-feedback] test.t, index: idx_ba, actual: 1, equality: 1, expected equality: 1, range: [-inf,6], actual: -1, expected: 6, buckets: {num: 8 lower_bound: 0 upper_bound: 7 repeats: 1}",
+		},
+		{
+			sql: "select b from t use index(idx_bc) where b = 1 and c <= 5",
+			result: "[stats-feedback] test.t, index: idx_bc, actual: 1, equality: 1, expected equality: 1, range: [-inf,6], pseudo count: 7",
 		},
 		{
 			sql:    "select b from t use index(idx_ba) where b = 1",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
panic: runtime error: index out of range                                 
                                                                         
goroutine 14313 [running]:                                               
github.com/pingcap/tidb/util/chunk.(*column).isNull(...)                 
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/chunk/column.go:71
github.com/pingcap/tidb/util/chunk.Row.IsNull(...)                       
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/chunk/row.go:222
github.com/pingcap/tidb/util/chunk.Row.GetDatum(0xc000021f50, 0xffffffffffffffff, 0x0, 0xc0004a5810, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/chunk/row.go:174 +0xbd0
github.com/pingcap/tidb/statistics.(*Histogram).GetUpper(0xc00058cd80, 0xffffffffffffffff, 0x13503b6)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/statistics/histogram.go:102 +0x82
github.com/pingcap/tidb/statistics.(*Histogram).bucketToString(0xc00058cd80, 0xffffffffffffffff, 0x0, 0x0, 0xc005c97780)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/statistics/histogram.go:356 +0x4d
github.com/pingcap/tidb/statistics.formatBuckets(0xc00058cd80, 0xffffffffffffffff, 0xffffffffffffffff, 0x0, 0xb, 0x12)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/statistics/feedback.go:767 +0x3e5
github.com/pingcap/tidb/statistics.colRangeToStr(0xc00058cd80, 0xc002461c20, 0xffffffffffffffff, 0x3ff448be405987b2, 0xc000345498, 0x0)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/statistics/feedback.go:781 +0x14b
github.com/pingcap/tidb/statistics.logForIndex(0xc0064a1890, 0x25, 0xc0057c0060, 0xc00058db00, 0xc000734f08, 0x1, 0x1, 0xc00162ffa8, 0x1, 0x1, ...)
        /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/statistics/feedback.go:858 +0xb72
```
### What is changed and how it works?

Only format buckets when there are buckes in the histogram, or it will panic when get the bucket boundaries. If there is no buckets, we only log the expected count. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - None

PTAL @jackysp @coocood @zz-jason @winoros 