### PR TITLE
planner: fix error caused by different length between inner and outer OrderByItems

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -547,4 +547,17 @@ Projection_4	2666.67	root	test.t.a
   └─Selection_6	2666.67	cop	gt(test.t.a, 0)
     └─TableScan_5	3333.33	cop	table:t, range:(0,+inf], keep order:false, stats:pseudo
 drop table if exists t;
+create table t(a int, b int, c int);
+explain select * from (select * from t order by (select 2)) t order by a, b;
+id	count	task	operator info
+Sort_12	10000.00	root	t.a:asc, t.b:asc
+└─TableReader_18	10000.00	root	data:TableScan_17
+  └─TableScan_17	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from (select * from t order by c) t order by a, b;
+id	count	task	operator info
+Sort_6	10000.00	root	t.a:asc, t.b:asc
+└─Sort_9	10000.00	root	test.t.c:asc
+  └─TableReader_12	10000.00	root	data:TableScan_11
+    └─TableScan_11	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table if exists t;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -117,4 +117,8 @@ explain select * from t where _tidb_rowid > 0;
 explain select a, _tidb_rowid from t where a > 0;
 explain select * from t where _tidb_rowid > 0 and a > 0;
 drop table if exists t;
+create table t(a int, b int, c int);
+explain select * from (select * from t order by (select 2)) t order by a, b;
+explain select * from (select * from t order by c) t order by a, b;
+drop table if exists t;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -744,6 +744,9 @@ func (lt *LogicalTopN) getPhysLimits() []PhysicalPlan {
 
 // Check if this prop's columns can match by items totally.
 func matchItems(p *property.PhysicalProperty, items []*ByItems) bool {
+	if len(items) < len(p.Cols) {
+		return false
+	}
 	for i, col := range p.Cols {
 		sortItem := items[i]
 		if sortItem.Desc != p.Desc || !sortItem.Expr.Equal(nil, col) {

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -189,7 +189,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from (select * from t use index() order by b) t left join t t1 on t.a=t1.a limit 10",
 			best: "IndexJoin{TableReader(Table(t)->TopN([test.t.b],0,10))->TopN([test.t.b],0,10)->TableReader(Table(t))}(test.t.a,t1.a)->Limit",
 		},
-		// Test nest different size order by.
+		// Test embedded ORDER BY which imposes on different number of columns than outer query.
 		{
 			sql:  "select * from ((SELECT 1 a,3 b) UNION (SELECT 2,1) ORDER BY (SELECT 2)) t order by a,b",
 			best: "UnionAll{Dual->Projection->Dual->Projection}->HashAgg->Sort",

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -189,6 +189,11 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from (select * from t use index() order by b) t left join t t1 on t.a=t1.a limit 10",
 			best: "IndexJoin{TableReader(Table(t)->TopN([test.t.b],0,10))->TopN([test.t.b],0,10)->TableReader(Table(t))}(test.t.a,t1.a)->Limit",
 		},
+		// Test nest different size order by.
+		{
+			sql:  "select * from ((SELECT 1 a,3 b) UNION (SELECT 2,1) ORDER BY (SELECT 2)) t order by a,b",
+			best: "UnionAll{Dual->Projection->Dual->Projection}->HashAgg->Sort",
+		},
 	}
 	for i, tt := range tests {
 		comment := Commentf("case:%v sql:%s", i, tt.sql)

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -194,6 +194,10 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from ((SELECT 1 a,3 b) UNION (SELECT 2,1) ORDER BY (SELECT 2)) t order by a,b",
 			best: "UnionAll{Dual->Projection->Dual->Projection}->HashAgg->Sort",
 		},
+		{
+			sql:  "select * from ((SELECT 1 a,6 b) UNION (SELECT 2,5) UNION (SELECT 2, 4) ORDER BY 1) t order by 1, 2",
+			best: "UnionAll{Dual->Projection->Dual->Projection->Dual->Projection}->HashAgg->Sort->Sort",
+		},
 	}
 	for i, tt := range tests {
 		comment := Commentf("case:%v sql:%s", i, tt.sql)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #8198 nest different size order by.


### What is changed and how it works?
`matchItems` function cannot cover the case that the length of columns is greater than items.
Check the length before iterating the columns.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
