### PR TITLE
planner: fix a sporadic panic due to the PR #7684 when using the prepared plan cache

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -125,6 +125,10 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	if _, ok := stmt.(ast.DDLNode); ok {
 		return ErrPrepareDDL
 	}
+	err = ResetContextOfStmt(e.ctx, stmt)
+	if err != nil {
+		return err
+	}
 	var extractor paramMarkerExtractor
 	stmt.Accept(&extractor)
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -399,7 +399,8 @@ func setGlobalVars() {
 	variable.SysVars[variable.TIDBMemQuotaQuery].Value = strconv.FormatInt(cfg.MemQuotaQuery, 10)
 	variable.SysVars["lower_case_table_names"].Value = strconv.Itoa(cfg.LowerCaseTableNames)
 
-	plannercore.SetPreparedPlanCache(cfg.PreparedPlanCache.Enabled)
+	// For CI environment we default enable prepare-plan-cache.
+	plannercore.SetPreparedPlanCache(config.CheckTableBeforeDrop || cfg.PreparedPlanCache.Enabled)
 	if plannercore.PreparedPlanCacheEnabled() {
 		plannercore.PreparedPlanCacheCapacity = cfg.PreparedPlanCache.Capacity
 	}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #8065

Fix the panics are occurred sporadically after merging the PR #7684 when using the prepared plan cache.

```
2018/10/19 09:40:58.035 conn.go:427: [error] lastCmd UPDATE usertable SET field9=? WHERE YCSB_KEY = ?, runtime error: index out of range, goroutine 531 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc0071d09c0, 0xc007301dff)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/conn.go:425 +0x10c
panic(0x11dddc0, 0x225f220)
    /usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/expression.(*builtinGetParamStringSig).evalString(0xc0080de400, 0x0, 0x0, 0x0, 0xc28114, 0xc0080de400, 0x15493a0, 0xc0072a2b60)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin_other.go:772 +0x1ec
github.com/pingcap/tidb/expression.(*ScalarFunction).EvalString(0xc00802f1d0, 0x15493a0, 0xc0072a2b60, 0x0, 0x0, 0x17, 0x0, 0x0, 0x116bf00, 0x86ede8)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/scalar_function.go:217 +0x4c
github.com/pingcap/tidb/expression.(*ScalarFunction).Eval(0xc00802f1d0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/scalar_function.go:189 +0x439
github.com/pingcap/tidb/expression.foldConstant(0x15486e0, 0xc0080c50a0, 0x1, 0xc007ec5821, 0x1)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/constant_fold.go:145 +0x107
github.com/pingcap/tidb/expression.foldConstant(0x1548860, 0xc00802f270, 0x12a78a0, 0x13a0401, 0xc00802f270)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/constant_fold.go:95 +0x5ac
github.com/pingcap/tidb/expression.FoldConstant(0x1548860, 0xc00802f270, 0x13a042d, 0x4)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/constant_fold.go:34 +0x35
github.com/pingcap/tidb/expression.BuildCastFunction(0x15493a0, 0xc0072a2b60, 0x15486e0, 0xc0080c50a0, 0xc008102000, 0x1548860, 0xc00802f220)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin_cast.go:1681 +0x2ba
github.com/pingcap/tidb/expression.WrapWithCastAsReal(0x15493a0, 0xc0072a2b60, 0x15486e0, 0xc0080c50a0, 0x1548860, 0xc00802f220)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin_cast.go:1709 +0x135
github.com/pingcap/tidb/expression.newBaseBuiltinFuncWithTp(0x15493a0, 0xc0072a2b60, 0xc0080a4b60, 0x2, 0x2, 0xc0080a4b00, 0xc007300b96, 0x2, 0x2, 0x0, ...)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin.go:74 +0x474
github.com/pingcap/tidb/expression.(*compareFunctionClass).generateCmpSigs(0xc00021f6b0, 0x15493a0, 0xc0072a2b60, 0xc0080a4b60, 0x2, 0x2, 0xc0080a4b01, 0x2, 0x2, 0x203002, ...)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin_compare.go:1169 +0xbb
github.com/pingcap/tidb/expression.(*compareFunctionClass).getFunction(0xc00021f6b0, 0x15493a0, 0xc0072a2b60, 0xc0080a4b40, 0x2, 0x2, 0x2, 0x2, 0xc00805fec0, 0x0)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/builtin_compare.go:1163 +0x178
github.com/pingcap/tidb/expression.NewFunction(0x15493a0, 0xc0072a2b60, 0x139f7f2, 0x2, 0xc00805fec0, 0xc007301040, 0x2, 0x2, 0xc0073010b8, 0x10, ...)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/expression/scalar_function.go:87 +0x210
github.com/pingcap/tidb/planner/core.(*expressionRewriter).constructBinaryOpFunction(0xc007f7b900, 0x1548620, 0xc00807ae00, 0x15486e0, 0xc0080c50a0, 0x139f7f2, 0x2, 0x2, 0x10, 0x0, ...)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:184 +0xcc7
github.com/pingcap/tidb/planner/core.(*expressionRewriter).binaryOpToExpression(0xc007f7b900, 0xc008056b60)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:914 +0xe8
github.com/pingcap/tidb/planner/core.(*expressionRewriter).Leave(0xc007f7b900, 0x151ac00, 0xc008056b60, 0x1532c80, 0xc007f73c80, 0x1)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/expression_rewriter.go:776 +0x8ec
github.com/pingcap/tidb/ast.(*BinaryOperationExpr).Accept(0xc008056b60, 0x1516b20, 0xc007f7b900, 0x1548920, 0xc0080a22c0, 0xc0073012e0)
    /home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/ast/expressions.go:227 +0x1a9
github.com/pingcap/tidb/planner/core.(*PlanBuilder).rewriteExprNode(0xc007eeb130, 0xc007f7b900, 0x1532700, 0xc008056b60, 0x13a6900, 0x9, 0x1548f20,
2018/10/19 09:40:58.035 server.go:316: [info] con:9 close connection
```

### What is changed and how it works?
Initialize UseCache of the statement context in BuildLogicalPlan 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - Enable the prepared plan cache in the TiDB configuration
```
[prepared-plan-cache]
enabled = true
capacity = 100
```
 - Deploy TiDB, TiKV, and PD with standalone mode
 - Create YCSB schema and user
```
create database ycsb;
use ycsb;
drop table usertable;

CREATE TABLE usertable (
    YCSB_KEY VARCHAR(255) PRIMARY KEY,
    FIELD0 TEXT, FIELD1 TEXT,
    FIELD2 TEXT, FIELD3 TEXT,
    FIELD4 TEXT, FIELD5 TEXT,
    FIELD6 TEXT, FIELD7 TEXT,
    FIELD8 TEXT, FIELD9 TEXT
) SHARD_ROW_ID_BITS = 2;

CREATE USER 'ycsb'@'localhost' IDENTIFIED BY 'pass';
CREATE USER 'ycsb'@'%' IDENTIFIED BY 'pass';
GRANT ALL ON *.* TO 'ycsb'@'localhost';
GRANT ALL ON *.* TO 'ycsb'@'%';
```

 - Load YCSB data
```
./bin/ycsb load jdbc \
        -P workloads/workloada \
        -s -p status.interval=10 \
        -p db.url='jdbc:mysql://127.0.0.1:4000/ycsb?useSSL=false&useServerPrepStmts=true&rewriteBatchedStatements=true' \
        -p db.driver=com.mysql.jdbc.Driver -p db.user=ycsb -p db.passwd=pass \
        -p jdbc.autocommit=true \
        -p recordcount=1000000 \
        -p jdbc.batchupdateapi=true \
        -p db.batchsize=100 \
        -threads 16
```
 - Run YCSB workloada (i.e., select : update = 1 : 1)
```
./bin/ycsb run jdbc \
        -P workloads/workloada \
        -s -p status.interval=10 \
        -p db.url='jdbc:mysql://127.0.0.1:4000/ycsb?useSSL=false&useServerPrepStmts=true&rewriteBatchedStatements=false' \
        -p db.driver=com.mysql.jdbc.Driver -p db.user=ycsb -p db.passwd=pass \
        -p jdbc.autocommit=true \
        -p operationcount=100000 \
        -target 1000 \
        -threads 10
```

Code changes

 - Has exported variable/fields change


Side effects

 - No

Related changes

 - Need to cherry-pick to the release branch