### PR TITLE
*:  collect coprocessor runtime stats for `explain analyze`

### DIFF
--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -74,8 +74,8 @@ func Select(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request, fie
 }
 
 // SelectWithRuntimeStats sends a DAG request, returns SelectResult.
-// The different from Select is SelectWithRuntimeStats will set copPlanIDs in selectResult,
-// which can help selectResult collects runtime stats.
+// The different from Select is SelectWithRuntimeStats will set copPlanIDs into selectResult,
+// which can help selectResult to collect runtime stats.
 func SelectWithRuntimeStats(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request,
 	fieldTypes []*types.FieldType, fb *statistics.QueryFeedback, copPlanIDs []string) (SelectResult, error) {
 	sr, err := Select(ctx, sctx, kvReq, fieldTypes, fb)

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -73,6 +73,21 @@ func Select(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request, fie
 	}, nil
 }
 
+// SelectWithRuntimeStats sends a DAG request, returns SelectResult.
+// The different from Select is SelectWithRuntimeStats will set copPlanIDs in selectResult,
+// which can help selectResult collects runtime stats.
+func SelectWithRuntimeStats(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request,
+	fieldTypes []*types.FieldType, fb *statistics.QueryFeedback, copPlanIDs []string) (SelectResult, error) {
+	sr, err := Select(ctx, sctx, kvReq, fieldTypes, fb)
+	if err != nil {
+		return sr, err
+	}
+	if selectResult, ok := sr.(*selectResult); ok {
+		selectResult.copPlanIDs = copPlanIDs
+	}
+	return sr, err
+}
+
 // Analyze do a analyze request.
 func Analyze(ctx context.Context, client kv.Client, kvReq *kv.Request, vars *kv.Variables,
 	isRestrict bool) (SelectResult, error) {

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -74,7 +74,7 @@ func Select(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request, fie
 }
 
 // SelectWithRuntimeStats sends a DAG request, returns SelectResult.
-// The different from Select is SelectWithRuntimeStats will set copPlanIDs into selectResult,
+// The difference from Select is that SelectWithRuntimeStats will set copPlanIDs into selectResult,
 // which can help selectResult to collect runtime stats.
 func SelectWithRuntimeStats(ctx context.Context, sctx sessionctx.Context, kvReq *kv.Request,
 	fieldTypes []*types.FieldType, fb *statistics.QueryFeedback, copPlanIDs []string) (SelectResult, error) {

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/pingcap/tipb/go-tipb"
 )
 
-func (s *testSuite) createSelectNormal(batch, totalRows int, c *C) (*selectResult, []*types.FieldType) {
+func (s *testSuite) createSelectNormal(batch, totalRows int, c *C, planIDs []string) (*selectResult, []*types.FieldType) {
 	request, err := (&RequestBuilder{}).SetKeyRanges(nil).
 		SetDAGRequest(&tipb.DAGRequest{}).
 		SetDesc(false).
@@ -60,7 +60,13 @@ func (s *testSuite) createSelectNormal(batch, totalRows int, c *C) (*selectResul
 	colTypes = append(colTypes, colTypes[0])
 
 	// Test Next.
-	response, err := Select(context.TODO(), s.sctx, request, colTypes, statistics.NewQueryFeedback(0, nil, 0, false))
+	var response SelectResult
+	if planIDs == nil {
+		response, err = Select(context.TODO(), s.sctx, request, colTypes, statistics.NewQueryFeedback(0, nil, 0, false))
+	} else {
+		response, err = SelectWithRuntimeStats(context.TODO(), s.sctx, request, colTypes, statistics.NewQueryFeedback(0, nil, 0, false), planIDs)
+	}
+
 	c.Assert(err, IsNil)
 	result, ok := response.(*selectResult)
 	c.Assert(ok, IsTrue)
@@ -77,7 +83,7 @@ func (s *testSuite) createSelectNormal(batch, totalRows int, c *C) (*selectResul
 }
 
 func (s *testSuite) TestSelectNormal(c *C) {
-	response, colTypes := s.createSelectNormal(1, 2, c)
+	response, colTypes := s.createSelectNormal(1, 2, c, nil)
 	response.Fetch(context.TODO())
 
 	// Test Next.
@@ -97,16 +103,15 @@ func (s *testSuite) TestSelectNormal(c *C) {
 }
 
 func (s *testSuite) TestSelectNormalChunkSize(c *C) {
-	response, colTypes := s.createSelectNormal(100, 1000000, c)
+	response, colTypes := s.createSelectNormal(100, 1000000, c, nil)
 	response.Fetch(context.TODO())
 	s.testChunkSize(response, colTypes, c)
 	c.Assert(response.Close(), IsNil)
 }
 
-
 func (s *testSuite) TestSelectWithRuntimeStats(c *C) {
-	response, colTypes := s.createSelectNormal(1, 2, c)
 	planIDs := []string{"1", "2", "3"}
+	response, colTypes := s.createSelectNormal(1, 2, c, planIDs)
 	if len(response.copPlanIDs) != len(planIDs) {
 		c.Fatal("invalid copPlanIDs")
 	}

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -188,7 +188,8 @@ func (r *selectResult) updateCopRuntimeStats(callee string) {
 			detail.NumProducedRows != nil && detail.NumIterations != nil {
 			planID := r.copPlanIDs[i]
 			r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
-				RecordOneCopTask(planID, callee, int64(*detail.TimeProcessedNs), int64(*detail.NumProducedRows), int32(*detail.NumIterations))
+				RecordOneCopTask(planID, callee, detail)
+			//, int64(*detail.TimeProcessedNs), int64(*detail.NumProducedRows), int32(*detail.NumIterations))
 		}
 	}
 }

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -69,8 +69,8 @@ type selectResult struct {
 	partialCount int64 // number of partial results.
 	sqlType      string
 
-	// copPlanIDs contains all copTasks' planID,
-	// which helps to collect copTasks' runtime stats.
+	// copPlanIDs contains all copTasks' planIDs,
+	// which help to collect copTasks' runtime stats.
 	copPlanIDs []string
 }
 
@@ -173,15 +173,15 @@ func (r *selectResult) getSelectResp() error {
 }
 
 func (r *selectResult) updateCopRuntimeStats(callee string) {
-	if len(r.selectResp.GetExecutionSummaries()) != len(r.copPlanIDs) {
+	if callee == "" || len(r.selectResp.GetExecutionSummaries()) != len(r.copPlanIDs) {
 		return
 	}
 
 	for i, detail := range r.selectResp.GetExecutionSummaries() {
-		planID := r.copPlanIDs[i]
-		stats := r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetCop(planID, callee)
 		if detail != nil && detail.TimeProcessedNs != nil &&
 			detail.NumProducedRows != nil && detail.NumIterations != nil {
+			planID := r.copPlanIDs[i]
+			stats := r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetCop(planID, callee)
 			stats.Record(*detail.TimeProcessedNs, *detail.NumProducedRows, *detail.NumIterations)
 		}
 	}

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -189,7 +189,6 @@ func (r *selectResult) updateCopRuntimeStats(callee string) {
 			planID := r.copPlanIDs[i]
 			r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
 				RecordOneCopTask(planID, callee, detail)
-			//, int64(*detail.TimeProcessedNs), int64(*detail.NumProducedRows), int32(*detail.NumIterations))
 		}
 	}
 }

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -173,7 +173,8 @@ func (r *selectResult) getSelectResp() error {
 }
 
 func (r *selectResult) updateCopRuntimeStats(callee string) {
-	if callee == "" || len(r.selectResp.GetExecutionSummaries()) != len(r.copPlanIDs) {
+	if r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil ||
+		callee == "" || len(r.selectResp.GetExecutionSummaries()) != len(r.copPlanIDs) {
 		return
 	}
 

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -181,8 +181,8 @@ func (r *selectResult) updateCopRuntimeStats(callee string) {
 		if detail != nil && detail.TimeProcessedNs != nil &&
 			detail.NumProducedRows != nil && detail.NumIterations != nil {
 			planID := r.copPlanIDs[i]
-			stats := r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetCop(planID, callee)
-			stats.Record(*detail.TimeProcessedNs, *detail.NumProducedRows, *detail.NumIterations)
+			r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.
+				RecordOneCopTask(planID, callee, *detail.TimeProcessedNs, *detail.NumProducedRows, *detail.NumIterations)
 		}
 	}
 }

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -240,7 +240,7 @@ func (e *IndexReaderExecutor) Close() error {
 	err := e.result.Close()
 	e.result = nil
 	if e.runtimeStats != nil {
-		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.plans[0].ExplainID())
+		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.plans[0].ExplainID())
 		copStats.SetRowNum(e.feedback.Actual())
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)
@@ -466,9 +466,9 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 			log.Error("close Select result failed:", errors.ErrorStack(err))
 		}
 		if e.runtimeStats != nil {
-			copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.idxPlans[len(e.idxPlans)-1].ExplainID())
+			copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.idxPlans[len(e.idxPlans)-1].ExplainID())
 			copStats.SetRowNum(count)
-			copStats = e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.tblPlans[0].ExplainID())
+			copStats = e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.tblPlans[0].ExplainID())
 			copStats.SetRowNum(count)
 		}
 		e.ctx.StoreQueryFeedback(e.feedback)
