### PR TITLE
executor: print arguments in execute statement in log files

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -321,7 +321,6 @@ func (a *ExecStmt) buildExecutor(ctx sessionctx.Context) (Executor, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		a.Text = executorExec.stmt.Text()
 		a.isPreparedStmt = true
 		a.Plan = executorExec.plan
 		e = executorExec.stmtExec

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -269,11 +269,11 @@ func CompileExecutePreparedStmt(ctx sessionctx.Context, ID uint32, args ...inter
 		Ctx:        ctx,
 	}
 	if prepared, ok := ctx.GetSessionVars().PreparedStmts[ID].(*plan.Prepared); ok {
+		argInfo := ""
 		if len(argStrs) > 0 {
-			prepared.Stmt.SetText(fmt.Sprintf("%s [arguments: %s]", prepared.Stmt.Text(),
-				strings.Join(argStrs, ",")))
+			argInfo = fmt.Sprintf(" [arguments: %s]", strings.Join(argStrs, ","))
 		}
-		stmt.Text = prepared.Stmt.Text()
+		stmt.Text = prepared.Stmt.Text() + argInfo
 	}
 	return stmt, nil
 }

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"fmt"
 	"math"
 	"strings"
 
@@ -101,7 +102,7 @@ func (s *testSuite) TestPrepared(c *C) {
 		// Check that ast.Statement created by executor.CompileExecutePreparedStmt has query text.
 		stmt, err := executor.CompileExecutePreparedStmt(tk.Se, stmtId, 1)
 		c.Assert(err, IsNil)
-		c.Assert(stmt.OriginText(), Equals, query)
+		c.Assert(stmt.OriginText(), Equals, fmt.Sprintf("%s [arguments: %d]", query, 1))
 
 		// Check that rebuild plan works.
 		tk.Se.PrepareTxnCtx(ctx)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The log of the `execute statement` looks like 
```
2018/09/13 13:52:31.659 session.go:1398: [info] [GENERAL_LOG] con:5 user:root@127.0.0.1 schema_ver:140 start_ts:0 sql:insert into t values (?)
```
We don't know what the exact argument value is.

### What is changed and how it works?
Append arguments info into log files.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
For slow query log, general log and debug log:
```
2018/09/13 13:55:07.553 adapter.go:371: [warning] [SLOW_QUERY] cost_time:1.002700677s  succ:true con:1 user:root@127.0.0.1 txn_start_ts:402867645723443200 database:test sql:SELECT sleep(?) [arguments: 1]
2018/09/13 13:52:31.659 session.go:1398: [info] [GENERAL_LOG] con:5 user:root@127.0.0.1 schema_ver:140 start_ts:0 sql:insert into t values (?) [arguments: 1]
2018/09/13 13:52:31.659 adapter.go:367: [debug] [QUERY] cost_time:53.653µs  succ:true con:5 user:root@127.0.0.1 txn_start_ts:402867605119696898 database:test sql:insert into t values (?) [arguments: 1]
```

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

PTAL @coocood @shenli 