### PR TITLE
metrics: register the metrics when TiDB starting up

### DIFF
--- a/metrics/ddl.go
+++ b/metrics/ddl.go
@@ -109,7 +109,8 @@ const (
 	LblVersion = "version"
 )
 
-func init() {
+// RegisterMetrics registers the metrics which are ONLY used in TiDB server.
+func RegisterMetrics() {
 	prometheus.MustRegister(JobsGauge)
 	prometheus.MustRegister(HandleJobHistogram)
 	prometheus.MustRegister(BatchAddIdxHistogram)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -190,6 +190,7 @@ func pushMetric(addr string, interval time.Duration) {
 		log.Info("disable Prometheus push client")
 		return
 	}
+	metrics.RegisterMetrics()
 	log.Infof("start Prometheus push client with server addr %s and interval %s", addr, interval)
 	go prometheusPushClient(addr, interval)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some tools, e.g. drainer use packages in TiDB, which will also register the metrics which only TiDB use them. It will cause some false alarms.

### What is changed and how it works?
Register the metrics when setup the metrics in main function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

PTAL @tiancaiamao @coocood 