### PR TITLE
Makefile: move 'go mod tidy' check to makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ before_install:
   - bash gitcookie.sh
 script:
   - make dev
-  - ./hack/check-tidy.sh

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CHECK_LDFLAGS += $(LDFLAGS) ${TEST_LDFLAGS}
 
 TARGET = ""
 
-.PHONY: all build update clean todo test gotest interpreter server dev benchkv benchraw check checklist parser
+.PHONY: all build update clean todo test gotest interpreter server dev benchkv benchraw check checklist parser tidy
 
 default: server buildsucc
 
@@ -64,7 +64,7 @@ check-setup:
 	@which retool >/dev/null 2>&1 || go get github.com/twitchtv/retool
 	@GO111MODULE=off retool sync
 
-check: check-setup fmt lint vet
+check: check-setup fmt lint vet tidy
 
 # These need to be fixed before they can be ran regularly
 check-fail: goword check-static check-slow
@@ -97,6 +97,10 @@ lint:
 vet:
 	@echo "vet"
 	$(GO) vet -all -shadow $(PACKAGES) 2>&1 | $(FAIL_ON_STDOUT)
+
+tidy:
+	@echo "go mod tidy"
+	./hack/check-tidy.sh
 
 clean:
 	$(GO) clean -i ./...

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,5 @@ jobs:
           name: "Build & Test"
           command: make dev
       - run:
-          name: "Go mod tidy"
-          command: ./hack/check-tidy.sh
-      - run:
           name: "Check go mod replace is removed"
           command: ./hack/check_parser_replace.sh


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The 'go mod tidy' check is introduced from https://github.com/pingcap/tidb/pull/8402
Sometimes `make dev` success, but the CI fail after pushing the commit, because the check script run in circle.yml & travis.yml
That make our contributors (including myself) confused, many of us believe `make dev` pass means everything is ok. So I file a PR to solve it.

### What is changed and how it works?

Move 'go mod tidy' check from CI script to Makefile 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

@zimulala @lysu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8690)
<!-- Reviewable:end -->
