### PR TITLE
ddl: allow enum to append values

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -349,6 +349,56 @@ type expectQuery struct {
 	rows []string
 }
 
+func (s *testStateChangeSuite) TestAppendEnum(c *C) {
+	_, err := s.se.Execute(context.Background(), `create table t (
+			c1 varchar(64),
+			c2 enum('N','Y') not null default 'N',
+			c3 timestamp on update current_timestamp,
+			c4 int primary key,
+			unique key idx2 (c2, c3))`)
+	c.Assert(err, IsNil)
+	defer s.se.Execute(context.Background(), "drop table t")
+	_, err = s.se.Execute(context.Background(), "insert into t values('a', 'N', '2017-07-01', 8)")
+	c.Assert(err, IsNil)
+	// Make sure these sqls use the the plan of index scan.
+	_, err = s.se.Execute(context.Background(), "drop stats t")
+	c.Assert(err, IsNil)
+	se, err := session.CreateSession(s.store)
+	c.Assert(err, IsNil)
+	_, err = se.Execute(context.Background(), "use test_db_state")
+	c.Assert(err, IsNil)
+
+	_, err = s.se.Execute(context.Background(), "insert into t values('a', 'A', '2018-09-19', 9)")
+	c.Assert(err.Error(), Equals, "[table:1366]Incorrect enum value: 'A' for column 'c2' at row 1")
+	failAlterTableSQL1 := "alter table t change c2 c2 enum('N') DEFAULT 'N'"
+	_, err = s.se.Execute(context.Background(), failAlterTableSQL1)
+	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify column the number of enum column's elements is less than the original: 2")
+	failAlterTableSQL2 := "alter table t change c2 c2 int default 0"
+	_, err = s.se.Execute(context.Background(), failAlterTableSQL2)
+	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify column charset binary not match origin utf8")
+	alterTableSQL := "alter table t change c2 c2 enum('N','Y','A') DEFAULT 'A'"
+	_, err = s.se.Execute(context.Background(), alterTableSQL)
+	c.Assert(err, IsNil)
+	_, err = se.Execute(context.Background(), "insert into t values('a', 'A', '2018-09-20', 10)")
+	c.Assert(err, IsNil)
+	_, err = se.Execute(context.Background(), "insert into t (c1, c3, c4) values('a', '2018-09-21', 11)")
+	c.Assert(err, IsNil)
+
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test_db_state")
+	result, err := s.execQuery(tk, "select c4, c2 from t order by c4 asc")
+	c.Assert(err, IsNil)
+	expected := []string{"8 N", "10 A", "11 A"}
+	checkResult(result, testkit.Rows(expected...))
+
+	_, err = s.se.Execute(context.Background(), "update t set c2='N' where c4 = 10")
+	c.Assert(err, IsNil)
+	result, err = s.execQuery(tk, "select c2 from t where c4 = 10")
+	c.Assert(err, IsNil)
+	expected = []string{"8 N", "10 N", "11 A"}
+	checkResult(result, testkit.Rows(expected...))
+}
+
 // https://github.com/pingcap/tidb/pull/6249 fixes the following two test cases.
 func (s *testStateChangeSuite) TestWriteOnlyWriteNULL(c *C) {
 	sqls := make([]sqlWithErr, 1)


### PR DESCRIPTION
## What have you changed? (mandatory)

fix #6398

Allow to append new values to existing ENUM fields.
Removing values or changing existing values is still unsupported.

## What are the type of the changes (mandatory)?

- Improvement (non-breaking change which is an improvement to an existing feature)

## How has this PR been tested (mandatory)?

- added unit test cases in ddl/db_change_test.go
