### PR TITLE
session: add transaction start timestamp to the log when retrying (#8091)

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -486,6 +486,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) error {
 
 	nh := GetHistory(s)
 	var err error
+	orgStartTS := s.GetSessionVars().TxnCtx.StartTS
 	for {
 		s.PrepareTxnCtx(ctx)
 		s.sessionVars.RetryInfo.ResetOffset()
@@ -514,6 +515,8 @@ func (s *session) retry(ctx context.Context, maxCnt uint) error {
 			}
 			s.StmtCommit()
 		}
+		log.Warnf("con:%d retrying_txn_start_ts:%d original_txn_start_ts:(%d)",
+			connID, s.GetSessionVars().TxnCtx.StartTS, orgStartTS)
 		if hook := ctx.Value("preCommitHook"); hook != nil {
 			// For testing purpose.
 			hook.(func())()


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry-pick #8091 to release 2.0.

PTAL @lysu @zimulala 