### PR TITLE
parser: Optimize mem alloc in parser

### DIFF
--- a/metrics/session.go
+++ b/metrics/session.go
@@ -23,7 +23,7 @@ var (
 			Subsystem: "session",
 			Name:      "parse_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) in parse SQL.",
-			Buckets:   prometheus.LinearBuckets(0.00004, 0.00001, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.00001, 2, 13),
 		}, []string{LblSQLType})
 	SessionExecuteCompileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -31,7 +31,7 @@ var (
 			Subsystem: "session",
 			Name:      "compile_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) in query optimize.",
-			Buckets:   prometheus.LinearBuckets(0.00004, 0.00001, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.00001, 2, 13),
 		}, []string{LblSQLType})
 	SessionExecuteRunDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/parser/bench_test.go
+++ b/parser/bench_test.go
@@ -15,6 +15,8 @@ package parser
 
 import (
 	"testing"
+
+	"github.com/pingcap/tidb/ast"
 )
 
 func BenchmarkSysbenchSelect(b *testing.B) {
@@ -38,6 +40,9 @@ func BenchmarkParseComplex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, v := range table {
 			_, err := parser.Parse(v, "", "")
+			// adding this because these resource will be released on
+			// the finish of each query.
+			ast.FreeColumnNames()
 			if err != nil {
 				b.Failed()
 			}

--- a/parser/goyacc/main.go
+++ b/parser/goyacc/main.go
@@ -572,13 +572,13 @@ yystack:
 	/* put a state and value onto the stack */
 	yyp++
 	if yyp >= len(yyS) {
-		nyys := make([]%[1]sSymType, len(yyS)*2)
-		copy(nyys, yyS)
-		yyS = nyys
+		yyS = append(yyS, parser.yyVAL)
 		parser.cache = yyS
+	} else {
+		yyS[yyp] = parser.yyVAL
+		yyS[yyp].yys = yystate
 	}
-	yyS[yyp] = parser.yyVAL
-	yyS[yyp].yys = yystate
+
 
 yynewstate:
 	if yychar < 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The problem, that this pr aims to solve, is too much pressure on gc when it comes to long query(more than 5000 characters).

### What is changed and how it works?
The way to solve the problem is created and released objects from `sync.Pool`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change


 - Has persistent data change

Side effects

Benchmark is as follows:


```

benchmark                   old ns/op     new ns/op     delta

BenchmarkParseComplex-8     256011        219986        -14.07%

 

benchmark                   old allocs     new allocs     delta

BenchmarkParseComplex-8     761            666            -12.48%

 

benchmark                   old bytes     new bytes     delta

BenchmarkParseComplex-8     72398         71639         -1.05%
```
