### PR TITLE
executor/test: fix data race of TestCoprocessorPriority

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2298,10 +2298,9 @@ func (s *testSuite) TestIssue4024(c *C) {
 }
 
 const (
-	checkRequestOff          = 0
-	checkRequestPriority     = 1
-	checkRequestSyncLog      = 3
-	checkDDLAddIndexPriority = 4
+	checkRequestOff = iota
+	checkRequestSyncLog
+	checkDDLAddIndexPriority
 )
 
 type checkRequestClient struct {
@@ -2328,14 +2327,7 @@ func (c *checkRequestClient) SendRequest(ctx context.Context, addr string, req *
 	c.mu.RLock()
 	checkFlags := c.mu.checkFlags
 	c.mu.RUnlock()
-	if checkFlags == checkRequestPriority {
-		switch req.Type {
-		case tikvrpc.CmdCop:
-			if c.getCheckPriority() != req.Priority {
-				return nil, errors.New("fail to set priority")
-			}
-		}
-	} else if checkFlags == checkRequestSyncLog {
+	if checkFlags == checkRequestSyncLog {
 		switch req.Type {
 		case tikvrpc.CmdPrewrite, tikvrpc.CmdCommit:
 			c.mu.RLock()
@@ -2477,69 +2469,6 @@ func (s *testSuite1) TestAlterTableComment(c *C) {
 	tk.MustExec("alter table `t_1` comment 'table t comment';")
 	result = tk.MustQuery("select table_comment from information_schema.tables where table_name = 't_1';")
 	result.Check(testkit.Rows("table t comment"))
-}
-
-func (s *testSuite1) TestCoprocessorPriority(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("create table t (id int primary key)")
-	tk.MustExec("create table t1 (id int, v int, unique index i_id (id))")
-	defer tk.MustExec("drop table t")
-	defer tk.MustExec("drop table t1")
-	tk.MustExec("insert into t values (1)")
-
-	// Insert some data to make sure plan build IndexLookup for t1.
-	for i := 0; i < 10; i++ {
-		tk.MustExec(fmt.Sprintf("insert into t1 values (%d, %d)", i, i))
-	}
-
-	cli := s.cli
-	cli.mu.Lock()
-	cli.mu.checkFlags = checkRequestPriority
-	cli.mu.Unlock()
-
-	cli.setCheckPriority(pb.CommandPri_High)
-	tk.MustQuery("select id from t where id = 1")
-	tk.MustQuery("select * from t1 where id = 1")
-
-	cli.setCheckPriority(pb.CommandPri_Normal)
-	tk.MustQuery("select count(*) from t")
-	tk.MustExec("update t set id = 3")
-	tk.MustExec("delete from t")
-	tk.MustExec("insert into t select * from t limit 2")
-	tk.MustExec("delete from t")
-
-	// Insert some data to make sure plan build IndexLookup for t.
-	tk.MustExec("insert into t values (1), (2)")
-
-	oldThreshold := config.GetGlobalConfig().Log.ExpensiveThreshold
-	config.GetGlobalConfig().Log.ExpensiveThreshold = 0
-	defer func() { config.GetGlobalConfig().Log.ExpensiveThreshold = oldThreshold }()
-
-	cli.setCheckPriority(pb.CommandPri_High)
-	tk.MustQuery("select id from t where id = 1")
-	tk.MustQuery("select * from t1 where id = 1")
-
-	cli.setCheckPriority(pb.CommandPri_Low)
-	tk.MustQuery("select count(*) from t")
-	tk.MustExec("delete from t")
-	tk.MustExec("insert into t values (3)")
-
-	// TODO: Those are not point get, but they should be high priority.
-	// cli.priority = pb.CommandPri_High
-	// tk.MustExec("delete from t where id = 2")
-	// tk.MustExec("update t set id = 2 where id = 1")
-
-	// Test priority specified by SQL statement.
-	cli.setCheckPriority(pb.CommandPri_High)
-	tk.MustQuery("select HIGH_PRIORITY * from t")
-
-	cli.setCheckPriority(pb.CommandPri_Low)
-	tk.MustQuery("select LOW_PRIORITY id from t where id = 1")
-
-	cli.mu.Lock()
-	cli.mu.checkFlags = checkRequestOff
-	cli.mu.Unlock()
 }
 
 func (s *testSuite) TestTimezonePushDown(c *C) {

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -28,9 +28,12 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	gofail "github.com/pingcap/gofail/runtime"
+	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
@@ -41,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
@@ -715,4 +719,108 @@ func generateBatchSQL(paramCount int) (sql string, paramSlice []interface{}) {
 		placeholders = append(placeholders, "(?)")
 	}
 	return "insert into t values " + strings.Join(placeholders, ","), params
+}
+
+type checkPrioClient struct {
+	tikv.Client
+	priority pb.CommandPri
+}
+
+func (c *checkPrioClient) setCheckPriority(priority pb.CommandPri) {
+	atomic.StoreInt32((*int32)(&c.priority), int32(priority))
+}
+
+func (c *checkPrioClient) getCheckPriority() pb.CommandPri {
+	return (pb.CommandPri)(atomic.LoadInt32((*int32)(&c.priority)))
+}
+
+func (c *checkPrioClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	resp, err := c.Client.SendRequest(ctx, addr, req, timeout)
+	switch req.Type {
+	case tikvrpc.CmdCop:
+		if c.getCheckPriority() != req.Priority {
+			return nil, errors.New("fail to set priority")
+		}
+	}
+	return resp, err
+}
+
+type seqTestSuite1 struct {
+	store kv.Storage
+	dom   *domain.Domain
+	cli   *checkPrioClient
+}
+
+func (s *seqTestSuite1) SetUpSuite(c *C) {
+	cli := &checkPrioClient{}
+	hijackClient := func(c tikv.Client) tikv.Client {
+		cli.Client = c
+		return cli
+	}
+	s.cli = cli
+
+	var err error
+	s.store, err = mockstore.NewMockTikvStore(
+		mockstore.WithHijackClient(hijackClient),
+	)
+	c.Assert(err, IsNil)
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+}
+
+func (s *seqTestSuite1) TearDownSuite(c *C) {
+	s.dom.Close()
+	s.store.Close()
+}
+
+func (s *seqTestSuite1) TestCoprocessorPriority(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (id int primary key)")
+	tk.MustExec("create table t1 (id int, v int, unique index i_id (id))")
+	defer tk.MustExec("drop table t")
+	defer tk.MustExec("drop table t1")
+	tk.MustExec("insert into t values (1)")
+
+	// Insert some data to make sure plan build IndexLookup for t1.
+	for i := 0; i < 10; i++ {
+		tk.MustExec(fmt.Sprintf("insert into t1 values (%d, %d)", i, i))
+	}
+
+	cli := s.cli
+	cli.setCheckPriority(pb.CommandPri_High)
+	tk.MustQuery("select id from t where id = 1")
+	tk.MustQuery("select * from t1 where id = 1")
+
+	cli.setCheckPriority(pb.CommandPri_Normal)
+	tk.MustQuery("select count(*) from t")
+	tk.MustExec("update t set id = 3")
+	tk.MustExec("delete from t")
+	tk.MustExec("insert into t select * from t limit 2")
+	tk.MustExec("delete from t")
+
+	// Insert some data to make sure plan build IndexLookup for t.
+	tk.MustExec("insert into t values (1), (2)")
+
+	oldThreshold := config.GetGlobalConfig().Log.ExpensiveThreshold
+	config.GetGlobalConfig().Log.ExpensiveThreshold = 0
+	defer func() { config.GetGlobalConfig().Log.ExpensiveThreshold = oldThreshold }()
+
+	cli.setCheckPriority(pb.CommandPri_High)
+	tk.MustQuery("select id from t where id = 1")
+	tk.MustQuery("select * from t1 where id = 1")
+	tk.MustExec("delete from t where id = 2")
+	tk.MustExec("update t set id = 2 where id = 1")
+
+	cli.setCheckPriority(pb.CommandPri_Low)
+	tk.MustQuery("select count(*) from t")
+	tk.MustExec("delete from t")
+	tk.MustExec("insert into t values (3)")
+
+	// Test priority specified by SQL statement.
+	cli.setCheckPriority(pb.CommandPri_High)
+	tk.MustQuery("select HIGH_PRIORITY * from t")
+
+	cli.setCheckPriority(pb.CommandPri_Low)
+	tk.MustQuery("select LOW_PRIORITY id from t where id = 1")
 }


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Data race caused by running unit tests in parallel:
```
WARNING: DATA RACE
Write at 0x000003136ab0 by goroutine 133:
  github.com/pingcap/tidb/executor_test.(*testSuite1).TestCoprocessorPriority()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:2516 +0x5a6

Previous read at 0x000003136ab0 by goroutine 124:
  github.com/pingcap/tidb/executor.isPhysicalPlanExpensive()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:106 +0x3e
  github.com/pingcap/tidb/executor.isExpensiveQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:91 +0x326
  github.com/pingcap/tidb/executor.logExpensiveQuery()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:69 +0x5d
  github.com/pingcap/tidb/executor.(*Compiler).Compile()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:55 +0x305
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:907 +0x9f7
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:869 +0xd4
  github.com/pingcap/tidb/ddl/util.CompleteDeleteRange()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/util/util.go:106 +0x18e
  github.com/pingcap/tidb/ddl.(*delRange).doTask()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:187 +0x443
```

### What is changed and how it works?

`TestCoprocessorPriority` would modify global variable `ExpensiveThreshold`, so make it being executed sequentially.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes
N/A

Side effects
N/A

Related changes
N/A