### PR TITLE
types: support str_to_date ms

### DIFF
--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1255,7 +1255,7 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		Date    string
 		Format  string
 		Success bool
-		Expect  time.Time
+		Expect  types.Time
 	}{
 		{"10/28/2011 9:46:29 pm", "%m/%d/%Y %l:%i:%s %p", true, time.Date(2011, 10, 28, 21, 46, 29, 0, time.Local)},
 		{"10/28/2011 9:46:29 Pm", "%m/%d/%Y %l:%i:%s %p", true, time.Date(2011, 10, 28, 21, 46, 29, 0, time.Local)},
@@ -1264,6 +1264,9 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		{"2016 11 22 16 50 22", `%Y%m%d%H%i%s`, true, time.Date(2016, 11, 22, 16, 50, 22, 0, time.Local)},
 		{"16-50-22 2016 11 22", `%H-%i-%s%Y%m%d`, true, time.Date(2016, 11, 22, 16, 50, 22, 0, time.Local)},
 		{"16-50 2016 11 22", `%H-%i-%s%Y%m%d`, false, time.Time{}},
+		{"16-50-22-01 2016 11 22", `%H-%i-%s-%f%Y%m%d`, true, time.Date(2016, 11, 22, 16, 50, 22, 1, time.Local)},
+		{"16-50-22-123 2016 11 22", `%H-%i-%s-%f%Y%m%d`, true, time.Date(2016, 11, 22, 16, 50, 22, 123, time.Local)},
+		{"16-50-22-123456 2016 11 22", `%H-%i-%s-%f%Y%m%d`, true, time.Date(2016, 11, 22, 16, 50, 22, 123456, time.Local)},
 		{"15-01-2001 1:59:58.999", "%d-%m-%Y %I:%i:%s.%f", true, time.Date(2001, 1, 15, 1, 59, 58, 999000000, time.Local)},
 		{"15-01-2001 1:59:58.1", "%d-%m-%Y %H:%i:%s.%f", true, time.Date(2001, 1, 15, 1, 59, 58, 100000000, time.Local)},
 		{"15-01-2001 1:59:58.", "%d-%m-%Y %H:%i:%s.%f", true, time.Date(2001, 1, 15, 1, 59, 58, 000000000, time.Local)},
@@ -1288,8 +1291,7 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		}
 		c.Assert(result.Kind(), Equals, types.KindMysqlTime)
 		value := result.GetMysqlTime()
-		t1, _ := value.Time.GoTime(time.Local)
-		c.Assert(t1, Equals, test.Expect)
+		c.Assert(value, Equals, test.Expect)
 	}
 }
 

--- a/types/time.go
+++ b/types/time.go
@@ -2458,6 +2458,9 @@ func isAMOrPM(t *MysqlTime, input string, ctx map[string]int) (string, bool) {
 // digitRegex: it was used to scan a variable-length monthly day or month in the string. Ex:  "01" or "1" or "30"
 var oneOrTwoDigitRegex = regexp.MustCompile("^[0-9]{1,2}")
 
+// digitRegex: it was used to scan a variable-length microSeconds in the string. Ex:  "1" or "01" or "001" or "0001" or "10001" or "100100"
+var oneToSixDigitRegex = regexp.MustCompile("^[0-9]{1,6}")
+
 // twoDigitRegex: it was just for two digit number string. Ex: "01" or "12"
 var twoDigitRegex = regexp.MustCompile("^[1-9][0-9]?")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make `str_to_date` ms work (fix #9039 ). 

### What is changed and how it works?

Add a new regex `oneToSixDigitRegex` to scan a variable-length microSeconds.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test