### PR TITLE
ddl: fix 'show create table' result not correct when the table with a compression option

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -598,7 +598,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 
 	// Displayed if the compression typed is set.
 	if len(tb.Meta().Compression) != 0 {
-		buf.WriteString(fmt.Sprintf(" COMPRESSION=`%s`", tb.Meta().Compression))
+		buf.WriteString(fmt.Sprintf(" COMPRESSION='%s'", tb.Meta().Compression))
 	}
 
 	// add partition info here.

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -397,8 +397,13 @@ func (s *testSuite) TestShow(c *C) {
 	tk.MustQuery("show create table t1").Check(testutil.RowsWithSep("|",
 		"t1 CREATE TABLE `t1` (\n"+
 			"  `c1` int(11) DEFAULT NULL\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION=`zlib`",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib'",
 	))
+
+	tk.MustExec(`drop table if exists t1`)
+	tk.MustExec(`CREATE TABLE t1 (
+  	  c1 int(11) DEFAULT NULL
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib';`)
 
 	// Test show create table year type
 	tk.MustExec(`drop table if exists t`)

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -400,11 +400,6 @@ func (s *testSuite) TestShow(c *C) {
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib'",
 	))
 
-	tk.MustExec(`drop table if exists t1`)
-	tk.MustExec(`CREATE TABLE t1 (
-  	  c1 int(11) DEFAULT NULL
-	) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib';`)
-
 	// Test show create table year type
 	tk.MustExec(`drop table if exists t`)
 	tk.MustExec(`create table t(y year unsigned signed zerofill zerofill, x int, primary key(y));`)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix issue #7791 .

### What is changed and how it works?
```
s/COMPRESSION=`%s`/COMPRESSION='%s'
```
* Error caused by symbol error.


`This PR branch`
```sql
mysql> CREATE TABLE t1 (c1 INT) COMPRESSION="zlib";
Query OK, 0 rows affected (0.11 sec)

mysql> show create table t1;
+-------+--------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                             |
+-------+--------------------------------------------------------------------------------------------------------------------------+
| t1    | CREATE TABLE `t1` (
  `c1` int(11) DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib' |
+-------+--------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> drop table t1;
Query OK, 0 rows affected (0.02 sec)

mysql> CREATE TABLE `t1` (
    ->   `c1` int(11) DEFAULT NULL
    -> ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMPRESSION='zlib';
Query OK, 0 rows affected (0.01 sec)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

@jackysp PTAL.