### PR TITLE
server: tweak error info(consistent with the previous `handleLoadData`)

### DIFF
--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -33,7 +33,7 @@ type Builder struct {
 }
 
 // ApplyDiff applies SchemaDiff to the new InfoSchema.
-// Return the detal updated table IDs that are produced from SchemaDiff and an error.
+// Return the detail updated table IDs that are produced from SchemaDiff and an error.
 func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, error) {
 	b.is.schemaMetaVersion = diff.Version
 	if diff.Type == model.ActionCreateSchema {

--- a/server/conn.go
+++ b/server/conn.go
@@ -866,7 +866,7 @@ func (cc *clientConn) handleLoadStats(ctx context.Context, loadStatsInfo *execut
 		return errNotAllowedCommand
 	}
 	if loadStatsInfo == nil {
-		return errors.New("Load stats: info is empty")
+		return errors.New("load stats: info is empty")
 	}
 	err := cc.writeReq(loadStatsInfo.Path)
 	if err != nil {


### PR DESCRIPTION
The error info should be kept consistent style(first letter lowercase) with previous:

https://github.com/pingcap/tidb/blob/6e2d6c7aa7eba3ac4f3a5201f1a36bf534fa6298/server/conn.go#L808

REF:`https://github.com/golang/go/wiki/CodeReviewComments#error-strings`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8626)
<!-- Reviewable:end -->
