### PR TITLE
store/tikv: refine backoff log

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1442,7 +1442,7 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 func logQuery(query string, vars *variable.SessionVars) {
 	if atomic.LoadUint32(&variable.ProcessGeneralLog) != 0 && !vars.InRestrictedSQL {
 		query = executor.QueryReplacer.Replace(query)
-		log.Infof("[GENERAL_LOG] con:%d user:%s schema_ver:%d start_ts:%d sql:%s%s",
+		log.Infof("[GENERAL_LOG] con:%d user:%s schema_ver:%d txn_start_ts:%d sql:%s%s",
 			vars.ConnectionID, vars.User, vars.TxnCtx.SchemaVersion, vars.TxnCtx.StartTS, query, vars.GetExecuteArgumentsInfo())
 	}
 }

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -569,7 +569,8 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) error {
 		if !committed && !undetermined {
 			c.cleanWg.Add(1)
 			go func() {
-				err := c.cleanupKeys(NewBackoffer(context.Background(), cleanupMaxBackoff).WithVars(c.txn.vars), c.keys)
+				cleanupKeysCtx := context.WithValue(context.Background(), TxnStartKey, ctx.Value(TxnStartKey))
+				err := c.cleanupKeys(NewBackoffer(cleanupKeysCtx, cleanupMaxBackoff).WithVars(c.txn.vars), c.keys)
 				if err != nil {
 					metrics.TiKVSecondaryLockCleanupFailureCounter.WithLabelValues("rollback").Inc()
 					log.Infof("con:%d 2PC cleanup err: %v, tid: %d", c.connID, err, c.startTS)

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -569,7 +569,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) error {
 		if !committed && !undetermined {
 			c.cleanWg.Add(1)
 			go func() {
-				cleanupKeysCtx := context.WithValue(context.Background(), TxnStartKey, ctx.Value(TxnStartKey))
+				cleanupKeysCtx := context.WithValue(context.Background(), txnStartKey, ctx.Value(txnStartKey))
 				err := c.cleanupKeys(NewBackoffer(cleanupKeysCtx, cleanupMaxBackoff).WithVars(c.txn.vars), c.keys)
 				if err != nil {
 					metrics.TiKVSecondaryLockCleanupFailureCounter.WithLabelValues("rollback").Inc()

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -185,8 +185,8 @@ type Backoffer struct {
 	vars       *kv.Variables
 }
 
-// TxnStartKey is a key for transaction start_ts info in context.Context.
-const TxnStartKey = "_txn_start_key"
+// txnStartKey is a key for transaction start_ts info in context.Context.
+const txnStartKey = "_txn_start_key"
 
 // NewBackoffer creates a Backoffer with maximum sleep time(in ms).
 func NewBackoffer(ctx context.Context, maxSleep int) *Backoffer {
@@ -232,10 +232,10 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 	b.types = append(b.types, typ)
 
 	var startTs interface{} = ""
-	if ts := b.ctx.Value(TxnStartKey); ts != nil {
+	if ts := b.ctx.Value(txnStartKey); ts != nil {
 		startTs = ts
 	}
-	log.Debugf("%v, retry later(totalsleep %dms, maxsleep %dms), type: %s, start_ts: %v", err, b.totalSleep, b.maxSleep, typ.String(), startTs)
+	log.Debugf("%v, retry later(totalsleep %dms, maxsleep %dms), type: %s, txn_start_ts: %v", err, b.totalSleep, b.maxSleep, typ.String(), startTs)
 
 	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
 	if b.maxSleep > 0 && b.totalSleep >= b.maxSleep {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -80,7 +80,7 @@ func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
 
 // Send builds the request and gets the coprocessor iterator response.
 func (c *CopClient) Send(ctx context.Context, req *kv.Request, vars *kv.Variables) kv.Response {
-	ctx = context.WithValue(ctx, TxnStartKey, req.StartTs)
+	ctx = context.WithValue(ctx, txnStartKey, req.StartTs)
 	bo := NewBackoffer(ctx, copBuildTaskMaxBackoff).WithVars(vars)
 	tasks, err := buildCopTasks(bo, c.store.regionCache, &copRanges{mid: req.KeyRanges}, req.Desc, req.Streaming)
 	if err != nil {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -80,6 +80,7 @@ func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
 
 // Send builds the request and gets the coprocessor iterator response.
 func (c *CopClient) Send(ctx context.Context, req *kv.Request, vars *kv.Variables) kv.Response {
+	ctx = context.WithValue(ctx, TxnStartKey, req.StartTs)
 	bo := NewBackoffer(ctx, copBuildTaskMaxBackoff).WithVars(vars)
 	tasks, err := buildCopTasks(bo, c.store.regionCache, &copRanges{mid: req.KeyRanges}, req.Desc, req.Streaming)
 	if err != nil {

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -74,7 +74,7 @@ func (s *Scanner) Value() []byte {
 
 // Next return next element.
 func (s *Scanner) Next() error {
-	bo := NewBackoffer(context.Background(), scannerNextMaxBackoff)
+	bo := NewBackoffer(context.WithValue(context.Background(), TxnStartKey, s.snapshot.version.Ver), scannerNextMaxBackoff)
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")
 	}

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -74,7 +74,7 @@ func (s *Scanner) Value() []byte {
 
 // Next return next element.
 func (s *Scanner) Next() error {
-	bo := NewBackoffer(context.WithValue(context.Background(), TxnStartKey, s.snapshot.version.Ver), scannerNextMaxBackoff)
+	bo := NewBackoffer(context.WithValue(context.Background(), txnStartKey, s.snapshot.version.Ver), scannerNextMaxBackoff)
 	if !s.valid {
 		return errors.New("scanner iterator is invalid")
 	}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -73,7 +73,7 @@ func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 
 	// We want [][]byte instead of []kv.Key, use some magic to save memory.
 	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
-	ctx := context.WithValue(context.Background(), TxnStartKey, s.version.Ver)
+	ctx := context.WithValue(context.Background(), txnStartKey, s.version.Ver)
 	bo := NewBackoffer(ctx, batchGetMaxBackoff).WithVars(s.vars)
 
 	// Create a map to collect key-values from region servers.
@@ -209,7 +209,7 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 
 // Get gets the value for key k from snapshot.
 func (s *tikvSnapshot) Get(k kv.Key) ([]byte, error) {
-	ctx := context.WithValue(context.Background(), TxnStartKey, s.version.Ver)
+	ctx := context.WithValue(context.Background(), txnStartKey, s.version.Ver)
 	val, err := s.get(NewBackoffer(ctx, getMaxBackoff), k)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -73,7 +73,8 @@ func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 
 	// We want [][]byte instead of []kv.Key, use some magic to save memory.
 	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
-	bo := NewBackoffer(context.Background(), batchGetMaxBackoff).WithVars(s.vars)
+	ctx := context.WithValue(context.Background(), TxnStartKey, s.version.Ver)
+	bo := NewBackoffer(ctx, batchGetMaxBackoff).WithVars(s.vars)
 
 	// Create a map to collect key-values from region servers.
 	var mu sync.Mutex
@@ -208,7 +209,8 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 
 // Get gets the value for key k from snapshot.
 func (s *tikvSnapshot) Get(k kv.Key) ([]byte, error) {
-	val, err := s.get(NewBackoffer(context.Background(), getMaxBackoff), k)
+	ctx := context.WithValue(context.Background(), TxnStartKey, s.version.Ver)
+	val, err := s.get(NewBackoffer(ctx, getMaxBackoff), k)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

current, backoff's debug log doesn't contain `start_ts` and `backtype` info, so it's hard to find out which stmt effect by backoff operation.

this PR add `backoff-type` and `start_ts` for `CopClient`, `Snapshot`, `Scanner` code path's backoff debug log.

so we can got sql from other stmt via `start_ts`, and know the retry reason by `type`.

### What is changed and how it works?

- annotate `start_ts` in `context.Context`
- output backoff type string

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test

Code changes

 - Add log

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8207)
<!-- Reviewable:end -->
