### PR TITLE
store/tikv/scan: Cut the scan range by region before sending request to TiKV

### DIFF
--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -91,11 +91,13 @@ func (s *testScanSuite) TestScan(c *C) {
 		c.Assert(err, IsNil)
 
 		if rowNum > 123 {
-			s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 123)))
+			err = s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 123)))
+			c.Assert(err, IsNil)
 		}
 
 		if rowNum > 456 {
-			s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 456)))
+			err = s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 456)))
+			c.Assert(err, IsNil)
 		}
 
 		txn2 := s.beginTxn(c)

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -35,7 +35,7 @@ func (s *testScanSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
-	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1)
+	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1, scanBatchSize*3)
 }
 
 func (s *testScanSuite) TearDownSuite(c *C) {
@@ -89,6 +89,14 @@ func (s *testScanSuite) TestScan(c *C) {
 		}
 		err := txn.Commit(context.Background())
 		c.Assert(err, IsNil)
+
+		if rowNum > 123 {
+			s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 123)))
+		}
+
+		if rowNum > 456 {
+			s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 456)))
+		}
 
 		txn2 := s.beginTxn(c)
 		val, err := txn2.Get(encodeKey(s.prefix, s08d("key", 0)))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR cuts the scan range by region before sending request to TiKV, so TiKV's new request range check won't fail.

### What is changed and how it works?

This PR cuts the scan range by region before sending request to TiKV

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - None

Side effects

 - Possible performance regression

Related changes

 - None
