### PR TITLE
Add comments to why TaskType can be a physical property.

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -844,6 +844,7 @@ func (la *LogicalAggregation) getHashAggs(prop *property.PhysicalProperty) []Phy
 		return nil
 	}
 	hashAggs := make([]PhysicalPlan, 0, len(wholeTaskTypes))
+	// TaskType is also a kind of property, as a result, you may get a cop/root task return.
 	for _, taskTp := range wholeTaskTypes {
 		agg := basePhysicalAgg{
 			GroupByItems: la.GroupByItems,

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -107,6 +107,8 @@ func (p *baseLogicalPlan) findBestTask(prop *property.PhysicalProperty) (bestTas
 		// Next, get the bestTask with enforced prop
 		prop.Items = []property.Item{}
 	}
+	// For props passed down from caller, we need to combine it with the a certain physical plan's props
+	// and compute what props needed to pass to child.
 	physicalPlans := p.self.exhaustPhysicalPlans(prop)
 	prop.Items = oldPropCols
 
@@ -368,6 +370,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, path *
 	matchProperty := false
 	all, desc := prop.AllSameOrder()
 	if !prop.IsEmpty() && all {
+		// this is used for multi index
 		for i, col := range idx.Columns {
 			// not matched
 			if col.Name.L == prop.Items[0].Col.ColName.L {
@@ -414,6 +417,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, path *
 	} else if _, ok := task.(*rootTask); ok {
 		return invalidTask, nil
 	}
+	// May return rootTask/CopTask(CopSingleReadTaskType, CopDoubleReadTaskType).
 	return task, nil
 }
 
@@ -564,6 +568,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, path *
 	} else if _, ok := task.(*rootTask); ok {
 		return invalidTask, nil
 	}
+	// May return rootTask/CopTask(CopSingleReadTaskType).
 	return task, nil
 }
 

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -489,6 +489,8 @@ func (p *PhysicalStreamAgg) attach2Task(tasks ...task) task {
 func (p *PhysicalHashAgg) attach2Task(tasks ...task) task {
 	cardinality := p.statsInfo().RowCount
 	t := tasks[0].copy()
+	// Since we may get a cop task from child (identified in child props), because we wanna push agg down to cop.
+	// So we got a copTask here to add partialAgg in the physical plan and finally convert it to a rootTask.
 	if cop, ok := t.(*copTask); ok {
 		partialAgg, finalAgg := p.newPartialAggregate()
 		if partialAgg != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add comments to why TaskType can be a physical property.

### What is changed and how it works?
Focus on when TaskType (especially copTask) become a child prop and what it will do in attach2Task when get a copTask back. We keep tracing this process by debugging a certain SQL like "select count(*) from tableName order by colName;"

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has added comments to the process

Side effects

 - None

Related changes

 - None