### PR TITLE
executor: reuse chunk to reduce memory usage in union scan

### DIFF
--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -270,6 +270,7 @@ func (us *UnionScanExec) compare(a, b []types.Datum) (int, error) {
 
 func (us *UnionScanExec) buildAndSortAddedRows() error {
 	us.addedRows = make([][]types.Datum, 0, len(us.dirty.addedRows))
+	mutableRow := chunk.MutRowFromTypes(us.retTypes())
 	for h, data := range us.dirty.addedRows {
 		newData := make([]types.Datum, 0, us.schema.Len())
 		for _, col := range us.columns {
@@ -279,7 +280,8 @@ func (us *UnionScanExec) buildAndSortAddedRows() error {
 				newData = append(newData, data[col.Offset])
 			}
 		}
-		matched, err := expression.EvalBool(us.ctx, us.conditions, chunk.MutRowFromDatums(newData).ToRow())
+		mutableRow.SetDatums(newData...)
+		matched, err := expression.EvalBool(us.ctx, us.conditions, mutableRow.ToRow())
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For a large transaction, union scan uses lots of memory which is harmful to the performance.

### What is changed and how it works?
Reuse chunk in when build added rows.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
execute 4900 update statements which affected 4900 rows  in one transaction.

| master | this PR |
| - | - |
| 17.944s | 7.079s |

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

PTAL @coocood @lysu 
