### PR TITLE
executor, expression: calculating the default value for datetime should consider the time zone

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -121,6 +121,7 @@ func (s *testSuite) TestInsertWrongValueForField(c *C) {
 func (s *testSuite) TestInsertDateTimeWithTimeZone(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
+	tk.MustExec(`use test;`)
 	tk.MustExec(`set time_zone="+09:00";`)
 	tk.MustExec(`drop table if exists t;`)
 	tk.MustExec(`create table t (id int, c1 datetime not null default CURRENT_TIMESTAMP);`)

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -117,3 +117,17 @@ func (s *testSuite) TestInsertWrongValueForField(c *C) {
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
 }
+
+func (s *testSuite) TestInsertDateTimeWithTimeZone(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec(`set time_zone="+09:00";`)
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t (id int, c1 datetime not null default CURRENT_TIMESTAMP);`)
+	tk.MustExec(`set TIMESTAMP = 1234;`)
+	tk.MustExec(`insert t (id) values (1);`)
+
+	tk.MustQuery(`select * from t;`).Check(testkit.Rows(
+		`1 1970-01-01 09:20:34`,
+	))
+}

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -59,7 +59,7 @@ func GetTimeValue(ctx sessionctx.Context, v interface{}, tp byte, fsp int) (d ty
 		upperX := strings.ToUpper(x)
 		if upperX == strings.ToUpper(ast.CurrentTimestamp) {
 			value.Time = types.FromGoTime(defaultTime.Truncate(time.Duration(math.Pow10(9-fsp)) * time.Nanosecond))
-			if tp == mysql.TypeTimestamp {
+			if tp == mysql.TypeTimestamp || tp == mysql.TypeDatetime {
 				err = value.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location())
 				if err != nil {
 					return d, errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The default value calculated for datetime column has not consider the timezone. This PR fixes it.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch
