### PR TITLE
expression: split aggregation descriptor for reuse

### DIFF
--- a/executor/aggfuncs/func_avg_test.go
+++ b/executor/aggfuncs/func_avg_test.go
@@ -32,11 +32,11 @@ func (s *testSuite) TestMergePartialResult4AvgDecimal(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncAvg,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncAvg
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 	partialDesc, finalDesc := desc.Split([]int{0, 1})
 
 	// build avg func for partial phase.
@@ -88,11 +88,11 @@ func (s *testSuite) TestMergePartialResult4AvgFloat(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncAvg,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeDouble),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncAvg
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeDouble)
 	partialDesc, finalDesc := desc.Split([]int{0, 1})
 
 	// build avg func for partial phase.

--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -32,11 +32,11 @@ func (s *testSuite) TestMergePartialResult4Count(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncCount,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLong), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeLonglong),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncCount
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLong), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeLonglong)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build count func for partial phase.

--- a/executor/aggfuncs/func_max_min_test.go
+++ b/executor/aggfuncs/func_max_min_test.go
@@ -32,11 +32,11 @@ func (s *testSuite) TestMergePartialResult4MaxDecimal(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncMax,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncMax
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build max func for partial phase.
@@ -85,11 +85,11 @@ func (s *testSuite) TestMergePartialResult4MaxFloat(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncMax,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeDouble),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncMax
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeDouble)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build max func for partial phase.
@@ -138,11 +138,11 @@ func (s *testSuite) TestMergePartialResult4MinDecimal(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncMin,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncMin
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build min func for partial phase.
@@ -193,11 +193,11 @@ func (s *testSuite) TestMergePartialResult4MinFloat(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncMin,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeDouble),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncMin
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeDouble)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build min func for partial phase.

--- a/executor/aggfuncs/func_sum_test.go
+++ b/executor/aggfuncs/func_sum_test.go
@@ -32,11 +32,11 @@ func (s *testSuite) TestMergePartialResult4SumDecimal(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncSum,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeNewDecimal),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncSum
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build sum func for partial phase.
@@ -88,11 +88,11 @@ func (s *testSuite) TestMergePartialResult4SumFloat(c *C) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 
 	desc := &aggregation.AggFuncDesc{
-		Name:  ast.AggFuncSum,
-		Mode:  aggregation.CompleteMode,
-		Args:  []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}},
-		RetTp: types.NewFieldType(mysql.TypeDouble),
+		Mode: aggregation.CompleteMode,
 	}
+	desc.Name = ast.AggFuncSum
+	desc.Args = []expression.Expression{&expression.Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}}
+	desc.RetTp = types.NewFieldType(mysql.TypeDouble)
 	partialDesc, finalDesc := desc.Split([]int{0})
 
 	// build sum func for partial phase.

