### PR TITLE
expression/json: add builtin function JSON_SEARCH

### DIFF
--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -892,7 +892,7 @@ func (b *builtinJSONSearchSig) Clone() builtinFunc {
 
 func (c *jsonSearchFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
 	if err := c.verifyArgs(args); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	// json_doc, one_or_all, search_str[, escape_char[, path] ...])
 	argTps := make([]types.EvalType, 0, len(args))
@@ -977,12 +977,12 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 		}
 		err = obj.Walk(walkFn, pathExprs...)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 	} else {
 		err = obj.Walk(walkFn)
 		if err != nil {
-			return res, true, errors.Trace(err)
+			return res, true, err
 		}
 	}
 

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -944,16 +944,22 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 	}
 	patChars, patTypes := stringutil.CompilePattern(searchStr, escape)
 
-	// result
-	result := make([]interface{}, 0)
+	// resultSet
+	resultSet := make(map[string]bool)
 
 	// walk json_doc
 	walkFn := func(fullpath json.PathExpression, bj json.BinaryJSON) (stop bool, err error) {
+		pathStr := fullpath.String()
+		if _, ok := resultSet[pathStr]; ok {
+			return false, nil
+		}
 		if bj.TypeCode == json.TypeCodeString && stringutil.DoMatch(string(bj.GetString()), patChars, patTypes) {
-			result = append(result, fullpath.String())
+			resultSet[pathStr] = true
 			if containType == json.ContainsPathOne {
 				return true, nil
 			}
+		} else {
+			resultSet[pathStr] = false
 		}
 		return false, nil
 	}
@@ -977,6 +983,13 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 		obj.Walk(walkFn)
 	}
 
+	// result
+	result := make([]interface{}, 0)
+	for path, match := range resultSet {
+		if match {
+			result = append(result, path)
+		}
+	}
 	switch len(result) {
 	case 0:
 		return res, true, nil

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -950,22 +950,14 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 
 	// result
 	result := make([]interface{}, 0)
-	resultSet := make(map[string]bool)
 
 	// walk json_doc
 	walkFn := func(fullpath json.PathExpression, bj json.BinaryJSON) (stop bool, err error) {
-		pathStr := fullpath.String()
-		if _, ok := resultSet[pathStr]; ok {
-			return false, nil
-		}
 		if bj.TypeCode == json.TypeCodeString && stringutil.DoMatch(string(bj.GetString()), patChars, patTypes) {
-			resultSet[pathStr] = true
-			result = append(result, pathStr)
+			result = append(result, fullpath.String())
 			if containType == json.ContainsPathOne {
 				return true, nil
 			}
-		} else {
-			resultSet[pathStr] = false
 		}
 		return false, nil
 	}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -944,7 +944,8 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 	}
 	patChars, patTypes := stringutil.CompilePattern(searchStr, escape)
 
-	// resultSet
+	// result
+	result := make([]interface{}, 0)
 	resultSet := make(map[string]bool)
 
 	// walk json_doc
@@ -955,6 +956,7 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 		}
 		if bj.TypeCode == json.TypeCodeString && stringutil.DoMatch(string(bj.GetString()), patChars, patTypes) {
 			resultSet[pathStr] = true
+			result = append(result, pathStr)
 			if containType == json.ContainsPathOne {
 				return true, nil
 			}
@@ -983,13 +985,7 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 		obj.Walk(walkFn)
 	}
 
-	// result
-	result := make([]interface{}, 0)
-	for path, match := range resultSet {
-		if match {
-			result = append(result, path)
-		}
-	}
+	// return
 	switch len(result) {
 	case 0:
 		return res, true, nil

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -16,6 +16,7 @@ package expression
 import (
 	"strings"
 
+	"fmt"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
@@ -876,8 +877,92 @@ type jsonSearchFunctionClass struct {
 	baseFunctionClass
 }
 
+type builtinJSONSearchSig struct {
+	baseBuiltinFunc
+}
+
+func (b *builtinJSONSearchSig) Clone() builtinFunc {
+	newSig := &builtinJSONSearchSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
+}
+
 func (c *jsonSearchFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	return nil, errFunctionNotExists.GenWithStackByArgs("FUNCTION", "JSON_SEARCH")
+	if err := c.verifyArgs(args); err != nil {
+		return nil, errors.Trace(err)
+	}
+	// json_doc, one_or_all, search_str[, escape_char[, path] ...])
+	argTps := make([]types.EvalType, 0, len(args))
+	argTps = append(argTps, types.ETJson)
+	for range args[1:] {
+		argTps = append(argTps, types.ETString)
+	}
+	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETJson, argTps...)
+	sig := &builtinJSONSearchSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_JsonSearchSig)
+	return sig, nil
+}
+
+func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
+	// json_doc
+	objOrigin, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	if isNull || err != nil {
+		return res, isNull, errors.Trace(err)
+	}
+	fmt.Println("[objOrigin]", objOrigin)
+
+	// one_or_all
+	containType, isNull, err := b.args[1].EvalString(b.ctx, row)
+	if isNull || err != nil {
+		return res, isNull, errors.Trace(err)
+	}
+	if containType != json.ContainsPathAll && containType != json.ContainsPathOne {
+		return res, true, json.ErrInvalidJSONContainsPathType
+	}
+
+	// search_str
+	searchStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	if isNull || err != nil {
+		return res, isNull, errors.Trace(err)
+	}
+
+	// escape_char
+	escapeChar := "\\"
+	if len(b.args) >= 4 {
+		escapeChar, isNull, err = b.args[3].EvalString(b.ctx, row)
+		if err != nil {
+			return res, isNull, errors.Trace(err)
+		}
+		if isNull {
+			escapeChar = "\\"
+		}
+	}
+	fmt.Println("[escapeChar]", escapeChar)
+
+	// path...
+	var obj json.BinaryJSON
+	if len(b.args) >= 5 {
+		pathExprs := make([]json.PathExpression, 0, len(b.args)-4)
+		for i := 4; i < len(b.args); i++ {
+			var s string
+			s, isNull, err = b.args[i].EvalString(b.ctx, row)
+			if isNull || err != nil {
+				return res, isNull, errors.Trace(err)
+			}
+			var pathExpr json.PathExpression
+			pathExpr, err = json.ParseJSONPathExpr(s)
+			if err != nil {
+				return res, true, errors.Trace(err)
+			}
+			pathExprs = append(pathExprs, pathExpr)
+		}
+		obj, exists = objOrigin.Extract
+	}
+
+	result := make([]interface{}, 0, 2)
+	result = append(result, searchStr)
+	result = append(result, escapeChar)
+	return json.CreateBinary(result), false, nil
 }
 
 type jsonStorageSizeFunctionClass struct {

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -908,13 +908,15 @@ func (c *jsonSearchFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 
 func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	// json_doc
-	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	var obj json.BinaryJSON
+	obj, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 
 	// one_or_all
-	containType, isNull, err := b.args[1].EvalString(b.ctx, row)
+	var containType string
+	containType, isNull, err = b.args[1].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
@@ -923,13 +925,15 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 	}
 
 	// search_str & escape_char
-	searchStr, isNull, err := b.args[2].EvalString(b.ctx, row)
+	var searchStr string
+	searchStr, isNull, err = b.args[2].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
 	escape := byte('\\')
 	if len(b.args) >= 4 {
-		escapeStr, isNull, err := b.args[3].EvalString(b.ctx, row)
+		var escapeStr string
+		escapeStr, isNull, err = b.args[3].EvalString(b.ctx, row)
 		if err != nil {
 			return res, isNull, errors.Trace(err)
 		}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -984,9 +984,15 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 			}
 			pathExprs = append(pathExprs, pathExpr)
 		}
