### PR TITLE
stats: fix compatibility of analyze period variables

### DIFF
--- a/statistics/update.go
+++ b/statistics/update.go
@@ -670,6 +670,12 @@ func parseAutoAnalyzeRatio(ratio string) float64 {
 }
 
 func parseAnalyzePeriod(start, end string) (time.Time, time.Time, error) {
+	if start == "" {
+		start = variable.DefAutoAnalyzeStartTime
+	}
+	if end == "" {
+		end = variable.DefAutoAnalyzeEndTime
+	}
 	s, err := time.ParseInLocation(variable.AnalyzeFullTimeFormat, start, time.UTC)
 	if err != nil {
 		return s, s, errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When upgrading tidb, the default value of `tidb_auto_analyze_start_time` and `tidb_auto_analyze_end_time` are not set, thus resulting in parse error.

### What is changed and how it works?

Fill the default value for the two variables when they are empty.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

     - start and stop an old tidb
     - use the current master, the parse error raises
     - use this pr, no error raises


Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - None

PTAL @jackysp @coocood @zz-jason @winoros 