### PR TITLE
 planner: cleanup prepare cache when client send deallocate

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -237,6 +237,11 @@ func (e *DeallocateExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		return errors.Trace(plannercore.ErrStmtNotFound)
 	}
 	delete(vars.PreparedStmtNameToID, e.Name)
+	if plannercore.PreparedPlanCacheEnabled() {
+		e.ctx.PreparedPlanCache().Delete(plannercore.NewPSTMTPlanCacheKey(
+			vars, id, vars.PreparedStmts[id].SchemaVersion,
+		))
+	}
 	delete(vars.PreparedStmts, id)
 	return nil
 }

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -575,32 +575,29 @@ func (s *testSuite) TestPrepareDealloc(c *C) {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
 	}()
-	flags := []bool{true}
-	for _, flag := range flags {
-		plannercore.SetPreparedPlanCache(flag)
-		plannercore.PreparedPlanCacheCapacity = 3
+	plannercore.SetPreparedPlanCache(true)
+	plannercore.PreparedPlanCacheCapacity = 3
 
-		tk := testkit.NewTestKit(c, s.store)
-		tk.MustExec("use test")
-		tk.MustExec("drop table if exists prepare_test")
-		tk.MustExec("create table prepare_test (id int PRIMARY KEY, c1 int)")
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists prepare_test")
+	tk.MustExec("create table prepare_test (id int PRIMARY KEY, c1 int)")
 
-		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
-		tk.MustExec(`prepare stmt1 from 'select * from prepare_test'`)
-		tk.MustExec("execute stmt1")
-		tk.MustExec(`prepare stmt2 from 'select * from prepare_test'`)
-		tk.MustExec("execute stmt2")
-		tk.MustExec(`prepare stmt3 from 'select * from prepare_test'`)
-		tk.MustExec("execute stmt3")
-		tk.MustExec(`prepare stmt4 from 'select * from prepare_test'`)
-		tk.MustExec("execute stmt4")
-		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
+	c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
+	tk.MustExec(`prepare stmt1 from 'select * from prepare_test'`)
+	tk.MustExec("execute stmt1")
+	tk.MustExec(`prepare stmt2 from 'select * from prepare_test'`)
+	tk.MustExec("execute stmt2")
+	tk.MustExec(`prepare stmt3 from 'select * from prepare_test'`)
+	tk.MustExec("execute stmt3")
+	tk.MustExec(`prepare stmt4 from 'select * from prepare_test'`)
+	tk.MustExec("execute stmt4")
+	c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
 
-		tk.MustExec("deallocate prepare stmt1")
-		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
-		tk.MustExec("deallocate prepare stmt2")
-		tk.MustExec("deallocate prepare stmt3")
-		tk.MustExec("deallocate prepare stmt4")
-		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
-	}
+	tk.MustExec("deallocate prepare stmt1")
+	c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
+	tk.MustExec("deallocate prepare stmt2")
+	tk.MustExec("deallocate prepare stmt3")
+	tk.MustExec("deallocate prepare stmt4")
+	c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
 }

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -567,3 +567,40 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 		result.Check(nil)
 	}
 }
