### PR TITLE
util/timeutil: fix data race caused by forgetting set stats lease to 0 (#7901)

### DIFF
--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -49,6 +49,7 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 		return nil, nil, errors.Trace(err)
 	}
 	session.SetSchemaLease(0)
+	session.SetStatsLease(0)
 	dom, err := session.BootstrapSession(store)
 	return store, dom, errors.Trace(err)
 }

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -117,9 +117,13 @@ func SystemLocation() *time.Location {
 	return loc
 }
 
+var setSysTZOnce sync.Once
+
 // SetSystemTZ sets systemTZ by the value loaded from mysql.tidb.
 func SetSystemTZ(name string) {
-	systemTZ = name
+	setSysTZOnce.Do(func() {
+		systemTZ = name
+	})
 }
 
 // getLoc first trying to load location from a cache map. If nothing found in such map, then call


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix data race in test, for https://github.com/pingcap/tidb/pull/8474

```
time="2018-11-27T12:55:53Z" level=info msg="[ddl-worker 32, tp add index] start DDL worker" 
time="2018-11-27T12:55:53Z" level=info msg="[ddl] start delRange emulator" 
time="2018-11-27T12:55:53Z" level=info msg="[ddl] start delRange emulator" 
time="2018-11-27T12:55:53Z" level=info msg="[ddl] full load InfoSchema from version 0 to 15, in 34.917678ms" 
time="2018-11-27T12:55:53Z" level=info msg="[ddl] full load and reset schema validator." 
==================
WARNING: DATA RACE
Write at 0x000002e02e10 by goroutine 16:
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/timeutil/time.go:122 +0xdf
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:777 +0x84
  github.com/pingcap/tidb/session.mustExecute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:773 +0x8a
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:720 +0x2f8
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:777 +0x84
  github.com/pingcap/tidb/session.mustExecute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:773 +0x8a
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:718 +0x2cb
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:777 +0x84
```

### What is changed and how it works?

Cherry pick https://github.com/pingcap/tidb/pull/7901


@jackysp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8485)
<!-- Reviewable:end -->
