### PR TITLE
*: modify tests to work with only-full-group-by on

### DIFF
--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -667,6 +667,10 @@ func main() {
 		log.Fatalf("set @@tidb_hash_join_concurrency=1 err[%v]", err)
 	}
 
+	if _, err = mdb.Exec("set sql_mode='STRICT_TRANS_TABLES'"); err != nil {
+		log.Fatalf("set sql_mode='STRICT_TRANS_TABLES' err[%v]", err)
+	}
+
 	tests := flag.Args()
 
 	// we will run all tests if no tests assigned

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -24,6 +24,7 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@tidb_hash_join_concurrency=1")
 	tk.MustExec("use test")
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'") // disable only-full-group-by
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c int, d int)")
 	tk.MustExec("insert t values (NULL, 1)")

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -171,6 +171,7 @@ func (s *testSuite) TestBigIntPK(c *C) {
 func (s *testSuite) TestCorColToRanges(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'") // disable only-full-group-by
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, index idx(b))")
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2 ,2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1873,6 +1873,8 @@ func (s *testSuite) TestColumnName(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c int, d int)")
+	// disable only full group by
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'")
 	rs, err := tk.Exec("select 1 + c, count(*) from t")
 	c.Check(err, IsNil)
 	fields := rs.Fields()

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -135,6 +135,7 @@ func (s *testIntegrationSuite) TestMiscellaneousBuiltin(c *C) {
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	// for uuid
 	r := tk.MustQuery("select uuid(), uuid(), uuid(), uuid(), uuid(), uuid();")
 	for _, it := range r.Rows() {

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -48,6 +48,7 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 		store.Close()
 	}()
 	tk.MustExec("use test")
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	tk.MustExec("create table t1(a int, b int, c int, key idx(a, b))")
 	tk.MustExec("create table t2(a int, b int)")
 	tk.MustExec("insert into t1 values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4)")
@@ -652,6 +653,7 @@ func (s *testAnalyzeSuite) TestCorrelatedEstimation(c *C) {
 		store.Close()
 	}()
 	tk.MustExec("use test")
+	tk.MustExec("set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	tk.MustExec("create table t(a int, b int, c int, index idx(c))")
 	tk.MustExec("insert into t values(1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5), (6,6,6), (7,7,7), (8,8,8), (9,9,9),(10,10,10)")
 	tk.MustExec("analyze table t")

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -436,7 +436,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSubquery(c *C) {
 	c.Assert(err, IsNil)
 	_, err = se.Execute(context.Background(), "use test")
 	c.Assert(err, IsNil)
-
+	se.Execute(context.Background(), "set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	tests := []struct {
 		sql  string
 		best string
@@ -782,6 +782,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 	se, err := session.CreateSession4Test(store)
 	c.Assert(err, IsNil)
 	se.Execute(context.Background(), "use test")
+	se.Execute(context.Background(), "set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	c.Assert(err, IsNil)
 
 	tests := []struct {
@@ -1176,7 +1177,7 @@ func (s *testPlanSuite) TestAggEliminater(c *C) {
 	c.Assert(err, IsNil)
 	_, err = se.Execute(context.Background(), "use test")
 	c.Assert(err, IsNil)
-
+	se.Execute(context.Background(), "set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	tests := []struct {
 		sql  string
 		best string


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR allows the test-suite to run with the compiled default sql-mode including `ONLY_FULL_GROUP_BY`.  It does not add any new tests (yet).

### What is changed and how it works?

The change is to explicitly set the sql mode in tests that require it.  A better long time fix might be to use the `ANY_VALUE` function (needs work: https://github.com/pingcap/tidb/issues/8161 ), or try running tests with only-full-group-by on/off.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

- Only test changes

Side effects

 - Only sets sql-mode to strict_trans_tables.  If other modes are later turned on by default, behavior might be strange.

Related changes

- Need to fix `ANY_VALUE`: https://github.com/pingcap/tidb/issues/8161
- Can change default to only-full-group-by as on: https://github.com/pingcap/parser/pull/11
