### PR TITLE
executor: add a variable to control whether we can write _tidb_rowid

### DIFF
--- a/executor/rowid_test.go
+++ b/executor/rowid_test.go
@@ -18,6 +18,9 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
+/*
+Insert, update and replace statements for _tidb_rowid are not support now.
+After we support it, the following operations can be passed.
 func (s *testSuite) TestExportRowID(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -38,15 +41,45 @@ func (s *testSuite) TestExportRowID(c *C) {
 	tk.MustQuery("select *, _tidb_rowid from t").
 		Check(testkit.Rows("1 7 1", "2 2 2", "1 9 3", "5 5 5"))
 
-	// If PK is handle, _tidb_rowid is unknown column.
-	tk.MustExec("create table s (a int primary key)")
-	tk.MustExec("insert s values (1)")
-	_, err := tk.Exec("insert s (a, _tidb_rowid) values (1, 2)")
-	c.Assert(err, NotNil)
-	_, err = tk.Exec("select _tidb_rowid from s")
-	c.Assert(err, NotNil)
-	_, err = tk.Exec("update s set a = 2 where _tidb_rowid = 1")
-	c.Assert(err, NotNil)
-	_, err = tk.Exec("delete from s where _tidb_rowid = 1")
-	c.Assert(err, NotNil)
+	 // If PK is handle, _tidb_rowid is unknown column.
+	 tk.MustExec("create table s (a int primary key)")
+	 tk.MustExec("insert s values (1)")
+	 _, err := tk.Exec("insert s (a, _tidb_rowid) values (1, 2)")
+	 c.Assert(err, NotNil)
+	 _, err = tk.Exec("select _tidb_rowid from s")
+	 c.Assert(err, NotNil)
+	 _, err = tk.Exec("update s set a = 2 where _tidb_rowid = 1")
+	 c.Assert(err, NotNil)
+	 _, err = tk.Exec("delete from s where _tidb_rowid = 1")
+	 c.Assert(err, NotNil)
+}
+*/
+
+func (s *testSuite) TestRowID(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table tt(id binary(10), c int, primary key(id));")
+	tk.MustExec("insert tt values (1, 10);")
+
+	// select statement
+	tk.MustQuery("select *, _tidb_rowid from tt").
+		Check(testkit.Rows("1\x00\x00\x00\x00\x00\x00\x00\x00\x00 10 1"))
+	// insert statement
+	_, err := tk.Exec("insert into tt (id, c, _tidb_rowid) values(30000,10,1);")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	// replace statement
+	_, err = tk.Exec("replace into tt (id, c, _tidb_rowid) values(30000,10,1);")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	// update statement
+	_, err = tk.Exec("update tt set id = 2, _tidb_rowid = 1 where _tidb_rowid = 1")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	tk.MustExec("update tt set id = 2 where _tidb_rowid = 1")
+
+	tk.MustExec("admin check table tt;")
+	tk.MustExec("drop table tt")
+
+	// Insert, update and replace statements for _tidb_rowid are not support now.
+	// After we support it, the following operations must be passed.
+	//	tk.MustExec("insert into tt (id, c, _tidb_rowid) values(30000,10,1);")
+	//	tk.MustExec("admin check table tt;")
 }

