### PR TITLE
util/chunk: preallocate the columns array in MutRow to avoid array resize

### DIFF
--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -40,7 +40,7 @@ func (mr MutRow) Len() int {
 
 // MutRowFromValues creates a MutRow from a interface slice.
 func MutRowFromValues(vals ...interface{}) MutRow {
-	c := &Chunk{}
+	c := &Chunk{columns: make([]*column, 0, len(vals))}
 	for _, val := range vals {
 		col := makeMutRowColumn(val)
 		c.columns = append(c.columns, col)
@@ -50,7 +50,7 @@ func MutRowFromValues(vals ...interface{}) MutRow {
 
 // MutRowFromDatums creates a MutRow from a datum slice.
 func MutRowFromDatums(datums []types.Datum) MutRow {
-	c := &Chunk{}
+	c := &Chunk{columns: make([]*column, 0, len(datums))}
 	for _, d := range datums {
 		col := makeMutRowColumn(d.GetValue())
 		c.columns = append(c.columns, col)
@@ -60,7 +60,7 @@ func MutRowFromDatums(datums []types.Datum) MutRow {
 
 // MutRowFromTypes creates a MutRow from a FieldType slice, each column is initialized to zero value.
 func MutRowFromTypes(types []*types.FieldType) MutRow {
-	c := &Chunk{}
+	c := &Chunk{columns: make([]*column, 0, len(types))}
 	for _, tp := range types {
 		col := makeMutRowColumn(zeroValForType(tp))
 		c.columns = append(c.columns, col)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When checking the flamegraph of Lightning (which does lots of INSERTs) on a table with 37 columns, I found that `MutRowFromDatums` spends a noticeable amount of time in `runtime.growslice`. This means the capacity of `c.columns` isn't large enough and `append()` will need to reallocate and move the content (as of Go 1.11 the capacity grows like 0 → 2 → 4 → 8 → 16 → …).

### What is changed and how it works?

Since the final length is known, we just preallocate the slice with the known capacity.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Patched the TiDB dependency in Lightning and verified that `runtime.growslice` no longer appears directly inside `MutRowFromDatums` in the `pprof` CPU profile.

Code changes

Side effects

Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8348)
<!-- Reviewable:end -->
