### PR TITLE
planner/core: add DefaultExpr support for expressionRewriter

### DIFF
--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
@@ -169,6 +170,7 @@ type expressionRewriter struct {
 	insertPlan *Insert
 }
 
+// constructBinaryOpFunction converts binary operator functions
 // 1. If op are EQ or NE or NullEQ, constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to (a0 op b0) and (a1 op b1) and (a2 op b2)
 // 2. Else constructBinaryOpFunctions converts (a0,a1,a2) op (b0,b1,b2) to
 // `IF( a0 NE b0, a0 op b0,
@@ -799,6 +801,8 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		er.isNullToExpression(v)
 	case *ast.IsTruthExpr:
 		er.isTrueToScalarFunc(v)
+	case *ast.DefaultExpr:
+		er.evalDefaultExpr(v)
 	default:
 		er.err = errors.Errorf("UnknownType: %T", v)
 		return retNode, false
@@ -1291,4 +1295,48 @@ func (er *expressionRewriter) toColumn(v *ast.ColumnName) {
 		er.b.curClause = orderByClause
 	}
 	er.err = ErrUnknownColumn.GenWithStackByArgs(v.String(), clauseMsg[er.b.curClause])
+}
+
+func (er *expressionRewriter) evalDefaultExpr(v *ast.DefaultExpr) {
+	col, err := er.schema.FindColumn(v.Name)
+	if err != nil {
+		er.err = errors.Trace(err)
+		return
+	}
+
+	table, err := er.b.is.TableByName(col.DBName, col.OrigTblName)
+	if err != nil {
+		er.err = errors.Trace(err)
+		return
+	}
+
+	var val *expression.Constant
+	for _, col := range table.Cols() {
+		if col.Name.L == v.Name.Name.L {
+			// if column default value is 'current_timestamp', use NULL to be compatible with MySQL 5.7
+			if hasCurrentTimestampDefault(col) {
+				val = expression.Null
+			} else {
+				val, er.err = er.b.getDefaultValue(col)
+			}
+			break
+		}
+	}
+	if er.err != nil {
+		return
+	}
+	stkLen := len(er.ctxStack)
+	er.ctxStack = er.ctxStack[:stkLen-1]
+	er.ctxStack = append(er.ctxStack, val)
+}
+
+func hasCurrentTimestampDefault(col *table.Column) bool {
+	if col.Tp != mysql.TypeTimestamp && col.Tp != mysql.TypeDatetime {
+		return false
+	}
+	x, ok := col.DefaultValue.(string)
+	if !ok {
+		return false
+	}
+	return strings.ToUpper(x) == strings.ToUpper(ast.CurrentTimestamp)
 }

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -97,7 +97,7 @@ func (s *testExpressionRewriterSuite) TestDefaultFunction(c *C) {
 	tk.MustExec("create table t2(a varchar(10), b varchar(10))")
 	tk.MustExec("insert into t2 values ('1', '1')")
 	err = tk.ExecToErr("select default(a) from t1, t2")
-	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[planner:1052]Column 'a' in field list is ambiguous")
 	tk.MustQuery("select default(t1.a) from t1, t2").Check(testkit.Rows("def"))
 
 	tk.MustExec(`create table t3(

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -80,7 +80,7 @@ func (s *testExpressionRewriterSuite) TestDefaultFunction(c *C) {
 		f datetime default current_timestamp);`)
 	tk.MustExec("insert into t1(a, b, c, d) values ('1', '1', 1, 1)")
 	tk.MustQuery(`select
-		default(a) as defa, 
+		default(a) as defa,
 		default(b) as defb,
 		default(c) as defc,
 		default(d) as defd,
@@ -93,6 +93,19 @@ func (s *testExpressionRewriterSuite) TestDefaultFunction(c *C) {
 	_, err = tk.Exec("select default(a) from t1, t2")
 	c.Assert(err, NotNil)
 	tk.MustQuery("select default(t1.a) from t1, t2").Check(testkit.Rows("def"))
+
+	tk.MustExec(`create table t3(
+		a datetime default current_timestamp,
+		b timestamp default current_timestamp,
+		c timestamp(6) default current_timestamp(6),
+		d varchar(20) default 'current_timestamp')`)
+	tk.MustExec("insert into t3 values ()")
+	tk.MustQuery(`select
+		default(a) as defa,
+		default(b) as defb,
+		default(c) as defc,
+		default(d) as defd
+		from t3`).Check(testutil.RowsWithSep("|", "<nil>|0000-00-00 00:00:00|0000-00-00 00:00:00.000000|current_timestamp"))
 
 	tk.MustExec("prepare stmt from 'select default(a) from t1';")
 	tk.MustQuery("execute stmt").Check(testkit.Rows("def"))

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -87,16 +87,16 @@ func (s *testExpressionRewriterSuite) TestDefaultFunction(c *C) {
 		default(e) as defe,
 		default(f) as deff
 		from t1`).Check(testutil.RowsWithSep("|", "def|<nil>|10|3.14|2018-01-01 00:00:00|<nil>"))
-	_, err = tk.Exec("select default(x) from t1")
+	err = tk.ExecToErr("select default(x) from t1")
 	c.Assert(err.Error(), Equals, "[planner:1054]Unknown column 'x' in 'field list'")
 
 	tk.MustQuery("select default(a0) from (select a as a0 from t1) as t0").Check(testkit.Rows("def"))
-	_, err = tk.Exec("select default(a0) from (select a+1 as a0 from t1) as t0")
+	err = tk.ExecToErr("select default(a0) from (select a+1 as a0 from t1) as t0")
 	c.Assert(err.Error(), Equals, "[table:1364]Field 'a0' doesn't have a default value")
 
 	tk.MustExec("create table t2(a varchar(10), b varchar(10))")
 	tk.MustExec("insert into t2 values ('1', '1')")
-	_, err = tk.Exec("select default(a) from t1, t2")
+	err = tk.ExecToErr("select default(a) from t1, t2")
 	c.Assert(err, NotNil)
 	tk.MustQuery("select default(t1.a) from t1, t2").Check(testkit.Rows("def"))
 

--- a/table/column.go
+++ b/table/column.go
@@ -390,7 +390,7 @@ func getColDefaultValueFromNil(ctx sessionctx.Context, col *model.ColumnInfo) (t
 		sc.AppendWarning(ErrColumnCantNull.GenWithStackByArgs(col.Name))
 		return GetZeroValue(col), nil
 	}
-	return types.Datum{}, ErrNoDefaultValue.GenWithStack("Field '%s' doesn't have a default value", col.Name)
+	return types.Datum{}, ErrNoDefaultValue.GenWithStackByArgs(col.Name)
 }
 
 // GetZeroValue gets zero value for given column type.

