### PR TITLE
executor,planner: fix 'show master status' output

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -500,6 +500,10 @@ func (b *executorBuilder) buildShow(v *plannercore.Show) Executor {
 	if e.Tp == ast.ShowGrants && e.User == nil {
 		e.User = e.ctx.GetSessionVars().User
 	}
+	if e.Tp == ast.ShowMasterStatus {
+		// show master status need start ts.
+		e.ctx.Txn(true)
+	}
 	if len(v.Conditions) == 0 {
 		return e
 	}

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -190,6 +190,7 @@ func (s *testSuite) TestShow(c *C) {
 	c.Check(result.Rows(), HasLen, 1)
 	row = result.Rows()[0]
 	c.Check(row, HasLen, 5)
+	c.Assert(row[1].(string) != "0", IsTrue)
 
 	tk.MustQuery("SHOW PRIVILEGES")
 

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1676,7 +1676,7 @@ func buildShowSchema(s *ast.ShowStmt) (schema *expression.Schema) {
 		names = []string{"Query_ID", "Duration", "Query"}
 		ftypes = []byte{mysql.TypeLong, mysql.TypeDouble, mysql.TypeVarchar}
 	case ast.ShowMasterStatus:
-		names = []string{"File", "UniqueID", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}
+		names = []string{"File", "Position", "Binlog_Do_DB", "Binlog_Ignore_DB", "Executed_Gtid_Set"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar}
 	case ast.ShowPrivileges:
 		names = []string{"Privilege", "Context", "Comment"}

--- a/planner/core/planbuilder_test.go
+++ b/planner/core/planbuilder_test.go
@@ -48,6 +48,7 @@ func (s *testPlanBuilderSuite) TestShow(c *C) {
 		ast.ShowProcessList,
 		ast.ShowCreateDatabase,
 		ast.ShowEvents,
+		ast.ShowMasterStatus,
 	}
 	for _, tp := range tps {
 		node.Tp = tp


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`show master status` is wrong:
```
mysql> show master status;
+-------------+----------+--------------+------------------+-------------------+
| File        | UniqueID | Binlog_Do_DB | Binlog_Ignore_DB | Executed_Gtid_Set |
+-------------+----------+--------------+------------------+-------------------+
| tidb-binlog |        0 |              |                  |                   |
+-------------+----------+--------------+------------------+-------------------+
1 row in set (0.01 sec)
```

### What is changed and how it works?

https://github.com/pingcap/tidb/pull/7218 modify the schema "Position" to "UniqueID" by mistake
https://github.com/pingcap/tidb/pull/8260 makes the result timestamp to be "0"

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8737)
<!-- Reviewable:end -->
