### PR TITLE
plan: support subquery in `Do` statement

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3329,3 +3329,16 @@ func (s *testSuite) TestRowID(c *C) {
 	tk.MustExec(`insert into t values('a')`)
 	tk.MustQuery("select *, _tidb_rowid from t use index(`primary`) where _tidb_rowid=1").Check(testkit.Rows("a 1"))
 }
+
+func (s *testSuite) TestDoSubquery(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`drop table if exists t`)
+	tk.MustExec(`create table t(a int)`)
+	_, err := tk.Exec(`do 1 in (select * from t)`)
+	c.Assert(err, IsNil, Commentf("err %v", err))
+	tk.MustExec(`insert into t values(1)`)
+	r, err := tk.Exec(`do 1 in (select * from t)`)
+	c.Assert(err, IsNil, Commentf("err %v", err))
+	c.Assert(r, IsNil, Commentf("result of Do not empty"))
+}

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -14,11 +14,12 @@
 package core
 
 import (
+	"fmt"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
-	log "github.com/sirupsen/logrus"
 )
 
 type columnPruner struct {
@@ -34,7 +35,7 @@ func getUsedList(usedCols []*expression.Column, schema *expression.Schema) []boo
 	for _, col := range usedCols {
 		idx := schema.ColumnIndex(col)
 		if idx == -1 {
-			log.Errorf("Can't find column %s from schema %s.", col, schema)
+			panic(fmt.Sprintf("Can't find column %s from schema %s.", col, schema))
 		}
 		used[idx] = true
 	}

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -32,6 +32,10 @@ func canProjectionBeEliminatedLoose(p *LogicalProjection) bool {
 // canProjectionBeEliminatedStrict checks whether a projection can be
 // eliminated, returns true if the projection just copy its child's output.
 func canProjectionBeEliminatedStrict(p *PhysicalProjection) bool {
+	// If this projection is specially added for `DO`, we keep it.
+	if p.CalculateNoDelay == true {
+		return false
+	}
 	if p.Schema().Len() == 0 {
 		return true
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before this PR:
```
mysql> select * from t1;
+------+
| id   |
+------+
|    1 |
+------+
1 row in set (0.01 sec)

mysql> select 1 in (select * from t1);
+-------------------------+
| 1 in (select * from t1) |
+-------------------------+
|                       1 |
+-------------------------+
1 row in set (0.00 sec)

mysql> do 1 in (select * from t1);
ERROR 2013 (HY000): Lost connection to MySQL server during query
```
while in MySQL:
```
mysql> select * from t1;
+--------------+
| processor_id |
+--------------+
|            1 |
+--------------+
1 row in set (0.00 sec)

mysql> do 1 in (select * from t1);
Query OK, 0 rows affected (0.00 sec)
```

MySQL states in https://dev.mysql.com/doc/refman/5.7/en/do.html that:
> DO only executes expressions. It cannot be used in all cases where SELECT can be used. For example, DO id FROM t1 is invalid because it references a table.

The documentation does not explicitly specify the boundary to which `Do` is compatible with `SELECT`. Since this case experimentally works in MySQL, we support it in TiDB.

### What is changed and how it works?

- involve full expression rewriting in plan building for `Do`;
- prevent `Projection` specially added for `Do` being eliminated in optimizer;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8343)
<!-- Reviewable:end -->
