### PR TITLE
planner,expression: recognize the three new expressions from pingcap/parser#142

### DIFF
--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -167,6 +167,22 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 		sr.rowToScalarFunc(v)
 	case *ast.ParenthesesExpr:
 	case *ast.ColumnName:
+	// TODO: Perhaps we don't need to transcode these back to generic integers/strings
+	case *ast.TrimDirectionExpr:
+		sr.push(&Constant{
+			Value:   types.NewIntDatum(int64(v.Direction)),
+			RetType: types.NewFieldType(mysql.TypeTiny),
+		})
+	case *ast.TimeUnitExpr:
+		sr.push(&Constant{
+			Value:   types.NewStringDatum(v.Unit.String()),
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		})
+	case *ast.GetFormatSelectorExpr:
+		sr.push(&Constant{
+			Value:   types.NewStringDatum(v.Selector.String()),
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		})
 	default:
 		sr.err = errors.Errorf("UnknownType: %T", v)
 		return retNode, false

--- a/expression/simple_rewriter_test.go
+++ b/expression/simple_rewriter_test.go
@@ -150,4 +150,19 @@ func (s *testEvaluatorSuite) TestSimpleRewriter(c *C) {
 	c.Assert(err, IsNil)
 	num, _, _ = exprs[0].EvalInt(ctx, chunk.Row{})
 	c.Assert(num, Equals, int64(1))
+
+	exprs, err = ParseSimpleExprsWithSchema(ctx, "trim(leading 'z' from 'zxyz')", sch)
+	c.Assert(err, IsNil)
+	str, _, _ := exprs[0].EvalString(ctx, chunk.Row{})
+	c.Assert(str, Equals, "xyz")
+
+	exprs, err = ParseSimpleExprsWithSchema(ctx, "get_format(datetime, 'ISO')", sch)
+	c.Assert(err, IsNil)
+	str, _, _ = exprs[0].EvalString(ctx, chunk.Row{})
+	c.Assert(str, Equals, "%Y-%m-%d %H:%i:%s")
+
+	exprs, err = ParseSimpleExprsWithSchema(ctx, "extract(day_minute from '2184-07-03 18:42:18.895059')", sch)
+	c.Assert(err, IsNil)
+	num, _, _ = exprs[0].EvalInt(ctx, chunk.Row{})
+	c.Assert(num, Equals, int64(31842))
 }

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190801033650-4849eb88ee66
+	github.com/pingcap/parser v0.0.0-20190803082711-3db5c165d5d9
 	github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190801033650-4849eb88ee66 h1:RQlXn268eNxAh4ZcDGHSdDkv20x1eJDQu8vYvQh3x5c=
-github.com/pingcap/parser v0.0.0-20190801033650-4849eb88ee66/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190803082711-3db5c165d5d9 h1:oEbyHJedKpf7wcD7lL45HgD24E/W0Qo/HBW6Zv9kPTI=
+github.com/pingcap/parser v0.0.0-20190803082711-3db5c165d5d9/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB52tXhVLEP7Ng3Qqsd6Z18iY=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -906,6 +906,22 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		er.isTrueToScalarFunc(v)
 	case *ast.DefaultExpr:
 		er.evalDefaultExpr(v)
+	// TODO: Perhaps we don't need to transcode these back to generic integers/strings
+	case *ast.TrimDirectionExpr:
+		er.ctxStack = append(er.ctxStack, &expression.Constant{
+			Value:   types.NewIntDatum(int64(v.Direction)),
+			RetType: types.NewFieldType(mysql.TypeTiny),
+		})
+	case *ast.TimeUnitExpr:
+		er.ctxStack = append(er.ctxStack, &expression.Constant{
+			Value:   types.NewStringDatum(v.Unit.String()),
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		})
+	case *ast.GetFormatSelectorExpr:
+		er.ctxStack = append(er.ctxStack, &expression.Constant{
+			Value:   types.NewStringDatum(v.Selector.String()),
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		})
 	default:
 		er.err = errors.Errorf("UnknownType: %T", v)
 		return retNode, false

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3139,10 +3139,13 @@ func (b *PlanBuilder) buildWindowFunctionFrameBound(ctx context.Context, spec *a
 	}
 
 	desc := orderByItems[0].Desc
-	if boundClause.Unit != nil {
-		// It can be guaranteed by the parser.
-		unitVal := boundClause.Unit.(*driver.ValueExpr)
-		unit := expression.Constant{Value: unitVal.Datum, RetType: unitVal.GetType()}
+	if boundClause.Unit != ast.TimeUnitInvalid {
+		// TODO: Perhaps we don't need to transcode this back to generic string
+		unitVal := boundClause.Unit.String()
+		unit := expression.Constant{
+			Value:   types.NewStringDatum(unitVal),
+			RetType: types.NewFieldType(mysql.TypeVarchar),
+		}
 
 		// When the order is asc:
 		//   `+` for following, and `-` for the preceding
@@ -3375,7 +3378,7 @@ func (b *PlanBuilder) checkOriginWindowFrameBound(bound *ast.FrameBound, spec *a
 
 	frameType := spec.Frame.Type
 	if frameType == ast.Rows {
-		if bound.Unit != nil {
+		if bound.Unit != ast.TimeUnitInvalid {
 			return ErrWindowRowsIntervalUse.GenWithStackByArgs(getWindowName(spec.Name.O))
 		}
 		_, isNull, isExpectedType := getUintFromNode(b.ctx, bound.Expr)
@@ -3393,10 +3396,10 @@ func (b *PlanBuilder) checkOriginWindowFrameBound(bound *ast.FrameBound, spec *a
 	if !isNumeric && !isTemporal {
 		return ErrWindowRangeFrameOrderType.GenWithStackByArgs(getWindowName(spec.Name.O))
 	}
-	if bound.Unit != nil && !isTemporal {
+	if bound.Unit != ast.TimeUnitInvalid && !isTemporal {
 		return ErrWindowRangeFrameNumericType.GenWithStackByArgs(getWindowName(spec.Name.O))
 	}
-	if bound.Unit == nil && !isNumeric {
+	if bound.Unit == ast.TimeUnitInvalid && !isNumeric {
 		return ErrWindowRangeFrameTemporalType.GenWithStackByArgs(getWindowName(spec.Name.O))
 	}
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

> DNM: Blocked by pingcap/parser#142

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, keyword arguments to functions like the `DATETIME` in `GET_FORMAT(DATETIME, 'EUR')` are converted into a string ValueExpr `"DATETIME"`. This interferes with #8532, as this will naturally be restored to a form with syntax error: `GET_FORMAT('DATETIME', 'EUR')`.

### What is changed and how it works?

In pingcap/parser#142 I've introduced three new expressions types to represent time and timestamp units (`MICROSECOND`, `YEAR_MONTH`, ...), trim direction (`BOTH`, `LEADING`, `TRAILING`) and GET_FORMAT selector (`DATE`, `TIME`, `DATETIME`). TiDB's expression_rewriter needs to be updated to recognize these expressions types, otherwise it will panic.

The current implementation changes these back to generic integers/strings to minimize diff. I also have another branch which refactors every time unit into `ast.TimeUnitType` which I could post after this PR is merged, if anything thinks it is worthwhile.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
    * Existing tests did not break

Code changes

Side effects

Related changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8891)
<!-- Reviewable:end -->
