### PR TITLE
stats: limit the length of sample values

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -15,9 +15,12 @@ package executor_test
 
 import (
 	"fmt"
+	"strings"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/model"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testkit"
@@ -106,4 +109,22 @@ func (s *testSuite) TestAnalyzeParameters(c *C) {
 	tk.MustExec("analyze table t with 4 buckets")
 	tbl = s.domain.StatsHandle().GetTableStats(tableInfo)
 	c.Assert(tbl.Columns[1].Len(), Equals, 4)
+}
+
+func (s *testSuite) TestAnalyzeTooLongColumns(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a json)")
+	value := fmt.Sprintf(`{"x":"%s"}`, strings.Repeat("x", mysql.MaxFieldVarCharLength))
+	tk.MustExec(fmt.Sprintf("insert into t values ('%s')", value))
+
+	tk.MustExec("analyze table t")
+	is := executor.GetInfoSchema(tk.Se.(sessionctx.Context))
+	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	tableInfo := table.Meta()
+	tbl := s.domain.StatsHandle().GetTableStats(tableInfo)
+	c.Assert(tbl.Columns[1].Len(), Equals, 0)
+	c.Assert(tbl.Columns[1].TotColSize, Equals, int64(65559))
 }

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 
 	"github.com/pingcap/tidb/ast"
+	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/types"
@@ -73,6 +74,8 @@ func SampleCollectorToProto(c *SampleCollector) *tipb.SampleCollector {
 	return collector
 }
 
+const maxSampleValueLength = mysql.MaxFieldVarCharLength / 2
+
 // SampleCollectorFromProto converts SampleCollector from its protobuf representation.
 func SampleCollectorFromProto(collector *tipb.SampleCollector) *SampleCollector {
 	s := &SampleCollector{
@@ -85,7 +88,10 @@ func SampleCollectorFromProto(collector *tipb.SampleCollector) *SampleCollector 
 	}
 	s.CMSketch = CMSketchFromProto(collector.CmSketch)
 	for _, val := range collector.Samples {
-		s.Samples = append(s.Samples, types.NewBytesDatum(val))
+		// When store the histogram bucket boundaries to kv, we need to limit the length of the value.
+		if len(val) <= maxSampleValueLength {
+			s.Samples = append(s.Samples, types.NewBytesDatum(val))
+		}
 	}
 	return s
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
[types:1406]Data too long for column 'upper_bound' at row 1
github.com/pingcap/tidb/vendor/github.com/pkg/errors.AddStack
        /go/src/github.com/pingcap/tidb/vendor/github.com/pkg/errors/errors.go:173
github.com/pingcap/tidb/terror.(*Error).GenWithStack
        /go/src/github.com/pingcap/tidb/terror/terror.go:224
github.com/pingcap/tidb/executor.resetErrDataTooLong
        /go/src/github.com/pingcap/tidb/executor/write.go:186
github.com/pingcap/tidb/executor.(*InsertValues).handleErr
        /go/src/github.com/pingcap/tidb/executor/insert_common.go:175
github.com/pingcap/tidb/executor.(*InsertValues).getRow
        /go/src/github.com/pingcap/tidb/executor/insert_common.go:210
github.com/pingcap/tidb/executor.(*InsertValues).insertRows
        /go/src/github.com/pingcap/tidb/executor/insert_common.go:161
github.com/pingcap/tidb/executor.(*InsertExec).Next
        /go/src/github.com/pingcap/tidb/executor/insert.go:145
github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor
        /go/src/github.com/pingcap/tidb/executor/adapter.go:273
github.com/pingcap/tidb/executor.(*ExecStmt).Exec
        /go/src/github.com/pingcap/tidb/executor/adapter.go:233
github.com/pingcap/tidb/session.runStmt
        /go/src/github.com/pingcap/tidb/session/tidb.go:148
github.com/pingcap/tidb/session.(*session).executeStatement
        /go/src/github.com/pingcap/tidb/session/session.go:734
github.com/pingcap/tidb/session.(*session).execute
        /go/src/github.com/pingcap/tidb/session/session.go:805
github.com/pingcap/tidb/session.(*session).Execute
        /go/src/github.com/pingcap/tidb/session/session.go:755
github.com/pingcap/tidb/statistics.(*Handle).SaveStatsToStorage
        /go/src/github.com/pingcap/tidb/statistics/histogram.go:262
github.com/pingcap/tidb/executor.(*AnalyzeExec).Next
        /go/src/github.com/pingcap/tidb/executor/analyze.go:80
```

### What is changed and how it works?

Since we store all the histogram buckets info in `mysql.stats_buckets`, and the `lower_bound` and `upper_bound` could only store at most 64k, so we need to limit the length of data length of the collected samples, which will be used to build histograms. For index, we do not need to worry because their size is much smaller than the limit.

For https://github.com/pingcap/tidb/issues/7868.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

- None

Related changes

- None

PTAL @zz-jason @winoros @eurekaka @lzmhhh123 