### PR TITLE
plan: use original field name when `Column` is extracted from `IfNull`

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -153,9 +153,10 @@ type Column struct {
 	ID int64
 	// UniqueID is the unique id of this column.
 	UniqueID int64
-	// IsAggOrSubq means if this column is referenced to a Aggregation column or a Subquery column.
+	// IsReferenced means if this column is referenced to an Aggregation column, or a Subquery column,
+	// or an argument column of function IfNull.
 	// If so, this column's name will be the plain sql text.
-	IsAggOrSubq bool
+	IsReferenced bool
 
 	// Index is used for execution, to tell the column's position in the given row.
 	Index int

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -119,7 +119,7 @@ func (s *Schema) FindColumnAndIndex(astCol *ast.ColumnName) (*Column, int, error
 				// we will get an Apply operator whose schema is [test.t1.a, test.t2.d, test.t2.d],
 				// we check whether the column of the schema comes from a subquery to avoid
 				// causing the ambiguous error when resolve the column `d` in the Selection.
-				if !col.IsAggOrSubq {
+				if !col.IsReferenced {
 					return nil, -1, errors.Errorf("Column %s is ambiguous", col.String())
 				}
 			}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1164,13 +1164,14 @@ func (er *expressionRewriter) rewriteFuncCall(v *ast.FuncCallExpr) bool {
 		}
 		stackLen := len(er.ctxStack)
 		arg1 := er.ctxStack[stackLen-2]
-		newArg1, isColumn := arg1.(*expression.Column)
+		col, isColumn := arg1.(*expression.Column)
 		// if expr1 is a column and column has not null flag, then we can eliminate ifnull on
 		// this column.
-		if isColumn && mysql.HasNotNullFlag(newArg1.RetType.Flag) {
-			newArg1.IsReferenced = true
+		if isColumn && mysql.HasNotNullFlag(col.RetType.Flag) {
+			newCol := col.Clone().(*expression.Column)
+			newCol.IsReferenced = true
 			er.ctxStack = er.ctxStack[:stackLen-len(v.Args)]
-			er.ctxStack = append(er.ctxStack, newArg1)
+			er.ctxStack = append(er.ctxStack, newCol)
 			return true
 		}
 

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -1,0 +1,43 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+var _ = Suite(&testExpressionRewriterSuite{})
+
+type testExpressionRewriterSuite struct {
+}
+
+func (s *testExpressionRewriterSuite) TestIfNullEliminateColName(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int not null, b int not null)")
+	rs, err := tk.Exec("select ifnull(a,b) from t")
+	c.Assert(err, IsNil)
+	fields := rs.Fields()
+	c.Assert(fields[0].Column.Name.L, Equals, "ifnull(a,b)")
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/8221

### What is changed and how it works?

Specially mark extracted `Column` to be a referenced column when eliminating `IfNull`, then in `BuildProjectionField`, this `Column` would be treated as an expression for inferring field name.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

N/A

Related changes

Since `IfNull` elimination is only in master branch, no cherry-pick for release branch needed.