### PR TITLE
 tidb/kv: remove useless errors.Trace

### DIFF
--- a/executor/trace.go
+++ b/executor/trace.go
@@ -86,7 +86,12 @@ func (e *TraceExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			chk.AppendString(0, string(data))
+			const rowMax = 4096
+			for len(data) > rowMax {
+				chk.AppendString(0, string(data[:rowMax]))
+				data = data[rowMax:]
+			}
+			chk.AppendString(0, string(data[:rowMax]))
 		}
 		e.exhausted = true
 		return nil

--- a/executor/trace.go
+++ b/executor/trace.go
@@ -86,12 +86,7 @@ func (e *TraceExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 			if err != nil {
 				return errors.Trace(err)
 			}
-			const rowMax = 4096
-			for len(data) > rowMax {
-				chk.AppendString(0, string(data[:rowMax]))
-				data = data[rowMax:]
-			}
-			chk.AppendString(0, string(data[:rowMax]))
+			chk.AppendString(0, string(data))
 		}
 		e.exhausted = true
 		return nil

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -105,7 +105,7 @@ type lazyMemBuffer struct {
 
 func (lmb *lazyMemBuffer) Get(k Key) ([]byte, error) {
 	if lmb.mb == nil {
-		return nil, errors.Trace(ErrNotExist)
+		return nil, ErrNotExist
 	}
 
 	return lmb.mb.Get(k)
@@ -176,7 +176,7 @@ func (us *unionStore) Get(k Key) ([]byte, error) {
 			} else {
 				us.markLazyConditionPair(k, nil, ErrKeyExists)
 			}
-			return nil, errors.Trace(ErrNotExist)
+			return nil, ErrNotExist
 		}
 	}
 	if IsErrNotFound(err) {
@@ -186,7 +186,7 @@ func (us *unionStore) Get(k Key) ([]byte, error) {
 		return v, errors.Trace(err)
 	}
 	if len(v) == 0 {
-		return nil, errors.Trace(ErrNotExist)
+		return nil, ErrNotExist
 	}
 	return v, nil
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -174,6 +174,9 @@ func (st *TxnState) Get(k kv.Key) ([]byte, error) {
 	val, err := st.buf.Get(k)
 	if kv.IsErrNotFound(err) {
 		val, err = st.Transaction.Get(k)
+		if kv.IsErrNotFound(err) {
+			return nil, err
+		}
 	}
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -92,6 +92,9 @@ func (txn *tikvTxn) Get(k kv.Key) ([]byte, error) {
 	defer func() { metrics.TiKVTxnCmdHistogram.WithLabelValues("get").Observe(time.Since(start).Seconds()) }()
 
 	ret, err := txn.us.Get(k)
+	if kv.IsErrNotFound(err) {
+		return nil, err
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

`ErrNotExist` no need to get stack, so we see it use much time in pprof

### What is changed and how it works?

In this PR just remove it to quickly fix.

maybe we should refine our pingcap/errors to meet `no need stack error` situation

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Old test

Code changes

 - Impl change

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8527)
<!-- Reviewable:end -->