--- a/executor/rowid_test.go
+++ b/executor/rowid_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 /*
-Insert, update and replace statements for _tidb_rowid are not support now.
+Insert, update and replace statements for _tidb_rowid are not supported now.
 After we support it, the following operations can be passed.
 func (s *testSuite) TestExportRowID(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
@@ -66,19 +66,19 @@ func (s *testSuite) TestRowID(c *C) {
 		Check(testkit.Rows("1\x00\x00\x00\x00\x00\x00\x00\x00\x00 10 1"))
 	// insert statement
 	_, err := tk.Exec("insert into tt (id, c, _tidb_rowid) values(30000,10,1);")
-	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not supported.")
 	// replace statement
 	_, err = tk.Exec("replace into tt (id, c, _tidb_rowid) values(30000,10,1);")
-	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not supported.")
 	// update statement
 	_, err = tk.Exec("update tt set id = 2, _tidb_rowid = 1 where _tidb_rowid = 1")
-	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not support.")
+	c.Assert(err.Error(), Equals, "insert, update and replace statements for _tidb_rowid are not supported.")
 	tk.MustExec("update tt set id = 2 where _tidb_rowid = 1")
 
 	tk.MustExec("admin check table tt;")
 	tk.MustExec("drop table tt")
 
-	// Insert, update and replace statements for _tidb_rowid are not support now.
+	// Insert, update and replace statements for _tidb_rowid are not supported now.
 	// After we support it, the following operations must be passed.
 	//	tk.MustExec("insert into tt (id, c, _tidb_rowid) values(30000,10,1);")
 	//	tk.MustExec("admin check table tt;")

--- a/executor/write.go
+++ b/executor/write.go
@@ -1371,7 +1371,7 @@ func (e *InsertValues) getColumns(tableCols []*table.Column) ([]*table.Column, e
 	for _, col := range cols {
 		if col.Name.L == model.ExtraHandleName.L {
 			e.hasExtraHandle = true
-			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not support.")
+			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not supported.")
 		}
 	}
 
@@ -1999,7 +1999,7 @@ func getUpdateColumns(assignList []*expression.Assignment, schemaLen int) ([]boo
 	assignFlag := make([]bool, schemaLen)
 	for _, v := range assignList {
 		if v.Col.ColName.L == model.ExtraHandleName.L {
-			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not support.")
+			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not supported.")
 		}
 		idx := v.Col.Index
 		assignFlag[idx] = true

--- a/executor/write.go
+++ b/executor/write.go
@@ -1371,7 +1371,7 @@ func (e *InsertValues) getColumns(tableCols []*table.Column) ([]*table.Column, e
 	for _, col := range cols {
 		if col.Name.L == model.ExtraHandleName.L {
 			e.hasExtraHandle = true
-			break
+			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not support.")
 		}
 	}
 
@@ -1998,6 +1998,9 @@ func (e *UpdateExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 func getUpdateColumns(assignList []*expression.Assignment, schemaLen int) ([]bool, error) {
 	assignFlag := make([]bool, schemaLen)
 	for _, v := range assignList {
+		if v.Col.ColName.L == model.ExtraHandleName.L {
+			return nil, errors.Errorf("insert, update and replace statements for _tidb_rowid are not support.")
+		}
 		idx := v.Col.Index
 		assignFlag[idx] = true
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -238,6 +238,10 @@ type SessionVars struct {
 	// AllowAggPushDown can be set to false to forbid aggregation push down.
 	AllowAggPushDown bool
 
+	// AllowWriteRowID can be set to false to forbid write data to _tidb_rowid.
+	// This variable is currently not recommended to be turned on.
+	AllowWriteRowID bool
+
 	// AllowInSubqueryUnFolding can be set to true to fold in subquery
 	AllowInSubqueryUnFolding bool
 
@@ -517,6 +521,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.SkipUTF8Check = TiDBOptOn(val)
 	case TiDBOptAggPushDown:
 		s.AllowAggPushDown = TiDBOptOn(val)
+	case TiDBOptWriteRowID:
+		s.AllowWriteRowID = TiDBOptOn(val)
 	case TiDBOptInSubqUnFolding:
 		s.AllowInSubqueryUnFolding = TiDBOptOn(val)
 	case TiDBIndexLookupConcurrency:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -610,6 +610,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBImportingData, "0"},
 	{ScopeSession, TiDBOptAggPushDown, boolToIntStr(DefOptAggPushDown)},
 	{ScopeSession, TiDBOptInSubqUnFolding, boolToIntStr(DefOptInSubqUnfolding)},
+	{ScopeSession, TiDBOptWriteRowID, boolToIntStr(DefOptWriteRowID)},
 	{ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},
 	{ScopeGlobal, TiDBAutoAnalyzeRatio, strconv.FormatFloat(DefAutoAnalyzeRatio, 'f', -1, 64)},
 	{ScopeSession, TiDBChecksumTableConcurrency, strconv.Itoa(DefChecksumTableConcurrency)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -39,6 +39,9 @@ const (
 	// tidb_opt_agg_push_down is used to enable/disable the optimizer rule of aggregation push down.
 	TiDBOptAggPushDown = "tidb_opt_agg_push_down"
 
+	// tidb_opt_write_row_id is used to enable/disable the operations of insert、replace and update to _tidb_rowid.
+	TiDBOptWriteRowID = "tidb_opt_write_row_id"
+
 	// tidb_opt_insubquery_unfold is used to enable/disable the optimizer rule of in subquery unfold.
 	TiDBOptInSubqUnFolding = "tidb_opt_insubquery_unfold"
 
@@ -172,6 +175,7 @@ const (
 	DefSkipUTF8Check                 = false
 	DefOptAggPushDown                = false
 	DefOptInSubqUnfolding            = false
+	DefOptWriteRowID                 = false
 	DefBatchInsert                   = false
 	DefBatchDelete                   = false
 	DefCurretTS                      = 0

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -74,6 +74,7 @@ func (s *testVarsutilSuite) TestNewSessionVars(c *C) {
 	c.Assert(vars.MemQuotaIndexLookupReader, Equals, int64(DefTiDBMemQuotaIndexLookupReader))
 	c.Assert(vars.MemQuotaIndexLookupJoin, Equals, int64(DefTiDBMemQuotaIndexLookupJoin))
 	c.Assert(vars.MemQuotaNestedLoopApply, Equals, int64(DefTiDBMemQuotaNestedLoopApply))
+	c.Assert(vars.AllowWriteRowID, Equals, DefOptWriteRowID)
 }
 
 func (s *testVarsutilSuite) TestVarsutil(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
There are problems handling the following case:
```
create table tt(id binary(10), c int, primary key(id));
insert tt values (1, 10);
insert into tt (id, c, _tidb_rowid) values(30000,10,1);
tidb> select * from tt use index(`primary`);
+------------+------+
| id         | c    |
+------------+------+
| 30000      |   10 |
| 30000      |   10 |
+------------+------+
2 rows in set (0.00 sec)
tidb> select * from tt;
+------------+------+
| id         | c    |
+------------+------+
| 30000      |   10 |
+------------+------+
1 row in set (0.00 sec)
```

### What is changed and how it works?
At the moment, if we have to deal with _tidb_rowid, it will be more complicated. So it is best not to support inserting, updating, and replacing _tidb_rowid statements now. But we have some tools that need to write _tidb_rowid, these tools will guarantee that they will not appear as above.
Currently, we want users not to open `AllowWriteRowID`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

