### PR TITLE
*: add a variable to force statement priority of TiDB server

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -348,8 +348,10 @@ func ResetStmtCtx(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.IgnoreTruncate = true
 		sc.IgnoreZeroInDate = true
 	}
-	if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
-		sc.Priority = priority
+	if !sessVars.InRestrictedSQL {
+		if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
+			sc.Priority = priority
+		}
 	}
 	if sessVars.LastInsertID > 0 {
 		sessVars.PrevLastInsertID = sessVars.LastInsertID

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -16,16 +16,19 @@ package executor
 import (
 	"math"
 	"sort"
+	"sync/atomic"
 
 	"fmt"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/plan"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
@@ -344,6 +347,9 @@ func ResetStmtCtx(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	default:
 		sc.IgnoreTruncate = true
 		sc.IgnoreZeroInDate = true
+	}
+	if priority := mysql.PriorityEnum(atomic.LoadInt32(&variable.ForcePriority)); priority != mysql.NoPriority {
+		sc.Priority = priority
 	}
 	if sessVars.LastInsertID > 0 {
 		sessVars.PrevLastInsertID = sessVars.LastInsertID

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -221,6 +221,19 @@ func (s *testSuite) TestSetVar(c *C) {
 
 	tk.MustExec("set @@tidb_general_log = 1")
 	tk.MustExec("set @@tidb_general_log = 0")
+
+	tk.MustExec(`set tidb_force_priority = "no_priority"`)
+	tk.MustQuery(`select @@tidb_force_priority;`).Check(testkit.Rows("NO_PRIORITY"))
+	tk.MustExec(`set tidb_force_priority = "low_priority"`)
+	tk.MustQuery(`select @@tidb_force_priority;`).Check(testkit.Rows("LOW_PRIORITY"))
+	tk.MustExec(`set tidb_force_priority = "high_priority"`)
+	tk.MustQuery(`select @@tidb_force_priority;`).Check(testkit.Rows("HIGH_PRIORITY"))
+	tk.MustExec(`set tidb_force_priority = "delayed"`)
+	tk.MustQuery(`select @@tidb_force_priority;`).Check(testkit.Rows("DELAYED"))
+	tk.MustExec(`set tidb_force_priority = "abc"`)
+	tk.MustQuery(`select @@tidb_force_priority;`).Check(testkit.Rows("NO_PRIORITY"))
+	_, err = tk.Exec(`set global tidb_force_priority = ""`)
+	c.Assert(err, NotNil)
 }
 
 func (s *testSuite) TestSetCharset(c *C) {

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -627,6 +627,39 @@ const (
 	DelayedPriority
 )
 
+// Priority2Str is used to convert the statement priority to string.
+var Priority2Str = map[PriorityEnum]string {
+	NoPriority: "NO_PRIORITY",
+	LowPriority: "LOW_PRIORITY",
+	HighPriority: "HIGH_PRIORITY",
+	DelayedPriority: "DELAYED",
+}
+
+// Str2Prority is used to convert a string to a priority.
+func Str2Prority(val string) PriorityEnum {
+	val = strings.ToUpper(val)
+	switch val {
+	case "NO_PRIORITY":
+		return NoPriority
+	case "HIGH_PRIORITY":
+		return HighPriority
+	case "LOW_PRIORITY":
+		return LowPriority
+	case "DELAYED":
+		return DelayedPriority
+	default:
+		return NoPriority
+	}
+}
+
+// Str2Priority is used to convert string to convert to string.
+var Str2Priority = map[string]PriorityEnum {
+	"NO_PRIORITY":   NoPriority,
+	"LOW_PRIORITY":  LowPriority,
+	"HIGH_PRIORITY": HighPriority,
+	"DELAYED":       DelayedPriority,
+}
+
 // PrimaryKeyName defines primary key name.
 const (
 	PrimaryKeyName = "PRIMARY"

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -628,15 +628,15 @@ const (
 )
 
 // Priority2Str is used to convert the statement priority to string.
-var Priority2Str = map[PriorityEnum]string {
-	NoPriority: "NO_PRIORITY",
-	LowPriority: "LOW_PRIORITY",
-	HighPriority: "HIGH_PRIORITY",
+var Priority2Str = map[PriorityEnum]string{
+	NoPriority:      "NO_PRIORITY",
+	LowPriority:     "LOW_PRIORITY",
+	HighPriority:    "HIGH_PRIORITY",
 	DelayedPriority: "DELAYED",
 }
 
-// Str2Prority is used to convert a string to a priority.
-func Str2Prority(val string) PriorityEnum {
+// Str2Priority is used to convert a string to a priority.
+func Str2Priority(val string) PriorityEnum {
 	val = strings.ToUpper(val)
 	switch val {
 	case "NO_PRIORITY":
@@ -650,14 +650,6 @@ func Str2Prority(val string) PriorityEnum {
 	default:
 		return NoPriority
 	}
-}
-
-// Str2Priority is used to convert string to convert to string.
-var Str2Priority = map[string]PriorityEnum {
-	"NO_PRIORITY":   NoPriority,
-	"LOW_PRIORITY":  LowPriority,
-	"HIGH_PRIORITY": HighPriority,
-	"DELAYED":       DelayedPriority,
 }
 
 // PrimaryKeyName defines primary key name.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -575,6 +575,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		SetDDLReorgWorkerCounter(int32(tidbOptPositiveInt32(val, DefTiDBDDLReorgWorkerCount)))
 	case TiDBDDLReorgPriority:
 		s.setDDLReorgPriority(val)
+	case TiDBForcePriority:
+		atomic.StoreInt32(&ForcePriority, int32(mysql.Str2Prority(val)))
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -576,7 +576,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	case TiDBDDLReorgPriority:
 		s.setDDLReorgPriority(val)
 	case TiDBForcePriority:
-		atomic.StoreInt32(&ForcePriority, int32(mysql.Str2Prority(val)))
+		atomic.StoreInt32(&ForcePriority, int32(mysql.Str2Priority(val)))
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -663,6 +663,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBConfig, ""},
 	{ScopeGlobal | ScopeSession, TiDBDDLReorgWorkerCount, strconv.Itoa(DefTiDBDDLReorgWorkerCount)},
 	{ScopeSession, TiDBDDLReorgPriority, "PRIORITY_LOW"},
+	{ScopeSession, TiDBForcePriority, mysql.Priority2Str[DefTiDBForcePriority]},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -13,6 +13,8 @@
 
 package variable
 
+import "github.com/pingcap/tidb/mysql"
+
 /*
 	Steps to add a new TiDB specific system variable:
 
@@ -181,6 +183,10 @@ const (
 	// tidb_ddl_reorg_priority defines the operations priority of adding indices.
 	// It can be: PRIORITY_LOW, PRIORITY_NORMAL, PRIORITY_HIGH
 	TiDBDDLReorgPriority = "tidb_ddl_reorg_priority"
+
+	// tidb_force_priority defines the operations priority of all statements.
+	// It can be "NO_PRIORITY", "LOW_PRIORITY", "HIGH_PRIORITY", "DELAYED"
+	TiDBForcePriority = "tidb_force_priority"
 )
 
 // Default TiDB system variable values.
@@ -220,13 +226,14 @@ const (
 	DefTiDBDDLReorgWorkerCount       = 16
 	DefTiDBHashAggPartialConcurrency = 4
 	DefTiDBHashAggFinalConcurrency   = 4
+	DefTiDBForcePriority             = mysql.NoPriority
 )
 
 // Process global variables.
 var (
 	ProcessGeneralLog      uint32
-	ddlReorgWorkerCounter  int32 = DefTiDBDDLReorgWorkerCount
-	maxDDLReorgWorkerCount int32 = 128
-	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
-	DDLSlowOprThreshold uint32 = 300
+	ddlReorgWorkerCounter  int32  = DefTiDBDDLReorgWorkerCount
+	maxDDLReorgWorkerCount int32  = 128
+	DDLSlowOprThreshold    uint32 = 300 // DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
+	ForcePriority                 = int32(DefTiDBForcePriority)
 )

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -82,6 +82,8 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 			return "", false, errors.Trace(err)
 		}
 		return string(j), true, nil
+	case TiDBForcePriority:
+		return mysql.Priority2Str[mysql.PriorityEnum(atomic.LoadInt32(&ForcePriority))], true, nil
 	}
 	sVal, ok := s.systems[key]
 	if ok {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add a variable to force statement priority of TiDB server. Fix https://github.com/pingcap/tidb/issues/7524 .

### What is changed and how it works?
Force the priority for each statement when tidb_force_priority is set to high/low/delayed priority.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
Watch the grafana of coprocess thread CPU usage when `set tidb_force_priority = "high_priority"/"low_priority"/"delayed"`

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity

Related changes

 - Need to be included in the release note

PTAL @coocood @morgo 