### PR TITLE
Add create view support

### DIFF
--- a/ast/ddl.go
+++ b/ast/ddl.go
@@ -560,8 +560,22 @@ type CreateViewStmt struct {
 
 // Accept implements Node Accept interface.
 func (n *CreateViewStmt) Accept(v Visitor) (Node, bool) {
-	// TODO: implement the details.
-	return n, true
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*CreateViewStmt)
+	node, ok := n.ViewName.Accept(v)
+	if !ok {
+		return n, false
+	}
+	n.ViewName = node.(*TableName)
+	selnode, ok := n.Select.Accept(v)
+	if !ok {
+		return n, false
+	}
+	n.Select = selnode.(*SelectStmt)
+	return v.Leave(n)
 }
 
 // CreateIndexStmt is a statement to create an index.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -19,7 +19,6 @@ package ddl
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/expression"
 	"sync"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/ngaut/pools"
 	"github.com/pingcap/tidb/ast"
 	"github.com/pingcap/tidb/ddl/util"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -19,6 +19,7 @@ package ddl
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/expression"
 	"sync"
 	"time"
 
@@ -107,6 +108,7 @@ var (
 	errTooManyFields            = terror.ClassDDL.New(codeTooManyFields, "Too many columns")
 	errInvalidSplitRegionRanges = terror.ClassDDL.New(codeInvalidRanges, "Failed to split region ranges")
 	errReorgPanic               = terror.ClassDDL.New(codeReorgWorkerPanic, "reorg worker panic.")
+	errViewWrongList            = terror.ClassDDL.New(codeViewWrongList, mysql.MySQLErrName[mysql.ErrViewWrongList])
 
 	// errWrongKeyColumn is for table column cannot be indexed.
 	errWrongKeyColumn = terror.ClassDDL.New(codeWrongKeyColumn, mysql.MySQLErrName[mysql.ErrWrongKeyColumn])
@@ -199,6 +201,7 @@ type DDL interface {
 	CreateSchema(ctx sessionctx.Context, name model.CIStr, charsetInfo *ast.CharsetOpt) error
 	DropSchema(ctx sessionctx.Context, schema model.CIStr) error
 	CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error
+	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt, fullCols []*expression.Column) error
 	CreateTableWithLike(ctx sessionctx.Context, ident, referIdent ast.Ident, ifNotExists bool) error
 	DropTable(ctx sessionctx.Context, tableIdent ast.Ident) (err error)
 	CreateIndex(ctx sessionctx.Context, tableIdent ast.Ident, unique bool, indexName model.CIStr,
@@ -598,6 +601,7 @@ const (
 	codeWrongKeyColumn                         = 1167
 	codeBlobKeyWithoutLength                   = 1170
 	codeInvalidOnUpdate                        = 1294
+	codeViewWrongList                          = 1353
 	codeUnsupportedOnGeneratedColumn           = 3106
 	codeGeneratedColumnNonPrior                = 3107
 	codeDependentByGeneratedColumn             = 3108
@@ -654,6 +658,7 @@ func init() {
 		codeTableMustHaveColumns:                   mysql.ErrTableMustHaveColumns,
 		codeTooManyFields:                          mysql.ErrTooManyFields,
 		codeErrTooLongIndexComment:                 mysql.ErrTooLongIndexComment,
+		codeViewWrongList:                          mysql.ErrViewWrongList,
 		codeUnknownCharacterSet:                    mysql.ErrUnknownCharacterSet,
 		codePartitionsMustBeDefined:                mysql.ErrPartitionsMustBeDefined,
 		codePartitionMgmtOnNonpartitioned:          mysql.ErrPartitionMgmtOnNonpartitioned,

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -473,6 +473,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onDropSchema(t, job)
 	case model.ActionCreateTable:
 		ver, err = onCreateTable(d, t, job)
+	case model.ActionCreateView:
+		ver, err = onCreateView(d, t, job)
 	case model.ActionDropTable:
 		ver, err = onDropTable(t, job)
 	case model.ActionDropTablePartition:

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -131,7 +131,7 @@ func MockTableInfo(ctx sessionctx.Context, stmt *ast.CreateTableStmt, tableID in
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	tbl, err := buildTableInfo(ctx, nil, stmt.Table.Name, cols, newConstraints)
+	tbl, err := buildTableInfo(ctx, nil, stmt.Table.Name, cols, newConstraints, false, "")
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -239,6 +239,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (sqlexec.RecordSet, error) {
 		// the Projection has two expressions and two columns in the schema, but we should
 		// not return the result of the two expressions.
 		return a.handleNoDelayExecutor(ctx, sctx, e)
+	} else if _, ok := e.(*DDLExec); ok {
+		// DDL executer should always return "Query OK"
+		return a.handleNoDelayExecutor(ctx, sctx, e)
 	}
 
 	return &recordSet{

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -142,6 +142,8 @@ func GetStmtLabel(stmtNode ast.StmtNode) string {
 		return "CreateIndex"
 	case *ast.CreateTableStmt:
 		return "CreateTable"
+	case *ast.CreateViewStmt:
+		return "CreateView"
 	case *ast.CreateUserStmt:
 		return "CreateUser"
 	case *ast.DeleteStmt:

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -76,6 +76,8 @@ func (e *DDLExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 		err = e.executeCreateDatabase(x)
 	case *ast.CreateTableStmt:
 		err = e.executeCreateTable(x)
+	case *ast.CreateViewStmt:
+		err = e.executeCreateView(x)
 	case *ast.CreateIndexStmt:
 		err = e.executeCreateIndex(x)
 	case *ast.DropDatabaseStmt:
@@ -145,6 +147,11 @@ func (e *DDLExec) executeCreateDatabase(s *ast.CreateDatabaseStmt) error {
 
 func (e *DDLExec) executeCreateTable(s *ast.CreateTableStmt) error {
 	err := domain.GetDomain(e.ctx).DDL().CreateTable(e.ctx, s)
+	return errors.Trace(err)
+}
+
+func (e *DDLExec) executeCreateView(s *ast.CreateViewStmt) error {
+	err := domain.GetDomain(e.ctx).DDL().CreateView(e.ctx, s, e.schema.Columns)
 	return errors.Trace(err)
 }
 

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -52,7 +52,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	var oldTableID, newTableID int64
 	tblIDs := make([]int64, 0, 2)
 	switch diff.Type {
-	case model.ActionCreateTable:
+	case model.ActionCreateTable, model.ActionCreateView:
 		newTableID = diff.TableID
 		tblIDs = append(tblIDs, newTableID)
 	case model.ActionDropTable:

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -296,6 +296,28 @@ func (m *Meta) CreateTable(dbID int64, tableInfo *model.TableInfo) error {
 	return m.txn.HSet(dbKey, tableKey, data)
 }
 
+// CreateView creates a view with tableInfo in database.
+func (m *Meta) CreateView(dbID int64, tableInfo *model.TableInfo, orReplace bool) error {
+	// Check if db exists.
+	dbKey := m.dbKey(dbID)
+	if err := m.checkDBExists(dbKey); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Check if view exists.
+	tableKey := m.tableKey(tableInfo.ID)
+	if err := m.checkTableNotExists(dbKey, tableKey); err != nil && !orReplace {
+		return errors.Trace(err)
+	}
+
+	data, err := json.Marshal(tableInfo)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return m.txn.HSet(dbKey, tableKey, data)
+}
+
 // DropDatabase drops whole database.
 func (m *Meta) DropDatabase(dbID int64) error {
 	// Check if db exists.

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -98,6 +98,7 @@ func (s *testSuite) TestMeta(c *C) {
 	tbInfo := &model.TableInfo{
 		ID:   1,
 		Name: model.NewCIStr("t"),
+		Type: model.BaseTable,
 	}
 	err = t.CreateTable(1, tbInfo)
 	c.Assert(err, IsNil)
@@ -128,6 +129,7 @@ func (s *testSuite) TestMeta(c *C) {
 	tbInfo2 := &model.TableInfo{
 		ID:   2,
 		Name: model.NewCIStr("bb"),
+		Type: model.BaseTable,
 	}
 	err = t.CreateTable(1, tbInfo2)
 	c.Assert(err, IsNil)
@@ -160,6 +162,7 @@ func (s *testSuite) TestMeta(c *C) {
 	tbInfo100 := &model.TableInfo{
 		ID:   tid,
 		Name: model.NewCIStr("t_rename"),
+		Type: model.BaseTable,
 	}
 	// Create table.
 	err = t.CreateTable(1, tbInfo100)

--- a/model/ddl.go
+++ b/model/ddl.go
@@ -50,6 +50,7 @@ const (
 	ActionRenameIndex        ActionType = 18
 	ActionAddTablePartition  ActionType = 19
 	ActionDropTablePartition ActionType = 20
+	ActionCreateView         ActionType = 21
 )
 
 // AddIndexStr is a string related to the operation of "add index".
@@ -76,6 +77,7 @@ var actionMap = map[ActionType]string{
 	ActionRenameIndex:        "rename index",
 	ActionAddTablePartition:  "add partition",
 	ActionDropTablePartition: "drop table partition",
+	ActionCreateView:         "create view",
 }
 
 // String return current ddl action in string

--- a/model/model.go
+++ b/model/model.go
@@ -135,6 +135,16 @@ func FindColumnInfo(cols []*ColumnInfo, name string) *ColumnInfo {
 // for use of execution phase.
 const ExtraHandleID = -1
 
+// TableType is te type of table object
+type TableType byte
+
+const (
+	// BaseTable means this table object is a basic data table
+	BaseTable TableType = iota
+	// View means this table object is a view
+	View
+)
+
 // ExtraHandleName is the name of ExtraHandle Column.
 var ExtraHandleName = NewCIStr("_tidb_rowid")
 
@@ -171,6 +181,10 @@ type TableInfo struct {
 	Partition *PartitionInfo `json:"partition"`
 
 	Compression string `json:"compression"`
+
+	ViewSelectStmt string `json:"view_select_stmt"`
+
+	Type TableType `json:"type"`
 }
 
 // GetPartitionInfo returns the partition information.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1836,6 +1836,15 @@ func (b *PlanBuilder) buildDataSource(tn *ast.TableName) (LogicalPlan, error) {
 	tableInfo := tbl.Meta()
 	b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, dbName.L, tableInfo.Name.L, "")
 
+	if tableInfo.Type == model.View {
+		parser := parser.New()
+		stmt, parserErr := parser.ParseOneStmt(tableInfo.ViewSelectStmt, "", "")
+		if parserErr != nil {
+			return nil, errors.Trace(parserErr)
+		}
+		return b.buildSelect(stmt.(*ast.SelectStmt))
+	}
+
 	if tableInfo.GetPartitionInfo() != nil {
 		b.optFlag = b.optFlag | flagPartitionProcessor
 	}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -194,7 +194,7 @@ func (b *PlanBuilder) Build(node ast.Node) (Plan, error) {
 		*ast.GrantStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.RevokeStmt, *ast.KillStmt, *ast.DropStatsStmt:
 		return b.buildSimple(node.(ast.StmtNode)), nil
 	case ast.DDLNode:
-		return b.buildDDL(x), nil
+		return b.buildDDL(x)
 	}
 	return nil, ErrUnsupportedType.GenWithStack("Unsupported type %T", node)
 }
@@ -1382,7 +1382,8 @@ func (b *PlanBuilder) buildLoadStats(ld *ast.LoadStatsStmt) Plan {
 	return p
 }
 
-func (b *PlanBuilder) buildDDL(node ast.DDLNode) Plan {
+func (b *PlanBuilder) buildDDL(node ast.DDLNode) (Plan, error) {
+	schema := expression.NewSchema()
 	switch v := node.(type) {
 	case *ast.AlterTableStmt:
 		b.visitInfo = append(b.visitInfo, visitInfo{
@@ -1412,6 +1413,19 @@ func (b *PlanBuilder) buildDDL(node ast.DDLNode) Plan {
 				privilege: mysql.SelectPriv,
 				db:        v.ReferTable.Schema.L,
 				table:     v.ReferTable.Name.L,
+			})
+		}
+	case *ast.CreateViewStmt:
+		plan, err := b.Build(v.Select)
+		if err != nil {
+			return nil, err
+		}
+		schema = plan.Schema()
+		if _, ok := plan.(LogicalPlan); ok {
+			b.visitInfo = append(b.visitInfo, visitInfo{
+				privilege: mysql.CreatePriv,
+				db:        v.ViewName.Schema.L,
+				table:     v.ViewName.Name.L,
 			})
 		}
 	case *ast.DropDatabaseStmt:
@@ -1453,7 +1467,8 @@ func (b *PlanBuilder) buildDDL(node ast.DDLNode) Plan {
 	}
 
 	p := &DDL{Statement: node}
-	return p
+	p.SetSchema(schema)
+	return p, nil
 }
 
 // buildTrace builds a trace plan. Inside this method, it first optimize the

--- a/session/session.go
+++ b/session/session.go
@@ -1423,7 +1423,8 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 	switch stmt := node.(type) {
 	case *ast.CreateUserStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.SetPwdStmt, *ast.GrantStmt,
 		*ast.RevokeStmt, *ast.AlterTableStmt, *ast.CreateDatabaseStmt, *ast.CreateIndexStmt, *ast.CreateTableStmt,
-		*ast.DropDatabaseStmt, *ast.DropIndexStmt, *ast.DropTableStmt, *ast.RenameTableStmt, *ast.TruncateTableStmt:
+		*ast.CreateViewStmt, *ast.DropDatabaseStmt, *ast.DropIndexStmt, *ast.DropTableStmt, *ast.RenameTableStmt,
+		*ast.TruncateTableStmt:
 		user := vars.User
 		schemaVersion := vars.TxnCtx.SchemaVersion
 		if ss, ok := node.(ast.SensitiveStmtNode); ok {

--- a/statistics/ddl.go
+++ b/statistics/ddl.go
@@ -29,7 +29,7 @@ import (
 // HandleDDLEvent begins to process a ddl task.
 func (h *Handle) HandleDDLEvent(t *util.Event) error {
 	switch t.Tp {
-	case model.ActionCreateTable, model.ActionTruncateTable:
+	case model.ActionCreateTable, model.ActionCreateView, model.ActionTruncateTable:
 		ids := getPhysicalIDs(t.TableInfo)
 		for _, id := range ids {
 			if err := h.insertTableStats2KV(t.TableInfo, id); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement view support, support following grammar:  
1. create or replace view as SelectStmt ...
2. drop table ...
3. show full tables
4. show create table viewname
5. select from view

issue ref [https://github.com/pingcap/tidb/issues/7974](https://github.com/pingcap/tidb/issues/7974)
Part of the code reference from [https://github.com/pingcap/tidb/pull/4874](https://github.com/pingcap/tidb/pull/4874)

### What is changed and how it works?
Use tableinfo to store view select statement

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change
Add CreateView interface to ddl/ddl.go
 - Has persistent data change

Side effects



Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8001)
<!-- Reviewable:end -->
