### PR TITLE
executor: add tryToMatchOuters to the joiner interface

### DIFF
--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -246,7 +246,7 @@ func (e *IndexLookUpJoin) Next(ctx context.Context, req *chunk.RecordBatch) erro
 
 		outerRow := task.outerResult.GetRow(task.cursor)
 		if e.innerIter.Current() != e.innerIter.End() {
-			matched, isNull, err := e.joiner.tryToMatch(outerRow, e.innerIter, req.Chunk)
+			matched, isNull, err := e.joiner.tryToMatchInners(outerRow, e.innerIter, req.Chunk)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/executor/join.go
+++ b/executor/join.go
@@ -426,7 +426,7 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 	iter := chunk.NewIterator4Slice(innerRows)
 	hasMatch, hasNull := false, false
 	for iter.Begin(); iter.Current() != iter.End(); {
-		matched, isNull, err := e.joiners[workerID].tryToMatch(outerRow, iter, joinResult.chk)
+		matched, isNull, err := e.joiners[workerID].tryToMatchInners(outerRow, iter, joinResult.chk)
 		if err != nil {
 			joinResult.err = errors.Trace(err)
 			return false, joinResult
@@ -726,7 +726,7 @@ func (e *NestedLoopApplyExec) Next(ctx context.Context, req *chunk.RecordBatch) 
 			e.innerIter.Begin()
 		}
 
-		matched, isNull, err := e.joiner.tryToMatch(*e.outerRow, e.innerIter, req.Chunk)
+		matched, isNull, err := e.joiner.tryToMatchInners(*e.outerRow, e.innerIter, req.Chunk)
 		e.hasMatch = e.hasMatch || matched
 		e.hasNull = e.hasNull || isNull
 

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -197,8 +197,8 @@ type semiJoiner struct {
 	baseJoiner
 }
 
+// tryToMatchInners implements joiner interface.
 func (j *semiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
-
 	if inners.Len() == 0 {
 		return false, false, nil
 	}
@@ -227,8 +227,8 @@ func (j *semiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, ch
 	return false, false, nil
 }
 
+// tryToMatchOuters implements joiner interface.
 func (j *semiJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
-
 	if outers.Len() == 0 {
 		return false, false, nil
 	}
@@ -264,7 +264,7 @@ type antiSemiJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *antiSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -291,7 +291,7 @@ func (j *antiSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator
 	return false, hasNull, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *antiSemiJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if outers.Len() == 0 {
 		return false, false, nil
@@ -328,7 +328,7 @@ type leftOuterSemiJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *leftOuterSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -357,7 +357,7 @@ func (j *leftOuterSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Ite
 	return false, hasNull, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *leftOuterSemiJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if outers.Len() == 0 {
 		return false, false, nil
@@ -404,7 +404,7 @@ type antiLeftOuterSemiJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *antiLeftOuterSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -433,7 +433,7 @@ func (j *antiLeftOuterSemiJoiner) tryToMatchInners(outer chunk.Row, inners chunk
 	return false, hasNull, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *antiLeftOuterSemiJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (matched bool, hasNull bool, err error) {
 	if outers.Len() == 0 {
 		return false, false, nil
@@ -480,7 +480,7 @@ type leftOuterJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *leftOuterJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -508,7 +508,7 @@ func (j *leftOuterJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterato
 	return matched, false, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *leftOuterJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if outers.Len() == 0 {
 		return false, false, nil
@@ -545,7 +545,7 @@ type rightOuterJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *rightOuterJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -573,7 +573,7 @@ func (j *rightOuterJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterat
 	return matched, false, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *rightOuterJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if outers.Len() == 0 {
 		return false, false, nil
@@ -610,7 +610,7 @@ type innerJoiner struct {
 	baseJoiner
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchInners implements joiner interface.
 func (j *innerJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if inners.Len() == 0 {
 		return false, false, nil
@@ -640,7 +640,7 @@ func (j *innerJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, c
 	return matched, false, nil
 }
 
-// tryToMatch implements joiner interface.
+// tryToMatchOuters implements joiner interface.
 func (j *innerJoiner) tryToMatchOuters(inner chunk.Row, outers chunk.Iterator, chk *chunk.Chunk) (bool, bool, error) {
 	if outers.Len() == 0 {
 		return false, false, nil

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -225,6 +225,7 @@ func (j *semiJoiner) tryToMatchInners(outer chunk.Row, inners chunk.Iterator, ch
 		}
 	}
 	return false, false, nil
+
 }
 
 // tryToMatchOuters implements joiner interface.

--- a/executor/joiner_test.go
+++ b/executor/joiner_test.go
@@ -72,7 +72,7 @@ func (s *testSuiteJoiner) TestRequiredRows(c *C) {
 					result.Reset()
 					it := chunk.NewIterator4Chunk(innerChk)
 					it.Begin()
-					_, _, err := joiner.tryToMatch(outerRow, it, result)
+					_, _, err := joiner.tryToMatchInners(outerRow, it, result)
 					c.Assert(err, IsNil)
 					c.Assert(result.NumRows(), Equals, required)
 				}

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -324,7 +324,7 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 			continue
 		}
 
-		matched, isNull, err := e.joiner.tryToMatch(e.outerTable.row, e.innerIter4Row, chk)
+		matched, isNull, err := e.joiner.tryToMatchInners(e.outerTable.row, e.innerIter4Row, chk)
 		if err != nil {
 			return false, errors.Trace(err)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/8470

### What is changed and how it works?
add new try2match joiner function, when  outer table is hash table
this function use in PR https://github.com/pingcap/tidb/pull/8661 which use outer table to build hash table then process join match
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes

