### PR TITLE
ddl: fix data race in unit test TestChangeColumn

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"fmt"
+	"sync/atomic"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -482,7 +483,7 @@ func allocateColumnID(tblInfo *model.TableInfo) int64 {
 }
 
 func checkAddColumnTooManyColumns(oldCols int) error {
-	if oldCols > TableColumnCountLimit {
+	if uint32(oldCols) > atomic.LoadUint32(&TableColumnCountLimit) {
 		return errTooManyFields
 	}
 	return nil

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -876,7 +877,7 @@ func (s *testDBSuite) TestColumn(c *C) {
 func (s *testDBSuite) TestAddColumnTooMany(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use test")
-	count := ddl.TableColumnCountLimit - 1
+	count := int(atomic.LoadUint32(&ddl.TableColumnCountLimit) - 1)
 	var cols []string
 	for i := 0; i < count; i++ {
 		cols = append(cols, fmt.Sprintf("a%d int", i))

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -54,21 +54,21 @@ const (
 	ddlPrompt   = "ddl"
 
 	shardRowIDBitsMax = 15
-)
-
-var (
-	// TableColumnCountLimit is limit of the number of columns in a table.
-	// It's exported for testing.
-	TableColumnCountLimit = 512
-	// EnableSplitTableRegion is a flag to decide whether to split a new region for
-	// a newly created table. It takes effect only if the Storage supports split
-	// region.
-	EnableSplitTableRegion = uint32(0)
 
 	// PartitionCountLimit is limit of the number of partitions in a table.
 	// Mysql maximum number of partitions is 8192, our maximum number of partitions is 1024.
 	// Reference linking https://dev.mysql.com/doc/refman/5.7/en/partitioning-limitations.html.
 	PartitionCountLimit = 1024
+)
+
+var (
+	// TableColumnCountLimit is limit of the number of columns in a table.
+	// It's exported for testing.
+	TableColumnCountLimit = uint32(512)
+	// EnableSplitTableRegion is a flag to decide whether to split a new region for
+	// a newly created table. It takes effect only if the Storage supports split
+	// region.
+	EnableSplitTableRegion = uint32(0)
 )
 
 var (

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cznic/mathutil"
@@ -616,7 +617,7 @@ func checkTooLongColumn(colDefs []*ast.ColumnDef) error {
 }
 
 func checkTooManyColumns(colDefs []*ast.ColumnDef) error {
-	if len(colDefs) > TableColumnCountLimit {
+	if uint32(len(colDefs)) > atomic.LoadUint32(&TableColumnCountLimit) {
 		return errTooManyFields
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
=============
WARNING: DATA RACE
Read at 0x000002df5a08 by goroutine 151:
  github.com/pingcap/tidb/ddl.(*ddl).CreateTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_api.go:619 +0x77f
  github.com/pingcap/tidb/executor.(*DDLExec).executeCreateTable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/ddl.go:157 +0xca
  github.com/pingcap/tidb/executor.(*DDLExec).Next()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/ddl.go:88 +0x518
  github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:289 +0x1d5
  github.com/pingcap/tidb/executor.(*ExecStmt).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:242 +0x617
  github.com/pingcap/tidb/session.runStmt()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:153 +0xd2
  github.com/pingcap/tidb/session.(*session).executeStatement()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:840 +0x21d
  github.com/pingcap/tidb/session.(*session).executeStatement()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:838 +0x1a7
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:908 +0x9d8
  github.com/pingcap/tidb/session.(*session).Execute()

Previous write at 0x000002df5a08 by goroutine 89:
  [failed to restore the stack]
```

### What is changed and how it works?

Use atomic to avoid race

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

@zimulala @winkyao 