@@ -542,7 +542,7 @@ func (e *IndexLookUpExecutor) Close() error {
 	e.memTracker.Detach()
 	e.memTracker = nil
 	if e.runtimeStats != nil {
-		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.idxPlans[0].ExplainID())
+		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.idxPlans[0].ExplainID())
 		copStats.SetRowNum(e.feedback.Actual())
 	}
 	return nil

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -440,7 +440,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		return errors.Trace(err)
 	}
 	// Since the first read only need handle information. So its returned col is only 1.
-	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.feedback, getPhysicalPlanIDs(e.tblPlans))
+	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.feedback, getPhysicalPlanIDs(e.idxPlans))
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -278,7 +278,15 @@ func (e *IndexReaderExecutor) Open(ctx context.Context) error {
 		e.feedback.Invalidate()
 		return errors.Trace(err)
 	}
-	return e.open(ctx, kvRanges)
+	if err := e.open(ctx, kvRanges); err != nil {
+		return errors.Trace(err)
+	}
+
+	if e.runtimeStats != nil {
+		collExec := true
+		e.dagPB.CollectExecutionSummaries = &collExec
+	}
+	return nil
 }
 
 func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) error {
@@ -372,6 +380,11 @@ func (e *IndexLookUpExecutor) Open(ctx context.Context) error {
 	err = e.open(ctx, kvRanges)
 	if err != nil {
 		e.feedback.Invalidate()
+	}
+
+	if e.runtimeStats != nil {
+		collExec := true
+		e.dagPB.CollectExecutionSummaries = &collExec
 	}
 	return errors.Trace(err)
 }

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -302,7 +302,11 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		e.feedback.Invalidate()
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.Select(ctx, e.ctx, kvReq, e.retTypes(), e.feedback)
+	copPlanIDs := make([]string, 0, len(e.plans))
+	for _, p := range e.plans {
+		copPlanIDs = append(copPlanIDs, p.ExplainID())
+	}
+	e.result, err = distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, copPlanIDs)
 	if err != nil {
 		e.feedback.Invalidate()
 		return errors.Trace(err)
@@ -427,7 +431,11 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		return errors.Trace(err)
 	}
 	// Since the first read only need handle information. So its returned col is only 1.
-	result, err := distsql.Select(ctx, e.ctx, kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.feedback)
+	copPlanIDs := make([]string, 0, len(e.idxPlans))
+	for _, p := range e.idxPlans {
+		copPlanIDs = append(copPlanIDs, p.ExplainID())
+	}
+	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, e.feedback, copPlanIDs)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -278,10 +278,7 @@ func (e *IndexReaderExecutor) Open(ctx context.Context) error {
 		e.feedback.Invalidate()
 		return errors.Trace(err)
 	}
-	if err := e.open(ctx, kvRanges); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
+	return e.open(ctx, kvRanges)
 }
 
 func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) error {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -514,9 +514,6 @@ func (e *IndexLookUpExecutor) buildTableReader(ctx context.Context, handles []in
 		corColInFilter:  e.corColInTblSide,
 		plans:           e.tblPlans,
 	}
-	// We assign `nil` to `runtimeStats` to forbidden `TableWorker` driven `IndexLookupExecutor`'s runtime stats collecting,
-	// because TableWorker information isn't showing in explain result now.
-	tableReaderExec.runtimeStats = nil
 	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles)
 	if err != nil {
 		log.Error(err)

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -302,7 +302,7 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		e.feedback.Invalidate()
 		return errors.Trace(err)
 	}
-	e.result, err = distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, getPhysicalPlanIDs(e.plans))
+	e.result, err = distsql.Select(ctx, e.ctx, kvReq, e.retTypes(), e.feedback)
 	if err != nil {
 		e.feedback.Invalidate()
 		return errors.Trace(err)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -139,7 +139,7 @@ func newBaseExecutor(ctx sessionctx.Context, schema *expression.Schema, id strin
 		maxChunkSize: ctx.GetSessionVars().MaxChunkSize,
 	}
 	if ctx.GetSessionVars().StmtCtx.RuntimeStatsColl != nil {
-		e.runtimeStats = e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.id)
+		e.runtimeStats = e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.id)
 	}
 	if schema != nil {
 		cols := schema.Columns

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -146,11 +146,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		return nil, errors.Trace(err)
 	}
 
