### PR TITLE
eliminate ifnull on not null column in expression rewriting process

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -420,5 +420,10 @@ id	count	task	operator info
 Projection_3	10000.00	root	plus(1, ifnull(test.t.a, 0))
 └─TableReader_5	10000.00	root	data:TableScan_4
   └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-drop table if exists t;
+explain select 1+ifnull(nb, 0) from t where nb=1;
+id	count	task	operator info
+Projection_4	10.00	root	plus(1, test.t.nb)
+└─TableReader_7	10.00	root	data:Selection_6
+  └─Selection_6	10.00	cop	eq(test.t.nb, 1)
+    └─TableScan_5	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -92,4 +92,5 @@ explain select ifnull(a, 0), ifnull(nb, 0) from t;
 explain select ifnull(nb, 0), ifnull(nb, 0) from t;
 explain select 1+ifnull(nb, 0) from t;
 explain select 1+ifnull(a, 0) from t;
+explain select 1+ifnull(nb, 0) from t where nb=1;
 drop table if exists t;

--- a/expression/column.go
+++ b/expression/column.go
@@ -160,6 +160,10 @@ type Column struct {
 	// Index is used for execution, to tell the column's position in the given row.
 	Index int
 
+	// Flag is a flag comes from model.ColumnInfo. We maintain here mainly because we
+	// want to eliminate ifnull on not null column.
+	Flag uint
+
 	hashcode []byte
 }
 

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -311,6 +311,7 @@ func ColumnInfos2ColumnsWithDBName(ctx sessionctx.Context, dbName, tblName model
 			ColName:  col.Name,
 			TblName:  tblName,
 			DBName:   dbName,
+			Flag:     col.Flag,
 			RetType:  &col.FieldType,
 			ID:       col.ID,
 			UniqueID: ctx.GetSessionVars().AllocPlanColumnID(),

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -576,37 +576,6 @@ func (b *PlanBuilder) buildProjectionField(id, position int, field *ast.SelectFi
 	}
 }
 
-func eliminateIfNullOnNotNullCol(p LogicalPlan, expr expression.Expression) expression.Expression {
-	ds, isDs := p.(*DataSource)
-	if !isDs {
-		return expr
-	}
-
-	scalarExpr, isScalarFunc := expr.(*expression.ScalarFunction)
-	if !isScalarFunc {
-		return expr
-	}
-	exprChildren := scalarExpr.GetArgs()
-	for i := 0; i < len(exprChildren); i++ {
-		exprChildren[i] = eliminateIfNullOnNotNullCol(p, exprChildren[i])
-	}
-
-	if scalarExpr.FuncName.L != ast.Ifnull {
-		return expr
-	}
-	colRef, isColRef := exprChildren[0].(*expression.Column)
-	if !isColRef {
-		return expr
-	}
-
-	colInfo := model.FindColumnInfo(ds.Columns, colRef.ColName.L)
-	if !mysql.HasNotNullFlag(colInfo.Flag) {
-		return expr
-	}
-
-	return colRef
-}
-
 // buildProjection returns a Projection plan and non-aux columns length.
 func (b *PlanBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int) (LogicalPlan, int, error) {
 	b.optFlag |= flagEliminateProjection
@@ -616,7 +585,6 @@ func (b *PlanBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 	oldLen := 0
 	for _, field := range fields {
 		newExpr, np, err := b.rewrite(field.Expr, p, mapper, true)
-		newExpr = eliminateIfNullOnNotNullCol(p, newExpr)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}
@@ -1874,6 +1842,7 @@ func (b *PlanBuilder) buildDataSource(tn *ast.TableName) (LogicalPlan, error) {
 			DBName:   dbName,
 			TblName:  tableInfo.Name,
 			ColName:  col.Name,
+			Flag:     col.Flag,
 			ID:       col.ID,
 			RetType:  &col.FieldType,
 		}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -486,6 +486,7 @@ func colInfoToColumn(db model.CIStr, tblName model.CIStr, asName model.CIStr, co
 		OrigTblName: tblName,
 		DBName:      db,
 		TblName:     tblName,
+		Flag:        col.Flag,
 		RetType:     &col.FieldType,
 		ID:          col.ID,
 		UniqueID:    int64(col.Offset),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
mysql> show create table t;
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                          |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) DEFAULT NULL,
  `nb` int(11) NOT NULL,
  `nc` int(11) NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
``` 

Before this PR, 
```
mysql> explain select 1+ifnull(nb, 0) from t where nb=1;
+-----------------------+----------+------+------------------------------------------------------------+
| id                    | count    | task | operator info                                              |
+-----------------------+----------+------+------------------------------------------------------------+
| Projection_4          | 10.00    | root | plus(1, ifnull(test.t.nb, 0))                                         |
| └─TableReader_7       | 10.00    | root | data:Selection_6                                           |
|   └─Selection_6       | 10.00    | cop  | eq(test.t.nb, 1)                                           |
|     └─TableScan_5     | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo |
+-----------------------+----------+------+------------------------------------------------------------+
4 rows in set (0.00 sec)
```
After,

```
mysql> explain select 1+ifnull(nb, 0) from t where nb=1;
+-----------------------+----------+------+------------------------------------------------------------+
| id                    | count    | task | operator info                                              |
+-----------------------+----------+------+------------------------------------------------------------+
| Projection_4          | 10.00    | root | plus(1, test.t.nb)                                         |
| └─TableReader_7       | 10.00    | root | data:Selection_6                                           |
|   └─Selection_6       | 10.00    | cop  | eq(test.t.nb, 1)                                           |
|     └─TableScan_5     | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo |
+-----------------------+----------+------+------------------------------------------------------------+
4 rows in set (0.00 sec)
```
### What is changed and how it works?
When converting model.ColumnInfo to expression.Column, we also pass flag info which can be used during epression rewriting stage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes
 - Need to cherry-pick to the release branch

