### PR TITLE
domain: run FLUSH PRIVILEGES synchronous on GRANT

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/sqlexec"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
@@ -956,6 +957,11 @@ func (do *Domain) NotifyUpdatePrivilege(ctx sessionctx.Context) {
 		if err != nil {
 			log.Warn("notify update privilege failed:", err)
 		}
+	}
+	// update locally
+	_, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, `FLUSH PRIVILEGES`)
+	if err != nil {
+		log.Errorf("Unable to update privileges: %s", err)
 	}
 }
 

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -104,7 +104,6 @@ func (s *testPrivilegeSuite) TearDownTest(c *C) {
 func (s *testPrivilegeSuite) TestCheckDBPrivilege(c *C) {
 	rootSe := newSession(c, s.store, s.dbName)
 	mustExec(c, rootSe, `CREATE USER 'testcheck'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 
 	se := newSession(c, s.store, s.dbName)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "testcheck", Hostname: "localhost"}, nil, nil), IsTrue)
@@ -112,19 +111,16 @@ func (s *testPrivilegeSuite) TestCheckDBPrivilege(c *C) {
 	c.Assert(pc.RequestVerification("test", "", "", mysql.SelectPriv), IsFalse)
 
 	mustExec(c, rootSe, `GRANT SELECT ON *.* TO  'testcheck'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 	c.Assert(pc.RequestVerification("test", "", "", mysql.SelectPriv), IsTrue)
 	c.Assert(pc.RequestVerification("test", "", "", mysql.UpdatePriv), IsFalse)
 
 	mustExec(c, rootSe, `GRANT Update ON test.* TO  'testcheck'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 	c.Assert(pc.RequestVerification("test", "", "", mysql.UpdatePriv), IsTrue)
 }
 
 func (s *testPrivilegeSuite) TestCheckTablePrivilege(c *C) {
 	rootSe := newSession(c, s.store, s.dbName)
 	mustExec(c, rootSe, `CREATE USER 'test1'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 
 	se := newSession(c, s.store, s.dbName)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "test1", Hostname: "localhost"}, nil, nil), IsTrue)
@@ -132,17 +128,14 @@ func (s *testPrivilegeSuite) TestCheckTablePrivilege(c *C) {
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.SelectPriv), IsFalse)
 
 	mustExec(c, rootSe, `GRANT SELECT ON *.* TO  'test1'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.SelectPriv), IsTrue)
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.UpdatePriv), IsFalse)
 
 	mustExec(c, rootSe, `GRANT Update ON test.* TO  'test1'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.UpdatePriv), IsTrue)
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.IndexPriv), IsFalse)
 
 	mustExec(c, rootSe, `GRANT Index ON test.test TO  'test1'@'localhost';`)
-	mustExec(c, rootSe, `FLUSH PRIVILEGES;`)
 	c.Assert(pc.RequestVerification("test", "test", "", mysql.IndexPriv), IsTrue)
 }
 
@@ -151,7 +144,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	ctx, _ := se.(sessionctx.Context)
 	mustExec(c, se, `CREATE USER 'show'@'localhost' identified by '123';`)
 	mustExec(c, se, `GRANT Index ON *.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	pc := privilege.GetPrivilegeManager(se)
 
 	gs, err := pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
@@ -160,7 +152,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	c.Assert(gs[0], Equals, `GRANT Index ON *.* TO 'show'@'localhost'`)
 
 	mustExec(c, se, `GRANT Select ON *.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 1)
@@ -168,7 +159,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 
 	// The order of privs is the same with AllGlobalPrivs
 	mustExec(c, se, `GRANT Update ON *.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 1)
@@ -176,7 +166,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 
 	// All privileges
 	mustExec(c, se, `GRANT ALL ON *.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 1)
@@ -184,7 +173,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 
 	// Add db scope privileges
 	mustExec(c, se, `GRANT Select ON test.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 2)
@@ -193,7 +181,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	c.Assert(testutil.CompareUnorderedStringSlice(gs, expected), IsTrue)
 
 	mustExec(c, se, `GRANT Index ON test1.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 3)
@@ -203,7 +190,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	c.Assert(testutil.CompareUnorderedStringSlice(gs, expected), IsTrue)
 
 	mustExec(c, se, `GRANT ALL ON test1.* TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 3)
@@ -214,7 +200,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 
 	// Add table scope privileges
 	mustExec(c, se, `GRANT Update ON test.test TO  'show'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 4)
@@ -229,7 +214,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	mustExec(c, se, `REVOKE Select on test.* FROM 'show'@'localhost'`)
 	mustExec(c, se, `REVOKE ALL ON test1.* FROM 'show'@'localhost'`)
 	mustExec(c, se, `REVOKE UPDATE on test.test FROM 'show'@'localhost'`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
 	c.Assert(err, IsNil)
 	c.Assert(gs, HasLen, 1)
@@ -239,7 +223,6 @@ func (s *testPrivilegeSuite) TestShowGrants(c *C) {
 	// Which we need privileges to do so!
 	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "root", Hostname: "localhost"}
 	mustExec(c, se, `DROP USER 'show'@'localhost'`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 
 	// This should now return an error
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"})
@@ -257,7 +240,6 @@ func (s *testPrivilegeSuite) TestDropTablePriv(c *C) {
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil), IsTrue)
 	mustExec(c, se, `CREATE USER 'drop'@'localhost';`)
 	mustExec(c, se, `GRANT Select ON test.todrop TO  'drop'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 
 	// ctx.GetSessionVars().User = "drop@localhost"
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "drop", Hostname: "localhost"}, nil, nil), IsTrue)
@@ -268,7 +250,6 @@ func (s *testPrivilegeSuite) TestDropTablePriv(c *C) {
 	se = newSession(c, s.store, s.dbName)
 	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "root", Hostname: "localhost"}
 	mustExec(c, se, `GRANT Drop ON test.todrop TO  'drop'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 
 	se = newSession(c, s.store, s.dbName)
 	ctx.GetSessionVars().User = &auth.UserIdentity{Username: "drop", Hostname: "localhost"}
@@ -283,16 +264,15 @@ func (s *testPrivilegeSuite) TestSetPasswdStmt(c *C) {
 	mustExec(c, se, "CREATE USER 'superuser'")
 	mustExec(c, se, "CREATE USER 'nobodyuser'")
 	mustExec(c, se, "GRANT ALL ON *.* TO 'superuser'")
-	mustExec(c, se, "FLUSH PRIVILEGES")
 
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "superuser", Hostname: "localhost", AuthUsername: "superuser", AuthHostname: "%"}, nil, nil), IsTrue)
 	mustExec(c, se, "SET PASSWORD for 'nobodyuser' = 'newpassword'")
