### PR TITLE
*: fix `Command` and `Time` in `show processlist`

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -46,12 +46,11 @@ type processinfoSetter interface {
 
 // recordSet wraps an executor, implements ast.RecordSet interface
 type recordSet struct {
-	fields      []*ast.ResultField
-	executor    Executor
-	stmt        *ExecStmt
-	processinfo processinfoSetter
-	lastErr     error
-	txnStartTS  uint64
+	fields     []*ast.ResultField
+	executor   Executor
+	stmt       *ExecStmt
+	lastErr    error
+	txnStartTS uint64
 }
 
 func (a *recordSet) Fields() []*ast.ResultField {
@@ -231,23 +230,22 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 
 	// If the executor doesn't return any result to the client, we execute it without delay.
 	if e.Schema().Len() == 0 {
-		return a.handleNoDelayExecutor(ctx, sctx, e, pi)
+		return a.handleNoDelayExecutor(ctx, sctx, e)
 	} else if proj, ok := e.(*ProjectionExec); ok && proj.calculateNoDelay {
 		// Currently this is only for the "DO" statement. Take "DO 1, @a=2;" as an example:
 		// the Projection has two expressions and two columns in the schema, but we should
 		// not return the result of the two expressions.
-		return a.handleNoDelayExecutor(ctx, sctx, e, pi)
+		return a.handleNoDelayExecutor(ctx, sctx, e)
 	}
 
 	return &recordSet{
-		executor:    e,
-		stmt:        a,
-		processinfo: pi,
-		txnStartTS:  sctx.Txn().StartTS(),
+		executor:   e,
+		stmt:       a,
+		txnStartTS: sctx.Txn().StartTS(),
 	}, nil
 }
 
-func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Context, e Executor, pi processinfoSetter) (ast.RecordSet, error) {
+func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Context, e Executor) (ast.RecordSet, error) {
 	// Check if "tidb_snapshot" is set for the write executors.
 	// In history read mode, we can not do write operations.
 	switch e.(type) {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -212,6 +212,11 @@ func (a *ExecStmt) Exec(ctx context.Context) (ast.RecordSet, error) {
 		return nil, errors.Trace(err)
 	}
 
+	var pi processinfoSetter
+	if raw, ok := sctx.(processinfoSetter); ok {
+		pi = raw
+	}
+
 	// If the executor doesn't return any result to the client, we execute it without delay.
 	if e.Schema().Len() == 0 {
 		return a.handleNoDelayExecutor(ctx, sctx, e, pi)

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
@@ -469,31 +468,8 @@ type mockSessionManager struct {
 	session.Session
 }
 
-// ShowProcessList implements the SessionManager.ShowProcessList interface.
-func (msm *mockSessionManager) ShowProcessList() map[uint64]util.ProcessInfo {
-	ps := msm.ShowProcess()
-	return map[uint64]util.ProcessInfo{ps.ID: ps}
-}
-
 // Kill implements the SessionManager.Kill interface.
 func (msm *mockSessionManager) Kill(cid uint64, query bool) {
-}
-
-func (s *testSuite) TestShowFullProcessList(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("select 1") // for tk.Se init
-
-	se := tk.Se
-	se.SetSessionManager(&mockSessionManager{se})
-
-	fullSQL := "show                                                                                        full processlist"
-	simpSQL := "show                                                                                        processlist"
-
-	cols := []int{4, 5, 6, 7} // columns to check: Command, Time, State, Info
-	tk.MustQuery(fullSQL).CheckAt(cols, testutil.RowsWithSep("|", "Query|0|2|"+fullSQL))
-	tk.MustQuery(simpSQL).CheckAt(cols, testutil.RowsWithSep("|", "Query|0|2|"+simpSQL[:100]))
-
-	se.SetSessionManager(nil) // reset sm so other tests won't use this
 }
 
 type stats struct {

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -122,6 +122,7 @@ const (
 	ComDaemon
 	ComBinlogDumpGtid
 	ComResetConnection
+	ComEnd
 )
 
 // Client information.
@@ -276,6 +277,42 @@ var Priv2UserCol = map[PrivilegeType]string{
 	AlterPriv:      "Alter_priv",
 	ExecutePriv:    "Execute_priv",
 	IndexPriv:      "Index_priv",
+}
+
+// Command2Str is the command information to command name.
+var Command2Str = map[byte]string{
+	ComSleep:            "Sleep",
+	ComQuit:             "Quit",
+	ComInitDB:           "Init DB",
+	ComQuery:            "Query",
+	ComFieldList:        "Field List",
+	ComCreateDB:         "Create DB",
+	ComDropDB:           "Drop DB",
+	ComRefresh:          "Refres",
+	ComShutdown:         "Shutdown",
+	ComStatistics:       "Statistics",
+	ComProcessInfo:      "Processlist",
+	ComConnect:          "Connect",
+	ComProcessKill:      "Kill",
+	ComDebug:            "Debug",
+	ComPing:             "Ping",
+	ComTime:             "Time",
+	ComDelayedInsert:    "Delayed Insert",
+	ComChangeUser:       "Change User",
+	ComBinlogDump:       "Binlog Dump",
+	ComTableDump:        "Table Dump",
+	ComConnectOut:       "Connect out",
+	ComRegisterSlave:    "Register Slave",
+	ComStmtPrepare:      "Prepare",
+	ComStmtExecute:      "Execute",
+	ComStmtSendLongData: "Long Data",
+	ComStmtClose:        "Close stmt",
+	ComStmtReset:        "Reset stmt",
+	ComSetOption:        "Set option",
+	ComStmtFetch:        "Fetch",
+	ComDaemon:           "Daemon",
+	ComBinlogDumpGtid:   "Binlog Dump",
+	ComResetConnection:  "Reset connect",
 }
 
 // Col2PrivType is the privilege tables column name to privilege type.

--- a/mysql/const.go
+++ b/mysql/const.go
@@ -288,7 +288,7 @@ var Command2Str = map[byte]string{
 	ComFieldList:        "Field List",
 	ComCreateDB:         "Create DB",
 	ComDropDB:           "Drop DB",
-	ComRefresh:          "Refres",
+	ComRefresh:          "Refresh",
 	ComShutdown:         "Shutdown",
 	ComStatistics:       "Statistics",
 	ComProcessInfo:      "Processlist",

--- a/server/conn.go
+++ b/server/conn.go
@@ -617,10 +617,10 @@ func (cc *clientConn) dispatch(data []byte) error {
 		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.writeOK()
 	case mysql.ComInitDB:
+		cc.ctx.SetProcessInfo("use "+hack.String(data), t, cmd)
 		if err := cc.useDB(ctx1, hack.String(data)); err != nil {
 			return errors.Trace(err)
 		}
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.writeOK()
 	case mysql.ComFieldList:
 		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)

--- a/server/conn.go
+++ b/server/conn.go
@@ -595,6 +595,18 @@ func (cc *clientConn) dispatch(data []byte) error {
 		span.Finish()
 	}()
 
+	if cmd < mysql.ComEnd {
+		cc.ctx.SetCommandValue(cmd)
+	}
+
+	switch cmd {
+	case mysql.ComPing, mysql.ComStmtClose, mysql.ComStmtSendLongData, mysql.ComStmtReset,
+		mysql.ComSetOption, mysql.ComChangeUser:
+		cc.ctx.SetProcessInfo("", t, cmd)
+	case mysql.ComInitDB:
+		cc.ctx.SetProcessInfo("use "+hack.String(data), t, cmd)
+	}
+
 	switch cmd {
 	case mysql.ComSleep:
 		// TODO: According to mysql document, this command is supposed to be used only internally.
@@ -611,41 +623,32 @@ func (cc *clientConn) dispatch(data []byte) error {
 		if len(data) > 0 && data[len(data)-1] == 0 {
 			data = data[:len(data)-1]
 		}
-		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
+		// cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleQuery(ctx1, hack.String(data))
 	case mysql.ComPing:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.writeOK()
 	case mysql.ComInitDB:
-		cc.ctx.SetProcessInfo("use "+hack.String(data), t, cmd)
 		if err := cc.useDB(ctx1, hack.String(data)); err != nil {
 			return errors.Trace(err)
 		}
 		return cc.writeOK()
 	case mysql.ComFieldList:
-		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleFieldList(hack.String(data))
 	case mysql.ComStmtPrepare:
-		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleStmtPrepare(hack.String(data))
 	case mysql.ComStmtExecute:
 		return cc.handleStmtExecute(ctx1, data)
 	case mysql.ComStmtFetch:
 		return cc.handleStmtFetch(ctx1, data)
 	case mysql.ComStmtClose:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtClose(data)
 	case mysql.ComStmtSendLongData:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtSendLongData(data)
 	case mysql.ComStmtReset:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtReset(data)
 	case mysql.ComSetOption:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleSetOption(data)
 	case mysql.ComChangeUser:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleChangeUser(data)
 	default:
 		return mysql.NewErrf(mysql.ErrUnknown, "command %d not supported now", cmd)

--- a/server/conn.go
+++ b/server/conn.go
@@ -623,7 +623,6 @@ func (cc *clientConn) dispatch(data []byte) error {
 		if len(data) > 0 && data[len(data)-1] == 0 {
 			data = data[:len(data)-1]
 		}
-		// cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleQuery(ctx1, hack.String(data))
 	case mysql.ComPing:
 		return cc.writeOK()

--- a/server/conn.go
+++ b/server/conn.go
@@ -590,15 +590,10 @@ func (cc *clientConn) dispatch(data []byte) error {
 	cc.lastCmd = hack.String(data)
 	token := cc.server.getToken()
 	defer func() {
-		cc.ctx.SetCommandValue(mysql.ComSleep)
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, mysql.ComSleep)
 		cc.server.releaseToken(token)
 		span.Finish()
 	}()
-
-	if cmd < mysql.ComEnd {
-		cc.ctx.SetCommandValue(cmd)
-	}
 
 	switch cmd {
 	case mysql.ComSleep:
@@ -616,43 +611,43 @@ func (cc *clientConn) dispatch(data []byte) error {
 		if len(data) > 0 && data[len(data)-1] == 0 {
 			data = data[:len(data)-1]
 		}
-		cc.ctx.SetProcessInfo(hack.String(data), t)
+		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleQuery(ctx1, hack.String(data))
 	case mysql.ComPing:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.writeOK()
 	case mysql.ComInitDB:
 		if err := cc.useDB(ctx1, hack.String(data)); err != nil {
 			return errors.Trace(err)
 		}
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.writeOK()
 	case mysql.ComFieldList:
-		cc.ctx.SetProcessInfo(hack.String(data), t)
+		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleFieldList(hack.String(data))
 	case mysql.ComStmtPrepare:
-		cc.ctx.SetProcessInfo(hack.String(data), t)
+		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleStmtPrepare(hack.String(data))
 	case mysql.ComStmtExecute:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtExecute(ctx1, data)
 	case mysql.ComStmtFetch:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtFetch(ctx1, data)
 	case mysql.ComStmtClose:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtClose(data)
 	case mysql.ComStmtSendLongData:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtSendLongData(data)
 	case mysql.ComStmtReset:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtReset(data)
 	case mysql.ComSetOption:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleSetOption(data)
 	case mysql.ComChangeUser:
-		cc.ctx.SetProcessInfo("", t)
+		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleChangeUser(data)
 	default:
 		return mysql.NewErrf(mysql.ErrUnknown, "command %d not supported now", cmd)

--- a/server/conn.go
+++ b/server/conn.go
@@ -629,7 +629,6 @@ func (cc *clientConn) dispatch(data []byte) error {
 		cc.ctx.SetProcessInfo(hack.String(data), t, cmd)
 		return cc.handleStmtPrepare(hack.String(data))
 	case mysql.ComStmtExecute:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtExecute(ctx1, data)
 	case mysql.ComStmtFetch:
 		cc.ctx.SetProcessInfo("", t, cmd)

--- a/server/conn.go
+++ b/server/conn.go
@@ -631,7 +631,6 @@ func (cc *clientConn) dispatch(data []byte) error {
 	case mysql.ComStmtExecute:
 		return cc.handleStmtExecute(ctx1, data)
 	case mysql.ComStmtFetch:
-		cc.ctx.SetProcessInfo("", t, cmd)
 		return cc.handleStmtFetch(ctx1, data)
 	case mysql.ComStmtClose:
 		cc.ctx.SetProcessInfo("", t, cmd)

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"time"
 
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/types"
@@ -117,6 +118,12 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		return mysql.NewErr(mysql.ErrUnknownStmtHandler,
 			strconv.FormatUint(uint64(stmtID), 10), "stmt_execute")
 	}
+
+	sql := ""
+	if prepared, ok := cc.ctx.GetStatement(int(stmtID)).(*TiDBStatement); ok {
+		sql = prepared.sql
+	}
+	cc.ctx.SetProcessInfo(sql, time.Now(), mysql.ComStmtExecute)
 
 	flag := data[pos]
 	pos++

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -119,12 +119,6 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 			strconv.FormatUint(uint64(stmtID), 10), "stmt_execute")
 	}
 
-	sql := ""
-	if prepared, ok := cc.ctx.GetStatement(int(stmtID)).(*TiDBStatement); ok {
-		sql = prepared.sql
-	}
-	cc.ctx.SetProcessInfo(sql, time.Now(), mysql.ComStmtExecute)
-
 	flag := data[pos]
 	pos++
 	// Please refer to https://dev.mysql.com/doc/internals/en/com-stmt-execute.html

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -224,6 +224,11 @@ func (cc *clientConn) handleStmtFetch(ctx context.Context, data []byte) (err err
 		return mysql.NewErr(mysql.ErrUnknownStmtHandler,
 			strconv.FormatUint(uint64(stmtID), 10), "stmt_fetch")
 	}
+	sql := ""
+	if prepared, ok := cc.ctx.GetStatement(int(stmtID)).(*TiDBStatement); ok {
+		sql = prepared.sql
+	}
+	cc.ctx.SetProcessInfo(sql, time.Now(), mysql.ComStmtExecute)
 	rs := stmt.GetResultSet()
 	if rs == nil {
 		return mysql.NewErr(mysql.ErrUnknownStmtHandler,

--- a/server/driver.go
+++ b/server/driver.go
@@ -48,8 +48,7 @@ type QueryCtx interface {
 	// SetValue saves a value associated with this context for key.
 	SetValue(key fmt.Stringer, value interface{})
 
-	SetCommandValue(command byte)
-	SetProcessInfo(sql string, t time.Time)
+	SetProcessInfo(sql string, t time.Time, command byte)
 
 	// CommitTxn commits the transaction operations.
 	CommitTxn(ctx context.Context) error

--- a/server/driver.go
+++ b/server/driver.go
@@ -89,6 +89,8 @@ type QueryCtx interface {
 	// GetSessionVars return SessionVars.
 	GetSessionVars() *variable.SessionVars
 
+	SetCommandValue(command byte)
+
 	SetSessionManager(util.SessionManager)
 }
 

--- a/server/driver.go
+++ b/server/driver.go
@@ -16,6 +16,7 @@ package server
 import (
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
@@ -46,6 +47,9 @@ type QueryCtx interface {
 
 	// SetValue saves a value associated with this context for key.
 	SetValue(key fmt.Stringer, value interface{})
+
+	SetCommandValue(command byte)
+	SetProcessInfo(sql string, t time.Time)
 
 	// CommitTxn commits the transaction operations.
 	CommitTxn(ctx context.Context) error

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -16,6 +16,7 @@ package server
 import (
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/kv"
@@ -205,6 +206,16 @@ func (tc *TiDBContext) SetValue(key fmt.Stringer, value interface{}) {
 // CommitTxn implements QueryCtx CommitTxn method.
 func (tc *TiDBContext) CommitTxn(ctx context.Context) error {
 	return tc.session.CommitTxn(ctx)
+}
+
+// SetCommandValue implements QueryCtx SetCommandValue method.
+func (tc *TiDBContext) SetCommandValue(command byte) {
+	tc.session.SetCommandValue(command)
+}
+
+// SetProcessInfo implements QueryCtx SetProcessInfo method.
+func (tc *TiDBContext) SetProcessInfo(sql string, t time.Time) {
+	tc.session.SetProcessInfo(sql, t)
 }
 
 // RollbackTxn implements QueryCtx RollbackTxn method.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -333,6 +333,11 @@ func (tc *TiDBContext) ShowProcess() util.ProcessInfo {
 	return tc.session.ShowProcess()
 }
 
+// SetCommandValue implements QueryCtx SetCommandValue method.
+func (tc *TiDBContext) SetCommandValue(command byte) {
+	tc.session.SetCommandValue(command)
+}
+
 // GetSessionVars return SessionVars.
 func (tc *TiDBContext) GetSessionVars() *variable.SessionVars {
 	return tc.session.GetSessionVars()

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -60,6 +60,7 @@ type TiDBStatement struct {
 	paramsType  []byte
 	ctx         *TiDBContext
 	rs          ResultSet
+	sql         string
 }
 
 // ID implements PreparedStatement ID method.
@@ -306,6 +307,7 @@ func (tc *TiDBContext) Prepare(sql string) (statement PreparedStatement, columns
 		return
 	}
 	stmt := &TiDBStatement{
+		sql:         sql,
 		id:          stmtID,
 		numParams:   paramCount,
 		boundParams: make([][]byte, paramCount),

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -208,14 +208,9 @@ func (tc *TiDBContext) CommitTxn(ctx context.Context) error {
 	return tc.session.CommitTxn(ctx)
 }
 
-// SetCommandValue implements QueryCtx SetCommandValue method.
-func (tc *TiDBContext) SetCommandValue(command byte) {
-	tc.session.SetCommandValue(command)
-}
-
 // SetProcessInfo implements QueryCtx SetProcessInfo method.
-func (tc *TiDBContext) SetProcessInfo(sql string, t time.Time) {
-	tc.session.SetProcessInfo(sql, t)
+func (tc *TiDBContext) SetProcessInfo(sql string, t time.Time, command byte) {
+	tc.session.SetProcessInfo(sql, t, command)
 }
 
 // RollbackTxn implements QueryCtx RollbackTxn method.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -590,6 +590,29 @@ func checkErrorCode(c *C, e error, codes ...uint16) {
 	c.Assert(isMatchCode, IsTrue, Commentf("got err %v, expected err codes %v", me, codes))
 }
 
+func runTestShowProcessList(c *C) {
+	runTests(c, nil, func(dbt *DBTest) {
+		fullSQL := "show                                                                                        full processlist"
+		simpSQL := "show                                                                                        processlist"
+		rows := dbt.mustQuery(fullSQL)
+		c.Assert(rows.Next(), IsTrue)
+		var outA, outB, outC, outD, outE, outF, outG, outH, outI string
+		err := rows.Scan(&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI)
+		c.Assert(err, IsNil)
+		c.Assert(outE, Equals, "Query")
+		c.Assert(outF, Equals, "0")
+		c.Assert(outG, Equals, "2")
+		c.Assert(outH, Equals, fullSQL)
+		rows = dbt.mustQuery(simpSQL)
+		err = rows.Scan(&outA, &outB, &outC, &outD, &outE, &outF, &outG, &outH, &outI)
+		c.Assert(err, IsNil)
+		c.Assert(outE, Equals, "Query")
+		c.Assert(outF, Equals, "0")
+		c.Assert(outG, Equals, "2")
+		c.Assert(outH, Equals, simpSQL[:100])
+	})
+}
+
 func runTestAuth(c *C) {
 	runTests(c, nil, func(dbt *DBTest) {
 		dbt.mustExec(`CREATE USER 'authtest'@'%' IDENTIFIED BY '123';`)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -526,17 +526,3 @@ func (ts *TidbTestSuite) TestSumAvg(c *C) {
 	c.Parallel()
 	runTestSumAvg(c)
 }
-
-func (ts *TidbTestSuite) TestShowProcess(c *C) {
-	qctx, err := ts.tidbdrv.OpenCtx(uint64(0), 0, uint8(tmysql.DefaultCollationID), "test", nil)
-	c.Assert(err, IsNil)
-	ctx := context.Background()
-	results, err := qctx.Execute(ctx, "select 1")
-	c.Assert(err, IsNil)
-	pi := qctx.ShowProcess()
-	c.Assert(pi.Command, Equals, "Query")
-	results[0].Close()
-	pi = qctx.ShowProcess()
-	c.Assert(pi.Command, Equals, "Sleep")
-	qctx.Close()
-}

--- a/session/session.go
+++ b/session/session.go
@@ -77,8 +77,7 @@ type Session interface {
 	DropPreparedStmt(stmtID uint32) error
 	SetClientCapability(uint32) // Set client capability flags.
 	SetConnectionID(uint64)
-	SetCommandValue(byte)
-	SetProcessInfo(string, time.Time)
+	SetProcessInfo(string, time.Time, byte)
 	SetTLSState(*tls.ConnectionState)
 	SetCollation(coID int) error
 	SetSessionManager(util.SessionManager)
@@ -191,10 +190,6 @@ func (s *session) SetClientCapability(capability uint32) {
 
 func (s *session) SetConnectionID(connectionID uint64) {
 	s.sessionVars.ConnectionID = connectionID
-}
-
-func (s *session) SetCommandValue(command byte) {
-	s.sessionVars.CommandValue = command
 }
 
 func (s *session) SetTLSState(tlsState *tls.ConnectionState) {
@@ -709,11 +704,11 @@ func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) 
 	return s.parser.Parse(sql, charset, collation)
 }
 
-func (s *session) SetProcessInfo(sql string, t time.Time) {
+func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 	pi := util.ProcessInfo{
 		ID:      s.sessionVars.ConnectionID,
 		DB:      s.sessionVars.CurrentDB,
-		Command: mysql.Command2Str[s.sessionVars.CommandValue],
+		Command: mysql.Command2Str[command],
 		Time:    t,
 		State:   s.Status(),
 		Info:    sql,

--- a/session/session.go
+++ b/session/session.go
@@ -77,6 +77,7 @@ type Session interface {
 	DropPreparedStmt(stmtID uint32) error
 	SetClientCapability(uint32) // Set client capability flags.
 	SetConnectionID(uint64)
+	SetCommandValue(byte)
 	SetProcessInfo(string, time.Time, byte)
 	SetTLSState(*tls.ConnectionState)
 	SetCollation(coID int) error
@@ -197,6 +198,10 @@ func (s *session) SetTLSState(tlsState *tls.ConnectionState) {
 	if tlsState != nil {
 		s.sessionVars.TLSConnectionState = tlsState
 	}
+}
+
+func (s *session) SetCommandValue(command byte) {
+	atomic.StoreUint32(&s.sessionVars.CommandValue, uint32(command))
 }
 
 func (s *session) GetTLSState() *tls.ConnectionState {

--- a/session/session.go
+++ b/session/session.go
@@ -713,9 +713,6 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 		State:   s.Status(),
 		Info:    sql,
 	}
-	if sql == "" {
-		pi.Command = "Sleep"
-	}
 	if s.sessionVars.User != nil {
 		pi.User = s.sessionVars.User.Username
 		pi.Host = s.sessionVars.User.Hostname

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -209,9 +209,6 @@ type SessionVars struct {
 	// ConnectionID is the connection id of the current session.
 	ConnectionID uint64
 
-	// CommandValue is the command which current session is doing.
-	CommandValue byte
-
 	// PlanID is the unique id of logical and physical plan.
 	PlanID int
 
@@ -328,12 +325,9 @@ func NewSessionVars() *SessionVars {
 		RetryLimit:                DefTiDBRetryLimit,
 		DisableTxnAutoRetry:       DefTiDBDisableTxnAutoRetry,
 		DDLReorgPriority:          kv.PriorityLow,
-<<<<<<< HEAD
 		EnableRadixJoin:           false,
 		L2CacheSize:               cpuid.CPU.Cache.L2,
-=======
 		CommandValue:              mysql.ComSleep,
->>>>>>> fix show processlist
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -304,6 +304,9 @@ type SessionVars struct {
 	// EnableRadixJoin indicates whether to use radix hash join to execute
 	// HashJoin.
 	EnableRadixJoin bool
+
+	// CommandValue indicates which command current session is doing.
+	CommandValue uint32
 }
 
 // NewSessionVars creates a session vars object.
@@ -327,6 +330,7 @@ func NewSessionVars() *SessionVars {
 		DDLReorgPriority:          kv.PriorityLow,
 		EnableRadixJoin:           false,
 		L2CacheSize:               cpuid.CPU.Cache.L2,
+		CommandValue:              uint32(mysql.ComSleep),
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -209,6 +209,9 @@ type SessionVars struct {
 	// ConnectionID is the connection id of the current session.
 	ConnectionID uint64
 
+	// CommandValue is the command which current session is doing.
+	CommandValue byte
+
 	// PlanID is the unique id of logical and physical plan.
 	PlanID int
 
@@ -325,8 +328,12 @@ func NewSessionVars() *SessionVars {
 		RetryLimit:                DefTiDBRetryLimit,
 		DisableTxnAutoRetry:       DefTiDBDisableTxnAutoRetry,
 		DDLReorgPriority:          kv.PriorityLow,
+<<<<<<< HEAD
 		EnableRadixJoin:           false,
 		L2CacheSize:               cpuid.CPU.Cache.L2,
+=======
+		CommandValue:              mysql.ComSleep,
+>>>>>>> fix show processlist
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -327,7 +327,6 @@ func NewSessionVars() *SessionVars {
 		DDLReorgPriority:          kv.PriorityLow,
 		EnableRadixJoin:           false,
 		L2CacheSize:               cpuid.CPU.Cache.L2,
-		CommandValue:              mysql.ComSleep,
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When execute `show processlist`, TiDB only has `Query` Command state. 
According to MySQL doc, `Command` has many values: https://dev.mysql.com/doc/refman/8.0/en/thread-commands.html
For example,  id 1 in query result below should has `Sleep` state.

    +------+------+-----------+------+---------+------+-------+------------------+------+
    | Id   | User | Host      | db   | Command | Time | State | Info             | Mem  |
    +------+------+-----------+------+---------+------+-------+------------------+------+
    |    1 | root | 127.0.0.1 |      | Query   |   90 | 2     |                  |    0 |
    |    2 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |    0 |
    +------+------+-----------+------+---------+------+-------+------------------+------+
    2 rows in set (0.00 sec)

In MySQL:

    +----+------+-----------+------+---------+------+-------+------------------+
    | Id | User | Host      | db   | Command | Time | State | Info             |
    +----+------+-----------+------+---------+------+-------+------------------+
    |  1 | root | localhost | NULL | Sleep   |   10 |       | NULL             |
    |  2 | root | localhost | NULL | Query   |    0 | init  | show processlist |
    +----+------+-----------+------+---------+------+-------+------------------+
    2 rows in set (0.00 sec)

### What is changed and how it works?

- Add `Command` values.
- Set `Command` and `Time` before query/prepare/execute.
- Set `Time` to 0 after action finish.
- Set `Command` to `Sleep` after action finish.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression


