### PR TITLE
expression: make tests work with mysql sql_mode

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1110,8 +1110,9 @@ func (s *testIntegrationSuite) TestTimeBuiltin(c *C) {
 	_, err := tk.Exec(`insert into t select year("aa")`)
 	c.Assert(err, NotNil)
 	c.Assert(terror.ErrorEqual(err, types.ErrInvalidTimeFormat), IsTrue, Commentf("err %v", err))
+	tk.MustExec(`set sql_mode='STRICT_TRANS_TABLES'`) // without zero date
 	tk.MustExec(`insert into t select year("0000-00-00 00:00:00")`)
-	tk.MustExec(`set sql_mode="NO_ZERO_DATE";`)
+	tk.MustExec(`set sql_mode="NO_ZERO_DATE";`) // with zero date
 	tk.MustExec(`insert into t select year("0000-00-00 00:00:00")`)
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Incorrect datetime value: '0000-00-00 00:00:00.000000'"))
 	tk.MustExec(`set sql_mode="NO_ZERO_DATE,STRICT_TRANS_TABLES";`)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

MySQL 5.7 enables NO_ZERO_DATE by default - TiDB does not.
This change allows tests to run with the mode on or off.

### What is changed and how it works?

No code: only tests are changed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - No code

Code changes

 - None

Side effects

 - None

Related changes

- As an upcoming code change in parser, we can set the sql mode to be same as MySQL.