### PR TITLE
domain: make TestSchemaValidator stable

### DIFF
--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -63,10 +64,12 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	validator.Restart()
 
 	// Sleep for a long time, check schema is invalid.
+	ts := <-oracleCh // Make sure that ts has timed out a lease.
 	time.Sleep(lease)
-	ts := <-oracleCh
+	ts = <-oracleCh
 	valid = validator.Check(ts, item.schemaVer, []int64{10})
-	c.Assert(valid, Equals, ResultUnknown)
+	c.Assert(valid, Equals, ResultUnknown, Commentf("validator latest schema ver %v, time %v, item schema ver %v, ts %v",
+		validator.latestSchemaVer, validator.latestSchemaExpire, item.schemaVer, oracle.GetTimeFromTS(ts)))
 
 	currVer := reload(validator, leaseGrantCh, 0)
 	valid = validator.Check(ts, item.schemaVer, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make TestSchemaValidator stable.
```
FAIL: schema_validator_test.go:30: testSuite.TestSchemaValidator
schema_validator_test.go:66:
    c.Assert(valid, Equals, ResultUnknown)
... obtained domain.checkResult = 0
... expected domain.checkResult = 2
```

### What is changed and how it works?
Make sure that ts has timed out a lease and add comments.

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8334)
<!-- Reviewable:end -->
