### PR TITLE
expression: fix date_add interval month diffs from mysql

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2639,7 +2639,7 @@ func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, int
 	// it says October 32 converts to November 1
 	// it conflits with mysql
 	// https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-add
-	df := getFixDays(int(year),int(month),int(day),goTime)
+	df := getFixDays(int(year), int(month), int(day), goTime)
 	if df != 0 {
 		goTime = goTime.AddDate(int(year), int(month), df)
 	} else {
@@ -2667,7 +2667,7 @@ func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, int
 	}
 
 	goTime = goTime.Add(dur)
-	df := getFixDays(int(year),int(month),int(day),goTime)
+	df := getFixDays(int(year), int(month), int(day), goTime)
 	if df != 0 {
 		goTime = goTime.AddDate(int(year), int(month), df)
 	} else {

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1534,7 +1534,7 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v.IsNull(), IsTrue)
 
-	tests := []struct {
+	testMonths := []struct {
 		input    string
 		months   int
 		expected string
@@ -1546,10 +1546,34 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 		{"2018-08-31", 1, "2018-09-30"},
 		{"2018-07-31", 2, "2018-09-30"},
 		{"2016-01-31", 27, "2018-04-30"},
+		{"2000-02-29", 12, "2001-02-28"},
 	}
 
-	for _, test := range tests {
+	for _, test := range testMonths {
 		args = types.MakeDatums(test.input, test.months, "MONTH")
+		f, err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
+		c.Assert(err, IsNil)
+		c.Assert(f, NotNil)
+		v, err = evalBuiltinFunc(f, nil)
+		c.Assert(err, IsNil)
+		c.Assert(v.GetMysqlTime().String(), Equals, test.expected)
+	}
+
+	testYears := []struct {
+		input    string
+		year     int
+		expected string
+	}{
+		{"1899-02-28", 1, "1900-02-28"},
+		{"1901-02-28", -1, "1900-02-28"},
+		{"2000-02-29", 1, "2001-02-28"},
+		{"2001-02-28", -1, "2000-02-28"},
+		{"2004-02-29", 1, "2005-02-28"},
+		{"2005-02-28", -1, "2004-02-28"},
+	}
+
+	for _, test := range testYears {
+		args = types.MakeDatums(test.input, test.year, "YEAR")
 		f, err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
 		c.Assert(err, IsNil)
 		c.Assert(f, NotNil)

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1535,22 +1535,22 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 	c.Assert(v.IsNull(), IsTrue)
 
 	tests := []struct {
-		input		string
-		months		int
-		expected	string
-	} {
-		{"1900-01-31",1,"1900-02-28"},
-		{"2000-01-31",1,"2000-02-29"},
-		{"2016-01-31",1,"2016-02-29"},
-		{"2018-07-31",1,"2018-08-31"},
-		{"2018-08-31",1,"2018-09-30"},
-		{"2018-07-31",2,"2018-09-30"},
-		{"2016-01-31",27,"2018-04-30"},
+		input    string
+		months   int
+		expected string
+	}{
+		{"1900-01-31", 1, "1900-02-28"},
+		{"2000-01-31", 1, "2000-02-29"},
+		{"2016-01-31", 1, "2016-02-29"},
+		{"2018-07-31", 1, "2018-08-31"},
+		{"2018-08-31", 1, "2018-09-30"},
+		{"2018-07-31", 2, "2018-09-30"},
+		{"2016-01-31", 27, "2018-04-30"},
 	}
 
-	for _, test := range tests{
-		args = types.MakeDatums(test.input,test.months,"MONTH")
-		f,err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
+	for _, test := range tests {
+		args = types.MakeDatums(test.input, test.months, "MONTH")
+		f, err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
 		c.Assert(err, IsNil)
 		c.Assert(f, NotNil)
 		v, err = evalBuiltinFunc(f, nil)

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1533,6 +1533,30 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 	v, err = evalBuiltinFunc(f, nil)
 	c.Assert(err, IsNil)
 	c.Assert(v.IsNull(), IsTrue)
+
+	tests := []struct {
+		input		string
+		months		int
+		expected	string
+	} {
+		{"1900-01-31",1,"1900-02-28"},
+		{"2000-01-31",1,"2000-02-29"},
+		{"2016-01-31",1,"2016-02-29"},
+		{"2018-07-31",1,"2018-08-31"},
+		{"2018-08-31",1,"2018-09-30"},
+		{"2018-07-31",2,"2018-09-30"},
+		{"2016-01-31",27,"2018-04-30"},
+	}
+
+	for _, test := range tests{
+		args = types.MakeDatums(test.input,test.months,"MONTH")
+		f,err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
+		c.Assert(err, IsNil)
+		c.Assert(f, NotNil)
+		v, err = evalBuiltinFunc(f, nil)
+		c.Assert(err, IsNil)
+		c.Assert(v.GetMysqlTime().String(), Equals, test.expected)
+	}
 }
 
 func (s *testEvaluatorSuite) TestTimestamp(c *C) {

--- a/types/mytime.go
+++ b/types/mytime.go
@@ -119,7 +119,25 @@ func (t MysqlTime) GoTime(loc *gotime.Location) (gotime.Time, error) {
 
 // IsLeapYear returns if it's leap year.
 func (t MysqlTime) IsLeapYear() bool {
-	return (t.year%4 == 0 && t.year%100 != 0) || t.year%400 == 0
+	return isLeapYear(t.year)
+}
+
+func isLeapYear(year uint16) bool {
+	return (year%4 == 0 && year%100 != 0) || year%400 == 0
+}
+
+var daysByMonth = [12]int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+
+// GetLastDay returns the last day of the month
+func GetLastDay(year, month int) int {
+	var day = 0
+	if month > 0 {
+		day = daysByMonth[month-1]
+	}
+	if month == 2 && isLeapYear(uint16(year)) {
+		day = 29
+	}
+	return day
 }
 
 func calcTimeFromSec(to *MysqlTime, seconds, microseconds int) {

--- a/types/mytime_test.go
+++ b/types/mytime_test.go
@@ -210,3 +210,22 @@ func (s *testMyTimeSuite) TestIsLeapYear(c *C) {
 		c.Assert(tt.T.IsLeapYear(), Equals, tt.Expect)
 	}
 }
+
+func (s *testMyTimeSuite) TestGetLastDay(c *C) {
+	tests := []struct {
+		year        int
+		month       int
+		expectedDay int
+	}{
+		{2000, 1, 31},
+		{2000, 2, 29},
+		{2000, 4, 30},
+		{1900, 2, 28},
+		{1996, 2, 29},
+	}
+
+	for _, t := range tests {
+		day := GetLastDay(t.year, t.month)
+		c.Assert(day, Equals, t.expectedDay)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

date_add interval month diffs from mysql

when we execute select date_add('2018-01-31',interval 1 month) in mysql we got 2018-02-28

but in tidb we got 2018-03-03

### What is changed and how it works?

1. fix the gap between golang api time.DateDate and mysql date_sub with days in expression/builtin_time.go
2. add GetLastDay in types/mytime.go to get last day in month
3. add test for above methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8534)
<!-- Reviewable:end -->
