### PR TITLE
executor, planner: clone proj schema for different children in buildProj4Union

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1076,6 +1076,11 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec(`set @@tidb_max_chunk_size=2;`)
 	tk.MustQuery(`select count(*) from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;`).Check(testkit.Rows("128"))
 	tk.MustQuery(`select tmp.a, count(*) from (select t1.a, t1.b from t1 left join t2 on t1.a=t2.a union all select t1.a, t1.a from t1 left join t2 on t1.a=t2.a) tmp;`).Check(testkit.Rows("1 128"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("insert into t value(1 ,2)")
+	tk.MustQuery("select a, b from (select a, 0 as d, b from t union all select a, 0 as d, b from t) test;").Check(testkit.Rows("1 2", "1 2"))
 }
 
 func (s *testSuite) TestIn(c *C) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -712,7 +712,7 @@ func (b *PlanBuilder) buildProjection4Union(u *LogicalUnionAll) {
 		}
 		b.optFlag |= flagEliminateProjection
 		proj := LogicalProjection{Exprs: exprs}.init(b.ctx)
-		proj.SetSchema(expression.NewSchema(unionCols...))
+		proj.SetSchema(u.schema.Clone())
 		proj.SetChildren(child)
 		u.children[childID] = proj
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
``` sql
create table t(a int, b int);
insert into t values(1,2);
select a, b from (select a, 0 as d, b from t union all select a, 0 as d, b from t) test;
```

we want:

``` sql
+------+------+
| a    | b    |
+------+------+
|    1 |    2 |
|    1 |    2 |
+------+------+
```

but got:
``` sql
+------+------+
| a    | b    |
+------+------+
|    1 |    0 |
|    1 |    2 |
+------+------+
```

### What is changed and how it works?
Clone the schema for different projections which are built in `buildProjection4Union`.

Before this commit, `Schema.Columns` of different `LogicalProjection`s which are built upon the children of Union refer to the *same* Column slice.

The `Schema.Columns` is `[test.a, d, test.b]` in the above example.
After calling Union.Children[0].PruneColumn, we use [this](https://github.com/pingcap/tidb/blob/master/planner/core/rule_column_pruning.go#L68) to prune the columns.
Thus Union.Children[1].schema.Columns will become `[test.a, test.b, test.b]`.
Furthermore, [used bool slice](https://github.com/pingcap/tidb/blob/master/planner/core/rule_column_pruning.go#L65) will become [true, true, false], and cause test.b be pruned wrongly. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects

none

Related changes

 - Need to cherry-pick to the release branch

