### PR TITLE
executor: set projection concurrency build bellow aggregate

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1015,6 +1015,7 @@ func (b *executorBuilder) buildProjBelowAgg(aggFuncs []*aggregation.AggFuncDesc,
 
 	return &ProjectionExec{
 		baseExecutor:  newBaseExecutor(b.ctx, expression.NewSchema(projSchemaCols...), projFromID, src),
+		numWorkers:    b.ctx.GetSessionVars().ProjectionConcurrency,
 		evaluatorSuit: expression.NewEvaluatorSuite(projExprs, false),
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

It was found in our internal test: aggregate 50M rows, the result is 10 rows, time consumption is nearly 2 minutes..

So I looked at the goroutine profile and found that the projection was executed unparallely. It's because we haven't set `numWorkers` for the newly added `ProjectionExec`.

After this change, the slow query executes from 2 minutes to 14 seconds:
```
mysql> explain analyze SELECT app_key,
    ->        SUM(msg_count) AS send_total,
    ->        SUM(IF(send_result = '1', msg_count, 0)) AS success_total,
    ->        SUM(IF(send_result = '-1', msg_count, 0)) AS no_return,
    ->        SUM(IF(send_result = '-2' OR send_result = '2', msg_count, 0)) AS fail,
    ->        SUM(IF(bill_state = '1', cost * msg_count, 0)) AS income,
    ->        SUM(IF(send_result = '1', channel_cost * msg_count, 0)) AS prime_total
    -> FROM open_platform_batch_2.sms_record
    -> WHERE submit_time > '2018-12-01 00:00:00'
    ->   AND submit_time < '2018-12-01 23:55:50'
    -> GROUP BY app_key
    -> ORDER BY send_total DESC
    -> LIMIT 0, 10;
+--------------------------+-------------+------+----------------------------------------------------------------------------------------------------------------------+------------------------------------------------+
| id                       | count       | task | operator info                                                                                                        | execution info                                 |
+--------------------------+-------------+------+----------------------------------------------------------------------------------------------------------------------+------------------------------------------------+
| Projection_8             | 10.00       | root | open_platform_batch_2.sms_record.app_key, 3_col_0, 3_col_1, 3_col_2, 3_col_3, 3_col_4, 3_col_5                       | time:14.852215584s, loops:2, rows:10           |
| └─TopN_11                | 10.00       | root | 3_col_0:desc, offset:0, count:10                                                                                     | time:14.852204419s, loops:2, rows:10           |
|   └─HashAgg_16           | 40000000.00 | root | group by:group_0, funcs:sum(sum_0), sum(sum_0), sum(sum_0), sum(sum_0), sum(sum_0), sum(sum_0), firstrow(firstrow_0) | time:14.851127922s, loops:10, rows:10          |
|     └─IndexLookUp_26     | 50000000.00 | root |                                                                                                                      | time:14.235685552s, loops:48830, rows:50000000 |
|       ├─IndexScan_24     | 50000000.00 | cop  | table:sms_record, index:submit_time, range:(2018-12-01 00:00:00,2018-12-01 23:55:50), keep order:false               | time:0s, loops:0, rows:50000000                |
|       └─TableScan_25     | 50000000.00 | cop  | table:sms_record, keep order:false                                                                                   | time:0s, loops:0, rows:50000000                |
+--------------------------+-------------+------+----------------------------------------------------------------------------------------------------------------------+------------------------------------------------+
6 rows in set (14.88 sec)
```

### What is changed and how it works?

Set `numWorkers` for the newly added `ProjectionExec`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8601)
<!-- Reviewable:end -->