+
+func (s *testSuite) TestPrepareDealloc(c *C) {
+	orgEnable := plannercore.PreparedPlanCacheEnabled()
+	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	defer func() {
+		plannercore.SetPreparedPlanCache(orgEnable)
+		plannercore.PreparedPlanCacheCapacity = orgCapacity
+	}()
+	flags := []bool{true}
+	for _, flag := range flags {
+		plannercore.SetPreparedPlanCache(flag)
+		plannercore.PreparedPlanCacheCapacity = 3
+
+		tk := testkit.NewTestKit(c, s.store)
+		tk.MustExec("use test")
+		tk.MustExec("drop table if exists prepare_test")
+		tk.MustExec("create table prepare_test (id int PRIMARY KEY, c1 int)")
+
+		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
+		tk.MustExec(`prepare stmt1 from 'select * from prepare_test'`)
+		tk.MustExec("execute stmt1")
+		tk.MustExec(`prepare stmt2 from 'select * from prepare_test'`)
+		tk.MustExec("execute stmt2")
+		tk.MustExec(`prepare stmt3 from 'select * from prepare_test'`)
+		tk.MustExec("execute stmt3")
+		tk.MustExec(`prepare stmt4 from 'select * from prepare_test'`)
+		tk.MustExec("execute stmt4")
+		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
+
+		tk.MustExec("deallocate prepare stmt1")
+		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 3)
+		tk.MustExec("deallocate prepare stmt2")
+		tk.MustExec("deallocate prepare stmt3")
+		tk.MustExec("deallocate prepare stmt4")
+		c.Assert(tk.Se.PreparedPlanCache().Size(), Equals, 0)
+	}
+}

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -87,6 +87,19 @@ func (key *pstmtPlanCacheKey) Hash() []byte {
 	return key.hash
 }
 
