### PR TITLE
plan: fix mistaken conversion from outer join to inner join

### DIFF
--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -305,3 +305,18 @@ Projection_9	1.00	root	count(a)
 select count(a) from t where b>0 group by a, b order by a limit 1;
 count(a)
 3
+drop table if exists t;
+create table t (id int primary key, a int, b int);
+explain select * from (t t1 left join t t2 on t1.a = t2.a) left join (t t3 left join t t4 on t3.a = t4.a) on t2.b = 1;
+id	count	task	operator info
+HashLeftJoin_10	156250000.00	root	left outer join, inner:HashLeftJoin_16, left cond:[eq(t2.b, 1)]
+├─HashLeftJoin_11	12500.00	root	left outer join, inner:TableReader_15, equal:[eq(t1.a, t2.a)]
+│ ├─TableReader_13	10000.00	root	data:TableScan_12
+│ │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+│ └─TableReader_15	10000.00	root	data:TableScan_14
+│   └─TableScan_14	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+└─HashLeftJoin_16	12500.00	root	left outer join, inner:TableReader_20, equal:[eq(t3.a, t4.a)]
+  ├─TableReader_18	10000.00	root	data:TableScan_17
+  │ └─TableScan_17	10000.00	cop	table:t3, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─TableReader_20	10000.00	root	data:TableScan_19
+    └─TableScan_19	10000.00	cop	table:t4, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -154,7 +154,7 @@ select count(a) from t where b>0 group by a, b order by a;
 explain select count(a) from t where b>0 group by a, b order by a limit 1;
 select count(a) from t where b>0 group by a, b order by a limit 1;
 
-#test outer join simplification
+# test outer join simplification, issue #7687
 drop table if exists t;
 create table t (id int primary key, a int, b int);
 explain select * from (t t1 left join t t2 on t1.a = t2.a) left join (t t3 left join t t4 on t3.a = t4.a) on t2.b = 1;

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -153,3 +153,8 @@ explain select count(a) from t where b>0 group by a, b order by a;
 select count(a) from t where b>0 group by a, b order by a;
 explain select count(a) from t where b>0 group by a, b order by a limit 1;
 select count(a) from t where b>0 group by a, b order by a limit 1;
+
+#test outer join simplification
+drop table if exists t;
+create table t (id int primary key, a int, b int);
+explain select * from (t t1 left join t t2 on t1.a = t2.a) left join (t t3 left join t t4 on t3.a = t4.a) on t2.b = 1;

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -910,3 +910,14 @@ func (s *testSuite) TestMergejoinOrder(c *C) {
 		`2.02`,
 	))
 }
+
+func (s *testSuite) TestEmbeddedOuterJoin(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int, b int)")
+	tk.MustExec("create table t2(a int, b int)")
+	tk.MustExec("insert into t1 values(1, 1)")
+	tk.MustQuery("select * from (t1 left join t2 on t1.a = t2.a) left join (t2 t3 left join t2 t4 on t3.a = t4.a) on t2.b = 1").
+		Check(testkit.Rows("1 1 <nil> <nil> <nil> <nil> <nil> <nil>"))
+}

--- a/plan/rule_predicate_push_down.go
+++ b/plan/rule_predicate_push_down.go
@@ -275,20 +275,6 @@ func isNullRejected(ctx sessionctx.Context, schema *expression.Schema, expr expr
 	return false
 }
 
-// concatOnAndWhereConds concatenate ON conditions with WHERE conditions.
-func concatOnAndWhereConds(join *LogicalJoin, predicates []expression.Expression) []expression.Expression {
-	numAllFilters := len(join.EqualConditions) + len(join.LeftConditions) + len(join.RightConditions) + len(join.OtherConditions) + len(predicates)
-	allFilters := make([]expression.Expression, 0, numAllFilters)
-	for _, equalCond := range join.EqualConditions {
-		allFilters = append(allFilters, equalCond)
-	}
-	allFilters = append(allFilters, join.LeftConditions...)
-	allFilters = append(allFilters, join.RightConditions...)
-	allFilters = append(allFilters, join.OtherConditions...)
-	allFilters = append(allFilters, predicates...)
-	return allFilters
-}
-
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
 func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression) (ret []expression.Expression, retPlan LogicalPlan) {
 	var push = make([]expression.Expression, 0, p.Schema().Len())

--- a/plan/rule_predicate_push_down.go
+++ b/plan/rule_predicate_push_down.go
@@ -230,20 +230,12 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 		innerTable, outerTable = outerTable, innerTable
 	}
 
-	var fullConditions []expression.Expression
-
 	// first simplify embedded outer join.
-	// When trying to simplify an embedded outer join operation in a query,
-	// we must take into account the join condition for the embedding outer join together with the WHERE condition.
 	if innerPlan, ok := innerTable.(*LogicalJoin); ok {
-		fullConditions = concatOnAndWhereConds(p, predicates)
-		simplifyOuterJoin(innerPlan, fullConditions)
+		simplifyOuterJoin(innerPlan, predicates)
 	}
 	if outerPlan, ok := outerTable.(*LogicalJoin); ok {
-		if fullConditions != nil {
-			fullConditions = concatOnAndWhereConds(p, predicates)
-		}
-		simplifyOuterJoin(outerPlan, fullConditions)
+		simplifyOuterJoin(outerPlan, predicates)
 	}
 
 	if p.JoinType == InnerJoin {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/7687

### What is changed and how it works?

exclude upper level join conditions from predicates when simplifying embedded outer join

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
