### PR TITLE
server: close all connection directly when terminate tidb

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -504,6 +504,7 @@ func (do *Domain) mustReload() (exitLoop bool) {
 
 // Close closes the Domain and release its resource.
 func (do *Domain) Close() {
+	do.SchemaValidator.Stop()
 	if do.ddl != nil {
 		terror.Log(errors.Trace(do.ddl.Stop()))
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -504,7 +504,6 @@ func (do *Domain) mustReload() (exitLoop bool) {
 
 // Close closes the Domain and release its resource.
 func (do *Domain) Close() {
-	do.SchemaValidator.Stop()
 	if do.ddl != nil {
 		terror.Log(errors.Trace(do.ddl.Stop()))
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -153,6 +153,10 @@ func (cc *clientConn) Close() error {
 	delete(cc.server.clients, cc.connectionID)
 	connections := len(cc.server.clients)
 	cc.server.rwlock.Unlock()
+	return closeConn(cc, connections)
+}
+
+func closeConn(cc *clientConn, connections int) error {
 	metrics.ConnGauge.Set(float64(connections))
 	err := cc.bufReadConn.Close()
 	terror.Log(errors.Trace(err))
@@ -160,6 +164,11 @@ func (cc *clientConn) Close() error {
 		return cc.ctx.Close()
 	}
 	return nil
+}
+
+func (cc *clientConn) CloseWithoutLock() error {
+	delete(cc.server.clients, cc.connectionID)
+	return closeConn(cc, len(cc.server.clients))
 }
 
 // writeInitialHandshake sends server version, connection ID, server capability, collation, server status

--- a/server/conn.go
+++ b/server/conn.go
@@ -166,7 +166,7 @@ func closeConn(cc *clientConn, connections int) error {
 	return nil
 }
 
-func (cc *clientConn) CloseWithoutLock() error {
+func (cc *clientConn) closeWithoutLock() error {
 	delete(cc.server.clients, cc.connectionID)
 	return closeConn(cc, len(cc.server.clients))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -377,7 +377,7 @@ func (s *Server) KillAllConnections() {
 
 	for _, conn := range s.clients {
 		atomic.StoreInt32(&conn.status, connStatusShutdown)
-		terror.Log(errors.Trace(conn.CloseWithoutLock()))
+		terror.Log(errors.Trace(conn.closeWithoutLock()))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -376,7 +376,8 @@ func (s *Server) KillAllConnections() {
 	log.Info("[server] kill all connections.")
 
 	for _, conn := range s.clients {
-		killConn(conn, false)
+		atomic.StoreInt32(&conn.status, connStatusShutdown)
+		terror.Log(errors.Trace(conn.CloseWithoutLock()))
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -378,6 +378,12 @@ func (s *Server) KillAllConnections() {
 	for _, conn := range s.clients {
 		atomic.StoreInt32(&conn.status, connStatusShutdown)
 		terror.Log(errors.Trace(conn.closeWithoutLock()))
+		conn.mu.RLock()
+		cancelFunc := conn.mu.cancelFunc
+		conn.mu.RUnlock()
+		if cancelFunc != nil {
+			cancelFunc()
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Close all connection directly when terminate tidb.
Currently, if TiDB got terminated signal, TiDB will call `cancelFunc` of the connection. But call `cancelFunc` will make the result be uncertainty to client. 
So just close the connections and return error.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8692)
<!-- Reviewable:end -->
