### PR TITLE
plan/executor: make semi joins null and empty aware

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -89,12 +89,12 @@ TableReader_7	0.33	root	data:Selection_6
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:sum(col_0)
-└─Projection_33	10000.00	root	cast(5_aux_0)
-  └─MergeJoin_26	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
-    ├─TableReader_19	10000.00	root	data:TableScan_18
-    │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
-    └─IndexReader_21	10000.00	root	index:IndexScan_20
-      └─IndexScan_20	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
+└─Projection_21	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_18	10000.00	root	left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
+    ├─TableReader_20	10000.00	root	data:TableScan_19
+    │ └─TableScan_19	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_17	10000.00	root	data:TableScan_16
+      └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	count	task	operator info
 Projection_9	9990.00	root	test.t1.c1
@@ -196,12 +196,12 @@ set @@session.tidb_opt_insubq_to_join_and_agg=0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:sum(col_0)
-└─Projection_33	10000.00	root	cast(5_aux_0)
-  └─MergeJoin_26	10000.00	root	left outer semi join, left key:test.t1.c1, right key:test.t2.c1
-    ├─TableReader_19	10000.00	root	data:TableScan_18
-    │ └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
-    └─IndexReader_21	10000.00	root	index:IndexScan_20
-      └─IndexScan_20	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
+└─Projection_21	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_18	10000.00	root	left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
+    ├─TableReader_20	10000.00	root	data:TableScan_19
+    │ └─TableScan_19	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_17	10000.00	root	data:TableScan_16
+      └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select 1 in (select c2 from t2) from t1;
 id	count	task	operator info
 Projection_6	10000.00	root	5_aux_0
@@ -229,25 +229,25 @@ subgraph cluster12{
 node [style=filled, color=lightgrey]
 color=black
 label = "root"
-"StreamAgg_12" -> "Projection_33"
-"Projection_33" -> "MergeJoin_26"
-"MergeJoin_26" -> "TableReader_19"
-"MergeJoin_26" -> "IndexReader_21"
+"StreamAgg_12" -> "Projection_21"
+"Projection_21" -> "HashLeftJoin_18"
+"HashLeftJoin_18" -> "TableReader_20"
+"HashLeftJoin_18" -> "TableReader_17"
 }
-subgraph cluster18{
+subgraph cluster19{
 node [style=filled, color=lightgrey]
 color=black
 label = "cop"
-"TableScan_18"
+"TableScan_19"
 }
-subgraph cluster20{
+subgraph cluster16{
 node [style=filled, color=lightgrey]
 color=black
 label = "cop"
-"IndexScan_20"
+"TableScan_16"
 }
-"TableReader_19" -> "TableScan_18"
-"IndexReader_21" -> "IndexScan_20"
+"TableReader_20" -> "TableScan_19"
+"TableReader_17" -> "TableScan_16"
 }
 
 explain format="dot" select 1 in (select c2 from t2) from t1;
@@ -284,7 +284,7 @@ create table t(a int primary key, b int, c int, index idx(b));
 explain select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, 7_col_0)]
