### PR TITLE
session: temporary fix for the nil transaction panic

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -254,6 +254,10 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 		if snapshotTS != 0 {
 			return nil, errors.New("can not execute write statement when 'tidb_snapshot' is set")
 		}
+		txn := sctx.Txn(true)
+		if !txn.Valid() {
+			return nil, errors.New("active transaction fail")
+		}
 	}
 
 	var err error

--- a/session/txn.go
+++ b/session/txn.go
@@ -215,6 +215,22 @@ func (st *TxnState) cleanup() {
 	}
 }
 
+// SetOption implement the kv.Transaction interface.
+func (st *TxnState) SetOption(opt kv.Option, val interface{}) {
+	if st.fail != nil {
+		return
+	}
+	st.Transaction.SetOption(opt, val)
+}
+
+// DelOption implement the kv.Transaction interface.
+func (st *TxnState) DelOption(opt kv.Option) {
+	if st.fail != nil {
+		return
+	}
+	st.Transaction.DelOption(opt)
+}
+
 func getBinlogMutation(ctx sessionctx.Context, tableID int64) *binlog.TableMutation {
 	bin := binloginfo.GetPrewriteValue(ctx, true)
 	for i := range bin.Mutations {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -223,6 +223,7 @@ func (ts *testSuite) TestUniqueIndexMultipleNullEntries(c *C) {
 	c.Assert(err, IsNil)
 	_, err = tb.AddRecord(sctx, types.MakeDatums(2, nil), false)
 	c.Assert(err, IsNil)
+	sctx.StmtCommit()
 	c.Assert(sctx.Txn(true).Rollback(), IsNil)
 	_, err = ts.se.Execute(context.Background(), "drop table test.t")
 	c.Assert(err, IsNil)


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If pd is down, Txn(true) would fail, and txn.Transaction is nil.
Call txn.SetOption would panic on that case.

```
/home/jenkins/workspace/tidb_ghpr_build/go/src/github.com/pingcap/tidb/server/conn.go:433 +0x10c
panic(0x107fda0, 0x1f780e0)
        /usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/session.(*TxnState).SetOption(0xc000c14eb0, 0x1, 0x0, 0x0)
        <autogenerated>:1 +0x2e
github.com/pingcap/tidb/executor.(*InsertExec).exec(0xc000935560, 0x7fa7eda5f530, 0xc0009cae10, 0xc001424480, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
        /home/jenkins/workspace/tidb_ghpr_build/go/src/github.com/pingcap/tidb/executor/write.go:895 +0x782
github.com/pingcap/tidb/executor.(*InsertExec).Next(0xc000935560, 0x7fa7eda5f530, 0xc0009cae10, 0xc001424420, 0x137f060, 0xc000935560)
        /home/jenkins/workspace/tidb_ghpr_build/go/src/github.com/pingcap/tidb/executor/write.go:1307 +0x156
github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor(0xc000400c80, 0x7fa7eda5f530, 0xc0009cae10, 0x139b220, 0xc000c14ea0, 0x137f060, 0xc000935560, 0x7fa7ed767488, 0xc000c14ea0, 0x0, ...)
        /home/jenkins/workspace/tidb_ghpr_build/go/src/github.com/pingcap/tidb/executor/adapter.go:273 +0x178
github.com/pingcap/tidb/executor.(*ExecStmt).Exec(0xc000400c80, 0x7fa7eda5f530, 0xc0009cae10, 0x0, 0x0, 0x0, 0x0)
        /home/jenkins/workspace/tidb_ghpr_build/go/src/github.com/pingcap/tidb/executor/adapter.go:228 +0x510
github.com/pingcap/tidb/session.runStmt(0x7fa7eda5f530, 0xc0009cae10, 0x139b220, 0xc000c14ea0, 0x137bac0, 0xc000400c80, 0x0, 0x0, 0x0, 0x0)
```

### What is changed and how it works?

A temporary fix to avoid the nil pointer error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Side effects

 - Increased code complexity

The commit is based on release-2.0
A better fix should be removing the txn.fail of the `TxnState` struct, I'll do it on master

@crazycs520 @winkyao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8703)
<!-- Reviewable:end -->
