### PR TITLE
Add two buildin function ( decode and encode)

### DIFF
--- a/util/encrypt/crypt.go
+++ b/util/encrypt/crypt.go
@@ -1,0 +1,141 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encrypt
+
+import (
+	"fmt"
+)
+
+type randStruct struct {
+	seed1       uint32
+	seed2       uint32
+	maxValue    uint32
+	maxValueDbl float64
+}
+
+func (rs *randStruct) randomInit(password []byte, length int) {
+	// hash password
+	var nr,add,nr2,tmp uint32      
+        nr = 1345345333
+        add=7
+        nr2=0x12345671
+
+        for i:=0; i< length; i++ {
+		pswChar := password[i]
+		if pswChar == ' ' || pswChar == '\t' {
+			continue;
+		}
+		tmp = uint32(pswChar)
+		nr^= (((nr & 63)+add)*tmp)+ (nr << 8)
+    		nr2+=(nr2 << 8) ^ nr
+    		add+=tmp
+        }
+	
+	seed1 := nr & ((uint32(1) << 31) -uint32(1))
+	seed2 := nr2 & ((uint32(1) << 31) -uint32(1))
+
+	fmt.Println(seed1)
+	fmt.Println(seed2)
+
+	// init rand struct
+	rs.maxValue = 0x3FFFFFFF
+	rs.maxValueDbl = float64(rs.maxValue)
+	rs.seed1 = seed1 % rs.maxValue
+	rs.seed2 = seed2 % rs.maxValue
+}
+
+func (rs *randStruct) myRand() float64 {
+	rs.seed1 = (rs.seed1*3 + rs.seed2) % rs.maxValue
+	rs.seed2 = (rs.seed1 + rs.seed2 + 33) % rs.maxValue
+
+	return ((float64(rs.seed1))/ rs.maxValueDbl)
+}
+
+type SqlCrypt struct {
+	rand    randStruct
+	orgRand randStruct
+
+	decodeBuff [256]byte
+	encodeBuff [256]byte
+	shift      uint32
+}
+
+func (sc *SqlCrypt) init(password []byte, length int) {
+	sc.rand.randomInit(password, length)
+
+	for i := 0; i <= 255; i++ {
+		sc.decodeBuff[i] = byte(i)
+	}
+
+	for i := 0; i <= 255; i++ {
+		idx := uint32(sc.rand.myRand() * 255.0)
+		a := sc.decodeBuff[idx]
+		sc.decodeBuff[idx] = sc.decodeBuff[i]
+		sc.decodeBuff[i] = a
+	}
+
+	for i := 0; i <= 255; i++ {
+		sc.encodeBuff[sc.decodeBuff[i]] = byte(i)
+	}
+
+	sc.orgRand = sc.rand
+	sc.shift = 0
+}
+
+func (sc *SqlCrypt) reinit() {
+	sc.shift = 0
+	sc.rand = sc.orgRand
+}
+
+func (sc *SqlCrypt) encode(str []byte, length int) {
+	for i := 0; i < length; i++ {
+		sc.shift ^= uint32(sc.rand.myRand() * 255.0)
+		idx := uint32(str[i])
+		str[i] = sc.encodeBuff[idx] ^ byte(sc.shift)
+		sc.shift ^= idx
+	}
+}
+
+func (sc *SqlCrypt) decode(str []byte, length int) {
+	for i := 0; i < length; i++ {
+		sc.shift ^= uint32(sc.rand.myRand() * 255.0)
+		idx := uint32(str[i] ^ byte(sc.shift))
+		str[i] = sc.decodeBuff[idx]
+		sc.shift ^= uint32(str[i])
+	}
+}
+
+func SQLDecode(str string, password string) (string,error) {
+	var sqlCrypt SqlCrypt
+	
+	strByte := []byte(str)
+	passwdByte := []byte(password)
+
+	sqlCrypt.init(passwdByte,len(passwdByte))
+        sqlCrypt.decode(strByte,len(strByte))
+
+	return string(strByte),nil
+}
+
+func SQLEncode(cryptStr string, password string) (string, error) {
+	var sqlCrypt SqlCrypt
+
+        cryptStrByte := []byte(cryptStr)
+        passwdByte := []byte(password)
+
+        sqlCrypt.init(passwdByte,len(passwdByte))
+        sqlCrypt.encode(cryptStrByte,len(cryptStrByte))
+	
+	return string(cryptStrByte),nil
+}

--- a/util/encrypt/crypt_test.go
+++ b/util/encrypt/crypt_test.go
@@ -1,0 +1,82 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package encrypt
+
+import (
+	"crypto/aes"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+
+func (s *testEncryptSuite) TestSQLDecode(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []struct {
+		str     string
+		passwd  string
+		expect  string
+		isError bool
+	}{
+		{"", "", "", false},
+		{"pingcap", "1234567890123456", "2C35B5A4ADF391", false},
+		{"pingcap", "asdfjasfwefjfjkj", "351CC412605905", false},
+		{"pingcap123", "123456789012345678901234", "7698723DC6DFE7724221", false}, 
+		{"pingcap#%$%^", "*^%YTu1234567", "8634B9C55FF55E5B6328F449", false},
+		{"pingcap", "", "4A77B524BD2C5C", false},
+	}
+
+	for _, t := range tests {
+		crypted, err := SQLDecode(t.str, t.passwd)
+		if t.isError {
+			c.Assert(err, NotNil, Commentf("%v", t))
+			continue
+		}
+		c.Assert(err, IsNil, Commentf("%v", t))
+		result := toHex(crypted)
+		c.Assert(result, Equals, t.expect, Commentf("%v", t))
+	}
+}
+
+func (s *testEncryptSuite) TestSQLEncode(c *C) {
+        defer testleak.AfterTest(c)()
+        tests := []struct {
+                str     string
+                passwd  string
+                expect  string
+                isError bool
+        }{
+                {"", "", "", false},
+                {"pingcap", "1234567890123456", "pingcap", false},
+                {"pingcap", "asdfjasfwefjfjkj", "pingcap", false},
+                {"pingcap123", "123456789012345678901234", "pingcap123", false},
+                {"pingcap#%$%^", "*^%YTu1234567", "pingcap#%$%^", false},
+                {"pingcap", "", "pingcap", false},
+        }
+
+        for _, t := range tests {
+                crypted, err := SQLDecode(t.str, t.passwd)
+		uncrypte, err := SQLEncode(crypte,  t.passwd)
+
+                if t.isError {
+                        c.Assert(err, NotNil, Commentf("%v", t))
+                        continue
+                }
+                c.Assert(err, IsNil, Commentf("%v", t))
+                c.Assert(ncrypte, Equals, t.expect, Commentf("%v", t))
+        }
+}


### PR DESCRIPTION
Add two buildin function ( decode and encode)：
1) add crypt.go to util/encrypt
2) modify buildin_encryption.go

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
