### PR TITLE
tidb-server: set TiDBMemQuotaQuery to the value in configuration file

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -388,6 +388,9 @@ func setGlobalVars() {
 	plan.AllowCartesianProduct = cfg.Performance.CrossJoin
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
 
+	variable.SysVars[variable.TIDBMemQuotaQuery].Value = strconv.FormatInt(cfg.MemQuotaQuery, 10)
+	variable.SysVars["lower_case_table_names"].Value = strconv.Itoa(cfg.LowerCaseTableNames)
+
 	plan.SetPreparedPlanCache(cfg.PreparedPlanCache.Enabled)
 	if plan.PreparedPlanCacheEnabled() {
 		plan.PreparedPlanCacheCapacity = cfg.PreparedPlanCache.Capacity
@@ -398,9 +401,6 @@ func setGlobalVars() {
 	}
 	tikv.GrpcKeepAliveTime = time.Duration(cfg.TiKVClient.GrpcKeepAliveTime) * time.Second
 	tikv.GrpcKeepAliveTimeout = time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout) * time.Second
-
-	// set lower_case_table_names
-	variable.SysVars["lower_case_table_names"].Value = strconv.Itoa(cfg.LowerCaseTableNames)
 
 	tikv.CommitMaxBackoff = int(parseDuration(cfg.TiKVClient.CommitTimeout).Seconds() * 1000)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
`select @@tidb_mem_quota_query;` gets the default value of TiDBMemQuotaQuery but
not the value configured in the configuration file.

### What is changed and how it works?
Update the `SysVar` when starting the tidb-server.

### Check List <!--REMOVE the items that are not applicable-->
- Manual test (add detailed scripts or steps below)
Set the `mem-quota-query` in the confiuration file to a value like 100000, then
`select @@tidb_mem_quota_query` from the mysql-client.

Code changes
 - Has exported function/method change


Side effects
none

Related changes
 - Need to cherry-pick to the release branch

