### PR TITLE
infoschema: fix pseudo data for profiling table

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1183,8 +1183,8 @@ func dataForPseudoProfiling() [][]types.Datum {
 		0,                      // PAGE_FAULTS_MAJOR
 		0,                      // PAGE_FAULTS_MINOR
 		0,                      // SWAPS
-		0,                      // SOURCE_FUNCTION
-		0,                      // SOURCE_FILE
+		"",                     // SOURCE_FUNCTION
+		"",                     // SOURCE_FILE
 		0,                      // SOURCE_LINE
 	)
 	rows = append(rows, row)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When selecting rows from `profiling`, tidb will get panics like:
```
encoding/binary.binary.littleEndian.PutUint64(...)
/usr/local/go/src/encoding/binary/binary.go:82
github.com/pingcap/tidb/util/chunk.MutRow.SetDatum(0xc4205a9880, 0x0, 0xf, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/chunk/mutrow.go:283 +0x8a1
github.com/pingcap/tidb/util/chunk.MutRow.SetDatums(0xc4205a9880, 0x0, 0xc42017d400, 0x12, 0x12)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/util/chunk/mutrow.go:270 +0xe9
github.com/pingcap/tidb/executor.(*TableScanExec).nextChunk4InfoSchema.func1(0x0, 0xc42017d400, 0x12, 0x12, 0xc42254ab40, 0x12, 0x12, 0x1, 0x1, 0x0)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/executor/executor.go:786 +0x68
github.com/pingcap/tidb/infoschema.(*infoschemaTable).IterRecords(0xc420627940, 0x142e980, 0xc420e74e00, 0x0, 0x0, 0x0, 0xc42254ab40, 0x12, 0x12, 0xc4205a98c0, ...)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/infoschema/tables.go:1169 +0x123
github.com/pingcap/tidb/executor.(*TableScanExec).nextChunk4InfoSchema(0xc4212d5860, 0x7f92db394118, 0xc42159f000, 0xc4205a95e0, 0x8b53b9, 0xc4205a95e0)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/executor/executor.go:785 +0x41d
```
### What is changed and how it works?

The type of `SOURCE_FUNCTION` and `SOURCE_FILE` is varchar, so the default value should be an empty string, not 0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

PTAL @zz-jason @winoros @eurekaka 