### PR TITLE
store/tikv: relax tso backoff limit

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -155,7 +155,7 @@ func (t backoffType) TError() *terror.Error {
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	copBuildTaskMaxBackoff         = 5000
-	tsoMaxBackoff                  = 5000
+	tsoMaxBackoff                  = 15000
 	scannerNextMaxBackoff          = 20000
 	batchGetMaxBackoff             = 20000
 	copNextMaxBackoff              = 20000


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
The current 5s timeout is too short. When the PD leader switches or the leader fails, some SQL statements will return errors.

### What is changed and how it works?
Relax max backoff to 15s.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
