### PR TITLE
planner/cascades: derive logical property for initial Group built

### DIFF
--- a/docs/design/2018-09-04-histograms-in-plan.md
+++ b/docs/design/2018-09-04-histograms-in-plan.md
@@ -30,7 +30,7 @@ type statsInfo struct {
 }
 ```
 
-This struct will be maintained when we call `deriveStats`.
+This struct will be maintained when we call `DeriveStats`.
 
 ### How to maintain it.
 

--- a/planner/cascades/group.go
+++ b/planner/cascades/group.go
@@ -16,6 +16,8 @@ package cascades
 import (
 	"container/list"
 	"fmt"
+
+	"github.com/pingcap/tidb/planner/property"
 )
 
 // Group is short for expression group, which is used to store all the
@@ -28,6 +30,8 @@ type Group struct {
 
 	explored        bool
 	selfFingerprint string
+
+	prop *property.LogicalProperty
 }
 
 // NewGroup creates a new Group.

--- a/planner/cascades/optimize_test.go
+++ b/planner/cascades/optimize_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cascades
+
+import (
+	. "github.com/pingcap/check"
+	plannercore "github.com/pingcap/tidb/planner/core"
+)
+
+func (s *testCascadesSuite) TestConvert2Group(c *C) {
+	stmt, err := s.ParseOneStmt("select a from t", "", "")
+	c.Assert(err, IsNil)
+	p, err := plannercore.BuildLogicalPlan(s.sctx, stmt, s.is)
+	c.Assert(err, IsNil)
+	logic, ok := p.(plannercore.LogicalPlan)
+	c.Assert(ok, IsTrue)
+	g, err := convert2Group(logic)
+	c.Assert(err, IsNil)
+	c.Assert(g.prop, NotNil)
+	c.Assert(g.prop.Schema.Len(), Equals, 1)
+	c.Assert(g.prop.Stats, NotNil)
+}

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -125,7 +125,7 @@ func logicalOptimize(flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 }
 
 func physicalOptimize(logic LogicalPlan) (PhysicalPlan, error) {
-	if _, err := logic.deriveStats(); err != nil {
+	if _, err := logic.DeriveStats(); err != nil {
 		return nil, errors.Trace(err)
 	}
 

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -82,8 +82,8 @@ type LogicalPlan interface {
 	// pushDownTopN will push down the topN or limit operator during logical optimization.
 	pushDownTopN(topN *LogicalTopN) LogicalPlan
 
-	// deriveStats derives statistic info between plans.
-	deriveStats() (*property.StatsInfo, error)
+	// DeriveStats derives statistic info between plans.
+	DeriveStats() (*property.StatsInfo, error)
 
 	// preparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.

--- a/planner/core/rule_join_reorder_dp.go
+++ b/planner/core/rule_join_reorder_dp.go
@@ -160,7 +160,7 @@ func (s *joinReorderDPSolver) newJoinWithEdge(leftPlan, rightPlan LogicalPlan, e
 		}
 	}
 	join := s.newJoin(leftPlan, rightPlan, eqConds)
-	_, err := join.deriveStats()
+	_, err := join.DeriveStats()
 	return join, err
 }
 

--- a/planner/core/rule_join_reorder_dp_test.go
+++ b/planner/core/rule_join_reorder_dp_test.go
@@ -49,7 +49,7 @@ func (mj mockLogicalJoin) init(ctx sessionctx.Context) *mockLogicalJoin {
 	return &mj
 }
 
-func (mj *mockLogicalJoin) deriveStats() (*property.StatsInfo, error) {
+func (mj *mockLogicalJoin) DeriveStats() (*property.StatsInfo, error) {
 	if mj.stats == nil {
 		mj.stats = mj.statsMap[mj.involvedNodeSet]
 	}

--- a/planner/core/rule_join_reorder_dp_test.go
+++ b/planner/core/rule_join_reorder_dp_test.go
@@ -49,6 +49,7 @@ func (mj mockLogicalJoin) init(ctx sessionctx.Context) *mockLogicalJoin {
 	return &mj
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (mj *mockLogicalJoin) DeriveStats() (*property.StatsInfo, error) {
 	if mj.stats == nil {
 		mj.stats = mj.statsMap[mj.involvedNodeSet]

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -25,6 +25,7 @@ func (p *basePhysicalPlan) StatsCount() float64 {
 	return p.stats.RowCount
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalTableDual) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -40,6 +41,7 @@ func (p *LogicalTableDual) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *baseLogicalPlan) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -90,6 +92,7 @@ func (ds *DataSource) getStatsByFilter(conds expression.CNFExprs) *property.Stat
 	return profile.Scale(selectivity)
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (ds *DataSource) DeriveStats() (*property.StatsInfo, error) {
 	if ds.stats != nil {
 		return ds.stats, nil
@@ -127,6 +130,7 @@ func (ds *DataSource) DeriveStats() (*property.StatsInfo, error) {
 	return ds.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalSelection) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -139,6 +143,7 @@ func (p *LogicalSelection) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalUnionAll) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -159,6 +164,7 @@ func (p *LogicalUnionAll) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalLimit) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -177,6 +183,7 @@ func (p *LogicalLimit) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (lt *LogicalTopN) DeriveStats() (*property.StatsInfo, error) {
 	if lt.stats != nil {
 		return lt.stats, nil
@@ -211,6 +218,7 @@ func getCardinality(cols []*expression.Column, schema *expression.Schema, profil
 	return cardinality
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalProjection) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil
@@ -230,6 +238,7 @@ func (p *LogicalProjection) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (la *LogicalAggregation) DeriveStats() (*property.StatsInfo, error) {
 	if la.stats != nil {
 		return la.stats, nil
@@ -328,6 +337,7 @@ func (p *LogicalJoin) DeriveStats() (*property.StatsInfo, error) {
 	return p.stats, nil
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (la *LogicalApply) DeriveStats() (*property.StatsInfo, error) {
 	if la.stats != nil {
 		return la.stats, nil
@@ -367,6 +377,7 @@ func getSingletonStats(len int) *property.StatsInfo {
 	return ret
 }
 
+// DeriveStats generates StatsInfo for current plan node.
 func (p *LogicalMaxOneRow) DeriveStats() (*property.StatsInfo, error) {
 	if p.stats != nil {
 		return p.stats, nil

--- a/planner/property/logical_property.go
+++ b/planner/property/logical_property.go
@@ -1,0 +1,26 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package property
+
+import (
+	"github.com/pingcap/tidb/expression"
+)
+
+// LogicalProperty stands for logical properties such as schema of expression,
+// or statistics of columns in schema for output of Group.
+// All group expressions in a group share same logical property.
+type LogicalProperty struct {
+	Stats  *StatsInfo
+	Schema *expression.Schema
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

As the title said, derive stats and schema info for initial `Group` built from `LogicalPlan`. In exploration phase, each time we generate a new `Group`, we should also build `LogicalProperty` for it.

### What is changed and how it works?

It's simple. Since `deriveStats` has already been changed to lazy style, we can export it and directly use it here for stats info. For schema, we just use the schema of `LogicalPlan` node.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

N/A

Related changes

This PR should have conflicts with https://github.com/pingcap/tidb/pull/8449, we can resolve them later once anyone is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8568)
<!-- Reviewable:end -->
