### PR TITLE
server, sessionctx: workaround var initialization

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -182,6 +182,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		stopListenerCh:    make(chan struct{}, 1),
 	}
 	s.loadTLSCertificates()
+	s.initDefaults()
 
 	s.capability = defaultCapability
 	if s.tlsConfig != nil {
@@ -227,6 +228,13 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	// Init rand seed for randomBuf()
 	rand.Seed(time.Now().UTC().UnixNano())
 	return s, nil
+}
+
+func (s *Server) initDefaults() {
+	// workaround for #9382
+	variable.SysVars["port"].Value = fmt.Sprintf("%d", s.cfg.Port)
+	variable.SysVars["socket"].Value = s.cfg.Socket
+	variable.SysVars["datadir"].Value = s.cfg.Path
 }
 
 func (s *Server) loadTLSCertificates() {

--- a/server/server.go
+++ b/server/server.go
@@ -182,7 +182,6 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		stopListenerCh:    make(chan struct{}, 1),
 	}
 	s.loadTLSCertificates()
-	s.initDefaults()
 
 	s.capability = defaultCapability
 	if s.tlsConfig != nil {
@@ -228,13 +227,6 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	// Init rand seed for randomBuf()
 	rand.Seed(time.Now().UTC().UnixNano())
 	return s, nil
-}
-
-func (s *Server) initDefaults() {
-	// workaround for #9382
-	variable.SysVars["port"].Value = fmt.Sprintf("%d", s.cfg.Port)
-	variable.SysVars["socket"].Value = s.cfg.Socket
-	variable.SysVars["datadir"].Value = s.cfg.Path
 }
 
 func (s *Server) loadTLSCertificates() {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -803,6 +803,10 @@ const (
 	PluginLoad = "plugin_load"
 	// Port is the name for 'port' system variable.
 	Port = "port"
+	// DataDir is the name for 'datadir' system variable.
+	DataDir = "datadir"
+	// Socket is the name for 'socket' system variable.
+	Socket = "socket"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -364,7 +364,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_buffer_pool_load_now", "OFF"},
 	{ScopeNone, "performance_schema_max_rwlock_classes", "40"},
 	{ScopeNone, "binlog_gtid_simple_recovery", "OFF"},
-	{ScopeNone, Port, strconv.FormatUint(uint64(config.GetGlobalConfig().Port), 10)},
+	{ScopeNone, Port, "4000"},
 	{ScopeNone, "performance_schema_digests_size", "10000"},
 	{ScopeGlobal | ScopeSession, "profiling", "OFF"},
 	{ScopeNone, "lower_case_table_names", "2"},

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -454,6 +454,10 @@ func setGlobalVars() {
 	variable.SysVars["lower_case_table_names"].Value = strconv.Itoa(cfg.LowerCaseTableNames)
 	variable.SysVars[variable.LogBin].Value = variable.BoolToIntStr(config.GetGlobalConfig().Binlog.Enable)
 
+	variable.SysVars[variable.Port].Value = fmt.Sprintf("%d", cfg.Port)
+	variable.SysVars[variable.Socket].Value = cfg.Socket
+	variable.SysVars[variable.DataDir].Value = cfg.Path
+
 	// For CI environment we default enable prepare-plan-cache.
 	plannercore.SetPreparedPlanCache(config.CheckTableBeforeDrop || cfg.PreparedPlanCache.Enabled)
 	if plannercore.PreparedPlanCacheEnabled() {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This provides a workaround for https://github.com/pingcap/tidb/issues/9382

I suggest a longer-term fix here: https://github.com/pingcap/tidb/issues/9381

### What is changed and how it works?

This makes various sysvars work:
- port
- datadir
- socket

Port was previously added in https://github.com/pingcap/tidb/pull/9365 , but it turns out this did not work correctly since it retrieved the 'default' port prior to parsing the config file.  I have changed the value to be "4000" in variables so it becomes less confusing since this doesn't work.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

The test-suite contains the server variables from the default config only, and so it is difficult to assert for these changes.

Code changes

 - Has exported variable/fields change

Side effects

 - Increased code complexity (workaround)

Related changes

 - Need to update the documentation
 - Need to be included in the release note
