### PR TITLE
distsql: refine distsql's batch control logic

### DIFF
--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -24,11 +24,6 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
-// XAPI error codes.
-const (
-	codeInvalidResp = 1
-)
-
 // Select sends a DAG request, returns SelectResult.
 // In kvReq, KeyRanges is required, Concurrency/KeepOrder/Desc/IsolationLevel/Priority are optional.
 func Select(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request, fieldTypes []*types.FieldType, fb *statistics.QueryFeedback) (SelectResult, error) {

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -70,7 +70,7 @@ func (s *testSuite) TestSelectNormal(c *C) {
 	response.Fetch(context.TODO())
 
 	// Test Next.
-	chk := chunk.New(colTypes, 32, 32)
+	chk := chunk.New(colTypes, 1, 32)
 	numAllRows := 0
 	for {
 		err = response.Next(context.TODO(), chk)
@@ -122,7 +122,7 @@ func (s *testSuite) TestSelectStreaming(c *C) {
 	response.Fetch(context.TODO())
 
 	// Test Next.
-	chk := chunk.New(colTypes, 32, 32)
+	chk := chunk.New(colTypes, 1, 32)
 	numAllRows := 0
 	for {
 		err = response.Next(context.TODO(), chk)

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -115,8 +115,8 @@ func (r *selectResult) NextRaw(ctx context.Context) ([]byte, error) {
 
 // Next reads data to the chunk.
 func (r *selectResult) Next(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	for chk.NumRows() < r.ctx.GetSessionVars().MaxChunkSize {
+	chk.GrowAndReset(r.ctx.GetSessionVars().MaxChunkSize)
+	for chk.NumRows() < chk.Capacity() {
 		if r.selectResp == nil || r.respChkIdx == len(r.selectResp.Chunks) {
 			err := r.getSelectResp()
 			if err != nil || r.selectResp == nil {
@@ -169,9 +169,8 @@ func (r *selectResult) getSelectResp() error {
 
 func (r *selectResult) readRowsData(chk *chunk.Chunk) (err error) {
 	rowsData := r.selectResp.Chunks[r.respChkIdx].RowsData
-	maxChunkSize := r.ctx.GetSessionVars().MaxChunkSize
 	decoder := codec.NewDecoder(chk, r.ctx.GetSessionVars().Location())
-	for chk.NumRows() < maxChunkSize && len(rowsData) > 0 {
+	for chk.NumRows() < chk.Capacity() && len(rowsData) > 0 {
 		for i := 0; i < r.rowLen; i++ {
 			rowsData, err = decoder.DecodeOne(rowsData, i, r.fieldTypes[i])
 			if err != nil {

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -44,9 +44,8 @@ type streamResult struct {
 func (r *streamResult) Fetch(context.Context) {}
 
 func (r *streamResult) Next(ctx context.Context, chk *chunk.Chunk) error {
-	chk.Reset()
-	maxChunkSize := r.ctx.GetSessionVars().MaxChunkSize
-	for chk.NumRows() < maxChunkSize {
+	chk.GrowAndReset(r.ctx.GetSessionVars().MaxChunkSize)
+	for chk.NumRows() < chk.Capacity() {
 		err := r.readDataIfNecessary(ctx)
 		if err != nil {
 			return errors.Trace(err)
@@ -115,9 +114,8 @@ func (r *streamResult) readDataIfNecessary(ctx context.Context) error {
 
 func (r *streamResult) flushToChunk(chk *chunk.Chunk) (err error) {
 	remainRowsData := r.curr.RowsData
-	maxChunkSize := r.ctx.GetSessionVars().MaxChunkSize
 	decoder := codec.NewDecoder(chk, r.ctx.GetSessionVars().Location())
-	for chk.NumRows() < maxChunkSize && len(remainRowsData) > 0 {
+	for chk.NumRows() < chk.Capacity() && len(remainRowsData) > 0 {
 		for i := 0; i < r.rowLen; i++ {
 			remainRowsData, err = decoder.DecodeOne(remainRowsData, i, r.fieldTypes[i])
 			if err != nil {

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -384,6 +384,9 @@ func (s *testSuite1) TestGroupConcatAggr(c *C) {
 	// issue #5411
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	// https://github.com/pingcap/tidb/issues/6838 isn't implemented, so use this trick.
+	tk.Se.GetSessionVars().InitChunkSize = 3
+	tk.Se.GetSessionVars().MaxChunkSize = 3
 	tk.MustExec("create table test(id int, name int)")
 	tk.MustExec("insert into test values(1, 10);")
 	tk.MustExec("insert into test values(1, 20);")

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -384,9 +384,9 @@ func (s *testSuite1) TestGroupConcatAggr(c *C) {
 	// issue #5411
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	// https://github.com/pingcap/tidb/issues/6838 isn't implemented, so use this trick.
+	// `group_concat` parallel gets chunks from blew `tableReader` and parallel running, the final result is unstable order in one group and hard to assert.
+	//  so set a big enough `InitChunkSize` to let tableReader return one group's result in one chunk to keep order.
 	tk.Se.GetSessionVars().InitChunkSize = 3
-	tk.Se.GetSessionVars().MaxChunkSize = 3
 	tk.MustExec("create table test(id int, name int)")
 	tk.MustExec("insert into test values(1, 10);")
 	tk.MustExec("insert into test values(1, 20);")

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -432,7 +432,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		finished:     e.finished,
 		resultCh:     e.resultCh,
 		keepOrder:    e.keepOrder,
-		batchSize:    1,
+		batchSize:    1, // slow start with small batch size to return first row quickly.
 		maxBatchSize: e.ctx.GetSessionVars().IndexLookupSize,
 		maxChunkSize: e.maxChunkSize,
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -740,7 +740,6 @@ func (e *LimitExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	// For limit N, we only need request N from child executor.
 	e.childResult = chunk.New(e.children[0].retTypes(), e.initCap, e.maxChunkSize)
 	e.cursor = 0
 	e.meetFirstBatch = e.begin == 0

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -740,7 +740,8 @@ func (e *LimitExec) Open(ctx context.Context) error {
 	if err := e.baseExecutor.Open(ctx); err != nil {
 		return errors.Trace(err)
 	}
-	e.childResult = e.children[0].newFirstChunk()
+	// For limit N, we only need request N from child executor.
+	e.childResult = chunk.New(e.children[0].retTypes(), e.initCap, e.maxChunkSize)
 	e.cursor = 0
 	e.meetFirstBatch = e.begin == 0
 	return nil

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -139,7 +139,7 @@ func (s *testSuite2) TestJoin(c *C) {
 	tk.MustQuery("select /*+ TIDB_INLJ(t) */ * from t1 join t on t.a=t1.a and t.a < t1.b").Check(testkit.Rows("1 2 1 1", "1 3 1 1", "1 4 1 1", "3 4 3 3"))
 	// Test single index reader.
 	tk.MustQuery("select /*+ TIDB_INLJ(t, t1) */ t1.b from t1 join t on t.b=t1.b").Check(testkit.Rows("2", "3"))
-	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ * from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1 1 1 2", "1 1 1 3", "1 1 1 4", "3 3 3 4", "<nil> <nil> 4 5"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ * from t right outer join t1 on t.a=t1.a order by t.a").Check(testkit.Rows("<nil> <nil> 4 5", "1 1 1 2", "1 1 1 3", "1 1 1 4", "3 3 3 4"))
 	tk.MustQuery("select /*+ TIDB_INLJ(t) */ avg(t.b) from t right outer join t1 on t.a=t1.a").Check(testkit.Rows("1.5000"))
 
 	// Test that two conflict hints will return error.
@@ -953,8 +953,7 @@ func (s *testSuite2) TestHashJoin(c *C) {
 	row := result.Rows()
 	c.Assert(len(row), Equals, 5)
 	outerExecInfo := row[1][4].(string)
-	// FIXME: revert this result to 1 after TableReaderExecutor can handle initChunkSize.
-	c.Assert(outerExecInfo[len(outerExecInfo)-1:], Equals, "5")
+	c.Assert(outerExecInfo[len(outerExecInfo)-1:], Equals, "1")
 	innerExecInfo := row[3][4].(string)
 	c.Assert(innerExecInfo[len(innerExecInfo)-1:], Equals, "0")
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -113,7 +113,7 @@ func (e *TableReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error 
 		e.feedback.Invalidate()
 		return err
 	}
-	return errors.Trace(nil)
+	return nil
 }
 
 // Close implements the Executor Close interface.

--- a/session/session.go
+++ b/session/session.go
@@ -825,11 +825,9 @@ func (s *session) SetGlobalSysVar(name, value string) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	sql := fmt.Sprintf(`REPLACE %s.%s VALUES ('%s', '%s');`,
 		mysql.SystemDB, mysql.GlobalVariablesTable, strings.ToLower(name), sVal)
 	_, _, err = s.ExecRestrictedSQL(s, sql)
-
 	return errors.Trace(err)
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1894,8 +1894,7 @@ func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
 		numChunks++
 	}
 	c.Assert(count, Equals, 100)
-	// FIXME: revert this result to new group value after distsql can handle initChunkSize.
-	c.Assert(numChunks, Equals, 1)
+	c.Assert(numChunks, Equals, 6)
 	rs.Close()
 }
 

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -172,10 +172,10 @@ const (
 	// when we need to keep the data output order the same as the order of index data.
 	TiDBIndexSerialScanConcurrency = "tidb_index_serial_scan_concurrency"
 
-	// TiDBMaxChunkSize is used to control the max chunk size during query execution.
+	// tidb_max_chunk_size is used to control the max chunk size during query execution.
 	TiDBMaxChunkSize = "tidb_max_chunk_size"
 
-	// TiDBInitChunkSize is used to control the init chunk size during query execution.
+	// tidb_init_chunk_size is used to control the init chunk size during query execution.
 	TiDBInitChunkSize = "tidb_init_chunk_size"
 
 	// tidb_enable_cascades_planner is used to control whether to enable the cascades planner.

--- a/util/chunk/chunk_util.go
+++ b/util/chunk/chunk_util.go
@@ -13,6 +13,8 @@
 
 package chunk
 
+import "unsafe"
+
 // CopySelectedJoinRows copies the selected joined rows from the source Chunk
 // to the destination Chunk.
 // Return true if at least one joined row was selected.
@@ -104,4 +106,15 @@ func copyOuterRows(innerColOffset, outerColOffset int, src *Chunk, numRows int, 
 			dstCol.offsets = offsets
 		}
 	}
+}
+
+// GetInt64InColumn returns all data in special column as int64 slice.
+func GetInt64InColumn(c *Chunk, colIdx int) []int64 {
+	rows := c.NumRows()
+	col := c.columns[colIdx]
+	nums := make([]int64, rows)
+	for ridx := 0; ridx < rows; ridx++ {
+		nums[ridx] = *(*int64)(unsafe.Pointer(&col.data[ridx*8]))
+	}
+	return nums
 }

--- a/util/chunk/chunk_util_test.go
+++ b/util/chunk/chunk_util_test.go
@@ -81,3 +81,36 @@ func BenchmarkAppendSelectedRow(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkGetInt64InColumn(b *testing.B) {
+	numRows := 1024
+	srcChk := newChunkWithInitCap(numRows, 8)
+	for i := 0; i < numRows; i++ {
+		srcChk.AppendRow(MutRowFromValues(2).ToRow())
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		GetInt64InColumn(srcChk, 0)
+	}
+}
+
+func BenchmarkGetInt64InRow(b *testing.B) {
+	numRows := 1024
+	srcChk := newChunkWithInitCap(numRows, 8)
+	for i := 0; i < numRows; i++ {
+		srcChk.AppendRow(MutRowFromValues(2).ToRow())
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		nums := make([]int64, 0, srcChk.NumRows())
+		for j := 0; j < srcChk.NumRows(); j++ {
+			num := srcChk.GetRow(j).GetInt64(0)
+			nums = append(nums, num)
+		}
+	}
+}
+
+//BenchmarkGetInt64InColumn-8       	  500000	      3816 ns/op	    8192 B/op	       1 allocs/op
+//BenchmarkGetInt64InRow-8          	  200000	      7506 ns/op	    8192 B/op	       1 allocs/op


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Follow up #8480.

refine distsql(selectResult, streamResult) using chunk#cap to implement old batchSize

### What is changed and how it works?

I. IndexLookUpExecutor

1. refine batchSize

- start batchSize with 1
- grow x2 in following Next call
- limit max batch size to IndexLookupSize

2. in-chunk size(used to get data from sub executor)

- use "fixed" batchSize chunk to request sub executor(selectResult, streamResult)
- grow children chunk only when batchSize growed
- so, it's a very special "grow" for IndexLookUpExecutor

3. out-chunk size(output for parent executor)

following `chunk.cap`, try it's best to return max `chunk.cap` records

II. TableReaderExecutor / IndexReaderExecutor

only out-chunk, following `chunk.cap`, try it's best to return max `chunk.cap` records

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - distsql

Side effects

 - Increased code complexity

Related changes

 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8903)
<!-- Reviewable:end -->
