### PR TITLE
config, session: add a batch commit config for the large transaction

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,6 +155,7 @@ type Performance struct {
 	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
 	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
+	BatchCommit         bool    `toml:"batch-commit" json:"batch-commit"`
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
 	QueryFeedbackLimit  uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
 	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
@@ -292,6 +293,7 @@ var defaultConf = Config{
 		StatsLease:          "3s",
 		RunAutoAnalyze:      true,
 		StmtCountLimit:      5000,
+		BatchCommit:         false,
 		FeedbackProbability: 0.05,
 		QueryFeedbackLimit:  1024,
 		PseudoEstimateRatio: 0.8,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -124,6 +124,8 @@ metrics-interval = 15
 max-procs = 0
 # StmtCountLimit limits the max count of statement inside a transaction.
 stmt-count-limit = 5000
+# If true, the transaction will be committed when it reaches stmt-count-limit and starts a new transaction.
+batch-commit = false
 
 # Set keep alive option for tcp connection.
 tcp-keep-alive = true

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -162,8 +162,8 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 	if !se.sessionVars.InTxn() {
 		if err != nil {
 			log.Info("RollbackTxn for ddl/autocommit error.")
-			err = se.RollbackTxn(ctx)
-			terror.Log(errors.Trace(err))
+			err1 := se.RollbackTxn(ctx)
+			terror.Log(errors.Trace(err1))
 		} else {
 			err = se.CommitTxn(ctx)
 		}
@@ -174,8 +174,8 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 		perfConfig := config.GetGlobalConfig().Performance
 		if history.Count() > int(perfConfig.StmtCountLimit) {
 			if !perfConfig.BatchCommit {
-				err = se.RollbackTxn(ctx)
-				terror.Log(errors.Trace(err))
+				err1 := se.RollbackTxn(ctx)
+				terror.Log(errors.Trace(err1))
 				return rs, errors.Errorf("statement count %d exceeds the transaction limitation, autocommit = %t",
 					history.Count(), sctx.GetSessionVars().IsAutocommit())
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
tidb_batch_insert / tidb_batch_delete only split the statement into several batches. If the transaction contains many statements, TiDB could not commit it in batch.

### What is changed and how it works?
Add a server config to control if the transaction should return an error or start a new transaction when it exceeds the statements limit of the transaction. It will be useful when importing data.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Related changes

 - Need to update the documentation

PTAL @tiancaiamao @lysu 