### PR TITLE
*: use timetuil.Now() rather than time.Now()

### DIFF
--- a/cmd/benchdb/main.go
+++ b/cmd/benchdb/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -197,7 +198,7 @@ func (ut *benchDB) runCountTimes(name string, count int, f func()) {
 	)
 	cLogf("%s started", name)
 	for i := 0; i < count; i++ {
-		before := time.Now()
+		before := timeutil.Now()
 		f()
 		dur := time.Since(before)
 		if first == 0 {

--- a/cmd/benchfilesort/main.go
+++ b/cmd/benchfilesort/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/filesort"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -200,7 +201,7 @@ func export() error {
 
 	outputBytes = encodeMeta(outputBytes, scale, keySize, valSize)
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	for i := 1; i <= scale; i++ {
@@ -280,7 +281,7 @@ func driveGenCmd() {
 	}
 
 	cLog("Generating...")
-	start := time.Now()
+	start := timeutil.Now()
 	err = export()
 	terror.MustNil(err)
 	cLog("Done!")
@@ -318,7 +319,7 @@ func driveRunCmd() {
 		fs      *filesort.FileSorter
 	)
 	cLog("Loading...")
-	start := time.Now()
+	start := timeutil.Now()
 	data, err := load(inputRatio)
 	terror.MustNil(err)
 	cLog("Done!")
@@ -343,7 +344,7 @@ func driveRunCmd() {
 	}
 
 	cLog("Inputing...")
-	start = time.Now()
+	start = timeutil.Now()
 	for _, r := range data {
 		err = fs.Input(r.key, r.val, r.handle)
 		terror.MustNil(err)
@@ -355,7 +356,7 @@ func driveRunCmd() {
 
 	cLog("Outputing...")
 	totalRows := int(float64(len(data)) * (float64(outputRatio) / 100.0))
-	start = time.Now()
+	start = timeutil.Now()
 	if cpuprofile != "" {
 		err = pprof.StartCPUProfile(profile)
 		terror.MustNil(err)
@@ -373,7 +374,7 @@ func driveRunCmd() {
 	cLog("=================================")
 
 	cLog("Closing...")
-	start = time.Now()
+	start = timeutil.Now()
 	err = fs.Close()
 	terror.MustNil(err)
 	cLog("Done!")

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -97,7 +98,7 @@ func batchRW(value []byte) {
 			defer wg.Done()
 			for j := 0; j < base; j++ {
 				txnCounter.WithLabelValues("txn").Inc()
-				start := time.Now()
+				start := timeutil.Now()
 				k := base*i + j
 				txn, err := store.Begin()
 				if err != nil {
@@ -125,7 +126,7 @@ func main() {
 	Init()
 
 	value := make([]byte, *valueSize)
-	t := time.Now()
+	t := timeutil.Now()
 	batchRW(value)
 	resp, err := http.Get("http://localhost:9191/metrics")
 	terror.MustNil(err)

--- a/cmd/benchraw/main.go
+++ b/cmd/benchraw/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -79,7 +80,7 @@ func main() {
 	}()
 
 	value := make([]byte, *valueSize)
-	t := time.Now()
+	t := timeutil.Now()
 	batchRawPut(value)
 
 	fmt.Printf("\nelapse:%v, total %v\n", time.Since(t), *dataCnt)

--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -25,15 +25,17 @@ import (
 	"strings"
 
 	"flag"
+	"time"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 const dbName = "test"
@@ -596,7 +598,7 @@ func resultExists(name string) bool {
 // openDBWithRetry opens a database specified by its database driver name and a
 // driver-specific data source name. And it will do some retries if the connection fails.
 func openDBWithRetry(driverName, dataSourceName string) (mdb *sql.DB, err error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	sleepTime := time.Millisecond * 500
 	retryCnt := 60
 	// The max retry interval is 30 s.

--- a/cmd/importer/data.go
+++ b/cmd/importer/data.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var defaultStep int64 = 1
@@ -115,7 +117,7 @@ func (d *datum) uniqTime() string {
 	defer d.Unlock()
 
 	if d.timeValue.IsZero() {
-		d.timeValue = time.Now()
+		d.timeValue = timeutil.Now()
 	} else {
 		d.timeValue = d.timeValue.Add(time.Duration(d.step) * time.Second)
 	}
@@ -128,7 +130,7 @@ func (d *datum) uniqDate() string {
 	defer d.Unlock()
 
 	if d.timeValue.IsZero() {
-		d.timeValue = time.Now()
+		d.timeValue = timeutil.Now()
 	} else {
 		d.timeValue = d.timeValue.AddDate(0, 0, int(d.step))
 	}
@@ -141,7 +143,7 @@ func (d *datum) uniqTimestamp() string {
 	defer d.Unlock()
 
 	if d.timeValue.IsZero() {
-		d.timeValue = time.Now()
+		d.timeValue = timeutil.Now()
 	} else {
 		d.timeValue = d.timeValue.Add(time.Duration(d.step) * time.Second)
 	}
@@ -156,7 +158,7 @@ func (d *datum) uniqYear() string {
 	defer d.Unlock()
 
 	if d.timeValue.IsZero() {
-		d.timeValue = time.Now()
+		d.timeValue = timeutil.Now()
 	} else {
 		d.timeValue = d.timeValue.AddDate(int(d.step), 0, 0)
 	}

--- a/cmd/importer/job.go
+++ b/cmd/importer/job.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -78,7 +79,7 @@ func doWait(doneChan chan struct{}, start time.Time, jobCount int, workerCount i
 
 	close(doneChan)
 
-	now := time.Now()
+	now := timeutil.Now()
 	seconds := now.Unix() - start.Unix()
 
 	tps := int64(-1)
@@ -93,7 +94,7 @@ func doProcess(table *table, dbs []*sql.DB, jobCount int, workerCount int, batch
 	jobChan := make(chan struct{}, 16*workerCount)
 	doneChan := make(chan struct{}, workerCount)
 
-	start := time.Now()
+	start := timeutil.Now()
 	go addJobs(jobCount, jobChan)
 
 	for i := 0; i < workerCount; i++ {

--- a/cmd/importer/rand.go
+++ b/cmd/importer/rand.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,7 +36,7 @@ const (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(timeutil.Now().UnixNano())
 }
 
 func randInt(min int, max int) int {
@@ -77,7 +78,7 @@ func randDate(col *column) string {
 
 	min, max := col.min, col.max
 	if len(min) == 0 {
-		year := time.Now().Year()
+		year := timeutil.Now().Year()
 		month := randInt(1, 12)
 		day := randInt(1, 28)
 		return fmt.Sprintf("%04d-%02d-%02d", year, month, day)
@@ -132,7 +133,7 @@ func randTimestamp(col *column) string {
 	}
 	min, max := col.min, col.max
 	if len(min) == 0 {
-		year := time.Now().Year()
+		year := timeutil.Now().Year()
 		month := randInt(1, 12)
 		day := randInt(1, 28)
 		hour := randInt(0, 23)
@@ -165,7 +166,7 @@ func randYear(col *column) string {
 	}
 	min, max := col.min, col.max
 	if len(min) == 0 || len(max) == 0 {
-		return fmt.Sprintf("%04d", time.Now().Year()-randInt(0, 10))
+		return fmt.Sprintf("%04d", timeutil.Now().Year()-randInt(0, 10))
 	}
 
 	minTime, err := time.Parse(yearFormat, min)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -780,7 +781,7 @@ LOOP:
 }
 
 func checkDelRangeDone(c *C, ctx sessionctx.Context, idx table.Index) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	f := func() map[int64]struct{} {
 		handles := make(map[int64]struct{})
 
@@ -3254,7 +3255,7 @@ LOOP:
 			c.Assert(err, IsNil, Commentf("err:%v", errors.ErrorStack(err)))
 		case <-ticker.C:
 			step := 10
-			rand.Seed(time.Now().Unix())
+			rand.Seed(timeutil.Now().Unix())
 			for i := num; i < num+step; i++ {
 				n := rand.Intn(num)
 				s.mustExec(c, "update partition_drop_idx set c2 = 1 where c1 = ?", n)
@@ -3331,7 +3332,7 @@ LOOP:
 				break
 			}
 			step := 10
-			rand.Seed(time.Now().Unix())
+			rand.Seed(timeutil.Now().Unix())
 			// delete some rows, and add some data
 			for i := count; i < count+step; i++ {
 				n := rand.Intn(count)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/terror"
 	tidbutil "github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/twinj/uuid"
@@ -393,7 +394,7 @@ func (d *ddl) close() {
 		return
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	close(d.quitCh)
 	d.ownerManager.Cancel()
 	err := d.schemaSyncer.RemoveSelfVersionPath()
@@ -498,7 +499,7 @@ func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 	// For every state changes, we will wait as lease 2 * lease time, so here the ticker check is 10 * lease.
 	// But we use etcd to speed up, normally it takes less than 0.5s now, so we use 0.5s or 1s or 3s as the max value.
 	ticker := time.NewTicker(chooseLeaseTime(10*d.lease, checkJobMaxInterval(job)))
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	metrics.JobsGauge.WithLabelValues(job.Type.String()).Inc()
 	defer func() {
 		ticker.Stop()

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/tidb/ast"
@@ -35,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -1272,7 +1272,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 
 	if col.OriginDefaultValue == strings.ToUpper(ast.CurrentTimestamp) &&
 		(col.Tp == mysql.TypeTimestamp || col.Tp == mysql.TypeDatetime) {
-		col.OriginDefaultValue = time.Now().Format(types.TimeFormat)
+		col.OriginDefaultValue = timeutil.Now().Format(types.TimeFormat)
 	}
 
 	job := &model.Job{

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -211,7 +212,7 @@ func constructLimitPB(count uint64) *tipb.Executor {
 func buildDescTableScanDAG(startTS uint64, tbl table.PhysicalTable, columns []*model.ColumnInfo, limit uint64) (*tipb.DAGRequest, error) {
 	dagReq := &tipb.DAGRequest{}
 	dagReq.StartTs = startTS
-	_, timeZoneOffset := time.Now().In(time.UTC).Zone()
+	_, timeZoneOffset := timeutil.Now().In(time.UTC).Zone()
 	dagReq.TimeZoneOffset = int64(timeZoneOffset)
 	for i := range columns {
 		dagReq.OutputOffsets = append(dagReq.OutputOffsets, uint32(i))

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -75,7 +76,7 @@ func (r *selectResult) Fetch(ctx context.Context) {
 }
 
 func (r *selectResult) fetch(ctx context.Context) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	defer func() {
 		close(r.results)
 		duration := time.Since(startTime)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -96,7 +97,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 		}
 	}()
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	ok, tblIDs, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, latestSchemaVersion)
 	if err != nil {
 		// We can fall back to full load, don't need to return the error.
@@ -286,7 +287,7 @@ func (do *Domain) Reload() error {
 	do.m.Lock()
 	defer do.m.Unlock()
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 
 	var err error
 	var latestSchemaVersion int64
@@ -712,12 +713,12 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 	loadFeedbackTicker := time.NewTicker(5 * lease)
 	defer loadFeedbackTicker.Stop()
 	statsHandle := do.StatsHandle()
-	t := time.Now()
+	t := timeutil.Now()
 	err := statsHandle.InitStats(do.InfoSchema())
 	if err != nil {
 		log.Debug("[stats] init stats info failed: ", errors.ErrorStack(err))
 	} else {
-		log.Info("[stats] init stats info takes ", time.Now().Sub(t))
+		log.Info("[stats] init stats info takes ", timeutil.Now().Sub(t))
 	}
 	defer func() {
 		recoverInDomain("updateStatsWorker", false)

--- a/domain/global_vars_cache.go
+++ b/domain/global_vars_cache.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 // GlobalVariableCache caches global variables.
@@ -34,7 +35,7 @@ const globalVariableCacheExpiry time.Duration = 2 * time.Second
 // Update updates the global variable cache.
 func (gvc *GlobalVariableCache) Update(rows []chunk.Row, fields []*ast.ResultField) {
 	gvc.Lock()
-	gvc.lastModify = time.Now()
+	gvc.lastModify = timeutil.Now()
 	gvc.rows = rows
 	gvc.fields = fields
 	gvc.Unlock()
@@ -44,7 +45,7 @@ func (gvc *GlobalVariableCache) Update(rows []chunk.Row, fields []*ast.ResultFie
 func (gvc *GlobalVariableCache) Get() (succ bool, rows []chunk.Row, fields []*ast.ResultField) {
 	gvc.RLock()
 	defer gvc.RUnlock()
-	if time.Now().Sub(gvc.lastModify) < globalVariableCacheExpiry {
+	if timeutil.Now().Sub(gvc.lastModify) < globalVariableCacheExpiry {
 		succ, rows, fields = true, gvc.rows, gvc.fields
 		return
 	}

--- a/domain/schema_checker_test.go
+++ b/domain/schema_checker_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func (s *testSuite) TestSchemaCheckerSimple(c *C) {
@@ -26,7 +27,7 @@ func (s *testSuite) TestSchemaCheckerSimple(c *C) {
 	checker := &SchemaChecker{SchemaValidator: validator}
 
 	// Add some schema versions and delta table IDs.
-	ts := uint64(time.Now().UnixNano())
+	ts := uint64(timeutil.Now().UnixNano())
 	validator.Update(ts, 0, 2, []int64{1})
 	validator.Update(ts, 2, 4, []int64{2})
 
@@ -57,7 +58,7 @@ func (s *testSuite) TestSchemaCheckerSimple(c *C) {
 	checker.relatedTableIDs = []int64{3}
 	err = checker.Check(ts)
 	c.Assert(err, IsNil)
-	nowTS := uint64(time.Now().UnixNano())
+	nowTS := uint64(timeutil.Now().UnixNano())
 	// Use checker.SchemaValidator.Check instead of checker.Check here because backoff make CI slow.
 	result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs)
 	c.Assert(result, Equals, ResultUnknown)

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 type leaseGrantItem struct {
@@ -90,7 +91,7 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	c.Assert(isTablesChanged, IsTrue)
 
 	// All schema versions is expired.
-	ts = uint64(time.Now().Add(lease).UnixNano())
+	ts = uint64(timeutil.Now().Add(lease).UnixNano())
 	valid = validator.Check(ts, newItem.schemaVer, nil)
 	c.Assert(valid, Equals, ResultUnknown)
 
@@ -109,7 +110,7 @@ func reload(validator SchemaValidator, leaseGrantCh chan leaseGrantItem, ids ...
 // Caller should communicate with it through channel to mock network.
 func serverFunc(lease time.Duration, requireLease chan leaseGrantItem, oracleCh chan uint64, exit chan struct{}) {
 	var version int64
-	leaseTS := uint64(time.Now().UnixNano())
+	leaseTS := uint64(timeutil.Now().UnixNano())
 	ticker := time.NewTicker(lease)
 	for {
 		select {
@@ -121,7 +122,7 @@ func serverFunc(lease time.Duration, requireLease chan leaseGrantItem, oracleCh 
 			oldVer:       version - 1,
 			schemaVer:    version,
 		}:
-		case oracleCh <- uint64(time.Now().UnixNano()):
+		case oracleCh <- uint64(timeutil.Now().UnixNano()):
 		case <-exit:
 			return
 		}

--- a/domain/topn_slow_query_test.go
+++ b/domain/topn_slow_query_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var _ = Suite(&testTopNSlowQuerySuite{})
@@ -69,8 +70,8 @@ func (t *testTopNSlowQuerySuite) TestPush(c *C) {
 	c.Assert(slowQuery.user.data[0].Duration, Equals, 1300*time.Millisecond)
 }
 
-func (t *testTopNSlowQuerySuite) TestRemoveExpired(c *C) {
-	now := time.Now()
+func (t *testTopNSlowQuerySuite) TestRefresh(c *C) {
+	now := timeutil.Now()
 	slowQuery := newTopNSlowQueries(6, 3*time.Second, 10)
 
 	slowQuery.Append(&SlowQueryInfo{Start: now, Duration: 6})

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -186,7 +187,7 @@ func (a *ExecStmt) RebuildPlan() (int64, error) {
 // like the INSERT, UPDATE statements, it executes in this function, if the Executor returns
 // result, execution is done after this function returns, in the returned ast.RecordSet Next method.
 func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
-	a.startTime = time.Now()
+	a.startTime = timeutil.Now()
 	sctx := a.Ctx
 	if _, ok := a.Plan.(*plannercore.Analyze); ok && sctx.GetSessionVars().InRestrictedSQL {
 		oriStats, _ := sctx.GetSessionVars().GetSystemVar(variable.TiDBBuildStatsConcurrency)

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/model"

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -161,7 +162,7 @@ func (s *testSuite) TestAlterTableAddColumn(c *C) {
 	tk.MustExec("insert into alter_test values(1)")
 	tk.MustExec("alter table alter_test add column c2 timestamp default current_timestamp")
 	time.Sleep(1 * time.Second)
-	now := time.Now().Add(-time.Duration(1 * time.Second)).Format(types.TimeFormat)
+	now := timeutil.Now().Add(-time.Duration(1 * time.Second)).Format(types.TimeFormat)
 	r, err := tk.Exec("select c2 from alter_test")
 	c.Assert(err, IsNil)
 	chk := r.NewChunk()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1847,7 +1847,7 @@ func (s *testSuite) TestHistoryRead(c *C) {
 
 	curVer1, _ := s.store.CurrentVersion()
 	time.Sleep(time.Millisecond)
-	snapshotTime := time.Now()
+	snapshotTime := timeutil.Now()
 	time.Sleep(time.Millisecond)
 	curVer2, _ := s.store.CurrentVersion()
 	tk.MustExec("insert history_read values (2)")
@@ -1871,7 +1871,7 @@ func (s *testSuite) TestHistoryRead(c *C) {
 	tk.MustExec("delete from history_read where a = 1")
 
 	time.Sleep(time.Millisecond)
-	snapshotTime = time.Now()
+	snapshotTime = timeutil.Now()
 	time.Sleep(time.Millisecond)
 	tk.MustExec("alter table history_read add column b int")
 	tk.MustExec("insert history_read values (8, 8), (9, 9)")

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 
 	"fmt"
+
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,7 +16,6 @@ package executor_test
 import (
 	"fmt"
 	"strconv"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/domain"
@@ -31,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -587,7 +587,7 @@ func (s *testSuite) TestShow2(c *C) {
 	c.Assert(err, IsNil)
 	create_time := model.TSConvert2Time(tblInfo.Meta().UpdateTS).String()
 	r := tk.MustQuery("show table status from test like 't'")
-	timeStr := time.Now().Format("2006-01-02 15:04:05")
+	timeStr := timeutil.Now().Format("2006-01-02 15:04:05")
 	r.Check(testkit.Rows(fmt.Sprintf("t InnoDB 10 Compact 100 100 100 100 100 100 100 %s %s %s utf8_general_ci   注释", create_time, timeStr, timeStr)))
 
 	tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, []byte("012345678901234567890"))

--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -16,6 +16,7 @@ package aggregation
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/model"

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func (s *testEvaluatorSuite) TestCast(c *C) {
@@ -230,7 +231,7 @@ func (s *testEvaluatorSuite) TestCast(c *C) {
 }
 
 var (
-	year, month, day     = time.Now().In(time.UTC).Date()
+	year, month, day     = timeutil.Now().In(time.UTC).Date()
 	curDateInt           = int64(year*10000 + int(month)*100 + day)
 	curTimeInt           = int64(curDateInt*1000000 + 125959)
 	curTimeWithFspReal   = float64(curTimeInt) + 0.555

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -79,7 +80,7 @@ func (s *testEvaluatorSuite) TestCompare(c *C) {
 	defer testleak.AfterTest(c)()
 
 	intVal, uintVal, realVal, stringVal, decimalVal := 1, uint64(1), 1.1, "123", types.NewDecFromFloatForTest(123.123)
-	timeVal := types.Time{Time: types.FromGoTime(time.Now()), Fsp: 6, Type: mysql.TypeDatetime}
+	timeVal := types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 6, Type: mysql.TypeDatetime}
 	durationVal := types.Duration{Duration: time.Duration(12*time.Hour + 1*time.Minute + 1*time.Second)}
 	jsonVal := json.CreateBinary("123")
 	// test cases for generating function signatures.

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -24,13 +24,13 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
 )
@@ -987,7 +987,7 @@ func (b *builtinRandSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_rand
 func (b *builtinRandSig) evalReal(row chunk.Row) (float64, bool, error) {
 	if b.randGen == nil {
-		b.randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+		b.randGen = rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	}
 	return b.randGen.Float64(), false, nil
 }
@@ -1013,7 +1013,7 @@ func (b *builtinRandWithSeedSig) evalReal(row chunk.Row) (float64, bool, error) 
 	if b.randGen == nil {
 		if isNull {
 			// When seed is NULL, it is equal to RAND().
-			b.randGen = rand.New(rand.NewSource(time.Now().UnixNano()))
+			b.randGen = rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 		} else {
 			b.randGen = rand.New(rand.NewSource(seed))
 		}

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -46,7 +47,7 @@ func (s *testEvaluatorSuite) TestLength(c *C) {
 		{1, 1, false, false},
 		{3.14, 4, false, false},
 		{types.NewDecFromFloatForTest(123.123), 7, false, false},
-		{types.Time{Time: types.FromGoTime(time.Now()), Fsp: 6, Type: mysql.TypeDatetime}, 26, false, false},
+		{types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 6, Type: mysql.TypeDatetime}, 26, false, false},
 		{types.NewBinaryLiteralFromUint(0x01, -1), 1, false, false},
 		{types.Set{Value: 1, Name: "abc"}, 3, false, false},
 		{types.Duration{Duration: time.Duration(12*time.Hour + 1*time.Minute + 1*time.Second), Fsp: types.DefaultFsp}, 8, false, false},

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -1909,7 +1910,7 @@ func (b *builtinSysDateWithFspSig) evalTime(row chunk.Row) (d types.Time, isNull
 	}
 
 	loc := b.ctx.GetSessionVars().Location()
-	now := time.Now().In(loc)
+	now := timeutil.Now().In(loc)
 	result, err := convertTimeToMysqlTime(now, int(fsp))
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
@@ -1931,7 +1932,7 @@ func (b *builtinSysDateWithoutFspSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_sysdate
 func (b *builtinSysDateWithoutFspSig) evalTime(row chunk.Row) (d types.Time, isNull bool, err error) {
 	tz := b.ctx.GetSessionVars().Location()
-	now := time.Now().In(tz)
+	now := timeutil.Now().In(tz)
 	result, err := convertTimeToMysqlTime(now, 0)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
@@ -1967,7 +1968,7 @@ func (b *builtinCurrentDateSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curdate
 func (b *builtinCurrentDateSig) evalTime(row chunk.Row) (d types.Time, isNull bool, err error) {
 	tz := b.ctx.GetSessionVars().Location()
-	year, month, day := time.Now().In(tz).Date()
+	year, month, day := timeutil.Now().In(tz).Date()
 	result := types.Time{
 		Time: types.FromDate(year, int(month), day, 0, 0, 0, 0),
 		Type: mysql.TypeDate,
@@ -2022,7 +2023,7 @@ func (b *builtinCurrentTime0ArgSig) Clone() builtinFunc {
 
 func (b *builtinCurrentTime0ArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	tz := b.ctx.GetSessionVars().Location()
-	dur := time.Now().In(tz).Format(types.TimeFormat)
+	dur := timeutil.Now().In(tz).Format(types.TimeFormat)
 	res, err := types.ParseDuration(dur, types.MinFsp)
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
@@ -2046,7 +2047,7 @@ func (b *builtinCurrentTime1ArgSig) evalDuration(row chunk.Row) (types.Duration,
 		return types.Duration{}, true, errors.Trace(err)
 	}
 	tz := b.ctx.GetSessionVars().Location()
-	dur := time.Now().In(tz).Format(types.TimeFSPFormat)
+	dur := timeutil.Now().In(tz).Format(types.TimeFSPFormat)
 	res, err := types.ParseDuration(dur, int(fsp))
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
@@ -2184,7 +2185,7 @@ func (b *builtinUTCDateSig) Clone() builtinFunc {
 // evalTime evals UTC_DATE, UTC_DATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-date
 func (b *builtinUTCDateSig) evalTime(row chunk.Row) (types.Time, bool, error) {
-	year, month, day := time.Now().UTC().Date()
+	year, month, day := timeutil.Now().UTC().Date()
 	result := types.Time{
 		Time: types.FromGoTime(time.Date(year, month, day, 0, 0, 0, 0, time.UTC)),
 		Type: mysql.TypeDate,
@@ -2241,7 +2242,7 @@ func (c *utcTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []E
 }
 
 func evalUTCTimestampWithFsp(fsp int) (types.Time, bool, error) {
-	result, err := convertTimeToMysqlTime(time.Now().UTC(), fsp)
+	result, err := convertTimeToMysqlTime(timeutil.Now().UTC(), fsp)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -3393,7 +3394,7 @@ func (b *builtinUnixTimestampCurrentSig) Clone() builtinFunc {
 // evalInt evals a UNIX_TIMESTAMP().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampCurrentSig) evalInt(row chunk.Row) (int64, bool, error) {
-	dec, err := goTimeToMysqlUnixTimestamp(time.Now(), 1)
+	dec, err := goTimeToMysqlUnixTimestamp(timeutil.Now(), 1)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -5332,7 +5333,7 @@ func (b *builtinUTCTimeWithoutArgSig) Clone() builtinFunc {
 // evalDuration evals a builtinUTCTimeWithoutArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithoutArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
-	v, err := types.ParseDuration(time.Now().UTC().Format(types.TimeFormat), 0)
+	v, err := types.ParseDuration(timeutil.Now().UTC().Format(types.TimeFormat), 0)
 	return v, false, err
 }
 
@@ -5359,7 +5360,7 @@ func (b *builtinUTCTimeWithArgSig) evalDuration(row chunk.Row) (types.Duration, 
 	if fsp < int64(types.MinFsp) {
 		return types.Duration{}, true, errors.Errorf("Invalid negative %d specified, must in [0, 6].", fsp)
 	}
-	v, err := types.ParseDuration(time.Now().UTC().Format(types.TimeFSPFormat), int(fsp))
+	v, err := types.ParseDuration(timeutil.Now().UTC().Format(types.TimeFSPFormat), int(fsp))
 	return v, false, err
 }
 

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -775,8 +775,8 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 		fc  functionClass
 		now func() time.Time
 	}{
-		{funcs[ast.Now], func() time.Time { return time.Now() }},
-		{funcs[ast.UTCTimestamp], func() time.Time { return time.Now().UTC() }},
+		{funcs[ast.Now], func() time.Time { return timeutil.Now() }},
+		{funcs[ast.UTCTimestamp], func() time.Time { return timeutil.Now().UTC() }},
 	} {
 		f, err := x.fc.getFunction(s.ctx, s.datumsToConstants(nil))
 		c.Assert(err, IsNil)
@@ -1006,13 +1006,13 @@ func (s *testEvaluatorSuite) TestSysDate(c *C) {
 		f, err := fc.getFunction(ctx, s.datumsToConstants(nil))
 		c.Assert(err, IsNil)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
-		last := time.Now()
+		last := timeutil.Now()
 		c.Assert(err, IsNil)
 		n := v.GetMysqlTime()
 		c.Assert(n.String(), GreaterEqual, last.Format(types.TimeFormat))
 	}
 
-	last := time.Now()
+	last := timeutil.Now()
 	f, err := fc.getFunction(ctx, s.datumsToConstants(types.MakeDatums(6)))
 	c.Assert(err, IsNil)
 	v, err := evalBuiltinFunc(f, chunk.Row{})
@@ -1143,7 +1143,7 @@ func (s *testEvaluatorSuite) TestFromUnixTime(c *C) {
 
 func (s *testEvaluatorSuite) TestCurrentDate(c *C) {
 	defer testleak.AfterTest(c)()
-	last := time.Now()
+	last := timeutil.Now()
 	fc := funcs[ast.CurrentDate]
 	f, err := fc.getFunction(mock.NewContext(), s.datumsToConstants(nil))
 	c.Assert(err, IsNil)
@@ -1157,7 +1157,7 @@ func (s *testEvaluatorSuite) TestCurrentTime(c *C) {
 	defer testleak.AfterTest(c)()
 	tfStr := "15:04:05"
 
-	last := time.Now()
+	last := timeutil.Now()
 	fc := funcs[ast.CurrentTime]
 	f, err := fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(nil)))
 	c.Assert(err, IsNil)
@@ -1193,7 +1193,7 @@ func (s *testEvaluatorSuite) TestCurrentTime(c *C) {
 func (s *testEvaluatorSuite) TestUTCTime(c *C) {
 	defer testleak.AfterTest(c)()
 
-	last := time.Now().UTC()
+	last := timeutil.Now().UTC()
 	tfStr := "00:00:00"
 	fc := funcs[ast.UTCTime]
 
@@ -1227,7 +1227,7 @@ func (s *testEvaluatorSuite) TestUTCTime(c *C) {
 
 func (s *testEvaluatorSuite) TestUTCDate(c *C) {
 	defer testleak.AfterTest(c)()
-	last := time.Now().UTC()
+	last := timeutil.Now().UTC()
 	fc := funcs[ast.UTCDate]
 	f, err := fc.getFunction(mock.NewContext(), s.datumsToConstants(nil))
 	c.Assert(err, IsNil)
@@ -1531,8 +1531,8 @@ func (s *testEvaluatorSuite) TestUnixTimestamp(c *C) {
 	c.Assert(err, IsNil)
 	d, err := evalBuiltinFunc(f, chunk.Row{})
 	c.Assert(err, IsNil)
-	c.Assert(d.GetInt64()-time.Now().Unix(), GreaterEqual, int64(-1))
-	c.Assert(d.GetInt64()-time.Now().Unix(), LessEqual, int64(1))
+	c.Assert(d.GetInt64()-timeutil.Now().Unix(), GreaterEqual, int64(-1))
+	c.Assert(d.GetInt64()-timeutil.Now().Unix(), LessEqual, int64(1))
 
 	// https://github.com/pingcap/tidb/issues/2496
 	// Test UNIX_TIMESTAMP(NOW()).
@@ -1547,8 +1547,8 @@ func (s *testEvaluatorSuite) TestUnixTimestamp(c *C) {
 	d, err = evalBuiltinFunc(f, chunk.Row{})
 	c.Assert(err, IsNil)
 	val, _ := d.GetMysqlDecimal().ToInt()
-	c.Assert(val-time.Now().Unix(), GreaterEqual, int64(-1))
-	c.Assert(val-time.Now().Unix(), LessEqual, int64(1))
+	c.Assert(val-timeutil.Now().Unix(), GreaterEqual, int64(-1))
+	c.Assert(val-timeutil.Now().Unix(), LessEqual, int64(1))
 
 	// https://github.com/pingcap/tidb/issues/2852
 	// Test UNIX_TIMESTAMP(NULL).
@@ -2355,7 +2355,7 @@ func (s *testEvaluatorSuite) TestWithTimeZone(c *C) {
 	}
 
 	for _, t := range tests {
-		now := time.Now().In(sv.TimeZone)
+		now := timeutil.Now().In(sv.TimeZone)
 		f, err := funcs[t.method].getFunction(s.ctx, s.datumsToConstants(t.Input))
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		c.Assert(err, IsNil)

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var _ = Suite(&testEvaluatorSuite{})
@@ -164,7 +165,7 @@ func (s *testEvaluatorSuite) TestSleep(c *C) {
 
 	// strict model
 	d[0].SetFloat64(0.5)
-	start := time.Now()
+	start := timeutil.Now()
 	f, err = fc.getFunction(ctx, s.datumsToConstants(d))
 	c.Assert(err, IsNil)
 	ret, isNull, err = f.evalInt(chunk.Row{})
@@ -179,7 +180,7 @@ func (s *testEvaluatorSuite) TestSleep(c *C) {
 	// d[0].SetFloat64(2)
 	// f, err = fc.getFunction(ctx, s.datumsToConstants(d))
 	// c.Assert(err, IsNil)
-	// start = time.Now()
+	// start = timeutil.Now()
 	// go func() {
 	// 	time.Sleep(1 * time.Second)
 	// 	ctx.Cancel()
@@ -385,8 +386,8 @@ func (s *testEvaluatorSuite) TestBinopNumeric(c *C) {
 		{uint64(1), ast.Mul, uint64(1), 1},
 		{types.Time{Time: types.FromDate(0, 0, 0, 0, 0, 0, 0)}, ast.Mul, 0, 0},
 		{types.ZeroDuration, ast.Mul, 0, 0},
-		{types.Time{Time: types.FromGoTime(time.Now()), Fsp: 0, Type: mysql.TypeDatetime}, ast.Mul, 0, 0},
-		{types.Time{Time: types.FromGoTime(time.Now()), Fsp: 6, Type: mysql.TypeDatetime}, ast.Mul, 0, 0},
+		{types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 0, Type: mysql.TypeDatetime}, ast.Mul, 0, 0},
+		{types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 6, Type: mysql.TypeDatetime}, ast.Mul, 0, 0},
 		{types.Duration{Duration: 100000000, Fsp: 6}, ast.Mul, 0, 0},
 
 		// div

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -121,7 +122,7 @@ func GetTimeValue(ctx sessionctx.Context, v interface{}, tp byte, fsp int) (d ty
 }
 
 func getSystemTimestamp(ctx sessionctx.Context) (time.Time, error) {
-	now := time.Now()
+	now := timeutil.Now()
 
 	if ctx == nil {
 		return now, nil

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -2753,7 +2754,7 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec(`insert into t2 values(1, 1.1, "2017-08-01 12:01:01", "12:01:01", "abcdef", 0b10101)`)
 
 	result = tk.MustQuery("select coalesce(NULL, a), coalesce(NULL, b, a), coalesce(c, NULL, a, b), coalesce(d, NULL), coalesce(d, c), coalesce(NULL, NULL, e, 1), coalesce(f), coalesce(1, a, b, c, d, e, f) from t2")
-	result.Check(testkit.Rows(fmt.Sprintf("1 1.1 2017-08-01 12:01:01 12:01:01 %s 12:01:01 abcdef 21 1", time.Now().In(tk.Se.GetSessionVars().Location()).Format("2006-01-02"))))
+	result.Check(testkit.Rows(fmt.Sprintf("1 1.1 2017-08-01 12:01:01 12:01:01 %s 12:01:01 abcdef 21 1", timeutil.Now().In(tk.Se.GetSessionVars().Location()).Format("2006-01-02"))))
 
 	// nullif
 	result = tk.MustQuery(`SELECT NULLIF(NULL, 1), NULLIF(1, NULL), NULLIF(1, 1), NULLIF(NULL, NULL);`)

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -803,7 +804,7 @@ func (c *statsCache) setLoading(loading bool) {
 
 func (c *statsCache) get(ctx sessionctx.Context) (map[int64]uint64, map[tableHistID]uint64, error) {
 	c.mu.Lock()
-	if time.Now().Sub(c.modifyTime) < TableStatsCacheExpiry || c.loading {
+	if timeutil.Now().Sub(c.modifyTime) < TableStatsCacheExpiry || c.loading {
 		tableRows, colLength := c.tableRows, c.colLength
 		c.mu.Unlock()
 		return tableRows, colLength, nil
@@ -826,7 +827,7 @@ func (c *statsCache) get(ctx sessionctx.Context) (map[int64]uint64, map[tableHis
 	c.loading = false
 	c.tableRows = tableRows
 	c.colLength = colLength
-	c.modifyTime = time.Now()
+	c.modifyTime = timeutil.Now()
 	c.mu.Unlock()
 	return tableRows, colLength, nil
 }

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -83,7 +84,7 @@ func (alloc *allocator) End() int64 {
 // NextGlobalAutoID implements autoid.Allocator NextGlobalAutoID interface.
 func (alloc *allocator) NextGlobalAutoID(tableID int64) (int64, error) {
 	var autoID int64
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 		var err1 error
 		m := meta.NewMeta(txn)
@@ -114,7 +115,7 @@ func (alloc *allocator) Rebase(tableID, requiredBase int64, allocIDs bool) error
 		return nil
 	}
 	var newBase, newEnd int64
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 		m := meta.NewMeta(txn)
 		currentEnd, err1 := m.GetAutoTableID(alloc.dbID, tableID)
@@ -157,7 +158,7 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 	defer alloc.mu.Unlock()
 	if alloc.base == alloc.end { // step
 		var newBase, newEnd int64
-		startTime := time.Now()
+		startTime := timeutil.Now()
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/structure"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -527,7 +528,7 @@ func (m *Meta) GetDDLJobByIdx(index int64, jobListKeys ...JobListKeyType) (*mode
 		listKey = jobListKeys[0]
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	job, err := m.getDDLJob(listKey, index)
 	metrics.MetaHistogram.WithLabelValues(metrics.GetDDLJobByIdx, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	return job, errors.Trace(err)
@@ -554,7 +555,7 @@ func (m *Meta) UpdateDDLJob(index int64, job *model.Job, updateRawArgs bool, job
 		listKey = jobListKeys[0]
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	err := m.updateDDLJob(index, job, listKey, updateRawArgs)
 	metrics.MetaHistogram.WithLabelValues(metrics.UpdateDDLJob, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	return errors.Trace(err)
@@ -652,7 +653,7 @@ func (m *Meta) getHistoryDDLJob(key []byte, id int64) (*model.Job, error) {
 
 // GetHistoryDDLJob gets a history DDL job.
 func (m *Meta) GetHistoryDDLJob(id int64) (*model.Job, error) {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	job, err := m.getHistoryDDLJob(mDDLJobHistoryKey, id)
 	metrics.MetaHistogram.WithLabelValues(metrics.GetHistoryDDLJob, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	return job, errors.Trace(err)
@@ -785,7 +786,7 @@ func (m *Meta) schemaDiffKey(schemaVersion int64) []byte {
 // GetSchemaDiff gets the modification information on a given schema version.
 func (m *Meta) GetSchemaDiff(schemaVersion int64) (*model.SchemaDiff, error) {
 	diffKey := m.schemaDiffKey(schemaVersion)
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	data, err := m.txn.Get(diffKey)
 	metrics.MetaHistogram.WithLabelValues(metrics.GetSchemaDiff, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	if err != nil {
@@ -806,7 +807,7 @@ func (m *Meta) SetSchemaDiff(diff *model.SchemaDiff) error {
 		return errors.Trace(err)
 	}
 	diffKey := m.schemaDiffKey(diff.Version)
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	err = m.txn.Set(diffKey, data)
 	metrics.MetaHistogram.WithLabelValues(metrics.SetSchemaDiff, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 	return errors.Trace(err)

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -147,7 +148,7 @@ func NewSession(ctx context.Context, logPrefix string, etcdCli *clientv3.Client,
 		//	if closeGrpc {
 		//		etcdCli.ActiveConnection().Close()
 		//	}
-		startTime := time.Now()
+		startTime := timeutil.Now()
 		etcdSession, err = concurrency.NewSession(etcdCli,
 			concurrency.WithTTL(ttl), concurrency.WithContext(ctx))
 		metrics.NewSessionHistogram.WithLabelValues(logPrefix, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -15,13 +15,13 @@ package core
 
 import (
 	"sync/atomic"
-	"time"
 
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/kvcache"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var (
@@ -91,7 +91,7 @@ func (key *pstmtPlanCacheKey) Hash() []byte {
 func NewPSTMTPlanCacheKey(sessionVars *variable.SessionVars, pstmtID uint32, schemaVersion int64) kvcache.Key {
 	timezoneOffset := 0
 	if sessionVars.TimeZone != nil {
-		_, timezoneOffset = time.Now().In(sessionVars.TimeZone).Zone()
+		_, timezoneOffset = timeutil.Now().In(sessionVars.TimeZone).Zone()
 	}
 	return &pstmtPlanCacheKey{
 		database:       sessionVars.CurrentDB,

--- a/server/conn.go
+++ b/server/conn.go
@@ -60,6 +60,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/memory"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -466,7 +467,7 @@ func (cc *clientConn) Run() {
 			return
 		}
 
-		startTime := time.Now()
+		startTime := timeutil.Now()
 		if err = cc.dispatch(data); err != nil {
 			if terror.ErrorEqual(err, io.EOF) {
 				cc.addMetrics(data[0], startTime, nil)

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -401,7 +402,7 @@ func (ts *HTTPHandlerTestSuite) TestDecodeColumnValue(c *C) {
 	row[0] = types.NewIntDatum(100)
 	row[1] = types.NewBytesDatum([]byte("abc"))
 	row[2] = types.NewDecimalDatum(types.NewDecFromInt(1))
-	row[3] = types.NewTimeDatum(types.Time{Time: types.FromGoTime(time.Now()), Fsp: 6, Type: mysql.TypeTimestamp})
+	row[3] = types.NewTimeDatum(types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 6, Type: mysql.TypeTimestamp})
 
 	// Encode the row.
 	colIDs := make([]int64, 0, 3)

--- a/server/server.go
+++ b/server/server.go
@@ -36,6 +36,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+
 	// For pprof
 	_ "net/http/pprof"
 	"sync"
@@ -49,6 +50,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -102,7 +104,7 @@ func (s *Server) ConnectionCount() int {
 }
 
 func (s *Server) getToken() *Token {
-	start := time.Now()
+	start := timeutil.Now()
 	tok := s.concurrentLimiter.Get()
 	// Note that data smaller than one microsecond is ignored, because that case can be viewed as non-block.
 	metrics.GetTokenDurationHistogram.Observe(float64(time.Since(start).Nanoseconds() / 1e3))
@@ -178,7 +180,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	}
 
 	// Init rand seed for randomBuf()
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.Seed(timeutil.Now().UTC().UnixNano())
 	return s, nil
 }
 

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -35,6 +35,7 @@ import (
 	tmysql "github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -188,7 +189,7 @@ func generateCert(sn int, commonName string, parentCert *x509.Certificate, paren
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-	notBefore := time.Now().Add(-10 * time.Minute).UTC()
+	notBefore := timeutil.Now().Add(-10 * time.Minute).UTC()
 	notAfter := notBefore.Add(1 * time.Hour).UTC()
 
 	template := x509.Certificate{

--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -17,12 +17,12 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -62,7 +62,7 @@ func prepareSortBenchData(se Session, colType string, valueFormat string, valueC
 	mustExecute(se, "drop table if exists t")
 	mustExecute(se, fmt.Sprintf("create table t (pk int primary key auto_increment, col %s)", colType))
 	mustExecute(se, "begin")
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 	for i := 0; i < valueCount; i++ {
 		if i%1000 == 0 {
 			mustExecute(se, "commit")

--- a/session/session.go
+++ b/session/session.go
@@ -1084,8 +1084,6 @@ func loadSystemTZ(se *session) (string, error) {
 	return chk.GetRow(0).GetString(0), nil
 }
 
-var mu sync.Mutex
-
 // BootstrapSession runs the first time when the TiDB server start.
 func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	ver := getStoreBootstrapVersion(store)
@@ -1105,9 +1103,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 		return nil, errors.Trace(err)
 	}
 
-	mu.Lock()
 	timeutil.SetSystemTZ(tz)
-	mu.Unlock()
 
 	dom := domain.GetDomain(se)
 	err = dom.LoadPrivilegeLoop(se)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
+	"github.com/pingcap/tidb/util/timeutil"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -1950,11 +1951,11 @@ func (s *testSessionSuite) TestStatementCountLimit(c *C) {
 func (s *testSessionSuite) TestCastTimeToDate(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("set time_zone = '-8:00'")
-	date := time.Now().In(time.FixedZone("", -8*int(time.Hour/time.Second)))
+	date := timeutil.Now().In(time.FixedZone("", -8*int(time.Hour/time.Second)))
 	tk.MustQuery("select cast(time('12:23:34') as date)").Check(testkit.Rows(date.Format("2006-01-02")))
 
 	tk.MustExec("set time_zone = '+08:00'")
-	date = time.Now().In(time.FixedZone("", 8*int(time.Hour/time.Second)))
+	date = timeutil.Now().In(time.FixedZone("", 8*int(time.Hour/time.Second)))
 	tk.MustQuery("select cast(time('12:23:34') as date)").Check(testkit.Rows(date.Format("2006-01-02")))
 }
 

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -80,7 +81,7 @@ func (s *testMainSuite) TearDownSuite(c *C) {
 func (s *testMainSuite) TestCheckArgs(c *C) {
 	checkArgs(nil, true, false, int8(1), int16(1), int32(1), int64(1), 1,
 		uint8(1), uint16(1), uint32(1), uint64(1), uint(1), float32(1), float64(1),
-		"abc", []byte("abc"), time.Now(), time.Hour, time.Local)
+		"abc", []byte("abc"), timeutil.Now(), time.Hour, time.Local)
 }
 
 func (s *testMainSuite) TestIsQuery(c *C) {
@@ -114,7 +115,7 @@ func (s *testMainSuite) TestTrimSQL(c *C) {
 }
 
 func (s *testMainSuite) TestRetryOpenStore(c *C) {
-	begin := time.Now()
+	begin := timeutil.Now()
 	RegisterStore("dummy", &brokenStore{})
 	store, err := newStoreWithRetry("dummy://dummy-store", 3)
 	if store != nil {
@@ -132,7 +133,7 @@ func (s *testMainSuite) TestRetryDialPumpClient(c *C) {
 			return true, errors.New("must fail")
 		})
 	}
-	begin := time.Now()
+	begin := timeutil.Now()
 	err := retryDialPumpClientMustFail("", nil, 3, nil)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "must fail")

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/timeutil"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
@@ -92,7 +93,7 @@ func (s *testBinlogSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
-	s.unixFile = "/tmp/mock-binlog-pump" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	s.unixFile = "/tmp/mock-binlog-pump" + strconv.FormatInt(timeutil.Now().UnixNano(), 10)
 	l, err := net.Listen("unix", s.unixFile)
 	c.Assert(err, IsNil)
 	s.serv = grpc.NewServer(grpc.MaxRecvMsgSize(maxRecvMsgSize))

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -283,7 +284,7 @@ func (h *Handle) DumpStatsDeltaToKV(dumpMode bool) error {
 		h.merge(collector)
 	}
 	h.listHead.Unlock()
-	currentTime := time.Now()
+	currentTime := timeutil.Now()
 	for id, item := range h.globalMap {
 		if dumpMode == DumpDelta && !needDumpStatsDelta(h, id, item, currentTime) {
 			continue
@@ -712,7 +713,7 @@ func (h *Handle) HandleAutoAnalyze(is infoschema.InfoSchema) error {
 				continue
 			}
 			tblName := "`" + db + "`.`" + tblInfo.Name.O + "`"
-			if NeedAnalyzeTable(statsTbl, 20*h.Lease, autoAnalyzeRatio, start, end, time.Now()) {
+			if NeedAnalyzeTable(statsTbl, 20*h.Lease, autoAnalyzeRatio, start, end, timeutil.Now()) {
 				sql := fmt.Sprintf("analyze table %s", tblName)
 				log.Infof("[stats] auto analyze table %s now", tblName)
 				return errors.Trace(h.execAutoAnalyze(sql))
@@ -733,7 +734,7 @@ func (h *Handle) HandleAutoAnalyze(is infoschema.InfoSchema) error {
 }
 
 func (h *Handle) execAutoAnalyze(sql string) error {
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	_, _, err := h.restrictedExec.ExecRestrictedSQL(nil, sql)
 	metrics.AutoAnalyzeHistogram.Observe(time.Since(startTime).Seconds())
 	if err != nil {

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -952,7 +953,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 	}{
 		// table was never analyzed and has reach the limit
 		{
-			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
+			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(timeutil.Now()))},
 			limit:  0,
 			ratio:  0,
 			start:  "00:00 +0800",
@@ -962,7 +963,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 		},
 		// table was never analyzed but has not reach the limit
 		{
-			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(time.Now()))},
+			tbl:    &statistics.Table{Version: oracle.EncodeTSO(oracle.GetPhysical(timeutil.Now()))},
 			limit:  time.Hour,
 			ratio:  0,
 			start:  "00:00 +0800",

--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 
 	"golang.org/x/net/context"
@@ -70,7 +71,7 @@ func (o *MockOracle) GetTimestamp(context.Context) (uint64, error) {
 	if o.stop {
 		return 0, errors.Trace(errStopped)
 	}
-	physical := oracle.GetPhysical(time.Now().Add(o.offset))
+	physical := oracle.GetPhysical(timeutil.Now().Add(o.offset))
 	ts := oracle.ComposeTS(physical, 0)
 	if oracle.ExtractPhysical(o.lastTS) == physical {
 		ts = o.lastTS + 1
@@ -98,7 +99,7 @@ func (o *MockOracle) IsExpired(lockTimestamp uint64, TTL uint64) bool {
 	o.RLock()
 	defer o.RUnlock()
 
-	return oracle.GetPhysical(time.Now().Add(o.offset)) >= oracle.ExtractPhysical(lockTimestamp)+int64(TTL)
+	return oracle.GetPhysical(timeutil.Now().Add(o.offset)) >= oracle.ExtractPhysical(lockTimestamp)+int64(TTL)
 }
 
 // Close implements oracle.Oracle interface.

--- a/store/mockstore/mocktikv/pd.go
+++ b/store/mockstore/mocktikv/pd.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/pd-client"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -49,7 +50,7 @@ func (c *pdClient) GetTS(context.Context) (int64, int64, error) {
 	tsMu.Lock()
 	defer tsMu.Unlock()
 
-	ts := time.Now().UnixNano() / int64(time.Millisecond)
+	ts := timeutil.Now().UnixNano() / int64(time.Millisecond)
 	if tsMu.physicalTS >= ts {
 		tsMu.logicalTS++
 	} else {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -406,7 +407,7 @@ func (s *testCommitterSuite) TestWrittenKeysOnConflict(c *C) {
 		c.Assert(err, NotNil)
 		commiter1.cleanWg.Wait()
 		txn3 := s.begin(c)
-		start := time.Now()
+		start := timeutil.Now()
 		txn3.Get([]byte("y1"))
 		totalTime += time.Since(start)
 		txn3.Commit(context.Background())

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -227,7 +228,7 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 
 	log.Debugf("%v, retry later(totalsleep %dms, maxsleep %dms)", err, b.totalSleep, b.maxSleep)
 
-	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
+	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), timeutil.Now().Format(time.RFC3339Nano)))
 	if b.maxSleep > 0 && b.totalSleep >= b.maxSleep {
 		errMsg := fmt.Sprintf("backoffer.maxSleep %dms is exceeded, errors:", b.maxSleep)
 		for i, err := range b.errors {

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -239,7 +240,7 @@ func (c *rpcClient) closeConns() {
 
 // SendRequest sends a Request to server and receives Response.
 func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
-	start := time.Now()
+	start := timeutil.Now()
 	reqType := req.Type.String()
 	storeID := strconv.FormatUint(req.Context.GetPeer().GetStoreId(), 10)
 	defer func() {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -236,7 +237,7 @@ func (r *copRanges) split(key []byte) (*copRanges, *copRanges) {
 const rangesPerTask = 25000
 
 func buildCopTasks(bo *Backoffer, cache *RegionCache, ranges *copRanges, desc bool, streaming bool) ([]*copTask, error) {
-	start := time.Now()
+	start := timeutil.Now()
 	rangesLen := ranges.len()
 	cmdType := tikvrpc.CmdCop
 	if streaming {
@@ -602,7 +603,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 			ScanDetail:     true,
 		},
 	}
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	resp, err := sender.SendReq(bo, req, task.region, ReadTimeoutMedium)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -72,7 +73,7 @@ func (s *testGCWorkerSuite) timeEqual(c *C, t1, t2 time.Time, epsilon time.Durat
 func (s *testGCWorkerSuite) TestGetOracleTime(c *C) {
 	t1, err := s.gcWorker.getOracleTime()
 	c.Assert(err, IsNil)
-	s.timeEqual(c, time.Now(), t1, time.Millisecond*10)
+	s.timeEqual(c, timeutil.Now(), t1, time.Millisecond*10)
 
 	s.oracle.AddOffset(time.Second * 10)
 	t2, err := s.gcWorker.getOracleTime()

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/oracle/oracles"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -187,7 +188,7 @@ func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Clie
 		regionCache: NewRegionCache(pdClient),
 		kv:          spkv,
 		safePoint:   0,
-		spTime:      time.Now(),
+		spTime:      timeutil.Now(),
 		closed:      make(chan struct{}),
 	}
 	store.lockResolver = newLockResolver(store)
@@ -404,5 +405,5 @@ func parsePath(path string) (etcdAddrs []string, disableGC bool, err error) {
 
 func init() {
 	mc.cache = make(map[string]*tikvStore)
-	rand.Seed(time.Now().UnixNano())
+	rand.Seed(timeutil.Now().UnixNano())
 }

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -174,7 +175,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 		return false, nil
 	}
 
-	startTime := time.Now()
+	startTime := timeutil.Now()
 	txnInfos := make(map[uint64]uint64)
 	for _, l := range expiredLocks {
 		if _, ok := txnInfos[l.TxnID]; ok {
@@ -203,7 +204,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 			TxnInfos: listTxnInfos,
 		},
 	}
-	startTime = time.Now()
+	startTime = timeutil.Now()
 	resp, err := lr.store.SendReq(bo, req, loc, readTimeoutShort)
 	if err != nil {
 		return false, errors.Trace(err)

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -250,7 +251,7 @@ func (s *testLockSuite) TestLockTTL(c *C) {
 
 	// Huge txn has a greater TTL.
 	txn, err = s.store.Begin()
-	start := time.Now()
+	start := timeutil.Now()
 	c.Assert(err, IsNil)
 	txn.Set(kv.Key("key"), []byte("value"))
 	for i := 0; i < 2048; i++ {
@@ -262,7 +263,7 @@ func (s *testLockSuite) TestLockTTL(c *C) {
 	s.ttlEquals(c, l.TTL, uint64(ttlFactor*2)+uint64(time.Since(start)/time.Millisecond))
 
 	// Txn with long read time.
-	start = time.Now()
+	start = timeutil.Now()
 	txn, err = s.store.Begin()
 	c.Assert(err, IsNil)
 	time.Sleep(time.Millisecond * 50)

--- a/store/tikv/oracle/oracles/local.go
+++ b/store/tikv/oracle/oracles/local.go
@@ -15,9 +15,9 @@ package oracles
 
 import (
 	"sync"
-	"time"
 
 	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -35,13 +35,13 @@ func NewLocalOracle() oracle.Oracle {
 }
 
 func (l *localOracle) IsExpired(lockTS uint64, TTL uint64) bool {
-	return oracle.GetPhysical(time.Now()) >= oracle.ExtractPhysical(lockTS)+int64(TTL)
+	return oracle.GetPhysical(timeutil.Now()) >= oracle.ExtractPhysical(lockTS)+int64(TTL)
 }
 
 func (l *localOracle) GetTimestamp(context.Context) (uint64, error) {
 	l.Lock()
 	defer l.Unlock()
-	physical := oracle.GetPhysical(time.Now())
+	physical := oracle.GetPhysical(timeutil.Now())
 	ts := oracle.ComposeTS(physical, 0)
 	if l.lastTimeStampTS == ts {
 		l.n++

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/pd/pd-client"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -81,7 +82,7 @@ type tsFuture struct {
 
 // Wait implements the oracle.Future interface.
 func (f *tsFuture) Wait() (uint64, error) {
-	now := time.Now()
+	now := timeutil.Now()
 	physical, logical, err := f.TSFuture.Wait()
 	metrics.TSFutureWaitDuration.Observe(time.Since(now).Seconds())
 	if err != nil {
@@ -98,7 +99,7 @@ func (o *pdOracle) GetTimestampAsync(ctx context.Context) oracle.Future {
 }
 
 func (o *pdOracle) getTimestamp(ctx context.Context) (uint64, error) {
-	now := time.Now()
+	now := timeutil.Now()
 	physical, logical, err := o.c.GetTS(ctx)
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -80,7 +81,7 @@ func (c *RawKVClient) ClusterID() uint64 {
 
 // Get queries value with the key. When the key does not exist, it returns `nil, nil`.
 func (c *RawKVClient) Get(key []byte) ([]byte, error) {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("get").Observe(time.Since(start).Seconds()) }()
 
 	req := &tikvrpc.Request{
@@ -108,7 +109,7 @@ func (c *RawKVClient) Get(key []byte) ([]byte, error) {
 
 // BatchGet queries values with the keys.
 func (c *RawKVClient) BatchGet(keys [][]byte) ([][]byte, error) {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() {
 		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_get").Observe(time.Since(start).Seconds())
 	}()
@@ -138,7 +139,7 @@ func (c *RawKVClient) BatchGet(keys [][]byte) ([][]byte, error) {
 
 // Put stores a key-value pair to TiKV.
 func (c *RawKVClient) Put(key, value []byte) error {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("put").Observe(time.Since(start).Seconds()) }()
 	metrics.TiKVRawkvSizeHistogram.WithLabelValues("key").Observe(float64(len(key)))
 	metrics.TiKVRawkvSizeHistogram.WithLabelValues("value").Observe(float64(len(value)))
@@ -170,7 +171,7 @@ func (c *RawKVClient) Put(key, value []byte) error {
 
 // BatchPut stores key-value pairs to TiKV.
 func (c *RawKVClient) BatchPut(keys, values [][]byte) error {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() {
 		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_put").Observe(time.Since(start).Seconds())
 	}()
@@ -190,7 +191,7 @@ func (c *RawKVClient) BatchPut(keys, values [][]byte) error {
 
 // Delete deletes a key-value pair from TiKV.
 func (c *RawKVClient) Delete(key []byte) error {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("delete").Observe(time.Since(start).Seconds()) }()
 
 	req := &tikvrpc.Request{
@@ -215,7 +216,7 @@ func (c *RawKVClient) Delete(key []byte) error {
 
 // BatchDelete deletes key-value pairs from TiKV
 func (c *RawKVClient) BatchDelete(keys [][]byte) error {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() {
 		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_delete").Observe(time.Since(start).Seconds())
 	}()
@@ -237,7 +238,7 @@ func (c *RawKVClient) BatchDelete(keys [][]byte) error {
 
 // DeleteRange deletes all key-value pairs in a range from TiKV
 func (c *RawKVClient) DeleteRange(startKey []byte, endKey []byte) error {
-	start := time.Now()
+	start := timeutil.Now()
 	var err error
 	defer func() {
 		var label = "delete_range"
@@ -271,7 +272,7 @@ func (c *RawKVClient) DeleteRange(startKey []byte, endKey []byte) error {
 // Scan queries continuous kv pairs, starts from startKey, up to limit pairs.
 // If you want to exclude the startKey, append a '\0' to the key: `Scan(append(startKey, '\0'), limit)`.
 func (c *RawKVClient) Scan(startKey []byte, limit int) (keys [][]byte, values [][]byte, err error) {
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("raw_scan").Observe(time.Since(start).Seconds()) }()
 
 	if limit > MaxRawKVScanLimit {

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/pd-client"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -267,7 +268,7 @@ func (c *RegionCache) insertRegionToCache(r *Region) {
 	}
 	c.mu.regions[r.VerID()] = &CachedRegion{
 		region:     r,
-		lastAccess: time.Now().Unix(),
+		lastAccess: timeutil.Now().Unix(),
 	}
 }
 
@@ -282,7 +283,7 @@ func (c *RegionCache) getCachedRegion(id RegionVerID) *Region {
 		return nil
 	}
 	if cachedRegion.isValid() {
-		atomic.StoreInt64(&cachedRegion.lastAccess, time.Now().Unix())
+		atomic.StoreInt64(&cachedRegion.lastAccess, timeutil.Now().Unix())
 		return cachedRegion.region
 	}
 	return nil

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -35,7 +36,7 @@ var _ = Suite(&testSafePointSuite{})
 func (s *testSafePointSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
-	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
+	s.prefix = fmt.Sprintf("seek_%d", timeutil.Now().Unix())
 }
 
 func (s *testSafePointSuite) TearDownSuite(c *C) {
@@ -62,7 +63,7 @@ func mymakeKeys(rowNum int, prefix string) []kv.Key {
 func (s *testSafePointSuite) waitUntilErrorPlugIn(t uint64) {
 	for {
 		saveSafePoint(s.store.GetSafePointKV(), GcSavedSafePoint, t+10)
-		cachedTime := time.Now()
+		cachedTime := timeutil.Now()
 		newSafePoint, err := loadSafePoint(s.store.GetSafePointKV(), GcSavedSafePoint)
 		if err == nil {
 			s.store.UpdateSPCache(newSafePoint, cachedTime)

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -15,10 +15,10 @@ package tikv
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/timeutil"
 	"golang.org/x/net/context"
 )
 
@@ -34,7 +34,7 @@ var _ = Suite(&testScanSuite{})
 func (s *testScanSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
-	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
+	s.prefix = fmt.Sprintf("seek_%d", timeutil.Now().Unix())
 	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1)
 }
 

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
@@ -68,7 +69,7 @@ func (s *tikvSnapshot) SetPriority(priority int) {
 // The map will not contain nonexistent keys.
 func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 	metrics.TiKVTxnCmdCounter.WithLabelValues("batch_get").Inc()
-	start := time.Now()
+	start := timeutil.Now()
 	defer func() { metrics.TiKVTxnCmdHistogram.WithLabelValues("batch_get").Observe(time.Since(start).Seconds()) }()
 
 	// We want [][]byte instead of []kv.Key, use some magic to save memory.

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -15,11 +15,11 @@ package tikv
 
 import (
 	"fmt"
-	"time"
 
 	. "github.com/pingcap/check"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -36,7 +36,7 @@ var _ = Suite(&testSnapshotSuite{})
 func (s *testSnapshotSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
-	s.prefix = fmt.Sprintf("snapshot_%d", time.Now().Unix())
+	s.prefix = fmt.Sprintf("snapshot_%d", timeutil.Now().Unix())
 	s.rowNums = append(s.rowNums, 1, 100, 191)
 }
 

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -17,12 +17,12 @@ import (
 	"flag"
 	"fmt"
 	"sync"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -87,7 +87,7 @@ var _ = Suite(&testTiclientSuite{})
 func (s *testTiclientSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
-	s.prefix = fmt.Sprintf("ticlient_%d", time.Now().Unix())
+	s.prefix = fmt.Sprintf("ticlient_%d", timeutil.Now().Unix())
 }
 
 func (s *testTiclientSuite) TearDownSuite(c *C) {

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 )
@@ -501,12 +502,12 @@ func CallRPC(ctx context.Context, client tikvpb.TikvClient, req *Request) (*Resp
 // Lease is used to implement grpc stream timeout.
 type Lease struct {
 	Cancel   context.CancelFunc
-	deadline int64 // A time.UnixNano value, if time.Now().UnixNano() > deadline, cancel() would be called.
+	deadline int64 // A time.UnixNano value, if timeutil.Now().UnixNano() > deadline, cancel() would be called.
 }
 
 // Recv overrides the stream client Recv() function.
 func (resp *CopStreamResponse) Recv() (*coprocessor.Response, error) {
-	deadline := time.Now().Add(resp.Timeout).UnixNano()
+	deadline := timeutil.Now().Add(resp.Timeout).UnixNano()
 	atomic.StoreInt64(&resp.Lease.deadline, deadline)
 
 	ret, err := resp.Tikv_CoprocessorStreamClient.Recv()

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -348,7 +348,7 @@ func (s *testTableCodecSuite) TestDecodeIndexKey(c *C) {
 		types.NewFloat64Datum(123.45),
 		// MysqlTime is not supported.
 		// types.NewTimeDatum(types.Time{
-		// 	Time: types.FromGoTime(time.Now()),
+		// 	Time: types.FromGoTime(timeutil.Now()),
 		// 	Fsp:  6,
 		// 	Type: mysql.TypeTimestamp,
 		// }),

--- a/types/compare_test.go
+++ b/types/compare_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var _ = Suite(&testCompareSuite{})
@@ -50,11 +51,11 @@ func (s *testCompareSuite) TestCompare(c *C) {
 		{"1", float64(2), -1},
 		{"1", uint64(1), 0},
 		{"1", NewDecFromInt(1), 0},
-		{"2011-01-01 11:11:11", Time{Time: FromGoTime(time.Now()), Type: mysql.TypeDatetime, Fsp: 0}, -1},
+		{"2011-01-01 11:11:11", Time{Time: FromGoTime(timeutil.Now()), Type: mysql.TypeDatetime, Fsp: 0}, -1},
 		{"12:00:00", ZeroDuration, 1},
 		{ZeroDuration, ZeroDuration, 0},
-		{Time{Time: FromGoTime(time.Now().Add(time.Second * 10)), Type: mysql.TypeDatetime, Fsp: 0},
-			Time{Time: FromGoTime(time.Now()), Type: mysql.TypeDatetime, Fsp: 0}, 1},
+		{Time{Time: FromGoTime(timeutil.Now().Add(time.Second * 10)), Type: mysql.TypeDatetime, Fsp: 0},
+			Time{Time: FromGoTime(timeutil.Now()), Type: mysql.TypeDatetime, Fsp: 0}, 1},
 
 		{nil, 2, -1},
 		{nil, nil, 0},
@@ -93,8 +94,8 @@ func (s *testCompareSuite) TestCompare(c *C) {
 		{[]byte(""), []byte("sff"), -1},
 
 		{Time{Time: ZeroTime}, nil, 1},
-		{Time{Time: ZeroTime}, Time{Time: FromGoTime(time.Now()), Type: mysql.TypeDatetime, Fsp: 3}, -1},
-		{Time{Time: FromGoTime(time.Now()), Type: mysql.TypeDatetime, Fsp: 3}, "0000-00-00 00:00:00", 1},
+		{Time{Time: ZeroTime}, Time{Time: FromGoTime(timeutil.Now()), Type: mysql.TypeDatetime, Fsp: 3}, -1},
+		{Time{Time: FromGoTime(timeutil.Now()), Type: mysql.TypeDatetime, Fsp: 3}, "0000-00-00 00:00:00", 1},
 
 		{Duration{Duration: time.Duration(34), Fsp: 2}, nil, 1},
 		{Duration{Duration: time.Duration(34), Fsp: 2}, Duration{Duration: time.Duration(29034), Fsp: 2}, -1},

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -273,7 +274,7 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 	v, err = Convert(dt, ft)
 	c.Assert(v, Equals, int64(2015))
 	v, err = Convert(ZeroDuration, ft)
-	c.Assert(v, Equals, int64(time.Now().Year()))
+	c.Assert(v, Equals, int64(timeutil.Now().Year()))
 
 	// For enum
 	ft = NewFieldType(mysql.TypeEnum)

--- a/types/datum.go
+++ b/types/datum.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/charset"
 	"github.com/pingcap/tidb/util/hack"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -1166,7 +1167,7 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	case KindMysqlTime:
 		y = int64(d.GetMysqlTime().Time.Year())
 	case KindMysqlDuration:
-		y = int64(time.Now().Year())
+		y = int64(timeutil.Now().Year())
 	default:
 		ret, err = d.convertToInt(sc, NewFieldType(mysql.TypeLonglong))
 		if err != nil {

--- a/types/time.go
+++ b/types/time.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -192,7 +193,7 @@ func MaxMySQLTime(fsp int) Time {
 
 // CurrentTime returns current time with type tp.
 func CurrentTime(tp uint8) Time {
-	return Time{Time: FromGoTime(gotime.Now()), Type: tp, Fsp: 0}
+	return Time{Time: FromGoTime(timeutil.Now()), Type: tp, Fsp: 0}
 }
 
 // ConvertTimeZone converts the time value from one timezone to another.
@@ -878,7 +879,7 @@ func (d Duration) ToNumber() *MyDecimal {
 // ConvertToTime converts duration to Time.
 // Tp is TypeDatetime, TypeTimestamp and TypeDate.
 func (d Duration) ConvertToTime(sc *stmtctx.StatementContext, tp uint8) (Time, error) {
-	year, month, day := gotime.Now().In(sc.TimeZone).Date()
+	year, month, day := timeutil.Now().Date()
 	sign, hour, minute, second, frac := splitDuration(d.Duration)
 	datePart := FromDate(year, int(month), day, 0, 0, 0, 0)
 	timePart := FromDate(0, 0, 0, hour, minute, second, frac)

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 var _ = Suite(&testTimeSuite{})
@@ -428,7 +429,7 @@ func (s *testTimeSuite) TestCodec(c *C) {
 
 	var t1 types.Time
 	t1.Type = mysql.TypeTimestamp
-	t1.Time = types.FromGoTime(time.Now())
+	t1.Time = types.FromGoTime(timeutil.Now())
 	packed, err = t1.ToPackedUint()
 	c.Assert(err, IsNil)
 
@@ -751,7 +752,7 @@ func (s *testTimeSuite) TestConvert(c *C) {
 	for _, t := range tblDuration {
 		v, err := types.ParseDuration(t.Input, t.Fsp)
 		c.Assert(err, IsNil)
-		year, month, day := time.Now().In(time.UTC).Date()
+		year, month, day := timeutil.Now().In(time.UTC).Date()
 		n := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 		t, err := v.ConvertToTime(sc, mysql.TypeDatetime)
 		c.Assert(err, IsNil)

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/hack"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func TestT(t *testing.T) {
@@ -444,7 +445,7 @@ func (s *testChunkSuite) TestChunkMemoryUsage(c *check.C) {
 
 	jsonObj, err := json.ParseBinaryFromString("1")
 	c.Assert(err, check.IsNil)
-	timeObj := types.Time{Time: types.FromGoTime(time.Now()), Fsp: 0, Type: mysql.TypeDatetime}
+	timeObj := types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 0, Type: mysql.TypeDatetime}
 	durationObj := types.Duration{Duration: math.MaxInt64, Fsp: 0}
 
 	chk.AppendFloat32(0, 12.4)
@@ -642,7 +643,7 @@ func BenchmarkChunkMemoryUsage(b *testing.B) {
 
 	initCap := 10
 	chk := NewChunkWithCapacity(fieldTypes, initCap)
-	timeObj := types.Time{Time: types.FromGoTime(time.Now()), Fsp: 0, Type: mysql.TypeDatetime}
+	timeObj := types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 0, Type: mysql.TypeDatetime}
 	durationObj := types.Duration{Duration: math.MaxInt64, Fsp: 0}
 
 	for i := 0; i < initCap; i++ {

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -16,12 +16,12 @@ package chunk
 import (
 	"math"
 	"testing"
-	"time"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func (s *testChunkSuite) TestList(c *check.C) {
@@ -89,7 +89,7 @@ func (s *testChunkSuite) TestListMemoryUsage(c *check.C) {
 
 	jsonObj, err := json.ParseBinaryFromString("1")
 	c.Assert(err, check.IsNil)
-	timeObj := types.Time{Time: types.FromGoTime(time.Now()), Fsp: 0, Type: mysql.TypeDatetime}
+	timeObj := types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 0, Type: mysql.TypeDatetime}
 	durationObj := types.Duration{Duration: math.MaxInt64, Fsp: 0}
 
 	maxChunkSize := 2
@@ -122,7 +122,7 @@ func BenchmarkListMemoryUsage(b *testing.B) {
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeDuration})
 
 	chk := NewChunkWithCapacity(fieldTypes, 2)
-	timeObj := types.Time{Time: types.FromGoTime(time.Now()), Fsp: 0, Type: mysql.TypeDatetime}
+	timeObj := types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 0, Type: mysql.TypeDatetime}
 	durationObj := types.Duration{Duration: math.MaxInt64, Fsp: 0}
 	chk.AppendFloat64(0, 123.123)
 	chk.AppendString(1, "123")

--- a/util/chunk/mutrow_test.go
+++ b/util/chunk/mutrow_test.go
@@ -15,13 +15,13 @@ package chunk
 
 import (
 	"testing"
-	"time"
 
 	"github.com/pingcap/check"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func (s *testChunkSuite) TestMutRow(c *check.C) {
@@ -154,7 +154,7 @@ func (s *testChunkSuite) TestMutRowShallowCopyPartialRow(c *check.C) {
 	row.c.AppendDatum(0, &d)
 	d = types.NewIntDatum(567)
 	row.c.AppendDatum(1, &d)
-	d = types.NewTimeDatum(types.Time{Time: types.FromGoTime(time.Now()), Fsp: 6, Type: mysql.TypeTimestamp})
+	d = types.NewTimeDatum(types.Time{Time: types.FromGoTime(timeutil.Now()), Fsp: 6, Type: mysql.TypeTimestamp})
 	row.c.AppendDatum(2, &d)
 
 	c.Assert(d.GetMysqlTime(), check.DeepEquals, mutRow.ToRow().GetTime(2))

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func TestT(t *testing.T) {
@@ -916,7 +917,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 		{types.CurrentTime(mysql.TypeDatetime), types.NewFieldType(mysql.TypeDatetime)},
 		{types.CurrentTime(mysql.TypeDate), types.NewFieldType(mysql.TypeDate)},
 		{types.Time{
-			Time: types.FromGoTime(time.Now()),
+			Time: types.FromGoTime(timeutil.Now()),
 			Type: mysql.TypeTimestamp,
 		}, types.NewFieldType(mysql.TypeTimestamp)},
 		{types.Duration{Duration: time.Second, Fsp: 1}, types.NewFieldType(mysql.TypeDuration)},

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 )
 
@@ -466,7 +467,7 @@ func (fs *FileSorter) Input(key []types.Datum, val []types.Datum, handle int64) 
 		handle: handle,
 	}
 
-	origin := time.Now()
+	origin := timeutil.Now()
 	// assign input row to some worker in a round-robin way
 	for {
 		for i := 0; i < fs.nWorkers; i++ {

--- a/util/filesort/filesort_test.go
+++ b/util/filesort/filesort_test.go
@@ -18,12 +18,12 @@ import (
 	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func TestT(t *testing.T) {
@@ -106,7 +106,7 @@ func (s *testFileSortSuite) TestLessThan(c *C) {
 func (s *testFileSortSuite) TestInMemory(c *C) {
 	defer testleak.AfterTest(c)()
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	sc := new(stmtctx.StatementContext)
@@ -156,7 +156,7 @@ func (s *testFileSortSuite) TestInMemory(c *C) {
 func (s *testFileSortSuite) TestMultipleFiles(c *C) {
 	defer testleak.AfterTest(c)()
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	sc := new(stmtctx.StatementContext)
@@ -206,7 +206,7 @@ func (s *testFileSortSuite) TestMultipleFiles(c *C) {
 func (s *testFileSortSuite) TestMultipleWorkers(c *C) {
 	defer testleak.AfterTest(c)()
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	sc := new(stmtctx.StatementContext)
@@ -256,7 +256,7 @@ func (s *testFileSortSuite) TestMultipleWorkers(c *C) {
 func (s *testFileSortSuite) TestClose(c *C) {
 	defer testleak.AfterTest(c)()
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	sc := new(stmtctx.StatementContext)
@@ -335,7 +335,7 @@ func (s *testFileSortSuite) TestClose(c *C) {
 func (s *testFileSortSuite) TestMismatchedUsage(c *C) {
 	defer testleak.AfterTest(c)()
 
-	seed := rand.NewSource(time.Now().UnixNano())
+	seed := rand.NewSource(timeutil.Now().UnixNano())
 	r := rand.New(seed)
 
 	sc := new(stmtctx.StatementContext)

--- a/util/systimemon/systime_mon_test.go
+++ b/util/systimemon/systime_mon_test.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/pingcap/tidb/util/timeutil"
 )
 
 func TestSystimeMonitor(t *testing.T) {
@@ -27,10 +29,10 @@ func TestSystimeMonitor(t *testing.T) {
 		func() time.Time {
 			if !trigged {
 				trigged = true
-				return time.Now()
+				return timeutil.Now()
 			}
 
-			return time.Now().Add(-2 * time.Second)
+			return timeutil.Now().Add(-2 * time.Second)
 		}, func() {
 			atomic.StoreInt32(&jumpForward, 1)
 		}, func() {})

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -89,7 +89,6 @@ func InferSystemTZ() string {
 }
 
 // inferTZNameFromFileName gets IANA timezone name from zoneinfo path.
-// TODO: It will be refined later. This is just a quick fix.
 func inferTZNameFromFileName(path string) (string, error) {
 	// phase1 only support read /etc/localtime which is a softlink to zoneinfo file
 	substr := "zoneinfo"
@@ -117,9 +116,13 @@ func SystemLocation() *time.Location {
 	return loc
 }
 
+var mu sync.Mutex
+
 // SetSystemTZ sets systemTZ by the value loaded from mysql.tidb.
 func SetSystemTZ(name string) {
+	mu.Lock()
 	systemTZ = name
+	mu.Unlock()
 }
 
 // getLoc first trying to load location from a cache map. If nothing found in such map, then call
@@ -150,7 +153,6 @@ func LoadLocation(name string) (*time.Location, error) {
 }
 
 // Zone returns the current timezone name and timezone offset in seconds.
-// In compatible with MySQL, we change `Local` to `System`.
 func Zone(loc *time.Location) (string, int64) {
 	_, offset := Now().In(loc).Zone()
 	var name string

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -116,7 +116,7 @@ func SystemLocation() *time.Location {
 	if systemLoc == &dummyLoc {
 		loc, err := LoadLocation(systemTZ)
 		if err != nil {
-			return nil
+			return time.Local
 		}
 		systemLoc = loc
 	}

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	// We need set systemTZ when it is in testing process.
 	if systemTZ == "" {
-		systemTZ = "Asia/Shanghai"
+		systemTZ = "System"
 	}
 	locCa = &locCache{}
 	locCa.locMap = make(map[string]*time.Location)

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -30,7 +30,7 @@ import (
 func init() {
 	// We need set systemTZ when it is in testing process.
 	if systemTZ == "" {
-		systemTZ = "System"
+		systemTZ = "Asia/Shanghai"
 	}
 	locCa = &locCache{}
 	locCa.locMap = make(map[string]*time.Location)
@@ -112,7 +112,7 @@ func inferTZNameFromFileName(path string) (string, error) {
 func SystemLocation() *time.Location {
 	loc, err := LoadLocation(systemTZ)
 	if err != nil {
-		return time.Local
+		return nil
 	}
 	return loc
 }
@@ -126,9 +126,6 @@ func SetSystemTZ(name string) {
 // `time.LoadLocation` to get a timezone location. After trying both way, an error will be returned
 //  if valid Location is not found.
 func (lm *locCache) getLoc(name string) (*time.Location, error) {
-	if name == "System" {
-		return time.Local, nil
-	}
 	lm.RLock()
 	v, ok := lm.locMap[name]
 	lm.RUnlock()
@@ -153,16 +150,11 @@ func LoadLocation(name string) (*time.Location, error) {
 }
 
 // Zone returns the current timezone name and timezone offset in seconds.
-// In compatible with MySQL, we change `SystemLocation` to `System`.
+// In compatible with MySQL, we change `Local` to `System`.
 func Zone(loc *time.Location) (string, int64) {
 	_, offset := Now().In(loc).Zone()
 	var name string
 	name = loc.String()
-	// when we found name is "System", we have no chice but push down
-	// "System" to tikv side.
-	if name == "Local" {
-		name = "System"
-	}
 
 	return name, int64(offset)
 }

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -155,7 +155,7 @@ func LoadLocation(name string) (*time.Location, error) {
 // Zone returns the current timezone name and timezone offset in seconds.
 // In compatible with MySQL, we change `SystemLocation` to `System`.
 func Zone(loc *time.Location) (string, int64) {
-	_, offset := time.Now().In(loc).Zone()
+	_, offset := Now().In(loc).Zone()
 	var name string
 	name = loc.String()
 	// when we found name is "System", we have no chice but push down
@@ -165,4 +165,9 @@ func Zone(loc *time.Location) (string, int64) {
 	}
 
 	return name, int64(offset)
+}
+
+// Now returns current time of TiDB's global timezone.
+func Now() time.Time {
+	return time.Now().In(SystemLocation())
 }

--- a/util/timeutil/time_test.go
+++ b/util/timeutil/time_test.go
@@ -54,12 +54,14 @@ func (s *testTimeSuite) TestLocal(c *C) {
 	os.Setenv("TZ", "UTC")
 	// reset systemTZ
 	systemTZ = InferSystemTZ()
+	systemLoc = &dummyLoc
 	loc = SystemLocation()
 	c.Assert(loc.String(), Equals, "UTC")
 
 	os.Setenv("TZ", "")
 	// reset systemTZ
 	systemTZ = InferSystemTZ()
+	systemLoc = &dummyLoc
 	loc = SystemLocation()
 	c.Assert(loc.String(), Equals, "UTC")
 	os.Unsetenv("TZ")

--- a/x-server/server.go
+++ b/x-server/server.go
@@ -18,13 +18,13 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/server"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/arena"
+	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -60,7 +60,7 @@ func NewServer(cfg *Config) (s *Server, err error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	rand.Seed(time.Now().UTC().UnixNano())
+	rand.Seed(timeutil.Now().UTC().UnixNano())
 	log.Infof("Server run MySQL Protocol Listen at [%s]", s.cfg.Addr)
 	return s, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It solves the ambiguous current time issue by using tidb's global system timezone

### What is changed and how it works?
Adding wrapper `Now()` in `timeutil`. Any use of `time.Now()` should be replaced by `timeutil.Now()`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - existing test

Code changes
 - Has exported function/method change


Side effects
 No side effects
Related changes
 - Need to cherry-pick to the release branch

