### PR TITLE
executor: convert inner key to the type of outer key’s when build hash table (#8697)

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -1067,9 +1067,19 @@ func (d *Datum) convertToMysqlDuration(sc *stmtctx.StatementContext, target *Fie
 }
 
 func (d *Datum) convertToMysqlDecimal(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {
+	defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(target.Tp)
+	flen, decimal := target.Flen, target.Decimal
+	if decimal == UnspecifiedLength {
+		decimal = defaultDecimal
+	}
+	if flen == UnspecifiedLength {
+		flen = defaultFlen
+	}
+
 	var ret Datum
-	ret.SetLength(target.Flen)
-	ret.SetFrac(target.Decimal)
+	ret.SetLength(flen)
+	ret.SetFrac(decimal)
+
 	var dec = &MyDecimal{}
 	var err error
 	switch d.k {


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->


### What problem does this PR solve? <!--add issue link with summary if exists-->
HashLeftJoin executor can't join two decimals with different fraction rightly; (#8697)



### What is changed and how it works?
When build inner hash table, convert inner keys to the type of outer keys like what IndexLookUpJoin do;


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8873)
<!-- Reviewable:end -->
