### PR TITLE
executor: temorary replace 'active transaction fail' error to a more useful one

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
+	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
@@ -256,6 +257,9 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 		}
 		txn := sctx.Txn(true)
 		if !txn.Valid() {
+			if txnState, ok := txn.(*session.TxnState); ok && txnState.Fail() != nil {
+				return nil, txnState.Fail()
+			}
 			return nil, errors.New("active transaction fail")
 		}
 	}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -29,12 +29,12 @@ import (
 	"github.com/pingcap/tidb/model"
 	"github.com/pingcap/tidb/mysql"
 	"github.com/pingcap/tidb/plan"
-	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/terror"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -257,8 +257,8 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 		}
 		txn := sctx.Txn(true)
 		if !txn.Valid() {
-			if txnState, ok := txn.(*session.TxnState); ok && txnState.Fail() != nil {
-				return nil, txnState.Fail()
+			if failer, ok := txn.(sqlexec.Failer); ok && failer.Fail() != nil {
+				return nil, failer.Fail()
 			}
 			return nil, errors.New("active transaction fail")
 		}

--- a/session/txn.go
+++ b/session/txn.go
@@ -60,6 +60,11 @@ func (st *TxnState) Valid() bool {
 	return st.Transaction != nil && st.Transaction.Valid()
 }
 
+// Fail returns st.fail, TODO: remove this func after we removed the st.fail.
+func (st *TxnState) Fail() error {
+	return st.fail
+}
+
 func (st *TxnState) pending() bool {
 	return st.Transaction == nil && st.txnFuture != nil
 }

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -52,3 +52,9 @@ type SQLExecutor interface {
 type SQLParser interface {
 	ParseSQL(sql, charset, collation string) ([]ast.StmtNode, error)
 }
+
+// Failer is temporary interface to use Fail method
+// TODO: remove this after we remove TxnState.fail.
+type Failer interface {
+	Fail() error
+}


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Replace 'active transaction fail' error to the real error, like `[tikv:9001]PD server timeout[try again later]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8710)
<!-- Reviewable:end -->
