### PR TITLE
*: clone AggDesc before modifying its `Mode` in AggDesc.Split

### DIFF
--- a/executor/aggfuncs/func_avg_test.go
+++ b/executor/aggfuncs/func_avg_test.go
@@ -37,7 +37,7 @@ func (s *testSuite) TestMergePartialResult4AvgDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0, 1})
+	finalDesc := desc.Split([]int{0, 1}, false)
 
 	// build avg func for partial phase.
 	partialAvgFunc := aggfuncs.Build(s.ctx, desc, 0)
@@ -93,7 +93,7 @@ func (s *testSuite) TestMergePartialResult4AvgFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0, 1})
+	finalDesc := desc.Split([]int{0, 1}, false)
 
 	// build avg func for partial phase.
 	partialAvgFunc := aggfuncs.Build(s.ctx, desc, 0)

--- a/executor/aggfuncs/func_avg_test.go
+++ b/executor/aggfuncs/func_avg_test.go
@@ -37,10 +37,10 @@ func (s *testSuite) TestMergePartialResult4AvgDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0, 1}, false)
+	partialDesc, finalDesc := desc.Split([]int{0, 1})
 
 	// build avg func for partial phase.
-	partialAvgFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialAvgFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialAvgFunc.AllocPartialResult()
 	partialPr2 := partialAvgFunc.AllocPartialResult()
 
@@ -93,10 +93,10 @@ func (s *testSuite) TestMergePartialResult4AvgFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0, 1}, false)
+	partialDesc, finalDesc := desc.Split([]int{0, 1})
 
 	// build avg func for partial phase.
-	partialAvgFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialAvgFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialAvgFunc.AllocPartialResult()
 	partialPr2 := partialAvgFunc.AllocPartialResult()
 

--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -32,14 +32,15 @@ func (s *testSuite) TestMergePartialResult4Count(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name: ast.AggFuncCount,
-		Mode: aggregation.CompleteMode,
-		Args: []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLong), Index: 0}},
+		Name:  ast.AggFuncCount,
+		Mode:  aggregation.CompleteMode,
+		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLong), Index: 0}},
+		RetTp: types.NewFieldType(mysql.TypeLonglong),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build count func for partial phase.
-	partialCountFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialCountFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialCountFunc.AllocPartialResult()
 
 	// build final func for final phase.

--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -36,7 +36,7 @@ func (s *testSuite) TestMergePartialResult4Count(c *C) {
 		Mode: aggregation.CompleteMode,
 		Args: []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLong), Index: 0}},
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build count func for partial phase.
 	partialCountFunc := aggfuncs.Build(s.ctx, desc, 0)

--- a/executor/aggfuncs/func_max_min_test.go
+++ b/executor/aggfuncs/func_max_min_test.go
@@ -37,10 +37,10 @@ func (s *testSuite) TestMergePartialResult4MaxDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build max func for partial phase.
-	partialMaxFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialMaxFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialMaxFunc.AllocPartialResult()
 	partialPr2 := partialMaxFunc.AllocPartialResult()
 
@@ -90,10 +90,10 @@ func (s *testSuite) TestMergePartialResult4MaxFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build max func for partial phase.
-	partialMaxFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialMaxFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialMaxFunc.AllocPartialResult()
 	partialPr2 := partialMaxFunc.AllocPartialResult()
 
@@ -143,10 +143,10 @@ func (s *testSuite) TestMergePartialResult4MinDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build min func for partial phase.
-	partialMinFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialMinFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialMinFunc.AllocPartialResult()
 	partialPr2 := partialMinFunc.AllocPartialResult()
 
@@ -198,10 +198,10 @@ func (s *testSuite) TestMergePartialResult4MinFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build min func for partial phase.
-	partialMinFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialMinFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialMinFunc.AllocPartialResult()
 	partialPr2 := partialMinFunc.AllocPartialResult()
 

--- a/executor/aggfuncs/func_max_min_test.go
+++ b/executor/aggfuncs/func_max_min_test.go
@@ -37,7 +37,7 @@ func (s *testSuite) TestMergePartialResult4MaxDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build max func for partial phase.
 	partialMaxFunc := aggfuncs.Build(s.ctx, desc, 0)
