### PR TITLE
tidb/store/mockstore: export mock tikv

### DIFF
--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -110,3 +110,16 @@ func NewMockTikvStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 
 	return tikv.NewTestTiKVStore(client, pdClient, opt.clientHijack, opt.pdClientHijack, opt.txnLocalLatches)
 }
+
+// NewRawKVClient creates a mocked tikv raw client with mvccStore
+func NewRawKVClient(mvccStore mocktikv.MVCCStore) *tikv.RawKVClient {
+	cluster := mocktikv.NewCluster()
+	pdClient := mocktikv.NewPDClient(cluster)
+
+	return tikv.NewRawKVClientWithClients(
+		0,
+		tikv.NewRegionCache(pdClient),
+		pdClient,
+		mocktikv.NewRPCClient(cluster, mvccStore),
+	)
+}

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -67,6 +67,16 @@ func NewRawKVClient(pdAddrs []string, security config.Security) (*RawKVClient, e
 	}, nil
 }
 
+// NewRawKVClientWithClients creates a client with custom pd/rpc client
+func NewRawKVClientWithClients(clusterID uint64, regionCache *RegionCache, pdClient pd.Client, rpcClient Client) *RawKVClient {
+	return &RawKVClient{
+		clusterID:   clusterID,
+		regionCache: regionCache,
+		pdClient:    pdClient,
+		rpcClient:   rpcClient,
+	}
+}
+
 // Close closes the client.
 func (c *RawKVClient) Close() error {
 	c.pdClient.Close()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

mocktikv is useful for testing tidb. Likewise, mock will also help the test on other projects using TiKV. Currently it is impossible to use mock from outside, as custom clients can not be set in RawKVClient. 
This PR solves it.

### What is changed and how it works?

add new utility functions

```go
mvccStore := mocktikv.MustNewMVCCStore()
defer mvccStore.Close()

rawClient := NewRawKVClient(mvccStore)
res := rawClient.Get([]byte{123})
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - none

Side effects

 - none

Related changes

 - none
