### PR TITLE
*: record cop scan rows in explain analyze

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1679,7 +1679,10 @@ func buildNoRangeTableReader(b *executorBuilder, v *plannercore.PhysicalTableRea
 	} else {
 		e.feedback = statistics.NewQueryFeedback(e.physicalTableID, ts.Hist, int64(ts.StatsCount()), ts.Desc)
 	}
-	collect := e.feedback.CollectFeedback(len(ts.Ranges))
+	collect := (b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl != nil) || e.feedback.CollectFeedback(len(ts.Ranges))
+	if !collect {
+		e.feedback.Invalidate()
+	}
 	e.dagPB.CollectRangeCounts = &collect
 
 	for i := range v.Schema().Columns {
@@ -1736,7 +1739,10 @@ func buildNoRangeIndexReader(b *executorBuilder, v *plannercore.PhysicalIndexRea
 	} else {
 		e.feedback = statistics.NewQueryFeedback(e.physicalTableID, is.Hist, int64(is.StatsCount()), is.Desc)
 	}
-	collect := e.feedback.CollectFeedback(len(is.Ranges))
+	collect := (b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl != nil) || e.feedback.CollectFeedback(len(is.Ranges))
+	if !collect {
+		e.feedback.Invalidate()
+	}
 	e.dagPB.CollectRangeCounts = &collect
 
 	for _, col := range v.OutputColumns {
@@ -1812,7 +1818,10 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 	// do not collect the feedback for table request.
 	collectTable := false
 	e.tableRequest.CollectRangeCounts = &collectTable
-	collectIndex := e.feedback.CollectFeedback(len(is.Ranges))
+	collectIndex := (b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl != nil) || e.feedback.CollectFeedback(len(is.Ranges))
+	if !collectIndex {
+		e.feedback.Invalidate()
+	}
 	e.dagPB.CollectRangeCounts = &collectIndex
 	if cols, ok := v.Schema().TblID2Handle[is.Table.ID]; ok {
 		e.handleIdx = cols[0].Index

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/ranger"
-	tipb "github.com/pingcap/tipb/go-tipb"
+	"github.com/pingcap/tipb/go-tipb"
 	"golang.org/x/net/context"
 )
 
@@ -118,8 +118,12 @@ func (e *TableReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error 
 
 // Close implements the Executor Close interface.
 func (e *TableReaderExecutor) Close() error {
-	e.ctx.StoreQueryFeedback(e.feedback)
 	err := e.resultHandler.Close()
+	if e.runtimeStats != nil {
+		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.plans[0].ExplainID())
+		copStats.SetRowNum(e.feedback.Actual())
+	}
+	e.ctx.StoreQueryFeedback(e.feedback)
 	return errors.Trace(err)
 }
 

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -38,16 +38,6 @@ var _ = Suite(&testAnalyzeSuite{})
 type testAnalyzeSuite struct {
 }
 
-func shouldContainsExecutorInfo(taskType, rootID, copID string) bool {
-	if taskType == "root" {
-		return true
-	}
-	if strings.Contains(rootID, "IndexLookUp") {
-		return strings.Contains(copID, "IndexScan")
-	}
-	return strings.Contains(copID, "Scan")
-}
-
 func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 	defer testleak.AfterTest(c)()
 	store, dom, err := newStoreWithBootstrap()
@@ -66,14 +56,11 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 	tk.MustExec("analyze table t1, t2")
 	rs := tk.MustQuery("explain analyze select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1")
 	c.Assert(len(rs.Rows()), Equals, 10)
-	var rootID string
 	for _, row := range rs.Rows() {
 		c.Assert(len(row), Equals, 5)
 		taskType := row[2].(string)
-		if taskType == "root" {
-			rootID = row[0].(string)
-		}
-		if shouldContainsExecutorInfo(taskType, rootID, row[0].(string)) {
+		id := row[0].(string)
+		if taskType == "root" || strings.Contains(id, "Scan") {
 			execInfo := row[4].(string)
 			c.Assert(strings.Contains(execInfo, "time"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "loops"), Equals, true)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -521,10 +521,10 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 	row := []string{e.prettyIdentifier(p.ExplainID(), indent, isLastChild), count, taskType, operatorInfo}
 	if e.Analyze {
 		runtimeStatsColl := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
-		if taskType == "cop" {
-			row = append(row, "") //TODO: wait collect resp from tikv
-		} else {
+		if runtimeStatsColl.Exists(p.ExplainID()) {
 			row = append(row, runtimeStatsColl.Get(p.ExplainID()).String())
+		} else {
+			row = append(row, "") //TODO: wait collect more executor info from tikv
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -90,11 +90,9 @@ var (
 // 3: it does not pass the probabilistic sampler.
 func (q *QueryFeedback) CollectFeedback(numOfRanges int) bool {
 	if q.hist == nil || q.hist.Len() == 0 {
-		q.Invalidate()
 		return false
 	}
 	if numOfRanges > MaxNumberOfRanges || rand.Float64() > FeedbackProbability {
-		q.Invalidate()
 		return false
 	}
 	return true

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -88,11 +88,24 @@ func (e *RuntimeStatsColl) Get(planID string) *RuntimeStats {
 	return runtimeStats
 }
 
+// Exists checks if the planID exists in the stats collection.
+func (e *RuntimeStatsColl) Exists(planID string) bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	_, exists := e.stats[planID]
+	return exists
+}
+
 // Record records executor's execution.
 func (e *RuntimeStats) Record(d time.Duration, rowNum int) {
 	atomic.AddInt32(&e.loop, 1)
 	atomic.AddInt64(&e.consume, int64(d))
 	atomic.AddInt64(&e.rows, int64(rowNum))
+}
+
+// SetRowNum sets the row num.
+func (e *RuntimeStats) SetRowNum(rowNum int64) {
+	atomic.StoreInt64(&e.rows, rowNum)
 }
 
 func (e *RuntimeStats) String() string {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The cop scan rows were not recorded in explain analyze.

### What is changed and how it works?

Use the stats feedback info to collect the cop scan rows, and record it when the distsql exectuor exits.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8423)
<!-- Reviewable:end -->
