### PR TITLE
executor: fix union dual table order by but not sort

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -379,3 +379,24 @@ Projection_5	8000.00	root	test.ta.a
     └─TableReader_9	10000.00	root	data:TableScan_8
       └─TableScan_8	10000.00	cop	table:ta, range:[-inf,+inf], keep order:false, stats:pseudo
 rollback;
+explain SELECT 0 AS a FROM dual UNION SELECT 1 AS a FROM dual ORDER BY a;
+id	count	task	operator info
+Sort_13	2.00	root	a:asc
+└─HashAgg_17	2.00	root	group by:a, funcs:firstrow(join_agg_0)
+  └─Union_18	2.00	root	
+    ├─HashAgg_21	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+    │ └─Projection_22	1.00	root	0
+    │   └─TableDual_23	1.00	root	rows:1
+    └─HashAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+      └─Projection_27	1.00	root	1
+        └─TableDual_28	1.00	root	rows:1
+explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a)
+id	count	task	operator info
+HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
+└─Union_16	2.00	root	
+  ├─HashAgg_19	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+  │ └─Projection_20	1.00	root	0
+  │   └─TableDual_21	1.00	root	rows:1
+  └─StreamAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+    └─Projection_31	1.00	root	1
+      └─TableDual_32	1.00	root	rows:1

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -80,3 +80,6 @@ begin;
 insert tb values ('1');
 explain select * from ta where a = 1;
 rollback;
+
+explain SELECT 0 AS a FROM dual UNION SELECT 1 AS a FROM dual ORDER BY a;
+explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1060,6 +1060,11 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec("CREATE TABLE t2 (a int not null, b char (10) not null)")
 	tk.MustExec("insert into t2 values(1,'a'),(2,'b'),(3,'c'),(3,'c')")
 	tk.MustQuery("select a from t1 union select a from t1 order by (select a+1);").Check(testkit.Rows("1", "2", "3"))
+
+	// #issue 8201
+	for i := 0; i < 4; i++ {
+		tk.MustQuery("SELECT(SELECT 0 AS a FROM dual UNION SELECT 1 AS a FROM dual ORDER BY a ASC  LIMIT 1) AS dev").Check(testkit.Rows("0"))
+	}
 }
 
 func (s *testSuite) TestNeighbouringProj(c *C) {

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -719,7 +719,7 @@ import (
 	SelectStmtLimit			"SELECT statement optional LIMIT clause"
 	SelectStmtOpts			"Select statement options"
 	SelectStmtBasic			"SELECT statement from constant value"
-	SelectStmtFromDual			"SELECT statement from dual"
+	SelectStmtFromDualTable			"SELECT statement from dual table"
 	SelectStmtFromTable			"SELECT statement from table"
 	SelectStmtGroup			"SELECT statement optional GROUP BY clause"
 	ShowTargetFilterable    	"Show target that can be filtered by WHERE or LIKE"
@@ -4240,21 +4240,17 @@ SelectStmtBasic:
 		$$ = st
 	}
 
-SelectStmtFromDual:
-	SelectStmtBasic FromDual WhereClauseOptional OrderByOptional
+SelectStmtFromDualTable:
+	SelectStmtBasic FromDual WhereClauseOptional
 	{
 		st := $1.(*ast.SelectStmt)
 		lastField := st.Fields.Fields[len(st.Fields.Fields)-1]
 		if lastField.Expr != nil && lastField.AsName.O == "" {
-			lastEnd := yyS[yypt-2].offset-1	
+			lastEnd := yyS[yypt-1].offset-1
 			lastField.SetText(parser.src[lastField.Offset:lastEnd])
 		}
 		if $3 != nil {
 			st.Where = $3.(ast.ExprNode)
-		}
-
-		if $4 != nil {
-			st.OrderBy = $4.(*ast.OrderByClause)
 		}
 	}
 
@@ -4316,13 +4312,16 @@ SelectStmt:
 		}
 		$$ = st
 	}
-|	SelectStmtFromDual SelectStmtLimit SelectLockOpt
+|	SelectStmtFromDualTable OrderByOptional SelectStmtLimit SelectLockOpt
 	{
 		st := $1.(*ast.SelectStmt)
-		st.LockTp = $3.(ast.SelectLockType)
 		if $2 != nil {
-			st.Limit = $2.(*ast.Limit)
+			st.OrderBy = $2.(*ast.OrderByClause)
 		}
+		if $3 != nil {
+		    st.Limit = $3.(*ast.Limit)
+        }
+        st.LockTp = $4.(ast.SelectLockType)
 		$$ = st
 	}
 |	SelectStmtFromTable OrderByOptional SelectStmtLimit SelectLockOpt
@@ -4784,19 +4783,24 @@ UnionStmt:
 		}
 		$$ = union
 	}
-|	UnionClauseList "UNION" UnionOpt SelectStmtFromDual SelectStmtLimit SelectLockOpt
+|	UnionClauseList "UNION" UnionOpt SelectStmtFromDualTable OrderByOptional
+         SelectStmtLimit SelectLockOpt
 	{
 		st := $4.(*ast.SelectStmt)
 		union := $1.(*ast.UnionStmt)
 		st.IsAfterUnionDistinct = $3.(bool)
 		lastSelect := union.SelectList.Selects[len(union.SelectList.Selects)-1]
-		endOffset := parser.endOffset(&yyS[yypt-4])
+		endOffset := parser.endOffset(&yyS[yypt-5])
 		parser.setLastSelectFieldText(lastSelect, endOffset)
 		union.SelectList.Selects = append(union.SelectList.Selects, st)
 		if $5 != nil {
-		    union.Limit = $5.(*ast.Limit)
-		} else {
-		    st.LockTp = $6.(ast.SelectLockType)
+		    union.OrderBy = $5.(*ast.OrderByClause)
+		}
+		if $6 != nil {
+		   union.Limit = $6.(*ast.Limit)
+		}
+		if $5 == nil && $6 == nil {
+		    st.LockTp = $7.(ast.SelectLockType)
 		}
 		$$ = union
 	}


### PR DESCRIPTION
cherry pick #8251 to 2.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8335)
<!-- Reviewable:end -->
