### PR TITLE
executor: refine `explain analyze`

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -502,9 +502,9 @@ func (w *HashAggFinalWorker) run(ctx sessionctx.Context, waitGroup *sync.WaitGro
 
 // Next implements the Executor Next interface.
 func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if e.isUnparallelExec {
@@ -761,9 +761,9 @@ func (e *StreamAggExec) Close() error {
 
 // Next implements the Executor Next interface.
 func (e *StreamAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for !e.executed && chk.NumRows() < e.maxChunkSize {

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -502,9 +502,9 @@ func (w *HashAggFinalWorker) run(ctx sessionctx.Context, waitGroup *sync.WaitGro
 
 // Next implements the Executor Next interface.
 func (e *HashAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if e.isUnparallelExec {
@@ -761,9 +761,9 @@ func (e *StreamAggExec) Close() error {
 
 // Next implements the Executor Next interface.
 func (e *StreamAggExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for !e.executed && chk.NumRows() < e.maxChunkSize {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -666,7 +666,7 @@ func (b *executorBuilder) buildExplain(v *plannercore.Explain) Executor {
 			StmtNode:   v.ExecStmt,
 			Ctx:        b.ctx,
 		}
-		b.ctx.GetSessionVars().StmtCtx.RuntimeStats = execdetails.NewRuntimeStats()
+		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStats()
 		ctx := context.Background()
 		rs, err := stmt.Exec(ctx)
 		if err != nil {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -664,7 +664,7 @@ func (b *executorBuilder) buildExplain(v *plannercore.Explain) Executor {
 		explain:      v,
 	}
 	if v.Analyze {
-		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStats()
+		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl()
 		explainExec.analyzeExec = b.build(v.ExecPlan)
 	}
 	return explainExec

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -659,41 +659,15 @@ func (b *executorBuilder) buildTrace(v *plannercore.Trace) Executor {
 
 // buildExplain builds a explain executor. `e.rows` collects final result to `ExplainExec`.
 func (b *executorBuilder) buildExplain(v *plannercore.Explain) Executor {
-	if v.Analyze {
-		stmt := &ExecStmt{
-			InfoSchema: GetInfoSchema(b.ctx),
-			Plan:       v.ExecPlan,
-			StmtNode:   v.ExecStmt,
-			Ctx:        b.ctx,
-		}
-		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStats()
-		ctx := context.Background()
-		rs, err := stmt.Exec(ctx)
-		if err != nil {
-			return nil
-		}
-		if rs != nil {
-			chk := rs.NewChunk()
-			for {
-				err := rs.Next(ctx, chk)
-				if err != nil {
-					return nil
-				}
-				if chk.NumRows() == 0 {
-					break
-				}
-			}
-		}
-	}
-	v.PrepareRows()
-	e := &ExplainExec{
+	explainExec := &ExplainExec{
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
+		explain:      v,
 	}
-	e.rows = make([][]string, 0, len(v.Rows))
-	for _, row := range v.Rows {
-		e.rows = append(e.rows, row)
+	if v.Analyze {
+		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStats()
+		explainExec.analyzeExec = b.build(v.ExecPlan)
 	}
-	return e
+	return explainExec
 }
 
 func (b *executorBuilder) buildUnionScanExec(v *plannercore.PhysicalUnionScan) Executor {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -489,6 +489,8 @@ func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, handles []in
 		corColInFilter:  e.corColInTblSide,
 		plans:           e.tblPlans,
 	}
+	// We assign `nil` to `runtimeStats` to forbidden `TableWorker` driven `IndexLookupExecutor`'s runtime stats collecting,
+	// because TableWorker information isn't showing in explain result now.
 	tableReaderExec.runtimeStats = nil
 	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles)
 	if err != nil {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -244,9 +244,9 @@ func (e *IndexReaderExecutor) Close() error {
 
 // Next implements the Executor Next interface.
 func (e *IndexReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	err := e.result.Next(ctx, chk)
 	if err != nil {
@@ -458,7 +458,6 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-chan *lookupTableTask) {
 	lookupConcurrencyLimit := e.ctx.GetSessionVars().IndexLookupConcurrency
 	e.tblWorkerWg.Add(lookupConcurrencyLimit)
-	e.baseExecutor.ctx.GetSessionVars().StmtCtx.RuntimeStats.GetRuntimeStat(e.id + "_tableReader")
 	for i := 0; i < lookupConcurrencyLimit; i++ {
 		worker := &tableWorker{
 			workCh:         workCh,
@@ -480,7 +479,7 @@ func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-cha
 }
 
 func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, handles []int64) (Executor, error) {
-	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, &TableReaderExecutor{
+	tableReaderExec := &TableReaderExecutor{
 		baseExecutor:    newBaseExecutor(e.ctx, e.schema, e.id+"_tableReader"),
 		table:           e.table,
 		physicalTableID: e.physicalTableID,
@@ -489,7 +488,9 @@ func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, handles []in
 		feedback:        statistics.NewQueryFeedback(0, nil, 0, false),
 		corColInFilter:  e.corColInTblSide,
 		plans:           e.tblPlans,
-	}, handles)
+	}
+	tableReaderExec.statsEnable = false
+	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles)
 	if err != nil {
 		log.Error(err)
 		return nil, errors.Trace(err)
@@ -518,9 +519,9 @@ func (e *IndexLookUpExecutor) Close() error {
 
 // Next implements Exec Next interface.
 func (e *IndexLookUpExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -244,9 +244,9 @@ func (e *IndexReaderExecutor) Close() error {
 
 // Next implements the Executor Next interface.
 func (e *IndexReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	err := e.result.Next(ctx, chk)
 	if err != nil {
@@ -489,7 +489,7 @@ func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, handles []in
 		corColInFilter:  e.corColInTblSide,
 		plans:           e.tblPlans,
 	}
-	tableReaderExec.statsEnable = false
+	tableReaderExec.runtimeStats = nil
 	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles)
 	if err != nil {
 		log.Error(err)
@@ -519,9 +519,9 @@ func (e *IndexLookUpExecutor) Close() error {
 
 // Next implements Exec Next interface.
 func (e *IndexLookUpExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for {

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -190,9 +190,9 @@ func (e *IndexLookUpJoin) newInnerWorker(taskCh chan *lookUpJoinTask) *innerWork
 
 // Next implements the Executor interface.
 func (e *IndexLookUpJoin) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	e.joinResult.Reset()

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -190,9 +190,9 @@ func (e *IndexLookUpJoin) newInnerWorker(taskCh chan *lookUpJoinTask) *innerWork
 
 // Next implements the Executor interface.
 func (e *IndexLookUpJoin) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	e.joinResult.Reset()

--- a/executor/join.go
+++ b/executor/join.go
@@ -509,9 +509,9 @@ func (e *HashJoinExec) join2Chunk(workerID uint, outerChk *chunk.Chunk, joinResu
 // step 1. fetch data from inner child and build a hash table;
 // step 2. fetch data from outer child in a background goroutine and probe the hash table in multiple join workers.
 func (e *HashJoinExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	if !e.prepared {
 		e.innerFinished = make(chan error, 1)
@@ -726,9 +726,9 @@ func (e *NestedLoopApplyExec) fetchAllInners(ctx context.Context) error {
 
 // Next implements the Executor interface.
 func (e *NestedLoopApplyExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for {

--- a/executor/join.go
+++ b/executor/join.go
@@ -509,9 +509,9 @@ func (e *HashJoinExec) join2Chunk(workerID uint, outerChk *chunk.Chunk, joinResu
 // step 1. fetch data from inner child and build a hash table;
 // step 2. fetch data from outer child in a background goroutine and probe the hash table in multiple join workers.
 func (e *HashJoinExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	if !e.prepared {
 		e.innerFinished = make(chan error, 1)
@@ -726,9 +726,9 @@ func (e *NestedLoopApplyExec) fetchAllInners(ctx context.Context) error {
 
 // Next implements the Executor interface.
 func (e *NestedLoopApplyExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	for {

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -263,9 +263,9 @@ func (e *MergeJoinExec) prepare(ctx context.Context, chk *chunk.Chunk) error {
 
 // Next implements the Executor Next interface.
 func (e *MergeJoinExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.prepared {

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -263,9 +263,9 @@ func (e *MergeJoinExec) prepare(ctx context.Context, chk *chunk.Chunk) error {
 
 // Next implements the Executor Next interface.
 func (e *MergeJoinExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.prepared {

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -141,9 +141,9 @@ func (e *ProjectionExec) Open(ctx context.Context) error {
 //  +------------------------------+       +----------------------+
 //
 func (e *ProjectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.GrowAndReset(e.maxChunkSize)
 	if e.isUnparallelExec() {

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -141,9 +141,9 @@ func (e *ProjectionExec) Open(ctx context.Context) error {
 //  +------------------------------+       +----------------------+
 //
 func (e *ProjectionExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.GrowAndReset(e.maxChunkSize)
 	if e.isUnparallelExec() {

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -74,9 +74,9 @@ func (e *SortExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (e *SortExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.fetched {
@@ -301,9 +301,9 @@ func (e *TopNExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (e *TopNExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.fetched {

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -74,9 +74,9 @@ func (e *SortExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (e *SortExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.fetched {
@@ -301,9 +301,9 @@ func (e *TopNExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (e *TopNExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.Reset()
 	if !e.fetched {

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -100,9 +100,9 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 // Next fills data into the chunk passed by its caller.
 // The task was actually done by tableReaderHandler.
 func (e *TableReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.statsEnable {
+	if e.runtimeStats != nil {
 		start := time.Now()
-		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	if err := e.resultHandler.nextChunk(ctx, chk); err != nil {
 		e.feedback.Invalidate()

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -100,9 +100,9 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 // Next fills data into the chunk passed by its caller.
 // The task was actually done by tableReaderHandler.
 func (e *TableReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if e.runtimeStat != nil {
+	if e.statsEnable {
 		start := time.Now()
-		defer func() { e.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { e.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	if err := e.resultHandler.nextChunk(ctx, chk); err != nil {
 		e.feedback.Invalidate()

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -126,9 +126,9 @@ func (us *UnionScanExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (us *UnionScanExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if us.statsEnable {
+	if us.runtimeStats != nil {
 		start := time.Now()
-		defer func() { us.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { us.runtimeStats.Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.GrowAndReset(us.maxChunkSize)
 	mutableRow := chunk.MutRowFromTypes(us.retTypes())

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -126,9 +126,9 @@ func (us *UnionScanExec) Open(ctx context.Context) error {
 
 // Next implements the Executor Next interface.
 func (us *UnionScanExec) Next(ctx context.Context, chk *chunk.Chunk) error {
-	if us.runtimeStat != nil {
+	if us.statsEnable {
 		start := time.Now()
-		defer func() { us.runtimeStat.Record(time.Now().Sub(start), chk.NumRows()) }()
+		defer func() { us.runtimeStats().Record(time.Now().Sub(start), chk.NumRows()) }()
 	}
 	chk.GrowAndReset(us.maxChunkSize)
 	mutableRow := chunk.MutRowFromTypes(us.retTypes())

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -494,7 +494,7 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 		if taskType == "cop" {
 			row = append(row, "") //TODO: wait collect resp from tikv
 		} else {
-			row = append(row, runtimeStatsColl.GetRuntimeStat(p.ExplainID()).String())
+			row = append(row, runtimeStatsColl.Get(p.ExplainID()).String())
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -17,12 +17,14 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/auth"
@@ -410,10 +412,50 @@ type Explain struct {
 	StmtPlan       Plan
 	Rows           [][]string
 	explainedPlans map[int]bool
-	PrepareRows    func() error
+	Format         string
 	Analyze        bool
 	ExecStmt       ast.StmtNode
 	ExecPlan       Plan
+}
+
+// prepareSchema prepares explain's result schema.
+func (e *Explain) prepareSchema() error {
+	switch strings.ToLower(e.Format) {
+	case ast.ExplainFormatROW:
+		retFields := []string{"id", "count", "task", "operator info"}
+		if e.Analyze {
+			retFields = append(retFields, "execution info")
+		}
+		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
+		for _, fieldName := range retFields {
+			schema.Append(buildColumn("", fieldName, mysql.TypeString, mysql.MaxBlobWidth))
+		}
+		e.SetSchema(schema)
+	case ast.ExplainFormatDOT:
+		retFields := []string{"dot contents"}
+		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
+		for _, fieldName := range retFields {
+			schema.Append(buildColumn("", fieldName, mysql.TypeString, mysql.MaxBlobWidth))
+		}
+		e.SetSchema(schema)
+	default:
+		return errors.Errorf("explain format '%s' is not supported now", e.Format)
+	}
+	return nil
+}
+
+// RenderResult renders the explain result as specified format.
+func (e *Explain) RenderResult() error {
+	switch strings.ToLower(e.Format) {
+	case ast.ExplainFormatROW:
+		e.explainedPlans = map[int]bool{}
+		e.explainPlanInRowFormat(e.StmtPlan.(PhysicalPlan), "root", "", true)
+	case ast.ExplainFormatDOT:
+		e.prepareDotInfo(e.StmtPlan.(PhysicalPlan))
+	default:
+		return errors.Errorf("explain format '%s' is not supported now", e.Format)
+	}
+	return nil
 }
 
 // explainPlanInRowFormat generates explain information for root-tasks.

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -448,11 +448,11 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 	count := string(strconv.AppendFloat([]byte{}, p.statsInfo().RowCount, 'f', 2, 64))
 	row := []string{e.prettyIdentifier(p.ExplainID(), indent, isLastChild), count, taskType, operatorInfo}
 	if e.Analyze {
-		runtimeStat := e.ctx.GetSessionVars().StmtCtx.RuntimeStats
+		runtimeStatsColl := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
 		if taskType == "cop" {
 			row = append(row, "") //TODO: wait collect resp from tikv
 		} else {
-			row = append(row, runtimeStat.GetRuntimeStat(p.ExplainID()).String())
+			row = append(row, runtimeStatsColl.GetRuntimeStat(p.ExplainID()).String())
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1503,7 +1503,7 @@ func (b *PlanBuilder) buildExplain(explain *ast.ExplainStmt) (Plan, error) {
 		case ast.ExplainFormatROW:
 			retFields := []string{"id", "count", "task", "operator info"}
 			if explain.Analyze {
-				retFields = append(retFields, "execution_info")
+				retFields = append(retFields, "execution info")
 			}
 			schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
 			for _, fieldName := range retFields {
@@ -1513,7 +1513,7 @@ func (b *PlanBuilder) buildExplain(explain *ast.ExplainStmt) (Plan, error) {
 			p.explainedPlans = map[int]bool{}
 			p.explainPlanInRowFormat(p.StmtPlan.(PhysicalPlan), "root", "", true)
 			if explain.Analyze {
-				b.ctx.GetSessionVars().StmtCtx.RuntimeStats = nil
+				b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = nil
 			}
 		case ast.ExplainFormatDOT:
 			retFields := []string{"dot contents"}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1496,37 +1496,11 @@ func (b *PlanBuilder) buildExplain(explain *ast.ExplainStmt) (Plan, error) {
 			return nil, ErrUnsupportedType.GenWithStackByArgs(targetPlan)
 		}
 	}
-	p := &Explain{StmtPlan: pp, Analyze: explain.Analyze, ExecStmt: explain.Stmt, ExecPlan: targetPlan}
+	p := &Explain{StmtPlan: pp, Analyze: explain.Analyze, Format: explain.Format, ExecStmt: explain.Stmt, ExecPlan: targetPlan}
 	p.ctx = b.ctx
-	p.PrepareRows = func() error {
-		switch strings.ToLower(explain.Format) {
-		case ast.ExplainFormatROW:
-			retFields := []string{"id", "count", "task", "operator info"}
-			if explain.Analyze {
-				retFields = append(retFields, "execution info")
-			}
-			schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
-			for _, fieldName := range retFields {
-				schema.Append(buildColumn("", fieldName, mysql.TypeString, mysql.MaxBlobWidth))
-			}
-			p.SetSchema(schema)
-			p.explainedPlans = map[int]bool{}
-			p.explainPlanInRowFormat(p.StmtPlan.(PhysicalPlan), "root", "", true)
-			if explain.Analyze {
-				b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = nil
-			}
-		case ast.ExplainFormatDOT:
-			retFields := []string{"dot contents"}
-			schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
-			for _, fieldName := range retFields {
-				schema.Append(buildColumn("", fieldName, mysql.TypeString, mysql.MaxBlobWidth))
-			}
-			p.SetSchema(schema)
-			p.prepareDotInfo(p.StmtPlan.(PhysicalPlan))
-		default:
-			return errors.Errorf("explain format '%s' is not supported now", explain.Format)
-		}
-		return nil
+	err = p.prepareSchema()
+	if err != nil {
+		return nil, err
 	}
 	return p, nil
 }

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -73,13 +73,13 @@ type StatementContext struct {
 	}
 
 	// Copied from SessionVars.TimeZone.
-	TimeZone     *time.Location
-	Priority     mysql.PriorityEnum
-	NotFillCache bool
-	MemTracker   *memory.Tracker
-	RuntimeStats execdetails.RuntimeStats
-	TableIDs     []int64
-	IndexIDs     []int64
+	TimeZone         *time.Location
+	Priority         mysql.PriorityEnum
+	NotFillCache     bool
+	MemTracker       *memory.Tracker
+	RuntimeStatsColl *execdetails.RuntimeStatsColl
+	TableIDs         []int64
+	IndexIDs         []int64
 }
 
 // AddAffectedRows adds affected rows.

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -71,16 +71,13 @@ type RuntimeStats struct {
 	rows int64
 }
 
-// NewRuntimeStats creates new executor collector.
-func NewRuntimeStats() *RuntimeStatsColl {
+// NewRuntimeStatsColl creates new executor collector.
+func NewRuntimeStatsColl() *RuntimeStatsColl {
 	return &RuntimeStatsColl{stats: make(map[string]*RuntimeStats)}
 }
 
-// GetRuntimeStat gets execStat for a executor.
-func (e *RuntimeStatsColl) GetRuntimeStat(planID string) *RuntimeStats {
-	if e == nil {
-		return nil
-	}
+// Get gets execStat for a executor.
+func (e *RuntimeStatsColl) Get(planID string) *RuntimeStats {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	runtimeStats, exists := e.stats[planID]

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -99,5 +99,5 @@ func (e *RuntimeStats) String() string {
 	if e == nil {
 		return ""
 	}
-	return fmt.Sprintf("time:%fms, loops:%d, rows:%d", time.Duration(e.consume).Seconds()*1e3, e.loop, e.rows)
+	return fmt.Sprintf("time:%v, loops:%d, rows:%d", time.Duration(e.consume), e.loop, e.rows)
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

this PR address the contiune comments in #7827 

the mainly change are:

- protect runtimeStats with mutex, `explain analyze` is infrequently operation but executor maybe uder concurrent execution.
- forbidden collect stats of the IndexLookupExecutor that owned by  table worker, it seems no other executor like this one - -
- refactor explainBuilder/explainExec, push render data & analyze logic down to explainExec
- rename some variable/struct

### What is changed and how it works?

- RT

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Old test

Code changes

 - impl refactor

Side effects

 - no

Related changes

 - Need to cherry-pick to 2.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/7888)
<!-- Reviewable:end -->
