### PR TITLE
expression: do not set ParseToJSONFlag to a JSON column

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1170,6 +1170,11 @@ func (c *compareFunctionClass) generateCmpSigs(ctx sessionctx.Context, args []Ex
 	if tp == types.ETJson {
 		// In compare, if we cast string to JSON, we shouldn't parse it.
 		for i := range args {
+			// If arg is a JSON column, we do not need to set the
+			// ParseToJSONFlag to it.
+			if _, isColumn := args[i].(*Column); isColumn {
+				continue
+			}
 			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
 		}
 	}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -174,7 +174,10 @@ func (c *jsonUnquoteFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 		return nil, errors.Trace(err)
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETJson)
-	args[0].GetType().Flag &= ^mysql.ParseToJSONFlag
+	// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+	if _, ok := args[0].(*Column); !ok {
+		args[0].GetType().Flag &= ^mysql.ParseToJSONFlag
+	}
 	sig := &builtinJSONUnquoteSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonUnquoteSig)
 	return sig, nil
@@ -218,7 +221,10 @@ func (c *jsonSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
 	for i := 2; i < len(args); i += 2 {
-		args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+		if _, ok := args[i].(*Column); !ok {
+			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		}
 	}
 	sig := &builtinJSONSetSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonSetSig)
@@ -258,7 +264,10 @@ func (c *jsonInsertFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
 	for i := 2; i < len(args); i += 2 {
-		args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+		if _, ok := args[i].(*Column); !ok {
+			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		}
 	}
 	sig := &builtinJSONInsertSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonInsertSig)
@@ -298,7 +307,10 @@ func (c *jsonReplaceFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
 	for i := 2; i < len(args); i += 2 {
-		args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+		if _, ok := args[i].(*Column); !ok {
+			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		}
 	}
 	sig := &builtinJSONReplaceSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonReplaceSig)
@@ -434,7 +446,10 @@ func (c *jsonObjectFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
 	for i := 1; i < len(args); i += 2 {
-		args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+		if _, ok := args[i].(*Column); !ok {
+			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		}
 	}
 	sig := &builtinJSONObjectSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonObjectSig)
@@ -497,7 +512,10 @@ func (c *jsonArrayFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
 	for i := range args {
-		args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		// If arg is a JSON column, we do not need to set the ParseToJSONFlag to it.
+		if _, ok := args[i].(*Column); !ok {
+			args[i].GetType().Flag &= ^mysql.ParseToJSONFlag
+		}
 	}
 	sig := &builtinJSONArraySig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonArraySig)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Do not set ParseToJSONFlag to a JSON column which can avoid the data race when another goroutine tries to read the column's flag.

### What is changed and how it works?
ParseToJSONFlag is used to effect the behavior of castStringAsJSON.
If ParseToJSONFlag is set, we invoke `json.ParseBinaryFromString(str)` to parse this string to a JSON, where `str` must be a valid JSON-string (e.g. '"abc"').
Or, we use json.CreateBinary(str) to wrap this string as a JSON directly without check.

ParseToJSONFlag is introduced to resolve the compatibility of compare function and JSON-related function with MySQL.

e.g.:
``` sql
json_unquote(str)    -- We use CreateBinary(str)
json_merge(str, str) -- We use ParseBinaryFromString(str)
```

For a JSON column, we do not need to set this flag for it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change

Side effects

N/A 

Related changes

 - Need to cherry-pick to the release branch
release-2.1 release-2.0