### PR TITLE
*: support auto analyze partition table (#7789)

### DIFF
--- a/ast/stats.go
+++ b/ast/stats.go
@@ -25,9 +25,10 @@ var (
 type AnalyzeTableStmt struct {
 	stmtNode
 
-	TableNames    []*TableName
-	IndexNames    []model.CIStr
-	MaxNumBuckets uint64
+	TableNames     []*TableName
+	PartitionNames []model.CIStr
+	IndexNames     []model.CIStr
+	MaxNumBuckets  uint64
 
 	// IndexFlag is true when we only analyze indices for a table.
 	IndexFlag bool

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -64,6 +64,29 @@ PARTITION BY RANGE ( a ) (
 			c.Assert(idx.Len(), Greater, 0)
 		}
 	}
+
+	tk.MustExec("drop table t")
+	tk.MustExec(createTable)
+	for i := 1; i < 21; i++ {
+		tk.MustExec(fmt.Sprintf(`insert into t values (%d, %d, "hello")`, i, i))
+	}
+	tk.MustExec("alter table t analyze partition p0")
+	is = executor.GetInfoSchema(tk.Se.(sessionctx.Context))
+	table, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	pi = table.Meta().GetPartitionInfo()
+	c.Assert(pi, NotNil)
+
+	for i, def := range pi.Definitions {
+		statsTbl := handle.GetPartitionStats(table.Meta(), def.ID)
+		if i == 0 {
+			c.Assert(statsTbl.Pseudo, IsFalse)
+			c.Assert(len(statsTbl.Columns), Equals, 2)
+			c.Assert(len(statsTbl.Indices), Equals, 1)
+		} else {
+			c.Assert(statsTbl.Pseudo, IsTrue)
+		}
+	}
 }
 
 func (s *testSuite) TestAnalyzeParameters(c *C) {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/opcode"
+	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner/property"
@@ -639,22 +640,46 @@ func getColsInfo(tn *ast.TableName) (indicesInfo []*model.IndexInfo, colsInfo []
 	return
 }
 
-func getPhysicalIDs(tblInfo *model.TableInfo) []int64 {
-	if pi := tblInfo.GetPartitionInfo(); pi != nil {
+func getPhysicalIDs(tblInfo *model.TableInfo, partitionNames []model.CIStr) ([]int64, error) {
+	pi := tblInfo.GetPartitionInfo()
+	if pi == nil {
+		if len(partitionNames) != 0 {
+			return nil, errors.Trace(ddl.ErrPartitionMgmtOnNonpartitioned)
+		}
+		return []int64{tblInfo.ID}, nil
+	}
+	if len(partitionNames) == 0 {
 		ids := make([]int64, 0, len(pi.Definitions))
 		for _, def := range pi.Definitions {
 			ids = append(ids, def.ID)
 		}
-		return ids
+		return ids, nil
 	}
-	return []int64{tblInfo.ID}
+	ids := make([]int64, 0, len(partitionNames))
+	for _, name := range partitionNames {
+		found := false
+		for _, def := range pi.Definitions {
+			if def.Name.L == name.L {
+				found = true
+				ids = append(ids, def.ID)
+				break
+			}
+		}
+		if !found {
+			return nil, errors.New(fmt.Sprintf("can not found the specified partition name %s in the table definition", name.O))
+		}
+	}
+	return ids, nil
 }
 
-func (b *planBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt) Plan {
+func (b *planBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt) (Plan, error) {
 	p := &Analyze{MaxNumBuckets: as.MaxNumBuckets}
 	for _, tbl := range as.TableNames {
 		idxInfo, colInfo, pkInfo := getColsInfo(tbl)
-		physicalIDs := getPhysicalIDs(tbl.TableInfo)
+		physicalIDs, err := getPhysicalIDs(tbl.TableInfo, as.PartitionNames)
+		if err != nil {
+			return nil, err
+		}
 		for _, idx := range idxInfo {
 			for _, id := range physicalIDs {
 				p.IdxTasks = append(p.IdxTasks, AnalyzeIndexTask{PhysicalTableID: id, IndexInfo: idx})
@@ -666,13 +691,16 @@ func (b *planBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt) Plan {
 			}
 		}
 	}
-	return p
+	return p, nil
 }
 
 func (b *planBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt) (Plan, error) {
 	p := &Analyze{MaxNumBuckets: as.MaxNumBuckets}
 	tblInfo := as.TableNames[0].TableInfo
-	physicalIDs := getPhysicalIDs(tblInfo)
+	physicalIDs, err := getPhysicalIDs(tblInfo, as.PartitionNames)
+	if err != nil {
+		return nil, err
+	}
 	for _, idxName := range as.IndexNames {
 		idx := findIndexByName(tblInfo.Indices, idxName)
 		if idx == nil || idx.State != model.StatePublic {
@@ -685,10 +713,13 @@ func (b *planBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt) (Plan, error) 
 	return p, nil
 }
 
-func (b *planBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt) Plan {
+func (b *planBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt) (Plan, error) {
 	p := &Analyze{MaxNumBuckets: as.MaxNumBuckets}
 	tblInfo := as.TableNames[0].TableInfo
-	physicalIDs := getPhysicalIDs(tblInfo)
+	physicalIDs, err := getPhysicalIDs(tblInfo, as.PartitionNames)
+	if err != nil {
+		return nil, err
+	}
 	for _, idx := range tblInfo.Indices {
 		if idx.State == model.StatePublic {
 			for _, id := range physicalIDs {
@@ -696,7 +727,7 @@ func (b *planBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt) Plan {
 			}
 		}
 	}
-	return p
+	return p, nil
 }
 
 const (
@@ -712,11 +743,11 @@ func (b *planBuilder) buildAnalyze(as *ast.AnalyzeTableStmt) (Plan, error) {
 	}
 	if as.IndexFlag {
 		if len(as.IndexNames) == 0 {
-			return b.buildAnalyzeAllIndex(as), nil
+			return b.buildAnalyzeAllIndex(as)
 		}
 		return b.buildAnalyzeIndex(as)
 	}
-	return b.buildAnalyzeTable(as), nil
+	return b.buildAnalyzeTable(as)
 }
 
 func buildShowNextRowID() *expression.Schema {

--- a/statistics/update.go
+++ b/statistics/update.go
@@ -703,29 +703,50 @@ func (h *Handle) HandleAutoAnalyze(is infoschema.InfoSchema) error {
 		tbls := is.SchemaTables(model.NewCIStr(db))
 		for _, tbl := range tbls {
 			tblInfo := tbl.Meta()
-			statsTbl := h.GetTableStats(tblInfo)
-			if statsTbl.Pseudo || statsTbl.Count < AutoAnalyzeMinCnt {
+			pi := tblInfo.GetPartitionInfo()
+			tblName := "`" + db + "`.`" + tblInfo.Name.O + "`"
+			if pi == nil {
+				statsTbl := h.GetTableStats(tblInfo)
+				sql := fmt.Sprintf("analyze table %s", tblName)
+				analyzed, err := h.autoAnalyzeTable(tblInfo, statsTbl, start, end, autoAnalyzeRatio, sql)
+				if analyzed {
+					return err
+				}
 				continue
 			}
-			tblName := "`" + db + "`.`" + tblInfo.Name.O + "`"
-			if NeedAnalyzeTable(statsTbl, 20*h.Lease, autoAnalyzeRatio, start, end, time.Now()) {
-				sql := fmt.Sprintf("analyze table %s", tblName)
-				log.Infof("[stats] auto analyze table %s now", tblName)
-				return errors.Trace(h.execAutoAnalyze(sql))
-			}
-			for _, idx := range tblInfo.Indices {
-				if idx.State != model.StatePublic {
-					continue
+			for _, def := range pi.Definitions {
+				sql := fmt.Sprintf("analyze table %s partition `%s`", tblName, def.Name.O)
+				statsTbl := h.GetPartitionStats(tblInfo, def.ID)
+				analyzed, err := h.autoAnalyzeTable(tblInfo, statsTbl, start, end, autoAnalyzeRatio, sql)
+				if analyzed {
+					return err
 				}
-				if _, ok := statsTbl.Indices[idx.ID]; !ok {
-					sql := fmt.Sprintf("analyze table %s index `%s`", tblName, idx.Name.O)
-					log.Infof("[stats] auto analyze index `%s` for table %s now", idx.Name.O, tblName)
-					return errors.Trace(h.execAutoAnalyze(sql))
-				}
+				continue
 			}
 		}
 	}
 	return nil
+}
+
+func (h *Handle) autoAnalyzeTable(tblInfo *model.TableInfo, statsTbl *Table, start, end time.Time, ratio float64, sql string) (bool, error) {
+	if statsTbl.Pseudo || statsTbl.Count < AutoAnalyzeMinCnt {
+		return false, nil
+	}
+	if NeedAnalyzeTable(statsTbl, 20*h.Lease, ratio, start, end, time.Now()) {
+		log.Infof("[stats] auto %s now", sql)
+		return true, h.execAutoAnalyze(sql)
+	}
+	for _, idx := range tblInfo.Indices {
+		if idx.State != model.StatePublic {
+			continue
+		}
+		if _, ok := statsTbl.Indices[idx.ID]; !ok {
+			sql = fmt.Sprintf("%s index `%s`", sql, idx.Name.O)
+			log.Infof("[stats] auto %s now", sql)
+			return true, h.execAutoAnalyze(sql)
+		}
+	}
+	return false, nil
 }
 
 func (h *Handle) execAutoAnalyze(sql string) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When creating a partition table, the stats will keep auto analyze that table.
 
### What is changed and how it works?

Each partition will have its own stats, so we cannot get the partition stats using the table id and we will repeatedly analyze that table.
Cherry-pick #7789

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @winoros @XuHuaiyu @eurekaka

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8649)
<!-- Reviewable:end -->
