### PR TITLE
expression: handle corrupted length in uncompress builtin function

### DIFF
--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -824,9 +824,14 @@ func (b *builtinUncompressSig) evalString(row chunk.Row) (string, bool, error) {
 		sc.AppendWarning(errZlibZData)
 		return "", true, nil
 	}
+	length := binary.LittleEndian.Uint32([]byte(payload[0:4]))
 	bytes, err := inflate([]byte(payload[4:]))
 	if err != nil {
 		sc.AppendWarning(errZlibZData)
+		return "", true, nil
+	}
+	if length < uint32(len(bytes)) {
+		sc.AppendWarning(errZlibZBuf)
 		return "", true, nil
 	}
 	return string(bytes), false, nil

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -374,6 +374,7 @@ func (s *testEvaluatorSuite) TestUncompress(c *C) {
 	}{
 		{decodeHex("0B000000789CCB48CDC9C95728CF2FCA4901001A0B045D"), "hello world"},         // zlib result from MySQL
 		{decodeHex("0B000000789CCA48CDC9C95728CF2FCA4901040000FFFF1A0B045D"), "hello world"}, // zlib result from TiDB
+		{decodeHex("02000000789CCB48CDC9C95728CF2FCA4901001A0B045D"), nil},                   // wrong length in the first four bytes
 		{decodeHex(""), ""},
 		{"1", nil},
 		{"1234", nil},

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -31,7 +31,8 @@ var (
 
 	// All the un-exported errors are defined here:
 	errFunctionNotExists             = terror.ClassExpression.New(mysql.ErrSpDoesNotExist, mysql.MySQLErrName[mysql.ErrSpDoesNotExist])
-	errZlibZData                     = terror.ClassTypes.New(mysql.ErrZlibZData, mysql.MySQLErrName[mysql.ErrZlibZData])
+	errZlibZData                     = terror.ClassExpression.New(mysql.ErrZlibZData, mysql.MySQLErrName[mysql.ErrZlibZData])
+	errZlibZBuf                      = terror.ClassExpression.New(mysql.ErrZlibZBuf, mysql.MySQLErrName[mysql.ErrZlibZBuf])
 	errIncorrectArgs                 = terror.ClassExpression.New(mysql.ErrWrongArguments, mysql.MySQLErrName[mysql.ErrWrongArguments])
 	errUnknownCharacterSet           = terror.ClassExpression.New(mysql.ErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
 	errDefaultValue                  = terror.ClassExpression.New(mysql.ErrInvalidDefault, "invalid default value")
@@ -48,6 +49,7 @@ func init() {
 		mysql.ErrDivisionByZero:                    mysql.ErrDivisionByZero,
 		mysql.ErrSpDoesNotExist:                    mysql.ErrSpDoesNotExist,
 		mysql.ErrZlibZData:                         mysql.ErrZlibZData,
+		mysql.ErrZlibZBuf:                          mysql.ErrZlibZBuf,
 		mysql.ErrWrongArguments:                    mysql.ErrWrongArguments,
 		mysql.ErrUnknownCharacterSet:               mysql.ErrUnknownCharacterSet,
 		mysql.ErrInvalidDefault:                    mysql.ErrInvalidDefault,


### PR DESCRIPTION
…8586)

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixes #8578 on release-2.1

### What is changed and how it works?
cherry-pick a [bug fix commit](url
https://github.com/pingcap/tidb/commit/e61bad0769c7dbb82b03250d588a263d2958d7be) from [this PR](https://github.com/pingcap/tidb/pull/8586).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note