### PR TITLE
Update issue templates and tikv repo links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,11 @@
+---
+name: "\U0001F41B Bug Report"
+about: Something isn't working as expected
+
+---
+
+## Bug Report
+
 Please answer these questions before submitting your issue. Thanks!
 
 1. What did you do?

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F680 Feature Request"
+about: I have a suggestion
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe:**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the feature you'd like:**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Describe alternatives you've considered:**
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
+
+**Teachability, Documentation, Adoption, Migration Strategy:**
+<!-- If you can, explain some scenarios how users might use this, situations it would be helpful in. Any API designs, mockups, or diagrams are also helpful. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,16 @@
+---
+name: "\U0001F914 Question"
+about: Usage question that isn't answered in docs or discussion
+
+---
+
+## Question
+
+Before asking a question, make sure you have:
+
+- Searched existing Stack Overflow questions.
+- Googled your question.
+- Searched open and closed [GitHub issues](https://github.com/pingcap/tidb/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- Read the documentation:
+  - [TiDB Readme](https://github.com/pingcap/tidb)
+  - [TiDB Doc](https://github.com/pingcap/docs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # TiDB Changelog
-All notable changes to this project will be documented in this file. See also [Release Notes](https://github.com/pingcap/docs/blob/master/releases/rn.md), [TiKV Changelog](https://github.com/pingcap/tikv/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
+All notable changes to this project will be documented in this file. See also [Release Notes](https://github.com/pingcap/docs/blob/master/releases/rn.md), [TiKV Changelog](https://github.com/tikv/tikv/blob/master/CHANGELOG.md) and [PD Changelog](https://github.com/pingcap/pd/blob/master/CHANGELOG.md).
 
 ## [2.0.0-rc.5] - 2018-04-17
 ### New Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ may be different than many other projects you have been involved in. This docume
 
 A Contributor refers to the person who contributes to the following projects:
 - TiDB: https://github.com/pingcap/tidb 
-- TiKV: https://github.com/pingcap/tikv 
+- TiKV: https://github.com/tikv/tikv 
 - TiSpark: https://github.com/pingcap/tispark 
 - PD: https://github.com/pingcap/pd 
 - Docs: https://github.com/pingcap/docs 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,7 +43,7 @@ This document defines the roadmap for TiDB development.
 ##### __Storage__  
 - [x] BoltDB
 - [x] GoLevelDB
-- [x] Homemade distributed KV ([pingcap/tikv](https://github.com/pingcap/tikv)):
+- [x] Homemade distributed KV ([tikv/tikv](https://github.com/tikv/tikv)):
     - [x] Transactions
     - [x] Replicate log using Raft
     - [x] Scale-out (Auto-rebalance)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. The current issue template is only suitable for bug report.
2. Some of the tikv repo links are out of date.

### What is changed and how it works?
1. Add two new templates for feature-request and question.
2. Fix tikv repo links.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code. Feel free to try the new templates in [my repo](https://github.com/shenli/tidb/issues). I have merged this commit already.
