### PR TITLE
server: add http api for get ddl history 

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -159,12 +159,12 @@ timezone.*
     curl -X POST http://{TiDBIP}:10080/ddl/owner/resign
     ```
     
-1. Get TiDB all ddl job history information.
+1. Get all TiDB DDL job history information.
 	```shell
 	curl http://{TiDBIP}:10080/ddl/history
 	```
 
-1. Get TiDB all ddl job history information can limit the number of displays.
+1. Get count {number} TiDB DDL job history information.
 	```shell
 	curl http://{TiDBIP}:10080/ddl/history?limit={number}
 	```

--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -159,4 +159,13 @@ timezone.*
     curl -X POST http://{TiDBIP}:10080/ddl/owner/resign
     ```
     
+1. Get TiDB all ddl job history information.
+	```shell
+	curl http://{TiDBIP}:10080/ddl/history
+	```
+
+1. Get TiDB all ddl job history information can limit the number of displays.
+	```shell
+	curl http://{TiDBIP}:10080/ddl/history?limit={number}
+	```
     **Note**: If you request a tidb that is not ddl owner, the response will be `This node is not a ddl owner, can't be resigned.`


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
From https://github.com/pingcap/tidb/pull/6245

Add `http api` query the all ddl history.

```shell
curl http://{TiDBIP}:10080/ddl/history
```

Get all ddl job history information can limit the number of displays.

```shell
curl http://{TiDBIP}:10080/ddl/history?limit={number}
```



### What is changed and how it works?





<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8256)
<!-- Reviewable:end -->
