### PR TITLE
planner, executor: add post-process after physical plan optimazation …

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -179,23 +179,27 @@ CREATE TABLE `tbl_008` (`a` int, `b` int);
 CREATE TABLE `tbl_009` (`a` int, `b` int);
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	count	task	operator info
-HashAgg_34	72000.00	root	group by:x.b, funcs:sum(x.a)
-└─Union_35	90000.00	root	
-  ├─TableReader_38	10000.00	root	data:TableScan_37
-  │ └─TableScan_37	10000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_41	10000.00	root	data:TableScan_40
-  │ └─TableScan_40	10000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_44	10000.00	root	data:TableScan_43
-  │ └─TableScan_43	10000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_47	10000.00	root	data:TableScan_46
-  │ └─TableScan_46	10000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_50	10000.00	root	data:TableScan_49
-  │ └─TableScan_49	10000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_53	10000.00	root	data:TableScan_52
-  │ └─TableScan_52	10000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_56	10000.00	root	data:TableScan_55
-  │ └─TableScan_55	10000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false, stats:pseudo
-  ├─TableReader_59	10000.00	root	data:TableScan_58
-  │ └─TableScan_58	10000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─TableReader_62	10000.00	root	data:TableScan_61
-    └─TableScan_61	10000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false, stats:pseudo
+HashAgg_34	72000.00	root	group by:group_0, funcs:sum(sum_0)
+└─Projection_63	90000.00	root	cast(x.a), x.b
+  └─Union_35	90000.00	root	
+    ├─TableReader_38	10000.00	root	data:TableScan_37
+    │ └─TableScan_37	10000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_41	10000.00	root	data:TableScan_40
+    │ └─TableScan_40	10000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_44	10000.00	root	data:TableScan_43
+    │ └─TableScan_43	10000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_47	10000.00	root	data:TableScan_46
+    │ └─TableScan_46	10000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_50	10000.00	root	data:TableScan_49
+    │ └─TableScan_49	10000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_53	10000.00	root	data:TableScan_52
+    │ └─TableScan_52	10000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_56	10000.00	root	data:TableScan_55
+    │ └─TableScan_55	10000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_59	10000.00	root	data:TableScan_58
+    │ └─TableScan_58	10000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_62	10000.00	root	data:TableScan_61
+      └─TableScan_61	10000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false, stats:pseudo
+
+
+

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -205,23 +205,27 @@ CREATE TABLE tbl_009 (a int, b int);
 load stats 's/explain_complex_stats_tbl_009.json';
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	count	task	operator info
-HashAgg_34	18000.00	root	group by:x.b, funcs:sum(x.a)
-└─Union_35	18000.00	root	
-  ├─TableReader_38	2000.00	root	data:TableScan_37
-  │ └─TableScan_37	2000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false
-  ├─TableReader_41	2000.00	root	data:TableScan_40
-  │ └─TableScan_40	2000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false
-  ├─TableReader_44	2000.00	root	data:TableScan_43
-  │ └─TableScan_43	2000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false
-  ├─TableReader_47	2000.00	root	data:TableScan_46
-  │ └─TableScan_46	2000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false
-  ├─TableReader_50	2000.00	root	data:TableScan_49
-  │ └─TableScan_49	2000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false
-  ├─TableReader_53	2000.00	root	data:TableScan_52
-  │ └─TableScan_52	2000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false
-  ├─TableReader_56	2000.00	root	data:TableScan_55
-  │ └─TableScan_55	2000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false
-  ├─TableReader_59	2000.00	root	data:TableScan_58
-  │ └─TableScan_58	2000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false
-  └─TableReader_62	2000.00	root	data:TableScan_61
-    └─TableScan_61	2000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false
+HashAgg_34	18000.00	root	group by:group_0, funcs:sum(sum_0)
+└─Projection_63	18000.00	root	cast(x.a), x.b
+  └─Union_35	18000.00	root	
+    ├─TableReader_38	2000.00	root	data:TableScan_37
+    │ └─TableScan_37	2000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false
+    ├─TableReader_41	2000.00	root	data:TableScan_40
+    │ └─TableScan_40	2000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false
+    ├─TableReader_44	2000.00	root	data:TableScan_43
+    │ └─TableScan_43	2000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false
+    ├─TableReader_47	2000.00	root	data:TableScan_46
+    │ └─TableScan_46	2000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false
+    ├─TableReader_50	2000.00	root	data:TableScan_49
+    │ └─TableScan_49	2000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false
+    ├─TableReader_53	2000.00	root	data:TableScan_52
+    │ └─TableScan_52	2000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false
+    ├─TableReader_56	2000.00	root	data:TableScan_55
+    │ └─TableScan_55	2000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false
+    ├─TableReader_59	2000.00	root	data:TableScan_58
+    │ └─TableScan_58	2000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false
+    └─TableReader_62	2000.00	root	data:TableScan_61
+      └─TableScan_61	2000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false
+
+
+

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -86,12 +86,13 @@ TableReader_7	0.33	root	data:Selection_6
   └─TableScan_5	1.00	cop	table:t1, range:[1,1], keep order:false, stats:pseudo
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(5_aux_0)
-└─MergeJoin_28	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
-  ├─TableReader_19	10000.00	root	data:TableScan_18
-  │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
-  └─IndexReader_23	10000.00	root	index:IndexScan_22
-    └─IndexScan_22	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
+StreamAgg_12	1.00	root	funcs:sum(sum_0)
+└─Projection_35	10000.00	root	cast(5_aux_0)
+  └─MergeJoin_28	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
+    ├─TableReader_19	10000.00	root	data:TableScan_18
+    │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
+    └─IndexReader_23	10000.00	root	index:IndexScan_22
+      └─IndexScan_22	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	count	task	operator info
 Projection_9	10000.00	root	test.t1.c1
@@ -190,12 +191,13 @@ HashAgg_18	24000.00	root	group by:c1, funcs:firstrow(join_agg_0)
 set @@session.tidb_opt_insubq_to_join_and_agg=0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(5_aux_0)
-└─MergeJoin_28	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
-  ├─TableReader_19	10000.00	root	data:TableScan_18
-  │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
-  └─IndexReader_23	10000.00	root	index:IndexScan_22
-    └─IndexScan_22	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
+StreamAgg_12	1.00	root	funcs:sum(sum_0)
+└─Projection_35	10000.00	root	cast(5_aux_0)
+  └─MergeJoin_28	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
+    ├─TableReader_19	10000.00	root	data:TableScan_18
+    │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
+    └─IndexReader_23	10000.00	root	index:IndexScan_22
+      └─IndexScan_22	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
 explain select 1 in (select c2 from t2) from t1;
 id	count	task	operator info
 Projection_6	10000.00	root	5_aux_0
