### PR TITLE
executor: Fix a bug in 'INSERT ... ON DUPLICATE KEY UPDATE'

### DIFF
--- a/executor/batch_checker.go
+++ b/executor/batch_checker.go
@@ -39,12 +39,12 @@ type toBeCheckedRow struct {
 	rowValue   []byte
 	handleKey  *keyValueWithDupInfo
 	uniqueKeys []*keyValueWithDupInfo
-	// The table or partition this row belongs to.
+	// t is the table or partition this row belongs to.
 	t table.Table
 }
 
 type batchChecker struct {
-	// For duplicate key update
+	// toBeCheckedRows is used for duplicate key update
 	toBeCheckedRows []toBeCheckedRow
 	dupKVs          map[string][]byte
 	dupOldRowValues map[string][]byte
@@ -257,13 +257,21 @@ func (b *batchChecker) fillBackKeys(t table.Table, row toBeCheckedRow, handle in
 	}
 }
 
-func (b *batchChecker) deleteDupKeys(row toBeCheckedRow) {
-	if row.handleKey != nil {
-		delete(b.dupKVs, string(row.handleKey.newKV.key))
+// deleteDupKeys picks primary/unique key-value pairs from rows and remove them from the dupKVs
+func (b *batchChecker) deleteDupKeys(ctx sessionctx.Context, t table.Table, rows [][]types.Datum) error {
+	cleanupRows, err := b.getKeysNeedCheck(ctx, t, rows)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	for _, uk := range row.uniqueKeys {
-		delete(b.dupKVs, string(uk.newKV.key))
+	for _, row := range cleanupRows {
+		if row.handleKey != nil {
+			delete(b.dupKVs, string(row.handleKey.newKV.key))
+		}
+		for _, uk := range row.uniqueKeys {
+			delete(b.dupKVs, string(uk.newKV.key))
+		}
 	}
+	return nil
 }
 
 // getOldRow gets the table record row from storage for batch check.

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -223,12 +223,9 @@ func (e *InsertExec) updateDupKeyValues(oldHandle int64, newHandle int64,
 		return errors.Trace(err)
 	}
 	// Delete old keys and fill back new key-values of the updated row.
-	cleanupRows, err := e.getKeysNeedCheck(e.ctx, e.Table, [][]types.Datum{oldRow})
+	err = e.deleteDupKeys(e.ctx, e.Table, [][]types.Datum{oldRow})
 	if err != nil {
 		return errors.Trace(err)
-	}
-	if len(cleanupRows) > 0 {
-		e.deleteDupKeys(cleanupRows[0])
 	}
 
 	if handleChanged {

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -178,7 +178,7 @@ func (e *InsertExec) updateDupRow(row toBeCheckedRow, handle int64, onDuplicate 
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return e.updateDupKeyValues(row, handle, newHandle, handleChanged, updatedRow)
+	return e.updateDupKeyValues(handle, newHandle, handleChanged, oldRow, updatedRow)
 }
 
 // doDupRowUpdate updates the duplicate row.
@@ -215,15 +215,22 @@ func (e *InsertExec) doDupRowUpdate(handle int64, oldRow []types.Datum, newRow [
 }
 
 // updateDupKeyValues updates the dupKeyValues for further duplicate key check.
-func (e *InsertExec) updateDupKeyValues(row toBeCheckedRow, oldHandle int64,
-	newHandle int64, handleChanged bool, updatedRow []types.Datum) error {
+func (e *InsertExec) updateDupKeyValues(oldHandle int64, newHandle int64,
+	handleChanged bool, oldRow []types.Datum, updatedRow []types.Datum) error {
 	// There is only one row per update.
 	fillBackKeysInRows, err := e.getKeysNeedCheck(e.ctx, e.Table, [][]types.Datum{updatedRow})
 	if err != nil {
 		return errors.Trace(err)
 	}
 	// Delete old keys and fill back new key-values of the updated row.
-	e.deleteDupKeys(row)
+	cleanupRows, err := e.getKeysNeedCheck(e.ctx, e.Table, [][]types.Datum{oldRow})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(cleanupRows) > 0 {
+		e.deleteDupKeys(cleanupRows[0])
+	}
+
 	if handleChanged {
 		delete(e.dupOldRowValues, string(e.Table.RecordKey(oldHandle)))
 		e.fillBackKeys(e.Table, fillBackKeysInRows[0], newHandle)

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -71,13 +71,9 @@ func (e *ReplaceExec) removeRow(handle int64, r toBeCheckedRow) (bool, error) {
 	e.ctx.GetSessionVars().StmtCtx.AddAffectedRows(1)
 
 	// Cleanup keys map, because the record was removed.
-	cleanupRows, err := e.getKeysNeedCheck(e.ctx, r.t, [][]types.Datum{oldRow})
+	err = e.deleteDupKeys(e.ctx, r.t, [][]types.Datum{oldRow})
 	if err != nil {
 		return false, errors.Trace(err)
-	}
-	if len(cleanupRows) > 0 {
-		// The length of need-to-cleanup rows should be at most 1, due to we only input 1 row.
-		e.deleteDupKeys(cleanupRows[0])
 	}
 	return false, nil
 }


### PR DESCRIPTION
### What problem does this PR solve?
Fix a bug in 'INSERT ... ON DUPLICATE KEY UPDATE' when unique key are updated, for example:

```
mysql> select * from t1;
+------+------+------+
| id   | a    | b    |
+------+------+------+
|    1 |    1 |    1 |
|    2 |    1 |    2 |
|    3 |    3 |    1 |
+------+------+------+
3 rows in set (0.00 sec)

mysql> create table t2(a int key, b int, unique(b));
Query OK, 0 rows affected (0.08 sec)

mysql> insert into t2 select a, b from t1 order by id on duplicate key update a=t1.a, b=t1.b;
Query OK, 6 rows affected (0.01 sec)

mysql> select * from t2;
+---+------+
| a | b    |
+---+------+
| 3 |    1 |
+---+------+
1 row in set (0.00 sec)
``` 
, which is incorrect. We should expect the following result instead:
```
mysql> select * from t2;
+---+------+
| a | b    |
+---+------+
| 1 |    2 |
| 3 |    1 |
+---+------+
2 rows in set (0.00 sec)
```

After this PR, it will be fixed.

### What is changed and how it works?
In `InsertExec`'s `updateDupKeyValues` function, `dupKVs`(a `map` that holds existing primary keys and unique keys for duplication detection) is updated by removing keys from the _inserting row_ first, then adding keys from the _updated row_. But we should remove keys from the _old row_ instead, because _old row_ is the one that to be replaced.

### Check List

Tests
 - Integration test

Code changes
 - Has exported function/method change

Side effects
 - No side effect

Related changes
 - Nothing else
