### PR TITLE
stats: fix panic caused by empty histogram (#7912)

### DIFF
--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -679,7 +679,7 @@ func (hg *Histogram) AvgCountPerValue(totalCount int64) float64 {
 }
 
 func (hg *Histogram) outOfRange(val types.Datum) bool {
-	if hg.Bounds == nil {
+	if hg.Len() == 0 {
 		return true
 	}
 	return chunk.Compare(hg.Bounds.GetRow(0), 0, &val) > 0 ||
@@ -858,7 +858,7 @@ func (idx *Index) getRowCount(sc *stmtctx.StatementContext, indexRanges []*range
 }
 
 func (idx *Index) outOfRange(val types.Datum) bool {
-	if idx.Bounds == nil {
+	if idx.Histogram.Len() == 0 {
 		return true
 	}
 	withInLowBoundOrPrefixMatch := chunk.Compare(idx.Bounds.GetRow(0), 0, &val) <= 0 ||

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -292,6 +292,18 @@ func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
 	count, err = statsTbl.GetRowCountByIndexRanges(sc, idxID, getRange(9, 30))
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, 2.2)
+
+	testKit.MustExec("truncate table t")
+	testKit.MustExec("insert into t values (null, null)")
+	testKit.MustExec("analyze table t")
+	table, err = s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	statsTbl = h.GetTableStats(table.Meta())
+
+	colID = table.Meta().Columns[0].ID
+	count, err = statsTbl.GetRowCountByColumnRanges(sc, colID, getRange(1, 30))
+	c.Assert(err, IsNil)
+	c.Assert(count, Equals, 0.0)
 }
 
 func BenchmarkSelectivity(b *testing.B) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Cherry pick #7912 
### What is changed and how it works?

Cherry pick #7912 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - None