@@ -90,7 +90,7 @@ func (s *testSuite) TestMergePartialResult4MaxFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build max func for partial phase.
 	partialMaxFunc := aggfuncs.Build(s.ctx, desc, 0)
@@ -143,7 +143,7 @@ func (s *testSuite) TestMergePartialResult4MinDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build min func for partial phase.
 	partialMinFunc := aggfuncs.Build(s.ctx, desc, 0)
@@ -198,7 +198,7 @@ func (s *testSuite) TestMergePartialResult4MinFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build min func for partial phase.
 	partialMinFunc := aggfuncs.Build(s.ctx, desc, 0)

--- a/executor/aggfuncs/func_sum_test.go
+++ b/executor/aggfuncs/func_sum_test.go
@@ -37,7 +37,7 @@ func (s *testSuite) TestMergePartialResult4SumDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build sum func for partial phase.
 	partialSumFunc := aggfuncs.Build(s.ctx, desc, 0)
@@ -93,7 +93,7 @@ func (s *testSuite) TestMergePartialResult4SumFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0})
+	finalDesc := desc.Split([]int{0}, false)
 
 	// build sum func for partial phase.
 	partialSumFunc := aggfuncs.Build(s.ctx, desc, 0)

--- a/executor/aggfuncs/func_sum_test.go
+++ b/executor/aggfuncs/func_sum_test.go
@@ -37,10 +37,10 @@ func (s *testSuite) TestMergePartialResult4SumDecimal(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build sum func for partial phase.
-	partialSumFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialSumFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialSumFunc.AllocPartialResult()
 	partialPr2 := partialSumFunc.AllocPartialResult()
 
@@ -93,10 +93,10 @@ func (s *testSuite) TestMergePartialResult4SumFloat(c *C) {
 		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
 		RetTp: types.NewFieldType(mysql.TypeDouble),
 	}
-	finalDesc := desc.Split([]int{0}, false)
+	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build sum func for partial phase.
-	partialSumFunc := aggfuncs.Build(s.ctx, desc, 0)
+	partialSumFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
 	partialPr1 := partialSumFunc.AllocPartialResult()
 	partialPr2 := partialSumFunc.AllocPartialResult()
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1075,7 +1075,7 @@ func (b *executorBuilder) buildHashAgg(v *plannercore.PhysicalHashAgg) Executor 
 				ordinal = append(ordinal, partialOrdinal+1)
 				partialOrdinal++
 			}
-			finalDesc := aggDesc.Split(ordinal)
+			finalDesc := aggDesc.Split(ordinal, sessionVars.StmtCtx.UseCache)
 			partialAggFunc := aggfuncs.Build(b.ctx, aggDesc, i)
 			finalAggFunc := aggfuncs.Build(b.ctx, finalDesc, i)
 			e.PartialAggFuncs = append(e.PartialAggFuncs, partialAggFunc)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1075,12 +1075,12 @@ func (b *executorBuilder) buildHashAgg(v *plannercore.PhysicalHashAgg) Executor 
 				ordinal = append(ordinal, partialOrdinal+1)
 				partialOrdinal++
 			}
-			finalDesc := aggDesc.Split(ordinal, sessionVars.StmtCtx.UseCache)
-			partialAggFunc := aggfuncs.Build(b.ctx, aggDesc, i)
+			partialAggDesc, finalDesc := aggDesc.Split(ordinal)
+			partialAggFunc := aggfuncs.Build(b.ctx, partialAggDesc, i)
 			finalAggFunc := aggfuncs.Build(b.ctx, finalDesc, i)
 			e.PartialAggFuncs = append(e.PartialAggFuncs, partialAggFunc)
 			e.FinalAggFuncs = append(e.FinalAggFuncs, finalAggFunc)
