### PR TITLE
builder: use empty db should return NoDB error

### DIFF
--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"context"
+	"github.com/pingcap/tidb/planner/core"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
@@ -301,4 +302,13 @@ func (s *testSuite3) TestFlushTables(c *C) {
 	_, err = tk.Exec("FLUSH TABLES WITH READ LOCK")
 	c.Check(err, NotNil)
 
+}
+
+func (s *testSuite3) TestUseDB(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	_, err := tk.Exec("USE test")
+	c.Check(err, IsNil)
+
+	_, err = tk.Exec("USE ``")
+	c.Assert(terror.ErrorEqual(core.ErrNoDB, err), IsTrue, Commentf("err %v", err))
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -196,7 +196,7 @@ func (b *PlanBuilder) Build(node ast.Node) (Plan, error) {
 	case *ast.BinlogStmt, *ast.FlushStmt, *ast.UseStmt,
 		*ast.BeginStmt, *ast.CommitStmt, *ast.RollbackStmt, *ast.CreateUserStmt, *ast.SetPwdStmt,
 		*ast.GrantStmt, *ast.DropUserStmt, *ast.AlterUserStmt, *ast.RevokeStmt, *ast.KillStmt, *ast.DropStatsStmt:
-		return b.buildSimple(node.(ast.StmtNode)), nil
+		return b.buildSimple(node.(ast.StmtNode))
 	case ast.DDLNode:
 		return b.buildDDL(x)
 	}
@@ -954,7 +954,7 @@ func (b *PlanBuilder) buildShow(show *ast.ShowStmt) (Plan, error) {
 	return p, nil
 }
 
-func (b *PlanBuilder) buildSimple(node ast.StmtNode) Plan {
+func (b *PlanBuilder) buildSimple(node ast.StmtNode) (Plan, error) {
 	p := &Simple{Statement: node}
 
 	switch raw := node.(type) {
@@ -977,8 +977,12 @@ func (b *PlanBuilder) buildSimple(node ast.StmtNode) Plan {
 				}
 			}
 		}
+	case *ast.UseStmt:
+		if raw.DBName == "" {
+			return nil, ErrNoDB
+		}
 	}
-	return p
+	return p, nil
 }
 
 func collectVisitInfoFromGrantStmt(vi []visitInfo, stmt *ast.GrantStmt) []visitInfo {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix error returned when using an empty db (<code>USE ``</code> )

MySQL:

``` shell
mysql> use ``;
ERROR 1046 (3D000): No database selected
```

TiDB:

``` shell
mysql> use ``;
ERROR 1049 (42000): Unknown database ''
```

### What is changed and how it works?

Check dbName when building plan.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8908)
<!-- Reviewable:end -->
