### PR TITLE
expression: fix incorrect date arithmitical with negative interval (#8523)

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -1524,7 +1524,7 @@ func extractSingleTimeValue(unit string, format string) (int64, int64, int64, fl
 	if err != nil {
 		return 0, 0, 0, 0, ErrIncorrectDatetimeValue.GenWithStackByArgs(format)
 	}
-	iv := int64(fv + 0.5)
+	iv := int64(math.Round(fv))
 
 	switch strings.ToUpper(unit) {
 	case "MICROSECOND":


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

cherry pick #8523  to release-2.1

### What is changed and how it works?

No conflict happened during cherry-picking.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8574)
<!-- Reviewable:end -->
