### PR TITLE
session: validate value for global time_zone sys variable

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -469,6 +469,10 @@ func (s *testSessionSuite) TestGlobalVarAccessor(c *C) {
 	result = tk.MustQuery("select @@autocommit;")
 	result.Check(testkit.Rows("ON"))
 	tk.MustExec("set @@global.autocommit=1")
+
+	_, err = tk.Exec("set global time_zone = 'timezone'")
+	c.Assert(err, NotNil)
+	c.Assert(terror.ErrorEqual(err, variable.ErrUnknownTimeZone), IsTrue)
 }
 
 func (s *testSessionSuite) TestGetSysVariables(c *C) {

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -315,7 +315,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		if strings.EqualFold(value, "SYSTEM") {
 			return "SYSTEM", nil
 		}
-		return value, nil
+		_, err := parseTimeZone(value)
+		return value, err
 	case ValidatePasswordLength, ValidatePasswordNumberCount:
 		return checkUInt64SystemVar(name, value, 0, math.MaxUint64, vars)
 	case WarningCount, ErrorCount:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before this PR:
```
mysql> set global time_zone = 'timezone';
Query OK, 0 rows affected (0.01 sec)

mysql> \q
Bye
[root@localhost ~/go/src/github.com/pingcap/tidb]$ mysql -u root -P4000 -h127.0.0.1 -D test
ERROR 1298 (HY000): Unknown or incorrect time zone: 'timezone'
```

### What is changed and how it works?

Validate value for global time_zone system variable before setting it.
After this PR:
```
mysql> set global time_zone = 'timezone';
ERROR 1298 (HY000): Unknown or incorrect time zone: 'timezone'
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8876)
<!-- Reviewable:end -->