@@ -207,13 +209,14 @@ Projection_6	10000.00	root	5_aux_0
       └─TableScan_10	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select sum(6 in (select c2 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(5_aux_0)
-└─HashLeftJoin_19	10000.00	root	left outer semi join, inner:TableReader_18
-  ├─TableReader_21	10000.00	root	data:TableScan_20
-  │ └─TableScan_20	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─TableReader_18	10.00	root	data:Selection_17
-    └─Selection_17	10.00	cop	eq(6, test.t2.c2)
-      └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_12	1.00	root	funcs:sum(sum_0)
+└─Projection_22	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_19	10000.00	root	left outer semi join, inner:TableReader_18
+    ├─TableReader_21	10000.00	root	data:TableScan_20
+    │ └─TableScan_20	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_18	10.00	root	data:Selection_17
+      └─Selection_17	10.00	cop	eq(6, test.t2.c2)
+        └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain format="dot" select sum(t1.c1 in (select c1 from t2)) from t1;
 dot contents
 
@@ -222,7 +225,8 @@ subgraph cluster12{
 node [style=filled, color=lightgrey]
 color=black
 label = "root"
-"StreamAgg_12" -> "MergeJoin_28"
+"StreamAgg_12" -> "Projection_35"
+"Projection_35" -> "MergeJoin_28"
 "MergeJoin_28" -> "TableReader_19"
 "MergeJoin_28" -> "IndexReader_23"
 }

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -250,19 +250,20 @@ limit 10;
 id	count	task	operator info
 Projection_14	10.00	root	tpch.lineitem.l_orderkey, 7_col_0, tpch.orders.o_orderdate, tpch.orders.o_shippriority
 └─TopN_17	10.00	root	7_col_0:desc, tpch.orders.o_orderdate:asc, offset:0, count:10
-  └─HashAgg_23	40227041.09	root	group by:tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority, funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), firstrow(tpch.orders.o_orderdate), firstrow(tpch.orders.o_shippriority), firstrow(tpch.lineitem.l_orderkey)
-    └─IndexJoin_29	91515927.49	root	inner join, inner:IndexLookUp_28, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─HashRightJoin_49	22592975.51	root	inner join, inner:TableReader_55, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-      │ ├─TableReader_55	1498236.00	root	data:Selection_54
-      │ │ └─Selection_54	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
-      │ │   └─TableScan_53	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-      │ └─TableReader_52	36870000.00	root	data:Selection_51
-      │   └─Selection_51	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
-      │     └─TableScan_50	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_28	162945114.27	root	
-        ├─IndexScan_25	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
-        └─Selection_27	162945114.27	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
-          └─TableScan_26	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_23	40227041.09	root	group by:group_0, group_1, group_2, funcs:sum(sum_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0)
+    └─Projection_59	91515927.49	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.orders.o_orderdate, tpch.orders.o_shippriority, tpch.lineitem.l_orderkey, tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority
+      └─IndexJoin_29	91515927.49	root	inner join, inner:IndexLookUp_28, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+        ├─HashRightJoin_49	22592975.51	root	inner join, inner:TableReader_55, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        │ ├─TableReader_55	1498236.00	root	data:Selection_54
+        │ │ └─Selection_54	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
+        │ │   └─TableScan_53	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        │ └─TableReader_52	36870000.00	root	data:Selection_51
+        │   └─Selection_51	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
+        │     └─TableScan_50	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─IndexLookUp_28	162945114.27	root	
+          ├─IndexScan_25	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
+          └─Selection_27	162945114.27	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
+            └─TableScan_26	1.00	cop	table:lineitem, keep order:false
 /*
 Q4 Order Priority Checking Query
 This query determines how well the order priority system is working and gives an assessment of customer satisfaction.
@@ -343,26 +344,27 @@ revenue desc;
 id	count	task	operator info
 Sort_23	5.00	root	revenue:desc
 └─Projection_25	5.00	root	tpch.nation.n_name, 13_col_0
-  └─HashAgg_28	5.00	root	group by:tpch.nation.n_name, funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), firstrow(tpch.nation.n_name)
-    └─IndexJoin_31	11822812.50	root	inner join, inner:TableReader_30, outer key:tpch.orders.o_custkey, inner key:tpch.customer.c_custkey, other cond:eq(tpch.supplier.s_nationkey, tpch.customer.c_nationkey)
-      ├─IndexJoin_38	11822812.50	root	inner join, inner:TableReader_37, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-      │ ├─HashRightJoin_42	61163763.01	root	inner join, inner:HashRightJoin_44, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
-      │ │ ├─HashRightJoin_44	100000.00	root	inner join, inner:HashRightJoin_50, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-      │ │ │ ├─HashRightJoin_50	5.00	root	inner join, inner:TableReader_55, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
-      │ │ │ │ ├─TableReader_55	1.00	root	data:Selection_54
-      │ │ │ │ │ └─Selection_54	1.00	cop	eq(tpch.region.r_name, "MIDDLE EAST")
-      │ │ │ │ │   └─TableScan_53	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-      │ │ │ │ └─TableReader_52	25.00	root	data:TableScan_51
-      │ │ │ │   └─TableScan_51	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-      │ │ │ └─TableReader_57	500000.00	root	data:TableScan_56
-      │ │ │   └─TableScan_56	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_59	300005811.00	root	data:TableScan_58
-      │ │   └─TableScan_58	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      │ └─TableReader_37	11822812.50	root	data:Selection_36
-      │   └─Selection_36	11822812.50	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
-      │     └─TableScan_35	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
-      └─TableReader_30	1.00	root	data:TableScan_29
-        └─TableScan_29	1.00	cop	table:customer, range: decided by [tpch.supplier.s_nationkey tpch.orders.o_custkey], keep order:false
+  └─HashAgg_28	5.00	root	group by:group_0, funcs:sum(sum_0), firstrow(firstrow_0)
+    └─Projection_66	11822812.50	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.nation.n_name, tpch.nation.n_name
+      └─IndexJoin_31	11822812.50	root	inner join, inner:TableReader_30, outer key:tpch.orders.o_custkey, inner key:tpch.customer.c_custkey, other cond:eq(tpch.supplier.s_nationkey, tpch.customer.c_nationkey)
+        ├─IndexJoin_38	11822812.50	root	inner join, inner:TableReader_37, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
+        │ ├─HashRightJoin_42	61163763.01	root	inner join, inner:HashRightJoin_44, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
+        │ │ ├─HashRightJoin_44	100000.00	root	inner join, inner:HashRightJoin_50, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+        │ │ │ ├─HashRightJoin_50	5.00	root	inner join, inner:TableReader_55, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
+        │ │ │ │ ├─TableReader_55	1.00	root	data:Selection_54
+        │ │ │ │ │ └─Selection_54	1.00	cop	eq(tpch.region.r_name, "MIDDLE EAST")
+        │ │ │ │ │   └─TableScan_53	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+        │ │ │ │ └─TableReader_52	25.00	root	data:TableScan_51
+        │ │ │ │   └─TableScan_51	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ │ └─TableReader_57	500000.00	root	data:TableScan_56
+        │ │ │   └─TableScan_56	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_59	300005811.00	root	data:TableScan_58
+        │ │   └─TableScan_58	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        │ └─TableReader_37	11822812.50	root	data:Selection_36
+        │   └─Selection_36	11822812.50	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
+        │     └─TableScan_35	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
+        └─TableReader_30	1.00	root	data:TableScan_29
+          └─TableScan_29	1.00	cop	table:customer, range: decided by [tpch.supplier.s_nationkey tpch.orders.o_custkey], keep order:false
 /*
 Q6 Forecasting Revenue Change Query
 This query quantifies the amount of revenue increase that would have resulted from eliminating certain companywide
@@ -515,35 +517,36 @@ o_year;
 id	count	task	operator info
 Sort_29	718.01	root	all_nations.o_year:asc
 └─Projection_31	718.01	root	all_nations.o_year, div(18_col_0, 18_col_1)
-  └─HashAgg_34	718.01	root	group by:all_nations.o_year, funcs:sum(case(eq(all_nations.nation, "INDIA"), all_nations.volume, 0)), sum(all_nations.volume), firstrow(all_nations.o_year)
-    └─Projection_35	562348.12	root	extract("YEAR", tpch.orders.o_orderdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), n2.n_name
-      └─HashLeftJoin_39	562348.12	root	inner join, inner:TableReader_87, equal:[eq(tpch.supplier.s_nationkey, n2.n_nationkey)]
-        ├─IndexJoin_43	562348.12	root	inner join, inner:TableReader_42, outer key:tpch.lineitem.l_suppkey, inner key:tpch.supplier.s_suppkey
-        │ ├─HashLeftJoin_50	562348.12	root	inner join, inner:TableReader_83, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
-        │ │ ├─IndexJoin_56	90661378.61	root	inner join, inner:IndexLookUp_55, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-        │ │ │ ├─HashRightJoin_60	22382008.93	root	inner join, inner:HashRightJoin_62, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-        │ │ │ │ ├─HashRightJoin_62	1500000.00	root	inner join, inner:HashRightJoin_68, equal:[eq(n1.n_nationkey, tpch.customer.c_nationkey)]
-        │ │ │ │ │ ├─HashRightJoin_68	5.00	root	inner join, inner:TableReader_73, equal:[eq(tpch.region.r_regionkey, n1.n_regionkey)]
-        │ │ │ │ │ │ ├─TableReader_73	1.00	root	data:Selection_72
-        │ │ │ │ │ │ │ └─Selection_72	1.00	cop	eq(tpch.region.r_name, "ASIA")
-        │ │ │ │ │ │ │   └─TableScan_71	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-        │ │ │ │ │ │ └─TableReader_70	25.00	root	data:TableScan_69
-        │ │ │ │ │ │   └─TableScan_69	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
-        │ │ │ │ │ └─TableReader_75	7500000.00	root	data:TableScan_74
-        │ │ │ │ │   └─TableScan_74	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        │ │ │ │ └─TableReader_78	22382008.93	root	data:Selection_77
-        │ │ │ │   └─Selection_77	22382008.93	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), le(tpch.orders.o_orderdate, 1996-12-31 00:00:00.000000)
-        │ │ │ │     └─TableScan_76	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        │ │ │ └─IndexLookUp_55	1.00	root	
-        │ │ │   ├─IndexScan_53	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
-        │ │ │   └─TableScan_54	1.00	cop	table:lineitem, keep order:false
-        │ │ └─TableReader_83	61674.00	root	data:Selection_82
-        │ │   └─Selection_82	61674.00	cop	eq(tpch.part.p_type, "SMALL PLATED COPPER")
-        │ │     └─TableScan_81	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-        │ └─TableReader_42	1.00	root	data:TableScan_41
-        │   └─TableScan_41	1.00	cop	table:supplier, range: decided by [tpch.lineitem.l_suppkey], keep order:false
-        └─TableReader_87	25.00	root	data:TableScan_86
-          └─TableScan_86	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
+  └─HashAgg_34	718.01	root	group by:group_0, funcs:sum(sum_0), sum(sum_0), firstrow(firstrow_0)
+    └─Projection_89	562348.12	root	case(eq(all_nations.nation, "INDIA"), all_nations.volume, 0), all_nations.volume, all_nations.o_year, all_nations.o_year
+      └─Projection_35	562348.12	root	extract("YEAR", tpch.orders.o_orderdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), n2.n_name
+        └─HashLeftJoin_39	562348.12	root	inner join, inner:TableReader_87, equal:[eq(tpch.supplier.s_nationkey, n2.n_nationkey)]
+          ├─IndexJoin_43	562348.12	root	inner join, inner:TableReader_42, outer key:tpch.lineitem.l_suppkey, inner key:tpch.supplier.s_suppkey
+          │ ├─HashLeftJoin_50	562348.12	root	inner join, inner:TableReader_83, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
+          │ │ ├─IndexJoin_56	90661378.61	root	inner join, inner:IndexLookUp_55, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+          │ │ │ ├─HashRightJoin_60	22382008.93	root	inner join, inner:HashRightJoin_62, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+          │ │ │ │ ├─HashRightJoin_62	1500000.00	root	inner join, inner:HashRightJoin_68, equal:[eq(n1.n_nationkey, tpch.customer.c_nationkey)]
+          │ │ │ │ │ ├─HashRightJoin_68	5.00	root	inner join, inner:TableReader_73, equal:[eq(tpch.region.r_regionkey, n1.n_regionkey)]
+          │ │ │ │ │ │ ├─TableReader_73	1.00	root	data:Selection_72
+          │ │ │ │ │ │ │ └─Selection_72	1.00	cop	eq(tpch.region.r_name, "ASIA")
+          │ │ │ │ │ │ │   └─TableScan_71	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+          │ │ │ │ │ │ └─TableReader_70	25.00	root	data:TableScan_69
+          │ │ │ │ │ │   └─TableScan_69	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
+          │ │ │ │ │ └─TableReader_75	7500000.00	root	data:TableScan_74
+          │ │ │ │ │   └─TableScan_74	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+          │ │ │ │ └─TableReader_78	22382008.93	root	data:Selection_77
+          │ │ │ │   └─Selection_77	22382008.93	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), le(tpch.orders.o_orderdate, 1996-12-31 00:00:00.000000)
+          │ │ │ │     └─TableScan_76	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+          │ │ │ └─IndexLookUp_55	1.00	root	
+          │ │ │   ├─IndexScan_53	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
+          │ │ │   └─TableScan_54	1.00	cop	table:lineitem, keep order:false
+          │ │ └─TableReader_83	61674.00	root	data:Selection_82
+          │ │   └─Selection_82	61674.00	cop	eq(tpch.part.p_type, "SMALL PLATED COPPER")
+          │ │     └─TableScan_81	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+          │ └─TableReader_42	1.00	root	data:TableScan_41
+          │   └─TableScan_41	1.00	cop	table:supplier, range: decided by [tpch.lineitem.l_suppkey], keep order:false
+          └─TableReader_87	25.00	root	data:TableScan_86
+            └─TableScan_86	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
 /*
 Q9 Product Type Profit Measure Query
 This query determines how much profit is made on a given line of parts, broken out by supplier nation and year.
@@ -657,21 +660,22 @@ limit 20;
 id	count	task	operator info
 Projection_17	20.00	root	tpch.customer.c_custkey, tpch.customer.c_name, 9_col_0, tpch.customer.c_acctbal, tpch.nation.n_name, tpch.customer.c_address, tpch.customer.c_phone, tpch.customer.c_comment
 └─TopN_20	20.00	root	9_col_0:desc, offset:0, count:20
-  └─HashAgg_26	3017307.69	root	group by:tpch.customer.c_acctbal, tpch.customer.c_address, tpch.customer.c_comment, tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_phone, tpch.nation.n_name, funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), firstrow(tpch.customer.c_custkey), firstrow(tpch.customer.c_name), firstrow(tpch.customer.c_address), firstrow(tpch.customer.c_phone), firstrow(tpch.customer.c_acctbal), firstrow(tpch.customer.c_comment), firstrow(tpch.nation.n_name)
-    └─IndexJoin_32	12222016.17	root	inner join, inner:IndexLookUp_31, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─HashLeftJoin_35	3017307.69	root	inner join, inner:TableReader_48, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-      │ ├─HashRightJoin_41	7500000.00	root	inner join, inner:TableReader_45, equal:[eq(tpch.nation.n_nationkey, tpch.customer.c_nationkey)]
-      │ │ ├─TableReader_45	25.00	root	data:TableScan_44
-      │ │ │ └─TableScan_44	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_43	7500000.00	root	data:TableScan_42
-      │ │   └─TableScan_42	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-      │ └─TableReader_48	3017307.69	root	data:Selection_47
-      │   └─Selection_47	3017307.69	cop	ge(tpch.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1993-11-01)
-      │     └─TableScan_46	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_31	73916005.00	root	
-        ├─IndexScan_28	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
-        └─Selection_30	73916005.00	cop	eq(tpch.lineitem.l_returnflag, "R")
-          └─TableScan_29	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_26	3017307.69	root	group by:group_0, group_1, group_2, group_3, group_4, group_5, group_6, funcs:sum(sum_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0), firstrow(firstrow_0)
+    └─Projection_52	12222016.17	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_address, tpch.customer.c_phone, tpch.customer.c_acctbal, tpch.customer.c_comment, tpch.nation.n_name, tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_acctbal, tpch.customer.c_phone, tpch.nation.n_name, tpch.customer.c_address, tpch.customer.c_comment
+      └─IndexJoin_32	12222016.17	root	inner join, inner:IndexLookUp_31, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+        ├─HashLeftJoin_35	3017307.69	root	inner join, inner:TableReader_48, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        │ ├─HashRightJoin_41	7500000.00	root	inner join, inner:TableReader_45, equal:[eq(tpch.nation.n_nationkey, tpch.customer.c_nationkey)]
+        │ │ ├─TableReader_45	25.00	root	data:TableScan_44
+        │ │ │ └─TableScan_44	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_43	7500000.00	root	data:TableScan_42
+        │ │   └─TableScan_42	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        │ └─TableReader_48	3017307.69	root	data:Selection_47
+        │   └─Selection_47	3017307.69	cop	ge(tpch.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1993-11-01)
+        │     └─TableScan_46	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─IndexLookUp_31	73916005.00	root	
+          ├─IndexScan_28	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [tpch.orders.o_orderkey], keep order:false
+          └─Selection_30	73916005.00	cop	eq(tpch.lineitem.l_returnflag, "R")
+            └─TableScan_29	1.00	cop	table:lineitem, keep order:false
 /*
 Q11 Important Stock Identification Query
 This query finds the most important subset of suppliers' stock in a given nation.
@@ -711,16 +715,17 @@ id	count	task	operator info
 Projection_63	1304801.67	root	tpch.partsupp.ps_partkey, value
 └─Sort_64	1304801.67	root	value:desc
   └─Selection_66	1304801.67	root	gt(sel_agg_4, NULL)
-    └─HashAgg_69	1631002.09	root	group by:tpch.partsupp.ps_partkey, funcs:sum(mul(tpch.partsupp.ps_supplycost, cast(tpch.partsupp.ps_availqty))), firstrow(tpch.partsupp.ps_partkey)
-      └─HashRightJoin_73	1631002.09	root	inner join, inner:HashRightJoin_79, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
-        ├─HashRightJoin_79	20000.00	root	inner join, inner:TableReader_84, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-        │ ├─TableReader_84	1.00	root	data:Selection_83
-        │ │ └─Selection_83	1.00	cop	eq(tpch.nation.n_name, "MOZAMBIQUE")
-        │ │   └─TableScan_82	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ └─TableReader_81	500000.00	root	data:TableScan_80
-        │   └─TableScan_80	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        └─TableReader_86	40000000.00	root	data:TableScan_85
-          └─TableScan_85	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+    └─HashAgg_69	1631002.09	root	group by:group_0, funcs:sum(sum_0), firstrow(firstrow_0)
+      └─Projection_88	1631002.09	root	mul(tpch.partsupp.ps_supplycost, cast(tpch.partsupp.ps_availqty)), tpch.partsupp.ps_partkey, tpch.partsupp.ps_partkey
+        └─HashRightJoin_73	1631002.09	root	inner join, inner:HashRightJoin_79, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
+          ├─HashRightJoin_79	20000.00	root	inner join, inner:TableReader_84, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+          │ ├─TableReader_84	1.00	root	data:Selection_83
+          │ │ └─Selection_83	1.00	cop	eq(tpch.nation.n_name, "MOZAMBIQUE")
+          │ │   └─TableScan_82	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+          │ └─TableReader_81	500000.00	root	data:TableScan_80
+          │   └─TableScan_80	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+          └─TableReader_86	40000000.00	root	data:TableScan_85
+            └─TableScan_85	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
 /*
 Q12 Shipping Modes and Order Priority Query
 This query determines whether selecting less expensive modes of shipping is negatively affecting the critical-priority
@@ -763,13 +768,14 @@ l_shipmode;
 id	count	task	operator info
 Sort_9	1.00	root	tpch.lineitem.l_shipmode:asc
 └─Projection_11	1.00	root	tpch.lineitem.l_shipmode, 5_col_0, 5_col_1
-  └─HashAgg_14	1.00	root	group by:tpch.lineitem.l_shipmode, funcs:sum(case(or(eq(tpch.orders.o_orderpriority, "1-URGENT"), eq(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), sum(case(and(ne(tpch.orders.o_orderpriority, "1-URGENT"), ne(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), firstrow(tpch.lineitem.l_shipmode)
-    └─IndexJoin_18	10023369.01	root	inner join, inner:TableReader_17, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-      ├─TableReader_35	10023369.01	root	data:Selection_34
-      │ └─Selection_34	10023369.01	cop	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
-      │   └─TableScan_33	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      └─TableReader_17	1.00	root	data:TableScan_16
-        └─TableScan_16	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
+  └─HashAgg_14	1.00	root	group by:group_0, funcs:sum(sum_0), sum(sum_0), firstrow(firstrow_0)
+    └─Projection_39	10023369.01	root	cast(case(or(eq(tpch.orders.o_orderpriority, "1-URGENT"), eq(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), cast(case(and(ne(tpch.orders.o_orderpriority, "1-URGENT"), ne(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), tpch.lineitem.l_shipmode, tpch.lineitem.l_shipmode
+      └─IndexJoin_18	10023369.01	root	inner join, inner:TableReader_17, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
+        ├─TableReader_35	10023369.01	root	data:Selection_34
+        │ └─Selection_34	10023369.01	cop	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
+        │   └─TableScan_33	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        └─TableReader_17	1.00	root	data:TableScan_16
+          └─TableScan_16	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
 /*
 Q13 Customer Distribution Query
 This query seeks relationships between customers and the size of their orders.
@@ -833,13 +839,14 @@ and l_shipdate >= '1996-12-01'
 and l_shipdate < date_add('1996-12-01', interval '1' month);
 id	count	task	operator info
 Projection_8	1.00	root	div(mul(100.00, 5_col_0), 5_col_1)
-└─StreamAgg_13	1.00	root	funcs:sum(case(like(tpch.part.p_type, "PROMO%", 92), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), 0)), sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)))
-  └─IndexJoin_26	4121984.49	root	inner join, inner:TableReader_25, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey
-    ├─TableReader_31	4121984.49	root	data:Selection_30
-    │ └─Selection_30	4121984.49	cop	ge(tpch.lineitem.l_shipdate, 1996-12-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1997-01-01)
-    │   └─TableScan_29	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-    └─TableReader_25	1.00	root	data:TableScan_24
-      └─TableScan_24	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:false
+└─StreamAgg_13	1.00	root	funcs:sum(sum_0), sum(sum_0)
+  └─Projection_34	4121984.49	root	case(like(tpch.part.p_type, "PROMO%", 92), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), 0), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
+    └─IndexJoin_26	4121984.49	root	inner join, inner:TableReader_25, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey
+      ├─TableReader_31	4121984.49	root	data:Selection_30
+      │ └─Selection_30	4121984.49	cop	ge(tpch.lineitem.l_shipdate, 1996-12-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1997-01-01)
+      │   └─TableScan_29	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+      └─TableReader_25	1.00	root	data:TableScan_24
+        └─TableScan_24	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:false
 /*
 Q15 Top Supplier Query
 This query determines the top supplier so it can be rewarded, given more business, or identified for special recognition.
@@ -1083,14 +1090,15 @@ and l_shipmode in ('AIR', 'AIR REG')
 and l_shipinstruct = 'DELIVER IN PERSON'
 );
 id	count	task	operator info
-StreamAgg_13	1.00	root	funcs:sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)))
-└─IndexJoin_29	6286493.79	root	inner join, inner:TableReader_28, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey, other cond:or(and(and(eq(tpch.part.p_brand, "Brand#52"), in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG")), and(ge(tpch.lineitem.l_quantity, 4), and(le(tpch.lineitem.l_quantity, 14), le(tpch.part.p_size, 5)))), or(and(and(eq(tpch.part.p_brand, "Brand#11"), in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")), and(ge(tpch.lineitem.l_quantity, 18), and(le(tpch.lineitem.l_quantity, 28), le(tpch.part.p_size, 10)))), and(and(eq(tpch.part.p_brand, "Brand#51"), in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG")), and(ge(tpch.lineitem.l_quantity, 29), and(le(tpch.lineitem.l_quantity, 39), le(tpch.part.p_size, 15))))))
-  ├─TableReader_34	6286493.79	root	data:Selection_33
-  │ └─Selection_33	6286493.79	cop	eq(tpch.lineitem.l_shipinstruct, "DELIVER IN PERSON"), in(tpch.lineitem.l_shipmode, "AIR", "AIR REG"), or(and(ge(tpch.lineitem.l_quantity, 4), le(tpch.lineitem.l_quantity, 14)), or(and(ge(tpch.lineitem.l_quantity, 18), le(tpch.lineitem.l_quantity, 28)), and(ge(tpch.lineitem.l_quantity, 29), le(tpch.lineitem.l_quantity, 39))))
-  │   └─TableScan_32	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-  └─TableReader_28	8000000.00	root	data:Selection_27
-    └─Selection_27	8000000.00	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
-      └─TableScan_26	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:false
+StreamAgg_13	1.00	root	funcs:sum(sum_0)
+└─Projection_38	6286493.79	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
+  └─IndexJoin_29	6286493.79	root	inner join, inner:TableReader_28, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey, other cond:or(and(and(eq(tpch.part.p_brand, "Brand#52"), in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG")), and(ge(tpch.lineitem.l_quantity, 4), and(le(tpch.lineitem.l_quantity, 14), le(tpch.part.p_size, 5)))), or(and(and(eq(tpch.part.p_brand, "Brand#11"), in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")), and(ge(tpch.lineitem.l_quantity, 18), and(le(tpch.lineitem.l_quantity, 28), le(tpch.part.p_size, 10)))), and(and(eq(tpch.part.p_brand, "Brand#51"), in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG")), and(ge(tpch.lineitem.l_quantity, 29), and(le(tpch.lineitem.l_quantity, 39), le(tpch.part.p_size, 15))))))
+    ├─TableReader_34	6286493.79	root	data:Selection_33
+    │ └─Selection_33	6286493.79	cop	eq(tpch.lineitem.l_shipinstruct, "DELIVER IN PERSON"), in(tpch.lineitem.l_shipmode, "AIR", "AIR REG"), or(and(ge(tpch.lineitem.l_quantity, 4), le(tpch.lineitem.l_quantity, 14)), or(and(ge(tpch.lineitem.l_quantity, 18), le(tpch.lineitem.l_quantity, 28)), and(ge(tpch.lineitem.l_quantity, 29), le(tpch.lineitem.l_quantity, 39))))
+    │   └─TableScan_32	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+    └─TableReader_28	8000000.00	root	data:Selection_27
+      └─Selection_27	8000000.00	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
+        └─TableScan_26	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:false
 /*
 Q20 Potential Part Promotion Query
 The Potential Part Promotion Query identifies suppliers in a particular nation having selected parts that may be candidates

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"math"
 	"sort"
 	"strings"
@@ -967,83 +966,12 @@ func (b *executorBuilder) wrapCastForAggArgs(funcs []*aggregation.AggFuncDesc) {
 	}
 }
 
-// buildProjBelowAgg builds a ProjectionExec below AggregationExec.
-// If all the args of `aggFuncs`, and all the item of `groupByItems`
-// are columns or constants, we do not need to build the `proj`.
-func (b *executorBuilder) buildProjBelowAgg(aggFuncs []*aggregation.AggFuncDesc, groupByItems []expression.Expression, src Executor) Executor {
-	hasScalarFunc := false
-	// If the mode is FinalMode, we do not need to wrap cast upon the args,
-	// since the types of the args are already the expected.
-	if len(aggFuncs) > 0 && aggFuncs[0].Mode != aggregation.FinalMode {
-		b.wrapCastForAggArgs(aggFuncs)
-	}
-	for i := 0; !hasScalarFunc && i < len(aggFuncs); i++ {
-		f := aggFuncs[i]
-		for _, arg := range f.Args {
-			_, isScalarFunc := arg.(*expression.ScalarFunction)
-			hasScalarFunc = hasScalarFunc || isScalarFunc
-		}
-	}
-	for i, isScalarFunc := 0, false; !hasScalarFunc && i < len(groupByItems); i++ {
-		_, isScalarFunc = groupByItems[i].(*expression.ScalarFunction)
-		hasScalarFunc = hasScalarFunc || isScalarFunc
-	}
-	if !hasScalarFunc {
-		return src
-	}
-
-	b.ctx.GetSessionVars().PlanID++
-	id := b.ctx.GetSessionVars().PlanID
-	projFromID := fmt.Sprintf("%s_%d", plannercore.TypeProj, id)
-
-	projSchemaCols := make([]*expression.Column, 0, len(aggFuncs)+len(groupByItems))
-	projExprs := make([]expression.Expression, 0, cap(projSchemaCols))
-	cursor := 0
-	for _, f := range aggFuncs {
-		for i, arg := range f.Args {
-			if _, isCnst := arg.(*expression.Constant); isCnst {
-				continue
-			}
-			projExprs = append(projExprs, arg)
-			newArg := &expression.Column{
-				RetType: arg.GetType(),
-				ColName: model.NewCIStr(fmt.Sprintf("%s_%d", f.Name, i)),
-				Index:   cursor,
-			}
-			projSchemaCols = append(projSchemaCols, newArg)
-			f.Args[i] = newArg
-			cursor++
-		}
-	}
-	for i, item := range groupByItems {
-		if _, isCnst := item.(*expression.Constant); isCnst {
-			continue
-		}
-		projExprs = append(projExprs, item)
-		newArg := &expression.Column{
-			RetType: item.GetType(),
-			ColName: model.NewCIStr(fmt.Sprintf("group_%d", i)),
-			Index:   cursor,
-		}
-		projSchemaCols = append(projSchemaCols, newArg)
-		groupByItems[i] = newArg
-		cursor++
-	}
-
-	return &ProjectionExec{
-		baseExecutor: newBaseExecutor(b.ctx, expression.NewSchema(projSchemaCols...), projFromID, src),
-		//numWorkers:    b.ctx.GetSessionVars().ProjectionConcurrency,
-		evaluatorSuit: expression.NewEvaluatorSuite(projExprs, false),
-	}
-}
-
 func (b *executorBuilder) buildHashAgg(v *plannercore.PhysicalHashAgg) Executor {
 	src := b.build(v.Children()[0])
 	if b.err != nil {
 		b.err = errors.Trace(b.err)
 		return nil
 	}
-	src = b.buildProjBelowAgg(v.AggFuncs, v.GroupByItems, src)
 	sessionVars := b.ctx.GetSessionVars()
 	e := &HashAggExec{
 		baseExecutor:    newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
@@ -1125,7 +1053,6 @@ func (b *executorBuilder) buildStreamAgg(v *plannercore.PhysicalStreamAgg) Execu
 		b.err = errors.Trace(b.err)
 		return nil
 	}
-	src = b.buildProjBelowAgg(v.AggFuncs, v.GroupByItems, src)
 	e := &StreamAggExec{
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), src),
 		StmtCtx:      b.ctx.GetSessionVars().StmtCtx,

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -77,7 +77,7 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 	tk.MustExec("insert into t2 values (2, 22), (3, 33), (5, 55)")
 	tk.MustExec("analyze table t1, t2")
 	rs := tk.MustQuery("explain analyze select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1")
-	c.Assert(len(rs.Rows()), Equals, 10)
+	c.Assert(len(rs.Rows()), Equals, 11)
 	for _, row := range rs.Rows() {
 		c.Assert(len(row), Equals, 5)
 		taskType := row[2].(string)
@@ -367,7 +367,7 @@ func (s *testAnalyzeSuite) TestIndexRead(c *C) {
 		},
 		{
 			sql:  "select sum(a) from t1 use index(idx) where a = 3 and b = 100000 group by a limit 1",
-			best: "IndexLookUp(Index(t1.idx)[[3,3]], Table(t1)->Sel([eq(test.t1.b, 100000)]))->StreamAgg->Limit",
+			best: "IndexLookUp(Index(t1.idx)[[3,3]], Table(t1)->Sel([eq(test.t1.b, 100000)]))->Projection->StreamAgg->Limit",
 		},
 	}
 	for _, tt := range tests {

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -14,15 +14,19 @@
 package core
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
 )
 
 // OptimizeAstNode optimizes the query to a physical plan directly.
@@ -105,8 +109,163 @@ func DoOptimize(flag uint64, logic LogicalPlan) (PhysicalPlan, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	finalPlan := eliminatePhysicalProjection(physical)
+	finalPlan, err := postOptimize(physical)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 	return finalPlan, nil
+}
+
+func postOptimize(plan PhysicalPlan) (PhysicalPlan, error) {
+	plan = eliminatePhysicalProjection(plan)
+
+	// build projection below aggregation
+	plan = buildProjBelowAgg(plan)
+	return plan, nil
+}
+
+// buildProjBelowAgg builds a ProjOperator below AggOperator.
+// If all the args of `aggFuncs`, and all the item of `groupByItems`
+// are columns or constants, we do not need to build the `proj`.
+func buildProjBelowAgg(plan PhysicalPlan) PhysicalPlan {
+	for i, child := range plan.Children() {
+		plan.Children()[i] = buildProjBelowAgg(child)
+	}
+
+	var aggFuncs []*aggregation.AggFuncDesc
+	var groupByItems []expression.Expression
+	if aggHash, ok := plan.(*PhysicalHashAgg); ok {
+		aggFuncs = aggHash.AggFuncs
+		groupByItems = aggHash.GroupByItems
+	} else if aggStream, ok := plan.(*PhysicalStreamAgg); ok {
+		aggFuncs = aggStream.AggFuncs
+		groupByItems = aggStream.GroupByItems
+	} else {
+		return plan
+	}
+
+	return doBuildProjBelowAgg(plan, aggFuncs, groupByItems)
+}
+
+func doBuildProjBelowAgg(aggPlan PhysicalPlan, aggFuncs []*aggregation.AggFuncDesc, groupByItems []expression.Expression) PhysicalPlan {
+	hasScalarFunc := false
+
+	// If the mode is FinalMode, we do not need to wrap cast upon the args,
+	// since the types of the args are already the expected.
+	if len(aggFuncs) > 0 && aggFuncs[0].Mode != aggregation.FinalMode {
+		wrapCastForAggArgs(aggPlan.context(), aggFuncs)
+	}
+
+	for i := 0; !hasScalarFunc && i < len(aggFuncs); i++ {
+		f := aggFuncs[i]
+		for _, arg := range f.Args {
+			_, isScalarFunc := arg.(*expression.ScalarFunction)
+			hasScalarFunc = hasScalarFunc || isScalarFunc
+		}
+	}
+	for i, isScalarFunc := 0, false; !hasScalarFunc && i < len(groupByItems); i++ {
+		_, isScalarFunc = groupByItems[i].(*expression.ScalarFunction)
+		hasScalarFunc = hasScalarFunc || isScalarFunc
+	}
+	if !hasScalarFunc {
+		return aggPlan
+	}
+
+	projSchemaCols := make([]*expression.Column, 0, len(aggFuncs)+len(groupByItems))
+	projExprs := make([]expression.Expression, 0, cap(projSchemaCols))
+	cursor := 0
+
+	for _, f := range aggFuncs {
+		for i, arg := range f.Args {
+			if _, isCnst := arg.(*expression.Constant); isCnst {
+				continue
+			}
+			projExprs = append(projExprs, arg)
+			newArg := &expression.Column{
+				RetType: arg.GetType(),
+				ColName: model.NewCIStr(fmt.Sprintf("%s_%d", f.Name, i)),
+				Index:   cursor,
+			}
+			projSchemaCols = append(projSchemaCols, newArg)
+			f.Args[i] = newArg
+			cursor++
+		}
+	}
+
+	for i, item := range groupByItems {
+		if _, isCnst := item.(*expression.Constant); isCnst {
+			continue
+		}
+		projExprs = append(projExprs, item)
+		newArg := &expression.Column{
+			RetType: item.GetType(),
+			ColName: model.NewCIStr(fmt.Sprintf("group_%d", i)),
+			Index:   cursor,
+		}
+		projSchemaCols = append(projSchemaCols, newArg)
+		groupByItems[i] = newArg
+		cursor++
+	}
+
+	child := aggPlan.Children()[0]
+	prop := aggPlan.GetChildReqProps(0).Clone()
+	proj := PhysicalProjection{
+		Exprs:                projExprs,
+		AvoidColumnEvaluator: false,
+	}.Init(aggPlan.context(), child.statsInfo().ScaleByExpectCnt(prop.ExpectedCnt), prop)
+	proj.SetSchema(expression.NewSchema(projSchemaCols...))
+	proj.SetChildren(child)
+
+	aggPlan.SetChildren(proj)
+	return aggPlan
+}
+
+// wrapCastForAggArgs wraps the args of an aggregate function with a cast function.
+func wrapCastForAggArgs(ctx sessionctx.Context, funcs []*aggregation.AggFuncDesc) {
+	for _, f := range funcs {
+		// We do not need to wrap cast upon these functions,
+		// since the EvalXXX method called by the arg is determined by the corresponding arg type.
+		if f.Name == ast.AggFuncCount || f.Name == ast.AggFuncMin || f.Name == ast.AggFuncMax || f.Name == ast.AggFuncFirstRow {
+			continue
+		}
+		var castFunc func(ctx sessionctx.Context, expr expression.Expression) expression.Expression
+		switch retTp := f.RetTp; retTp.EvalType() {
+		case types.ETInt:
+			castFunc = expression.WrapWithCastAsInt
+		case types.ETReal:
+			castFunc = expression.WrapWithCastAsReal
+		case types.ETString:
+			castFunc = expression.WrapWithCastAsString
+		case types.ETDecimal:
+			castFunc = expression.WrapWithCastAsDecimal
+		default:
+			panic("should never happen in executorBuilder.wrapCastForAggArgs")
+		}
+		for i := range f.Args {
+			f.Args[i] = castFunc(ctx, f.Args[i])
+			if f.Name != ast.AggFuncAvg && f.Name != ast.AggFuncSum {
+				continue
+			}
+			// After wrapping cast on the argument, flen etc. may not the same
+			// as the type of the aggregation function. The following part set
+			// the type of the argument exactly as the type of the aggregation
+			// function.
+			// Note: If the `Tp` of argument is the same as the `Tp` of the
+			// aggregation function, it will not wrap cast function on it
+			// internally. The reason of the special handling for `Column` is
+			// that the `RetType` of `Column` refers to the `infoschema`, so we
+			// need to set a new variable for it to avoid modifying the
+			// definition in `infoschema`.
+			if col, ok := f.Args[i].(*expression.Column); ok {
+				col.RetType = types.NewFieldType(col.RetType.Tp)
+			}
+			// originTp is used when the the `Tp` of column is TypeFloat32 while
+			// the type of the aggregation function is TypeFloat64.
+			originTp := f.Args[i].GetType().Tp
+			*(f.Args[i].GetType()) = *(f.RetTp)
+			f.Args[i].GetType().Tp = originTp
+		}
+	}
 }
 
 func logicalOptimize(flag uint64, logic LogicalPlan) (LogicalPlan, error) {

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -472,7 +472,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSubquery(c *C) {
 		// Test Nested sub query.
 		{
 			sql:  "select * from t where exists (select s.a from t s where s.c in (select c from t as k where k.d = s.d) having sum(s.a) = t.a )",
-			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->IndexReader(Index(t.c_d_e)[[NULL,+inf]])}(s.c,k.c)(s.d,k.d)->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->IndexReader(Index(t.c_d_e)[[NULL,+inf]])}(s.c,k.c)(s.d,k.d)->Projection->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
 		},
 		// Test Semi Join + Order by.
 		{
@@ -821,7 +821,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		},
 		{
 			sql:  "select sum(distinct a), avg(b + c) from t group by d",
-			best: "TableReader(Table(t))->HashAgg",
+			best: "TableReader(Table(t))->Projection->HashAgg",
 		},
 		//  Test group by (c + d)
 		{
@@ -841,27 +841,27 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		// Test hash agg + index double.
 		{
 			sql:  "select sum(e), avg(b + c) from t where c = 1 and e = 1 group by d",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t))->HashAgg",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t))->Projection->HashAgg",
 		},
 		// Test stream agg + index double.
 		{
 			sql:  "select sum(e), avg(b + c) from t where c = 1 and b = 1 group by c",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]], Table(t)->Sel([eq(test.t.b, 1)]))->StreamAgg",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]], Table(t)->Sel([eq(test.t.b, 1)]))->Projection->StreamAgg",
 		},
 		// Test hash agg + order.
 		{
 			sql:  "select sum(e) as k, avg(b + c) from t where c = 1 and b = 1 and e = 1 group by d order by k",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->HashAgg->Sort",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->HashAgg->Sort",
 		},
 		// Test stream agg + order.
 		{
 			sql:  "select sum(e) as k, avg(b + c) from t where c = 1 and b = 1 and e = 1 group by c order by k",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->StreamAgg->Sort",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->StreamAgg->Sort",
 		},
 		// Test agg can't push down.
 		{
 			sql:  "select sum(to_base64(e)) from t where c = 1",
-			best: "IndexReader(Index(t.c_d_e)[[1,1]])->StreamAgg",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]])->Projection->StreamAgg",
 		},
 		{
 			sql:  "select (select count(1) k from t s where s.a = t.a having k != 0) from t",
@@ -870,7 +870,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		// Test stream agg with multi group by columns.
 		{
 			sql:  "select sum(to_base64(e)) from t group by e,d,c order by c",
-			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->StreamAgg->Projection",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->Projection->StreamAgg->Projection",
 		},
 		{
 			sql:  "select sum(e+1) from t group by e,d,c order by c",
@@ -878,7 +878,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		},
 		{
 			sql:  "select sum(to_base64(e)) from t group by e,d,c order by c,e",
-			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->StreamAgg->Sort->Projection",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->Projection->StreamAgg->Sort->Projection",
 		},
 		{
 			sql:  "select sum(e+1) from t group by e,d,c order by c,e",
@@ -917,16 +917,16 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 		// Test merge join + stream agg
 		{
 			sql:  "select sum(a.g), sum(b.g) from t a join t b on a.g = b.g group by a.g",
-			best: "MergeInnerJoin{IndexReader(Index(t.g)[[NULL,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]])}(a.g,b.g)->StreamAgg",
+			best: "MergeInnerJoin{IndexReader(Index(t.g)[[NULL,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]])}(a.g,b.g)->Projection->StreamAgg",
 		},
 		// Test index join + stream agg
 		{
 			sql:  "select /*+ tidb_inlj(a,b) */ sum(a.g), sum(b.g) from t a join t b on a.g = b.g and a.g > 60 group by a.g order by a.g limit 1",
-			best: "IndexJoin{IndexReader(Index(t.g)[(60,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(b.g, 60)]))}(a.g,b.g)->StreamAgg->Limit->Projection",
+			best: "IndexJoin{IndexReader(Index(t.g)[(60,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(b.g, 60)]))}(a.g,b.g)->Projection->StreamAgg->Limit->Projection",
 		},
 		{
 			sql:  "select sum(a.g), sum(b.g) from t a join t b on a.g = b.g and a.a>5 group by a.g order by a.g limit 1",
-			best: "IndexJoin{IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(a.a, 5)]))->IndexReader(Index(t.g)[[NULL,+inf]])}(a.g,b.g)->StreamAgg->Limit->Projection",
+			best: "IndexJoin{IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(a.a, 5)]))->IndexReader(Index(t.g)[[NULL,+inf]])}(a.g,b.g)->Projection->StreamAgg->Limit->Projection",
 		},
 		{
 			sql:  "select sum(d) from t",
@@ -1217,7 +1217,7 @@ func (s *testPlanSuite) TestAggEliminater(c *C) {
 		// If max/min contains scalar function, we can still do transformation.
 		{
 			sql:  "select max(a+1) from t;",
-			best: "TableReader(Table(t)->Sel([not(isnull(plus(test.t.a, 1)))])->TopN([plus(test.t.a, 1) true],0,1))->TopN([plus(test.t.a, 1) true],0,1)->StreamAgg",
+			best: "TableReader(Table(t)->Sel([not(isnull(plus(test.t.a, 1)))])->TopN([plus(test.t.a, 1) true],0,1))->TopN([plus(test.t.a, 1) true],0,1)->Projection->StreamAgg",
 		},
 		// Do nothing to max+min.
 		{


### PR DESCRIPTION
…and move buildProjBelowAgg from executor to planner

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a post process function after DoOptimize() in package "planner/core". In this post process, we can:

1. eliminate physical projection eliminatePhysicalProjection;
2. build projection operator below aggregation operator;

So after this code change, the plan in explain xx is equals to explain analyze xx, and the plan generation is back to the "planner" package.

Hope this can make the code more readable and maintainable.


### What is changed and how it works?

1. add a postOptimize() after DoOptimize() at planner/core/optimizer.go;
2. move buildProjBelowAgg() from executor/builder.go to planner/core/optimizer.go;
3. update some unit tests;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test