### PR TITLE
planner: remove constant sort items after substitution (#9333)

### DIFF
--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -183,3 +183,8 @@ Projection_12	0.00	root	te.expect_time
     │       └─TableScan_31	10.00	cop	table:te, keep order:false, stats:pseudo
     └─IndexReader_135	10.00	root	index:IndexScan_134
       └─IndexScan_134	10.00	cop	table:p, index:relate_id, range: decided by [tr.id], keep order:false, stats:pseudo
+desc select 1 as a from dual order by a limit 1;
+id	count	task	operator info
+Projection_7	1.00	root	1
+└─Limit_8	1.00	root	offset:0, count:1
+  └─TableDual_11	1.00	root	rows:1

--- a/cmd/explaintest/t/topn_push_down.test
+++ b/cmd/explaintest/t/topn_push_down.test
@@ -171,3 +171,5 @@ WHERE
     te.expect_time BETWEEN '2018-04-23 00:00:00.0' AND '2018-04-23 23:59:59.0'
 ORDER BY te.expect_time asc
 LIMIT 0, 5;
+
+desc select 1 as a from dual order by a limit 1;

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -96,6 +96,14 @@ func (p *LogicalProjection) pushDownTopN(topN *LogicalTopN) LogicalPlan {
 		for _, by := range topN.ByItems {
 			by.Expr = expression.ColumnSubstitute(by.Expr, p.schema, p.Exprs)
 		}
+
+		// remove meaningless constant sort items.
+		for i := len(topN.ByItems) - 1; i >= 0; i-- {
+			_, isConst := topN.ByItems[i].Expr.(*expression.Constant)
+			if isConst {
+				topN.ByItems = append(topN.ByItems[:i], topN.ByItems[i+1:]...)
+			}
+		}
 	}
 	p.children[0] = p.children[0].pushDownTopN(topN)
 	return p


### PR DESCRIPTION
cherry pick #9333 to release 2.1