### PR TITLE
stats: fix panic when dumping stats

### DIFF
--- a/statistics/dump_test.go
+++ b/statistics/dump_test.go
@@ -120,3 +120,21 @@ PARTITION BY RANGE ( a ) (
 		assertTableEqual(c, originTables[i], t)
 	}
 }
+
+func (s *testDumpStatsSuite) TestDumpAlteredTable(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	h := s.do.StatsHandle()
+	oriLease := h.Lease
+	h.Lease = 1
+	defer func() { h.Lease = oriLease }()
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("analyze table t")
+	tk.MustExec("alter table t drop column a")
+	table, err := s.do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	_, err = h.DumpStatsToJSON("test", table.Meta())
+	c.Assert(err, IsNil)
+}

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -411,7 +411,7 @@ func (hg *Histogram) greaterAndEqRowCount(value types.Datum) float64 {
 // lessRowCount estimates the row count where the column less than value.
 func (hg *Histogram) lessRowCountWithBktIdx(value types.Datum) (float64, int) {
 	// all the values is null
-	if hg.Bounds == nil {
+	if hg.Bounds.NumRows() == 0 {
 		return 0, 0
 	}
 	index, match := hg.Bounds.LowerBound(0, &value)
@@ -735,7 +735,7 @@ func (c *Column) equalRowCount(sc *stmtctx.StatementContext, val types.Datum, mo
 		return float64(c.NullCount), nil
 	}
 	// all the values is null
-	if c.Histogram.Bounds == nil {
+	if c.Histogram.Bounds.NumRows() == 0 {
 		return 0.0, nil
 	}
 	if c.NDV > 0 && c.outOfRange(val) {

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -177,14 +177,7 @@ func (h *Handle) columnStatsFromStorage(row chunk.Row, table *Table, tableInfo *
 				return errors.Trace(err)
 			}
 			col = &Column{
-				Histogram: Histogram{
-					ID:                histID,
-					NDV:               distinct,
-					NullCount:         nullCount,
-					tp:                &colInfo.FieldType,
-					LastUpdateVersion: histVer,
-					TotColSize:        totColSize,
-				},
+				Histogram: *NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
 				Info:      colInfo,
 				Count:     count + nullCount,
 				ErrorRate: errorRate,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When dumping stats, we get panic log like:
```
... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x45B81A)

/usr/lib/go/src/runtime/panic.go:513
  in gopanic
/usr/lib/go/src/runtime/panic.go:82
  in panicmem
/usr/lib/go/src/runtime/signal_unix.go:390
  in sigpanic
/home/aliv/go/src/github.com/pingcap/tidb/util/chunk/chunk.go:241
  in Histogram.ConvertTo
histogram.go:159
  in Histogram.ConvertTo
dump.go:103
  in Handle.tableStatsToJSON
dump.go:64
  in Handle.DumpStatsToJSON
```
### What is changed and how it works?

If the column is not primary key, we will load the bucket info by need, thus leaving the `Bound` as nil. If the column is droped, we will not delete it immediately, so this column will still be in the cache, so when dumping the stats, we will meet panic when using the `Bound` info.

This PR fixes this by assigning empty chunk to `Bound`, so it will never be `nil`, and this will make future code does not meet the same problem again.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8448)
<!-- Reviewable:end -->
