### PR TITLE
tikv: accelerate tikv package testcase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ clean:
 	rm -rf *.out
 	rm -rf parser
 
-test: checklist gotest explaintest
+test: checklist checkdep gotest explaintest
 
 explaintest: server
 	@cd cmd/explaintest && ./run-tests.sh -s ../../bin/tidb-server
@@ -192,3 +192,6 @@ gofail-enable:
 gofail-disable:
 # Restoring gofail failpoints...
 	@$(GOFAIL_DISABLE)
+
+checkdep:
+	$(GO) list -f '{{ join .Imports "\n" }}' github.com/pingcap/tidb/store/tikv | grep ^github.com/pingcap/parser$$ || exit 0; exit 1

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -239,7 +239,7 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 
 	b.errors = append(b.errors, errors.Errorf("%s at %s", err.Error(), time.Now().Format(time.RFC3339Nano)))
 	if b.maxSleep > 0 && b.totalSleep >= b.maxSleep {
-		errMsg := fmt.Sprintf("backoffer.maxSleep %dms is exceeded, errors:", b.maxSleep)
+		errMsg := fmt.Sprintf("%s backoffer.maxSleep %dms is exceeded, errors:", typ.String(), b.maxSleep)
 		for i, err := range b.errors {
 			// Print only last 3 errors for non-DEBUG log levels.
 			if log.GetLevel() == log.DebugLevel || i >= len(b.errors)-3 {

--- a/store/tikv/oracle/oracles/local_test.go
+++ b/store/tikv/oracle/oracles/local_test.go
@@ -41,12 +41,12 @@ func TestIsExpired(t *testing.T) {
 	o := NewLocalOracle()
 	defer o.Close()
 	ts, _ := o.GetTimestamp(context.Background())
-	time.Sleep(1 * time.Second)
-	expire := o.IsExpired(uint64(ts), 500)
+	time.Sleep(50 * time.Millisecond)
+	expire := o.IsExpired(uint64(ts), 40)
 	if !expire {
 		t.Error("should expired")
 	}
-	expire = o.IsExpired(uint64(ts), 2000)
+	expire = o.IsExpired(uint64(ts), 200)
 	if expire {
 		t.Error("should not expired")
 	}

--- a/store/tikv/tikv_test.go
+++ b/store/tikv/tikv_test.go
@@ -14,14 +14,7 @@
 package tikv
 
 import (
-	"go/build"
-	"os"
-	"path"
-	"reflect"
-	"strings"
-
 	. "github.com/pingcap/check"
-	"github.com/pingcap/parser"
 )
 
 // OneByOneSuite is a suite, When with-tikv flag is true, there is only one storage, so the test suite have to run one by one.
@@ -45,41 +38,3 @@ type testTiKVSuite struct {
 }
 
 var _ = Suite(&testTiKVSuite{})
-
-func getImportedPackages(c *C, srcDir string, pkgName string, pkgs *map[string][]string) {
-	if pkgName == "C" {
-		return
-	}
-	if _, exists := (*pkgs)[pkgName]; exists {
-		return
-	}
-	if strings.HasPrefix(pkgName, "golang_org") {
-		pkgName = path.Join("vendor", pkgName)
-	}
-	pkg, err := build.Import(pkgName, srcDir, 0)
-	c.Assert(err, IsNil)
-	(*pkgs)[pkgName] = pkg.Imports
-	for _, name := range (*pkgs)[pkgName] {
-		getImportedPackages(c, srcDir, name, pkgs)
-	}
-}
-
-// TestParserNoDep tests whether this package does not depend on tidb/parser.
-func (s *testTiKVSuite) TestParserNoDep(c *C) {
-	srcDir, err := os.Getwd()
-	c.Assert(err, IsNil)
-
-	pkgs := make(map[string][]string)
-	currentPkgName := reflect.TypeOf(testTiKVSuite{}).PkgPath()
-	getImportedPackages(c, srcDir, currentPkgName, &pkgs)
-
-	parse := parser.New()
-	parserPkgName := reflect.TypeOf(*parse).PkgPath()
-
-	for pkgName, imports := range pkgs {
-		for _, importName := range imports {
-			c.Assert(importName == parserPkgName, IsFalse,
-				Commentf("`%s` is imported from `%s`, which is a child dependency of `%s`", parserPkgName, pkgName, currentPkgName))
-		}
-	}
-}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

current tikv test is slow, often take 40s to run tikv root package test.

list top file time:

```
➜  tidb git:(master) ✗ cat t.txt | grep PASS | awk -F'\t' '{print $NF, $1}' | sort -nr
17.316s PASS: tikv_test.go:68: testTiKVSuite.TestParserNoDep
2.537s PASS: 2pc_fail_test.go:27: testCommitterSuite.TestFailCommitPrimaryRpcErrors
2.113s PASS: 2pc_fail_test.go:60: testCommitterSuite.TestFailCommitPrimaryRPCErrorThenRegionError
2.031s PASS: 2pc_fail_test.go:45: testCommitterSuite.TestFailCommitPrimaryRegionError
2.012s PASS: 2pc_fail_test.go:87: testCommitterSuite.TestFailCommitTimeout
1.979s PASS: sql_fail_test.go:54: testSQLSuite.TestFailBusyServerCop
1.921s PASS: store_fail_test.go:25: testStoreSuite.TestFailBusyServerKV
1.106s PASS: isolation_test.go:105: testIsolationSuite.TestWriteWriteConflict
0.464s PASS: lock_test.go:242: testLockSuite.TestLockTTL
0.291s PASS: store_test.go:61: testStoreSuite.TestOracle
0.280s PASS: rawkv_test.go:160: testRawKVSuite.TestRawBatch
0.231s PASS: 2pc_test.go:124: testCommitterSuite.TestPrewriteRollback
0.160s PASS: 2pc_slow_test.go:21: testCommitterSuite.TestCommitMultipleRegions
0.106s PASS: lock_test.go:166: testLockSuite.TestCleanLock
```
first test case can be improve, other 2+s test case is about backoff and timeout behave maybe better don't modify time configuration now.

### What is changed and how it works?

- remove `TestParserNoDep` and add `checkdep` step in make file(pkg dependence enforce rule also can be land in this step in future)
- speed up TSO test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Test

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8562)
<!-- Reviewable:end -->
