### PR TITLE
ddl: fix concurrent access to `do.infoHandle` has a data race error

### DIFF
--- a/ddl/fail_db_test.go
+++ b/ddl/fail_db_test.go
@@ -124,7 +124,6 @@ func (s *testFailDBSuite) TestHalfwayCancelOperations(c *C) {
 	c.Assert(row.Len(), Equals, 1)
 	c.Assert(row.GetInt64(0), DeepEquals, int64(1))
 	c.Assert(rs[0].Close(), IsNil)
-	// Execute ddl statement reload schema.
 	_, err = s.se.Execute(context.Background(), "alter table tx comment 'tx'")
 	c.Assert(err, IsNil)
 	err = s.dom.DDL().(ddl.DDLForTest).GetHook().OnChanged(nil)

--- a/ddl/fail_db_test.go
+++ b/ddl/fail_db_test.go
@@ -91,8 +91,9 @@ func (s *testFailDBSuite) TestHalfwayCancelOperations(c *C) {
 	c.Assert(row.Len(), Equals, 1)
 	c.Assert(row.GetInt64(0), DeepEquals, int64(1))
 	c.Assert(rs[0].Close(), IsNil)
-	// Reload schema.
-	s.dom.ResetHandle(s.store)
+	// Execute ddl statement reload schema.
+	_, err = s.se.Execute(context.Background(), "alter table t comment 'test1'")
+	c.Assert(err, IsNil)
 	err = s.dom.DDL().(ddl.DDLForTest).GetHook().OnChanged(nil)
 	c.Assert(err, IsNil)
 	s.se, err = session.CreateSession4Test(s.store)
@@ -104,8 +105,8 @@ func (s *testFailDBSuite) TestHalfwayCancelOperations(c *C) {
 	c.Assert(err, IsNil)
 
 	// test for renaming table
-	gofail.Enable("github.com/pingcap/tidb/ddl/errRenameTable", `return(true)`)
-	defer gofail.Disable("github.com/pingcap/tidb/ddl/errRenameTable")
+	gofail.Enable("github.com/pingcap/tidb/ddl/renameTableErr", `return(true)`)
+	defer gofail.Disable("github.com/pingcap/tidb/ddl/renameTableErr")
 	_, err = s.se.Execute(context.Background(), "create table tx(a int)")
 	c.Assert(err, IsNil)
 	_, err = s.se.Execute(context.Background(), "insert into tx values(1)")
@@ -123,8 +124,9 @@ func (s *testFailDBSuite) TestHalfwayCancelOperations(c *C) {
 	c.Assert(row.Len(), Equals, 1)
 	c.Assert(row.GetInt64(0), DeepEquals, int64(1))
 	c.Assert(rs[0].Close(), IsNil)
-	// Reload schema.
-	s.dom.ResetHandle(s.store)
+	// Execute ddl statement reload schema.
+	_, err = s.se.Execute(context.Background(), "alter table tx comment 'tx'")
+	c.Assert(err, IsNil)
 	err = s.dom.DDL().(ddl.DDLForTest).GetHook().OnChanged(nil)
 	c.Assert(err, IsNil)
 	s.se, err = session.CreateSession4Test(s.store)

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -533,11 +533,6 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 	}
 }
 
-// ResetHandle resets the domain's infoschema handle. It is used for testing.
-func (do *Domain) ResetHandle(store kv.Storage) {
-	do.infoHandle = infoschema.NewHandle(store)
-}
-
 // Init initializes a domain.
 func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.Resource, error)) error {
 	if ebd, ok := do.store.(EtcdBackend); ok {


### PR DESCRIPTION
Cherry pick #8287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8464)
<!-- Reviewable:end -->
