### PR TITLE
planner: specify order for every property column

### DIFF
--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -184,36 +184,36 @@ limit 100;
 id	count	task	operator info
 Projection_36	100.00	root	tpch.supplier.s_acctbal, tpch.supplier.s_name, tpch.nation.n_name, tpch.part.p_partkey, tpch.part.p_mfgr, tpch.supplier.s_address, tpch.supplier.s_phone, tpch.supplier.s_comment
 └─TopN_39	100.00	root	tpch.supplier.s_acctbal:desc, tpch.nation.n_name:asc, tpch.supplier.s_name:asc, tpch.part.p_partkey:asc, offset:0, count:100
-  └─HashRightJoin_41	155496.00	root	inner join, inner:HashLeftJoin_47, equal:[eq(tpch.part.p_partkey, tpch.partsupp.ps_partkey) eq(tpch.partsupp.ps_supplycost, min(ps_supplycost))]
-    ├─HashLeftJoin_47	155496.00	root	inner join, inner:TableReader_70, equal:[eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)]
-    │ ├─HashRightJoin_50	8155010.44	root	inner join, inner:HashRightJoin_52, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
-    │ │ ├─HashRightJoin_52	100000.00	root	inner join, inner:HashRightJoin_58, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-    │ │ │ ├─HashRightJoin_58	5.00	root	inner join, inner:TableReader_63, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
-    │ │ │ │ ├─TableReader_63	1.00	root	data:Selection_62
-    │ │ │ │ │ └─Selection_62	1.00	cop	eq(tpch.region.r_name, "ASIA")
-    │ │ │ │ │   └─TableScan_61	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-    │ │ │ │ └─TableReader_60	25.00	root	data:TableScan_59
-    │ │ │ │   └─TableScan_59	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-    │ │ │ └─TableReader_65	500000.00	root	data:TableScan_64
-    │ │ │   └─TableScan_64	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-    │ │ └─TableReader_67	40000000.00	root	data:TableScan_66
-    │ │   └─TableScan_66	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
-    │ └─TableReader_70	155496.00	root	data:Selection_69
-    │   └─Selection_69	155496.00	cop	eq(tpch.part.p_size, 30), like(tpch.part.p_type, "%STEEL", 92)
-    │     └─TableScan_68	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-    └─HashAgg_73	8155010.44	root	group by:tpch.partsupp.ps_partkey, funcs:min(tpch.partsupp.ps_supplycost), firstrow(tpch.partsupp.ps_partkey)
-      └─HashRightJoin_77	8155010.44	root	inner join, inner:HashRightJoin_79, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
-        ├─HashRightJoin_79	100000.00	root	inner join, inner:HashRightJoin_85, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-        │ ├─HashRightJoin_85	5.00	root	inner join, inner:TableReader_90, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
-        │ │ ├─TableReader_90	1.00	root	data:Selection_89
-        │ │ │ └─Selection_89	1.00	cop	eq(tpch.region.r_name, "ASIA")
-        │ │ │   └─TableScan_88	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_87	25.00	root	data:TableScan_86
-        │ │   └─TableScan_86	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ └─TableReader_92	500000.00	root	data:TableScan_91
-        │   └─TableScan_91	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        └─TableReader_94	40000000.00	root	data:TableScan_93
-          └─TableScan_93	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+  └─HashRightJoin_44	155496.00	root	inner join, inner:HashLeftJoin_50, equal:[eq(tpch.part.p_partkey, tpch.partsupp.ps_partkey) eq(tpch.partsupp.ps_supplycost, min(ps_supplycost))]
+    ├─HashLeftJoin_50	155496.00	root	inner join, inner:TableReader_73, equal:[eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)]
+    │ ├─HashRightJoin_53	8155010.44	root	inner join, inner:HashRightJoin_55, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
+    │ │ ├─HashRightJoin_55	100000.00	root	inner join, inner:HashRightJoin_61, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+    │ │ │ ├─HashRightJoin_61	5.00	root	inner join, inner:TableReader_66, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
+    │ │ │ │ ├─TableReader_66	1.00	root	data:Selection_65
+    │ │ │ │ │ └─Selection_65	1.00	cop	eq(tpch.region.r_name, "ASIA")
+    │ │ │ │ │   └─TableScan_64	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+    │ │ │ │ └─TableReader_63	25.00	root	data:TableScan_62
+    │ │ │ │   └─TableScan_62	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+    │ │ │ └─TableReader_68	500000.00	root	data:TableScan_67
+    │ │ │   └─TableScan_67	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+    │ │ └─TableReader_70	40000000.00	root	data:TableScan_69
+    │ │   └─TableScan_69	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+    │ └─TableReader_73	155496.00	root	data:Selection_72
+    │   └─Selection_72	155496.00	cop	eq(tpch.part.p_size, 30), like(tpch.part.p_type, "%STEEL", 92)
+    │     └─TableScan_71	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+    └─HashAgg_76	8155010.44	root	group by:tpch.partsupp.ps_partkey, funcs:min(tpch.partsupp.ps_supplycost), firstrow(tpch.partsupp.ps_partkey)
+      └─HashRightJoin_80	8155010.44	root	inner join, inner:HashRightJoin_82, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
+        ├─HashRightJoin_82	100000.00	root	inner join, inner:HashRightJoin_88, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+        │ ├─HashRightJoin_88	5.00	root	inner join, inner:TableReader_93, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
+        │ │ ├─TableReader_93	1.00	root	data:Selection_92
+        │ │ │ └─Selection_92	1.00	cop	eq(tpch.region.r_name, "ASIA")
+        │ │ │   └─TableScan_91	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_90	25.00	root	data:TableScan_89
+        │ │   └─TableScan_89	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ └─TableReader_95	500000.00	root	data:TableScan_94
+        │   └─TableScan_94	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        └─TableReader_97	40000000.00	root	data:TableScan_96
+          └─TableScan_96	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
 /*
 Q3 Shipping Priority Query
 This query retrieves the 10 unshipped orders with the highest value.
@@ -250,19 +250,19 @@ limit 10;
 id	count	task	operator info
 Projection_14	10.00	root	tpch.lineitem.l_orderkey, 7_col_0, tpch.orders.o_orderdate, tpch.orders.o_shippriority
 └─TopN_17	10.00	root	7_col_0:desc, tpch.orders.o_orderdate:asc, offset:0, count:10
-  └─HashAgg_20	40227041.09	root	group by:tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority, funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), firstrow(tpch.orders.o_orderdate), firstrow(tpch.orders.o_shippriority), firstrow(tpch.lineitem.l_orderkey)
-    └─IndexJoin_26	91515927.49	root	inner join, inner:IndexLookUp_25, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─HashRightJoin_46	22592975.51	root	inner join, inner:TableReader_52, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-      │ ├─TableReader_52	1498236.00	root	data:Selection_51
-      │ │ └─Selection_51	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
-      │ │   └─TableScan_50	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-      │ └─TableReader_49	36870000.00	root	data:Selection_48
-      │   └─Selection_48	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
-      │     └─TableScan_47	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_25	162945114.27	root	
-        ├─IndexScan_22	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
-        └─Selection_24	162945114.27	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
-          └─TableScan_23	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_23	40227041.09	root	group by:tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority, funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), firstrow(tpch.orders.o_orderdate), firstrow(tpch.orders.o_shippriority), firstrow(tpch.lineitem.l_orderkey)
+    └─IndexJoin_29	91515927.49	root	inner join, inner:IndexLookUp_28, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+      ├─HashRightJoin_49	22592975.51	root	inner join, inner:TableReader_55, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+      │ ├─TableReader_55	1498236.00	root	data:Selection_54
+      │ │ └─Selection_54	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
+      │ │   └─TableScan_53	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+      │ └─TableReader_52	36870000.00	root	data:Selection_51
+      │   └─Selection_51	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
+      │     └─TableScan_50	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+      └─IndexLookUp_28	162945114.27	root	
+        ├─IndexScan_25	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
+        └─Selection_27	162945114.27	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
+          └─TableScan_26	1.00	cop	table:lineitem, keep order:false
 /*
 Q4 Order Priority Checking Query
 This query determines how well the order priority system is working and gives an assessment of customer satisfaction.
@@ -589,28 +589,28 @@ nation,
 o_year desc;
 id	count	task	operator info
 Sort_25	2406.00	root	profit.nation:asc, profit.o_year:desc
-└─Projection_26	2406.00	root	profit.nation, profit.o_year, 14_col_0
-  └─HashAgg_29	2406.00	root	group by:profit.nation, profit.o_year, funcs:sum(profit.amount), firstrow(profit.nation), firstrow(profit.o_year)
-    └─Projection_30	971049283.51	root	tpch.nation.n_name, extract("YEAR", tpch.orders.o_orderdate), minus(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), mul(tpch.partsupp.ps_supplycost, tpch.lineitem.l_quantity))
-      └─IndexJoin_34	971049283.51	root	inner join, inner:IndexLookUp_33, outer key:tpch.lineitem.l_suppkey, tpch.lineitem.l_partkey, inner key:tpch.partsupp.ps_suppkey, tpch.partsupp.ps_partkey
-        ├─IndexJoin_40	241379546.70	root	inner join, inner:TableReader_39, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-        │ ├─HashLeftJoin_51	241379546.70	root	inner join, inner:TableReader_68, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
-        │ │ ├─HashRightJoin_54	300005811.00	root	inner join, inner:HashRightJoin_59, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
-        │ │ │ ├─HashRightJoin_59	500000.00	root	inner join, inner:TableReader_63, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-        │ │ │ │ ├─TableReader_63	25.00	root	data:TableScan_62
-        │ │ │ │ │ └─TableScan_62	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ │ │ │ └─TableReader_61	500000.00	root	data:TableScan_60
-        │ │ │ │   └─TableScan_60	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        │ │ │ └─TableReader_65	300005811.00	root	data:TableScan_64
-        │ │ │   └─TableScan_64	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_68	8000000.00	root	data:Selection_67
-        │ │   └─Selection_67	8000000.00	cop	like(tpch.part.p_name, "%dim%", 92)
-        │ │     └─TableScan_66	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-        │ └─TableReader_39	1.00	root	data:TableScan_38
-        │   └─TableScan_38	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
-        └─IndexLookUp_33	1.00	root	
-          ├─IndexScan_31	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [tpch.lineitem.l_suppkey tpch.lineitem.l_partkey], keep order:false
-          └─TableScan_32	1.00	cop	table:partsupp, keep order:false
+└─Projection_27	2406.00	root	profit.nation, profit.o_year, 14_col_0
+  └─HashAgg_30	2406.00	root	group by:profit.nation, profit.o_year, funcs:sum(profit.amount), firstrow(profit.nation), firstrow(profit.o_year)
+    └─Projection_31	971049283.51	root	tpch.nation.n_name, extract("YEAR", tpch.orders.o_orderdate), minus(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), mul(tpch.partsupp.ps_supplycost, tpch.lineitem.l_quantity))
+      └─IndexJoin_35	971049283.51	root	inner join, inner:IndexLookUp_34, outer key:tpch.lineitem.l_suppkey, tpch.lineitem.l_partkey, inner key:tpch.partsupp.ps_suppkey, tpch.partsupp.ps_partkey
+        ├─IndexJoin_41	241379546.70	root	inner join, inner:TableReader_40, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
+        │ ├─HashLeftJoin_52	241379546.70	root	inner join, inner:TableReader_69, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
+        │ │ ├─HashRightJoin_55	300005811.00	root	inner join, inner:HashRightJoin_60, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
+        │ │ │ ├─HashRightJoin_60	500000.00	root	inner join, inner:TableReader_64, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+        │ │ │ │ ├─TableReader_64	25.00	root	data:TableScan_63
+        │ │ │ │ │ └─TableScan_63	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ │ │ └─TableReader_62	500000.00	root	data:TableScan_61
+        │ │ │ │   └─TableScan_61	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        │ │ │ └─TableReader_66	300005811.00	root	data:TableScan_65
+        │ │ │   └─TableScan_65	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_69	8000000.00	root	data:Selection_68
+        │ │   └─Selection_68	8000000.00	cop	like(tpch.part.p_name, "%dim%", 92)
+        │ │     └─TableScan_67	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+        │ └─TableReader_40	1.00	root	data:TableScan_39
+        │   └─TableScan_39	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
+        └─IndexLookUp_34	1.00	root	
+          ├─IndexScan_32	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [tpch.lineitem.l_suppkey tpch.lineitem.l_partkey], keep order:false
+          └─TableScan_33	1.00	cop	table:partsupp, keep order:false
 /*
 Q10 Returned Item Reporting Query
 The query identifies customers who might be having problems with the parts that are shipped to them.
@@ -921,18 +921,18 @@ p_type,
 p_size;
 id	count	task	operator info
 Sort_13	3863988.24	root	supplier_cnt:desc, tpch.part.p_brand:asc, tpch.part.p_type:asc, tpch.part.p_size:asc
-└─Projection_14	3863988.24	root	tpch.part.p_brand, tpch.part.p_type, tpch.part.p_size, 9_col_0
-  └─HashAgg_17	3863988.24	root	group by:tpch.part.p_brand, tpch.part.p_size, tpch.part.p_type, funcs:count(distinct tpch.partsupp.ps_suppkey), firstrow(tpch.part.p_brand), firstrow(tpch.part.p_type), firstrow(tpch.part.p_size)
-    └─HashLeftJoin_22	3863988.24	root	anti semi join, inner:TableReader_46, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
-      ├─IndexJoin_26	4829985.30	root	inner join, inner:IndexReader_25, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
-      │ ├─TableReader_41	1200618.43	root	data:Selection_40
-      │ │ └─Selection_40	1200618.43	cop	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
-      │ │   └─TableScan_39	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-      │ └─IndexReader_25	1.00	root	index:IndexScan_24
-      │   └─IndexScan_24	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [tpch.part.p_partkey], keep order:false
-      └─TableReader_46	400000.00	root	data:Selection_45
-        └─Selection_45	400000.00	cop	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
-          └─TableScan_44	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+└─Projection_15	3863988.24	root	tpch.part.p_brand, tpch.part.p_type, tpch.part.p_size, 9_col_0
+  └─HashAgg_18	3863988.24	root	group by:tpch.part.p_brand, tpch.part.p_size, tpch.part.p_type, funcs:count(distinct tpch.partsupp.ps_suppkey), firstrow(tpch.part.p_brand), firstrow(tpch.part.p_type), firstrow(tpch.part.p_size)
+    └─HashLeftJoin_23	3863988.24	root	anti semi join, inner:TableReader_47, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
+      ├─IndexJoin_27	4829985.30	root	inner join, inner:IndexReader_26, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
+      │ ├─TableReader_42	1200618.43	root	data:Selection_41
+      │ │ └─Selection_41	1200618.43	cop	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
+      │ │   └─TableScan_40	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+      │ └─IndexReader_26	1.00	root	index:IndexScan_25
+      │   └─IndexScan_25	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [tpch.part.p_partkey], keep order:false
+      └─TableReader_47	400000.00	root	data:Selection_46
+        └─Selection_46	400000.00	cop	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
+          └─TableScan_45	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
 /*
 Q17 Small-Quantity-Order Revenue Query
 This query determines how much average yearly revenue would be lost if orders were no longer filled for small
@@ -1021,22 +1021,22 @@ limit 100;
 id	count	task	operator info
 Projection_24	100.00	root	tpch.customer.c_name, tpch.customer.c_custkey, tpch.orders.o_orderkey, tpch.orders.o_orderdate, tpch.orders.o_totalprice, 14_col_0
 └─TopN_27	100.00	root	tpch.orders.o_totalprice:desc, tpch.orders.o_orderdate:asc, offset:0, count:100
-  └─HashAgg_30	59251097.60	root	group by:tpch.customer.c_custkey, tpch.customer.c_name, tpch.orders.o_orderdate, tpch.orders.o_orderkey, tpch.orders.o_totalprice, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.customer.c_custkey), firstrow(tpch.customer.c_name), firstrow(tpch.orders.o_orderkey), firstrow(tpch.orders.o_totalprice), firstrow(tpch.orders.o_orderdate)
-    └─IndexJoin_35	240004648.80	root	inner join, inner:IndexLookUp_34, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─HashLeftJoin_38	59251097.60	root	inner join, inner:Selection_49, equal:[eq(tpch.orders.o_orderkey, tpch.lineitem.l_orderkey)]
-      │ ├─HashRightJoin_44	75000000.00	root	inner join, inner:TableReader_48, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-      │ │ ├─TableReader_48	7500000.00	root	data:TableScan_47
-      │ │ │ └─TableScan_47	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_46	75000000.00	root	data:TableScan_45
-      │ │   └─TableScan_45	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      │ └─Selection_49	59251097.60	root	gt(sel_agg_2, 314)
-      │   └─HashAgg_56	74063872.00	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
-      │     └─TableReader_57	74063872.00	root	data:HashAgg_50
-      │       └─HashAgg_50	74063872.00	cop	group by:tpch.lineitem.l_orderkey, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.lineitem.l_orderkey)
-      │         └─TableScan_55	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_34	1.00	root	
-        ├─IndexScan_32	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
-        └─TableScan_33	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_33	59251097.60	root	group by:tpch.customer.c_custkey, tpch.customer.c_name, tpch.orders.o_orderdate, tpch.orders.o_orderkey, tpch.orders.o_totalprice, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.customer.c_custkey), firstrow(tpch.customer.c_name), firstrow(tpch.orders.o_orderkey), firstrow(tpch.orders.o_totalprice), firstrow(tpch.orders.o_orderdate)
+    └─IndexJoin_38	240004648.80	root	inner join, inner:IndexLookUp_37, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+      ├─HashLeftJoin_41	59251097.60	root	inner join, inner:Selection_52, equal:[eq(tpch.orders.o_orderkey, tpch.lineitem.l_orderkey)]
+      │ ├─HashRightJoin_47	75000000.00	root	inner join, inner:TableReader_51, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+      │ │ ├─TableReader_51	7500000.00	root	data:TableScan_50
+      │ │ │ └─TableScan_50	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+      │ │ └─TableReader_49	75000000.00	root	data:TableScan_48
+      │ │   └─TableScan_48	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+      │ └─Selection_52	59251097.60	root	gt(sel_agg_2, 314)
+      │   └─HashAgg_59	74063872.00	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
+      │     └─TableReader_60	74063872.00	root	data:HashAgg_53
+      │       └─HashAgg_53	74063872.00	cop	group by:tpch.lineitem.l_orderkey, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.lineitem.l_orderkey)
+      │         └─TableScan_58	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+      └─IndexLookUp_37	1.00	root	
+        ├─IndexScan_35	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
+        └─TableScan_36	1.00	cop	table:lineitem, keep order:false
 /*
 Q19 Discounted Revenue Query
 The Discounted Revenue Query reports the gross discounted revenue attributed to the sale of selected parts handled
@@ -1213,30 +1213,30 @@ limit 100;
 id	count	task	operator info
 Projection_25	1.00	root	tpch.supplier.s_name, 17_col_0
 └─TopN_28	1.00	root	17_col_0:desc, tpch.supplier.s_name:asc, offset:0, count:100
-  └─HashAgg_31	1.00	root	group by:tpch.supplier.s_name, funcs:count(1), firstrow(tpch.supplier.s_name)
-    └─IndexJoin_37	7828961.66	root	anti semi join, inner:IndexLookUp_36, outer key:l1.l_orderkey, inner key:l3.l_orderkey, other cond:ne(l3.l_suppkey, l1.l_suppkey), ne(l3.l_suppkey, tpch.supplier.s_suppkey)
-      ├─IndexJoin_53	9786202.08	root	semi join, inner:IndexLookUp_52, outer key:l1.l_orderkey, inner key:l2.l_orderkey, other cond:ne(l2.l_suppkey, l1.l_suppkey), ne(l2.l_suppkey, tpch.supplier.s_suppkey)
-      │ ├─IndexJoin_59	12232752.60	root	inner join, inner:TableReader_58, outer key:l1.l_orderkey, inner key:tpch.orders.o_orderkey
-      │ │ ├─HashRightJoin_63	12232752.60	root	inner join, inner:HashRightJoin_69, equal:[eq(tpch.supplier.s_suppkey, l1.l_suppkey)]
-      │ │ │ ├─HashRightJoin_69	20000.00	root	inner join, inner:TableReader_74, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-      │ │ │ │ ├─TableReader_74	1.00	root	data:Selection_73
-      │ │ │ │ │ └─Selection_73	1.00	cop	eq(tpch.nation.n_name, "EGYPT")
-      │ │ │ │ │   └─TableScan_72	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-      │ │ │ │ └─TableReader_71	500000.00	root	data:TableScan_70
-      │ │ │ │   └─TableScan_70	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-      │ │ │ └─TableReader_77	240004648.80	root	data:Selection_76
-      │ │ │   └─Selection_76	240004648.80	cop	gt(l1.l_receiptdate, l1.l_commitdate)
-      │ │ │     └─TableScan_75	300005811.00	cop	table:l1, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_58	36517371.00	root	data:Selection_57
-      │ │   └─Selection_57	36517371.00	cop	eq(tpch.orders.o_orderstatus, "F")
-      │ │     └─TableScan_56	1.00	cop	table:orders, range: decided by [l1.l_orderkey], keep order:false
-      │ └─IndexLookUp_52	1.00	root	
-      │   ├─IndexScan_50	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [l1.l_orderkey], keep order:false
-      │   └─TableScan_51	1.00	cop	table:lineitem, keep order:false
-      └─IndexLookUp_36	240004648.80	root	
-        ├─IndexScan_33	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [l1.l_orderkey], keep order:false
-        └─Selection_35	240004648.80	cop	gt(l3.l_receiptdate, l3.l_commitdate)
-          └─TableScan_34	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_34	1.00	root	group by:tpch.supplier.s_name, funcs:count(1), firstrow(tpch.supplier.s_name)
+    └─IndexJoin_40	7828961.66	root	anti semi join, inner:IndexLookUp_39, outer key:l1.l_orderkey, inner key:l3.l_orderkey, other cond:ne(l3.l_suppkey, l1.l_suppkey), ne(l3.l_suppkey, tpch.supplier.s_suppkey)
+      ├─IndexJoin_56	9786202.08	root	semi join, inner:IndexLookUp_55, outer key:l1.l_orderkey, inner key:l2.l_orderkey, other cond:ne(l2.l_suppkey, l1.l_suppkey), ne(l2.l_suppkey, tpch.supplier.s_suppkey)
+      │ ├─IndexJoin_62	12232752.60	root	inner join, inner:TableReader_61, outer key:l1.l_orderkey, inner key:tpch.orders.o_orderkey
+      │ │ ├─HashRightJoin_66	12232752.60	root	inner join, inner:HashRightJoin_72, equal:[eq(tpch.supplier.s_suppkey, l1.l_suppkey)]
+      │ │ │ ├─HashRightJoin_72	20000.00	root	inner join, inner:TableReader_77, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+      │ │ │ │ ├─TableReader_77	1.00	root	data:Selection_76
+      │ │ │ │ │ └─Selection_76	1.00	cop	eq(tpch.nation.n_name, "EGYPT")
+      │ │ │ │ │   └─TableScan_75	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+      │ │ │ │ └─TableReader_74	500000.00	root	data:TableScan_73
+      │ │ │ │   └─TableScan_73	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+      │ │ │ └─TableReader_80	240004648.80	root	data:Selection_79
+      │ │ │   └─Selection_79	240004648.80	cop	gt(l1.l_receiptdate, l1.l_commitdate)
+      │ │ │     └─TableScan_78	300005811.00	cop	table:l1, range:[-inf,+inf], keep order:false
+      │ │ └─TableReader_61	36517371.00	root	data:Selection_60
+      │ │   └─Selection_60	36517371.00	cop	eq(tpch.orders.o_orderstatus, "F")
+      │ │     └─TableScan_59	1.00	cop	table:orders, range: decided by [l1.l_orderkey], keep order:false
+      │ └─IndexLookUp_55	1.00	root	
+      │   ├─IndexScan_53	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [l1.l_orderkey], keep order:false
+      │   └─TableScan_54	1.00	cop	table:lineitem, keep order:false
+      └─IndexLookUp_39	240004648.80	root	
+        ├─IndexScan_36	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [l1.l_orderkey], keep order:false
+        └─Selection_38	240004648.80	cop	gt(l3.l_receiptdate, l3.l_commitdate)
+          └─TableScan_37	1.00	cop	table:lineitem, keep order:false
 /*
 Q22 Global Sales Opportunity Query
 The Global Sales Opportunity Query identifies geographies where there are customers who may be likely to make a

--- a/planner/cascades/enforcer_rules.go
+++ b/planner/cascades/enforcer_rules.go
@@ -56,12 +56,12 @@ func (e *OrderEnforcer) NewProperty(prop *property.PhysicalProperty) (newProp *p
 // OnEnforce adds sort operator to satisfy required order property.
 func (e *OrderEnforcer) OnEnforce(reqProp *property.PhysicalProperty, child memo.Implementation) (impl memo.Implementation) {
 	sort := &plannercore.PhysicalSort{
-		ByItems: make([]*plannercore.ByItems, 0, len(reqProp.Cols)),
+		ByItems: make([]*plannercore.ByItems, 0, len(reqProp.Items)),
 	}
-	for _, col := range reqProp.Cols {
+	for _, item := range reqProp.Items {
 		item := &plannercore.ByItems{
-			Expr: col,
-			Desc: reqProp.Desc,
+			Expr: item.Col,
+			Desc: item.Desc,
 		}
 		sort.ByItems = append(sort.ByItems, item)
 	}

--- a/planner/cascades/enforcer_rules_test.go
+++ b/planner/cascades/enforcer_rules_test.go
@@ -24,7 +24,7 @@ func (s *testCascadesSuite) TestGetEnforcerRules(c *C) {
 	enforcers := GetEnforcerRules(prop)
 	c.Assert(enforcers, IsNil)
 	col := &expression.Column{}
-	prop.Cols = append(prop.Cols, col)
+	prop.Items = append(prop.Items, property.Item{Col: col})
 	enforcers = GetEnforcerRules(prop)
 	c.Assert(enforcers, NotNil)
 	c.Assert(len(enforcers), Equals, 1)
@@ -35,9 +35,9 @@ func (s *testCascadesSuite) TestGetEnforcerRules(c *C) {
 func (s *testCascadesSuite) TestNewProperties(c *C) {
 	prop := &property.PhysicalProperty{}
 	col := &expression.Column{}
-	prop.Cols = append(prop.Cols, col)
+	prop.Items = append(prop.Items, property.Item{Col: col})
 	enforcers := GetEnforcerRules(prop)
 	orderEnforcer, _ := enforcers[0].(*OrderEnforcer)
 	newProp := orderEnforcer.NewProperty(prop)
-	c.Assert(newProp.Cols, IsNil)
+	c.Assert(newProp.Items, IsNil)
 }

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -85,11 +85,12 @@ func (p *LogicalJoin) moveEqualToOtherConditions(offsets []int) []expression.Exp
 
 // Only if the input required prop is the prefix fo join keys, we can pass through this property.
 func (p *PhysicalMergeJoin) tryToGetChildReqProp(prop *property.PhysicalProperty) ([]*property.PhysicalProperty, bool) {
-	lProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Cols: p.LeftKeys, ExpectedCnt: math.MaxFloat64}
-	rProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Cols: p.RightKeys, ExpectedCnt: math.MaxFloat64}
+	lProp := property.NewPhysicalProperty(property.RootTaskType, p.LeftKeys, false, math.MaxFloat64, false)
+	rProp := property.NewPhysicalProperty(property.RootTaskType, p.RightKeys, false, math.MaxFloat64, false)
 	if !prop.IsEmpty() {
 		// sort merge join fits the cases of massive ordered data, so desc scan is always expensive.
-		if prop.Desc {
+		all, desc := prop.AllSameOrder()
+		if !all || desc {
 			return nil, false
 		}
 		if !prop.IsPrefix(lProp) && !prop.IsPrefix(rProp) {
@@ -197,14 +198,18 @@ func getNewEqualConditionsByOffsets(oldEqualCond []*expression.ScalarFunction, o
 func (p *LogicalJoin) getEnforcedMergeJoin(prop *property.PhysicalProperty) []PhysicalPlan {
 	// Check whether SMJ can satisfy the required property
 	offsets := make([]int, 0, len(p.LeftJoinKeys))
-	for _, col := range prop.Cols {
+	all, desc := prop.AllSameOrder()
+	if !all {
+		return nil
+	}
+	for _, item := range prop.Items {
 		isExist := false
 		for joinKeyPos := 0; joinKeyPos < len(p.LeftJoinKeys); joinKeyPos++ {
 			var key *expression.Column
-			if col.Equal(p.ctx, p.LeftJoinKeys[joinKeyPos]) {
+			if item.Col.Equal(p.ctx, p.LeftJoinKeys[joinKeyPos]) {
 				key = p.LeftJoinKeys[joinKeyPos]
 			}
-			if col.Equal(p.ctx, p.RightJoinKeys[joinKeyPos]) {
+			if item.Col.Equal(p.ctx, p.RightJoinKeys[joinKeyPos]) {
 				key = p.RightJoinKeys[joinKeyPos]
 			}
 			if key == nil {
@@ -229,8 +234,8 @@ func (p *LogicalJoin) getEnforcedMergeJoin(prop *property.PhysicalProperty) []Ph
 	// Generate the enforced sort merge join
 	leftKeys := getNewJoinKeysByOffsets(p.LeftJoinKeys, offsets)
 	rightKeys := getNewJoinKeysByOffsets(p.RightJoinKeys, offsets)
-	lProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Cols: leftKeys, ExpectedCnt: math.MaxFloat64, Enforced: true, Desc: prop.Desc}
-	rProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Cols: rightKeys, ExpectedCnt: math.MaxFloat64, Enforced: true, Desc: prop.Desc}
+	lProp := property.NewPhysicalProperty(property.RootTaskType, leftKeys, desc, math.MaxFloat64, true)
+	rProp := property.NewPhysicalProperty(property.RootTaskType, rightKeys, desc, math.MaxFloat64, true)
 	enforcedPhysicalMergeJoin := PhysicalMergeJoin{
 		JoinType:        p.JoinType,
 		LeftConditions:  p.LeftConditions,
@@ -314,12 +319,13 @@ func (p *LogicalJoin) constructIndexJoin(prop *property.PhysicalProperty, innerJ
 	innerPlan PhysicalPlan, ranges []*ranger.Range, keyOff2IdxOff []int) []PhysicalPlan {
 	joinType := p.JoinType
 	outerSchema := p.children[outerIdx].Schema()
+	all, _ := prop.AllSameOrder()
 	// If the order by columns are not all from outer child, index join cannot promise the order.
-	if !prop.AllColsFromSchema(outerSchema) {
+	if !prop.AllColsFromSchema(outerSchema) || !all {
 		return nil
 	}
 	chReqProps := make([]*property.PhysicalProperty, 2)
-	chReqProps[outerIdx] = &property.PhysicalProperty{TaskTp: property.RootTaskType, ExpectedCnt: prop.ExpectedCnt, Cols: prop.Cols, Desc: prop.Desc}
+	chReqProps[outerIdx] = &property.PhysicalProperty{TaskTp: property.RootTaskType, ExpectedCnt: prop.ExpectedCnt, Items: prop.Items}
 	newInnerKeys := make([]*expression.Column, 0, len(innerJoinKeys))
 	newOuterKeys := make([]*expression.Column, 0, len(outerJoinKeys))
 	newKeyOff := make([]int, 0, len(keyOff2IdxOff))
@@ -683,18 +689,17 @@ func (p *LogicalJoin) exhaustPhysicalPlans(prop *property.PhysicalProperty) []Ph
 // When a sort column will be replaced by a constant, we just remove it.
 func (p *LogicalProjection) tryToGetChildProp(prop *property.PhysicalProperty) (*property.PhysicalProperty, bool) {
 	newProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, ExpectedCnt: prop.ExpectedCnt}
-	newCols := make([]*expression.Column, 0, len(prop.Cols))
-	for _, col := range prop.Cols {
-		idx := p.schema.ColumnIndex(col)
+	newCols := make([]property.Item, 0, len(prop.Items))
+	for _, col := range prop.Items {
+		idx := p.schema.ColumnIndex(col.Col)
 		switch expr := p.Exprs[idx].(type) {
 		case *expression.Column:
-			newCols = append(newCols, expr)
+			newCols = append(newCols, property.Item{Col: expr, Desc: col.Desc})
 		case *expression.ScalarFunction:
 			return nil, false
 		}
 	}
-	newProp.Cols = newCols
-	newProp.Desc = prop.Desc
+	newProp.Items = newCols
 	return newProp, true
 }
 
@@ -733,7 +738,7 @@ func (lt *LogicalTopN) getPhysLimits() []PhysicalPlan {
 	}
 	ret := make([]PhysicalPlan, 0, 3)
 	for _, tp := range wholeTaskTypes {
-		resultProp := &property.PhysicalProperty{TaskTp: tp, ExpectedCnt: float64(lt.Count + lt.Offset), Cols: prop.Cols, Desc: prop.Desc}
+		resultProp := &property.PhysicalProperty{TaskTp: tp, ExpectedCnt: float64(lt.Count + lt.Offset), Items: prop.Items}
 		limit := PhysicalLimit{
 			Count:  lt.Count,
 			Offset: lt.Offset,
@@ -745,12 +750,12 @@ func (lt *LogicalTopN) getPhysLimits() []PhysicalPlan {
 
 // Check if this prop's columns can match by items totally.
 func matchItems(p *property.PhysicalProperty, items []*ByItems) bool {
-	if len(items) < len(p.Cols) {
+	if len(items) < len(p.Items) {
 		return false
 	}
-	for i, col := range p.Cols {
+	for i, col := range p.Items {
 		sortItem := items[i]
-		if sortItem.Desc != p.Desc || !sortItem.Expr.Equal(nil, col) {
+		if sortItem.Desc != col.Desc || !sortItem.Expr.Equal(nil, col.Col) {
 			return false
 		}
 	}
@@ -774,7 +779,7 @@ func (la *LogicalApply) exhaustPhysicalPlans(prop *property.PhysicalProperty) []
 		rightChOffset: la.children[0].Schema().Len(),
 	}.Init(la.ctx,
 		la.stats.ScaleByExpectCnt(prop.ExpectedCnt),
-		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, Cols: prop.Cols, Desc: prop.Desc},
+		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64, Items: prop.Items},
 		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64})
 	apply.SetSchema(la.schema)
 	return []PhysicalPlan{apply}
@@ -786,7 +791,8 @@ func (p *baseLogicalPlan) exhaustPhysicalPlans(_ *property.PhysicalProperty) []P
 }
 
 func (la *LogicalAggregation) getStreamAggs(prop *property.PhysicalProperty) []PhysicalPlan {
-	if len(la.possibleProperties) == 0 {
+	all, desc := prop.AllSameOrder()
+	if len(la.possibleProperties) == 0 || !all {
 		return nil
 	}
 	for _, aggFunc := range la.AggFuncs {
@@ -801,7 +807,6 @@ func (la *LogicalAggregation) getStreamAggs(prop *property.PhysicalProperty) []P
 
 	streamAggs := make([]PhysicalPlan, 0, len(la.possibleProperties)*(len(wholeTaskTypes)-1))
 	childProp := &property.PhysicalProperty{
-		Desc:        prop.Desc,
 		ExpectedCnt: math.Max(prop.ExpectedCnt*la.inputCount/la.stats.RowCount, prop.ExpectedCnt),
 	}
 
@@ -811,7 +816,7 @@ func (la *LogicalAggregation) getStreamAggs(prop *property.PhysicalProperty) []P
 			continue
 		}
 
-		childProp.Cols = possibleChildProperty[:len(sortColOffsets)]
+		childProp.Items = property.ItemsFromCols(possibleChildProperty[:len(sortColOffsets)], desc)
 		if !prop.IsPrefix(childProp) {
 			continue
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -48,22 +48,17 @@ var wholeTaskTypes = [...]property.TaskType{property.CopSingleReadTaskType, prop
 var invalidTask = &rootTask{cst: math.MaxFloat64}
 
 // getPropByOrderByItems will check if this sort property can be pushed or not. In order to simplify the problem, we only
-// consider the case that all expression are columns and all of them are asc or desc.
+// consider the case that all expression are columns.
 func getPropByOrderByItems(items []*ByItems) (*property.PhysicalProperty, bool) {
-	desc := false
-	cols := make([]*expression.Column, 0, len(items))
-	for i, item := range items {
+	propItems := make([]property.Item, 0, len(items))
+	for _, item := range items {
 		col, ok := item.Expr.(*expression.Column)
 		if !ok {
 			return nil, false
 		}
-		cols = append(cols, col)
-		desc = item.Desc
-		if i > 0 && item.Desc != items[i-1].Desc {
-			return nil, false
-		}
+		propItems = append(propItems, property.Item{Col: col, Desc: item.Desc})
 	}
-	return &property.PhysicalProperty{Cols: cols, Desc: desc}, true
+	return &property.PhysicalProperty{Items: propItems}, true
 }
 
 func (p *LogicalTableDual) findBestTask(prop *property.PhysicalProperty) (task, error) {
@@ -100,7 +95,7 @@ func (p *baseLogicalPlan) findBestTask(prop *property.PhysicalProperty) (bestTas
 
 	// If prop.enforced is true, cols of prop as parameter in exhaustPhysicalPlans should be nil
 	// And reset it for enforcing task prop and storing map<prop,task>
-	oldPropCols := prop.Cols
+	oldPropCols := prop.Items
 	if prop.Enforced {
 		// First, get the bestTask without enforced prop
 		prop.Enforced = false
@@ -110,10 +105,10 @@ func (p *baseLogicalPlan) findBestTask(prop *property.PhysicalProperty) (bestTas
 		}
 		prop.Enforced = true
 		// Next, get the bestTask with enforced prop
-		prop.Cols = []*expression.Column{}
+		prop.Items = []property.Item{}
 	}
 	physicalPlans := p.self.exhaustPhysicalPlans(prop)
-	prop.Cols = oldPropCols
+	prop.Items = oldPropCols
 
 	for _, pp := range physicalPlans {
 		// find best child tasks firstly.
@@ -217,7 +212,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 
 	// If prop.enforced is true, the prop.cols need to be set nil for ds.findBestTask.
 	// Before function return, reset it for enforcing task prop and storing map<prop,task>.
-	oldPropCols := prop.Cols
+	oldPropCols := prop.Items
 	if prop.Enforced {
 		// First, get the bestTask without enforced prop
 		prop.Enforced = false
@@ -231,14 +226,14 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 			return
 		}
 		// Next, get the bestTask with enforced prop
-		prop.Cols = []*expression.Column{}
+		prop.Items = []property.Item{}
 	}
 	defer func() {
 		if err != nil {
 			return
 		}
 		if prop.Enforced {
-			prop.Cols = oldPropCols
+			prop.Items = oldPropCols
 			t = enforceProperty(prop, t, ds.basePlan.ctx)
 		}
 		ds.storeTask(prop, t)
@@ -278,7 +273,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 		// this path's access cond is not nil or
 		// we have prop to match or
 		// this index is forced to choose.
-		if len(path.accessConds) > 0 || len(prop.Cols) > 0 || path.forced {
+		if len(path.accessConds) > 0 || len(prop.Items) > 0 || path.forced {
 			idxTask, err := ds.convertToIndexScan(prop, path)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -371,11 +366,12 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, path *
 	is.initSchema(ds.id, idx, cop.tablePlan != nil)
 	// Check if this plan matches the property.
 	matchProperty := false
-	if !prop.IsEmpty() {
+	all, desc := prop.AllSameOrder()
+	if !prop.IsEmpty() && all {
 		for i, col := range idx.Columns {
 			// not matched
-			if col.Name.L == prop.Cols[0].ColName.L {
-				matchProperty = matchIndicesProp(idx.Columns[i:], prop.Cols)
+			if col.Name.L == prop.Items[0].Col.ColName.L {
+				matchProperty = matchIndicesProp(idx.Columns[i:], prop.Items)
 				break
 			} else if i >= path.eqCondCount {
 				break
@@ -394,7 +390,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, path *
 	cop.cst = rowCount * scanFactor
 	task = cop
 	if matchProperty {
-		if prop.Desc {
+		if desc {
 			is.Desc = true
 			cop.cst = rowCount * descScanFactor
 		}
@@ -477,12 +473,12 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	}
 }
 
-func matchIndicesProp(idxCols []*model.IndexColumn, propCols []*expression.Column) bool {
-	if len(idxCols) < len(propCols) {
+func matchIndicesProp(idxCols []*model.IndexColumn, propItems []property.Item) bool {
+	if len(idxCols) < len(propItems) {
 		return false
 	}
-	for i, col := range propCols {
-		if idxCols[i].Length != types.UnspecifiedLength || col.ColName.L != idxCols[i].Name.L {
+	for i, item := range propItems {
+		if idxCols[i].Length != types.UnspecifiedLength || item.Col.ColName.L != idxCols[i].Name.L {
 			return false
 		}
 	}
@@ -535,7 +531,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, path *
 		indexPlanFinished: true,
 	}
 	task = copTask
-	matchProperty := len(prop.Cols) == 1 && pkCol != nil && prop.Cols[0].Equal(nil, pkCol)
+	matchProperty := len(prop.Items) == 1 && pkCol != nil && prop.Items[0].Col.Equal(nil, pkCol)
 	// Only use expectedCnt when it's smaller than the count we calculated.
 	// e.g. IndexScan(count1)->After Filter(count2). The `ds.stats.RowCount` is count2. count1 is the one we need to calculate
 	// If expectedCnt and count2 are both zero and we go into the below `if` block, the count1 will be set to zero though it's shouldn't be.
@@ -547,7 +543,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, path *
 	ts.stats.UsePseudoStats = ds.statisticTable.Pseudo
 	copTask.cst = rowCount * scanFactor
 	if matchProperty {
-		if prop.Desc {
+		if prop.Items[0].Desc {
 			ts.Desc = true
 			copTask.cst = rowCount * descScanFactor
 		}

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -49,10 +49,10 @@ func enforceProperty(p *property.PhysicalProperty, tsk task, ctx sessionctx.Cont
 		return tsk
 	}
 	tsk = finishCopTask(ctx, tsk)
-	sortReqProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Cols: p.Cols, ExpectedCnt: math.MaxFloat64}
-	sort := PhysicalSort{ByItems: make([]*ByItems, 0, len(p.Cols))}.Init(ctx, tsk.plan().statsInfo(), sortReqProp)
-	for _, col := range p.Cols {
-		sort.ByItems = append(sort.ByItems, &ByItems{col, p.Desc})
+	sortReqProp := &property.PhysicalProperty{TaskTp: property.RootTaskType, Items: p.Items, ExpectedCnt: math.MaxFloat64}
+	sort := PhysicalSort{ByItems: make([]*ByItems, 0, len(p.Items))}.Init(ctx, tsk.plan().statsInfo(), sortReqProp)
+	for _, col := range p.Items {
+		sort.ByItems = append(sort.ByItems, &ByItems{col.Col, col.Desc})
 	}
 	return sort.attach2Task(tsk)
 }

--- a/planner/memo/group_test.go
+++ b/planner/memo/group_test.go
@@ -125,7 +125,7 @@ func (impl *fakeImpl) GetPlan() plannercore.PhysicalPlan              { return i
 func (s *testMemoSuite) TestGetInsertGroupImpl(c *C) {
 	g := NewGroup(NewGroupExpr(plannercore.LogicalLimit{}.Init(s.sctx)))
 	emptyProp := &property.PhysicalProperty{}
-	orderProp := &property.PhysicalProperty{Cols: []*expression.Column{{}}}
+	orderProp := &property.PhysicalProperty{Items: []property.Item{{Col: &expression.Column{}}}}
 
 	impl := g.GetImpl(emptyProp)
 	c.Assert(impl, IsNil)

--- a/planner/property/physical_property.go
+++ b/planner/property/physical_property.go
@@ -20,11 +20,16 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 )
 
-// PhysicalProperty stands for the required physical property by parents.
-// It contains the orders, if the order is desc and the task types.
-type PhysicalProperty struct {
-	Cols []*expression.Column
+// Item wraps the column and its order.
+type Item struct {
+	Col  *expression.Column
 	Desc bool
+}
+
+// PhysicalProperty stands for the required physical property by parents.
+// It contains the orders and the task types.
+type PhysicalProperty struct {
+	Items []Item
 
 	// TaskTp means the type of task that an operator requires.
 	//
@@ -48,19 +53,43 @@ type PhysicalProperty struct {
 	Enforced bool
 }
 
+// NewPhysicalProperty builds property from columns.
+func NewPhysicalProperty(taskTp TaskType, cols []*expression.Column, desc bool, expectCnt float64, enforced bool) *PhysicalProperty {
+	return &PhysicalProperty{
+		Items:       ItemsFromCols(cols, desc),
+		TaskTp:      taskTp,
+		ExpectedCnt: expectCnt,
+		Enforced:    enforced,
+	}
+}
+
+// ItemsFromCols builds property items from columns.
+func ItemsFromCols(cols []*expression.Column, desc bool) []Item {
+	items := make([]Item, 0, len(cols))
+	for _, col := range cols {
+		items = append(items, Item{Col: col, Desc: desc})
+	}
+	return items
+}
+
 // AllColsFromSchema checks whether all the columns needed by this physical
 // property can be found in the given schema.
 func (p *PhysicalProperty) AllColsFromSchema(schema *expression.Schema) bool {
-	return schema.ColumnsIndices(p.Cols) != nil
+	for _, col := range p.Items {
+		if schema.ColumnIndex(col.Col) == -1 {
+			return false
+		}
+	}
+	return true
 }
 
 // IsPrefix checks whether the order property is the prefix of another.
 func (p *PhysicalProperty) IsPrefix(prop *PhysicalProperty) bool {
-	if len(p.Cols) > len(prop.Cols) || p.Desc != prop.Desc {
+	if len(p.Items) > len(prop.Items) {
 		return false
 	}
-	for i := range p.Cols {
-		if !p.Cols[i].Equal(nil, prop.Cols[i]) {
+	for i := range p.Items {
+		if !p.Items[i].Col.Equal(nil, prop.Items[i].Col) || p.Items[i].Desc != prop.Items[i].Desc {
 			return false
 		}
 	}
@@ -69,7 +98,7 @@ func (p *PhysicalProperty) IsPrefix(prop *PhysicalProperty) bool {
 
 // IsEmpty checks whether the order property is empty.
 func (p *PhysicalProperty) IsEmpty() bool {
-	return len(p.Cols) == 0
+	return len(p.Items) == 0
 }
 
 // HashCode calculates hash code for a PhysicalProperty object.
@@ -77,13 +106,8 @@ func (p *PhysicalProperty) HashCode() []byte {
 	if p.hashcode != nil {
 		return p.hashcode
 	}
-	hashcodeSize := 8 + 8 + 8 + 16*len(p.Cols) + 8
+	hashcodeSize := 8 + 8 + 8 + (16+8)*len(p.Items) + 8
 	p.hashcode = make([]byte, 0, hashcodeSize)
-	if p.Desc {
-		p.hashcode = codec.EncodeInt(p.hashcode, 1)
-	} else {
-		p.hashcode = codec.EncodeInt(p.hashcode, 0)
-	}
 	if p.Enforced {
 		p.hashcode = codec.EncodeInt(p.hashcode, 1)
 	} else {
@@ -91,27 +115,44 @@ func (p *PhysicalProperty) HashCode() []byte {
 	}
 	p.hashcode = codec.EncodeInt(p.hashcode, int64(p.TaskTp))
 	p.hashcode = codec.EncodeFloat(p.hashcode, p.ExpectedCnt)
-	for i, length := 0, len(p.Cols); i < length; i++ {
-		p.hashcode = append(p.hashcode, p.Cols[i].HashCode(nil)...)
+	for _, item := range p.Items {
+		p.hashcode = append(p.hashcode, item.Col.HashCode(nil)...)
+		if item.Desc {
+			p.hashcode = codec.EncodeInt(p.hashcode, 1)
+		} else {
+			p.hashcode = codec.EncodeInt(p.hashcode, 0)
+		}
 	}
 	return p.hashcode
 }
 
 // String implements fmt.Stringer interface. Just for test.
 func (p *PhysicalProperty) String() string {
-	return fmt.Sprintf("Prop{cols: %v, desc: %v, TaskTp: %s, expectedCount: %v}", p.Cols, p.Desc, p.TaskTp, p.ExpectedCnt)
+	return fmt.Sprintf("Prop{cols: %v, TaskTp: %s, expectedCount: %v}", p.Items, p.TaskTp, p.ExpectedCnt)
 }
 
 // Clone returns a copy of PhysicalProperty. Currently, this function is only used to build new
 // required property for children plan in `exhaustPhysicalPlans`, so we don't copy `Enforced` field
-// because if `Enforced` is true, the `Cols` must be empty now, this makes `Enforced` meaningless
+// because if `Enforced` is true, the `Items` must be empty now, this makes `Enforced` meaningless
 // for children nodes.
 func (p *PhysicalProperty) Clone() *PhysicalProperty {
 	prop := &PhysicalProperty{
-		Cols:        p.Cols,
-		Desc:        p.Desc,
+		Items:       p.Items,
 		TaskTp:      p.TaskTp,
 		ExpectedCnt: p.ExpectedCnt,
 	}
 	return prop
+}
+
+// AllSameOrder checks if all the items have same order.
+func (p *PhysicalProperty) AllSameOrder() (bool, bool) {
+	if len(p.Items) == 0 {
+		return true, false
+	}
+	for i := 1; i < len(p.Items); i++ {
+		if p.Items[i].Desc != p.Items[i-1].Desc {
+			return false, false
+		}
+	}
+	return true, p.Items[0].Desc
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For SQL like `select avg(a) over (order by a desc, b asc) from t order by a desc, b asc`, we cannot push down the property of `order by` to window functions, because all the columns in the property must have same order.

### What is changed and how it works?

Allow specifying an order for every column in the physical property.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @winoros @eurekaka

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8715)
<!-- Reviewable:end -->
