### PR TITLE
planner, executor: fix `PREPARE FROM @var_name`

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -217,11 +217,16 @@ func (s *testSuite) TestPrepared(c *C) {
 		// issue 8074
 		tk.MustExec("drop table if exists prepare1;")
 		tk.MustExec("create table prepare1 (a decimal(1))")
+		tk.MustExec("insert into prepare1 values(1);")
 		_, err = tk.Exec("prepare stmt FROM @sql1")
 		c.Assert(err.Error(), Equals, "line 1 column 4 near \"\" (total length 4)")
 		tk.MustExec("SET @sql = 'update prepare1 set a=5 where a=?';")
 		_, err = tk.Exec("prepare stmt FROM @sql")
 		c.Assert(err, IsNil)
+		tk.MustExec("set @var=1;")
+		_, err = tk.Exec("execute stmt using @var")
+		c.Assert(err, IsNil)
+		tk.MustQuery("select a from prepare1;").Check(testkit.Rows("5"))
 
 		// Coverage.
 		exec := &executor.ExecuteExec{}

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -214,6 +214,15 @@ func (s *testSuite) TestPrepared(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(len(fields), Equals, 0)
 
+		// issue 8074
+		tk.MustExec("drop table if exists prepare1;")
+		tk.MustExec("create table prepare1 (a decimal(1))")
+		_, err = tk.Exec("prepare stmt FROM @sql1")
+		c.Assert(err.Error(), Equals, "line 1 column 4 near \"\" (total length 4)")
+		tk.MustExec("SET @sql = 'update prepare1 set a=5 where a=?';")
+		_, err = tk.Exec("prepare stmt FROM @sql")
+		c.Assert(err, IsNil)
+
 		// Coverage.
 		exec := &executor.ExecuteExec{}
 		exec.Next(ctx, nil)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -175,7 +175,7 @@ func (b *PlanBuilder) Build(node ast.Node) (Plan, error) {
 	case *ast.LoadStatsStmt:
 		return b.buildLoadStats(x), nil
 	case *ast.PrepareStmt:
-		return b.buildPrepare(x)
+		return b.buildPrepare(x), nil
 	case *ast.SelectStmt:
 		return b.buildSelect(x)
 	case *ast.UnionStmt:
@@ -396,7 +396,7 @@ func (b *PlanBuilder) buildSelectLock(src LogicalPlan, lock ast.SelectLockType) 
 	return selectLock
 }
 
-func (b *PlanBuilder) buildPrepare(x *ast.PrepareStmt) (Plan, error) {
+func (b *PlanBuilder) buildPrepare(x *ast.PrepareStmt) Plan {
 	p := &Prepare{
 		Name: x.Name,
 	}
@@ -409,7 +409,7 @@ func (b *PlanBuilder) buildPrepare(x *ast.PrepareStmt) (Plan, error) {
 	} else {
 		p.SQLText = x.SQLText
 	}
-	return p, nil
+	return p
 }
 
 func (b *PlanBuilder) buildCheckIndex(dbName model.CIStr, as *ast.AdminStmt) (Plan, error) {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
PlanBuilder: Fix prepare from session value issue #8074 

### What is changed and how it works?
When prepare from a user defined session name, replace session name with session value. 
Improve mysql grammar compatibility.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8437)
<!-- Reviewable:end -->
