### PR TITLE
ddl: fix a data race in unit test TestTableSplit

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.11
+      - image: golang:1.11.3
     working_directory: /go/src/github.com/pingcap/tidb
     steps:
       - checkout

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -63,7 +63,7 @@ var (
 	// EnableSplitTableRegion is a flag to decide whether to split a new region for
 	// a newly created table. It takes effect only if the Storage supports split
 	// region.
-	EnableSplitTableRegion = false
+	EnableSplitTableRegion = uint32(0)
 
 	// PartitionCountLimit is limit of the number of partitions in a table.
 	// Mysql maximum number of partitions is 8192, our maximum number of partitions is 1024.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -59,7 +60,7 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		if err != nil {
 			return ver, errors.Trace(err)
 		}
-		if EnableSplitTableRegion {
+		if atomic.LoadUint32(&EnableSplitTableRegion) != 0 {
 			// TODO: Add restrictions to this operation.
 			go splitTableRegion(d.store, tbInfo.ID)
 		}

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -16,6 +16,7 @@ package ddl_test
 import (
 	"bytes"
 	"context"
+	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -37,11 +38,11 @@ func (s *testDDLTableSplitSuite) TestTableSplit(c *C) {
 	defer store.Close()
 	session.SetSchemaLease(0)
 	session.SetStatsLease(0)
-	ddl.EnableSplitTableRegion = true
+	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
 	dom, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)
 	defer dom.Close()
-	ddl.EnableSplitTableRegion = false
+	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
 	infoSchema := dom.InfoSchema()
 	c.Assert(infoSchema, NotNil)
 	t, err := infoSchema.TableByName(model.NewCIStr("mysql"), model.NewCIStr("tidb"))

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -20,6 +20,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -399,7 +400,9 @@ func setGlobalVars() {
 	statistics.MaxQueryFeedbackCount = int(cfg.Performance.QueryFeedbackLimit)
 	statistics.RatioOfPseudoEstimate = cfg.Performance.PseudoEstimateRatio
 	ddl.RunWorker = cfg.RunDDL
-	ddl.EnableSplitTableRegion = cfg.SplitTable
+	if cfg.SplitTable {
+		atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
+	}
 	plannercore.AllowCartesianProduct = cfg.Performance.CrossJoin
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
 	variable.ForcePriority = int32(mysql.Str2Priority(cfg.Performance.ForcePriority))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Found in the unit test:

```
==================
WARNING: DATA RACE
Write at 0x0000030f923c by goroutine 198:
  github.com/pingcap/tidb/ddl_test.(*testDDLTableSplitSuite).TestTableSplit()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/table_split_test.go:44 +0x27d
  github.com/pingcap/tidb/privilege/privileges.(*MySQLPrivilege).LoadDBTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:256 +0x8b
  github.com/pingcap/tidb/privilege/privileges.(*MySQLPrivilege).LoadAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:121 +0x9d
  github.com/pingcap/tidb/privilege/privileges.(*MySQLPrivilege).LoadUserTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:159 +0xa2
  github.com/pingcap/tidb/privilege/privileges.(*MySQLPrivilege).LoadAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:116 +0x5f
  github.com/pingcap/tidb/privilege/privileges.(*Handle).Update()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:708 +0xa8
  github.com/pingcap/tidb/domain.(*Domain).LoadPrivilegeLoop()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:723 +0x148
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1235 +0x10a


Previous read at 0x0000030f923c by goroutine 162:
  github.com/pingcap/tidb/ddl.onCreateTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/table.go:62 +0x2e7
  github.com/pingcap/tidb/ddl.(*worker).runDDLJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:470 +0x70d
  github.com/sirupsen/logrus.Infof()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/sirupsen/logrus@v1.2.0/exported.go:148 +0x7c
  github.com/pingcap/tidb/ddl.(*worker).runDDLJob()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:447 +0xdf
  github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:384 +0x63b
  github.com/pingcap/tidb/ddl.(*TestDDLCallback).OnJobRunBefore()
```

### What is changed and how it works?

Make `EnableSplitTableRegion`  automic

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

@zimulala @winkyao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8719)
<!-- Reviewable:end -->