-		obj.Walk(walkFn, pathExprs...)
+		err = obj.Walk(walkFn, pathExprs...)
+		if err != nil {
+			return res, true, errors.Trace(err)
+		}
 	} else {
-		obj.Walk(walkFn)
+		err = obj.Walk(walkFn)
+		if err != nil {
+			return res, true, errors.Trace(err)
+		}
 	}
 
 	// return

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
@@ -905,11 +906,11 @@ func (c *jsonSearchFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 
 func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNull bool, err error) {
 	// json_doc
-	objOrigin, isNull, err := b.args[0].EvalJSON(b.ctx, row)
+	obj, isNull, err := b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, errors.Trace(err)
 	}
-	fmt.Println("[objOrigin]", objOrigin)
+	fmt.Println("[obj]", obj)
 
 	// one_or_all
 	containType, isNull, err := b.args[1].EvalString(b.ctx, row)
@@ -939,9 +940,22 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 	}
 	fmt.Println("[escapeChar]", escapeChar)
 
-	// path...
-	var obj json.BinaryJSON
-	if len(b.args) >= 5 {
+	// result
+	result := make([]interface{}, 0)
+
+	// walk json_doc
+	walkFn := func(fullpath json.PathExpression, bj json.BinaryJSON) (stop bool, err error) {
+		fmt.Println(fullpath, bj)
+
+		if bj.TypeCode == json.TypeCodeString && string(bj.GetString()) == searchStr {
+			result = append(result, fullpath.String())
+			if containType == json.ContainsPathOne {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	if len(b.args) >= 5 { // path...
 		pathExprs := make([]json.PathExpression, 0, len(b.args)-4)
 		for i := 4; i < len(b.args); i++ {
 			var s string
@@ -956,13 +970,19 @@ func (b *builtinJSONSearchSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isN
 			}
 			pathExprs = append(pathExprs, pathExpr)
 		}
-		obj, exists = objOrigin.Extract
+		obj.Walk(walkFn, pathExprs...)
+	} else {
+		obj.Walk(walkFn)
 	}
 
-	result := make([]interface{}, 0, 2)
-	result = append(result, searchStr)
-	result = append(result, escapeChar)
-	return json.CreateBinary(result), false, nil
+	switch len(result) {
+	case 0:
+		return res, true, nil
+	case 1:
+		return json.CreateBinary(result[0]), false, nil
+	default:
+		return json.CreateBinary(result), false, nil
+	}
 }
 
 type jsonStorageSizeFunctionClass struct {

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -16,8 +16,6 @@ package expression
 import (
 	"strings"
 
-	"fmt"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -773,3 +773,74 @@ func (s *testEvaluatorSuite) TestJSONArrayAppend(c *C) {
 		c.Assert(json.CompareBinary(j1, d.GetMysqlJSON()), Equals, 0, comment)
 	}
 }
+
+func (s *testEvaluatorSuite) TestJSONSearch(c *C) {
+	defer testleak.AfterTest(c)()
+	fc := funcs[ast.JSONSearch]
+	jsonString := `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`
+	jsonString2 := `["abc", [{"k": "10"}, "def"], {"x":"ab%d"}, {"y":"abcd"}]`
+	tbl := []struct {
+		input    []interface{}
+		expected interface{}
+		success  bool
+	}{
+		// simple case
+		{[]interface{}{jsonString, `one`, `abc`}, `"$[0]"`, true},
+		{[]interface{}{jsonString, `all`, `abc`}, `["$[0]", "$[2].x"]`, true},
+		{[]interface{}{jsonString, `all`, `ghi`}, nil, true},
+		{[]interface{}{jsonString, `all`, `10`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$[*]`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$**.k`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$[*][0].k`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$[1]`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `10`, nil, `$[1][0]`}, `"$[1][0].k"`, true},
+		{[]interface{}{jsonString, `all`, `abc`, nil, `$[2]`}, `"$[2].x"`, true},
+
+		// search pattern
+		{[]interface{}{jsonString, `all`, `%a%`}, `["$[0]", "$[2].x"]`, true},
+		{[]interface{}{jsonString, `all`, `%b%`}, `["$[0]", "$[2].x", "$[3].y"]`, true},
+		{[]interface{}{jsonString, `all`, `%b%`, nil, `$[0]`}, `"$[0]"`, true},
+		{[]interface{}{jsonString, `all`, `%b%`, nil, `$[2]`}, `"$[2].x"`, true},
+		{[]interface{}{jsonString, `all`, `%b%`, nil, `$[1]`}, nil, true},
+		{[]interface{}{jsonString, `all`, `%b%`, ``, `$[1]`}, nil, true},
+		{[]interface{}{jsonString, `all`, `%b%`, nil, `$[3]`}, `"$[3].y"`, true},
+		{[]interface{}{jsonString2, `all`, `ab_d`}, `["$[2].x", "$[3].y"]`, true},
+
+		// escape char
+		{[]interface{}{jsonString2, `all`, `ab%d`}, `["$[2].x", "$[3].y"]`, true},
+		{[]interface{}{jsonString2, `all`, `ab\%d`}, `"$[2].x"`, true},
+		{[]interface{}{jsonString2, `all`, `ab|%d`, `|`}, `"$[2].x"`, true},
+
+		// error handle
+		{[]interface{}{nil, `all`, `abc`}, nil, true},                     // NULL json
+		{[]interface{}{`a`, `all`, `abc`}, nil, false},                    // non json
+		{[]interface{}{jsonString, `wrong`, `abc`}, nil, false},           // wrong one_or_all
+		{[]interface{}{jsonString, `all`, nil}, nil, true},                // NULL search_str
+		{[]interface{}{jsonString, `all`, `abc`, `??`}, nil, false},       // wrong escape_char
+		{[]interface{}{jsonString, `all`, `abc`, nil, nil}, nil, true},    // NULL path
+		{[]interface{}{jsonString, `all`, `abc`, nil, `$xx`}, nil, false}, // wrong path
+	}
+	for _, t := range tbl {
+		args := types.MakeDatums(t.input...)
+		f, err := fc.getFunction(s.ctx, s.datumsToConstants(args))
+		c.Assert(err, IsNil)
+		d, err := evalBuiltinFunc(f, chunk.Row{})
+		if t.success {
+			c.Assert(err, IsNil)
+			switch x := t.expected.(type) {
+			case string:
+				j1, err := json.ParseBinaryFromString(x)
+				c.Assert(err, IsNil)
+				j2 := d.GetMysqlJSON()
+				cmp := json.CompareBinary(j1, j2)
+				//fmt.Println(j1, j2)
+				c.Assert(cmp, Equals, 0)
+			case nil:
+				c.Assert(d.IsNull(), IsTrue)
+			}
+		} else {
+			c.Assert(err, NotNil)
+		}
+	}
+}

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -796,6 +796,8 @@ func (s *testEvaluatorSuite) TestJSONSearch(c *C) {
 		{[]interface{}{jsonString, `all`, `10`, nil, `$[1]`}, `"$[1][0].k"`, true},
 		{[]interface{}{jsonString, `all`, `10`, nil, `$[1][0]`}, `"$[1][0].k"`, true},
 		{[]interface{}{jsonString, `all`, `abc`, nil, `$[2]`}, `"$[2].x"`, true},
+		{[]interface{}{jsonString, `all`, `abc`, nil, `$[2]`, `$[0]`}, `["$[2].x", "$[0]"]`, true},
+		{[]interface{}{jsonString, `all`, `abc`, nil, `$[2]`, `$[2]`}, `"$[2].x"`, true},
 
 		// search pattern
 		{[]interface{}{jsonString, `all`, `%a%`}, `["$[0]", "$[2].x"]`, true},
@@ -830,9 +832,10 @@ func (s *testEvaluatorSuite) TestJSONSearch(c *C) {
 			c.Assert(err, IsNil)
 			switch x := t.expected.(type) {
 			case string:
-				j1, err := json.ParseBinaryFromString(x)
+				var j1, j2 json.BinaryJSON
+				j1, err = json.ParseBinaryFromString(x)
 				c.Assert(err, IsNil)
-				j2 := d.GetMysqlJSON()
+				j2 = d.GetMysqlJSON()
 				cmp := json.CompareBinary(j1, j2)
 				//fmt.Println(j1, j2)
 				c.Assert(cmp, Equals, 0)

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -444,6 +444,8 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinJSONLengthSig{base}
 	case tipb.ScalarFuncSig_JsonDepthSig:
 		f = &builtinJSONDepthSig{base}
+	case tipb.ScalarFuncSig_JsonSearchSig:
+		f = &builtinJSONSearchSig{base}
 
 	case tipb.ScalarFuncSig_InInt:
 		f = &builtinInIntSig{base}

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -112,13 +112,13 @@ func (s *testEvalSuite) TestEval(c *C) {
 		{
 			scalarFunctionExpr(tipb.ScalarFuncSig_JsonSearchSig,
 				toPBFieldType(newJSONFieldType()),
-				jsonDatumExpr(`["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`),
-				datumExpr(types.NewBytesDatum([]byte(`all`))),
-				datumExpr(types.NewBytesDatum([]byte(`10`))),
-				datumExpr(types.NewBytesDatum([]byte(`\`))),
-				datumExpr(types.NewBytesDatum([]byte(`$**.k`))),
+				jsonDatumExpr(c, `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`),
+				datumExpr(c, types.NewBytesDatum([]byte(`all`))),
+				datumExpr(c, types.NewBytesDatum([]byte(`10`))),
+				datumExpr(c, types.NewBytesDatum([]byte(`\`))),
+				datumExpr(c, types.NewBytesDatum([]byte(`$**.k`))),
 			),
-			newJSONDatum(`"$[1][0].k"`),
+			newJSONDatum(c, `"$[1][0].k"`),
 		},
 	}
 	sc := new(stmtctx.StatementContext)
@@ -190,21 +190,15 @@ func datumExpr(c *C, d types.Datum) *tipb.Expr {
 	return expr
 }
 
-func newJSONDatum(s string) (d types.Datum) {
+func newJSONDatum(c *C, s string) (d types.Datum) {
 	j, err := json.ParseBinaryFromString(s)
-	if err != nil {
-		log.Warnf("err happened when json.ParseBinaryFromString in newJSONDatum:%s", err.Error())
-	}
+	c.Assert(err, IsNil)
 	d.SetMysqlJSON(j)
 	return d
 }
 
 func jsonDatumExpr(c *C, s string) *tipb.Expr {
-	var d types.Datum
-	j, err := json.ParseBinaryFromString(s)
-	c.Assert(err, IsNil)
-	d.SetMysqlJSON(j)
-	return datumExpr(c, d)
+	return datumExpr(c, newJSONDatum(c, s))
 }
 
 func columnExpr(columnID int64) *tipb.Expr {

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
@@ -108,6 +109,17 @@ func (s *testEvalSuite) TestEval(c *C) {
 			),
 			types.NewIntDatum(3),
 		},
+		{
+			scalarFunctionExpr(tipb.ScalarFuncSig_JsonSearchSig,
+				toPBFieldType(newJSONFieldType()),
+				jsonDatumExpr(`["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`),
+				datumExpr(types.NewBytesDatum([]byte(`all`))),
+				datumExpr(types.NewBytesDatum([]byte(`10`))),
+				datumExpr(types.NewBytesDatum([]byte(`\`))),
+				datumExpr(types.NewBytesDatum([]byte(`$**.k`))),
+			),
+			newJSONDatum(`"$[1][0].k"`),
+		},
 	}
 	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
@@ -178,6 +190,15 @@ func datumExpr(c *C, d types.Datum) *tipb.Expr {
 	return expr
 }
 
+func newJSONDatum(s string) (d types.Datum) {
+	j, err := json.ParseBinaryFromString(s)
+	if err != nil {
+		log.Warnf("err happened when json.ParseBinaryFromString in newJSONDatum:%s", err.Error())
+	}
+	d.SetMysqlJSON(j)
+	return d
+}
+
 func jsonDatumExpr(c *C, s string) *tipb.Expr {
 	var d types.Datum
 	j, err := json.ParseBinaryFromString(s)
@@ -211,6 +232,16 @@ func newIntFieldType() *types.FieldType {
 		Flen:    mysql.MaxIntWidth,
 		Decimal: 0,
 		Flag:    mysql.BinaryFlag,
+	}
+}
+
+func newJSONFieldType() *types.FieldType {
+	return &types.FieldType{
+		Tp:      mysql.TypeJSON,
+		Flen:    types.UnspecifiedLength,
+		Decimal: 0,
+		Charset: charset.CharsetBin,
+		Collate: charset.CollationBin,
 	}
 }
 

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -149,7 +149,7 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	return
 }
 
-// quoteString escape spe for JSON_QUOTE
+// quoteString escapes interior quote and other characters for JSON_QUOTE
 // https://dev.mysql.com/doc/refman/5.7/en/json-creation-functions.html#function_json-quote
 // TODO: add JSON_QUOTE builtin
 func quoteString(s string) string {
@@ -967,7 +967,8 @@ func (bj BinaryJSON) Walk(walkFn BinaryJSONWalkFunc, pathExprList ...PathExpress
 	fullpath := PathExpression{legs: make([]pathLeg, 0, 32), flags: pathExpressionFlag(0)}
 	if len(pathExprList) > 0 {
 		for _, pathExpr := range pathExprList {
-			stop, err := bj.extractToCallback(pathExpr, doWalk, fullpath)
+			var stop bool
+			stop, err = bj.extractToCallback(pathExpr, doWalk, fullpath)
 			if stop || err != nil {
 				return err
 			}

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -819,7 +819,7 @@ func (bj BinaryJSON) extractToCallback(pathExpr PathExpression, callbackFn extra
 		if currentLeg.dotKey == "*" {
 			for i := 0; i < elemCount; i++ {
 				//buf = bj.objectGetVal(i).extractTo(buf, subPathExpr)
-				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				path := fullpath.pushBackOneKeyLeg(string(bj.objectGetKey(i)))
 				stop, err = bj.objectGetVal(i).extractToCallback(subPathExpr, callbackFn, path)
 				if stop || err != nil {
 					return
@@ -857,7 +857,7 @@ func (bj BinaryJSON) extractToCallback(pathExpr PathExpression, callbackFn extra
 			elemCount := bj.GetElemCount()
 			for i := 0; i < elemCount; i++ {
 				//buf = bj.objectGetVal(i).extractTo(buf, pathExpr)
-				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				path := fullpath.pushBackOneKeyLeg(string(bj.objectGetKey(i)))
 				stop, err = bj.objectGetVal(i).extractToCallback(pathExpr, callbackFn, path)
 				if stop || err != nil {
 					return
@@ -892,7 +892,7 @@ func (bj BinaryJSON) Walk(walkFn BinaryJSONWalkFunc, pathExprList ...PathExpress
 		} else if bj.TypeCode == TypeCodeObject {
 			elemCount := bj.GetElemCount()
 			for i := 0; i < elemCount; i++ {
-				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				path := fullpath.pushBackOneKeyLeg(string(bj.objectGetKey(i)))
 				stop, err = doWalk(path, bj.objectGetVal(i))
 				if stop || err != nil {
 					return

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -935,9 +935,17 @@ type BinaryJSONWalkFunc func(fullpath PathExpression, bj BinaryJSON) (stop bool,
 
 // Walk traverse BinaryJSON objects
 func (bj BinaryJSON) Walk(walkFn BinaryJSONWalkFunc, pathExprList ...PathExpression) (err error) {
+	pathSet := make(map[string]bool)
+
 	var doWalk extractCallbackFn
 	doWalk = func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error) {
+		pathStr := fullpath.String()
+		if _, ok := pathSet[pathStr]; ok {
+			return false, nil
+		}
+
 		stop, err = walkFn(fullpath, bj)
+		pathSet[pathStr] = true
 		if stop || err != nil {
 			return
 		}

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -778,3 +778,143 @@ func (bj BinaryJSON) GetElemDepth() int {
 		return 1
 	}
 }
+
+// extractCallbackFn: the type of CALLBACK function for extractToCallback
+type extractCallbackFn func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error)
+
+// extractToCallback: callback alternative of extractTo
+// NOTICE: path [0] for JSON object other than array is INVALID, which is different from extractTo.
+//         Which is caused by the difference between JSON_SEARCH and JSON_EXTRACT.
+//            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$.a');                       ==> "1"
+//            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$[0].a');                    ==> "1"
+//            SELECT  JSON_SEARCH('{"a":"1", "b":2}', 'all', '1', NULL, '$.a');     ==> "$.a"
+//            SELECT  JSON_SEARCH('{"a":"1", "b":2}', 'all', '1', NULL, '$[0].a');  ==> NULL
+func (bj BinaryJSON) extractToCallback(pathExpr PathExpression, callbackFn extractCallbackFn, fullpath PathExpression) (stop bool, err error) {
+	if len(pathExpr.legs) == 0 {
+		return callbackFn(fullpath, bj)
+	}
+
+	currentLeg, subPathExpr := pathExpr.popOneLeg()
+	if currentLeg.typ == pathLegIndex && bj.TypeCode == TypeCodeArray {
+		elemCount := bj.GetElemCount()
+		if currentLeg.arrayIndex == arrayIndexAsterisk {
+			for i := 0; i < elemCount; i++ {
+				//buf = bj.arrayGetElem(i).extractTo(buf, subPathExpr)
+				path := fullpath.pushBackOneIndexLeg(i)
+				stop, err = bj.arrayGetElem(i).extractToCallback(subPathExpr, callbackFn, path)
+				if stop || err != nil {
+					return
+				}
+			}
+		} else if currentLeg.arrayIndex < elemCount {
+			//buf = bj.arrayGetElem(currentLeg.arrayIndex).extractTo(buf, subPathExpr)
+			path := fullpath.pushBackOneIndexLeg(currentLeg.arrayIndex)
+			stop, err = bj.arrayGetElem(currentLeg.arrayIndex).extractToCallback(subPathExpr, callbackFn, path)
+			if stop || err != nil {
+				return
+			}
+		}
+	} else if currentLeg.typ == pathLegKey && bj.TypeCode == TypeCodeObject {
+		elemCount := bj.GetElemCount()
+		if currentLeg.dotKey == "*" {
+			for i := 0; i < elemCount; i++ {
+				//buf = bj.objectGetVal(i).extractTo(buf, subPathExpr)
+				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				stop, err = bj.objectGetVal(i).extractToCallback(subPathExpr, callbackFn, path)
+				if stop || err != nil {
+					return
+				}
+			}
+		} else {
+			child, ok := bj.objectSearchKey(hack.Slice(currentLeg.dotKey))
+			if ok {
+				//buf = child.extractTo(buf, subPathExpr)
+				path := fullpath.pushBackOneKeyLeg(currentLeg.dotKey)
+				stop, err = child.extractToCallback(subPathExpr, callbackFn, path)
+				if stop || err != nil {
+					return
+				}
+			}
+		}
+	} else if currentLeg.typ == pathLegDoubleAsterisk {
+		//buf = bj.extractTo(buf, subPathExpr)
+		stop, err = bj.extractToCallback(subPathExpr, callbackFn, fullpath)
+		if stop || err != nil {
+			return
+		}
+
+		if bj.TypeCode == TypeCodeArray {
+			elemCount := bj.GetElemCount()
+			for i := 0; i < elemCount; i++ {
+				//buf = bj.arrayGetElem(i).extractTo(buf, pathExpr)
+				path := fullpath.pushBackOneIndexLeg(i)
+				stop, err = bj.arrayGetElem(i).extractToCallback(pathExpr, callbackFn, path)
+				if stop || err != nil {
+					return
+				}
+			}
+		} else if bj.TypeCode == TypeCodeObject {
+			elemCount := bj.GetElemCount()
+			for i := 0; i < elemCount; i++ {
+				//buf = bj.objectGetVal(i).extractTo(buf, pathExpr)
+				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				stop, err = bj.objectGetVal(i).extractToCallback(pathExpr, callbackFn, path)
+				if stop || err != nil {
+					return
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+// BinaryJSONWalkFunc is used as callback function for BinaryJSON.Walk
+type BinaryJSONWalkFunc func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error)
+
+// Walk traverse BinaryJSON objects
+func (bj BinaryJSON) Walk(walkFn BinaryJSONWalkFunc, pathExprList ...PathExpression) (err error) {
+	var doWalk extractCallbackFn
+	doWalk = func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error) {
+		stop, err = walkFn(fullpath, bj)
+		if stop || err != nil {
+			return
+		}
+
+		if bj.TypeCode == TypeCodeArray {
+			elemCount := bj.GetElemCount()
+			for i := 0; i < elemCount; i++ {
+				path := fullpath.pushBackOneIndexLeg(i)
+				stop, err = doWalk(path, bj.arrayGetElem(i))
+				if stop || err != nil {
+					return
+				}
+			}
+		} else if bj.TypeCode == TypeCodeObject {
+			elemCount := bj.GetElemCount()
+			for i := 0; i < elemCount; i++ {
+				path := fullpath.pushBackOneKeyLeg(hack.String(bj.objectGetKey(i)))
+				stop, err = doWalk(path, bj.objectGetVal(i))
+				if stop || err != nil {
+					return
+				}
+			}
+		}
+		return false, nil
+	}
+
+	fullpath := PathExpression{legs: make([]pathLeg, 0, 32), flags: pathExpressionFlag(0)}
+	if len(pathExprList) > 0 {
+		for _, pathExpr := range pathExprList {
+			stop, err := bj.extractToCallback(pathExpr, doWalk, fullpath)
+			if stop || err != nil {
+				return err
+			}
+		}
+	} else {
+		_, err = doWalk(fullpath, bj)
+		if err != nil {
+			return
+		}
+	}
+	return nil
+}

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -149,6 +149,67 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	return
 }
 
+// quoteString escape spe for JSON_QUOTE
+// https://dev.mysql.com/doc/refman/5.7/en/json-creation-functions.html#function_json-quote
+// TODO: add JSON_QUOTE builtin
+func quoteString(s string) string {
+	var escapeByteMap = map[byte]string{
+		'\\': "\\\\",
+		'"':  "\\\"",
+		'\b': "\\b",
+		'\f': "\\f",
+		'\n': "\\n",
+		'\r': "\\r",
+		'\t': "\\t",
+	}
+
+	ret := new(bytes.Buffer)
+	ret.WriteByte('"')
+
+	start := 0
+	hasEscaped := false
+
+	for i := 0; i < len(s); {
+		if b := s[i]; b < utf8.RuneSelf {
+			escaped, ok := escapeByteMap[b]
+			if ok {
+				if start < i {
+					ret.WriteString(s[start:i])
+				}
+				hasEscaped = true
+				ret.WriteString(escaped)
+				i++
+				start = i
+			} else {
+				i++
+			}
+		} else {
+			c, size := utf8.DecodeRune([]byte(s[i:]))
+			if c == utf8.RuneError && size == 1 { // refer to codes of `binary.marshalStringTo`
+				if start < i {
+					ret.WriteString(s[start:i])
+				}
+				hasEscaped = true
+				ret.WriteString(`\ufffd`)
+				i += size
+				start = i
+				continue
+			}
+			i += size
+		}
+	}
+
+	if start < len(s) {
+		ret.WriteString(s[start:])
+	}
+
+	if hasEscaped {
+		ret.WriteByte('"')
+		return ret.String()
+	}
+	return ret.String()[1:]
+}
+
 // Extract receives several path expressions as arguments, matches them in bj, and returns:
 //  ret: target JSON matched any path expressions. maybe autowrapped as an array.
 //  found: true if any path expressions matched.

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -846,11 +846,6 @@ type extractCallbackFn func(fullpath PathExpression, bj BinaryJSON) (stop bool, 
 // extractToCallback: callback alternative of extractTo
 //     would be more effective when walk through the whole JSON is unnecessary
 // NOTICE: path [0] & [*] for JSON object other than array is INVALID, which is different from extractTo.
-//         Due to the difference between JSON_SEARCH and JSON_EXTRACT.
-//            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$.a');                       ==> "1"
-//            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$[0].a');                    ==> "1"
-//            SELECT  JSON_SEARCH('{"a":"1", "b":2}', 'all', '1', NULL, '$.a');     ==> "$.a"
-//            SELECT  JSON_SEARCH('{"a":"1", "b":2}', 'all', '1', NULL, '$[0].a');  ==> NULL
 func (bj BinaryJSON) extractToCallback(pathExpr PathExpression, callbackFn extractCallbackFn, fullpath PathExpression) (stop bool, err error) {
 	if len(pathExpr.legs) == 0 {
 		return callbackFn(fullpath, bj)

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -783,8 +783,9 @@ func (bj BinaryJSON) GetElemDepth() int {
 type extractCallbackFn func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error)
 
 // extractToCallback: callback alternative of extractTo
-// NOTICE: path [0] for JSON object other than array is INVALID, which is different from extractTo.
-//         Which is caused by the difference between JSON_SEARCH and JSON_EXTRACT.
+//     would be more effective when walk through the whole JSON is unnecessary
+// NOTICE: path [0] & [*] for JSON object other than array is INVALID, which is different from extractTo.
+//         Due to the difference between JSON_SEARCH and JSON_EXTRACT.
 //            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$.a');                       ==> "1"
 //            SELECT JSON_EXTRACT('{"a":"1", "b":2}', '$[0].a');                    ==> "1"
 //            SELECT  JSON_SEARCH('{"a":"1", "b":2}', 'all', '1', NULL, '$.a');     ==> "$.a"

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -420,3 +420,70 @@ func (s *testJSONSuite) TestFunctions(c *C) {
 	c.Assert(n, Equals, 0)
 	c.Assert(err, ErrorMatches, "Cant peek from empty bytes")
 }
+
+func (s *testJSONSuite) TestBinaryJSONExtractCallback(c *C) {
+	bj1 := mustParseBinaryFromString(c, `{"\"hello\"": "world", "a": [1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}], "b": true, "c": ["d"]}`)
+	bj2 := mustParseBinaryFromString(c, `[{"a": 1, "b": true}, 3, 3.5, "hello, world", null, true]`)
+
+	type ExpectedPair struct {
+		path string
+		bj   BinaryJSON
+	}
+	var tests = []struct {
+		bj       BinaryJSON
+		pathExpr string
+		expected []ExpectedPair
+	}{
+		/*FAIL {bj1, "$.a", []ExpectedPair{
+			{"$.a", mustParseBinaryFromString(c, `[1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}]`)},
+		}},*/
+		{bj2, "$.a", []ExpectedPair{}},
+		{bj1, "$[0]", []ExpectedPair{}}, // in extractToCallback/Walk/Search, DON'T autowraped bj as an array.
+		/*FAIL {bj2, "$[0]", []ExpectedPair{
+			{"$[0]", mustParseBinaryFromString(c, `{"a": 1, "b": true}`)},
+		}},*/
+		/*FAIL {bj1, "$.a[2].aa", []ExpectedPair{
+			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
+		}},*/
+		{bj1, "$.a[*].aa", []ExpectedPair{
+			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
+			{"$.a[4].aa", mustParseBinaryFromString(c, `"cc"`)},
+		}},
+		{bj1, "$.*[0]", []ExpectedPair{
+			// {"$.\"hello\"[0]", mustParseBinaryFromString(c, `"world"`)},  // NO autowraped as an array.
+			{"$.a[0]", mustParseBinaryFromString(c, `1`)},
+			// {"$.b[0]", mustParseBinaryFromString(c, `true`)},  // NO autowraped as an array.
+			{"$.c[0]", mustParseBinaryFromString(c, `"d"`)},
+		}},
+		{bj1, `$.a[*]."aa"`, []ExpectedPair{
+			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
+			{"$.a[4].aa", mustParseBinaryFromString(c, `"cc"`)},
+		}},
+		/*FAIL {bj1, `$."hello"`, []ExpectedPair{
+			{`$."hello"`, mustParseBinaryFromString(c, `"world"`)},
+		}},*/
+		/*FAIL {bj1, `$**[1]`, []ExpectedPair{
+			{`$.a[1]`, mustParseBinaryFromString(c, `"2"`)},
+		}},*/
+	}
+
+	for _, tt := range tests {
+		pe, err := ParseJSONPathExpr(tt.pathExpr)
+		c.Assert(err, IsNil)
+
+		count := 0
+		cb := func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error) {
+			c.Assert(count, Less, len(tt.expected))
+			if count < len(tt.expected) {
+				c.Assert(fullpath.String(), Equals, tt.expected[count].path)
+				c.Assert(bj.String(), Equals, tt.expected[count].bj.String())
+			}
+			count++
+			return false, nil
+		}
+		fullpath := PathExpression{legs: make([]pathLeg, 0), flags: pathExpressionFlag(0)}
+		_, err = tt.bj.extractToCallback(pe, cb, fullpath)
+		c.Assert(err, IsNil)
+		c.Assert(count, Equals, len(tt.expected))
+	}
+}

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -132,6 +132,27 @@ func (s *testJSONSuite) TestBinaryJSONUnquote(c *C) {
 	}
 }
 
+func (s *testJSONSuite) TestQuoteString(c *C) {
+	var tests = []struct {
+		j      string
+		quoted string
+	}{
+		{j: "3", quoted: `3`},
+		{j: "hello, \"escaped quotes\" world", quoted: `"hello, \"escaped quotes\" world"`},
+		{j: "你", quoted: `你`},
+		{j: "true", quoted: `true`},
+		{j: "null", quoted: `null`},
+		{j: `"`, quoted: `"\""`},
+		{j: `'`, quoted: `'`},
+		{j: `''`, quoted: `''`},
+		{j: ``, quoted: ``},
+		{j: "\\ \" \b \f \n \r \t", quoted: `"\\ \" \b \f \n \r \t"`},
+	}
+	for _, tt := range tests {
+		c.Assert(quoteString(tt.j), Equals, tt.quoted)
+	}
+}
+
 func (s *testJSONSuite) TestBinaryJSONModify(c *C) {
 	c.Parallel()
 	var tests = []struct {
@@ -434,17 +455,17 @@ func (s *testJSONSuite) TestBinaryJSONExtractCallback(c *C) {
 		pathExpr string
 		expected []ExpectedPair
 	}{
-		/*FAIL {bj1, "$.a", []ExpectedPair{
+		{bj1, "$.a", []ExpectedPair{
 			{"$.a", mustParseBinaryFromString(c, `[1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}]`)},
-		}},*/
+		}},
 		{bj2, "$.a", []ExpectedPair{}},
 		{bj1, "$[0]", []ExpectedPair{}}, // in extractToCallback/Walk/Search, DON'T autowraped bj as an array.
-		/*FAIL {bj2, "$[0]", []ExpectedPair{
+		{bj2, "$[0]", []ExpectedPair{
 			{"$[0]", mustParseBinaryFromString(c, `{"a": 1, "b": true}`)},
-		}},*/
-		/*FAIL {bj1, "$.a[2].aa", []ExpectedPair{
+		}},
+		{bj1, "$.a[2].aa", []ExpectedPair{
 			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
-		}},*/
+		}},
 		{bj1, "$.a[*].aa", []ExpectedPair{
 			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
 			{"$.a[4].aa", mustParseBinaryFromString(c, `"cc"`)},
@@ -459,12 +480,12 @@ func (s *testJSONSuite) TestBinaryJSONExtractCallback(c *C) {
 			{"$.a[2].aa", mustParseBinaryFromString(c, `"bb"`)},
 			{"$.a[4].aa", mustParseBinaryFromString(c, `"cc"`)},
 		}},
-		/*FAIL {bj1, `$."hello"`, []ExpectedPair{
-			{`$."hello"`, mustParseBinaryFromString(c, `"world"`)},
-		}},*/
-		/*FAIL {bj1, `$**[1]`, []ExpectedPair{
+		{bj1, `$."\"hello\""`, []ExpectedPair{
+			{`$."\"hello\""`, mustParseBinaryFromString(c, `"world"`)},
+		}},
+		{bj1, `$**[1]`, []ExpectedPair{
 			{`$.a[1]`, mustParseBinaryFromString(c, `"2"`)},
-		}},*/
+		}},
 	}
 
 	for _, tt := range tests {
@@ -483,6 +504,69 @@ func (s *testJSONSuite) TestBinaryJSONExtractCallback(c *C) {
 		}
 		fullpath := PathExpression{legs: make([]pathLeg, 0), flags: pathExpressionFlag(0)}
 		_, err = tt.bj.extractToCallback(pe, cb, fullpath)
+		c.Assert(err, IsNil)
+		c.Assert(count, Equals, len(tt.expected))
+	}
+}
+
+func (s *testJSONSuite) TestBinaryJSONWalk(c *C) {
+	bj1 := mustParseBinaryFromString(c, `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`)
+	bj2 := mustParseBinaryFromString(c, `{}`)
+
+	type ExpectedPair struct {
+		path string
+		bj   BinaryJSON
+	}
+	var tests = []struct {
+		bj       BinaryJSON
+		pathExpr string
+		expected []ExpectedPair
+	}{
+		{bj1, ``, []ExpectedPair{
+			{`$`, mustParseBinaryFromString(c, `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`)},
+			{`$[0]`, mustParseBinaryFromString(c, `"abc"`)},
+			{`$[1]`, mustParseBinaryFromString(c, `[{"k": "10"}, "def"]`)},
+			{`$[1][0]`, mustParseBinaryFromString(c, `{"k": "10"}`)},
+			{`$[1][0].k`, mustParseBinaryFromString(c, `"10"`)},
+			{`$[1][1]`, mustParseBinaryFromString(c, `"def"`)},
+			{`$[2]`, mustParseBinaryFromString(c, `{"x":"abc"}`)},
+			{`$[2].x`, mustParseBinaryFromString(c, `"abc"`)},
+			{`$[3]`, mustParseBinaryFromString(c, `{"y":"bcd"}`)},
+			{`$[3].y`, mustParseBinaryFromString(c, `"bcd"`)},
+		}},
+		{bj1, `$[1]`, []ExpectedPair{
+			{`$[1]`, mustParseBinaryFromString(c, `[{"k": "10"}, "def"]`)},
+			{`$[1][0]`, mustParseBinaryFromString(c, `{"k": "10"}`)},
+			{`$[1][0].k`, mustParseBinaryFromString(c, `"10"`)},
+			{`$[1][1]`, mustParseBinaryFromString(c, `"def"`)},
+		}},
+		{bj1, `$.m`, []ExpectedPair{}},
+		{bj2, ``, []ExpectedPair{
+			{`$`, mustParseBinaryFromString(c, `{}`)},
+		}},
+	}
+
+	for _, tt := range tests {
+		count := 0
+		cb := func(fullpath PathExpression, bj BinaryJSON) (stop bool, err error) {
+			c.Assert(count, Less, len(tt.expected))
+			if count < len(tt.expected) {
+				c.Assert(fullpath.String(), Equals, tt.expected[count].path)
+				c.Assert(bj.String(), Equals, tt.expected[count].bj.String())
+			}
+			count++
+			return false, nil
+		}
+
+		var err error
+		if len(tt.pathExpr) > 0 {
+			pe, errPath := ParseJSONPathExpr(tt.pathExpr)
+			c.Assert(errPath, IsNil)
+
+			err = tt.bj.Walk(cb, pe)
+		} else {
+			err = tt.bj.Walk(cb)
+		}
 		c.Assert(err, IsNil)
 		c.Assert(count, Equals, len(tt.expected))
 	}

--- a/types/json/path_expr.go
+++ b/types/json/path_expr.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/hack"
 )
 
 /*
@@ -117,6 +118,30 @@ func (pe PathExpression) popOneLastLeg() (PathExpression, pathLeg) {
 	return PathExpression{legs: pe.legs[:lastLegIdx]}, lastLeg
 }
 
+// pushBackOneIndexLeg pushback one leg of INDEX type
+func (pe PathExpression) pushBackOneIndexLeg(index int) PathExpression {
+	newPe := PathExpression{
+		legs:  append(pe.legs, pathLeg{typ: pathLegIndex, arrayIndex: index}),
+		flags: pe.flags,
+	}
+	if index == -1 {
+		newPe.flags |= pathExpressionContainsAsterisk
+	}
+	return newPe
+}
+
+// pushBackOneKeyLeg pushback one leg of KEY type
+func (pe PathExpression) pushBackOneKeyLeg(key string) PathExpression {
+	newPe := PathExpression{
+		legs:  append(pe.legs, pathLeg{typ: pathLegKey, dotKey: key}),
+		flags: pe.flags,
+	}
+	if key == "*" {
+		newPe.flags |= pathExpressionContainsAsterisk
+	}
+	return newPe
+}
+
 // ContainsAnyAsterisk returns true if pe contains any asterisk.
 func (pe PathExpression) ContainsAnyAsterisk() bool {
 	return pe.flags.containsAnyAsterisk()
@@ -211,4 +236,28 @@ func isBlank(c rune) bool {
 		return true
 	}
 	return false
+}
+
+func (pe PathExpression) String() string {
+	buf := make([]byte, 0)
+
+	buf = append(buf, '$')
+	for _, leg := range pe.legs {
+		switch leg.typ {
+		case pathLegIndex:
+			if leg.arrayIndex == -1 {
+				buf = append(buf, "[*]"...)
+			} else {
+				buf = append(buf, '[')
+				buf = append(buf, hack.Slice(strconv.Itoa(leg.arrayIndex))...)
+				buf = append(buf, ']')
+			}
+		case pathLegKey:
+			buf = append(buf, '.')
+			buf = append(buf, hack.Slice(leg.dotKey)...)
+		case pathLegDoubleAsterisk:
+			buf = append(buf, "**"...)
+		}
+	}
+	return string(buf)
 }

--- a/types/json/path_expr.go
+++ b/types/json/path_expr.go
@@ -253,7 +253,7 @@ func (pe PathExpression) String() string {
 			}
 		case pathLegKey:
 			s.WriteString(".")
-			s.WriteString(leg.dotKey)
+			s.WriteString(quoteString(leg.dotKey))
 		case pathLegDoubleAsterisk:
 			s.WriteString("**")
 		}

--- a/types/json/path_expr.go
+++ b/types/json/path_expr.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/util/hack"
 )
 
 /*
@@ -239,25 +238,25 @@ func isBlank(c rune) bool {
 }
 
 func (pe PathExpression) String() string {
-	buf := make([]byte, 0)
+	var s strings.Builder
 
-	buf = append(buf, '$')
+	s.WriteString("$")
 	for _, leg := range pe.legs {
 		switch leg.typ {
 		case pathLegIndex:
 			if leg.arrayIndex == -1 {
-				buf = append(buf, "[*]"...)
+				s.WriteString("[*]")
 			} else {
-				buf = append(buf, '[')
-				buf = append(buf, hack.Slice(strconv.Itoa(leg.arrayIndex))...)
-				buf = append(buf, ']')
+				s.WriteString("[")
+				s.WriteString(strconv.Itoa(leg.arrayIndex))
+				s.WriteString("]")
 			}
 		case pathLegKey:
-			buf = append(buf, '.')
-			buf = append(buf, hack.Slice(leg.dotKey)...)
+			s.WriteString(".")
+			s.WriteString(leg.dotKey)
 		case pathLegDoubleAsterisk:
-			buf = append(buf, "**"...)
+			s.WriteString("**")
 		}
 	}
-	return string(buf)
+	return s.String()
 }

--- a/types/json/path_expr_test.go
+++ b/types/json/path_expr_test.go
@@ -71,6 +71,7 @@ func (s *testJSONSuite) TestPathExprToString(c *C) {
 		{"$.a[*]"},
 		{"$.*[2]"},
 		{"$**.a[3]"},
+		{`$."\"hello\""`},
 	}
 	for _, tt := range tests {
 		pe, err := ParseJSONPathExpr(tt.exprString)

--- a/types/json/path_expr_test.go
+++ b/types/json/path_expr_test.go
@@ -62,3 +62,67 @@ func (s *testJSONSuite) TestValidatePathExpr(c *C) {
 		}
 	}
 }
+
+func (s *testJSONSuite) TestPathExprToString(c *C) {
+	var tests = []struct {
+		exprString string
+	}{
+		{"$.a[1]"},
+		{"$.a[*]"},
+		{"$.*[2]"},
+		{"$**.a[3]"},
+	}
+	for _, tt := range tests {
+		pe, err := ParseJSONPathExpr(tt.exprString)
+		c.Assert(err, IsNil)
+		c.Assert(pe.String(), Equals, tt.exprString)
+	}
+}
+
+func (s *testJSONSuite) TestPushBackOneIndexLeg(c *C) {
+	var tests = []struct {
+		exprString          string
+		index               int
+		expected            string
+		containsAnyAsterisk bool
+	}{
+		{"$", 1, "$[1]", false},
+		{"$.a[1]", 1, "$.a[1][1]", false},
+		{"$.a[1]", -1, "$.a[1][*]", true},
+		{"$.a[*]", 10, "$.a[*][10]", true},
+		{"$.*[2]", 2, "$.*[2][2]", true},
+		{"$**.a[3]", 3, "$**.a[3][3]", true},
+	}
+	for _, tt := range tests {
+		pe, err := ParseJSONPathExpr(tt.exprString)
+		c.Assert(err, IsNil)
+
+		pe = pe.pushBackOneIndexLeg(tt.index)
+		c.Assert(pe.String(), Equals, tt.expected)
+		c.Assert(pe.ContainsAnyAsterisk(), Equals, tt.containsAnyAsterisk)
+	}
+}
+
+func (s *testJSONSuite) TestPushBackOneKeyLeg(c *C) {
+	var tests = []struct {
+		exprString          string
+		key                 string
+		expected            string
+		containsAnyAsterisk bool
+	}{
+		{"$", "aa", "$.aa", false},
+		{"$.a[1]", "aa", "$.a[1].aa", false},
+		{"$.a[1]", "*", "$.a[1].*", true},
+		{"$.a[*]", "k", "$.a[*].k", true},
+		{"$.*[2]", "bb", "$.*[2].bb", true},
+		{"$**.a[3]", "cc", "$**.a[3].cc", true},
+	}
+	for _, tt := range tests {
+		pe, err := ParseJSONPathExpr(tt.exprString)
+		c.Assert(err, IsNil)
+
+		pe = pe.pushBackOneKeyLeg(tt.key)
+		c.Assert(pe.String(), Equals, tt.expected)
+		c.Assert(pe.ContainsAnyAsterisk(), Equals, tt.containsAnyAsterisk)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add json builtin function JSON_SEARCH described in #7546

### What is changed and how it works?
Add struct builtinJSONSearchSig, 2 functions for `walking` and utility for string quoting to BinaryJSON, and 3 utility function for json PathExpression

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test: YES
 - Integration test: YES
 - Manual test (add detailed scripts or steps below)
> mysql> 
> mysql> SET @j = '["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]';
> Query OK, 0 rows affected (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'one', 'abc');
> +-------------------------------+
> | JSON_SEARCH(@j, 'one', 'abc') |
> +-------------------------------+
> | "$[0]"                        |
> +-------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', 'abc');
> +-------------------------------+
> | JSON_SEARCH(@j, 'all', 'abc') |
> +-------------------------------+
> | ["$[0]", "$[2].x"]            |
> +-------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', 'ghi');
> +-------------------------------+
> | JSON_SEARCH(@j, 'all', 'ghi') |
> +-------------------------------+
> | NULL                          |
> +-------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10');
> +------------------------------+
> | JSON_SEARCH(@j, 'all', '10') |
> +------------------------------+
> | "$[1][0].k"                  |
> +------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$');
> +-----------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$') |
> +-----------------------------------------+
> | "$[1][0].k"                             |
> +-----------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$[*]');
> +--------------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$[*]') |
> +--------------------------------------------+
> | "$[1][0].k"                                |
> +--------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$**.k');
> +---------------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$**.k') |
> +---------------------------------------------+
> | "$[1][0].k"                                 |
> +---------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$[*][0].k');
> +-------------------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$[*][0].k') |
> +-------------------------------------------------+
> | "$[1][0].k"                                     |
> +-------------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$[1]');
> +--------------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$[1]') |
> +--------------------------------------------+
> | "$[1][0].k"                                |
> +--------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '10', NULL, '$[1][0]');
> +-----------------------------------------------+
> | JSON_SEARCH(@j, 'all', '10', NULL, '$[1][0]') |
> +-----------------------------------------------+
> | "$[1][0].k"                                   |
> +-----------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', 'abc', NULL, '$[2]');
> +---------------------------------------------+
> | JSON_SEARCH(@j, 'all', 'abc', NULL, '$[2]') |
> +---------------------------------------------+
> | "$[2].x"                                    |
> +---------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%a%');
> +-------------------------------+
> | JSON_SEARCH(@j, 'all', '%a%') |
> +-------------------------------+
> | ["$[0]", "$[2].x"]            |
> +-------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%');
> +-------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%') |
> +-------------------------------+
> | ["$[0]", "$[2].x", "$[3].y"]  |
> +-------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%', NULL, '$[0]');
> +---------------------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%', NULL, '$[0]') |
> +---------------------------------------------+
> | "$[0]"                                      |
> +---------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%', NULL, '$[2]');
> +---------------------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%', NULL, '$[2]') |
> +---------------------------------------------+
> | "$[2].x"                                    |
> +---------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%', NULL, '$[1]');
> +---------------------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%', NULL, '$[1]') |
> +---------------------------------------------+
> | NULL                                        |
> +---------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%', '', '$[1]');
> +-------------------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%', '', '$[1]') |
> +-------------------------------------------+
> | NULL                                      |
> +-------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j, 'all', '%b%', '', '$[3]');
> +-------------------------------------------+
> | JSON_SEARCH(@j, 'all', '%b%', '', '$[3]') |
> +-------------------------------------------+
> | "$[3].y"                                  |
> +-------------------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> 
> mysql> 
> mysql> set @j3 = '{"\\"hello世界\\"": "world", "a": [1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}], "b": true, "c": ["d"]}';
> Query OK, 0 rows affected (0.00 sec)
> 
> mysql> SELECT JSON_SEARCH(@j3, 'all', 'world');
> +----------------------------------+
> | JSON_SEARCH(@j3, 'all', 'world') |
> +----------------------------------+
> | "$.\"\\\"hello世界\\\"\""        |
> +----------------------------------+
> 1 row in set (0.00 sec)
> 
> mysql> 

Code changes

 - Has exported function/method change
    BinaryJSON.Walk, PathExpression.String

Side effects

 - NO

Related changes

 - Need to update the documentation
    JSON_SEARCH supported

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8704)
<!-- Reviewable:end -->
