### PR TITLE
util/execdetails: fix data race

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -40,9 +40,6 @@ func (e *ExplainExec) Open(ctx context.Context) error {
 
 // Close implements the Executor Close interface.
 func (e *ExplainExec) Close() error {
-	if e.analyzeExec != nil {
-		e.analyzeExec.Close()
-	}
 	e.rows = nil
 	return nil
 }
@@ -84,6 +81,7 @@ func (e *ExplainExec) generateExplainInfo(ctx context.Context) ([][]string, erro
 				break
 			}
 		}
+		e.analyzeExec.Close()
 	}
 	e.explain.RenderResult()
 	if e.analyzeExec != nil {

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -99,5 +99,5 @@ func (e *RuntimeStats) String() string {
 	if e == nil {
 		return ""
 	}
-	return fmt.Sprintf("time:%v, loops:%d, rows:%d", time.Duration(atomic.LoadInt64(&e.consume)), atomic.LoadInt32(&e.loop), atomic.LoadInt64(&e.rows))
+	return fmt.Sprintf("time:%v, loops:%d, rows:%d", time.Duration(e.consume), e.loop, e.rows)
 }

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -99,5 +99,5 @@ func (e *RuntimeStats) String() string {
 	if e == nil {
 		return ""
 	}
-	return fmt.Sprintf("time:%v, loops:%d, rows:%d", time.Duration(e.consume), e.loop, e.rows)
+	return fmt.Sprintf("time:%v, loops:%d, rows:%d", time.Duration(atomic.LoadInt64(&e.consume)), atomic.LoadInt32(&e.loop), atomic.LoadInt64(&e.rows))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```log
==================
WARNING: DATA RACE
Read at 0x00c00300d3c8 by goroutine 413:
  github.com/pingcap/tidb/util/execdetails.(*RuntimeStats).String()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/execdetails/execdetails.go:102 +0x52
  github.com/pingcap/tidb/planner/core.(*Explain).prepareOperatorInfo()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:527 +0x569
  github.com/pingcap/tidb/planner/core.(*Explain).explainPlanInRowFormat()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:493 +0xac
  github.com/pingcap/tidb/planner/core.(*Explain).explainPlanInRowFormat()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:502 +0x5f6
  github.com/pingcap/tidb/planner/core.(*Explain).RenderResult()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/common_plans.go:482 +0x219
  github.com/pingcap/tidb/executor.(*ExplainExec).generateExplainInfo()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/explain.go:88 +0x9b
  github.com/pingcap/tidb/executor.(*ExplainExec).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/explain.go:54 +0x9a3
  github.com/pingcap/tidb/executor.(*recordSet).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:97 +0x97
  github.com/pingcap/tidb/session.GetRows4Test()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:217 +0x39b
  github.com/pingcap/tidb/util/testkit.(*TestKit).ResultSetToResult()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:186 +0x11a
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:180 +0x4f2
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:953 +0x996
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:952 +0x8e2
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:951 +0x82e
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:950 +0x7f7
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:949 +0x7c0
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:935 +0x3aa
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:934 +0x373
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:933 +0x2bf
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:177 +0x259
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:932 +0x20b
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:931 +0x1d4
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:817 +0x9d8
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:770 +0x84
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:137 +0x109
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:930 +0x19d
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:817 +0x9d8
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:770 +0x84
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:137 +0x109
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:929 +0x166
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:137 +0x109
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:928 +0x12f
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:166 +0x94
  github.com/pingcap/tidb/executor_test.(*testSuite).TestHashJoin()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join_test.go:927 +0xf8
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:522 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/check.go:798 +0xa04
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/check.go:692 +0x89

Previous write at 0x00c00300d3c8 by goroutine 438:
  sync/atomic.AddInt64()
      /usr/local/go/src/runtime/race_amd64.s:276 +0xb
  github.com/pingcap/tidb/util/execdetails.(*RuntimeStats).Record()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/execdetails/execdetails.go:94 +0x5e
  github.com/pingcap/tidb/executor.(*TableReaderExecutor).Next.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/table_reader.go:105 +0xdd
  github.com/pingcap/tidb/executor.(*TableReaderExecutor).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/table_reader.go:111 +0x1f6
  github.com/pingcap/tidb/executor.(*HashJoinExec).fetchInnerRows()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join.go:277 +0x6a6
  github.com/pingcap/tidb/executor.(*HashJoinExec).fetchInnerAndBuildHashTable.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join.go:553 +0x65
  github.com/pingcap/tidb/util.WithRecovery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/misc.go:73 +0x5a

Goroutine 413 (running) created at:
  github.com/pingcap/check.(*suiteRunner).forkCall()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/check.go:689 +0x4a5
  github.com/pingcap/check.(*suiteRunner).forkTest()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/check.go:780 +0x126
  github.com/pingcap/check.(*suiteRunner).run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/check.go:631 +0x22c
  github.com/pingcap/check.Run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/run.go:96 +0x5a
  github.com/pingcap/check.RunAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/run.go:88 +0x129
  github.com/pingcap/check.TestingT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20171206051426-1c287c953996/run.go:76 +0x79b
  github.com/pingcap/tidb/executor_test.TestT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:75 +0xef
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:827 +0x162

Goroutine 438 (finished) created at:
  github.com/pingcap/tidb/executor.(*HashJoinExec).fetchInnerAndBuildHashTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join.go:553 +0x1a9
  github.com/pingcap/tidb/executor.(*HashJoinExec).Next.func2()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/join.go:521 +0x53
  github.com/pingcap/tidb/util.WithRecovery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/misc.go:73 +0x5a
...
...
...
```

[log.txt](https://github.com/pingcap/tidb/files/2583454/log.txt)

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

Side effects

Related changes

