### PR TITLE
plan: build separate required physical property for children

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -29,7 +29,8 @@ import (
 )
 
 func (p *LogicalUnionScan) exhaustPhysicalPlans(prop *property.PhysicalProperty) []PhysicalPlan {
-	us := PhysicalUnionScan{Conditions: p.conditions}.Init(p.ctx, p.stats, prop)
+	childProp := prop.Clone()
+	us := PhysicalUnionScan{Conditions: p.conditions}.Init(p.ctx, p.stats, childProp)
 	return []PhysicalPlan{us}
 }
 
@@ -857,9 +858,10 @@ func (la *LogicalAggregation) exhaustPhysicalPlans(prop *property.PhysicalProper
 }
 
 func (p *LogicalSelection) exhaustPhysicalPlans(prop *property.PhysicalProperty) []PhysicalPlan {
+	childProp := prop.Clone()
 	sel := PhysicalSelection{
 		Conditions: p.Conditions,
-	}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), prop)
+	}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 	return []PhysicalPlan{sel}
 }
 
@@ -880,9 +882,10 @@ func (p *LogicalLimit) exhaustPhysicalPlans(prop *property.PhysicalProperty) []P
 }
 
 func (p *LogicalLock) exhaustPhysicalPlans(prop *property.PhysicalProperty) []PhysicalPlan {
+	childProp := prop.Clone()
 	lock := PhysicalLock{
 		Lock: p.Lock,
-	}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), prop)
+	}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 	return []PhysicalPlan{lock}
 }
 

--- a/planner/property/physical_property.go
+++ b/planner/property/physical_property.go
@@ -101,3 +101,14 @@ func (p *PhysicalProperty) HashCode() []byte {
 func (p *PhysicalProperty) String() string {
 	return fmt.Sprintf("Prop{cols: %v, desc: %v, TaskTp: %s, expectedCount: %v}", p.Cols, p.Desc, p.TaskTp, p.ExpectedCnt)
 }
+
+// Clone returns a copy of PhysicalProperty.
+func (p *PhysicalProperty) Clone() *PhysicalProperty {
+	prop := &PhysicalProperty{
+		Cols:        p.Cols,
+		Desc:        p.Desc,
+		TaskTp:      p.TaskTp,
+		ExpectedCnt: p.ExpectedCnt,
+	}
+	return prop
+}

--- a/planner/property/physical_property.go
+++ b/planner/property/physical_property.go
@@ -102,7 +102,10 @@ func (p *PhysicalProperty) String() string {
 	return fmt.Sprintf("Prop{cols: %v, desc: %v, TaskTp: %s, expectedCount: %v}", p.Cols, p.Desc, p.TaskTp, p.ExpectedCnt)
 }
 
-// Clone returns a copy of PhysicalProperty.
+// Clone returns a copy of PhysicalProperty. Currently, this function is only used to build new
+// required property for children plan in `exhaustPhysicalPlans`, so we don't copy `Enforced` field
+// because if `Enforced` is true, the `Cols` must be empty now, this makes `Enforced` meaningless
+// for children nodes.
 func (p *PhysicalProperty) Clone() *PhysicalProperty {
 	prop := &PhysicalProperty{
 		Cols:        p.Cols,


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/8634

### What is changed and how it works?

RCA is provided here https://github.com/pingcap/tidb/issues/8634#issuecomment-445703564

For logical operator which passes the required physical property down to its children, make a copy for it instead of direct assignment using the original pointer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8635)
<!-- Reviewable:end -->
