### PR TITLE
*: clean up code for insert/update statement

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -129,7 +129,6 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 	// 5. If handle changed, remove the old then add the new record, otherwise update the record.
 	var err error
 	if handleChanged {
-		skipHandleCheck := false
 		if sc.DupKeyAsWarning {
 			// For `UPDATE IGNORE`/`INSERT IGNORE ON DUPLICATE KEY UPDATE`
 			// If the new handle exists, this will avoid to remove the record.
@@ -137,13 +136,12 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 			if err != nil {
 				return false, handleChanged, newHandle, errors.Trace(err)
 			}
-			skipHandleCheck = true
 		}
 		if err = t.RemoveRecord(ctx, h, oldData); err != nil {
 			return false, false, 0, errors.Trace(err)
 		}
 		// the `affectedRows` is increased when adding new record.
-		newHandle, err = t.AddRecord(ctx, newData, skipHandleCheck)
+		newHandle, err = t.AddRecord(ctx, newData, sc.DupKeyAsWarning)
 		if err != nil {
 			return false, false, 0, errors.Trace(err)
 		}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -32,8 +32,6 @@ const (
 	PresumeKeyNotExistsError
 	// BinlogInfo contains the binlog data and client.
 	BinlogInfo
-	// Skip existing check when "prewrite".
-	SkipCheckForWrite
 	// SchemaChecker is used for checking schema-validity.
 	SchemaChecker
 	// IsolationLevel sets isolation level for current transaction. The default level is SI.

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -67,6 +67,10 @@ func (s *tikvSnapshot) SetPriority(priority int) {
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
 // The map will not contain nonexistent keys.
 func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
+	m := make(map[string][]byte)
+	if len(keys) == 0 {
+		return m, nil
+	}
 	metrics.TiKVTxnCmdCounter.WithLabelValues("batch_get").Inc()
 	start := time.Now()
 	defer func() { metrics.TiKVTxnCmdHistogram.WithLabelValues("batch_get").Observe(time.Since(start).Seconds()) }()
@@ -78,7 +82,6 @@ func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 
 	// Create a map to collect key-values from region servers.
 	var mu sync.Mutex
-	m := make(map[string][]byte)
 	err := s.batchGetKeysByRegions(bo, bytesKeys, func(k, v []byte) {
 		if len(v) == 0 {
 			return

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -447,12 +447,6 @@ func (t *tableCommon) AddRecord(ctx sessionctx.Context, r []types.Datum, skipHan
 	}
 
 	sessVars := ctx.GetSessionVars()
-	// when LightningMode or BatchCheck is true,
-	// no needs to check the key constrains, so we names the variable skipCheck.
-	skipCheck := sessVars.LightningMode || ctx.GetSessionVars().StmtCtx.BatchCheck
-	if skipCheck {
-		txn.SetOption(kv.SkipCheckForWrite, true)
-	}
 
 	rm, err := t.getRollbackableMemStore(ctx)
 	// Insert new entries into indices.
@@ -565,7 +559,7 @@ func (t *tableCommon) addIndices(ctx sessionctx.Context, recordID int64, r []typ
 			return 0, errors.Trace(err2)
 		}
 		var dupKeyErr error
-		if !skipCheck && (v.Meta().Unique || v.Meta().Primary) {
+		if !skipCheck && v.Meta().Unique {
 			entryKey, err1 := t.genIndexKeyStr(indexVals)
 			if err1 != nil {
 				return 0, errors.Trace(err1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. metrics of batch get will always inc(1) even if nothing to get.
1. `kv.SkipCheckForWrite` is unused for a long while https://github.com/pingcap/tidb/pull/3600, make a cleanup.
1. some other cleanup.

### What is changed and how it works?
Fix them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported variable/fields change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8867)
<!-- Reviewable:end -->
