### PR TITLE
executor: fix session time in `show processlist`

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -190,11 +190,6 @@ func (e *ShowExec) fetchShowProcessList() error {
 
 	pl := sm.ShowProcessList()
 	for _, pi := range pl {
-		var t uint64
-		if len(pi.Info) != 0 {
-			t = uint64(time.Since(pi.Time) / time.Second)
-		}
-
 		var info string
 		if e.Full {
 			info = pi.Info
@@ -208,7 +203,7 @@ func (e *ShowExec) fetchShowProcessList() error {
 			pi.Host,
 			pi.DB,
 			pi.Command,
-			t,
+			uint64(time.Since(pi.Time) / time.Second),
 			fmt.Sprintf("%d", pi.State),
 			info,
 			pi.Mem,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix time show in `show processlist`.

### What is changed and how it works?
In original code, if the client is in sleep state, process info is always "". So the time is always 0 
like this:

    +------+------+-----------+------+---------+------+-------+------------------+------+
    | Id   | User | Host      | db   | Command | Time | State | Info             | Mem  |
    +------+------+-----------+------+---------+------+-------+------------------+------+
    |    1 | root | 127.0.0.1 | test | Sleep   |    0 | 2     |                  |    0 |
    |    2 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |    0 |
    +------+------+-----------+------+---------+------+-------+------------------+------+

After fixed:
  
    +------+------+-----------+------+---------+------+-------+------------------+------+
    | Id   | User | Host      | db   | Command | Time | State | Info             | Mem  |
    +------+------+-----------+------+---------+------+-------+------------------+------+
    |    1 | root | 127.0.0.1 |      | Query   |   90 | 2     |                  |    0 |
    |    2 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |    0 |
    +------+------+-----------+------+---------+------+-------+------------------+------+
    2 rows in set (0.00 sec)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects


