### PR TITLE
server: close connection when tidb server closed.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -355,17 +355,17 @@ func (s *Server) Kill(connectionID uint64, query bool) {
 }
 
 func killConn(conn *clientConn, query bool) {
+	if !query {
+		// Mark the client connection status as WaitShutdown, when the goroutine detect
+		// this, it will end the dispatch loop and exit.
+		atomic.StoreInt32(&conn.status, connStatusWaitShutdown)
+	}
+
 	conn.mu.RLock()
 	cancelFunc := conn.mu.cancelFunc
 	conn.mu.RUnlock()
 	if cancelFunc != nil {
 		cancelFunc()
-	}
-
-	if !query {
-		// Mark the client connection status as WaitShutdown, when the goroutine detect
-		// this, it will end the dispatch loop and exit.
-		atomic.StoreInt32(&conn.status, connStatusWaitShutdown)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -369,6 +369,7 @@ func killConn(conn *clientConn, query bool) {
 	}
 }
 
+// KillAllConnections kills all connections when server is not gracefully shutdown.
 func (s *Server) KillAllConnections() {
 	s.rwlock.Lock()
 	defer s.rwlock.Unlock()

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -513,6 +513,8 @@ func closeDomainAndStorage() {
 func cleanup() {
 	if graceful {
 		svr.GracefulDown()
+	} else {
+		svr.KillAllConnections()
 	}
 	closeDomainAndStorage()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If tidb is not gracefully shutdown, tidb should kill connection to avoid continue processing the connection request. Because after `ddl.Stop()`, the schema version maybe outdate, processing request now may cause some data inconsistency problem.

### What is changed and how it works?
Kill all connection when server close if server is not gracefully shutdown.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test, add test later... Actually, I am thinking how to add test, If anyone know, please tell me. Thank you very much. 😂 😂 😂 

Code changes

 - Has exported function/method change


Side effects


Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8446)
<!-- Reviewable:end -->
