### PR TITLE
planner: eliminate ifnull in expression rewriting process

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -428,7 +428,88 @@ id	count	task	operator info
 Projection_3	10000.00	root	plus(1, ifnull(test.t.a, 0))
 └─TableReader_5	10000.00	root	data:TableScan_4
   └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-drop table if exists t;
+explain select 1+ifnull(nb, 0) from t where nb=1;
+id	count	task	operator info
+Projection_4	10.00	root	plus(1, test.t.nb)
+└─TableReader_7	10.00	root	data:Selection_6
+  └─Selection_6	10.00	cop	eq(test.t.nb, 1)
+    └─TableScan_5	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(ta.nb, 1) or ta.nb is null;
+id	count	task	operator info
+HashLeftJoin_7	8320.83	root	left outer join, inner:TableReader_12, equal:[eq(ta.nb, tb.nb)], left cond:[gt(ta.a, 1)]
+├─TableReader_10	6656.67	root	data:Selection_9
+│ └─Selection_9	6656.67	cop	or(ta.nb, isnull(ta.nb))
+│   └─TableScan_8	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
+└─TableReader_12	10000.00	root	data:TableScan_11
+  └─TableScan_11	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
+id	count	task	operator info
+HashRightJoin_7	6656.67	root	right outer join, inner:TableReader_10, equal:[eq(ta.nb, tb.nb)]
+├─TableReader_10	3333.33	root	data:Selection_9
+│ └─Selection_9	3333.33	cop	gt(ta.a, 1)
+│   └─TableScan_8	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
+└─TableReader_13	6656.67	root	data:Selection_12
+  └─Selection_12	6656.67	cop	or(tb.nb, isnull(tb.nb))
+    └─TableScan_11	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
+id	count	task	operator info
+HashRightJoin_8	4166.67	root	inner join, inner:TableReader_11, equal:[eq(ta.nb, tb.nb)]
+├─TableReader_11	3333.33	root	data:Selection_10
+│ └─Selection_10	3333.33	cop	gt(ta.a, 1)
+│   └─TableScan_9	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
+└─TableReader_14	6656.67	root	data:Selection_13
+  └─Selection_13	6656.67	cop	or(tb.nb, isnull(tb.nb))
+    └─TableScan_12	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
+id	count	task	operator info
+Projection_12	10000.00	root	9_aux_0
+└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, equal:[eq(test.t.nc, 7_col_0)]
+  ├─TableReader_16	10000.00	root	data:TableScan_15
+  │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
+    └─HashLeftJoin_20	8000.00	root	inner join, inner:HashAgg_30, equal:[eq(s.a, t1.a)]
+      ├─TableReader_24	8000.00	root	data:Selection_23
+      │ └─Selection_23	8000.00	cop	eq(s.a, test.t.a)
+      │   └─TableScan_22	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+      └─HashAgg_30	6400.00	root	group by:col_2, funcs:count(col_0), firstrow(col_1)
+        └─TableReader_31	6400.00	root	data:HashAgg_25
+          └─HashAgg_25	6400.00	cop	group by:t1.a, funcs:count(1), firstrow(t1.a)
+            └─Selection_29	8000.00	cop	eq(t1.a, test.t.a)
+              └─TableScan_28	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
+id	count	task	operator info
+Selection_7	10000.00	root	or(ifnull(tb.a, 1), isnull(tb.a))
+└─HashLeftJoin_8	12500.00	root	left outer join, inner:TableReader_12, equal:[eq(ta.nb, tb.nb)], left cond:[gt(ta.a, 1)]
+  ├─TableReader_10	10000.00	root	data:TableScan_9
+  │ └─TableScan_9	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─TableReader_12	10000.00	root	data:TableScan_11
+    └─TableScan_11	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
+id	count	task	operator info
+HashRightJoin_7	8000.00	root	right outer join, inner:TableReader_10, equal:[eq(ta.nb, tb.nb)]
+├─TableReader_10	3333.33	root	data:Selection_9
+│ └─Selection_9	3333.33	cop	gt(ta.a, 1)
+│   └─TableScan_8	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
+└─TableReader_13	8000.00	root	data:Selection_12
+  └─Selection_12	8000.00	cop	or(ifnull(tb.a, 1), isnull(tb.a))
+    └─TableScan_11	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
+id	count	task	operator info
+Projection_14	10000.00	root	9_aux_0
+└─Apply_16	10000.00	root	left outer semi join, inner:Projection_20, equal:[eq(ifnull(test.t.a, 1), 7_col_0)]
+  ├─Projection_17	10000.00	root	test.t.a, ifnull(test.t.a, 1)
+  │ └─TableReader_19	10000.00	root	data:TableScan_18
+  │   └─TableScan_18	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_23	1.00	root	funcs:count(join_agg_0)
+    └─HashLeftJoin_24	8000.00	root	inner join, inner:HashAgg_34, equal:[eq(s.a, t1.a)]
+      ├─TableReader_28	8000.00	root	data:Selection_27
+      │ └─Selection_27	8000.00	cop	eq(s.a, test.t.a)
+      │   └─TableScan_26	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+      └─HashAgg_34	6400.00	root	group by:col_2, funcs:count(col_0), firstrow(col_1)
+        └─TableReader_35	6400.00	root	data:HashAgg_29
+          └─HashAgg_29	6400.00	cop	group by:t1.a, funcs:count(1), firstrow(t1.a)
+            └─Selection_33	8000.00	cop	eq(t1.a, test.t.a)
+              └─TableScan_32	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -92,7 +92,17 @@ explain select ifnull(a, 0), ifnull(nb, 0) from t;
 explain select ifnull(nb, 0), ifnull(nb, 0) from t;
 explain select 1+ifnull(nb, 0) from t;
 explain select 1+ifnull(a, 0) from t;
