### PR TITLE
session: check transaction too large before real commit in stmtCommit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -86,3 +86,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/goleveldb => github.com/lysu/goleveldb v0.0.0-20190103061555-970c620d7c45

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDK
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/lysu/goleveldb v0.0.0-20190103061555-970c620d7c45 h1:JTyjv57itdeqh3sqTlc37l+r9qvDj4Mv8ZFqwAk0vi8=
+github.com/lysu/goleveldb v0.0.0-20190103061555-970c620d7c45/go.mod h1:wEKRnAZJh0FViv3jt7fqjF+Fs8H2wD9q69CblJp9vbk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 h1:pmpDGKLw4n82EtrNiLqB+xSz/JQwFOaZuMALYUHwX5s=

--- a/go.sum
+++ b/go.sum
@@ -81,7 +81,6 @@ github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5 h1:2U0HzY8BJ8hVwDK
 github.com/klauspost/cpuid v0.0.0-20170728055534-ae7887de9fa5/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/lysu/goleveldb v0.0.0-20190103061555-970c620d7c45 h1:JTyjv57itdeqh3sqTlc37l+r9qvDj4Mv8ZFqwAk0vi8=
 github.com/lysu/goleveldb v0.0.0-20190103061555-970c620d7c45/go.mod h1:wEKRnAZJh0FViv3jt7fqjF+Fs8H2wD9q69CblJp9vbk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -114,12 +114,14 @@ type memDBAware interface {
 	MemDB() *memdb.DB
 }
 
+// MemDB returns the `memdb.DB` under it
 func (m *memDbBuffer) MemDB() *memdb.DB {
 	return m.db
 }
 
-func (m *memDbBuffer) CheckMerge(o MemBuffer) error {
-	memDBAware := o.(memDBAware) // force panic if use wrong type.
+// CheckMerge checks whether other buffer can merged to current buff.
+func (m *memDbBuffer) CheckMerge(other MemBuffer) error {
+	memDBAware := other.(memDBAware) // force panic if use wrong type.
 	memDB := memDBAware.MemDB()
 	mergedSize, mergedCount, maxEntrySize := m.db.PreMerge(memDB.NewIterator(&util.Range{}))
 	if maxEntrySize > m.entrySizeLimit {

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 
 	"github.com/pingcap/errors"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // UnionStore is a store that wraps a snapshot for read and a BufferStore for buffered write.
@@ -170,11 +170,12 @@ type mergeCheckable interface {
 	CheckMerge(o MemBuffer) error
 }
 
-func (lmb *lazyMemBuffer) CheckMerge(o MemBuffer) error {
+// CheckMerge checks whether other buffer can merged to current buff.
+func (lmb *lazyMemBuffer) CheckMerge(other MemBuffer) error {
 	if checker, ok := lmb.mb.(mergeCheckable); ok {
-		return checker.CheckMerge(o)
+		return checker.CheckMerge(other)
 	}
-	logrus.Fatalf("unsupport check merge for %v", o)
+	log.Fatalf("unsupport check merge for %v", other)
 	return nil
 }
 

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 
 	"github.com/pingcap/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // UnionStore is a store that wraps a snapshot for read and a BufferStore for buffered write.
@@ -163,6 +164,18 @@ func (lmb *lazyMemBuffer) Reset() {
 
 func (lmb *lazyMemBuffer) SetCap(cap int) {
 	lmb.cap = cap
+}
+
+type mergeCheckable interface {
+	CheckMerge(o MemBuffer) error
+}
+
+func (lmb *lazyMemBuffer) CheckMerge(o MemBuffer) error {
+	if checker, ok := lmb.mb.(mergeCheckable); ok {
+		return checker.CheckMerge(o)
+	}
+	logrus.Fatalf("unsupport check merge for %v", o)
+	return nil
 }
 
 // Get implements the Retriever interface.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

another solution to #8918 question, pre check stmt buffer size.

### What is changed and how it works?

- add PreMerge method in goleveldb at https://github.com/pingcap/goleveldb/pull/9
- hack membuffer to support `MergeCheckable` interface
- precheck in stmtCommit before set data.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8920)
<!-- Reviewable:end -->