+	mustExec(c, se, "SET PASSWORD for 'nobodyuser' = ''")
 
 	// low privileged user trying to set password for other user (fails)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "nobodyuser", Hostname: "localhost", AuthUsername: "nobodyuser", AuthHostname: "%"}, nil, nil), IsTrue)
 	_, err := se.Execute(context.Background(), "SET PASSWORD for 'superuser' = 'newpassword'")
 	c.Assert(err, NotNil)
-
 }
 
 func (s *testPrivilegeSuite) TestCheckAuthenticate(c *C) {
@@ -302,7 +282,7 @@ func (s *testPrivilegeSuite) TestCheckAuthenticate(c *C) {
 	mustExec(c, se, `CREATE USER 'u2'@'localhost' identified by 'abc';`)
 	mustExec(c, se, `CREATE USER 'u3@example.com'@'localhost';`)
 	mustExec(c, se, `CREATE USER u4@localhost;`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
+
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u1", Hostname: "localhost"}, nil, nil), IsTrue)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u2", Hostname: "localhost"}, nil, nil), IsFalse)
 	salt := []byte{85, 92, 45, 22, 58, 79, 107, 6, 122, 125, 58, 80, 12, 90, 103, 32, 90, 10, 74, 82}
@@ -316,7 +296,6 @@ func (s *testPrivilegeSuite) TestCheckAuthenticate(c *C) {
 	mustExec(c, se1, "drop user 'u2'@'localhost'")
 	mustExec(c, se1, "drop user 'u3@example.com'@'localhost'")
 	mustExec(c, se1, "drop user u4@localhost")
-	mustExec(c, se1, `FLUSH PRIVILEGES;`)
 
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u1", Hostname: "localhost"}, nil, nil), IsFalse)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u2", Hostname: "localhost"}, nil, nil), IsFalse)
@@ -331,7 +310,6 @@ func (s *testPrivilegeSuite) TestUseDb(c *C) {
 	mustExec(c, se, "CREATE USER 'usesuper'")
 	mustExec(c, se, "CREATE USER 'usenobody'")
 	mustExec(c, se, "GRANT ALL ON *.* TO 'usesuper'")
-	mustExec(c, se, "FLUSH PRIVILEGES")
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "usesuper", Hostname: "localhost", AuthUsername: "usesuper", AuthHostname: "%"}, nil, nil), IsTrue)
 	mustExec(c, se, "use mysql")
 	// low privileged user
@@ -342,7 +320,6 @@ func (s *testPrivilegeSuite) TestUseDb(c *C) {
 	// try again after privilege granted
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "usesuper", Hostname: "localhost", AuthUsername: "usesuper", AuthHostname: "%"}, nil, nil), IsTrue)
 	mustExec(c, se, "GRANT SELECT ON mysql.* TO 'usenobody'")
-	mustExec(c, se, "FLUSH PRIVILEGES")
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "usenobody", Hostname: "localhost", AuthUsername: "usenobody", AuthHostname: "%"}, nil, nil), IsTrue)
 	_, err = se.Execute(context.Background(), "use mysql")
 	c.Assert(err, IsNil)
@@ -354,7 +331,6 @@ func (s *testPrivilegeSuite) TestInformationSchema(c *C) {
 	// This test tests no privilege check for INFORMATION_SCHEMA database.
 	se := newSession(c, s.store, s.dbName)
 	mustExec(c, se, `CREATE USER 'u1'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u1", Hostname: "localhost"}, nil, nil), IsTrue)
 	mustExec(c, se, `select * from information_schema.tables`)
 	mustExec(c, se, `select * from information_schema.key_column_usage`)
@@ -364,7 +340,6 @@ func (s *testPrivilegeSuite) TestAdminCommand(c *C) {
 	se := newSession(c, s.store, s.dbName)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost"}, nil, nil), IsTrue)
 	mustExec(c, se, `CREATE USER 'test_admin'@'localhost';`)
-	mustExec(c, se, `FLUSH PRIVILEGES;`)
 	mustExec(c, se, `CREATE TABLE t(a int)`)
 
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "test_admin", Hostname: "localhost"}, nil, nil), IsTrue)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #8427

### What is changed and how it works?

When a `GRANT`, `DROP USER`, `CREATE USER` is run, TiDB will asynchronously notify peers via etcd.  The problem is that for the test suite, mocktikv (and MySQL compatibility) it is required to run `FLUSH PRIVILEGES` synchronously.  This is because changes are expected to apply immediately.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

- Yes

Side effects

 - Possible performance regression (the server will do more work, since it will re-run `FLUSH PRIVILEGES` when it receives the etcd notification)
 - Increased code complexity (or actually decreased when you consider test simplification)

Related changes

 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8886)
<!-- Reviewable:end -->
