### PR TITLE
executor: do not build range for NullOuterVal in IndexLookUpJoin (#8505)

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -864,6 +864,23 @@ func (s *testSuite) TestIndexLookupJoin(c *C) {
 		`1 5 1 1`,
 		`1 6 1 2`,
 	))
+
+	tk.MustExec(`drop table if exists t1, t2, t3;`)
+	tk.MustExec("create table t1(a int primary key, b int)")
+	tk.MustExec("insert into t1 values(1, 0), (2, null)")
+	tk.MustExec("create table t2(a int primary key)")
+	tk.MustExec("insert into t2 values(0)")
+	tk.MustQuery("select /*+ TIDB_INLJ(t2)*/ * from t1 left join t2 on t1.b = t2.a;").Check(testkit.Rows(
+		`1 0 0`,
+		`2 <nil> <nil>`,
+	))
+
+	tk.MustExec("create table t3(a int, key(a))")
+	tk.MustExec("insert into t3 values(0)")
+	tk.MustQuery("select /*+ TIDB_INLJ(t3)*/ * from t1 left join t3 on t1.b = t3.a;").Check(testkit.Rows(
+		`1 0 0`,
+		`2 <nil> <nil>`,
+	))
 }
 
 func (s *testSuite) TestMergejoinOrder(c *C) {


### PR DESCRIPTION
cherry-pick #8505

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8507)
<!-- Reviewable:end -->
