### PR TITLE
*： ignore unknown hint and return warning instead of return a parser error

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -114,7 +114,11 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	} else {
 		p := parser.New()
 		p.EnableWindowFunc(vars.EnableWindowFunction)
-		stmts, err = p.Parse(e.sqlText, charset, collation)
+		var warns []error
+		stmts, warns, err = p.Parse(e.sqlText, charset, collation)
+		for _, warn := range warns {
+			e.ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+		}
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -117,7 +117,7 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 		var warns []error
 		stmts, warns, err = p.Parse(e.sqlText, charset, collation)
 		for _, warn := range warns {
-			e.ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+			e.ctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 		}
 	}
 	if err != nil {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3697,6 +3697,16 @@ func (s *testIntegrationSuite) TestDecimalMul(c *C) {
 	res.Check(testkit.Rows("0.55125221922461136"))
 }
 
+func (s *testIntegrationSuite) TestUnknowHintIgnore(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("USE test")
+	tk.MustExec("create table t(a int)")
+	tk.MustQuery("select /*+ unkown_hint(c1)*/ 1").Check(testkit.Rows("1"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 line 1 column 28 near \" 1\" (total length 30)"))
+	_, err := tk.Exec("select 1 from /*+ test1() */ t")
+	c.Assert(err, NotNil)
+}
+
 func (s *testIntegrationSuite) TestValuesInNonInsertStmt(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test;`)

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -39,7 +39,7 @@ func ParseSimpleExprWithTableInfo(ctx sessionctx.Context, exprStr string, tableI
 	exprStr = "select " + exprStr
 	stmts, warns, err := parser.New().Parse(exprStr, "", "")
 	for _, warn := range warns {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 	}
 	if err != nil {
 		return nil, err
@@ -77,7 +77,7 @@ func ParseSimpleExprsWithSchema(ctx sessionctx.Context, exprStr string, schema *
 	exprStr = "select " + exprStr
 	stmts, warns, err := parser.New().Parse(exprStr, "", "")
 	for _, warn := range warns {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 	}
 	if err != nil {
 		return nil, err

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -37,7 +37,10 @@ type simpleRewriter struct {
 // The expression string must only reference the column in table Info.
 func ParseSimpleExprWithTableInfo(ctx sessionctx.Context, exprStr string, tableInfo *model.TableInfo) (Expression, error) {
 	exprStr = "select " + exprStr
-	stmts, err := parser.New().Parse(exprStr, "", "")
+	stmts, warns, err := parser.New().Parse(exprStr, "", "")
+	for _, warn := range warns {
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +75,10 @@ func RewriteSimpleExprWithTableInfo(ctx sessionctx.Context, tbl *model.TableInfo
 // The expression string must only reference the column in the given schema.
 func ParseSimpleExprsWithSchema(ctx sessionctx.Context, exprStr string, schema *Schema) ([]Expression, error) {
 	exprStr = "select " + exprStr
-	stmts, err := parser.New().Parse(exprStr, "", "")
+	stmts, warns, err := parser.New().Parse(exprStr, "", "")
+	for _, warn := range warns {
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181213120705-37d75752f8c7
+replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181214072822-f4a73fbf9703

--- a/go.mod
+++ b/go.mod
@@ -86,3 +86,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181213120705-37d75752f8c7

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26
-	github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e
+	github.com/pingcap/parser v0.0.0-20181221050948-947d4ab3052f
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.1-0.20181218072513-b2235d442b06+incompatible
 	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323
@@ -86,5 +86,3 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-
-replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a
+replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181214072822-f4a73fbf9703
+replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181214074717-4107cb4dc6d9

--- a/go.mod
+++ b/go.mod
@@ -87,4 +87,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181214074717-4107cb4dc6d9
+replace github.com/pingcap/parser => github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,10 @@ github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDK
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a h1:sJ+0Jo2G1SZxt1Obequ9Hk/jtVK4x0Y2UM9CXASaiL0=
+github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a/go.mod h1:CJk6LPzPxAcwHIcTugQaKxzvTR10NDJ5ln8XR7uYTJk=
+github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182 h1:XIPHxFmMZ9dfDXbFWfQ5p6kuwkTF6VRgbF3wLaYioKo=
+github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182/go.mod h1:CJk6LPzPxAcwHIcTugQaKxzvTR10NDJ5ln8XR7uYTJk=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=

--- a/go.sum
+++ b/go.sum
@@ -84,10 +84,6 @@ github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDK
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a h1:sJ+0Jo2G1SZxt1Obequ9Hk/jtVK4x0Y2UM9CXASaiL0=
-github.com/lysu/parser v0.0.0-20181218132805-b5f5b4fbae0a/go.mod h1:CJk6LPzPxAcwHIcTugQaKxzvTR10NDJ5ln8XR7uYTJk=
-github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182 h1:XIPHxFmMZ9dfDXbFWfQ5p6kuwkTF6VRgbF3wLaYioKo=
-github.com/lysu/parser v0.0.0-20181221031749-30d2d93c9182/go.mod h1:CJk6LPzPxAcwHIcTugQaKxzvTR10NDJ5ln8XR7uYTJk=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
@@ -129,8 +125,6 @@ github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rG
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26 h1:JK4VLNYbSn36QSbCnqALi2ySXdH0DfcMssT/zmLf4Ls=
 github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26/go.mod h1:0gwbe1F2iBIjuQ9AH0DbQhL+Dpr5GofU8fgYyXk+ykk=
-github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e h1:jKibIs55HR7OMo62uhjA6Bfx3GK+rbHK4Gfd4/8aTzk=
-github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20181221050948-947d4ab3052f h1:X2ZRYBERoJ5VDp7CdtXWfwbKqbeYn2kkdGA0b5/VwJ8=
 github.com/pingcap/parser v0.0.0-20181221050948-947d4ab3052f/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26 h1:JK4VLNYbSn36QSb
 github.com/pingcap/kvproto v0.0.0-20181105061835-1b5d69cd1d26/go.mod h1:0gwbe1F2iBIjuQ9AH0DbQhL+Dpr5GofU8fgYyXk+ykk=
 github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e h1:jKibIs55HR7OMo62uhjA6Bfx3GK+rbHK4Gfd4/8aTzk=
 github.com/pingcap/parser v0.0.0-20181218071912-deacf026787e/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20181221050948-947d4ab3052f h1:X2ZRYBERoJ5VDp7CdtXWfwbKqbeYn2kkdGA0b5/VwJ8=
+github.com/pingcap/parser v0.0.0-20181221050948-947d4ab3052f/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.1-0.20181218072513-b2235d442b06+incompatible h1:Bsd+NHosPVowEGB3BCx+2d8wUQGDTXSSC5ljeNS6cXo=

--- a/session/session.go
+++ b/session/session.go
@@ -810,7 +810,7 @@ func (s *session) SetGlobalSysVar(name, value string) error {
 	return errors.Trace(err)
 }
 
-func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) ([]ast.StmtNode, error) {
+func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) ([]ast.StmtNode, []error, error) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.ParseSQL", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
@@ -885,7 +885,10 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 
 	// Step1: Compile query string to abstract syntax trees(ASTs).
 	startTS := time.Now()
-	stmtNodes, err := s.ParseSQL(ctx, sql, charsetInfo, collation)
+	stmtNodes, warns, err := s.ParseSQL(ctx, sql, charsetInfo, collation)
+	for _, warn := range warns {
+		s.sessionVars.StmtCtx.AppendWarning(warn)
+	}
 	if err != nil {
 		s.rollbackOnError(ctx)
 		log.Warnf("con:%d parse error:\n%v\n%s", connID, err, sql)

--- a/session/session.go
+++ b/session/session.go
@@ -886,9 +886,6 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 	// Step1: Compile query string to abstract syntax trees(ASTs).
 	startTS := time.Now()
 	stmtNodes, warns, err := s.ParseSQL(ctx, sql, charsetInfo, collation)
-	for _, warn := range warns {
-		s.sessionVars.StmtCtx.AppendWarning(warn)
-	}
 	if err != nil {
 		s.rollbackOnError(ctx)
 		log.Warnf("con:%d parse error:\n%v\n%s", connID, err, sql)
@@ -924,6 +921,10 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 	if s.sessionVars.ClientCapability&mysql.ClientMultiResults == 0 && len(recordSets) > 1 {
 		// return the first recordset if client doesn't support ClientMultiResults.
 		recordSets = recordSets[:1]
+	}
+
+	for _, warn := range warns {
+		s.sessionVars.StmtCtx.AppendWarning(warn)
 	}
 	return recordSets, nil
 }

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -125,7 +125,10 @@ func Parse(ctx sessionctx.Context, src string) ([]ast.StmtNode, error) {
 	p := parser.New()
 	p.EnableWindowFunc(ctx.GetSessionVars().EnableWindowFunction)
 	p.SetSQLMode(ctx.GetSessionVars().SQLMode)
-	stmts, err := p.Parse(src, charset, collation)
+	stmts, warns, err := p.Parse(src, charset, collation)
+	for _, warn := range warns {
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+	}
 	if err != nil {
 		log.Warnf("compiling %s, error: %v", src, err)
 		return nil, errors.Trace(err)

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -127,7 +127,7 @@ func Parse(ctx sessionctx.Context, src string) ([]ast.StmtNode, error) {
 	p.SetSQLMode(ctx.GetSessionVars().SQLMode)
 	stmts, warns, err := p.Parse(src, charset, collation)
 	for _, warn := range warns {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(warn	)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 	}
 	if err != nil {
 		log.Warnf("compiling %s, error: %v", src, err)

--- a/table/tables/gen_expr.go
+++ b/table/tables/gen_expr.go
@@ -61,7 +61,7 @@ func (nr *nameResolver) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 func parseExpression(expr string) (node ast.ExprNode, err error) {
 	expr = fmt.Sprintf("select %s", expr)
 	charset, collation := charset.GetDefaultCharsetAndCollate()
-	stmts, err := parser.New().Parse(expr, charset, collation)
+	stmts, _, err := parser.New().Parse(expr, charset, collation)
 	if err == nil {
 		node = stmts[0].(*ast.SelectStmt).Fields.Fields[0].Expr
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

using https://github.com/pingcap/parser/pull/80's parser

Current, when we meet unknow hint token whole sql will be failure.

This PR will ignore whole hint when meet unknow token and run without hint,  so we can compatible to SQL that generate by tool and target to other database.

### What is changed and how it works?

use new parser that ignore hint parser error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Old Test

Code changes

 - Dependency 

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8685)
<!-- Reviewable:end -->
