### PR TITLE
executor: fix show columns panic

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -304,6 +304,17 @@ func (e *ShowExec) fetchShowColumns() error {
 		}
 
 		desc := table.NewColDesc(col)
+		var columnDefault interface{}
+		if desc.DefaultValue != nil {
+			// SHOW COLUMNS result expects string value
+			defaultValStr := fmt.Sprintf("%v", desc.DefaultValue)
+			if col.Tp == mysql.TypeBit {
+				defaultValBinaryLiteral := types.BinaryLiteral(defaultValStr)
+				columnDefault = defaultValBinaryLiteral.ToBitLiteralString(true)
+			} else {
+				columnDefault = defaultValStr
+			}
+		}
 
 		// The FULL keyword causes the output to include the column collation and comments,
 		// as well as the privileges you have for each column.
@@ -314,7 +325,7 @@ func (e *ShowExec) fetchShowColumns() error {
 				desc.Collation,
 				desc.Null,
 				desc.Key,
-				desc.DefaultValue,
+				columnDefault,
 				desc.Extra,
 				desc.Privileges,
 				desc.Comment,
@@ -325,7 +336,7 @@ func (e *ShowExec) fetchShowColumns() error {
 				desc.Type,
 				desc.Null,
 				desc.Key,
-				desc.DefaultValue,
+				columnDefault,
 				desc.Extra,
 			})
 		}

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -422,20 +422,28 @@ func (s *testSuite) TestShow(c *C) {
 	// Test show columns with different types of default value
 	tk.MustExec(`drop table if exists t`)
 	tk.MustExec(`create table t(
-		c1 int default 1,
-		c2 int default b'010',
-		c3 bigint default x'A7',
-		c4 bit(8) default b'00110001',
-		c5 varchar(6) default b'00110001',
-		c6 varchar(6) default '\'C6\''
+		c0 int default 1,
+		c1 int default b'010',
+		c2 bigint default x'A7',
+		c3 bit(8) default b'00110001',
+		c4 varchar(6) default b'00110001',
+		c5 varchar(6) default '\'C6\'',
+		c6 enum('s', 'm', 'l', 'xl') default 'xl',
+		c7 set('a', 'b', 'c', 'd') default 'a,c,c',
+		c8 datetime default current_timestamp on update current_timestamp,
+		c9 year default '2014'
 	);`)
-	tk.MustQuery(`show columns from t`).Check(testutil.RowsWithSep(",",
-		"c1,int(11),YES,,1,",
-		"c2,int(11),YES,,2,",
-		"c3,bigint(20),YES,,167,",
-		"c4,bit(8),YES,,b'110001',",
-		"c5,varchar(6),YES,,1,",
-		"c6,varchar(6),YES,,'C6',",
+	tk.MustQuery(`show columns from t`).Check(testutil.RowsWithSep("|",
+		"c0|int(11)|YES||1|",
+		"c1|int(11)|YES||2|",
+		"c2|bigint(20)|YES||167|",
+		"c3|bit(8)|YES||b'110001'|",
+		"c4|varchar(6)|YES||1|",
+		"c5|varchar(6)|YES||'C6'|",
+		"c6|enum('s','m','l','xl')|YES||xl|",
+		"c7|set('a','b','c','d')|YES||a,c,c|",
+		"c8|datetime|YES||CURRENT_TIMESTAMP|on update CURRENT_TIMESTAMP",
+		"c9|year|YES||2014|",
 	))
 }
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -418,6 +418,25 @@ func (s *testSuite) TestShow(c *C) {
 			"  `val` tinyint(10) UNSIGNED ZEROFILL DEFAULT NULL,\n"+
 			"  PRIMARY KEY (`id`)\n"+
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"))
+
+	// Test show columns with different types of default value
+	tk.MustExec(`drop table if exists t`)
+	tk.MustExec(`create table t(
+		c1 int default 1,
+		c2 int default b'010',
+		c3 bigint default x'A7',
+		c4 bit(8) default b'00110001',
+		c5 varchar(6) default b'00110001',
+		c6 varchar(6) default '\'C6\''
+	);`)
+	tk.MustQuery(`show columns from t`).Check(testutil.RowsWithSep(",",
+		"c1,int(11),YES,,1,",
+		"c2,int(11),YES,,2,",
+		"c3,bigint(20),YES,,167,",
+		"c4,bit(8),YES,,b'110001',",
+		"c5,varchar(6),YES,,1,",
+		"c6,varchar(6),YES,,'C6',",
+	))
 }
 
 func (s *testSuite) TestShowVisibility(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?
This is a bug-fix for following `SHOW COLUMNS` cases that cause TiDB server panic:

```
mysql> create table t(a int default x'A0');
Query OK, 0 rows affected (0.01 sec)

mysql> desc t;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

The TiDB log will be something like:

```
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc007523e10, 0xc007037dff)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:425 +0x10c
panic(0x1dde100, 0x2e37390)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/server.(*clientConn).writeResultset.func1(0x0, 0x21299a0, 0xc007d5be50, 0xc007037ba0, 0xc007523e10)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:951 +0x32f
panic(0x1dde100, 0x2e37390)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/util/chunk.(*column).appendFloat64(...)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/util/chunk/column.go:146
github.com/pingcap/tidb/util/chunk.(*Chunk).AppendFloat64(0xc007dbe3f0, 0x4, 0x4064000000000000)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/util/chunk/chunk.go:424 +0x235
github.com/pingcap/tidb/executor.(*ShowExec).appendRow(0xc007dafe00, 0xc007037530, 0x6, 0x6)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/executor/show.go:833 +0x468
github.com/pingcap/tidb/executor.(*ShowExec).fetchShowColumns(0xc007dafe00, 0x20, 0x20)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/executor/show.go:323 +0x485
github.com/pingcap/tidb/executor.(*ShowExec).fetchAll(0xc007dafe00, 0xc007dbe3f0, 0x1)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/executor/show.go:103 +0xf6
github.com/pingcap/tidb/executor.(*ShowExec).Next(0xc007dafe00, 0x6b61e58, 0xc007db2e80, 0xc007dbe390, 0x6, 0x20)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/executor/show.go:70 +0x190
github.com/pingcap/tidb/executor.(*recordSet).Next(0xc007d5be00, 0x6b61e58, 0xc007db2e80, 0xc007dbe390, 0xc007d5be00, 0xc007dbe390)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/executor/adapter.go:97 +0x56
github.com/pingcap/tidb/server.(*tidbResultSet).Next(0xc007d5be50, 0x6b61e58, 0xc007db2e80, 0xc007dbe390, 0x4, 0x400)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/driver_tidb.go:359 +0x51
github.com/pingcap/tidb/server.(*clientConn).writeChunks(0xc007523e10, 0x6b61e58, 0xc007db2e80, 0x21299a0, 0xc007d5be50, 0xc000007b00, 0xc007523e10, 0xc007be5170)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:1000 +0x33d
github.com/pingcap/tidb/server.(*clientConn).writeResultset(0xc007523e10, 0x6b61e58, 0xc007db2e80, 0x21299a0, 0xc007d5be50, 0xc000005100, 0x0, 0x0, 0x0)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:964 +0x1bc
github.com/pingcap/tidb/server.(*clientConn).handleQuery(0xc007523e10, 0x6b61e58, 0xc007db2e80, 0xc007c8fb21, 0x6, 0x0, 0x0)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:881 +0x124
github.com/pingcap/tidb/server.(*clientConn).dispatch(0xc007523e10, 0xc007c8fb21, 0x7, 0x7, 0x0, 0x0)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:626 +0x686
github.com/pingcap/tidb/server.(*clientConn).Run(0xc007523e10)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/conn.go:470 +0x1be
github.com/pingcap/tidb/server.(*Server).onConn(0xc006e172c0, 0x212c4c0, 0xc00758a840)
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/server.go:324 +0x224
created by github.com/pingcap/tidb/server.(*Server).Run
	/Users/cong/Projects/go/gopath/src/github.com/pingcap/tidb/server/server.go:264 +0x4a9
```

### What is changed and how it works?
According to https://github.com/pingcap/tidb/blob/master/ddl/ddl_api.go#L455, the default value of a column may be of type `int`(and then become `float` after json's unmarshal), but show columns expects `string` type, trying to append `int64`/`float64` causes the panic.

This PR converts non-nil default values to `string` and make it be consistent with MySQL 5.7

### Check List 

Tests 
 - Integration test

Code changes
 - Has internal function/method change
 
Side effects
 - No side effect

Related changes
 - No related change