### PR TITLE
expression,util/encrypt: Add support for AES OFB mode

### DIFF
--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -93,6 +93,9 @@ var aesModes = map[string]*aesModeAttr{
 	"aes-128-cbc": {"cbc", 16, true},
 	"aes-192-cbc": {"cbc", 24, true},
 	"aes-256-cbc": {"cbc", 32, true},
+	"aes-128-ofb": {"ofb", 16, true},
+	"aes-192-ofb": {"ofb", 24, true},
+	"aes-256-ofb": {"ofb", 32, true},
 }
 
 type aesDecryptFunctionClass struct {
@@ -209,6 +212,8 @@ func (b *builtinAesDecryptIVSig) evalString(row chunk.Row) (string, bool, error)
 	switch b.modeName {
 	case "cbc":
 		plainText, err = encrypt.AESDecryptWithCBC([]byte(cryptStr), key, []byte(iv))
+	case "ofb":
+		plainText, err = encrypt.AESDecryptWithOFB([]byte(cryptStr), key, []byte(iv))
 	default:
 		return "", true, errors.Errorf("unsupported block encryption mode - %v", b.modeName)
 	}
@@ -332,6 +337,8 @@ func (b *builtinAesEncryptIVSig) evalString(row chunk.Row) (string, bool, error)
 	switch b.modeName {
 	case "cbc":
 		cipherText, err = encrypt.AESEncryptWithCBC([]byte(str), key, []byte(iv))
+	case "ofb":
+		cipherText, err = encrypt.AESEncryptWithOFB([]byte(str), key, []byte(iv))
 	default:
 		return "", true, errors.Errorf("unsupported block encryption mode - %v", b.modeName)
 	}

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -101,6 +101,13 @@ var aesTests = []struct {
 	{"aes-256-cbc", "pingcap", []interface{}{"1234567890123456", "1234567890123456"}, "5D0E22C1E77523AEF5C3E10B65653C8F"},
 	{"aes-256-cbc", "pingcap", []interface{}{"12345678901234561234567890123456", "1234567890123456"}, "A26BA27CA4BE9D361D545AA84A17002D"},
 	{"aes-256-cbc", "pingcap", []interface{}{"1234567890123456", "12345678901234561234567890123456"}, "5D0E22C1E77523AEF5C3E10B65653C8F"},
+	// test for ofb
+	{"aes-128-ofb", "pingcap", []interface{}{"1234567890123456", "1234567890123456"}, "0515A36BBF3DE0"},
+	{"aes-128-ofb", "pingcap", []interface{}{"123456789012345678901234", "1234567890123456"}, "C2A93A93818546"},
+	{"aes-192-ofb", "pingcap", []interface{}{"1234567890123456", "1234567890123456"}, "FE09DCCF14D458"},
+	{"aes-256-ofb", "pingcap", []interface{}{"1234567890123456", "1234567890123456"}, "2E70FCAC0C0834"},
+	{"aes-256-ofb", "pingcap", []interface{}{"12345678901234561234567890123456", "1234567890123456"}, "83E2B30A71F011"},
+	{"aes-256-ofb", "pingcap", []interface{}{"1234567890123456", "12345678901234561234567890123456"}, "2E70FCAC0C0834"},
 }
 
 func (s *testEvaluatorSuite) TestAESEncrypt(c *C) {

--- a/util/encrypt/aes.go
+++ b/util/encrypt/aes.go
@@ -173,6 +173,30 @@ func AESDecryptWithCBC(cryptStr, key []byte, iv []byte) ([]byte, error) {
 	return aesDecrypt(cryptStr, mode)
 }
 
+// AESEncryptWithOFB encrypts data using AES with OFB mode.
+func AESEncryptWithOFB(plainStr []byte, key []byte, iv []byte) ([]byte, error) {
+	cb, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	mode := cipher.NewOFB(cb, iv)
+	crypted := make([]byte, len(plainStr))
+	mode.XORKeyStream(crypted, plainStr)
+	return crypted, nil
+}
+
+// AESDecryptWithOFB decrypts data using AES with OFB mode.
+func AESDecryptWithOFB(cipherStr []byte, key []byte, iv []byte) ([]byte, error) {
+	cb, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	mode := cipher.NewOFB(cb, iv)
+	plainStr := make([]byte, len(cipherStr))
+	mode.XORKeyStream(plainStr, cipherStr)
+	return plainStr, nil
+}
+
 // aesDecrypt decrypts data using AES.
 func aesDecrypt(cryptStr []byte, mode cipher.BlockMode) ([]byte, error) {
 	blockSize := mode.BlockSize()

--- a/util/encrypt/aes_test.go
+++ b/util/encrypt/aes_test.go
@@ -304,6 +304,75 @@ func (s *testEncryptSuite) TestAESEncryptWithCBC(c *C) {
 	}
 }
 
+func (s *testEncryptSuite) TestAESEncryptWithOFB(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []struct {
+		str     string
+		key     string
+		iv      string
+		expect  string
+		isError bool
+	}{
+		// 128 bits key
+		{"pingcap", "1234567890123456", "1234567890123456", "0515A36BBF3DE0", false},
+		{"pingcap123", "1234567890123456", "1234567890123456", "0515A36BBF3DE0DBE9DD", false},
+		// 192 bits key
+		{"pingcap", "123456789012345678901234", "1234567890123456", "45A57592449893", false}, // 192 bit
+		// negtive cases: invalid key length
+		{"pingcap", "12345678901234567", "1234567890123456", "", true},
+		{"pingcap", "123456789012345", "1234567890123456", "", true},
+	}
+
+	for _, t := range tests {
+		str := []byte(t.str)
+		key := []byte(t.key)
+		iv := []byte(t.iv)
+
+		crypted, err := AESEncryptWithOFB(str, key, iv)
+		if t.isError {
+			c.Assert(err, NotNil, Commentf("%v", t))
+			continue
+		}
+		c.Assert(err, IsNil, Commentf("%v", t))
+		result := toHex(crypted)
+		c.Assert(result, Equals, t.expect, Commentf("%v", t))
+	}
+}
+
+func (s *testEncryptSuite) TestAESDecryptWithOFB(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []struct {
+		str     string
+		key     string
+		iv      string
+		expect  string
+		isError bool
+	}{
+		// 128 bits key
+		{"0515A36BBF3DE0", "1234567890123456", "1234567890123456", "pingcap", false},
+		{"0515A36BBF3DE0DBE9DD", "1234567890123456", "1234567890123456", "pingcap123", false},
+		// 192 bits key
+		{"45A57592449893", "123456789012345678901234", "1234567890123456", "pingcap", false}, // 192 bit
+		// negtive cases: invalid key length
+		{"pingcap", "12345678901234567", "1234567890123456", "", true},
+		{"pingcap", "123456789012345", "1234567890123456", "", true},
+	}
+
+	for _, t := range tests {
+		str, _ := hex.DecodeString(t.str)
+		key := []byte(t.key)
+		iv := []byte(t.iv)
+
+		plainText, err := AESDecryptWithOFB(str, key, iv)
+		if t.isError {
+			c.Assert(err, NotNil, Commentf("%v", t))
+			continue
+		}
+		c.Assert(err, IsNil, Commentf("%v", t))
+		c.Assert(string(plainText), Equals, t.expect, Commentf("%v", t))
+	}
+}
+
 func (s *testEncryptSuite) TestAESDecryptWithCBC(c *C) {
 	defer testleak.AfterTest(c)()
 	tests := []struct {


### PR DESCRIPTION
### What problem does this PR solve? 
This PR solves part #7490 (add more modes for AES)

### What is changed and how it works?
I have included implementation for _aes-128-ofb, aes-192-ofb, aes-256-ofb_

### Check List 

Tests 

 - Unit test

Code changes

 - Exported `AESDecryptWithOFB` and `AESEncryptWithOFB` functions

