### PR TITLE
planner: set correct mysql error code

### DIFF
--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -62,6 +62,8 @@ const (
 	codeWindowDuplicateName             = mysql.ErrWindowDuplicateName
 	codeErrTooBigPrecision              = mysql.ErrTooBigPrecision
 	codePartitionClauseOnNonpartitioned = mysql.ErrPartitionClauseOnNonpartitioned
+	codeTableaccessDenied               = mysql.ErrTableaccessDenied
+	codeSpecificAccessDenied            = mysql.ErrSpecificAccessDenied
 )
 
 // error definitions.
@@ -110,6 +112,8 @@ var (
 	ErrWindowDuplicateName             = terror.ClassOptimizer.New(codeWindowDuplicateName, mysql.MySQLErrName[mysql.ErrWindowDuplicateName])
 	ErrPartitionClauseOnNonpartitioned = terror.ClassOptimizer.New(codePartitionClauseOnNonpartitioned, mysql.MySQLErrName[mysql.ErrPartitionClauseOnNonpartitioned])
 	errTooBigPrecision                 = terror.ClassExpression.New(mysql.ErrTooBigPrecision, mysql.MySQLErrName[mysql.ErrTooBigPrecision])
+	ErrTableaccessDenied               = terror.ClassOptimizer.New(mysql.ErrTableaccessDenied, mysql.MySQLErrName[mysql.ErrTableaccessDenied])
+	ErrSpecificAccessDenied            = terror.ClassOptimizer.New(mysql.ErrSpecificAccessDenied, mysql.MySQLErrName[mysql.ErrSpecificAccessDenied])
 )
 
 func init() {
@@ -148,6 +152,8 @@ func init() {
 		codeWindowDuplicateName:             mysql.ErrWindowDuplicateName,
 		codePartitionClauseOnNonpartitioned: mysql.ErrPartitionClauseOnNonpartitioned,
 		codeErrTooBigPrecision:              mysql.ErrTooBigPrecision,
+		codeTableaccessDenied:               mysql.ErrTableaccessDenied,
+		codeSpecificAccessDenied:            mysql.ErrSpecificAccessDenied,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassOptimizer] = mysqlErrCodeMap
 }

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -324,7 +324,6 @@ func (s *testPrivilegeSuite) TestUseDb(c *C) {
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "usenobody", Hostname: "localhost", AuthUsername: "usenobody", AuthHostname: "%"}, nil, nil), IsTrue)
 	_, err = se.Execute(context.Background(), "use mysql")
 	c.Assert(err, IsNil)
-
 }
 
 func (s *testPrivilegeSuite) TestSetGlobal(c *C) {
@@ -339,7 +338,6 @@ func (s *testPrivilegeSuite) TestSetGlobal(c *C) {
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "setglobal_b", Hostname: "localhost"}, nil, nil), IsTrue)
 	_, err := se.Execute(context.Background(), `set global innodb_commit_concurrency=16`)
 	c.Assert(terror.ErrorEqual(err, core.ErrSpecificAccessDenied), IsTrue)
-
 }
 
 func (s *testPrivilegeSuite) TestAnalyzeTable(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This partially addresses #8946 

### What is changed and how it works?

The error codes for `SET GLOBAL` and `ANALYZE TABLE` are made correct.

There is one small incompatibility remaining, which is that if a user lacks both `INSERT` AND `SELECT` privileges on a table, MySQL will say in the error message `INSERT, SELECT` whereas TiDB will just show the `INSERT` privilege as missing.  This is a limitation of how privilege checks are done in `visitInfo`.. it might have to support the ability to merge these checks.  In any case, at least the code is correct so I do not currently have plans to address.

I also used the string "SUPER" even though there is a map Col2PrivType in `parser/mysql/const.go`.  The MySQL behavior is to use upper case, but in TiDB these are defined in lower.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Change in error codes only

Side effects

 - Increased code complexity
 - Breaking backward compatibility (for broken apps)

Related changes

 - Need to be included in the release note
