### PR TITLE
planner, executor: set memory size to MAXUint64 for prepare plan cache test

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/metrics"
 	plannercore "github.com/pingcap/tidb/planner/core"
-	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/testkit"
 	dto "github.com/prometheus/client_model/go"
 	"golang.org/x/net/context"
@@ -47,7 +46,9 @@ func (s *testSuite) TestPrepared(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -253,7 +254,9 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -296,7 +299,9 @@ func (s *testSuite) TestPreparedNullParam(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -368,7 +373,9 @@ func (s *testSuite) TestPrepareWithAggregation(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -413,7 +420,9 @@ func (s *testSuite) TestPreparedIssue7579(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -467,7 +476,9 @@ func (s *testSuite) TestPreparedInsert(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -549,7 +560,9 @@ func (s *testSuite) TestPreparedUpdate(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -608,7 +621,9 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
@@ -662,7 +677,9 @@ func (s *testSuite) TestPrepareDealloc(c *C) {
 	plannercore.SetPreparedPlanCache(true)
 	plannercore.PreparedPlanCacheCapacity = 3
 	plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-	plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 
 	tk := testkit.NewTestKit(c, s.store)

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -707,7 +707,9 @@ func (s *testSuite) TestPreparedIssue8153(c *C) {
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
-		plannercore.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+		// behavior would not be effected by the uncertain memory utilization.
+		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -49,7 +49,6 @@ func (s *testSuite) TestPrepared(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -257,7 +256,6 @@ func (s *testSuite) TestPreparedLimitOffset(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -302,7 +300,6 @@ func (s *testSuite) TestPreparedNullParam(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -376,7 +373,6 @@ func (s *testSuite) TestPrepareWithAggregation(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -423,7 +419,6 @@ func (s *testSuite) TestPreparedIssue7579(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists t")
@@ -479,7 +474,6 @@ func (s *testSuite) TestPreparedInsert(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -563,7 +557,6 @@ func (s *testSuite) TestPreparedUpdate(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -624,7 +617,6 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 		// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 		// behavior would not be effected by the uncertain memory utilization.
 		plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-		c.Assert(err, IsNil)
 		tk := testkit.NewTestKit(c, s.store)
 		tk.MustExec("use test")
 		tk.MustExec("drop table if exists prepare_test")
@@ -680,7 +672,6 @@ func (s *testSuite) TestPrepareDealloc(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	plannercore.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -293,7 +293,6 @@ func (s *testSuite) TestPreparedNullParam(c *C) {
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -366,7 +365,6 @@ func (s *testSuite) TestPrepareWithAggregation(c *C) {
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -412,7 +410,6 @@ func (s *testSuite) TestPreparedIssue7579(c *C) {
 	}()
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -467,7 +464,6 @@ func (s *testSuite) TestPreparedInsert(c *C) {
 	pb := &dto.Metric{}
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -550,7 +546,6 @@ func (s *testSuite) TestPreparedUpdate(c *C) {
 	pb := &dto.Metric{}
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -610,7 +605,6 @@ func (s *testSuite) TestPreparedDelete(c *C) {
 	pb := &dto.Metric{}
 	flags := []bool{false, true}
 	for _, flag := range flags {
-		var err error
 		plannercore.SetPreparedPlanCache(flag)
 		plannercore.PreparedPlanCacheCapacity = 100
 		plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1
@@ -665,7 +659,6 @@ func (s *testSuite) TestPrepareDealloc(c *C) {
 		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
 		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
-	var err error
 	plannercore.SetPreparedPlanCache(true)
 	plannercore.PreparedPlanCacheCapacity = 3
 	plannercore.PreparedPlanCacheMemoryGuardRatio = 0.1

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -52,7 +52,6 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, key idx_bc(b,c))")

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -14,10 +14,11 @@
 package core_test
 
 import (
+	"math"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/planner/core"
-	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	dto "github.com/prometheus/client_model/go"
@@ -48,7 +49,9 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -59,7 +59,6 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key, b int, c int, index idx1(b, a), index idx2(b))")
@@ -110,7 +109,6 @@ func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, c int, primary key (a, b))")
@@ -145,7 +143,6 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 
 	defer testleak.AfterTest(c)()
 
@@ -207,7 +204,6 @@ func (s *testPrepareSuite) TestPrepareCacheNow(c *C) {
 	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
-	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec(`prepare stmt1 from "select now(), sleep(1), now()"`)
 	// When executing one statement at the first time, we don't use cache, so we need to execute it at least twice to test the cache.

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -14,6 +14,7 @@
 package core_test
 
 import (
+	"math"
 	"strconv"
 	"time"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/prometheus/client_golang/prometheus"
@@ -56,7 +56,9 @@ func (s *testPrepareSuite) TestPrepareCache(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -105,7 +107,9 @@ func (s *testPrepareSuite) TestPrepareCacheIndexScan(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -138,7 +142,9 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 
 	defer testleak.AfterTest(c)()
@@ -198,7 +204,9 @@ func (s *testPrepareSuite) TestPrepareCacheNow(c *C) {
 	core.SetPreparedPlanCache(true)
 	core.PreparedPlanCacheCapacity = 100
 	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	core.PreparedPlanCacheMaxMemory, err = memory.MemTotal()
+	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
+	// behavior would not be effected by the uncertain memory utilization.
+	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 	c.Assert(err, IsNil)
 	tk.MustExec("use test")
 	tk.MustExec(`prepare stmt1 from "select now(), sleep(1), now()"`)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Set memory size to MAXUint64 for prepare plan cache test

### What is changed and how it works?
The test for prepare plan cache is unstable caused by the machine memory utilization after #8339 .
So I set the memory size to MAX_Uint64 to make the test result stable every time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes
N/A

Side effects
N/A

Related changes
N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8556)
<!-- Reviewable:end -->
