### PR TITLE
[experimental] Constant.Eval() uses RetType directly

### DIFF
--- a/expression/constant.go
+++ b/expression/constant.go
@@ -100,11 +100,10 @@ func (c *Constant) Eval(_ chunk.Row) (types.Datum, error) {
 				c.Value.SetNull()
 				return c.Value, nil
 			}
-			retType := types.NewFieldType(c.RetType.Tp)
-			if retType.Tp == mysql.TypeUnspecified {
-				retType.Tp = mysql.TypeVarString
+			if c.RetType.Tp == mysql.TypeUnspecified {
+				c.RetType.Tp = mysql.TypeVarString
 			}
-			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, retType)
+			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
 			if err != nil {
 				return dt, err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
* To check the idea for the issue #8615 
* Please do not review the PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8631)
<!-- Reviewable:end -->
