### PR TITLE
store/tikv/scan: Cut the scan range by region before sending request to TiKV (#9070)

### DIFF
--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -14,6 +14,8 @@
 package tikv
 
 import (
+	"bytes"
+
 	"github.com/pingcap/errors"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
@@ -150,11 +152,17 @@ func (s *Scanner) getData(bo *Backoffer) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		reqEndKey := s.endKey
+		if len(reqEndKey) > 0 && len(loc.EndKey) > 0 && bytes.Compare(loc.EndKey, reqEndKey) < 0 {
+			reqEndKey = loc.EndKey
+		}
+
 		req := &tikvrpc.Request{
 			Type: tikvrpc.CmdScan,
 			Scan: &pb.ScanRequest{
 				StartKey: s.nextStartKey,
-				EndKey:   s.endKey,
+				EndKey:   reqEndKey,
 				Limit:    uint32(s.batchSize),
 				Version:  s.startTS(),
 				KeyOnly:  s.snapshot.keyOnly,

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -35,7 +35,7 @@ func (s *testScanSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
 	s.store = NewTestStore(c).(*tikvStore)
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
-	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1)
+	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1, scanBatchSize*3)
 }
 
 func (s *testScanSuite) TearDownSuite(c *C) {
@@ -89,6 +89,16 @@ func (s *testScanSuite) TestScan(c *C) {
 		}
 		err := txn.Commit(context.Background())
 		c.Assert(err, IsNil)
+
+		if rowNum > 123 {
+			err = s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 123)))
+			c.Assert(err, IsNil)
+		}
+
+		if rowNum > 456 {
+			err = s.store.SplitRegion(encodeKey(s.prefix, s08d("key", 456)))
+			c.Assert(err, IsNil)
+		}
 
 		txn2 := s.beginTxn(c)
 		val, err := txn2.Get(encodeKey(s.prefix, s08d("key", 0)))


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR cherry-picks #9070 to release-2.1 branch. Cuts the scan range by Region before sending request to TiKV, so TiKV's new request range check won't fail.

### What is changed and how it works?

This PR cherry-picks #9070 to release-2.1 branch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - None of those listed

Side effects

 - Possible performance regression

Related changes

 - No