### PR TITLE
variable: validate setting tx_isolation variable value

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -515,4 +515,35 @@ func (s *testSuite) TestValidateSetVar(c *C) {
 
 	tk.MustExec("set @@innodb_lock_wait_timeout = 1073741825")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect innodb_lock_wait_timeout value: '1073741825'"))
+
+	_, err = tk.Exec("set @@tx_isolation=''")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
+
+	_, err = tk.Exec("set global tx_isolation=''")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
+
+	_, err = tk.Exec("set @@transaction_isolation=''")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
+
+	_, err = tk.Exec("set global transaction_isolation=''")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
+
+	_, err = tk.Exec("set global tx_isolation='REPEATABLE-READ1'")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
+
+	tk.MustExec("set @@tx_isolation='READ-COMMITTED'")
+	result = tk.MustQuery("select @@tx_isolation;")
+	result.Check(testkit.Rows("READ-COMMITTED"))
+
+	tk.MustExec("set @@tx_isolation='read-COMMITTED'")
+	result = tk.MustQuery("select @@tx_isolation;")
+	result.Check(testkit.Rows("READ-COMMITTED"))
+
+	tk.MustExec("set @@tx_isolation='REPEATABLE-READ'")
+	result = tk.MustQuery("select @@tx_isolation;")
+	result.Check(testkit.Rows("REPEATABLE-READ"))
+
+	tk.MustExec("set @@tx_isolation='SERIALIZABLE'")
+	result = tk.MustQuery("select @@tx_isolation;")
+	result.Check(testkit.Rows("SERIALIZABLE"))
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -646,13 +646,23 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 
 // special session variables.
 const (
-	SQLModeVar          = "sql_mode"
-	AutocommitVar       = "autocommit"
-	CharacterSetResults = "character_set_results"
-	MaxAllowedPacket    = "max_allowed_packet"
-	TimeZone            = "time_zone"
-	TxnIsolation        = "tx_isolation"
-	TxnIsolationOneShot = "tx_isolation_one_shot"
+	SQLModeVar           = "sql_mode"
+	AutocommitVar        = "autocommit"
+	CharacterSetResults  = "character_set_results"
+	MaxAllowedPacket     = "max_allowed_packet"
+	TimeZone             = "time_zone"
+	TxnIsolation         = "tx_isolation"
+	TransactionIsolation = "transaction_isolation"
+	TxnIsolationOneShot  = "tx_isolation_one_shot"
+)
+
+var (
+	TxIsolationNames = map[string]struct{}{
+		"READ-UNCOMMITTED": struct{}{},
+		"READ-COMMITTED":   struct{}{},
+		"REPEATABLE-READ":  struct{}{},
+		"SERIALIZABLE":     struct{}{},
+	}
 )
 
 // TableDelta stands for the changed count for one table.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -343,6 +343,13 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "", errors.Trace(err)
 		}
 		return v, nil
+	case TxnIsolation, TransactionIsolation:
+		upVal := strings.ToUpper(value)
+		_, exists := TxIsolationNames[upVal]
+		if !exists {
+			return "", ErrWrongValueForVar.GenWithStackByArgs(name, value)
+		}
+		return upVal, nil
 	}
 	return value, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

MySQL:

```
mysql> set @@tx_isolation='';
ERROR 1231 (42000): Variable 'tx_isolation' can't be set to the value of ''
```

TiDB:
```
mysql> set global tx_isolation="";
Query OK, 0 rows affected (0.00 sec)
```

### What is changed and how it works?

validate the setting tx_isolation or transaction_isolation values;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch
