### PR TITLE
executor: change the type of AggFunc.args and AggExec.groupByItem to []*Column

### DIFF
--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -1287,15 +1287,15 @@ cntrycode
 order by
 cntrycode;
 id	count	task	operator info
-Sort_32	1.00	root	custsale.cntrycode:asc
-└─Projection_34	1.00	root	custsale.cntrycode, 28_col_0, 28_col_1
-  └─HashAgg_37	1.00	root	group by:custsale.cntrycode, funcs:count(1), sum(custsale.c_acctbal), firstrow(custsale.cntrycode)
-    └─Projection_38	0.00	root	substring(tpch.customer.c_phone, 1, 2), tpch.customer.c_acctbal
-      └─Selection_39	0.00	root	not(26_aux_0)
-        └─HashLeftJoin_40	0.00	root	left outer semi join, inner:TableReader_46, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-          ├─Selection_41	0.00	root	in(substring(tpch.customer.c_phone, 1, 2), "20", "40", "22", "30", "39", "42", "21")
-          │ └─TableReader_44	0.00	root	data:Selection_43
-          │   └─Selection_43	0.00	cop	gt(tpch.customer.c_acctbal, NULL)
-          │     └─TableScan_42	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-          └─TableReader_46	75000000.00	root	data:TableScan_45
-            └─TableScan_45	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+Sort_33	1.00	root	custsale.cntrycode:asc
+└─Projection_35	1.00	root	custsale.cntrycode, 29_col_0, 29_col_1
+  └─HashAgg_38	1.00	root	group by:custsale.cntrycode, funcs:count(1), sum(custsale.c_acctbal), firstrow(custsale.cntrycode)
+    └─Projection_39	0.00	root	substring(tpch.customer.c_phone, 1, 2), tpch.customer.c_acctbal
+      └─Selection_40	0.00	root	not(27_aux_0)
+        └─HashLeftJoin_41	0.00	root	left outer semi join, inner:TableReader_47, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+          ├─Selection_42	0.00	root	in(substring(tpch.customer.c_phone, 1, 2), "20", "40", "22", "30", "39", "42", "21")
+          │ └─TableReader_45	0.00	root	data:Selection_44
+          │   └─Selection_44	0.00	cop	gt(tpch.customer.c_acctbal, NULL)
+          │     └─TableScan_43	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+          └─TableReader_47	75000000.00	root	data:TableScan_46
+            └─TableScan_46	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false

