### PR TITLE
[WIP] Implement ScanReverse in tikv go client

### DIFF
--- a/kv/buffer_store.go
+++ b/kv/buffer_store.go
@@ -88,12 +88,12 @@ func (s *BufferStore) Iter(k Key, upperBound Key) (Iterator, error) {
 }
 
 // IterReverse implements the Retriever interface.
-func (s *BufferStore) IterReverse(k Key) (Iterator, error) {
-	bufferIt, err := s.MemBuffer.IterReverse(k)
+func (s *BufferStore) IterReverse(k Key, lowerBound Key) (Iterator, error) {
+	bufferIt, err := s.MemBuffer.IterReverse(k, lowerBound)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	retrieverIt, err := s.r.IterReverse(k)
+	retrieverIt, err := s.r.IterReverse(k, lowerBound)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -87,8 +87,7 @@ type Retriever interface {
 	// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
 	// The returned iterator will iterate from greater key to smaller key.
 	// If k is nil, the returned iterator will be positioned at the last key.
-	// TODO: Add lower bound limit
-	IterReverse(k Key) (Iterator, error)
+	IterReverse(k Key, lowerBound Key) (Iterator, error)
 }
 
 // Mutator is the interface wraps the basic Set and Delete methods.

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -65,12 +65,12 @@ func (m *memDbBuffer) SetCap(cap int) {
 
 }
 
-func (m *memDbBuffer) IterReverse(k Key) (Iterator, error) {
+func (m *memDbBuffer) IterReverse(k Key, lowerBound Key) (Iterator, error) {
 	var i *memDbIter
 	if k == nil {
-		i = &memDbIter{iter: m.db.NewIterator(&util.Range{}), reverse: true}
+		i = &memDbIter{iter: m.db.NewIterator(&util.Range{Start: lowerBound}), reverse: true}
 	} else {
-		i = &memDbIter{iter: m.db.NewIterator(&util.Range{Limit: []byte(k)}), reverse: true}
+		i = &memDbIter{iter: m.db.NewIterator(&util.Range{Start: lowerBound, Limit: []byte(k)}), reverse: true}
 	}
 	i.iter.Last()
 	return i, nil

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -71,7 +71,7 @@ func (t *mockTxn) Iter(k Key, upperBound Key) (Iterator, error) {
 	return nil, nil
 }
 
-func (t *mockTxn) IterReverse(k Key) (Iterator, error) {
+func (t *mockTxn) IterReverse(k Key, lowerBound Key) (Iterator, error) {
 	return nil, nil
 }
 
@@ -214,6 +214,6 @@ func (s *mockSnapshot) Iter(k Key, upperBound Key) (Iterator, error) {
 	return s.store.Iter(k, upperBound)
 }
 
-func (s *mockSnapshot) IterReverse(k Key) (Iterator, error) {
-	return s.store.IterReverse(k)
+func (s *mockSnapshot) IterReverse(k Key, lowerBound Key) (Iterator, error) {
+	return s.store.IterReverse(k, lowerBound)
 }

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -48,7 +48,7 @@ func (s testMockSuite) TestInterface(c *C) {
 		transaction.Get(Key("lock"))
 		transaction.Set(Key("lock"), []byte{})
 		transaction.Iter(Key("lock"), nil)
-		transaction.IterReverse(Key("lock"))
+		transaction.IterReverse(Key("lock"), nil)
 	}
 	transaction.Commit(context.Background())
 

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -134,11 +134,11 @@ func (lmb *lazyMemBuffer) Iter(k Key, upperBound Key) (Iterator, error) {
 	return lmb.mb.Iter(k, upperBound)
 }
 
-func (lmb *lazyMemBuffer) IterReverse(k Key) (Iterator, error) {
+func (lmb *lazyMemBuffer) IterReverse(k Key, lowerBound Key) (Iterator, error) {
 	if lmb.mb == nil {
 		return invalidIterator{}, nil
 	}
-	return lmb.mb.IterReverse(k)
+	return lmb.mb.IterReverse(k, lowerBound)
 }
 
 func (lmb *lazyMemBuffer) Size() int {

--- a/kv/union_store_test.go
+++ b/kv/union_store_test.go
@@ -88,21 +88,21 @@ func (s *testUnionStoreSuite) TestIterReverse(c *C) {
 	s.store.Set([]byte("2"), []byte("2"))
 	s.store.Set([]byte("3"), []byte("3"))
 
-	iter, err := s.us.IterReverse(nil)
+	iter, err := s.us.IterReverse(nil, nil)
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("3"), []byte("2"), []byte("1")}, [][]byte{[]byte("3"), []byte("2"), []byte("1")})
 
-	iter, err = s.us.IterReverse([]byte("3"))
+	iter, err = s.us.IterReverse([]byte("3"), nil)
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("1")}, [][]byte{[]byte("2"), []byte("1")})
 
 	s.us.Set([]byte("0"), []byte("0"))
-	iter, err = s.us.IterReverse([]byte("3"))
+	iter, err = s.us.IterReverse([]byte("3"), nil)
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("1"), []byte("0")}, [][]byte{[]byte("2"), []byte("1"), []byte("0")})
 
 	s.us.Delete([]byte("1"))
-	iter, err = s.us.IterReverse([]byte("3"))
+	iter, err = s.us.IterReverse([]byte("3"), nil)
 	c.Assert(err, IsNil)
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("0")}, [][]byte{[]byte("2"), []byte("0")})
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -228,12 +228,12 @@ func (st *TxnState) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 }
 
 // IterReverse overrides the Transaction interface.
