### PR TITLE
planner: fix wrong row compare logic in expression_rewriter

### DIFF
--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -221,13 +221,13 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 			return nil, errors.Trace(err)
 		}
 		if evalexpr, ok := expr1.(*expression.Constant); ok {
-			_, isNull, err1 := evalexpr.EvalInt(er.ctx, nil)
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
 			if err1 != nil || isNull {
 				return expr1, err1
 			}
 		}
 		if evalexpr, ok := expr2.(*expression.Constant); ok {
-			_, isNull, err1 := evalexpr.EvalInt(er.ctx, nil)
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
 			if err1 != nil || isNull {
 				return expr2, err1
 			}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -221,21 +221,15 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 			return nil, errors.Trace(err)
 		}
 		if evalexpr, ok := expr1.(*expression.Constant); ok {
-			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
-			if err1 != nil {
-				return nil, errors.Trace(err1)
-			}
-			if isNull {
-				return expr1, nil
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, nil)
+			if err1 != nil || isNull {
+				return expr1, err1
 			}
 		}
 		if evalexpr, ok := expr2.(*expression.Constant); ok {
-			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
-			if err1 != nil {
-				return nil, errors.Trace(err1)
-			}
-			if isNull {
-				return expr2, nil
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, nil)
+			if err1 != nil || isNull {
+				return expr2, err1
 			}
 		}
 		expr3, err = er.constructBinaryOpFunction(l, r, op)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -220,6 +220,24 @@ func (er *expressionRewriter) constructBinaryOpFunction(l expression.Expression,
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		if evalexpr, ok := expr1.(*expression.Constant); ok {
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
+			if err1 != nil {
+				return nil, errors.Trace(err1)
+			}
+			if isNull {
+				return expr1, nil
+			}
+		}
+		if evalexpr, ok := expr2.(*expression.Constant); ok {
+			_, isNull, err1 := evalexpr.EvalInt(er.ctx, chunk.Row{})
+			if err1 != nil {
+				return nil, errors.Trace(err1)
+			}
+			if isNull {
+				return expr2, nil
+			}
+		}
 		expr3, err = er.constructBinaryOpFunction(l, r, op)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/planner/core/expression_test.go
+++ b/planner/core/expression_test.go
@@ -241,6 +241,14 @@ func (s *testExpressionSuite) TestCompareRow(c *C) {
 			exprStr:   "row(1+3,2,3)<>row(1+3,2,3)",
 			resultStr: "0",
 		},
+		{
+			exprStr:   "row(1,2,3)<row(1,NULL,3)",
+			resultStr: "<nil>",
+		},
+		{
+			exprStr:   "row(1,2,3)<row(2,NULL,3)",
+			resultStr: "1",
+		},
 	}
 	s.runTests(c, tests)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When execute this SQL: `SELECT (1,2,3) < (1,NULL, 3)`.
TiDB:
```
mysql> SELECT (1,2,3) < (1,    NULL, 3);
+---------------------------+
| (1,2,3) < (1,    NULL, 3) |
+---------------------------+
|                         0 |
+---------------------------+
1 row in set (0.00 sec)
```
MySQL:
```
mysql> SELECT (1,2,3) < (1,    NULL, 3);
+---------------------------+
| (1,2,3) < (1,    NULL, 3) |
+---------------------------+
|                      NULL |
+---------------------------+
1 row in set (0.00 sec)

```

Correct compare logic is comparing prefix of row until there is different digit between them.
If they has same prefix before `NULL` digit, it will return `NULL`.

### What is changed and how it works?
adding check code before entering next recursion.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release branch

