### PR TITLE
statistics: add PhysicalID to Column

### DIFF
--- a/statistics/bootstrap.go
+++ b/statistics/bootstrap.go
@@ -120,7 +120,13 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, tables stat
 				continue
 			}
 			hist := NewHistogram(id, ndv, nullCount, version, &colInfo.FieldType, 0, totColSize)
-			table.Columns[hist.ID] = &Column{Histogram: *hist, Info: colInfo, Count: nullCount, isHandle: tbl.Meta().PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag)}
+			table.Columns[hist.ID] = &Column{
+				Histogram:  *hist,
+				PhysicalID: table.PhysicalID,
+				Info:       colInfo,
+				Count:      nullCount,
+				isHandle:   tbl.Meta().PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+			}
 		}
 	}
 }

--- a/statistics/dump.go
+++ b/statistics/dump.go
@@ -212,11 +212,12 @@ func TableStatsFromJSON(tableInfo *model.TableInfo, physicalID int64, jsonTbl *J
 			}
 			hist.ID, hist.NullCount, hist.LastUpdateVersion, hist.TotColSize = colInfo.ID, jsonCol.NullCount, jsonCol.LastUpdateVersion, jsonCol.TotColSize
 			col := &Column{
-				Histogram: *hist,
-				CMSketch:  CMSketchFromProto(jsonCol.CMSketch),
-				Info:      colInfo,
-				Count:     count,
-				isHandle:  tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				PhysicalID: physicalID,
+				Histogram:  *hist,
+				CMSketch:   CMSketchFromProto(jsonCol.CMSketch),
+				Info:       colInfo,
+				Count:      count,
+				isHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
 			}
 			tbl.Columns[col.ID] = col
 		}

--- a/statistics/handle.go
+++ b/statistics/handle.go
@@ -264,7 +264,14 @@ func (h *Handle) LoadNeededHistograms() error {
 		if err != nil {
 			return errors.Trace(err)
 		}
-		tbl.Columns[c.ID] = &Column{Histogram: *hg, Info: c.Info, CMSketch: cms, Count: int64(hg.totalRowCount()), isHandle: c.isHandle}
+		tbl.Columns[c.ID] = &Column{
+			PhysicalID: col.tableID,
+			Histogram:  *hg,
+			Info:       c.Info,
+			CMSketch:   cms,
+			Count:      int64(hg.totalRowCount()),
+			isHandle:   c.isHandle,
+		}
 		h.UpdateTableStats([]*Table{tbl}, nil)
 		histogramNeededColumns.delete(col)
 	}

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -743,9 +743,10 @@ func (e *ErrorRate) merge(rate *ErrorRate) {
 type Column struct {
 	Histogram
 	*CMSketch
-	Count    int64
-	Info     *model.ColumnInfo
-	isHandle bool
+	PhysicalID int64
+	Count      int64
+	Info       *model.ColumnInfo
+	isHandle   bool
 	ErrorRate
 }
 
@@ -1001,7 +1002,12 @@ func (coll *HistColl) NewHistCollBySelectivity(sc *stmtctx.StatementContext, sta
 		if !ok {
 			continue
 		}
-		newCol := &Column{Info: oldCol.Info, isHandle: oldCol.isHandle, CMSketch: oldCol.CMSketch}
+		newCol := &Column{
+			PhysicalID: oldCol.PhysicalID,
+			Info:       oldCol.Info,
+			isHandle:   oldCol.isHandle,
+			CMSketch:   oldCol.CMSketch,
+		}
 		newCol.Histogram = *NewHistogram(oldCol.ID, int64(float64(oldCol.NDV)*node.Selectivity), 0, 0, oldCol.Tp, chunk.InitialCapacity, 0)
 		var err error
 		splitRanges := oldCol.Histogram.SplitRange(sc, node.Ranges, false)

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -170,7 +170,7 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 			continue
 		}
 
-		if coll.ColumnIsInvalid(sc, c.UniqueID) {
+		if colHist := coll.Columns[c.UniqueID]; colHist == nil || colHist.IsInvalid(sc, coll.Pseudo) {
 			ret *= 1.0 / pseudoEqualRate
 			continue
 		}

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -177,11 +177,12 @@ func (h *Handle) columnStatsFromStorage(row chunk.Row, table *Table, tableInfo *
 				return errors.Trace(err)
 			}
 			col = &Column{
-				Histogram: *NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
-				Info:      colInfo,
-				Count:     count + nullCount,
-				ErrorRate: errorRate,
-				isHandle:  tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				PhysicalID: table.PhysicalID,
+				Histogram:  *NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
+				Info:       colInfo,
+				Count:      count + nullCount,
+				ErrorRate:  errorRate,
+				isHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
 			}
 			break
 		}
@@ -195,12 +196,13 @@ func (h *Handle) columnStatsFromStorage(row chunk.Row, table *Table, tableInfo *
 				return errors.Trace(err)
 			}
 			col = &Column{
-				Histogram: *hg,
-				Info:      colInfo,
-				CMSketch:  cms,
-				Count:     int64(hg.totalRowCount()),
-				ErrorRate: errorRate,
-				isHandle:  tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				PhysicalID: table.PhysicalID,
+				Histogram:  *hg,
+				Info:       colInfo,
+				CMSketch:   cms,
+				Count:      int64(hg.totalRowCount()),
+				ErrorRate:  errorRate,
+				isHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
 			}
 			break
 		}
