### PR TITLE
table: fix error code different from mysql "error 1604 : locate partition failed"

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -84,6 +84,8 @@ var (
 
 	// ErrUnknownPartition returns unknown partition error.
 	ErrUnknownPartition = terror.ClassTable.New(codeUnknownPartition, mysql.MySQLErrName[mysql.ErrUnknownPartition])
+	// ErrNoPartitionForGivenValue returns table has no partition for value.
+	ErrNoPartitionForGivenValue = terror.ClassTable.New(codeNoPartitionForGivenValue, mysql.MySQLErrName[mysql.ErrNoPartitionForGivenValue])
 )
 
 // RecordIterFunc is used for low-level record iteration.
@@ -208,7 +210,8 @@ const (
 	// It may happen when inserting some data outside of all table partitions.
 	codeTrgInvalidCreationCtx = 1604
 
-	codeUnknownPartition = mysql.ErrUnknownPartition
+	codeUnknownPartition         = mysql.ErrUnknownPartition
+	codeNoPartitionForGivenValue = mysql.ErrNoPartitionForGivenValue
 )
 
 // Slice is used for table sorting.
@@ -224,13 +227,14 @@ func (s Slice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func init() {
 	tableMySQLErrCodes := map[terror.ErrCode]uint16{
-		codeColumnCantNull:        mysql.ErrBadNull,
-		codeUnknownColumn:         mysql.ErrBadField,
-		codeDuplicateColumn:       mysql.ErrFieldSpecifiedTwice,
-		codeNoDefaultValue:        mysql.ErrNoDefaultForField,
-		codeTruncateWrongValue:    mysql.ErrTruncatedWrongValueForField,
-		codeTrgInvalidCreationCtx: mysql.ErrTrgInvalidCreationCtx,
-		codeUnknownPartition:      mysql.ErrUnknownPartition,
+		codeColumnCantNull:           mysql.ErrBadNull,
+		codeUnknownColumn:            mysql.ErrBadField,
+		codeDuplicateColumn:          mysql.ErrFieldSpecifiedTwice,
+		codeNoDefaultValue:           mysql.ErrNoDefaultForField,
+		codeTruncateWrongValue:       mysql.ErrTruncatedWrongValueForField,
+		codeTrgInvalidCreationCtx:    mysql.ErrTrgInvalidCreationCtx,
+		codeUnknownPartition:         mysql.ErrUnknownPartition,
+		codeNoPartitionForGivenValue: mysql.ErrNoPartitionForGivenValue,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassTable] = tableMySQLErrCodes
 }

--- a/table/table.go
+++ b/table/table.go
@@ -79,8 +79,6 @@ var (
 	ErrTruncateWrongValue = terror.ClassTable.New(codeTruncateWrongValue, "incorrect value")
 	// ErrTruncatedWrongValueForField returns for truncate wrong value for field.
 	ErrTruncatedWrongValueForField = terror.ClassTable.New(codeTruncateWrongValue, mysql.MySQLErrName[mysql.ErrTruncatedWrongValueForField])
-	// ErrTrgInvalidCreationCtx happens when inserting a value outside the table partitions.
-	ErrTrgInvalidCreationCtx = terror.ClassTable.New(codeTrgInvalidCreationCtx, "locate partition failed")
 
 	// ErrUnknownPartition returns unknown partition error.
 	ErrUnknownPartition = terror.ClassTable.New(codeUnknownPartition, mysql.MySQLErrName[mysql.ErrUnknownPartition])
@@ -208,7 +206,6 @@ const (
 	codeTruncateWrongValue = 1366
 	// MySQL error code, "Trigger creation context of table `%-.64s`.`%-.64s` is invalid".
 	// It may happen when inserting some data outside of all table partitions.
-	codeTrgInvalidCreationCtx = 1604
 
 	codeUnknownPartition         = mysql.ErrUnknownPartition
 	codeNoPartitionForGivenValue = mysql.ErrNoPartitionForGivenValue
@@ -232,7 +229,6 @@ func init() {
 		codeDuplicateColumn:          mysql.ErrFieldSpecifiedTwice,
 		codeNoDefaultValue:           mysql.ErrNoDefaultForField,
 		codeTruncateWrongValue:       mysql.ErrTruncatedWrongValueForField,
-		codeTrgInvalidCreationCtx:    mysql.ErrTrgInvalidCreationCtx,
 		codeUnknownPartition:         mysql.ErrUnknownPartition,
 		codeNoPartitionForGivenValue: mysql.ErrNoPartitionForGivenValue,
 	}

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -265,7 +265,7 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *mode
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		
+
 		ret, _, err2 := e.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
 		if err2 != nil {
 			return 0, errors.Trace(err2)

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -260,8 +260,9 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *mode
 		idx = 0
 	}
 	if idx < 0 || idx >= len(partitionExprs) {
-		// The data does not belong to any of the partition?
-		return 0, errors.Trace(table.ErrTrgInvalidCreationCtx)
+		// The data does not belong to returns `table has no partition for value %s`.
+		partitionForValue := fmt.Sprintf("%d", chunk.MutRowFromDatums(r).ToRow().GetInt64(0))
+		return 0, errors.Trace(table.ErrNoPartitionForGivenValue.GenWithStackByArgs(partitionForValue))
 	}
 	return idx, nil
 }

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -260,7 +260,7 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *mode
 		idx = 0
 	}
 	if idx < 0 || idx >= len(partitionExprs) {
-		// The data does not belong to returns `table has no partition for value %s`.
+		// The data does not belong to any of the partition returns `table has no partition for value %s`.
 		partitionForValue := fmt.Sprintf("%d", chunk.MutRowFromDatums(r).ToRow().GetInt64(0))
 		return 0, errors.Trace(table.ErrNoPartitionForGivenValue.GenWithStackByArgs(partitionForValue))
 	}

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -265,7 +265,7 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *mode
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		e.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
+		
 		ret, _, err2 := e.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
 		if err2 != nil {
 			return 0, errors.Trace(err2)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -427,6 +427,18 @@ PARTITION BY RANGE ( id ) (
 	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(0))
 	c.Assert(err, IsNil)
+
+	createTable4 := `create table test.t4 (a int,b int) partition by range (a+b)
+	(
+	partition p0 values less than (10)
+	);`
+	_, err = ts.se.Execute(context.Background(), createTable4)
+	c.Assert(err, IsNil)
+	c.Assert(ts.se.NewTxn(ctx), IsNil)
+	tb, err = ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t4"))
+	c.Assert(err, IsNil)
+	_, err = tb.AddRecord(ts.se, types.MakeDatums(1, 11))
+	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
 }
 
 func (ts *testSuite) TestHashPartitionAddRecord(c *C) {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -396,7 +396,7 @@ PARTITION BY RANGE ( id ) (
 
 	// Value must locates in one partition.
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(22))
-	c.Assert(table.ErrTrgInvalidCreationCtx.Equal(err), IsTrue)
+	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
 	ts.se.Execute(context.Background(), "rollback")
 
 	createTable2 := `CREATE TABLE test.t2 (id int(11))
@@ -411,6 +411,20 @@ PARTITION BY RANGE ( id ) (
 	c.Assert(err, IsNil)
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(22))
 	c.Assert(err, IsNil) // Insert into maxvalue partition.
+
+	createTable3 := `create table test.t3 (id int) partition by range (id) 
+	(
+       partition p0 values less than (10)
+	)`
+	_, err = ts.se.Execute(context.Background(), createTable3)
+	c.Assert(err, IsNil)
+	c.Assert(ts.se.NewTxn(ctx), IsNil)
+	tb, err = ts.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t3"))
+	c.Assert(err, IsNil)
+	_, err = tb.AddRecord(ts.se, types.MakeDatums(11))
+	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
+	_, err = tb.AddRecord(ts.se, types.MakeDatums(10))
+	c.Assert(err, IsNil)
 }
 
 func (ts *testSuite) TestHashPartitionAddRecord(c *C) {

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -424,6 +424,8 @@ PARTITION BY RANGE ( id ) (
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(11))
 	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
 	_, err = tb.AddRecord(ts.se, types.MakeDatums(10))
+	c.Assert(table.ErrNoPartitionForGivenValue.Equal(err), IsTrue)
+	_, err = tb.AddRecord(ts.se, types.MakeDatums(0))
 	c.Assert(err, IsNil)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

From https://github.com/pingcap/tidb/issues/9099

### What is changed and how it works?
After this PR:
```sql
create table t (id int) partition by range (id) (
       partition p0 values less than (10)
);
insert into t values (11);
ERROR 1526(HY000): Table has no partition for value 11

drop table t;
create table t (a int,b int) partition by range (a+b) (partition p0 values less than (10));
insert into t values (1,11);
ERROR 1526 (HY000): Table has no partition for value 12
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test