-drop table if exists t;
+explain select 1+ifnull(nb, 0) from t where nb=1;
+# ifnull can be eliminated
+explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(ta.nb, 1) or ta.nb is null;
+explain select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
+explain select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
+explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
+# ifnull cannot be eliminated
+explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
+explain select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
+# when it comes to inner join case, ifnull can always be eliminated on not null column
+explain select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1174,6 +1174,24 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 // Otherwise it should return false to indicate (the caller) that original behavior needs to be performed.
 func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 	switch v.FnName.L {
+	// when column is not null, ifnull on such column is not necessary.
+	case ast.Ifnull:
+		if len(v.Args) != 2 {
+			er.err = expression.ErrIncorrectParameterCount.GenWithStackByArgs(v.FnName.O)
+			return true
+		}
+		stackLen := len(er.ctxStack)
+		arg1 := er.ctxStack[stackLen-2]
+		newArg1, isColumn := arg1.(*expression.Column)
+		// if expr1 is a column and column has not null flag, then we can eliminate ifnull on
+		// this column.
+		if isColumn && mysql.HasNotNullFlag(newArg1.RetType.Flag) {
+			er.ctxStack = er.ctxStack[:stackLen-len(v.Args)]
+			er.ctxStack = append(er.ctxStack, newArg1)
+			return true
+		}
+
+		return false
 	case ast.Nullif:
 		if len(v.Args) != 2 {
 			er.err = expression.ErrIncorrectParameterCount.GenWithStackByArgs(v.FnName.O)
@@ -1216,9 +1234,11 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 	if er.err != nil {
 		return
 	}
+
 	if er.rewriteFuncCall(v) {
 		return
 	}
+
 	var function expression.Expression
 	function, er.err = expression.NewFunction(er.ctx, v.FnName.L, &v.Type, args...)
 	er.ctxStack = er.ctxStack[:stackLen-len(v.Args)]

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -272,6 +272,16 @@ func (p *LogicalJoin) setPreferredJoinType(hintInfo *tableHintInfo) error {
 	return nil
 }
 
+func resetNotNullFlag(schema *expression.Schema, start, end int) {
+	for i := start; i < end; i++ {
+		col := *schema.Columns[i]
+		newFieldType := *col.RetType
+		newFieldType.Flag &= ^mysql.NotNullFlag
+		col.RetType = &newFieldType
+		schema.Columns[i] = &col
+	}
+}
+
 func (b *PlanBuilder) buildJoin(joinNode *ast.Join) (LogicalPlan, error) {
 	// We will construct a "Join" node for some statements like "INSERT",
 	// "DELETE", "UPDATE", "REPLACE". For this scenario "joinNode.Right" is nil
@@ -300,8 +310,10 @@ func (b *PlanBuilder) buildJoin(joinNode *ast.Join) (LogicalPlan, error) {
 	switch joinNode.Tp {
 	case ast.LeftJoin:
 		joinPlan.JoinType = LeftOuterJoin
+		resetNotNullFlag(joinPlan.schema, leftPlan.Schema().Len(), joinPlan.schema.Len())
 	case ast.RightJoin:
 		joinPlan.JoinType = RightOuterJoin
+		resetNotNullFlag(joinPlan.schema, 0, leftPlan.Schema().Len()-1)
 	default:
 		joinPlan.JoinType = InnerJoin
 	}
@@ -459,6 +471,7 @@ func (b *PlanBuilder) buildSelection(p LogicalPlan, where ast.ExprNode, AggMappe
 	if b.curClause != havingClause {
 		b.curClause = whereClause
 	}
+
 	conditions := splitWhere(where)
 	expressions := make([]expression.Expression, 0, len(conditions))
 	selection := LogicalSelection{}.Init(b.ctx)
@@ -578,37 +591,6 @@ func (b *PlanBuilder) buildProjectionField(id, position int, field *ast.SelectFi
 	}
 }
 
-func eliminateIfNullOnNotNullCol(p LogicalPlan, expr expression.Expression) expression.Expression {
-	ds, isDs := p.(*DataSource)
-	if !isDs {
-		return expr
-	}
-
-	scalarExpr, isScalarFunc := expr.(*expression.ScalarFunction)
-	if !isScalarFunc {
-		return expr
-	}
-	exprChildren := scalarExpr.GetArgs()
-	for i := 0; i < len(exprChildren); i++ {
-		exprChildren[i] = eliminateIfNullOnNotNullCol(p, exprChildren[i])
-	}
-
-	if scalarExpr.FuncName.L != ast.Ifnull {
-		return expr
-	}
-	colRef, isColRef := exprChildren[0].(*expression.Column)
-	if !isColRef {
-		return expr
-	}
-
-	colInfo := model.FindColumnInfo(ds.Columns, colRef.ColName.L)
-	if !mysql.HasNotNullFlag(colInfo.Flag) {
-		return expr
-	}
-
-	return colRef
-}
-
 // buildProjection returns a Projection plan and non-aux columns length.
 func (b *PlanBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, mapper map[*ast.AggregateFuncExpr]int) (LogicalPlan, int, error) {
 	b.optFlag |= flagEliminateProjection
@@ -618,7 +600,6 @@ func (b *PlanBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 	oldLen := 0
 	for _, field := range fields {
 		newExpr, np, err := b.rewrite(field.Expr, p, mapper, true)
-		newExpr = eliminateIfNullOnNotNullCol(p, newExpr)
 		if err != nil {
 			return nil, 0, errors.Trace(err)
 		}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -313,7 +313,7 @@ func (b *PlanBuilder) buildJoin(joinNode *ast.Join) (LogicalPlan, error) {
 		resetNotNullFlag(joinPlan.schema, leftPlan.Schema().Len(), joinPlan.schema.Len())
 	case ast.RightJoin:
 		joinPlan.JoinType = RightOuterJoin
-		resetNotNullFlag(joinPlan.schema, 0, leftPlan.Schema().Len()-1)
+		resetNotNullFlag(joinPlan.schema, 0, leftPlan.Schema().Len())
 	default:
 		joinPlan.JoinType = InnerJoin
 	}

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -255,6 +255,13 @@ func MockTable() *model.TableInfo {
 		FieldType: newLongType(),
 		ID:        10,
 	}
+	col6 := &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    10,
+		Name:      model.NewCIStr("h"),
+		FieldType: newLongType(),
+		ID:        10,
+	}
 	pkColumn.Flag = mysql.PriKeyFlag | mysql.NotNullFlag
 	// Column 'b', 'c', 'd', 'f', 'g' is not null.
 	col0.Flag = mysql.NotNullFlag
@@ -262,8 +269,9 @@ func MockTable() *model.TableInfo {
 	col2.Flag = mysql.NotNullFlag
 	col4.Flag = mysql.NotNullFlag
 	col5.Flag = mysql.NotNullFlag
+	col6.Flag = mysql.NoDefaultValueFlag
 	table := &model.TableInfo{
-		Columns:    []*model.ColumnInfo{pkColumn, col0, col1, col2, col3, colStr1, colStr2, colStr3, col4, col5},
+		Columns:    []*model.ColumnInfo{pkColumn, col0, col1, col2, col3, colStr1, colStr2, colStr3, col4, col5, col6},
 		Indices:    indices,
 		Name:       model.NewCIStr("t"),
 		PKIsHandle: true,
@@ -366,8 +374,8 @@ func (s *testPlanSuite) TestPredicatePushDown(c *C) {
 			best: "Join{DataScan(ta)->Join{DataScan(tb)->DataScan(tc)}(tb.b,tc.b)}(ta.a,tb.a)(ta.c,tc.c)->Sel([or(gt(tc.d, 0), gt(ta.d, 0))])->Projection",
 		},
 		{
-			sql:  "select * from t ta left outer join t tb on ta.d = tb.d and ta.a > 1 where ifnull(tb.d, null) or tb.d is null",
-			best: "Join{DataScan(ta)->DataScan(tb)}(ta.d,tb.d)->Sel([or(ifnull(tb.d, <nil>), isnull(tb.d))])->Projection",
+			sql:  "select * from t ta left outer join t tb on ta.d = tb.d and ta.a > 1 where ifnull(tb.d, 1) or tb.d is null",
+			best: "Join{DataScan(ta)->DataScan(tb)}(ta.d,tb.d)->Sel([or(ifnull(tb.d, 1), isnull(tb.d))])->Projection",
 		},
 		{
 			sql:  "select a, d from (select * from t union all select * from t union all select * from t) z where a < 10",
@@ -1941,7 +1949,12 @@ func (s *testPlanSuite) TestTopNPushDown(c *C) {
 		// Test `ByItem` containing column from both sides.
 		{
 			sql:  "select ifnull(t1.b, t2.a) from t t1 left join t t2 on t1.e=t2.e order by ifnull(t1.b, t2.a) limit 5",
-			best: "Join{DataScan(t1)->DataScan(t2)}(t1.e,t2.e)->TopN([ifnull(t1.b, t2.a)],0,5)->Projection->Projection",
+			best: "Join{DataScan(t1)->TopN([t1.b],0,5)->DataScan(t2)}(t1.e,t2.e)->TopN([t1.b],0,5)->Projection",
+		},
+		// Test ifnull cannot be eliminated
+		{
+			sql:  "select ifnull(t1.h, t2.b) from t t1 left join t t2 on t1.e=t2.e order by ifnull(t1.h, t2.b) limit 5",
+			best: "Join{DataScan(t1)->DataScan(t2)}(t1.e,t2.e)->TopN([ifnull(t1.h, t2.b)],0,5)->Projection->Projection",
 		},
 	}
 	for i, tt := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
mysql> show create table t;
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                          |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) DEFAULT NULL,
  `nb` int(11) NOT NULL,
  `nc` int(11) NOT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
``` 

Before this PR, 
```
mysql> explain select 1+ifnull(nb, 0) from t where nb=1;
+-----------------------+----------+------+------------------------------------------------------------+
| id                    | count    | task | operator info                                              |
+-----------------------+----------+------+------------------------------------------------------------+
| Projection_4          | 10.00    | root | plus(1, ifnull(test.t.nb, 0))                                         |
| └─TableReader_7       | 10.00    | root | data:Selection_6                                           |
|   └─Selection_6       | 10.00    | cop  | eq(test.t.nb, 1)                                           |
|     └─TableScan_5     | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo |
+-----------------------+----------+------+------------------------------------------------------------+
4 rows in set (0.00 sec)
```
After,

```
mysql> explain select 1+ifnull(nb, 0) from t where nb=1;
+-----------------------+----------+------+------------------------------------------------------------+
| id                    | count    | task | operator info                                              |
+-----------------------+----------+------+------------------------------------------------------------+
| Projection_4          | 10.00    | root | plus(1, test.t.nb)                                         |
| └─TableReader_7       | 10.00    | root | data:Selection_6                                           |
|   └─Selection_6       | 10.00    | cop  | eq(test.t.nb, 1)                                           |
|     └─TableScan_5     | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo |
+-----------------------+----------+------+------------------------------------------------------------+
4 rows in set (0.00 sec)
```
### What is changed and how it works?
When converting model.ColumnInfo to expression.Column, we also pass flag info which can be used during epression rewriting stage.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes
 - Need to cherry-pick to the release branch

