### PR TITLE
executor: fix csv parser 

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -198,6 +198,11 @@ func (s *testExecSuite) TestGetFieldsFromLine(c *C) {
 			`"\0\b\n\r\t\Z\\\  \c\'\""`,
 			[]string{string([]byte{0, '\b', '\n', '\r', '\t', 26, '\\', ' ', ' ', 'c', '\'', '"'})},
 		},
+		// Test mixed.
+		{
+			`"123",456,"\t7890",abcd`,
+			[]string{"123", "456", "\t7890", "abcd"},
+		},
 	}
 
 	ldInfo := LoadDataInfo{

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -214,7 +214,7 @@ func (s *testExecSuite) TestGetFieldsFromLine(c *C) {
 	}
 
 	_, err := ldInfo.getFieldsFromLine([]byte(`1,a string,100.20`))
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }
 
 func assertEqualStrings(c *C, got []field, expect []string) {

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -428,9 +428,8 @@ func (w *fieldWriter) GetField() (bool, field) {
 				if w.isTerminator() {
 					ret := w.outputField(true)
 					return false, ret
-				} else {
-					w.OutputBuf = append(w.OutputBuf, ch)
 				}
+				w.OutputBuf = append(w.OutputBuf, ch)
 			} else {
 				w.OutputBuf = append(w.OutputBuf, w.enclosedChar)
 				w.rollback()

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -409,7 +409,6 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 				buf = buf[0:0]
 				enclosed = false
 				start = true
-				continue
 			} else {
 				// if not at the ned, roll back.
 				pos = chkpt
@@ -471,7 +470,6 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 					buf = buf[0:0]
 					enclosed = false
 					start = true
-					continue
 				} else {
 					// If not terminated, roll back
 					pos = chkpt

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -410,11 +410,10 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 				enclosed = false
 				start = true
 				continue
-			} else {
-				// if not at the ned, roll back.
-				pos = chkpt
-				buf = append(buf, curChar)
 			}
+			// if not at the ned, roll back.
+			pos = chkpt
+			buf = append(buf, curChar)
 		} else if ch == enclosedChar && enclosed {
 			// If it is enclosed and has a enclosed char currently
 			if pos == len(line) {
@@ -472,11 +471,10 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 					enclosed = false
 					start = true
 					continue
-				} else {
-					// If not terminated, roll back
-					pos = chkpt
-					buf = append(buf, curChar)
 				}
+				// If not terminated, roll back
+				pos = chkpt
+				buf = append(buf, curChar)
 			}
 			// roll back
 			pos--

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -409,6 +409,7 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 				buf = buf[0:0]
 				enclosed = false
 				start = true
+				continue
 			} else {
 				// if not at the ned, roll back.
 				pos = chkpt
@@ -470,6 +471,7 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 					buf = buf[0:0]
 					enclosed = false
 					start = true
+					continue
 				} else {
 					// If not terminated, roll back
 					pos = chkpt

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -528,6 +528,104 @@ func runTestLoadData(c *C, server *Server) {
 		dbt.mustExec("delete from test")
 	})
 
