### PR TITLE
domain: avoid an annoying log message

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -878,3 +878,8 @@ var (
 	// ErrInfoSchemaChanged returns the error that information schema is changed.
 	ErrInfoSchemaChanged = terror.ClassDomain.New(codeInfoSchemaChanged, "Information schema is changed.")
 )
+
+func init() {
+	// Map error codes to mysql error codes.
+	terror.ErrClassToMySQLCodes[terror.ClassDomain] = make(map[terror.ErrCode]uint16)
+}

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
@@ -129,4 +130,9 @@ func (*testSuite) TestT(c *C) {
 
 	err = store.Close()
 	c.Assert(err, IsNil)
+}
+
+func (*testSuite) TestErrorCode(c *C) {
+	c.Assert(int(ErrInfoSchemaExpired.ToSQLError().Code), Equals, mysql.ErrUnknown)
+	c.Assert(int(ErrInfoSchemaExpired.ToSQLError().Code), Equals, mysql.ErrUnknown)
 }

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -134,5 +134,5 @@ func (*testSuite) TestT(c *C) {
 
 func (*testSuite) TestErrorCode(c *C) {
 	c.Assert(int(ErrInfoSchemaExpired.ToSQLError().Code), Equals, mysql.ErrUnknown)
-	c.Assert(int(ErrInfoSchemaExpired.ToSQLError().Code), Equals, mysql.ErrUnknown)
+	c.Assert(int(ErrInfoSchemaChanged.ToSQLError().Code), Equals, mysql.ErrUnknown)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before:

```
➜  domain git:(master) ✗ HTTPS_PROXY='http://localhost:8123' GO111MODULE=on go test -check.f TestErrorCode
WARN[0000] Unknown error class: domain                  
WARN[0000] Unknown error class: domain                  
PASS: domain_test.go:135: testSuite.TestErrorCode	0.000s
OK: 1 passed
PASS
ok  	github.com/pingcap/tidb/domain	0.007s
```

After:
```
➜  domain git:(master) ✗ HTTPS_PROXY='http://localhost:8123' GO111MODULE=on go test -check.f TestErrorCode
PASS: domain_test.go:135: testSuite.TestErrorCode	0.000s
OK: 1 passed
PASS
ok  	github.com/pingcap/tidb/domain	0.007s
```


### What is changed and how it works?

Initialize the map, thus it doesn't print this annoying warning:

> WARN[0000] Unknown error class: domain    

Ref https://github.com/pingcap/parser/blob/master/terror/terror.go#L273


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

@zimulala 