### PR TITLE
ticlient: check nil when Backoff set vars

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -196,9 +196,7 @@ func NewBackoffer(ctx context.Context, maxSleep int) *Backoffer {
 
 // WithVars sets the kv.Variables to the Backoffer and return it.
 func (b *Backoffer) WithVars(vars *kv.Variables) *Backoffer {
-	if vars == nil {
-		b.vars = kv.DefaultVars
-	} else {
+	if vars != nil {
 		b.vars = vars
 	}
 	return b

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -196,7 +196,11 @@ func NewBackoffer(ctx context.Context, maxSleep int) *Backoffer {
 
 // WithVars sets the kv.Variables to the Backoffer and return it.
 func (b *Backoffer) WithVars(vars *kv.Variables) *Backoffer {
-	b.vars = vars
+	if vars == nil {
+		b.vars = kv.DefaultVars
+	} else {
+		b.vars = vars
+	}
 	return b
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
when use `CopClient.Send`, we may pass vars with nil. `Backoff.vars` will be set to nil and then panic will occur when using it.

```go
func (c *CopClient) Send(ctx context.Context, req *kv.Request, vars *kv.Variables) kv.Response {
	bo := NewBackoffer(ctx, copBuildTaskMaxBackoff).WithVars(vars)
```

### What is changed and how it works?
check nil

### Check List 
 - No code

Code changes
 - Has exported function/method change

Related changes
 - Need to cherry-pick to the release branch
