### PR TITLE
*: add a variable tidb_query_log_max_len to set the max length of the query string in the log dynamically

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,7 +90,7 @@ type Log struct {
 	SlowQueryFile      string `toml:"slow-query-file" json:"slow-query-file"`
 	SlowThreshold      uint64 `toml:"slow-threshold" json:"slow-threshold"`
 	ExpensiveThreshold uint   `toml:"expensive-threshold" json:"expensive-threshold"`
-	QueryLogMaxLen     uint   `toml:"query-log-max-len" json:"query-log-max-len"`
+	QueryLogMaxLen     uint64 `toml:"query-log-max-len" json:"query-log-max-len"`
 }
 
 // Security is the security section of the config.
@@ -277,7 +277,7 @@ var defaultConf = Config{
 		},
 		SlowThreshold:      logutil.DefaultSlowThreshold,
 		ExpensiveThreshold: 10000,
-		QueryLogMaxLen:     2048,
+		QueryLogMaxLen:     logutil.DefaultQueryLogMaxLen,
 	},
 	Status: Status{
 		ReportStatus:    true,

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -344,8 +344,8 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 		return
 	}
 	sql := a.Text
-	if len(sql) > int(cfg.Log.QueryLogMaxLen) {
-		sql = fmt.Sprintf("%.*q(len:%d)", cfg.Log.QueryLogMaxLen, sql, len(a.Text))
+	if maxQueryLen := atomic.LoadUint64(&cfg.Log.QueryLogMaxLen); uint64(len(sql)) > maxQueryLen {
+		sql = fmt.Sprintf("%.*q(len:%d)", maxQueryLen, sql, len(a.Text))
 	}
 	sessVars := a.Ctx.GetSessionVars()
 	sql = QueryReplacer.Replace(sql) + sessVars.GetExecuteArgumentsInfo()

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -446,19 +446,9 @@ func (e *InsertValues) adjustAutoIncrementDatum(d types.Datum, hasValue bool, c 
 		d.SetNull()
 	}
 	if !d.IsNull() {
-		sc := e.ctx.GetSessionVars().StmtCtx
-		if mysql.HasUnsignedFlag(c.Flag) {
-			var uintD types.Datum
-			uintD, err = d.ConvertTo(sc, &c.FieldType)
-			if e.filterErr(err) != nil {
-				return types.Datum{}, err
-			}
-			recordID = int64(uintD.GetUint64())
-		} else {
-			recordID, err = d.ToInt64(sc)
-			if e.filterErr(err) != nil {
-				return types.Datum{}, errors.Trace(err)
-			}
+		recordID, err = d.ToInt64(e.ctx.GetSessionVars().StmtCtx)
+		if e.filterErr(err) != nil {
+			return types.Datum{}, errors.Trace(err)
 		}
 	}
 	// Use the value if it's not null and not 0.

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -446,9 +446,19 @@ func (e *InsertValues) adjustAutoIncrementDatum(d types.Datum, hasValue bool, c 
 		d.SetNull()
 	}
 	if !d.IsNull() {
-		recordID, err = d.ToInt64(e.ctx.GetSessionVars().StmtCtx)
-		if e.filterErr(err) != nil {
-			return types.Datum{}, errors.Trace(err)
+		sc := e.ctx.GetSessionVars().StmtCtx
+		if mysql.HasUnsignedFlag(c.Flag) {
+			var uintD types.Datum
+			uintD, err = d.ConvertTo(sc, &c.FieldType)
+			if e.filterErr(err) != nil {
+				return types.Datum{}, err
+			}
+			recordID = int64(uintD.GetUint64())
+		} else {
+			recordID, err = d.ToInt64(sc)
+			if e.filterErr(err) != nil {
+				return types.Datum{}, errors.Trace(err)
+			}
 		}
 	}
 	// Use the value if it's not null and not 0.

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -246,6 +246,13 @@ func (s *testSuite) TestSetVar(c *C) {
 	tk.MustQuery("select @@session.tidb_slow_log_threshold;").Check(testkit.Rows("1"))
 	_, err = tk.Exec("set global tidb_slow_log_threshold = 0")
 	c.Assert(err, NotNil)
+
+	tk.MustExec("set tidb_query_log_max_len = 0")
+	tk.MustQuery("select @@session.tidb_query_log_max_len;").Check(testkit.Rows("0"))
+	tk.MustExec("set tidb_query_log_max_len = 20")
+	tk.MustQuery("select @@session.tidb_query_log_max_len;").Check(testkit.Rows("20"))
+	_, err = tk.Exec("set global tidb_query_log_max_len = 20")
+	c.Assert(err, NotNil)
 }
 
 func (s *testSuite) TestSetCharset(c *C) {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -611,6 +611,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		atomic.StoreUint32(&ProcessGeneralLog, uint32(tidbOptPositiveInt32(val, DefTiDBGeneralLog)))
 	case TiDBSlowLogThreshold:
 		atomic.StoreUint64(&config.GetGlobalConfig().Log.SlowThreshold, uint64(tidbOptInt64(val, logutil.DefaultSlowThreshold)))
+	case TiDBQueryLogMaxLen:
+		atomic.StoreUint64(&config.GetGlobalConfig().Log.QueryLogMaxLen, uint64(tidbOptInt64(val, logutil.DefaultQueryLogMaxLen)))
 	case TiDBRetryLimit:
 		s.RetryLimit = tidbOptInt64(val, DefTiDBRetryLimit)
 	case TiDBDisableTxnAutoRetry:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -664,6 +664,7 @@ var defaultSysVars = []*SysVar{
 	/* The following variable is defined as session scope but is actually server scope. */
 	{ScopeSession, TiDBGeneralLog, strconv.Itoa(DefTiDBGeneralLog)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},
+	{ScopeSession, TiDBQueryLogMaxLen, strconv.Itoa(logutil.DefaultQueryLogMaxLen)},
 	{ScopeSession, TiDBConfig, ""},
 	{ScopeGlobal | ScopeSession, TiDBDDLReorgWorkerCount, strconv.Itoa(DefTiDBDDLReorgWorkerCount)},
 	{ScopeSession, TiDBDDLReorgPriority, "PRIORITY_LOW"},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -98,6 +98,9 @@ const (
 	// tidb_slow_log_threshold is used to set the slow log threshold in the server.
 	TiDBSlowLogThreshold = "tidb_slow_log_threshold"
 
+	// tidb_query_log_max_len is used to set the max length of the query in the log.
+	TiDBQueryLogMaxLen = "tidb_query_log_max_len"
+
 	// tidb_retry_limit is the maximum number of retries when committing a transaction.
 	TiDBRetryLimit = "tidb_retry_limit"
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -87,6 +87,8 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 		return mysql.Priority2Str[mysql.PriorityEnum(atomic.LoadInt32(&ForcePriority))], true, nil
 	case TiDBSlowLogThreshold:
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.SlowThreshold), 10), true, nil
+	case TiDBQueryLogMaxLen:
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.QueryLogMaxLen), 10), true, nil
 	}
 	sVal, ok := s.systems[key]
 	if ok {
@@ -327,7 +329,9 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TIDBMemQuotaIndexLookupReader,
 		TIDBMemQuotaIndexLookupJoin,
 		TIDBMemQuotaNestedLoopApply,
-		TiDBRetryLimit, TiDBSlowLogThreshold:
+		TiDBRetryLimit,
+		TiDBSlowLogThreshold,
+		TiDBQueryLogMaxLen:
 		_, err := strconv.ParseInt(value, 10, 64)
 		if err != nil {
 			return value, ErrWrongValueForVar.GenWithStackByArgs(name)

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -35,6 +35,8 @@ const (
 	defaultLogLevel   = log.InfoLevel
 	// DefaultSlowThreshold is the default slow log threshold in millisecond.
 	DefaultSlowThreshold = 300
+	// DefaultQueryLogMaxLen is the default max length of the query in the log.
+	DefaultQueryLogMaxLen = 2048
 )
 
 // FileLogConfig serializes file log related config in toml/json.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Change the max length of the query in the log files need to reboot the TiDB server, which is not easy for debugging.

### What is changed and how it works?
Add a variable for it to set it dynamically.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

PTAL @XuHuaiyu @lysu 
