### PR TITLE
executor: fix lost insert row when insert multi rows on duplicate key update

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -594,6 +594,12 @@ commit;`
 	INSERT t1 VALUES (1) ON DUPLICATE KEY UPDATE f1 = 1;`
 	tk.MustExec(testSQL)
 	tk.MustQuery(`SELECT * FROM t1;`).Check(testkit.Rows("1"))
+
+	testSQL = `drop table if exists t1;
+	create table t1(a int key, b int, unique(b));
+	insert into t1 values (1,1),(1,2),(3,1) on duplicate key update a=values(a), b=values(b);`
+	tk.MustExec(testSQL)
+	tk.MustQuery(`SELECT * FROM t1 order by a;`).Check(testkit.Rows("1 2", "3 1"))
 }
 
 func (s *testSuite) TestInsertIgnoreOnDup(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the same bug on release-2.0 as https://github.com/pingcap/tidb/pull/7675.
When the table has two or more unique index and its primary key is int type, the statement with three rows, the second and third rows conflict with the first one but with different indices. The second row will update the first row, but it deletes the dupKV map with itself by mistake. It will cause a fake update instead of insert without conflicts. See the test case in this PR as an example.

### What is changed and how it works?
Delete the correct keys in dupKV map.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

PTAL @coocood 
