### PR TITLE
ddl: fix add index on timestamp column bug

### DIFF
--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -481,6 +481,15 @@ func (s *testSuite) TestAdminCheckTable(c *C) {
 	tk.MustExec(`admin check table test.t;`)
 	_, err := tk.Exec("admin check table t")
 	c.Assert(err, NotNil)
+
+	// test add index on timestamp column which have default value
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t1`)
+	tk.MustExec(`CREATE TABLE t1 (c2 YEAR, PRIMARY KEY (c2))`)
+	tk.MustExec(`INSERT INTO t1 SET c2 = '1912'`)
+	tk.MustExec(`ALTER TABLE t1 ADD COLUMN c3 TIMESTAMP NULL DEFAULT '1976-08-29 16:28:11'`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX c5 (c2, c3)`)
+	tk.MustExec(`admin check table t1`)
 }
 
 func (s *testSuite) TestAdminCheckPrimaryIndex(c *C) {

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -482,13 +482,21 @@ func (s *testSuite) TestAdminCheckTable(c *C) {
 	_, err := tk.Exec("admin check table t")
 	c.Assert(err, NotNil)
 
-	// test add index on timestamp column which have default value
+	// test add index on time type column which have default value
 	tk.MustExec("use test")
 	tk.MustExec(`drop table if exists t1`)
 	tk.MustExec(`CREATE TABLE t1 (c2 YEAR, PRIMARY KEY (c2))`)
 	tk.MustExec(`INSERT INTO t1 SET c2 = '1912'`)
 	tk.MustExec(`ALTER TABLE t1 ADD COLUMN c3 TIMESTAMP NULL DEFAULT '1976-08-29 16:28:11'`)
-	tk.MustExec(`ALTER TABLE t1 ADD INDEX c5 (c2, c3)`)
+	tk.MustExec(`ALTER TABLE t1 ADD COLUMN c4 DATE      NULL DEFAULT '1976-08-29'`)
+	tk.MustExec(`ALTER TABLE t1 ADD COLUMN c5 TIME      NULL DEFAULT '16:28:11'`)
+	tk.MustExec(`ALTER TABLE t1 ADD COLUMN c6 YEAR      NULL DEFAULT '1976'`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx1 (c2, c3,c4,c5,c6)`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx2 (c2)`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx3 (c3)`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx4 (c4)`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx5 (c5)`)
+	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx6 (c6)`)
 	tk.MustExec(`admin check table t1`)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
reproduce SQL:
```SQL
 drop table if exists t1
 CREATE TABLE t1 (c2 YEAR, PRIMARY KEY (c2))
 INSERT INTO t1 SET c2 = '1912'
 ALTER TABLE t1 ADD COLUMN c3 TIMESTAMP NULL DEFAULT '1976-08-29 16:28:11'
 ALTER TABLE t1 ADD INDEX c5 (c2, c3)
 admin check table t1
```
In old TiDB version, the SQL:  `admin check table t1` will return error cause by wrong index record.

### What is changed and how it works?
In back fill record to index, if use the column default value, and if the column type is timestamp, We should convert the default timestamp value to UTC timestamp value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch ?
