### PR TITLE
expression: maintain `DeferredExpr` in aggressive constant folding.

### DIFF
--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -15,7 +15,6 @@ package expression
 
 import (
 	"github.com/pingcap/tidb/ast"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/7914

### What is changed and how it works?

Store `DeferredExpr` in folded constant for `ScalarFunction` according to whether its arguments are deferred;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch