### PR TITLE
plan: disable plan cache for query containing `SubqueryExpr`

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -88,6 +88,26 @@ func (s *testSuite) TestPrepared(c *C) {
 		c.Assert(err, IsNil)
 		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
 
+		tk.MustExec("delete from prepare_test")
+		query = "select c1 from prepare_test where c1 = (select c1 from prepare_test where c1 = ?)"
+		stmtId, _, _, err = tk.Se.PrepareStmt(query)
+		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk1.MustExec("insert prepare_test (c1) values (3)")
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
+
+		tk.MustExec("delete from prepare_test")
+		query = "select c1 from prepare_test where c1 in (select c1 from prepare_test where c1 = ?)"
+		stmtId, _, _, err = tk.Se.PrepareStmt(query)
+		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk1.MustExec("insert prepare_test (c1) values (3)")
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtId, 3)
+		c.Assert(err, IsNil)
+		tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("3"))
+
 		tk.MustExec("begin")
 		tk.MustExec("insert prepare_test (c1) values (4)")
 		query = "select c1, c2 from prepare_test where c1 = ?"

--- a/plan/cacheable_checker.go
+++ b/plan/cacheable_checker.go
@@ -42,7 +42,7 @@ type cacheableChecker struct {
 // Enter implements Visitor interface.
 func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	switch node := in.(type) {
-	case *ast.VariableExpr, *ast.ExistsSubqueryExpr:
+	case *ast.VariableExpr, *ast.ExistsSubqueryExpr, *ast.SubqueryExpr:
 		checker.cacheable = false
 		return in, true
 	case *ast.FuncCallExpr:


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/8064

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8395)
<!-- Reviewable:end -->