-func (st *TxnState) IterReverse(k kv.Key) (kv.Iterator, error) {
-	bufferIt, err := st.buf.IterReverse(k)
+func (st *TxnState) IterReverse(k kv.Key, lowerBound kv.Key) (kv.Iterator, error) {
+	bufferIt, err := st.buf.IterReverse(k, lowerBound)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	retrieverIt, err := st.Transaction.IterReverse(k)
+	retrieverIt, err := st.Transaction.IterReverse(k, lowerBound)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/pingcap/tidb/util/codec"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 )
@@ -134,5 +136,73 @@ func (s *testScanSuite) TestScan(c *C) {
 		scan, err = txn3.Iter(encodeKey(s.prefix, ""), encodeKey(s.prefix, s08d("key", upperBound)))
 		c.Assert(err, IsNil)
 		check(c, scan, upperBound, true)
+	}
+}
+
+func (s *testScanSuite) TestScanReverse(c *C) {
+	check := func(c *C, scan kv.Iterator, rowNum int, lowerBound int, keyOnly bool) {
+		for i := rowNum - 1; i > lowerBound; i-- {
+			k := scan.Key()
+			_, buf, err := codec.DecodeBytes([]byte(k), nil)
+			c.Assert(err, IsNil)
+			fmt.Println(string(buf), i, s08d("key", i))
+			c.Assert([]byte(k), BytesEquals, encodeKey(s.prefix, s08d("key", i)))
+			if !keyOnly {
+				v := scan.Value()
+				c.Assert(v, BytesEquals, valueBytes(i))
+			}
+			// Because newScan return first item without calling scan.Next() just like go-hbase,
+			// for-loop count will decrease 1.
+			if i > lowerBound {
+				scan.Next()
+			}
+		}
+		scan.Next()
+		c.Assert(scan.Valid(), IsFalse)
+	}
+
+	for _, rowNum := range s.rowNums {
+		txn := s.beginTxn(c)
+		for i := 0; i < rowNum; i++ {
+			err := txn.Set(encodeKey(s.prefix, s08d("key", i)), valueBytes(i))
+			c.Assert(err, IsNil)
+		}
+		err := txn.Commit(context.Background())
+		c.Assert(err, IsNil)
+
+		txn2 := s.beginTxn(c)
+		val, err := txn2.Get(encodeKey(s.prefix, s08d("key", 0)))
+		c.Assert(err, IsNil)
+		c.Assert(val, BytesEquals, valueBytes(0))
+		// Test scan without lowerBound
+		scan, err := txn2.IterReverse(encodeKey(s.prefix, s08d("key", rowNum)), nil)
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, -1, false)
+		// Test scan with lowerBound
+		lowerBound := rowNum / 2
+		scan, err = txn2.IterReverse(encodeKey(s.prefix, s08d("key", rowNum)), encodeKey(s.prefix, s08d("key", lowerBound)))
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, lowerBound, false)
+
+		txn3 := s.beginTxn(c)
+		txn3.SetOption(kv.KeyOnly, true)
+		// Test scan without lower bound
+		scan, err = txn3.IterReverse(encodeKey(s.prefix, s08d("key", rowNum)), nil)
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, -1, true)
+		// test scan with lower bound
+		scan, err = txn3.IterReverse(encodeKey(s.prefix, s08d("key", rowNum)), encodeKey(s.prefix, s08d("key", lowerBound)))
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, lowerBound, true)
+
+		// Restore KeyOnly to false
+		txn3.SetOption(kv.KeyOnly, false)
+		scan, err = txn3.IterReverse(encodeKey(s.prefix, s08d("key", rowNum)), nil)
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, -1, true)
+		// test scan with lower bound
+		scan, err = txn3.Iter(encodeKey(s.prefix, s08d("key", rowNum)), encodeKey(s.prefix, s08d("key", lowerBound)))
+		c.Assert(err, IsNil)
+		check(c, scan, rowNum, lowerBound, true)
 	}
 }

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -290,8 +290,9 @@ func (s *tikvSnapshot) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
-func (s *tikvSnapshot) IterReverse(k kv.Key) (kv.Iterator, error) {
-	return nil, kv.ErrNotImplemented
+func (s *tikvSnapshot) IterReverse(k kv.Key, lowerBound kv.Key) (kv.Iterator, error) {
+	scanner, err := newScannerReverse(s, k, lowerBound, scanBatchSize)
+	return scanner, errors.Trace(err)
 }
 
 func extractLockFromKeyErr(keyErr *pb.KeyError) (*Lock, error) {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -128,14 +128,14 @@ func (txn *tikvTxn) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
-func (txn *tikvTxn) IterReverse(k kv.Key) (kv.Iterator, error) {
+func (txn *tikvTxn) IterReverse(k kv.Key, lowerBound kv.Key) (kv.Iterator, error) {
 	metrics.TiKVTxnCmdCounter.WithLabelValues("seek_reverse").Inc()
 	start := time.Now()
 	defer func() {
 		metrics.TiKVTxnCmdHistogram.WithLabelValues("seek_reverse").Observe(time.Since(start).Seconds())
 	}()
 
-	return txn.us.IterReverse(k)
+	return txn.us.IterReverse(k, lowerBound)
 }
 
 func (txn *tikvTxn) Delete(k kv.Key) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`IterReverse` not implemented in tikv go client

### What is changed and how it works?

- [x] change `IterReverse(key string)` to `IterReverse(key kv.Key, lowerbound kv.Key)` in many interfaces
- [x] implement IterReverse
- [ ] implement scan reverse in mocktikv to pass the test

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
Yes
 - Has exported variable/fields change
Yes
 - Has interface methods change
Yes
 - Has persistent data change
No

Side effects

 - Breaking backward compatibility

Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8483)
<!-- Reviewable:end -->
