### PR TITLE
ddl: fast fail check for create index to accelerate CI

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2035,6 +2035,12 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, unique bool, ind
 		return errors.Trace(err)
 	}
 
+	// Check before put the job is put to the queue.
+	_, err = buildIndexColumns(t.Meta().Columns, idxColNames)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	if indexOption != nil {
 		// May be truncate comment here, when index comment too long and sql_mode is't strict.
 		indexOption.Comment, err = validateCommentLength(ctx.GetSessionVars(),

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2036,6 +2036,10 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, unique bool, ind
 	}
 
 	// Check before put the job is put to the queue.
+	// This check is redudant, but useful. If DDL check fail before the job is put
+	// to job queue, the fail path logic is super fast.
+	// After DDL job is put to the queue, and if the check fail, TiDB will run the DDL cancel logic.
+	// The recover step causes DDL wait a few seconds, makes the unit test painfully slow.
 	_, err = buildIndexColumns(t.Meta().Columns, idxColNames)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make the CI run faster !

```
➜  session git:(master) ✗ GO111MODULE=on go test  -check.f TestIndexMaxLength
before:
ok  	github.com/pingcap/tidb/session	18.229s
after:
ok  	github.com/pingcap/tidb/session	0.146s
```

### What is changed and how it works?

If DDL check fail before the job is put to job queue, the fail path logic is super fast.
After DDL job is put to the queue, and if the check fail, TiDB will run the DDL cancel process, 
and the recover step cause DDL wait few seconds, that's painfully slow.

In unit test session.TestIndexMaxLength, it cover a index key lengh too long case, and triggers the DDL fail logic.
Each time that logic is triggered, it waits about 3s ... the total test runs 18s

This commit add a check for create index before the job is put to the job queue.

 - No code

@winkyao @zimulala @jackysp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8592)
<!-- Reviewable:end -->
