### PR TITLE
parser: fix single line comment end with newline error

### DIFF
--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -307,12 +307,14 @@ func startWithSharp(s *Scanner) (tok int, pos Pos, lit string) {
 
 func startWithDash(s *Scanner) (tok int, pos Pos, lit string) {
 	pos = s.r.pos()
-	if strings.HasPrefix(s.r.s[pos.Offset:], "-- ") {
-		s.r.incN(3)
-		s.r.incAsLongAs(func(ch rune) bool {
-			return ch != '\n'
-		})
-		return s.scan()
+	if strings.HasPrefix(s.r.s[pos.Offset:], "--") {
+		remainLen := len(s.r.s[pos.Offset:])
+		if remainLen == 2 || (remainLen > 2 && unicode.IsSpace(rune(s.r.s[pos.Offset+2]))) {
+			s.r.incAsLongAs(func(ch rune) bool {
+				return ch != '\n'
+			})
+			return s.scan()
+		}
 	}
 	if strings.HasPrefix(s.r.s[pos.Offset:], "->>") {
 		tok = juss

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -174,6 +174,10 @@ SELECT`, selectKwd},
 SELECT`, selectKwd},
 		{"#comment\n123", intLit},
 		{"--5", int('-')},
+		{"--\nSELECT", selectKwd},
+		{"--\tSELECT", 0},
+		{"--\r\nSELECT", selectKwd},
+		{"--", 0},
 	}
 	runTest(c, table)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #7603

### What is changed and how it works?

support single line comment end with newline and  `\t`, also EOF

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - impl

Side effects

 - no

Related changes

 - Need to cherry-pick to the release branch(need confirm)
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7612)
<!-- Reviewable:end -->
