### PR TITLE
planner/cascades: add a transformation rule FilterAggregateTranspose

### DIFF
--- a/planner/cascades/expr_iterator.go
+++ b/planner/cascades/expr_iterator.go
@@ -36,6 +36,7 @@ type ExprIter struct {
 	children []*ExprIter
 }
 
+// GetGroupExpr returns the group expression pointed by this iterator.
 func (iter *ExprIter) GetGroupExpr() *GroupExpr {
 	return iter.element.Value.(*GroupExpr)
 }

--- a/planner/cascades/expr_iterator.go
+++ b/planner/cascades/expr_iterator.go
@@ -36,6 +36,10 @@ type ExprIter struct {
 	children []*ExprIter
 }
 
+func (iter *ExprIter) GetGroupExpr() *GroupExpr {
+	return iter.element.Value.(*GroupExpr)
+}
+
 // Next returns the next group expression matches the pattern.
 func (iter *ExprIter) Next() (found bool) {
 	defer func() {

--- a/planner/cascades/rule_FilterAggregateTranspose.go
+++ b/planner/cascades/rule_FilterAggregateTranspose.go
@@ -1,0 +1,136 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cascades
+
+import (
+	"github.com/pingcap/tidb/expression"
+	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/util/set"
+)
+
+/**
+type Transformation interface {
+	GetPattern() *Pattern
+	Match(expr *ExprIter) (matched bool)
+	OnTransform(old *ExprIter) (new *GroupExpr, eraseOld bool, err error)
+}
+*/
+
+type baseRuleImpl struct {
+	pattern *Pattern
+}
+
+func (r *baseRuleImpl) GetPattern() *Pattern {
+	return r.pattern
+}
+
+func (r *baseRuleImpl) Match(expr *ExprIter) bool {
+	return true
+}
+
+type FilterAggregateTransposeRule struct {
+	baseRuleImpl
+}
+
+func NewFilterAggregateTransposeRule() *FilterAggregateTransposeRule {
+	pattern := BuildPattern(OperandSelection, BuildPattern(OperandAggregation))
+	return &FilterAggregateTransposeRule{baseRuleImpl{pattern}}
+}
+
+// OnTransform push the filters through the aggregate:
+// before: filter(aggregate(any), f1, f2, ...)
+// after:  aggregate(filter(any, f1, f2, ...)),      totaly push through
+//    or:  filter(aggregate(filter(any, f1)), f2), partialy push through
+func (r *FilterAggregateTransposeRule) OnTransform(sctx sessionctx.Context, old *ExprIter) (new *GroupExpr, eraseOld bool, err error) {
+	selGroupExpr := old.GetGroupExpr()
+	aggGroupExpr := old.children[0].GetGroupExpr()
+
+	pushed, remained := r.collectPushedFilters(selGroupExpr, aggGroupExpr)
+	if len(pushed) == 0 {
+		return nil, false, nil
+	}
+
+	// construct the first selection before aggregation.
+	newSel := plannercore.LogicalSelection{Conditions: pushed}.Init(sctx)
+	newSelGroupExpr := NewGroupExpr(newSel)
+	newSelGroupExpr.children = aggGroupExpr.children
+	newSelGroup := NewGroup(newSelGroupExpr)
+
+	// construct the new aggregation upon the new selection.
+	agg := aggGroupExpr.exprNode.(*plannercore.LogicalAggregation)
+	newAgg := plannercore.LogicalAggregation{
+		AggFuncs:     agg.AggFuncs,
+		GroupByItems: agg.GroupByItems,
+	}.Init(sctx)
+	newAggGroupExpr := NewGroupExpr(newAgg)
+	newAggGroupExpr.children = []*Group{newSelGroup}
+
+	// no more selection opon the new aggregation.
+	if len(remained) == 0 {
+		return newAggGroupExpr, true, nil
+	}
+
+	// otherwise, construct a new selection upon the new aggregation.
+	newAggGroup := NewGroup(newAggGroupExpr)
+	newSel = plannercore.LogicalSelection{Conditions: remained}.Init(sctx)
+	newSelGroupExpr = NewGroupExpr(newSel)
+	newSelGroupExpr.children = []*Group{newAggGroup}
+	return newSelGroupExpr, true, nil
+}
+
+func (r *FilterAggregateTransposeRule) collectPushedFilters(selGroupExpr, aggGroupExpr *GroupExpr) (pushed, remained []expression.Expression) {
+	sel := selGroupExpr.exprNode.(*plannercore.LogicalSelection)
+	agg := aggGroupExpr.exprNode.(*plannercore.LogicalAggregation)
+	gbyColIds := r.collectGbyCols(agg)
+	for _, cond := range sel.Conditions {
+		if !r.coveredByGbyCols(cond, gbyColIds) {
+			if remained == nil {
+				remained = make([]expression.Expression, 0, len(sel.Conditions)-len(pushed))
+			}
+			remained = append(remained, cond)
+		} else {
+			if pushed == nil {
+				pushed = make([]expression.Expression, 0, len(sel.Conditions)-len(remained))
+			}
+			pushed = append(pushed, cond)
+		}
+	}
+	return pushed, remained
+}
+
+func (r *FilterAggregateTransposeRule) collectGbyCols(agg *plannercore.LogicalAggregation) set.Int64Set {
+	gbyColIds := set.NewInt64Set()
+	for i := range agg.GroupByItems {
+		gbyCol, isCol := agg.GroupByItems[i].(*expression.Column)
+		if isCol {
+			gbyColIds.Insert(gbyCol.UniqueID)
+		}
+	}
+	return gbyColIds
+}
+
+func (r *FilterAggregateTransposeRule) coveredByGbyCols(filter expression.Expression, gbyColIds set.Int64Set) bool {
+	switch v := filter.(type) {
+	case *expression.Column:
+		return gbyColIds.Exist(v.UniqueID)
+	case *expression.ScalarFunction:
+		for _, arg := range v.GetArgs() {
+			if !r.coveredByGbyCols(arg, gbyColIds) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/planner/cascades/rule_FilterAggregateTranspose.go
+++ b/planner/cascades/rule_FilterAggregateTranspose.go
@@ -40,10 +40,15 @@ func (r *baseRuleImpl) Match(expr *ExprIter) bool {
 	return true
 }
 
+// FilterAggregateTransposeRule pushes the filters through the aggregate:
+// before: filter(aggregate(any), f1, f2, ...)
+// after:  aggregate(filter(any, f1, f2, ...)),      totaly push through
+//    or:  filter(aggregate(filter(any, f1)), f2), partialy push through
 type FilterAggregateTransposeRule struct {
 	baseRuleImpl
 }
 
+// NewFilterAggregateTransposeRule creates a new FilterAggregateTransposeRule.
 func NewFilterAggregateTransposeRule() *FilterAggregateTransposeRule {
 	pattern := BuildPattern(OperandSelection, BuildPattern(OperandAggregation))
 	return &FilterAggregateTransposeRule{baseRuleImpl{pattern}}

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -15,13 +15,14 @@ package cascades
 
 import (
 	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx"
 )
 
 // Transformation defines the interface for the transformation rules.
 type Transformation interface {
 	GetPattern() *Pattern
 	Match(expr *ExprIter) (matched bool)
-	OnTransform(old *ExprIter) (new *GroupExpr, eraseOld bool, err error)
+	OnTransform(sctx sessionctx.Context, old *ExprIter) (new *GroupExpr, eraseOld bool, err error)
 }
 
 // GetTransformationRules gets the all the candidate transformation rules based
@@ -31,12 +32,16 @@ func GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
 }
 
 var transformationMap = map[Operand][]Transformation{
-	/**
-	operandSelect: []Transformation{
+	OperandSelection: []Transformation{
+		NewFilterAggregateTransposeRule(),
+	},
+	OperandProjection: []Transformation{
 		nil,
 	},
-	operandProject: []Transformation{
+	OperandAggregation: []Transformation{
 		nil,
 	},
-	*/
+	OperandJoin: []Transformation{
+		nil,
+	},
 }

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -32,16 +32,16 @@ func GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
 }
 
 var transformationMap = map[Operand][]Transformation{
-	OperandSelection: []Transformation{
+	OperandSelection: {
 		NewFilterAggregateTransposeRule(),
 	},
-	OperandProjection: []Transformation{
+	OperandProjection: {
 		nil,
 	},
-	OperandAggregation: []Transformation{
+	OperandAggregation: {
 		nil,
 	},
-	OperandJoin: []Transformation{
+	OperandJoin: {
 		nil,
 	},
 }

--- a/util/set/int64_set.go
+++ b/util/set/int64_set.go
@@ -16,7 +16,7 @@ package set
 // Int64Set is a string set.
 type Int64Set map[int64]struct{}
 
-// NewStringSet builds a float64 set.
+// NewInt64Set builds a Int64Set set.
 func NewInt64Set() Int64Set {
 	return make(map[int64]struct{})
 }

--- a/util/set/int64_set.go
+++ b/util/set/int64_set.go
@@ -1,0 +1,33 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package set
+
+// Int64Set is a string set.
+type Int64Set map[int64]struct{}
+
+// NewStringSet builds a float64 set.
+func NewInt64Set() Int64Set {
+	return make(map[int64]struct{})
+}
+
+// Exist checks whether `val` exists in `s`.
+func (s Int64Set) Exist(val int64) bool {
+	_, ok := s[val]
+	return ok
+}
+
+// Insert inserts `val` into `s`.
+func (s Int64Set) Insert(val int64) {
+	s[val] = struct{}{}
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Trying to add a new transformation rule, which pushes the filter through the aggregate.

### What is changed and how it works?

There is a little code change in the transformation framework. Group logical property has not derived.

test will be added later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8665)
<!-- Reviewable:end -->
