### PR TITLE
binlog: use pumps client to write binlog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -177,7 +177,7 @@ type PreparedPlanCache struct {
 
 // OpenTracing is the opentracing section of the config.
 type OpenTracing struct {
-	Enable     bool                `toml:"enable" json:"enbale"`
+	Enable     bool                `toml:"enable" json:"enable"`
 	Sampler    OpenTracingSampler  `toml:"sampler" json:"sampler"`
 	Reporter   OpenTracingReporter `toml:"reporter" json:"reporter"`
 	RPCMetrics bool                `toml:"rpc-metrics" json:"rpc-metrics"`
@@ -229,7 +229,7 @@ type TiKVClient struct {
 
 // Binlog is the config for binlog.
 type Binlog struct {
-	Enable       bool   `toml:"enable" json:"enbale"`
+	Enable       bool   `toml:"enable" json:"enable"`
 	WriteTimeout string `toml:"write-timeout" json:"write-timeout"`
 	// If IgnoreError is true, when writting binlog meets error, TiDB would
 	// ignore the error.

--- a/config/config.go
+++ b/config/config.go
@@ -229,7 +229,8 @@ type TiKVClient struct {
 
 // Binlog is the config for binlog.
 type Binlog struct {
-	BinlogSocket string `toml:"binlog-socket" json:"binlog-socket"`
+	Enable bool `toml:"enable" json:"enbale"`
+	//BinlogSocket string `toml:"binlog-socket" json:"binlog-socket"`
 	WriteTimeout string `toml:"write-timeout" json:"write-timeout"`
 	// If IgnoreError is true, when writting binlog meets error, TiDB would
 	// ignore the error.

--- a/config/config.go
+++ b/config/config.go
@@ -229,8 +229,7 @@ type TiKVClient struct {
 
 // Binlog is the config for binlog.
 type Binlog struct {
-	Enable bool `toml:"enable" json:"enbale"`
-	//BinlogSocket string `toml:"binlog-socket" json:"binlog-socket"`
+	Enable       bool   `toml:"enable" json:"enbale"`
 	WriteTimeout string `toml:"write-timeout" json:"write-timeout"`
 	// If IgnoreError is true, when writting binlog meets error, TiDB would
 	// ignore the error.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -229,7 +229,8 @@ commit-timeout = "41s"
 [binlog]
 
 # Socket file to write binlog.
-binlog-socket = ""
+#binlog-socket = ""
+enable = false
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.
 write-timeout = "15s"

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -227,9 +227,7 @@ grpc-keepalive-timeout = 3
 commit-timeout = "41s"
 
 [binlog]
-
-# Socket file to write binlog.
-#binlog-socket = ""
+# enable to write binlog.
 enable = false
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestT(t *testing.T) {
 
 func (s *testConfigSuite) TestConfig(c *C) {
 	conf := new(Config)
-	conf.Binlog.BinlogSocket = "/tmp/socket"
+	conf.Binlog.Enable = true
 	conf.Binlog.IgnoreError = true
 	conf.Performance.RetryLimit = 20
 	conf.TiKVClient.CommitTimeout = "10s"
@@ -54,7 +54,7 @@ commit-timeout="41s"`)
 	c.Assert(conf.Load(configFile), IsNil)
 
 	// Test that the original value will not be clear by load the config file that does not contain the option.
-	c.Assert(conf.Binlog.BinlogSocket, Equals, "/tmp/socket")
+	c.Assert(conf.Binlog.BinlogSocket, Equals, true)
 
 	// Test that the value will be overwritten by the config file.
 	c.Assert(conf.Performance.RetryLimit, Equals, uint(10))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -54,7 +54,7 @@ commit-timeout="41s"`)
 	c.Assert(conf.Load(configFile), IsNil)
 
 	// Test that the original value will not be clear by load the config file that does not contain the option.
-	c.Assert(conf.Binlog.BinlogSocket, Equals, true)
+	c.Assert(conf.Binlog.Enable, Equals, true)
 
 	// Test that the value will be overwritten by the config file.
 	c.Assert(conf.Performance.RetryLimit, Equals, uint(10))

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -284,7 +284,7 @@ func newDDL(ctx context.Context, etcdCli *clientv3.Client, store kv.Storage,
 		schemaSyncer: syncer,
 		workerVars:   variable.NewSessionVars(),
 	}
-	d.workerVars.BinlogClient = binloginfo.GetPumpClient()
+	d.workerVars.BinlogClient = binloginfo.GetPumpsClient()
 
 	if ctxPool != nil {
 		supportDelRange := store.SupportDeleteRange()

--- a/session/session.go
+++ b/session/session.go
@@ -30,7 +30,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/pools"
 	"github.com/opentracing/opentracing-go"
-	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -291,7 +290,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		s.txn.changeToInvalid()
 		s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	}()
-	if binloginfo.IsValidPumpsClient(s.sessionVars.BinlogClient) {
+	if s.sessionVars.BinlogClient != nil {
 		prewriteValue := binloginfo.GetPrewriteValue(s, false)
 		if prewriteValue != nil {
 			prewriteData, err := prewriteValue.Marshal()
@@ -303,7 +302,7 @@ func (s *session) doCommit(ctx context.Context) error {
 					Tp:            binlog.BinlogType_Prewrite,
 					PrewriteValue: prewriteData,
 				},
-				Client: s.sessionVars.BinlogClient.(*pumpcli.PumpsClient),
+				Client: s.sessionVars.BinlogClient,
 			}
 			s.txn.SetOption(kv.BinlogInfo, info)
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -30,7 +30,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/pools"
 	"github.com/opentracing/opentracing-go"
-	pClient "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
+	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -291,7 +291,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		s.txn.changeToInvalid()
 		s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	}()
-	if binloginfo.IsValidePumpsClient(s.sessionVars.BinlogClient) {
+	if binloginfo.IsValidPumpsClient(s.sessionVars.BinlogClient) {
 		prewriteValue := binloginfo.GetPrewriteValue(s, false)
 		if prewriteValue != nil {
 			prewriteData, err := prewriteValue.Marshal()
@@ -303,7 +303,7 @@ func (s *session) doCommit(ctx context.Context) error {
 					Tp:            binlog.BinlogType_Prewrite,
 					PrewriteValue: prewriteData,
 				},
-				Client: s.sessionVars.BinlogClient.(*pClient.PumpsClient),
+				Client: s.sessionVars.BinlogClient.(*pumpcli.PumpsClient),
 			}
 			s.txn.SetOption(kv.BinlogInfo, info)
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -30,6 +30,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/ngaut/pools"
 	"github.com/opentracing/opentracing-go"
+	pClient "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -302,7 +303,7 @@ func (s *session) doCommit(ctx context.Context) error {
 					Tp:            binlog.BinlogType_Prewrite,
 					PrewriteValue: prewriteData,
 				},
-				Client: s.sessionVars.BinlogClient.(binlog.PumpClient),
+				Client: s.sessionVars.BinlogClient.(*pClient.PumpsClient),
 			}
 			s.txn.SetOption(kv.BinlogInfo, info)
 		}
@@ -1195,7 +1196,7 @@ func createSession(store kv.Storage) (*session, error) {
 	domain.BindDomain(s, dom)
 	// session implements variable.GlobalVarAccessor. Bind it to ctx.
 	s.sessionVars.GlobalVarsAccessor = s
-	s.sessionVars.BinlogClient = binloginfo.GetPumpClient()
+	s.sessionVars.BinlogClient = binloginfo.GetPumpsClient()
 	s.txn.init()
 	return s, nil
 }

--- a/session/session.go
+++ b/session/session.go
@@ -291,7 +291,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		s.txn.changeToInvalid()
 		s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	}()
-	if s.sessionVars.BinlogClient != nil {
+	if binloginfo.IsValidePumpsClient(s.sessionVars.BinlogClient) {
 		prewriteValue := binloginfo.GetPrewriteValue(s, false)
 		if prewriteValue != nil {
 			prewriteData, err := prewriteValue.Marshal()

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -33,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
@@ -131,7 +131,7 @@ func (s *testSessionSuite) TestForCoverage(c *C) {
 	tk.MustExec("admin check table t")
 
 	// Cover dirty table operations in StateTxn.
-	tk.Se.GetSessionVars().BinlogClient = &pumpcli.PumpsClient{}
+	tk.Se.GetSessionVars().BinlogClient = binloginfo.MockPumpsClient(&mockBinlogPump{})
 	tk.MustExec("begin")
 	tk.MustExec("truncate table t")
 	tk.MustExec("insert t values ()")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -44,7 +45,6 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	binlog "github.com/pingcap/tipb/go-binlog"
-	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -93,7 +93,7 @@ func (s *testSessionSuite) TearDownTest(c *C) {
 type mockBinlogPump struct {
 }
 
-var _ binlog.PumpClient = &pumpcli.PumpsClient{}
+var _ binlog.PumpClient = &mockBinlogPump{}
 
 func (p *mockBinlogPump) WriteBinlog(ctx context.Context, in *binlog.WriteBinlogReq, opts ...grpc.CallOption) (*binlog.WriteBinlogResp, error) {
 	return &binlog.WriteBinlogResp{}, nil
@@ -131,7 +131,7 @@ func (s *testSessionSuite) TestForCoverage(c *C) {
 	tk.MustExec("admin check table t")
 
 	// Cover dirty table operations in StateTxn.
-	tk.Se.GetSessionVars().BinlogClient = &mockBinlogPump{}
+	tk.Se.GetSessionVars().BinlogClient = &pumpcli.PumpsClient{}
 	tk.MustExec("begin")
 	tk.MustExec("truncate table t")
 	tk.MustExec("insert t values ()")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	binlog "github.com/pingcap/tipb/go-binlog"
+	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
@@ -92,7 +93,7 @@ func (s *testSessionSuite) TearDownTest(c *C) {
 type mockBinlogPump struct {
 }
 
-var _ binlog.PumpClient = &mockBinlogPump{}
+var _ binlog.PumpClient = &pumpcli.PumpsClient{}
 
 func (p *mockBinlogPump) WriteBinlog(ctx context.Context, in *binlog.WriteBinlogReq, opts ...grpc.CallOption) (*binlog.WriteBinlogResp, error) {
 	return &binlog.WriteBinlogResp{}, nil

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -30,12 +30,10 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testleak"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 func TestT(t *testing.T) {

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -124,21 +124,6 @@ func (s *testMainSuite) TestRetryOpenStore(c *C) {
 	c.Assert(uint64(elapse), GreaterEqual, uint64(3*time.Second))
 }
 
-func (s *testMainSuite) TestRetryDialPumpClient(c *C) {
-	retryDialPumpClientMustFail := func(binlogSocket string, clientCon *grpc.ClientConn, maxRetries int, dialerOpt grpc.DialOption) (err error) {
-		return util.RunWithRetry(maxRetries, 10, func() (bool, error) {
-			// Assume that it'll always return an error.
-			return true, errors.New("must fail")
-		})
-	}
-	begin := time.Now()
-	err := retryDialPumpClientMustFail("", nil, 3, nil)
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "must fail")
-	elapse := time.Since(begin)
-	c.Assert(uint64(elapse), GreaterEqual, uint64(6*10*time.Millisecond))
-}
-
 func (s *testMainSuite) TestSysSessionPoolGoroutineLeak(c *C) {
 	c.Skip("make leak should check it")
 	// TODO: testleak package should be able to find this leak.

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -14,6 +14,7 @@
 package binloginfo
 
 import (
+	"io/ioutil"
 	"regexp"
 	"strings"
 	"sync"
@@ -33,6 +34,8 @@ import (
 
 func init() {
 	grpc.EnableTracing = false
+	// don't need output pumps client's log
+	pClient.Logger.Out = ioutil.Discard
 }
 
 var binlogWriteTimeout = 15 * time.Second

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -117,8 +117,7 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 	}
 
 	if info.Client == nil {
-		log.Error("pump client is nil")
-		return errors.New("pump client is nil")
+		return errors.New("pumps client is nil")
 	}
 
 	// will retry in PumpsClient if write binlog fail.
@@ -141,9 +140,10 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 
 // SetDDLBinlog sets DDL binlog in the kv.Transaction.
 func SetDDLBinlog(client interface{}, txn kv.Transaction, jobID int64, ddlQuery string) {
-	if client.(*pClient.PumpsClient) == nil {
+	if !IsValidePumpsClient(client) {
 		return
 	}
+
 	ddlQuery = addSpecialComment(ddlQuery)
 	info := &BinlogInfo{
 		Data: &binlog.Binlog{

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -201,7 +201,7 @@ func MockPumpsClient(client binlog.PumpClient) *pumpcli.PumpsClient {
 		Pumps:              pumpInfos,
 		Selector:           pumpcli.NewSelector(pumpcli.Range),
 		RetryTime:          1,
-		BinlogWriteTimeout: 15 * time.Second,
+		BinlogWriteTimeout: binlogWriteTimeout,
 	}
 	pCli.Selector.SetPumps([]*pumpcli.PumpStatus{pump})
 

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -59,15 +59,6 @@ func GetPumpsClient() *pumpcli.PumpsClient {
 	return client
 }
 
-// IsValidPumpsClient returns true if client is not a nil PumpsClient.
-func IsValidPumpsClient(client interface{}) bool {
-	if client == nil {
-		return false
-	}
-
-	return client.(*pumpcli.PumpsClient) != nil
-}
-
 // SetGRPCTimeout sets grpc timeout for writing binlog.
 func SetGRPCTimeout(timeout time.Duration) {
 	if timeout < 300*time.Millisecond {
@@ -146,8 +137,8 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 }
 
 // SetDDLBinlog sets DDL binlog in the kv.Transaction.
-func SetDDLBinlog(client interface{}, txn kv.Transaction, jobID int64, ddlQuery string) {
-	if !IsValidPumpsClient(client) {
+func SetDDLBinlog(client *pumpcli.PumpsClient, txn kv.Transaction, jobID int64, ddlQuery string) {
+	if client == nil {
 		return
 	}
 
@@ -158,7 +149,7 @@ func SetDDLBinlog(client interface{}, txn kv.Transaction, jobID int64, ddlQuery 
 			DdlJobId: jobID,
 			DdlQuery: []byte(ddlQuery),
 		},
-		Client: client.(*pumpcli.PumpsClient),
+		Client: client,
 	}
 	txn.SetOption(kv.BinlogInfo, info)
 }

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -130,6 +130,11 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 			return nil
 		}
 
+		if strings.Contains(err.Error(), "received message larger than max") {
+			// This kind of error is not critical, return directly.
+			return errors.Errorf("binlog data is too large (%s)", err.Error())
+		}
+
 		return terror.ErrCritical.GenByArgs(err)
 	}
 

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -132,17 +132,21 @@ func (s *testBinlogSuite) MockPumpsClient(clientConn *grpc.ClientConn) *pumpcli.
 	selector.SetPumps([]*pumpcli.PumpStatus{pump})
 
 	pumpInfos := &pumpcli.PumpInfos{
-		Pumps:          make(map[string]*pumpcli.PumpStatus),
-		AvaliablePumps: make(map[string]*pumpcli.PumpStatus),
+		Pumps:            make(map[string]*pumpcli.PumpStatus),
+		AvaliablePumps:   make(map[string]*pumpcli.PumpStatus),
+		UnAvaliablePumps: make(map[string]*pumpcli.PumpStatus),
 	}
 	pumpInfos.Pumps[nodeID] = pump
 	pumpInfos.AvaliablePumps[nodeID] = pump
 
-	return &pumpcli.PumpsClient{
+	pCli := &pumpcli.PumpsClient{
 		ClusterID: 1,
 		Pumps:     pumpInfos,
-		Selector:  selector,
+		Selector:  pumpcli.NewSelector(pumpcli.Range),
 	}
+	pCli.Selector.SetPumps([]*pumpcli.PumpStatus{pump})
+
+	return pCli
 }
 
 func (s *testBinlogSuite) TearDownSuite(c *C) {

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -117,7 +117,7 @@ func (s *testBinlogSuite) SetUpSuite(c *C) {
 	s.ddl.WorkerVars().BinlogClient = s.client
 }
 
-func (s *testBinlogSuite) MockPumpsClient(clientCon *grpc.ClientConn) pumpcli.PumpsClient {
+func (s *testBinlogSuite) MockPumpsClient(clientConn *grpc.ClientConn) *pumpcli.PumpsClient {
 	nodeID := "pump-1"
 	pump := &pumpcli.PumpStatus{
 		Status: node.Status{
@@ -125,24 +125,20 @@ func (s *testBinlogSuite) MockPumpsClient(clientCon *grpc.ClientConn) pumpcli.Pu
 			State:  pumpcli.Online,
 		},
 		IsAvaliable: true,
-		grpcConn:    clientCon,
-		Client:      binlog.NewPumpClient(clientCon),
+		Client:      binlog.NewPumpClient(clientConn),
 	}
 
 	selector := pumpcli.NewSelector(pumpcli.Range)
 	selector.SetPumps([]*pumpcli.PumpStatus{pump})
 
 	pumpInfos := &pumpcli.PumpInfos{
-		Pumps:          make(map[string]*PumpStatus),
-		AvaliablePumps: make(map[string]*PumpStatus),
+		Pumps:          make(map[string]*pumpcli.PumpStatus),
+		AvaliablePumps: make(map[string]*pumpcli.PumpStatus),
 	}
 	pumpInfos.Pumps[nodeID] = pump
 	pumpInfos.AvaliablePumps[nodeID] = pump
 
-	ctx, cancel := context.WithCancel(context.Background())
 	return &pumpcli.PumpsClient{
-		ctx:       ctx,
-		cancel:    cancel,
 		ClusterID: 1,
 		Pumps:     pumpInfos,
 		Selector:  selector,

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/store/mockstore"
-	//"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/logutil"
@@ -272,9 +272,7 @@ func (s *testBinlogSuite) TestMaxRecvSize(c *C) {
 	}
 	err := info.WriteBinlog(1)
 	c.Assert(err, NotNil)
-	// FIXME: pumpsclient now only return "write binlog failed" error or "no avaliable pump to write binlog" error,
-	// remove comment after pumpsclient support return "binlog data is too large" error.
-	//c.Assert(terror.ErrCritical.Equal(err), IsFalse, Commentf("%v", err))
+	c.Assert(terror.ErrCritical.Equal(err), IsFalse, Commentf("%v", err))
 }
 
 func getLatestBinlogPrewriteValue(c *C, pump *mockBinlogPump) *binlog.PrewriteValue {

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -140,9 +140,11 @@ func (s *testBinlogSuite) MockPumpsClient(clientConn *grpc.ClientConn) *pumpcli.
 	pumpInfos.AvaliablePumps[nodeID] = pump
 
 	pCli := &pumpcli.PumpsClient{
-		ClusterID: 1,
-		Pumps:     pumpInfos,
-		Selector:  pumpcli.NewSelector(pumpcli.Range),
+		ClusterID:          1,
+		Pumps:              pumpInfos,
+		Selector:           pumpcli.NewSelector(pumpcli.Range),
+		RetryTime:          1,
+		BinlogWriteTimeout: 15 * time.Second,
 	}
 	pCli.Selector.SetPumps([]*pumpcli.PumpStatus{pump})
 
@@ -305,6 +307,7 @@ func (s *testBinlogSuite) TestMaxRecvSize(c *C) {
 	}
 	err := info.WriteBinlog(1)
 	c.Assert(err, NotNil)
+	c.Assert(terror.ErrCritical.Equal(err), IsFalse)
 	c.Assert(terror.ErrCritical.Equal(err), IsFalse, Commentf("%v", err))
 }
 

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -122,7 +122,7 @@ func (s *testBinlogSuite) MockPumpsClient(clientConn *grpc.ClientConn) *pumpcli.
 	pump := &pumpcli.PumpStatus{
 		Status: node.Status{
 			NodeID: nodeID,
-			State:  pumpcli.Online,
+			State:  node.Online,
 		},
 		IsAvaliable: true,
 		Client:      binlog.NewPumpClient(clientConn),

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/juju/errors"
+	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -224,7 +225,7 @@ type SessionVars struct {
 	SnapshotInfoschema interface{}
 
 	// BinlogClient is used to write binlog.
-	BinlogClient interface{}
+	BinlogClient *pumpcli.PumpsClient
 
 	// GlobalVarsAccessor is used to set and get global variables.
 	GlobalVarsAccessor GlobalVarAccessor

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -850,7 +850,7 @@ func (t *Table) Type() table.Type {
 }
 
 func shouldWriteBinlog(ctx sessionctx.Context) bool {
-	if !binloginfo.IsValidePumpsClient(ctx.GetSessionVars().BinlogClient) {
+	if !binloginfo.IsValidPumpsClient(ctx.GetSessionVars().BinlogClient) {
 		return false
 	}
 	return !ctx.GetSessionVars().InRestrictedSQL

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
@@ -850,7 +849,7 @@ func (t *Table) Type() table.Type {
 }
 
 func shouldWriteBinlog(ctx sessionctx.Context) bool {
-	if !binloginfo.IsValidPumpsClient(ctx.GetSessionVars().BinlogClient) {
+	if ctx.GetSessionVars().BinlogClient == nil {
 		return false
 	}
 	return !ctx.GetSessionVars().InRestrictedSQL

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
@@ -849,7 +850,7 @@ func (t *Table) Type() table.Type {
 }
 
 func shouldWriteBinlog(ctx sessionctx.Context) bool {
-	if ctx.GetSessionVars().BinlogClient == nil {
+	if !binloginfo.IsValidePumpsClient(ctx.GetSessionVars().BinlogClient) {
 		return false
 	}
 	return !ctx.GetSessionVars().InRestrictedSQL

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -76,7 +76,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(autoid, Greater, int64(0))
 
-	ctx.GetSessionVars().BinlogClient = binloginfo.GetPumpClient()
+	ctx.GetSessionVars().BinlogClient = binloginfo.GetPumpsClient()
 	ctx.GetSessionVars().InRestrictedSQL = false
 	rid, err := tb.AddRecord(ctx, types.MakeDatums(1, "abc"), false)
 	c.Assert(err, IsNil)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/juju/errors"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/pd/pd-client"
-	pClient "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
+	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
@@ -171,7 +171,7 @@ func setupBinlogClient() {
 		binloginfo.SetIgnoreError(true)
 	}
 
-	client, err := pClient.NewPumpsClient(cfg.Path, pd.SecurityOption{
+	client, err := pumpcli.NewPumpsClient(cfg.Path, pd.SecurityOption{
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,
 		KeyPath:  cfg.Security.ClusterSSLKey,

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -173,17 +173,12 @@ func setupBinlogClient() {
 		binloginfo.SetIgnoreError(true)
 	}
 
-	log.Infof("set pumps client")
 	client, err := pClient.NewPumpsClient(cfg.Path, pd.SecurityOption{
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,
 		KeyPath:  cfg.Security.ClusterSSLKey,
 	})
-	//terror.MustNil(err)
-	if err != nil {
-		log.Errorf("create pumps client error %v", err)
-		return
-	}
+	terror.MustNil(err)
 
 	binloginfo.SetGRPCTimeout(parseDuration(cfg.Binlog.WriteTimeout))
 	binloginfo.SetPumpsClient(client)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"net"
 	"os"
 	"os/signal"
 	"runtime"
@@ -27,6 +26,8 @@ import (
 
 	"github.com/juju/errors"
 	"github.com/opentracing/opentracing-go"
+	"github.com/pingcap/pd/pd-client"
+	pClient "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
@@ -43,29 +44,27 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/gcworker"
 	"github.com/pingcap/tidb/terror"
-	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/printer"
 	"github.com/pingcap/tidb/util/systimemon"
 	"github.com/pingcap/tidb/x-server"
-	binlog "github.com/pingcap/tipb/go-binlog"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 )
 
 // Flag Names
 const (
-	nmVersion         = "V"
-	nmConfig          = "config"
-	nmStore           = "store"
-	nmStorePath       = "path"
-	nmHost            = "host"
-	nmPort            = "P"
-	nmSocket          = "socket"
-	nmBinlogSocket    = "binlog-socket"
+	nmVersion   = "V"
+	nmConfig    = "config"
+	nmStore     = "store"
+	nmStorePath = "path"
+	nmHost      = "host"
+	nmPort      = "P"
+	nmSocket    = "socket"
+	//nmBinlogSocket    = "binlog-socket"
+	nmEnableBinlog    = "enable-binlog"
 	nmRunDDL          = "run-ddl"
 	nmLogLevel        = "L"
 	nmLogFile         = "log-file"
@@ -91,7 +90,7 @@ var (
 	host         = flag.String(nmHost, "0.0.0.0", "tidb server host")
 	port         = flag.String(nmPort, "4000", "tidb server port")
 	socket       = flag.String(nmSocket, "", "The socket file to use for connection.")
-	binlogSocket = flag.String(nmBinlogSocket, "", "socket file to write binlog")
+	enableBinlog = flagBoolean(nmEnableBinlog, false, "enable generate binlog")
 	runDDL       = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
 	ddlLease     = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
 	tokenLimit   = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
@@ -165,20 +164,30 @@ func createStoreAndDomain() {
 }
 
 func setupBinlogClient() {
-	if cfg.Binlog.BinlogSocket == "" {
+	if !cfg.Binlog.Enable {
+		log.Info("no pump client")
 		return
 	}
-	dialerOpt := grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-		return net.DialTimeout("unix", addr, timeout)
-	})
-	clientConn, err := session.DialPumpClientWithRetry(cfg.Binlog.BinlogSocket, util.DefaultMaxRetries, dialerOpt)
-	terror.MustNil(err)
+
 	if cfg.Binlog.IgnoreError {
 		binloginfo.SetIgnoreError(true)
 	}
+
+	log.Infof("set pumps client")
+	client, err := pClient.NewPumpsClient(cfg.Path, pd.SecurityOption{
+		CAPath:   cfg.Security.ClusterSSLCA,
+		CertPath: cfg.Security.ClusterSSLCert,
+		KeyPath:  cfg.Security.ClusterSSLKey,
+	})
+	//terror.MustNil(err)
+	if err != nil {
+		log.Errorf("create pumps client error %v", err)
+		return
+	}
+
 	binloginfo.SetGRPCTimeout(parseDuration(cfg.Binlog.WriteTimeout))
-	binloginfo.SetPumpClient(binlog.NewPumpClient(clientConn))
-	log.Infof("created binlog client at %s, ignore error %v", cfg.Binlog.BinlogSocket, cfg.Binlog.IgnoreError)
+	binloginfo.SetPumpsClient(client)
+	log.Infof("create pumps client success, ignore binlog error %v", cfg.Binlog.IgnoreError)
 }
 
 // Prometheus push.
@@ -279,8 +288,8 @@ func overrideConfig() {
 	if actualFlags[nmSocket] {
 		cfg.Socket = *socket
 	}
-	if actualFlags[nmBinlogSocket] {
-		cfg.Binlog.BinlogSocket = *binlogSocket
+	if actualFlags[nmEnableBinlog] {
+		cfg.Binlog.Enable = *enableBinlog
 	}
 	if actualFlags[nmRunDDL] {
 		cfg.RunDDL = *runDDL

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -178,6 +178,7 @@ func setupBinlogClient() {
 	})
 	terror.MustNil(err)
 
+	// TODO: pumps client use default timeout value, will support set timeout later.
 	binloginfo.SetGRPCTimeout(parseDuration(cfg.Binlog.WriteTimeout))
 	binloginfo.SetPumpsClient(client)
 	log.Infof("create pumps client success, ignore binlog error %v", cfg.Binlog.IgnoreError)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -56,14 +56,13 @@ import (
 
 // Flag Names
 const (
-	nmVersion   = "V"
-	nmConfig    = "config"
-	nmStore     = "store"
-	nmStorePath = "path"
-	nmHost      = "host"
-	nmPort      = "P"
-	nmSocket    = "socket"
-	//nmBinlogSocket    = "binlog-socket"
+	nmVersion         = "V"
+	nmConfig          = "config"
+	nmStore           = "store"
+	nmStorePath       = "path"
+	nmHost            = "host"
+	nmPort            = "P"
+	nmSocket          = "socket"
 	nmEnableBinlog    = "enable-binlog"
 	nmRunDDL          = "run-ddl"
 	nmLogLevel        = "L"
@@ -165,7 +164,6 @@ func createStoreAndDomain() {
 
 func setupBinlogClient() {
 	if !cfg.Binlog.Enable {
-		log.Info("no pump client")
 		return
 	}
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -171,15 +171,13 @@ func setupBinlogClient() {
 		binloginfo.SetIgnoreError(true)
 	}
 
-	client, err := pumpcli.NewPumpsClient(cfg.Path, pd.SecurityOption{
+	client, err := pumpcli.NewPumpsClient(cfg.Path, parseDuration(cfg.Binlog.WriteTimeout), pd.SecurityOption{
 		CAPath:   cfg.Security.ClusterSSLCA,
 		CertPath: cfg.Security.ClusterSSLCert,
 		KeyPath:  cfg.Security.ClusterSSLKey,
 	})
 	terror.MustNil(err)
 
-	// TODO: pumps client use default timeout value, will support set timeout later.
-	binloginfo.SetGRPCTimeout(parseDuration(cfg.Binlog.WriteTimeout))
 	binloginfo.SetPumpsClient(client)
 	log.Infof("create pumps client success, ignore binlog error %v", cfg.Binlog.IgnoreError)
 }


### PR DESCRIPTION

### What problem does this PR solve? 
use pumps client to write binlog.

### What is changed and how it works?

use pumps client to write binlog, and tidb will send binlog to pump cluster.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

most changed in sessionctx/binloginfo.go and tidb-server/main.go


