### PR TITLE
admin: fix admin check table compare bug

### DIFF
--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -498,6 +498,14 @@ func (s *testSuite) TestAdminCheckTable(c *C) {
 	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx5 (c5)`)
 	tk.MustExec(`ALTER TABLE t1 ADD INDEX idx6 (c6)`)
 	tk.MustExec(`admin check table t1`)
+
+	// Test add index on decimal column.
+	tk.MustExec(`drop table if exists td1;`)
+	tk.MustExec(`CREATE TABLE td1 (c2 INT NULL DEFAULT '70');`)
+	tk.MustExec(`INSERT INTO td1 SET c2 = '5';`)
+	tk.MustExec(`ALTER TABLE td1 ADD COLUMN c4 DECIMAL(12,8) NULL DEFAULT '213.41598062';`)
+	tk.MustExec(`ALTER TABLE td1 ADD INDEX id2 (c4) ;`)
+	tk.MustExec(`ADMIN CHECK TABLE td1;`)
 }
 
 func (s *testSuite) TestAdminCheckPrimaryIndex(c *C) {

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -391,9 +391,15 @@ func compareDatumSlice(sc *stmtctx.StatementContext, val1s, val2s []types.Datum)
 		return false
 	}
 	for i, v := range val1s {
-		res, err := v.CompareDatum(sc, &val2s[i])
-		if err != nil || res != 0 {
-			return false
+		if v.Kind() == types.KindMysqlDecimal {
+			res, err := v.CompareDatum(sc, &val2s[i])
+			if err != nil || res != 0 {
+				return false
+			}
+		} else {
+			if !reflect.DeepEqual(v, val2s[i]) {
+				return false
+			}
 		}
 	}
 	return true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
SQL:
```sql
drop table if exists td1;
CREATE TABLE td1 (c2 INT NULL DEFAULT '70');
INSERT INTO td1 SET c2 = '5';
ALTER TABLE td1 ADD COLUMN c4 DECIMAL(12,8) NULL DEFAULT '213.41598062';
ALTER TABLE td1 ADD INDEX id2 (c4) ;
ADMIN CHECK TABLE td1;
```
**root cause**
decimal type is not `reflect.DeepEqual` between orginal datum and the datum after codec.encode and decode.
eg: 0.1234
```
origin:
&types.MyDecimal{digitsInt:1, digitsFrac:4, resultFrac:4, negative:false, wordBuf:[9]int32{0, 123400000, 0, 0, 0, 0, 0, 0, 0}} !=
after codec encode and decode:
&types.MyDecimal{digitsInt:0, digitsFrac:4, resultFrac:4, negative:false, wordBuf:[9]int32{123400000, 0, 0, 0, 0, 0, 0, 0, 0}}
```

### What is changed and how it works?
Use `Datum. CompareDatum()` to replace `reflect.DeepEqual` in admin check table when datum type is decimal.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

 - Possible performance regression

Related changes

