### PR TITLE
executor,sessionctx:Add correctness for system variable: sync_binlog,…

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -440,9 +440,39 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 	result = tk.MustQuery("select @@sql_select_limit;")
 	result.Check(testkit.Rows("18446744073709551615"))
 
+	tk.MustExec("set @@global.sync_binlog=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect sync_binlog value: '-1'"))
+
+	tk.MustExec("set @@global.sync_binlog=4294967299")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect sync_binlog value: '4294967299'"))
+
 	tk.MustExec("set @@global.flush_time=31536001")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect flush_time value: '31536001'"))
 
 	tk.MustExec("set @@global.interactive_timeout=31536001")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect interactive_timeout value: '31536001'"))
+
+	tk.MustExec("set @@global.innodb_commit_concurrency = -1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_commit_concurrency value: '-1'"))
+
+	tk.MustExec("set @@global.innodb_commit_concurrency = 1001")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_commit_concurrency value: '1001'"))
+
+	tk.MustExec("set @@global.innodb_fast_shutdown = -1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_fast_shutdown value: '-1'"))
+
+	tk.MustExec("set @@global.innodb_fast_shutdown = 3")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_fast_shutdown value: '3'"))
+
+	tk.MustExec("set @@global.innodb_lock_wait_timeout = 0")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '0'"))
+
+	tk.MustExec("set @@global.innodb_lock_wait_timeout = 1073741825")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
+
+	tk.MustExec("set @@innodb_lock_wait_timeout = 0")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '0'"))
+
+	tk.MustExec("set @@innodb_lock_wait_timeout = 1073741825")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -137,11 +137,11 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "default_storage_engine", "InnoDB"},
 	{ScopeNone, "ft_query_expansion_limit", "20"},
 	{ScopeGlobal, MaxConnectErrors, "100"},
-	{ScopeGlobal, "sync_binlog", "0"},
+	{ScopeGlobal, SyncBinlog, "0"},
 	{ScopeNone, "max_digest_length", "1024"},
 	{ScopeNone, "innodb_force_load_corrupted", "OFF"},
 	{ScopeNone, "performance_schema_max_table_handles", "4000"},
-	{ScopeGlobal, "innodb_fast_shutdown", "1"},
+	{ScopeGlobal, InnodbFastShutdown, "1"},
 	{ScopeNone, "ft_max_word_len", "84"},
 	{ScopeGlobal, "log_backward_compatible_user_definitions", ""},
 	{ScopeNone, "lc_messages_dir", "/usr/local/mysql-5.6.25-osx10.8-x86_64/share/"},
@@ -452,7 +452,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "innodb_api_enable_mdl", "OFF"},
 	{ScopeGlobal, "binlog_cache_size", "32768"},
 	{ScopeGlobal, "innodb_compression_pad_pct_max", "50"},
-	{ScopeGlobal, "innodb_commit_concurrency", "0"},
+	{ScopeGlobal, InnodbCommitConcurrency, "0"},
 	{ScopeNone, "ft_min_word_len", "4"},
 	{ScopeGlobal, "enforce_gtid_consistency", "OFF"},
 	{ScopeGlobal, "secure_auth", "ON"},
@@ -550,7 +550,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "basedir", "/usr/local/mysql"},
 	{ScopeGlobal, "innodb_old_blocks_time", "1000"},
 	{ScopeGlobal, "innodb_stats_method", "nulls_equal"},
-	{ScopeGlobal | ScopeSession, "innodb_lock_wait_timeout", "50"},
+	{ScopeGlobal | ScopeSession, InnodbLockWaitTimeout, "50"},
 	{ScopeGlobal, "local_infile", "ON"},
 	{ScopeGlobal | ScopeSession, "myisam_stats_method", "nulls_unequal"},
 	{ScopeNone, "version_compile_os", "osx10.8"},