+	err = fp.Close()
+	c.Assert(err, IsNil)
+	err = os.Remove(path)
+	c.Assert(err, IsNil)
+
+	fp, err = os.Create(path)
+	c.Assert(err, IsNil)
+	c.Assert(fp, NotNil)
+
+	// Test irregular csv file.
+	_, err = fp.WriteString(
+		`,\N,NULL,,` + "\n" +
+			"00,0,000000,,\n" +
+			`2003-03-03, 20030303,030303,\N` + "\n")
+	c.Assert(err, IsNil)
+
+	runTestsOnNewDB(c, func(config *mysql.Config) {
+		config.AllowAllFiles = true
+		config.Strict = false
+	}, "LoadData", func(dbt *DBTest) {
+		dbt.mustExec("create table test (a date, b date, c date not null, d date)")
+		_, err1 := dbt.db.Exec(`load data local infile '/tmp/load_data_test.csv' into table test FIELDS TERMINATED BY ','`)
+		dbt.Assert(err1, IsNil)
+		var (
+			a sql.NullString
+			b sql.NullString
+			d sql.NullString
+			c sql.NullString
+		)
+		rows := dbt.mustQuery("select * from test")
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		err = rows.Scan(&a, &b, &c, &d)
+		dbt.Check(err, IsNil)
+		dbt.Check(a.String, Equals, "0000-00-00")
+		dbt.Check(b.String, Equals, "")
+		dbt.Check(c.String, Equals, "0000-00-00")
+		dbt.Check(d.String, Equals, "0000-00-00")
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		rows.Scan(&a, &b, &c, &d)
+		dbt.Check(a.String, Equals, "0000-00-00")
+		dbt.Check(b.String, Equals, "0000-00-00")
+		dbt.Check(c.String, Equals, "0000-00-00")
+		dbt.Check(d.String, Equals, "0000-00-00")
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		rows.Scan(&a, &b, &c, &d)
+		dbt.Check(a.String, Equals, "2003-03-03")
+		dbt.Check(b.String, Equals, "2003-03-03")
+		dbt.Check(c.String, Equals, "2003-03-03")
+		dbt.Check(d.String, Equals, "")
+		dbt.Check(rows.Next(), IsFalse, Commentf("unexpected data"))
+		dbt.mustExec("delete from test")
+	})
+
+	err = fp.Close()
+	c.Assert(err, IsNil)
+	err = os.Remove(path)
+	c.Assert(err, IsNil)
+
+	fp, err = os.Create(path)
+	c.Assert(err, IsNil)
+	c.Assert(fp, NotNil)
+
+	// Test double enclosed.
+	_, err = fp.WriteString(
+		`"field1","field2"` + "\n" +
+			`"a""b","cd""ef"` + "\n" +
+			`"a"b",c"d"e` + "\n")
+	c.Assert(err, IsNil)
+
+	runTestsOnNewDB(c, func(config *mysql.Config) {
+		config.AllowAllFiles = true
+		config.Strict = false
+	}, "LoadData", func(dbt *DBTest) {
+		dbt.mustExec("create table test (a varchar(20), b varchar(20))")
+		_, err1 := dbt.db.Exec(`load data local infile '/tmp/load_data_test.csv' into table test FIELDS TERMINATED BY ',' enclosed by '"'`)
+		dbt.Assert(err1, IsNil)
+		var (
+			a sql.NullString
+			b sql.NullString
+		)
+		rows := dbt.mustQuery("select * from test")
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		err = rows.Scan(&a, &b)
+		dbt.Check(err, IsNil)
+		dbt.Check(a.String, Equals, "field1")
+		dbt.Check(b.String, Equals, "field2")
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		rows.Scan(&a, &b)
+		dbt.Check(a.String, Equals, `a"b`)
+		dbt.Check(b.String, Equals, `cd"ef`)
+		dbt.Check(rows.Next(), IsTrue, Commentf("unexpected data"))
+		rows.Scan(&a, &b)
+		dbt.Check(a.String, Equals, `a"b`)
+		dbt.Check(b.String, Equals, `c"d"e`)
+		dbt.Check(rows.Next(), IsFalse, Commentf("unexpected data"))
+		dbt.mustExec("delete from test")
+	})
+
 	// unsupport ClientLocalFiles capability
 	server.capability ^= tmysql.ClientLocalFiles
 	runTestsOnNewDB(c, func(config *mysql.Config) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB will panic when encounter irregular csv format, like this.
```
\N
"\N",
"NULL",
NULL
```
Test SQL:
```
create table test (i int default null);
load data local infile 'abc.csv' into table test FIELDS TERMINATED BY ',' enclosed by '"';

```
This is because csv file above mixed enclosed words and unenclosed words.

another case will cause panic is shown below.
```
abc,123,
"def",456
hij,"789",
```
TiDB:
```
mysql> create table test (str varchar(10) default null, i int default null);
Query OK, 0 rows affected (0.01 sec)

mysql> load data local infile '~/test.csv' into table test FIELDS TERMINATED BY ',' enclosed by '"';
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

MySQL:
```
mysql> create table test (str varchar(10) default null, i int default null);
Query OK, 0 rows affected (0.02 sec)

mysql> load data local infile '~/test.csv' into table test FIELDS TERMINATED BY ',' enclosed by '"';
Query OK, 3 rows affected (0.00 sec)
Records: 3  Deleted: 0  Skipped: 0  Warnings: 0

mysql> select * from test;
+------+------+
| str  | i    |
+------+------+
| abc  |  123 |
| def  |  456 |
| hij  |  789 |
+------+------+
3 rows in set (0.00 sec)
```

### What is changed and how it works?
Restructuring `getFieldsFromLine` function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

