### PR TITLE
binlog: update vendor for pump client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -299,7 +299,7 @@
   revision = "eed819b6999186a4bf2d25255f8d61b371a450d6"
 
 [[projects]]
-  digest = "1:092e8028d95cfd9badd8625b3636b5c99a2d941ce0cea8a63f91a4fb54b4438a"
+  digest = "1:29a09d9b9b319c795fb861fd19b62d27995995b9c1395de3ac2255ab5799a839"
   name = "github.com/pingcap/tidb-tools"
   packages = [
     "pkg/etcd",
@@ -308,7 +308,7 @@
     "tidb-binlog/pump_client",
   ]
   pruneopts = "NUT"
-  revision = "ff0ddbf51b5744cca6d426b892a5dac5aa97a014"
+  revision = "8b1ff6f60738cf3fb5638684b3e74040ed87221f"
 
 [[projects]]
   branch = "master"
@@ -555,6 +555,7 @@
     "github.com/pingcap/kvproto/pkg/metapb",
     "github.com/pingcap/kvproto/pkg/tikvpb",
     "github.com/pingcap/pd/pd-client",
+    "github.com/pingcap/tidb-tools/tidb-binlog/node",
     "github.com/pingcap/tidb-tools/tidb-binlog/pump_client",
     "github.com/pingcap/tipb/go-binlog",
     "github.com/pingcap/tipb/go-mysqlx",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -80,4 +80,4 @@ ignored = ["github.com/coreos/etcd/etcdserver", "github.com/coreos/etcd/mvcc", "
 
 [[constraint]]
   name = "github.com/pingcap/tidb-tools"
-  revision = "ff0ddbf51b5744cca6d426b892a5dac5aa97a014"
+  revision = "8b1ff6f60738cf3fb5638684b3e74040ed87221f"

--- a/vendor/github.com/pingcap/tidb-tools/tidb-binlog/pump_client/client.go
+++ b/vendor/github.com/pingcap/tidb-tools/tidb-binlog/pump_client/client.go
@@ -224,7 +224,7 @@ func (c *PumpsClient) WriteBinlog(binlog *pb.Binlog) error {
 			// every pump can retry 5 times, if retry 5 times and still failed, set this pump unavaliable, and choose a new pump.
 			if (retryTime+1)%5 == 0 {
 				c.setPumpAvaliable(pump, false)
-				pump = c.Selector.Next(pump, binlog, retryTime/5+1)
+				pump = c.Selector.Next(binlog, retryTime/5+1)
 				Logger.Debugf("[pumps client] avaliable pumps: %v, write binlog choose pump %v", c.Pumps.AvaliablePumps, pump)
 			}
 


### PR DESCRIPTION
### What problem does this PR solve? 
update vendor for pump client

### What is changed and how it works?
remove tidb-tools's info in Gopkg.toml, and then 
dep ensure -add github.com/pingcap/tidb-tools/tidb-binlog/pump_client@8b1ff6f60738cf3fb5638684b3e74040ed87221f
sh hack/clean_vendor.sh
