### PR TITLE
expression: handle Float32 for builtin function Values()

### DIFF
--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -554,6 +554,9 @@ func (b *builtinValuesRealSig) evalReal(_ chunk.Row) (float64, bool, error) {
 		if row.IsNull(b.offset) {
 			return 0, true, nil
 		}
+		if b.getRetTp().Tp == mysql.TypeFloat {
+			return float64(row.GetFloat32(b.offset)), false, nil
+		}
 		return row.GetFloat64(b.offset), false, nil
 	}
 	return 0, true, errors.Errorf("Session current insert values len %d and column's offset %v don't match", row.Len(), b.offset)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3872,3 +3872,14 @@ func (s *testIntegrationSuite) TestCastAsTime(c *C) {
 	err = tk.ExecToErr(`select cast(col5 as time(31)) from t where col1 is null;`)
 	c.Assert(err.Error(), Equals, "[expression:1426]Too big precision 31 specified for column 'CAST'. Maximum is 6.")
 }
+
+func (s *testIntegrationSuite) TestValuesFloat32(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t (i int key, j float);`)
+	tk.MustExec(`insert into t values (1, 0.01);`)
+	tk.MustQuery(`select * from t;`).Check(testkit.Rows(`1 0.01`))
+	tk.MustExec(`insert into t values (1, 0.02) on duplicate key update j = values (j);`)
+	tk.MustQuery(`select * from t;`).Check(testkit.Rows(`1 0.02`))
+}


### PR DESCRIPTION
Signed-off-by: Jian Zhang <zjsariel@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix #8934 

### What is changed and how it works?

The builtin function `Values()` should get a floag32 value from the input Chunk when it's output type is `mysql.TypeFloat`.

Only `Column` and `builtinValuesRealSig` call `Chunk.GetFloat64()`. `Column` has handled the float32 input value correctly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
