### PR TITLE
planner: fix error caused by different length between inner and outer OrderByItems(#8273)

### DIFF
--- a/plan/physical_plan_test.go
+++ b/plan/physical_plan_test.go
@@ -188,6 +188,15 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 			sql:  "select * from (select * from t use index() order by b) t left join t t1 on t.a=t1.a limit 10",
 			best: "IndexJoin{TableReader(Table(t)->TopN([test.t.b],0,10))->TopN([test.t.b],0,10)->TableReader(Table(t))}(test.t.a,t1.a)->Limit",
 		},
+		// Test embedded ORDER BY which imposes on different number of columns than outer query.
+		{
+			sql:  "select * from ((SELECT 1 a,3 b) UNION (SELECT 2,1) ORDER BY (SELECT 2)) t order by a,b",
+			best: "UnionAll{Dual->Projection->Dual->Projection}->HashAgg->Sort",
+		},
+		{
+			sql:  "select * from ((SELECT 1 a,6 b) UNION (SELECT 2,5) UNION (SELECT 2, 4) ORDER BY 1) t order by 1, 2",
+			best: "UnionAll{Dual->Projection->Dual->Projection->Dual->Projection}->HashAgg->Sort->Sort",
+		},
 	}
 	for i, tt := range tests {
 		comment := Commentf("case:%v sql:%s", i, tt.sql)

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -100,6 +100,9 @@ func (p *requiredProp) isPrefix(prop *requiredProp) bool {
 
 // Check if this prop's columns can match by items totally.
 func (p *requiredProp) matchItems(items []*ByItems) bool {
+	if len(items) < len(p.cols) {
+		return false
+	}
 	for i, col := range p.cols {
 		sortItem := items[i]
 		if sortItem.Desc != p.desc || !sortItem.Expr.Equal(nil, col) {


### PR DESCRIPTION
cherry-pick #8273