### PR TITLE
config, util.kvcache: support the memory guard to prevent OOM for the plan cache

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -150,6 +150,7 @@ type Status struct {
 // Performance is the performance section of the config.
 type Performance struct {
 	MaxProcs            uint    `toml:"max-procs" json:"max-procs"`
+	MaxMemory           uint64  `toml:"max-memory" json:"max-memory"`
 	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
 	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
 	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
@@ -184,8 +185,9 @@ type TxnLocalLatches struct {
 
 // PreparedPlanCache is the PreparedPlanCache section of the config.
 type PreparedPlanCache struct {
-	Enabled  bool `toml:"enabled" json:"enabled"`
-	Capacity uint `toml:"capacity" json:"capacity"`
+	Enabled          bool    `toml:"enabled" json:"enabled"`
+	Capacity         uint    `toml:"capacity" json:"capacity"`
+	MemoryGuardRatio float64 `toml:"memory-guard-ratio" json:"memory-guard-ratio"`
 }
 
 // OpenTracing is the opentracing section of the config.
@@ -287,6 +289,7 @@ var defaultConf = Config{
 		MetricsInterval: 15,
 	},
 	Performance: Performance{
+		MaxMemory:           0,
 		TCPKeepAlive:        true,
 		CrossJoin:           true,
 		StatsLease:          "3s",
@@ -306,8 +309,9 @@ var defaultConf = Config{
 		HeaderTimeout: 5,
 	},
 	PreparedPlanCache: PreparedPlanCache{
-		Enabled:  false,
-		Capacity: 100,
+		Enabled:          false,
+		Capacity:         100,
+		MemoryGuardRatio: 0.1,
 	},
 	OpenTracing: OpenTracing{
 		Enable: false,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -122,6 +122,8 @@ metrics-interval = 15
 [performance]
 # Max CPUs to use, 0 use number of CPUs in the machine.
 max-procs = 0
+# Max memory size to use, 0 use the total usable memory in the machine.
+max-memory = 0
 # StmtCountLimit limits the max count of statement inside a transaction.
 stmt-count-limit = 5000
 
@@ -162,6 +164,7 @@ header-timeout = 5
 [prepared-plan-cache]
 enabled = false
 capacity = 100
+memory-guard-ratio = 0.1
 
 [opentracing]
 # Enable opentracing.

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -31,15 +31,21 @@ import (
 func (s *testSuite) TestPrepared(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -215,15 +221,21 @@ func (s *testSuite) TestPrepared(c *C) {
 func (s *testSuite) TestPreparedLimitOffset(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	flags := []bool{false, true}
 	ctx := context.Background()
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -251,14 +263,20 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 func (s *testSuite) TestPreparedNullParam(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -315,14 +333,20 @@ func (s *testSuite) TestPrepareMaxParamCountCheck(c *C) {
 func (s *testSuite) TestPrepareWithAggregation(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -352,14 +376,20 @@ func generateBatchSQL(paramCount int) (sql string, paramSlice []interface{}) {
 func (s *testSuite) TestPreparedIssue7579(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -395,9 +425,13 @@ func (s *testSuite) TestPreparedIssue7579(c *C) {
 func (s *testSuite) TestPreparedInsert(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
@@ -406,6 +440,8 @@ func (s *testSuite) TestPreparedInsert(c *C) {
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -469,9 +505,13 @@ func (s *testSuite) TestPreparedInsert(c *C) {
 func (s *testSuite) TestPreparedUpdate(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
@@ -480,6 +520,8 @@ func (s *testSuite) TestPreparedUpdate(c *C) {
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -520,9 +562,13 @@ func (s *testSuite) TestPreparedUpdate(c *C) {
 func (s *testSuite) TestPreparedDelete(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
@@ -531,6 +577,8 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 	for _, flag := range flags {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
+		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -571,12 +619,18 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 func (s *testSuite) TestPrepareDealloc(c *C) {
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	orgCapacity := plannercore.PreparedPlanCacheCapacity
+	orgMemGuardRatio := plannercore.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := plannercore.PreparedPlanCacheMaxMemory
 	defer func() {
 		plannercore.SetPreparedPlanCache(orgEnable)
 		plannercore.PreparedPlanCacheCapacity = orgCapacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	plannercore.SetPreparedPlanCache(true)
 	plannercore.PreparedPlanCacheCapacity = 3
+	plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+	plannercore.PreparedPlanCacheMaxMemory = 32 << 30
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect
 	github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 // indirect
+	github.com/shirou/gopsutil v2.18.10+incompatible
 	github.com/sirupsen/logrus v1.2.0
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72
 	github.com/twinj/uuid v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,7 @@ github.com/pingcap/tidb-tools v0.0.0-20181101090416-cfac1096162e h1:LKGiK9RwOntq
 github.com/pingcap/tidb-tools v0.0.0-20181101090416-cfac1096162e/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v0.0.0-20181112132202-4860a0d5de03 h1:xVuo5U+l6XAWHsb+xhkZ8zz3jerIwDfCHAO6kR2Kaog=
 github.com/pingcap/tidb-tools v0.0.0-20181112132202-4860a0d5de03/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v2.1.0-rc.5+incompatible h1:x+vS+/RXiJsX2lvED0zGSP08Yc2e6r2WtQCCmwc9ASg=
 github.com/pingcap/tipb v0.0.0-20171213095807-07ff5b094233/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323 h1:mRKKzRjDNaUNPnAkPAHnRqpNmwNWBX1iA+hxlmvQ93I=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
@@ -257,6 +258,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446 h1:/NRJ5vAYoqz+7sG51ubIDHXeWO8DlTSrToPu6q11ziA=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
+github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/siddontang/go v0.0.0-20170517070808-cb568a3e5cc0/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726/go.mod h1:3yhqj7WBBfRhbBlzyOC3gUxftwsU0u8gqevxwIHQpMw=
 github.com/sirupsen/logrus v0.0.0-20170323161349-3bcb09397d6d/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -31,6 +31,10 @@ var (
 	preparedPlanCacheEnabledValue int32
 	// PreparedPlanCacheCapacity stores the global config "prepared-plan-cache-capacity".
 	PreparedPlanCacheCapacity uint
+	// PreparedPlanCacheMemoryGuardRatio stores the global config "prepared-plan-cache-memory-guard-ratio".
+	PreparedPlanCacheMemoryGuardRatio float64
+	// PreparedPlanCacheMaxMemory stores the max memory size defined in the global config "performance-max-memory".
+	PreparedPlanCacheMaxMemory uint64
 )
 
 const (

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -34,14 +34,20 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
 	orgCapacity := core.PreparedPlanCacheCapacity
+	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
 		core.PreparedPlanCacheCapacity = orgCapacity
+		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
+	core.PreparedPlanCacheMemoryGuardRatio = 0.1
+	core.PreparedPlanCacheMaxMemory = 32 << 30
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, key idx_bc(b,c))")

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	dto "github.com/prometheus/client_model/go"
@@ -47,7 +48,8 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory = 32 << 30
+	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, key idx_bc(b,c))")

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -38,14 +38,20 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
 	orgCapacity := core.PreparedPlanCacheCapacity
+	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
 		core.PreparedPlanCacheCapacity = orgCapacity
+		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
+	core.PreparedPlanCacheMemoryGuardRatio = 0.1
+	core.PreparedPlanCacheMaxMemory = 32 << 30
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, index idx1(b, a), index idx2(b))")
@@ -80,14 +86,20 @@ func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
 	orgCapacity := core.PreparedPlanCacheCapacity
+	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
 		core.PreparedPlanCacheCapacity = orgCapacity
+		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
+	core.PreparedPlanCacheMemoryGuardRatio = 0.1
+	core.PreparedPlanCacheMaxMemory = 32 << 30
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, primary key (a, b))")
@@ -106,14 +118,20 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
 	orgCapacity := core.PreparedPlanCacheCapacity
+	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
 		core.PreparedPlanCacheCapacity = orgCapacity
+		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
+	core.PreparedPlanCacheMemoryGuardRatio = 0.1
+	core.PreparedPlanCacheMaxMemory = 32 << 30
 
 	defer testleak.AfterTest(c)()
 
@@ -159,14 +177,20 @@ func (s *testPrepareSuite) TestPrepareCacheNow(c *C) {
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
 	orgCapacity := core.PreparedPlanCacheCapacity
+	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
+	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
 		core.PreparedPlanCacheCapacity = orgCapacity
+		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
+		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
+	core.PreparedPlanCacheMemoryGuardRatio = 0.1
+	core.PreparedPlanCacheMaxMemory = 32 << 30
 	tk.MustExec("use test")
 	tk.MustExec(`prepare stmt1 from "select now(), sleep(1), now()"`)
 	// When executing one statement at the first time, we don't use cache, so we need to execute it at least twice to test the cache.

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	dto "github.com/prometheus/client_model/go"
@@ -51,7 +52,8 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory = 32 << 30
+	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, index idx1(b, a), index idx2(b))")
@@ -99,7 +101,8 @@ func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory = 32 << 30
+	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, primary key (a, b))")
@@ -131,7 +134,8 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory = 32 << 30
+	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	c.Assert(err, IsNil)
 
 	defer testleak.AfterTest(c)()
 
@@ -190,7 +194,8 @@ func (s *testPrepareSuite) TestPrepareCacheNow(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory = 32 << 30
+	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec(`prepare stmt1 from "select now(), sleep(1), now()"`)
 	// When executing one statement at the first time, we don't use cache, so we need to execute it at least twice to test the cache.

--- a/session/session.go
+++ b/session/session.go
@@ -1282,7 +1282,8 @@ func createSession(store kv.Storage) (*session, error) {
 		ddlOwnerChecker: dom.DDL().OwnerManager(),
 	}
 	if plannercore.PreparedPlanCacheEnabled() {
-		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity)
+		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity,
+			plannercore.PreparedPlanCacheMemoryGuardRatio, plannercore.PreparedPlanCacheMaxMemory)
 	}
 	s.mu.values = make(map[fmt.Stringer]interface{})
 	domain.BindDomain(s, dom)
@@ -1304,7 +1305,8 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 		sessionVars: variable.NewSessionVars(),
 	}
 	if plannercore.PreparedPlanCacheEnabled() {
-		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity)
+		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity,
+			plannercore.PreparedPlanCacheMemoryGuardRatio, plannercore.PreparedPlanCacheMaxMemory)
 	}
 	s.mu.values = make(map[fmt.Stringer]interface{})
 	domain.BindDomain(s, dom)

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/gcworker"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/printer"
 	"github.com/pingcap/tidb/util/signal"
 	"github.com/pingcap/tidb/util/systimemon"
@@ -403,6 +404,13 @@ func setGlobalVars() {
 	plannercore.SetPreparedPlanCache(config.CheckTableBeforeDrop || cfg.PreparedPlanCache.Enabled)
 	if plannercore.PreparedPlanCacheEnabled() {
 		plannercore.PreparedPlanCacheCapacity = cfg.PreparedPlanCache.Capacity
+		plannercore.PreparedPlanCacheMemoryGuardRatio = cfg.PreparedPlanCache.MemoryGuardRatio
+		plannercore.PreparedPlanCacheMaxMemory = cfg.Performance.MaxMemory
+		if plannercore.PreparedPlanCacheMaxMemory == 0 {
+			total, err := memory.MemTotal()
+			terror.MustNil(err)
+			plannercore.PreparedPlanCacheMaxMemory = total
+		}
 	}
 
 	if cfg.TiKVClient.GrpcConnectionCount > 0 {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -405,10 +405,13 @@ func setGlobalVars() {
 	if plannercore.PreparedPlanCacheEnabled() {
 		plannercore.PreparedPlanCacheCapacity = cfg.PreparedPlanCache.Capacity
 		plannercore.PreparedPlanCacheMemoryGuardRatio = cfg.PreparedPlanCache.MemoryGuardRatio
+		if plannercore.PreparedPlanCacheMemoryGuardRatio < 0.0 || plannercore.PreparedPlanCacheMemoryGuardRatio > 1.0 {
+			plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
+		}
 		plannercore.PreparedPlanCacheMaxMemory = cfg.Performance.MaxMemory
-		if plannercore.PreparedPlanCacheMaxMemory == 0 {
-			total, err := memory.MemTotal()
-			terror.MustNil(err)
+		total, err := memory.MemTotal()
+		terror.MustNil(err)
+		if plannercore.PreparedPlanCacheMaxMemory > total || plannercore.PreparedPlanCacheMaxMemory <= 0 {
 			plannercore.PreparedPlanCacheMaxMemory = total
 		}
 	}

--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -192,3 +192,26 @@ func (s *testLRUCacheSuite) TestDelete(c *C) {
 	_, exists = lru.Get(keys[2])
 	c.Assert(exists, IsTrue)
 }
+
+func (s *testLRUCacheSuite) TestDeleteAll(c *C) {
+	lru := NewSimpleLRUCache(3, 0.1, 32<<30)
+
+	keys := make([]*mockCacheKey, 3)
+	vals := make([]int64, 3)
+
+	for i := 0; i < 3; i++ {
+		keys[i] = newMockHashKey(int64(i))
+		vals[i] = int64(i)
+		lru.Put(keys[i], vals[i])
+	}
+	c.Assert(int(lru.size), Equals, 3)
+
+	lru.DeleteAll()
+
+	for i := 0; i < 3; i++ {
+		value, exists := lru.Get(keys[i])
+		c.Assert(exists, IsFalse)
+		c.Assert(value, IsNil)
+		c.Assert(int(lru.size), Equals, 0)
+	}
+}

--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/memory"
 )
 
 func TestT(t *testing.T) {
@@ -52,7 +53,10 @@ func newMockHashKey(key int64) *mockCacheKey {
 }
 
 func (s *testLRUCacheSuite) TestPut(c *C) {
-	lru := NewSimpleLRUCache(3, 0.1, 32<<30)
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(3, 0.1, maxMem)
 	c.Assert(lru.capacity, Equals, uint(3))
 
 	keys := make([]*mockCacheKey, 5)
@@ -104,8 +108,11 @@ func (s *testLRUCacheSuite) TestPut(c *C) {
 	c.Assert(root, IsNil)
 }
 
-func (s *testLRUCacheSuite) TestiOOMGuard(c *C) {
-	lru := NewSimpleLRUCache(3, 1.0, 32<<30)
+func (s *testLRUCacheSuite) TestOOMGuard(c *C) {
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(3, 1.0, maxMem)
 	c.Assert(lru.capacity, Equals, uint(3))
 
 	keys := make([]*mockCacheKey, 5)
@@ -128,7 +135,10 @@ func (s *testLRUCacheSuite) TestiOOMGuard(c *C) {
 }
 
 func (s *testLRUCacheSuite) TestGet(c *C) {
-	lru := NewSimpleLRUCache(3, 0.1, 32<<30)
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(3, 0.1, maxMem)
 
 	keys := make([]*mockCacheKey, 5)
 	vals := make([]int64, 5)
@@ -168,7 +178,10 @@ func (s *testLRUCacheSuite) TestGet(c *C) {
 }
 
 func (s *testLRUCacheSuite) TestDelete(c *C) {
-	lru := NewSimpleLRUCache(3, 0.1, 32<<30)
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(3, 0.1, maxMem)
 
 	keys := make([]*mockCacheKey, 3)
 	vals := make([]int64, 3)
@@ -194,7 +207,10 @@ func (s *testLRUCacheSuite) TestDelete(c *C) {
 }
 
 func (s *testLRUCacheSuite) TestDeleteAll(c *C) {
-	lru := NewSimpleLRUCache(3, 0.1, 32<<30)
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(3, 0.1, maxMem)
 
 	keys := make([]*mockCacheKey, 3)
 	vals := make([]int64, 3)

--- a/util/memory/bench_test.go
+++ b/util/memory/bench_test.go
@@ -14,17 +14,17 @@
 package memory
 
 import (
-	"github.com/shirou/gopsutil/mem"
+	"testing"
 )
 
-// MemTotal returns the total amount of RAM on this system
-func MemTotal() (uint64, error) {
-	v, err := mem.VirtualMemory()
-	return v.Total, err
+func BenchmarkMemTotal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = MemTotal()
+	}
 }
 
-// MemUsed returns the total used amount of RAM on this system
-func MemUsed() (uint64, error) {
-	v, err := mem.VirtualMemory()
-	return v.Total - (v.Free + v.Buffers + v.Cached), err
+func BenchmarkMemUsed(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = MemUsed()
+	}
 }

--- a/util/memory/meminfo.go
+++ b/util/memory/meminfo.go
@@ -1,0 +1,17 @@
+package memory
+
+import (
+	"github.com/shirou/gopsutil/mem"
+)
+
+// MemTotal returns the total amount of RAM on this system
+func MemTotal() (uint64, error) {
+	v, err := mem.VirtualMemory()
+	return v.Total, err
+}
+
+// MemUsed returns the total used amount of RAM on this system
+func MemUsed() (uint64, error) {
+	v, err := mem.VirtualMemory()
+	return v.Total - (v.Free + v.Buffers + v.Cached), err
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #8330 

### What is changed and how it works?
* add new configuration parameters to represent the memory guard ratio and the total memory size  to prevent OOM for the plan cache 
* cache a new input item only if the ratio of the available memory to the total memory size is larger than the memory guard ratio
* compute the current memory usage approximately by using ``gopsutil.VirtualMemory()`` whenever the new element is put

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has changed the default value
 - Has added a new configuration parameter

Side effects

 - None

Related changes

 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8339)
<!-- Reviewable:end -->
