### PR TITLE
stats: support dump stats for partition table

### DIFF
--- a/cmd/importer/stats.go
+++ b/cmd/importer/stats.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
-	"github.com/pingcap/tidb/util/mock"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
@@ -39,8 +38,7 @@ func loadStats(tblInfo *model.TableInfo, path string) (*stats.Table, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	handle := stats.NewHandle(mock.NewContext(), 0)
-	return handle.LoadStatsFromJSONToTable(tblInfo, jsTable)
+	return stats.TableStatsFromJSON(tblInfo, tblInfo.ID, jsTable)
 }
 
 type histogram struct {

--- a/statistics/dump.go
+++ b/statistics/dump.go
@@ -33,6 +33,7 @@ type JSONTable struct {
 	Indices      map[string]*jsonColumn `json:"indices"`
 	Count        int64                  `json:"count"`
 	ModifyCount  int64                  `json:"modify_count"`
+	Partitions   map[string]*JSONTable  `json:"partitions"`
 }
 
 type jsonColumn struct {
@@ -58,7 +59,30 @@ func dumpJSONCol(hist *Histogram, CMSketch *CMSketch) *jsonColumn {
 
 // DumpStatsToJSON dumps statistic to json.
 func (h *Handle) DumpStatsToJSON(dbName string, tableInfo *model.TableInfo) (*JSONTable, error) {
-	tbl, err := h.tableStatsFromStorage(tableInfo, tableInfo.ID, true)
+	pi := tableInfo.GetPartitionInfo()
+	if pi == nil {
+		return h.tableStatsToJSON(dbName, tableInfo, tableInfo.ID)
+	}
+	jsonTbl := &JSONTable{
+		DatabaseName: dbName,
+		TableName:    tableInfo.Name.L,
+		Partitions:   make(map[string]*JSONTable, len(pi.Definitions)),
+	}
+	for _, def := range pi.Definitions {
+		tbl, err := h.tableStatsToJSON(dbName, tableInfo, def.ID)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if tbl == nil {
+			continue
+		}
+		jsonTbl.Partitions[def.Name.L] = tbl
+	}
+	return jsonTbl, nil
+}
+
+func (h *Handle) tableStatsToJSON(dbName string, tableInfo *model.TableInfo, physicalID int64) (*JSONTable, error) {
+	tbl, err := h.tableStatsFromStorage(tableInfo, physicalID, true)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -91,11 +115,37 @@ func (h *Handle) DumpStatsToJSON(dbName string, tableInfo *model.TableInfo) (*JS
 
 // LoadStatsFromJSON will load statistic from JSONTable, and save it to the storage.
 func (h *Handle) LoadStatsFromJSON(is infoschema.InfoSchema, jsonTbl *JSONTable) error {
-	tableInfo, err := is.TableByName(model.NewCIStr(jsonTbl.DatabaseName), model.NewCIStr(jsonTbl.TableName))
+	table, err := is.TableByName(model.NewCIStr(jsonTbl.DatabaseName), model.NewCIStr(jsonTbl.TableName))
 	if err != nil {
 		return errors.Trace(err)
 	}
-	tbl, err := h.LoadStatsFromJSONToTable(tableInfo.Meta(), jsonTbl)
+	tableInfo := table.Meta()
+	pi := tableInfo.GetPartitionInfo()
+	if pi == nil {
+		err := h.loadStatsFromJSON(tableInfo, tableInfo.ID, jsonTbl)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		if jsonTbl.Partitions == nil {
+			return errors.New("No partition statistics")
+		}
+		for _, def := range pi.Definitions {
+			tbl := jsonTbl.Partitions[def.Name.L]
+			if tbl == nil {
+				continue
+			}
+			err := h.loadStatsFromJSON(tableInfo, def.ID, tbl)
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return errors.Trace(h.Update(is))
+}
+
+func (h *Handle) loadStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl *JSONTable) error {
+	tbl, err := TableStatsFromJSON(tableInfo, physicalID, jsonTbl)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -116,13 +166,13 @@ func (h *Handle) LoadStatsFromJSON(is infoschema.InfoSchema, jsonTbl *JSONTable)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	return errors.Trace(h.Update(is))
+	return nil
 }
 
-// LoadStatsFromJSONToTable load statistic from JSONTable and return the Table of statistic.
-func (h *Handle) LoadStatsFromJSONToTable(tableInfo *model.TableInfo, jsonTbl *JSONTable) (*Table, error) {
+// TableStatsFromJSON loads statistic from JSONTable and return the Table of statistic.
+func TableStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl *JSONTable) (*Table, error) {
 	newHistColl := HistColl{
-		PhysicalID:     tableInfo.ID,
+		PhysicalID:     physicalID,
 		HavePhysicalID: true,
 		Count:          jsonTbl.Count,
 		ModifyCount:    jsonTbl.ModifyCount,

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -229,7 +229,7 @@ func (h *Handle) columnStatsFromStorage(row chunk.Row, table *Table, tableInfo *
 
 // tableStatsFromStorage loads table stats info from storage.
 func (h *Handle) tableStatsFromStorage(tableInfo *model.TableInfo, physicalID int64, loadAll bool) (*Table, error) {
-	table, ok := h.statsCache.Load().(statsCache)[tableInfo.ID]
+	table, ok := h.statsCache.Load().(statsCache)[physicalID]
 	// If table stats is pseudo, we also need to copy it, since we will use the column stats when
 	// the average error rate of it is small.
 	if !ok {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Support dump statistics for partition table.

### What is changed and how it works?

Add a new field in the json to store the partition stats.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

- None