+// PstmtCacheKeyMutator is the interface that change Prepared statement's cache key.
+type PstmtCacheKeyMutator interface {
+	SetPstmtIDSchemaVersion(pstmtID uint32, schemaVersion int64)
+}
+
+// SetPstmtIDSchemaVersion implements PstmtCacheKeyMutator interface to change pstmtID and schemaVersion of cacheKey.
+// so we can reuse Key instead of new every time.
+func (key *pstmtPlanCacheKey) SetPstmtIDSchemaVersion(pstmtID uint32, schemaVersion int64) {
+	key.pstmtID = pstmtID
+	key.schemaVersion = schemaVersion
+	key.hash = nil
+}
+
 // NewPSTMTPlanCacheKey creates a new pstmtPlanCacheKey object.
 func NewPSTMTPlanCacheKey(sessionVars *variable.SessionVars, pstmtID uint32, schemaVersion int64) kvcache.Key {
 	timezoneOffset := 0

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -70,12 +70,14 @@ type pstmtPlanCacheKey struct {
 
 // Hash implements Key interface.
 func (key *pstmtPlanCacheKey) Hash() []byte {
-	if key.hash == nil {
+	if len(key.hash) == 0 {
 		var (
 			dbBytes    = hack.Slice(key.database)
 			bufferSize = len(dbBytes) + 8*6
 		)
-		key.hash = make([]byte, 0, bufferSize)
+		if key.hash == nil {
+			key.hash = make([]byte, 0, bufferSize)
+		}
 		key.hash = append(key.hash, dbBytes...)
 		key.hash = codec.EncodeInt(key.hash, int64(key.connID))
 		key.hash = codec.EncodeInt(key.hash, int64(key.pstmtID))
@@ -87,17 +89,16 @@ func (key *pstmtPlanCacheKey) Hash() []byte {
 	return key.hash
 }
 
-// PstmtCacheKeyMutator is the interface that change Prepared statement's cache key.
-type PstmtCacheKeyMutator interface {
-	SetPstmtIDSchemaVersion(pstmtID uint32, schemaVersion int64)
-}
-
 // SetPstmtIDSchemaVersion implements PstmtCacheKeyMutator interface to change pstmtID and schemaVersion of cacheKey.
 // so we can reuse Key instead of new every time.
-func (key *pstmtPlanCacheKey) SetPstmtIDSchemaVersion(pstmtID uint32, schemaVersion int64) {
-	key.pstmtID = pstmtID
-	key.schemaVersion = schemaVersion
-	key.hash = nil
+func SetPstmtIDSchemaVersion(key kvcache.Key, pstmtID uint32, schemaVersion int64) {
+	psStmtKey, isPsStmtKey := key.(*pstmtPlanCacheKey)
+	if !isPsStmtKey {
+		return
+	}
+	psStmtKey.pstmtID = pstmtID
+	psStmtKey.schemaVersion = schemaVersion
+	psStmtKey.hash = psStmtKey.hash[:0]
 }
 
 // NewPSTMTPlanCacheKey creates a new pstmtPlanCacheKey object.

--- a/util/kvcache/simple_lru.go
+++ b/util/kvcache/simple_lru.go
@@ -90,7 +90,7 @@ func (l *SimpleLRUCache) Put(key Key, value Value) {
 	}
 }
 
-// Delete deletes the key and its from the LRU Cache.
+// Delete deletes the key-value pair from the LRU Cache.
 func (l *SimpleLRUCache) Delete(key Key) {
 	k := string(key.Hash())
 	element := l.elements[k]

--- a/util/kvcache/simple_lru.go
+++ b/util/kvcache/simple_lru.go
@@ -89,3 +89,11 @@ func (l *SimpleLRUCache) Put(key Key, value Value) {
 		l.size--
 	}
 }
+
+// Delete delete the key and its from the LRU Cache.
+func (l *SimpleLRUCache) Delete(key Key) {
+	k := string(key.Hash())
+	l.cache.Remove(l.elements[k])
+	delete(l.elements, k)
+	l.size--
+}

--- a/util/kvcache/simple_lru.go
+++ b/util/kvcache/simple_lru.go
@@ -90,7 +90,7 @@ func (l *SimpleLRUCache) Put(key Key, value Value) {
 	}
 }
 
-// Delete delete the key and its from the LRU Cache.
+// Delete deletes the key and its from the LRU Cache.
 func (l *SimpleLRUCache) Delete(key Key) {
 	k := string(key.Hash())
 	element := l.elements[k]
@@ -100,4 +100,9 @@ func (l *SimpleLRUCache) Delete(key Key) {
 	l.cache.Remove(element)
 	delete(l.elements, k)
 	l.size--
+}
+
+// Size gets the current cache size.
+func (l *SimpleLRUCache) Size() int {
+	return int(l.size)
 }

--- a/util/kvcache/simple_lru.go
+++ b/util/kvcache/simple_lru.go
@@ -93,7 +93,11 @@ func (l *SimpleLRUCache) Put(key Key, value Value) {
 // Delete delete the key and its from the LRU Cache.
 func (l *SimpleLRUCache) Delete(key Key) {
 	k := string(key.Hash())
-	l.cache.Remove(l.elements[k])
+	element := l.elements[k]
+	if element == nil {
+		return
+	}
+	l.cache.Remove(element)
 	delete(l.elements, k)
 	l.size--
 }

--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -143,3 +143,29 @@ func (s *testLRUCacheSuite) TestGet(c *C) {
 		c.Assert(value, Equals, vals[i])
 	}
 }
+
+func (s *testLRUCacheSuite) TestDelete(c *C) {
+	lru := NewSimpleLRUCache(3)
+
+	keys := make([]*mockCacheKey, 3)
+	vals := make([]int64, 3)
+
+	for i := 0; i < 3; i++ {
+		keys[i] = newMockHashKey(int64(i))
+		vals[i] = int64(i)
+		lru.Put(keys[i], vals[i])
+	}
+	c.Assert(int(lru.size), Equals, 3)
+
+	lru.Delete(keys[1])
+	value, exists := lru.Get(keys[1])
+	c.Assert(exists, IsFalse)
+	c.Assert(value, IsNil)
+	c.Assert(int(lru.size), Equals, 2)
+
+	_, exists = lru.Get(keys[0])
+	c.Assert(exists, IsTrue)
+
+	_, exists = lru.Get(keys[2])
+	c.Assert(exists, IsTrue)
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

ref #8330, current tidb's ps deallocate handler doesn't release plan-cache memory, this PR fix it.

### What is changed and how it works?

delete plan cache when client deallocate a prepared stmt.

- in handleStmt for binary protocol
- in deallocExec for text protocol "deallocate prepare stmtX"
- add some test case

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

use code in issue doesn't saw OOM any more

Code changes

 - Has exported function/method change
 - Has interface methods change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

### Remain Question

current impl simple use current sessionVars, if `sql_mode` or `schema_version` are changed before deallocate, then we can not free previous item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8332)
<!-- Reviewable:end -->
