### PR TITLE
executor: make sure hashjoin's goroutine exit before `Close` return

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -553,6 +553,9 @@ func (e *HashJoinExec) fetchInnerAndBuildHashTable(ctx context.Context) {
 	go util.WithRecovery(func() { e.fetchInnerRows(ctx, innerResultCh, doneCh) }, nil)
 
 	if e.finished.Load().(bool) {
+		// wait fetchInnerRows goroutine exit.
+		for range innerResultCh {
+		}
 		return
 	}
 	// TODO: Parallel build hash table. Currently not support because `mvmap` is not thread-safe.
@@ -587,6 +590,9 @@ func (e *HashJoinExec) buildHashTableForList(innerResultCh chan *chunk.Chunk) er
 	chkIdx := uint32(0)
 	for chk := range innerResultCh {
 		if e.finished.Load().(bool) {
+			// wait fetchInnerRows goroutine exit.
+			for range innerResultCh {
+			}
 			return nil
 		}
 		numRows := chk.NumRows()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #8337 

### What is changed and how it works?

also wait `fetchInnerRows` goroutine exit when found `finished` be setted.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Old test

Code changes

 - Close logic

Side effects

 -  N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8338)
<!-- Reviewable:end -->
