### PR TITLE
ddl:fix type bit could have null as its default value

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1534,6 +1534,47 @@ func (s *testDBSuite) TestBitDefaultValue(c *C) {
 	tk.MustExec("insert into t_bit set c2=1;")
 	tk.MustQuery("select bin(c1),c2 from t_bit").Check(testkit.Rows("11111010 1"))
 	tk.MustExec("drop table t_bit")
+	tk.MustExec(`create table testalltypes1 (
+    field_1 bit default 1,
+    field_2 tinyint null default null
+	);`)
+	tk.MustExec(`create table testalltypes2 (
+    field_1 bit null default null,
+    field_2 tinyint null default null,
+    field_3 tinyint unsigned null default null,
+    field_4 bigint null default null,
+    field_5 bigint unsigned null default null,
+    field_6 mediumblob null default null,
+    field_7 longblob null default null,
+    field_8 blob null default null,
+    field_9 tinyblob null default null,
+    field_10 varbinary(255) null default null,
+    field_11 binary(255) null default null,
+    field_12 mediumtext null default null,
+    field_13 longtext null default null,
+    field_14 text null default null,
+    field_15 tinytext null default null,
+    field_16 char(255) null default null,
+    field_17 numeric null default null,
+    field_18 decimal null default null,
+    field_19 integer null default null,
+    field_20 integer unsigned null default null,
+    field_21 int null default null,
+    field_22 int unsigned null default null,
+    field_23 mediumint null default null,
+    field_24 mediumint unsigned null default null,
+    field_25 smallint null default null,
+    field_26 smallint unsigned null default null,
+    field_27 float null default null,
+    field_28 double null default null,
+    field_29 double precision null default null,
+    field_30 real null default null,
+    field_31 varchar(255) null default null,
+    field_32 date null default null,
+    field_33 time null default null,
+    field_34 datetime null default null,
+    field_35 timestamp null default null
+	);`)
 }
 
 func (s *testDBSuite) TestCreateTableWithPartition(c *C) {

--- a/model/model.go
+++ b/model/model.go
@@ -96,6 +96,9 @@ func (c *ColumnInfo) SetDefaultValue(value interface{}) error {
 	if c.Tp == mysql.TypeBit {
 		// For mysql.TypeBit type, the default value storage format must be a string.
 		// Other value such as int must convert to string format first.
+		if value == nil {
+			return nil
+		}
 		if v, ok := value.(string); ok {
 			c.DefaultValueBit = []byte(v)
 			return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
* Fix issue #7594
* Fix type bit could have null as its default value.


### What is changed and how it works?


master branch
```sql
mysql> CREATE TABLE testAllTypes (
    ->     field_1 BIT NULL DEFAULT NULL,
    ->     field_2 TINYINT NULL DEFAULT NULL,
    ->     field_3 TINYINT UNSIGNED NULL DEFAULT NULL,
    ->     field_4 BIGINT NULL DEFAULT NULL,
    ->     field_5 BIGINT UNSIGNED NULL DEFAULT NULL,
    ->     field_6 MEDIUMBLOB NULL DEFAULT NULL,
    ->     field_7 LONGBLOB NULL DEFAULT NULL,
    ->     field_8 BLOB NULL DEFAULT NULL,
    ->     field_9 TINYBLOB NULL DEFAULT NULL,
    ->     field_10 VARBINARY(255) NULL DEFAULT NULL,
    ->     field_11 BINARY(255) NULL DEFAULT NULL,
    ->     field_12 MEDIUMTEXT NULL DEFAULT NULL,
    ->     field_13 LONGTEXT NULL DEFAULT NULL,
    ->     field_14 TEXT NULL DEFAULT NULL,
    ->     field_15 TINYTEXT NULL DEFAULT NULL,
    ->     field_16 CHAR(255) NULL DEFAULT NULL,
    ->     field_17 NUMERIC NULL DEFAULT NULL,
    ->     field_18 DECIMAL NULL DEFAULT NULL,
    ->     field_19 INTEGER NULL DEFAULT NULL,
    ->     field_20 INTEGER UNSIGNED NULL DEFAULT NULL,
    ->     field_21 INT NULL DEFAULT NULL,
    ->     field_22 INT UNSIGNED NULL DEFAULT NULL,
    ->     field_23 MEDIUMINT NULL DEFAULT NULL,
    ->     field_24 MEDIUMINT UNSIGNED NULL DEFAULT NULL,
    ->     field_25 SMALLINT NULL DEFAULT NULL,
    ->     field_26 SMALLINT UNSIGNED NULL DEFAULT NULL,
    ->     field_27 FLOAT NULL DEFAULT NULL,
    ->     field_28 DOUBLE NULL DEFAULT NULL,
    ->     field_29 DOUBLE PRECISION NULL DEFAULT NULL,
    ->     field_30 REAL NULL DEFAULT NULL,
    ->     field_31 VARCHAR(255) NULL DEFAULT NULL,
    ->     field_32 DATE NULL DEFAULT NULL,
    ->     field_33 TIME NULL DEFAULT NULL,
    ->     field_34 DATETIME NULL DEFAULT NULL,
    ->     field_35 TIMESTAMP NULL DEFAULT NULL
    -> );
Query OK, 0 rows affected (0.02 sec)
```

mysql
```
No error.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
