### PR TITLE
ddl: fix default value precision problem for time types

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -378,7 +378,7 @@ func columnDefToCol(ctx sessionctx.Context, offset int, colDef *ast.ColumnDef, o
 				constraints = append(constraints, constraint)
 				col.Flag |= mysql.UniqueKeyFlag
 			case ast.ColumnOptionDefaultValue:
-				value, err := getDefaultValue(ctx, v, colDef.Tp.Tp, colDef.Tp.Decimal)
+				value, err := getDefaultValue(ctx, v, colDef.Tp)
 				if err != nil {
 					return nil, nil, ErrColumnBadNull.GenWithStack("invalid default value - %s", err)
 				}
@@ -457,7 +457,8 @@ func columnDefToCol(ctx sessionctx.Context, offset int, colDef *ast.ColumnDef, o
 	return col, constraints, nil
 }
 
-func getDefaultValue(ctx sessionctx.Context, c *ast.ColumnOption, tp byte, fsp int) (interface{}, error) {
+func getDefaultValue(ctx sessionctx.Context, c *ast.ColumnOption, t *types.FieldType) (interface{}, error) {
+	tp, fsp := t.Tp, t.Decimal
 	if tp == mysql.TypeTimestamp || tp == mysql.TypeDatetime {
 		vd, err := expression.GetTimeValue(ctx, c.Expr, tp, fsp)
 		value := vd.GetValue()
@@ -497,6 +498,13 @@ func getDefaultValue(ctx sessionctx.Context, c *ast.ColumnOption, tp byte, fsp i
 		}
 		// For other kind of fields (e.g. INT), we supply its integer value so that it acts as integers.
 		return v.GetBinaryLiteral().ToInt(ctx.GetSessionVars().StmtCtx)
+	}
+
+	if tp == mysql.TypeDuration {
+		var err error
+		if v, err = v.ConvertTo(ctx.GetSessionVars().StmtCtx, t); err != nil {
+			return "", errors.Trace(err)
+		}
 	}
 
 	if tp == mysql.TypeBit {
@@ -1934,7 +1942,7 @@ func modifiable(origin *types.FieldType, to *types.FieldType) error {
 }
 
 func setDefaultValue(ctx sessionctx.Context, col *table.Column, option *ast.ColumnOption) error {
-	value, err := getDefaultValue(ctx, option, col.Tp, col.Decimal)
+	value, err := getDefaultValue(ctx, option, &col.FieldType)
 	if err != nil {
 		return ErrColumnBadNull.GenWithStack("invalid default value - %s", err)
 	}
@@ -1963,7 +1971,7 @@ func setDefaultAndComment(ctx sessionctx.Context, col *table.Column, options []*
 	for _, opt := range options {
 		switch opt.Tp {
 		case ast.ColumnOptionDefaultValue:
-			value, err := getDefaultValue(ctx, opt, col.Tp, col.Decimal)
+			value, err := getDefaultValue(ctx, opt, &col.FieldType)
 			if err != nil {
 				return ErrColumnBadNull.GenWithStack("invalid default value - %s", err)
 			}

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -602,12 +602,36 @@ func (s *testSuite3) TestIssue9205(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec(`drop table if exists t;`)
 	tk.MustExec(`create table t(c time DEFAULT '12:12:12.8');`)
-	tk.MustExec(`ALTER TABLE t ADD COLUMN c1 time DEFAULT '12:12:12.000000';`)
+	tk.MustQuery("show create table `t`").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `c` time DEFAULT '12:12:13'\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+	tk.MustExec(`alter table t add column c1 time default '12:12:12.000000';`)
 	tk.MustQuery("show create table `t`").Check(testutil.RowsWithSep("|",
 		""+
 			"t CREATE TABLE `t` (\n"+
 			"  `c` time DEFAULT '12:12:13',\n"+
 			"  `c1` time DEFAULT '12:12:12'\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+
+	tk.MustExec(`alter table t alter column c1 set default '2019-02-01 12:12:10.4';`)
+	tk.MustQuery("show create table `t`").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `c` time DEFAULT '12:12:13',\n"+
+			"  `c1` time DEFAULT '12:12:10'\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
+	))
+
+	tk.MustExec(`alter table t modify c1 time DEFAULT '770:12:12.000000';`)
+	tk.MustQuery("show create table `t`").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `c` time DEFAULT '12:12:13',\n"+
+			"  `c1` time DEFAULT '770:12:12'\n"+
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin",
 	))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve? <!--add issue link with summary if exists-->
As is described in  issue #9205 ,  default value precision is not right for type `time` in TiDB for now.

for example, in TiDB:
```sql

tidb> create table t(c time DEFAULT '12:12:12.8');
Query OK, 0 rows affected (0.01 sec)

tidb> ALTER TABLE t ADD COLUMN c1 time DEFAULT '12:12:12.000000';
Query OK, 0 rows affected (0.01 sec)

tidb> show create table t;
+-------+--------------------------------------------------------------------------------------------------------------------------------------
-----------------+
| Table | Create Table                                                                                                                         
                 |
+-------+--------------------------------------------------------------------------------------------------------------------------------------
-----------------+
| t     | CREATE TABLE `t` (
  `c` time DEFAULT '12:12:12.8',
  `c1` time DEFAULT '12:12:12.000000'
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+--------------------------------------------------------------------------------------------------------------------------------------
-----------------+
1 row in set (0.00 sec)

```

while in MySQL:
```sql
mysql> create table t(c time DEFAULT '12:12:12.8');
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t;
+-------+-----------------------------------------------------------------------------------------+
| Table | Create Table                                                                            |
+-------+-----------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `c` time DEFAULT '12:12:13'
) ENGINE=InnoDB DEFAULT CHARSET=latin1 |
+-------+-----------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> ALTER TABLE t ADD COLUMN c1 time DEFAULT '12:12:12.000000';
Query OK, 0 rows affected (0.04 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> show create table t;
+-------+-------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                            |
+-------+-------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `c` time DEFAULT '12:12:13',
  `c1` time DEFAULT '12:12:12'
) ENGINE=InnoDB DEFAULT CHARSET=latin1 |
+-------+-------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)


```


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects

Related changes
