### PR TITLE
session: add a `doNotCommit` flag to transaction when `StmtCommit` fail

### DIFF
--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -29,11 +29,12 @@ func (s *testSessionSuite) TestFailStatementCommit(c *C) {
 	tk.MustExec("insert into t values (1)")
 
 	gofail.Enable("github.com/pingcap/tidb/session/mockStmtCommitError", `return(true)`)
-	_, err := tk.Exec("insert into t values (2)")
+	_, err := tk.Exec("insert into t values (2),(3),(4),(5)")
 	c.Assert(err, NotNil)
 
 	gofail.Disable("github.com/pingcap/tidb/session/mockStmtCommitError")
 
+	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
 	tk.MustExec("insert into t values (3)")
 	tk.MustExec("insert into t values (4)")
 	_, err = tk.Exec("commit")

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -22,17 +22,24 @@ import (
 )
 
 func (s *testSessionSuite) TestFailStatementCommit(c *C) {
-	defer gofail.Disable("github.com/pingcap/tidb/session/mockStmtCommitError")
 
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
 	tk.MustExec("begin")
 	tk.MustExec("insert into t values (1)")
+
 	gofail.Enable("github.com/pingcap/tidb/session/mockStmtCommitError", `return(true)`)
 	_, err := tk.Exec("insert into t values (2)")
 	c.Assert(err, NotNil)
-	tk.MustExec("commit")
-	tk.MustQuery(`select * from t`).Check(testkit.Rows("1"))
+
+	gofail.Disable("github.com/pingcap/tidb/session/mockStmtCommitError")
+
+	tk.MustExec("insert into t values (3)")
+	tk.MustExec("insert into t values (4)")
+	_, err = tk.Exec("commit")
+	c.Assert(err, NotNil)
+
+	tk.MustQuery(`select * from t`).Check(testkit.Rows())
 }
 
 func (s *testSessionSuite) TestGetTSFailDirtyState(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If `StmtCommit` meets error, it should not leave dirty data in Txn.
When the operation is irreversible, it's better to mark the whole Txn as failed.

### What is changed and how it works?

Add a `doNotCommit` flag.
If a Txn has this flag, it acts as a normal Txn, except that it can't Commit. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Side effects

 - Increased code complexity


@winkyao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8918)
<!-- Reviewable:end -->
