### PR TITLE
Add check for system variables validate_password_xxxx

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -515,4 +515,26 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 
 	tk.MustExec("set @@innodb_lock_wait_timeout = 1073741825")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
+
+	tk.MustExec("set @@global.validate_password_number_count=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_number_count value: '-1'"))
+
+	tk.MustExec("set @@global.validate_password_special_char_count=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_special_char_count: '-1'"))
+
+	tk.MustExec("set @@global.validate_password_length=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_length: '-1'"))
+
+	tk.MustExec("set @@global.validate_password_mixed_case_count=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_mixed_case_count: '-1'"))
+
+	tk.MustExec("set @@global.validate_password_policy=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_policy: '-1'"))
+	result = tk.MustQuery("select @@validate_password_policy;")
+	result.Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@global.validate_password_policy=3")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_policy: '3'"))
+	result = tk.MustQuery("select @@validate_password_policy;")
+	result.Check(testkit.Rows("2"))
 }

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -516,11 +516,6 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 	tk.MustExec("set @@innodb_lock_wait_timeout = 1073741825")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
 
-	tk.MustExec("set @@rpl_semi_sync_master_wait_for_slave_count=0")
-	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect rpl_semi_sync_master_wait_for_slave_count value: '0'"))
-	tk.MustExec("set @@rpl_semi_sync_master_wait_for_slave_count=65536")
-	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect rpl_semi_sync_master_wait_for_slave_count value: '65536'"))
-
 	tk.MustExec("set @@global.validate_password_number_count=-1")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_number_count value: '-1'"))
 

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -516,6 +516,11 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 	tk.MustExec("set @@innodb_lock_wait_timeout = 1073741825")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
 
+	tk.MustExec("set @@rpl_semi_sync_master_wait_for_slave_count=0")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect rpl_semi_sync_master_wait_for_slave_count value: '0'"))
+	tk.MustExec("set @@rpl_semi_sync_master_wait_for_slave_count=65536")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect rpl_semi_sync_master_wait_for_slave_count value: '65536'"))
+
 	tk.MustExec("set @@global.validate_password_number_count=-1")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_number_count value: '-1'"))
 
@@ -523,7 +528,7 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_special_char_count: '-1'"))
 
 	tk.MustExec("set @@global.validate_password_length=-1")
-	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_length: '-1'"))
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_length value: '-1'"))
 
 	tk.MustExec("set @@global.validate_password_mixed_case_count=-1")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect validate_password_mixed_case_count: '-1'"))

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -127,6 +127,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "slave_pending_jobs_size_max", "16777216"},
 	{ScopeNone, "innodb_sync_array_size", "1"},
 	{ScopeSession, "rand_seed2", ""},
+	{ScopeGlobal, "validate_password_check_user_name", "OFF"},
 	{ScopeGlobal, "validate_password_number_count", "1"},
 	{ScopeSession, "gtid_next", ""},
 	{ScopeGlobal | ScopeSession, SQLSelectLimit, "18446744073709551615"},
@@ -775,6 +776,16 @@ const (
 	SyncBinlog = "sync_binlog"
 	// BlockEncryptionMode is the name for 'block_encryption_mode' system variable.
 	BlockEncryptionMode = "block_encryption_mode"
+	// ValidatePassswordNumberCount is the name of 'validate_password_number_count' system variable.
+	ValidatePasswordNumberCount = "validate_password_number_count"
+	// ValidatePassswordSpecialCharCount is the name of 'validate_password_special_char_count' system variable.
+	ValidatePasswordSpecialCharCount = "validate_password_special_char_count";
+	// ValidatePassswordLength is the name of 'validate_password_length' system variable.
+	ValidatePasswordLength = "validate_password_length";
+	// ValidatePassswordMixedCaseCount is the name of 'validate_password_mixed_case_count' system variable.
+	ValidatePasswordMixedCaseCount = "validate_password_mixed_case_count";
+	// ValidatePassswordPolicy is the name of 'validate_password_policy' system variable.
+	ValidatePasswordPolicy = "validate_password_policy";
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -285,6 +285,17 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "SYSTEM", nil
 		}
 		return value, nil
+	case ValidatePasswordPolicy:
+		if strings.EqualFold(value, "0") || value == "0" {
+			return "0", nil
+		} else if strings.EqualFold(value, "1") || value == "1" {
+			return "1", nil
+		} else if strings.EqualFold(value, "2") || value == "2" {
+			return "2", nil
+		}
+		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
+	case ValidatePasswordLength, ValidatePasswordMixedCaseCount, ValidatePasswordNumberCount, ValidatePasswordSpecialCharCount:
+		return checkUInt64SystemVar(name, value, 0, math.MaxUint64, vars);
 	case WarningCount, ErrorCount:
 		return value, ErrReadOnly.GenWithStackByArgs(name)
 	case GeneralLog, TiDBGeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Corresponding to [Issue #7195](https://github.com/pingcap/tidb/issues/7195), I added correctness check for system variables: `validate_password_number_count`, `validate_password_special_char_count`, `validate_password_length`, `validate_password_mixed_case_count`, `validate_password_policy`.

### What is changed and how it works?
Executor and sessionctx are modified according to the framework mentioned in [#7117](https://github.com/pingcap/tidb/pull/7117)

### Tests 
 - Unit test