@@ -713,6 +713,12 @@ const (
 	DelayKeyWrite = "delay_key_write"
 	// EndMakersInJSON is the name for 'end_markers_in_json' system variable.
 	EndMakersInJSON = "end_markers_in_json"
+	//InnodbCommitConcurrency is the name for 'innodb_commit_concurrency' system variable.
+	InnodbCommitConcurrency = "innodb_commit_concurrency"
+	//InnodbFastShutdown is the name for 'innodb_fast_shutdown' system variable.
+	InnodbFastShutdown = "innodb_fast_shutdown"
+	//InnodbLockWaitTimeout is the name for 'innodb_lock_wait_timeout' system variable.
+	InnodbLockWaitTimeout = "innodb_lock_wait_timeout"
 	// SQLLogBin is the name for 'sql_log_bin' system variable.
 	SQLLogBin = "sql_log_bin"
 	// MaxSortLength is the name for 'max_sort_length' system variable.
@@ -757,6 +763,8 @@ const (
 	TmpTableSize = "tmp_table_size"
 	// ConnectTimeout is the name for 'connect_timeout' system variable.
 	ConnectTimeout = "connect_timeout"
+	//SyncBinlog is the name for 'sync_binlog' system variable.
+	SyncBinlog = "sync_binlog"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -713,11 +713,11 @@ const (
 	DelayKeyWrite = "delay_key_write"
 	// EndMakersInJSON is the name for 'end_markers_in_json' system variable.
 	EndMakersInJSON = "end_markers_in_json"
-	//InnodbCommitConcurrency is the name for 'innodb_commit_concurrency' system variable.
+	// InnodbCommitConcurrency is the name for 'innodb_commit_concurrency' system variable.
 	InnodbCommitConcurrency = "innodb_commit_concurrency"
-	//InnodbFastShutdown is the name for 'innodb_fast_shutdown' system variable.
+	// InnodbFastShutdown is the name for 'innodb_fast_shutdown' system variable.
 	InnodbFastShutdown = "innodb_fast_shutdown"
-	//InnodbLockWaitTimeout is the name for 'innodb_lock_wait_timeout' system variable.
+	// InnodbLockWaitTimeout is the name for 'innodb_lock_wait_timeout' system variable.
 	InnodbLockWaitTimeout = "innodb_lock_wait_timeout"
 	// SQLLogBin is the name for 'sql_log_bin' system variable.
 	SQLLogBin = "sql_log_bin"
@@ -763,7 +763,7 @@ const (
 	TmpTableSize = "tmp_table_size"
 	// ConnectTimeout is the name for 'connect_timeout' system variable.
 	ConnectTimeout = "connect_timeout"
-	//SyncBinlog is the name for 'sync_binlog' system variable.
+	// SyncBinlog is the name for 'sync_binlog' system variable.
 	SyncBinlog = "sync_binlog"
 )
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -236,6 +236,12 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return checkUInt64SystemVar(name, value, 4, math.MaxUint64, vars)
 	case InteractiveTimeout:
 		return checkUInt64SystemVar(name, value, 1, secondsPerYear, vars)
+	case InnodbCommitConcurrency:
+		return checkUInt64SystemVar(name, value, 0, 1000, vars)
+	case InnodbFastShutdown:
+		return checkUInt64SystemVar(name, value, 0, 2, vars)
+	case InnodbLockWaitTimeout:
+		return checkUInt64SystemVar(name, value, 1, 1073741824, vars)
 	case MaxConnections:
 		return checkUInt64SystemVar(name, value, 1, 100000, vars)
 	case MaxConnectErrors:
@@ -259,6 +265,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
 	case SQLSelectLimit:
 		return checkUInt64SystemVar(name, value, 0, math.MaxUint64, vars)
+	case SyncBinlog:
+		return checkUInt64SystemVar(name, value, 0, 4294967295, vars)
 	case TableDefinitionCache:
 		return checkUInt64SystemVar(name, value, 400, 524288, vars)
 	case TmpTableSize:


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
for #7195
Add correctness for system variable: sync_binlog, innodb_commit_concurrency, innodb_fast_shutdown, innodb_lock_wait_timeout.

### What is changed and how it works?
changed executor, sessionctx
use the framework added in #7117 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
Unit test

Code changes

Side effects

Related changes