### PR TITLE
executor,infoschema: check privilege for 'show processlist'

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/auth"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
@@ -78,6 +79,7 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 	}
 	sctx := mock.NewContext()
 	sctx.SetSessionManager(sm)
+	sctx.GetSessionVars().User = &auth.UserIdentity{Username: "test"}
 
 	// Compose executor.
 	e := &ShowExec{

--- a/executor/show.go
+++ b/executor/show.go
@@ -188,6 +188,14 @@ func (e *ShowExec) fetchShowProcessList() error {
 		return nil
 	}
 
+	loginUser := e.ctx.GetSessionVars().User
+	var hasProcessPriv bool
+	if pm := privilege.GetPrivilegeManager(e.ctx); pm != nil {
+		if pm.RequestVerification("", "", "", mysql.ProcessPriv) {
+			hasProcessPriv = true
+		}
+	}
+
 	pl := sm.ShowProcessList()
 	for _, pi := range pl {
 		var info string
@@ -195,6 +203,12 @@ func (e *ShowExec) fetchShowProcessList() error {
 			info = pi.Info
 		} else {
 			info = fmt.Sprintf("%.100v", pi.Info)
+		}
+
+		// If you have the PROCESS privilege, you can see all threads. Otherwise, you can
+		// see only your own threads.
+		if !hasProcessPriv && pi.User != loginUser.Username {
+			continue
 		}
 
 		e.appendRow([]interface{}{

--- a/executor/show.go
+++ b/executor/show.go
@@ -205,8 +205,8 @@ func (e *ShowExec) fetchShowProcessList() error {
 			info = fmt.Sprintf("%.100v", pi.Info)
 		}
 
-		// If you have the PROCESS privilege, you can see all threads. Otherwise, you can
-		// see only your own threads.
+		// If you have the PROCESS privilege, you can see all threads.
+		// Otherwise, you can see only your own threads.
 		if !hasProcessPriv && pi.User != loginUser.Username {
 			continue
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

"show processlist" requires the PROCESS privilege.
Otherwise, the user can see only his own threads.

### What is changed and how it works?

Add check for PROCESS privilege.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

As the `util.SessionManager` is mocked, its `ShowProcessList` can't work.
I test manually to check the changes in this PR works.

```
mysql -h 127.0.0.1 -u root -P 4000
create user noprivs;

// open another terminal
mysql  -h 127.0.0.1 -u noprivs -P 4000
mysql> show processlist;                                                                                                                                                                      +------+---------+-----------+------+---------+------+-------+------------------+------+
| Id   | User    | Host      | db   | Command | Time | State | Info             | Mem  |
+------+---------+-----------+------+---------+------+-------+------------------+------+
|    6 | noprivs | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |    0 |
+------+---------+-----------+------+---------+------+-------+------------------+------+
1 row in set (0.01 sec)

// back to previous terminal
mysql> show processlist;
+------+---------+-----------+------+---------+------+-------+------------------+------+
| Id   | User    | Host      | db   | Command | Time | State | Info             | Mem  |
+------+---------+-----------+------+---------+------+-------+------------------+------+
|    5 | root    | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |    0 |
|    6 | noprivs | 127.0.0.1 |      | Sleep   |   27 | 2     |                  |    0 |
+------+---------+-----------+------+---------+------+-------+------------------+------+
2 rows in set (0.00 sec)
```

@jackysp @lysu 