### PR TITLE
*: merge statement buffer when BatchGetValues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # Builder image
-FROM golang:1.11.2-alpine as builder
+FROM golang:1.11.5-alpine as builder
 
 RUN apk add --no-cache \
     wget \
     make \
-    git
+    git \
+    gcc \
+    musl-dev
 
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
  && chmod +x /usr/local/bin/dumb-init
@@ -16,16 +18,13 @@ WORKDIR /go/src/github.com/pingcap/tidb/
 RUN make
 
 # Executable image
-FROM scratch
+FROM alpine
 
 COPY --from=builder /go/src/github.com/pingcap/tidb/bin/tidb-server /tidb-server
 COPY --from=builder /usr/local/bin/dumb-init /usr/local/bin/dumb-init
-
-
 
 WORKDIR /
 
 EXPOSE 4000
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "/tidb-server"]
-

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -710,7 +710,7 @@ func (w *addIndexWorker) batchCheckUniqueKey(txn kv.Transaction, idxRecords []*i
 		w.distinctCheckFlags = append(w.distinctCheckFlags, distinct)
 	}
 
-	batchVals, err := kv.BatchGetValues(txn, w.batchCheckKeys)
+	batchVals, err := txn.BatchGet(w.batchCheckKeys)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -376,7 +376,7 @@ func (e *RecoverIndexExec) batchMarkDup(txn kv.Transaction, rows []recoverRows) 
 		distinctFlags[i] = distinct
 	}
 
