### PR TITLE
sessionctx: show correct TiDB port instead of 3306

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -363,7 +363,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_buffer_pool_load_now", "OFF"},
 	{ScopeNone, "performance_schema_max_rwlock_classes", "40"},
 	{ScopeNone, "binlog_gtid_simple_recovery", "OFF"},
-	{ScopeNone, "port", "3306"},
+	{ScopeNone, "port", strconv.FormatUint(uint64(config.GetGlobalConfig().Port), 10)},
 	{ScopeNone, "performance_schema_digests_size", "10000"},
 	{ScopeGlobal | ScopeSession, "profiling", "OFF"},
 	{ScopeNone, "lower_case_table_names", "2"},
@@ -798,6 +798,8 @@ const (
 	PluginDir = "plugin_dir"
 	// PluginLoad is the name of 'plugin_load' system variable.
 	PluginLoad = "plugin_load"
+	// Port is the name for 'port' system variable.
+	Port = "port"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -363,7 +363,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_buffer_pool_load_now", "OFF"},
 	{ScopeNone, "performance_schema_max_rwlock_classes", "40"},
 	{ScopeNone, "binlog_gtid_simple_recovery", "OFF"},
-	{ScopeNone, "port", strconv.FormatUint(uint64(config.GetGlobalConfig().Port), 10)},
+	{ScopeNone, Port, strconv.FormatUint(uint64(config.GetGlobalConfig().Port), 10)},
 	{ScopeNone, "performance_schema_digests_size", "10000"},
 	{ScopeGlobal | ScopeSession, "profiling", "OFF"},
 	{ScopeNone, "lower_case_table_names", "2"},

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -39,4 +39,9 @@ func (*testSysVarSuite) TestSysVar(c *C) {
 	f = GetSysVar("explicit_defaults_for_timestamp")
 	c.Assert(f, NotNil)
 	c.Assert(f.Value, Equals, "ON")
+
+	f = GetSysVar("port")
+	c.Assert(f, NotNil)
+	c.Assert(f.Value, Equals, "4000")
+
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #9362

### What is changed and how it works?

Previously TiDB lied about the port configured (showing MySQL's default of 3306).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported variable/fields change

Side effects

 - Increased code complexity
 - Breaking backward compatibility (for broken apps)

Related changes

 - Need to be included in the release note
