### PR TITLE
executor: return error if autoid overflows shard bits. (#8936)

### DIFF
--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -1,0 +1,32 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package autoid
+
+import (
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
+)
+
+// Error instances.
+var (
+	ErrAutoincReadFailed = terror.ClassAutoid.New(mysql.ErrAutoincReadFailed, mysql.MySQLErrName[mysql.ErrAutoincReadFailed])
+)
+
+func init() {
+	// Map error codes to mysql error codes.
+	tableMySQLErrCodes := map[terror.ErrCode]uint16{
+		mysql.ErrAutoincReadFailed: mysql.ErrAutoincReadFailed,
+	}
+	terror.ErrClassToMySQLCodes[terror.ClassAutoid] = tableMySQLErrCodes
+}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -909,6 +909,16 @@ func (t *tableCommon) AllocAutoID(ctx sessionctx.Context) (int64, error) {
 		return 0, errors.Trace(err)
 	}
 	if t.meta.ShardRowIDBits > 0 {
+		if t.overflowShardBits(rowID) {
+			// If overflow, the rowID may be duplicated. For examples,
+			// t.meta.ShardRowIDBits = 4
+			// rowID = 0010111111111111111111111111111111111111111111111111111111111111
+			// shard = 01000000000000000000000000000000000000000000000000000000000000000
+			// will be duplicated with:
+			// rowID = 0100111111111111111111111111111111111111111111111111111111111111
+			// shard = 0010000000000000000000000000000000000000000000000000000000000000
+			return 0, autoid.ErrAutoincReadFailed
+		}
 		txnCtx := ctx.GetSessionVars().TxnCtx
 		if txnCtx.Shard == nil {
 			shard := t.calcShard(txnCtx.StartTS)
@@ -917,6 +927,12 @@ func (t *tableCommon) AllocAutoID(ctx sessionctx.Context) (int64, error) {
 		rowID |= *txnCtx.Shard
 	}
 	return rowID, nil
+}
+
+// overflowShardBits check whether the rowID overflow `1<<(64-t.meta.ShardRowIDBits-1) -1`.
+func (t *tableCommon) overflowShardBits(rowID int64) bool {
+	mask := (1<<t.meta.ShardRowIDBits - 1) << (64 - t.meta.ShardRowIDBits - 1)
+	return rowID&int64(mask) > 0
 }
 
 func (t *tableCommon) calcShard(startTS uint64) int64 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

cherry-pick from #8936 


