### PR TITLE
executor: control Chunk size for TopN&Sort

### DIFF
--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -16,7 +16,7 @@ package executor
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
+	"math"
 	"math/rand"
 
 	"github.com/cznic/mathutil"
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
 )
 
@@ -324,6 +325,15 @@ func (s *testExecSuite) TestTopNRequiredRows(c *C) {
 			requiredRows:   []int{1, 2, 3},
 			expectedRows:   []int{0, 0, 0},
 			expectedRowsDS: []int{maxChunkSize, maxChunkSize, maxChunkSize, maxChunkSize, maxChunkSize, 10, 0, 0},
+		},
+		{
+			totalRows:      maxChunkSize + maxChunkSize + 10,
+			topNOffset:     10,
+			topNCount:      math.MaxInt64,
+			groupBy:        []int{0, 1},
+			requiredRows:   []int{1, 2, 3, maxChunkSize, maxChunkSize},
+			expectedRows:   []int{1, 2, 3, maxChunkSize, maxChunkSize - 1 - 2 - 3},
+			expectedRowsDS: []int{maxChunkSize, maxChunkSize, 10, 0, 0},
 		},
 	}
 

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -93,10 +93,7 @@ func (e *SortExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		sort.Slice(e.rowPtrs, e.keyColumnsLess)
 		e.fetched = true
 	}
-	for !req.IsFull() {
-		if e.Idx >= len(e.rowPtrs) {
-			return nil
-		}
+	for !req.IsFull() && e.Idx < len(e.rowPtrs) {
 		rowPtr := e.rowPtrs[e.Idx]
 		req.AppendRow(e.rowChunks.GetRow(rowPtr))
 		e.Idx++


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Control the number of rows in chunks returned by `LimitExec`.
Following up #9354, this PR is a subtask of #9166.

### What is changed and how it works?
* Modify `TopN` and `Sort` to make them support chunk size control.
* Add some unit tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
