### PR TITLE
store/tikv: fix typo

### DIFF
--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -75,7 +75,7 @@ func (txn *tikvTxn) SetVars(vars *kv.Variables) {
 	txn.snapshot.vars = vars
 }
 
-// SetMemBufCap sets the transaction's MemBuffer capability, to reduce memory allocations.
+// SetCap sets the transaction's MemBuffer capability, to reduce memory allocations.
 func (txn *tikvTxn) SetCap(cap int) {
 	txn.us.SetCap(cap)
 }


### PR DESCRIPTION
Correct `SetCap` func's comment.