### PR TITLE
DDL: add error log when info schema change

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -39,10 +39,9 @@ import (
 type DDLExec struct {
 	baseExecutor
 
-	stmt       ast.StmtNode
-	is         infoschema.InfoSchema
-	done       bool
-	retryCount int
+	stmt ast.StmtNode
+	is   infoschema.InfoSchema
+	done bool
 }
 
 // toErr converts the error to the ErrInfoSchemaChanged when the schema is outdated.
@@ -94,12 +93,9 @@ func (e *DDLExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 	}
 	if err != nil {
 		err1 := e.toErr(err)
-		if terror.ErrorEqual(err1, domain.ErrInfoSchemaChanged) && e.retryCount < 1000 {
+		if !terror.ErrorEqual(err1, err) {
 			query, _ := e.ctx.Value(sessionctx.QueryString).(string)
-			e.retryCount++
-			log.Errorf("run query %s , error: %v\nInfo schema changed, retry[%d].", query, errors.Trace(err), e.retryCount)
-			e.is = domain.GetDomain(e.ctx).InfoSchema()
-			return e.Next(ctx, chk)
+			log.Errorf("run query %s , error: %v\nInfo schema changed.", query, errors.Trace(err))
 		}
 		return errors.Trace(err1)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -95,7 +95,7 @@ func (e *DDLExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 		err1 := e.toErr(err)
 		if !terror.ErrorEqual(err1, err) {
 			query, _ := e.ctx.Value(sessionctx.QueryString).(string)
-			log.Errorf("run query %s , error: %v\nInfo schema changed.", query, errors.Trace(err))
+			log.Errorf("run query %s , error: %v\nInfo schema changed.", query, errors.ErrorStack(err))
 		}
 		return errors.Trace(err1)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When do DDL SQL, may return error cause by `Information schema is changed`.
This PR add a retry in this scenario. 
The PR is for schrodinger-test. 
Do not merge.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->


