### PR TITLE
privilege: Add USAGE for mysql compatibility

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -574,6 +574,7 @@ func (p *MySQLPrivilege) DBIsVisible(user, host, db string) bool {
 
 func (p *MySQLPrivilege) showGrants(user, host string) []string {
 	var gs []string
+	var hasUsage bool
 	// Show global grants
 	for _, record := range p.User {
 		if record.User == user && record.Host == host {
@@ -589,6 +590,7 @@ func (p *MySQLPrivilege) showGrants(user, host string) []string {
 	// Show db scope grants
 	for _, record := range p.DB {
 		if record.User == user && record.Host == host {
+			hasUsage = true
 			g := dbPrivToString(record.Privileges)
 			if len(g) > 0 {
 				s := fmt.Sprintf(`GRANT %s ON %s.* TO '%s'@'%s'`, g, record.DB, record.User, record.Host)
@@ -606,6 +608,11 @@ func (p *MySQLPrivilege) showGrants(user, host string) []string {
 				gs = append(gs, s)
 			}
 		}
+	}
+
+	if len(gs) == 0 && hasUsage {
+		s := fmt.Sprintf("GRANT USAGE ON *.* TO '%s'@'%s'", user, host)
+		gs = append(gs, s)
 	}
 	return gs
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, a user with only login privileges shows an empty string for GRANTS.  For MySQL compatibility, this should be the "USAGE" privilege.

Partially addresses https://github.com/pingcap/tidb/issues/7614

### What is changed and how it works?

Added output to say the user has 'usage' in the event they have a login.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Breaking backward compatibility

There is a chance apps could be broken expecting this behaviour.  For example, our test suite relied on the non-mysql behaviour and has been fixed.

Related changes

- May need to check the `tidb-ansible` repository
