### PR TITLE
*: remove `kv.BypassLatch` option and enable latch scheduler by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -262,8 +262,8 @@ var defaultConf = Config{
 	MemQuotaQuery:    32 << 30,
 	EnableStreaming:  false,
 	TxnLocalLatches: TxnLocalLatches{
-		Enabled:  false,
-		Capacity: 10240000,
+		Enabled:  true,
+		Capacity: 2048000,
 	},
 	LowerCaseTableNames: 2,
 	Log: Log{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -232,8 +232,8 @@ commit-timeout = "41s"
 [txn-local-latches]
 # Enable local latches for transactions. Enable it when
 # there are lots of conflicts between transactions.
-enabled = false
-capacity = 10240000
+enabled = true
+capacity = 2048000
 
 [binlog]
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -43,9 +43,6 @@ const (
 	NotFillCache
 	// SyncLog decides whether the WAL(write-ahead log) of this request should be synchronized.
 	SyncLog
-	// BypassLatch option tells 2PC commit to bypass latches, it would be true when the
-	// transaction is not conflict-retryable, for example: 'select for update', 'load data'.
-	BypassLatch
 	// KeyOnly retrieve only keys, it can be used in scan now.
 	KeyOnly
 )

--- a/server/conn.go
+++ b/server/conn.go
@@ -764,11 +764,6 @@ func insertDataWithCommit(ctx context.Context, prevData, curData []byte, loadDat
 			break
 		}
 		loadDataInfo.Ctx.StmtCommit()
-		// Load data should not use latches, because:
-		// 1. latches may result in false positive transaction conflicts.
-		// 2. load data is not retryable when it meets conflicts.
-		// 3. load data will abort abnormally under condition 1 + 2.
-		loadDataInfo.Ctx.Txn().SetOption(kv.BypassLatch, true)
 		// Make sure that there are no retries when committing.
 		if err = loadDataInfo.Ctx.RefreshTxnCtx(ctx); err != nil {
 			return nil, errors.Trace(err)
@@ -837,7 +832,6 @@ func (cc *clientConn) handleLoadData(ctx context.Context, loadDataInfo *executor
 		return errors.Trace(err)
 	}
 
-	txn.SetOption(kv.BypassLatch, true)
 	return errors.Trace(cc.ctx.CommitTxn(sessionctx.SetCommitCtx(ctx, loadDataInfo.Ctx)))
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -312,9 +312,6 @@ func (s *session) doCommit(ctx context.Context) error {
 	}
 	// Set this option for 2 phase commit to validate schema lease.
 	s.txn.SetOption(kv.SchemaChecker, domain.NewSchemaChecker(domain.GetDomain(s), s.sessionVars.TxnCtx.SchemaVersion, tableIDs))
-	if s.sessionVars.TxnCtx.ForUpdate {
-		s.txn.SetOption(kv.BypassLatch, true)
-	}
 
 	if err := s.txn.Commit(sessionctx.SetCommitCtx(ctx, s)); err != nil {
 		return errors.Trace(err)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -192,17 +192,6 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 	}
 
 	// latches enabled
-	var bypassLatch bool
-	if option := txn.us.GetOption(kv.BypassLatch); option != nil {
-		bypassLatch = option.(bool)
-	}
-	// When bypassLatch flag is true, commit directly.
-	if bypassLatch {
-		err = committer.executeAndWriteFinishBinlog(ctx)
-		log.Debug("[kv]", connID, " txnLatches enabled while txn not retryable, 2pc directly:", err)
-		return errors.Trace(err)
-	}
-
 	// for transactions which need to acquire latches
 	lock := txn.store.txnLatches.Lock(committer.startTS, committer.keys)
 	defer txn.store.txnLatches.UnLock(lock)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. `kv.BypassLatch` was introduced to handle the fake transaction conflicting problem
in the old implementation. After [redesign of the latch scheduler](https://github.com/pingcap/tidb/pull/7711), it's not needed any more.

2. Enable latch scheduler by default makes CI to run it, we can fix bugs and make this feature
more stable.

### What is changed and how it works?

Set `Capacity` to 2048000 cost about 96M memory.
The old value 10240000 cost more than 700M, which I think is too large.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

There is a small performance penalty, less than 5%, users are free to disable it.

@shenli 