-	planIDs := make([]string, 0, len(e.plans))
-	for _, p := range e.plans {
-		planIDs = append(planIDs, p.ExplainID())
-	}
-	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, planIDs)
+	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, getPhysicalPlanIDs(e.plans))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -145,7 +145,12 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	result, err := distsql.Select(ctx, e.ctx, kvReq, e.retTypes(), e.feedback)
+
+	planIDs := make([]string, 0, len(e.plans))
+	for _, p := range e.plans {
+		planIDs = append(planIDs, p.ExplainID())
+	}
+	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, planIDs)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -128,7 +128,7 @@ func (e *TableReaderExecutor) Next(ctx context.Context, req *chunk.RecordBatch) 
 func (e *TableReaderExecutor) Close() error {
 	err := e.resultHandler.Close()
 	if e.runtimeStats != nil {
-		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.Get(e.plans[0].ExplainID())
+		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.plans[0].ExplainID())
 		copStats.SetRowNum(e.feedback.Actual())
 	}
 	e.ctx.StoreQueryFeedback(e.feedback)

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/distsql"
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/ranger"
-	tipb "github.com/pingcap/tipb/go-tipb"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 // make sure `TableReaderExecutor` implements `Executor`.
@@ -66,6 +66,10 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+	}
+	if e.runtimeStats != nil {
+		collExec := true
+		e.dagPB.CollectExecutionSummaries = &collExec
 	}
 	if e.corColInAccess {
 		ts := e.plans[0].(*plannercore.PhysicalTableScan)

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -149,7 +149,6 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-
 	result, err := distsql.SelectWithRuntimeStats(ctx, e.ctx, kvReq, e.retTypes(), e.feedback, getPhysicalPlanIDs(e.plans))
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7
-	github.com/pkg/errors v0.8.0 // indirect
 	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,8 @@ require (
 	github.com/pingcap/parser v0.0.0-20190212061044-a71b434969f3
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible
-	github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323
+	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7
+	github.com/pkg/errors v0.8.0 // indirect
 	github.com/prometheus/client_golang v0.9.0
 	github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
 	github.com/prometheus/common v0.0.0-20181020173914-7e9e6cabbd39 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,10 @@ github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible 
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323 h1:mRKKzRjDNaUNPnAkPAHnRqpNmwNWBX1iA+hxlmvQ93I=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 h1:wnjdQRhybddDesBVBKyOLUPgDaOFdtqA92pduBgWvVQ=
+github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
+github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.0 h1:tXuTFVHC03mW0D+Ua1Q2d1EAVqLTuggX50V0VLICCzY=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible 
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 h1:wnjdQRhybddDesBVBKyOLUPgDaOFdtqA92pduBgWvVQ=
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.0 h1:tXuTFVHC03mW0D+Ua1Q2d1EAVqLTuggX50V0VLICCzY=

--- a/go.sum
+++ b/go.sum
@@ -117,10 +117,15 @@ github.com/pingcap/parser v0.0.0-20190212061044-a71b434969f3 h1:Wn8ERRenAuN00KT7
 github.com/pingcap/parser v0.0.0-20190212061044-a71b434969f3/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
+<<<<<<< HEAD
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible h1:e9Gi/LP9181HT3gBfSOeSBA+5JfemuE4aEAhqNgoE4k=
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323 h1:mRKKzRjDNaUNPnAkPAHnRqpNmwNWBX1iA+hxlmvQ93I=
 github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+=======
+github.com/pingcap/tidb-tools v2.1.3-0.20190104033906-883b07a04a73+incompatible h1:Ba48wwPwPq5hd1kkQpgua49dqB5cthC2zXVo7fUUDec=
+github.com/pingcap/tidb-tools v2.1.3-0.20190104033906-883b07a04a73+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+>>>>>>> check golang tidy
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 h1:wnjdQRhybddDesBVBKyOLUPgDaOFdtqA92pduBgWvVQ=
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/go.sum
+++ b/go.sum
@@ -117,15 +117,8 @@ github.com/pingcap/parser v0.0.0-20190212061044-a71b434969f3 h1:Wn8ERRenAuN00KT7
 github.com/pingcap/parser v0.0.0-20190212061044-a71b434969f3/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
-<<<<<<< HEAD
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible h1:e9Gi/LP9181HT3gBfSOeSBA+5JfemuE4aEAhqNgoE4k=
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323 h1:mRKKzRjDNaUNPnAkPAHnRqpNmwNWBX1iA+hxlmvQ93I=
-github.com/pingcap/tipb v0.0.0-20181012112600-11e33c750323/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
-=======
-github.com/pingcap/tidb-tools v2.1.3-0.20190104033906-883b07a04a73+incompatible h1:Ba48wwPwPq5hd1kkQpgua49dqB5cthC2zXVo7fUUDec=
-github.com/pingcap/tidb-tools v2.1.3-0.20190104033906-883b07a04a73+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
->>>>>>> check golang tidy
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7 h1:wnjdQRhybddDesBVBKyOLUPgDaOFdtqA92pduBgWvVQ=
 github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -88,7 +88,7 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
 		} else { // cop task
 			execInfo := row[4].(string)
-			c.Assert(strings.Contains(execInfo, "procNs"), Equals, true)
+			c.Assert(strings.Contains(execInfo, "proc"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "iters"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "tasks"), Equals, true)

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -86,7 +86,7 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 			c.Assert(strings.Contains(execInfo, "time"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "loops"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
-		} else {
+		} else { // cop task
 			execInfo := row[4].(string)
 			c.Assert(strings.Contains(execInfo, "procNs"), Equals, true)
 			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -80,19 +80,10 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 	c.Assert(len(rs.Rows()), Equals, 10)
 	for _, row := range rs.Rows() {
 		c.Assert(len(row), Equals, 5)
-		taskType := row[2].(string)
-		if taskType == "root" {
-			execInfo := row[4].(string)
-			c.Assert(strings.Contains(execInfo, "time"), Equals, true)
-			c.Assert(strings.Contains(execInfo, "loops"), Equals, true)
-			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
-		} else { // cop task
-			execInfo := row[4].(string)
-			c.Assert(strings.Contains(execInfo, "proc"), Equals, true)
-			c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
-			c.Assert(strings.Contains(execInfo, "iters"), Equals, true)
-			c.Assert(strings.Contains(execInfo, "tasks"), Equals, true)
-		}
+		execInfo := row[4].(string)
+		c.Assert(strings.Contains(execInfo, "time"), Equals, true)
+		c.Assert(strings.Contains(execInfo, "loops"), Equals, true)
+		c.Assert(strings.Contains(execInfo, "rows"), Equals, true)
 	}
 }
 

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -529,11 +529,10 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 	row := []string{e.prettyIdentifier(p.ExplainID(), indent, isLastChild), count, taskType, operatorInfo}
 	if e.Analyze {
 		runtimeStatsColl := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
-		copTaskExecDetail := runtimeStatsColl.CopSummary(p.ExplainID())
 		// There maybe some mock information for cop task to let runtimeStatsColl.Exists(p.ExplainID()) is true.
 		// So check copTaskExecDetail first and print the real cop task information if it's not empty.
-		if copTaskExecDetail != "" {
-			row = append(row, copTaskExecDetail)
+		if runtimeStatsColl.ExistsCopStats(p.ExplainID()) {
+			row = append(row, runtimeStatsColl.GetCopStats(p.ExplainID()).String())
 		} else if runtimeStatsColl.ExistsRootStats(p.ExplainID()) {
 			row = append(row, runtimeStatsColl.GetRootStats(p.ExplainID()).String())
 		}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -536,8 +536,6 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 			row = append(row, copTaskExecDetail)
 		} else if runtimeStatsColl.ExistsRootStats(p.ExplainID()) {
 			row = append(row, runtimeStatsColl.GetRootStats(p.ExplainID()).String())
-		} else {
-			row = append(row, "")
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -534,8 +534,8 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 		// So check copTaskExecDetail first and print the real cop task information if it's not empty.
 		if copTaskExecDetail != "" {
 			row = append(row, copTaskExecDetail)
-		} else if runtimeStatsColl.Exists(p.ExplainID()) {
-			row = append(row, runtimeStatsColl.Get(p.ExplainID()).String())
+		} else if runtimeStatsColl.ExistsRootStats(p.ExplainID()) {
+			row = append(row, runtimeStatsColl.GetRootStats(p.ExplainID()).String())
 		} else {
 			row = append(row, "")
 		}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -530,12 +530,14 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 	if e.Analyze {
 		runtimeStatsColl := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl
 		copTaskExecDetail := runtimeStatsColl.CopSummary(p.ExplainID())
-		// There maybe some mock execution details for cop task to let runtimeStatsColl.Exists(p.ExplainID()) is true.
-		// So check copTaskExecDetail first and print the real cop task detail if it's not empty.
+		// There maybe some mock information for cop task to let runtimeStatsColl.Exists(p.ExplainID()) is true.
+		// So check copTaskExecDetail first and print the real cop task information if it's not empty.
 		if copTaskExecDetail != "" {
 			row = append(row, copTaskExecDetail)
 		} else if runtimeStatsColl.Exists(p.ExplainID()) {
 			row = append(row, runtimeStatsColl.Get(p.ExplainID()).String())
+		} else {
+			row = append(row, "")
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -532,7 +532,7 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 		if runtimeStatsColl.Exists(p.ExplainID()) {
 			row = append(row, runtimeStatsColl.Get(p.ExplainID()).String())
 		} else {
-			row = append(row, "") //TODO: wait collect more executor info from tikv
+			row = append(row, runtimeStatsColl.CopSummary(p.ExplainID()))
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -45,7 +45,7 @@ type hashAggExec struct {
 	executed          bool
 	currGroupIdx      int
 	count             int64
-	execDetail        execDetail
+	execDetail        *execDetail
 
 	src executor
 }
@@ -55,7 +55,7 @@ func (e *hashAggExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append(suffix, &e.execDetail)
+	return append(suffix, e.execDetail)
 }
 
 func (e *hashAggExec) SetSrcExec(exec executor) {
@@ -95,9 +95,7 @@ func (e *hashAggExec) Cursor() ([]byte, bool) {
 
 func (e *hashAggExec) Next(ctx context.Context) (value [][]byte, err error) {
 	defer func(begin time.Time) {
-		e.execDetail.numIterations++
-		e.execDetail.timeProcessed += time.Since(begin)
-		e.execDetail.numProducedRows += len(value)
+		e.execDetail.update(begin, value)
 	}(time.Now())
 	e.count++
 	if e.aggCtxsMap == nil {
@@ -218,7 +216,7 @@ type streamAggExec struct {
 	executed          bool
 	hasData           bool
 	count             int64
-	execDetail        execDetail
+	execDetail        *execDetail
 
 	src executor
 }
@@ -228,7 +226,7 @@ func (e *streamAggExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append(suffix, &e.execDetail)
+	return append(suffix, e.execDetail)
 }
 
 func (e *streamAggExec) SetSrcExec(exec executor) {
@@ -313,9 +311,7 @@ func (e *streamAggExec) Cursor() ([]byte, bool) {
 
 func (e *streamAggExec) Next(ctx context.Context) (retRow [][]byte, err error) {
 	defer func(begin time.Time) {
-		e.execDetail.numIterations++
-		e.execDetail.timeProcessed += time.Since(begin)
-		e.execDetail.numProducedRows += len(retRow)
+		e.execDetail.update(begin, retRow)
 	}(time.Now())
 	e.count++
 	if e.executed {

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -15,6 +15,7 @@ package mocktikv
 
 import (
 	"context"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
@@ -44,8 +45,17 @@ type hashAggExec struct {
 	executed          bool
 	currGroupIdx      int
 	count             int64
+	execDetail        execDetail
 
 	src executor
+}
+
+func (e *hashAggExec) ExecDetails() []*execDetail {
+	var suffix []*execDetail
+	if e.src != nil {
+		suffix = e.src.ExecDetails()
+	}
+	return append([]*execDetail{&e.execDetail}, suffix...)
 }
 
 func (e *hashAggExec) SetSrcExec(exec executor) {
@@ -84,6 +94,11 @@ func (e *hashAggExec) Cursor() ([]byte, bool) {
 }
 
 func (e *hashAggExec) Next(ctx context.Context) (value [][]byte, err error) {
+	defer func(begin time.Time) {
+		e.execDetail.numIterations++
+		e.execDetail.timeProcessed += time.Since(begin)
+		e.execDetail.numProducedRows += len(value)
+	}(time.Now())
 	e.count++
 	if e.aggCtxsMap == nil {
 		e.aggCtxsMap = make(aggCtxsMapper)
@@ -203,8 +218,17 @@ type streamAggExec struct {
 	executed          bool
 	hasData           bool
 	count             int64
+	execDetail        execDetail
 
 	src executor
+}
+
+func (e *streamAggExec) ExecDetails() []*execDetail {
+	var suffix []*execDetail
+	if e.src != nil {
+		suffix = e.src.ExecDetails()
+	}
+	return append([]*execDetail{&e.execDetail}, suffix...)
 }
 
 func (e *streamAggExec) SetSrcExec(exec executor) {
@@ -288,6 +312,11 @@ func (e *streamAggExec) Cursor() ([]byte, bool) {
 }
 
 func (e *streamAggExec) Next(ctx context.Context) (retRow [][]byte, err error) {
+	defer func(begin time.Time) {
+		e.execDetail.numIterations++
+		e.execDetail.timeProcessed += time.Since(begin)
+		e.execDetail.numProducedRows += len(retRow)
+	}(time.Now())
 	e.count++
 	if e.executed {
 		return nil, nil

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -55,7 +55,7 @@ func (e *hashAggExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *hashAggExec) SetSrcExec(exec executor) {
@@ -228,7 +228,7 @@ func (e *streamAggExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *streamAggExec) SetSrcExec(exec executor) {

--- a/store/mockstore/mocktikv/analyze.go
+++ b/store/mockstore/mocktikv/analyze.go
@@ -71,6 +71,7 @@ func (h *rpcHandler) handleAnalyzeIndexReq(req *coprocessor.Request, analyzeReq 
 		isolationLevel: h.isolationLevel,
 		mvccStore:      h.mvccStore,
 		IndexScan:      &tipb.IndexScan{Desc: false},
+		execDetail:     new(execDetail),
 	}
 	statsBuilder := statistics.NewSortedBuilder(flagsToStatementContext(analyzeReq.Flags), analyzeReq.IdxReq.BucketSize, 0, types.NewFieldType(mysql.TypeBlob))
 	var cms *statistics.CMSketch
@@ -138,6 +139,7 @@ func (h *rpcHandler) handleAnalyzeColumnsReq(req *coprocessor.Request, analyzeRe
 			startTS:        analyzeReq.GetStartTs(),
 			isolationLevel: h.isolationLevel,
 			mvccStore:      h.mvccStore,
+			execDetail:     new(execDetail),
 		},
 	}
 	e.fields = make([]*ast.ResultField, len(columns))

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -166,7 +166,7 @@ func (h *rpcHandler) buildExec(ctx *dagContext, curr *tipb.Executor) (executor, 
 	case tipb.ExecType_TypeTopN:
 		currExec, err = h.buildTopN(ctx, curr)
 	case tipb.ExecType_TypeLimit:
-		currExec = &limitExec{limit: curr.Limit.GetLimit()}
+		currExec = &limitExec{limit: curr.Limit.GetLimit(), execDetail: new(execDetail)}
 	default:
 		// TODO: Support other types.
 		err = errors.Errorf("this exec type %v doesn't support yet.", curr.GetTp())
@@ -203,6 +203,7 @@ func (h *rpcHandler) buildTableScan(ctx *dagContext, executor *tipb.Executor) (*
 		startTS:        ctx.dagReq.GetStartTs(),
 		isolationLevel: h.isolationLevel,
 		mvccStore:      h.mvccStore,
+		execDetail:     new(execDetail),
 	}
 	if ctx.dagReq.CollectRangeCounts != nil && *ctx.dagReq.CollectRangeCounts {
 		e.counts = make([]int64, len(ranges))
@@ -241,6 +242,7 @@ func (h *rpcHandler) buildIndexScan(ctx *dagContext, executor *tipb.Executor) (*
 		isolationLevel: h.isolationLevel,
 		mvccStore:      h.mvccStore,
 		pkStatus:       pkStatus,
+		execDetail:     new(execDetail),
 	}
 	if ctx.dagReq.CollectRangeCounts != nil && *ctx.dagReq.CollectRangeCounts {
 		e.counts = make([]int64, len(ranges))
@@ -268,6 +270,7 @@ func (h *rpcHandler) buildSelection(ctx *dagContext, executor *tipb.Executor) (*
 		relatedColOffsets: relatedColOffsets,
 		conditions:        conds,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
+		execDetail:        new(execDetail),
 	}, nil
 }
 
@@ -316,6 +319,7 @@ func (h *rpcHandler) buildHashAgg(ctx *dagContext, executor *tipb.Executor) (*ha
 		groupKeys:         make([][]byte, 0),
 		relatedColOffsets: relatedColOffsets,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
+		execDetail:        new(execDetail),
 	}, nil
 }
 
@@ -337,6 +341,7 @@ func (h *rpcHandler) buildStreamAgg(ctx *dagContext, executor *tipb.Executor) (*
 		currGroupByValues: make([][]byte, 0),
 		relatedColOffsets: relatedColOffsets,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
+		execDetail:        new(execDetail),
 	}, nil
 }
 
@@ -371,6 +376,7 @@ func (h *rpcHandler) buildTopN(ctx *dagContext, executor *tipb.Executor) (*topNE
 		relatedColOffsets: relatedColOffsets,
 		orderByExprs:      conds,
 		row:               make([]types.Datum, len(ctx.evalCtx.columnInfos)),
+		execDetail:        new(execDetail),
 	}, nil
 }
 

--- a/store/mockstore/mocktikv/executor.go
+++ b/store/mockstore/mocktikv/executor.go
@@ -57,7 +57,7 @@ type executor interface {
 	// Cursor returns the key gonna to be scanned by the Next() function.
 	Cursor() (key []byte, desc bool)
 	// ExecDetails returns its and its children's execution details.
-	// The order is from parent to child, [parent, child, child's child, ...].
+	// The order is same as DAGRequest.Executors, which child is in front of parent.
 	ExecDetails() []*execDetail
 }
 
@@ -82,7 +82,7 @@ func (e *tableScanExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *tableScanExec) SetSrcExec(exec executor) {
@@ -268,7 +268,7 @@ func (e *indexScanExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *indexScanExec) SetSrcExec(exec executor) {
@@ -456,7 +456,7 @@ func (e *selectionExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *selectionExec) SetSrcExec(exec executor) {
@@ -548,7 +548,7 @@ func (e *topNExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *topNExec) SetSrcExec(src executor) {
@@ -651,7 +651,7 @@ func (e *limitExec) ExecDetails() []*execDetail {
 	if e.src != nil {
 		suffix = e.src.ExecDetails()
 	}
-	return append([]*execDetail{&e.execDetail}, suffix...)
+	return append(suffix, &e.execDetail)
 }
 
 func (e *limitExec) SetSrcExec(src executor) {

--- a/store/mockstore/mocktikv/executor.go
+++ b/store/mockstore/mocktikv/executor.go
@@ -57,7 +57,7 @@ type executor interface {
 	// Cursor returns the key gonna to be scanned by the Next() function.
 	Cursor() (key []byte, desc bool)
 	// ExecDetails returns its and its children's execution details.
-	// The order is same as DAGRequest.Executors, which child is in front of parent.
+	// The order is same as DAGRequest.Executors, which children are in front of parents.
 	ExecDetails() []*execDetail
 }
 

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -753,7 +753,9 @@ func (worker *copIteratorWorker) handleCopResponse(bo *Backoffer, rpcCtx *RPCCon
 		resp.startKey = task.ranges.at(0).StartKey
 	}
 	resp.BackoffTime = time.Duration(bo.totalSleep) * time.Millisecond
-	resp.CalleeAddress = rpcCtx.Addr
+	if rpcCtx != nil {
+		resp.CalleeAddress = rpcCtx.Addr
+	}
 	if pbDetails := resp.pbResp.ExecDetails; pbDetails != nil {
 		if handleTime := pbDetails.HandleTime; handleTime != nil {
 			resp.WaitTime = time.Duration(handleTime.WaitMs) * time.Millisecond

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -60,6 +60,12 @@ func NewRegionRequestSender(regionCache *RegionCache, client Client) *RegionRequ
 
 // SendReq sends a request to tikv server.
 func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regionID RegionVerID, timeout time.Duration) (*tikvrpc.Response, error) {
+	resp, _, err := s.SendReqCtx(bo, req, regionID, timeout)
+	return resp, err
+}
+
+// SendReqCtx sends a request to tikv server and return response and RPCCtx.
+func (s *RegionRequestSender) SendReqCtx(bo *Backoffer, req *tikvrpc.Request, regionID RegionVerID, timeout time.Duration) (*tikvrpc.Response, *RPCContext, error) {
 
 	// gofail: var tikvStoreSendReqResult string
 	// switch tikvStoreSendReqResult {
@@ -84,7 +90,7 @@ func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regio
 	for {
 		ctx, err := s.regionCache.GetRPCContext(bo, regionID)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
 		if ctx == nil {
 			// If the region is not found in cache, it must be out
@@ -93,13 +99,14 @@ func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regio
 
 			// TODO: Change the returned error to something like "region missing in cache",
 			// and handle this error like EpochNotMatch, which means to re-split the request and retry.
-			return tikvrpc.GenRegionErrorResp(req, &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}})
+			resp, err := tikvrpc.GenRegionErrorResp(req, &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{}})
+			return resp, nil, err
 		}
 
 		s.storeAddr = ctx.Addr
 		resp, retry, err := s.sendReqToRegion(bo, ctx, req, timeout)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
 		if retry {
 			continue
@@ -107,18 +114,18 @@ func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regio
 
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, nil, errors.Trace(err)
 		}
 		if regionErr != nil {
 			retry, err := s.onRegionError(bo, ctx, regionErr)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, nil, errors.Trace(err)
 			}
 			if retry {
 				continue
 			}
 		}
-		return resp, nil
+		return resp, ctx, nil
 	}
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -70,20 +70,20 @@ func (s *RegionRequestSender) SendReqCtx(bo *Backoffer, req *tikvrpc.Request, re
 	// gofail: var tikvStoreSendReqResult string
 	// switch tikvStoreSendReqResult {
 	// case "timeout":
-	// 	 return nil, errors.New("timeout")
+	// 	 return nil, nil, errors.New("timeout")
 	// case "GCNotLeader":
 	// 	 if req.Type == tikvrpc.CmdGC {
 	//		 return &tikvrpc.Response{
 	//			 Type:   tikvrpc.CmdGC,
 	//			 GC: &kvrpcpb.GCResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
-	//		 }, nil
+	//		 }, nil, nil
 	//	 }
 	// case "GCServerIsBusy":
 	//	 if req.Type == tikvrpc.CmdGC {
 	//		 return &tikvrpc.Response{
 	//			 Type: tikvrpc.CmdGC,
 	//			 GC:   &kvrpcpb.GCResponse{RegionError: &errorpb.Error{ServerIsBusy: &errorpb.ServerIsBusy{}}},
-	//		 }, nil
+	//		 }, nil, nil
 	//	 }
 	// }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -64,7 +64,7 @@ func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regio
 	return resp, err
 }
 
-// SendReqCtx sends a request to tikv server and return response and RPCCtx.
+// SendReqCtx sends a request to tikv server and return response and RPCCtx of this RPC.
 func (s *RegionRequestSender) SendReqCtx(bo *Backoffer, req *tikvrpc.Request, regionID RegionVerID, timeout time.Duration) (*tikvrpc.Response, *RPCContext, error) {
 
 	// gofail: var tikvStoreSendReqResult string

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -89,6 +89,23 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithStoreRestart(c *C) {
 	c.Assert(resp.RawPut, NotNil)
 }
 
+func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {
+	req := &tikvrpc.Request{
+		Type: tikvrpc.CmdRawPut,
+		RawPut: &kvrpcpb.RawPutRequest{
+			Key:   []byte("key"),
+			Value: []byte("value"),
+		},
+	}
+	region, err := s.cache.LocateRegionByID(s.bo, s.region)
+	c.Assert(err, IsNil)
+	c.Assert(region, NotNil)
+	resp, ctx, err := s.regionRequestSender.SendReqCtx(s.bo, req, region.Region, time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(resp.RawPut, NotNil)
+	c.Assert(ctx, NotNil)
+}
+
 func (s *testRegionRequestSuite) TestOnSendFailedWithCancelled(c *C) {
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawPut,

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -157,6 +157,7 @@ func (e *RuntimeStatsColl) Get(planID string) *RuntimeStats {
 	return runtimeStats
 }
 
+// GetCop gets a CopRuntimeStats by planID and address.
 func (e *RuntimeStatsColl) GetCop(planID, address string) *CopRuntimeStats {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -173,6 +174,7 @@ func (e *RuntimeStatsColl) GetCop(planID, address string) *CopRuntimeStats {
 	return stat
 }
 
+// CopSummary gets a summary of the cop task's execution information.
 func (e *RuntimeStatsColl) CopSummary(planID string) string {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -199,6 +201,7 @@ func (e *RuntimeStatsColl) Exists(planID string) bool {
 	return exists
 }
 
+// Record records executor's information.
 func (e *CopRuntimeStats) Record(timeProcessedNs, numProducedRows, numIterations uint64) {
 	e.timeProcessedNs += timeProcessedNs
 	e.numProducedRows += numProducedRows

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -115,11 +115,11 @@ func (d ExecDetails) String() string {
 type CopRuntimeStats struct {
 	sync.Mutex
 
-	// Usually, CopTasks are executed on TiKV cluster consist of multiple instances,
-	// so coprocessors' addresses must be taken into account.
-	// And Sometimes, several cop tasks of one operator can be executed in a same TiKV instance,
-	// which depend on how we split cop tasks and the distribution of data regions.
-	// So we have to use a list to maintain all tasks executed on each instance.
+	// stats stores the runtime statistics of coprocessor tasks.
+	// The key of the map is the tikv-server address. Because a tikv-server can
+	// have many region leaders, several coprocessor tasks can be sent to the
+	// same tikv-server instance. We have to use a list to maintain all tasks
+	// executed on each instance.
 	stats map[string][]*RuntimeStats
 }
 
@@ -146,6 +146,10 @@ func (crs *CopRuntimeStats) String() string {
 			totalIters += stat.loop
 			totalTasks++
 		}
+	}
+
+	if totalTasks == 1 {
+		return fmt.Sprintf("time:%v, loops:%d, rows:%d", procTimes[0], totalIters, totalRows)
 	}
 
 	n := len(procTimes)

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -15,12 +15,13 @@ package execdetails
 
 import (
 	"fmt"
-	"github.com/pingcap/tipb/go-tipb"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 // CommitDetailCtxKey presents CommitDetail info key in context.
@@ -193,7 +194,7 @@ func (e *RuntimeStatsColl) GetRootStats(planID string) *RuntimeStats {
 	return runtimeStats
 }
 
-// GetCopStats gets the CopRuntimeStats specified by planID
+// GetCopStats gets the CopRuntimeStats specified by planID.
 func (e *RuntimeStatsColl) GetCopStats(planID string) *CopRuntimeStats {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -117,8 +117,8 @@ type RuntimeStatsColl struct {
 	// Usually, CopTasks are executed on TiKV cluster consist of multiple instances,
 	// so coprocessors' addresses must be taken into account.
 	// And Sometimes, several cop tasks of one operator can be executed in a same TiKV instance,
-	// which depend on how we split the cop tasks and the distribution of data regions.
-	// So we have to use a list to maintain all tasks executed on the instance.
+	// which depend on how we split cop tasks and the distribution of data regions.
+	// So we have to use a list to maintain all tasks executed on each instance.
 	// Then the type is map[operator ID]map[TiKV instance address][all tasks executed on this instance].
 	copStats map[string]map[string][]*CopRuntimeStats
 }

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -185,10 +185,10 @@ func (e *RuntimeStatsColl) CopSummary(planID string) string {
 		return ""
 	}
 	var totalRows, totalIters, totalTasks uint64
-	procTimes := make([]uint64, 0, 32)
+	procTimes := make([]time.Duration, 0, 32)
 	for _, instanceStats := range stats {
 		for _, stat := range instanceStats {
-			procTimes = append(procTimes, stat.timeProcessedNs)
+			procTimes = append(procTimes, time.Duration(stat.timeProcessedNs)*time.Nanosecond)
 			totalRows += stat.numProducedRows
 			totalIters += stat.numIterations
 			totalTasks++
@@ -197,7 +197,7 @@ func (e *RuntimeStatsColl) CopSummary(planID string) string {
 
 	n := len(procTimes)
 	sort.Slice(procTimes, func(i, j int) bool { return procTimes[i] < procTimes[j] })
-	return fmt.Sprintf("procNs max:%v, min:%v, p80:%v, p95:%v, rows:%v, iters:%v, tasks:%v",
+	return fmt.Sprintf("proc max:%v, min:%v, p80:%v, p95:%v, rows:%v, iters:%v, tasks:%v",
 		procTimes[n-1], procTimes[0], procTimes[n*4/5], procTimes[n*19/20], totalRows, totalIters, totalTasks)
 }
 

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -111,16 +111,19 @@ func (d ExecDetails) String() string {
 	return strings.Join(parts, " ")
 }
 
-// Usually, CopTasks are executed on TiKV cluster consist of multiple instances,
-// so coprocessors' addresses must be taken into account.
-// And Sometimes, several cop tasks of one operator can be executed in a same TiKV instance,
-// which depend on how we split cop tasks and the distribution of data regions.
-// So we have to use a list to maintain all tasks executed on each instance.
+// CopRuntimeStats collects cop tasks' execution info.
 type CopRuntimeStats struct {
 	sync.Mutex
+
+	// Usually, CopTasks are executed on TiKV cluster consist of multiple instances,
+	// so coprocessors' addresses must be taken into account.
+	// And Sometimes, several cop tasks of one operator can be executed in a same TiKV instance,
+	// which depend on how we split cop tasks and the distribution of data regions.
+	// So we have to use a list to maintain all tasks executed on each instance.
 	stats map[string][]*RuntimeStats
 }
 
+// RecordOneCopTask records a specific cop tasks's execution detail.
 func (crs *CopRuntimeStats) RecordOneCopTask(address string, summary *tipb.ExecutorExecutionSummary) {
 	crs.Lock()
 	defer crs.Unlock()
@@ -163,6 +166,7 @@ func (e *RuntimeStatsColl) GetRootStats(planID string) *RuntimeStats {
 	return runtimeStats
 }
 
+// GetCopStats gets the CopRuntimeStats specified by planID
 func (e *RuntimeStatsColl) GetCopStats(planID string) *CopRuntimeStats {
 	e.mu.Lock()
 	defer e.mu.Unlock()

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -205,14 +205,6 @@ func (e *CopRuntimeStats) Record(timeProcessedNs, numProducedRows, numIterations
 	e.numIterations += numIterations
 }
 
-func (e *CopRuntimeStats) String() string {
-	if e == nil {
-		return ""
-	}
-	// TODO(zhangyuanjia)
-	return ""
-}
-
 // Record records executor's execution.
 func (e *RuntimeStats) Record(d time.Duration, rowNum int) {
 	atomic.AddInt32(&e.loop, 1)

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -197,7 +197,7 @@ func (e *RuntimeStatsColl) CopSummary(planID string) string {
 
 	n := len(procTimes)
 	sort.Slice(procTimes, func(i, j int) bool { return procTimes[i] < procTimes[j] })
-	return fmt.Sprintf("procNs max:%v, min:%v, p80:%v, p95:%v, numRows:%v, numIters:%v, numTasks:%v",
+	return fmt.Sprintf("procNs max:%v, min:%v, p80:%v, p95:%v, rows:%v, iters:%v, tasks:%v",
 		procTimes[n-1], procTimes[0], procTimes[n*4/5], procTimes[n*19/20], totalRows, totalIters, totalTasks)
 }
 

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -113,7 +113,7 @@ func (d ExecDetails) String() string {
 type RuntimeStatsColl struct {
 	mu    sync.Mutex
 	stats map[string]*RuntimeStats
-	// Usually, CopTasks are executed on TiKV cluster consist of multiple instance,
+	// Usually, CopTasks are executed on TiKV cluster consist of multiple instances,
 	// So coprocessors' addresses must be taken into account.
 	// Then the first key is executor's planID and the second is coprocessor's address.
 	copStats map[string]map[string]*CopRuntimeStats
@@ -162,7 +162,7 @@ func (e *RuntimeStatsColl) GetCop(planID, address string) *CopRuntimeStats {
 	defer e.mu.Unlock()
 	stats, ok := e.copStats[planID]
 	if !ok {
-		stats = make(map[string]*CopRuntimeStats, 5)
+		stats = make(map[string]*CopRuntimeStats, 8)
 		e.copStats[planID] = stats
 	}
 	stat, ok := stats[address]

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -55,10 +55,10 @@ func TestCopRuntimeStats(t *testing.T) {
 	stats.RecordOneCopTask("table_scan", "8.8.8.9", 2, 2, 2)
 	stats.RecordOneCopTask("agg", "8.8.8.8", 3, 3, 3)
 	stats.RecordOneCopTask("agg", "8.8.8.9", 4, 4, 4)
-	if stats.CopSummary("table_scan") != "procNs max:2, min:1, p80:2, p95:2, numRows:3, numIters:3, numTasks:2" {
+	if stats.CopSummary("table_scan") != "procNs max:2, min:1, p80:2, p95:2, rows:3, iters:3, tasks:2" {
 		t.Fatal("table_scan")
 	}
-	if stats.CopSummary("agg") != "procNs max:4, min:3, p80:4, p95:4, numRows:7, numIters:7, numTasks:2" {
+	if stats.CopSummary("agg") != "procNs max:4, min:3, p80:4, p95:4, rows:7, iters:7, tasks:2" {
 		t.Fatal("agg")
 	}
 }

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -48,3 +48,17 @@ func TestString(t *testing.T) {
 		t.Errorf("got:\n%s\nexpected:\n", str)
 	}
 }
+
+func TestCopRuntimeStats(t *testing.T) {
+	stats := NewRuntimeStatsColl()
+	stats.GetCop("table_scan", "8.8.8.8").Record(1, 1, 1)
+	stats.GetCop("table_scan", "8.8.8.9").Record(2, 2, 2)
+	stats.GetCop("agg", "8.8.8.8").Record(3, 3, 3)
+	stats.GetCop("agg", "8.8.8.9").Record(4, 4, 4)
+	if stats.CopSummary("table_scan") != "max proc ns:2, total rows:3, total iters:3" {
+		t.Fatal("table_scan")
+	}
+	if stats.CopSummary("agg") != "max proc ns:4, total rows:7, total iters:7" {
+		t.Fatal("agg")
+	}
+}

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -14,6 +14,7 @@
 package execdetails
 
 import (
+	"github.com/pingcap/tipb/go-tipb"
 	"testing"
 	"time"
 )
@@ -49,12 +50,16 @@ func TestString(t *testing.T) {
 	}
 }
 
+func mockExecutorExecutionSummary(TimeProcessedNs, NumProducedRows, NumIterations uint64) *tipb.ExecutorExecutionSummary {
+	return &tipb.ExecutorExecutionSummary{&TimeProcessedNs, &NumProducedRows, &NumIterations, nil}
+}
+
 func TestCopRuntimeStats(t *testing.T) {
 	stats := NewRuntimeStatsColl()
-	stats.RecordOneCopTask("table_scan", "8.8.8.8", 1, 1, 1)
-	stats.RecordOneCopTask("table_scan", "8.8.8.9", 2, 2, 2)
-	stats.RecordOneCopTask("agg", "8.8.8.8", 3, 3, 3)
-	stats.RecordOneCopTask("agg", "8.8.8.9", 4, 4, 4)
+	stats.RecordOneCopTask("table_scan", "8.8.8.8", mockExecutorExecutionSummary(1, 1, 1))
+	stats.RecordOneCopTask("table_scan", "8.8.8.9", mockExecutorExecutionSummary(2, 2, 2))
+	stats.RecordOneCopTask("agg", "8.8.8.8", mockExecutorExecutionSummary(3, 3, 3))
+	stats.RecordOneCopTask("agg", "8.8.8.9", mockExecutorExecutionSummary(4, 4, 4))
 	if stats.CopSummary("table_scan") != "proc max:2ns, min:1ns, p80:2ns, p95:2ns, rows:3, iters:3, tasks:2" {
 		t.Fatal("table_scan")
 	}

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -14,9 +14,10 @@
 package execdetails
 
 import (
-	"github.com/pingcap/tipb/go-tipb"
 	"testing"
 	"time"
+
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 func TestString(t *testing.T) {

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -55,10 +55,10 @@ func TestCopRuntimeStats(t *testing.T) {
 	stats.RecordOneCopTask("table_scan", "8.8.8.9", 2, 2, 2)
 	stats.RecordOneCopTask("agg", "8.8.8.8", 3, 3, 3)
 	stats.RecordOneCopTask("agg", "8.8.8.9", 4, 4, 4)
-	if stats.CopSummary("table_scan") != "procNs max:2, min:1, p80:2, p95:2, rows:3, iters:3, tasks:2" {
+	if stats.CopSummary("table_scan") != "proc max:2ns, min:1ns, p80:2ns, p95:2ns, rows:3, iters:3, tasks:2" {
 		t.Fatal("table_scan")
 	}
-	if stats.CopSummary("agg") != "procNs max:4, min:3, p80:4, p95:4, rows:7, iters:7, tasks:2" {
+	if stats.CopSummary("agg") != "proc max:4ns, min:3ns, p80:4ns, p95:4ns, rows:7, iters:7, tasks:2" {
 		t.Fatal("agg")
 	}
 }

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -14,6 +14,7 @@
 package execdetails
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -51,14 +52,16 @@ func TestString(t *testing.T) {
 
 func TestCopRuntimeStats(t *testing.T) {
 	stats := NewRuntimeStatsColl()
-	stats.GetCop("table_scan", "8.8.8.8").Record(1, 1, 1)
-	stats.GetCop("table_scan", "8.8.8.9").Record(2, 2, 2)
-	stats.GetCop("agg", "8.8.8.8").Record(3, 3, 3)
-	stats.GetCop("agg", "8.8.8.9").Record(4, 4, 4)
-	if stats.CopSummary("table_scan") != "max proc ns:2, total rows:3, total iters:3" {
+	stats.RecordOneCopTask("table_scan", "8.8.8.8", 1, 1, 1)
+	stats.RecordOneCopTask("table_scan", "8.8.8.9", 2, 2, 2)
+	stats.RecordOneCopTask("agg", "8.8.8.8", 3, 3, 3)
+	stats.RecordOneCopTask("agg", "8.8.8.9", 4, 4, 4)
+	fmt.Println(stats.CopSummary("table_scan"))
+	fmt.Println(stats.CopSummary("agg"))
+	if stats.CopSummary("table_scan") != "procNs max:2, min:1, p80:2, p95:2, numRows:3, numIters:3, numTasks:2" {
 		t.Fatal("table_scan")
 	}
-	if stats.CopSummary("agg") != "max proc ns:4, total rows:7, total iters:7" {
+	if stats.CopSummary("agg") != "procNs max:4, min:3, p80:4, p95:4, numRows:7, numIters:7, numTasks:2" {
 		t.Fatal("agg")
 	}
 }

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -60,10 +60,13 @@ func TestCopRuntimeStats(t *testing.T) {
 	stats.RecordOneCopTask("table_scan", "8.8.8.9", mockExecutorExecutionSummary(2, 2, 2))
 	stats.RecordOneCopTask("agg", "8.8.8.8", mockExecutorExecutionSummary(3, 3, 3))
 	stats.RecordOneCopTask("agg", "8.8.8.9", mockExecutorExecutionSummary(4, 4, 4))
-	if stats.CopSummary("table_scan") != "proc max:2ns, min:1ns, p80:2ns, p95:2ns, rows:3, iters:3, tasks:2" {
+	if stats.ExistsCopStats("table_scan") != true {
+		t.Fatal("exist")
+	}
+	if stats.GetCopStats("table_scan").String() != "proc max:2ns, min:1ns, p80:2ns, p95:2ns, rows:3, iters:3, tasks:2" {
 		t.Fatal("table_scan")
 	}
-	if stats.CopSummary("agg") != "proc max:4ns, min:3ns, p80:4ns, p95:4ns, rows:7, iters:7, tasks:2" {
+	if stats.GetCopStats("agg").String() != "proc max:4ns, min:3ns, p80:4ns, p95:4ns, rows:7, iters:7, tasks:2" {
 		t.Fatal("agg")
 	}
 }

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -14,7 +14,6 @@
 package execdetails
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -56,8 +55,6 @@ func TestCopRuntimeStats(t *testing.T) {
 	stats.RecordOneCopTask("table_scan", "8.8.8.9", 2, 2, 2)
 	stats.RecordOneCopTask("agg", "8.8.8.8", 3, 3, 3)
 	stats.RecordOneCopTask("agg", "8.8.8.9", 4, 4, 4)
-	fmt.Println(stats.CopSummary("table_scan"))
-	fmt.Println(stats.CopSummary("agg"))
 	if stats.CopSummary("table_scan") != "procNs max:2, min:1, p80:2, p95:2, numRows:3, numIters:3, numTasks:2" {
 		t.Fatal("table_scan")
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
SQL `explain analyze` can get execution information from TiKV(#8881).

### What is changed and how it works?
1. Update execution protocol (tipb) with TiKV to get its execution information.
2. Add `CopRuntimeStats` into `RuntimeStatsColl` to help to collect cop task execution information.
3. Modify `copIterator` and `RegionRequestSender` to set RPC callee address into `ExecDetails`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes
