### PR TITLE
executor: fix panic when limit is too large

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -711,6 +711,10 @@ func (s *testSuite) TestSelectOrderBy(c *C) {
 	r = tk.MustQuery("select * from select_order_test order by name, id limit 1 offset 100;")
 	r.Check(testkit.Rows())
 
+	// Test limit exceeds int range.
+	r = tk.MustQuery("select id from select_order_test order by name, id limit 18446744073709551615;")
+	r.Check(testkit.Rows("1", "2"))
+
 	// Test multiple field
 	r = tk.MustQuery("select id, name from select_order_test where id = 1 group by id, name limit 1 offset 0;")
 	r.Check(testkit.Rows("1 hello"))

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -227,7 +227,7 @@ func (e *SortExec) keyChunksLess(i, j int) bool {
 type TopNExec struct {
 	SortExec
 	limit      *plannercore.PhysicalLimit
-	totalLimit int
+	totalLimit uint64
 
 	chkHeap *topNChunkHeap
 }
@@ -307,7 +307,7 @@ func (e *TopNExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 	chk.Reset()
 	if !e.fetched {
-		e.totalLimit = int(e.limit.Offset + e.limit.Count)
+		e.totalLimit = e.limit.Offset + e.limit.Count
 		e.Idx = int(e.limit.Offset)
 		err := e.loadChunksUntilTotalLimit(ctx)
 		if err != nil {
@@ -335,7 +335,7 @@ func (e *TopNExec) loadChunksUntilTotalLimit(ctx context.Context) error {
 	e.rowChunks = chunk.NewList(e.retTypes(), e.initCap, e.maxChunkSize)
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel("rowChunks")
-	for e.rowChunks.Len() < e.totalLimit {
+	for uint64(e.rowChunks.Len()) < e.totalLimit {
 		srcChk := e.children[0].newFirstChunk()
 		err := e.children[0].Next(ctx, srcChk)
 		if err != nil {
@@ -363,7 +363,7 @@ const topNCompactionFactor = 4
 
 func (e *TopNExec) executeTopN(ctx context.Context) error {
 	heap.Init(e.chkHeap)
-	for len(e.rowPtrs) > e.totalLimit {
+	for uint64(len(e.rowPtrs)) > e.totalLimit {
 		// The number of rows we loaded may exceeds total limit, remove greatest rows by Pop.
 		heap.Pop(e.chkHeap)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When limit is too large. `TopN.totalLimit` will overflow int and got panicked.

### What is changed and how it works?

Let `TopN.totalLimit` become uint64.

Let me know if you have better idea.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
