### PR TITLE
admin check: use datum compare instead of relect deepequal

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -244,6 +244,42 @@ func (s *testSuite) TestAdmin(c *C) {
 	tk.MustExec("ALTER TABLE t1 ADD COLUMN c4 bit(10) default 127;")
 	tk.MustExec("ALTER TABLE t1 ADD INDEX idx3 (c4);")
 	tk.MustExec("admin check table t1;")
+
+	// For add index on virtual column
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec(`create table t1 (
+		a int             as (JSON_EXTRACT(k,'$.a')),
+		c double          as (JSON_EXTRACT(k,'$.c')),
+		d decimal(20,10)  as (JSON_EXTRACT(k,'$.d')),
+		e char(10)        as (JSON_EXTRACT(k,'$.e')),
+		f date            as (JSON_EXTRACT(k,'$.f')),
+		g time            as (JSON_EXTRACT(k,'$.g')),
+		h datetime        as (JSON_EXTRACT(k,'$.h')),
+		i timestamp       as (JSON_EXTRACT(k,'$.i')),
+		j year            as (JSON_EXTRACT(k,'$.j')),
+		k json);`)
+
+	tk.MustExec("insert into t1 set k='{\"a\": 100,\"c\":1.234,\"d\":1.2340000000,\"e\":\"abcdefg\",\"f\":\"2018-09-28\",\"g\":\"12:59:59\",\"h\":\"2018-09-28 12:59:59\",\"i\":\"2018-09-28 16:40:33\",\"j\":\"2018\"}';")
+	tk.MustExec("alter table t1 add index idx_a(a);")
+	tk.MustExec("alter table t1 add index idx_c(c);")
+	tk.MustExec("alter table t1 add index idx_d(d);")
+	tk.MustExec("alter table t1 add index idx_e(e);")
+	tk.MustExec("alter table t1 add index idx_f(f);")
+	tk.MustExec("alter table t1 add index idx_g(g);")
+	tk.MustExec("alter table t1 add index idx_h(h);")
+	tk.MustExec("alter table t1 add index idx_j(j);")
+	tk.MustExec("alter table t1 add index idx_i(i);")
+	tk.MustExec("alter table t1 add index idx_m(a,c,d,e,f,g,h,i,j);")
+	tk.MustExec("admin check table t1;")
+
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("CREATE TABLE t1 (c1 int);")
+	tk.MustExec("INSERT INTO t1 SET c1 = 1;")
+	tk.MustExec("ALTER TABLE t1 ADD COLUMN cc1 CHAR(36)    NULL DEFAULT '';")
+	tk.MustExec("ALTER TABLE t1 ADD COLUMN cc2 VARCHAR(36) NULL DEFAULT ''")
+	tk.MustExec("ALTER TABLE t1 ADD INDEX idx1 (cc1);")
+	tk.MustExec("ALTER TABLE t1 ADD INDEX idx2 (cc2);")
+	tk.MustExec("admin check table t1;")
 }
 
 func (s *testSuite) fillData(tk *testkit.TestKit, table string) {

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -14,6 +14,8 @@
 package types
 
 import (
+	"reflect"
+	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -588,5 +590,41 @@ func (ts *testDatumSuite) TestCopyDatum(c *C) {
 		if tt.b != nil {
 			c.Assert(&tt.b[0], Not(Equals), &tt1.b[0])
 		}
+	}
+}
+
+func prepareCompareDatums() ([]Datum, []Datum) {
+	vals := make([]Datum, 0, 5)
+	vals = append(vals, NewIntDatum(1))
+	vals = append(vals, NewFloat64Datum(1.23))
+	vals = append(vals, NewStringDatum("abcde"))
+	vals = append(vals, NewDecimalDatum(NewDecFromStringForTest("1.2345")))
+	vals = append(vals, NewTimeDatum(Time{Time: FromGoTime(time.Date(2018, 3, 8, 16, 1, 0, 315313000, time.UTC)), Fsp: 6, Type: mysql.TypeTimestamp}))
+
+	vals1 := make([]Datum, 0, 5)
+	vals1 = append(vals1, NewIntDatum(1))
+	vals1 = append(vals1, NewFloat64Datum(1.23))
+	vals1 = append(vals1, NewStringDatum("abcde"))
+	vals1 = append(vals1, NewDecimalDatum(NewDecFromStringForTest("1.2345")))
+	vals1 = append(vals1, NewTimeDatum(Time{Time: FromGoTime(time.Date(2018, 3, 8, 16, 1, 0, 315313000, time.UTC)), Fsp: 6, Type: mysql.TypeTimestamp}))
+	return vals, vals1
+}
+
+func BenchmarkCompareDatum(b *testing.B) {
+	vals, vals1 := prepareCompareDatums()
+	sc := new(stmtctx.StatementContext)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j, v := range vals {
+			v.CompareDatum(sc, &vals1[j])
+		}
+	}
+}
+
+func BenchmarkCompareDatumByReflect(b *testing.B) {
+	vals, vals1 := prepareCompareDatums()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		reflect.DeepEqual(vals, vals1)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick from #7887 
There so many miss report cause by admin check that use `reflect.DeepEqual ` when do `schrodinger-test`. So I cherry pick this to 2.0.