### PR TITLE
*: change golang.org/x/net/context to standard context

### DIFF
--- a/cmd/benchdb/main.go
+++ b/cmd/benchdb/main.go
@@ -21,12 +21,12 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/logutil"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/cmd/benchdb/main.go
+++ b/cmd/benchdb/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"math/rand"
@@ -21,7 +22,6 @@ import (
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/tikv"

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -23,8 +24,6 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -24,13 +24,13 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/ddl/callback.go
+++ b/ddl/callback.go
@@ -14,10 +14,10 @@
 package ddl
 
 import (
+	"context"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
-	"golang.org/x/net/context"
 )
 
 // Interceptor is used for DDL.

--- a/ddl/callback.go
+++ b/ddl/callback.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"

--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"

--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -14,12 +14,12 @@
 package ddl
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type TestInterceptor struct {

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -14,11 +14,11 @@
 package ddl
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testColumnChangeSuite{})

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"sync"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testColumnSuite{})

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -14,10 +14,10 @@
 package ddl
 
 import (
+	"context"
 	"reflect"
 	"sync"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -14,13 +14,13 @@
 package ddl_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
@@ -38,7 +39,6 @@ import (
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testStateChangeSuite{})

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -14,6 +14,7 @@
 package ddl_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -23,7 +24,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -49,7 +50,6 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -18,11 +18,11 @@
 package ddl
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
@@ -43,7 +44,6 @@ import (
 	tidbutil "github.com/pingcap/tidb/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/twinj/uuid"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -14,11 +14,11 @@
 package ddl
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
@@ -33,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type DDLForTest interface {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -14,12 +14,12 @@
 package ddl
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/ngaut/pools"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -14,10 +14,10 @@
 package ddl
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testDDLSuite{})

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"sync"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -14,12 +14,12 @@
 package ddl
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"math"
 	"sync"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"

--- a/ddl/fail_db_test.go
+++ b/ddl/fail_db_test.go
@@ -14,11 +14,11 @@
 package ddl_test
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"time"
 
-	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"

--- a/ddl/fail_db_test.go
+++ b/ddl/fail_db_test.go
@@ -18,6 +18,7 @@ import (
 	"math/rand"
 	"time"
 
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testFailDBSuite{})

--- a/ddl/fail_test.go
+++ b/ddl/fail_test.go
@@ -14,12 +14,12 @@
 package ddl
 
 import (
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/types"
-	"golang.org/x/net/context"
 )
 
 func (s *testColumnChangeSuite) TestFailBeforeDecodeArgs(c *C) {

--- a/ddl/fail_test.go
+++ b/ddl/fail_test.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testForeighKeySuite{})

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -14,10 +14,10 @@
 package ddl
 
 import (
+	"context"
 	"strings"
 	"sync"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -14,6 +14,7 @@
 package ddl
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testIndexChangeSuite{})

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -17,12 +17,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
-	"golang.org/x/net/context"
 )
 
 var _ SchemaSyncer = &MockSchemaSyncer{}

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -14,10 +14,10 @@
 package ddl
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -14,11 +14,11 @@
 package ddl
 
 import (
+	"context"
 	"math"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // reorgCtx is for reorganization.

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -14,9 +14,9 @@
 package ddl
 
 import (
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -16,12 +16,12 @@ package ddl
 import (
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/types"
-	"golang.org/x/net/context"
 )
 
 type testCtxKeyType int

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -16,6 +16,7 @@ package ddl
 import (
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testSchemaSuite{})

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -14,9 +14,9 @@
 package ddl
 
 import (
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -14,9 +14,9 @@
 package ddl
 
 import (
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/util/mock"

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -16,11 +16,11 @@ package ddl
 import (
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testStatSuite{})

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -22,13 +22,13 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/owner"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -14,6 +14,7 @@
 package ddl
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -22,7 +23,6 @@ import (
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/ddl"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/tablecodec"
-	"golang.org/x/net/context"
 )
 
 type testDDLTableSplitSuite struct{}

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -15,9 +15,9 @@ package ddl_test
 
 import (
 	"bytes"
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/ddl"

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -16,6 +16,7 @@ package ddl
 import (
 	"fmt"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testTableSuite{})

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -14,9 +14,9 @@
 package ddl
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"

--- a/ddl/util/util.go
+++ b/ddl/util/util.go
@@ -14,10 +14,10 @@
 package util
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/ddl/util/util.go
+++ b/ddl/util/util.go
@@ -17,13 +17,13 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -14,13 +14,13 @@
 package distsql
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/types"
-	"golang.org/x/net/context"
 )
 
 // XAPI error codes.

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -15,6 +15,7 @@ package distsql
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestSelectNormal(c *C) {

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -14,11 +14,11 @@
 package distsql
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -14,9 +14,9 @@
 package distsql
 
 import (
+	"context"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -16,6 +16,7 @@ package distsql
 import (
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -14,6 +14,7 @@
 package distsql
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // streamResult implements the SelectResult interface.

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -15,6 +15,7 @@ package distsql
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/ngaut/pools"
@@ -42,7 +43,6 @@ import (
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/util"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -14,6 +14,7 @@
 package domain
 
 import (
+	"context"
 	"crypto/tls"
 	"os"
 	"sync"
@@ -21,7 +22,6 @@ import (
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/ngaut/pools"

--- a/domain/info.go
+++ b/domain/info.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/printer"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/domain/info.go
+++ b/domain/info.go
@@ -14,11 +14,11 @@
 package domain
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/pingcap/errors"

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -40,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type processinfoSetter interface {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -14,13 +14,13 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"math"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"math"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/executor"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestAdminCheckIndexRange(c *C) {

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -14,10 +14,10 @@
 package executor_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/executor"

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/set"
 	log "github.com/sirupsen/logrus"
 	"github.com/spaolacci/murmur3"
-	"golang.org/x/net/context"
 )
 
 type aggPartialResultMapper map[string][]aggfuncs.PartialResult

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var _ Executor = &AnalyzeExec{}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"runtime"
 	"strconv"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/cznic/sortutil"
 	"github.com/pingcap/errors"
@@ -48,7 +49,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // executorBuilder builds an Executor from a Plan.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -22,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	"github.com/cznic/mathutil"
 	"github.com/cznic/sortutil"
 	"github.com/pingcap/errors"

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"strconv"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/distsql"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var _ Executor = &ChecksumTableExec{}

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"strconv"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/distsql"

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"fmt"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -26,7 +27,6 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Compiler compiles an ast.StmtNode to a physical plan.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // DDLExec represents a DDL executor.

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestTruncateTable(c *C) {

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -14,12 +14,12 @@
 package executor_test
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/expression"
@@ -21,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // DeleteExec represents a delete executor.

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/expression"

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"math"
 	"runtime"
 	"sort"
@@ -22,7 +23,6 @@ import (
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -41,7 +42,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 // TestIndexDoubleReadClose checks that when a index double read returns before reading all the rows, the goroutine doesn't

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -15,13 +15,13 @@ package executor_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"runtime/pprof"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -14,13 +14,13 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/cznic/mathutil"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -44,7 +45,6 @@ import (
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testExecSuite{})

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"math"
@@ -25,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	"github.com/golang/protobuf/proto"
 	. "github.com/pingcap/check"

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	"github.com/golang/protobuf/proto"
 	. "github.com/pingcap/check"
@@ -63,7 +64,6 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // ExplainExec represents an explain executor.

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/util/chunk"

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 /***

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"sort"
@@ -21,7 +22,6 @@ import (
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/mvmap"
 	"github.com/pingcap/tidb/util/ranger"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var _ Executor = &IndexLookUpJoin{}

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // InsertExec represents an insert executor.

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"fmt"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // InsertValues is the data to insert.

--- a/executor/join.go
+++ b/executor/join.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mvmap"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/executor/join.go
+++ b/executor/join.go
@@ -14,13 +14,13 @@
 package executor
 
 import (
+	"context"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -14,9 +14,9 @@
 package executor_test
 
 import (
+	"context"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -16,11 +16,11 @@ package executor_test
 import (
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestJoinPanic(c *C) {

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -15,10 +15,10 @@ package executor
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // LoadDataExec represents a load data executor.

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -16,12 +16,12 @@ package executor
 import (
 	"encoding/json"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 var _ Executor = &LoadStatsExec{}

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/sessionctx"

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -16,12 +16,12 @@ package executor
 import (
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
-	"golang.org/x/net/context"
 )
 
 // MergeJoinExec implements the merge join algorithm.

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
@@ -11,7 +12,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&pkgTestSuite{})

--- a/executor/pkg_test.go
+++ b/executor/pkg_test.go
@@ -1,9 +1,9 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"math"
 	"sort"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"sort"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"strings"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
@@ -25,7 +26,6 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/util/testkit"
 	dto "github.com/prometheus/client_model/go"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestPrepared(c *C) {

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -14,10 +14,10 @@
 package executor_test
 
 import (
+	"context"
 	"math"
 	"strings"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // This file contains the implementation of the physical Projection Operator:

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -14,13 +14,13 @@
 package executor
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // ReplaceExec represents a replace executor.

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"fmt"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 /***

--- a/executor/revoke.go
+++ b/executor/revoke.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"

--- a/executor/set.go
+++ b/executor/set.go
@@ -14,11 +14,11 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"

--- a/executor/set.go
+++ b/executor/set.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // SetExecutor executes set statement.

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -14,13 +14,13 @@
 package executor_test
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestSetVar(c *C) {

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"

--- a/executor/show.go
+++ b/executor/show.go
@@ -15,13 +15,13 @@ package executor
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
-	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/executor/show.go
+++ b/executor/show.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -39,7 +40,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/format"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 // ShowExec represents a show executor.

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -14,10 +14,10 @@
 package executor_test
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestShow(c *C) {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"
@@ -32,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // SimpleExec represents simple statement executor.

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 func (s *testSuite) TestCharsetDatabase(c *C) {

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
-	"golang.org/x/net/context"
 )
 
 // SortExec represents sorting executor.

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -15,10 +15,10 @@ package executor
 
 import (
 	"container/heap"
+	"context"
 	"sort"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // make sure `TableReaderExecutor` implements `Executor`.

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -14,9 +14,9 @@
 package executor
 
 import (
+	"context"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"

--- a/executor/trace.go
+++ b/executor/trace.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"context"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/tracing"
-	"golang.org/x/net/context"
 	"sourcegraph.com/sourcegraph/appdash"
 	traceImpl "sourcegraph.com/sourcegraph/appdash/opentracing"
 )

--- a/executor/trace.go
+++ b/executor/trace.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 
-	"context"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -14,10 +14,10 @@
 package executor
 
 import (
+	"context"
 	"sort"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -17,13 +17,13 @@ import (
 	"sort"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // DirtyDB stores uncommitted write operations for a transaction.

--- a/executor/update.go
+++ b/executor/update.go
@@ -14,6 +14,7 @@
 package executor
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
@@ -22,7 +23,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // UpdateExec represents a new update executor.

--- a/executor/update.go
+++ b/executor/update.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/executor"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 type testBypassSuite struct{}

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -14,12 +14,12 @@
 package executor_test
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/executor"

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
@@ -39,7 +40,6 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testIntegrationSuite{})

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -15,12 +15,12 @@ package expression_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect
-	golang.org/x/net v0.0.0-20181029044818-c44066c5c816
+	golang.org/x/net v0.0.0-20181029044818-c44066c5c816 // indirect
 	golang.org/x/text v0.3.0
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c // indirect
 	google.golang.org/grpc v1.16.0

--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -14,9 +14,8 @@
 package kv
 
 import (
-	"sync"
-
 	"context"
+	"sync"
 )
 
 // InjectionConfig is used for fault injections for KV components.

--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -16,7 +16,7 @@ package kv
 import (
 	"sync"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // InjectionConfig is used for fault injections for KV components.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -14,9 +14,9 @@
 package kv
 
 import (
+	"context"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/execdetails"
-	"golang.org/x/net/context"
 )
 
 // Transaction options

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -15,6 +15,7 @@ package kv
 
 import (
 	"context"
+
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/execdetails"
 )

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -15,6 +15,7 @@ package kv
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -14,9 +14,9 @@
 package kv
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-	"golang.org/x/net/context"
 )
 
 // mockTxn is a txn that returns a retryAble error when called Commit.

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -14,8 +14,8 @@
 package kv
 
 import (
+	"context"
 	. "github.com/pingcap/check"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(testMockSuite{})

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -15,6 +15,7 @@ package kv
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 )
 

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -14,11 +14,11 @@
 package kv
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	log "github.com/sirupsen/logrus"

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -18,10 +18,10 @@ import (
 	"math/rand"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // ContextKey is the type of context's key

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -14,11 +14,11 @@
 package meta_test
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/meta"

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -18,12 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/owner/fail_test.go
+++ b/owner/fail_test.go
@@ -14,13 +14,13 @@
 package owner
 
 import (
+	"context"
 	"math"
 	"net"
 	"os"
 	"testing"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"

--- a/owner/fail_test.go
+++ b/owner/fail_test.go
@@ -20,13 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -14,6 +14,7 @@
 package owner
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"os"
@@ -22,7 +23,6 @@ import (
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
 	"github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -171,8 +171,7 @@ func (m *ownerManager) CampaignOwner(ctx context.Context) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	cancelCtx, _ := context.WithCancel(ctx)
-	go m.campaignLoop(cancelCtx, session)
+	go m.campaignLoop(ctx, session)
 	return nil
 }
 
@@ -204,7 +203,10 @@ func (m *ownerManager) RetireOwner() {
 }
 
 func (m *ownerManager) campaignLoop(ctx context.Context, etcdSession *concurrency.Session) {
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithCancel(ctx)
 	defer func() {
+		cancel()
 		if r := recover(); r != nil {
 			buf := util.GetStack()
 			log.Errorf("[%s] recover panic:%v, %s", m.prompt, r, buf)

--- a/owner/mock.go
+++ b/owner/mock.go
@@ -16,8 +16,8 @@ package owner
 import (
 	"sync/atomic"
 
+	"context"
 	"github.com/pingcap/errors"
-	"golang.org/x/net/context"
 )
 
 var _ Manager = &mockManager{}

--- a/owner/mock.go
+++ b/owner/mock.go
@@ -14,9 +14,9 @@
 package owner
 
 import (
+	"context"
 	"sync/atomic"
 
-	"context"
 	"github.com/pingcap/errors"
 )
 

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -15,6 +15,7 @@ package core_test
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/model"

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -14,6 +14,7 @@
 package core_test
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/model"
@@ -24,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testPlanSuite{})

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -14,6 +14,7 @@
 package core_test
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testValidatorSuite{})

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -15,6 +15,7 @@ package core_test
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -14,13 +14,13 @@
 package privileges
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/stringutil"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -14,11 +14,11 @@
 package privileges_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"

--- a/server/conn.go
+++ b/server/conn.go
@@ -36,6 +36,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -48,7 +49,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"

--- a/server/conn.go
+++ b/server/conn.go
@@ -48,6 +48,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
@@ -63,7 +64,6 @@ import (
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/memory"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -41,11 +41,11 @@ import (
 	"strconv"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/hack"
-	"golang.org/x/net/context"
 )
 
 func (cc *clientConn) handleStmtPrepare(sql string) error {

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -35,13 +35,13 @@
 package server
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"strconv"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"

--- a/server/driver.go
+++ b/server/driver.go
@@ -14,11 +14,11 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"time"
 
-	"context"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"

--- a/server/driver.go
+++ b/server/driver.go
@@ -18,11 +18,11 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // IDriver opens IContext.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -14,11 +14,11 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 // TiDBDriver implements IDriver.

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -27,6 +27,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/gorilla/mux"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -50,7 +51,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -15,6 +15,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -27,7 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/gorilla/mux"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"time"
 
+	"context"
 	"github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -36,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
-	"golang.org/x/net/context"
 )
 
 type TidbTestSuite struct {

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -26,7 +27,6 @@ import (
 	"os"
 	"time"
 
-	"context"
 	"github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"

--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -14,12 +14,12 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
 	"time"
 
-	"context"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"

--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -19,12 +19,12 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var smallCount = 100

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -18,6 +18,7 @@
 package session
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"runtime/debug"
@@ -25,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"
@@ -35,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/timeutil"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -14,9 +14,9 @@
 package session
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/auth"

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -16,6 +16,7 @@ package session
 import (
 	"fmt"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/auth"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testBootstrapSuite{})

--- a/session/session.go
+++ b/session/session.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/ngaut/pools"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -60,7 +61,6 @@ import (
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Session context

--- a/session/session.go
+++ b/session/session.go
@@ -18,6 +18,7 @@
 package session
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -28,7 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/ngaut/pools"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/auth"
@@ -45,7 +46,6 @@ import (
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -14,13 +14,13 @@
 package session_test
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/auth"

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
@@ -38,7 +39,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type domainMap struct {

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -18,12 +18,12 @@
 package session
 
 import (
+	"context"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -14,6 +14,7 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -21,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/session/txn.go
+++ b/session/txn.go
@@ -14,10 +14,10 @@
 package session
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
-	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/executor"

--- a/session/txn.go
+++ b/session/txn.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strings"
 
+	"context"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/executor"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // TxnState wraps kv.Transaction to provide a new kv.Transaction.

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
@@ -37,7 +38,6 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testkit"
 	binlog "github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -14,6 +14,7 @@
 package binloginfo_test
 
 import (
+	"context"
 	"net"
 	"os"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -16,6 +16,7 @@ package sessionctx
 import (
 	"fmt"
 
+	"context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/kvcache"
 	binlog "github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 )
 
 // Context is an interface for transaction and executive args environment.

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -14,9 +14,9 @@
 package sessionctx
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/sessionctx/variable"

--- a/statistics/bootstrap.go
+++ b/statistics/bootstrap.go
@@ -16,6 +16,7 @@ package statistics
 import (
 	"fmt"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, tables statsCache, iter *chunk.Iterator4Chunk) {

--- a/statistics/bootstrap.go
+++ b/statistics/bootstrap.go
@@ -14,9 +14,9 @@
 package statistics
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/ddl.go
+++ b/statistics/ddl.go
@@ -16,6 +16,7 @@ package statistics
 import (
 	"fmt"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 // HandleDDLEvent begins to process a ddl task.

--- a/statistics/ddl.go
+++ b/statistics/ddl.go
@@ -14,9 +14,9 @@
 package statistics
 
 import (
+	"context"
 	"fmt"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/gc.go
+++ b/statistics/gc.go
@@ -14,10 +14,10 @@
 package statistics
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/infoschema"

--- a/statistics/gc.go
+++ b/statistics/gc.go
@@ -17,11 +17,11 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 // GCStats will garbage collect the useless stats info. For dropped tables, we will first update their version so that

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -15,12 +15,12 @@ package statistics
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -33,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // Histogram represents statistics for a column or index.

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -14,10 +14,10 @@
 package statistics
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math/rand"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // SampleCollector will collect Samples and calculate the count and ndv of an attribute.

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -32,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -14,11 +14,11 @@
 package statistics
 
 import (
+	"context"
 	"math"
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type tableDeltaMap map[int64]variable.TableDelta

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -14,6 +14,7 @@
 package statistics
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"

--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 var errStopped = errors.New("stopped")

--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -14,13 +14,12 @@
 package mockoracle
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-
-	"context"
 )
 
 var errStopped = errors.New("stopped")

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -15,6 +15,7 @@ package mocktikv
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -14,13 +14,13 @@
 package mocktikv
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 type aggCtxsMapper map[string][]*aggregation.AggEvaluateContext

--- a/store/mockstore/mocktikv/analyze.go
+++ b/store/mockstore/mocktikv/analyze.go
@@ -15,6 +15,7 @@ package mocktikv
 
 import (
 	"context"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"

--- a/store/mockstore/mocktikv/analyze.go
+++ b/store/mockstore/mocktikv/analyze.go
@@ -14,6 +14,7 @@
 package mocktikv
 
 import (
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 func (h *rpcHandler) handleCopAnalyzeRequest(req *coprocessor.Request) *coprocessor.Response {

--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -18,11 +18,11 @@ import (
 	"math"
 	"sync"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/tablecodec"
-	"golang.org/x/net/context"
 )
 
 // Cluster simulates a TiKV cluster. It focuses on management and the change of

--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -15,10 +15,10 @@ package mocktikv
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"sync"
 
-	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"

--- a/store/mockstore/mocktikv/cluster_test.go
+++ b/store/mockstore/mocktikv/cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testClusterSuite{})

--- a/store/mockstore/mocktikv/cluster_test.go
+++ b/store/mockstore/mocktikv/cluster_test.go
@@ -15,11 +15,11 @@ package mocktikv_test
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"strconv"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -37,7 +38,6 @@ import (
 	mockpkg "github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -15,10 +15,10 @@ package mocktikv
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"time"
 
-	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"

--- a/store/mockstore/mocktikv/executor.go
+++ b/store/mockstore/mocktikv/executor.go
@@ -15,10 +15,10 @@ package mocktikv
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"sort"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/model"

--- a/store/mockstore/mocktikv/executor.go
+++ b/store/mockstore/mocktikv/executor.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"sort"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/model"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/store/mockstore/mocktikv/pd.go
+++ b/store/mockstore/mocktikv/pd.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"
-	"golang.org/x/net/context"
 )
 
 // Use global variables to prevent pdClients from creating duplicate timestamps.

--- a/store/mockstore/mocktikv/pd.go
+++ b/store/mockstore/mocktikv/pd.go
@@ -14,10 +14,10 @@
 package mocktikv
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -749,6 +749,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		ctx1, cancel := context.WithCancel(ctx)
 		copStream, err := handler.handleCopStream(ctx1, r)
 		if err != nil {
+			cancel()
 			return nil, errors.Trace(err)
 		}
 

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"time"
 
+	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -28,7 +29,6 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 )
 
 // For gofail injection.

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -15,11 +15,11 @@ package mocktikv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"time"
 
-	"context"
 	"github.com/golang/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -21,12 +21,12 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -14,6 +14,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -21,7 +22,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -15,12 +15,12 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"math"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/terror"

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/terror"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	binlog "github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type twoPhaseCommitAction int

--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
-	"golang.org/x/net/context"
 )
 
 // TestFailCommitPrimaryRpcErrors tests rpc errors are handled properly when

--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -19,12 +19,12 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 )
 
 type testCommitterSuite struct {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -14,13 +14,13 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -20,13 +20,13 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -15,13 +15,13 @@
 package tikv
 
 import (
+	"context"
 	"io"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/grpc-ecosystem/go-grpc-middleware"
 	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -32,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -263,6 +263,7 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	ctx1, cancel := context.WithCancel(ctx)
 	resp, err := tikvrpc.CallRPC(ctx1, client, req)
 	if err != nil {
+		cancel() // This line stops the silly lint tool from complaining.
 		return nil, errors.Trace(err)
 	}
 

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -23,7 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tipb/go-tipb"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // CopClient is coprocessor client.

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -14,11 +14,11 @@
 package tikv
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
-	"golang.org/x/net/context"
 )
 
 type testCoprocessorSuite struct {

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -40,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	tidbutil "github.com/pingcap/tidb/util"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // GCWorker periodically triggers GC process on tikv server.

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -15,6 +15,7 @@ package gcworker
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -23,7 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -14,12 +14,12 @@
 package gcworker
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"testing"
 	"time"
 
-	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/errorpb"

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/errorpb"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/store/tikv/isolation_test.go
+++ b/store/tikv/isolation_test.go
@@ -16,12 +16,12 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/isolation_test.go
+++ b/store/tikv/isolation_test.go
@@ -21,10 +21,10 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
-	"golang.org/x/net/context"
 )
 
 // The test suite takes too long under the race detector.

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pingcap/errors"
@@ -34,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle/oracles"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -14,6 +14,7 @@
 package tikv
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math/rand"
@@ -22,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/pingcap/errors"

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -15,11 +15,11 @@ package tikv
 
 import (
 	"container/list"
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/pd/client"

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/pd/client"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // ResolvedCacheSize is max number of cached txn status.

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -14,11 +14,11 @@
 package tikv
 
 import (
+	"context"
 	"math"
 	"runtime"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -18,11 +18,11 @@ import (
 	"runtime"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 )
 
 type testLockSuite struct {

--- a/store/tikv/oracle/oracle.go
+++ b/store/tikv/oracle/oracle.go
@@ -16,7 +16,7 @@ package oracle
 import (
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Oracle is the interface that provides strictly ascending timestamps.

--- a/store/tikv/oracle/oracle.go
+++ b/store/tikv/oracle/oracle.go
@@ -14,9 +14,8 @@
 package oracle
 
 import (
-	"time"
-
 	"context"
+	"time"
 )
 
 // Oracle is the interface that provides strictly ascending timestamps.

--- a/store/tikv/oracle/oracles/local.go
+++ b/store/tikv/oracle/oracles/local.go
@@ -14,10 +14,10 @@
 package oracles
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )
 

--- a/store/tikv/oracle/oracles/local.go
+++ b/store/tikv/oracle/oracles/local.go
@@ -17,8 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-	"golang.org/x/net/context"
 )
 
 var _ oracle.Oracle = &localOracle{}

--- a/store/tikv/oracle/oracles/local_test.go
+++ b/store/tikv/oracle/oracles/local_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 func TestLocalOracle(t *testing.T) {

--- a/store/tikv/oracle/oracles/local_test.go
+++ b/store/tikv/oracle/oracles/local_test.go
@@ -14,10 +14,9 @@
 package oracles
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"context"
 )
 
 func TestLocalOracle(t *testing.T) {

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -14,10 +14,10 @@
 package oracles
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -17,12 +17,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var _ oracle.Oracle = &pdOracle{}

--- a/store/tikv/pd_codec.go
+++ b/store/tikv/pd_codec.go
@@ -14,11 +14,11 @@
 package tikv
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 type codecPDClient struct {

--- a/store/tikv/pd_codec.go
+++ b/store/tikv/pd_codec.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -17,13 +17,13 @@ import (
 	"bytes"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -15,9 +15,9 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/pd/client"

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -15,9 +15,9 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -17,9 +17,9 @@ import (
 	"bytes"
 	"fmt"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
-	"golang.org/x/net/context"
 )
 
 type testRawKVSuite struct {

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -15,11 +15,11 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/google/btree"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/google/btree"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -19,9 +19,9 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
-	"golang.org/x/net/context"
 )
 
 type testRegionCacheSuite struct {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -14,9 +14,9 @@
 package tikv
 
 import (
+	"context"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"net"
 	"strings"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )
 

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"crypto/tls"
 	"strconv"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/errors"
 	log "github.com/sirupsen/logrus"

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -19,10 +19,10 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/pingcap/errors"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Safe point constants.

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -17,11 +17,11 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
-	"golang.org/x/net/context"
 )
 
 type testSafePointSuite struct {

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // Scanner support tikv scan

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 )

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -14,9 +14,9 @@
 package tikv
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
-	"golang.org/x/net/context"
 )
 
 type testScanMockSuite struct {

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 )

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -17,9 +17,9 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
-	"golang.org/x/net/context"
 )
 
 type testScanSuite struct {

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -15,12 +15,12 @@ package tikv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sync"
 	"time"
 	"unsafe"
 
-	"context"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unsafe"
 
+	"context"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/tablecodec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -17,11 +17,11 @@ import (
 	"fmt"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 type testSnapshotSuite struct {

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -16,12 +16,12 @@ package tikv
 import (
 	"bytes"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 // SplitRegion splits the region contains splitKey into 2 regions: [start,

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -15,8 +15,8 @@ package tikv
 
 import (
 	"bytes"
-
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
-	"golang.org/x/net/context"
 )
 
 type testSplitSuite struct {

--- a/store/tikv/sql_fail_test.go
+++ b/store/tikv/sql_fail_test.go
@@ -14,11 +14,11 @@
 package tikv_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"

--- a/store/tikv/sql_fail_test.go
+++ b/store/tikv/sql_fail_test.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
@@ -26,7 +27,6 @@ import (
 	. "github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(new(testSQLSuite))

--- a/store/tikv/store_fail_test.go
+++ b/store/tikv/store_fail_test.go
@@ -17,9 +17,9 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
-	"golang.org/x/net/context"
 )
 
 func (s *testStoreSuite) TestFailBusyServerKV(c *C) {

--- a/store/tikv/store_fail_test.go
+++ b/store/tikv/store_fail_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	gofail "github.com/etcd-io/gofail/runtime"
 	. "github.com/pingcap/check"
 )

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -14,10 +14,10 @@
 package tikv
 
 import (
+	"context"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-	"golang.org/x/net/context"
 )
 
 var errStopped = errors.New("stopped")

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -14,12 +14,12 @@
 package tikv
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -19,12 +19,12 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/codec"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -14,11 +14,11 @@
 package tikvrpc
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/errorpb"

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -18,13 +18,13 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
-	"golang.org/x/net/context"
 )
 
 // CmdType represents the concrete request type in Request or response type in Response.

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -14,11 +14,11 @@
 package tikv
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -18,12 +18,12 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/structure/structure_test.go
+++ b/structure/structure_test.go
@@ -16,12 +16,12 @@ package structure_test
 import (
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/structure"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestTxStructure(t *testing.T) {

--- a/structure/structure_test.go
+++ b/structure/structure_test.go
@@ -14,9 +14,9 @@
 package structure_test
 
 import (
+	"context"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -14,10 +14,10 @@
 package tables_test
 
 import (
+	"context"
 	"io"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testIndexSuite{})

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -18,13 +18,13 @@
 package tables
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"math"
 	"strings"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -42,7 +43,6 @@ import (
 	binlog "github.com/pingcap/tipb/go-binlog"
 	log "github.com/sirupsen/logrus"
 	"github.com/spaolacci/murmur3"
-	"golang.org/x/net/context"
 )
 
 // tableCommon is shared by both Table and partition.

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -16,6 +16,7 @@ package tables_test
 import (
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -14,9 +14,9 @@
 package tables_test
 
 import (
+	"context"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"

--- a/types/const_test.go
+++ b/types/const_test.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/mysql"
@@ -27,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/types/const_test.go
+++ b/types/const_test.go
@@ -14,10 +14,10 @@
 package types_test
 
 import (
+	"context"
 	"flag"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/mysql"

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -14,11 +14,11 @@
 package admin_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
@@ -35,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 func TestT(t *testing.T) {

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"
@@ -30,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/tablecodec"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 )
 
 var _ KvEncoder = &kvEncoder{}

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -15,12 +15,12 @@ package kvenc
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"

--- a/util/mock/client.go
+++ b/util/mock/client.go
@@ -14,9 +14,9 @@
 package mock
 
 import (
+	"context"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tipb/go-tipb"
-	"golang.org/x/net/context"
 )
 
 // Client implement kv.Client interface, mocked from "CopClient" defined in

--- a/util/mock/client.go
+++ b/util/mock/client.go
@@ -15,6 +15,7 @@ package mock
 
 import (
 	"context"
+
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tipb/go-tipb"
 )

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/owner"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tidb/util/sqlexec"
 	binlog "github.com/pingcap/tipb/go-binlog"
-	"golang.org/x/net/context"
 )
 
 var _ sessionctx.Context = (*Context)(nil)

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -15,11 +15,11 @@
 package mock
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
-	"context"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/owner"

--- a/util/prefix_helper_test.go
+++ b/util/prefix_helper_test.go
@@ -14,10 +14,10 @@
 package util_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
-	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"

--- a/util/prefix_helper_test.go
+++ b/util/prefix_helper_test.go
@@ -17,12 +17,12 @@ import (
 	"fmt"
 	"testing"
 
+	"context"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testleak"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -15,6 +15,7 @@ package sqlexec
 
 import (
 	"context"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -14,10 +14,10 @@
 package sqlexec
 
 import (
+	"context"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
-	"golang.org/x/net/context"
 )
 
 // RestrictedSQLExecutor is an interface provides executing restricted sql statement.

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -19,13 +19,13 @@ import (
 	"sort"
 	"sync/atomic"
 
+	"context"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testutil"
-	"golang.org/x/net/context"
 )
 
 // TestKit is a utility to run sql test.

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -15,11 +15,11 @@ package testkit
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"sort"
 	"sync/atomic"
 
-	"context"
 	"github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"

--- a/util/tracing/util.go
+++ b/util/tracing/util.go
@@ -14,9 +14,9 @@
 package tracing
 
 import (
+	"context"
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
-	"golang.org/x/net/context"
 )
 
 // TiDBTrace is set as Baggage on traces which are used for tidb tracing.

--- a/util/tracing/util.go
+++ b/util/tracing/util.go
@@ -15,6 +15,7 @@ package tracing
 
 import (
 	"context"
+
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 )

--- a/util/tracing/util_test.go
+++ b/util/tracing/util_test.go
@@ -18,10 +18,10 @@ import (
 
 	. "github.com/pingcap/check"
 
+	"context"
 	basictracer "github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/tidb/util/tracing"
-	"golang.org/x/net/context"
 )
 
 var _ = Suite(&testTraceSuite{})

--- a/util/tracing/util_test.go
+++ b/util/tracing/util_test.go
@@ -14,13 +14,12 @@
 package tracing_test
 
 import (
+	"context"
 	"testing"
 
-	. "github.com/pingcap/check"
-
-	"context"
 	basictracer "github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
+	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/tracing"
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Replace "golang.net/x/context" with standard "context"

It's a long time since https://github.com/pingcap/tidb/pull/2890, when many dependent libraries are still using "golang.net/x/context",
TiDB choose to use "golang.net/x/context"  for compatibility

I'm not sure the standard context works now, but it worth a try.

### What is changed and how it works?

run `GO111MODULE=on go fix ./...`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Side effects

 - Maybe compatibility issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8579)
<!-- Reviewable:end -->
