### PR TITLE
gcworker: let gofail in gcworker run serially, make ci happy

### DIFF
--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -42,6 +42,7 @@ type testGCWorkerSuite struct {
 }
 
 var _ = Suite(&testGCWorkerSuite{})
+var _ = SerialSuites(&testGCWorkerSerialSuite{})
 
 func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	tikv.NewGCHandlerFunc = NewGCWorker
@@ -160,7 +161,58 @@ func (s *testGCWorkerSuite) TestPrepareGC(c *C) {
 	c.Assert(ok, IsTrue)
 }
 
-func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
+func (s *testGCWorkerSuite) TestDoGC(c *C) {
+	var err error
+	ctx := context.Background()
+
+	gcSafePointCacheInterval = 1
+
+	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcDefaultConcurrency))
+	c.Assert(err, IsNil)
+	err = s.gcWorker.doGC(ctx, 20)
+	c.Assert(err, IsNil)
+
+	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcMinConcurrency))
+	c.Assert(err, IsNil)
+	err = s.gcWorker.doGC(ctx, 20)
+	c.Assert(err, IsNil)
+
+	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcMaxConcurrency))
+	c.Assert(err, IsNil)
+	err = s.gcWorker.doGC(ctx, 20)
+	c.Assert(err, IsNil)
+}
+
+type testGCWorkerSerialSuite struct {
+	store    tikv.Storage
+	oracle   *mockoracle.MockOracle
+	gcWorker *GCWorker
+	dom      *domain.Domain
+}
+
+func (s *testGCWorkerSerialSuite) SetUpTest(c *C) {
+	tikv.NewGCHandlerFunc = NewGCWorker
+	store, err := mockstore.NewMockTikvStore()
+	s.store = store.(tikv.Storage)
+	c.Assert(err, IsNil)
+	s.oracle = &mockoracle.MockOracle{}
+	s.store.SetOracle(s.oracle)
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+	gcWorker, err := NewGCWorker(s.store, nil)
+	c.Assert(err, IsNil)
+	gcWorker.Start()
+	gcWorker.Close()
+	s.gcWorker = gcWorker.(*GCWorker)
+}
+
+func (s *testGCWorkerSerialSuite) TearDownTest(c *C) {
+	s.dom.Close()
+	err := s.store.Close()
+	c.Assert(err, IsNil)
+}
+
+func (s *testGCWorkerSerialSuite) TestDoGCForOneRegion(c *C) {
 	var successRegions int32
 	var failedRegions int32
 	taskWorker := newGCTaskWorker(s.store, nil, nil, s.gcWorker.uuid, &successRegions, &failedRegions)
@@ -191,26 +243,4 @@ func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
 	c.Assert(regionErr.GetServerIsBusy(), NotNil)
 	c.Assert(err, IsNil)
 	gofail.Disable("github.com/pingcap/tidb/store/tikv/tikvStoreSendReqResult")
-}
-
-func (s *testGCWorkerSuite) TestDoGC(c *C) {
-	var err error
-	ctx := context.Background()
-
-	gcSafePointCacheInterval = 1
-
-	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcDefaultConcurrency))
-	c.Assert(err, IsNil)
-	err = s.gcWorker.doGC(ctx, 20)
-	c.Assert(err, IsNil)
-
-	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcMinConcurrency))
-	c.Assert(err, IsNil)
-	err = s.gcWorker.doGC(ctx, 20)
-	c.Assert(err, IsNil)
-
-	err = s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcMaxConcurrency))
-	c.Assert(err, IsNil)
-	err = s.gcWorker.doGC(ctx, 20)
-	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We got error message from https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/790/pipeline:

```
----------------------------------------------------------------------

FAIL: gc_worker_test.go:163: testGCWorkerSuite.TestDoGCForOneRegion



gc_worker_test.go:180:

    c.Assert(err, NotNil)

... value = nil

```

It is caused by https://github.com/pingcap/check/commit/5c2b07721bdbc69274b9915c168c88c0bdffc83e, the gofail will affect global code, if we run the test suite parallel, it may be failed like above.

### What is changed and how it works?

run the gofail test cases serially.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8912)
<!-- Reviewable:end -->
