### PR TITLE
store/tikv/latch: use an object allocator for node

### DIFF
--- a/store/tikv/latch/alloc.go
+++ b/store/tikv/latch/alloc.go
@@ -1,0 +1,91 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package latch
+
+import (
+	"sync"
+)
+
+const nodeBlockSize = 1024
+
+type nodeBlock [nodeBlockSize]node
+
+// init makes the nodeBlock into a list.
+func (b *nodeBlock) init(start int) {
+	for i := 0; i < nodeBlockSize-1; i++ {
+		(*b)[i].next = nodePtr(start + i + 1)
+	}
+}
+
+type nodeAlloc struct {
+	// Note that physically, all nodeBlocks are not in a continuous memory,
+	// but logically they are conotinuous:
+	// data[0] contains node[0-1023]
+	// data[1] contains node[1024-2047] ...
+	data     []*nodeBlock
+	freeList nodePtr
+	sync.RWMutex
+}
+
+type nodePtr int
+
+func (a *nodeAlloc) New() nodePtr {
+	a.Lock()
+	defer a.Unlock()
+
+	if a.freeList.IsNil() {
+		block := new(nodeBlock)
+		start := len(a.data) * nodeBlockSize
+		block.init(start)
+		a.data = append(a.data, block)
+		a.freeList = nodePtr(start)
+		if a.freeList == 0 {
+			// nodePtr == 0 means IsNil, so don't use the data[0] node.
+			a.freeList++
+		}
+	}
+	ret := a.freeList
+	n := ret.value(a)
+	a.freeList = n.next
+	*n = node{}
+	return ret
+}
+
+func (p nodePtr) IsNil() bool {
+	return p == 0
+}
+
+func (p nodePtr) Next(alloc *nodeAlloc) nodePtr {
+	return p.Value(alloc).next
+}
+
+func (p nodePtr) Value(alloc *nodeAlloc) *node {
+	alloc.RLock()
+	defer alloc.RUnlock()
+	return p.value(alloc)
+}
+
+func (p nodePtr) value(alloc *nodeAlloc) *node {
+	idx := p / nodeBlockSize
+	offset := p % nodeBlockSize
+	block := alloc.data[idx]
+	return &(*block)[offset]
+}
+
+func (p nodePtr) Free(alloc *nodeAlloc) {
+	alloc.Lock()
+	defer alloc.Unlock()
+
+	p.value(alloc).next = alloc.freeList
+	alloc.freeList = p
+}

