### PR TITLE
Infoschema: Refactor charsets, collations

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -530,37 +530,56 @@ var tableProcesslistCols = []columnInfo{
 }
 
 func dataForCharacterSets() (records [][]types.Datum) {
-	records = append(records,
-		types.MakeDatums("ascii", "ascii_general_ci", "US ASCII", 1),
-		types.MakeDatums("binary", "binary", "Binary pseudo charset", 1),
-		types.MakeDatums("latin1", "latin1_swedish_ci", "cp1252 West European", 1),
-		types.MakeDatums("utf8", "utf8_general_ci", "UTF-8 Unicode", 3),
-		types.MakeDatums("utf8mb4", "utf8mb4_general_ci", "UTF-8 Unicode", 4),
-	)
+
+	charsets := charset.GetAllCharsets()
+
+	for _, charset := range charsets {
+
+		records = append(records,
+			types.MakeDatums(charset.Name, charset.DefaultCollation, charset.Desc, charset.Maxlen),
+		)
+
+	}
+
 	return records
+
 }
 
-func dataForColltions() (records [][]types.Datum) {
-	records = append(records,
-		types.MakeDatums("ascii_general_ci", "ascii", 1, "Yes", "Yes", 1),
-		types.MakeDatums("binary", "binary", 2, "Yes", "Yes", 1),
-		types.MakeDatums("latin1_swedish_ci", "latin1", 3, "Yes", "Yes", 1),
-		types.MakeDatums("utf8_general_ci", "utf8", 4, "Yes", "Yes", 1),
-		types.MakeDatums("utf8mb4_general_ci", "utf8mb4", 5, "Yes", "Yes", 1),
-	)
+func dataForCollations() (records [][]types.Datum) {
+
+	collations := charset.GetCollations()
+
+	for _, collation := range collations {
+
+		isDefault := ""
+		if collation.IsDefault {
+			isDefault = "Yes"
+		}
+
+		records = append(records,
+			types.MakeDatums(collation.Name, collation.CharsetName, collation.ID, isDefault, "Yes", 1),
+		)
+
+	}
+
 	return records
+
 }
 
 func dataForCollationCharacterSetApplicability() (records [][]types.Datum) {
-	records = append(records,
-		types.MakeDatums("ascii_general_ci", "ascii"),
-		types.MakeDatums("binary", "binary"),
-		types.MakeDatums("latin1_swedish_ci", "latin1"),
-		types.MakeDatums("utf8_general_ci", "utf8"),
-		types.MakeDatums("utf8_bin", "utf8"),
-		types.MakeDatums("utf8mb4_general_ci", "utf8mb4"),
-	)
+
+	collations := charset.GetCollations()
+
+	for _, collation := range collations {
+
+		records = append(records,
+			types.MakeDatums(collation.Name, collation.CharsetName),
+		)
+
+	}
+
 	return records
+
 }
 
 func dataForSessionVar(ctx sessionctx.Context) (records [][]types.Datum, err error) {
@@ -1006,24 +1025,24 @@ func dataForTableConstraints(schemas []*model.DBInfo) [][]types.Datum {
 func dataForPseudoProfiling() [][]types.Datum {
 	var rows [][]types.Datum
 	row := types.MakeDatums(
-		0,                      // QUERY_ID
-		0,                      // SEQ
-		"",                     // STATE
+		0,  // QUERY_ID
+		0,  // SEQ
+		"", // STATE
 		types.NewDecFromInt(0), // DURATION
 		types.NewDecFromInt(0), // CPU_USER
 		types.NewDecFromInt(0), // CPU_SYSTEM
-		0,                      // CONTEXT_VOLUNTARY
-		0,                      // CONTEXT_INVOLUNTARY
-		0,                      // BLOCK_OPS_IN
-		0,                      // BLOCK_OPS_OUT
-		0,                      // MESSAGES_SENT
-		0,                      // MESSAGES_RECEIVED
-		0,                      // PAGE_FAULTS_MAJOR
-		0,                      // PAGE_FAULTS_MINOR
-		0,                      // SWAPS
-		0,                      // SOURCE_FUNCTION
-		0,                      // SOURCE_FILE
-		0,                      // SOURCE_LINE
+		0, // CONTEXT_VOLUNTARY
+		0, // CONTEXT_INVOLUNTARY
+		0, // BLOCK_OPS_IN
+		0, // BLOCK_OPS_OUT
+		0, // MESSAGES_SENT
+		0, // MESSAGES_RECEIVED
+		0, // PAGE_FAULTS_MAJOR
+		0, // PAGE_FAULTS_MINOR
+		0, // SWAPS
+		0, // SOURCE_FUNCTION
+		0, // SOURCE_FILE
+		0, // SOURCE_LINE
 	)
 	rows = append(rows, row)
 	return rows
@@ -1208,7 +1227,7 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 	case tableCharacterSets:
 		fullRows = dataForCharacterSets()
 	case tableCollations:
-		fullRows = dataForColltions()
+		fullRows = dataForCollations()
 	case tableSessionVar:
 		fullRows, err = dataForSessionVar(ctx)
 	case tableConstraints:


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I noticed that SHOW CHARACTER SET and SHOW COLLATION commands differ from infoschema tables.  The infoschema tables were just hard-coded values, including incorrect default collations.

### What is changed and how it works?

The information_schema tables are now unified to present the same information as the `SHOW` commands, which come from an internal structure instead of hard coding.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Side effects

 - Breaking backward compatibility

The main downside to this change is that `SELECT * FROM information_schema.collations` and `SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY shows a lot more rows.  This includes charsets and collations which are not actually supported.  But on the plus side, at least it is consistent.

Existing tests pass, but please let me know if/where new integration tests should be added.