### PR TITLE
stats: optimize unit test execution time

### DIFF
--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -87,7 +87,7 @@ func (s *testStatisticsSuite) TestCMSketch(c *C) {
 		},
 	}
 	d, w := int32(5), int32(2048)
-	total, imax := uint64(1000000), uint64(10000000)
+	total, imax := uint64(100000), uint64(1000000)
 	for _, t := range tests {
 		lSketch, lMap, err := buildCMSketchAndMap(d, w, 0, total, imax, t.zipfFactor)
 		c.Check(err, IsNil)

--- a/statistics/ddl_test.go
+++ b/statistics/ddl_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testStatsCacheSuite) TestDDLAfterLoad(c *C) {
+func (s *testStatsSuite) TestDDLAfterLoad(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -55,7 +55,7 @@ func (s *testStatsCacheSuite) TestDDLAfterLoad(c *C) {
 	c.Assert(int(count), Equals, 333)
 }
 
-func (s *testStatsCacheSuite) TestDDLTable(c *C) {
+func (s *testStatsSuite) TestDDLTable(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -95,7 +95,7 @@ func (s *testStatsCacheSuite) TestDDLTable(c *C) {
 	c.Assert(statsTbl.Pseudo, IsFalse)
 }
 
-func (s *testStatsCacheSuite) TestDDLHistogram(c *C) {
+func (s *testStatsSuite) TestDDLHistogram(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	do := s.do
@@ -172,7 +172,7 @@ func (s *testStatsCacheSuite) TestDDLHistogram(c *C) {
 	rs.Check(testkit.Rows("2"))
 }
 
-func (s *testStatsCacheSuite) TestDDLPartition(c *C) {
+func (s *testStatsSuite) TestDDLPartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")

--- a/statistics/gc_test.go
+++ b/statistics/gc_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testStatsUpdateSuite) TestGCStats(c *C) {
+func (s *testStatsSuite) TestGCStats(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -53,7 +53,7 @@ func (s *testStatsUpdateSuite) TestGCStats(c *C) {
 	testKit.MustQuery("select count(*) from mysql.stats_meta").Check(testkit.Rows("0"))
 }
 
-func (s *testStatsUpdateSuite) TestGCPartition(c *C) {
+func (s *testStatsSuite) TestGCPartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")

--- a/statistics/handle_test.go
+++ b/statistics/handle_test.go
@@ -29,28 +29,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 )
-
-var _ = Suite(&testStatsCacheSuite{})
-
-type testStatsCacheSuite struct {
-	store kv.Storage
-	do    *domain.Domain
-}
-
-func (s *testStatsCacheSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
-	var err error
-	s.store, s.do, err = newStoreWithBootstrap(0)
-	c.Assert(err, IsNil)
-}
-
-func (s *testStatsCacheSuite) TearDownSuite(c *C) {
-	s.do.Close()
-	s.store.Close()
-	testleak.AfterTest(c)()
-}
 
 func cleanEnv(c *C, store kv.Storage, do *domain.Domain) {
 	tk := testkit.NewTestKit(c, store)
@@ -60,13 +39,13 @@ func cleanEnv(c *C, store kv.Storage, do *domain.Domain) {
 		tableName := tb[0]
 		tk.MustExec(fmt.Sprintf("drop table %v", tableName))
 	}
-	tk.MustExec("truncate table mysql.stats_meta")
-	tk.MustExec("truncate table mysql.stats_histograms")
-	tk.MustExec("truncate table mysql.stats_buckets")
+	tk.MustExec("delete from mysql.stats_meta")
+	tk.MustExec("delete from mysql.stats_histograms")
+	tk.MustExec("delete from mysql.stats_buckets")
 	do.StatsHandle().Clear()
 }
 
-func (s *testStatsCacheSuite) TestStatsCache(c *C) {
+func (s *testStatsSuite) TestStatsCache(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -135,7 +114,7 @@ func assertTableEqual(c *C, a *statistics.Table, b *statistics.Table) {
 	}
 }
 
-func (s *testStatsCacheSuite) TestStatsStoreAndLoad(c *C) {
+func (s *testStatsSuite) TestStatsStoreAndLoad(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -162,7 +141,7 @@ func (s *testStatsCacheSuite) TestStatsStoreAndLoad(c *C) {
 	assertTableEqual(c, statsTbl1, statsTbl2)
 }
 
-func (s *testStatsCacheSuite) TestEmptyTable(c *C) {
+func (s *testStatsSuite) TestEmptyTable(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -179,7 +158,7 @@ func (s *testStatsCacheSuite) TestEmptyTable(c *C) {
 	c.Assert(count, Equals, 0.0)
 }
 
-func (s *testStatsCacheSuite) TestColumnIDs(c *C) {
+func (s *testStatsSuite) TestColumnIDs(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -210,7 +189,7 @@ func (s *testStatsCacheSuite) TestColumnIDs(c *C) {
 	c.Assert(count, Equals, 0.0)
 }
 
-func (s *testStatsCacheSuite) TestAvgColLen(c *C) {
+func (s *testStatsSuite) TestAvgColLen(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -238,7 +217,7 @@ func (s *testStatsCacheSuite) TestAvgColLen(c *C) {
 	c.Assert(statsTbl.Columns[tableInfo.Columns[3].ID].AvgColSize(statsTbl.Count), Equals, 16.0)
 }
 
-func (s *testStatsCacheSuite) TestDurationToTS(c *C) {
+func (s *testStatsSuite) TestDurationToTS(c *C) {
 	tests := []time.Duration{time.Millisecond, time.Second, time.Minute, time.Hour}
 	for _, t := range tests {
 		ts := statistics.DurationToTS(t)
@@ -246,7 +225,7 @@ func (s *testStatsCacheSuite) TestDurationToTS(c *C) {
 	}
 }
 
-func (s *testStatsCacheSuite) TestVersion(c *C) {
+func (s *testStatsSuite) TestVersion(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -323,7 +302,7 @@ func (s *testStatsCacheSuite) TestVersion(c *C) {
 	c.Assert(statsTbl2.Columns[int64(3)], NotNil)
 }
 
-func (s *testStatsCacheSuite) TestLoadHist(c *C) {
+func (s *testStatsSuite) TestLoadHist(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -381,7 +360,7 @@ func (s *testStatsCacheSuite) TestLoadHist(c *C) {
 	c.Assert(newStatsTbl2.Columns[int64(3)].LastUpdateVersion, Greater, newStatsTbl2.Columns[int64(1)].LastUpdateVersion)
 }
 
-func (s *testStatsCacheSuite) TestInitStats(c *C) {
+func (s *testStatsSuite) TestInitStats(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -406,24 +385,25 @@ func (s *testStatsCacheSuite) TestInitStats(c *C) {
 	h.Lease = 0
 }
 
-func (s *testStatsUpdateSuite) TestLoadStats(c *C) {
+func (s *testStatsSuite) TestLoadStats(c *C) {
 	defer cleanEnv(c, s.store, s.do)
-	store, do, err := newStoreWithBootstrap(10 * time.Millisecond)
-	c.Assert(err, IsNil)
-	defer store.Close()
-	defer do.Close()
-	testKit := testkit.NewTestKit(c, store)
+	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
 	testKit.MustExec("create table t(a int, b int, c int, primary key(a), key idx(b))")
 	testKit.MustExec("insert into t values (1,1,1),(2,2,2),(3,3,3)")
+
+	oriLease := s.do.StatsHandle().Lease
+	s.do.StatsHandle().Lease = 1
+	defer func() {
+		s.do.StatsHandle().Lease = oriLease
+	}()
 	testKit.MustExec("analyze table t")
 
-	is := do.InfoSchema()
+	is := s.do.InfoSchema()
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	c.Assert(err, IsNil)
 	tableInfo := tbl.Meta()
-	h := do.StatsHandle()
-	time.Sleep(1 * time.Second)
+	h := s.do.StatsHandle()
 	stat := h.GetTableStats(tableInfo)
 	hg := stat.Columns[tableInfo.Columns[0].ID].Histogram
 	c.Assert(hg.Len(), Greater, 0)
@@ -439,7 +419,7 @@ func (s *testStatsUpdateSuite) TestLoadStats(c *C) {
 	c.Assert(cms, IsNil)
 	_, err = stat.ColumnEqualRowCount(testKit.Se.GetSessionVars().StmtCtx, types.NewIntDatum(1), tableInfo.Columns[2].ID)
 	c.Assert(err, IsNil)
-	time.Sleep(1 * time.Second)
+	c.Assert(h.LoadNeededHistograms(), IsNil)
 	stat = h.GetTableStats(tableInfo)
 	hg = stat.Columns[tableInfo.Columns[2].ID].Histogram
 	c.Assert(hg.Len(), Greater, 0)

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -24,8 +24,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/tidb/domain"
-	"github.com/pingcap/tidb/kv"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
@@ -39,28 +37,9 @@ import (
 
 const eps = 1e-9
 
-var _ = Suite(&testSelectivitySuite{})
-
-type testSelectivitySuite struct {
-	store kv.Storage
-	dom   *domain.Domain
-}
-
-func (s *testSelectivitySuite) SetUpSuite(c *C) {
-	store, dom, err := newStoreWithBootstrap(0)
-	c.Assert(err, IsNil)
-	s.dom = dom
-	s.store = store
-}
-
-func (s *testSelectivitySuite) TearDownSuite(c *C) {
-	s.dom.Close()
-	s.store.Close()
-}
-
 // generateIntDatum will generate a datum slice, every dimension is begin from 0, end with num - 1.
 // If dimension is x, num is y, the total number of datum is y^x. And This slice is sorted.
-func (s *testSelectivitySuite) generateIntDatum(dimension, num int) ([]types.Datum, error) {
+func (s *testStatsSuite) generateIntDatum(dimension, num int) ([]types.Datum, error) {
 	length := int(math.Pow(float64(num), float64(dimension)))
 	ret := make([]types.Datum, length)
 	if dimension == 1 {
@@ -111,12 +90,12 @@ func mockStatsTable(tbl *model.TableInfo, rowCount int64) *statistics.Table {
 	return statsTbl
 }
 
-func (s *testSelectivitySuite) prepareSelectivity(testKit *testkit.TestKit, c *C) *statistics.Table {
+func (s *testStatsSuite) prepareSelectivity(testKit *testkit.TestKit, c *C) *statistics.Table {
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
 	testKit.MustExec("create table t(a int primary key, b int, c int, d int, e int, index idx_cd(c, d), index idx_de(d, e))")
 
-	is := s.dom.InfoSchema()
+	is := s.do.InfoSchema()
 	tb, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	c.Assert(err, IsNil)
 	tbl := tb.Meta()
@@ -139,10 +118,11 @@ func (s *testSelectivitySuite) prepareSelectivity(testKit *testkit.TestKit, c *C
 	return statsTbl
 }
 
-func (s *testSelectivitySuite) TestSelectivity(c *C) {
+func (s *testStatsSuite) TestSelectivity(c *C) {
+	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	statsTbl := s.prepareSelectivity(testKit, c)
-	is := s.dom.InfoSchema()
+	is := s.do.InfoSchema()
 
 	tests := []struct {
 		exprs       string
@@ -212,7 +192,8 @@ func (s *testSelectivitySuite) TestSelectivity(c *C) {
 
 // TestDiscreteDistribution tests the estimation for discrete data distribution. This is more common when the index
 // consists several columns, and the first column has small NDV.
-func (s *testSelectivitySuite) TestDiscreteDistribution(c *C) {
+func (s *testStatsSuite) TestDiscreteDistribution(c *C) {
+	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
@@ -229,7 +210,8 @@ func (s *testSelectivitySuite) TestDiscreteDistribution(c *C) {
 		"└─IndexScan_8 0.00 cop table:t, index:a, b, range:[\"tw\" -inf,\"tw\" 0), keep order:false"))
 }
 
-func (s *testSelectivitySuite) TestSelectCombinedLowBound(c *C) {
+func (s *testStatsSuite) TestSelectCombinedLowBound(c *C) {
+	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
@@ -249,7 +231,8 @@ func getRange(start, end int64) []*ranger.Range {
 	return []*ranger.Range{ran}
 }
 
-func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
+func (s *testStatsSuite) TestEstimationForUnknownValues(c *C) {
+	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
@@ -258,15 +241,15 @@ func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
 	for i := 0; i < 10; i++ {
 		testKit.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i, i))
 	}
-	h := s.dom.StatsHandle()
+	h := s.do.StatsHandle()
 	h.DumpStatsDeltaToKV(statistics.DumpAll)
 	testKit.MustExec("analyze table t")
 	for i := 0; i < 10; i++ {
 		testKit.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i+10, i+10))
 	}
 	h.DumpStatsDeltaToKV(statistics.DumpAll)
-	c.Assert(h.Update(s.dom.InfoSchema()), IsNil)
-	table, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(h.Update(s.do.InfoSchema()), IsNil)
+	table, err := s.do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	c.Assert(err, IsNil)
 	statsTbl := h.GetTableStats(table.Meta())
 
@@ -296,7 +279,7 @@ func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
 	testKit.MustExec("truncate table t")
 	testKit.MustExec("insert into t values (null, null)")
 	testKit.MustExec("analyze table t")
-	table, err = s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	table, err = s.do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	c.Assert(err, IsNil)
 	statsTbl = h.GetTableStats(table.Meta())
 
@@ -309,7 +292,7 @@ func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
 	testKit.MustExec("create table t(a int, b int, index idx(b))")
 	testKit.MustExec("insert into t values (1,1)")
 	testKit.MustExec("analyze table t")
-	table, err = s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	table, err = s.do.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
 	c.Assert(err, IsNil)
 	statsTbl = h.GetTableStats(table.Meta())
 
@@ -324,7 +307,8 @@ func (s *testSelectivitySuite) TestEstimationForUnknownValues(c *C) {
 	c.Assert(count, Equals, 0.0)
 }
 
-func (s *testSelectivitySuite) TestPrimaryKeySelectivity(c *C) {
+func (s *testStatsSuite) TestPrimaryKeySelectivity(c *C) {
+	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
@@ -343,13 +327,13 @@ func (s *testSelectivitySuite) TestPrimaryKeySelectivity(c *C) {
 
 func BenchmarkSelectivity(b *testing.B) {
 	c := &C{}
-	s := &testSelectivitySuite{}
+	s := &testStatsSuite{}
 	s.SetUpSuite(c)
 	defer s.TearDownSuite(c)
 
 	testKit := testkit.NewTestKit(c, s.store)
 	statsTbl := s.prepareSelectivity(testKit, c)
-	is := s.dom.InfoSchema()
+	is := s.do.InfoSchema()
 	exprs := "a > 1 and b < 2 and c > 3 and d < 4 and e > 5"
 	sql := "select * from t where " + exprs
 	comment := Commentf("for %s", exprs)

--- a/statistics/update_test.go
+++ b/statistics/update_test.go
@@ -35,15 +35,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ = Suite(&testStatsUpdateSuite{})
+var _ = Suite(&testStatsSuite{})
 
-type testStatsUpdateSuite struct {
+type testStatsSuite struct {
 	store kv.Storage
 	do    *domain.Domain
 	hook  logHook
 }
 
-func (s *testStatsUpdateSuite) SetUpSuite(c *C) {
+func (s *testStatsSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
 	// Add the hook here to avoid data race.
 	log.AddHook(&s.hook)
@@ -52,13 +52,13 @@ func (s *testStatsUpdateSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *testStatsUpdateSuite) TearDownSuite(c *C) {
+func (s *testStatsSuite) TearDownSuite(c *C) {
 	s.do.Close()
 	s.store.Close()
 	testleak.AfterTest(c)()
 }
 
-func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
+func (s *testStatsSuite) TestSingleSessionInsert(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -179,7 +179,7 @@ func (s *testStatsUpdateSuite) TestSingleSessionInsert(c *C) {
 	c.Assert(stats1.Count, Equals, int64(rowCount1+1))
 }
 
-func (s *testStatsUpdateSuite) TestRollback(c *C) {
+func (s *testStatsSuite) TestRollback(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -202,7 +202,7 @@ func (s *testStatsUpdateSuite) TestRollback(c *C) {
 	c.Assert(stats.ModifyCount, Equals, int64(0))
 }
 
-func (s *testStatsUpdateSuite) TestMultiSession(c *C) {
+func (s *testStatsSuite) TestMultiSession(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -259,7 +259,7 @@ func (s *testStatsUpdateSuite) TestMultiSession(c *C) {
 	rs.Check(testkit.Rows("60"))
 }
 
-func (s *testStatsUpdateSuite) TestTxnWithFailure(c *C) {
+func (s *testStatsSuite) TestTxnWithFailure(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -305,7 +305,7 @@ func (s *testStatsUpdateSuite) TestTxnWithFailure(c *C) {
 	c.Assert(stats1.Count, Equals, int64(rowCount1+1))
 }
 
-func (s *testStatsUpdateSuite) TestUpdatePartition(c *C) {
+func (s *testStatsSuite) TestUpdatePartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -355,7 +355,7 @@ func (s *testStatsUpdateSuite) TestUpdatePartition(c *C) {
 	}
 }
 
-func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
+func (s *testStatsSuite) TestAutoUpdate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -456,7 +456,7 @@ func (s *testStatsUpdateSuite) TestAutoUpdate(c *C) {
 	c.Assert(hg.Len(), Equals, 3)
 }
 
-func (s *testStatsUpdateSuite) TestAutoUpdatePartition(c *C) {
+func (s *testStatsSuite) TestAutoUpdatePartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -493,7 +493,7 @@ func (s *testStatsUpdateSuite) TestAutoUpdatePartition(c *C) {
 	c.Assert(stats.ModifyCount, Equals, int64(0))
 }
 
-func (s *testStatsUpdateSuite) TestTableAnalyzed(c *C) {
+func (s *testStatsSuite) TestTableAnalyzed(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -527,7 +527,7 @@ func (s *testStatsUpdateSuite) TestTableAnalyzed(c *C) {
 	c.Assert(statistics.TableAnalyzed(statsTbl), IsTrue)
 }
 
-func (s *testStatsUpdateSuite) TestUpdateErrorRate(c *C) {
+func (s *testStatsSuite) TestUpdateErrorRate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	h := s.do.StatsHandle()
 	is := s.do.InfoSchema()
@@ -597,7 +597,7 @@ func (s *testStatsUpdateSuite) TestUpdateErrorRate(c *C) {
 	c.Assert(tbl.Indices[bID].QueryTotal, Equals, int64(0))
 }
 
-func (s *testStatsUpdateSuite) TestUpdatePartitionErrorRate(c *C) {
+func (s *testStatsSuite) TestUpdatePartitionErrorRate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	h := s.do.StatsHandle()
 	is := s.do.InfoSchema()
@@ -656,7 +656,7 @@ func appendBucket(h *statistics.Histogram, l, r int64) {
 	h.AppendBucket(&lower, &upper, 0, 0)
 }
 
-func (s *testStatsUpdateSuite) TestSplitRange(c *C) {
+func (s *testStatsSuite) TestSplitRange(c *C) {
 	h := statistics.NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeLong), 5, 0)
 	appendBucket(h, 1, 1)
 	appendBucket(h, 2, 5)
@@ -710,7 +710,7 @@ func (s *testStatsUpdateSuite) TestSplitRange(c *C) {
 	}
 }
 
-func (s *testStatsUpdateSuite) TestQueryFeedback(c *C) {
+func (s *testStatsSuite) TestQueryFeedback(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -822,7 +822,7 @@ func (s *testStatsUpdateSuite) TestQueryFeedback(c *C) {
 	c.Assert(h.HandleUpdateStats(s.do.InfoSchema()), IsNil)
 }
 
-func (s *testStatsUpdateSuite) TestQueryFeedbackForPartition(c *C) {
+func (s *testStatsSuite) TestQueryFeedbackForPartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -900,7 +900,7 @@ func (s *testStatsUpdateSuite) TestQueryFeedbackForPartition(c *C) {
 	testKit.MustExec("drop table t")
 }
 
-func (s *testStatsUpdateSuite) TestUpdateSystemTable(c *C) {
+func (s *testStatsSuite) TestUpdateSystemTable(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -915,7 +915,7 @@ func (s *testStatsUpdateSuite) TestUpdateSystemTable(c *C) {
 	c.Assert(len(feedback), Equals, 0)
 }
 
-func (s *testStatsUpdateSuite) TestOutOfOrderUpdate(c *C) {
+func (s *testStatsSuite) TestOutOfOrderUpdate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -946,7 +946,7 @@ func (s *testStatsUpdateSuite) TestOutOfOrderUpdate(c *C) {
 	testKit.MustQuery("select count from mysql.stats_meta").Check(testkit.Rows("0"))
 }
 
-func (s *testStatsUpdateSuite) TestUpdateStatsByLocalFeedback(c *C) {
+func (s *testStatsSuite) TestUpdateStatsByLocalFeedback(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -1000,7 +1000,7 @@ func (s *testStatsUpdateSuite) TestUpdateStatsByLocalFeedback(c *C) {
 	h.UpdateStatsByLocalFeedback(s.do.InfoSchema())
 }
 
-func (s *testStatsUpdateSuite) TestUpdatePartitionStatsByLocalFeedback(c *C) {
+func (s *testStatsSuite) TestUpdatePartitionStatsByLocalFeedback(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -1051,7 +1051,7 @@ func (hook *logHook) Fire(entry *log.Entry) error {
 	return nil
 }
 
-func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
+func (s *testStatsSuite) TestLogDetailedInfo(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 
 	oriProbability := statistics.FeedbackProbability
@@ -1113,7 +1113,7 @@ func (s *testStatsUpdateSuite) TestLogDetailedInfo(c *C) {
 	}
 }
 
-func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
+func (s *testStatsSuite) TestNeedAnalyzeTable(c *C) {
 	columns := map[int64]*statistics.Column{}
 	columns[1] = &statistics.Column{Count: 1}
 	tests := []struct {
@@ -1217,7 +1217,7 @@ func (s *testStatsUpdateSuite) TestNeedAnalyzeTable(c *C) {
 	}
 }
 
-func (s *testStatsUpdateSuite) TestIndexQueryFeedback(c *C) {
+func (s *testStatsSuite) TestIndexQueryFeedback(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 
@@ -1294,7 +1294,7 @@ func (s *testStatsUpdateSuite) TestIndexQueryFeedback(c *C) {
 	}
 }
 
-func (s *testStatsUpdateSuite) TestFeedbackRanges(c *C) {
+func (s *testStatsSuite) TestFeedbackRanges(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	h := s.do.StatsHandle()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Stats unit test runs slow.

### What is changed and how it works?

- There are some costly ddl operations like `truncate table`, they are changed to `delete from`
- Combining stats test so we do not need to boostrap many times.
- Rewrite some tests so we do not need to sleep
- Reduce the testing row count of CM Sketch

After the changes, the exectution time is reduced from 10s to 2.5s.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Just unit test

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @winoros @eurekaka

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8597)
<!-- Reviewable:end -->
