### PR TITLE
plan: disable plan cache for query containing `SubqueryExpr`

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -88,6 +88,26 @@ func (s *testSuite) TestPrepared(c *C) {
 		c.Assert(err, IsNil)
 		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
 
+		tk.MustExec("delete from prepare_test")
+		query = "select c1 from prepare_test where c1 = (select c1 from prepare_test where c1 = ?)"
+		stmtId, _, _, err = tk.Se.PrepareStmt(query)
+		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk1.MustExec("insert prepare_test (c1) values (3)")
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
+
+		tk.MustExec("delete from prepare_test")
+		query = "select c1 from prepare_test where c1 in (select c1 from prepare_test where c1 = ?)"
+		stmtId, _, _, err = tk.Se.PrepareStmt(query)
+		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk1.MustExec("insert prepare_test (c1) values (3)")
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
+
 		tk.MustExec("begin")
 		tk.MustExec("insert prepare_test (c1) values (4)")
 		query = "select c1, c2 from prepare_test where c1 = ?"

--- a/planner/core/cacheable_checker.go
+++ b/planner/core/cacheable_checker.go
@@ -43,7 +43,7 @@ type cacheableChecker struct {
 // Enter implements Visitor interface.
 func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch node := in.(type) {
-	case *ast.VariableExpr, *ast.ExistsSubqueryExpr:
+	case *ast.VariableExpr, *ast.ExistsSubqueryExpr, *ast.SubqueryExpr:
 		checker.cacheable = false
 		return in, true
 	case *ast.FuncCallExpr:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/8062

### What is changed and how it works?

The reason of the wrong result is: during first `execute` in session 1, a plan would be built and cached; during the expression rewriting of the plan building step, un-correlated subquery is detected and evaluated in optimizer, so the query is simplified to `select * from t where a = null`, thus the `ParamMarkerExpr` is lost in the plan, so we get empty result in the second `execute`.

Check the AST and mark it uncacheable if it contains `SubqueryExpr`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
