### PR TITLE
executor: accelerate unit test TestTSOFail

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3367,9 +3367,9 @@ func (s *testSuite) TestTSOFail(c *C) {
 	tk.MustExec(`drop table if exists t`)
 	tk.MustExec(`create table t(a int)`)
 
-	gofail.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/mockGetTSFail", `return(true)`)
-	defer gofail.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/mockGetTSFail")
-	_, err := tk.Exec(`select * from t`)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, "mockGetTSFail", struct{}{})
+	_, err := tk.Se.Execute(ctx, `select * from t`)
 	c.Assert(err, NotNil)
 }
 

--- a/store/mockstore/mocktikv/pd.go
+++ b/store/mockstore/mocktikv/pd.go
@@ -47,11 +47,6 @@ func (c *pdClient) GetClusterID(ctx context.Context) uint64 {
 }
 
 func (c *pdClient) GetTS(context.Context) (int64, int64, error) {
-	// gofail: var mockGetTSFail bool
-	// if mockGetTSFail {
-	// 	return 0, 0, errors.New("mock get timestamp fail")
-	// }
-
 	tsMu.Lock()
 	defer tsMu.Unlock()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Accelerate unit test of executor package

```
GO111MODULE=on go test -check.f TestTSOFail

Before:
ok  	github.com/pingcap/tidb/executor	17.853s
After:
ok  	github.com/pingcap/tidb/executor	0.103s
```

### What is changed and how it works?

Use context instead of `gofail` the very low level function.
The sleep & retry waste too much time in the old way to mock get tso fail.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8717)
<!-- Reviewable:end -->
