### PR TITLE
session: add arguments info for retry

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -475,7 +475,8 @@ func (s *session) retry(ctx context.Context, maxCnt uint) error {
 	nh := GetHistory(s)
 	var err error
 	var schemaVersion int64
-	orgStartTS := s.GetSessionVars().TxnCtx.StartTS
+	sessVars := s.GetSessionVars()
+	orgStartTS := sessVars.TxnCtx.StartTS
 	label := s.getSQLLabel()
 	for {
 		s.PrepareTxnCtx(ctx)
@@ -493,7 +494,8 @@ func (s *session) retry(ctx context.Context, maxCnt uint) error {
 			if retryCnt == 0 {
 				// We do not have to log the query every time.
 				// We print the queries at the first try only.
-				log.Warnf("con:%d schema_ver:%d retry_cnt:%d query_num:%d sql:%s", connID, schemaVersion, retryCnt, i, sqlForLog(st.OriginText()))
+				log.Warnf("con:%d schema_ver:%d retry_cnt:%d query_num:%d sql:%s%s", connID, schemaVersion, retryCnt,
+					i, sqlForLog(st.OriginText()), sessVars.GetExecuteArgumentsInfo())
 			} else {
 				log.Warnf("con:%d schema_ver:%d retry_cnt:%d query_num:%d", connID, schemaVersion, retryCnt, i)
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
For binary execute statement, the arguments info are missing when the transaction is retrying.

### What is changed and how it works?
Add the arguments info when retrying.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
The log looks as the following, the arguments appare twice, due to TiDB doesn't reset arguments when retrying. Related to https://github.com/pingcap/tidb/pull/8034
2018/11/29 14:14:23.300 session.go:497: [warning] con:7 schema_ver:24 retry_cnt:0 query_num:0 sql:update t set i = ? [arguments: 2, 2]

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

PTAL @lysu @tiancaiamao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8506)
<!-- Reviewable:end -->
