### PR TITLE
support system variable wait_timeout. (#8245)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -222,7 +222,7 @@ func (cc *clientConn) getSessionVarsWaitTimeout() uint64 {
 	if err != nil {
 		log.Errorf("con:%d get sysval wait_timeout error, use default value.", cc.connectionID)
 		// if get waitTimeout error, use default value
-		waitTimeout, _ = strconv.ParseUint(variable.WaitTimeoutDefaultValue, 10, 64)
+		waitTimeout = variable.DefWaitTimeout
 	}
 	return waitTimeout
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1373,6 +1373,7 @@ const loadCommonGlobalVarsSQL = "select HIGH_PRIORITY * from mysql.global_variab
 	variable.MaxAllowedPacket + quoteCommaQuote +
 	variable.TimeZone + quoteCommaQuote +
 	variable.BlockEncryptionMode + quoteCommaQuote +
+	variable.WaitTimeout + quoteCommaQuote +
 	/* TiDB specific global variables: */
 	variable.TiDBSkipUTF8Check + quoteCommaQuote +
 	variable.TiDBIndexJoinBatchSize + quoteCommaQuote +

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -535,7 +535,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_buffer_pool_size", "134217728"},
 	{ScopeGlobal, "innodb_adaptive_flushing", "ON"},
 	{ScopeNone, "datadir", "/usr/local/mysql/data/"},
-	{ScopeGlobal | ScopeSession, "wait_timeout", "28800"},
+	{ScopeGlobal | ScopeSession, WaitTimeout, WaitTimeoutDefaultValue},
 	{ScopeGlobal, "innodb_monitor_enable", ""},
 	{ScopeNone, "date_format", "%Y-%m-%d"},
 	{ScopeGlobal, "innodb_buffer_pool_filename", "ib_buffer_pool"},
@@ -774,6 +774,10 @@ const (
 	SyncBinlog = "sync_binlog"
 	// BlockEncryptionMode is the name for 'block_encryption_mode' system variable.
 	BlockEncryptionMode = "block_encryption_mode"
+	// WaitTimeout is the name for 'wait_timeout' system variable.
+	WaitTimeout = "wait_timeout"
+	// WaitTimeoutDefaultValue is the default value of 'wait_timeout' system variable.
+	WaitTimeoutDefaultValue = "28800"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -535,7 +535,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_buffer_pool_size", "134217728"},
 	{ScopeGlobal, "innodb_adaptive_flushing", "ON"},
 	{ScopeNone, "datadir", "/usr/local/mysql/data/"},
-	{ScopeGlobal | ScopeSession, WaitTimeout, WaitTimeoutDefaultValue},
+	{ScopeGlobal | ScopeSession, WaitTimeout, strconv.FormatInt(DefWaitTimeout, 10)},
 	{ScopeGlobal, "innodb_monitor_enable", ""},
 	{ScopeNone, "date_format", "%Y-%m-%d"},
 	{ScopeGlobal, "innodb_buffer_pool_filename", "ib_buffer_pool"},
@@ -776,8 +776,6 @@ const (
 	BlockEncryptionMode = "block_encryption_mode"
 	// WaitTimeout is the name for 'wait_timeout' system variable.
 	WaitTimeout = "wait_timeout"
-	// WaitTimeoutDefaultValue is the default value of 'wait_timeout' system variable.
-	WaitTimeoutDefaultValue = "28800"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -240,6 +240,7 @@ const (
 	DefCurretTS                      = 0
 	DefMaxChunkSize                  = 32
 	DefDMLBatchSize                  = 20000
+	DefWaitTimeout                   = 28800
 	DefTiDBMemQuotaHashJoin          = 32 << 30 // 32GB.
 	DefTiDBMemQuotaMergeJoin         = 32 << 30 // 32GB.
 	DefTiDBMemQuotaSort              = 32 << 30 // 32GB.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -280,6 +280,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return checkUInt64SystemVar(name, value, 400, 524288, vars)
 	case TmpTableSize:
 		return checkUInt64SystemVar(name, value, 1024, math.MaxUint64, vars)
+	case WaitTimeout:
+		return checkUInt64SystemVar(name, value, 1, 31536000, vars)
 	case TimeZone:
 		if strings.EqualFold(value, "SYSTEM") {
 			return "SYSTEM", nil


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close client connection when the server waited for a long time ,  support system variable `wait_timeout`  to define the wait time.  #8245 

### What is changed and how it works?
use  TCPConn.SetReadDeadline()  before  readPacket()

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integeration test 

Code changes
 - Has exported variable/fields change

Related changes
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8346)
<!-- Reviewable:end -->
