### PR TITLE
plan: support limit/group-by/order-by clauses in point get

### DIFF
--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -155,6 +155,26 @@ label = "cop"
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1;
 id	count	task	operator info
 Point_Get_1	1.00	root	table:index_prune, index:a b
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 0;
+id	count	task	operator info
+TableDual_5	0.00	root	rows:0
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 1;
+id	count	task	operator info
+Limit_9	1.00	root	offset:1, count:1
+└─IndexLookUp_15	1.00	root	
+  ├─Limit_14	1.00	cop	offset:0, count:2
+  │ └─IndexScan_12	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
+  └─TableScan_13	1.00	cop	table:index_prune, keep order:false
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 0;
+id	count	task	operator info
+Limit_9	0.00	root	offset:1, count:0
+└─IndexLookUp_15	0.00	root	
+  ├─Limit_14	0.00	cop	offset:0, count:1
+  │ └─IndexScan_12	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
+  └─TableScan_13	0.00	cop	table:index_prune, keep order:false
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 0, 1;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:index_prune, index:a b
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 ORDER BY a;
 id	count	task	operator info
 Point_Get_1	1.00	root	table:index_prune, index:a b

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -154,9 +154,5 @@ label = "cop"
 
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1;
 id	count	task	operator info
-Limit_9	1.00	root	offset:0, count:1
-└─IndexLookUp_15	1.00	root	
-  ├─Limit_14	1.00	cop	offset:0, count:1
-  │ └─IndexScan_12	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
-  └─TableScan_13	1.00	cop	table:index_prune, keep order:false
+Point_Get_1	1.00	root	table:index_prune, index:a b
 drop table if exists t1, t2, t3, index_prune;

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -155,4 +155,13 @@ label = "cop"
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1;
 id	count	task	operator info
 Point_Get_1	1.00	root	table:index_prune, index:a b
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 ORDER BY a;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:index_prune, index:a b
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:index_prune, index:a b
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b ORDER BY a limit 1;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:index_prune, index:a b
 drop table if exists t1, t2, t3, index_prune;

--- a/cmd/explaintest/t/explain_easy_stats.test
+++ b/cmd/explaintest/t/explain_easy_stats.test
@@ -48,5 +48,8 @@ explain select 1 in (select c2 from t2) from t1;
 explain format="dot" select 1 in (select c2 from t2) from t1;
 
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 ORDER BY a;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b ORDER BY a limit 1;
 
 drop table if exists t1, t2, t3, index_prune;

--- a/cmd/explaintest/t/explain_easy_stats.test
+++ b/cmd/explaintest/t/explain_easy_stats.test
@@ -48,6 +48,10 @@ explain select 1 in (select c2 from t2) from t1;
 explain format="dot" select 1 in (select c2 from t2) from t1;
 
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 0;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 1;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 0;
+explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 0, 1;
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 ORDER BY a;
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b;
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 GROUP BY b ORDER BY a limit 1;

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -805,6 +805,23 @@ func getUintForLimitOffset(sc *stmtctx.StatementContext, val interface{}) (uint6
 	return 0, errors.Errorf("Invalid type %T for LogicalLimit/Offset", val)
 }
 
