### PR TITLE
planner: fix a panic of a cached prepared statement with IndexScan

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -427,7 +427,11 @@ func (is *PhysicalIndexScan) initSchema(id int, idx *model.IndexInfo, isDoubleRe
 	for _, col := range idx.Columns {
 		colFound := is.dataSourceSchema.FindColumnByName(col.Name.L)
 		if colFound == nil {
-			colFound = &expression.Column{ColName: col.Name, UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID()}
+			colFound = &expression.Column{
+				ColName:  col.Name,
+				RetType:  &is.Table.Columns[col.Offset].FieldType,
+				UniqueID: is.ctx.GetSessionVars().AllocPlanColumnID(),
+			}
 		} else {
 			colFound = colFound.Clone().(*expression.Column)
 		}

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -63,3 +63,29 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	tk.MustQuery("execute stmt5").Check(testkit.Rows("1", "2", "2", "3", "4", "5"))
 	tk.MustQuery("execute stmt5").Check(testkit.Rows("1", "2", "2", "3", "4", "5"))
 }
+
+func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	orgEnable := core.PreparedPlanCacheEnabled()
+	orgCapacity := core.PreparedPlanCacheCapacity
+	defer func() {
+		dom.Close()
+		store.Close()
+		core.SetPreparedPlanCache(orgEnable)
+		core.PreparedPlanCacheCapacity = orgCapacity
+	}()
+	core.SetPreparedPlanCache(true)
+	core.PreparedPlanCacheCapacity = 100
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int, c int, primary key (a, b))")
+	tk.MustExec("insert into t values(1, 1, 2), (1, 2, 3), (1, 3, 3), (2, 1, 2), (2, 2, 3), (2, 3, 3)")
+	tk.MustExec(`prepare stmt1 from "select a, c from t where a = ? and c = ?"`)
+	tk.MustExec("set @a=1, @b=3")
+	// When executing one statement at the first time, we don't use cache, so we need to execute it at least twice to test the cache.
+	tk.MustQuery("execute stmt1 using @a, @b").Check(testkit.Rows("1 3", "1 3"))
+	tk.MustQuery("execute stmt1 using @a, @b").Check(testkit.Rows("1 3", "1 3"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the panic of the prepared statement with IndexScan when using the prepared plan cache. Here, the plan tries to use the column info that is not in the data source schema.

* BEFORE the PR
```
Database changed
mysql> drop table if exists t;
Query OK, 0 rows affected (0.37 sec)

mysql> create table t(a int, b int, c int, primary key (a, b));
Query OK, 0 rows affected (0.19 sec)

mysql> insert into t values(1, 1, 2), (1, 2, 3), (1, 3, 3), (2, 1, 2), (2, 2, 3), (2, 3, 3);
Query OK, 6 rows affected (0.06 sec)

mysql> prepare stmt1 from "select a, c from t where a = ? and c = ?";
Query OK, 0 rows affected (0.00 sec)

mysql> set @a=1, @b=3;
Query OK, 0 rows affected (0.00 sec)

mysql> execute stmt1 using @a, @b;
+---+------+
| a | c    |
+---+------+
| 1 |    3 |
| 1 |    3 |
+---+------+
2 rows in set (0.00 sec)

mysql> execute stmt1 using @a, @b;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```
```
2018/10/23 17:23:56.297 conn.go:427: [error] lastCmd execute stmt1 using @a, @b, runtime error: invalid memory address or nil pointer dereference, goroutine 1250 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc008528410, 0xc007553dff)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/conn.go:425 +0x10c
panic(0x11ce380, 0x220b1e0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/util/ranger.newFieldType(...)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/util/ranger/ranger.go:453
github.com/pingcap/tidb/util/ranger.DetachCondAndBuildRangeForIndex(0x1533540, 0xc00845c8c0, 0xc0089deac0, 0x1, 0x1, 0xc008aa73c0, 0x2, 0x2, 0xc008bda0b0, 0x2, ...)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/util/ranger/detacher.go:308 +0xbd
github.com/pingcap/tidb/planner/core.(*Execute).buildRangeForIndexScan(0xc008b68ea0, 0x1533540, 0xc00845c8c0, 0xc008217500, 0x40baf8, 0x125aac0, 0x12cc4e0, 0x0, 0x1517d60)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:260 +0x2eb
github.com/pingcap/tidb/planner/core.(*Execute).rebuildRange(0xc008b68ea0, 0x1516080, 0xc008999a00, 0x1, 0x1517d60)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:239 +0x130
github.com/pingcap/tidb/planner/core.(*Execute).getPhysicalPlan(0xc008b68ea0, 0x1533540, 0xc00845c8c0, 0x151d2e0, 0xc00892d050, 0xc008af82c0, 0x1, 0x1, 0x0, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:191 +0x3eb
github.com/pingcap/tidb/planner/core.(*Execute).OptimizePreparedPlan(0xc008b68ea0, 0x1533540, 0xc00845c8c0, 0x151d2e0, 0xc00892d050, 0x1, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:173 +0x344
github.com/pingcap/tidb/planner.Optimize(0x1533540, 0xc00845c8c0, 0x1505640, 0xc008b71f80, 0x151d2e0, 0xc00892d050, 0x227fc00, 0x0, 0x0, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/planner/optimize.go:53 +0x39e
github.com/pingcap/tidb/executor.(*Compiler).Compile(0xc007553980, 0x7f8e5d86c460, 0xc008b71f40, 0x150f640, 0xc008b71f80, 0x0, 0x0, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/executor/compiler.go:49 +0x1d2
github.com/pingcap/tidb/session.(*session).execute(0xc00845c8c0, 0x7f8e5d86c460, 0xc008b71f40, 0xc008a66e21, 0x1a, 0x203002, 0x203002, 0xc008239180, 0xc008548000, 0x30)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/session/session.go:803 +0x6ba
github.com/pingcap/tidb/session.(*session).Execute(0xc00845c8c0, 0x7f8e5d86c460, 0xc008b71f40, 0xc008a66e21, 0x1a, 0x1, 0x0, 0x0, 0xc007553b58, 0x4d6e80)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/session/session.go:762 +0x69
github.com/pingcap/tidb/server.(*TiDBContext).Execute(0xc00852e5d0, 0x7f8e5d86c460, 0xc008b71f40, 0xc008a66e21, 0x1a, 0xc007553be8, 0x1052761, 0xc0001a3a40, 0x4000000000000000, 0x225fdc0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/driver_tidb.go:240 +0x7c
github.com/pingcap/tidb/server.(*clientConn).handleQuery(0xc008528410, 0x7f8e5d86c460, 0xc008b71f40, 0xc008a66e21, 0x1a, 0x0, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/conn.go:874 +0x8e
github.com/pingcap/tidb/server.(*clientConn).dispatch(0xc008528410, 0xc008a66e21, 0x1b, 0x1b, 0x0, 0x0)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/conn.go:626 +0x686
github.com/pingcap/tidb/server.(*clientConn).Run(0xc008528410)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/conn.go:470 +0x1be
github.com/pingcap/tidb/server.(*Server).onConn(0xc0074cbb00, 0x15196e0, 0xc000191920)
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/server.go:324 +0x224
created by github.com/pingcap/tidb/server.(*Server).Run
	/home/jsheo/dev/deps/go/src/github.com/pingcap/tidb/server/server.go:264 +0x4a9
```

* AFTER the PR
```
mysql> use test;
create table t(a int, b int, c int, primary key (a, b));
insert into t values(1, 1, 2), (1, 2, 3), (1, 3, 3), (2, 1, 2), (2, 2, 3), (2, 3, 3);
prepare stmt1 from "select a, c from t where a = ? and c = ?";
Database changed
mysql> drop table if exists t;
set @a=1, @b=3;
execute stmt1 using @a, @b;
execute stmt1 using @a, @b;Query OK, 0 rows affected (0.34 sec)

mysql> create table t(a int, b int, c int, primary key (a, b));
Query OK, 0 rows affected (0.18 sec)

mysql> insert into t values(1, 1, 2), (1, 2, 3), (1, 3, 3), (2, 1, 2), (2, 2, 3), (2, 3, 3);
Query OK, 6 rows affected (0.05 sec)

mysql> prepare stmt1 from "select a, c from t where a = ? and c = ?";
Query OK, 0 rows affected (0.00 sec)

mysql> set @a=1, @b=3;
Query OK, 0 rows affected (0.00 sec)

mysql> execute stmt1 using @a, @b;
+---+------+
| a | c    |
+---+------+
| 1 |    3 |
| 1 |    3 |
+---+------+
2 rows in set (0.01 sec)

mysql> execute stmt1 using @a, @b;
+---+------+
| a | c    |
+---+------+
| 1 |    3 |
| 1 |    3 |
+---+------+
2 rows in set (0.00 sec)

```

### What is changed and how it works?
When creating the schema of the PhysicalIndexScan, the PR uses the table schema to get a specified column if a specified column is not found from the datasource schema.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported variable/fields change


Side effects

 - No

Related changes

 - Need to cherry-pick to the release branch