--- a/expression/aggregation/agg_to_pb_test.go
+++ b/expression/aggregation/agg_to_pb_test.go
@@ -76,11 +76,11 @@ func (s *testEvaluatorSuite) TestAggFunc2Pb(c *C) {
 	}
 	for i, funcName := range funcNames {
 		aggFunc := &AggFuncDesc{
-			Name:        funcName,
-			Args:        []expression.Expression{dg.genColumn(mysql.TypeDouble, 1)},
 			HasDistinct: true,
-			RetTp:       funcTypes[i],
 		}
+		aggFunc.Name = funcName
+		aggFunc.Args = []expression.Expression{dg.genColumn(mysql.TypeDouble, 1)}
+		aggFunc.RetTp = funcTypes[i]
 		pbExpr := AggFuncToPBExpr(sc, client, aggFunc)
 		js, err := json.Marshal(pbExpr)
 		c.Assert(err, IsNil)
@@ -98,11 +98,11 @@ func (s *testEvaluatorSuite) TestAggFunc2Pb(c *C) {
 	}
 	for i, funcName := range funcNames {
 		aggFunc := &AggFuncDesc{
-			Name:        funcName,
-			Args:        []expression.Expression{dg.genColumn(mysql.TypeDouble, 1)},
 			HasDistinct: false,
-			RetTp:       funcTypes[i],
 		}
+		aggFunc.Name = funcName
+		aggFunc.Args = []expression.Expression{dg.genColumn(mysql.TypeDouble, 1)}
+		aggFunc.RetTp = funcTypes[i]
 		pbExpr := AggFuncToPBExpr(sc, client, aggFunc)
 		js, err := json.Marshal(pbExpr)
 		c.Assert(err, IsNil)

--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -126,11 +126,10 @@ type aggFunction struct {
 }
 
 func newAggFunc(funcName string, args []expression.Expression, hasDistinct bool) aggFunction {
-	return aggFunction{AggFuncDesc: &AggFuncDesc{
-		Name:        funcName,
-		Args:        args,
-		HasDistinct: hasDistinct,
-	}}
+	agg := &AggFuncDesc{HasDistinct: hasDistinct}
+	agg.Name = funcName
+	agg.Args = args
+	return aggFunction{AggFuncDesc: agg}
 }
 
 // CreateContext implements Aggregation interface.

--- a/expression/aggregation/base_func.go
+++ b/expression/aggregation/base_func.go
@@ -1,0 +1,213 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggregation
+
+import (
+	"bytes"
+	"math"
+	"strings"
+
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/charset"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+)
+
+// baseFuncDesc describes an function signature, only used in planner.
+type baseFuncDesc struct {
+	// Name represents the function name.
+	Name string
+	// Args represents the arguments of the function.
+	Args []expression.Expression
+	// RetTp represents the return type of the function.
+	RetTp *types.FieldType
+}
+
+func newBaseFuncDesc(ctx sessionctx.Context, name string, args []expression.Expression) baseFuncDesc {
+	b := baseFuncDesc{Name: strings.ToLower(name), Args: args}
+	b.typeInfer(ctx)
+	return b
+}
+
+func (a *baseFuncDesc) equal(ctx sessionctx.Context, other *baseFuncDesc) bool {
+	if a.Name != other.Name || len(a.Args) != len(other.Args) {
+		return false
+	}
+	for i := range a.Args {
+		if !a.Args[i].Equal(ctx, other.Args[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *baseFuncDesc) clone() *baseFuncDesc {
+	clone := *a
+	newTp := *a.RetTp
+	clone.RetTp = &newTp
+	for i := range a.Args {
+		clone.Args[i] = a.Args[i].Clone()
+	}
+	return &clone
+}
+
+// String implements the fmt.Stringer interface.
+func (a *baseFuncDesc) String() string {
+	buffer := bytes.NewBufferString(a.Name)
+	buffer.WriteString("(")
+	for i, arg := range a.Args {
+		buffer.WriteString(arg.String())
+		if i+1 != len(a.Args) {
+			buffer.WriteString(", ")
+		}
+	}
+	buffer.WriteString(")")
+	return buffer.String()
+}
+
+// typeInfer infers the arguments and return types of an function.
+func (a *baseFuncDesc) typeInfer(ctx sessionctx.Context) {
+	switch a.Name {
+	case ast.AggFuncCount:
+		a.typeInfer4Count(ctx)
+	case ast.AggFuncSum:
+		a.typeInfer4Sum(ctx)
+	case ast.AggFuncAvg:
+		a.typeInfer4Avg(ctx)
+	case ast.AggFuncGroupConcat:
+		a.typeInfer4GroupConcat(ctx)
+	case ast.AggFuncMax, ast.AggFuncMin, ast.AggFuncFirstRow:
+		a.typeInfer4MaxMin(ctx)
+	case ast.AggFuncBitAnd, ast.AggFuncBitOr, ast.AggFuncBitXor:
+		a.typeInfer4BitFuncs(ctx)
+	default:
+		panic("unsupported agg function: " + a.Name)
+	}
+}
+
+func (a *baseFuncDesc) typeInfer4Count(ctx sessionctx.Context) {
+	a.RetTp = types.NewFieldType(mysql.TypeLonglong)
+	a.RetTp.Flen = 21
+	types.SetBinChsClnFlag(a.RetTp)
+}
+
+// typeInfer4Sum should returns a "decimal", otherwise it returns a "double".
+// Because child returns integer or decimal type.
+func (a *baseFuncDesc) typeInfer4Sum(ctx sessionctx.Context) {
+	switch a.Args[0].GetType().Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
+		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxDecimalWidth, 0
+	case mysql.TypeNewDecimal:
+		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxDecimalWidth, a.Args[0].GetType().Decimal
+		if a.RetTp.Decimal < 0 || a.RetTp.Decimal > mysql.MaxDecimalScale {
+			a.RetTp.Decimal = mysql.MaxDecimalScale
+		}
+	case mysql.TypeDouble, mysql.TypeFloat:
+		a.RetTp = types.NewFieldType(mysql.TypeDouble)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, a.Args[0].GetType().Decimal
+	default:
+		a.RetTp = types.NewFieldType(mysql.TypeDouble)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
+	}
+	types.SetBinChsClnFlag(a.RetTp)
+}
+
+// typeInfer4Avg should returns a "decimal", otherwise it returns a "double".
+// Because child returns integer or decimal type.
+func (a *baseFuncDesc) typeInfer4Avg(ctx sessionctx.Context) {
+	switch a.Args[0].GetType().Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
+		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
+		if a.Args[0].GetType().Decimal < 0 {
+			a.RetTp.Decimal = mysql.MaxDecimalScale
+		} else {
+			a.RetTp.Decimal = mathutil.Min(a.Args[0].GetType().Decimal+types.DivFracIncr, mysql.MaxDecimalScale)
+		}
+		a.RetTp.Flen = mysql.MaxDecimalWidth
+	case mysql.TypeDouble, mysql.TypeFloat:
+		a.RetTp = types.NewFieldType(mysql.TypeDouble)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, a.Args[0].GetType().Decimal
+	default:
+		a.RetTp = types.NewFieldType(mysql.TypeDouble)
+		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
+	}
+	types.SetBinChsClnFlag(a.RetTp)
+}
+
+func (a *baseFuncDesc) typeInfer4GroupConcat(ctx sessionctx.Context) {
+	a.RetTp = types.NewFieldType(mysql.TypeVarString)
+	a.RetTp.Charset, a.RetTp.Collate = charset.GetDefaultCharsetAndCollate()
+
+	a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxBlobWidth, 0
+	// TODO: a.Args[i] = expression.WrapWithCastAsString(ctx, a.Args[i])
+}
+
+func (a *baseFuncDesc) typeInfer4MaxMin(ctx sessionctx.Context) {
+	_, argIsScalaFunc := a.Args[0].(*expression.ScalarFunction)
+	if argIsScalaFunc && a.Args[0].GetType().Tp == mysql.TypeFloat {
+		// For scalar function, the result of "float32" is set to the "float64"
+		// field in the "Datum". If we do not wrap a cast-as-double function on a.Args[0],
+		// error would happen when extracting the evaluation of a.Args[0] to a ProjectionExec.
+		tp := types.NewFieldType(mysql.TypeDouble)
+		tp.Flen, tp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
+		types.SetBinChsClnFlag(tp)
+		a.Args[0] = expression.BuildCastFunction(ctx, a.Args[0], tp)
+	}
+	a.RetTp = a.Args[0].GetType()
+	if a.RetTp.Tp == mysql.TypeEnum || a.RetTp.Tp == mysql.TypeSet {
+		a.RetTp = &types.FieldType{Tp: mysql.TypeString, Flen: mysql.MaxFieldCharLength}
+	}
+}
+
+func (a *baseFuncDesc) typeInfer4BitFuncs(ctx sessionctx.Context) {
+	a.RetTp = types.NewFieldType(mysql.TypeLonglong)
+	a.RetTp.Flen = 21
+	types.SetBinChsClnFlag(a.RetTp)
+	a.RetTp.Flag |= mysql.UnsignedFlag | mysql.NotNullFlag
+	// TODO: a.Args[0] = expression.WrapWithCastAsInt(ctx, a.Args[0])
+}
+
+// GetDefaultValue gets the default value when the function's input is null.
+// According to MySQL, default values of the function are listed as follows:
+// e.g.
+// Table t which is empty:
+// +-------+---------+---------+
+// | Table | Field   | Type    |
+// +-------+---------+---------+
+// | t     | a       | int(11) |
+// +-------+---------+---------+
+//
+// Query: `select a, avg(a), sum(a), count(a), bit_xor(a), bit_or(a), bit_and(a), max(a), min(a), group_concat(a) from t;`
+// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
+// | a    | avg(a) | sum(a) | count(a) | bit_xor(a) | bit_or(a) | bit_and(a)           | max(a) | min(a) | group_concat(a) |
+// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
+// | NULL |   NULL |   NULL |        0 |          0 |         0 | 18446744073709551615 |   NULL |   NULL | NULL            |
+// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
+func (a *baseFuncDesc) GetDefaultValue() (v types.Datum) {
+	switch a.Name {
+	case ast.AggFuncCount, ast.AggFuncBitOr, ast.AggFuncBitXor:
+		v = types.NewIntDatum(0)
+	case ast.AggFuncFirstRow, ast.AggFuncAvg, ast.AggFuncSum, ast.AggFuncMax,
+		ast.AggFuncMin, ast.AggFuncGroupConcat:
+		v = types.Datum{}
+	case ast.AggFuncBitAnd:
+		v = types.NewUintDatum(uint64(math.MaxUint64))
+	}
+	return
+}

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -14,15 +14,11 @@
 package aggregation
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 
-	"github.com/cznic/mathutil"
 	"github.com/pingcap/parser/ast"
-	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -33,12 +29,7 @@ import (
 
 // AggFuncDesc describes an aggregation function signature, only used in planner.
 type AggFuncDesc struct {
-	// Name represents the aggregation function name.
-	Name string
-	// Args represents the arguments of the aggregation function.
-	Args []expression.Expression
-	// RetTp represents the return type of the aggregation function.
-	RetTp *types.FieldType
+	baseFuncDesc
 	// Mode represents the execution mode of the aggregation function.
 	Mode AggFunctionMode
 	// HasDistinct represents whether the aggregation function contains distinct attribute.
@@ -47,36 +38,22 @@ type AggFuncDesc struct {
 
 // NewAggFuncDesc creates an aggregation function signature descriptor.
 func NewAggFuncDesc(ctx sessionctx.Context, name string, args []expression.Expression, hasDistinct bool) *AggFuncDesc {
-	a := &AggFuncDesc{
-		Name:        strings.ToLower(name),
-		Args:        args,
-		HasDistinct: hasDistinct,
-	}
-	a.typeInfer(ctx)
-	return a
+	b := newBaseFuncDesc(ctx, name, args)
+	return &AggFuncDesc{baseFuncDesc: b, HasDistinct: hasDistinct}
 }
 
 // Equal checks whether two aggregation function signatures are equal.
 func (a *AggFuncDesc) Equal(ctx sessionctx.Context, other *AggFuncDesc) bool {
-	if a.Name != other.Name || a.HasDistinct != other.HasDistinct || len(a.Args) != len(other.Args) {
+	if a.HasDistinct != other.HasDistinct {
 		return false
 	}
-	for i := range a.Args {
-		if !a.Args[i].Equal(ctx, other.Args[i]) {
-			return false
-		}
-	}
-	return true
+	return a.baseFuncDesc.equal(ctx, &other.baseFuncDesc)
 }
 
 // Clone copies an aggregation function signature totally.
 func (a *AggFuncDesc) Clone() *AggFuncDesc {
 	clone := *a
-	newTp := *a.RetTp
-	clone.RetTp = &newTp
-	for i := range a.Args {
-		clone.Args[i] = a.Args[i].Clone()
-	}
+	clone.baseFuncDesc = *a.baseFuncDesc.clone()
 	return &clone
 }
 
@@ -94,11 +71,11 @@ func (a *AggFuncDesc) Split(ordinal []int) (partialAggDesc, finalAggDesc *AggFun
 		panic("Error happened during AggFuncDesc.Split, the AggFunctionMode is not CompleteMode or FinalMode.")
 	}
 	finalAggDesc = &AggFuncDesc{
-		Name:        a.Name,
 		Mode:        FinalMode, // We only support FinalMode now in final phase.
 		HasDistinct: a.HasDistinct,
-		RetTp:       a.RetTp,
 	}
+	finalAggDesc.Name = a.Name
+	finalAggDesc.RetTp = a.RetTp
 	switch a.Name {
 	case ast.AggFuncAvg:
 		args := make([]expression.Expression, 0, 2)
@@ -126,40 +103,6 @@ func (a *AggFuncDesc) Split(ordinal []int) (partialAggDesc, finalAggDesc *AggFun
 		}
 	}
 	return
-}
-
-// String implements the fmt.Stringer interface.
-func (a *AggFuncDesc) String() string {
-	buffer := bytes.NewBufferString(a.Name)
-	buffer.WriteString("(")
-	for i, arg := range a.Args {
-		buffer.WriteString(arg.String())
-		if i+1 != len(a.Args) {
-			buffer.WriteString(", ")
-		}
-	}
-	buffer.WriteString(")")
-	return buffer.String()
-}
-
-// typeInfer infers the arguments and return types of an aggregation function.
-func (a *AggFuncDesc) typeInfer(ctx sessionctx.Context) {
-	switch a.Name {
-	case ast.AggFuncCount:
-		a.typeInfer4Count(ctx)
-	case ast.AggFuncSum:
-		a.typeInfer4Sum(ctx)
-	case ast.AggFuncAvg:
-		a.typeInfer4Avg(ctx)
-	case ast.AggFuncGroupConcat:
-		a.typeInfer4GroupConcat(ctx)
-	case ast.AggFuncMax, ast.AggFuncMin, ast.AggFuncFirstRow:
-		a.typeInfer4MaxMin(ctx)
-	case ast.AggFuncBitAnd, ast.AggFuncBitOr, ast.AggFuncBitXor:
-		a.typeInfer4BitFuncs(ctx)
-	default:
-		panic("unsupported agg function: " + a.Name)
-	}
 }
 
 // EvalNullValueInOuterJoin gets the null value when the aggregation is upon an outer join,
@@ -213,35 +156,6 @@ func (a *AggFuncDesc) EvalNullValueInOuterJoin(ctx sessionctx.Context, schema *e
 	}
 }
 
-// GetDefaultValue gets the default value when the aggregation function's input is null.
-// According to MySQL, default values of the aggregation function are listed as follows:
-// e.g.
-// Table t which is empty:
-// +-------+---------+---------+
-// | Table | Field   | Type    |
-// +-------+---------+---------+
-// | t     | a       | int(11) |
-// +-------+---------+---------+
-//
-// Query: `select a, avg(a), sum(a), count(a), bit_xor(a), bit_or(a), bit_and(a), max(a), min(a), group_concat(a) from t;`
-// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
-// | a    | avg(a) | sum(a) | count(a) | bit_xor(a) | bit_or(a) | bit_and(a)           | max(a) | min(a) | group_concat(a) |
-// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
-// | NULL |   NULL |   NULL |        0 |          0 |         0 | 18446744073709551615 |   NULL |   NULL | NULL            |
-// +------+--------+--------+----------+------------+-----------+----------------------+--------+--------+-----------------+
-func (a *AggFuncDesc) GetDefaultValue() (v types.Datum) {
-	switch a.Name {
-	case ast.AggFuncCount, ast.AggFuncBitOr, ast.AggFuncBitXor:
-		v = types.NewIntDatum(0)
-	case ast.AggFuncFirstRow, ast.AggFuncAvg, ast.AggFuncSum, ast.AggFuncMax,
-		ast.AggFuncMin, ast.AggFuncGroupConcat:
-		v = types.Datum{}
-	case ast.AggFuncBitAnd:
-		v = types.NewUintDatum(uint64(math.MaxUint64))
-	}
-	return
-}
-
 // GetAggFunc gets an evaluator according to the aggregation function signature.
 func (a *AggFuncDesc) GetAggFunc(ctx sessionctx.Context) Aggregation {
 	aggFunc := aggFunction{AggFuncDesc: a}
@@ -280,90 +194,6 @@ func (a *AggFuncDesc) GetAggFunc(ctx sessionctx.Context) Aggregation {
 	default:
 		panic("unsupported agg function")
 	}
-}
-
-func (a *AggFuncDesc) typeInfer4Count(ctx sessionctx.Context) {
-	a.RetTp = types.NewFieldType(mysql.TypeLonglong)
-	a.RetTp.Flen = 21
-	types.SetBinChsClnFlag(a.RetTp)
-}
-
-// typeInfer4Sum should returns a "decimal", otherwise it returns a "double".
-// Because child returns integer or decimal type.
-func (a *AggFuncDesc) typeInfer4Sum(ctx sessionctx.Context) {
-	switch a.Args[0].GetType().Tp {
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
-		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxDecimalWidth, 0
-	case mysql.TypeNewDecimal:
-		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxDecimalWidth, a.Args[0].GetType().Decimal
-		if a.RetTp.Decimal < 0 || a.RetTp.Decimal > mysql.MaxDecimalScale {
-			a.RetTp.Decimal = mysql.MaxDecimalScale
-		}
-	case mysql.TypeDouble, mysql.TypeFloat:
-		a.RetTp = types.NewFieldType(mysql.TypeDouble)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, a.Args[0].GetType().Decimal
-	default:
-		a.RetTp = types.NewFieldType(mysql.TypeDouble)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
-	}
-	types.SetBinChsClnFlag(a.RetTp)
-}
-
-// typeInfer4Avg should returns a "decimal", otherwise it returns a "double".
-// Because child returns integer or decimal type.
-func (a *AggFuncDesc) typeInfer4Avg(ctx sessionctx.Context) {
-	switch a.Args[0].GetType().Tp {
-	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeNewDecimal:
-		a.RetTp = types.NewFieldType(mysql.TypeNewDecimal)
-		if a.Args[0].GetType().Decimal < 0 {
-			a.RetTp.Decimal = mysql.MaxDecimalScale
-		} else {
-			a.RetTp.Decimal = mathutil.Min(a.Args[0].GetType().Decimal+types.DivFracIncr, mysql.MaxDecimalScale)
-		}
-		a.RetTp.Flen = mysql.MaxDecimalWidth
-	case mysql.TypeDouble, mysql.TypeFloat:
-		a.RetTp = types.NewFieldType(mysql.TypeDouble)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, a.Args[0].GetType().Decimal
-	default:
-		a.RetTp = types.NewFieldType(mysql.TypeDouble)
-		a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
-	}
-	types.SetBinChsClnFlag(a.RetTp)
-}
-
-func (a *AggFuncDesc) typeInfer4GroupConcat(ctx sessionctx.Context) {
-	a.RetTp = types.NewFieldType(mysql.TypeVarString)
-	a.RetTp.Charset, a.RetTp.Collate = charset.GetDefaultCharsetAndCollate()
-
-	a.RetTp.Flen, a.RetTp.Decimal = mysql.MaxBlobWidth, 0
-	// TODO: a.Args[i] = expression.WrapWithCastAsString(ctx, a.Args[i])
-}
-
-func (a *AggFuncDesc) typeInfer4MaxMin(ctx sessionctx.Context) {
-	_, argIsScalaFunc := a.Args[0].(*expression.ScalarFunction)
-	if argIsScalaFunc && a.Args[0].GetType().Tp == mysql.TypeFloat {
-		// For scalar function, the result of "float32" is set to the "float64"
-		// field in the "Datum". If we do not wrap a cast-as-double function on a.Args[0],
-		// error would happen when extracting the evaluation of a.Args[0] to a ProjectionExec.
-		tp := types.NewFieldType(mysql.TypeDouble)
-		tp.Flen, tp.Decimal = mysql.MaxRealWidth, types.UnspecifiedLength
-		types.SetBinChsClnFlag(tp)
-		a.Args[0] = expression.BuildCastFunction(ctx, a.Args[0], tp)
-	}
-	a.RetTp = a.Args[0].GetType()
-	if a.RetTp.Tp == mysql.TypeEnum || a.RetTp.Tp == mysql.TypeSet {
-		a.RetTp = &types.FieldType{Tp: mysql.TypeString, Flen: mysql.MaxFieldCharLength}
-	}
-}
-
-func (a *AggFuncDesc) typeInfer4BitFuncs(ctx sessionctx.Context) {
-	a.RetTp = types.NewFieldType(mysql.TypeLonglong)
-	a.RetTp.Flen = 21
-	types.SetBinChsClnFlag(a.RetTp)
-	a.RetTp.Flag |= mysql.UnsignedFlag | mysql.NotNullFlag
-	// TODO: a.Args[0] = expression.WrapWithCastAsInt(ctx, a.Args[0])
 }
 
 func (a *AggFuncDesc) evalNullValueInOuterJoin4Count(ctx sessionctx.Context, schema *expression.Schema) (types.Datum, bool) {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -401,7 +401,8 @@ func (p *basePhysicalAgg) newPartialAggregate() (partial, final PhysicalPlan) {
 	partialCursor := 0
 	finalAggFuncs := make([]*aggregation.AggFuncDesc, len(p.AggFuncs))
 	for i, aggFun := range p.AggFuncs {
-		finalAggFunc := &aggregation.AggFuncDesc{Name: aggFun.Name, HasDistinct: false}
+		finalAggFunc := &aggregation.AggFuncDesc{HasDistinct: false}
+		finalAggFunc.Name = aggFun.Name
 		args := make([]expression.Expression, 0, len(aggFun.Args))
 		if aggregation.NeedCount(finalAggFunc.Name) {
 			ft := types.NewFieldType(mysql.TypeLonglong)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Window functions also need to use some logic in aggregation descriptor, like type infer.

### What is changed and how it works?

Split the `AggFuncDesc` into `baseFuncDesc`, so it can be reused in window function desc.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @XuHuaiyu @winoros 
