### PR TITLE
parser: support `:=` in the `set` syntax

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -820,6 +820,7 @@ import (
 	TableOptimizerHintList	"Table level optimizer hint list"
 
 %type	<ident>
+	EQOrAssignmentEQ	"= or :="
 	AsOpt			"AS or EmptyString"
 	KeyOrIndex		"{KEY|INDEX}"
 	ColumnKeywordOpt	"Column keyword or empty"
@@ -4926,11 +4927,11 @@ SetStmt:
 	{
 		$$ = &ast.SetStmt{Variables: $2.([]*ast.VariableAssignment)}
 	}
-|	"SET" "PASSWORD" eq PasswordOpt
+|	"SET" "PASSWORD" EQOrAssignmentEQ PasswordOpt
 	{
 		$$ = &ast.SetPwdStmt{Password: $4.(string)}
 	}
-|	"SET" "PASSWORD" "FOR" Username eq PasswordOpt
+|	"SET" "PASSWORD" "FOR" Username EQOrAssignmentEQ PasswordOpt
 	{
 		$$ = &ast.SetPwdStmt{User: $4.(*auth.UserIdentity), Password: $6.(string)}
 	}
@@ -5026,23 +5027,23 @@ SetExpr:
 |	ExprOrDefault
 
 VariableAssignment:
-	Identifier eq SetExpr
+	Identifier EQOrAssignmentEQ SetExpr
 	{
 		$$ = &ast.VariableAssignment{Name: $1, Value: $3, IsSystem: true}
 	}
-|	"GLOBAL" Identifier eq SetExpr
+|	"GLOBAL" Identifier EQOrAssignmentEQ SetExpr
 	{
 		$$ = &ast.VariableAssignment{Name: $2, Value: $4, IsGlobal: true, IsSystem: true}
 	}
-|	"SESSION" Identifier eq SetExpr
+|	"SESSION" Identifier EQOrAssignmentEQ SetExpr
 	{
 		$$ = &ast.VariableAssignment{Name: $2, Value: $4, IsSystem: true}
 	}
-|	"LOCAL" Identifier eq Expression
+|	"LOCAL" Identifier EQOrAssignmentEQ Expression
 	{
 		$$ = &ast.VariableAssignment{Name: $2, Value: $4, IsSystem: true}
 	}
-|	doubleAtIdentifier eq SetExpr
+|	doubleAtIdentifier EQOrAssignmentEQ SetExpr
 	{
 		v := strings.ToLower($1)
 		var isGlobal bool
@@ -5058,13 +5059,7 @@ VariableAssignment:
 		}
 		$$ = &ast.VariableAssignment{Name: v, Value: $3, IsGlobal: isGlobal, IsSystem: true}
 	}
-|	singleAtIdentifier eq Expression
-	{
-		v := $1
-		v = strings.TrimPrefix(v, "@")
-		$$ = &ast.VariableAssignment{Name: v, Value: $3}
-	}
-|	singleAtIdentifier assignmentEq Expression
+|	singleAtIdentifier EQOrAssignmentEQ Expression
 	{
 		v := $1
 		v = strings.TrimPrefix(v, "@")
@@ -5195,6 +5190,14 @@ AuthString:
 	stringLit
 	{
 		$$ = $1
+	}
+
+EQOrAssignmentEQ:
+	eq
+	{
+	}
+|	assignmentEq
+	{
 	}
 
 /****************************Admin Statement*******************************/

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -584,19 +584,28 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		{"SET @_e._$. = 1", true},
 		{"SET @~f = 1", false},
 		{"SET @`g,` = 1", true},
+		{"SET @`g,` := 1", true},
 		// session system variables
 		{"SET SESSION autocommit = 1", true},
+		{"SET SESSION autocommit := 1", true},
 		{"SET @@session.autocommit = 1", true},
+		{"SET @@session.autocommit := 1", true},
 		{"SET @@SESSION.autocommit = 1", true},
 		{"SET @@GLOBAL.GTID_PURGED = '123'", true},
 		{"SET @MYSQLDUMP_TEMP_LOG_BIN = @@SESSION.SQL_LOG_BIN", true},
+		{"SET @MYSQLDUMP_TEMP_LOG_BIN := @@SESSION.SQL_LOG_BIN", true},
 		{"SET LOCAL autocommit = 1", true},
+		{"SET LOCAL autocommit := 1", true},
 		{"SET @@local.autocommit = 1", true},
 		{"SET @@autocommit = 1", true},
+		{"SET @@SQL_MODE := ''", true},
 		{"SET autocommit = 1", true},
+		{"SET autocommit := 1", true},
 		// global system variables
 		{"SET GLOBAL autocommit = 1", true},
+		{"SET GLOBAL autocommit := 1", true},
 		{"SET @@global.autocommit = 1", true},
+		{"SET @@global.autocommit := 1", true},
 		// set default value
 		{"SET @@global.autocommit = default", true},
 		{"SET @@session.autocommit = default", true},
@@ -605,7 +614,9 @@ func (s *testParserSuite) TestDBAStmt(c *C) {
 		{"SET CHARACTER SET 'utf8mb4';", true},
 		// set password
 		{"SET PASSWORD = 'password';", true},
+		{"SET PASSWORD := 'password';", true},
 		{"SET PASSWORD FOR 'root'@'localhost' = 'password';", true},
+		{"SET PASSWORD FOR 'root'@'localhost' := 'password';", true},
 		// SET TRANSACTION Syntax
 		{"SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ", true},
 		{"SET GLOBAL TRANSACTION ISOLATION LEVEL REPEATABLE READ", true},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

According to MySQL document, `set` use the = assignment operator,
but the := assignment operator is also permitted

Fix https://github.com/pingcap/tidb/issues/7995

### What is changed and how it works?

tiny change parser.y

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

@lysu @crazycs520 
