### PR TITLE
config: fix comment typo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -396,7 +396,7 @@ func init() {
 }
 
 // The following constants represents the valid action configurations for OOMAction.
-// NOTE: Althrough the values is case insensitiv, we should use lower-case
+// NOTE: Although the values is case insensitive, we should use lower-case
 // strings because the configuration value will be transformed to lower-case
 // string and compared with these constants in the further usage.
 const (


### PR DESCRIPTION
Correct constants `OOMAction*`'s comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8541)
<!-- Reviewable:end -->
