### PR TITLE
executor: let information_schema be the first database in ShowDatabases

### DIFF
--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -110,3 +110,33 @@ func (s *pkgTestSuite) TestNestedLoopApply(c *C) {
 		}
 	}
 }
+
+func (s *pkgTestSuite) TestMoveInfoSchemaToFront(c *C) {
+	dbss := [][]string{
+		{},
+		{"A", "B", "C", "a", "b", "c"},
+		{"A", "B", "C", "INFORMATION_SCHEMA"},
+		{"A", "B", "INFORMATION_SCHEMA", "a"},
+		{"INFORMATION_SCHEMA"},
+		{"A", "B", "C", "INFORMATION_SCHEMA", "a", "b"},
+	}
+	wanted := [][]string{
+		{},
+		{"A", "B", "C", "a", "b", "c"},
+		{"INFORMATION_SCHEMA", "A", "B", "C"},
+		{"INFORMATION_SCHEMA", "A", "B", "a"},
+		{"INFORMATION_SCHEMA"},
+		{"INFORMATION_SCHEMA", "A", "B", "C", "a", "b"},
+	}
+
+	for _, dbs := range dbss {
+		moveInfoSchemaToFront(dbs)
+	}
+
+	for i, dbs := range wanted {
+		c.Check(len(dbss[i]), Equals, len(dbs))
+		for j, db := range dbs {
+			c.Check(dbss[i][j], Equals, db)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
show databases;
INFORMATION_SCHEMA is not first database

### What is changed and how it works?
Add one function to replace INFORMATION_SCHEMA to the first database if the first database is not INFORMATION_SCHEMA

### Check List
Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