+└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -297,7 +297,7 @@ Projection_11	10000.00	root	9_aux_0
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, 7_col_0)]
+└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -309,7 +309,7 @@ Projection_11	10000.00	root	9_aux_0
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, 7_col_0)]
+└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -486,7 +486,7 @@ HashRightJoin_9	4166.67	root	inner join, inner:TableReader_12, equal:[eq(ta.nb, 
 explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_12	10000.00	root	9_aux_0
-└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, equal:[eq(test.t.nc, 7_col_0)]
+└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, other cond:eq(test.t.nc, 7_col_0)
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
@@ -518,21 +518,20 @@ HashRightJoin_7	8000.00	root	right outer join, inner:TableReader_10, equal:[eq(t
     └─TableScan_11	10000.00	cop	table:tb, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
-Projection_14	10000.00	root	9_aux_0
-└─Apply_16	10000.00	root	left outer semi join, inner:Projection_20, equal:[eq(ifnull(test.t.a, 1), 7_col_0)]
-  ├─Projection_17	10000.00	root	test.t.a, ifnull(test.t.a, 1)
-  │ └─TableReader_19	10000.00	root	data:TableScan_18
-  │   └─TableScan_18	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─HashAgg_23	1.00	root	funcs:count(join_agg_0)
-    └─HashLeftJoin_24	9.99	root	inner join, inner:HashAgg_34, equal:[eq(s.a, t1.a)]
-      ├─TableReader_28	9.99	root	data:Selection_27
-      │ └─Selection_27	9.99	cop	eq(s.a, test.t.a), not(isnull(s.a))
-      │   └─TableScan_26	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
-      └─HashAgg_34	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_1)
-        └─TableReader_35	7.99	root	data:HashAgg_29
-          └─HashAgg_29	7.99	cop	group by:t1.a, funcs:count(1), firstrow(t1.a)
-            └─Selection_33	9.99	cop	eq(t1.a, test.t.a), not(isnull(t1.a))
-              └─TableScan_32	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+Projection_12	10000.00	root	9_aux_0
+└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, other cond:eq(ifnull(test.t.a, 1), 7_col_0)
+  ├─TableReader_16	10000.00	root	data:TableScan_15
+  │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
+    └─HashLeftJoin_20	9.99	root	inner join, inner:HashAgg_30, equal:[eq(s.a, t1.a)]
+      ├─TableReader_24	9.99	root	data:Selection_23
+      │ └─Selection_23	9.99	cop	eq(s.a, test.t.a), not(isnull(s.a))
+      │   └─TableScan_22	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+      └─HashAgg_30	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_1)
+        └─TableReader_31	7.99	root	data:HashAgg_25
+          └─HashAgg_25	7.99	cop	group by:t1.a, funcs:count(1), firstrow(t1.a)
+            └─Selection_29	9.99	cop	eq(t1.a, test.t.a), not(isnull(t1.a))
+              └─TableScan_28	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -382,3 +382,35 @@ Projection_9	10000.00	root	or(and(and(le(col_count, 1), eq(t1.a, col_firstrow)),
     └─Projection_27	10000.00	root	t2.a, t2.a, cast(isnull(t2.a))
       └─TableReader_24	10000.00	root	data:TableScan_23
         └─TableScan_23	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table if exists t;
+create table t(a int, b int);
+drop table if exists s;
+create table s(a varchar(20), b varchar(20));
+explain select a in (select a from s where s.b = t.b) from t;
+id	count	task	operator info
+Projection_9	10000.00	root	6_aux_0
+└─HashLeftJoin_10	10000.00	root	left outer semi join, inner:Projection_14, equal:[eq(cast(test.t.b), cast(test.s.b))], other cond:eq(cast(test.t.a), cast(test.s.a))
+  ├─Projection_11	10000.00	root	test.t.a, test.t.b, cast(test.t.b)
+  │ └─TableReader_13	10000.00	root	data:TableScan_12
+  │   └─TableScan_12	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─Projection_14	10000.00	root	test.s.a, test.s.b, cast(test.s.b)
+    └─TableReader_16	10000.00	root	data:TableScan_15
+      └─TableScan_15	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select a in (select a+b from t t2 where t2.b = t1.b) from t t1;
+id	count	task	operator info
+Projection_7	10000.00	root	6_aux_0
+└─HashLeftJoin_8	10000.00	root	left outer semi join, inner:TableReader_12, equal:[eq(t1.b, t2.b)], other cond:eq(t1.a, plus(t2.a, t2.b))
+  ├─TableReader_10	10000.00	root	data:TableScan_9
+  │ └─TableScan_9	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─TableReader_12	10000.00	root	data:TableScan_11
+    └─TableScan_11	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table t;
+create table t(a int not null, b int);
+explain select a in (select a from t t2 where t2.b = t1.b) from t t1;
+id	count	task	operator info
+Projection_7	10000.00	root	6_aux_0
+└─HashLeftJoin_8	10000.00	root	left outer semi join, inner:TableReader_12, equal:[eq(t1.b, t2.b) eq(t1.a, t2.a)]
+  ├─TableReader_10	10000.00	root	data:TableScan_9
+  │ └─TableScan_9	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─TableReader_12	10000.00	root	data:TableScan_11
+    └─TableScan_11	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -181,3 +181,13 @@ drop table if exists t;
 create table t(a int, b int);
 explain select a != any (select a from t t2) from t t1;
 explain select a = all (select a from t t2) from t t1;
+
+drop table if exists t;
+create table t(a int, b int);
+drop table if exists s;
+create table s(a varchar(20), b varchar(20));
+explain select a in (select a from s where s.b = t.b) from t;
+explain select a in (select a+b from t t2 where t2.b = t1.b) from t t1;
+drop table t;
+create table t(a int not null, b int);
+explain select a in (select a from t t2 where t2.b = t1.b) from t t1;

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -947,7 +947,7 @@ func (e *SelectionExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 func (e *SelectionExec) unBatchedNext(ctx context.Context, chk *chunk.Chunk) error {
 	for {
 		for ; e.inputRow != e.inputIter.End(); e.inputRow = e.inputIter.Next() {
-			selected, err := expression.EvalBool(e.ctx, e.filters, e.inputRow)
+			selected, _, err := expression.EvalBool(e.ctx, e.filters, e.inputRow)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/executor/join.go
+++ b/executor/join.go
@@ -184,7 +184,6 @@ func (e *HashJoinExec) getJoinKeyFromChkRow(isOuterKey bool, row chunk.Row, keyB
 			return true, keyBuf, nil
 		}
 	}
-
 	keyBuf = keyBuf[:0]
 	keyBuf, err = codec.HashChunkRow(e.ctx.GetSessionVars().StmtCtx, keyBuf, row, allTypes, keyColIdx)
 	if err != nil {
@@ -402,13 +401,13 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 		return false, joinResult
 	}
 	if hasNull {
-		e.joiners[workerID].onMissMatch(outerRow, joinResult.chk)
+		e.joiners[workerID].onMissMatch(false, outerRow, joinResult.chk)
 		return true, joinResult
 	}
 	e.hashTableValBufs[workerID] = e.globalHashTable.Get(joinKey, e.hashTableValBufs[workerID][:0])
 	innerPtrs := e.hashTableValBufs[workerID]
 	if len(innerPtrs) == 0 {
-		e.joiners[workerID].onMissMatch(outerRow, joinResult.chk)
+		e.joiners[workerID].onMissMatch(false, outerRow, joinResult.chk)
 		return true, joinResult
 	}
 	innerRows := make([]chunk.Row, 0, len(innerPtrs))
@@ -418,14 +417,15 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 		innerRows = append(innerRows, matchedInner)
 	}
 	iter := chunk.NewIterator4Slice(innerRows)
-	hasMatch := false
+	hasMatch, hasNull := false, false
 	for iter.Begin(); iter.Current() != iter.End(); {
-		matched, err := e.joiners[workerID].tryToMatch(outerRow, iter, joinResult.chk)
+		matched, isNull, err := e.joiners[workerID].tryToMatch(outerRow, iter, joinResult.chk)
 		if err != nil {
 			joinResult.err = errors.Trace(err)
 			return false, joinResult
 		}
 		hasMatch = hasMatch || matched
+		hasNull = hasNull || isNull
 
 		if joinResult.chk.NumRows() == e.maxChunkSize {
 			e.joinResultCh <- joinResult
@@ -436,7 +436,7 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 		}
 	}
 	if !hasMatch {
-		e.joiners[workerID].onMissMatch(outerRow, joinResult.chk)
+		e.joiners[workerID].onMissMatch(hasNull, outerRow, joinResult.chk)
 	}
 	return true, joinResult
 }
@@ -464,7 +464,7 @@ func (e *HashJoinExec) join2Chunk(workerID uint, outerChk *chunk.Chunk, joinResu
 	}
 	for i := range selected {
 		if !selected[i] { // process unmatched outer rows
-			e.joiners[workerID].onMissMatch(outerChk.GetRow(i), joinResult.chk)
+			e.joiners[workerID].onMissMatch(false, outerChk.GetRow(i), joinResult.chk)
 		} else { // process matched outer rows
 			ok, joinResult = e.joinMatchedOuterRow2Chunk(workerID, outerChk.GetRow(i), joinResult)
 			if !ok {
@@ -590,6 +590,7 @@ type NestedLoopApplyExec struct {
 	innerIter        chunk.Iterator
 	outerRow         *chunk.Row
 	hasMatch         bool
+	hasNull          bool
 
 	memTracker *memory.Tracker // track memory usage.
 }
@@ -647,7 +648,7 @@ func (e *NestedLoopApplyExec) fetchSelectedOuterRow(ctx context.Context, chk *ch
 		if selected {
 			return &outerRow, nil
 		} else if e.outer {
-			e.joiner.onMissMatch(outerRow, chk)
+			e.joiner.onMissMatch(false, outerRow, chk)
 			if chk.NumRows() == e.maxChunkSize {
 				return nil, nil
 			}
@@ -695,13 +696,14 @@ func (e *NestedLoopApplyExec) Next(ctx context.Context, req *chunk.RecordBatch) 
 	for {
 		if e.innerIter == nil || e.innerIter.Current() == e.innerIter.End() {
 			if e.outerRow != nil && !e.hasMatch {
-				e.joiner.onMissMatch(*e.outerRow, req.Chunk)
+				e.joiner.onMissMatch(e.hasNull, *e.outerRow, req.Chunk)
 			}
 			e.outerRow, err = e.fetchSelectedOuterRow(ctx, req.Chunk)
 			if e.outerRow == nil || err != nil {
 				return errors.Trace(err)
 			}
 			e.hasMatch = false
+			e.hasNull = false
 
 			for _, col := range e.outerSchema {
 				*col.Data = e.outerRow.GetDatum(col.Index, col.RetType)
@@ -714,8 +716,9 @@ func (e *NestedLoopApplyExec) Next(ctx context.Context, req *chunk.RecordBatch) 
 			e.innerIter.Begin()
 		}
 
-		matched, err := e.joiner.tryToMatch(*e.outerRow, e.innerIter, req.Chunk)
+		matched, isNull, err := e.joiner.tryToMatch(*e.outerRow, e.innerIter, req.Chunk)
 		e.hasMatch = e.hasMatch || matched
+		e.hasNull = e.hasNull || isNull
 
 		if err != nil || req.NumRows() == e.maxChunkSize {
 			return errors.Trace(err)

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -35,14 +35,15 @@ var (
 // joiner is used to generate join results according to the join type.
 // A typical instruction flow is:
 //
-//     hasMatch := false
+//     hasMatch, hasNull := false, false
 //     for innerIter.Current() != innerIter.End() {
-//         matched, err := j.tryToMatch(outer, innerIter, chk)
+//         matched, isNull, err := j.tryToMatch(outer, innerIter, chk)
 //         // handle err
 //         hasMatch = hasMatch || matched
+//         hasNull = hasNull || isNull
 //     }
 //     if !hasMatch {
-//         j.onMissMatch(outer)
+//         j.onMissMatch(hasNull, outer, chk)
 //     }
 //
 // NOTE: This interface is **not** thread-safe.
@@ -51,11 +52,15 @@ type joiner interface {
 	// 'inners.Len != 0' but all the joined rows are filtered, the outer row is
 	// considered unmatched. Otherwise, the outer row is matched and some joined
 	// rows are appended to `chk`. The size of `chk` is limited to MaxChunkSize.
+	// Note that when the outer row is considered unmatched, we need to differentiate
+	// whether the join conditions return null or false, because that matters for
+	// AntiSemiJoin/LeftOuterSemiJoin/AntiLeftOuterSemijoin, and the result is reflected
+	// by the second return value; for other join types, we always return false.
 	//
 	// NOTE: Callers need to call this function multiple times to consume all
 	// the inner rows for an outer row, and dicide whether the outer row can be
 	// matched with at lease one inner row.
-	tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, error)
+	tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error)
 
 	// onMissMatch operates on the unmatched outer row according to the join
 	// type. An outer row can be considered miss matched if:
@@ -76,7 +81,13 @@ type joiner interface {
 	//   6. 'RightOuterJoin': concats the unmatched outer row with a row of NULLs
 	//      and appends it to the result buffer.
 	//   7. 'InnerJoin': ignores the unmatched outer row.
-	onMissMatch(outer chunk.Row, chk *chunk.Chunk)
+	//
+	// Note that, for LeftOuterSemiJoin, AntiSemiJoin and AntiLeftOuterSemiJoin,
+	// we need to know the reason of outer row being treated as unmatched:
+	// whether the join condition returns false, or returns null, because
+	// it decides if this outer row should be outputed, hence we have a `hasNull`
+	// parameter passed to `onMissMatch`.
+	onMissMatch(hasNull bool, outer chunk.Row, chk *chunk.Chunk)
 }
 
 func newJoiner(ctx sessionctx.Context, joinType plannercore.JoinType,
@@ -176,34 +187,36 @@ type semiJoiner struct {
 	baseJoiner
 }
 
-func (j *semiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, err error) {
+func (j *semiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	if len(j.conditions) == 0 {
 		chk.AppendPartialRow(0, outer)
 		inners.ReachEnd()
-		return true, nil
+		return true, false, nil
 	}
 
 	for inner := inners.Current(); inner != inners.End(); inner = inners.Next() {
 		j.makeShallowJoinRow(j.outerIsRight, inner, outer)
 
-		matched, err = expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
+		// For SemiJoin, we can safely treat null result of join conditions as false,
+		// so we ignore the nullness returned by EvalBool here.
+		matched, _, err = expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, false, errors.Trace(err)
 		}
 		if matched {
 			chk.AppendPartialRow(0, outer)
 			inners.ReachEnd()
-			return true, nil
+			return true, false, nil
 		}
 	}
-	return false, nil
+	return false, false, nil
 }
 
-func (j *semiJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *semiJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }
 
 type antiSemiJoiner struct {
@@ -211,33 +224,36 @@ type antiSemiJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *antiSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, err error) {
+func (j *antiSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	if len(j.conditions) == 0 {
 		inners.ReachEnd()
-		return true, nil
+		return true, false, nil
 	}
 
 	for inner := inners.Current(); inner != inners.End(); inner = inners.Next() {
 		j.makeShallowJoinRow(j.outerIsRight, inner, outer)
 
-		matched, err = expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
+		matched, isNull, err := expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, false, errors.Trace(err)
 		}
 		if matched {
 			inners.ReachEnd()
-			return true, nil
+			return true, false, nil
 		}
+		hasNull = hasNull || isNull
 	}
-	return false, nil
+	return false, hasNull, nil
 }
 
-func (j *antiSemiJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
-	chk.AppendRow(outer)
+func (j *antiSemiJoiner) onMissMatch(hasNull bool, outer chunk.Row, chk *chunk.Chunk) {
+	if !hasNull {
+		chk.AppendRow(outer)
+	}
 }
 
 type leftOuterSemiJoiner struct {
@@ -245,31 +261,32 @@ type leftOuterSemiJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *leftOuterSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, err error) {
+func (j *leftOuterSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	if len(j.conditions) == 0 {
 		j.onMatch(outer, chk)
 		inners.ReachEnd()
-		return true, nil
+		return true, false, nil
 	}
 
 	for inner := inners.Current(); inner != inners.End(); inner = inners.Next() {
 		j.makeShallowJoinRow(false, inner, outer)
 
-		matched, err = expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
+		matched, isNull, err := expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, false, errors.Trace(err)
 		}
 		if matched {
 			j.onMatch(outer, chk)
 			inners.ReachEnd()
-			return true, nil
+			return true, false, nil
 		}
+		hasNull = hasNull || isNull
 	}
-	return false, nil
+	return false, hasNull, nil
 }
 
 func (j *leftOuterSemiJoiner) onMatch(outer chunk.Row, chk *chunk.Chunk) {
@@ -277,9 +294,13 @@ func (j *leftOuterSemiJoiner) onMatch(outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendInt64(outer.Len(), 1)
 }
 
-func (j *leftOuterSemiJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *leftOuterSemiJoiner) onMissMatch(hasNull bool, outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendPartialRow(0, outer)
-	chk.AppendInt64(outer.Len(), 0)
+	if hasNull {
+		chk.AppendNull(outer.Len())
+	} else {
+		chk.AppendInt64(outer.Len(), 0)
+	}
 }
 
 type antiLeftOuterSemiJoiner struct {
@@ -287,31 +308,32 @@ type antiLeftOuterSemiJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *antiLeftOuterSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, err error) {
+func (j *antiLeftOuterSemiJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	if len(j.conditions) == 0 {
 		j.onMatch(outer, chk)
 		inners.ReachEnd()
-		return true, nil
+		return true, false, nil
 	}
 
 	for inner := inners.Current(); inner != inners.End(); inner = inners.Next() {
 		j.makeShallowJoinRow(false, inner, outer)
 
-		matched, err := expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
+		matched, isNull, err := expression.EvalBool(j.ctx, j.conditions, j.shallowRow.ToRow())
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, false, errors.Trace(err)
 		}
 		if matched {
 			j.onMatch(outer, chk)
 			inners.ReachEnd()
-			return true, nil
+			return true, false, nil
 		}
+		hasNull = hasNull || isNull
 	}
-	return false, nil
+	return false, hasNull, nil
 }
 
 func (j *antiLeftOuterSemiJoiner) onMatch(outer chunk.Row, chk *chunk.Chunk) {
@@ -319,9 +341,13 @@ func (j *antiLeftOuterSemiJoiner) onMatch(outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendInt64(outer.Len(), 0)
 }
 
-func (j *antiLeftOuterSemiJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *antiLeftOuterSemiJoiner) onMissMatch(hasNull bool, outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendPartialRow(0, outer)
-	chk.AppendInt64(outer.Len(), 1)
+	if hasNull {
+		chk.AppendNull(outer.Len())
+	} else {
+		chk.AppendInt64(outer.Len(), 1)
+	}
 }
 
 type leftOuterJoiner struct {
@@ -329,9 +355,9 @@ type leftOuterJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *leftOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, error) {
+func (j *leftOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 	j.chk.Reset()
 	chkForJoin := j.chk
@@ -345,18 +371,18 @@ func (j *leftOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk
 		inners.Next()
 	}
 	if len(j.conditions) == 0 {
-		return true, nil
+		return true, false, nil
 	}
 
 	// reach here, chkForJoin is j.chk
 	matched, err := j.filter(chkForJoin, chk, outer.Len())
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return matched, nil
+	return matched, false, nil
 }
 
-func (j *leftOuterJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *leftOuterJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendPartialRow(0, outer)
 	chk.AppendPartialRow(outer.Len(), j.defaultInner)
 }
@@ -366,9 +392,9 @@ type rightOuterJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *rightOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, error) {
+func (j *rightOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 
 	j.chk.Reset()
@@ -383,17 +409,17 @@ func (j *rightOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, ch
 		inners.Next()
 	}
 	if len(j.conditions) == 0 {
-		return true, nil
+		return true, false, nil
 	}
 
 	matched, err := j.filter(chkForJoin, chk, outer.Len())
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return matched, nil
+	return matched, false, nil
 }
 
-func (j *rightOuterJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *rightOuterJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 	chk.AppendPartialRow(0, j.defaultInner)
 	chk.AppendPartialRow(j.defaultInner.Len(), outer)
 }
@@ -403,9 +429,9 @@ type innerJoiner struct {
 }
 
 // tryToMatch implements joiner interface.
-func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, error) {
+func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
-		return false, nil
+		return false, false, nil
 	}
 	j.chk.Reset()
 	chkForJoin := j.chk
@@ -421,17 +447,16 @@ func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *ch
 		}
 	}
 	if len(j.conditions) == 0 {
-		return true, nil
+		return true, false, nil
 	}
 
 	// reach here, chkForJoin is j.chk
 	matched, err := j.filter(chkForJoin, chk, outer.Len())
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, false, errors.Trace(err)
 	}
-	return matched, nil
-
+	return matched, false, nil
 }
 
-func (j *innerJoiner) onMissMatch(outer chunk.Row, chk *chunk.Chunk) {
+func (j *innerJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -63,6 +63,7 @@ type mergeJoinOuterTable struct {
 	iter     *chunk.Iterator4Chunk
 	row      chunk.Row
 	hasMatch bool
+	hasNull  bool
 }
 
 // mergeJoinInnerTable represents the inner table of merge join.
@@ -305,13 +306,14 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 		}
 
 		if cmpResult < 0 {
-			e.joiner.onMissMatch(e.outerTable.row, chk)
+			e.joiner.onMissMatch(false, e.outerTable.row, chk)
 			if err != nil {
 				return false, errors.Trace(err)
 			}
 
 			e.outerTable.row = e.outerTable.iter.Next()
 			e.outerTable.hasMatch = false
+			e.outerTable.hasNull = false
 
 			if chk.NumRows() == e.maxChunkSize {
 				return true, nil
@@ -319,18 +321,20 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 			continue
 		}
 
-		matched, err := e.joiner.tryToMatch(e.outerTable.row, e.innerIter4Row, chk)
+		matched, isNull, err := e.joiner.tryToMatch(e.outerTable.row, e.innerIter4Row, chk)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
 		e.outerTable.hasMatch = e.outerTable.hasMatch || matched
+		e.outerTable.hasNull = e.outerTable.hasNull || isNull
 
 		if e.innerIter4Row.Current() == e.innerIter4Row.End() {
 			if !e.outerTable.hasMatch {
-				e.joiner.onMissMatch(e.outerTable.row, chk)
+				e.joiner.onMissMatch(e.outerTable.hasNull, e.outerTable.row, chk)
 			}
 			e.outerTable.row = e.outerTable.iter.Next()
 			e.outerTable.hasMatch = false
+			e.outerTable.hasNull = false
 			e.innerIter4Row.Begin()
 		}
 

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -350,13 +350,11 @@ func (s *testSuite1) TestMergeJoin(c *C) {
 	tk.MustExec("insert into s values(1,1)")
 	tk.MustQuery("explain select /*+ TIDB_SMJ(t, s) */ a in (select a from s where s.b >= t.b) from t").Check(testkit.Rows(
 		"Projection_7 10000.00 root 6_aux_0",
-		"└─MergeJoin_8 10000.00 root left outer semi join, left key:test.t.a, right key:test.s.a, other cond:ge(test.s.b, test.t.b)",
-		"  ├─Sort_12 10000.00 root test.t.a:asc",
-		"  │ └─TableReader_11 10000.00 root data:TableScan_10",
-		"  │   └─TableScan_10 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"  └─Sort_16 10000.00 root test.s.a:asc",
-		"    └─TableReader_15 10000.00 root data:TableScan_14",
-		"      └─TableScan_14 10000.00 cop table:s, range:[-inf,+inf], keep order:false, stats:pseudo",
+		"└─MergeJoin_8 10000.00 root left outer semi join, other cond:eq(test.t.a, test.s.a), ge(test.s.b, test.t.b)",
+		"  ├─TableReader_10 10000.00 root data:TableScan_9",
+		"  │ └─TableScan_9 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
+		"  └─TableReader_12 10000.00 root data:TableScan_11",
+		"    └─TableScan_11 10000.00 cop table:s, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("select /*+ TIDB_SMJ(t, s) */ a in (select a from s where s.b >= t.b) from t").Check(testkit.Rows(
 		"1",

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -291,7 +291,7 @@ func (us *UnionScanExec) buildAndSortAddedRows() error {
 			}
 		}
 		mutableRow.SetDatums(newData...)
-		matched, err := expression.EvalBool(us.ctx, us.conditions, mutableRow.ToRow())
+		matched, _, err := expression.EvalBool(us.ctx, us.conditions, mutableRow.ToRow())
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/expression/chunk_executor.go
+++ b/expression/chunk_executor.go
@@ -252,7 +252,7 @@ func VectorizedFilter(ctx sessionctx.Context, filters []Expression, iterator *ch
 				selected[row.Idx()] = selected[row.Idx()] && !isNull && (filterResult != 0)
 			} else {
 				// TODO: should rewrite the filter to `cast(expr as SIGNED) != 0` and always use `EvalInt`.
-				bVal, err := EvalBool(ctx, []Expression{filter}, row)
+				bVal, _, err := EvalBool(ctx, []Expression{filter}, row)
 				if err != nil {
 					return nil, err
 				}

--- a/expression/column.go
+++ b/expression/column.go
@@ -162,6 +162,10 @@ type Column struct {
 	Index int
 
 	hashcode []byte
+
+	// InOperand indicates whether this column is the inner operand of column equal condition converted
+	// from `[not] in (subq)`.
+	InOperand bool
 }
 
 // Equal implements Expression interface.

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -245,7 +245,7 @@ func (s *propConstSolver) pickNewEQConds(visited []bool) (retMapper map[int]*Con
 		var ok bool
 		if col == nil {
 			if con, ok = cond.(*Constant); ok {
-				value, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
+				value, _, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
 				if err != nil {
 					terror.Log(err)
 					return nil
@@ -338,7 +338,7 @@ func (s *propOuterJoinConstSolver) pickEQCondsOnOuterCol(retMapper map[int]*Cons
 		var ok bool
 		if col == nil {
 			if con, ok = cond.(*Constant); ok {
-				value, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
+				value, _, err := EvalBool(s.ctx, []Expression{con}, chunk.Row{})
 				if err != nil {
 					terror.Log(err)
 					return nil

--- a/expression/constant_propagation_test.go
+++ b/expression/constant_propagation_test.go
@@ -245,11 +245,11 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"└─TableReader_12 10000.00 root data:TableScan_11",
 		"  └─TableScan_11 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
-	// Constant propagation over left outer semi join, filter with aux column should be be derived.
+	// Constant propagation over left outer semi join, filter with aux column should not be derived.
 	tk.MustQuery("explain select * from t1 where t1.b > 1 or t1.b in (select b from t2);").Check(testkit.Rows(
 		"Projection_7 8000.00 root test.t1.id, test.t1.a, test.t1.b",
 		"└─Selection_8 8000.00 root or(gt(test.t1.b, 1), 5_aux_0)",
-		"  └─HashLeftJoin_9 10000.00 root left outer semi join, inner:TableReader_13, equal:[eq(test.t1.b, test.t2.b)]",
+		"  └─HashLeftJoin_9 10000.00 root left outer semi join, inner:TableReader_13, other cond:eq(test.t1.b, test.t2.b)",
 		"    ├─TableReader_11 10000.00 root data:TableScan_10",
 		"    │ └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"    └─TableReader_13 10000.00 root data:TableScan_12",

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -111,26 +111,57 @@ func (e CNFExprs) Clone() CNFExprs {
 	return cnf
 }
 
-// EvalBool evaluates expression list to a boolean value.
-func EvalBool(ctx sessionctx.Context, exprList CNFExprs, row chunk.Row) (bool, error) {
+func isColumnInOperand(c *Column) bool {
+	return c.InOperand
+}
+
+// IsEQCondFromIn checks if an expression is equal condition converted from `[not] in (subq)`.
+func IsEQCondFromIn(expr Expression) bool {
+	sf, ok := expr.(*ScalarFunction)
+	if !ok || sf.FuncName.L != ast.EQ {
+		return false
+	}
+	cols := make([]*Column, 0, 1)
+	cols = ExtractColumnsFromExpressions(cols, sf.GetArgs(), isColumnInOperand)
+	return len(cols) > 0
+}
+
+// EvalBool evaluates expression list to a boolean value. The first returned value
+// indicates bool result of the expression list, the second returned value indicates
+// whether the result of the expression list is null, it can only be true when the
+// first returned values is false.
+func EvalBool(ctx sessionctx.Context, exprList CNFExprs, row chunk.Row) (bool, bool, error) {
+	hasNull := false
 	for _, expr := range exprList {
 		data, err := expr.Eval(row)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if data.IsNull() {
-			return false, nil
+			// For queries like `select a in (select a from s where t.b = s.b) from t`,
+			// if result of `t.a = s.a` is null, we cannot return immediately until
+			// we have checked if `t.b = s.b` is null or false, because it means
+			// subquery is empty, and we should return false as the result of the whole
+			// exprList in that case, instead of null.
+			if !IsEQCondFromIn(expr) {
+				return false, false, nil
+			}
+			hasNull = true
+			continue
 		}
 
 		i, err := data.ToBool(ctx.GetSessionVars().StmtCtx)
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 		if i == 0 {
-			return false, nil
+			return false, false, nil
 		}
 	}
-	return true, nil
+	if hasNull {
+		return false, true, nil
+	}
+	return true, false, nil
 }
 
 // composeConditionWithBinaryOp composes condition with binary operator into a balance deep tree, which benefits a lot for pb decoder/encoder.

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -689,7 +689,7 @@ func (s *testAnalyzeSuite) TestCorrelatedEstimation(c *C) {
 	tk.MustQuery("explain select t.c in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;").
 		Check(testkit.Rows(
 			"Projection_11 10.00 root 9_aux_0",
-			"└─Apply_13 10.00 root left outer semi join, inner:StreamAgg_20, equal:[eq(test.t.c, 7_col_0)]",
+			"└─Apply_13 10.00 root left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)",
 			"  ├─TableReader_15 10.00 root data:TableScan_14",
 			"  │ └─TableScan_14 10.00 cop table:t, range:[-inf,+inf], keep order:false",
 			"  └─StreamAgg_20 1.00 root funcs:count(1)",

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -337,6 +337,23 @@ func (er *expressionRewriter) handleWindowFunction(v *ast.WindowFuncExpr) (ast.N
 	return v, true
 }
 
+func (er *expressionRewriter) buildSemiApplyFromEqualSubq(np LogicalPlan, l, r expression.Expression, not bool) {
+	var condition expression.Expression
+	if rCol, ok := r.(*expression.Column); ok && (er.asScalar || not) {
+		rCol.InOperand = true
+		// If both input columns of `!= all / = any` expression are not null, we can treat the expression
+		// as normal column equal condition.
+		if lCol, ok := l.(*expression.Column); ok && mysql.HasNotNullFlag(lCol.GetType().Flag) && mysql.HasNotNullFlag(rCol.GetType().Flag) {
+			rCol.InOperand = false
+		}
+	}
+	condition, er.err = er.constructBinaryOpFunction(l, r, ast.EQ)
+	if er.err != nil {
+		return
+	}
+	er.p, er.err = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, not)
+}
+
 func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) (ast.Node, bool) {
 	v.L.Accept(er)
 	if er.err != nil {
@@ -364,7 +381,6 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 		er.err = expression.ErrOperandColumns.GenWithStackByArgs(lLen)
 		return v, true
 	}
-	var condition expression.Expression
 	var rexpr expression.Expression
 	if np.Schema().Len() == 1 {
 		rexpr = np.Schema().Columns[0]
@@ -382,20 +398,23 @@ func (er *expressionRewriter) handleCompareSubquery(v *ast.CompareSubqueryExpr) 
 	switch v.Op {
 	// Only EQ, NE and NullEQ can be composed with and.
 	case opcode.EQ, opcode.NE, opcode.NullEQ:
-		condition, er.err = er.constructBinaryOpFunction(lexpr, rexpr, ast.EQ)
-		if er.err != nil {
-			er.err = errors.Trace(er.err)
-			return v, true
-		}
 		if v.Op == opcode.EQ {
 			if v.All {
 				er.handleEQAll(lexpr, rexpr, np)
 			} else {
-				er.p, er.err = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, false)
+				// `a = any(subq)` will be rewriten as `a in (subq)`.
+				er.buildSemiApplyFromEqualSubq(np, lexpr, rexpr, false)
+				if er.err != nil {
+					return v, true
+				}
 			}
 		} else if v.Op == opcode.NE {
 			if v.All {
-				er.p, er.err = er.b.buildSemiApply(er.p, np, []expression.Expression{condition}, er.asScalar, true)
+				// `a != all(subq)` will be rewriten as `a not in (subq)`.
+				er.buildSemiApplyFromEqualSubq(np, lexpr, rexpr, true)
+				if er.err != nil {
+					return v, true
+				}
 			} else {
 				er.handleNEAny(lexpr, rexpr, np)
 			}
@@ -657,6 +676,18 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 	var rexpr expression.Expression
 	if np.Schema().Len() == 1 {
 		rexpr = np.Schema().Columns[0]
+		rCol := rexpr.(*expression.Column)
+		// For AntiSemiJoin/LeftOuterSemiJoin/AntiLeftOuterSemiJoin, we cannot treat `in` expression as
+		// normal column equal condition, so we specially mark the inner operand here.
+		if v.Not || asScalar {
+			rCol.InOperand = true
+			// If both input columns of `in` expression are not null, we can treat the expression
+			// as normal column equal condition instead.
+			lCol, ok := lexpr.(*expression.Column)
+			if ok && mysql.HasNotNullFlag(lCol.GetType().Flag) && mysql.HasNotNullFlag(rCol.GetType().Flag) {
+				rCol.InOperand = false
+			}
+		}
 	} else {
 		args := make([]expression.Expression, 0, np.Schema().Len())
 		for _, col := range np.Schema().Columns {
@@ -668,8 +699,6 @@ func (er *expressionRewriter) handleInSubquery(v *ast.PatternInExpr) (ast.Node, 
 			return v, true
 		}
 	}
-	// a in (subq) will be rewrote as a = any(subq).
-	// a not in (subq) will be rewrote as a != all(subq).
 	checkCondition, err := er.constructBinaryOpFunction(lexpr, rexpr, ast.EQ)
 	if err != nil {
 		er.err = errors.Trace(err)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -181,7 +181,7 @@ func (ds *DataSource) tryToGetMemTask(prop *property.PhysicalProperty) (task tas
 func (ds *DataSource) tryToGetDualTask() (task, error) {
 	for _, cond := range ds.pushedDownConds {
 		if con, ok := cond.(*expression.Constant); ok && con.DeferredExpr == nil {
-			result, err := expression.EvalBool(ds.ctx, []expression.Expression{cond}, chunk.Row{})
+			result, _, err := expression.EvalBool(ds.ctx, []expression.Expression{cond}, chunk.Row{})
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -220,7 +220,12 @@ func (p *LogicalJoin) extractOnCondition(conditions []expression.Expression, der
 						}
 					}
 				}
-				if leftCol != nil && binop.FuncName.L == ast.EQ {
+				// For quries like `select a in (select a from s where s.b = t.b) from t`,
+				// if subquery is empty caused by `s.b = t.b`, the result should always be
+				// false even if t.a is null or s.a is null. To make this join "empty aware",
+				// we should differentiate `t.a = s.a` from other column equal conditions, so
+				// we put it into OtherConditions instead of EqualConditions of join.
+				if leftCol != nil && binop.FuncName.L == ast.EQ && !leftCol.InOperand && !rightCol.InOperand {
 					cond := expression.NewFunctionInternal(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), leftCol, rightCol)
 					eqCond = append(eqCond, cond.(*expression.ScalarFunction))
 					continue
@@ -518,7 +523,7 @@ func (b *PlanBuilder) buildSelection(p LogicalPlan, where ast.ExprNode, AggMappe
 		cnfItems := expression.SplitCNFItems(expr)
 		for _, item := range cnfItems {
 			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil {
-				ret, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
+				ret, _, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
 				if err != nil || ret {
 					continue
 				}

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -55,9 +55,9 @@ func canProjectionBeEliminatedStrict(p *PhysicalProjection) bool {
 func resolveColumnAndReplace(origin *expression.Column, replace map[string]*expression.Column) {
 	dst := replace[string(origin.HashCode(nil))]
 	if dst != nil {
-		colName, retType := origin.ColName, origin.RetType
+		colName, retType, inOperand := origin.ColName, origin.RetType, origin.InOperand
 		*origin = *dst
-		origin.ColName, origin.RetType = colName, retType
+		origin.ColName, origin.RetType, origin.InOperand = colName, retType, inOperand
 	}
 }
 

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -144,7 +144,7 @@ func (s *partitionProcessor) canBePruned(sctx sessionctx.Context, partCol *expre
 	if len(conds) == 1 {
 		// Constant false.
 		if con, ok := conds[0].(*expression.Constant); ok && con.DeferredExpr == nil {
-			ret, err := expression.EvalBool(sctx, expression.CNFExprs{con}, chunk.Row{})
+			ret, _, err := expression.EvalBool(sctx, expression.CNFExprs{con}, chunk.Row{})
 			if err == nil && ret == false {
 				return true, nil
 			}

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -195,6 +195,12 @@ func (p *LogicalJoin) updateEQCond() {
 	for i := len(p.OtherConditions) - 1; i >= 0; i-- {
 		need2Remove := false
 		if eqCond, ok := p.OtherConditions[i].(*expression.ScalarFunction); ok && eqCond.FuncName.L == ast.EQ {
+			// If it is a column equal condition converted from `[not] in (subq)`, do not move it
+			// to EqualConditions, and keep it in OtherConditions. Reference comments in `extractOnCondition`
+			// for detailed reasons.
+			if expression.IsEQCondFromIn(eqCond) {
+				continue
+			}
 			lExpr, rExpr := eqCond.GetArgs()[0], eqCond.GetArgs()[1]
 			if expression.ExprFromSchema(lExpr, lChild.Schema()) && expression.ExprFromSchema(rExpr, rChild.Schema()) {
 				lKeys = append(lKeys, lExpr)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/8844 and https://github.com/pingcap/tidb/issues/8642

### What is changed and how it works?

- mark column as operand of in expression, to differentiate column equal condition converted from in expression with other normal column equal conditions;
- put in expression into `OtherConditions` of join to make join operators be empty aware;
- check if null exists in operands of in expression, and determine result of semi joins.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has interface methods change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch: let's see if it is easy to cherry-pick and decide later.
