### PR TITLE
parser,executor: make `load data` support  `user_var` in column list and `set` clause

### DIFF
--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -36,7 +36,7 @@ func (ts *testDMLSuite) TestDMLVisitorCover(c *C) {
 		{&DeleteStmt{TableRefs: tableRefsClause, Tables: &DeleteTableList{}, Where: ce,
 			Order: &OrderByClause{}, Limit: &Limit{Count: ce, Offset: ce}}, 4, 4},
 		{&ShowStmt{Table: &TableName{}, Column: &ColumnName{}, Pattern: &PatternLikeExpr{Expr: ce, Pattern: ce}, Where: ce}, 3, 3},
-		{&LoadDataStmt{Table: &TableName{}, Columns: []ExprNode{}, SetList: []*Assignment{{}}, FieldsInfo: &FieldsClause{}, LinesInfo: &LinesClause{}}, 0, 0},
+		{&LoadDataStmt{Table: &TableName{}, ColumnOrVars: []ExprNode{}, SetList: []*Assignment{{}}, FieldsInfo: &FieldsClause{}, LinesInfo: &LinesClause{}}, 0, 0},
 		{&Assignment{Column: &ColumnName{}, Expr: ce}, 1, 1},
 		{&ByItem{Expr: ce}, 1, 1},
 		{&GroupByClause{Items: []*ByItem{{Expr: ce}, {Expr: ce}}}, 2, 2},

--- a/ast/dml_test.go
+++ b/ast/dml_test.go
@@ -36,7 +36,7 @@ func (ts *testDMLSuite) TestDMLVisitorCover(c *C) {
 		{&DeleteStmt{TableRefs: tableRefsClause, Tables: &DeleteTableList{}, Where: ce,
 			Order: &OrderByClause{}, Limit: &Limit{Count: ce, Offset: ce}}, 4, 4},
 		{&ShowStmt{Table: &TableName{}, Column: &ColumnName{}, Pattern: &PatternLikeExpr{Expr: ce, Pattern: ce}, Where: ce}, 3, 3},
-		{&LoadDataStmt{Table: &TableName{}, Columns: []*ColumnName{{}}, FieldsInfo: &FieldsClause{}, LinesInfo: &LinesClause{}}, 0, 0},
+		{&LoadDataStmt{Table: &TableName{}, Columns: []ExprNode{}, SetList: []*Assignment{{}}, FieldsInfo: &FieldsClause{}, LinesInfo: &LinesClause{}}, 0, 0},
 		{&Assignment{Column: &ColumnName{}, Expr: ce}, 1, 1},
 		{&ByItem{Expr: ce}, 1, 1},
 		{&GroupByClause{Items: []*ByItem{{Expr: ce}, {Expr: ce}}}, 2, 2},

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -36,18 +36,6 @@ type LoadDataExec struct {
 	loadDataInfo *LoadDataInfo
 }
 
-// NewLoadDataInfo returns a LoadDataInfo structure, and it's only used for tests now.
-func NewLoadDataInfo(ctx sessionctx.Context, row []types.Datum, tbl table.Table, cols []*table.Column) *LoadDataInfo {
-	insertVal := &InsertValues{baseExecutor: newBaseExecutor(ctx, nil, "InsertValues"), Table: tbl}
-	return &LoadDataInfo{
-		row:          row,
-		InsertValues: insertVal,
-		Table:        tbl,
-		Ctx:          ctx,
-		columns:      cols,
-	}
-}
-
 // Next implements the Executor Next interface.
 func (e *LoadDataExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.GrowAndReset(e.maxChunkSize)
@@ -95,7 +83,9 @@ type LoadDataInfo struct {
 	LinesInfo   *ast.LinesClause
 	IgnoreLines uint64
 	Ctx         sessionctx.Context
-	columns     []*table.Column
+	colOrVar    []ast.ExprNode
+	colInfo     []*table.Column
+	colPivot    int
 }
 
 // SetMaxRowsInBatch sets the max number of rows to insert in a batch.
@@ -274,13 +264,68 @@ func (e *LoadDataInfo) colsToRow(cols []field) []types.Datum {
 			e.row[i].SetString(string(cols[i].str))
 		}
 	}
-	row, err := e.getRow(e.columns, e.row)
+	row, err := e.fillRowData4LoadData(e.row)
 	if err != nil {
 		e.handleWarning(err,
 			fmt.Sprintf("Load Data: insert data:%v failed:%v", e.row, errors.ErrorStack(err)))
 		return nil
 	}
 	return row
+}
+
+func (e *LoadDataInfo) fillRowData4LoadData(vals []types.Datum) ([]types.Datum, error) {
+	row := make([]types.Datum, len(e.Table.Cols()))
+	hasValue := make([]bool, len(e.Table.Cols()))
+	i := 0
+	for _, v := range vals {
+		colInfo := e.colInfo[i]
+		if colInfo == nil {
+			if !v.IsNull() {
+				vs, err := v.ToString()
+				if err != nil {
+					return nil, err
+				}
+				e.ctx.GetSessionVars().Users[(e.colOrVar[i]).(*ast.VariableExpr).Name] = vs
+			}
+			i++
+			if i == e.colPivot {
+				break
+			}
+			continue
+		}
+		casted, err := table.CastValue(e.ctx, v, colInfo.ToInfo())
+		if e.filterErr(err) != nil {
+			return nil, errors.Trace(err)
+		}
+		offset := colInfo.Offset
+		row[offset] = casted
+		hasValue[offset] = true
+		i++
+		if i == e.colPivot {
+			break
+		}
+	}
+
+	if len(e.SetList) > 0 {
+		mRow := chunk.MutRowFromDatums(row).ToRow()
+		for _, setExpr := range e.SetList {
+			colInfo := e.colInfo[i]
+			v, err := setExpr.Expr.Eval(mRow)
+			if err != nil {
+				return nil, err
+			}
+			casted, err := table.CastValue(e.ctx, v, colInfo.ToInfo())
+			if e.filterErr(err) != nil {
+				return nil, errors.Trace(err)
+			}
+			offset := colInfo.Offset
+			row[offset] = casted
+			hasValue[offset] = true
+			i++
+		}
+	}
+
+	return e.fillGenColData(e.colInfo, len(vals), hasValue, row)
 }
 
 func (e *LoadDataInfo) addRecordLD(row []types.Datum) (int64, error) {

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -264,7 +264,7 @@ func (e *LoadDataInfo) colsToRow(cols []field) []types.Datum {
 			e.row[i].SetString(string(cols[i].str))
 		}
 	}
-	row, err := e.fillRowData4LoadData(e.row)
+	row, err := e.getRow4LoadData(e.row)
 	if err != nil {
 		e.handleWarning(err,
 			fmt.Sprintf("Load Data: insert data:%v failed:%v", e.row, errors.ErrorStack(err)))
@@ -273,7 +273,7 @@ func (e *LoadDataInfo) colsToRow(cols []field) []types.Datum {
 	return row
 }
 
-func (e *LoadDataInfo) fillRowData4LoadData(vals []types.Datum) ([]types.Datum, error) {
+func (e *LoadDataInfo) getRow4LoadData(vals []types.Datum) ([]types.Datum, error) {
 	row := make([]types.Datum, len(e.Table.Cols()))
 	hasValue := make([]bool, len(e.Table.Cols()))
 	i := 0
@@ -325,7 +325,7 @@ func (e *LoadDataInfo) fillRowData4LoadData(vals []types.Datum) ([]types.Datum, 
 		}
 	}
 
-	return e.fillGenColData(e.colInfo, len(vals), hasValue, row)
+	return e.fillRow(row, hasValue)
 }
 
 func (e *LoadDataInfo) addRecordLD(row []types.Datum) (int64, error) {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -6989,11 +6989,11 @@ LoadDataStmt:
 	"LOAD" "DATA" LocalOpt "INFILE" stringLit "INTO" "TABLE" TableName CharsetOpt Fields Lines IgnoreLines ColumnOrVarListOptWithBrackets LoadDataSetOpt
 	{
 		x := &ast.LoadDataStmt{
-			Path:       $5,
-			Table:      $8.(*ast.TableName),
-			Columns:    $13.([]ast.ExprNode),
-			IgnoreLines:$12.(uint64),
-			SetList:    $14.([]*ast.Assignment),
+			Path:        $5,
+			Table:       $8.(*ast.TableName),
+			ColumnOrVars:$13.([]ast.ExprNode),
+			IgnoreLines: $12.(uint64),
+			SetList:     $14.([]*ast.Assignment),
 		}
 		if $3 != nil {
 			x.IsLocal = true

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -378,15 +378,16 @@ type Analyze struct {
 type LoadData struct {
 	baseSchemaProducer
 
-	IsLocal     bool
-	Path        string
-	Table       *ast.TableName
-	Columns     []*ast.ColumnName
-	FieldsInfo  *ast.FieldsClause
-	LinesInfo   *ast.LinesClause
-	IgnoreLines uint64
-
-	GenCols InsertGeneratedColumns
+	IsLocal      bool
+	Path         string
+	Table        *ast.TableName
+	ColumnOrVars []ast.ExprNode
+	FieldsInfo   *ast.FieldsClause
+	LinesInfo    *ast.LinesClause
+	IgnoreLines  uint64
+	SetList      []*expression.Assignment
+	tableSchema  *expression.Schema
+	GenCols      InsertGeneratedColumns
 }
 
 // LoadStats represents a load stats plan.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1371,7 +1371,7 @@ func (b *PlanBuilder) buildLoadData(ld *ast.LoadDataStmt) (Plan, error) {
 		IsLocal:      ld.IsLocal,
 		Path:         ld.Path,
 		Table:        ld.Table,
-		ColumnOrVars: ld.Columns,
+		ColumnOrVars: ld.ColumnOrVars,
 		FieldsInfo:   ld.FieldsInfo,
 		LinesInfo:    ld.LinesInfo,
 		IgnoreLines:  ld.IgnoreLines,

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -118,6 +118,11 @@ func (ts *TidbTestSuite) TestLoadData(c *C) {
 	runTestLoadData(c, suite.server)
 }
 
+func (ts *TidbTestSuite) TestLoadDataWithSet(c *C) {
+	c.Parallel()
+	runTestLoadDataWithSet(c, suite.server)
+}
+
 func (ts *TidbTestSuite) TestConcurrentUpdate(c *C) {
 	c.Parallel()
 	runTestConcurrentUpdate(c)

--- a/table/column.go
+++ b/table/column.go
@@ -83,6 +83,10 @@ func ToColumn(col *model.ColumnInfo) *Column {
 func FindCols(cols []*Column, names []string, pkIsHandle bool) ([]*Column, error) {
 	var rcols []*Column
 	for _, name := range names {
+		if name == "" {
+			rcols = append(rcols, nil)
+			continue
+		}
 		col := FindCol(cols, name)
 		if col != nil {
 			rcols = append(rcols, col)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #7404 

from: https://dev.mysql.com/doc/refman/5.7/en/load-data.html

`LOAD DATA`  support 

```
    [(col_name_or_user_var
        [, col_name_or_user_var] ...)]
    [SET col_name={expr | DEFAULT},
        [, col_name={expr | DEFAULT}] ...]
```

this PR, make TiDB support `SET` clause and `user_var`(we are alreay support col_name) which make user have ability to change data during loading data(like exchange column order or call some function to transform), also some type like `binary` 's import require this feature(just as mysql-doc said).

### What is changed and how it works?

- make parser support `set` and `@xx` in load data
- change executor

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test  

Code changes

 - logic change

Side effects

 - no

Related changes

 - Need to update the documentation
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7707)
<!-- Reviewable:end -->

### Remain question
- unsupport correlated subquery
- it seem `ignore`/`replace` is unsupport 
- `enclosed by` still unsupport