### PR TITLE
kv: optimize IsPoint

### DIFF
--- a/kv/key.go
+++ b/kv/key.go
@@ -90,22 +90,24 @@ func (r *KeyRange) IsPoint() bool {
 	// Works like
 	//   return bytes.Equal(r.StartKey.PrefixNext(), r.EndKey)
 
-	// all255SuffixIdx is the index after which all bytes in StartKey are 255 and all bytes in EndKey are 0.
-	all255SuffixIdx := len(r.StartKey)
-	for i := len(r.StartKey) - 1; i >= 0; i-- {
+	i := len(r.StartKey) - 1
+	for ; i >= 0; i-- {
 		if r.StartKey[i] != 255 {
 			break
 		}
 		if r.EndKey[i] != 0 {
 			return false
 		}
-		all255SuffixIdx = i
+	}
+	if i < 0 {
+		// In case all bytes in StartKey are 255.
+		return false
 	}
 	// The byte at diffIdx in StartKey should be one less than the byte at diffIdx in EndKey.
 	// And bytes in StartKey and EndKey before diffIdx should be equal.
-	diffIdx := all255SuffixIdx - 1
-	return r.StartKey[diffIdx]+1 == r.EndKey[diffIdx] &&
-		bytes.Equal(r.StartKey[:diffIdx], r.EndKey[:diffIdx])
+	diffOneIdx := i
+	return r.StartKey[diffOneIdx]+1 == r.EndKey[diffOneIdx] &&
+		bytes.Equal(r.StartKey[:diffOneIdx], r.EndKey[:diffOneIdx])
 }
 
 // EncodedKey represents encoded key in low-level storage engine.

--- a/kv/key.go
+++ b/kv/key.go
@@ -79,12 +79,17 @@ type KeyRange struct {
 // IsPoint checks if the key range represents a point.
 func (r *KeyRange) IsPoint() bool {
 	if len(r.StartKey) != len(r.EndKey) {
-		// StartKey.Next() == EndKey
+		// Works like
+		//   return bytes.Equal(r.StartKey.Next(), r.EndKey)
+
 		startLen := len(r.StartKey)
 		return startLen+1 == len(r.EndKey) &&
 			r.EndKey[startLen] == 0 &&
 			bytes.Equal(r.StartKey, r.EndKey[:startLen])
 	}
+	// Works like
+	//   return bytes.Equal(r.StartKey.PrefixNext(), r.EndKey)
+
 	// all255SuffixIdx is the index after which all bytes in StartKey are 255 and all bytes in EndKey are 0.
 	all255SuffixIdx := len(r.StartKey)
 	for i := len(r.StartKey) - 1; i >= 0; i-- {

--- a/kv/key.go
+++ b/kv/key.go
@@ -79,11 +79,13 @@ type KeyRange struct {
 // IsPoint checks if the key range represents a point.
 func (r *KeyRange) IsPoint() bool {
 	if len(r.StartKey) != len(r.EndKey) {
+		// StartKey.Next() == EndKey
 		startLen := len(r.StartKey)
 		return startLen+1 == len(r.EndKey) &&
 			r.EndKey[startLen] == 0 &&
 			bytes.Equal(r.StartKey, r.EndKey[:startLen])
 	}
+	// all255SuffixIdx is the index after which all bytes in StartKey are 255 and all bytes in EndKey are 0.
 	all255SuffixIdx := len(r.StartKey)
 	for i := len(r.StartKey) - 1; i >= 0; i-- {
 		if r.StartKey[i] != 255 {
@@ -94,6 +96,8 @@ func (r *KeyRange) IsPoint() bool {
 		}
 		all255SuffixIdx = i
 	}
+	// The byte at diffIdx in StartKey should be one less than the byte at diffIdx in EndKey.
+	// And bytes in StartKey and EndKey before diffIdx should be equal.
 	diffIdx := all255SuffixIdx - 1
 	return r.StartKey[diffIdx]+1 == r.EndKey[diffIdx] &&
 		bytes.Equal(r.StartKey[:diffIdx], r.EndKey[:diffIdx])

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -106,14 +106,3 @@ func BenchmarkIsPoint(b *testing.B) {
 		kr.IsPoint()
 	}
 }
-
-func BenchmarkIsPointByPrefixNext(b *testing.B) {
-	b.ReportAllocs()
-	kr := KeyRange{
-		StartKey: []byte("rowkey1"),
-		EndKey:   []byte("rowkey2"),
-	}
-	for i := 0; i < b.N; i++ {
-		bytes.Equal(kr.StartKey.PrefixNext(), kr.EndKey)
-	}
-}

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -86,6 +86,11 @@ func (s *testKeySuite) TestIsPoint(c *C) {
 			end:     []byte{123, 124, 0, 1},
 			isPoint: false,
 		},
+		{
+			start:   []byte{123, 123},
+			end:     []byte{123, 123, 0},
+			isPoint: true,
+		},
 	}
 	for _, tt := range tests {
 		kr := KeyRange{

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -91,6 +91,11 @@ func (s *testKeySuite) TestIsPoint(c *C) {
 			end:     []byte{123, 123, 0},
 			isPoint: true,
 		},
+		{
+			start:   []byte{255},
+			end:     []byte{0},
+			isPoint: false,
+		},
 	}
 	for _, tt := range tests {
 		kr := KeyRange{


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Improve performance of `IsPoint`.
```
benchmark               old ns/op     new ns/op     delta
BenchmarkIsPoint-12     5.35          21.1          +294.39%

benchmark               old allocs     new allocs     delta
BenchmarkIsPoint-12     0              1              +Inf%

benchmark               old bytes     new bytes     delta
BenchmarkIsPoint-12     0             8             +Inf%
```

### What is changed and how it works?
Avoid memory allocation by comparing bytes directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


