### PR TITLE
store/gc_worker: Fix that gc_delete_range table is queried with wrong form of TS

### DIFF
--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -208,7 +207,7 @@ func (dr *delRange) doTask(ctx sessionctx.Context, r util.DelRangeTask) error {
 // and inserts a new record into gc_delete_range table. The primary key is
 // job ID, so we ignore key conflict error.
 func insertJobIntoDeleteRangeTable(ctx sessionctx.Context, job *model.Job) error {
-	now, err := getNowTS(ctx)
+	now, err := getNowTSO(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -302,7 +301,7 @@ func insertJobIntoDeleteRangeTable(ctx sessionctx.Context, job *model.Job) error
 	return nil
 }
 
-func doInsert(s sqlexec.SQLExecutor, jobID int64, elementID int64, startKey, endKey kv.Key, ts int64) error {
+func doInsert(s sqlexec.SQLExecutor, jobID int64, elementID int64, startKey, endKey kv.Key, ts uint64) error {
 	log.Infof("[ddl] insert into delete-range table with key: (%d,%d)", jobID, elementID)
 	startKeyEncoded := hex.EncodeToString(startKey)
 	endKeyEncoded := hex.EncodeToString(endKey)
@@ -311,12 +310,11 @@ func doInsert(s sqlexec.SQLExecutor, jobID int64, elementID int64, startKey, end
 	return errors.Trace(err)
 }
 
-// getNowTS gets the current timestamp, in second.
-func getNowTS(ctx sessionctx.Context) (int64, error) {
+// getNowTS gets the current timestamp, in TSO.
+func getNowTSO(ctx sessionctx.Context) (uint64, error) {
 	currVer, err := ctx.GetStore().CurrentVersion()
 	if err != nil {
 		return 0, errors.Trace(err)
 	}
-	physical := oracle.ExtractPhysical(currVer.Ver)
-	return physical / 1e3, nil
+	return currVer.Ver, nil
 }

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -186,7 +186,7 @@ const (
 		element_id BIGINT NOT NULL COMMENT "the schema element ID",
 		start_key VARCHAR(255) NOT NULL COMMENT "encoded in hex",
 		end_key VARCHAR(255) NOT NULL COMMENT "encoded in hex",
-		ts BIGINT NOT NULL COMMENT "timestamp in int64",
+		ts BIGINT NOT NULL COMMENT "timestamp in uint64",
 		UNIQUE KEY delete_range_index (job_id, element_id)
 	);`
 
@@ -196,7 +196,7 @@ const (
 		element_id BIGINT NOT NULL COMMENT "the schema element ID",
 		start_key VARCHAR(255) NOT NULL COMMENT "encoded in hex",
 		end_key VARCHAR(255) NOT NULL COMMENT "encoded in hex",
-		ts BIGINT NOT NULL COMMENT "timestamp in int64",
+		ts BIGINT NOT NULL COMMENT "timestamp in uint64",
 		UNIQUE KEY delete_range_done_index (job_id, element_id)
 	);`
 


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The GC worker checks table `mysql.gc_delete_range` with ts < safePoint and the ranges indicated by them. But unfortunately (and dramatically) the table was queried with incorrect form of TS previously. GCWorker calculated a safePoint in the form `physical << 18 | logical`, where the `physical` is a timestamp in milliseconds and logical is 0. However the ts field in `gc_delete_range` is in seconds. So these timestamps in the table is always much less than safePoint, and as a result the ranges will be immediately deleted at the next time GC runs.

This PR fixes it.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

* Manually.

Related changes

 - Need to cherry-pick to the release branch