+func extractLimitCountOffset(sc *stmtctx.StatementContext, limit *ast.Limit) (count uint64,
+	offset uint64, err error) {
+	if limit.Count != nil {
+		count, err = getUintForLimitOffset(sc, limit.Count.GetValue())
+		if err != nil {
+			return 0, 0, ErrWrongArguments.GenWithStackByArgs("LIMIT")
+		}
+	}
+	if limit.Offset != nil {
+		offset, err = getUintForLimitOffset(sc, limit.Offset.GetValue())
+		if err != nil {
+			return 0, 0, ErrWrongArguments.GenWithStackByArgs("LIMIT")
+		}
+	}
+	return count, offset, nil
+}
+
 func (b *planBuilder) buildLimit(src LogicalPlan, limit *ast.Limit) (LogicalPlan, error) {
 	b.optFlag = b.optFlag | flagPushDownTopN
 	var (
@@ -812,18 +829,8 @@ func (b *planBuilder) buildLimit(src LogicalPlan, limit *ast.Limit) (LogicalPlan
 		err           error
 	)
 	sc := b.ctx.GetSessionVars().StmtCtx
-	if limit.Offset != nil {
-		offset, err = getUintForLimitOffset(sc, limit.Offset.GetValue())
-		if err != nil {
-			return nil, ErrWrongArguments.GenWithStackByArgs("LIMIT")
-		}
-	}
-
-	if limit.Count != nil {
-		count, err = getUintForLimitOffset(sc, limit.Count.GetValue())
-		if err != nil {
-			return nil, ErrWrongArguments.GenWithStackByArgs("LIMIT")
-		}
+	if count, offset, err = extractLimitCountOffset(sc, limit); err != nil {
+		return nil, err
 	}
 
 	if count > math.MaxUint64-offset {

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -144,8 +144,7 @@ func tryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 // 3. All the columns must be public and generated.
 // 4. The condition is an access path that the range is a unique key.
 func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetPlan {
-	if selStmt.GroupBy != nil || selStmt.Having != nil || selStmt.OrderBy != nil || selStmt.Limit != nil ||
-		selStmt.LockTp != ast.SelectLockNone {
+	if selStmt.Having != nil || selStmt.LockTp != ast.SelectLockNone {
 		return nil
 	}
 	tblName := getSingleTableName(selStmt.From)

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // PointGetPlan is a fast plan for simple point get.
@@ -140,7 +139,7 @@ func tryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 // tryPointGetPlan determine if the SelectStmt can use a PointGetPlan.
 // Returns nil if not applicable.
 // To use the PointGetPlan the following rules must be satisfied:
-// 1. No group-by, having, order by, limit clause.
+// 1. No group-by, having, order by clause. For limit clause, the count should at least 1 and the offset is 0.
 // 2. It must be a single table select.
 // 3. All the columns must be public and generated.
 // 4. The condition is an access path that the range is a unique key.
@@ -150,7 +149,6 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 	} else if selStmt.Limit != nil {
 		sc := ctx.GetSessionVars().StmtCtx
 		count, offset, err := extractLimitCountOffset(sc, selStmt.Limit)
-		logrus.Infof("YUSP count %d, offset %d", count, offset)
 		if err != nil || count == 0 || offset > 0 {
 			return nil
 		}

--- a/plan/point_get_plan.go
+++ b/plan/point_get_plan.go
@@ -139,7 +139,7 @@ func tryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 // tryPointGetPlan determine if the SelectStmt can use a PointGetPlan.
 // Returns nil if not applicable.
 // To use the PointGetPlan the following rules must be satisfied:
-// 1. No group-by, having, order by clause. For limit clause, the count should at least 1 and the offset is 0.
+// 1. For the limit clause, the count should at least 1 and the offset is 0.
 // 2. It must be a single table select.
 // 3. All the columns must be public and generated.
 // 4. The condition is an access path that the range is a unique key.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When the where clause can locate a unique row if the SQL has a limit/group-by/order-by it still can not use point get.
```
mysql> create table t (i int key, j int);
Query OK, 0 rows affected (0.12 sec)

mysql> explain select * from t where i = 1;
+-------------+-------+------+-------------------+
| id          | count | task | operator info     |
+-------------+-------+------+-------------------+
| Point_Get_1 | 1.00  | root | table:t, handle:1 |
+-------------+-------+------+-------------------+
1 row in set (0.00 sec)

mysql> explain select * from t where i = 1 limit 1;
+------------------------+-------+------+------------------------------------------------------+
| id                     | count | task | operator info                                        |
+------------------------+-------+------+------------------------------------------------------+
| Limit_8                | 1.00  | root | offset:0, count:1                                    |
| └─TableReader_13       | 1.00  | root | data:Limit_12                                        |
|   └─Limit_12           | 1.00  | cop  | offset:0, count:1                                    |
|     └─TableScan_11     | 1.00  | cop  | table:t, range:[1,1], keep order:false, stats:pseudo |
+------------------------+-------+------+------------------------------------------------------+
4 rows in set (0.00 sec)

mysql> explain select * from t where i = 1 order by i;
+--------------------+-------+------+-----------------------------------------------------+
| id                 | count | task | operator info                                       |
+--------------------+-------+------+-----------------------------------------------------+
| TableReader_12     | 1.00  | root | data:TableScan_11                                   |
| └─TableScan_11     | 1.00  | cop  | table:t, range:[1,1], keep order:true, stats:pseudo |
+--------------------+-------+------+-----------------------------------------------------+
2 rows in set (0.00 sec)

mysql> explain select * from t where i = 1 group by i;
+------------------------+-------+------+-----------------------------------------------------------------+
| id                     | count | task | operator info                                                   |
+------------------------+-------+------+-----------------------------------------------------------------+
| StreamAgg_17           | 1.00  | root | group by:col_2, funcs:firstrow(col_0), firstrow(col_1)          |
| └─TableReader_18       | 1.00  | root | data:StreamAgg_9                                                |
|   └─StreamAgg_9        | 1.00  | cop  | group by:test.t.i, funcs:firstrow(test.t.i), firstrow(test.t.j) |
|     └─TableScan_16     | 1.00  | cop  | table:t, range:[1,1], keep order:true, stats:pseudo             |
+------------------------+-------+------+-----------------------------------------------------------------+
4 rows in set (0.00 sec)
```

### What is changed and how it works?
Pass these clauses when try to use point get.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

PTAL @coocood @zz-jason 
