### PR TITLE
planner, privilege: check user priv on SET GLOBAL

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -249,7 +249,7 @@ func (b *PlanBuilder) buildSet(v *ast.SetStmt) (Plan, error) {
 	p := &Set{}
 	for _, vars := range v.Variables {
 		if vars.IsGlobal {
-			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "")
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", nil)
 		}
 		assign := &expression.VarAssignment{
 			Name:     vars.Name,

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -245,6 +245,9 @@ func (b *PlanBuilder) buildDo(v *ast.DoStmt) (Plan, error) {
 func (b *PlanBuilder) buildSet(v *ast.SetStmt) (Plan, error) {
 	p := &Set{}
 	for _, vars := range v.Variables {
+		if vars.IsGlobal {
+			b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "")
+		}
 		assign := &expression.VarAssignment{
 			Name:     vars.Name,
 			IsGlobal: vars.IsGlobal,

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -363,6 +363,7 @@ func (s *testPrivilegeSuite) TestSetGlobal(c *C) {
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "setglobal_b", Hostname: "localhost"}, nil, nil), IsTrue)
 	_, err := se.Execute(context.Background(), `set global innodb_commit_concurrency=16`)
 	c.Assert(strings.Contains(err.Error(), "privilege check fail"), IsTrue)
+}
 
 func (s *testPrivilegeSuite) TestAnalyzeTable(c *C) {
 

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -350,7 +350,6 @@ func (s *testPrivilegeSuite) TestUseDb(c *C) {
 }
 
 func (s *testPrivilegeSuite) TestSetGlobal(c *C) {
-
 	se := newSession(c, s.store, s.dbName)
 	mustExec(c, se, `CREATE USER setglobal_a@localhost`)
 	mustExec(c, se, `CREATE USER setglobal_b@localhost`)

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -349,6 +349,23 @@ func (s *testPrivilegeSuite) TestUseDb(c *C) {
 
 }
 
+func (s *testPrivilegeSuite) TestSetGlobal(c *C) {
+
+	se := newSession(c, s.store, s.dbName)
+	mustExec(c, se, `CREATE USER setglobal_a@localhost`)
+	mustExec(c, se, `CREATE USER setglobal_b@localhost`)
+	mustExec(c, se, `GRANT SUPER ON *.* to setglobal_a@localhost`)
+	mustExec(c, se, `FLUSH PRIVILEGES`)
+
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "setglobal_a", Hostname: "localhost"}, nil, nil), IsTrue)
+	mustExec(c, se, `set global innodb_commit_concurrency=16`)
+
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "setglobal_b", Hostname: "localhost"}, nil, nil), IsTrue)
+	_, err := se.Execute(context.Background(), `set global innodb_commit_concurrency=16`)
+	c.Assert(strings.Contains(err.Error(), "privilege check fail"), IsTrue)
+
+}
+
 func (s *testPrivilegeSuite) TestInformationSchema(c *C) {
 
 	// This test tests no privilege check for INFORMATION_SCHEMA database.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #7403

### What is changed and how it works?

Checks that `SET GLOBAL` requires the super privilege.  Does not check any session level vars - I took a look, and I don't believe any in TiDB require privilege check.

(In MySQL commands like `SET SESSION sql_log_bin=0` require super privs, but I believe this is not applicable to TiDB).

It is not 100% compatible with MySQL, since the error codes/messages differ, but this is not a new issue, and is inherint to all checking in `visitInfo`.  I will create a separate issue to discuss how to enhance it, since I think it should have an argument to pass the error message on failure.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity
 - Breaking backward compatibility (broken apps)

Related changes

 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8837)
<!-- Reviewable:end -->
