### PR TITLE
*: fix the issue of executing DDL after executing SQL failure in txn …

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -476,11 +476,6 @@ func (d *ddl) asyncNotifyWorker(jobTp model.ActionType) {
 }
 
 func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
-	// For every DDL, we must commit current transaction.
-	if err := ctx.NewTxn(); err != nil {
-		return errors.Trace(err)
-	}
-
 	// Get a global job ID and put the DDL job in the queue.
 	err := d.addDDLJob(ctx, job)
 	if err != nil {

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -78,7 +78,9 @@ func (s *testForeighKeySuite) testCreateForeignKey(c *C, tblInfo *model.TableInf
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       []interface{}{fkInfo},
 	}
-	err := s.d.doDDLJob(s.ctx, job)
+	err := s.ctx.NewTxn()
+	c.Assert(err, IsNil)
+	err = s.d.doDDLJob(s.ctx, job)
 	c.Assert(err, IsNil)
 	return job
 }

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -67,6 +67,11 @@ func (e *DDLExec) Next(ctx context.Context, chk *chunk.Chunk) (err error) {
 		return nil
 	}
 	e.done = true
+
+	// For each DDL, we should commit the previous transaction and create a new transaction.
+	if err = e.ctx.NewTxn(); err != nil {
+		return errors.Trace(err)
+	}
 	defer func() { e.ctx.GetSessionVars().StmtCtx.IsDDLJobInQueue = false }()
 
 	switch x := e.stmt.(type) {


### PR DESCRIPTION
* ddl, executor: fix the issue of executing DDL after executing SQL failure in txn

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #8044 
Fix the issue of the following case:

- Execute the SQL of "begin";
- A SQL that will fail to execute;
- Execute DDL.