@@ -342,53 +344,52 @@ func (t *Table) IsOutdated() bool {
 	return false
 }
 
-// ColumnIsInvalid checks if this column is invalid. If this column has histogram but not loaded yet, then we mark it
+// IsInvalid checks if this column is invalid. If this column has histogram but not loaded yet, then we mark it
 // as need histogram.
-func (coll *HistColl) ColumnIsInvalid(sc *stmtctx.StatementContext, colID int64) bool {
-	col, ok := coll.Columns[colID]
-	if !ok || coll.Pseudo && col.NotAccurate() {
+func (c *Column) IsInvalid(sc *stmtctx.StatementContext, collPseudo bool) bool {
+	if collPseudo && c.NotAccurate() {
 		return true
 	}
-	if col.NDV > 0 && col.Len() == 0 && coll.HavePhysicalID {
+	if c.NDV > 0 && c.Len() == 0 {
 		sc.SetHistogramsNotLoad()
-		histogramNeededColumns.insert(tableColumnID{tableID: coll.PhysicalID, columnID: col.Info.ID})
+		histogramNeededColumns.insert(tableColumnID{tableID: c.PhysicalID, columnID: c.Info.ID})
 	}
-	return col.totalRowCount() == 0 || (col.NDV > 0 && col.Len() == 0)
+	return c.totalRowCount() == 0 || (c.NDV > 0 && c.Len() == 0)
 }
 
 // ColumnGreaterRowCount estimates the row count where the column greater than value.
 func (t *Table) ColumnGreaterRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) float64 {
-	if t.ColumnIsInvalid(sc, colID) {
+	c, ok := t.Columns[colID]
+	if !ok || c.IsInvalid(sc, t.Pseudo) {
 		return float64(t.Count) / pseudoLessRate
 	}
-	c := t.Columns[colID]
 	return c.greaterRowCount(value) * c.getIncreaseFactor(t.Count)
 }
 
 // ColumnLessRowCount estimates the row count where the column less than value.
 func (t *Table) ColumnLessRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) float64 {
-	if t.ColumnIsInvalid(sc, colID) {
+	c, ok := t.Columns[colID]
+	if !ok || c.IsInvalid(sc, t.Pseudo) {
 		return float64(t.Count) / pseudoLessRate
 	}
-	c := t.Columns[colID]
 	return c.lessRowCount(value) * c.getIncreaseFactor(t.Count)
 }
 
 // ColumnBetweenRowCount estimates the row count where column greater or equal to a and less than b.
 func (t *Table) ColumnBetweenRowCount(sc *stmtctx.StatementContext, a, b types.Datum, colID int64) float64 {
-	if t.ColumnIsInvalid(sc, colID) {
+	c, ok := t.Columns[colID]
+	if !ok || c.IsInvalid(sc, t.Pseudo) {
 		return float64(t.Count) / pseudoBetweenRate
 	}
-	c := t.Columns[colID]
 	return c.betweenRowCount(a, b) * c.getIncreaseFactor(t.Count)
 }
 
 // ColumnEqualRowCount estimates the row count where the column equals to value.
 func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Datum, colID int64) (float64, error) {
-	if t.ColumnIsInvalid(sc, colID) {
+	c, ok := t.Columns[colID]
+	if !ok || c.IsInvalid(sc, t.Pseudo) {
 		return float64(t.Count) / pseudoEqualRate, nil
 	}
-	c := t.Columns[colID]
 	result, err := c.equalRowCount(sc, value, t.ModifyCount)
 	result *= c.getIncreaseFactor(t.Count)
 	return result, errors.Trace(err)
@@ -396,7 +397,8 @@ func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Da
 
 // GetRowCountByIntColumnRanges estimates the row count by a slice of IntColumnRange.
 func (coll *HistColl) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext, colID int64, intRanges []*ranger.Range) (float64, error) {
-	if coll.ColumnIsInvalid(sc, colID) {
+	c, ok := coll.Columns[colID]
+	if !ok || c.IsInvalid(sc, coll.Pseudo) {
 		if len(intRanges) == 0 {
 			return 0, nil
 		}
@@ -405,7 +407,6 @@ func (coll *HistColl) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext,
 		}
 		return getPseudoRowCountByUnsignedIntRanges(intRanges, float64(coll.Count)), nil
 	}
-	c := coll.Columns[colID]
 	result, err := c.getColumnRowCount(sc, intRanges, coll.ModifyCount)
 	result *= c.getIncreaseFactor(coll.Count)
 	return result, errors.Trace(err)
@@ -413,11 +414,10 @@ func (coll *HistColl) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext,
 
 // GetRowCountByColumnRanges estimates the row count by a slice of Range.
 func (coll *HistColl) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, colID int64, colRanges []*ranger.Range) (float64, error) {
-	// Column not exists or haven't been loaded.
-	if coll.ColumnIsInvalid(sc, colID) {
+	c, ok := coll.Columns[colID]
+	if !ok || c.IsInvalid(sc, coll.Pseudo) {
 		return getPseudoRowCountByColumnRanges(sc, float64(coll.Count), colRanges, 0)
 	}
-	c := coll.Columns[colID]
 	result, err := c.getColumnRowCount(sc, colRanges, coll.ModifyCount)
 	result *= c.getIncreaseFactor(coll.Count)
 	return result, errors.Trace(err)
@@ -590,6 +590,8 @@ func (coll *HistColl) getIndexRowCount(sc *stmtctx.StatementContext, idxID int64
 	return totalCount, nil
 }
 
+const fakePhysicalID int64 = -1
+
 // PseudoTable creates a pseudo table statistics.
 func PseudoTable(tblInfo *model.TableInfo) *Table {
 	pseudoHistColl := HistColl{
@@ -605,7 +607,11 @@ func PseudoTable(tblInfo *model.TableInfo) *Table {
 	}
 	for _, col := range tblInfo.Columns {
 		if col.State == model.StatePublic {
-			t.Columns[col.ID] = &Column{Info: col, isHandle: tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag)}
+			t.Columns[col.ID] = &Column{
+				PhysicalID: fakePhysicalID,
+				Info:       col,
+				isHandle:   tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag),
+			}
 		}
 	}
 	for _, idx := range tblInfo.Indices {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Previous whether load column or not depends on the `PhysicalID` of `HistColl`. When maintaining it in join node. It's impossible to do it properly.

### What is changed and how it works?

Add `PhysicalID` to `statistics.Column`, change the `IsInvalid`'s logic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Existing Unit test covered this change.

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
