### PR TITLE
util: move disjoint set to util package

### DIFF
--- a/util/disjointset/int_set.go
+++ b/util/disjointset/int_set.go
@@ -1,0 +1,45 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disjointset
+
+type IntSet struct {
+	parent []int
+}
+
+func NewIntSet(size int) *IntSet {
+	p := make([]int, size)
+	for i := range p {
+		p[i] = i
+	}
+	return &IntSet{parent: p}
+}
+
+func (m *IntSet) Init(l int) {
+	m.parent = make([]int, l)
+	for i := range m.parent {
+		m.parent[i] = i
+	}
+}
+
+func (m *IntSet) AddRelation(a int, b int) {
+	m.parent[m.FindRoot(a)] = m.FindRoot(b)
+}
+
+func (m *IntSet) FindRoot(a int) int {
+	if a == m.parent[a] {
+		return a
+	}
+	m.parent[a] = m.FindRoot(m.parent[a])
+	return m.parent[a]
+}

--- a/util/disjointset/int_set_test.go
+++ b/util/disjointset/int_set_test.go
@@ -1,0 +1,57 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disjointset
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testDisjointSetSuite{})
+
+func TestT(t *testing.T) {
+	CustomVerboseFlag = true
+	TestingT(t)
+}
+
+type testDisjointSetSuite struct {
+}
+
+func (s *testDisjointSetSuite) TestIntDisjointSet(c *C) {
+	set := NewIntSet(5)
+	c.Assert(len(set.parent), Equals, 5)
+	for i := range set.parent {
+		c.Assert(set.parent[i], Equals, i)
+	}
+	set.Init(10)
+	c.Assert(len(set.parent), Equals, 10)
+	for i := range set.parent {
+		c.Assert(set.parent[i], Equals, i)
+	}
+	set.AddRelation(0, 1)
+	set.AddRelation(1, 3)
+	set.AddRelation(4, 2)
+	set.AddRelation(2, 6)
+	set.AddRelation(3, 5)
+	set.AddRelation(7, 8)
+	set.AddRelation(9, 6)
+	c.Assert(set.FindRoot(0), Equals, set.FindRoot(1))
+	c.Assert(set.FindRoot(3), Equals, set.FindRoot(1))
+	c.Assert(set.FindRoot(5), Equals, set.FindRoot(1))
+	c.Assert(set.FindRoot(2), Equals, set.FindRoot(4))
+	c.Assert(set.FindRoot(6), Equals, set.FindRoot(4))
+	c.Assert(set.FindRoot(9), Equals, set.FindRoot(2))
+	c.Assert(set.FindRoot(7), Equals, set.FindRoot(8))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Split the int disjoint set out from `expression` package. So it can be used in other package.

### What is changed and how it works?

Move it to `util` package

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
