### PR TITLE
index path pruning, query as  first column of composite PK with auto_increment property

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -454,3 +454,17 @@ Projection_4	2666.67	root	test.t.a
     └─TableScan_5	3333.33	cop	table:t, range:(0,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;
+create table t(a bigint(20) NOT NULL AUTO_INCREMENT, b bigint(20) NOT NULL, primary key(a, b));
+explain select * from t WHERE a = 1 AND b = 2;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:t, index:a b
+explain select * from t WHERE a = 1;
+id	count	task	operator info
+IndexReader_6	10.00	root	index:IndexScan_5
+└─IndexScan_5	10.00	cop	table:t, index:a, b, range:[1,1], keep order:false, stats:pseudo
+explain select * from t where  b = 2;
+id	count	task	operator info
+TableReader_7	1.00	root	data:Selection_6
+└─Selection_6	1.00	cop	eq(test.t.b, 2)
+  └─TableScan_5	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table if exists t;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -101,3 +101,8 @@ explain select a, _tidb_rowid from t where a > 0;
 explain select * from t where _tidb_rowid > 0 and a > 0;
 drop table if exists t;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;
+create table t(a bigint(20) NOT NULL AUTO_INCREMENT, b bigint(20) NOT NULL, primary key(a, b));
+explain select * from t WHERE a = 1 AND b = 2;
+explain select * from t WHERE a = 1;
+explain select * from t where  b = 2;
+drop table if exists t;

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -343,9 +343,13 @@ func (ds *DataSource) deriveTablePathStats(path *accessPath) (bool, error) {
 	}
 	if pkCol == nil {
 		path.ranges = ranger.FullIntRange(false)
-		extraHandleCol := ds.Columns[len(ds.Columns)-1]
-		if extraHandleCol.ID == model.ExtraHandleID {
-			pkCol = expression.ColInfo2Col(ds.schema.Columns, extraHandleCol)
+		if len(ds.Columns) > 0 {
+			extraHandleCol := ds.Columns[len(ds.Columns)-1]
+			if extraHandleCol.ID == model.ExtraHandleID {
+				pkCol = expression.ColInfo2Col(ds.schema.Columns, extraHandleCol)
+			} else {
+				return false, nil
+			}
 		} else {
 			return false, nil
 		}

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -343,7 +343,12 @@ func (ds *DataSource) deriveTablePathStats(path *accessPath) (bool, error) {
 	}
 	if pkCol == nil {
 		path.ranges = ranger.FullIntRange(false)
-		return false, nil
+		extraHandleCol := ds.Columns[len(ds.Columns)-1]
+		if extraHandleCol.ID == model.ExtraHandleID {
+			pkCol = expression.ColInfo2Col(ds.schema.Columns, extraHandleCol)
+		} else {
+			return false, nil
+		}
 	}
 
 	path.ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(pkCol.RetType.Flag))

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -343,16 +343,7 @@ func (ds *DataSource) deriveTablePathStats(path *accessPath) (bool, error) {
 	}
 	if pkCol == nil {
 		path.ranges = ranger.FullIntRange(false)
-		if len(ds.Columns) > 0 {
-			extraHandleCol := ds.Columns[len(ds.Columns)-1]
-			if extraHandleCol.ID == model.ExtraHandleID {
-				pkCol = expression.ColInfo2Col(ds.schema.Columns, extraHandleCol)
-			} else {
-				return false, nil
-			}
-		} else {
-			return false, nil
-		}
+		return false, nil
 	}
 
 	path.ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(pkCol.RetType.Flag))

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -462,15 +462,16 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	// Check whether there's only point query.
 	noIntervalRanges := true
 	haveNullVal := false
+
 	for _, ran := range path.ranges {
 		// Not point or the not full matched.
-		if !ran.IsPoint(sc) || len(ran.HighVal) != len(path.index.Columns) {
+		if !ran.IsPoint(sc) || (len(path.idxCols) > 0 && !mysql.HasAutoIncrementFlag(path.idxCols[0].RetType.Flag) && len(ran.HighVal) != len(path.index.Columns)) {
 			noIntervalRanges = false
 			break
 		}
 		// Check whether there's null value.
 		for i := 0; i < len(path.index.Columns); i++ {
-			if ran.HighVal[i].IsNull() {
+			if i < len(ran.HighVal) && ran.HighVal[i].IsNull() {
 				haveNullVal = true
 				break
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/8121

### What is changed and how it works?
asset first column of primary key have auto_increment property 
choose  if column's length assert  needed


Tests <!-- At least one of them must be included. -->
 - Unit test
 - Integration test

Code changes
 - Has exported variable/fields change


