### PR TITLE
planner/core: use stable sort to make CI stable

### DIFF
--- a/planner/core/rule_join_reorder_greedy.go
+++ b/planner/core/rule_join_reorder_greedy.go
@@ -74,7 +74,7 @@ func (s *joinReOrderGreedySolver) solve() (LogicalPlan, error) {
 			return nil, err
 		}
 	}
-	sort.Slice(s.curJoinGroup, func(i, j int) bool {
+	sort.SliceStable(s.curJoinGroup, func(i, j int) bool {
 		return s.curJoinGroup[i].statsInfo().RowCount < s.curJoinGroup[j].statsInfo().RowCount
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

sort.Slice may return unstable data so the order of join's child may be unstable.
Hence, CI's result is unstable.

### What is changed and how it works?

use sort.SliceStable instead.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8650)
<!-- Reviewable:end -->
