### PR TITLE
ddl: make the leak test stable

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 )
 
@@ -42,7 +41,6 @@ type testColumnChangeSuite struct {
 }
 
 func (s *testColumnChangeSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	WaitTimeWhenErrorOccured = 1 * time.Microsecond
 	s.store = testCreateStore(c, "test_column_change")
 	s.dbInfo = &model.DBInfo{
@@ -58,7 +56,6 @@ func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 
 func (s *testColumnChangeSuite) TearDownSuite(c *C) {
 	s.store.Close()
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testColumnChangeSuite) TestColumnChange(c *C) {

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testColumnSuite{})
@@ -44,7 +43,6 @@ type testColumnSuite struct {
 }
 
 func (s *testColumnSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_column")
 	s.d = testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 
@@ -58,7 +56,6 @@ func (s *testColumnSuite) TearDownSuite(c *C) {
 
 	err := s.store.Close()
 	c.Assert(err, IsNil)
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func buildCreateColumnJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, colName string,

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,7 +52,6 @@ type testStateChangeSuite struct {
 }
 
 func (s *testStateChangeSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.lease = 200 * time.Millisecond
 	ddl.WaitTimeWhenErrorOccured = 1 * time.Microsecond
 	var err error
@@ -76,7 +74,6 @@ func (s *testStateChangeSuite) TearDownSuite(c *C) {
 	s.se.Close()
 	s.dom.Close()
 	s.store.Close()
-	testleak.AfterTest(c, ddl.TestLeakCheckCnt)()
 }
 
 // TestShowCreateTable tests the result of "show create table" when we are running "add index" or "add column".

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testIntegrationSuite{})
@@ -68,7 +67,6 @@ func (s *testIntegrationSuite) TearDownTest(c *C) {
 
 func (s *testIntegrationSuite) SetUpSuite(c *C) {
 	var err error
-	testleak.BeforeTest()
 	s.lease = 50 * time.Millisecond
 
 	s.cluster = mocktikv.NewCluster()
@@ -95,7 +93,6 @@ func (s *testIntegrationSuite) SetUpSuite(c *C) {
 func (s *testIntegrationSuite) TearDownSuite(c *C) {
 	s.dom.Close()
 	s.store.Close()
-	testleak.AfterTest(c, ddl.TestLeakCheckCnt)()
 }
 
 func (s *testIntegrationSuite) TestNoZeroDateMode(c *C) {

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -49,7 +49,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/schemautil"
 	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 	"github.com/pingcap/tidb/util/testutil"
 )
 
@@ -78,7 +77,6 @@ type testDBSuite struct {
 
 func (s *testDBSuite) SetUpSuite(c *C) {
 	var err error
-	testleak.BeforeTest()
 
 	s.lease = 200 * time.Millisecond
 	session.SetSchemaLease(s.lease)
@@ -112,7 +110,6 @@ func (s *testDBSuite) TearDownSuite(c *C) {
 	s.s.Close()
 	s.dom.Close()
 	s.store.Close()
-	testleak.AfterTest(c, ddl.TestLeakCheckCnt)()
 }
 
 func (s *testDBSuite) testErrorCode(c *C, sql string, errCode int) {

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testDDLSuite{})
@@ -41,7 +40,6 @@ type testDDLSuite struct{}
 const testLease = 5 * time.Millisecond
 
 func (s *testDDLSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	WaitTimeWhenErrorOccured = 1 * time.Microsecond
 
 	// We hope that this test is serially executed. So put it here.
@@ -49,7 +47,6 @@ func (s *testDDLSuite) SetUpSuite(c *C) {
 }
 
 func (s *testDDLSuite) TearDownSuite(c *C) {
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testDDLSuite) TestCheckOwner(c *C) {

--- a/ddl/failtest/fail_db_test.go
+++ b/ddl/failtest/fail_db_test.go
@@ -48,7 +48,12 @@ func TestT(t *testing.T) {
 		Level:  logLevel,
 		Format: "highlight",
 	})
+	testleak.BeforeTest()
 	TestingT(t)
+	errorFunc := func(cnt int, g string) {
+		t.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
+	}
+	testleak.AfterTestT(errorFunc)()
 }
 
 var _ = Suite(&testFailDBSuite{})
@@ -64,7 +69,6 @@ type testFailDBSuite struct {
 }
 
 func (s *testFailDBSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.lease = 200 * time.Millisecond
 	ddl.WaitTimeWhenErrorOccured = 1 * time.Microsecond
 	var err error
@@ -90,7 +94,6 @@ func (s *testFailDBSuite) TearDownSuite(c *C) {
 	s.se.Close()
 	s.dom.Close()
 	s.store.Close()
-	testleak.AfterTest(c)()
 }
 
 // TestHalfwayCancelOperations tests the case that the schema is correct after the execution of operations are cancelled halfway.

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testForeighKeySuite{})
@@ -38,14 +37,12 @@ type testForeighKeySuite struct {
 }
 
 func (s *testForeighKeySuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_foreign")
 }
 
 func (s *testForeighKeySuite) TearDownSuite(c *C) {
 	err := s.store.Close()
 	c.Assert(err, IsNil)
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testForeighKeySuite) testCreateForeignKey(c *C, tblInfo *model.TableInfo, fkName string, keys []string, refTable string, refKeys []string, onDelete ast.ReferOptionType, onUpdate ast.ReferOptionType) *model.Job {

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testIndexChangeSuite{})
@@ -36,7 +35,6 @@ type testIndexChangeSuite struct {
 }
 
 func (s *testIndexChangeSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_index_change")
 	s.dbInfo = &model.DBInfo{
 		Name: model.NewCIStr("test_index_change"),
@@ -51,7 +49,6 @@ func (s *testIndexChangeSuite) SetUpSuite(c *C) {
 
 func (s *testIndexChangeSuite) TearDownSuite(c *C) {
 	s.store.Close()
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testIndexChangeSuite) TestIndexChange(c *C) {

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testSchemaSuite{})
@@ -34,11 +33,9 @@ var _ = Suite(&testSchemaSuite{})
 type testSchemaSuite struct{}
 
 func (s *testSchemaSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 }
 
 func (s *testSchemaSuite) TearDownSuite(c *C) {
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func testSchemaInfo(c *C, d *ddl, name string) *model.DBInfo {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = SerialSuites(&testSerialSuite{})
@@ -44,7 +43,6 @@ type testSerialSuite struct {
 }
 
 func (s *testSerialSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	session.SetSchemaLease(200 * time.Millisecond)
 	session.SetStatsLease(0)
 
@@ -64,7 +62,6 @@ func (s *testSerialSuite) TearDownSuite(c *C) {
 	if s.store != nil {
 		s.store.Close()
 	}
-	testleak.AfterTest(c)()
 }
 
 // TestCancelAddIndex1 tests canceling ddl job when the add index worker is not started.

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testStatSuite{})
@@ -29,11 +28,9 @@ type testStatSuite struct {
 }
 
 func (s *testStatSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 }
 
 func (s *testStatSuite) TearDownSuite(c *C) {
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testStatSuite) getDDLSchemaVer(c *C, d *ddl) int64 {

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 var _ = Suite(&testTableSuite{})
@@ -245,7 +244,6 @@ func testGetTableWithError(d *ddl, schemaID, tableID int64) (table.Table, error)
 }
 
 func (s *testTableSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	s.store = testCreateStore(c, "test_table")
 	s.d = testNewDDL(context.Background(), nil, s.store, nil, nil, testLease)
 
@@ -257,7 +255,6 @@ func (s *testTableSuite) TearDownSuite(c *C) {
 	testDropSchema(c, testNewContext(s.d), s.d, s.dbInfo)
 	s.d.Stop()
 	s.store.Close()
-	testleak.AfterTest(c, TestLeakCheckCnt)()
 }
 
 func (s *testTableSuite) TestTable(c *C) {

--- a/util/testleak/fake.go
+++ b/util/testleak/fake.go
@@ -25,3 +25,9 @@ func AfterTest(c *check.C, checkCnt ...int) func() {
 	return func() {
 	}
 }
+
+// AfterTestT is used after all the test cases is finished.
+func AfterTestT(errorFunc func(cnt int, g string)) func() {
+	return func() {
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix leak in ddl test:

```
----------------------------------------------------------------------
FAIL: index_change_test.go:52: testIndexChangeSuite.TearDownSuite
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testColumnChangeSuite).TearDownSuite(0xc0003589c0, 0xc0003a80f0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/column_change_test.go:61 +0x73
reflect.Value.call(0x1b9f300, 0xc0003589c0, 0x613, 0x1c98b42, 0x4, 0xc0001cff70, 0x1, 0x1, 0xc000e48040, 0x4e99b8ed, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1b9f300, 0xc0003589c0, 0x613, 0xc004882f70, 0x1, 0x1, 0x1bd60c0, 0xc004882f58, 0xc004882f88)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc0003a80f0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc00036a180, 0xc0003a80f0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testColumnSuite).TearDownSuite(0xc0003589e0, 0xc004a8d3b0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/column_test.go:61 +0x10a
reflect.Value.call(0x1c2c840, 0xc0003589e0, 0x613, 0x1c98b42, 0x4, 0xc0000b3f70, 0x1, 0x1, 0xc00311fd40, 0x95cbbb1b, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1c2c840, 0xc0003589e0, 0x613, 0xc004883770, 0x1, 0x1, 0x1e6ca60, 0xc00003c078, 0xc004883788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc004a8d3b0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc00036af80, 0xc004a8d3b0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testForeighKeySuite).TearDownSuite(0xc00036edb0, 0xc002a16ff0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/foreign_key_test.go:48 +0xc1
reflect.Value.call(0x1b1d4a0, 0xc00036edb0, 0x613, 0x1c98b42, 0x4, 0xc00378ff70, 0x1, 0x1, 0xc001bf36c0, 0x3ba06da0, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1b1d4a0, 0xc00036edb0, 0x613, 0xc004b5f770, 0x1, 0x1, 0xff695f6465ff6b63, 0x726f6d65ff6d5f6e, 0xc004b5f788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc002a16ff0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc000225600, 0xc002a16ff0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testSchemaSuite).TearDownSuite(0x2ef48f8, 0xc0032363c0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/schema_test.go:41 +0x5d
reflect.Value.call(0x1b414e0, 0x2ef48f8, 0x613, 0x1c98b42, 0x4, 0xc0001cdf70, 0x1, 0x1, 0xc002defc80, 0x6f054d6f, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1b414e0, 0x2ef48f8, 0x613, 0xc004883770, 0x1, 0x1, 0xc004883720, 0x2, 0xc004883788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc0032363c0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc000224000, 0xc0032363c0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testStatSuite).TearDownSuite(0x2ef48f8, 0xc002a173b0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/stat_test.go:36 +0x5d
reflect.Value.call(0x1b1f840, 0x2ef48f8, 0x613, 0x1c98b42, 0x4, 0xc0001caf70, 0x1, 0x1, 0xc0012d2d80, 0x3f6bdb0b, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1b1f840, 0x2ef48f8, 0x613, 0xc0004e1770, 0x1, 0x1, 0x0, 0x0, 0xc0004e1788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc002a173b0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc0001d4080, 0xc002a173b0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl.(*testTableSuite).TearDownSuite(0xc000358a40, 0xc0032361e0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/table_test.go:260 +0xc0
reflect.Value.call(0x1b1bb00, 0xc000358a40, 0x613, 0x1c98b42, 0x4, 0xc00378cf70, 0x1, 0x1, 0xc0004ed900, 0x6613ac1a, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1b1bb00, 0xc000358a40, 0x613, 0xc0030fd770, 0x1, 0x1, 0x1bd60c0, 0xc0030fd758, 0xc0030fd788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc0032361e0)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc0001d4200, 0xc0032361e0, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x237
index_change_test.go:54:
    testleak.AfterTest(c, TestLeakCheckCnt)()
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:120:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 1000 appears to have leaked: time.Sleep(0x2faf080)
    /usr/local/go/src/runtime/time.go:105 +0x14f
github.com/pingcap/tidb/util/testleak.AfterTest.func1()
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:113 +0x140
github.com/pingcap/tidb/ddl_test.(*testDBSuite).TearDownSuite(0xc000382150, 0xc0014b6c30)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/db_test.go:115 +0xe5
reflect.Value.call(0x1c891a0, 0xc000382150, 0x613, 0x1c98b42, 0x4, 0xc00378cf70, 0x1, 0x1, 0xc006804b40, 0xaadf57268, ...)
    /usr/local/go/src/reflect/value.go:447 +0x449
reflect.Value.Call(0x1c891a0, 0xc000382150, 0x613, 0xc008797770, 0x1, 0x1, 0x1bd60c0, 0xc008797758, 0xc008797788)
    /usr/local/go/src/reflect/value.go:308 +0xa4
github.com/pingcap/check.(*suiteRunner).runFixture.func1(0xc0014b6c30)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x13a
github.com/pingcap/check.(*suiteRunner).forkCall.func1(0xc002fb2180, 0xc0014b6c30, 0x1d194c8)
    /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0x7c
created by github.com/pingcap/check.(*suiteRunner).forkCall

```


