### PR TITLE
expression: maintain `DeferredExpr` in aggressive constant folding.

### DIFF
--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -118,9 +118,15 @@ func foldConstant(expr Expression) (Expression, bool) {
 				return expr, isDeferredConst
 			}
 			if value.IsNull() {
+				if isDeferredConst {
+					return &Constant{Value: value, RetType: x.RetType, DeferredExpr: x}, true
+				}
 				return &Constant{Value: value, RetType: x.RetType}, false
 			}
 			if isTrue, err := value.ToBool(sc); err == nil && isTrue == 0 {
+				if isDeferredConst {
+					return &Constant{Value: value, RetType: x.RetType, DeferredExpr: x}, true
+				}
 				return &Constant{Value: value, RetType: x.RetType}, false
 			}
 			return expr, isDeferredConst


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Cherry-picked from https://github.com/pingcap/tidb/pull/7915

### What is changed and how it works?

Store `DeferredExpr` in folded constant for `ScalarFunction` according to whether its arguments are deferred;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

N/A

Related changes

N/A