--- a/store/tikv/latch/alloc.go
+++ b/store/tikv/latch/alloc.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package latch
 
 import (

--- a/store/tikv/latch/alloc.go
+++ b/store/tikv/latch/alloc.go
@@ -14,6 +14,8 @@ package latch
 
 import (
 	"sync"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const nodeBlockSize = 1024
@@ -53,6 +55,7 @@ func (a *nodeAlloc) New() nodePtr {
 			// nodePtr == 0 means IsNil, so don't use the data[0] node.
 			a.freeList++
 		}
+		log.Debug("nodeAlloc len(a.data) = ", len(a.data))
 	}
 	ret := a.freeList
 	n := ret.value(a)

--- a/store/tikv/latch/alloc_test.go
+++ b/store/tikv/latch/alloc_test.go
@@ -10,6 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package latch
 
 import (
@@ -22,9 +23,9 @@ var _ = Suite(&testNodeAlloc{})
 
 type testNodeAlloc struct{}
 
-func (_ *testNodeAlloc) SetUpTest(c *C) {}
+func (s *testNodeAlloc) SetUpTest(c *C) {}
 
-func (_ *testNodeAlloc) TestNodeAlloc(c *C) {
+func (s *testNodeAlloc) TestNodeAlloc(c *C) {
 	var alloc nodeAlloc
 	var ptrs []nodePtr
 	for i := 0; i < nodeBlockSize*3+1; i++ {

--- a/store/tikv/latch/alloc_test.go
+++ b/store/tikv/latch/alloc_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package latch
+
+import (
+	"math/rand"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testNodeAlloc{})
+
+type testNodeAlloc struct{}
+
+func (_ *testNodeAlloc) SetUpTest(c *C) {}
+
+func (_ *testNodeAlloc) TestNodeAlloc(c *C) {
+	var alloc nodeAlloc
+	var ptrs []nodePtr
+	for i := 0; i < nodeBlockSize*3+1; i++ {
+		ptr := alloc.New()
+		ptrs = append(ptrs, ptr)
+	}
+	for i := 0; i < len(ptrs); i++ {
+		ptrs[i].Free(&alloc)
+	}
+
+	for len(ptrs) < nodeBlockSize*2 {
+		if rand.Intn(3) == 0 && len(ptrs) > 0 {
+			r := rand.Intn(len(ptrs))
+			ptr := ptrs[r]
+			if ptr.IsNil() {
+				ptr.Free(&alloc)
+				ptrs[r] = 0
+			}
+		} else {
+			ptr := alloc.New()
+			ptrs = append(ptrs, ptr)
+		}
+	}
+}

--- a/store/tikv/latch/latch_test.go
+++ b/store/tikv/latch/latch_test.go
@@ -136,17 +136,18 @@ func (s *testLatchSuite) TestRecycle(c *C) {
 	allEmpty := true
 	for i := 0; i < len(latches.slots); i++ {
 		latch := &latches.slots[i]
-		if latch.queue != nil {
+		if !latch.queue.IsNil() {
 			allEmpty = false
 		}
 	}
 	c.Assert(allEmpty, IsFalse)
 
 	currentTS := oracle.ComposeTS(oracle.GetPhysical(now.Add(expireDuration)), 3)
+
 	latches.recycle(currentTS)
 
 	for i := 0; i < len(latches.slots); i++ {
 		latch := &latches.slots[i]
-		c.Assert(latch.queue, IsNil)
+		c.Assert(latch.queue, Equals, nodePtr(0))
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Reduce the inuse object count to reduce GC scan pressure.

Inuse objects before:

![image](https://user-images.githubusercontent.com/1420062/49351161-17b1a400-f6ed-11e8-8822-f681241ef213.png)

Inuse objects after:

![image](https://user-images.githubusercontent.com/1420062/49351188-36b03600-f6ed-11e8-82ea-a56a0c26b6b1.png)

The inuse objects count reduce a half.
GC scan time is reduced because the inuse objects count reduce.

Before:
![image](https://user-images.githubusercontent.com/1420062/48635342-d6d64180-ea02-11e8-9049-86471e062d34.png)

After:
![image](https://user-images.githubusercontent.com/1420062/49351585-14b7b300-f6ef-11e8-9d09-10f23b928e00.png)



### What is changed and how it works?

I write a object allocator for `node` struct, and handle the node's allocate/free manually.

Together with https://github.com/pingcap/tidb/pull/8344
I want to make the node definition:

```
type node struct {
	slotID      int
	key         uintptr
	maxCommitTS uint64
	value       uintptr

	next nodePtr
}

```

Then there will be no pointer in the node struct, and GC would totally skip the scan of it, thus avoid the GC cost totally.


### Check List <!--REMOVE the items that are not applicable-->

Memory usage is basically the same, maybe the modified version use a bit more. This is because the allocate pool will not shrink, so the memory usage will be the maximum size it would reach.
Run sysbench prepare memory usage before vs after is 12.x% to 12.4% (stable after a while) on my local machine.


Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Run sysbench prepare and observe the memory usage, to make sure there is no leak in the implementation.

Side effects

 - Increased code complexity

I find the there is no free lunch here.
The object allocator is not lock free data struct, during the test, I observed that the cost in mutex has increased. I'm still not quite sure the improvement on GC worth the complexity and it makes the compensation for the mutex costs.

Any idea? @lysu @zhangjinpeng1987

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8554)
<!-- Reviewable:end -->
