### PR TITLE
server: compatible to old handshake protocol

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -249,6 +249,7 @@ type handshakeResponse41 struct {
 func parseOldHandshakeResponseHeader(packet *handshakeResponse41, data []byte) (parsedBytes int, err error) {
 	// Ensure there are enough data to read:
 	// https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse320
+	log.Debugf("Try to parse hanshake response as Protocol::HandshakeResponse320 , packet data: %v", data)
 	if len(data) < 2+3 {
 		log.Errorf("Got malformed handshake response, packet data: %v", data)
 		return 0, mysql.ErrMalformPacket
@@ -306,7 +307,6 @@ func parseHandshakeResponseHeader(packet *handshakeResponse41, data []byte) (par
 	// Ensure there are enough data to read:
 	// http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
 	if len(data) < 4+4+1+23 {
-		log.Errorf("Got malformed handshake response, packet data: %v", data)
 		return 0, mysql.ErrMalformPacket
 	}
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -307,6 +307,7 @@ func parseHandshakeResponseHeader(packet *handshakeResponse41, data []byte) (par
 	// Ensure there are enough data to read:
 	// http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::SSLRequest
 	if len(data) < 4+4+1+23 {
+		log.Errorf("Got malformed handshake response, packet data: %v", data)
 		return 0, mysql.ErrMalformPacket
 	}
 

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -93,6 +93,20 @@ func (ts ConnTestSuite) TestParseHandshakeResponse(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(p.User, Equals, "pam")
 	c.Assert(p.DBName, Equals, "test")
+
+	// Test for compatibility of Protocol::HandshakeResponse320
+	data = []byte{
+		0x00, 0x80, 0x00, 0x00, 0x01, 0x72, 0x6f, 0x6f, 0x74, 0x00, 0x00,
+	}
+	p = handshakeResponse41{}
+	offset, err = parseOldHandshakeResponseHeader(&p, data)
+	c.Assert(err, IsNil)
+	capability = mysql.ClientProtocol41 |
+		mysql.ClientSecureConnection
+	c.Assert(p.Capability&capability, Equals, capability)
+	err = parseOldHandshakeResponseBody(&p, data, offset)
+	c.Assert(err, IsNil)
+	c.Assert(p.User, Equals, "root")
 }
 
 func (ts ConnTestSuite) TestIssue1768(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When using HAProxy connect to TiDB server, `option mysql-check user root` will cause handshake fail error because TiDB do not support [Protocol::HandshakeResponse320](https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse320)

### What is changed and how it works?
Parser`Protocol::HandshakeResponse320` to `Protocol::HandshakeResponse41`, which is supported by TiDB.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8812)
<!-- Reviewable:end -->
