### PR TITLE
plan: fix predicate push down for UnionScan

### DIFF
--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -78,3 +78,16 @@ func (s *testSuite) TestDirtyTransaction(c *C) {
 	tk.MustQuery("select * from t use index(idx) where c > 1 and d = 4").Check(testkit.Rows("1 2 3 4"))
 	tk.MustExec("commit")
 }
+
+func (s *testSuite) TestUnionScanWithCastCondition(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table ta (a varchar(20))")
+	tk.MustExec("insert ta values ('1'), ('2')")
+	tk.MustExec("create table tb (a varchar(20))")
+	tk.MustExec("begin")
+	tk.MustQuery("select * from ta where a = 1").Check(testkit.Rows("1"))
+	tk.MustExec("insert tb values ('0')")
+	tk.MustQuery("select * from ta where a = 1").Check(testkit.Rows("1"))
+	tk.MustExec("rollback")
+}

--- a/plan/predicate_push_down.go
+++ b/plan/predicate_push_down.go
@@ -62,12 +62,13 @@ func (p *LogicalSelection) PredicatePushDown(predicates []expression.Expression)
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
 func (p *LogicalUnionScan) PredicatePushDown(predicates []expression.Expression) ([]expression.Expression, LogicalPlan) {
-	p.children[0].PredicatePushDown(predicates)
+	retainedPredicates, _ := p.children[0].PredicatePushDown(predicates)
 	p.conditions = make([]expression.Expression, 0, len(predicates))
 	for _, cond := range predicates {
 		p.conditions = append(p.conditions, cond.Clone())
 	}
-	return nil, p
+	// The conditions in UnionScan is only used for added rows, so parent Selection should not be removed.
+	return retainedPredicates, p
 }
 
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry-pick https://github.com/pingcap/tidb/pull/7695

### What is changed and how it works?
The predicate push down for UnionScan plan returns retained predicates instead of nil.

If we return nil predicates, the parent Selection will be removed, but conditions in UnionScan is only used to evaluate dirty table added rows, the conditions that cannot be pushed down to coprocessor will be lost.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