--- a/table/table.go
+++ b/table/table.go
@@ -58,7 +58,7 @@ var (
 
 	// ErrNoDefaultValue is used when insert a row, the column value is not given, and the column has not null flag
 	// and it doesn't have a default value.
-	ErrNoDefaultValue = terror.ClassTable.New(codeNoDefaultValue, "field doesn't have a default value")
+	ErrNoDefaultValue = terror.ClassTable.New(codeNoDefaultValue, mysql.MySQLErrName[mysql.ErrNoDefaultForField])
 	// ErrIndexOutBound returns for index column offset out of bound.
 	ErrIndexOutBound = terror.ClassTable.New(codeIndexOutBound, "index column offset out of bound")
 	// ErrUnsupportedOp returns for unsupported operation.


### PR DESCRIPTION
### What problem does this PR solve? 

This PR simply fix a compatibility issue about `default()` function in `expressionRewriter`:

```
mysql> create table t(a int default 5);
Query OK, 0 rows affected (0.00 sec)

mysql> insert into t values (1);
Query OK, 1 row affected (0.00 sec)

mysql> select default(a) from t;
ERROR 1105 (HY000): UnknownType: *ast.DefaultExpr
mysql> update t set a=default(a);
ERROR 1105 (HY000): UnknownType: *ast.DefaultExpr
```
`default()` function should return the default value of a given column:
https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_default

### What is changed and how it works?
In `expressionRewriter`, this PR adds a branch to handle `ast.DefaultExpr` to avoid the `UnknownType` error and fix this issue.

### Check List 

Tests
 - Integration test

Related changes
 - Nothing else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8540)
<!-- Reviewable:end -->
