### PR TITLE
ddl :fix cancel add/drop partitioned table ddl job

### DIFF
--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -95,6 +95,10 @@ func isJobRollbackable(job *model.Job, id int64) error {
 		if job.SchemaState != model.StateNone {
 			return ErrCannotCancelDDLJob.GenWithStackByArgs(id)
 		}
+	case model.ActionDropTablePartition, model.ActionAddTablePartition:
+		if job.SchemaState != model.StateNone {
+			return ErrCannotCancelDDLJob.GenWithStackByArgs(id)
+		}
 	case model.ActionDropSchema, model.ActionDropTable:
 		// To simplify the rollback logic, cannot be canceled in the following states.
 		if job.SchemaState == model.StateWriteOnly ||


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We can only cancel add partitioned table job when the job state is on JobStateNone , if the job status is JobStateDone or JobStateRunning, the job will not be canceled.

### What is changed and how it works?

Only added tests.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/8938)
<!-- Reviewable:end -->