--- a/executor/aggfuncs/aggfuncs.go
+++ b/executor/aggfuncs/aggfuncs.go
@@ -16,7 +16,6 @@ package aggfuncs
 import (
 	"unsafe"
 
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -126,13 +125,12 @@ type AggFunc interface {
 }
 
 type baseAggFunc struct {
-	// args stores the input arguments for an aggregate function, we should
-	// call arg.EvalXXX to get the actual input data for this function.
-	args []expression.Expression
+	// argsOrdinal stores the index of input Column arguments in the input raw data for an aggregate function
+	argsOrdinal []int
 
-	// ordinal stores the ordinal of the columns in the output chunk, which is
+	// resultOrdinal stores the resultOrdinal of the columns in the output chunk, which is
 	// used to append the final result of this function.
-	ordinal int
+	resultOrdinal int
 }
 
 func (*baseAggFunc) MergePartialResult(sctx sessionctx.Context, src, dst PartialResult) error {

--- a/executor/aggfuncs/func_bitfuncs.go
+++ b/executor/aggfuncs/func_bitfuncs.go
@@ -16,7 +16,6 @@ package aggfuncs
 import (
 	"math"
 
-	"github.com/juju/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -38,7 +37,7 @@ func (e *baseBitAggFunc) ResetPartialResult(pr PartialResult) {
 
 func (e *baseBitAggFunc) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4BitFunc)(pr)
-	chk.AppendUint64(e.ordinal, *p)
+	chk.AppendUint64(e.resultOrdinal, *p)
 	return nil
 }
 
@@ -49,13 +48,10 @@ type bitOrUint64 struct {
 func (e *bitOrUint64) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4BitFunc)(pr)
 	for _, row := range rowsInGroup {
-		inputValue, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		inputValue := row.GetInt64(e.argsOrdinal[0])
 		*p |= uint64(inputValue)
 	}
 	return nil
@@ -74,13 +70,10 @@ type bitXorUint64 struct {
 func (e *bitXorUint64) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4BitFunc)(pr)
 	for _, row := range rowsInGroup {
-		inputValue, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		inputValue := row.GetInt64(e.argsOrdinal[0])
 		*p ^= uint64(inputValue)
 	}
 	return nil
@@ -110,13 +103,10 @@ func (e *bitAndUint64) ResetPartialResult(pr PartialResult) {
 func (e *bitAndUint64) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4BitFunc)(pr)
 	for _, row := range rowsInGroup {
-		inputValue, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		inputValue := row.GetInt64(e.argsOrdinal[0])
 		*p &= uint64(inputValue)
 	}
 	return nil

--- a/executor/aggfuncs/func_first_row.go
+++ b/executor/aggfuncs/func_first_row.go
@@ -14,7 +14,6 @@
 package aggfuncs
 
 import (
-	"github.com/juju/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -97,10 +96,8 @@ func (e *firstRow4Int) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup 
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetInt64(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, input
 		break
 	}
@@ -118,10 +115,10 @@ func (*firstRow4Int) MergePartialResult(sctx sessionctx.Context, src PartialResu
 func (e *firstRow4Int) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowInt)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendInt64(e.ordinal, p.val)
+	chk.AppendInt64(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -144,10 +141,8 @@ func (e *firstRow4Float32) UpdatePartialResult(sctx sessionctx.Context, rowsInGr
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalReal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetFloat32(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, float32(input)
 		break
 	}
@@ -164,10 +159,10 @@ func (*firstRow4Float32) MergePartialResult(sctx sessionctx.Context, src Partial
 func (e *firstRow4Float32) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowFloat32)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendFloat32(e.ordinal, p.val)
+	chk.AppendFloat32(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -190,10 +185,8 @@ func (e *firstRow4Float64) UpdatePartialResult(sctx sessionctx.Context, rowsInGr
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalReal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetFloat64(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, input
 		break
 	}
@@ -210,10 +203,10 @@ func (*firstRow4Float64) MergePartialResult(sctx sessionctx.Context, src Partial
 func (e *firstRow4Float64) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowFloat64)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendFloat64(e.ordinal, p.val)
+	chk.AppendFloat64(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -236,10 +229,8 @@ func (e *firstRow4String) UpdatePartialResult(sctx sessionctx.Context, rowsInGro
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalString(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetString(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, stringutil.Copy(input)
 		break
 	}
@@ -257,10 +248,10 @@ func (*firstRow4String) MergePartialResult(sctx sessionctx.Context, src PartialR
 func (e *firstRow4String) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowString)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendString(e.ordinal, p.val)
+	chk.AppendString(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -283,10 +274,8 @@ func (e *firstRow4Time) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalTime(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetTime(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, input
 		break
 	}
@@ -304,15 +293,17 @@ func (*firstRow4Time) MergePartialResult(sctx sessionctx.Context, src PartialRes
 func (e *firstRow4Time) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowTime)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendTime(e.ordinal, p.val)
+	chk.AppendTime(e.resultOrdinal, p.val)
 	return nil
 }
 
 type firstRow4Duration struct {
 	baseAggFunc
+
+	fillFsp int
 }
 
 func (e *firstRow4Duration) AllocPartialResult() PartialResult {
@@ -330,10 +321,8 @@ func (e *firstRow4Duration) UpdatePartialResult(sctx sessionctx.Context, rowsInG
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalDuration(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetDuration(e.argsOrdinal[0], e.fillFsp)
 		p.gotFirstRow, p.isNull, p.val = true, isNull, input
 		break
 	}
@@ -350,10 +339,10 @@ func (*firstRow4Duration) MergePartialResult(sctx sessionctx.Context, src Partia
 func (e *firstRow4Duration) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowDuration)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendDuration(e.ordinal, p.val)
+	chk.AppendDuration(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -376,10 +365,8 @@ func (e *firstRow4JSON) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalJSON(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetJSON(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull, p.val = true, isNull, input
 		break
 	}
@@ -396,10 +383,10 @@ func (*firstRow4JSON) MergePartialResult(sctx sessionctx.Context, src PartialRes
 func (e *firstRow4JSON) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowJSON)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendJSON(e.ordinal, p.val)
+	chk.AppendJSON(e.resultOrdinal, p.val)
 	return nil
 }
 
@@ -422,10 +409,8 @@ func (e *firstRow4Decimal) UpdatePartialResult(sctx sessionctx.Context, rowsInGr
 		return nil
 	}
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalDecimal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		isNull := row.IsNull(e.argsOrdinal[0])
+		input := row.GetMyDecimal(e.argsOrdinal[0])
 		p.gotFirstRow, p.isNull = true, isNull
 		if input != nil {
 			p.val = *input
@@ -438,10 +423,10 @@ func (e *firstRow4Decimal) UpdatePartialResult(sctx sessionctx.Context, rowsInGr
 func (e *firstRow4Decimal) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4FirstRowDecimal)(pr)
 	if p.isNull || !p.gotFirstRow {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendMyDecimal(e.ordinal, &p.val)
+	chk.AppendMyDecimal(e.resultOrdinal, &p.val)
 	return nil
 }
 

--- a/executor/aggfuncs/func_max_min.go
+++ b/executor/aggfuncs/func_max_min.go
@@ -14,7 +14,6 @@
 package aggfuncs
 
 import (
-	"github.com/juju/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -95,23 +94,20 @@ func (e *maxMin4Int) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Int) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinInt)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendInt64(e.ordinal, p.val)
+	chk.AppendInt64(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Int) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinInt)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetInt64(e.argsOrdinal[0])
 		if p.isNull {
 			p.val = input
 			p.isNull = false
@@ -158,23 +154,20 @@ func (e *maxMin4Uint) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Uint) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinUint)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendUint64(e.ordinal, p.val)
+	chk.AppendUint64(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Uint) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinUint)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalInt(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetInt64(e.argsOrdinal[0])
 		uintVal := uint64(input)
 		if p.isNull {
 			p.val = uintVal
@@ -223,31 +216,27 @@ func (e *maxMin4Float32) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Float32) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinFloat32)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendFloat32(e.ordinal, p.val)
+	chk.AppendFloat32(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Float32) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinFloat32)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalReal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
-		f := float32(input)
+		input := row.GetFloat32(e.argsOrdinal[0])
 		if p.isNull {
-			p.val = f
+			p.val = input
 			p.isNull = false
 			continue
 		}
-		if e.isMax && f > p.val || !e.isMax && f < p.val {
-			p.val = f
+		if e.isMax && input > p.val || !e.isMax && input < p.val {
+			p.val = input
 		}
 	}
 	return nil
@@ -287,23 +276,20 @@ func (e *maxMin4Float64) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Float64) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinFloat64)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendFloat64(e.ordinal, p.val)
+	chk.AppendFloat64(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Float64) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinFloat64)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalReal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetFloat64(e.argsOrdinal[0])
 		if p.isNull {
 			p.val = input
 			p.isNull = false
@@ -349,23 +335,20 @@ func (e *maxMin4Decimal) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Decimal) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinDecimal)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendMyDecimal(e.ordinal, &p.val)
+	chk.AppendMyDecimal(e.resultOrdinal, &p.val)
 	return nil
 }
 
 func (e *maxMin4Decimal) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinDecimal)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalDecimal(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetMyDecimal(e.argsOrdinal[0])
 		if p.isNull {
 			p.val = *input
 			p.isNull = false
@@ -413,23 +396,20 @@ func (e *maxMin4String) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4String) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinString)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendString(e.ordinal, p.val)
+	chk.AppendString(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4String) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinString)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalString(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetString(e.argsOrdinal[0])
 		if p.isNull {
 			// The string returned by `EvalString` may be referenced to an underlying buffer,
 			// for example ‘Chunk’, which could be reset and reused multiply times.
@@ -481,23 +461,20 @@ func (e *maxMin4Time) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Time) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4Time)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendTime(e.ordinal, p.val)
+	chk.AppendTime(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Time) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4Time)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalTime(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetTime(e.argsOrdinal[0])
 		if p.isNull {
 			p.val = input
 			p.isNull = false
@@ -529,6 +506,8 @@ func (e *maxMin4Time) MergePartialResult(sctx sessionctx.Context, src, dst Parti
 
 type maxMin4Duration struct {
 	baseMaxMinAggFunc
+
+	fillFsp int
 }
 
 func (e *maxMin4Duration) AllocPartialResult() PartialResult {
@@ -545,23 +524,20 @@ func (e *maxMin4Duration) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4Duration) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinDuration)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendDuration(e.ordinal, p.val)
+	chk.AppendDuration(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4Duration) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinDuration)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalDuration(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetDuration(e.argsOrdinal[0], e.fillFsp)
 		if p.isNull {
 			p.val = input
 			p.isNull = false
@@ -609,23 +585,20 @@ func (e *maxMin4JSON) ResetPartialResult(pr PartialResult) {
 func (e *maxMin4JSON) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
 	p := (*partialResult4MaxMinJSON)(pr)
 	if p.isNull {
-		chk.AppendNull(e.ordinal)
+		chk.AppendNull(e.resultOrdinal)
 		return nil
 	}
-	chk.AppendJSON(e.ordinal, p.val)
+	chk.AppendJSON(e.resultOrdinal, p.val)
 	return nil
 }
 
 func (e *maxMin4JSON) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
 	p := (*partialResult4MaxMinJSON)(pr)
 	for _, row := range rowsInGroup {
-		input, isNull, err := e.args[0].EvalJSON(sctx, row)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if isNull {
+		if row.IsNull(e.argsOrdinal[0]) {
 			continue
 		}
+		input := row.GetJSON(e.argsOrdinal[0])
 		if p.isNull {
 			p.val = input
 			p.isNull = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix issue #7674 

Before this PR, the types of definitions for `arguments`
of AggFunc and AggExec.GroupByItem are defined as 
[]Expression. This PR change them to []*Column.

### What is changed and how it works?

After this PR, we can directly use `row.Getxxx` when 
evaluating AggFunc.Args and GroupByItems, thus avoid
the cost of function call when using Expression.Eval.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

exist tests

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects
Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7697)
<!-- Reviewable:end -->
