### PR TITLE
types: fix processing of "0000" value for  `year` type

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -227,12 +227,28 @@ func (s *testSuite3) TestInsertZeroYear(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec(`drop table if exists t1;`)
 	tk.MustExec(`create table t1(a year(4));`)
-	tk.MustExec(`insert into t1 values(0000),(00),("0000"),("00");`)
+	tk.MustExec(`insert into t1 values(0000),(00),("0000"),("000"), ("00"), ("0"), (79), ("79");`)
 	tk.MustQuery(`select * from t1;`).Check(testkit.Rows(
 		`0`,
 		`0`,
+		`0`,
 		`2000`,
 		`2000`,
+		`2000`,
+		`1979`,
+		`1979`,
+	))
+
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t(f_year year NOT NULL DEFAULT '0000')ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`)
+	tk.MustExec(`insert into t values();`)
+	tk.MustQuery(`select * from t;`).Check(testkit.Rows(
+		`0`,
+	))
+	tk.MustExec(`insert into t values('0000');`)
+	tk.MustQuery(`select * from t;`).Check(testkit.Rows(
+		`0`,
+		`0`,
 	))
 }
 

--- a/types/datum.go
+++ b/types/datum.go
@@ -1169,18 +1169,19 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *stmtctx.Statem
 
 func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {
 	var (
-		ret     Datum
-		y       int64
-		err     error
-		fromStr bool
+		ret    Datum
+		y      int64
+		err    error
+		adjust bool
 	)
 	switch d.k {
 	case KindString, KindBytes:
-		y, err = StrToInt(sc, d.GetString())
+		s := d.GetString()
+		y, err = StrToInt(sc, s)
 		if err != nil {
 			return ret, errors.Trace(err)
 		}
-		fromStr = true
+		adjust = len(s) < 4
 	case KindMysqlTime:
 		y = int64(d.GetMysqlTime().Time.Year())
 	case KindMysqlDuration:
@@ -1192,7 +1193,7 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 		}
 		y = ret.GetInt64()
 	}
-	y, err = AdjustYear(y, fromStr)
+	y, err = AdjustYear(y, adjust)
 	if err != nil {
 		return invalidConv(d, target.Tp)
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -791,8 +791,8 @@ func adjustYear(y int) int {
 }
 
 // AdjustYear is used for adjusting year and checking its validation.
-func AdjustYear(y int64, fromStr bool) (int64, error) {
-	if y == 0 && !fromStr {
+func AdjustYear(y int64, shouldAdjust bool) (int64, error) {
+	if y == 0 && !shouldAdjust {
 		return y, nil
 	}
 	y = int64(adjustYear(int(y)))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #9192 .  For the sql below:
```sql
create table t(f_year year NOT NULL DEFAULT '0000')ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
insert into t values();
select * from t;
insert into t values('0000');
select * from t;
```

In MySQL:
```
mysql> create table t(f_year year NOT NULL DEFAULT '0000')ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
Query OK, 0 rows affected (0.03 sec)

mysql> insert into t values();
Query OK, 1 row affected (0.01 sec)

mysql> select * from t;
+--------+
| f_year |
+--------+
|   0000 |
+--------+
1 row in set (0.00 sec)

mysql> insert into t values('0000');
Query OK, 1 row affected (0.01 sec)

mysql> select * from t;
+--------+
| f_year |
+--------+
|   0000 |
|   0000 |
+--------+
2 rows in set (0.00 sec)

```

While in TiDB:
```sql
tidb> create table t(f_year year NOT NULL DEFAULT '0000')ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
Query OK, 0 rows affected (0.01 sec)

tidb> insert into t values();
Query OK, 1 row affected (0.00 sec)

tidb> select * from t;
+--------+
| f_year |
+--------+
|   2000 |
+--------+
1 row in set (0.00 sec)

tidb> insert into t values('0000');
Query OK, 1 row affected (0.00 sec)

tidb> select * from t;
+--------+
| f_year |
+--------+
|   2000 |
|   2000 |
+--------+
2 rows in set (0.01 sec)

```

### What is changed and how it works?

This is a corner case for [#8292](https://github.com/pingcap/tidb/pull/8292). MySQL deal with 3- or 4-digit strings differently.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch
