### PR TITLE
expression: fix a bug in baseFuncDesc.clone()

### DIFF
--- a/expression/aggregation/base_func.go
+++ b/expression/aggregation/base_func.go
@@ -59,6 +59,7 @@ func (a *baseFuncDesc) clone() *baseFuncDesc {
 	clone := *a
 	newTp := *a.RetTp
 	clone.RetTp = &newTp
+	clone.Args = make([]expression.Expression, len(a.Args))
 	for i := range a.Args {
 		clone.Args[i] = a.Args[i].Clone()
 	}

--- a/expression/aggregation/base_func_test.go
+++ b/expression/aggregation/base_func_test.go
@@ -1,0 +1,40 @@
+package aggregation
+
+import (
+	"github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+var _ = check.Suite(&testBaseFuncSuite{})
+
+type testBaseFuncSuite struct {
+	ctx sessionctx.Context
+}
+
+func (s *testBaseFuncSuite) SetUpSuite(c *check.C) {
+	s.ctx = mock.NewContext()
+}
+
+func (s *testBaseFuncSuite) TestClone(c *check.C) {
+	col := &expression.Column{
+		UniqueID: 0,
+		RetType:  types.NewFieldType(mysql.TypeLonglong),
+	}
+	desc := newBaseFuncDesc(s.ctx, ast.AggFuncFirstRow, []expression.Expression{col})
+	cloned := desc.clone()
+	c.Assert(desc.equal(s.ctx, cloned), check.IsTrue)
+
+	col1 := &expression.Column{
+		UniqueID: 1,
+		RetType:  types.NewFieldType(mysql.TypeVarchar),
+	}
+	cloned.Args[0] = col1
+
+	c.Assert(desc.Args[0], check.Equals, col)
+	c.Assert(desc.equal(s.ctx, cloned), check.IsFalse)
+}


### PR DESCRIPTION
### What problem does this PR solve? 
Trivially fix a slice copy bug in `aggreation.baseFuncDesc.clone()`

### What is changed and how it works?
It creates a new slice when cloning the struct

Tests
 - Unit test

Code changes
- No

Side effects
- No

Related changes
- No
