### PR TITLE
expression: remove redundant "errors.Trace()" in "expression" package

### DIFF
--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -16,6 +16,7 @@ package aggregation
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
@@ -63,7 +64,7 @@ func NewDistAggFunc(expr *tipb.Expr, fieldTps []*types.FieldType, sc *stmtctx.St
 	for _, child := range expr.Children {
 		arg, err := expression.PBToExpr(child, fieldTps, sc)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		args = append(args, arg)
 	}
@@ -152,7 +153,7 @@ func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 	a := af.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if value.IsNull() {
 		return nil
@@ -160,7 +161,7 @@ func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 	if af.HasDistinct {
 		d, err1 := evalCtx.DistinctChecker.Check([]types.Datum{value})
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
 		if !d {
 			return nil
@@ -168,7 +169,7 @@ func (af *aggFunction) updateSum(sc *stmtctx.StatementContext, evalCtx *AggEvalu
 	}
 	evalCtx.Value, err = calculateSum(sc, evalCtx.Value, value)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	evalCtx.Count++
 	return nil

--- a/expression/aggregation/bit_and.go
+++ b/expression/aggregation/bit_and.go
@@ -16,7 +16,6 @@ package aggregation
 import (
 	"math"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -41,7 +40,7 @@ func (bf *bitAndFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if !value.IsNull() {
 		if value.Kind() == types.KindUint64 {
@@ -49,7 +48,7 @@ func (bf *bitAndFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		} else {
 			int64Value, err := value.ToInt64(sc)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() & uint64(int64Value))
 		}

--- a/expression/aggregation/bit_or.go
+++ b/expression/aggregation/bit_or.go
@@ -14,7 +14,6 @@
 package aggregation
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -39,7 +38,7 @@ func (bf *bitOrFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if !value.IsNull() {
 		if value.Kind() == types.KindUint64 {
@@ -47,7 +46,7 @@ func (bf *bitOrFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 		} else {
 			int64Value, err := value.ToInt64(sc)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() | uint64(int64Value))
 		}

--- a/expression/aggregation/bit_xor.go
+++ b/expression/aggregation/bit_xor.go
@@ -14,7 +14,6 @@
 package aggregation
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -39,7 +38,7 @@ func (bf *bitXorFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 	a := bf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if !value.IsNull() {
 		if value.Kind() == types.KindUint64 {
@@ -47,7 +46,7 @@ func (bf *bitXorFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 		} else {
 			int64Value, err := value.ToInt64(sc)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			evalCtx.Value.SetUint64(evalCtx.Value.GetUint64() ^ uint64(int64Value))
 		}

--- a/expression/aggregation/concat.go
+++ b/expression/aggregation/concat.go
@@ -48,13 +48,13 @@ func (cf *concatFunction) initSeparator(sc *stmtctx.StatementContext, row chunk.
 	sepArg := cf.Args[len(cf.Args)-1]
 	sepDatum, err := sepArg.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if sepDatum.IsNull() {
 		return errors.Errorf("Invalid separator argument.")
 	}
 	cf.separator, err = sepDatum.ToString()
-	return errors.Trace(err)
+	return err
 }
 
 // Update implements Aggregation interface.
@@ -63,7 +63,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 	if !cf.sepInited {
 		err := cf.initSeparator(sc, row)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		cf.sepInited = true
 	}
@@ -72,7 +72,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 	for i, length := 0, len(cf.Args)-1; i < length; i++ {
 		value, err := cf.Args[i].Eval(row)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if value.IsNull() {
 			return nil
@@ -82,7 +82,7 @@ func (cf *concatFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Statem
 	if cf.HasDistinct {
 		d, err := evalCtx.DistinctChecker.Check(datumBuf)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if !d {
 			return nil

--- a/expression/aggregation/count.go
+++ b/expression/aggregation/count.go
@@ -14,7 +14,6 @@
 package aggregation
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -33,7 +32,7 @@ func (cf *countFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 	for _, a := range cf.Args {
 		value, err := a.Eval(row)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if value.IsNull() {
 			return nil
@@ -48,7 +47,7 @@ func (cf *countFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stateme
 	if cf.HasDistinct {
 		d, err := evalCtx.DistinctChecker.Check(datumBuf)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if !d {
 			return nil

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -34,7 +34,7 @@ func (ff *firstRowFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stat
 	}
 	value, err := ff.Args[0].Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	evalCtx.Value = types.CopyDatum(value)
 	evalCtx.GotFirstRow = true

--- a/expression/aggregation/max_min.go
+++ b/expression/aggregation/max_min.go
@@ -14,7 +14,6 @@
 package aggregation
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -40,7 +39,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 	a := mmf.Args[0]
 	value, err := a.Eval(row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if evalCtx.Value.IsNull() {
 		evalCtx.Value = *(&value).Copy()
@@ -51,7 +50,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 	var c int
 	c, err = evalCtx.Value.CompareDatum(sc, &value)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if (mmf.isMax && c == -1) || (!mmf.isMax && c == 1) {
 		evalCtx.Value = *(&value).Copy()

--- a/expression/aggregation/util.go
+++ b/expression/aggregation/util.go
@@ -43,7 +43,7 @@ func (d *distinctChecker) Check(values []types.Datum) (bool, error) {
 	var err error
 	d.key, err = codec.EncodeValue(d.sc, d.key, values...)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	d.vals = d.existingKeys.Get(d.key, d.vals[:0])
 	if len(d.vals) > 0 {
@@ -78,7 +78,7 @@ func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.
 	}
 
 	if err != nil {
-		return data, errors.Trace(err)
+		return data, err
 	}
 	if data.IsNull() {
 		return sum, nil

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -18,7 +18,6 @@ import (
 	"math"
 
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
@@ -150,7 +149,7 @@ type arithmeticPlusFunctionClass struct {
 
 func (c *arithmeticPlusFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
 	lhsEvalTp, rhsEvalTp := numericContextResultType(lhsTp), numericContextResultType(rhsTp)
@@ -191,12 +190,12 @@ func (s *builtinArithmeticPlusIntSig) Clone() builtinFunc {
 func (s *builtinArithmeticPlusIntSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	isLHSUnsigned := mysql.HasUnsignedFlag(s.args[0].GetType().Flag)
@@ -243,16 +242,16 @@ func (s *builtinArithmeticPlusDecimalSig) Clone() builtinFunc {
 func (s *builtinArithmeticPlusDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	c := &types.MyDecimal{}
 	err = types.DecimalAdd(a, b, c)
 	if err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return c, false, nil
 }
@@ -270,11 +269,11 @@ func (s *builtinArithmeticPlusRealSig) Clone() builtinFunc {
 func (s *builtinArithmeticPlusRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if (a > 0 && b > math.MaxFloat64-a) || (a < 0 && b < -math.MaxFloat64-a) {
 		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
@@ -288,7 +287,7 @@ type arithmeticMinusFunctionClass struct {
 
 func (c *arithmeticMinusFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
 	lhsEvalTp, rhsEvalTp := numericContextResultType(lhsTp), numericContextResultType(rhsTp)
@@ -330,11 +329,11 @@ func (s *builtinArithmeticMinusRealSig) Clone() builtinFunc {
 func (s *builtinArithmeticMinusRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if (a > 0 && -b > math.MaxFloat64-a) || (a < 0 && -b < -math.MaxFloat64-a) {
 		return 0, true, types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s - %s)", s.args[0].String(), s.args[1].String()))
@@ -355,16 +354,16 @@ func (s *builtinArithmeticMinusDecimalSig) Clone() builtinFunc {
 func (s *builtinArithmeticMinusDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	c := &types.MyDecimal{}
 	err = types.DecimalSub(a, b, c)
 	if err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return c, false, nil
 }
@@ -382,12 +381,12 @@ func (s *builtinArithmeticMinusIntSig) Clone() builtinFunc {
 func (s *builtinArithmeticMinusIntSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	forceToSigned := s.ctx.GetSessionVars().SQLMode.HasNoUnsignedSubtractionMode()
 	isLHSUnsigned := !forceToSigned && mysql.HasUnsignedFlag(s.args[0].GetType().Flag)
@@ -434,7 +433,7 @@ type arithmeticMultiplyFunctionClass struct {
 
 func (c *arithmeticMultiplyFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
 	lhsEvalTp, rhsEvalTp := numericContextResultType(lhsTp), numericContextResultType(rhsTp)
@@ -501,11 +500,11 @@ func (s *builtinArithmeticMultiplyIntSig) Clone() builtinFunc {
 func (s *builtinArithmeticMultiplyRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	result := a * b
 	if math.IsInf(result, 0) {
@@ -517,16 +516,16 @@ func (s *builtinArithmeticMultiplyRealSig) evalReal(row chunk.Row) (float64, boo
 func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	c := &types.MyDecimal{}
 	err = types.DecimalMul(a, b, c)
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return c, false, nil
 }
@@ -534,12 +533,12 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(row chunk.Row) (*types
 func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	unsignedA := uint64(a)
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	unsignedB := uint64(b)
 	result := unsignedA * unsignedB
@@ -552,11 +551,11 @@ func (s *builtinArithmeticMultiplyIntUnsignedSig) evalInt(row chunk.Row) (val in
 func (s *builtinArithmeticMultiplyIntSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	result := a * b
 	if a != 0 && result/a != b {
@@ -571,7 +570,7 @@ type arithmeticDivideFunctionClass struct {
 
 func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
 	lhsEvalTp, rhsEvalTp := numericContextResultType(lhsTp), numericContextResultType(rhsTp)
@@ -608,14 +607,14 @@ func (s *builtinArithmeticDivideDecimalSig) Clone() builtinFunc {
 func (s *builtinArithmeticDivideRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if b == 0 {
-		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 	result := a / b
 	if math.IsInf(result, 0) {
@@ -627,25 +626,25 @@ func (s *builtinArithmeticDivideRealSig) evalReal(row chunk.Row) (float64, bool,
 func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 
 	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 
 	c := &types.MyDecimal{}
 	err = types.DecimalDiv(a, b, c, types.DivFracIncr)
 	if err == types.ErrDivByZero {
-		return c, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return c, true, handleDivisionByZeroError(s.ctx)
 	} else if err == nil {
 		_, frac := c.PrecisionAndFrac()
 		if frac < s.baseBuiltinFunc.tp.Decimal {
 			err = c.Round(c, s.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven)
 		}
 	}
-	return c, false, errors.Trace(err)
+	return c, false, err
 }
 
 type arithmeticIntDivideFunctionClass struct {
@@ -654,7 +653,7 @@ type arithmeticIntDivideFunctionClass struct {
 
 func (c *arithmeticIntDivideFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
@@ -694,16 +693,16 @@ func (s *builtinArithmeticIntDivideDecimalSig) Clone() builtinFunc {
 func (s *builtinArithmeticIntDivideIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	var (
@@ -726,7 +725,7 @@ func (s *builtinArithmeticIntDivideIntSig) evalInt(row chunk.Row) (int64, bool, 
 		ret, err = types.DivInt64(a, b)
 	}
 
-	return ret, err != nil, errors.Trace(err)
+	return ret, err != nil, err
 }
 
 func (s *builtinArithmeticIntDivideDecimalSig) evalInt(row chunk.Row) (ret int64, isNull bool, err error) {
@@ -743,14 +742,14 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(row chunk.Row) (ret int64
 			err = sc.HandleOverflow(newErr, newErr)
 		}
 		if isNull || err != nil {
-			return 0, isNull, errors.Trace(err)
+			return 0, isNull, err
 		}
 	}
 
 	c := &types.MyDecimal{}
 	err = types.DecimalDiv(num[0], num[1], c, types.DivFracIncr)
 	if err == types.ErrDivByZero {
-		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 	if err == types.ErrTruncated {
 		err = sc.HandleTruncate(errTruncatedWrongValue.GenWithStackByArgs("DECIMAL", c))
@@ -760,7 +759,7 @@ func (s *builtinArithmeticIntDivideDecimalSig) evalInt(row chunk.Row) (ret int64
 		err = sc.HandleOverflow(newErr, newErr)
 	}
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	ret, err = c.ToInt()
@@ -799,7 +798,7 @@ func (c *arithmeticModFunctionClass) setType4ModRealOrDecimal(retTp, a, b *types
 
 func (c *arithmeticModFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	lhsTp, rhsTp := args[0].GetType(), args[1].GetType()
 	lhsEvalTp, rhsEvalTp := numericContextResultType(lhsTp), numericContextResultType(rhsTp)
@@ -842,16 +841,16 @@ func (s *builtinArithmeticModRealSig) Clone() builtinFunc {
 func (s *builtinArithmeticModRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	b, isNull, err := s.args[1].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 
 	a, isNull, err := s.args[0].EvalReal(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return math.Mod(a, b), false, nil
@@ -870,18 +869,18 @@ func (s *builtinArithmeticModDecimalSig) Clone() builtinFunc {
 func (s *builtinArithmeticModDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	a, isNull, err := s.args[0].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	b, isNull, err := s.args[1].EvalDecimal(s.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	c := &types.MyDecimal{}
 	err = types.DecimalMod(a, b, c)
 	if err == types.ErrDivByZero {
-		return c, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return c, true, handleDivisionByZeroError(s.ctx)
 	}
-	return c, err != nil, errors.Trace(err)
+	return c, err != nil, err
 }
 
 type builtinArithmeticModIntSig struct {
@@ -897,16 +896,16 @@ func (s *builtinArithmeticModIntSig) Clone() builtinFunc {
 func (s *builtinArithmeticModIntSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	b, isNull, err := s.args[1].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if b == 0 {
-		return 0, true, errors.Trace(handleDivisionByZeroError(s.ctx))
+		return 0, true, handleDivisionByZeroError(s.ctx)
 	}
 
 	a, isNull, err := s.args[0].EvalInt(s.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	var ret int64

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
@@ -115,7 +114,7 @@ type castAsIntFunctionClass struct {
 
 func (c *castAsIntFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinCastFunc(newBaseBuiltinFunc(ctx, args), ctx.Value(inUnionCastContext) != nil)
 	bf.tp = c.tp
@@ -161,7 +160,7 @@ type castAsRealFunctionClass struct {
 
 func (c *castAsRealFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinCastFunc(newBaseBuiltinFunc(ctx, args), ctx.Value(inUnionCastContext) != nil)
 	bf.tp = c.tp
@@ -212,7 +211,7 @@ type castAsDecimalFunctionClass struct {
 
 func (c *castAsDecimalFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinCastFunc(newBaseBuiltinFunc(ctx, args), ctx.Value(inUnionCastContext) != nil)
 	bf.tp = c.tp
@@ -263,7 +262,7 @@ type castAsStringFunctionClass struct {
 
 func (c *castAsStringFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFunc(ctx, args)
 	bf.tp = c.tp
@@ -309,7 +308,7 @@ type castAsTimeFunctionClass struct {
 
 func (c *castAsTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFunc(ctx, args)
 	bf.tp = c.tp
@@ -350,7 +349,7 @@ type castAsDurationFunctionClass struct {
 
 func (c *castAsDurationFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFunc(ctx, args)
 	bf.tp = c.tp
@@ -391,7 +390,7 @@ type castAsJSONFunctionClass struct {
 
 func (c *castAsJSONFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFunc(ctx, args)
 	bf.tp = c.tp
@@ -456,7 +455,7 @@ func (b *builtinCastIntAsRealSig) Clone() builtinFunc {
 func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
 		res = float64(val)
@@ -467,7 +466,7 @@ func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull b
 		uVal, err = types.ConvertIntToUint(val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
 		res = float64(uVal)
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastIntAsDecimalSig struct {
@@ -483,7 +482,7 @@ func (b *builtinCastIntAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = types.NewDecFromInt(val)
@@ -493,12 +492,12 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 		var uVal uint64
 		uVal, err = types.ConvertIntToUint(val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
 		if err != nil {
-			return res, false, errors.Trace(err)
+			return res, false, err
 		}
 		res = types.NewDecFromUint(uVal)
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type builtinCastIntAsStringSig struct {
@@ -514,7 +513,7 @@ func (b *builtinCastIntAsStringSig) Clone() builtinFunc {
 func (b *builtinCastIntAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = strconv.FormatInt(val, 10)
@@ -522,12 +521,12 @@ func (b *builtinCastIntAsStringSig) evalString(row chunk.Row) (res string, isNul
 		var uVal uint64
 		uVal, err = types.ConvertIntToUint(val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
 		if err != nil {
-			return res, false, errors.Trace(err)
+			return res, false, err
 		}
 		res = strconv.FormatUint(uVal, 10)
 	}
 	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastIntAsTimeSig struct {
@@ -543,11 +542,11 @@ func (b *builtinCastIntAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastIntAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = types.ParseTimeFromNum(b.ctx.GetSessionVars().StmtCtx, val, b.tp.Tp, b.tp.Decimal)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	if b.tp.Tp == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -569,16 +568,16 @@ func (b *builtinCastIntAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastIntAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	dur, err := types.NumberToDuration(val, b.tp.Decimal)
 	if err != nil {
 		if types.ErrOverflow.Equal(err) {
 			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, err)
 		}
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
-	return dur, false, errors.Trace(err)
+	return dur, false, err
 }
 
 type builtinCastIntAsJSONSig struct {
@@ -594,7 +593,7 @@ func (b *builtinCastIntAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastIntAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if mysql.HasIsBooleanFlag(b.args[0].GetType().Flag) {
 		res = json.CreateBinary(val != 0)
@@ -619,7 +618,7 @@ func (b *builtinCastRealAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastRealAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	// FIXME: `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
-	return json.CreateBinary(val), isNull, errors.Trace(err)
+	return json.CreateBinary(val), isNull, err
 }
 
 type builtinCastDecimalAsJSONSig struct {
@@ -635,14 +634,14 @@ func (b *builtinCastDecimalAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsJSONSig) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return json.BinaryJSON{}, true, errors.Trace(err)
+		return json.BinaryJSON{}, true, err
 	}
 	// FIXME: `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.
 	f64, err := val.ToFloat64()
 	if err != nil {
-		return json.BinaryJSON{}, true, errors.Trace(err)
+		return json.BinaryJSON{}, true, err
 	}
-	return json.CreateBinary(f64), isNull, errors.Trace(err)
+	return json.CreateBinary(f64), isNull, err
 }
 
 type builtinCastStringAsJSONSig struct {
@@ -658,14 +657,14 @@ func (b *builtinCastStringAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastStringAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if mysql.HasParseToJSONFlag(b.tp.Flag) {
 		res, err = json.ParseBinaryFromString(val)
 	} else {
 		res = json.CreateBinary(val)
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsJSONSig struct {
@@ -681,7 +680,7 @@ func (b *builtinCastDurationAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	val.Fsp = types.MaxFsp
 	return json.CreateBinary(val.String()), false, nil
@@ -700,7 +699,7 @@ func (b *builtinCastTimeAsJSONSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if val.Type == mysql.TypeDatetime || val.Type == mysql.TypeTimestamp {
 		val.Fsp = types.MaxFsp
@@ -739,7 +738,7 @@ func (b *builtinCastRealAsIntSig) Clone() builtinFunc {
 func (b *builtinCastRealAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
 		res, err = types.ConvertFloatToInt(val, types.SignedLowerBound[mysql.TypeLonglong], types.SignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
@@ -750,7 +749,7 @@ func (b *builtinCastRealAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool
 		uintVal, err = types.ConvertFloatToUint(val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
 		res = int64(uintVal)
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type builtinCastRealAsDecimalSig struct {
@@ -766,17 +765,17 @@ func (b *builtinCastRealAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastRealAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res = new(types.MyDecimal)
 	if !b.inUnion || val >= 0 {
 		err = res.FromFloat64(val)
 		if err != nil {
-			return res, false, errors.Trace(err)
+			return res, false, err
 		}
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastRealAsStringSig struct {
@@ -792,10 +791,10 @@ func (b *builtinCastRealAsStringSig) Clone() builtinFunc {
 func (b *builtinCastRealAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, 64), b.tp, b.ctx.GetSessionVars().StmtCtx)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type builtinCastRealAsTimeSig struct {
@@ -811,12 +810,12 @@ func (b *builtinCastRealAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastRealAsTimeSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err := types.ParseTime(sc, strconv.FormatFloat(val, 'f', -1, 64), b.tp.Tp, b.tp.Decimal)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	if b.tp.Tp == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -838,10 +837,10 @@ func (b *builtinCastRealAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastRealAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, strconv.FormatFloat(val, 'f', -1, 64), b.tp.Decimal)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsDecimalSig struct {
@@ -857,7 +856,7 @@ func (b *builtinCastDecimalAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	evalDecimal, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res = &types.MyDecimal{}
 	if !(b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag) && evalDecimal.IsNegative()) {
@@ -865,7 +864,7 @@ func (b *builtinCastDecimalAsDecimalSig) evalDecimal(row chunk.Row) (res *types.
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsIntSig struct {
@@ -881,14 +880,14 @@ func (b *builtinCastDecimalAsIntSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	// Round is needed for both unsigned and signed.
 	var to types.MyDecimal
 	err = val.Round(&to, 0, types.ModeHalfEven)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
@@ -906,7 +905,7 @@ func (b *builtinCastDecimalAsIntSig) evalInt(row chunk.Row) (res int64, isNull b
 		err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
 	}
 
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsStringSig struct {
@@ -922,11 +921,11 @@ func (b *builtinCastDecimalAsStringSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(string(val.ToString()), b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsRealSig struct {
@@ -942,14 +941,14 @@ func (b *builtinCastDecimalAsRealSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsRealSig) evalReal(row chunk.Row) (res float64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag) && val.IsNegative() {
 		res = 0
 	} else {
 		res, err = val.ToFloat64()
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsTimeSig struct {
@@ -965,18 +964,18 @@ func (b *builtinCastDecimalAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTimeFromFloatString(sc, string(val.ToString()), b.tp.Tp, b.tp.Decimal)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	if b.tp.Tp == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
 		res.Time = types.FromDate(res.Time.Year(), res.Time.Month(), res.Time.Day(), 0, 0, 0, 0)
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDecimalAsDurationSig struct {
@@ -992,17 +991,17 @@ func (b *builtinCastDecimalAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastDecimalAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, string(val.ToString()), b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = b.ctx.GetSessionVars().StmtCtx.HandleTruncate(err)
 		// ZeroDuration of error ErrTruncatedWrongVal needs to be considered NULL.
 		if res == types.ZeroDuration {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastStringAsStringSig struct {
@@ -1018,11 +1017,11 @@ func (b *builtinCastStringAsStringSig) Clone() builtinFunc {
 func (b *builtinCastStringAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(res, b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastStringAsIntSig struct {
@@ -1065,7 +1064,7 @@ func (b *builtinCastStringAsIntSig) evalInt(row chunk.Row) (res int64, isNull bo
 	}
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	val = strings.TrimSpace(val)
@@ -1094,7 +1093,7 @@ func (b *builtinCastStringAsIntSig) evalInt(row chunk.Row) (res int64, isNull bo
 	}
 
 	res, err = b.handleOverflow(res, val, err, isNegative)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastStringAsRealSig struct {
@@ -1113,18 +1112,18 @@ func (b *builtinCastStringAsRealSig) evalReal(row chunk.Row) (res float64, isNul
 	}
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.StrToFloat(sc, val)
 	if err != nil {
-		return 0, false, errors.Trace(err)
+		return 0, false, err
 	}
 	if b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag) && res < 0 {
 		res = 0
 	}
 	res, err = types.ProduceFloatWithSpecifiedTp(res, b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastStringAsDecimalSig struct {
@@ -1143,18 +1142,18 @@ func (b *builtinCastStringAsDecimalSig) evalDecimal(row chunk.Row) (res *types.M
 	}
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res = new(types.MyDecimal)
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if !(b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag) && res.IsNegative()) {
 		err = sc.HandleTruncate(res.FromString([]byte(val)))
 		if err != nil {
-			return res, false, errors.Trace(err)
+			return res, false, err
 		}
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastStringAsTimeSig struct {
@@ -1170,7 +1169,7 @@ func (b *builtinCastStringAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastStringAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc, val, b.tp.Tp, b.tp.Decimal)
@@ -1197,7 +1196,7 @@ func (b *builtinCastStringAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastStringAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, val, b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
@@ -1205,10 +1204,10 @@ func (b *builtinCastStringAsDurationSig) evalDuration(row chunk.Row) (res types.
 		err = sc.HandleTruncate(err)
 		// ZeroDuration of error ErrTruncatedWrongVal needs to be considered NULL.
 		if res == types.ZeroDuration {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsTimeSig struct {
@@ -1224,12 +1223,12 @@ func (b *builtinCastTimeAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if res, err = res.Convert(sc, b.tp.Tp); err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	res, err = res.RoundFrac(sc, b.tp.Decimal)
 	if b.tp.Tp == mysql.TypeDate {
@@ -1237,7 +1236,7 @@ func (b *builtinCastTimeAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNu
 		res.Time = types.FromDate(res.Time.Year(), res.Time.Month(), res.Time.Day(), 0, 0, 0, 0)
 		res.Type = b.tp.Tp
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsIntSig struct {
@@ -1253,15 +1252,15 @@ func (b *builtinCastTimeAsIntSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	t, err := val.RoundFrac(sc, types.DefaultFsp)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = t.ToNumber().ToInt()
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsRealSig struct {
@@ -1277,10 +1276,10 @@ func (b *builtinCastTimeAsRealSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsRealSig) evalReal(row chunk.Row) (res float64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = val.ToNumber().ToFloat64()
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsDecimalSig struct {
@@ -1296,11 +1295,11 @@ func (b *builtinCastTimeAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(val.ToNumber(), b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsStringSig struct {
@@ -1316,11 +1315,11 @@ func (b *builtinCastTimeAsStringSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastTimeAsDurationSig struct {
@@ -1336,14 +1335,14 @@ func (b *builtinCastTimeAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastTimeAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = val.ConvertToDuration()
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = res.RoundFrac(b.tp.Decimal)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsDurationSig struct {
@@ -1359,10 +1358,10 @@ func (b *builtinCastDurationAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = res.RoundFrac(b.tp.Decimal)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsIntSig struct {
@@ -1378,14 +1377,14 @@ func (b *builtinCastDurationAsIntSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	dur, err := val.RoundFrac(types.DefaultFsp)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = dur.ToNumber().ToInt()
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsRealSig struct {
@@ -1401,10 +1400,10 @@ func (b *builtinCastDurationAsRealSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsRealSig) evalReal(row chunk.Row) (res float64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	res, err = val.ToNumber().ToFloat64()
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsDecimalSig struct {
@@ -1420,11 +1419,11 @@ func (b *builtinCastDurationAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceDecWithSpecifiedTp(val.ToNumber(), b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsStringSig struct {
@@ -1440,11 +1439,11 @@ func (b *builtinCastDurationAsStringSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ProduceStrWithSpecifiedTp(val.String(), b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastDurationAsTimeSig struct {
@@ -1460,15 +1459,15 @@ func (b *builtinCastDurationAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastDurationAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = val.ConvertToTime(sc, b.tp.Tp)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = res.RoundFrac(sc, b.tp.Decimal)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastJSONAsJSONSig struct {
@@ -1498,7 +1497,7 @@ func (b *builtinCastJSONAsIntSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToInt(sc, val, mysql.HasUnsignedFlag(b.tp.Flag))
@@ -1518,7 +1517,7 @@ func (b *builtinCastJSONAsRealSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsRealSig) evalReal(row chunk.Row) (res float64, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToFloat(sc, val)
@@ -1538,15 +1537,15 @@ func (b *builtinCastJSONAsDecimalSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDecimal, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ConvertJSONToDecimal(sc, val)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, sc)
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCastJSONAsStringSig struct {
@@ -1562,7 +1561,7 @@ func (b *builtinCastJSONAsStringSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsStringSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	return val.String(), false, nil
 }
@@ -1580,16 +1579,16 @@ func (b *builtinCastJSONAsTimeSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsTimeSig) evalTime(row chunk.Row) (res types.Time, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	s, err := val.Unquote()
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	res, err = types.ParseTime(sc, s, b.tp.Tp, b.tp.Decimal)
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	if b.tp.Tp == mysql.TypeDate {
 		// Truncate hh:mm:ss part if the type is Date.
@@ -1611,11 +1610,11 @@ func (b *builtinCastJSONAsDurationSig) Clone() builtinFunc {
 func (b *builtinCastJSONAsDurationSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	val, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	s, err := val.Unquote()
 	if err != nil {
-		return res, false, errors.Trace(err)
+		return res, false, err
 	}
 	res, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, b.tp.Decimal)
 	if types.ErrTruncatedWrongVal.Equal(err) {
@@ -1668,7 +1667,7 @@ func BuildCastFunction(ctx sessionctx.Context, expr Expression, tp *types.FieldT
 		fc = &castAsStringFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
 	}
 	f, err := fc.getFunction(ctx, []Expression{expr})
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	res = &ScalarFunction{
 		FuncName: model.NewCIStr(ast.Cast),
 		RetType:  tp,

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"math"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/opcode"
@@ -108,7 +107,7 @@ type coalesceFunctionClass struct {
 
 func (c *coalesceFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	fieldTps := make([]*types.FieldType, 0, len(args))
@@ -199,7 +198,7 @@ func (c *coalesceFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	case types.ETDuration:
 		bf.tp.Decimal, err = getExpressionFsp(ctx, args[0])
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		sig = &builtinCoalesceDurationSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_CoalesceDuration)
@@ -227,7 +226,7 @@ func (b *builtinCoalesceIntSig) evalInt(row chunk.Row) (res int64, isNull bool, 
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // builtinCoalesceRealSig is buitin function coalesce signature which return type real
@@ -249,7 +248,7 @@ func (b *builtinCoalesceRealSig) evalReal(row chunk.Row) (res float64, isNull bo
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // builtinCoalesceDecimalSig is buitin function coalesce signature which return type Decimal
@@ -271,7 +270,7 @@ func (b *builtinCoalesceDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDec
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // builtinCoalesceStringSig is buitin function coalesce signature which return type string
@@ -293,7 +292,7 @@ func (b *builtinCoalesceStringSig) evalString(row chunk.Row) (res string, isNull
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // builtinCoalesceTimeSig is buitin function coalesce signature which return type time
@@ -315,7 +314,7 @@ func (b *builtinCoalesceTimeSig) evalTime(row chunk.Row) (res types.Time, isNull
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // builtinCoalesceDurationSig is buitin function coalesce signature which return type duration
@@ -337,7 +336,7 @@ func (b *builtinCoalesceDurationSig) evalDuration(row chunk.Row) (res types.Dura
 			break
 		}
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // temporalWithDateAsNumEvalType makes DATE, DATETIME, TIMESTAMP pretend to be numbers rather than strings.
@@ -395,7 +394,7 @@ type greatestFunctionClass struct {
 
 func (c *greatestFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tp, cmpAsDatetime := getCmpTp4MinMax(args), false
 	if tp == types.ETDatetime {
@@ -440,13 +439,13 @@ func (b *builtinGreatestIntSig) Clone() builtinFunc {
 func (b *builtinGreatestIntSig) evalInt(row chunk.Row) (max int64, isNull bool, err error) {
 	max, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return max, isNull, errors.Trace(err)
+		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
 		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
 		if isNull || err != nil {
-			return max, isNull, errors.Trace(err)
+			return max, isNull, err
 		}
 		if v > max {
 			max = v
@@ -470,13 +469,13 @@ func (b *builtinGreatestRealSig) Clone() builtinFunc {
 func (b *builtinGreatestRealSig) evalReal(row chunk.Row) (max float64, isNull bool, err error) {
 	max, isNull, err = b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return max, isNull, errors.Trace(err)
+		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
 		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
 		if isNull || err != nil {
-			return max, isNull, errors.Trace(err)
+			return max, isNull, err
 		}
 		if v > max {
 			max = v
@@ -500,13 +499,13 @@ func (b *builtinGreatestDecimalSig) Clone() builtinFunc {
 func (b *builtinGreatestDecimalSig) evalDecimal(row chunk.Row) (max *types.MyDecimal, isNull bool, err error) {
 	max, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return max, isNull, errors.Trace(err)
+		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
 		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
 		if isNull || err != nil {
-			return max, isNull, errors.Trace(err)
+			return max, isNull, err
 		}
 		if v.Compare(max) > 0 {
 			max = v
@@ -530,13 +529,13 @@ func (b *builtinGreatestStringSig) Clone() builtinFunc {
 func (b *builtinGreatestStringSig) evalString(row chunk.Row) (max string, isNull bool, err error) {
 	max, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return max, isNull, errors.Trace(err)
+		return max, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
 		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return max, isNull, errors.Trace(err)
+			return max, isNull, err
 		}
 		if types.CompareString(v, max) > 0 {
 			max = v
@@ -567,12 +566,12 @@ func (b *builtinGreatestTimeSig) evalString(row chunk.Row) (_ string, isNull boo
 	for i := 0; i < len(b.args); i++ {
 		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		t, err = types.ParseDatetime(sc, v)
 		if err != nil {
 			if err = handleInvalidTimeError(b.ctx, err); err != nil {
-				return v, true, errors.Trace(err)
+				return v, true, err
 			}
 			continue
 		}
@@ -589,7 +588,7 @@ type leastFunctionClass struct {
 
 func (c *leastFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tp, cmpAsDatetime := getCmpTp4MinMax(args), false
 	if tp == types.ETDatetime {
@@ -634,13 +633,13 @@ func (b *builtinLeastIntSig) Clone() builtinFunc {
 func (b *builtinLeastIntSig) evalInt(row chunk.Row) (min int64, isNull bool, err error) {
 	min, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return min, isNull, errors.Trace(err)
+		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v int64
 		v, isNull, err = b.args[i].EvalInt(b.ctx, row)
 		if isNull || err != nil {
-			return min, isNull, errors.Trace(err)
+			return min, isNull, err
 		}
 		if v < min {
 			min = v
@@ -664,13 +663,13 @@ func (b *builtinLeastRealSig) Clone() builtinFunc {
 func (b *builtinLeastRealSig) evalReal(row chunk.Row) (min float64, isNull bool, err error) {
 	min, isNull, err = b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return min, isNull, errors.Trace(err)
+		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v float64
 		v, isNull, err = b.args[i].EvalReal(b.ctx, row)
 		if isNull || err != nil {
-			return min, isNull, errors.Trace(err)
+			return min, isNull, err
 		}
 		if v < min {
 			min = v
@@ -694,13 +693,13 @@ func (b *builtinLeastDecimalSig) Clone() builtinFunc {
 func (b *builtinLeastDecimalSig) evalDecimal(row chunk.Row) (min *types.MyDecimal, isNull bool, err error) {
 	min, isNull, err = b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return min, isNull, errors.Trace(err)
+		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v *types.MyDecimal
 		v, isNull, err = b.args[i].EvalDecimal(b.ctx, row)
 		if isNull || err != nil {
-			return min, isNull, errors.Trace(err)
+			return min, isNull, err
 		}
 		if v.Compare(min) < 0 {
 			min = v
@@ -724,13 +723,13 @@ func (b *builtinLeastStringSig) Clone() builtinFunc {
 func (b *builtinLeastStringSig) evalString(row chunk.Row) (min string, isNull bool, err error) {
 	min, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return min, isNull, errors.Trace(err)
+		return min, isNull, err
 	}
 	for i := 1; i < len(b.args); i++ {
 		var v string
 		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return min, isNull, errors.Trace(err)
+			return min, isNull, err
 		}
 		if types.CompareString(v, min) < 0 {
 			min = v
@@ -766,12 +765,12 @@ func (b *builtinLeastTimeSig) evalString(row chunk.Row) (res string, isNull bool
 	for i := 0; i < len(b.args); i++ {
 		v, isNull, err = b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		t, err = types.ParseDatetime(sc, v)
 		if err != nil {
 			if err = handleInvalidTimeError(b.ctx, err); err != nil {
-				return v, true, errors.Trace(err)
+				return v, true, err
 			} else if !findInvalidTime {
 				res = v
 				findInvalidTime = true
@@ -793,7 +792,7 @@ type intervalFunctionClass struct {
 
 func (c *intervalFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	allInt := true
@@ -835,13 +834,13 @@ func (b *builtinIntervalIntSig) Clone() builtinFunc {
 func (b *builtinIntervalIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	args0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull {
 		return -1, false, nil
 	}
 	idx, err := b.binSearch(args0, mysql.HasUnsignedFlag(b.args[0].GetType().Flag), b.args[1:], row)
-	return int64(idx), err != nil, errors.Trace(err)
+	return int64(idx), err != nil, err
 }
 
 // binSearch is a binary search method.
@@ -877,7 +876,7 @@ func (b *builtinIntervalIntSig) binSearch(target int64, isUint1 bool, args []Exp
 			j = mid
 		}
 	}
-	return i, errors.Trace(err)
+	return i, err
 }
 
 type builtinIntervalRealSig struct {
@@ -895,13 +894,13 @@ func (b *builtinIntervalRealSig) Clone() builtinFunc {
 func (b *builtinIntervalRealSig) evalInt(row chunk.Row) (int64, bool, error) {
 	args0, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull {
 		return -1, false, nil
 	}
 	idx, err := b.binSearch(args0, b.args[1:], row)
-	return int64(idx), err != nil, errors.Trace(err)
+	return int64(idx), err != nil, err
 }
 
 func (b *builtinIntervalRealSig) binSearch(target float64, args []Expression, row chunk.Row) (_ int, err error) {
@@ -921,7 +920,7 @@ func (b *builtinIntervalRealSig) binSearch(target float64, args []Expression, ro
 			j = mid
 		}
 	}
-	return i, errors.Trace(err)
+	return i, err
 }
 
 type compareFunctionClass struct {
@@ -1156,12 +1155,12 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 // getFunction sets compare built-in function signatures for various types.
 func (c *compareFunctionClass) getFunction(ctx sessionctx.Context, rawArgs []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(rawArgs); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	args := c.refineArgs(ctx, rawArgs)
 	cmpType := GetAccurateCmpType(args[0], args[1])
 	sig, err = c.generateCmpSigs(ctx, args, cmpType)
-	return sig, errors.Trace(err)
+	return sig, err
 }
 
 // generateCmpSigs generates compare function signatures.
@@ -1948,11 +1947,11 @@ func (b *builtinNullEQIntSig) Clone() builtinFunc {
 func (b *builtinNullEQIntSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	isUnsigned0, isUnsigned1 := mysql.HasUnsignedFlag(b.args[0].GetType().Flag), mysql.HasUnsignedFlag(b.args[1].GetType().Flag)
 	var res int64
@@ -1996,11 +1995,11 @@ func (b *builtinNullEQRealSig) Clone() builtinFunc {
 func (b *builtinNullEQRealSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2027,11 +2026,11 @@ func (b *builtinNullEQDecimalSig) Clone() builtinFunc {
 func (b *builtinNullEQDecimalSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalDecimal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2058,11 +2057,11 @@ func (b *builtinNullEQStringSig) Clone() builtinFunc {
 func (b *builtinNullEQStringSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalString(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2089,11 +2088,11 @@ func (b *builtinNullEQDurationSig) Clone() builtinFunc {
 func (b *builtinNullEQDurationSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalDuration(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalDuration(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2120,11 +2119,11 @@ func (b *builtinNullEQTimeSig) Clone() builtinFunc {
 func (b *builtinNullEQTimeSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalTime(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalTime(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2151,11 +2150,11 @@ func (b *builtinNullEQJSONSig) Clone() builtinFunc {
 func (b *builtinNullEQJSONSig) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalJSON(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalJSON(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	var res int64
 	switch {
@@ -2174,7 +2173,7 @@ func (b *builtinNullEQJSONSig) evalInt(row chunk.Row) (val int64, isNull bool, e
 
 func resOfLT(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val < 0 {
 		val = 1
@@ -2186,7 +2185,7 @@ func resOfLT(val int64, isNull bool, err error) (int64, bool, error) {
 
 func resOfLE(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val <= 0 {
 		val = 1
@@ -2198,7 +2197,7 @@ func resOfLE(val int64, isNull bool, err error) (int64, bool, error) {
 
 func resOfGT(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val > 0 {
 		val = 1
@@ -2210,7 +2209,7 @@ func resOfGT(val int64, isNull bool, err error) (int64, bool, error) {
 
 func resOfGE(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val >= 0 {
 		val = 1
@@ -2222,7 +2221,7 @@ func resOfGE(val int64, isNull bool, err error) (int64, bool, error) {
 
 func resOfEQ(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val == 0 {
 		val = 1
@@ -2234,7 +2233,7 @@ func resOfEQ(val int64, isNull bool, err error) (int64, bool, error) {
 
 func resOfNE(val int64, isNull bool, err error) (int64, bool, error) {
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val != 0 {
 		val = 1
@@ -2247,11 +2246,11 @@ func resOfNE(val int64, isNull bool, err error) (int64, bool, error) {
 func compareInt(ctx sessionctx.Context, args []Expression, row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := args[0].EvalInt(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalInt(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	isUnsigned0, isUnsigned1 := mysql.HasUnsignedFlag(args[0].GetType().Flag), mysql.HasUnsignedFlag(args[1].GetType().Flag)
 	var res int
@@ -2279,11 +2278,11 @@ func compareInt(ctx sessionctx.Context, args []Expression, row chunk.Row) (val i
 func compareString(args []Expression, row chunk.Row, ctx sessionctx.Context) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := args[0].EvalString(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalString(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(types.CompareString(arg0, arg1)), false, nil
 }
@@ -2291,11 +2290,11 @@ func compareString(args []Expression, row chunk.Row, ctx sessionctx.Context) (va
 func compareReal(ctx sessionctx.Context, args []Expression, row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := args[0].EvalReal(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalReal(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(types.CompareFloat64(arg0, arg1)), false, nil
 }
@@ -2303,14 +2302,14 @@ func compareReal(ctx sessionctx.Context, args []Expression, row chunk.Row) (val 
 func compareDecimal(ctx sessionctx.Context, args []Expression, row chunk.Row) (val int64, isNull bool, err error) {
 	arg0, isNull0, err := args[0].EvalDecimal(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalDecimal(ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(arg0.Compare(arg1)), false, nil
 }
@@ -2318,11 +2317,11 @@ func compareDecimal(ctx sessionctx.Context, args []Expression, row chunk.Row) (v
 func compareTime(ctx sessionctx.Context, args []Expression, row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := args[0].EvalTime(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalTime(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(arg0.Compare(arg1)), false, nil
 }
@@ -2330,11 +2329,11 @@ func compareTime(ctx sessionctx.Context, args []Expression, row chunk.Row) (int6
 func compareDuration(args []Expression, row chunk.Row, ctx sessionctx.Context) (int64, bool, error) {
 	arg0, isNull0, err := args[0].EvalDuration(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalDuration(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(arg0.Compare(arg1)), false, nil
 }
@@ -2342,11 +2341,11 @@ func compareDuration(args []Expression, row chunk.Row, ctx sessionctx.Context) (
 func compareJSON(ctx sessionctx.Context, args []Expression, row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := args[0].EvalJSON(ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	arg1, isNull1, err := args[1].EvalJSON(ctx, row)
 	if isNull1 || err != nil {
-		return 0, isNull1, errors.Trace(err)
+		return 0, isNull1, err
 	}
 	return int64(json.CompareBinary(arg0, arg1)), false, nil
 }

--- a/expression/builtin_control.go
+++ b/expression/builtin_control.go
@@ -15,7 +15,6 @@ package expression
 
 import (
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -135,7 +134,7 @@ type caseWhenFunctionClass struct {
 
 func (c *caseWhenFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	l := len(args)
 	// Fill in each 'THEN' clause parameter type.
@@ -230,20 +229,20 @@ func (b *builtinCaseWhenIntSig) evalInt(row chunk.Row) (ret int64, isNull bool, 
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return 0, isNull, errors.Trace(err)
+			return 0, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalInt(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalInt(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -266,20 +265,20 @@ func (b *builtinCaseWhenRealSig) evalReal(row chunk.Row) (ret float64, isNull bo
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return 0, isNull, errors.Trace(err)
+			return 0, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalReal(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalReal(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -302,20 +301,20 @@ func (b *builtinCaseWhenDecimalSig) evalDecimal(row chunk.Row) (ret *types.MyDec
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return nil, isNull, errors.Trace(err)
+			return nil, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalDecimal(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalDecimal(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -338,20 +337,20 @@ func (b *builtinCaseWhenStringSig) evalString(row chunk.Row) (ret string, isNull
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return "", isNull, errors.Trace(err)
+			return "", isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalString(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalString(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -374,20 +373,20 @@ func (b *builtinCaseWhenTimeSig) evalTime(row chunk.Row) (ret types.Time, isNull
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return ret, isNull, errors.Trace(err)
+			return ret, isNull, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalTime(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalTime(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -410,20 +409,20 @@ func (b *builtinCaseWhenDurationSig) evalDuration(row chunk.Row) (ret types.Dura
 	for i := 0; i < l-1; i += 2 {
 		condition, isNull, err = args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return ret, true, errors.Trace(err)
+			return ret, true, err
 		}
 		if isNull || condition == 0 {
 			continue
 		}
 		ret, isNull, err = args[i+1].EvalDuration(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	// when clause(condition, result) -> args[i], args[i+1]; (i >= 0 && i+1 < l-1)
 	// else clause -> args[l-1]
 	// If case clause has else clause, l%2 == 1.
 	if l%2 == 1 {
 		ret, isNull, err = args[l-1].EvalDuration(b.ctx, row)
-		return ret, isNull, errors.Trace(err)
+		return ret, isNull, err
 	}
 	return ret, true, nil
 }
@@ -469,7 +468,7 @@ type ifFunctionClass struct {
 // getFunction see https://dev.mysql.com/doc/refman/5.7/en/control-flow-functions.html#function_if
 func (c *ifFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	retTp := inferType4ControlFuncs(args[1].GetType(), args[2].GetType())
 	evalTps := retTp.EvalType()
@@ -515,14 +514,14 @@ func (b *builtinIfIntSig) Clone() builtinFunc {
 func (b *builtinIfIntSig) evalInt(row chunk.Row) (ret int64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalInt(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfRealSig struct {
@@ -538,14 +537,14 @@ func (b *builtinIfRealSig) Clone() builtinFunc {
 func (b *builtinIfRealSig) evalReal(row chunk.Row) (ret float64, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalReal(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalReal(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfDecimalSig struct {
@@ -561,14 +560,14 @@ func (b *builtinIfDecimalSig) Clone() builtinFunc {
 func (b *builtinIfDecimalSig) evalDecimal(row chunk.Row) (ret *types.MyDecimal, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalDecimal(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalDecimal(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfStringSig struct {
@@ -584,14 +583,14 @@ func (b *builtinIfStringSig) Clone() builtinFunc {
 func (b *builtinIfStringSig) evalString(row chunk.Row) (ret string, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalString(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalString(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfTimeSig struct {
@@ -607,14 +606,14 @@ func (b *builtinIfTimeSig) Clone() builtinFunc {
 func (b *builtinIfTimeSig) evalTime(row chunk.Row) (ret types.Time, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return ret, true, errors.Trace(err)
+		return ret, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalTime(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalTime(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfDurationSig struct {
@@ -630,14 +629,14 @@ func (b *builtinIfDurationSig) Clone() builtinFunc {
 func (b *builtinIfDurationSig) evalDuration(row chunk.Row) (ret types.Duration, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return ret, true, errors.Trace(err)
+		return ret, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalDuration(b.ctx, row)
 	if (!isNull0 && arg0 != 0) || err != nil {
-		return arg1, isNull1, errors.Trace(err)
+		return arg1, isNull1, err
 	}
 	arg2, isNull2, err := b.args[2].EvalDuration(b.ctx, row)
-	return arg2, isNull2, errors.Trace(err)
+	return arg2, isNull2, err
 }
 
 type builtinIfJSONSig struct {
@@ -653,15 +652,15 @@ func (b *builtinIfJSONSig) Clone() builtinFunc {
 func (b *builtinIfJSONSig) evalJSON(row chunk.Row) (ret json.BinaryJSON, isNull bool, err error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return ret, true, errors.Trace(err)
+		return ret, true, err
 	}
 	arg1, isNull1, err := b.args[1].EvalJSON(b.ctx, row)
 	if err != nil {
-		return ret, true, errors.Trace(err)
+		return ret, true, err
 	}
 	arg2, isNull2, err := b.args[2].EvalJSON(b.ctx, row)
 	if err != nil {
-		return ret, true, errors.Trace(err)
+		return ret, true, err
 	}
 	switch {
 	case isNull0 || arg0 == 0:
@@ -677,8 +676,8 @@ type ifNullFunctionClass struct {
 }
 
 func (c *ifNullFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
-	if err = errors.Trace(c.verifyArgs(args)); err != nil {
-		return nil, errors.Trace(err)
+	if err = c.verifyArgs(args); err != nil {
+		return nil, err
 	}
 	lhs, rhs := args[0].GetType(), args[1].GetType()
 	retTp := inferType4ControlFuncs(lhs, rhs)
@@ -730,10 +729,10 @@ func (b *builtinIfNullIntSig) Clone() builtinFunc {
 func (b *builtinIfNullIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullRealSig struct {
@@ -749,10 +748,10 @@ func (b *builtinIfNullRealSig) Clone() builtinFunc {
 func (b *builtinIfNullRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalReal(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullDecimalSig struct {
@@ -768,10 +767,10 @@ func (b *builtinIfNullDecimalSig) Clone() builtinFunc {
 func (b *builtinIfNullDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalDecimal(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullStringSig struct {
@@ -787,10 +786,10 @@ func (b *builtinIfNullStringSig) Clone() builtinFunc {
 func (b *builtinIfNullStringSig) evalString(row chunk.Row) (string, bool, error) {
 	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullTimeSig struct {
@@ -806,10 +805,10 @@ func (b *builtinIfNullTimeSig) Clone() builtinFunc {
 func (b *builtinIfNullTimeSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalTime(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullDurationSig struct {
@@ -825,10 +824,10 @@ func (b *builtinIfNullDurationSig) Clone() builtinFunc {
 func (b *builtinIfNullDurationSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if !isNull || err != nil {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }
 
 type builtinIfNullJSONSig struct {
@@ -844,8 +843,8 @@ func (b *builtinIfNullJSONSig) Clone() builtinFunc {
 func (b *builtinIfNullJSONSig) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error) {
 	arg0, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if !isNull {
-		return arg0, err != nil, errors.Trace(err)
+		return arg0, err != nil, err
 	}
 	arg1, isNull, err := b.args[1].EvalJSON(b.ctx, row)
-	return arg1, isNull || err != nil, errors.Trace(err)
+	return arg1, isNull || err != nil, err
 }

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -101,7 +101,7 @@ type aesDecryptFunctionClass struct {
 
 func (c *aesDecryptFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(c.verifyArgs(args))
+		return nil, c.verifyArgs(args)
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for range args {
@@ -143,11 +143,11 @@ func (b *builtinAesDecryptSig) evalString(row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
 	cryptStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
@@ -186,17 +186,17 @@ func (b *builtinAesDecryptIVSig) evalString(row chunk.Row) (string, bool, error)
 	// According to doc: If either function argument is NULL, the function returns NULL.
 	cryptStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	iv, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if len(iv) < aes.BlockSize {
 		return "", true, errIncorrectArgs.GenWithStack("The initialization vector supplied to aes_decrypt is too short. Must be at least %d bytes long", aes.BlockSize)
@@ -224,7 +224,7 @@ type aesEncryptFunctionClass struct {
 
 func (c *aesEncryptFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(c.verifyArgs(args))
+		return nil, c.verifyArgs(args)
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for range args {
@@ -266,11 +266,11 @@ func (b *builtinAesEncryptSig) evalString(row chunk.Row) (string, bool, error) {
 	// According to doc: If either function argument is NULL, the function returns NULL.
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if !b.ivRequired && len(b.args) == 3 {
 		// For modes that do not require init_vector, it is ignored and a warning is generated if it is specified.
@@ -309,17 +309,17 @@ func (b *builtinAesEncryptIVSig) evalString(row chunk.Row) (string, bool, error)
 	// According to doc: If either function argument is NULL, the function returns NULL.
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	keyStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	iv, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if len(iv) < aes.BlockSize {
 		return "", true, errIncorrectArgs.GenWithStack("The initialization vector supplied to aes_encrypt is too short. Must be at least %d bytes long", aes.BlockSize)
@@ -347,7 +347,7 @@ type decodeFunctionClass struct {
 
 func (c *decodeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
@@ -372,12 +372,12 @@ func (b *builtinDecodeSig) Clone() builtinFunc {
 func (b *builtinDecodeSig) evalString(row chunk.Row) (string, bool, error) {
 	dataStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	passwordStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	decodeStr, err := encrypt.SQLDecode(dataStr, passwordStr)
@@ -406,7 +406,7 @@ type encodeFunctionClass struct {
 
 func (c *encodeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
@@ -431,12 +431,12 @@ func (b *builtinEncodeSig) Clone() builtinFunc {
 func (b *builtinEncodeSig) evalString(row chunk.Row) (string, bool, error) {
 	decodeStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	passwordStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	dataStr, err := encrypt.SQLEncode(decodeStr, passwordStr)
@@ -465,7 +465,7 @@ type passwordFunctionClass struct {
 
 func (c *passwordFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = mysql.PWDHashLen + 1
@@ -488,7 +488,7 @@ func (b *builtinPasswordSig) Clone() builtinFunc {
 func (b *builtinPasswordSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	pass, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", err != nil, errors.Trace(err)
+		return "", err != nil, err
 	}
 
 	if len(pass) == 0 {
@@ -508,7 +508,7 @@ type randomBytesFunctionClass struct {
 
 func (c *randomBytesFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = 1024 // Max allowed random bytes
@@ -532,14 +532,14 @@ func (b *builtinRandomBytesSig) Clone() builtinFunc {
 func (b *builtinRandomBytesSig) evalString(row chunk.Row) (string, bool, error) {
 	len, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if len < 1 || len > 1024 {
 		return "", false, types.ErrOverflow.GenWithStackByArgs("length", "random_bytes")
 	}
 	buf := make([]byte, len)
 	if n, err := rand.Read(buf); err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	} else if int64(n) != len {
 		return "", false, errors.New("fail to generate random bytes")
 	}
@@ -552,7 +552,7 @@ type md5FunctionClass struct {
 
 func (c *md5FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 32
@@ -575,7 +575,7 @@ func (b *builtinMD5Sig) Clone() builtinFunc {
 func (b *builtinMD5Sig) evalString(row chunk.Row) (string, bool, error) {
 	arg, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	sum := md5.Sum([]byte(arg))
 	hexStr := fmt.Sprintf("%x", sum)
@@ -588,7 +588,7 @@ type sha1FunctionClass struct {
 
 func (c *sha1FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 40
@@ -612,12 +612,12 @@ func (b *builtinSHA1Sig) Clone() builtinFunc {
 func (b *builtinSHA1Sig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	hasher := sha1.New()
 	_, err = hasher.Write([]byte(str))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return fmt.Sprintf("%x", hasher.Sum(nil)), false, nil
 }
@@ -628,7 +628,7 @@ type sha2FunctionClass struct {
 
 func (c *sha2FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt)
 	bf.tp.Flen = 128 // sha512
@@ -660,11 +660,11 @@ const (
 func (b *builtinSHA2Sig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	hashLength, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	var hasher hash.Hash
 	switch int(hashLength) {
@@ -683,7 +683,7 @@ func (b *builtinSHA2Sig) evalString(row chunk.Row) (string, bool, error) {
 
 	_, err = hasher.Write([]byte(str))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return fmt.Sprintf("%x", hasher.Sum(nil)), false, nil
 }
@@ -693,10 +693,10 @@ func deflate(data []byte) ([]byte, error) {
 	var buffer bytes.Buffer
 	w := zlib.NewWriter(&buffer)
 	if _, err := w.Write(data); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if err := w.Close(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return buffer.Bytes(), nil
 }
@@ -707,13 +707,13 @@ func inflate(compressStr []byte) ([]byte, error) {
 	var out bytes.Buffer
 	r, err := zlib.NewReader(reader)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if _, err = io.Copy(&out, r); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	err = r.Close()
-	return out.Bytes(), errors.Trace(err)
+	return out.Bytes(), err
 }
 
 type compressFunctionClass struct {
@@ -722,7 +722,7 @@ type compressFunctionClass struct {
 
 func (c *compressFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	srcLen := args[0].GetType().Flen
@@ -751,7 +751,7 @@ func (b *builtinCompressSig) Clone() builtinFunc {
 func (b *builtinCompressSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	// According to doc: Empty strings are stored as empty strings.
@@ -789,7 +789,7 @@ type uncompressFunctionClass struct {
 
 func (c *uncompressFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = mysql.MaxBlobWidth
@@ -814,7 +814,7 @@ func (b *builtinUncompressSig) evalString(row chunk.Row) (string, bool, error) {
 	sc := b.ctx.GetSessionVars().StmtCtx
 	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if len(payload) == 0 {
 		return "", false, nil
@@ -843,7 +843,7 @@ type uncompressedLengthFunctionClass struct {
 
 func (c *uncompressedLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
@@ -867,7 +867,7 @@ func (b *builtinUncompressedLengthSig) evalInt(row chunk.Row) (int64, bool, erro
 	sc := b.ctx.GetSessionVars().StmtCtx
 	payload, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if len(payload) == 0 {
 		return 0, false, nil

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -61,7 +61,7 @@ type databaseFunctionClass struct {
 }
 
 func (c *databaseFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
+	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
@@ -92,7 +92,7 @@ type foundRowsFunctionClass struct {
 }
 
 func (c *foundRowsFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
+	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt)
@@ -127,8 +127,8 @@ type currentUserFunctionClass struct {
 }
 
 func (c *currentUserFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
-		return nil, errors.Trace(err)
+	if err := c.verifyArgs(args); err != nil {
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
 	bf.tp.Flen = 64
@@ -161,7 +161,7 @@ type userFunctionClass struct {
 }
 
 func (c *userFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
+	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
@@ -196,7 +196,7 @@ type connectionIDFunctionClass struct {
 }
 
 func (c *connectionIDFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
+	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt)
@@ -229,7 +229,7 @@ type lastInsertIDFunctionClass struct {
 
 func (c *lastInsertIDFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	var argsTp []types.EvalType
@@ -244,7 +244,7 @@ func (c *lastInsertIDFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	} else {
 		sig = &builtinLastInsertIDSig{bf}
 	}
-	return sig, errors.Trace(err)
+	return sig, err
 }
 
 type builtinLastInsertIDSig struct {
@@ -279,7 +279,7 @@ func (b *builtinLastInsertIDWithIDSig) Clone() builtinFunc {
 func (b *builtinLastInsertIDWithIDSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	b.ctx.GetSessionVars().SetLastInsertID(uint64(res))
@@ -291,7 +291,7 @@ type versionFunctionClass struct {
 }
 
 func (c *versionFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	if err := errors.Trace(c.verifyArgs(args)); err != nil {
+	if err := c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
@@ -322,7 +322,7 @@ type tidbVersionFunctionClass struct {
 
 func (c *tidbVersionFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
 	bf.tp.Flen = len(printer.GetTiDBInfo())
@@ -352,7 +352,7 @@ type tidbIsDDLOwnerFunctionClass struct {
 
 func (c *tidbIsDDLOwnerFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt)
 	sig := &builtinTiDBIsDDLOwnerSig{bf}
@@ -417,7 +417,7 @@ type rowCountFunctionClass struct {
 
 func (c *rowCountFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt)
 	sig = &builtinRowCountSig{bf}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -83,7 +83,7 @@ func (b *builtinJSONTypeSig) Clone() builtinFunc {
 
 func (c *jsonTypeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETJson)
 	bf.tp.Flen = 51 // Flen of JSON_TYPE is length of UNSIGNED INTEGER.
@@ -96,7 +96,7 @@ func (b *builtinJSONTypeSig) evalString(row chunk.Row) (res string, isNull bool,
 	var j json.BinaryJSON
 	j, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	return j.Type(), false, nil
 }
@@ -117,7 +117,7 @@ func (b *builtinJSONExtractSig) Clone() builtinFunc {
 
 func (c *jsonExtractFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETJson)
@@ -140,11 +140,11 @@ func (b *builtinJSONExtractSig) evalJSON(row chunk.Row) (res json.BinaryJSON, is
 		var s string
 		s, isNull, err = arg.EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		pathExpr, err := json.ParseJSONPathExpr(s)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		pathExprs = append(pathExprs, pathExpr)
 	}
@@ -171,7 +171,7 @@ func (b *builtinJSONUnquoteSig) Clone() builtinFunc {
 
 func (c *jsonUnquoteFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETJson)
 	args[0].GetType().Flag &= ^mysql.ParseToJSONFlag
@@ -184,10 +184,10 @@ func (b *builtinJSONUnquoteSig) evalString(row chunk.Row) (res string, isNull bo
 	var j json.BinaryJSON
 	j, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	res, err = j.Unquote()
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 type jsonSetFunctionClass struct {
@@ -206,7 +206,7 @@ func (b *builtinJSONSetSig) Clone() builtinFunc {
 
 func (c *jsonSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(args)&1 != 1 {
 		return nil, ErrIncorrectParameterCount.GenWithStackByArgs(c.funcName)
@@ -227,7 +227,7 @@ func (c *jsonSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 
 func (b *builtinJSONSetSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifySet)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type jsonInsertFunctionClass struct {
@@ -246,7 +246,7 @@ func (b *builtinJSONInsertSig) Clone() builtinFunc {
 
 func (c *jsonInsertFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(args)&1 != 1 {
 		return nil, ErrIncorrectParameterCount.GenWithStackByArgs(c.funcName)
@@ -267,7 +267,7 @@ func (c *jsonInsertFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 
 func (b *builtinJSONInsertSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifyInsert)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type jsonReplaceFunctionClass struct {
@@ -286,7 +286,7 @@ func (b *builtinJSONReplaceSig) Clone() builtinFunc {
 
 func (c *jsonReplaceFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(args)&1 != 1 {
 		return nil, ErrIncorrectParameterCount.GenWithStackByArgs(c.funcName)
@@ -307,7 +307,7 @@ func (c *jsonReplaceFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 
 func (b *builtinJSONReplaceSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = jsonModify(b.ctx, b.args, row, json.ModifyReplace)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type jsonRemoveFunctionClass struct {
@@ -326,7 +326,7 @@ func (b *builtinJSONRemoveSig) Clone() builtinFunc {
 
 func (c *jsonRemoveFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETJson)
@@ -342,25 +342,25 @@ func (c *jsonRemoveFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 func (b *builtinJSONRemoveSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	pathExprs := make([]json.PathExpression, 0, len(b.args)-1)
 	for _, arg := range b.args[1:] {
 		var s string
 		s, isNull, err = arg.EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		var pathExpr json.PathExpression
 		pathExpr, err = json.ParseJSONPathExpr(s)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		pathExprs = append(pathExprs, pathExpr)
 	}
 	res, err = res.Remove(pathExprs)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	return res, false, nil
 }
@@ -381,7 +381,7 @@ func (b *builtinJSONMergeSig) Clone() builtinFunc {
 
 func (c *jsonMergeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for range args {
@@ -399,7 +399,7 @@ func (b *builtinJSONMergeSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNu
 		var value json.BinaryJSON
 		value, isNull, err = arg.EvalJSON(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		values = append(values, value)
 	}
@@ -423,7 +423,7 @@ func (b *builtinJSONObjectSig) Clone() builtinFunc {
 
 func (c *jsonObjectFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(args)&1 != 0 {
 		return nil, ErrIncorrectParameterCount.GenWithStackByArgs(c.funcName)
@@ -444,7 +444,7 @@ func (c *jsonObjectFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 func (b *builtinJSONObjectSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	if len(b.args)&1 == 1 {
 		err = ErrIncorrectParameterCount.GenWithStackByArgs(ast.JSONObject)
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	jsons := make(map[string]interface{}, len(b.args)>>1)
 	var key string
@@ -453,16 +453,16 @@ func (b *builtinJSONObjectSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 		if i&1 == 0 {
 			key, isNull, err = arg.EvalString(b.ctx, row)
 			if err != nil {
-				return res, true, errors.Trace(err)
+				return res, true, err
 			}
 			if isNull {
 				err = errors.New("JSON documents may not contain NULL member names")
-				return res, true, errors.Trace(err)
+				return res, true, err
 			}
 		} else {
 			value, isNull, err = arg.EvalJSON(b.ctx, row)
 			if err != nil {
-				return res, true, errors.Trace(err)
+				return res, true, err
 			}
 			if isNull {
 				value = json.CreateBinary(nil)
@@ -489,7 +489,7 @@ func (b *builtinJSONArraySig) Clone() builtinFunc {
 
 func (c *jsonArrayFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for range args {
@@ -509,7 +509,7 @@ func (b *builtinJSONArraySig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNu
 	for _, arg := range b.args {
 		j, isNull, err := arg.EvalJSON(b.ctx, row)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		if isNull {
 			j = json.CreateBinary(nil)
@@ -535,7 +535,7 @@ func (b *builtinJSONContainsPathSig) Clone() builtinFunc {
 
 func (c *jsonContainsPathFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := []types.EvalType{types.ETJson, types.ETString}
 	for i := 3; i <= len(args); i++ {
@@ -550,11 +550,11 @@ func (c *jsonContainsPathFunctionClass) getFunction(ctx sessionctx.Context, args
 func (b *builtinJSONContainsPathSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	containType, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if containType != json.ContainsPathAll && containType != json.ContainsPathOne {
 		return res, true, json.ErrInvalidJSONContainsPathType
@@ -564,10 +564,10 @@ func (b *builtinJSONContainsPathSig) evalInt(row chunk.Row) (res int64, isNull b
 	for i := 2; i < len(b.args); i++ {
 		path, isNull, err := b.args[i].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		if pathExpr, err = json.ParseJSONPathExpr(path); err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		_, exists := obj.Extract([]json.PathExpression{pathExpr})
 		switch {
@@ -585,7 +585,7 @@ func (b *builtinJSONContainsPathSig) evalInt(row chunk.Row) (res int64, isNull b
 func jsonModify(ctx sessionctx.Context, args []Expression, row chunk.Row, mt json.ModifyType) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = args[0].EvalJSON(ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	pathExprs := make([]json.PathExpression, 0, (len(args)-1)/2+1)
 	for i := 1; i < len(args); i += 2 {
@@ -593,12 +593,12 @@ func jsonModify(ctx sessionctx.Context, args []Expression, row chunk.Row, mt jso
 		var s string
 		s, isNull, err = args[i].EvalString(ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		var pathExpr json.PathExpression
 		pathExpr, err = json.ParseJSONPathExpr(s)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		pathExprs = append(pathExprs, pathExpr)
 	}
@@ -607,7 +607,7 @@ func jsonModify(ctx sessionctx.Context, args []Expression, row chunk.Row, mt jso
 		var value json.BinaryJSON
 		value, isNull, err = args[i].EvalJSON(ctx, row)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		if isNull {
 			value = json.CreateBinary(nil)
@@ -616,7 +616,7 @@ func jsonModify(ctx sessionctx.Context, args []Expression, row chunk.Row, mt jso
 	}
 	res, err = res.Modify(pathExprs, values, mt)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	return res, false, nil
 }
@@ -637,7 +637,7 @@ func (b *builtinJSONContainsSig) Clone() builtinFunc {
 
 func (c *jsonContainsFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := []types.EvalType{types.ETJson, types.ETJson}
 	if len(args) == 3 {
@@ -652,21 +652,21 @@ func (c *jsonContainsFunctionClass) getFunction(ctx sessionctx.Context, args []E
 func (b *builtinJSONContainsSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	target, isNull, err := b.args[1].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	var pathExpr json.PathExpression
 	if len(b.args) == 3 {
 		path, isNull, err := b.args[2].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 		pathExpr, err = json.ParseJSONPathExpr(path)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		if pathExpr.ContainsAnyAsterisk() {
 			return res, true, json.ErrInvalidJSONPathWildcard
@@ -772,7 +772,7 @@ func (b *builtinJSONDepthSig) Clone() builtinFunc {
 
 func (c *jsonDepthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETJson)
@@ -784,7 +784,7 @@ func (c *jsonDepthFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 func (b *builtinJSONDepthSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	return int64(obj.GetElemDepth()), false, nil
@@ -796,7 +796,7 @@ type jsonKeysFunctionClass struct {
 
 func (c *jsonKeysFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := []types.EvalType{types.ETJson}
 	if len(args) == 2 {
@@ -828,7 +828,7 @@ func (b *builtinJSONKeysSig) Clone() builtinFunc {
 func (b *builtinJSONKeysSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if res.TypeCode != json.TypeCodeObject {
 		return res, true, json.ErrInvalidJSONData
@@ -849,7 +849,7 @@ func (b *builtinJSONKeys2ArgsSig) Clone() builtinFunc {
 func (b *builtinJSONKeys2ArgsSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	if res.TypeCode != json.TypeCodeObject {
 		return res, true, json.ErrInvalidJSONData
@@ -857,12 +857,12 @@ func (b *builtinJSONKeys2ArgsSig) evalJSON(row chunk.Row) (res json.BinaryJSON, 
 
 	path, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	pathExpr, err := json.ParseJSONPathExpr(path)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	if pathExpr.ContainsAnyAsterisk() {
 		return res, true, json.ErrInvalidJSONPathWildcard
@@ -895,7 +895,7 @@ func (b *builtinJSONLengthSig) Clone() builtinFunc {
 
 func (c *jsonLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argTps := make([]types.EvalType, 0, len(args))
@@ -913,7 +913,7 @@ func (c *jsonLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 func (b *builtinJSONLengthSig) evalInt(row chunk.Row) (res int64, isNull bool, err error) {
 	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	if obj.TypeCode != json.TypeCodeObject && obj.TypeCode != json.TypeCodeArray {
@@ -923,12 +923,12 @@ func (b *builtinJSONLengthSig) evalInt(row chunk.Row) (res int64, isNull bool, e
 	if len(b.args) == 2 {
 		path, isNull, err := b.args[1].EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return res, isNull, errors.Trace(err)
+			return res, isNull, err
 		}
 
 		pathExpr, err := json.ParseJSONPathExpr(path)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 		if pathExpr.ContainsAnyAsterisk() {
 			return res, true, json.ErrInvalidJSONPathWildcard

--- a/expression/builtin_like.go
+++ b/expression/builtin_like.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"regexp"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -41,7 +40,7 @@ type likeFunctionClass struct {
 
 func (c *likeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTp := []types.EvalType{types.ETString, types.ETString, types.ETInt}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, argTp...)
@@ -67,17 +66,17 @@ func (b *builtinLikeSig) Clone() builtinFunc {
 func (b *builtinLikeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	valStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	// TODO: We don't need to compile pattern if it has been compiled or it is static.
 	patternStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	val, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	escape := byte(val)
 	patChars, patTypes := stringutil.CompilePattern(patternStr, escape)
@@ -91,7 +90,7 @@ type regexpFunctionClass struct {
 
 func (c *regexpFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETString)
 	bf.tp.Flen = 1
@@ -117,12 +116,12 @@ func (b *builtinRegexpBinarySig) Clone() builtinFunc {
 func (b *builtinRegexpBinarySig) evalInt(row chunk.Row) (int64, bool, error) {
 	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	pat, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	// TODO: We don't need to compile pattern if it has been compiled or it is static.
@@ -148,12 +147,12 @@ func (b *builtinRegexpSig) Clone() builtinFunc {
 func (b *builtinRegexpSig) evalInt(row chunk.Row) (int64, bool, error) {
 	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	pat, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	// TODO: We don't need to compile pattern if it has been compiled or it is static.

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -119,7 +118,7 @@ type absFunctionClass struct {
 
 func (c *absFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(c.verifyArgs(args))
+		return nil, c.verifyArgs(args)
 	}
 
 	argFieldTp := args[0].GetType()
@@ -174,7 +173,7 @@ func (b *builtinAbsRealSig) Clone() builtinFunc {
 func (b *builtinAbsRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Abs(val), false, nil
 }
@@ -194,7 +193,7 @@ func (b *builtinAbsIntSig) Clone() builtinFunc {
 func (b *builtinAbsIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val >= 0 {
 		return val, false, nil
@@ -236,14 +235,14 @@ func (b *builtinAbsDecSig) Clone() builtinFunc {
 func (b *builtinAbsDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	to := new(types.MyDecimal)
 	if !val.IsNegative() {
 		*to = *val
 	} else {
 		if err = types.DecimalSub(new(types.MyDecimal), val, to); err != nil {
-			return nil, true, errors.Trace(err)
+			return nil, true, err
 		}
 	}
 	return to, false, nil
@@ -251,7 +250,7 @@ func (b *builtinAbsDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, e
 
 func (c *roundFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(c.verifyArgs(args))
+		return nil, c.verifyArgs(args)
 	}
 	argTp := args[0].GetType().EvalType()
 	if argTp != types.ETInt && argTp != types.ETDecimal {
@@ -331,7 +330,7 @@ func (b *builtinRoundRealSig) Clone() builtinFunc {
 func (b *builtinRoundRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return types.Round(val, 0), false, nil
 }
@@ -367,11 +366,11 @@ func (b *builtinRoundDecSig) Clone() builtinFunc {
 func (b *builtinRoundDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	to := new(types.MyDecimal)
 	if err = val.Round(to, 0, types.ModeHalfEven); err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return to, false, nil
 }
@@ -391,11 +390,11 @@ func (b *builtinRoundWithFracRealSig) Clone() builtinFunc {
 func (b *builtinRoundWithFracRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return types.Round(val, int(frac)), false, nil
 }
@@ -415,11 +414,11 @@ func (b *builtinRoundWithFracIntSig) Clone() builtinFunc {
 func (b *builtinRoundWithFracIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(types.Round(float64(val), int(frac))), false, nil
 }
@@ -439,15 +438,15 @@ func (b *builtinRoundWithFracDecSig) Clone() builtinFunc {
 func (b *builtinRoundWithFracDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	frac, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 	to := new(types.MyDecimal)
 	if err = val.Round(to, mathutil.Min(int(frac), b.tp.Decimal), types.ModeHalfEven); err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return to, false, nil
 }
@@ -458,7 +457,7 @@ type ceilFunctionClass struct {
 
 func (c *ceilFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	retTp, argTp := getEvalTp4FloorAndCeil(args[0])
@@ -506,7 +505,7 @@ func (b *builtinCeilRealSig) Clone() builtinFunc {
 func (b *builtinCeilRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Ceil(val), false, nil
 }
@@ -542,7 +541,7 @@ func (b *builtinCeilIntToDecSig) Clone() builtinFunc {
 func (b *builtinCeilIntToDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 
 	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) || val >= 0 {
@@ -566,7 +565,7 @@ func (b *builtinCeilDecToIntSig) Clone() builtinFunc {
 func (b *builtinCeilDecToIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	// err here will only be ErrOverFlow(will never happen) or ErrTruncate(can be ignored).
 	res, err := val.ToInt()
@@ -576,7 +575,7 @@ func (b *builtinCeilDecToIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 			res = res + 1
 		}
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinCeilDecToDecSig struct {
@@ -593,22 +592,22 @@ func (b *builtinCeilDecToDecSig) Clone() builtinFunc {
 func (b *builtinCeilDecToDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 
 	res := new(types.MyDecimal)
 	if val.IsNegative() {
 		err = val.Round(res, 0, types.ModeTruncate)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 
 	err = val.Round(res, 0, types.ModeTruncate)
 	if err != nil || res.Compare(val) == 0 {
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 
 	err = types.DecimalAdd(res, types.NewDecFromInt(1), res)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 type floorFunctionClass struct {
@@ -645,7 +644,7 @@ func setFlag4FloorAndCeil(tp *types.FieldType, arg Expression) {
 
 func (c *floorFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	retTp, argTp := getEvalTp4FloorAndCeil(args[0])
@@ -691,7 +690,7 @@ func (b *builtinFloorRealSig) Clone() builtinFunc {
 func (b *builtinFloorRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Floor(val), false, nil
 }
@@ -727,7 +726,7 @@ func (b *builtinFloorIntToDecSig) Clone() builtinFunc {
 func (b *builtinFloorIntToDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 
 	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) || val >= 0 {
@@ -751,7 +750,7 @@ func (b *builtinFloorDecToIntSig) Clone() builtinFunc {
 func (b *builtinFloorDecToIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	// err here will only be ErrOverFlow(will never happen) or ErrTruncate(can be ignored).
 	res, err := val.ToInt()
@@ -761,7 +760,7 @@ func (b *builtinFloorDecToIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 			res--
 		}
 	}
-	return res, false, errors.Trace(err)
+	return res, false, err
 }
 
 type builtinFloorDecToDecSig struct {
@@ -778,22 +777,22 @@ func (b *builtinFloorDecToDecSig) Clone() builtinFunc {
 func (b *builtinFloorDecToDecSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	val, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 
 	res := new(types.MyDecimal)
 	if !val.IsNegative() {
 		err = val.Round(res, 0, types.ModeTruncate)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 
 	err = val.Round(res, 0, types.ModeTruncate)
 	if err != nil || res.Compare(val) == 0 {
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 
 	err = types.DecimalSub(res, types.NewDecFromInt(1), res)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 type logFunctionClass struct {
@@ -802,7 +801,7 @@ type logFunctionClass struct {
 
 func (c *logFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var (
 		sig     builtinFunc
@@ -840,7 +839,7 @@ func (b *builtinLog1ArgSig) Clone() builtinFunc {
 func (b *builtinLog1ArgSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val <= 0 {
 		return 0, true, nil
@@ -863,12 +862,12 @@ func (b *builtinLog2ArgsSig) Clone() builtinFunc {
 func (b *builtinLog2ArgsSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if val1 <= 0 || val1 == 1 || val2 <= 0 {
@@ -884,7 +883,7 @@ type log2FunctionClass struct {
 
 func (c *log2FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinLog2Sig{bf}
@@ -906,7 +905,7 @@ func (b *builtinLog2Sig) Clone() builtinFunc {
 func (b *builtinLog2Sig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val <= 0 {
 		return 0, true, nil
@@ -920,7 +919,7 @@ type log10FunctionClass struct {
 
 func (c *log10FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinLog10Sig{bf}
@@ -942,7 +941,7 @@ func (b *builtinLog10Sig) Clone() builtinFunc {
 func (b *builtinLog10Sig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val <= 0 {
 		return 0, true, nil
@@ -956,7 +955,7 @@ type randFunctionClass struct {
 
 func (c *randFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var sig builtinFunc
 	var argTps []types.EvalType
@@ -1009,7 +1008,7 @@ func (b *builtinRandWithSeedSig) Clone() builtinFunc {
 func (b *builtinRandWithSeedSig) evalReal(row chunk.Row) (float64, bool, error) {
 	seed, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if b.randGen == nil {
 		if isNull {
@@ -1028,7 +1027,7 @@ type powFunctionClass struct {
 
 func (c *powFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal, types.ETReal)
 	sig := &builtinPowSig{bf}
@@ -1050,11 +1049,11 @@ func (b *builtinPowSig) Clone() builtinFunc {
 func (b *builtinPowSig) evalReal(row chunk.Row) (float64, bool, error) {
 	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	y, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	power := math.Pow(x, y)
 	if math.IsInf(power, -1) || math.IsInf(power, 1) || math.IsNaN(power) {
@@ -1073,7 +1072,7 @@ type convFunctionClass struct {
 
 func (c *convFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETInt)
@@ -1097,17 +1096,17 @@ func (b *builtinConvSig) Clone() builtinFunc {
 func (b *builtinConvSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	n, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	fromBase, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	toBase, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	var (
@@ -1178,7 +1177,7 @@ type crc32FunctionClass struct {
 
 func (c *crc32FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
@@ -1202,7 +1201,7 @@ func (b *builtinCRC32Sig) Clone() builtinFunc {
 func (b *builtinCRC32Sig) evalInt(row chunk.Row) (int64, bool, error) {
 	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	r := crc32.ChecksumIEEE([]byte(x))
 	return int64(r), false, nil
@@ -1214,7 +1213,7 @@ type signFunctionClass struct {
 
 func (c *signFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETReal)
 	sig := &builtinSignSig{bf}
@@ -1236,7 +1235,7 @@ func (b *builtinSignSig) Clone() builtinFunc {
 func (b *builtinSignSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val > 0 {
 		return 1, false, nil
@@ -1253,7 +1252,7 @@ type sqrtFunctionClass struct {
 
 func (c *sqrtFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinSqrtSig{bf}
@@ -1275,7 +1274,7 @@ func (b *builtinSqrtSig) Clone() builtinFunc {
 func (b *builtinSqrtSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val < 0 {
 		return 0, true, nil
@@ -1289,7 +1288,7 @@ type acosFunctionClass struct {
 
 func (c *acosFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinAcosSig{bf}
@@ -1311,7 +1310,7 @@ func (b *builtinAcosSig) Clone() builtinFunc {
 func (b *builtinAcosSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if val < -1 || val > 1 {
 		return 0, true, nil
@@ -1326,7 +1325,7 @@ type asinFunctionClass struct {
 
 func (c *asinFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinAsinSig{bf}
@@ -1348,7 +1347,7 @@ func (b *builtinAsinSig) Clone() builtinFunc {
 func (b *builtinAsinSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if val < -1 || val > 1 {
@@ -1364,7 +1363,7 @@ type atanFunctionClass struct {
 
 func (c *atanFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var (
 		sig     builtinFunc
@@ -1402,7 +1401,7 @@ func (b *builtinAtan1ArgSig) Clone() builtinFunc {
 func (b *builtinAtan1ArgSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return math.Atan(val), false, nil
@@ -1423,12 +1422,12 @@ func (b *builtinAtan2ArgsSig) Clone() builtinFunc {
 func (b *builtinAtan2ArgsSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val1, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	val2, isNull, err := b.args[1].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return math.Atan2(val1, val2), false, nil
@@ -1440,7 +1439,7 @@ type cosFunctionClass struct {
 
 func (c *cosFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinCosSig{bf}
@@ -1462,7 +1461,7 @@ func (b *builtinCosSig) Clone() builtinFunc {
 func (b *builtinCosSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Cos(val), false, nil
 }
@@ -1473,7 +1472,7 @@ type cotFunctionClass struct {
 
 func (c *cotFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinCotSig{bf}
@@ -1495,7 +1494,7 @@ func (b *builtinCotSig) Clone() builtinFunc {
 func (b *builtinCotSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	tan := math.Tan(val)
@@ -1514,7 +1513,7 @@ type degreesFunctionClass struct {
 
 func (c *degreesFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinDegreesSig{bf}
@@ -1536,7 +1535,7 @@ func (b *builtinDegreesSig) Clone() builtinFunc {
 func (b *builtinDegreesSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	res := val * 180 / math.Pi
 	return res, false, nil
@@ -1548,7 +1547,7 @@ type expFunctionClass struct {
 
 func (c *expFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinExpSig{bf}
@@ -1570,7 +1569,7 @@ func (b *builtinExpSig) Clone() builtinFunc {
 func (b *builtinExpSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	exp := math.Exp(val)
 	if math.IsInf(exp, 0) || math.IsNaN(exp) {
@@ -1586,7 +1585,7 @@ type piFunctionClass struct {
 
 func (c *piFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var (
 		bf  baseBuiltinFunc
@@ -1622,7 +1621,7 @@ type radiansFunctionClass struct {
 
 func (c *radiansFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinRadiansSig{bf}
@@ -1644,7 +1643,7 @@ func (b *builtinRadiansSig) Clone() builtinFunc {
 func (b *builtinRadiansSig) evalReal(row chunk.Row) (float64, bool, error) {
 	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return x * math.Pi / 180, false, nil
 }
@@ -1655,7 +1654,7 @@ type sinFunctionClass struct {
 
 func (c *sinFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinSinSig{bf}
@@ -1677,7 +1676,7 @@ func (b *builtinSinSig) Clone() builtinFunc {
 func (b *builtinSinSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Sin(val), false, nil
 }
@@ -1688,7 +1687,7 @@ type tanFunctionClass struct {
 
 func (c *tanFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinTanSig{bf}
@@ -1710,7 +1709,7 @@ func (b *builtinTanSig) Clone() builtinFunc {
 func (b *builtinTanSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return math.Tan(val), false, nil
 }
@@ -1721,7 +1720,7 @@ type truncateFunctionClass struct {
 
 func (c *truncateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argTp := args[0].GetType().EvalType()
@@ -1767,17 +1766,17 @@ func (b *builtinTruncateDecimalSig) Clone() builtinFunc {
 func (b *builtinTruncateDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	x, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 
 	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return nil, isNull, errors.Trace(err)
+		return nil, isNull, err
 	}
 
 	result := new(types.MyDecimal)
 	if err := x.Round(result, mathutil.Min(int(d), b.getRetTp().Decimal), types.ModeTruncate); err != nil {
-		return nil, true, errors.Trace(err)
+		return nil, true, err
 	}
 	return result, false, nil
 }
@@ -1797,12 +1796,12 @@ func (b *builtinTruncateRealSig) Clone() builtinFunc {
 func (b *builtinTruncateRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	x, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return types.Truncate(x, int(d)), false, nil
@@ -1823,12 +1822,12 @@ func (b *builtinTruncateIntSig) Clone() builtinFunc {
 func (b *builtinTruncateIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if d >= 0 {
@@ -1853,13 +1852,13 @@ type builtinTruncateUintSig struct {
 func (b *builtinTruncateUintSig) evalInt(row chunk.Row) (int64, bool, error) {
 	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	uintx := uint64(x)
 
 	d, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if d >= 0 {
 		return x, false, nil

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -81,7 +80,7 @@ type sleepFunctionClass struct {
 
 func (c *sleepFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETReal)
 	bf.tp.Flen = 21
@@ -104,7 +103,7 @@ func (b *builtinSleepSig) Clone() builtinFunc {
 func (b *builtinSleepSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	sessVars := b.ctx.GetSessionVars()
 	if isNull {
@@ -139,7 +138,7 @@ type lockFunctionClass struct {
 
 func (c *lockFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETInt)
 	sig := &builtinLockSig{bf}
@@ -171,7 +170,7 @@ type releaseLockFunctionClass struct {
 
 func (c *releaseLockFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	sig := &builtinReleaseLockSig{bf}
@@ -203,7 +202,7 @@ type anyValueFunctionClass struct {
 
 func (c *anyValueFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTp := args[0].GetType().EvalType()
 	bf := newBaseBuiltinFuncWithTp(ctx, args, argTp, argTp)
@@ -360,7 +359,7 @@ type inetAtonFunctionClass struct {
 
 func (c *inetAtonFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 21
@@ -384,7 +383,7 @@ func (b *builtinInetAtonSig) Clone() builtinFunc {
 func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	// ip address should not end with '.'.
 	if len(val) == 0 || val[len(val)-1] == '.' {
@@ -433,7 +432,7 @@ type inetNtoaFunctionClass struct {
 
 func (c *inetNtoaFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = 93
@@ -457,7 +456,7 @@ func (b *builtinInetNtoaSig) Clone() builtinFunc {
 func (b *builtinInetNtoaSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil || isNull {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	if val < 0 || uint64(val) > math.MaxUint32 {
@@ -481,7 +480,7 @@ type inet6AtonFunctionClass struct {
 
 func (c *inet6AtonFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 16
@@ -506,7 +505,7 @@ func (b *builtinInet6AtonSig) Clone() builtinFunc {
 func (b *builtinInet6AtonSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	if len(val) == 0 {
@@ -550,7 +549,7 @@ type inet6NtoaFunctionClass struct {
 
 func (c *inet6NtoaFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 117
@@ -574,7 +573,7 @@ func (b *builtinInet6NtoaSig) Clone() builtinFunc {
 func (b *builtinInet6NtoaSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	ip := net.IP([]byte(val)).String()
 	if len(val) == net.IPv6len && !strings.Contains(ip, ":") {
@@ -602,7 +601,7 @@ type isIPv4FunctionClass struct {
 
 func (c *isIPv4FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 1
@@ -625,7 +624,7 @@ func (b *builtinIsIPv4Sig) Clone() builtinFunc {
 func (b *builtinIsIPv4Sig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	if isIPv4(val) {
 		return 1, false, nil
@@ -666,7 +665,7 @@ type isIPv4CompatFunctionClass struct {
 
 func (c *isIPv4CompatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 1
@@ -689,7 +688,7 @@ func (b *builtinIsIPv4CompatSig) Clone() builtinFunc {
 func (b *builtinIsIPv4CompatSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 
 	ipAddress := []byte(val)
@@ -711,7 +710,7 @@ type isIPv4MappedFunctionClass struct {
 
 func (c *isIPv4MappedFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 1
@@ -734,7 +733,7 @@ func (b *builtinIsIPv4MappedSig) Clone() builtinFunc {
 func (b *builtinIsIPv4MappedSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 
 	ipAddress := []byte(val)
@@ -756,7 +755,7 @@ type isIPv6FunctionClass struct {
 
 func (c *isIPv6FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 1
@@ -779,7 +778,7 @@ func (b *builtinIsIPv6Sig) Clone() builtinFunc {
 func (b *builtinIsIPv6Sig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	ip := net.ParseIP(val)
 	if ip != nil && !isIPv4(val) {
@@ -826,7 +825,7 @@ type uuidFunctionClass struct {
 
 func (c *uuidFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString)
 	bf.tp.Flen = 36

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx"
@@ -63,7 +62,7 @@ type logicAndFunctionClass struct {
 func (c *logicAndFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinLogicAndSig{bf}
@@ -85,11 +84,11 @@ func (b *builtinLogicAndSig) Clone() builtinFunc {
 func (b *builtinLogicAndSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil || (!isNull0 && arg0 == 0) {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil || (!isNull1 && arg1 == 0) {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	if isNull0 || isNull1 {
 		return 0, true, nil
@@ -104,7 +103,7 @@ type logicOrFunctionClass struct {
 func (c *logicOrFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	bf.tp.Flen = 1
@@ -126,14 +125,14 @@ func (b *builtinLogicOrSig) Clone() builtinFunc {
 func (b *builtinLogicOrSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if !isNull0 && arg0 != 0 {
 		return 1, false, nil
 	}
 	arg1, isNull1, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if !isNull1 && arg1 != 0 {
 		return 1, false, nil
@@ -151,7 +150,7 @@ type logicXorFunctionClass struct {
 func (c *logicXorFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinLogicXorSig{bf}
@@ -173,11 +172,11 @@ func (b *builtinLogicXorSig) Clone() builtinFunc {
 func (b *builtinLogicXorSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if (arg0 != 0 && arg1 != 0) || (arg0 == 0 && arg1 == 0) {
 		return 0, false, nil
@@ -192,7 +191,7 @@ type bitAndFunctionClass struct {
 func (c *bitAndFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinBitAndSig{bf}
@@ -214,11 +213,11 @@ func (b *builtinBitAndSig) Clone() builtinFunc {
 func (b *builtinBitAndSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return arg0 & arg1, false, nil
 }
@@ -230,7 +229,7 @@ type bitOrFunctionClass struct {
 func (c *bitOrFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinBitOrSig{bf}
@@ -252,11 +251,11 @@ func (b *builtinBitOrSig) Clone() builtinFunc {
 func (b *builtinBitOrSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return arg0 | arg1, false, nil
 }
@@ -268,7 +267,7 @@ type bitXorFunctionClass struct {
 func (c *bitXorFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinBitXorSig{bf}
@@ -290,11 +289,11 @@ func (b *builtinBitXorSig) Clone() builtinFunc {
 func (b *builtinBitXorSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return arg0 ^ arg1, false, nil
 }
@@ -306,7 +305,7 @@ type leftShiftFunctionClass struct {
 func (c *leftShiftFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinLeftShiftSig{bf}
@@ -327,11 +326,11 @@ func (b *builtinLeftShiftSig) Clone() builtinFunc {
 func (b *builtinLeftShiftSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(uint64(arg0) << uint64(arg1)), false, nil
 }
@@ -343,7 +342,7 @@ type rightShiftFunctionClass struct {
 func (c *rightShiftFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinRightShiftSig{bf}
@@ -364,11 +363,11 @@ func (b *builtinRightShiftSig) Clone() builtinFunc {
 func (b *builtinRightShiftSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(uint64(arg0) >> uint64(arg1)), false, nil
 }
@@ -380,7 +379,7 @@ type isTrueOrFalseFunctionClass struct {
 
 func (c *isTrueOrFalseFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argTp := args[0].GetType().EvalType()
@@ -434,7 +433,7 @@ func (b *builtinRealIsTrueSig) Clone() builtinFunc {
 func (b *builtinRealIsTrueSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || input == 0 {
 		return 0, false, nil
@@ -455,7 +454,7 @@ func (b *builtinDecimalIsTrueSig) Clone() builtinFunc {
 func (b *builtinDecimalIsTrueSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || input.IsZero() {
 		return 0, false, nil
@@ -476,7 +475,7 @@ func (b *builtinIntIsTrueSig) Clone() builtinFunc {
 func (b *builtinIntIsTrueSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || input == 0 {
 		return 0, false, nil
@@ -497,7 +496,7 @@ func (b *builtinRealIsFalseSig) Clone() builtinFunc {
 func (b *builtinRealIsFalseSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || input != 0 {
 		return 0, false, nil
@@ -518,7 +517,7 @@ func (b *builtinDecimalIsFalseSig) Clone() builtinFunc {
 func (b *builtinDecimalIsFalseSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || !input.IsZero() {
 		return 0, false, nil
@@ -539,7 +538,7 @@ func (b *builtinIntIsFalseSig) Clone() builtinFunc {
 func (b *builtinIntIsFalseSig) evalInt(row chunk.Row) (int64, bool, error) {
 	input, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull || input != 0 {
 		return 0, false, nil
@@ -553,7 +552,7 @@ type bitNegFunctionClass struct {
 
 func (c *bitNegFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt)
 	bf.tp.Flag |= mysql.UnsignedFlag
@@ -575,7 +574,7 @@ func (b *builtinBitNegSig) Clone() builtinFunc {
 func (b *builtinBitNegSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return ^arg, false, nil
 }
@@ -586,7 +585,7 @@ type unaryNotFunctionClass struct {
 
 func (c *unaryNotFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt)
@@ -610,7 +609,7 @@ func (b *builtinUnaryNotSig) Clone() builtinFunc {
 func (b *builtinUnaryNotSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if arg != 0 {
 		return 0, false, nil
@@ -663,7 +662,7 @@ func (c *unaryMinusFunctionClass) typeInfer(ctx sessionctx.Context, argExpr Expr
 
 func (c *unaryMinusFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argExpr, argExprTp := args[0], args[0].GetType()
@@ -704,7 +703,7 @@ func (c *unaryMinusFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 		}
 	}
 	bf.tp.Flen = argExprTp.Flen + 1
-	return sig, errors.Trace(err)
+	return sig, err
 }
 
 type builtinUnaryMinusIntSig struct {
@@ -721,7 +720,7 @@ func (b *builtinUnaryMinusIntSig) evalInt(row chunk.Row) (res int64, isNull bool
 	var val int64
 	val, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if err != nil || isNull {
-		return val, isNull, errors.Trace(err)
+		return val, isNull, err
 	}
 
 	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
@@ -752,7 +751,7 @@ func (b *builtinUnaryMinusDecimalSig) Clone() builtinFunc {
 func (b *builtinUnaryMinusDecimalSig) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	dec, isNull, err := b.args[0].EvalDecimal(b.ctx, row)
 	if err != nil || isNull {
-		return dec, isNull, errors.Trace(err)
+		return dec, isNull, err
 	}
 	return types.DecimalNeg(dec), false, nil
 }
@@ -769,7 +768,7 @@ func (b *builtinUnaryMinusRealSig) Clone() builtinFunc {
 
 func (b *builtinUnaryMinusRealSig) evalReal(row chunk.Row) (float64, bool, error) {
 	val, isNull, err := b.args[0].EvalReal(b.ctx, row)
-	return -val, isNull, errors.Trace(err)
+	return -val, isNull, err
 }
 
 type isNullFunctionClass struct {
@@ -778,7 +777,7 @@ type isNullFunctionClass struct {
 
 func (c *isNullFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTp := args[0].GetType().EvalType()
 	if argTp == types.ETTimestamp {
@@ -826,7 +825,7 @@ func (b *builtinDecimalIsNullSig) Clone() builtinFunc {
 
 func evalIsNull(isNull bool, err error) (int64, bool, error) {
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull {
 		return 1, false, nil

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -68,7 +68,7 @@ type inFunctionClass struct {
 
 func (c *inFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, len(args))
 	for i := range args {
@@ -116,14 +116,14 @@ func (b *builtinInIntSig) Clone() builtinFunc {
 func (b *builtinInIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalInt(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -165,13 +165,13 @@ func (b *builtinInStringSig) Clone() builtinFunc {
 func (b *builtinInStringSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalString(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalString(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -198,13 +198,13 @@ func (b *builtinInRealSig) Clone() builtinFunc {
 func (b *builtinInRealSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalReal(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -231,13 +231,13 @@ func (b *builtinInDecimalSig) Clone() builtinFunc {
 func (b *builtinInDecimalSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalDecimal(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalDecimal(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -264,13 +264,13 @@ func (b *builtinInTimeSig) Clone() builtinFunc {
 func (b *builtinInTimeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalTime(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -297,13 +297,13 @@ func (b *builtinInDurationSig) Clone() builtinFunc {
 func (b *builtinInDurationSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalDuration(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -330,13 +330,13 @@ func (b *builtinInJSONSig) Clone() builtinFunc {
 func (b *builtinInJSONSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg0, isNull0, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull0 || err != nil {
-		return 0, isNull0, errors.Trace(err)
+		return 0, isNull0, err
 	}
 	var hasNull bool
 	for _, arg := range b.args[1:] {
 		evaledArg, isNull, err := arg.EvalJSON(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if isNull {
 			hasNull = true
@@ -356,7 +356,7 @@ type rowFunctionClass struct {
 
 func (c *rowFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, len(args))
 	for i := range argTps {
@@ -387,14 +387,14 @@ type setVarFunctionClass struct {
 }
 
 func (c *setVarFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
-	if err = errors.Trace(c.verifyArgs(args)); err != nil {
+	if err = c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
 	bf.tp.Flen = args[1].GetType().Flen
 	// TODO: we should consider the type of the argument, but not take it as string for all situations.
 	sig = &builtinSetVarSig{bf}
-	return sig, errors.Trace(err)
+	return sig, err
 }
 
 type builtinSetVarSig struct {
@@ -412,11 +412,11 @@ func (b *builtinSetVarSig) evalString(row chunk.Row) (res string, isNull bool, e
 	sessionVars := b.ctx.GetSessionVars()
 	varName, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	res, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.Lock()
@@ -430,7 +430,7 @@ type getVarFunctionClass struct {
 }
 
 func (c *getVarFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
-	if err = errors.Trace(c.verifyArgs(args)); err != nil {
+	if err = c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	// TODO: we should consider the type of the argument, but not take it as string for all situations.
@@ -454,7 +454,7 @@ func (b *builtinGetVarSig) evalString(row chunk.Row) (string, bool, error) {
 	sessionVars := b.ctx.GetSessionVars()
 	varName, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.RLock()
@@ -473,7 +473,7 @@ type valuesFunctionClass struct {
 }
 
 func (c *valuesFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
-	if err = errors.Trace(c.verifyArgs(args)); err != nil {
+	if err = c.verifyArgs(args); err != nil {
 		return nil, err
 	}
 	bf := newBaseBuiltinFunc(ctx, args)
@@ -721,7 +721,7 @@ type bitCountFunctionClass struct {
 
 func (c *bitCountFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt)
 	bf.tp.Flen = 2
@@ -747,7 +747,7 @@ func (b *builtinBitCountSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if err != nil && types.ErrOverflow.Equal(err) {
 			return 64, false, nil
 		}
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	var count int64
@@ -766,7 +766,7 @@ type getParamFunctionClass struct {
 // TODO: more typed functions will be added when typed parameters are supported.
 func (c *getParamFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = mysql.MaxFieldVarCharLength
@@ -788,7 +788,7 @@ func (b *builtinGetParamStringSig) evalString(row chunk.Row) (string, bool, erro
 	sessionVars := b.ctx.GetSessionVars()
 	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	v := sessionVars.PreparedParams[idx]
 

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -180,7 +180,7 @@ type lengthFunctionClass struct {
 
 func (c *lengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
@@ -203,7 +203,7 @@ func (b *builtinLengthSig) Clone() builtinFunc {
 func (b *builtinLengthSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(len([]byte(val))), false, nil
 }
@@ -214,7 +214,7 @@ type asciiFunctionClass struct {
 
 func (c *asciiFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 3
@@ -237,7 +237,7 @@ func (b *builtinASCIISig) Clone() builtinFunc {
 func (b *builtinASCIISig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if len(val) == 0 {
 		return 0, false, nil
@@ -251,7 +251,7 @@ type concatFunctionClass struct {
 
 func (c *concatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for i := 0; i < len(args); i++ {
@@ -292,7 +292,7 @@ func (b *builtinConcatSig) evalString(row chunk.Row) (d string, isNull bool, err
 	for _, a := range b.getArgs() {
 		d, isNull, err = a.EvalString(b.ctx, row)
 		if isNull || err != nil {
-			return d, isNull, errors.Trace(err)
+			return d, isNull, err
 		}
 		s = append(s, []byte(d)...)
 	}
@@ -305,7 +305,7 @@ type concatWSFunctionClass struct {
 
 func (c *concatWSFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for i := 0; i < len(args); i++ {
@@ -359,7 +359,7 @@ func (b *builtinConcatWSSig) evalString(row chunk.Row) (string, bool, error) {
 	for i, arg := range args {
 		val, isNull, err := arg.EvalString(b.ctx, row)
 		if err != nil {
-			return val, isNull, errors.Trace(err)
+			return val, isNull, err
 		}
 
 		if isNull {
@@ -389,7 +389,7 @@ type leftFunctionClass struct {
 
 func (c *leftFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt)
 	argType := args[0].GetType()
@@ -418,11 +418,11 @@ func (b *builtinLeftBinarySig) Clone() builtinFunc {
 func (b *builtinLeftBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	leftLength := int(left)
 	if strLength := len(str); leftLength > strLength {
@@ -448,11 +448,11 @@ func (b *builtinLeftSig) Clone() builtinFunc {
 func (b *builtinLeftSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	left, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runes, leftLength := []rune(str), int(left)
 	if runeLength := len(runes); leftLength > runeLength {
@@ -469,7 +469,7 @@ type rightFunctionClass struct {
 
 func (c *rightFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt)
 	argType := args[0].GetType()
@@ -498,11 +498,11 @@ func (b *builtinRightBinarySig) Clone() builtinFunc {
 func (b *builtinRightBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	strLength, rightLength := len(str), int(right)
 	if rightLength > strLength {
@@ -528,11 +528,11 @@ func (b *builtinRightSig) Clone() builtinFunc {
 func (b *builtinRightSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	right, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runes := []rune(str)
 	strLength, rightLength := len(runes), int(right)
@@ -550,7 +550,7 @@ type repeatFunctionClass struct {
 
 func (c *repeatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt)
 	bf.tp.Flen = mysql.MaxBlobWidth
@@ -558,7 +558,7 @@ func (c *repeatFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	sig := &builtinRepeatSig{bf, maxAllowedPacket}
 	return sig, nil
@@ -581,13 +581,13 @@ func (b *builtinRepeatSig) Clone() builtinFunc {
 func (b *builtinRepeatSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	byteLength := len(str)
 
 	num, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	if num < 1 {
 		return "", false, nil
@@ -613,7 +613,7 @@ type lowerFunctionClass struct {
 
 func (c *lowerFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	argTp := args[0].GetType()
@@ -638,7 +638,7 @@ func (b *builtinLowerSig) Clone() builtinFunc {
 func (b *builtinLowerSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	if types.IsBinaryStr(b.args[0].GetType()) {
@@ -654,7 +654,7 @@ type reverseFunctionClass struct {
 
 func (c *reverseFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	retTp := *args[0].GetType()
@@ -685,7 +685,7 @@ func (b *builtinReverseBinarySig) Clone() builtinFunc {
 func (b *builtinReverseBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	reversed := reverseBytes([]byte(str))
 	return string(reversed), false, nil
@@ -706,7 +706,7 @@ func (b *builtinReverseSig) Clone() builtinFunc {
 func (b *builtinReverseSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	reversed := reverseRunes([]rune(str))
 	return string(reversed), false, nil
@@ -718,14 +718,14 @@ type spaceFunctionClass struct {
 
 func (c *spaceFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = mysql.MaxBlobWidth
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	sig := &builtinSpaceSig{bf, maxAllowedPacket}
 	return sig, nil
@@ -750,7 +750,7 @@ func (b *builtinSpaceSig) evalString(row chunk.Row) (d string, isNull bool, err 
 
 	x, isNull, err = b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	if x < 0 {
 		x = 0
@@ -771,7 +771,7 @@ type upperFunctionClass struct {
 
 func (c *upperFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	argTp := args[0].GetType()
@@ -796,7 +796,7 @@ func (b *builtinUpperSig) Clone() builtinFunc {
 func (b *builtinUpperSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	if types.IsBinaryStr(b.args[0].GetType()) {
@@ -812,7 +812,7 @@ type strcmpFunctionClass struct {
 
 func (c *strcmpFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETString)
 	bf.tp.Flen = 2
@@ -842,11 +842,11 @@ func (b *builtinStrcmpSig) evalInt(row chunk.Row) (int64, bool, error) {
 
 	left, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	right, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	res := types.CompareString(left, right)
 	return int64(res), false, nil
@@ -858,7 +858,7 @@ type replaceFunctionClass struct {
 
 func (c *replaceFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString, types.ETString)
 	bf.tp.Flen = c.fixLength(args)
@@ -897,15 +897,15 @@ func (b *builtinReplaceSig) evalString(row chunk.Row) (d string, isNull bool, er
 
 	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	oldStr, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	newStr, isNull, err = b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	if oldStr == "" {
 		return str, false, nil
@@ -919,7 +919,7 @@ type convertFunctionClass struct {
 
 func (c *convertFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
 	// TODO: issue #4436: The second parameter should be a constant.
@@ -945,12 +945,12 @@ func (b *builtinConvertSig) Clone() builtinFunc {
 func (b *builtinConvertSig) evalString(row chunk.Row) (string, bool, error) {
 	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	charsetName, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	encoding, _ := charset.Lookup(charsetName)
@@ -959,7 +959,7 @@ func (b *builtinConvertSig) evalString(row chunk.Row) (string, bool, error) {
 	}
 
 	target, _, err := transform.String(encoding.NewDecoder(), expr)
-	return target, err != nil, errors.Trace(err)
+	return target, err != nil, err
 }
 
 type substringFunctionClass struct {
@@ -968,7 +968,7 @@ type substringFunctionClass struct {
 
 func (c *substringFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := []types.EvalType{types.ETString, types.ETInt}
 	if len(args) == 3 {
@@ -1012,11 +1012,11 @@ func (b *builtinSubstringBinary2ArgsSig) Clone() builtinFunc {
 func (b *builtinSubstringBinary2ArgsSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	length := int64(len(str))
 	if pos < 0 {
@@ -1045,11 +1045,11 @@ func (b *builtinSubstring2ArgsSig) Clone() builtinFunc {
 func (b *builtinSubstring2ArgsSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runes := []rune(str)
 	length := int64(len(runes))
@@ -1079,15 +1079,15 @@ func (b *builtinSubstringBinary3ArgsSig) Clone() builtinFunc {
 func (b *builtinSubstringBinary3ArgsSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	byteLen := int64(len(str))
 	if pos < 0 {
@@ -1122,15 +1122,15 @@ func (b *builtinSubstring3ArgsSig) Clone() builtinFunc {
 func (b *builtinSubstring3ArgsSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runes := []rune(str)
 	numRunes := int64(len(runes))
@@ -1157,7 +1157,7 @@ type substringIndexFunctionClass struct {
 
 func (c *substringIndexFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString, types.ETInt)
 	argType := args[0].GetType()
@@ -1186,15 +1186,15 @@ func (b *builtinSubstringIndexSig) evalString(row chunk.Row) (d string, isNull b
 	)
 	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	delim, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	count, isNull, err = b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	if len(delim) == 0 {
 		return "", false, nil
@@ -1229,7 +1229,7 @@ type locateFunctionClass struct {
 
 func (c *locateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	hasStartPos, argTps := len(args) == 3, []types.EvalType{types.ETString, types.ETString}
 	if hasStartPos {
@@ -1267,11 +1267,11 @@ func (b *builtinLocateBinary2ArgsSig) Clone() builtinFunc {
 func (b *builtinLocateBinary2ArgsSig) evalInt(row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	subStrLen := len(subStr)
 	if subStrLen == 0 {
@@ -1299,11 +1299,11 @@ func (b *builtinLocate2ArgsSig) Clone() builtinFunc {
 func (b *builtinLocate2ArgsSig) evalInt(row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if int64(len([]rune(subStr))) == 0 {
 		return 1, false, nil
@@ -1331,17 +1331,17 @@ func (b *builtinLocateBinary3ArgsSig) Clone() builtinFunc {
 func (b *builtinLocateBinary3ArgsSig) evalInt(row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	subStrLen := len(subStr)
 	if pos < 0 || pos > int64(len(str)-subStrLen) {
@@ -1372,17 +1372,17 @@ func (b *builtinLocate3ArgsSig) Clone() builtinFunc {
 func (b *builtinLocate3ArgsSig) evalInt(row chunk.Row) (int64, bool, error) {
 	subStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	str, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	pos, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	// Transfer the argument which starts from 1 to real index which starts from 0.
 	pos--
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	subStrLen := len([]rune(subStr))
 	if pos < 0 || pos > int64(len([]rune(strings.ToLower(str)))-subStrLen) {
@@ -1404,7 +1404,7 @@ type hexFunctionClass struct {
 
 func (c *hexFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argTp := args[0].GetType().EvalType()
@@ -1440,7 +1440,7 @@ func (b *builtinHexStrArgSig) Clone() builtinFunc {
 func (b *builtinHexStrArgSig) evalString(row chunk.Row) (string, bool, error) {
 	d, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	return strings.ToUpper(hex.EncodeToString(hack.Slice(d))), false, nil
 }
@@ -1460,7 +1460,7 @@ func (b *builtinHexIntArgSig) Clone() builtinFunc {
 func (b *builtinHexIntArgSig) evalString(row chunk.Row) (string, bool, error) {
 	x, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	return strings.ToUpper(fmt.Sprintf("%x", uint64(x))), false, nil
 }
@@ -1471,12 +1471,12 @@ type unhexFunctionClass struct {
 
 func (c *unhexFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var retFlen int
 
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argType := args[0].GetType()
 	argEvalTp := argType.EvalType()
@@ -1515,7 +1515,7 @@ func (b *builtinUnHexSig) evalString(row chunk.Row) (string, bool, error) {
 
 	d, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	// Add a '0' to the front, if the length is not the multiple of 2
 	if len(d)%2 != 0 {
@@ -1539,7 +1539,7 @@ type trimFunctionClass struct {
 // but we wil convert it into trim(str), trim(str, remstr) and trim(str, remstr, direction) in AST.
 func (c *trimFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	switch len(args) {
@@ -1567,7 +1567,7 @@ func (c *trimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 		return sig, nil
 
 	default:
-		return nil, errors.Trace(c.verifyArgs(args))
+		return nil, c.verifyArgs(args)
 	}
 }
 
@@ -1586,7 +1586,7 @@ func (b *builtinTrim1ArgSig) Clone() builtinFunc {
 func (b *builtinTrim1ArgSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	return strings.Trim(d, spaceChars), false, nil
 }
@@ -1608,11 +1608,11 @@ func (b *builtinTrim2ArgsSig) evalString(row chunk.Row) (d string, isNull bool, 
 
 	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	remstr, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	d = trimLeft(str, remstr)
 	d = trimRight(d, remstr)
@@ -1640,15 +1640,15 @@ func (b *builtinTrim3ArgsSig) evalString(row chunk.Row) (d string, isNull bool, 
 	)
 	str, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	remstr, isRemStrNull, err = b.args[1].EvalString(b.ctx, row)
 	if err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	x, isNull, err = b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	direction = ast.TrimDirectionType(x)
 	if direction == ast.TrimLeading {
@@ -1680,7 +1680,7 @@ type lTrimFunctionClass struct {
 
 func (c *lTrimFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	argType := args[0].GetType()
@@ -1705,7 +1705,7 @@ func (b *builtinLTrimSig) Clone() builtinFunc {
 func (b *builtinLTrimSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	return strings.TrimLeft(d, spaceChars), false, nil
 }
@@ -1716,7 +1716,7 @@ type rTrimFunctionClass struct {
 
 func (c *rTrimFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	argType := args[0].GetType()
@@ -1741,7 +1741,7 @@ func (b *builtinRTrimSig) Clone() builtinFunc {
 func (b *builtinRTrimSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	d, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 	return strings.TrimRight(d, spaceChars), false, nil
 }
@@ -1786,7 +1786,7 @@ type lpadFunctionClass struct {
 
 func (c *lpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETString)
 	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx, args[1])
@@ -1796,7 +1796,7 @@ func (c *lpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
@@ -1827,13 +1827,13 @@ func (b *builtinLpadBinarySig) Clone() builtinFunc {
 func (b *builtinLpadBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	byteLength := len(str)
 
 	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	targetLength := int(length)
 
@@ -1844,7 +1844,7 @@ func (b *builtinLpadBinarySig) evalString(row chunk.Row) (string, bool, error) {
 
 	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	padLength := len(padStr)
 
@@ -1876,13 +1876,13 @@ func (b *builtinLpadSig) Clone() builtinFunc {
 func (b *builtinLpadSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runeLength := len([]rune(str))
 
 	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	targetLength := int(length)
 
@@ -1893,7 +1893,7 @@ func (b *builtinLpadSig) evalString(row chunk.Row) (string, bool, error) {
 
 	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	padLength := len([]rune(padStr))
 
@@ -1914,7 +1914,7 @@ type rpadFunctionClass struct {
 
 func (c *rpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETString)
 	bf.tp.Flen = getFlen4LpadAndRpad(bf.ctx, args[1])
@@ -1924,7 +1924,7 @@ func (c *rpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
@@ -1955,13 +1955,13 @@ func (b *builtinRpadBinarySig) Clone() builtinFunc {
 func (b *builtinRpadBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	byteLength := len(str)
 
 	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	targetLength := int(length)
 	if uint64(targetLength) > b.maxAllowedPacket {
@@ -1971,7 +1971,7 @@ func (b *builtinRpadBinarySig) evalString(row chunk.Row) (string, bool, error) {
 
 	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	padLength := len(padStr)
 
@@ -2003,13 +2003,13 @@ func (b *builtinRpadSig) Clone() builtinFunc {
 func (b *builtinRpadSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runeLength := len([]rune(str))
 
 	length, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	targetLength := int(length)
 
@@ -2020,7 +2020,7 @@ func (b *builtinRpadSig) evalString(row chunk.Row) (string, bool, error) {
 
 	padStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	padLength := len([]rune(padStr))
 
@@ -2041,7 +2041,7 @@ type bitLengthFunctionClass struct {
 
 func (c *bitLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
@@ -2064,7 +2064,7 @@ func (b *builtinBitLengthSig) Clone() builtinFunc {
 func (b *builtinBitLengthSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return int64(len(val) * 8), false, nil
@@ -2076,7 +2076,7 @@ type charFunctionClass struct {
 
 func (c *charFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	for i := 0; i < len(args)-1; i++ {
@@ -2122,7 +2122,7 @@ func (b *builtinCharSig) evalString(row chunk.Row) (string, bool, error) {
 	for i := 0; i < len(b.args)-1; i++ {
 		val, IsNull, err := b.args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		if IsNull {
 			continue
@@ -2133,7 +2133,7 @@ func (b *builtinCharSig) evalString(row chunk.Row) (string, bool, error) {
 	// Use default charset utf8 if it is nil.
 	argCharset, IsNull, err := b.args[len(b.args)-1].EvalString(b.ctx, row)
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	result := string(b.convertToBytes(bigints))
@@ -2151,7 +2151,7 @@ func (b *builtinCharSig) evalString(row chunk.Row) (string, bool, error) {
 	result, _, err = transform.String(encoding.NewDecoder(), result)
 	if err != nil {
 		log.Errorf("Convert %s to %s with error: %v", oldStr, charsetName, err.Error())
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return result, false, nil
 }
@@ -2162,7 +2162,7 @@ type charLengthFunctionClass struct {
 
 func (c *charLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if argsErr := c.verifyArgs(args); argsErr != nil {
-		return nil, errors.Trace(argsErr)
+		return nil, argsErr
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	if types.IsBinaryStr(args[0].GetType()) {
@@ -2188,7 +2188,7 @@ func (b *builtinCharLengthBinarySig) Clone() builtinFunc {
 func (b *builtinCharLengthBinarySig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(len(val)), false, nil
 }
@@ -2208,7 +2208,7 @@ func (b *builtinCharLengthSig) Clone() builtinFunc {
 func (b *builtinCharLengthSig) evalInt(row chunk.Row) (int64, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	return int64(len([]rune(val))), false, nil
 }
@@ -2219,7 +2219,7 @@ type findInSetFunctionClass struct {
 
 func (c *findInSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETString)
 	bf.tp.Flen = 3
@@ -2244,12 +2244,12 @@ func (b *builtinFindInSetSig) Clone() builtinFunc {
 func (b *builtinFindInSetSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	strlist, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	if len(strlist) == 0 {
@@ -2270,7 +2270,7 @@ type fieldFunctionClass struct {
 
 func (c *fieldFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	isAllString, isAllNumber := true, true
@@ -2318,12 +2318,12 @@ func (b *builtinFieldIntSig) Clone() builtinFunc {
 func (b *builtinFieldIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
 		stri, isNull, err := b.args[i].EvalInt(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if !isNull && str == stri {
 			return int64(i), false, nil
@@ -2347,12 +2347,12 @@ func (b *builtinFieldRealSig) Clone() builtinFunc {
 func (b *builtinFieldRealSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
 		stri, isNull, err := b.args[i].EvalReal(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if !isNull && str == stri {
 			return int64(i), false, nil
@@ -2376,12 +2376,12 @@ func (b *builtinFieldStringSig) Clone() builtinFunc {
 func (b *builtinFieldStringSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, err != nil, errors.Trace(err)
+		return 0, err != nil, err
 	}
 	for i, length := 1, len(b.args); i < length; i++ {
 		stri, isNull, err := b.args[i].EvalString(b.ctx, row)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if !isNull && str == stri {
 			return int64(i), false, nil
@@ -2419,7 +2419,7 @@ func (c *makeSetFunctionClass) getFlen(ctx sessionctx.Context, args []Expression
 
 func (c *makeSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, len(args))
 	argTps[0] = types.ETInt
@@ -2453,7 +2453,7 @@ func (b *builtinMakeSetSig) Clone() builtinFunc {
 func (b *builtinMakeSetSig) evalString(row chunk.Row) (string, bool, error) {
 	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	sets := make([]string, 0, len(b.args)-1)
@@ -2463,7 +2463,7 @@ func (b *builtinMakeSetSig) evalString(row chunk.Row) (string, bool, error) {
 		}
 		str, isNull, err := b.args[i].EvalString(b.ctx, row)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		if !isNull {
 			sets = append(sets, str)
@@ -2479,7 +2479,7 @@ type octFunctionClass struct {
 
 func (c *octFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var sig builtinFunc
 	if IsBinaryLiteral(args[0]) || args[0].GetType().EvalType() == types.ETInt {
@@ -2510,7 +2510,7 @@ func (b *builtinOctIntSig) Clone() builtinFunc {
 func (b *builtinOctIntSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 
 	return strconv.FormatUint(uint64(val), 8), false, nil
@@ -2531,7 +2531,7 @@ func (b *builtinOctStringSig) Clone() builtinFunc {
 func (b *builtinOctStringSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 
 	negative, overflow := false, false
@@ -2547,7 +2547,7 @@ func (b *builtinOctStringSig) evalString(row chunk.Row) (string, bool, error) {
 	if err != nil {
 		numError, ok := err.(*strconv.NumError)
 		if !ok || numError.Err != strconv.ErrRange {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		overflow = true
 	}
@@ -2563,7 +2563,7 @@ type ordFunctionClass struct {
 
 func (c *ordFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
@@ -2586,7 +2586,7 @@ func (b *builtinOrdSig) Clone() builtinFunc {
 func (b *builtinOrdSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	if len(str) == 0 {
 		return 0, false, nil
@@ -2610,7 +2610,7 @@ type quoteFunctionClass struct {
 
 func (c *quoteFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	SetBinFlagOrBinStr(args[0].GetType(), bf.tp)
@@ -2637,7 +2637,7 @@ func (b *builtinQuoteSig) Clone() builtinFunc {
 func (b *builtinQuoteSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	runes := []rune(str)
@@ -2669,7 +2669,7 @@ type binFunctionClass struct {
 
 func (c *binFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = 64
@@ -2692,7 +2692,7 @@ func (b *builtinBinSig) Clone() builtinFunc {
 func (b *builtinBinSig) evalString(row chunk.Row) (string, bool, error) {
 	val, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return fmt.Sprintf("%b", uint64(val)), false, nil
 }
@@ -2703,7 +2703,7 @@ type eltFunctionClass struct {
 
 func (c *eltFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if argsErr := c.verifyArgs(args); argsErr != nil {
-		return nil, errors.Trace(argsErr)
+		return nil, argsErr
 	}
 	argTps := make([]types.EvalType, 0, len(args))
 	argTps = append(argTps, types.ETInt)
@@ -2739,14 +2739,14 @@ func (b *builtinEltSig) Clone() builtinFunc {
 func (b *builtinEltSig) evalString(row chunk.Row) (string, bool, error) {
 	idx, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if idx < 1 || idx >= int64(len(b.args)) {
 		return "", true, nil
 	}
 	arg, isNull, err := b.args[idx].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return arg, false, nil
 }
@@ -2757,7 +2757,7 @@ type exportSetFunctionClass struct {
 
 func (c *exportSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, 5)
 	argTps = append(argTps, types.ETInt, types.ETString, types.ETString)
@@ -2812,17 +2812,17 @@ func (b *builtinExportSet3ArgSig) Clone() builtinFunc {
 func (b *builtinExportSet3ArgSig) evalString(row chunk.Row) (string, bool, error) {
 	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	return exportSet(bits, on, off, ",", 64), false, nil
@@ -2843,22 +2843,22 @@ func (b *builtinExportSet4ArgSig) Clone() builtinFunc {
 func (b *builtinExportSet4ArgSig) evalString(row chunk.Row) (string, bool, error) {
 	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	return exportSet(bits, on, off, separator, 64), false, nil
@@ -2879,27 +2879,27 @@ func (b *builtinExportSet5ArgSig) Clone() builtinFunc {
 func (b *builtinExportSet5ArgSig) evalString(row chunk.Row) (string, bool, error) {
 	bits, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	on, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	off, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	separator, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	numberOfBits, isNull, err := b.args[4].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if numberOfBits < 0 || numberOfBits > 64 {
 		numberOfBits = 64
@@ -2914,7 +2914,7 @@ type formatFunctionClass struct {
 
 func (c *formatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 2, 3)
 	argTps[0], argTps[1] = types.ETString, types.ETString
@@ -2947,21 +2947,21 @@ func (b *builtinFormatWithLocaleSig) Clone() builtinFunc {
 func (b *builtinFormatWithLocaleSig) evalString(row chunk.Row) (string, bool, error) {
 	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	d, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	locale, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	formatString, err := mysql.GetLocaleFormatFunction(locale)(x, d)
-	return formatString, err != nil, errors.Trace(err)
+	return formatString, err != nil, err
 }
 
 type builtinFormatSig struct {
@@ -2979,16 +2979,16 @@ func (b *builtinFormatSig) Clone() builtinFunc {
 func (b *builtinFormatSig) evalString(row chunk.Row) (string, bool, error) {
 	x, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	d, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	formatString, err := mysql.GetLocaleFormatFunction("en_US")(x, d)
-	return formatString, err != nil, errors.Trace(err)
+	return formatString, err != nil, err
 }
 
 type fromBase64FunctionClass struct {
@@ -2997,7 +2997,7 @@ type fromBase64FunctionClass struct {
 
 func (c *fromBase64FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = mysql.MaxBlobWidth
@@ -3005,7 +3005,7 @@ func (c *fromBase64FunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	types.SetBinChsClnFlag(bf.tp)
@@ -3042,7 +3042,7 @@ func (b *builtinFromBase64Sig) Clone() builtinFunc {
 func (b *builtinFromBase64Sig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	needDecodeLen := base64NeededDecodedLength(len(str))
@@ -3070,7 +3070,7 @@ type toBase64FunctionClass struct {
 
 func (c *toBase64FunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = base64NeededEncodedLength(bf.args[0].GetType().Flen)
@@ -3078,7 +3078,7 @@ func (c *toBase64FunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	sig := &builtinToBase64Sig{bf, maxAllowedPacket}
@@ -3125,7 +3125,7 @@ func base64NeededEncodedLength(n int) int {
 func (b *builtinToBase64Sig) evalString(row chunk.Row) (d string, isNull bool, err error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	needEncodeLen := base64NeededEncodedLength(len(str))
 	if needEncodeLen == -1 {
@@ -3169,7 +3169,7 @@ type insertFunctionClass struct {
 
 func (c *insertFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETInt, types.ETString)
 	bf.tp.Flen = mysql.MaxBlobWidth
@@ -3179,7 +3179,7 @@ func (c *insertFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	valStr, _ := ctx.GetSessionVars().GetSystemVar(variable.MaxAllowedPacket)
 	maxAllowedPacket, err := strconv.ParseUint(valStr, 10, 64)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if types.IsBinaryStr(args[0].GetType()) {
@@ -3207,13 +3207,13 @@ func (b *builtinInsertBinarySig) Clone() builtinFunc {
 func (b *builtinInsertBinarySig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	strLength := int64(len(str))
 
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if pos < 1 || pos > strLength {
 		return str, false, nil
@@ -3221,12 +3221,12 @@ func (b *builtinInsertBinarySig) evalString(row chunk.Row) (string, bool, error)
 
 	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	if length > strLength-pos+1 || length < 0 {
@@ -3258,14 +3258,14 @@ func (b *builtinInsertSig) Clone() builtinFunc {
 func (b *builtinInsertSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	runes := []rune(str)
 	runeLength := int64(len(runes))
 
 	pos, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if pos < 1 || pos > runeLength {
 		return str, false, nil
@@ -3273,12 +3273,12 @@ func (b *builtinInsertSig) evalString(row chunk.Row) (string, bool, error) {
 
 	length, isNull, err := b.args[2].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	newstr, isNull, err := b.args[3].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	if length > runeLength-pos+1 || length < 0 {
@@ -3300,7 +3300,7 @@ type instrFunctionClass struct {
 
 func (c *instrFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETString)
 	bf.tp.Flen = 11
@@ -3333,13 +3333,13 @@ func (b *builtinInstrBinarySig) Clone() builtinFunc {
 func (b *builtinInstrSig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
 	if IsNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	str = strings.ToLower(str)
 
 	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
 	if IsNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	substr = strings.ToLower(substr)
 
@@ -3355,12 +3355,12 @@ func (b *builtinInstrSig) evalInt(row chunk.Row) (int64, bool, error) {
 func (b *builtinInstrBinarySig) evalInt(row chunk.Row) (int64, bool, error) {
 	str, IsNull, err := b.args[0].EvalString(b.ctx, row)
 	if IsNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	substr, IsNull, err := b.args[1].EvalString(b.ctx, row)
 	if IsNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	idx := strings.Index(str, substr)

--- a/expression/builtin_test.go
+++ b/expression/builtin_test.go
@@ -17,7 +17,6 @@ import (
 	"reflect"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
@@ -58,7 +57,7 @@ func evalBuiltinFunc(f builtinFunc, row chunk.Row) (d types.Datum, err error) {
 
 	if isNull || err != nil {
 		d.SetValue(nil)
-		return d, errors.Trace(err)
+		return d, err
 	}
 	d.SetValue(res)
 	return
@@ -145,7 +144,7 @@ func newFunctionForTest(ctx sessionctx.Context, funcName string, args ...Express
 	copy(funcArgs, args)
 	f, err := fc.getFunction(ctx, funcArgs)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &ScalarFunction{
 		FuncName: model.NewCIStr(funcName),

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -235,7 +235,7 @@ var (
 func convertTimeToMysqlTime(t time.Time, fsp int) (types.Time, error) {
 	tr, err := types.RoundFrac(t, fsp)
 	if err != nil {
-		return types.Time{}, errors.Trace(err)
+		return types.Time{}, err
 	}
 
 	return types.Time{
@@ -251,7 +251,7 @@ type dateFunctionClass struct {
 
 func (c *dateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETDatetime)
 	bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, 10, 0
@@ -274,11 +274,11 @@ func (b *builtinDateSig) Clone() builtinFunc {
 func (b *builtinDateSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	expr, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if expr.IsZero() {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(expr.String())))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(expr.String()))
 	}
 
 	expr.Time = types.FromDate(expr.Time.Year(), expr.Time.Month(), expr.Time.Day(), 0, 0, 0, 0)
@@ -292,7 +292,7 @@ type dateLiteralFunctionClass struct {
 
 func (c *dateLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	con, ok := args[0].(*Constant)
 	if !ok {
@@ -300,7 +300,7 @@ func (c *dateLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	}
 	dt, err := con.Eval(chunk.Row{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	str := dt.GetString()
 	if !datePattern.MatchString(str) {
@@ -308,7 +308,7 @@ func (c *dateLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	}
 	tm, err := types.ParseDate(ctx.GetSessionVars().StmtCtx, str)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, []Expression{}, types.ETDatetime)
 	bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, 10, 0
@@ -346,7 +346,7 @@ type dateDiffFunctionClass struct {
 
 func (c *dateDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime, types.ETDatetime)
 	sig := &builtinDateDiffSig{bf}
@@ -368,11 +368,11 @@ func (b *builtinDateDiffSig) Clone() builtinFunc {
 func (b *builtinDateDiffSig) evalInt(row chunk.Row) (int64, bool, error) {
 	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	if invalidLHS, invalidRHS := lhs.InvalidZero(), rhs.InvalidZero(); invalidLHS || invalidRHS {
 		if invalidLHS {
@@ -381,7 +381,7 @@ func (b *builtinDateDiffSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if invalidRHS {
 			err = handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(rhs.String()))
 		}
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	return int64(types.DateDiff(lhs.Time, rhs.Time)), false, nil
 }
@@ -401,7 +401,7 @@ func (c *timeDiffFunctionClass) getArgEvalTp(fieldTp *types.FieldType) types.Eva
 
 func (c *timeDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	arg0FieldTp, arg1FieldTp := args[0].GetType(), args[1].GetType()
@@ -410,11 +410,11 @@ func (c *timeDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 
 	arg0Dec, err := getExpressionFsp(ctx, args[0])
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	arg1Dec, err := getExpressionFsp(ctx, args[1])
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf.tp.Decimal = mathutil.Max(arg0Dec, arg1Dec)
 
@@ -470,16 +470,16 @@ func (b *builtinDurationDurationTimeDiffSig) Clone() builtinFunc {
 func (b *builtinDurationDurationTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinTimeTimeTimeDiffSig struct {
@@ -497,17 +497,17 @@ func (b *builtinTimeTimeTimeDiffSig) Clone() builtinFunc {
 func (b *builtinTimeTimeTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	d, isNull, err = calculateTimeDiff(sc, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinDurationStringTimeDiffSig struct {
@@ -525,22 +525,22 @@ func (b *builtinDurationStringTimeDiffSig) Clone() builtinFunc {
 func (b *builtinDurationStringTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhs, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	rhs, _, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.Decimal)
 	if err != nil || !isDuration {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinStringDurationTimeDiffSig struct {
@@ -558,22 +558,22 @@ func (b *builtinStringDurationTimeDiffSig) Clone() builtinFunc {
 func (b *builtinStringDurationTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhs, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	lhs, _, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.Decimal)
 	if err != nil || !isDuration {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	d, isNull, err = calculateDurationTimeDiff(b.ctx, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 // calculateTimeDiff calculates interval difference of two types.Time.
@@ -583,14 +583,14 @@ func calculateTimeDiff(sc *stmtctx.StatementContext, lhs, rhs types.Time) (d typ
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
-	return d, err != nil, errors.Trace(err)
+	return d, err != nil, err
 }
 
 // calculateDurationTimeDiff calculates interval difference of two types.Duration.
 func calculateDurationTimeDiff(ctx sessionctx.Context, lhs, rhs types.Duration) (d types.Duration, isNull bool, err error) {
 	d, err = lhs.Sub(rhs)
 	if err != nil {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	d.Duration, err = types.TruncateOverflowMySQLTime(d.Duration)
@@ -598,7 +598,7 @@ func calculateDurationTimeDiff(ctx sessionctx.Context, lhs, rhs types.Duration) 
 		sc := ctx.GetSessionVars().StmtCtx
 		err = sc.HandleTruncate(err)
 	}
-	return d, err != nil, errors.Trace(err)
+	return d, err != nil, err
 }
 
 type builtinTimeStringTimeDiffSig struct {
@@ -616,22 +616,22 @@ func (b *builtinTimeStringTimeDiffSig) Clone() builtinFunc {
 func (b *builtinTimeStringTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhs, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhsStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	_, rhs, isDuration, err := convertStringToDuration(sc, rhsStr, b.tp.Decimal)
 	if err != nil || isDuration {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	d, isNull, err = calculateTimeDiff(sc, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinStringTimeTimeDiffSig struct {
@@ -649,22 +649,22 @@ func (b *builtinStringTimeTimeDiffSig) Clone() builtinFunc {
 func (b *builtinStringTimeTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhsStr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	_, lhs, isDuration, err := convertStringToDuration(sc, lhsStr, b.tp.Decimal)
 	if err != nil || isDuration {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	d, isNull, err = calculateTimeDiff(sc, lhs, rhs)
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinStringStringTimeDiffSig struct {
@@ -682,24 +682,24 @@ func (b *builtinStringStringTimeDiffSig) Clone() builtinFunc {
 func (b *builtinStringStringTimeDiffSig) evalDuration(row chunk.Row) (d types.Duration, isNull bool, err error) {
 	lhs, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	rhs, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return d, isNull, errors.Trace(err)
+		return d, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
 	fsp := b.tp.Decimal
 	lhsDur, lhsTime, lhsIsDuration, err := convertStringToDuration(sc, lhs, fsp)
 	if err != nil {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	rhsDur, rhsTime, rhsIsDuration, err := convertStringToDuration(sc, rhs, fsp)
 	if err != nil {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 
 	if lhsIsDuration != rhsIsDuration {
@@ -712,7 +712,7 @@ func (b *builtinStringStringTimeDiffSig) evalDuration(row chunk.Row) (d types.Du
 		d, isNull, err = calculateTimeDiff(sc, lhsTime, rhsTime)
 	}
 
-	return d, isNull, errors.Trace(err)
+	return d, isNull, err
 }
 
 type builtinNullTimeDiffSig struct {
@@ -750,7 +750,7 @@ type dateFormatFunctionClass struct {
 
 func (c *dateFormatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDatetime, types.ETString)
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
@@ -775,18 +775,18 @@ func (b *builtinDateFormatSig) Clone() builtinFunc {
 func (b *builtinDateFormatSig) evalString(row chunk.Row) (string, bool, error) {
 	t, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return "", isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	if t.InvalidZero() {
-		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(t.String())))
+		return "", true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(t.String()))
 	}
 	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 
 	res, err := t.DateFormat(formatMask)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type fromDaysFunctionClass struct {
@@ -795,7 +795,7 @@ type fromDaysFunctionClass struct {
 
 func (c *fromDaysFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETInt)
 	bf.tp.Flen, bf.tp.Decimal = 10, 0
@@ -818,7 +818,7 @@ func (b *builtinFromDaysSig) Clone() builtinFunc {
 func (b *builtinFromDaysSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	n, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	return types.TimeFromDays(n), false, nil
@@ -830,7 +830,7 @@ type hourFunctionClass struct {
 
 func (c *hourFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 3, 0
@@ -865,7 +865,7 @@ type minuteFunctionClass struct {
 
 func (c *minuteFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
@@ -900,7 +900,7 @@ type secondFunctionClass struct {
 
 func (c *secondFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
@@ -935,7 +935,7 @@ type microSecondFunctionClass struct {
 
 func (c *microSecondFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 6, 0
@@ -970,7 +970,7 @@ type monthFunctionClass struct {
 
 func (c *monthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
@@ -994,12 +994,12 @@ func (b *builtinMonthSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
 		if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-			return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+			return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 		}
 		return 0, false, nil
 	}
@@ -1014,7 +1014,7 @@ type monthNameFunctionClass struct {
 
 func (c *monthNameFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDatetime)
 	bf.tp.Flen = 10
@@ -1035,11 +1035,11 @@ func (b *builtinMonthNameSig) Clone() builtinFunc {
 func (b *builtinMonthNameSig) evalString(row chunk.Row) (string, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return "", true, handleInvalidTimeError(b.ctx, err)
 	}
 	mon := arg.Time.Month()
 	if (arg.IsZero() && b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode()) || mon < 0 || mon > len(types.MonthNames) {
-		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return "", true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	} else if mon == 0 || arg.IsZero() {
 		return "", true, nil
 	}
@@ -1052,7 +1052,7 @@ type dayNameFunctionClass struct {
 
 func (c *dayNameFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDatetime)
 	bf.tp.Flen = 10
@@ -1075,10 +1075,10 @@ func (b *builtinDayNameSig) Clone() builtinFunc {
 func (b *builtinDayNameSig) evalString(row chunk.Row) (string, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	if arg.InvalidZero() {
-		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return "", true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 	// Monday is 0, ... Sunday = 6 in MySQL
 	// but in go, Sunday is 0, ... Saturday is 6
@@ -1093,7 +1093,7 @@ type dayOfMonthFunctionClass struct {
 
 func (c *dayOfMonthFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 2
@@ -1116,11 +1116,11 @@ func (b *builtinDayOfMonthSig) Clone() builtinFunc {
 func (b *builtinDayOfMonthSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	if arg.IsZero() {
 		if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-			return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+			return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 		}
 		return 0, false, nil
 	}
@@ -1133,7 +1133,7 @@ type dayOfWeekFunctionClass struct {
 
 func (c *dayOfWeekFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 1
@@ -1156,10 +1156,10 @@ func (b *builtinDayOfWeekSig) Clone() builtinFunc {
 func (b *builtinDayOfWeekSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 	// 1 is Sunday, 2 is Monday, .... 7 is Saturday
 	return int64(arg.Time.Weekday() + 1), false, nil
@@ -1171,7 +1171,7 @@ type dayOfYearFunctionClass struct {
 
 func (c *dayOfYearFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 3
@@ -1194,10 +1194,10 @@ func (b *builtinDayOfYearSig) Clone() builtinFunc {
 func (b *builtinDayOfYearSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	if arg.InvalidZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 
 	return int64(arg.Time.YearDay()), false, nil
@@ -1209,7 +1209,7 @@ type weekFunctionClass struct {
 
 func (c *weekFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	argTps := []types.EvalType{types.ETDatetime}
@@ -1246,16 +1246,16 @@ func (b *builtinWeekWithModeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	week := date.Time.Week(int(mode))
@@ -1278,11 +1278,11 @@ func (b *builtinWeekWithoutModeSig) evalInt(row chunk.Row) (int64, bool, error) 
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	week := date.Time.Week(0)
@@ -1295,7 +1295,7 @@ type weekDayFunctionClass struct {
 
 func (c *weekDayFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
@@ -1319,11 +1319,11 @@ func (b *builtinWeekDaySig) Clone() builtinFunc {
 func (b *builtinWeekDaySig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	return int64(date.Time.Weekday()+6) % 7, false, nil
@@ -1335,7 +1335,7 @@ type weekOfYearFunctionClass struct {
 
 func (c *weekOfYearFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
@@ -1359,11 +1359,11 @@ func (b *builtinWeekOfYearSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	week := date.Time.Week(3)
@@ -1376,7 +1376,7 @@ type yearFunctionClass struct {
 
 func (c *yearFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 4, 0
@@ -1400,12 +1400,12 @@ func (b *builtinYearSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
 		if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
-			return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+			return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 		}
 		return 0, false, nil
 	}
@@ -1418,7 +1418,7 @@ type yearWeekFunctionClass struct {
 
 func (c *yearWeekFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := []types.EvalType{types.ETDatetime}
 	if len(args) == 2 {
@@ -1453,15 +1453,15 @@ func (b *builtinYearWeekWithModeSig) Clone() builtinFunc {
 func (b *builtinYearWeekWithModeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	mode, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	if isNull {
 		mode = 0
@@ -1490,11 +1490,11 @@ func (b *builtinYearWeekWithoutModeSig) Clone() builtinFunc {
 func (b *builtinYearWeekWithoutModeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.InvalidZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	year, week := date.Time.YearWeek(0)
@@ -1511,7 +1511,7 @@ type fromUnixTimeFunctionClass struct {
 
 func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	retTp, argTps := types.ETDatetime, make([]types.EvalType, 0, len(args))
@@ -1530,7 +1530,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []E
 		} else if isArg0Con {
 			arg0, _, err1 := args[0].EvalDecimal(ctx, chunk.Row{})
 			if err1 != nil {
-				return sig, errors.Trace(err1)
+				return sig, err1
 			}
 			fsp := int(arg0.GetDigitsFrac())
 			if fsp > types.MaxFsp {
@@ -1549,7 +1549,7 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []E
 func evalFromUnixTime(ctx sessionctx.Context, fsp int, row chunk.Row, arg Expression) (res types.Time, isNull bool, err error) {
 	unixTimeStamp, isNull, err := arg.EvalDecimal(ctx, row)
 	if err != nil || isNull {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 	// 0 <= unixTimeStamp <= INT32_MAX
 	if unixTimeStamp.IsNegative() {
@@ -1557,7 +1557,7 @@ func evalFromUnixTime(ctx sessionctx.Context, fsp int, row chunk.Row, arg Expres
 	}
 	integralPart, err := unixTimeStamp.ToInt()
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	if integralPart > int64(math.MaxInt32) {
 		return res, true, nil
@@ -1570,17 +1570,17 @@ func evalFromUnixTime(ctx sessionctx.Context, fsp int, row chunk.Row, arg Expres
 	fracDecimalTp := new(types.MyDecimal)
 	err = types.DecimalSub(unixTimeStamp, integerDecimalTp, fracDecimalTp)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	nano := new(types.MyDecimal).FromInt(int64(time.Second))
 	x := new(types.MyDecimal)
 	err = types.DecimalMul(fracDecimalTp, nano, x)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	fractionalPart, err := x.ToInt() // here fractionalPart is result multiplying the original fractional part by 10^9.
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	fracDigitsNumber := int(unixTimeStamp.GetDigitsFrac())
 	if fsp < 0 {
@@ -1595,7 +1595,7 @@ func evalFromUnixTime(ctx sessionctx.Context, fsp int, row chunk.Row, arg Expres
 	tmp := time.Unix(integralPart, fractionalPart).In(sc.TimeZone)
 	t, err := convertTimeToMysqlTime(tmp, fsp)
 	if err != nil {
-		return res, true, errors.Trace(err)
+		return res, true, err
 	}
 	return t, false, nil
 }
@@ -1631,14 +1631,14 @@ func (b *builtinFromUnixTime2ArgSig) Clone() builtinFunc {
 func (b *builtinFromUnixTime2ArgSig) evalString(row chunk.Row) (res string, isNull bool, err error) {
 	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	t, isNull, err := evalFromUnixTime(b.ctx, b.tp.Decimal, row, b.args[0])
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	res, err = t.DateFormat(format)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 type getFormatFunctionClass struct {
@@ -1647,7 +1647,7 @@ type getFormatFunctionClass struct {
 
 func (c *getFormatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
 	bf.tp.Flen = 17
@@ -1670,11 +1670,11 @@ func (b *builtinGetFormatSig) Clone() builtinFunc {
 func (b *builtinGetFormatSig) evalString(row chunk.Row) (string, bool, error) {
 	t, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	l, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 
 	var res string
@@ -1752,7 +1752,7 @@ func (c *strToDateFunctionClass) getRetTp(ctx sessionctx.Context, arg Expression
 // getFunction see https://dev.mysql.com/doc/refman/5.5/en/date-and-time-functions.html#function_str-to-date
 func (c *strToDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	retTp, fsp := c.getRetTp(ctx, args[1])
 	switch retTp {
@@ -1793,11 +1793,11 @@ func (b *builtinStrToDateDateSig) Clone() builtinFunc {
 func (b *builtinStrToDateDateSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	var t types.Time
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -1822,11 +1822,11 @@ func (b *builtinStrToDateDatetimeSig) Clone() builtinFunc {
 func (b *builtinStrToDateDatetimeSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	var t types.Time
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -1854,11 +1854,11 @@ func (b *builtinStrToDateDurationSig) Clone() builtinFunc {
 func (b *builtinStrToDateDurationSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	date, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Duration{}, isNull, errors.Trace(err)
+		return types.Duration{}, isNull, err
 	}
 	format, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Duration{}, isNull, errors.Trace(err)
+		return types.Duration{}, isNull, err
 	}
 	var t types.Time
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -1868,7 +1868,7 @@ func (b *builtinStrToDateDurationSig) evalDuration(row chunk.Row) (types.Duratio
 	}
 	t.Fsp = b.tp.Decimal
 	dur, err := t.ConvertToDuration()
-	return dur, err != nil, errors.Trace(err)
+	return dur, err != nil, err
 }
 
 type sysDateFunctionClass struct {
@@ -1877,7 +1877,7 @@ type sysDateFunctionClass struct {
 
 func (c *sysDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var argTps = make([]types.EvalType, 0)
 	if len(args) == 1 {
@@ -1910,14 +1910,14 @@ func (b *builtinSysDateWithFspSig) Clone() builtinFunc {
 func (b *builtinSysDateWithFspSig) evalTime(row chunk.Row) (d types.Time, isNull bool, err error) {
 	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 
 	loc := b.ctx.GetSessionVars().Location()
 	now := time.Now().In(loc)
 	result, err := convertTimeToMysqlTime(now, int(fsp))
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	return result, false, nil
 }
@@ -1939,7 +1939,7 @@ func (b *builtinSysDateWithoutFspSig) evalTime(row chunk.Row) (d types.Time, isN
 	now := time.Now().In(tz)
 	result, err := convertTimeToMysqlTime(now, 0)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	return result, false, nil
 }
@@ -1950,7 +1950,7 @@ type currentDateFunctionClass struct {
 
 func (c *currentDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 10, 0
@@ -1990,7 +1990,7 @@ type currentTimeFunctionClass struct {
 
 func (c *currentTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if len(args) == 0 {
@@ -2005,7 +2005,7 @@ func (c *currentTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	if ok {
 		fsp, _, err = args[0].EvalInt(ctx, chunk.Row{})
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		if fsp > int64(types.MaxFsp) {
 			return nil, errors.Errorf("Too-big precision %v specified for 'curtime'. Maximum is %v.", fsp, types.MaxFsp)
@@ -2038,7 +2038,7 @@ func (b *builtinCurrentTime0ArgSig) evalDuration(row chunk.Row) (types.Duration,
 	dur := nowTs.In(tz).Format(types.TimeFormat)
 	res, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, dur, types.MinFsp)
 	if err != nil {
-		return types.Duration{}, true, errors.Trace(err)
+		return types.Duration{}, true, err
 	}
 	return res, false, nil
 }
@@ -2056,7 +2056,7 @@ func (b *builtinCurrentTime1ArgSig) Clone() builtinFunc {
 func (b *builtinCurrentTime1ArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	fsp, _, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return types.Duration{}, true, errors.Trace(err)
+		return types.Duration{}, true, err
 	}
 	tz := b.ctx.GetSessionVars().Location()
 	var nowTs = &b.ctx.GetSessionVars().StmtCtx.NowTs
@@ -2066,7 +2066,7 @@ func (b *builtinCurrentTime1ArgSig) evalDuration(row chunk.Row) (types.Duration,
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
 	res, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, dur, int(fsp))
 	if err != nil {
-		return types.Duration{}, true, errors.Trace(err)
+		return types.Duration{}, true, err
 	}
 	return res, false, nil
 }
@@ -2078,12 +2078,12 @@ type timeFunctionClass struct {
 func (c *timeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	err := c.verifyArgs(args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, types.ETString)
 	bf.tp.Decimal, err = getExpressionFsp(ctx, args[0])
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	sig := &builtinTimeSig{bf}
 	return sig, nil
@@ -2104,7 +2104,7 @@ func (b *builtinTimeSig) Clone() builtinFunc {
 func (b *builtinTimeSig) evalDuration(row chunk.Row) (res types.Duration, isNull bool, err error) {
 	expr, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	fsp := 0
@@ -2113,7 +2113,7 @@ func (b *builtinTimeSig) evalDuration(row chunk.Row) (res types.Duration, isNull
 	}
 
 	if fsp, err = types.CheckFsp(fsp); err != nil {
-		return res, isNull, errors.Trace(err)
+		return res, isNull, err
 	}
 
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -2121,7 +2121,7 @@ func (b *builtinTimeSig) evalDuration(row chunk.Row) (res types.Duration, isNull
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
 	}
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 type timeLiteralFunctionClass struct {
@@ -2130,7 +2130,7 @@ type timeLiteralFunctionClass struct {
 
 func (c *timeLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	con, ok := args[0].(*Constant)
 	if !ok {
@@ -2138,7 +2138,7 @@ func (c *timeLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	}
 	dt, err := con.Eval(chunk.Row{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	str := dt.GetString()
 	if !isDuration(str) {
@@ -2146,7 +2146,7 @@ func (c *timeLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	}
 	duration, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx, str, types.GetFsp(str))
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, []Expression{}, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 10, duration.Fsp
@@ -2180,7 +2180,7 @@ type utcDateFunctionClass struct {
 
 func (c *utcDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 10, 0
@@ -2238,7 +2238,7 @@ func getFlenAndDecimal4UTCTimestampAndNow(ctx sessionctx.Context, arg Expression
 
 func (c *utcTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, 1)
 	if len(args) == 1 {
@@ -2268,7 +2268,7 @@ func evalUTCTimestampWithFsp(ctx sessionctx.Context, fsp int) (types.Time, bool,
 	}
 	result, err := convertTimeToMysqlTime(nowTs.UTC(), fsp)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	return result, false, nil
 }
@@ -2288,7 +2288,7 @@ func (b *builtinUTCTimestampWithArgSig) Clone() builtinFunc {
 func (b *builtinUTCTimestampWithArgSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	num, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	if !isNull && num > int64(types.MaxFsp) {
@@ -2299,7 +2299,7 @@ func (b *builtinUTCTimestampWithArgSig) evalTime(row chunk.Row) (types.Time, boo
 	}
 
 	result, isNull, err := evalUTCTimestampWithFsp(b.ctx, int(num))
-	return result, isNull, errors.Trace(err)
+	return result, isNull, err
 }
 
 type builtinUTCTimestampWithoutArgSig struct {
@@ -2316,7 +2316,7 @@ func (b *builtinUTCTimestampWithoutArgSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-timestamp
 func (b *builtinUTCTimestampWithoutArgSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	result, isNull, err := evalUTCTimestampWithFsp(b.ctx, 0)
-	return result, isNull, errors.Trace(err)
+	return result, isNull, err
 }
 
 type nowFunctionClass struct {
@@ -2325,7 +2325,7 @@ type nowFunctionClass struct {
 
 func (c *nowFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, 1)
 	if len(args) == 1 {
@@ -2354,18 +2354,18 @@ func evalNowWithFsp(ctx sessionctx.Context, fsp int) (types.Time, bool, error) {
 		var err error
 		*sysTs, err = getSystemTimestamp(ctx)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 	}
 
 	result, err := convertTimeToMysqlTime(*sysTs, fsp)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	err = result.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location())
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	return result, false, nil
@@ -2387,7 +2387,7 @@ func (b *builtinNowWithArgSig) evalTime(row chunk.Row) (types.Time, bool, error)
 	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	if isNull {
@@ -2399,7 +2399,7 @@ func (b *builtinNowWithArgSig) evalTime(row chunk.Row) (types.Time, bool, error)
 	}
 
 	result, isNull, err := evalNowWithFsp(b.ctx, int(fsp))
-	return result, isNull, errors.Trace(err)
+	return result, isNull, err
 }
 
 type builtinNowWithoutArgSig struct {
@@ -2416,7 +2416,7 @@ func (b *builtinNowWithoutArgSig) Clone() builtinFunc {
 // see: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_now
 func (b *builtinNowWithoutArgSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	result, isNull, err := evalNowWithFsp(b.ctx, 0)
-	return result, isNull, errors.Trace(err)
+	return result, isNull, err
 }
 
 type extractFunctionClass struct {
@@ -2425,7 +2425,7 @@ type extractFunctionClass struct {
 
 func (c *extractFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	datetimeUnits := map[string]struct{}{
@@ -2445,7 +2445,7 @@ func (c *extractFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	if _, isCon := args[0].(*Constant); isCon {
 		unit, _, err1 := args[0].EvalString(ctx, chunk.Row{})
 		if err1 != nil {
-			return nil, errors.Trace(err1)
+			return nil, err1
 		}
 		_, isDatetimeUnit = datetimeUnits[unit]
 	}
@@ -2475,14 +2475,14 @@ func (b *builtinExtractDatetimeSig) Clone() builtinFunc {
 func (b *builtinExtractDatetimeSig) evalInt(row chunk.Row) (int64, bool, error) {
 	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	dt, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	res, err := types.ExtractDatetimeNum(&dt, unit)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 type builtinExtractDurationSig struct {
@@ -2500,14 +2500,14 @@ func (b *builtinExtractDurationSig) Clone() builtinFunc {
 func (b *builtinExtractDurationSig) evalInt(row chunk.Row) (int64, bool, error) {
 	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	dur, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	res, err := types.ExtractDurationNum(&dur, unit)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 // baseDateArithmitical is the base class for all "builtinAddDateXXXSig" and "builtinSubDateXXXSig",
@@ -2526,7 +2526,7 @@ func newDateArighmeticalUtil() baseDateArithmitical {
 func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
 	dateStr, isNull, err := args[0].EvalString(ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	dateTp := mysql.TypeDate
@@ -2536,19 +2536,19 @@ func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args [
 
 	sc := ctx.GetSessionVars().StmtCtx
 	date, err := types.ParseTime(sc, dateStr, dateTp, types.MaxFsp)
-	return date, err != nil, errors.Trace(handleInvalidTimeError(ctx, err))
+	return date, err != nil, handleInvalidTimeError(ctx, err)
 }
 
 func (du *baseDateArithmitical) getDateFromInt(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
 	dateInt, isNull, err := args[0].EvalInt(ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	sc := ctx.GetSessionVars().StmtCtx
 	date, err := types.ParseTimeFromInt64(sc, dateInt)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(ctx, err)
 	}
 
 	dateTp := mysql.TypeDate
@@ -2562,7 +2562,7 @@ func (du *baseDateArithmitical) getDateFromInt(ctx sessionctx.Context, args []Ex
 func (du *baseDateArithmitical) getDateFromDatetime(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
 	date, isNull, err := args[0].EvalTime(ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	dateTp := mysql.TypeDate
@@ -2576,7 +2576,7 @@ func (du *baseDateArithmitical) getDateFromDatetime(ctx sessionctx.Context, args
 func (du *baseDateArithmitical) getIntervalFromString(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (string, bool, error) {
 	interval, isNull, err := args[1].EvalString(ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	// unit "DAY" and "HOUR" has to be specially handled.
 	if toLower := strings.ToLower(unit); toLower == "day" || toLower == "hour" {
@@ -2594,7 +2594,7 @@ func (du *baseDateArithmitical) getIntervalFromString(ctx sessionctx.Context, ar
 func (du *baseDateArithmitical) getIntervalFromDecimal(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (string, bool, error) {
 	interval, isNull, err := args[1].EvalString(ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 
 	switch strings.ToUpper(unit) {
@@ -2622,14 +2622,14 @@ func (du *baseDateArithmitical) getIntervalFromDecimal(ctx sessionctx.Context, a
 		args[1] = WrapWithCastAsReal(ctx, args[1])
 		interval, isNull, err = args[1].EvalString(ctx, row)
 		if isNull || err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 	default:
 		// YEAR, QUARTER, MONTH, WEEK, DAY, HOUR, MINUTE
 		args[1] = WrapWithCastAsInt(ctx, args[1])
 		interval, isNull, err = args[1].EvalString(ctx, row)
 		if isNull || err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 	}
 
@@ -2639,7 +2639,7 @@ func (du *baseDateArithmitical) getIntervalFromDecimal(ctx sessionctx.Context, a
 func (du *baseDateArithmitical) getIntervalFromInt(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (string, bool, error) {
 	interval, isNull, err := args[1].EvalInt(ctx, row)
 	if isNull || err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return strconv.FormatInt(interval, 10), false, nil
 }
@@ -2647,12 +2647,12 @@ func (du *baseDateArithmitical) getIntervalFromInt(ctx sessionctx.Context, args 
 func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, interval string, unit string) (types.Time, bool, error) {
 	year, month, day, dur, err := types.ExtractTimeValue(unit, interval)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(ctx, err)
 	}
 
 	goTime, err := date.Time.GoTime(time.Local)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	duration := time.Duration(dur)
@@ -2672,13 +2672,13 @@ func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, int
 func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, interval string, unit string) (types.Time, bool, error) {
 	year, month, day, dur, err := types.ExtractTimeValue(unit, interval)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(ctx, err)
 	}
 	year, month, day, dur = -year, -month, -day, -dur
 
 	goTime, err := date.Time.GoTime(time.Local)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	duration := time.Duration(dur)
@@ -2701,7 +2701,7 @@ type addDateFunctionClass struct {
 
 func (c *addDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	dateEvalTp := args[0].GetType().EvalType()
@@ -2784,21 +2784,21 @@ func (b *builtinAddDateStringStringSig) Clone() builtinFunc {
 func (b *builtinAddDateStringStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateStringIntSig struct {
@@ -2817,21 +2817,21 @@ func (b *builtinAddDateStringIntSig) Clone() builtinFunc {
 func (b *builtinAddDateStringIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateStringDecimalSig struct {
@@ -2850,21 +2850,21 @@ func (b *builtinAddDateStringDecimalSig) Clone() builtinFunc {
 func (b *builtinAddDateStringDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateIntStringSig struct {
@@ -2883,21 +2883,21 @@ func (b *builtinAddDateIntStringSig) Clone() builtinFunc {
 func (b *builtinAddDateIntStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateIntIntSig struct {
@@ -2916,21 +2916,21 @@ func (b *builtinAddDateIntIntSig) Clone() builtinFunc {
 func (b *builtinAddDateIntIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateIntDecimalSig struct {
@@ -2949,21 +2949,21 @@ func (b *builtinAddDateIntDecimalSig) Clone() builtinFunc {
 func (b *builtinAddDateIntDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateDatetimeStringSig struct {
@@ -2982,21 +2982,21 @@ func (b *builtinAddDateDatetimeStringSig) Clone() builtinFunc {
 func (b *builtinAddDateDatetimeStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateDatetimeIntSig struct {
@@ -3015,21 +3015,21 @@ func (b *builtinAddDateDatetimeIntSig) Clone() builtinFunc {
 func (b *builtinAddDateDatetimeIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinAddDateDatetimeDecimalSig struct {
@@ -3048,21 +3048,21 @@ func (b *builtinAddDateDatetimeDecimalSig) Clone() builtinFunc {
 func (b *builtinAddDateDatetimeDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.add(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type subDateFunctionClass struct {
@@ -3071,7 +3071,7 @@ type subDateFunctionClass struct {
 
 func (c *subDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	dateEvalTp := args[0].GetType().EvalType()
@@ -3154,21 +3154,21 @@ func (b *builtinSubDateStringStringSig) Clone() builtinFunc {
 func (b *builtinSubDateStringStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateStringIntSig struct {
@@ -3187,21 +3187,21 @@ func (b *builtinSubDateStringIntSig) Clone() builtinFunc {
 func (b *builtinSubDateStringIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateStringDecimalSig struct {
@@ -3218,21 +3218,21 @@ func (b *builtinSubDateStringDecimalSig) Clone() builtinFunc {
 func (b *builtinSubDateStringDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateIntStringSig struct {
@@ -3251,21 +3251,21 @@ func (b *builtinSubDateIntStringSig) Clone() builtinFunc {
 func (b *builtinSubDateIntStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateIntIntSig struct {
@@ -3284,21 +3284,21 @@ func (b *builtinSubDateIntIntSig) Clone() builtinFunc {
 func (b *builtinSubDateIntIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateDatetimeStringSig struct {
@@ -3322,21 +3322,21 @@ func (b *builtinSubDateIntDecimalSig) Clone() builtinFunc {
 func (b *builtinSubDateIntDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 func (b *builtinSubDateDatetimeStringSig) Clone() builtinFunc {
@@ -3350,21 +3350,21 @@ func (b *builtinSubDateDatetimeStringSig) Clone() builtinFunc {
 func (b *builtinSubDateDatetimeStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromString(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateDatetimeIntSig struct {
@@ -3383,21 +3383,21 @@ func (b *builtinSubDateDatetimeIntSig) Clone() builtinFunc {
 func (b *builtinSubDateDatetimeIntSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromInt(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type builtinSubDateDatetimeDecimalSig struct {
@@ -3416,21 +3416,21 @@ func (b *builtinSubDateDatetimeDecimalSig) Clone() builtinFunc {
 func (b *builtinSubDateDatetimeDecimalSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	unit, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	date, isNull, err := b.getDateFromDatetime(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	interval, isNull, err := b.getIntervalFromDecimal(b.ctx, b.args, row, unit)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	result, isNull, err := b.sub(b.ctx, date, interval, unit)
-	return result, isNull || err != nil, errors.Trace(err)
+	return result, isNull || err != nil, err
 }
 
 type timestampDiffFunctionClass struct {
@@ -3439,7 +3439,7 @@ type timestampDiffFunctionClass struct {
 
 func (c *timestampDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETDatetime, types.ETDatetime)
 	sig := &builtinTimestampDiffSig{bf}
@@ -3461,15 +3461,15 @@ func (b *builtinTimestampDiffSig) Clone() builtinFunc {
 func (b *builtinTimestampDiffSig) evalInt(row chunk.Row) (int64, bool, error) {
 	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	lhs, isNull, err := b.args[1].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	rhs, isNull, err := b.args[2].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	if invalidLHS, invalidRHS := lhs.InvalidZero(), rhs.InvalidZero(); invalidLHS || invalidRHS {
 		if invalidLHS {
@@ -3478,7 +3478,7 @@ func (b *builtinTimestampDiffSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if invalidRHS {
 			err = handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(rhs.String()))
 		}
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	return types.TimestampDiff(unit, lhs, rhs), false, nil
 }
@@ -3489,7 +3489,7 @@ type unixTimestampFunctionClass struct {
 
 func (c *unixTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var (
 		argTps              []types.EvalType
@@ -3509,7 +3509,7 @@ func (c *unixTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []
 			if cnst, ok := args[0].(*Constant); ok {
 				tmpStr, _, err := cnst.EvalString(ctx, chunk.Row{})
 				if err != nil {
-					return nil, errors.Trace(err)
+					return nil, err
 				}
 				retDecimal = 0
 				if dotIdx := strings.LastIndex(tmpStr, "."); dotIdx >= 0 {
@@ -3563,10 +3563,10 @@ func goTimeToMysqlUnixTimestamp(t time.Time, decimal int) (*types.MyDecimal, err
 	dec.FromInt(nanoSeconds)
 	err := dec.Shift(-9)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	err = dec.Round(dec, decimal, types.ModeHalfEven)
-	return dec, errors.Trace(err)
+	return dec, err
 }
 
 type builtinUnixTimestampCurrentSig struct {
@@ -3588,10 +3588,10 @@ func (b *builtinUnixTimestampCurrentSig) evalInt(row chunk.Row) (int64, bool, er
 	}
 	dec, err := goTimeToMysqlUnixTimestamp(*nowTs, 1)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	intVal, err := dec.ToInt()
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return intVal, false, nil
 }
 
@@ -3622,10 +3622,10 @@ func (b *builtinUnixTimestampIntSig) evalInt(row chunk.Row) (int64, bool, error)
 	}
 	dec, err := goTimeToMysqlUnixTimestamp(t, 1)
 	if err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	intVal, err := dec.ToInt()
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return intVal, false, nil
 }
 
@@ -3652,7 +3652,7 @@ func (b *builtinUnixTimestampDecSig) evalDecimal(row chunk.Row) (*types.MyDecima
 		return new(types.MyDecimal), false, nil
 	}
 	result, err := goTimeToMysqlUnixTimestamp(t, b.tp.Decimal)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type timestampFunctionClass struct {
@@ -3680,7 +3680,7 @@ func (c *timestampFunctionClass) getDefaultFsp(tp *types.FieldType) int {
 
 func (c *timestampFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	evalTps, argLen := []types.EvalType{types.ETString}, len(args)
 	if argLen == 2 {
@@ -3726,7 +3726,7 @@ func (b *builtinTimestamp1ArgSig) Clone() builtinFunc {
 func (b *builtinTimestamp1ArgSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	s, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	var tm types.Time
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -3736,7 +3736,7 @@ func (b *builtinTimestamp1ArgSig) evalTime(row chunk.Row) (types.Time, bool, err
 		tm, err = types.ParseTime(sc, s, mysql.TypeDatetime, types.GetFsp(s))
 	}
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 	return tm, false, nil
 }
@@ -3758,7 +3758,7 @@ func (b *builtinTimestamp2ArgsSig) Clone() builtinFunc {
 func (b *builtinTimestamp2ArgsSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	var tm types.Time
 	sc := b.ctx.GetSessionVars().StmtCtx
@@ -3768,22 +3768,22 @@ func (b *builtinTimestamp2ArgsSig) evalTime(row chunk.Row) (types.Time, bool, er
 		tm, err = types.ParseTime(sc, arg0, mysql.TypeDatetime, types.GetFsp(arg0))
 	}
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 	arg1, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, isNull, errors.Trace(err)
+		return types.Time{}, isNull, err
 	}
 	if !isDuration(arg1) {
 		return types.Time{}, true, nil
 	}
 	duration, err := types.ParseDuration(sc, arg1, types.GetFsp(arg1))
 	if err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 	tmp, err := tm.Add(sc, duration)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	return tmp, false, nil
 }
@@ -3794,7 +3794,7 @@ type timestampLiteralFunctionClass struct {
 
 func (c *timestampLiteralFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	con, ok := args[0].(*Constant)
 	if !ok {
@@ -3802,18 +3802,18 @@ func (c *timestampLiteralFunctionClass) getFunction(ctx sessionctx.Context, args
 	}
 	dt, err := con.Eval(chunk.Row{})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	str, err := dt.ToString()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if !timestampPattern.MatchString(str) {
 		return nil, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(str)
 	}
 	tm, err := types.ParseTime(ctx.GetSessionVars().StmtCtx, str, mysql.TypeTimestamp, types.GetFsp(str))
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, []Expression{}, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = mysql.MaxDatetimeWidthNoFsp, tm.Fsp
@@ -3912,11 +3912,11 @@ func isDuration(str string) bool {
 func strDatetimeAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseTime(sc, d, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	ret, err := arg0.Add(sc, arg1)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	fsp := types.MaxFsp
 	if ret.Time.Microsecond() == 0 {
@@ -3930,11 +3930,11 @@ func strDatetimeAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.D
 func strDurationAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseDuration(sc, d, types.MaxFsp)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	tmpDuration, err := arg0.Add(arg1)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	tmpDuration.Fsp = types.MaxFsp
 	if tmpDuration.MicroSecond() == 0 {
@@ -3947,11 +3947,11 @@ func strDurationAddDuration(sc *stmtctx.StatementContext, d string, arg1 types.D
 func strDatetimeSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseTime(sc, d, mysql.TypeDatetime, types.MaxFsp)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	arg1time, err := arg1.ConvertToTime(sc, uint8(types.GetFsp(arg1.String())))
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	tmpDuration := arg0.Sub(sc, &arg1time)
 	fsp := types.MaxFsp
@@ -3960,7 +3960,7 @@ func strDatetimeSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.D
 	}
 	resultDuration, err := tmpDuration.ConvertToTime(sc, mysql.TypeDatetime)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	resultDuration.Fsp = fsp
 	return resultDuration.String(), nil
@@ -3970,11 +3970,11 @@ func strDatetimeSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.D
 func strDurationSubDuration(sc *stmtctx.StatementContext, d string, arg1 types.Duration) (string, error) {
 	arg0, err := types.ParseDuration(sc, d, types.MaxFsp)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	tmpDuration, err := arg0.Sub(arg1)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	tmpDuration.Fsp = types.MaxFsp
 	if tmpDuration.MicroSecond() == 0 {
@@ -3989,7 +3989,7 @@ type addTimeFunctionClass struct {
 
 func (c *addTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tp1, tp2, bf, err := getBf4TimeAddSub(ctx, args)
 	if err != nil {
@@ -4067,14 +4067,14 @@ func (b *builtinAddDatetimeAndDurationSig) Clone() builtinFunc {
 func (b *builtinAddDatetimeAndDurationSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	result, err := arg0.Add(b.ctx.GetSessionVars().StmtCtx, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinAddDatetimeAndStringSig struct {
@@ -4092,11 +4092,11 @@ func (b *builtinAddDatetimeAndStringSig) Clone() builtinFunc {
 func (b *builtinAddDatetimeAndStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDatetime, true, nil
@@ -4104,10 +4104,10 @@ func (b *builtinAddDatetimeAndStringSig) evalTime(row chunk.Row) (types.Time, bo
 	sc := b.ctx.GetSessionVars().StmtCtx
 	arg1, err := types.ParseDuration(sc, s, types.GetFsp(s))
 	if err != nil {
-		return types.ZeroDatetime, true, errors.Trace(err)
+		return types.ZeroDatetime, true, err
 	}
 	result, err := arg0.Add(sc, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinAddTimeDurationNullSig struct {
@@ -4141,15 +4141,15 @@ func (b *builtinAddDurationAndDurationSig) Clone() builtinFunc {
 func (b *builtinAddDurationAndDurationSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	result, err := arg0.Add(arg1)
 	if err != nil {
-		return types.ZeroDuration, true, errors.Trace(err)
+		return types.ZeroDuration, true, err
 	}
 	return result, false, nil
 }
@@ -4169,22 +4169,22 @@ func (b *builtinAddDurationAndStringSig) Clone() builtinFunc {
 func (b *builtinAddDurationAndStringSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDuration, true, nil
 	}
 	arg1, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, types.GetFsp(s))
 	if err != nil {
-		return types.ZeroDuration, true, errors.Trace(err)
+		return types.ZeroDuration, true, err
 	}
 	result, err := arg0.Add(arg1)
 	if err != nil {
-		return types.ZeroDuration, true, errors.Trace(err)
+		return types.ZeroDuration, true, err
 	}
 	return result, false, nil
 }
@@ -4224,22 +4224,22 @@ func (b *builtinAddStringAndDurationSig) evalString(row chunk.Row) (result strin
 	)
 	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		return result, false, nil
 	}
 	result, err = strDatetimeAddDuration(sc, arg0, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinAddStringAndStringSig struct {
@@ -4261,26 +4261,26 @@ func (b *builtinAddStringAndStringSig) evalString(row chunk.Row) (result string,
 	)
 	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1Str, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	arg1, err = types.ParseDuration(sc, arg1Str, getFsp4TimeAddSub(arg1Str))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		return result, false, nil
 	}
 	result, err = strDatetimeAddDuration(sc, arg0, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinAddDateAndDurationSig struct {
@@ -4298,14 +4298,14 @@ func (b *builtinAddDateAndDurationSig) Clone() builtinFunc {
 func (b *builtinAddDateAndDurationSig) evalString(row chunk.Row) (string, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	result, err := arg0.Add(arg1)
-	return result.String(), err != nil, errors.Trace(err)
+	return result.String(), err != nil, err
 }
 
 type builtinAddDateAndStringSig struct {
@@ -4323,21 +4323,21 @@ func (b *builtinAddDateAndStringSig) Clone() builtinFunc {
 func (b *builtinAddDateAndStringSig) evalString(row chunk.Row) (string, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	if !isDuration(s) {
 		return "", true, nil
 	}
 	arg1, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, getFsp4TimeAddSub(s))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	result, err := arg0.Add(arg1)
-	return result.String(), err != nil, errors.Trace(err)
+	return result.String(), err != nil, err
 }
 
 type convertTzFunctionClass struct {
@@ -4370,12 +4370,12 @@ func (c *convertTzFunctionClass) getDecimal(ctx sessionctx.Context, arg Expressi
 
 func (c *convertTzFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	// tzRegex holds the regex to check whether a string is a time zone.
 	tzRegex, err := regexp.Compile(`(^(\+|-)(0?[0-9]|1[0-2]):[0-5]?\d$)|(^\+13:00$)`)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	decimal := c.getDecimal(ctx, args[0])
@@ -4404,17 +4404,17 @@ func (b *builtinConvertTzSig) Clone() builtinFunc {
 func (b *builtinConvertTzSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	dt, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	fromTzStr, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	toTzStr, isNull, err := b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	fromTzMatched := b.timezoneRegex.MatchString(fromTzStr)
@@ -4423,17 +4423,17 @@ func (b *builtinConvertTzSig) evalTime(row chunk.Row) (types.Time, bool, error) 
 	if !fromTzMatched && !toTzMatched {
 		fromTz, err := time.LoadLocation(fromTzStr)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 
 		toTz, err := time.LoadLocation(toTzStr)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 
 		t, err := dt.Time.GoTime(fromTz)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 
 		return types.Time{
@@ -4445,7 +4445,7 @@ func (b *builtinConvertTzSig) evalTime(row chunk.Row) (types.Time, bool, error) 
 	if fromTzMatched && toTzMatched {
 		t, err := dt.Time.GoTime(time.Local)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 
 		return types.Time{
@@ -4463,7 +4463,7 @@ type makeDateFunctionClass struct {
 
 func (c *makeDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETInt, types.ETInt)
 	tp := bf.tp
@@ -4489,11 +4489,11 @@ func (b *builtinMakeDateSig) evalTime(row chunk.Row) (d types.Time, isNull bool,
 	var year, dayOfYear int64
 	year, isNull, err = args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 	dayOfYear, isNull, err = args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return d, true, errors.Trace(err)
+		return d, true, err
 	}
 	if dayOfYear <= 0 || year < 0 || year > 9999 {
 		return d, true, nil
@@ -4510,7 +4510,7 @@ func (b *builtinMakeDateSig) evalTime(row chunk.Row) (d types.Time, isNull bool,
 	}
 	retTimestamp := types.TimestampDiff("DAY", types.ZeroDate, startTime)
 	if retTimestamp == 0 {
-		return d, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(startTime.String())))
+		return d, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(startTime.String()))
 	}
 	ret := types.TimeFromDays(retTimestamp + dayOfYear - 1)
 	if ret.IsZero() || ret.Time.Year() > 9999 {
@@ -4525,7 +4525,7 @@ type makeTimeFunctionClass struct {
 
 func (c *makeTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tp, flen, decimal := args[2].GetType().EvalType(), 10, 0
 	switch tp {
@@ -4570,14 +4570,13 @@ func (b *builtinMakeTimeSig) Clone() builtinFunc {
 	return newSig
 }
 
-// calculate for hour and minute
 func (b *builtinMakeTimeSig) getIntParam(arg Expression, row chunk.Row) (int64, bool, error) {
 	if arg.GetType().EvalType() == types.ETReal {
 		fRes, isNull, err := arg.EvalReal(b.ctx, row)
-		return int64(fRes), isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return int64(fRes), isNull, handleInvalidTimeError(b.ctx, err)
 	}
 	iRes, isNull, err := arg.EvalInt(b.ctx, row)
-	return iRes, isNull, errors.Trace(handleInvalidTimeError(b.ctx, err))
+	return iRes, isNull, handleInvalidTimeError(b.ctx, err)
 }
 
 // evalDuration evals a builtinMakeTimeIntSig.
@@ -4598,7 +4597,7 @@ func (b *builtinMakeTimeSig) evalDuration(row chunk.Row) (types.Duration, bool, 
 	}
 	second, isNull, err := b.args[2].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return dur, isNull, errors.Trace(err)
+		return dur, isNull, err
 	}
 	if second < 0 || second >= 60 {
 		return dur, true, nil
@@ -4625,7 +4624,7 @@ func (b *builtinMakeTimeSig) evalDuration(row chunk.Row) (types.Duration, bool, 
 	fsp := b.tp.Decimal
 	dur, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, fmt.Sprintf("%02d:%02d:%v", hour, minute, second), fsp)
 	if err != nil {
-		return dur, true, errors.Trace(err)
+		return dur, true, err
 	}
 	return dur, false, nil
 }
@@ -4636,7 +4635,7 @@ type periodAddFunctionClass struct {
 
 func (c *periodAddFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
@@ -4693,7 +4692,7 @@ func (b *builtinPeriodAddSig) Clone() builtinFunc {
 func (b *builtinPeriodAddSig) evalInt(row chunk.Row) (int64, bool, error) {
 	p, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	if p == 0 {
@@ -4702,7 +4701,7 @@ func (b *builtinPeriodAddSig) evalInt(row chunk.Row) (int64, bool, error) {
 
 	n, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 
 	sumMonth := int64(period2Month(uint64(p))) + n
@@ -4715,7 +4714,7 @@ type periodDiffFunctionClass struct {
 
 func (c *periodDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	bf.tp.Flen = 6
@@ -4738,12 +4737,12 @@ func (b *builtinPeriodDiffSig) Clone() builtinFunc {
 func (b *builtinPeriodDiffSig) evalInt(row chunk.Row) (int64, bool, error) {
 	p1, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	p2, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 
 	return int64(period2Month(uint64(p1)) - period2Month(uint64(p2))), false, nil
@@ -4755,7 +4754,7 @@ type quarterFunctionClass struct {
 
 func (c *quarterFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
@@ -4780,11 +4779,11 @@ func (b *builtinQuarterSig) Clone() builtinFunc {
 func (b *builtinQuarterSig) evalInt(row chunk.Row) (int64, bool, error) {
 	date, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	if date.IsZero() {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(date.String()))
 	}
 
 	return int64((date.Time.Month() + 2) / 3), false, nil
@@ -4796,7 +4795,7 @@ type secToTimeFunctionClass struct {
 
 func (c *secToTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var retFlen, retFsp int
 	argType := args[0].GetType()
@@ -4836,7 +4835,7 @@ func (b *builtinSecToTimeSig) Clone() builtinFunc {
 func (b *builtinSecToTimeSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	secondsFloat, isNull, err := b.args[0].EvalReal(b.ctx, row)
 	if isNull || err != nil {
-		return types.Duration{}, isNull, errors.Trace(err)
+		return types.Duration{}, isNull, err
 	}
 	var (
 		hour          int64
@@ -4868,7 +4867,7 @@ func (b *builtinSecToTimeSig) evalDuration(row chunk.Row) (types.Duration, bool,
 	var dur types.Duration
 	dur, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, fmt.Sprintf("%s%02d:%02d:%v", negative, hour, minute, secondDemical), b.tp.Decimal)
 	if err != nil {
-		return types.Duration{}, err != nil, errors.Trace(err)
+		return types.Duration{}, err != nil, err
 	}
 	return dur, false, nil
 }
@@ -4879,7 +4878,7 @@ type subTimeFunctionClass struct {
 
 func (c *subTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (sig builtinFunc, err error) {
 	if err = c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tp1, tp2, bf, err := getBf4TimeAddSub(ctx, args)
 	if err != nil {
@@ -4941,20 +4940,20 @@ func (b *builtinSubDatetimeAndDurationSig) Clone() builtinFunc {
 func (b *builtinSubDatetimeAndDurationSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	arg1time, err := arg1.ConvertToTime(sc, mysql.TypeDatetime)
 	if err != nil {
-		return arg1time, true, errors.Trace(err)
+		return arg1time, true, err
 	}
 	tmpDuration := arg0.Sub(sc, &arg1time)
 	result, err := tmpDuration.ConvertToTime(sc, arg0.Type)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinSubDatetimeAndStringSig struct {
@@ -4972,14 +4971,14 @@ func (b *builtinSubDatetimeAndStringSig) Clone() builtinFunc {
 func (b *builtinSubDatetimeAndStringSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg0, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDatetime, isNull, errors.Trace(err)
+		return types.ZeroDatetime, isNull, err
 	}
 	if err != nil {
-		return types.ZeroDatetime, true, errors.Trace(err)
+		return types.ZeroDatetime, true, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDatetime, true, nil
@@ -4987,15 +4986,15 @@ func (b *builtinSubDatetimeAndStringSig) evalTime(row chunk.Row) (types.Time, bo
 	sc := b.ctx.GetSessionVars().StmtCtx
 	arg1, err := types.ParseDuration(sc, s, types.GetFsp(s))
 	if err != nil {
-		return types.ZeroDatetime, true, errors.Trace(err)
+		return types.ZeroDatetime, true, err
 	}
 	arg1time, err := arg1.ConvertToTime(sc, mysql.TypeDatetime)
 	if err != nil {
-		return types.ZeroDatetime, true, errors.Trace(err)
+		return types.ZeroDatetime, true, err
 	}
 	tmpDuration := arg0.Sub(sc, &arg1time)
 	result, err := tmpDuration.ConvertToTime(sc, mysql.TypeDatetime)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinSubTimeDateTimeNullSig struct {
@@ -5033,22 +5032,22 @@ func (b *builtinSubStringAndDurationSig) evalString(row chunk.Row) (result strin
 	)
 	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1, isNull, err = b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationSubDuration(sc, arg0, arg1)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		return result, false, nil
 	}
 	result, err = strDatetimeSubDuration(sc, arg0, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinSubStringAndStringSig struct {
@@ -5070,26 +5069,26 @@ func (b *builtinSubStringAndStringSig) evalString(row chunk.Row) (result string,
 	)
 	arg0, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	s, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1, err = types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, getFsp4TimeAddSub(s))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
 	if isDuration(arg0) {
 		result, err = strDurationSubDuration(sc, arg0, arg1)
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		return result, false, nil
 	}
 	result, err = strDatetimeSubDuration(sc, arg0, arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinSubTimeStringNullSig struct {
@@ -5123,15 +5122,15 @@ func (b *builtinSubDurationAndDurationSig) Clone() builtinFunc {
 func (b *builtinSubDurationAndDurationSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	result, err := arg0.Sub(arg1)
 	if err != nil {
-		return types.ZeroDuration, true, errors.Trace(err)
+		return types.ZeroDuration, true, err
 	}
 	return result, false, nil
 }
@@ -5151,21 +5150,21 @@ func (b *builtinSubDurationAndStringSig) Clone() builtinFunc {
 func (b *builtinSubDurationAndStringSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return types.ZeroDuration, isNull, errors.Trace(err)
+		return types.ZeroDuration, isNull, err
 	}
 	if !isDuration(s) {
 		return types.ZeroDuration, true, nil
 	}
 	arg1, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, types.GetFsp(s))
 	if err != nil {
-		return types.ZeroDuration, true, errors.Trace(err)
+		return types.ZeroDuration, true, err
 	}
 	result, err := arg0.Sub(arg1)
-	return result, err != nil, errors.Trace(err)
+	return result, err != nil, err
 }
 
 type builtinSubTimeDurationNullSig struct {
@@ -5199,14 +5198,14 @@ func (b *builtinSubDateAndDurationSig) Clone() builtinFunc {
 func (b *builtinSubDateAndDurationSig) evalString(row chunk.Row) (string, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg1, isNull, err := b.args[1].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	result, err := arg0.Sub(arg1)
-	return result.String(), err != nil, errors.Trace(err)
+	return result.String(), err != nil, err
 }
 
 type builtinSubDateAndStringSig struct {
@@ -5224,22 +5223,22 @@ func (b *builtinSubDateAndStringSig) Clone() builtinFunc {
 func (b *builtinSubDateAndStringSig) evalString(row chunk.Row) (string, bool, error) {
 	arg0, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	s, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	if !isDuration(s) {
 		return "", true, nil
 	}
 	arg1, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, s, getFsp4TimeAddSub(s))
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	result, err := arg0.Sub(arg1)
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return result.String(), false, nil
 }
@@ -5250,7 +5249,7 @@ type timeFormatFunctionClass struct {
 
 func (c *timeFormatFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDuration, types.ETString)
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
@@ -5278,14 +5277,14 @@ func (b *builtinTimeFormatSig) evalString(row chunk.Row) (string, bool, error) {
 		log.Warnf("Expression.EvalDuration() in time_format() failed, due to %s", err.Error())
 	}
 	if isNull {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	formatMask, isNull, err := b.args[1].EvalString(b.ctx, row)
 	if err != nil || isNull {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	res, err := b.formatTime(b.ctx, dur, formatMask)
-	return res, isNull, errors.Trace(err)
+	return res, isNull, err
 }
 
 // formatTime see https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_time-format
@@ -5295,7 +5294,7 @@ func (b *builtinTimeFormatSig) formatTime(ctx sessionctx.Context, t types.Durati
 		Type: mysql.TypeDate, Fsp: 0}
 
 	str, err := t2.DateFormat(formatMask)
-	return str, errors.Trace(err)
+	return str, err
 }
 
 type timeToSecFunctionClass struct {
@@ -5304,7 +5303,7 @@ type timeToSecFunctionClass struct {
 
 func (c *timeToSecFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen = 10
@@ -5327,7 +5326,7 @@ func (b *builtinTimeToSecSig) Clone() builtinFunc {
 func (b *builtinTimeToSecSig) evalInt(row chunk.Row) (int64, bool, error) {
 	duration, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	if isNull || err != nil {
-		return 0, isNull, errors.Trace(err)
+		return 0, isNull, err
 	}
 	var sign int
 	if duration.Duration >= 0 {
@@ -5344,7 +5343,7 @@ type timestampAddFunctionClass struct {
 
 func (c *timestampAddFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETDatetime)
 	bf.tp = &types.FieldType{Tp: mysql.TypeString, Flen: mysql.MaxDatetimeWidthNoFsp, Decimal: types.UnspecifiedLength}
@@ -5368,19 +5367,19 @@ func (b *builtinTimestampAddSig) Clone() builtinFunc {
 func (b *builtinTimestampAddSig) evalString(row chunk.Row) (string, bool, error) {
 	unit, isNull, err := b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	v, isNull, err := b.args[1].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	arg, isNull, err := b.args[2].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	tm1, err := arg.Time.GoTime(time.Local)
 	if err != nil {
-		return "", isNull, errors.Trace(err)
+		return "", isNull, err
 	}
 	var tb time.Time
 	fsp := types.DefaultFsp
@@ -5405,11 +5404,11 @@ func (b *builtinTimestampAddSig) evalString(row chunk.Row) (string, bool, error)
 	case "YEAR":
 		tb = tm1.AddDate(int(v), 0, 0)
 	default:
-		return "", true, errors.Trace(types.ErrInvalidTimeFormat.GenWithStackByArgs(unit))
+		return "", true, types.ErrInvalidTimeFormat.GenWithStackByArgs(unit)
 	}
 	r := types.Time{Time: types.FromGoTime(tb), Type: mysql.TypeDatetime, Fsp: fsp}
 	if err = r.Check(b.ctx.GetSessionVars().StmtCtx); err != nil {
-		return "", true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return "", true, handleInvalidTimeError(b.ctx, err)
 	}
 	return r.String(), false, nil
 }
@@ -5420,7 +5419,7 @@ type toDaysFunctionClass struct {
 
 func (c *toDaysFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	sig := &builtinToDaysSig{bf}
@@ -5443,11 +5442,11 @@ func (b *builtinToDaysSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	ret := types.TimestampDiff("DAY", types.ZeroDate, arg)
 	if ret == 0 {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 	return ret, false, nil
 }
@@ -5458,7 +5457,7 @@ type toSecondsFunctionClass struct {
 
 func (c *toSecondsFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	sig := &builtinToSecondsSig{bf}
@@ -5480,11 +5479,11 @@ func (b *builtinToSecondsSig) Clone() builtinFunc {
 func (b *builtinToSecondsSig) evalInt(row chunk.Row) (int64, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return 0, true, handleInvalidTimeError(b.ctx, err)
 	}
 	ret := types.TimestampDiff("SECOND", types.ZeroDate, arg)
 	if ret == 0 {
-		return 0, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return 0, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 	return ret, false, nil
 }
@@ -5518,7 +5517,7 @@ func (c *utcTimeFunctionClass) getFlenAndDecimal4UTCTime(ctx sessionctx.Context,
 
 func (c *utcTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTps := make([]types.EvalType, 0, 1)
 	if len(args) == 1 {
@@ -5572,7 +5571,7 @@ func (b *builtinUTCTimeWithArgSig) Clone() builtinFunc {
 func (b *builtinUTCTimeWithArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	fsp, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil {
-		return types.Duration{}, isNull, errors.Trace(err)
+		return types.Duration{}, isNull, err
 	}
 	if fsp > int64(types.MaxFsp) {
 		return types.Duration{}, true, errors.Errorf("Too-big precision %v specified for 'utc_time'. Maximum is %v.", fsp, types.MaxFsp)
@@ -5594,7 +5593,7 @@ type lastDayFunctionClass struct {
 
 func (c *lastDayFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETDatetime)
 	bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, mysql.MaxDateWidth, types.DefaultFsp
@@ -5617,12 +5616,12 @@ func (b *builtinLastDaySig) Clone() builtinFunc {
 func (b *builtinLastDaySig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	if isNull || err != nil {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 	tm := arg.Time
 	year, month, day := tm.Year(), tm.Month(), 30
 	if year == 0 && month == 0 && tm.Day() == 0 {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String())))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
 	if month == 1 || month == 3 || month == 5 ||
 		month == 7 || month == 8 || month == 10 || month == 12 {
@@ -5647,21 +5646,21 @@ func getExpressionFsp(ctx sessionctx.Context, expression Expression) (int, error
 	if isConstant && types.IsString(expression.GetType().Tp) && !isTemporalColumn(expression) {
 		str, isNil, err := constExp.EvalString(ctx, chunk.Row{})
 		if isNil || err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		return types.GetFsp(str), nil
 	}
 	return mathutil.Min(expression.GetType().Decimal, types.MaxFsp), nil
 }
 
-//tidbParseTsoFunction extracts physical time from a tso
+// tidbParseTsoFunctionClass extracts physical time from a tso
 type tidbParseTsoFunctionClass struct {
 	baseFunctionClass
 }
 
 func (c *tidbParseTsoFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	argTp := args[0].GetType().EvalType()
 	bf := newBaseBuiltinFuncWithTp(ctx, args, argTp, types.ETInt)
@@ -5685,7 +5684,7 @@ func (b *builtinTidbParseTsoSig) Clone() builtinFunc {
 func (b *builtinTidbParseTsoSig) evalTime(row chunk.Row) (types.Time, bool, error) {
 	arg, isNull, err := b.args[0].EvalInt(b.ctx, row)
 	if isNull || err != nil || arg <= 0 {
-		return types.Time{}, true, errors.Trace(handleInvalidTimeError(b.ctx, err))
+		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 
 	t := oracle.GetTimeFromTS(uint64(arg))
@@ -5696,7 +5695,7 @@ func (b *builtinTidbParseTsoSig) evalTime(row chunk.Row) (types.Time, bool, erro
 	}
 	err = result.ConvertTimeZone(time.Local, b.ctx.GetSessionVars().Location())
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 	return result, false, nil
 }

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1048,7 +1048,7 @@ func convertToTimeWithFsp(sc *stmtctx.StatementContext, arg types.Datum, tp byte
 	d, err = arg.ConvertTo(sc, f)
 	if err != nil {
 		d.SetNull()
-		return d, errors.Trace(err)
+		return d, err
 	}
 
 	if d.IsNull() {
@@ -1069,7 +1069,7 @@ func convertToTime(sc *stmtctx.StatementContext, arg types.Datum, tp byte) (d ty
 func builtinDateFormat(ctx sessionctx.Context, args []types.Datum) (d types.Datum, err error) {
 	date, err := convertToTime(ctx.GetSessionVars().StmtCtx, args[0], mysql.TypeDatetime)
 	if err != nil {
-		return d, errors.Trace(err)
+		return d, err
 	}
 
 	if date.IsNull() {
@@ -1078,7 +1078,7 @@ func builtinDateFormat(ctx sessionctx.Context, args []types.Datum) (d types.Datu
 	t := date.GetMysqlTime()
 	str, err := t.DateFormat(args[1].GetString())
 	if err != nil {
-		return d, errors.Trace(err)
+		return d, err
 	}
 	d.SetString(str)
 	return

--- a/expression/chunk_executor.go
+++ b/expression/chunk_executor.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"strconv"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -59,7 +58,7 @@ func VectorizedExecute(ctx sessionctx.Context, exprs []Expression, iterator *chu
 	for colID, expr := range exprs {
 		err := evalOneColumn(ctx, expr, iterator, output, colID)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil
@@ -96,7 +95,7 @@ func evalOneColumn(ctx sessionctx.Context, expr Expression, iterator *chunk.Iter
 			err = executeToString(ctx, expr, fieldType, row, output, colID)
 		}
 	}
-	return errors.Trace(err)
+	return err
 }
 
 func evalOneCell(ctx sessionctx.Context, expr Expression, row chunk.Row, output *chunk.Chunk, colID int) (err error) {
@@ -116,13 +115,13 @@ func evalOneCell(ctx sessionctx.Context, expr Expression, row chunk.Row, output 
 	case types.ETString:
 		err = executeToString(ctx, expr, fieldType, row, output, colID)
 	}
-	return errors.Trace(err)
+	return err
 }
 
 func executeToInt(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalInt(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -143,7 +142,7 @@ func executeToInt(ctx sessionctx.Context, expr Expression, fieldType *types.Fiel
 func executeToReal(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalReal(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -160,7 +159,7 @@ func executeToReal(ctx sessionctx.Context, expr Expression, fieldType *types.Fie
 func executeToDecimal(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalDecimal(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -173,7 +172,7 @@ func executeToDecimal(ctx sessionctx.Context, expr Expression, fieldType *types.
 func executeToDatetime(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalTime(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -186,7 +185,7 @@ func executeToDatetime(ctx sessionctx.Context, expr Expression, fieldType *types
 func executeToDuration(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalDuration(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -199,7 +198,7 @@ func executeToDuration(ctx sessionctx.Context, expr Expression, fieldType *types
 func executeToJSON(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalJSON(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -212,7 +211,7 @@ func executeToJSON(ctx sessionctx.Context, expr Expression, fieldType *types.Fie
 func executeToString(ctx sessionctx.Context, expr Expression, fieldType *types.FieldType, row chunk.Row, output *chunk.Chunk, colID int) error {
 	res, isNull, err := expr.EvalString(ctx, row)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if isNull {
 		output.AppendNull(colID)
@@ -248,14 +247,14 @@ func VectorizedFilter(ctx sessionctx.Context, filters []Expression, iterator *ch
 			if isIntType {
 				filterResult, isNull, err := filter.EvalInt(ctx, row)
 				if err != nil {
-					return nil, errors.Trace(err)
+					return nil, err
 				}
 				selected[row.Idx()] = selected[row.Idx()] && !isNull && (filterResult != 0)
 			} else {
 				// TODO: should rewrite the filter to `cast(expr as SIGNED) != 0` and always use `EvalInt`.
 				bVal, err := EvalBool(ctx, []Expression{filter}, row)
 				if err != nil {
-					return nil, errors.Trace(err)
+					return nil, err
 				}
 				selected[row.Idx()] = selected[row.Idx()] && bVal
 			}

--- a/expression/column.go
+++ b/expression/column.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -53,7 +52,7 @@ func (col *CorrelatedColumn) EvalInt(ctx sessionctx.Context, row chunk.Row) (int
 	}
 	if col.GetType().Hybrid() {
 		res, err := col.Data.ToInt64(ctx.GetSessionVars().StmtCtx)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 	return col.Data.GetInt64(), false, nil
 }
@@ -76,7 +75,7 @@ func (col *CorrelatedColumn) EvalString(ctx sessionctx.Context, row chunk.Row) (
 	if resLen < col.RetType.Flen && ctx.GetSessionVars().StmtCtx.PadCharToFullLength {
 		res = res + strings.Repeat(" ", col.RetType.Flen-resLen)
 	}
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 // EvalDecimal returns decimal representation of CorrelatedColumn.
@@ -207,7 +206,7 @@ func (col *Column) EvalInt(ctx sessionctx.Context, row chunk.Row) (int64, bool, 
 			return 0, true, nil
 		}
 		res, err := val.ToInt64(ctx.GetSessionVars().StmtCtx)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 	if row.IsNull(col.Index) {
 		return 0, true, nil
@@ -241,7 +240,7 @@ func (col *Column) EvalString(ctx sessionctx.Context, row chunk.Row) (string, bo
 		if ctx.GetSessionVars().StmtCtx.PadCharToFullLength && col.GetType().Tp == mysql.TypeString && resLen < col.RetType.Flen {
 			res = res + strings.Repeat(" ", col.RetType.Flen-resLen)
 		}
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 	val := row.GetString(col.Index)
 	if ctx.GetSessionVars().StmtCtx.PadCharToFullLength && col.GetType().Tp == mysql.TypeString {

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
@@ -119,14 +118,14 @@ func (c *Constant) EvalInt(ctx sessionctx.Context, _ chunk.Row) (int64, bool, er
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if dt.IsNull() {
 			return 0, true, nil
 		}
 		val, err := dt.ToInt64(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		c.Value.SetInt64(val)
 	} else {
@@ -136,7 +135,7 @@ func (c *Constant) EvalInt(ctx sessionctx.Context, _ chunk.Row) (int64, bool, er
 	}
 	if c.GetType().Hybrid() || c.Value.Kind() == types.KindBinaryLiteral || c.Value.Kind() == types.KindString {
 		res, err := c.Value.ToInt64(ctx.GetSessionVars().StmtCtx)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 	return c.Value.GetInt64(), false, nil
 }
@@ -146,14 +145,14 @@ func (c *Constant) EvalReal(ctx sessionctx.Context, _ chunk.Row) (float64, bool,
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		if dt.IsNull() {
 			return 0, true, nil
 		}
 		val, err := dt.ToFloat64(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
-			return 0, true, errors.Trace(err)
+			return 0, true, err
 		}
 		c.Value.SetFloat64(val)
 	} else {
@@ -163,7 +162,7 @@ func (c *Constant) EvalReal(ctx sessionctx.Context, _ chunk.Row) (float64, bool,
 	}
 	if c.GetType().Hybrid() || c.Value.Kind() == types.KindBinaryLiteral || c.Value.Kind() == types.KindString {
 		res, err := c.Value.ToFloat64(ctx.GetSessionVars().StmtCtx)
-		return res, err != nil, errors.Trace(err)
+		return res, err != nil, err
 	}
 	return c.Value.GetFloat64(), false, nil
 }
@@ -173,14 +172,14 @@ func (c *Constant) EvalString(ctx sessionctx.Context, _ chunk.Row) (string, bool
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		if dt.IsNull() {
 			return "", true, nil
 		}
 		val, err := dt.ToString()
 		if err != nil {
-			return "", true, errors.Trace(err)
+			return "", true, err
 		}
 		c.Value.SetString(val)
 	} else {
@@ -189,7 +188,7 @@ func (c *Constant) EvalString(ctx sessionctx.Context, _ chunk.Row) (string, bool
 		}
 	}
 	res, err := c.Value.ToString()
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 // EvalDecimal returns decimal representation of Constant.
@@ -197,7 +196,7 @@ func (c *Constant) EvalDecimal(ctx sessionctx.Context, _ chunk.Row) (*types.MyDe
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return nil, true, errors.Trace(err)
+			return nil, true, err
 		}
 		if dt.IsNull() {
 			return nil, true, nil
@@ -209,7 +208,7 @@ func (c *Constant) EvalDecimal(ctx sessionctx.Context, _ chunk.Row) (*types.MyDe
 		}
 	}
 	res, err := c.Value.ToDecimal(ctx.GetSessionVars().StmtCtx)
-	return res, err != nil, errors.Trace(err)
+	return res, err != nil, err
 }
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.
@@ -217,18 +216,18 @@ func (c *Constant) EvalTime(ctx sessionctx.Context, _ chunk.Row) (val types.Time
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 		if dt.IsNull() {
 			return types.Time{}, true, nil
 		}
 		val, err := dt.ToString()
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 		tim, err := types.ParseDatetime(ctx.GetSessionVars().StmtCtx, val)
 		if err != nil {
-			return types.Time{}, true, errors.Trace(err)
+			return types.Time{}, true, err
 		}
 		c.Value.SetMysqlTime(tim)
 	} else {
@@ -244,18 +243,18 @@ func (c *Constant) EvalDuration(ctx sessionctx.Context, _ chunk.Row) (val types.
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return types.Duration{}, true, errors.Trace(err)
+			return types.Duration{}, true, err
 		}
 		if dt.IsNull() {
 			return types.Duration{}, true, nil
 		}
 		val, err := dt.ToString()
 		if err != nil {
-			return types.Duration{}, true, errors.Trace(err)
+			return types.Duration{}, true, err
 		}
 		dur, err := types.ParseDuration(ctx.GetSessionVars().StmtCtx, val, types.MaxFsp)
 		if err != nil {
-			return types.Duration{}, true, errors.Trace(err)
+			return types.Duration{}, true, err
 		}
 		c.Value.SetMysqlDuration(dur)
 	} else {
@@ -271,14 +270,14 @@ func (c *Constant) EvalJSON(ctx sessionctx.Context, _ chunk.Row) (json.BinaryJSO
 	if c.DeferredExpr != nil {
 		dt, err := c.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			return json.BinaryJSON{}, true, errors.Trace(err)
+			return json.BinaryJSON{}, true, err
 		}
 		if dt.IsNull() {
 			return json.BinaryJSON{}, true, nil
 		}
 		val, err := dt.ConvertTo(ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeJSON))
 		if err != nil {
-			return json.BinaryJSON{}, true, errors.Trace(err)
+			return json.BinaryJSON{}, true, err
 		}
 		fmt.Println("const eval json", val.GetMysqlJSON().String())
 		c.Value.SetMysqlJSON(val.GetMysqlJSON())
@@ -326,12 +325,12 @@ func (c *Constant) HashCode(sc *stmtctx.StatementContext) []byte {
 	}
 	_, err := c.Eval(chunk.Row{})
 	if err != nil {
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}
 	c.hashcode = append(c.hashcode, constantFlag)
 	c.hashcode, err = codec.EncodeValue(sc, c.hashcode, c.Value)
 	if err != nil {
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}
 	return c.hashcode
 }

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
@@ -248,7 +247,7 @@ func (s *propConstSolver) pickNewEQConds(visited []bool) (retMapper map[int]*Con
 			if con, ok = cond.(*Constant); ok {
 				value, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
 				if err != nil {
-					terror.Log(errors.Trace(err))
+					terror.Log(err)
 					return nil
 				}
 				if !value {
@@ -337,7 +336,7 @@ func (s *propOuterJoinConstSolver) pickEQCondsOnOuterCol(retMapper map[int]*Cons
 			if con, ok = cond.(*Constant); ok {
 				value, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
 				if err != nil {
-					terror.Log(errors.Trace(err))
+					terror.Log(err)
 					return nil
 				}
 				if !value {

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -461,7 +461,7 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 
 	default:
 		e = errFunctionNotExists.GenWithStackByArgs("FUNCTION", sigCode)
-		return nil, errors.Trace(e)
+		return nil, e
 	}
 	return f, nil
 }
@@ -471,7 +471,7 @@ func newDistSQLFunctionBySig(sc *stmtctx.StatementContext, sigCode tipb.ScalarFu
 	ctx.GetSessionVars().StmtCtx = sc
 	f, err := getSignatureByPB(ctx, sigCode, tp, args)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &ScalarFunction{
 		FuncName: model.NewCIStr(fmt.Sprintf("sig_%T", f)),
@@ -486,7 +486,7 @@ func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *stmtctx.StatementCont
 	case tipb.ExprType_ColumnRef:
 		_, offset, err := codec.DecodeInt(expr.Val)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		return &Column{Index: int(offset), RetType: tps[offset]}, nil
 	case tipb.ExprType_Null:
@@ -521,7 +521,7 @@ func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *stmtctx.StatementCont
 		if child.Tp == tipb.ExprType_ValueList {
 			results, err := decodeValueList(child.Val)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			if len(results) == 0 {
 				return &Constant{Value: types.NewDatum(false), RetType: types.NewFieldType(mysql.TypeLonglong)}, nil
@@ -531,7 +531,7 @@ func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *stmtctx.StatementCont
 		}
 		arg, err := PBToExpr(child, tps, sc)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		args = append(args, arg)
 	}
@@ -552,19 +552,19 @@ func convertTime(data []byte, ftPB *tipb.FieldType, tz *time.Location) (*Constan
 	ft := fieldTypeFromPB(ftPB)
 	_, v, err := codec.DecodeUint(data)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	var t types.Time
 	t.Type = ft.Tp
 	t.Fsp = ft.Decimal
 	err = t.FromPackedUint(v)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if ft.Tp == mysql.TypeTimestamp && !t.IsZero() {
 		err = t.ConvertTimeZone(time.UTC, tz)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	return &Constant{Value: types.NewTimeDatum(t), RetType: ft}, nil
@@ -576,7 +576,7 @@ func decodeValueList(data []byte) ([]Expression, error) {
 	}
 	list, err := codec.Decode(data, 1)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	result := make([]Expression, 0, len(list))
 	for _, value := range list {

--- a/expression/evaluator.go
+++ b/expression/evaluator.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -47,7 +46,7 @@ func (e *defaultEvaluator) run(ctx sessionctx.Context, input, output *chunk.Chun
 		for i := range e.outputIdxes {
 			err := evalOneColumn(ctx, e.exprs[i], iter, output, e.outputIdxes[i])
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 		return nil
@@ -57,7 +56,7 @@ func (e *defaultEvaluator) run(ctx sessionctx.Context, input, output *chunk.Chun
 		for i := range e.outputIdxes {
 			err := evalOneCell(ctx, e.exprs[i], row, output, e.outputIdxes[i])
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 	}
@@ -113,7 +112,7 @@ func (e *EvaluatorSuite) Run(ctx sessionctx.Context, input, output *chunk.Chunk)
 	if e.defaultEvaluator != nil {
 		err := e.defaultEvaluator.run(ctx, input, output)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
@@ -162,7 +161,7 @@ func (pc *PbConverter) encodeDatum(d types.Datum) (tipb.ExprType, []byte, bool) 
 			t := d.GetMysqlTime()
 			if t.Type == mysql.TypeTimestamp && loc != time.UTC {
 				err := t.ConvertTimeZone(loc, time.UTC)
-				terror.Log(errors.Trace(err))
+				terror.Log(err)
 			}
 			v, err := t.ToPackedUint()
 			if err != nil {

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -17,7 +17,6 @@ import (
 	goJSON "encoding/json"
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -117,7 +116,7 @@ func EvalBool(ctx sessionctx.Context, exprList CNFExprs, row chunk.Row) (bool, e
 	for _, expr := range exprList {
 		data, err := expr.Eval(row)
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 		if data.IsNull() {
 			return false, nil
@@ -125,7 +124,7 @@ func EvalBool(ctx sessionctx.Context, exprList CNFExprs, row chunk.Row) (bool, e
 
 		i, err := data.ToBool(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 		if i == 0 {
 			return false, nil
@@ -325,7 +324,7 @@ func ColumnInfos2ColumnsWithDBName(ctx sessionctx.Context, dbName, tblName model
 func NewValuesFunc(ctx sessionctx.Context, offset int, retTp *types.FieldType) *ScalarFunction {
 	fc := &valuesFunctionClass{baseFunctionClass{ast.Values, 0, 0}, offset, retTp}
 	bt, err := fc.getFunction(ctx, nil)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return &ScalarFunction{
 		FuncName: model.NewCIStr(ast.Values),
 		RetType:  retTp,

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3636,11 +3636,11 @@ func (s *testIntegrationSuite) testTiDBIsOwnerFunc(c *C) {
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	session.SetSchemaLease(0)
 	dom, err := session.BootstrapSession(store)
-	return store, dom, errors.Trace(err)
+	return store, dom, err
 }
 
 func (s *testIntegrationSuite) TestTwoDecimalTruncate(c *C) {

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -86,7 +86,7 @@ func newFunctionImpl(ctx sessionctx.Context, fold bool, funcName string, retType
 	copy(funcArgs, args)
 	f, err := fc.getFunction(ctx, funcArgs)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if builtinRetTp := f.getRetTp(); builtinRetTp.Tp != mysql.TypeUnspecified || retType.Tp == mysql.TypeUnspecified {
 		retType = builtinRetTp
@@ -115,7 +115,7 @@ func NewFunctionBase(ctx sessionctx.Context, funcName string, retType *types.Fie
 // NewFunctionInternal is similar to NewFunction, but do not returns error, should only be used internally.
 func NewFunctionInternal(ctx sessionctx.Context, funcName string, retType *types.FieldType, args ...Expression) Expression {
 	expr, err := NewFunction(ctx, funcName, retType, args...)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return expr
 }
 
@@ -204,7 +204,7 @@ func (sf *ScalarFunction) Eval(row chunk.Row) (d types.Datum, err error) {
 
 	if isNull || err != nil {
 		d.SetValue(nil)
-		return d, errors.Trace(err)
+		return d, err
 	}
 	d.SetValue(res)
 	return

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -98,7 +98,7 @@ func ExprFromSchema(expr Expression, schema *Schema) bool {
 // If there are more than one result, it will raise ambiguous error.
 func (s *Schema) FindColumn(astCol *ast.ColumnName) (*Column, error) {
 	col, _, err := s.FindColumnAndIndex(astCol)
-	return col, errors.Trace(err)
+	return col, err
 }
 
 // FindColumnAndIndex finds an Column and its index from schema for a ast.ColumnName.

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -39,7 +39,7 @@ func ParseSimpleExprWithTableInfo(ctx sessionctx.Context, exprStr string, tableI
 	exprStr = "select " + exprStr
 	stmts, err := parser.New().Parse(exprStr, "", "")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	expr := stmts[0].(*ast.SelectStmt).Fields.Fields[0].Expr
 	return RewriteSimpleExprWithTableInfo(ctx, tableInfo, expr)
@@ -50,7 +50,7 @@ func ParseSimpleExprWithTableInfo(ctx sessionctx.Context, exprStr string, tableI
 func ParseSimpleExprCastWithTableInfo(ctx sessionctx.Context, exprStr string, tableInfo *model.TableInfo, targetFt *types.FieldType) (Expression, error) {
 	e, err := ParseSimpleExprWithTableInfo(ctx, exprStr, tableInfo)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	e = BuildCastFunction(ctx, e, targetFt)
 	return e, nil
@@ -63,7 +63,7 @@ func RewriteSimpleExprWithTableInfo(ctx sessionctx.Context, tbl *model.TableInfo
 	rewriter := &simpleRewriter{ctx: ctx, schema: NewSchema(columns...)}
 	expr.Accept(rewriter)
 	if rewriter.err != nil {
-		return nil, errors.Trace(rewriter.err)
+		return nil, rewriter.err
 	}
 	return rewriter.pop(), nil
 }
@@ -74,14 +74,14 @@ func ParseSimpleExprsWithSchema(ctx sessionctx.Context, exprStr string, schema *
 	exprStr = "select " + exprStr
 	stmts, err := parser.New().Parse(exprStr, "", "")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	fields := stmts[0].(*ast.SelectStmt).Fields.Fields
 	exprs := make([]Expression, 0, len(fields))
 	for _, field := range fields {
 		expr, err := RewriteSimpleExprWithSchema(ctx, field.Expr, schema)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		exprs = append(exprs, expr)
 	}
@@ -93,7 +93,7 @@ func RewriteSimpleExprWithSchema(ctx sessionctx.Context, expr ast.ExprNode, sche
 	rewriter := &simpleRewriter{ctx: ctx, schema: schema}
 	expr.Accept(rewriter)
 	if rewriter.err != nil {
-		return nil, errors.Trace(rewriter.err)
+		return nil, rewriter.err
 	}
 	return rewriter.pop(), nil
 }
@@ -115,7 +115,7 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 	case *ast.ColumnNameExpr:
 		column, err := sr.rewriteColumn(v)
 		if err != nil {
-			sr.err = errors.Trace(err)
+			sr.err = err
 			return originInNode, false
 		}
 		sr.push(column)
@@ -126,7 +126,7 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 		sr.funcCallToExpression(v)
 	case *ast.FuncCastExpr:
 		arg := sr.pop()
-		sr.err = errors.Trace(CheckArgsNotMultiColumnRow(arg))
+		sr.err = CheckArgsNotMultiColumnRow(arg)
 		if sr.err != nil {
 			return retNode, false
 		}
@@ -192,7 +192,6 @@ func (sr *simpleRewriter) binaryOpToExpression(v *ast.BinaryOperationExpr) {
 		function, sr.err = NewFunction(sr.ctx, v.Op.String(), types.NewFieldType(mysql.TypeUnspecified), left, right)
 	}
 	if sr.err != nil {
-		sr.err = errors.Trace(sr.err)
 		return
 	}
 	sr.push(function)
@@ -200,7 +199,7 @@ func (sr *simpleRewriter) binaryOpToExpression(v *ast.BinaryOperationExpr) {
 
 func (sr *simpleRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 	args := sr.popN(len(v.Args))
-	sr.err = errors.Trace(CheckArgsNotMultiColumnRow(args...))
+	sr.err = CheckArgsNotMultiColumnRow(args...)
 	if sr.err != nil {
 		return
 	}
@@ -272,7 +271,7 @@ func (sr *simpleRewriter) constructBinaryOpFunction(l Expression, r Expression, 
 			var err error
 			funcs[i], err = sr.constructBinaryOpFunction(GetFuncArg(l, i), GetFuncArg(r, i), op)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 		}
 		if op == ast.NE {
@@ -293,15 +292,15 @@ func (sr *simpleRewriter) constructBinaryOpFunction(l Expression, r Expression, 
 		var err error
 		l, err = PopRowFirstArg(sr.ctx, l)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		r, err = PopRowFirstArg(sr.ctx, r)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		expr3, err = sr.constructBinaryOpFunction(l, r, op)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		return NewFunction(sr.ctx, ast.If, types.NewFieldType(mysql.TypeTiny), expr1, expr2, expr3)
 	}
@@ -336,7 +335,7 @@ func (sr *simpleRewriter) unaryOpToExpression(v *ast.UnaryOperationExpr) {
 func (sr *simpleRewriter) likeToScalarFunc(v *ast.PatternLikeExpr) {
 	pattern := sr.pop()
 	expr := sr.pop()
-	sr.err = errors.Trace(CheckArgsNotMultiColumnRow(expr, pattern))
+	sr.err = CheckArgsNotMultiColumnRow(expr, pattern)
 	if sr.err != nil {
 		return
 	}
@@ -350,7 +349,7 @@ func (sr *simpleRewriter) likeToScalarFunc(v *ast.PatternLikeExpr) {
 func (sr *simpleRewriter) regexpToScalarFunc(v *ast.PatternRegexpExpr) {
 	parttern := sr.pop()
 	expr := sr.pop()
-	sr.err = errors.Trace(CheckArgsNotMultiColumnRow(expr, parttern))
+	sr.err = CheckArgsNotMultiColumnRow(expr, parttern)
 	if sr.err != nil {
 		return
 	}
@@ -362,7 +361,7 @@ func (sr *simpleRewriter) rowToScalarFunc(v *ast.RowExpr) {
 	elems := sr.popN(len(v.Values))
 	function, err := NewFunction(sr.ctx, ast.RowFunc, elems[0].GetType(), elems...)
 	if err != nil {
-		sr.err = errors.Trace(err)
+		sr.err = err
 		return
 	}
 	sr.push(function)
@@ -372,7 +371,7 @@ func (sr *simpleRewriter) betweenToExpression(v *ast.BetweenExpr) {
 	right := sr.pop()
 	left := sr.pop()
 	expr := sr.pop()
-	sr.err = errors.Trace(CheckArgsNotMultiColumnRow(expr))
+	sr.err = CheckArgsNotMultiColumnRow(expr)
 	if sr.err != nil {
 		return
 	}
@@ -382,18 +381,17 @@ func (sr *simpleRewriter) betweenToExpression(v *ast.BetweenExpr) {
 		r, sr.err = NewFunction(sr.ctx, ast.LE, &v.Type, expr, right)
 	}
 	if sr.err != nil {
-		sr.err = errors.Trace(sr.err)
 		return
 	}
 	function, err := NewFunction(sr.ctx, ast.LogicAnd, &v.Type, l, r)
 	if err != nil {
-		sr.err = errors.Trace(err)
+		sr.err = err
 		return
 	}
 	if v.Not {
 		function, err = NewFunction(sr.ctx, ast.UnaryNot, &v.Type, function)
 		if err != nil {
-			sr.err = errors.Trace(err)
+			sr.err = err
 			return
 		}
 	}
@@ -414,7 +412,7 @@ func (sr *simpleRewriter) notToExpression(hasNot bool, op string, tp *types.Fiel
 	args ...Expression) Expression {
 	opFunc, err := NewFunction(sr.ctx, op, tp, args...)
 	if err != nil {
-		sr.err = errors.Trace(err)
+		sr.err = err
 		return nil
 	}
 	if !hasNot {
@@ -423,7 +421,7 @@ func (sr *simpleRewriter) notToExpression(hasNot bool, op string, tp *types.Fiel
 
 	opFunc, err = NewFunction(sr.ctx, ast.UnaryNot, tp, opFunc)
 	if err != nil {
-		sr.err = errors.Trace(err)
+		sr.err = err
 		return nil
 	}
 	return opFunc

--- a/expression/util.go
+++ b/expression/util.go
@@ -167,7 +167,7 @@ func SubstituteCorCol2Constant(expr Expression) (Expression, error) {
 		for _, arg := range x.GetArgs() {
 			newArg, err := SubstituteCorCol2Constant(arg)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			_, ok := newArg.(*Constant)
 			newArgs = append(newArgs, newArg)
@@ -176,7 +176,7 @@ func SubstituteCorCol2Constant(expr Expression) (Expression, error) {
 		if allConstant {
 			val, err := x.Eval(chunk.Row{})
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			return &Constant{Value: val, RetType: x.GetType()}, nil
 		}
@@ -208,9 +208,9 @@ func timeZone2Duration(tz string) time.Duration {
 
 	i := strings.Index(tz, ":")
 	h, err := strconv.Atoi(tz[1:i])
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	m, err := strconv.Atoi(tz[i+1:])
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return time.Duration(sign) * (time.Duration(h)*time.Hour + time.Duration(m)*time.Minute)
 }
 
@@ -448,7 +448,7 @@ func PopRowFirstArg(ctx sessionctx.Context, e Expression) (ret Expression, err e
 			return args[1], nil
 		}
 		ret, err = NewFunction(ctx, ast.RowFunc, f.GetType(), args[1:]...)
-		return ret, errors.Trace(err)
+		return ret, err
 	}
 	return
 }
@@ -520,7 +520,7 @@ func GetParamExpression(ctx sessionctx.Context, v *driver.ParamMarkerExpr) (Expr
 		f, err := NewFunctionBase(ctx, ast.GetParam, &v.Type,
 			DatumToConstant(types.NewIntDatum(int64(v.Order)), mysql.TypeLonglong))
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		f.GetType().Tp = v.Type.Tp
 		value.DeferredExpr = f
@@ -544,7 +544,7 @@ func PosFromPositionExpr(ctx sessionctx.Context, v *ast.PositionExpr) (int, bool
 	}
 	pos, isNull, err := GetIntFromConstant(ctx, value)
 	if err != nil || isNull {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	return pos, false, nil
 }
@@ -554,11 +554,11 @@ func GetStringFromConstant(ctx sessionctx.Context, value Expression) (string, bo
 	con, ok := value.(*Constant)
 	if !ok {
 		err := errors.Errorf("Not a Constant expression %+v", value)
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	str, isNull, err := con.EvalString(ctx, chunk.Row{})
 	if err != nil || isNull {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	return str, false, nil
 }
@@ -567,7 +567,7 @@ func GetStringFromConstant(ctx sessionctx.Context, value Expression) (string, bo
 func GetIntFromConstant(ctx sessionctx.Context, value Expression) (int, bool, error) {
 	str, isNull, err := GetStringFromConstant(ctx, value)
 	if err != nil || isNull {
-		return 0, true, errors.Trace(err)
+		return 0, true, err
 	}
 	intNum, err := strconv.Atoi(str)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixes #8216 

### What is changed and how it works?
Replace all `errors.Trace()` to `err` (or the argument of `errors.Trace()` calls).

To get `goword` check passed, fix some comments.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8609)
<!-- Reviewable:end -->
