### PR TITLE
expression: fix wrong compare result of row

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2887,6 +2887,18 @@ func (s *testIntegrationSuite) TestCompareBuiltin(c *C) {
 	tk.MustExec("create table t(a bigint unsigned)")
 	tk.MustExec("insert into t value(17666000000000000000)")
 	tk.MustQuery("select * from t where a = 17666000000000000000").Check(testkit.Rows("17666000000000000000"))
+
+	// test for compare row
+	result = tk.MustQuery(`select row(1,2,3)=row(1,2,3)`)
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery(`select row(1,2,3)=row(1+3,2,3)`)
+	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery(`select row(1,2,3)<>row(1,2,3)`)
+	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery(`select row(1,2,3)<>row(1+3,2,3)`)
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery(`select row(1+3,2,3)<>row(1+3,2,3)`)
+	result.Check(testkit.Rows("0"))
 }
 
 func (s *testIntegrationSuite) TestAggregationBuiltin(c *C) {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -275,6 +275,9 @@ func (sr *simpleRewriter) constructBinaryOpFunction(l Expression, r Expression, 
 				return nil, errors.Trace(err)
 			}
 		}
+		if op == ast.NE {
+			return ComposeDNFCondition(sr.ctx, funcs...), nil
+		}
 		return ComposeCNFCondition(sr.ctx, funcs...), nil
 	default:
 		larg0, rarg0 := GetFuncArg(l, 0), GetFuncArg(r, 0)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -196,6 +196,9 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 				return nil, errors.Trace(err)
 			}
 		}
+		if op == ast.NE {
+			return expression.ComposeDNFCondition(er.ctx, funcs...), nil
+		}
 		return expression.ComposeCNFCondition(er.ctx, funcs...), nil
 	default:
 		larg0, rarg0 := expression.GetFuncArg(l, 0), expression.GetFuncArg(r, 0)

--- a/planner/core/expression_test.go
+++ b/planner/core/expression_test.go
@@ -218,6 +218,33 @@ func (s *testExpressionSuite) TestIsNull(c *C) {
 	s.runTests(c, tests)
 }
 
+func (s *testExpressionSuite) TestCompareRow(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []testCase{
+		{
+			exprStr:   "row(1,2,3)=row(1,2,3)",
+			resultStr: "1",
+		},
+		{
+			exprStr:   "row(1,2,3)=row(1+3,2,3)",
+			resultStr: "0",
+		},
+		{
+			exprStr:   "row(1,2,3)<>row(1,2,3)",
+			resultStr: "0",
+		},
+		{
+			exprStr:   "row(1,2,3)<>row(1+3,2,3)",
+			resultStr: "1",
+		},
+		{
+			exprStr:   "row(1+3,2,3)<>row(1+3,2,3)",
+			resultStr: "0",
+		},
+	}
+	s.runTests(c, tests)
+}
+
 func (s *testExpressionSuite) TestIsTruth(c *C) {
 	defer testleak.AfterTest(c)()
 	tests := []testCase{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
see #8197 for detail.

TiDB will has wrong result when execute `SELECT ROW(1,2,3)<>ROW(2+1,2,3)`
because of wrong logic dealing with `<>` operator.

### What is changed and how it works?
fix compare logic of `<>` operator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

test case:
```
mysql> SELECT ROW(1,2,3)<>ROW(3,2,3);
+------------------------+
| ROW(1,2,3)<>ROW(3,2,3) |
+------------------------+
|                      1 |
+------------------------+
1 row in set (0.00 sec)
```

Code changes
no change

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch

