### PR TITLE
executor: control Chunk size for Selection&Projection

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -920,7 +920,7 @@ func (e *SelectionExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 			if !e.selected[e.inputRow.Idx()] {
 				continue
 			}
-			if req.NumRows() >= req.Capacity() {
+			if req.IsFull() {
 				return nil
 			}
 			req.AppendRow(e.inputRow)

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -178,6 +178,7 @@ func (s *testExecSuite) TestLimitRequiredRows(c *C) {
 			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
 			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
@@ -259,6 +260,7 @@ func (s *testExecSuite) TestSortRequiredRows(c *C) {
 			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
 			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
@@ -365,6 +367,7 @@ func (s *testExecSuite) TestTopNRequiredRows(c *C) {
 			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
 			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
@@ -457,6 +460,7 @@ func (s *testExecSuite) TestSelectionRequiredRows(c *C) {
 			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
 			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
@@ -514,6 +518,7 @@ func (s *testExecSuite) TestProjectionUnparallelRequiredRows(c *C) {
 			c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
 			c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
@@ -541,13 +546,13 @@ func (s *testExecSuite) TestProjectionParallelRequiredRows(c *C) {
 			expectedRows:   []int{7, 7, maxChunkSize, maxChunkSize - 14},
 			expectedRowsDS: []int{7, 7, maxChunkSize, maxChunkSize - 14, 0},
 		},
-		//{
-		//	totalRows:      20,
-		//	numWorkers:     2,
-		//	requiredRows:   []int{1, 2, 3, 4, 5, 6, 1, 1, 1},
-		//	expectedRows:   []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
-		//	expectedRowsDS: []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
-		//},
+		{
+			totalRows:      20,
+			numWorkers:     2,
+			requiredRows:   []int{1, 2, 3, 4, 5, 6, 1, 1, 1},
+			expectedRows:   []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
+			expectedRowsDS: []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -572,6 +572,7 @@ func (s *testExecSuite) TestProjectionParallelRequiredRows(c *C) {
 			// from child in the background.
 			time.Sleep(time.Millisecond * 5)
 		}
+		c.Assert(exec.Close(), IsNil)
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -541,13 +541,13 @@ func (s *testExecSuite) TestProjectionParallelRequiredRows(c *C) {
 			expectedRows:   []int{7, 7, maxChunkSize, maxChunkSize - 14},
 			expectedRowsDS: []int{7, 7, maxChunkSize, maxChunkSize - 14, 0},
 		},
-		{
-			totalRows:      20,
-			numWorkers:     2,
-			requiredRows:   []int{1, 2, 3, 4, 5, 6, 1, 1, 1},
-			expectedRows:   []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
-			expectedRowsDS: []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
-		},
+		//{
+		//	totalRows:      20,
+		//	numWorkers:     2,
+		//	requiredRows:   []int{1, 2, 3, 4, 5, 6, 1, 1, 1},
+		//	expectedRows:   []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
+		//	expectedRowsDS: []int{1, 1, 1, 2, 3, 4, 5, 3, 0},
+		//},
 	}
 
 	for _, testCase := range testCases {

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -64,7 +64,7 @@ type ProjectionExec struct {
 	workers     []*projectionWorker
 	childResult *chunk.Chunk
 
-	// requiredRowsNow indicates how many rows the parent executor is
+	// parentReqRows indicates how many rows the parent executor is
 	// requiring. It is set when parallelExecute() is called and used by the
 	// concurrent projectionInputFetcher.
 	//

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -17,7 +17,7 @@ import (
 	"context"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
@@ -166,6 +166,8 @@ func (e *ProjectionExec) isUnparallelExec() bool {
 }
 
 func (e *ProjectionExec) unParallelExecute(ctx context.Context, chk *chunk.Chunk) error {
+	// transmit the requiredRows
+	e.childResult.SetRequiredRows(chk.RequiredRows(), e.maxChunkSize)
 	err := e.children[0].Next(ctx, chunk.NewRecordBatch(e.childResult))
 	if err != nil {
 		return errors.Trace(err)

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -64,9 +64,11 @@ type ProjectionExec struct {
 	workers     []*projectionWorker
 	childResult *chunk.Chunk
 
-	// requiredRowsNow indicates how many rows the parent executor now.
-	// projectionInputFetcher sets its chunk's RequiredRows to this value while
-	// fetching data from child in the background.
+	// requiredRowsNow indicates how many rows the parent executor is
+	// requiring. It is set when parallelExecute() is called and used by the
+	// concurrent projectionInputFetcher.
+	//
+	// NOTE: It should be protected by atomic operations.
 	requiredRowsNow int64
 }
 

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -186,11 +186,11 @@ func (e *ProjectionExec) unParallelExecute(ctx context.Context, chk *chunk.Chunk
 }
 
 func (e *ProjectionExec) parallelExecute(ctx context.Context, chk *chunk.Chunk) error {
+	atomic.StoreInt64(&e.parentReqRows, int64(chk.RequiredRows()))
 	if !e.prepared {
 		e.prepare(ctx)
 		e.prepared = true
 	}
-	atomic.StoreInt64(&e.parentReqRows, int64(chk.RequiredRows()))
 
 	output, ok := <-e.outputCh
 	if !ok {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Control the number of rows in chunks returned by `Selection` & `Projection`.
Following up #9364, this PR is a subtask of #9166.

### What is changed and how it works?
* Make `Selection` support chunk size control.
* Make `Projection` support chunk size control.
* Add unit tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
