### PR TITLE
Control the number of rows in chunks returned by LimitExec

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -711,6 +711,7 @@ func (e *LimitExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		return nil
 	}
 	for !e.meetFirstBatch {
+		// transfer req's requiredRows to childResult and then adjust it in childResult
 		e.childResult = e.childResult.SetRequiredRows(req.RequiredRows(), e.maxChunkSize)
 		err := e.children[0].Next(ctx, chunk.NewRecordBatch(e.adjustRequiredRows(e.childResult)))
 		if err != nil {

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -32,11 +32,12 @@ type requiredRowsDataSource struct {
 	baseExecutor
 	totalRows    int
 	count        int
-	requiredLast int
+	requiredLast int // the number of rows required in the last call of Next
 	ctx          sessionctx.Context
 }
 
 func newRequiredRowsDataSource(ctx sessionctx.Context, totalRows int) *requiredRowsDataSource {
+	// the schema of output is fixed now, which is [Double, Long]
 	retTypes := []*types.FieldType{types.NewFieldType(mysql.TypeDouble), types.NewFieldType(mysql.TypeLonglong)}
 	cols := make([]*expression.Column, len(retTypes))
 	for i := range retTypes {

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -1,0 +1,159 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"math/rand"
+
+	"github.com/cznic/mathutil"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+type requiredRowsDataSource struct {
+	baseExecutor
+	totalRows    int
+	count        int
+	requiredLast int
+	ctx          sessionctx.Context
+}
+
+func newRequiredRowsDataSource(ctx sessionctx.Context, totalRows int) *requiredRowsDataSource {
+	retTypes := []*types.FieldType{types.NewFieldType(mysql.TypeDouble), types.NewFieldType(mysql.TypeLonglong)}
+	cols := make([]*expression.Column, len(retTypes))
+	for i := range retTypes {
+		cols[i] = &expression.Column{Index: i, RetType: retTypes[i]}
+	}
+	schema := expression.NewSchema(cols...)
+	baseExec := newBaseExecutor(ctx, schema, "")
+	return &requiredRowsDataSource{baseExec, totalRows, 0, 0, ctx}
+}
+
+func (r *requiredRowsDataSource) Next(ctx context.Context, req *chunk.RecordBatch) error {
+	req.Reset()
+	if r.count > r.totalRows {
+		r.requiredLast = 0
+		return nil
+	}
+	r.requiredLast = mathutil.Min(req.RequiredRows(), r.totalRows-r.count)
+	for i := 0; i < r.requiredLast; i++ {
+		req.AppendRow(r.genOneRow())
+	}
+	r.count += r.requiredLast
+	return nil
+}
+
+func (r *requiredRowsDataSource) genOneRow() chunk.Row {
+	row := chunk.MutRowFromTypes(r.retTypes())
+	for i := range r.retTypes() {
+		row.SetValue(i, r.genValue(r.retTypes()[i]))
+	}
+	return row.ToRow()
+}
+
+func (r *requiredRowsDataSource) genValue(valType *types.FieldType) interface{} {
+	switch valType.Tp {
+	case mysql.TypeLong, mysql.TypeLonglong:
+		return int64(rand.Int())
+	case mysql.TypeDouble:
+		return rand.Float64()
+	default:
+		panic("not implement")
+	}
+}
+
+func (s *testExecSuite) TestLimitRequiredRows(c *C) {
+	testCases := []struct {
+		totalRows      int
+		limitOffset    int
+		limitCount     int
+		requiredRows   []int
+		expectedRows   []int
+		expectedRowsDS []int
+	}{
+		{
+			totalRows:      20,
+			limitOffset:    0,
+			limitCount:     10,
+			requiredRows:   []int{3, 5, 1, 500, 500},
+			expectedRows:   []int{3, 5, 1, 1, 0},
+			expectedRowsDS: []int{3, 5, 1, 1, 1},
+		},
+		{
+			totalRows:      20,
+			limitOffset:    0,
+			limitCount:     25,
+			requiredRows:   []int{9, 500},
+			expectedRows:   []int{9, 11},
+			expectedRowsDS: []int{9, 11},
+		},
+		{
+			totalRows:      100,
+			limitOffset:    50,
+			limitCount:     30,
+			requiredRows:   []int{10, 5, 10, 20},
+			expectedRows:   []int{10, 5, 10, 5},
+			expectedRowsDS: []int{60, 5, 10, 5},
+		},
+		{
+			totalRows:      100,
+			limitOffset:    101,
+			limitCount:     10,
+			requiredRows:   []int{10},
+			expectedRows:   []int{0},
+			expectedRowsDS: []int{0},
+		},
+	}
+
+	sctx := defaultCtx()
+	ctx := context.Background()
+	for _, testCase := range testCases {
+		ds := newRequiredRowsDataSource(sctx, testCase.totalRows)
+		exec := buildLimitExec(sctx, ds, testCase.limitOffset, testCase.limitCount)
+		c.Assert(exec.Open(ctx), IsNil)
+		chk := exec.newFirstChunk()
+		for i := range testCase.requiredRows {
+			chk.SetRequiredRows(testCase.requiredRows[i], sctx.GetSessionVars().MaxChunkSize)
+			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
+			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
+			c.Assert(ds.requiredLast, Equals, testCase.expectedRowsDS[i])
+		}
+	}
+}
+
+func buildLimitExec(ctx sessionctx.Context, src Executor, offset, count int) Executor {
+	n := mathutil.Min(count, ctx.GetSessionVars().MaxChunkSize)
+	base := newBaseExecutor(ctx, src.Schema(), "", src)
+	base.initCap = n
+	limitExec := &LimitExec{
+		baseExecutor: base,
+		begin:        uint64(offset),
+		end:          uint64(offset + count),
+	}
+	return limitExec
+}
+
+func defaultCtx() sessionctx.Context {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
+	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
+	return ctx
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Control the number of rows in chunks returned by `LimitExec`.
Following up #9293, this PR is a subtask of #9166.

### What is changed and how it works?
* Introduce `adjustRequiredRows` into `LimitExec` to adjust the required rows before each call of 
child's `Next`.
* Introduce `requiredRowsDataSource` as mock DataSource when test.
* Add some unit tests for `LimitExec`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
