### PR TITLE
sessionctx: Change pfs default to OFF

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -557,7 +557,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeNone, "relay_log_recovery", "OFF"},
 	{ScopeNone, "old", "OFF"},
 	{ScopeGlobal | ScopeSession, "innodb_table_locks", "ON"},
-	{ScopeNone, "performance_schema", "ON"},
+	{ScopeNone, "performance_schema", "OFF"},
 	{ScopeNone, "myisam_recover_options", "OFF"},
 	{ScopeGlobal | ScopeSession, "net_buffer_length", "16384"},
 	{ScopeGlobal, "rpl_semi_sync_master_wait_for_slave_count", ""},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This changes TiDB's "default" to say that performance schema is turned off.  It has no functional impact on TiDB, but may help apps that check first to see if performance schema (aka pfs) is enabled.

For example: https://github.com/pingcap/docs/issues/625

(I've not verified this with dbForge specifically.)

### What is changed and how it works?

The output of `SHOW GLOBAL VARIABLES` and other commands lists pfs as OFF now.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Checked pfs is disabled with `SHOW GLOBAL VARIABLES`.  There is no functional change, so I didn't write tests.

Code changes

 - Has exported variable/fields change


Side effects
 - Breaking backward compatibility

An application may correct pfs is enabled and depend on that, but not use it.  It is unlikely though.

Related changes

No need to document or make other updates.  The manual already says pfs is not supported in TiDB.