### PR TITLE
ddl: fix DROP TABLE IF EXISTS behavior difference (#7867)

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -250,8 +250,12 @@ func (e *DDLExec) executeDropTable(s *ast.DropTableStmt) error {
 			return errors.Trace(err)
 		}
 	}
-	if len(notExistTables) > 0 && !s.IfExists {
-		return infoschema.ErrTableDropExists.GenWithStackByArgs(strings.Join(notExistTables, ","))
+	if len(notExistTables) > 0 {
+		if !s.IfExists {
+			return infoschema.ErrTableDropExists.GenWithStackByArgs(strings.Join(notExistTables, ","))
+		} else {
+			e.ctx.GetSessionVars().StmtCtx.AppendNote(infoschema.ErrTableDropExists.GenWithStackByArgs(strings.Join(notExistTables, ",")))
+		}
 	}
 	return nil
 }

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
 	"golang.org/x/net/context"
 )
 
@@ -169,6 +170,13 @@ func (s *testSuite) TestCreateDropIndex(c *C) {
 	tk.MustExec("create index idx_a on drop_test (a)")
 	tk.MustExec("drop index idx_a on drop_test")
 	tk.MustExec("drop table drop_test")
+}
+
+func (s *testSuite) TestDropTableIfExists(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists drop_if_exists_test")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Note|1051|Unknown table 'test.drop_if_exists_test'"))
 }
 
 func (s *testSuite) TestAlterTableAddColumn(c *C) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -495,7 +495,9 @@ func runTestLoadData(c *C, server *Server) {
 
 func runTestConcurrentUpdate(c *C) {
 	// TODO: Should be runTestsOnNewDB. See #4205.
-	runTests(c, nil, func(dbt *DBTest) {
+	runTests(c, func(config *mysql.Config) {
+		config.Strict = false
+	}, func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists test2")
 		dbt.mustExec("create table test2 (a int, b int)")
 		dbt.mustExec("insert test2 values (1, 1)")
@@ -712,7 +714,9 @@ func runTestDBNameEscape(c *C) {
 }
 
 func runTestResultFieldTableIsNull(c *C) {
-	runTestsOnNewDB(c, nil, "ResultFieldTableIsNull", func(dbt *DBTest) {
+	runTestsOnNewDB(c, func(config *mysql.Config) {
+		config.Strict = false
+	}, "ResultFieldTableIsNull", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists test;")
 		dbt.mustExec("create table test (c int);")
 		dbt.mustExec("explain select * from test;")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #7867   DROP TABLE IF EXISTS  not warning info


### What is changed and how it works?
Add warning info and unit test. Two old unit tests set `mysql.Config.Strict = false` for ignore warnings.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change


Side effects



Related changes

 - Need to cherry-pick to the release branch

