### PR TITLE
executor: fix point get null values

### DIFF
--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -143,6 +143,9 @@ func (e *PointGetExecutor) decodeRowValToChunk(rowVal []byte, chk *chunk.Chunk) 
 	if err != nil {
 		return errors.Trace(err)
 	}
+	if colVals == nil {
+		colVals = make([][]byte, len(colIDs))
+	}
 	decoder := codec.NewDecoder(chk, e.ctx.GetSessionVars().Location())
 	for id, offset := range colIDs {
 		if e.tblInfo.PKIsHandle && mysql.HasPriKeyFlag(e.schema.Columns[offset].RetType.Flag) {
@@ -153,8 +156,7 @@ func (e *PointGetExecutor) decodeRowValToChunk(rowVal []byte, chk *chunk.Chunk) 
 			chk.AppendInt64(offset, e.handle)
 			continue
 		}
-
-		if offset >= len(colVals) || len(colVals[offset]) == 0 {
+		if len(colVals[offset]) == 0 {
 			colInfo := getColInfoByID(e.tblInfo, id)
 			d, err1 := table.GetColOriginDefaultValue(e.ctx, colInfo)
 			if err1 != nil {

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -153,8 +153,8 @@ func (e *PointGetExecutor) decodeRowValToChunk(rowVal []byte, chk *chunk.Chunk) 
 			chk.AppendInt64(offset, e.handle)
 			continue
 		}
-		colVal := colVals[offset]
-		if len(colVal) == 0 {
+
+		if offset >= len(colVals) || len(colVals[offset]) == 0 {
 			colInfo := getColInfoByID(e.tblInfo, id)
 			d, err1 := table.GetColOriginDefaultValue(e.ctx, colInfo)
 			if err1 != nil {

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -35,4 +35,20 @@ func (s *testSuite) TestPointGet(c *C) {
 	tk.MustExec("CREATE UNIQUE INDEX idx_tab3_0 ON tab3 (col4);")
 	tk.MustExec("INSERT INTO tab3 VALUES(0,854,111.96,'mguub',711,966.36,'snwlo');")
 	tk.MustQuery("SELECT ALL * FROM tab3 WHERE col4 = 85;").Check(testkit.Rows())
+
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t(a bigint primary key, b bigint, c bigint);`)
+	tk.MustExec(`insert into t values(1, NULL, NULL), (2, NULL, 2), (3, 3, NULL), (4, 4, 4);`)
+	tk.MustQuery(`select * from t where a = 1;`).Check(testkit.Rows(
+		`1 <nil> <nil>`,
+	))
+	tk.MustQuery(`select * from t where a = 2;`).Check(testkit.Rows(
+		`2 <nil> 2`,
+	))
+	tk.MustQuery(`select * from t where a = 3;`).Check(testkit.Rows(
+		`3 3 <nil>`,
+	))
+	tk.MustQuery(`select * from t where a = 4;`).Check(testkit.Rows(
+		`4 4 4`,
+	))
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the "index out of range" panic caused by point getting all null values.

Let's say we have the following table:
```sql
drop table if exists t;
create table t(a bigint primary key, b bigint, c bigint);
insert into t values(1, NULL, NULL);
```

In master branch, the following query can reach a panic:
```sql
select * from t where a = 1;
```

This PR fixes the above problem.

### What is changed and how it works?

if the length of the returned column values is smaller than the column offset, that indicates the value of that column is null or should be covered by the default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

