### PR TITLE
stats: use local feedback for partition table

### DIFF
--- a/statistics/update.go
+++ b/statistics/update.go
@@ -199,7 +199,7 @@ func (s *SessionStatsCollector) StoreQueryFeedback(feedback interface{}, h *Hand
 	s.Lock()
 	defer s.Unlock()
 	isIndex := q.tp == indexType
-	s.rateMap.update(q.tableID, q.hist.ID, rate, isIndex)
+	s.rateMap.update(q.physicalID, q.hist.ID, rate, isIndex)
 	if len(s.feedback) < MaxQueryFeedbackCount {
 		s.feedback = append(s.feedback, q)
 	}
@@ -367,7 +367,7 @@ func (h *Handle) DumpStatsFeedbackToKV() error {
 		if fb.tp == pkType {
 			err = h.dumpFeedbackToKV(fb)
 		} else {
-			t, ok := h.statsCache.Load().(statsCache)[fb.tableID]
+			t, ok := h.statsCache.Load().(statsCache)[fb.physicalID]
 			if ok {
 				err = dumpFeedbackForIndex(h, fb, t)
 			}
@@ -392,7 +392,7 @@ func (h *Handle) dumpFeedbackToKV(fb *QueryFeedback) error {
 		isIndex = 1
 	}
 	sql := fmt.Sprintf("insert into mysql.stats_feedback (table_id, hist_id, is_index, feedback) values "+
-		"(%d, %d, %d, X'%X')", fb.tableID, fb.hist.ID, isIndex, vals)
+		"(%d, %d, %d, X'%X')", fb.physicalID, fb.hist.ID, isIndex, vals)
 	h.mu.Lock()
 	_, err = h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	h.mu.Unlock()
@@ -416,11 +416,13 @@ func (h *Handle) UpdateStatsByLocalFeedback(is infoschema.InfoSchema) {
 	}
 	h.listHead.Unlock()
 	for _, fb := range h.feedback {
-		table, ok := is.TableByID(fb.tableID)
+		h.mu.Lock()
+		table, ok := h.getTableByPhysicalID(is, fb.physicalID)
+		h.mu.Unlock()
 		if !ok {
 			continue
 		}
-		tblStats := h.GetTableStats(table.Meta())
+		tblStats := h.GetPartitionStats(table.Meta(), fb.physicalID)
 		newTblStats := tblStats.copy()
 		if fb.tp == indexType {
 			idx, ok := tblStats.Indices[fb.hist.ID]

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -949,6 +949,41 @@ func (s *testStatsUpdateSuite) TestUpdateStatsByLocalFeedback(c *C) {
 	h.UpdateStatsByLocalFeedback(s.do.InfoSchema())
 }
 
+func (s *testStatsUpdateSuite) TestUpdatePartitionStatsByLocalFeedback(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	testKit := testkit.NewTestKit(c, s.store)
+	testKit.MustExec("use test")
+	testKit.MustExec("set @@session.tidb_enable_table_partition=1")
+	testKit.MustExec("create table t (a bigint(64), b bigint(64), primary key(a)) partition by range (a) (partition p0 values less than (6))")
+	testKit.MustExec("insert into t values (1,2),(2,2),(4,5)")
+	testKit.MustExec("analyze table t")
+	testKit.MustExec("insert into t values (3,5)")
+	h := s.do.StatsHandle()
+
+	oriProbability := statistics.FeedbackProbability
+	defer func() {
+		statistics.FeedbackProbability = oriProbability
+	}()
+	statistics.FeedbackProbability = 1
+
+	is := s.do.InfoSchema()
+	table, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+
+	testKit.MustQuery("select * from t where a > 1")
+
+	h.UpdateStatsByLocalFeedback(s.do.InfoSchema())
+
+	tblInfo := table.Meta()
+	pid := tblInfo.Partition.Definitions[0].ID
+	tbl := h.GetPartitionStats(tblInfo, pid)
+
+	c.Assert(tbl.Columns[tblInfo.Columns[0].ID].ToString(0), Equals, "column:1 ndv:3 totColSize:0\n"+
+		"num: 1 lower_bound: 1 upper_bound: 1 repeats: 1\n"+
+		"num: 1 lower_bound: 2 upper_bound: 2 repeats: 1\n"+
+		"num: 2 lower_bound: 3 upper_bound: 9223372036854775807 repeats: 0")
+}
+
 type logHook struct {
 	results string
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Partition table should be able to use the local feedback to refine their stats.
### What is changed and how it works?

When using the local feedback, first locate the table info by partition id, then use the table info and partition id to get the stats, which will be used to update later.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @winoros @eurekaka 