### PR TITLE
store/tikv/latch: fix a deadlock in the latch scheduler (#8186)

### DIFF
--- a/store/tikv/latch/latch_test.go
+++ b/store/tikv/latch/latch_test.go
@@ -122,6 +122,9 @@ func (s *testLatchSuite) TestRecycle(c *C) {
 	lock.SetCommitTS(startTS + 1)
 	var wakeupList []*Lock
 	latches.release(lock, wakeupList)
+	// Release lock will grant latch to lock1 automatically,
+	// so release lock1 is called here.
+	latches.release(lock1, wakeupList)
 
 	lock2 := latches.genLock(startTS+3, [][]byte{
 		[]byte("b"), []byte("c"),

--- a/store/tikv/latch/scheduler.go
+++ b/store/tikv/latch/scheduler.go
@@ -44,9 +44,8 @@ func NewScheduler(size uint) *LatchesScheduler {
 	return scheduler
 }
 
-// A transaction can last for at most 10 minutes, see also gcworker.
-const expireDuration = 10 * time.Minute
-const checkInterval = 5 * time.Minute
+const expireDuration = 2 * time.Minute
+const checkInterval = 1 * time.Minute
 const checkCounter = 50000
 const latchListCount = 5
 
@@ -62,7 +61,7 @@ func (scheduler *LatchesScheduler) run() {
 		if lock.commitTS > lock.startTS {
 			currentTS := lock.commitTS
 			elapsed := tsoSub(currentTS, scheduler.lastRecycleTime)
-			if elapsed > checkInterval && counter > checkCounter {
+			if elapsed > checkInterval || counter > checkCounter {
 				go scheduler.latches.recycle(lock.commitTS)
 				scheduler.lastRecycleTime = currentTS
 				counter = 0

--- a/store/tikv/latch/scheduler_test.go
+++ b/store/tikv/latch/scheduler_test.go
@@ -14,7 +14,10 @@
 package latch
 
 import (
+	"bytes"
+	"math/rand"
 	"sync"
+	"time"
 
 	. "github.com/pingcap/check"
 )
@@ -28,28 +31,64 @@ func (s *testSchedulerSuite) SetUpTest(c *C) {
 }
 
 func (s *testSchedulerSuite) TestWithConcurrency(c *C) {
-	txns := [][][]byte{
-		{[]byte("a"), []byte("b"), []byte("c")},
-		{[]byte("a"), []byte("d"), []byte("e"), []byte("f")},
-		{[]byte("e"), []byte("f"), []byte("g"), []byte("h")},
-	}
-	sched := NewScheduler(1024)
+	sched := NewScheduler(7)
 	defer sched.Close()
+	rand.Seed(time.Now().Unix())
 
+	ch := make(chan [][]byte, 100)
+	const workerCount = 10
 	var wg sync.WaitGroup
-	wg.Add(len(txns))
-	for _, txn := range txns {
-		go func(txn [][]byte, wg *sync.WaitGroup) {
-			lock := sched.Lock(getTso(), txn)
-			defer sched.UnLock(lock)
-			if lock.IsStale() {
-				// Should restart the transaction or return error
-			} else {
-				lock.SetCommitTS(getTso())
-				// Do 2pc
+	wg.Add(workerCount)
+	for i := 0; i < workerCount; i++ {
+		go func(ch <-chan [][]byte, wg *sync.WaitGroup) {
+			for txn := range ch {
+				lock := sched.Lock(getTso(), txn)
+				if lock.IsStale() {
+					// Should restart the transaction or return error
+				} else {
+					lock.SetCommitTS(getTso())
+					// Do 2pc
+				}
+				sched.UnLock(lock)
 			}
 			wg.Done()
-		}(txn, &wg)
+		}(ch, &wg)
 	}
+
+	for i := 0; i < 999; i++ {
+		ch <- generate()
+	}
+	close(ch)
+
 	wg.Wait()
+}
+
+// generate generates something like:
+// {[]byte("a"), []byte("b"), []byte("c")}
+// {[]byte("a"), []byte("d"), []byte("e"), []byte("f")}
+// {[]byte("e"), []byte("f"), []byte("g"), []byte("h")}
+// The data should not repeat in the sequence.
+func generate() [][]byte {
+	table := []byte{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'}
+	ret := make([][]byte, 0, 5)
+	chance := []int{100, 60, 40, 20}
+	for i := 0; i < len(chance); i++ {
+		needMore := rand.Intn(100) < chance[i]
+		if needMore {
+			randBytes := []byte{table[rand.Intn(len(table))]}
+			if !contains(randBytes, ret) {
+				ret = append(ret, randBytes)
+			}
+		}
+	}
+	return ret
+}
+
+func contains(x []byte, set [][]byte) bool {
+	for _, y := range set {
+		if bytes.Compare(x, y) == 0 {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Cherry-pick from https://github.com/pingcap/tidb/pull/8186

Although latch is not enabled by default in 2.1, bug fix should still be cherry pick.

@disksing @zhangjinpeng1987 @shenli 