### PR TITLE
[WIP] privilege: return error on check for missing user

### DIFF
--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -14,6 +14,7 @@
 package privileges
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/pingcap/parser/auth"
@@ -139,10 +140,17 @@ func (p *UserPrivileges) UserPrivilegesTable() [][]types.Datum {
 }
 
 // ShowGrants implements privilege.Manager ShowGrants interface.
-func (p *UserPrivileges) ShowGrants(ctx sessionctx.Context, user *auth.UserIdentity) ([]string, error) {
+func (p *UserPrivileges) ShowGrants(ctx sessionctx.Context, user *auth.UserIdentity) (grants []string, err error) {
 	mysqlPrivilege := p.Handle.Get()
+	u := user.Username
+	h := user.Hostname
 	if len(user.AuthUsername) > 0 && len(user.AuthHostname) > 0 {
-		return mysqlPrivilege.showGrants(user.AuthUsername, user.AuthHostname), nil
+		u = user.AuthUsername
+		h = user.AuthHostname
 	}
-	return mysqlPrivilege.showGrants(user.Username, user.Hostname), nil
+	grants = mysqlPrivilege.showGrants(u,h)
+	if len(grants) == 0 {
+		err = fmt.Errorf("There is no such grant defined for user '%s' on host '%s'", u, h);
+	}
+	return
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #7614

Makes TiDB return an error when running "SHOW GRANTS FOR [missing-user]", as in MySQL.

### What is changed and how it works?

I changed the privilege system to generate an error, interfaces remain the same.  Depends on early patches which partially fixed #7614 (all merged to master)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Code changes

 - Minimal

Side effects

 - Increased code complexity
 - Breaking backwards compatibility (bad tests and programs may rely on TiDB specific behaviour)

Related changes

 - Need to be included in the release note
