### PR TITLE
expression,planner: fix to preserve the precision information of a timestamp-typed column in the plan cache

### DIFF
--- a/expression/constant.go
+++ b/expression/constant.go
@@ -103,6 +103,7 @@ func (c *Constant) Eval(_ chunk.Row) (types.Datum, error) {
 			if retType.Tp == mysql.TypeUnspecified {
 				retType.Tp = mysql.TypeVarString
 			}
+			retType.Decimal = c.RetType.Decimal
 			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, retType)
 			if err != nil {
 				return dt, err

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -99,12 +99,10 @@ func (c *Constant) Eval(_ chunk.Row) (types.Datum, error) {
 				c.Value.SetNull()
 				return c.Value, nil
 			}
-			retType := types.NewFieldType(c.RetType.Tp)
-			if retType.Tp == mysql.TypeUnspecified {
-				retType.Tp = mysql.TypeVarString
+			if c.RetType.Tp == mysql.TypeUnspecified {
+				c.RetType.Tp = mysql.TypeVarString
 			}
-			retType.Decimal = c.RetType.Decimal
-			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, retType)
+			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
 			if err != nil {
 				return dt, err
 			}

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -99,9 +99,6 @@ func (c *Constant) Eval(_ chunk.Row) (types.Datum, error) {
 				c.Value.SetNull()
 				return c.Value, nil
 			}
-			if c.RetType.Tp == mysql.TypeUnspecified {
-				c.RetType.Tp = mysql.TypeVarString
-			}
 			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
 			if err != nil {
 				return dt, err

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1242,9 +1242,7 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 	er.ctxStack = er.ctxStack[:stackLen-len(v.Args)]
 	if _, ok := expression.DeferredFunctions[v.FnName.L]; er.useCache() && ok {
 		function, er.err = expression.NewFunctionBase(er.ctx, v.FnName.L, &v.Type, args...)
-		c := &expression.Constant{Value: types.NewDatum(nil), RetType: &v.Type, DeferredExpr: function}
-		c.GetType().Tp = function.GetType().Tp
-		c.GetType().Decimal = function.GetType().Decimal
+		c := &expression.Constant{Value: types.NewDatum(nil), RetType: types.CloneFieldType(function.GetType()), DeferredExpr: function}
 		er.ctxStack = append(er.ctxStack, c)
 	} else {
 		function, er.err = expression.NewFunction(er.ctx, v.FnName.L, &v.Type, args...)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1244,6 +1244,7 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 		function, er.err = expression.NewFunctionBase(er.ctx, v.FnName.L, &v.Type, args...)
 		c := &expression.Constant{Value: types.NewDatum(nil), RetType: &v.Type, DeferredExpr: function}
 		c.GetType().Tp = function.GetType().Tp
+		c.GetType().Decimal = function.GetType().Decimal
 		er.ctxStack = append(er.ctxStack, c)
 	} else {
 		function, er.err = expression.NewFunction(er.ctx, v.FnName.L, &v.Type, args...)

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -152,7 +152,7 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	tk.MustExec("prepare sel1 from 'select id, c1 from t1 where c1 < now(3)'")
 
 	sql1 := "execute sel1"
-	expectedPattern := `IndexReader\(Index\(t1.idx1\)\[\[-inf,[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9].000\)\]\)`
+	expectedPattern := `IndexReader\(Index\(t1.idx1\)\[\[-inf,[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1]) (2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9].[0-9][0-9][0-9]\)\]\)`
 
 	var cnt [2]float64
 	var planStr [2]string
@@ -176,7 +176,7 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 		counter.Write(pb)
 		cnt[i] = pb.GetCounter().GetValue()
 		c.Check(cnt[i], Equals, float64(i))
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 10)
 	}
 	c.Assert(planStr[0] < planStr[1], IsTrue)
 }

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -40,6 +40,12 @@ func NewFieldType(tp byte) *FieldType {
 	}
 }
 
+// CloneFieldType clones the given FieldType.
+func CloneFieldType(src *FieldType) *FieldType {
+	ft := *src
+	return &ft
+}
+
 // AggFieldType aggregates field types for a multi-argument function like `IF`, `IFNULL`, `COALESCE`
 // whose return type is determined by the arguments' FieldTypes.
 // Aggregation is performed by MergeFieldType function.

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -129,11 +129,14 @@ func setTypeFlag(flag *uint, flagItem uint, on bool) {
 func DefaultParamTypeForValue(value interface{}, tp *FieldType) {
 	switch value.(type) {
 	case nil:
-		tp.Tp = mysql.TypeUnspecified
+		tp.Tp = mysql.TypeVarString
 		tp.Flen = UnspecifiedLength
 		tp.Decimal = UnspecifiedLength
 	default:
 		DefaultTypeForValue(value, tp)
+		if tp.Tp == mysql.TypeUnspecified {
+			tp.Tp = mysql.TypeVarString
+		}
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #8615 

### What is changed and how it works?
When cloning ``FieldType.Tp`` from the source, ``FieldType.Decimal`` should be cloned too because it can be used as ``Fsp`` in ``Timestamp`` type.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Code changes
 - Has exported function/method change

Side effects
 - None

Related changes
 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8619)
<!-- Reviewable:end -->