-	values, err := kv.BatchGetValues(txn, e.batchKeys)
+	values, err := txn.BatchGet(e.batchKeys)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -500,7 +500,7 @@ func (e *CleanupIndexExec) batchGetRecord(txn kv.Transaction) (map[string][]byte
 	for handle := range e.idxValues {
 		e.batchKeys = append(e.batchKeys, e.table.RecordKey(handle))
 	}
-	values, err := kv.BatchGetValues(txn, e.batchKeys)
+	values, err := txn.BatchGet(e.batchKeys)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/executor/batch_checker.go
+++ b/executor/batch_checker.go
@@ -56,7 +56,7 @@ func (b *batchChecker) batchGetOldValues(ctx sessionctx.Context, batchKeys []kv.
 	if err != nil {
 		return errors.Trace(err)
 	}
-	values, err := kv.BatchGetValues(txn, batchKeys)
+	values, err := txn.BatchGet(batchKeys)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -213,7 +213,7 @@ func (b *batchChecker) batchGetInsertKeys(ctx sessionctx.Context, t table.Table,
 	if err != nil {
 		return errors.Trace(err)
 	}
-	b.dupKVs, err = kv.BatchGetValues(txn, batchKeys)
+	b.dupKVs, err = txn.BatchGet(batchKeys)
 	return errors.Trace(err)
 }
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -309,7 +309,7 @@ func (s *testSuite) TestMultiBatch(c *C) {
 	tk.MustExec("create table t0 (i int)")
 	tk.MustExec("insert into t0 values (1), (1)")
 	tk.MustExec("create table t (i int unique key)")
-	tk.MustExec("set tidb_dml_batch_size = 1")
+	tk.MustExec("set @@tidb_dml_batch_size = 1")
 	tk.MustExec("insert ignore into t select * from t0")
 	tk.MustExec("admin check table t")
 }

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -303,6 +303,17 @@ func (s *testSuite2) TestInsert(c *C) {
 	tk.MustExec("drop view v")
 }
 
+func (s *testSuite) TestMultiBatch(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t0 (i int)")
+	tk.MustExec("insert into t0 values (1), (1)")
+	tk.MustExec("create table t (i int unique key)")
+	tk.MustExec("set tidb_dml_batch_size = 1")
+	tk.MustExec("insert ignore into t select * from t0")
+	tk.MustExec("admin check table t")
+}
+
 func (s *testSuite2) TestInsertAutoInc(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -97,6 +97,16 @@ func (t *InjectedTransaction) Get(k Key) ([]byte, error) {
 	return t.Transaction.Get(k)
 }
 
+// BatchGet returns an error if cfg.getError is set.
+func (t *InjectedTransaction) BatchGet(keys []Key) (map[string][]byte, error) {
+	t.cfg.RLock()
+	defer t.cfg.RUnlock()
+	if t.cfg.getError != nil {
+		return nil, t.cfg.getError
+	}
+	return t.Transaction.BatchGet(keys)
+}
+
 // Commit returns an error if cfg.commitError is set.
 func (t *InjectedTransaction) Commit(ctx context.Context) error {
 	t.cfg.RLock()
@@ -105,14 +115,6 @@ func (t *InjectedTransaction) Commit(ctx context.Context) error {
 		return t.cfg.commitError
 	}
 	return t.Transaction.Commit(ctx)
-}
-
-// GetSnapshot implements Transaction GetSnapshot method.
-func (t *InjectedTransaction) GetSnapshot() Snapshot {
-	return &InjectedSnapshot{
-		Snapshot: t.Transaction.GetSnapshot(),
-		cfg:      t.cfg,
-	}
 }
 
 // InjectedSnapshot wraps a Snapshot with injections.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -150,6 +150,8 @@ type Transaction interface {
 	GetSnapshot() Snapshot
 	// SetVars sets variables to the transaction.
 	SetVars(vars *Variables)
+	// MemGet get kv from the memory buffer.
+	MemGet(k Key) ([]byte, error)
 }
 
 // Client is used to send request to KV layer.

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -146,12 +146,10 @@ type Transaction interface {
 	Valid() bool
 	// GetMemBuffer return the MemBuffer binding to this transaction.
 	GetMemBuffer() MemBuffer
-	// GetSnapshot returns the snapshot of this transaction.
-	GetSnapshot() Snapshot
 	// SetVars sets variables to the transaction.
 	SetVars(vars *Variables)
-	// MemGet get kv from the memory buffer.
-	MemGet(k Key) ([]byte, error)
+	// BatchGet gets kv from the memory buffer of statement and transaction, and the kv storage.
+	BatchGet(keys []Key) (map[string][]byte, error)
 }
 
 // Client is used to send request to KV layer.

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -116,6 +116,10 @@ func (t *mockTxn) SetVars(vars *Variables) {
 
 }
 
+func (t *mockTxn) MemGet(k Key) ([]byte, error) {
+	return nil, nil
+}
+
 // NewMockTxn new a mockTxn.
 func NewMockTxn() Transaction {
 	return &mockTxn{

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -67,6 +67,10 @@ func (t *mockTxn) Get(k Key) ([]byte, error) {
 	return nil, nil
 }
 
+func (t *mockTxn) BatchGet(keys []Key) (map[string][]byte, error) {
+	return nil, nil
+}
+
 func (t *mockTxn) Iter(k Key, upperBound Key) (Iterator, error) {
 	return nil, nil
 }
@@ -98,12 +102,6 @@ func (t *mockTxn) GetMemBuffer() MemBuffer {
 	return nil
 }
 
-func (t *mockTxn) GetSnapshot() Snapshot {
-	return &mockSnapshot{
-		store: NewMemDbBuffer(DefaultTxnMembufCap),
-	}
-}
-
 func (t *mockTxn) SetCap(cap int) {
 
 }
@@ -114,10 +112,6 @@ func (t *mockTxn) Reset() {
 
 func (t *mockTxn) SetVars(vars *Variables) {
 
-}
-
-func (t *mockTxn) MemGet(k Key) ([]byte, error) {
-	return nil, nil
 }
 
 // NewMockTxn new a mockTxn.

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -94,13 +94,10 @@ func BackOff(attempts uint) int {
 // BatchGetValues gets values in batch.
 // The values from buffer in transaction and the values from the storage node are merged together.
 func BatchGetValues(txn Transaction, keys []Key) (map[string][]byte, error) {
-	if txn.IsReadOnly() {
-		return txn.GetSnapshot().BatchGet(keys)
-	}
 	bufferValues := make([][]byte, len(keys))
 	shrinkKeys := make([]Key, 0, len(keys))
 	for i, key := range keys {
-		val, err := txn.GetMemBuffer().Get(key)
+		val, err := txn.MemGet(key)
 		if IsErrNotFound(err) {
 			shrinkKeys = append(shrinkKeys, key)
 			continue

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -91,37 +91,6 @@ func BackOff(attempts uint) int {
 	return int(sleep)
 }
 
-// BatchGetValues gets values in batch.
-// The values from buffer in transaction and the values from the storage node are merged together.
-func BatchGetValues(txn Transaction, keys []Key) (map[string][]byte, error) {
-	bufferValues := make([][]byte, len(keys))
-	shrinkKeys := make([]Key, 0, len(keys))
-	for i, key := range keys {
-		val, err := txn.MemGet(key)
-		if IsErrNotFound(err) {
-			shrinkKeys = append(shrinkKeys, key)
-			continue
-		}
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-		if len(val) != 0 {
-			bufferValues[i] = val
-		}
-	}
-	storageValues, err := txn.GetSnapshot().BatchGet(shrinkKeys)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	for i, key := range keys {
-		if bufferValues[i] == nil {
-			continue
-		}
-		storageValues[string(key)] = bufferValues[i]
-	}
-	return storageValues, nil
-}
-
 // mockCommitErrorEnable uses to enable `mockCommitError` and only mock error once.
 var mockCommitErrorEnable = int64(0)
 

--- a/session/txn.go
+++ b/session/txn.go
@@ -213,6 +213,15 @@ func (st *TxnState) Get(k kv.Key) ([]byte, error) {
 	return val, nil
 }
 
+// MemGet overrides the Transaction interface.
+func (st *TxnState) MemGet(k kv.Key) ([]byte, error) {
+	val, err := st.buf.Get(k)
+	if kv.IsErrNotFound(err) {
+		return st.Transaction.MemGet(k)
+	}
+	return val, err
+}
+
 // Set overrides the Transaction interface.
 func (st *TxnState) Set(k kv.Key, v []byte) error {
 	return st.buf.Set(k, v)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -282,3 +282,7 @@ func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {
 func (txn *tikvTxn) GetSnapshot() kv.Snapshot {
 	return txn.snapshot
 }
+
+func (txn *tikvTxn) MemGet(k kv.Key) ([]byte, error) {
+	return txn.GetMemBuffer().Get(k)
+}

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -108,6 +108,38 @@ func (txn *tikvTxn) Get(k kv.Key) ([]byte, error) {
 	return ret, nil
 }
 
+func (txn *tikvTxn) BatchGet(keys []kv.Key) (map[string][]byte, error) {
+	if txn.IsReadOnly() {
+		return txn.snapshot.BatchGet(keys)
+	}
+	bufferValues := make([][]byte, len(keys))
+	shrinkKeys := make([]kv.Key, 0, len(keys))
+	for i, key := range keys {
+		val, err := txn.GetMemBuffer().Get(key)
+		if kv.IsErrNotFound(err) {
+			shrinkKeys = append(shrinkKeys, key)
+			continue
+		}
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if len(val) != 0 {
+			bufferValues[i] = val
+		}
+	}
+	storageValues, err := txn.snapshot.BatchGet(shrinkKeys)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	for i, key := range keys {
+		if bufferValues[i] == nil {
+			continue
+		}
+		storageValues[string(key)] = bufferValues[i]
+	}
+	return storageValues, nil
+}
+
 func (txn *tikvTxn) Set(k kv.Key, v []byte) error {
 	txn.setCnt++
 
@@ -277,12 +309,4 @@ func (txn *tikvTxn) Size() int {
 
 func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {
 	return txn.us.GetMemBuffer()
-}
-
-func (txn *tikvTxn) GetSnapshot() kv.Snapshot {
-	return txn.snapshot
-}
-
-func (txn *tikvTxn) MemGet(k kv.Key) ([]byte, error) {
-	return txn.GetMemBuffer().Get(k)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The BatchGetValues may be used several times in one statement, but it does not contain the row add in the statement itself, which will cause some keys did not check.

### What is changed and how it works?
Add an interface `BatchGet` to get the statement and the transaction key/values, and merge them with the storage BatchGet results.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
