### PR TITLE
domain,session: simplify the session pool of domain

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -651,11 +651,12 @@ func (p *sessionPool) Put(resource pools.Resource) {
 }
 func (p *sessionPool) Close() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
 	if p.mu.closed {
+		p.mu.Unlock()
 		return
 	}
 	p.mu.closed = true
+	p.mu.Unlock()
 
 	close(p.resources)
 	for r := range p.resources {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -657,10 +657,10 @@ func (p *sessionPool) Close() {
 	}
 	p.mu.closed = true
 
+	close(p.resources)
 	for r := range p.resources {
 		r.Close()
 	}
-	close(p.resources)
 }
 
 // SysSessionPool returns the system session pool.

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -60,7 +60,7 @@ type Domain struct {
 	info            *InfoSyncer
 	m               sync.Mutex
 	SchemaValidator SchemaValidator
-	sysSessionPool  *pools.ResourcePool
+	sysSessionPool  *sessionPool
 	exit            chan struct{}
 	etcdClient      *clientv3.Client
 	wg              sync.WaitGroup
@@ -526,7 +526,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 		store:           store,
 		SchemaValidator: NewSchemaValidator(ddlLease),
 		exit:            make(chan struct{}),
-		sysSessionPool:  pools.NewResourcePool(factory, capacity, capacity, resourceIdleTimeout),
+		sysSessionPool:  newSessionPool(capacity, factory),
 		statsLease:      statsLease,
 		infoHandle:      infoschema.NewHandle(store),
 		slowQuery:       newTopNSlowQueries(30, time.Hour*24*7, 500),
@@ -606,8 +606,54 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 	return nil
 }
 
+type sessionPool struct {
+	resources chan pools.Resource
+	factory   pools.Factory
+	closed    int64
+}
+
+func newSessionPool(cap int, factory pools.Factory) *sessionPool {
+	return &sessionPool{
+		resources: make(chan pools.Resource, cap),
+		factory:   factory,
+	}
+}
+
+func (p *sessionPool) Get() (resource pools.Resource, err error) {
+	var ok bool
+	select {
+	case resource, ok = <-p.resources:
+		if !ok {
+			err = errors.New("session pool closed")
+		}
+	default:
+		resource, err = p.factory()
+	}
+	return
+}
+
+func (p *sessionPool) Put(resource pools.Resource) {
+	if atomic.LoadInt64(&p.closed) != 0 {
+		return
+	}
+	select {
+	case p.resources <- resource:
+	default:
+		resource.Close()
+	}
+}
+func (p *sessionPool) Close() {
+	if !atomic.CompareAndSwapInt64(&p.closed, 0, 1) {
+		return
+	}
+	for r := range p.resources {
+		r.Close()
+	}
+	close(p.resources)
+}
+
 // SysSessionPool returns the system session pool.
-func (do *Domain) SysSessionPool() *pools.ResourcePool {
+func (do *Domain) SysSessionPool() *sessionPool {
 	return do.sysSessionPool
 }
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -656,9 +656,9 @@ func (p *sessionPool) Close() {
 		return
 	}
 	p.mu.closed = true
+	close(p.resources)
 	p.mu.Unlock()
 
-	close(p.resources)
 	for r := range p.resources {
 		r.Close()
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -577,7 +577,12 @@ func sqlForLog(sql string) string {
 	return executor.QueryReplacer.Replace(sql)
 }
 
-func (s *session) sysSessionPool() *pools.ResourcePool {
+type sessionPool interface {
+	Get() (pools.Resource, error)
+	Put(pools.Resource)
+}
+
+func (s *session) sysSessionPool() sessionPool {
 	return domain.GetDomain(s).SysSessionPool()
 }
 

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -143,8 +143,6 @@ func (s *testMainSuite) TestSysSessionPoolGoroutineLeak(c *C) {
 		}(se)
 	}
 	wg.Wait()
-	se.sysSessionPool().Close()
-	c.Assert(se.sysSessionPool().IsClosed(), Equals, true)
 }
 
 func newStore(c *C, dbPath string) kv.Storage {


### PR DESCRIPTION



<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the bug that TiDB may hang a long time even after it get the exit signal.

DDL or stats may take sessions from the session pool to `ExecRestrictedSQL` for a long time,
while the old pool will block waiting until the session to put back to the pool.

### What is changed and how it works?

The session pool now just serve as a cache, close the pool will no longer
wait for all resources to be put back to the pool.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code  (actually a refactor, no new code)

PTAL @winkyao @zimulala

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8456)
<!-- Reviewable:end -->
