### PR TITLE
ddl: fix cancel drop index error

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -518,6 +518,92 @@ func (s *testDBSuite) TestCancelAddIndex1(c *C) {
 	s.mustExec(c, "alter table t drop index idx_c2")
 }
 
+// TestCancelDropIndex tests cancel ddl job which type is drop index.
+func (s *testDBSuite) TestCancelDropIndex(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.mustExec(c, "use test_db")
+	s.mustExec(c, "drop table if exists t")
+	s.mustExec(c, "create table t(c1 int, c2 int)")
+	defer s.mustExec(c, "drop table t;")
+	for i := 0; i < 5; i++ {
+		s.mustExec(c, "insert into t values (?, ?)", i, i)
+	}
+
+	testCases := []struct {
+		needAddIndex   bool
+		jobState       model.JobState
+		JobSchemaState model.SchemaState
+		cancelSucc     bool
+	}{
+		// model.JobStateNone means the jobs is canceled before the first run.
+		{true, model.JobStateNone, model.StateNone, true},
+		{false, model.JobStateRunning, model.StateWriteOnly, true},
+		{false, model.JobStateRunning, model.StateDeleteOnly, false},
+		{true, model.JobStateRunning, model.StateDeleteReorganization, false},
+	}
+
+	var checkErr error
+	oldReorgWaitTimeout := ddl.ReorgWaitTimeout
+	ddl.ReorgWaitTimeout = 50 * time.Millisecond
+	defer func() { ddl.ReorgWaitTimeout = oldReorgWaitTimeout }()
+	hook := &ddl.TestDDLCallback{}
+	var jobID int64
+	for _, testCase := range testCases {
+		hook.OnJobRunBeforeExported = func(job *model.Job) {
+			if job.Type == model.ActionDropIndex && job.State == testCase.jobState && job.SchemaState == testCase.JobSchemaState {
+				jobID = job.ID
+				jobIDs := []int64{job.ID}
+				hookCtx := mock.NewContext()
+				hookCtx.Store = s.store
+				err := hookCtx.NewTxn()
+				if err != nil {
+					checkErr = errors.Trace(err)
+					return
+				}
+				errs, err := admin.CancelJobs(hookCtx.Txn(true), jobIDs)
+				if err != nil {
+					checkErr = errors.Trace(err)
+					return
+				}
+
+				if errs[0] != nil {
+					checkErr = errors.Trace(errs[0])
+					return
+				}
+
+				checkErr = hookCtx.Txn(true).Commit(context.Background())
+			}
+		}
+		s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
+		if testCase.needAddIndex {
+			s.mustExec(c, "alter table t add index idx_c2(c2)")
+		}
+		rs, err := s.tk.Exec("alter table t drop index idx_c2")
+		if rs != nil {
+			rs.Close()
+		}
+
+		t := s.testGetTable(c, "t")
+		indexInfo := ddl.FindIndexByName("idx_c2", t.Meta().Indices)
+		if testCase.cancelSucc {
+			c.Assert(checkErr, IsNil)
+			c.Assert(err, NotNil)
+			c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+
+			c.Assert(indexInfo, NotNil)
+			c.Assert(indexInfo.State, Equals, model.StatePublic)
+		} else {
+			err1 := admin.ErrCannotCancelDDLJob.GenWithStackByArgs(jobID)
+			c.Assert(err, IsNil)
+			c.Assert(checkErr, NotNil)
+			c.Assert(checkErr.Error(), Equals, err1.Error())
+
+			c.Assert(indexInfo, IsNil)
+		}
+	}
+	s.dom.DDL().(ddl.DDLForTest).SetHook(&ddl.TestDDLCallback{})
+}
+
 func (s *testDBSuite) TestAddAnonymousIndex(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -602,6 +602,8 @@ func (s *testDBSuite) TestCancelDropIndex(c *C) {
 		}
 	}
 	s.dom.DDL().(ddl.DDLForTest).SetHook(&ddl.TestDDLCallback{})
+	s.mustExec(c, "alter table t add index idx_c2(c2)")
+	s.mustExec(c, "alter table t drop index idx_c2")
 }
 
 func (s *testDBSuite) TestAddAnonymousIndex(c *C) {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1179,6 +1179,11 @@ func findIndexByName(idxName string, indices []*model.IndexInfo) *model.IndexInf
 	return nil
 }
 
+// FindIndexByName exports for testing.
+func FindIndexByName(idxName string, indices []*model.IndexInfo) *model.IndexInfo {
+	return findIndexByName(idxName, indices)
+}
+
 func allocateIndexID(tblInfo *model.TableInfo) int64 {
 	tblInfo.MaxIndexID++
 	return tblInfo.MaxIndexID


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
releate PR #8171 
This PR make cancel drop index work correctly. Old tidb version cancel drop index may cause the index states neither on `StatePublic` nor `StateNone`. For client, the index is not visible, but client add index with the same name will fail because the name of 'xxx' index is already exists.

### What is changed and how it works?
We can only cancel drop index job when the index state is on `StatePublic` or `StateWriteOnly`, otherwise, cancel index and make the index state rollback to public may cause data consistency.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
