### PR TITLE
domain: close slow query channel after closing session pool

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -457,8 +457,8 @@ func (do *Domain) Close() {
 	if do.etcdClient != nil {
 		terror.Log(errors.Trace(do.etcdClient.Close()))
 	}
-	do.slowQuery.Close()
 	do.sysSessionPool.Close()
+	do.slowQuery.Close()
 	do.wg.Wait()
 	log.Info("[domain] close")
 }

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -335,6 +335,12 @@ func (do *Domain) Reload() error {
 
 // LogSlowQuery keeps topN recent slow queries in domain.
 func (do *Domain) LogSlowQuery(query *SlowQueryInfo) {
+	do.slowQuery.mu.RLock()
+	defer do.slowQuery.mu.RUnlock()
+	if do.slowQuery.mu.closed {
+		return
+	}
+
 	select {
 	case do.slowQuery.ch <- query:
 	default:

--- a/domain/topn_slow_query.go
+++ b/domain/topn_slow_query.go
@@ -196,14 +196,6 @@ func (q *topNSlowQueries) QueryTop(count int, kind ast.ShowSlowKind) []*SlowQuer
 }
 
 func (q *topNSlowQueries) Close() {
-	done := false
-	for !done {
-		select {
-		case <-q.ch:
-		default:
-			done = true
-		}
-	}
 	close(q.ch)
 }
 

--- a/domain/topn_slow_query.go
+++ b/domain/topn_slow_query.go
@@ -115,6 +115,11 @@ type topNSlowQueries struct {
 	period   time.Duration
 	ch       chan *SlowQueryInfo
 	msgCh    chan *showSlowMessage
+
+	mu struct {
+		sync.RWMutex
+		closed bool
+	}
 }
 
 func newTopNSlowQueries(topN int, period time.Duration, queueSize int) *topNSlowQueries {
@@ -196,6 +201,10 @@ func (q *topNSlowQueries) QueryTop(count int, kind ast.ShowSlowKind) []*SlowQuer
 }
 
 func (q *topNSlowQueries) Close() {
+	q.mu.Lock()
+	q.mu.closed = true
+	q.mu.Unlock()
+
 	close(q.ch)
 }
 

--- a/domain/topn_slow_query.go
+++ b/domain/topn_slow_query.go
@@ -196,6 +196,14 @@ func (q *topNSlowQueries) QueryTop(count int, kind ast.ShowSlowKind) []*SlowQuer
 }
 
 func (q *topNSlowQueries) Close() {
+	done := false
+	for !done {
+		select {
+		case <-q.ch:
+		default:
+			done = true
+		}
+	}
 	close(q.ch)
 }
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


If slow query channel is closed before session pool, some session's goroutine may still
writing to the channel. Writing to a closed channel would cause TiDB panic.

![image](https://user-images.githubusercontent.com/1420062/46648569-4406e380-cbc8-11e8-88be-ab8511c3b196.png)

### What is changed and how it works?

* Change the close order, close slow query channel after closing session pool.
* Drain the channel data before close the channel.
* Assume that after `domain.Close()` is called, there will be no more session executing.

### Check List <!--REMOVE the items that are not applicable-->

Related changes

 - Need to cherry-pick to the release branch
