### PR TITLE
server: reset bound arguments when it is executed by execute command

### DIFF
--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -174,6 +174,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		}
 
 		err = parseStmtArgs(args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues)
+		stmt.Reset()
 		if err != nil {
 			return errors.Annotatef(err, "%s", cc.preparedStmt2String(stmtID))
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`comStmtSendLongData` will always append values no matter the arguments are used or not. It will cause
```
insert into t values ("a");
insert into t values ("b");
```
the second statement will insert "ab" not "b" if the client use `comStmtSendLongData`.

### What is changed and how it works?
Reset the bound arguments when executing.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 JDBC test case.

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch

PTAL @lysu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8645)
<!-- Reviewable:end -->
