### PR TITLE
parser: fix bug empty string in "ESCAPED BY" subclause of "FIELDS" cause panic (#7880)

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -7013,10 +7013,14 @@ Fields:
 		}else if len(str) != 0 {
 			enclosed = str[0]
 		}
+		var escaped byte
+		if len(escape) > 0 {
+			escaped = escape[0]
+		}
 		$$ = &ast.FieldsClause{
 			Terminated: $2.(string),
 			Enclosed:   enclosed,
-			Escaped:    escape[0],
+			Escaped:    escaped,
 		}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -394,6 +394,7 @@ func (s *testParserSuite) TestDMLStmt(c *C) {
 		{"load data local infile '/tmp/t.csv' into table t fields terminated by 'ab' enclosed by 'b' (a,b) ignore 1 lines", false},
 		{"load data local infile '/tmp/t.csv' into table t lines starting by 'ab' terminated by 'xy' ignore 1 lines", true},
 		{"load data local infile '/tmp/t.csv' into table t fields terminated by 'ab' enclosed by 'b' escaped by '*' ignore 1 lines (a,b)", true},
+		{"load data local infile '/tmp/t.csv' into table t fields terminated by 'ab' enclosed by 'b' escaped by ''", true},
 
 		// select for update
 		{"SELECT * from t for update", true},


### PR DESCRIPTION
…use panic (#7880)

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #7880 