### PR TITLE
ddl: check unique key constraint for 'alter table add index' on partitioned table

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2369,4 +2369,11 @@ func (s *testDBSuite) TestIssue9100(c *C) {
 	tk.MustExec("create table employ (a int, b int) partition by range (b) (partition p0 values less than (1));")
 	_, err := tk.Exec("alter table employ add unique index  p_a (a);")
 	c.Assert(err.Error(), Equals, "[ddl:1503]A UNIQUE INDEX must include all columns in the table's partitioning function")
+
+	tk.MustExec("create table t1 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col2)) partition by range( col1 ) (partition p1 values less than (11))")
+	tk.MustExec("alter table t1 add unique index  p_col1 (col1)")
+
+	tk.MustExec("create table t2 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col3)) partition by range( col1 + col3 ) (partition p1 values less than (11))")
+	_, err = tk.Exec("alter table t2 add unique index  p_col1 (col1)")
+	c.Assert(err.Error(), Equals, "[ddl:1503]A UNIQUE INDEX must include all columns in the table's partitioning function")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2370,10 +2370,10 @@ func (s *testDBSuite) TestIssue9100(c *C) {
 	_, err := tk.Exec("alter table employ add unique index  p_a (a);")
 	c.Assert(err.Error(), Equals, "[ddl:1503]A UNIQUE INDEX must include all columns in the table's partitioning function")
 
-	tk.MustExec("create table t1 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col2)) partition by range( col1 ) (partition p1 values less than (11))")
-	tk.MustExec("alter table t1 add unique index  p_col1 (col1)")
+	tk.MustExec("create table issue9100t1 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col2)) partition by range( col1 ) (partition p1 values less than (11))")
+	tk.MustExec("alter table issue9100t1 add unique index  p_col1 (col1)")
 
-	tk.MustExec("create table t2 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col3)) partition by range( col1 + col3 ) (partition p1 values less than (11))")
-	_, err = tk.Exec("alter table t2 add unique index  p_col1 (col1)")
+	tk.MustExec("create table issue9100t2 (col1 int not null, col2 date not null, col3 int not null, unique key (col1, col3)) partition by range( col1 + col3 ) (partition p1 values less than (11))")
+	_, err = tk.Exec("alter table issue9100t2 add unique index  p_col1 (col1)")
 	c.Assert(err.Error(), Equals, "[ddl:1503]A UNIQUE INDEX must include all columns in the table's partitioning function")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2362,3 +2362,11 @@ func (s *testDBSuite) TestAddIndexForGeneratedColumn(c *C) {
 	s.mustExec(c, "alter table t add index idx_y(y1)")
 	s.mustExec(c, "alter table t drop index idx_y")
 }
+
+func (s *testDBSuite) TestIssue9100(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test_db")
+	tk.MustExec("create table employ (a int, b int) partition by range (b) (partition p0 values less than (1));")
+	_, err := tk.Exec("alter table employ add unique index  p_a (a);")
+	c.Assert(err.Error(), Equals, "[ddl:1503]A PRIMARY KEY must include all columns in the table's partitioning function")
+}

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2368,5 +2368,5 @@ func (s *testDBSuite) TestIssue9100(c *C) {
 	tk.MustExec("use test_db")
 	tk.MustExec("create table employ (a int, b int) partition by range (b) (partition p0 values less than (1));")
 	_, err := tk.Exec("alter table employ add unique index  p_a (a);")
-	c.Assert(err.Error(), Equals, "[ddl:1503]A PRIMARY KEY must include all columns in the table's partitioning function")
+	c.Assert(err.Error(), Equals, "[ddl:1503]A UNIQUE INDEX must include all columns in the table's partitioning function")
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2509,6 +2509,30 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, unique bool, ind
 		return errors.Trace(err)
 	}
 
+	tblInfo := t.Meta()
+	// Every unique key on the table must use every column in the table's partitioning expression.
+	// See https://dev.mysql.com/doc/refman/5.7/en/partitioning-limitations-partitioning-keys-unique-keys.html.
+	if unique && tblInfo.GetPartitionInfo() != nil {
+		// Parse partitioning key, extract the column names in the partitioning key to slice.
+		expr := tblInfo.GetPartitionInfo().Expr
+		e, err := expression.ParseSimpleExprWithTableInfo(ctx, expr, tblInfo)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		cols := expression.ExtractColumns(e)
+		partkeys := make([]string, 0, len(cols))
+		for _, col := range cols {
+			partkeys = append(partkeys, col.ColName.L)
+		}
+		constraints := make(map[string]struct{})
+		for _, uniqCol := range idxColNames {
+			constraints[uniqCol.Column.Name.L] = struct{}{}
+		}
+		if !checkConstraintIncludePartKey(partkeys, constraints) {
+			return ErrUniqueKeyNeedAllFieldsInPf.GenWithStackByArgs(primarykey)
+		}
+	}
+
 	if indexOption != nil {
 		// May be truncate comment here, when index comment too long and sql_mode is't strict.
 		indexOption.Comment, err = validateCommentLength(ctx.GetSessionVars(),

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -517,8 +517,8 @@ func extractPartitionColumns(sctx sessionctx.Context, partExpr string, tblInfo *
 }
 
 // checkConstraintIncludePartKey checks that the partitioning key is included in the constraint.
-func checkConstraintIncludePartKey(partCols []string, constraints map[string]struct{}) bool {
-	for _, pk := range partCols {
+func checkConstraintIncludePartKey(partkeys []string, constraints map[string]struct{}) bool {
+	for _, pk := range partkeys {
 		if _, ok := constraints[pk]; !ok {
 			return false
 		}


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/9100

### What is changed and how it works?

> Every unique key on the table must use every column in the table's partitioning expression.

We have this check when creating a table, 'alter table add index' should also check this.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


