### PR TITLE
Added hostname sysvar, fixes #7740

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -287,7 +287,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "thread_cache_size", "9"},
 	{ScopeGlobal, "log_slow_admin_statements", "OFF"},
 	{ScopeNone, "innodb_checksums", "ON"},
-	{ScopeNone, "hostname", "localhost"},
+	{ScopeNone, "hostname", ServerHostname},
 	{ScopeGlobal | ScopeSession, "auto_increment_offset", "1"},
 	{ScopeNone, "ft_stopword_file", "(built-in)"},
 	{ScopeGlobal, "innodb_max_dirty_pages_pct_lwm", "0"},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -13,6 +13,10 @@
 
 package variable
 
+import (
+	"os"
+)
+
 /*
 	Steps to add a new TiDB specific system variable:
 
@@ -229,4 +233,5 @@ var (
 	maxDDLReorgWorkerCount int32 = 128
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold uint32 = 300
+	ServerHostname, _          = os.Hostname()
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This fixes #7740 and changes the hostname sysvar from a "localhost" to the value returned by the OS.

### What is changed and how it works?

Changed the syvar to return accurate.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

I was not sure how to add tests, because every host will have a different hostname :-)

Code changes

 - Has exported variable/fields change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

None.