### PR TITLE
admin: admin check table only check the public index

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -466,6 +466,9 @@ func (e *CheckTableExec) doCheckPartitionedTable(tbl table.PartitionedTable) err
 
 func (e *CheckTableExec) doCheckTable(tbl table.Table) error {
 	for _, idx := range tbl.Indices() {
+		if idx.Meta().State != model.StatePublic {
+			continue
+		}
 		txn := e.ctx.Txn(true)
 		err := admin.CompareIndexData(e.ctx, txn, tbl, idx, e.genExprs)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If an index state is on the StateWriteReorganization, still have some record doesn't backfilled. 
Current tidb admin check table will check all index no matter what state the index is in. Then admin check table will return an error, because there are some records doesn't finish fill back index.

We should only check public index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8748)
<!-- Reviewable:end -->