-			if aggDesc.Name == ast.AggFuncGroupConcat {
+			if partialAggDesc.Name == ast.AggFuncGroupConcat {
 				// For group_concat, finalAggFunc and partialAggFunc need shared `truncate` flag to do duplicate.
 				finalAggFunc.(interface{ SetTruncated(t *int32) }).SetTruncated(
 					partialAggFunc.(interface{ GetTruncated() *int32 }).GetTruncated(),

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -84,12 +84,12 @@ func (a *AggFuncDesc) Clone() *AggFuncDesc {
 // final phase individually.
 // This function is only used when executing aggregate function parallelly.
 // ordinal indicates the column ordinal of the intermediate result.
-func (a *AggFuncDesc) Split(ordinal []int) (finalAggDesc *AggFuncDesc) {
+func (a *AggFuncDesc) Split(ordinal []int, isPreparedCacheEnable bool) (finalAggDesc *AggFuncDesc) {
 	if a.Mode == CompleteMode {
 		a.Mode = Partial1Mode
 	} else if a.Mode == FinalMode {
 		a.Mode = Partial2Mode
-	} else {
+	} else if !isPreparedCacheEnable {
 		return
 	}
 	finalAggDesc = &AggFuncDesc{

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -84,13 +84,14 @@ func (a *AggFuncDesc) Clone() *AggFuncDesc {
 // final phase individually.
 // This function is only used when executing aggregate function parallelly.
 // ordinal indicates the column ordinal of the intermediate result.
-func (a *AggFuncDesc) Split(ordinal []int, isPreparedCacheEnable bool) (finalAggDesc *AggFuncDesc) {
+func (a *AggFuncDesc) Split(ordinal []int) (partialAggDesc, finalAggDesc *AggFuncDesc) {
+	partialAggDesc = a.Clone()
 	if a.Mode == CompleteMode {
-		a.Mode = Partial1Mode
+		partialAggDesc.Mode = Partial1Mode
 	} else if a.Mode == FinalMode {
-		a.Mode = Partial2Mode
-	} else if !isPreparedCacheEnable {
-		return
+		partialAggDesc.Mode = Partial2Mode
+	} else {
+		panic("Error happened during AggFuncDesc.Split, the AggFunctionMode is not CompleteMode or FinalMode.")
 	}
 	finalAggDesc = &AggFuncDesc{
 		Name:        a.Name,
@@ -124,7 +125,7 @@ func (a *AggFuncDesc) Split(ordinal []int, isPreparedCacheEnable bool) (finalAgg
 			finalAggDesc.Args = append(finalAggDesc.Args, a.Args[len(a.Args)-1]) // separator
 		}
 	}
-	return finalAggDesc
+	return
 }
 
 // String implements the fmt.Stringer interface.

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -68,6 +68,9 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	tk.MustExec(`prepare stmt5 from "select c from t order by c"`)
 	tk.MustQuery("execute stmt5").Check(testkit.Rows("1", "2", "2", "3", "4", "5"))
 	tk.MustQuery("execute stmt5").Check(testkit.Rows("1", "2", "2", "3", "4", "5"))
+	tk.MustExec(`prepare stmt6 from "select distinct a from t order by a"`)
+	tk.MustQuery("execute stmt6").Check(testkit.Rows("1", "2", "3", "4", "5", "6"))
+	tk.MustQuery("execute stmt6").Check(testkit.Rows("1", "2", "3", "4", "5", "6"))
 }
 
 func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit, when enabling prepare plan cache, the following sql will panic:
``` sql
create table t(a int, b int);
insert into t value(1,1),(2,2);
prepare stmt from 'select distinct a from t order by a';

execute stmt;
execute stmt; -- This will fail.
```

### What is changed and how it works?

Why PlanCache will impact the behavior of the above sql?
1. If the aggregate function can be executed parallelly, AggFuncDesc.Split will be called when building HashAggExec to split the AggFuncDesc into partialAggDesc and finalAggDesc.
2. Before AggFuncDesc.Split, the AggFuncMode will **ONLY** be CompleteMode and FinalMode.
3. After AggFuncDesc.Split, the origin AggFuncDesc.Mode will be changed into Partial1Mode or Partial2Mode.
4. PreparePlanCache would cache the physical plan, when we use the cached plan to build the HashAggExec again, the AggFuncDesc.Mode has been modified in `step 3`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
release-2.1
