### PR TITLE
planner, executor: refine ColumnPrune for LogicalUnionAll

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1057,6 +1057,20 @@ func (s *testSuite) TestUnion(c *C) {
 
 	tk.MustQuery("select 1 union select 1 union all select 1").Check(testkit.Rows("1", "1"))
 	tk.MustQuery("select 1 union all select 1 union select 1").Check(testkit.Rows("1"))
+
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec(`create table t1(a bigint, b bigint);`)
+	tk.MustExec(`create table t2(a bigint, b bigint);`)
+	tk.MustExec(`insert into t1 values(1, 1);`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t1 select * from t1;`)
+	tk.MustExec(`insert into t2 values(1, 1);`)
+	tk.MustExec(`set @@tidb_max_chunk_size=2;`)
+	tk.MustQuery(`select count(*) from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;`).Check(testkit.Rows("128"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1071,6 +1071,7 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec(`insert into t2 values(1, 1);`)
 	tk.MustExec(`set @@tidb_max_chunk_size=2;`)
 	tk.MustQuery(`select count(*) from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;`).Check(testkit.Rows("128"))
+	tk.MustQuery(`select tmp.a, count(*) from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;`).Check(testkit.Rows("1 128"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -129,6 +129,13 @@ func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) {
 
 // PruneColumns implements LogicalPlan interface.
 func (p *LogicalUnionAll) PruneColumns(parentUsedCols []*expression.Column) {
+	used := getUsedList(parentUsedCols, p.schema)
+	for i := range used{
+		if used[i]{
+			continue
+		}
+		parentUsedCols = append(parentUsedCols, p.schema.Columns[i])
+	}
 	for _, child := range p.Children() {
 		child.PruneColumns(parentUsedCols)
 	}

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -130,8 +130,8 @@ func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) {
 // PruneColumns implements LogicalPlan interface.
 func (p *LogicalUnionAll) PruneColumns(parentUsedCols []*expression.Column) {
 	used := getUsedList(parentUsedCols, p.schema)
-	for i := range used{
-		if used[i]{
+	for i := range used {
+		if used[i] {
 			continue
 		}
 		parentUsedCols = append(parentUsedCols, p.schema.Columns[i])

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -130,11 +130,13 @@ func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) {
 // PruneColumns implements LogicalPlan interface.
 func (p *LogicalUnionAll) PruneColumns(parentUsedCols []*expression.Column) {
 	used := getUsedList(parentUsedCols, p.schema)
+	hasBeenUsed := false
 	for i := range used {
-		if used[i] {
-			continue
-		}
-		parentUsedCols = append(parentUsedCols, p.schema.Columns[i])
+		hasBeenUsed = hasBeenUsed || used[i]
+	}
+	if !hasBeenUsed {
+		parentUsedCols = make([]*expression.Column, len(p.schema.Columns))
+		copy(parentUsedCols, p.schema.Columns)
 	}
 	for _, child := range p.Children() {
 		child.PruneColumns(parentUsedCols)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
``` sql
create table t1(a bigint, b bigint);
create table t2(a bigint, b bigint);
insert into t1 values(1, 1);
insert into t1 select * from t1; -- repeat this sql 10 times
insert into t2 values(1, 1);

set @@tidb_max_chunk_size=2;
select 1, 1 from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;  -- panic
```

### What is changed and how it works?
Schema of the parent node upon Union is empty, so after ColumnPruning,
Union.Schema will be empty.
When calling UnionExec.Next(), we'll use chk.SwapColumns() to swap the chunk of UnionExec.newFirstChunk()`(whose column length is 0)` with UnionExec.Child.newFirstChunk()`(whose column length is 2)`. And this will cause the panic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects

Related changes

 - Need to cherry-pick to the release branch
