### PR TITLE
session: set Sleep state for process info (#7826)

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -526,3 +526,17 @@ func (ts *TidbTestSuite) TestSumAvg(c *C) {
 	c.Parallel()
 	runTestSumAvg(c)
 }
+
+func (ts *TidbTestSuite) TestShowProcess(c *C) {
+	qctx, err := ts.tidbdrv.OpenCtx(uint64(0), 0, uint8(tmysql.DefaultCollationID), "test", nil)
+	c.Assert(err, IsNil)
+	ctx := context.Background()
+	results, err := qctx.Execute(ctx, "select 1")
+	c.Assert(err, IsNil)
+	pi := qctx.ShowProcess()
+	c.Assert(pi.Command, Equals, "Query")
+	results[0].Close()
+	pi = qctx.ShowProcess()
+	c.Assert(pi.Command, Equals, "Sleep")
+	qctx.Close()
+}

--- a/session/session.go
+++ b/session/session.go
@@ -712,6 +712,9 @@ func (s *session) SetProcessInfo(sql string) {
 		State:   s.Status(),
 		Info:    sql,
 	}
+	if sql == "" {
+		pi.Command = "Sleep"
+	}
 	if s.sessionVars.User != nil {
 		pi.User = s.sessionVars.User.Username
 		pi.Host = s.sessionVars.User.Hostname


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry-pick #7826 

### What is changed and how it works?
Set the process command to Sleep if sql argument is empty.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

