### PR TITLE
plan: exclude IsNull from constant propagation

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -347,6 +347,15 @@ TableDual_5	0.00	root	rows:0
 explain select * from t where b = 1 and b = 2;
 id	count	task	operator info
 TableDual_5	0.00	root	rows:0
+explain select * from t t1 join t t2 where t1.b = t2.b and t2.b is null;
+id	count	task	operator info
+Projection_7	12.50	root	t1.a, t1.b, t2.a, t2.b
+└─HashRightJoin_9	12.50	root	inner join, inner:TableReader_12, equal:[eq(t2.b, t1.b)]
+  ├─TableReader_12	10.00	root	data:Selection_11
+  │ └─Selection_11	10.00	cop	isnull(t2.b)
+  │   └─TableScan_10	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─TableReader_14	10000.00	root	data:TableScan_13
+    └─TableScan_13	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a bigint primary key);
 explain select * from t where a = 1 and a = 2;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -66,6 +66,7 @@ explain select * from t where b in (1, 2) and b in (1, 3);
 explain select * from t where a = 1 and a = 1;
 explain select * from t where a = 1 and a = 2;
 explain select * from t where b = 1 and b = 2;
+explain select * from t t1 join t t2 where t1.b = t2.b and t2.b is null;
 
 drop table if exists t;
 create table t(a bigint primary key);

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -188,6 +188,9 @@ func (s *propagateConstantSolver) tryToReplaceCond(src *Column, tgt *Column, con
 	if _, ok := unFoldableFunctions[sf.FuncName.L]; ok {
 		return false, true, cond
 	}
+	if _, ok := inequalFunctions[sf.FuncName.L]; ok {
+		return false, true, cond
+	}
 	for idx, expr := range sf.GetArgs() {
 		if src.Equal(nil, expr) {
 			replaced = true

--- a/expression/function_traits.go
+++ b/expression/function_traits.go
@@ -50,3 +50,8 @@ var unFoldableFunctions = map[string]struct{}{
 	ast.GetVar:    {},
 	ast.GetParam:  {},
 }
+
+// inequalFunctions stores functions which cannot be propagated from column equal condition.
+var inequalFunctions = map[string]struct{}{
+	ast.IsNull: {},
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/7834

### What is changed and how it works?

quick return in constant propagation when the ScalarFunction is `IsNull`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
