### PR TITLE
session: release datum memory after transaction finished

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -418,6 +418,7 @@ func (s *session) CommitTxn(ctx context.Context) error {
 	if err != nil {
 		label = metrics.LblError
 	}
+	s.sessionVars.TxnCtx.Cleanup()
 	metrics.TransactionCounter.WithLabelValues(s.getSQLLabel(), label).Inc()
 	return errors.Trace(err)
 }
@@ -435,6 +436,7 @@ func (s *session) RollbackTxn(ctx context.Context) error {
 	}
 	s.cleanRetryInfo()
 	s.txn.changeToInvalid()
+	s.sessionVars.TxnCtx.Cleanup()
 	s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	return errors.Trace(err)
 }

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -174,7 +174,6 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 		} else {
 			err = se.CommitTxn(ctx)
 		}
-		se.sessionVars.TxnCtx.Cleanup()
 	} else {
 		// If the user insert, insert, insert ... but never commit, TiDB would OOM.
 		// So we limit the statement count in a transaction here.

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -174,6 +174,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 		} else {
 			err = se.CommitTxn(ctx)
 		}
+		se.sessionVars.TxnCtx.Cleanup()
 	} else {
 		// If the user insert, insert, insert ... but never commit, TiDB would OOM.
 		// So we limit the statement count in a transaction here.

--- a/session/txn.go
+++ b/session/txn.go
@@ -196,6 +196,10 @@ func (st *TxnState) cleanup() {
 		delete(st.mutations, key)
 	}
 	if st.dirtyTableOP != nil {
+		empty := dirtyTableOperation{}
+		for i := 0; i < len(st.dirtyTableOP); i++ {
+			st.dirtyTableOP[i] = empty
+		}
 		st.dirtyTableOP = st.dirtyTableOP[:0]
 	}
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -125,6 +125,15 @@ func (tc *TransactionContext) UpdateDeltaForTable(tableID int64, delta int64, co
 	tc.TableDeltaMap[tableID] = item
 }
 
+// Cleanup clears up transaction info that no longer use.
+func (tc *TransactionContext) Cleanup() {
+	//tc.InfoSchema = nil; we cannot do it now, because some operation like handleFieldList depend on this.
+	tc.DirtyDB = nil
+	tc.Binlog = nil
+	tc.Histroy = nil
+	tc.TableDeltaMap = nil
+}
+
 // ClearDelta clears the delta map.
 func (tc *TransactionContext) ClearDelta() {
 	tc.TableDeltaMap = nil


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Current, TiDB will try best to reuse last allocated memory on each conection.

but we meet some customer using wide table and batch insert many record at once, so memory will be hold until next stmt, and it will even worser in much idle connection in connection pool situation.

### What is changed and how it works?

- keep reuse dirtyTableOperation slice, but release the link to datum quickly (@tiancaiamao 's idea)
- cleanup transactionCtx

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

old testcase

 - Unit test
 - Integration test

Code changes

 - cleanup impl change

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8458)
<!-- Reviewable:end -->
