### PR TITLE
metrics: monitor index/table access

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -336,7 +336,7 @@ func (a *ExecStmt) logSlowQuery(txnTS uint64, succ bool) {
 	sessVars := a.Ctx.GetSessionVars()
 	if !sessVars.InRestrictedSQL {
 		for access := range sessVars.StmtCtx.AccessDigest {
-			metrics.IndexAccessCounter.WithLabelValues(access.Tbl, access.Idx).Inc()
+			metrics.IndexAccessCounter.WithLabelValues(access.DB, access.Tbl, access.Idx).Inc()
 		}
 	}
 	level := log.GetLevel()

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -333,6 +333,12 @@ func (a *ExecStmt) buildExecutor(ctx sessionctx.Context) (Executor, error) {
 var QueryReplacer = strings.NewReplacer("\r", " ", "\n", " ", "\t", " ")
 
 func (a *ExecStmt) logSlowQuery(txnTS uint64, succ bool) {
+	sessVars := a.Ctx.GetSessionVars()
+	if !sessVars.InRestrictedSQL {
+		for access := range sessVars.StmtCtx.AccessDigest {
+			metrics.IndexAccessCounter.WithLabelValues(access.Tbl, access.Idx).Inc()
+		}
+	}
 	level := log.GetLevel()
 	if level < log.WarnLevel {
 		return
@@ -347,7 +353,7 @@ func (a *ExecStmt) logSlowQuery(txnTS uint64, succ bool) {
 	if len(sql) > int(cfg.Log.QueryLogMaxLen) {
 		sql = fmt.Sprintf("%.*q(len:%d)", cfg.Log.QueryLogMaxLen, sql, len(a.Text))
 	}
-	sessVars := a.Ctx.GetSessionVars()
+
 	sql = QueryReplacer.Replace(sql) + sessVars.GetExecuteArgumentsInfo()
 
 	connID := sessVars.ConnectionID

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1138,6 +1138,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = vars.Location()
 	sc.MemTracker = memory.NewTracker(s.Text(), vars.MemQuotaQuery)
+	sc.AccessDigest = make(map[stmtctx.AccessDigest]struct{})
 	switch config.GetGlobalConfig().OOMAction {
 	case config.OOMActionCancel:
 		sc.MemTracker.SetActionOnExceed(&memory.PanicOnExceed{})

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -83,6 +83,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(PseudoEstimation)
 	prometheus.MustRegister(QueryDurationHistogram)
 	prometheus.MustRegister(QueryTotalCounter)
+	prometheus.MustRegister(IndexAccessCounter)
 	prometheus.MustRegister(SchemaLeaseErrorCounter)
 	prometheus.MustRegister(ServerEventCounter)
 	prometheus.MustRegister(SessionExecuteCompileDuration)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -40,6 +40,14 @@ var (
 			Help:      "Counter of queries.",
 		}, []string{LblType, LblResult})
 
+	IndexAccessCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "index_access",
+			Help:      "access of index.",
+		}, []string{LbTable, LbIndex})
+
 	ConnGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "tidb",

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -46,7 +46,7 @@ var (
 			Subsystem: "server",
 			Name:      "index_access",
 			Help:      "access of index.",
-		}, []string{LbTable, LbIndex})
+		}, []string{LbDB, LbTable, LbIndex})
 
 	ConnGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{

--- a/metrics/session.go
+++ b/metrics/session.go
@@ -110,6 +110,7 @@ const (
 	LblSQLType     = "sql_type"
 	LblGeneral     = "general"
 	LblInternal    = "internal"
+	LbDB           = "db"
 	LbTable        = "table"
 	LbIndex        = "index"
 )

--- a/metrics/session.go
+++ b/metrics/session.go
@@ -110,4 +110,6 @@ const (
 	LblSQLType     = "sql_type"
 	LblGeneral     = "general"
 	LblInternal    = "internal"
+	LbTable        = "table"
+	LbIndex        = "index"
 )

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -97,7 +97,9 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 		Desc:    p.Desc,
 	}
 	err := SetPBColumnsDefaultValue(ctx, tsExec.Columns, p.Columns)
-	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{Tbl: p.Table.Name.L, Idx: "table-scan"}] = struct{}{}
+	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{
+		DB: p.DBName.L, Tbl: p.Table.Name.L, Idx: "table-scan",
+	}] = struct{}{}
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tsExec}, errors.Trace(err)
 }
 
@@ -135,7 +137,9 @@ func (p *PhysicalIndexScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 	}
 	unique := checkCoverIndex(p.Index, p.Ranges)
 	idxExec.Unique = &unique
-	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{Tbl: p.Table.Name.L, Idx: p.Index.Name.L}] = struct{}{}
+	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{
+		DB: p.DBName.L, Tbl: p.Table.Name.L, Idx: p.Index.Name.L,
+	}] = struct{}{}
 	return &tipb.Executor{Tp: tipb.ExecType_TypeIndexScan, IdxScan: idxExec}, nil
 }
 

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/ranger"
@@ -96,6 +97,7 @@ func (p *PhysicalTableScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 		Desc:    p.Desc,
 	}
 	err := SetPBColumnsDefaultValue(ctx, tsExec.Columns, p.Columns)
+	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{Tbl: p.Table.Name.L, Idx: "table-scan"}] = struct{}{}
 	return &tipb.Executor{Tp: tipb.ExecType_TypeTableScan, TblScan: tsExec}, errors.Trace(err)
 }
 
@@ -133,6 +135,7 @@ func (p *PhysicalIndexScan) ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
 	}
 	unique := checkCoverIndex(p.Index, p.Ranges)
 	idxExec.Unique = &unique
+	p.ctx.GetSessionVars().StmtCtx.AccessDigest[stmtctx.AccessDigest{Tbl: p.Table.Name.L, Idx: p.Index.Name.L}] = struct{}{}
 	return &tipb.Executor{Tp: tipb.ExecType_TypeIndexScan, IdxScan: idxExec}, nil
 }
 

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -40,6 +40,7 @@ type SQLWarn struct {
 
 // AccessDigest presents stmt access digest.
 type AccessDigest struct {
+	DB  string
 	Tbl string
 	Idx string
 }

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -38,6 +38,12 @@ type SQLWarn struct {
 	Err   error
 }
 
+// AccessDigest presents stmt access digest.
+type AccessDigest struct {
+	Tbl string
+	Idx string
+}
+
 // StatementContext contains variables for a statement.
 // It should be reset before executing a statement.
 type StatementContext struct {
@@ -79,6 +85,7 @@ type StatementContext struct {
 	MemTracker   *memory.Tracker
 	TableIDs     []int64
 	IndexIDs     []int64
+	AccessDigest map[AccessDigest]struct{}
 }
 
 // AddAffectedRows adds affected rows.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

monitor tidb's index/table access and make user can find hot table/index in special time. 

### What is changed and how it works?

- collect access index/table digest in stmt ctx
- record them as counter to prometheus with label values
- find hot index or table for special time use `topk` in in grafana

```
topk(x, sum(rate(tidb_server_index_access[1m])) by (table, index))
```

![2018-10-10-214827_3836x1988_scrot](https://user-images.githubusercontent.com/528332/46741333-63406680-ccd7-11e8-85c8-090a74ee16e7.png)

and we also can got a new expression as need.

### Check List 

Tests <!-- At least one of them must be included. -->

 - old test and no function change

Code changes

 - add metric

Side effects

 - More label values in prometheus

Related changes

 - Need to modify grafana template

### Question

Not quite sure prometheus's `agg + topK`'s performance under many(several thousand level? ) index/table, so it's proposal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7866)
<!-- Reviewable:end -->
