### PR TITLE
planner, expression: converting to TableDual only when the empty range is not derived from deferred constants (#7579)

### DIFF
--- a/expression/util.go
+++ b/expression/util.go
@@ -191,7 +191,7 @@ func SubstituteCorCol2Constant(expr Expression) (Expression, error) {
 	case *Constant:
 		if x.DeferredExpr != nil {
 			newExpr := FoldConstant(x)
-			return &Constant{Value: newExpr.(*Constant).Value, RetType: x.GetType()}, nil
+			return &Constant{Value: newExpr.(*Constant).Value, RetType: x.GetType(), DeferredExpr: x.DeferredExpr}, nil
 		}
 	}
 	return expr, nil

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -179,7 +179,7 @@ func (ds *DataSource) tryToGetMemTask(prop *property.PhysicalProperty) (task tas
 // tryToGetDualTask will check if the push down predicate has false constant. If so, it will return table dual.
 func (ds *DataSource) tryToGetDualTask() (task, error) {
 	for _, cond := range ds.pushedDownConds {
-		if _, ok := cond.(*expression.Constant); ok {
+		if con, ok := cond.(*expression.Constant); ok && con.DeferredExpr == nil {
 			result, err := expression.EvalBool(ds.ctx, []expression.Expression{cond}, chunk.Row{})
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -470,7 +470,7 @@ func (b *planBuilder) buildSelection(p LogicalPlan, where ast.ExprNode, AggMappe
 		}
 		cnfItems := expression.SplitCNFItems(expr)
 		for _, item := range cnfItems {
-			if con, ok := item.(*expression.Constant); ok {
+			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil {
 				ret, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
 				if err != nil || ret {
 					continue


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixes #7579 

### What is changed and how it works?
fix the condition to allow only non-deferred constants

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes
- impl changes

Side effects
- no

Related changes
 - Need to be included in the release note
