### PR TITLE
don't cast AggFuncs' arguments when they are Partial2Mode

### DIFF
--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -121,10 +121,10 @@ func injectProjBelowAgg(aggPlan PhysicalPlan, aggFuncs []*aggregation.AggFuncDes
 	}
 
 	child := aggPlan.Children()[0]
-	proj := PhysicalProjection{
+	proj := PhysicalProjection{ // give a nil property since physical optimization has finished
 		Exprs:                projExprs,
 		AvoidColumnEvaluator: false,
-	}.Init(aggPlan.context(), child.statsInfo()) // give a nil property since physical optimization has finished.
+	}.Init(aggPlan.context(), child.statsInfo())
 	proj.SetSchema(expression.NewSchema(projSchemaCols...))
 	proj.SetChildren(child)
 

--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -126,10 +126,11 @@ func injectProjBelowAgg(aggPlan PhysicalPlan, aggFuncs []*aggregation.AggFuncDes
 	}
 
 	child := aggPlan.Children()[0]
-	proj := PhysicalProjection{ // give a nil property since physical optimization has finished
+	prop := aggPlan.GetChildReqProps(0).Clone()
+	proj := PhysicalProjection{
 		Exprs:                projExprs,
 		AvoidColumnEvaluator: false,
-	}.Init(aggPlan.context(), child.statsInfo())
+	}.Init(aggPlan.context(), child.statsInfo().ScaleByExpectCnt(prop.ExpectedCnt), prop)
 	proj.SetSchema(expression.NewSchema(projSchemaCols...))
 	proj.SetChildren(child)
 

--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -15,11 +15,11 @@ package core
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/sessionctx"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
+	"github.com/pingcap/tidb/sessionctx"
 )
 
 // injectExtraProjection is used to extract the expressions of specific

--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/sessionctx"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
@@ -55,20 +56,24 @@ func (pe *projInjector) inject(plan PhysicalPlan) PhysicalPlan {
 	return plan
 }
 
+// wrapCastForAggFunc wraps the args of an aggregate function with a cast function.
+// If the mode is FinalMode or Partial2Mode, we do not need to wrap cast upon the args,
+// since the types of the args are already the expected.
+func wrapCastForAggFuncs(sctx sessionctx.Context, aggFuncs []*aggregation.AggFuncDesc) {
+	for i := range aggFuncs {
+		if aggFuncs[i].Mode != aggregation.FinalMode && aggFuncs[i].Mode != aggregation.Partial2Mode {
+			aggFuncs[i].WrapCastForAggArgs(sctx)
+		}
+	}
+}
+
 // injectProjBelowAgg injects a ProjOperator below AggOperator. If all the args
 // of `aggFuncs`, and all the item of `groupByItems` are columns or constants,
 // we do not need to build the `proj`.
 func injectProjBelowAgg(aggPlan PhysicalPlan, aggFuncs []*aggregation.AggFuncDesc, groupByItems []expression.Expression) PhysicalPlan {
 	hasScalarFunc := false
 
-	// If the mode is FinalMode or Partial2Mode, we do not need to wrap cast upon the args,
-	// since the types of the args are already the expected.
-	if len(aggFuncs) > 0 && aggFuncs[0].Mode != aggregation.FinalMode && aggFuncs[0].Mode != aggregation.Partial2Mode {
-		for _, agg := range aggFuncs {
-			agg.WrapCastForAggArgs(aggPlan.context())
-		}
-	}
-
+	wrapCastForAggFuncs(aggPlan.context(), aggFuncs)
 	for i := 0; !hasScalarFunc && i < len(aggFuncs); i++ {
 		for _, arg := range aggFuncs[i].Args {
 			_, isScalarFunc := arg.(*expression.ScalarFunction)

--- a/planner/core/rule_inject_extra_projection_test.go
+++ b/planner/core/rule_inject_extra_projection_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+var _ = Suite(&testInjectProjSuite{})
+
+type testInjectProjSuite struct {
+}
+
+func (s *testInjectProjSuite) TestWrapCastForAggFuncs(c *C) {
+	aggNames := []string{ast.AggFuncSum}
+	modes := []aggregation.AggFunctionMode{aggregation.CompleteMode,
+		aggregation.FinalMode, aggregation.Partial1Mode, aggregation.Partial1Mode}
+	retTypes := []byte{mysql.TypeLong, mysql.TypeNewDecimal, mysql.TypeDouble, mysql.TypeLonglong, mysql.TypeInt24}
+	hasDistincts := []bool{true, false}
+
+	aggFuncs := make([]*aggregation.AggFuncDesc, 0, 32)
+	for _, hasDistinct := range hasDistincts {
+		for _, name := range aggNames {
+			for _, mode := range modes {
+				for _, retType := range retTypes {
+					sctx := mock.NewContext()
+					aggFunc := aggregation.NewAggFuncDesc(sctx, name,
+						[]expression.Expression{&expression.Constant{Value: types.Datum{}, RetType: types.NewFieldType(retType)}},
+						hasDistinct)
+					aggFunc.Mode = mode
+					aggFuncs = append(aggFuncs, aggFunc)
+				}
+			}
+		}
+	}
+
+	orgAggFuncs := make([]*aggregation.AggFuncDesc, 0, len(aggFuncs))
+	for _, agg := range aggFuncs {
+		orgAggFuncs = append(orgAggFuncs, agg.Clone())
+	}
+
+	wrapCastForAggFuncs(mock.NewContext(), aggFuncs)
+	for i := range aggFuncs {
+		if aggFuncs[i].Mode != aggregation.FinalMode && aggFuncs[i].Mode != aggregation.Partial2Mode {
+			c.Assert(aggFuncs[i].RetTp.Tp, Equals, aggFuncs[i].Args[0].GetType().Tp)
+		} else {
+			c.Assert(aggFuncs[i].Args[0].GetType().Tp, Equals, orgAggFuncs[i].Args[0].GetType().Tp)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It's unnecessary to wrap cast upon arguments of `AggFuncs` which are in `Partital2Mode`.

### What is changed and how it works?
Judge `AggFuncs'` type before wrapping cast.
