### PR TITLE
planner/core: fix panic when generate index join

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -380,7 +380,11 @@ func (p *LogicalJoin) getIndexJoinByOuterIdx(prop *property.PhysicalProperty, ou
 		return nil
 	}
 	if isUnionScan {
-		ds = us.Children()[0].(*DataSource)
+		// The child of union scan may be union all for partition table.
+		ds, isDataSource = us.Children()[0].(*DataSource)
+		if !isDataSource {
+			return nil
+		}
 	}
 	var tblPath *accessPath
 	for _, path := range ds.possibleAccessPaths {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -449,29 +449,6 @@ func (s *testPlanSuite) TestAntiSemiJoinConstFalse(c *C) {
 	}
 }
 
-func newPartitionInfoSchema(definitions []model.PartitionDefinition) infoschema.InfoSchema {
-	tableInfo := *MockTable()
-	cols := make([]*model.ColumnInfo, 0, len(tableInfo.Columns))
-	cols = append(cols, tableInfo.Columns...)
-	cols = append(cols, &model.ColumnInfo{
-		State:     model.StatePublic,
-		Offset:    10,
-		Name:      model.NewCIStr("h"),
-		FieldType: newLongType(),
-		ID:        11,
-	})
-	partition := &model.PartitionInfo{
-		Type:        model.PartitionTypeRange,
-		Expr:        "h",
-		Enable:      true,
-		Definitions: definitions,
-	}
-	tableInfo.Columns = cols
-	tableInfo.Partition = partition
-	is := infoschema.MockInfoSchema([]*model.TableInfo{&tableInfo})
-	return is
-}
-
 func (s *testPlanSuite) TestTablePartition(c *C) {
 	defer testleak.AfterTest(c)()
 	definitions := []model.PartitionDefinition{
@@ -501,11 +478,11 @@ func (s *testPlanSuite) TestTablePartition(c *C) {
 			LessThan: []string{"maxvalue"},
 		},
 	}
-	is := newPartitionInfoSchema(definitions)
+	is := MockPartitionInfoSchema(definitions)
 	// is1 equals to is without maxvalue partition.
 	definitions1 := make([]model.PartitionDefinition, len(definitions)-1)
 	copy(definitions1, definitions)
-	is1 := newPartitionInfoSchema(definitions1)
+	is1 := MockPartitionInfoSchema(definitions1)
 
 	tests := []struct {
 		sql   string

--- a/planner/core/mock.go
+++ b/planner/core/mock.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
@@ -291,4 +292,28 @@ func MockContext() sessionctx.Context {
 	do.CreateStatsHandle(ctx)
 	domain.BindDomain(ctx, do)
 	return ctx
+}
+
+// MockPartitionInfoSchema mocks an info schema for partition table.
+func MockPartitionInfoSchema(definitions []model.PartitionDefinition) infoschema.InfoSchema {
+	tableInfo := *MockTable()
+	cols := make([]*model.ColumnInfo, 0, len(tableInfo.Columns))
+	cols = append(cols, tableInfo.Columns...)
+	cols = append(cols, &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    10,
+		Name:      model.NewCIStr("h"),
+		FieldType: newLongType(),
+		ID:        11,
+	})
+	partition := &model.PartitionInfo{
+		Type:        model.PartitionTypeRange,
+		Expr:        "h",
+		Enable:      true,
+		Definitions: definitions,
+	}
+	tableInfo.Columns = cols
+	tableInfo.Partition = partition
+	is := infoschema.MockInfoSchema([]*model.TableInfo{&tableInfo})
+	return is
 }

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -1296,24 +1296,49 @@ func (s *testPlanSuite) TestIndexJoinUnionScan(c *C) {
 	c.Assert(err, IsNil)
 	_, err = se.Execute(context.Background(), "use test")
 	c.Assert(err, IsNil)
+
+	definitions := []model.PartitionDefinition{
+		{
+			ID:       41,
+			Name:     model.NewCIStr("p1"),
+			LessThan: []string{"16"},
+		},
+		{
+			ID:       42,
+			Name:     model.NewCIStr("p2"),
+			LessThan: []string{"32"},
+		},
+	}
+	pis := core.MockPartitionInfoSchema(definitions)
+
 	tests := []struct {
 		sql  string
 		best string
+		is   infoschema.InfoSchema
 	}{
 		// Test Index Join + UnionScan + TableScan.
 		{
 			sql:  "select /*+ TIDB_INLJ(t1, t2) */ * from t t1, t t2 where t1.a = t2.a",
 			best: "IndexJoin{TableReader(Table(t))->UnionScan([])->TableReader(Table(t))->UnionScan([])}(t1.a,t2.a)",
+			is:   s.is,
 		},
 		// Test Index Join + UnionScan + DoubleRead.
 		{
 			sql:  "select /*+ TIDB_INLJ(t1, t2) */ * from t t1, t t2 where t1.a = t2.c",
 			best: "IndexJoin{TableReader(Table(t))->UnionScan([])->IndexLookUp(Index(t.c_d_e)[[NULL,+inf]], Table(t))->UnionScan([])}(t1.a,t2.c)",
+			is:   s.is,
 		},
 		// Test Index Join + UnionScan + IndexScan.
 		{
 			sql:  "select /*+ TIDB_INLJ(t1, t2) */ t1.a , t2.c from t t1, t t2 where t1.a = t2.c",
 			best: "IndexJoin{TableReader(Table(t))->UnionScan([])->IndexReader(Index(t.c_d_e)[[NULL,+inf]])->UnionScan([])}(t1.a,t2.c)->Projection",
+			is:   s.is,
+		},
+		// Index Join + Union Scan + Union All is not supported now.
+		{
+			sql:  "select /*+ TIDB_INLJ(t1, t2) */ * from t t1, t t2 where t1.a = t2.a",
+			best: "LeftHashJoin{UnionAll{TableReader(Table(t))->TableReader(Table(t))}->UnionScan([])->UnionAll{TableReader(Table(t))->TableReader(Table(t))}->UnionScan([])}(t1.a,t2.a)",
+			is:   pis,
 		},
 	}
 	for i, tt := range tests {
@@ -1327,7 +1352,7 @@ func (s *testPlanSuite) TestIndexJoinUnionScan(c *C) {
 		c.Assert(err, IsNil)
 		txn.Set(kv.Key("AAA"), []byte("BBB"))
 		c.Assert(se.StmtCommit(), IsNil)
-		p, err := planner.Optimize(se, stmt, s.is)
+		p, err := planner.Optimize(se, stmt, tt.is)
 		c.Assert(err, IsNil)
 		c.Assert(core.ToString(p), Equals, tt.best, comment)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
interface conversion: core.LogicalPlan is *core.LogicalUnionAll, not *core.DataSource, goroutine 1229 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0xc008405c70, 0xc00ad4bdbf)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/server/conn.go:439 +0x10c
panic(0x12c4280, 0xc00c63a0f0)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/pingcap/tidb/planner/core.(*LogicalJoin).getIndexJoinByOuterIdx(0xc00a9d4180, 0xc008954af0, 0x0, 0xc00d3f8460, 0x0, 0x2)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/planner/core/exhaust_physical_plans.go:376 +0x84f
github.com/pingcap/tidb/planner/core.(*LogicalJoin).tryToGetIndexJoin(0xc00a9d4180, 0xc008954af0, 0x0, 0x5, 0x2449308, 0x0)
	/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/planner/core/exhaust_physical_plans.go:630 +0x164
```
### What is changed and how it works?

When generating index join, we assumes that the child of union scan must be data source, in fact, it may be union all for partition table. This PR fixes the panic by removing the assumption.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

PTAL @zz-jason @eurekaka @winoros 