### PR TITLE
executor: change sort to parallel

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1141,7 +1141,7 @@ func (b *executorBuilder) buildSort(v *plannercore.PhysicalSort) Executor {
 		b.err = errors.Trace(b.err)
 		return nil
 	}
-	sortExec := SortExec{
+	sortExec := MergeSortExec{
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), childExec),
 		ByItems:      v.ByItems,
 		schema:       v.Schema(),

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -71,6 +71,7 @@ var (
 	_ Executor = &HashJoinExec{}
 	_ Executor = &IndexLookUpExecutor{}
 	_ Executor = &MergeJoinExec{}
+	_ Executor = &MergeSortExec{}
 )
 
 type baseExecutor struct {

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -110,7 +110,7 @@ func (e *MergeSortExec) Close() error {
 func (e *MergeSortExec) Open(ctx context.Context) error {
 	e.fetched = false
 	e.Idx = 0
-	e.concurrency = 4
+	e.concurrency = 8
 	e.workerRowIdx = make([]int, e.concurrency)
 	e.workerRowLen = make([]int, e.concurrency)
 	e.workerRowPtrs = make([]*[]chunk.RowPtr, e.concurrency)

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -191,7 +191,7 @@ func (e *MergeSortExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 		go e.wait4WorkerSort(wg, finishedCh)
 
 		for i := 0; i < e.concurrency; i++ {
-			// last worker must complete the rest of rows
+			// Last worker must complete the rest of rows.
 			if i == e.concurrency-1 {
 				workerRowsCount += e.rowChunks.Len() % e.concurrency
 			}

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
+	log "github.com/sirupsen/logrus"
+
 )
 
 // MergeSortExec represents sorting executor.
@@ -167,7 +169,7 @@ func (e *MergeSortExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 		go e.wait4WorkerSort(wg, e.finishedCh)
 		avgLen := 0
 		avgLen = e.rowChunks.Len() / e.concurrency
-		//log.Infof("allcolumnExpr %v row count %d  row chunk %d avgLen %d", e.allColumnExpr, e.rowChunks.Len(),e.rowChunks.NumChunks(),  avgLen)
+		log.Infof("allcolumnExpr %v row count %d  row chunk %d avgLen %d", e.allColumnExpr, e.rowChunks.Len(),e.rowChunks.NumChunks(),  avgLen)
 
 		for i := 0; i < e.concurrency; i++ {
 			chkIdx := (avgLen * i) / e.maxChunkSize
@@ -191,7 +193,7 @@ func (e *MergeSortExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 		e.fetched = true
 		<-e.finishedCh
 		for i := 0; i < e.concurrency; i++ {
-			//log.Infof("worker %d row count %d row len %d",i, len(*e.workerRowPtrs[i]), e.workerRowLen[i])
+			log.Infof("worker %d row count %d row len %d",i, len(*e.workerRowPtrs[i]), e.workerRowLen[i])
 		//	for j := 0; j < len(*e.workerRowPtrs[i]); j++ {
 		//		//log.Infof("worker %d row %d ptr %v",i, j, (*e.workerRowPtrs[i])[j])
 		//	}

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -57,6 +57,7 @@ type MergeSortExec struct {
 	concurrency   int
 	allColumnExpr bool
 }
+
 // SortWorker represents worker routine to process sort
 type SortWorker struct {
 	MergeSortExec

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -1,0 +1,340 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"github.com/pingcap/tidb/util"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/expression"
+	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/memory"
+)
+
+// MergeSortExec represents sorting executor.
+type MergeSortExec struct {
+	baseExecutor
+
+	ByItems []*plannercore.ByItems
+	Idx     int
+	fetched bool
+	schema  *expression.Schema
+
+	keyExprs []expression.Expression
+	keyTypes []*types.FieldType
+	// keyColumns is the column index of the by items.
+	keyColumns []int
+	// keyCmpFuncs is used to compare each ByItem.
+	keyCmpFuncs []chunk.CompareFunc
+	// keyChunks is used to store ByItems values when not all ByItems are column.
+	keyChunks *chunk.List
+	// rowChunks is the chunks to store row values.
+	rowChunks *chunk.List
+	// rowPointer store the chunk index and row index for each row.
+	workerRowPtrs []*[]chunk.RowPtr
+
+	workerRowLen []int
+	workerRowIdx []int
+
+	memTracker *memory.Tracker
+
+	concurrency int
+
+	allColumnExpr bool
+
+	workerWg *sync.WaitGroup
+
+	finishedCh chan struct{}
+}
+
+type SortWorker struct {
+	MergeSortExec
+	chkIdx  int
+	rowIdx  int
+	len     int
+	rowPtrs []chunk.RowPtr
+}
+
+func (sw *SortWorker) run() {
+	//sw.memTracker.Consume(int64(8 * sw.rowChunks.Len()))
+	//log.Infof("chkIdx %d rowIdx %d workerlen %d", sw.chkIdx, sw.rowIdx, sw.len)
+	for chkIdx := sw.chkIdx; chkIdx < sw.rowChunks.NumChunks(); chkIdx++ {
+		rowChk := sw.rowChunks.GetChunk(chkIdx)
+		for rowIdx := sw.rowIdx; rowIdx < rowChk.NumRows() && len(sw.rowPtrs) < sw.len; rowIdx++ {
+			sw.rowPtrs = append(sw.rowPtrs, chunk.RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)})
+		}
+	}
+
+	if sw.allColumnExpr {
+		sort.Slice(sw.rowPtrs, sw.keyColumnsLess)
+	} else {
+		sort.Slice(sw.rowPtrs, sw.keyChunksLess)
+	}
+	return
+}
+
+// Close implements the Executor Close interface.
+func (e *MergeSortExec) Close() error {
+	e.memTracker.Detach()
+	e.memTracker = nil
+	return errors.Trace(e.children[0].Close())
+}
+
+// Open implements the Executor Open interface.
+func (e *MergeSortExec) Open(ctx context.Context) error {
+	e.fetched = false
+	e.Idx = 0
+	e.concurrency = 4
+	e.workerRowIdx = make([]int, e.concurrency)
+	e.workerRowLen = make([]int, e.concurrency)
+	e.workerRowPtrs = make([]*[]chunk.RowPtr, e.concurrency)
+	// To avoid duplicated initialization for TopNExec.
+	if e.memTracker == nil {
+		e.memTracker = memory.NewTracker(e.id, e.ctx.GetSessionVars().MemQuotaSort)
+		e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
+	}
+	return errors.Trace(e.children[0].Open(ctx))
+}
+
+func (e *MergeSortExec) newSortWorker(chk, row, len int) *SortWorker {
+	return &SortWorker{
+		MergeSortExec: *e,
+		chkIdx:        chk,
+		rowIdx:        row,
+		len:           len,
+		rowPtrs:       make([]chunk.RowPtr, 0, len),
+	}
+}
+
+func (e *MergeSortExec) wait4WorkerSort(wg *sync.WaitGroup, finishedCh chan struct{}) {
+	wg.Wait()
+	close(finishedCh)
+}
+
+// Next implements the Executor Next interface.
+func (e *MergeSortExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
+	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
+		span1 := span.Tracer().StartSpan("sort.Next", opentracing.ChildOf(span.Context()))
+		defer span1.Finish()
+	}
+	if e.runtimeStats != nil {
+		start := time.Now()
+		defer func() { e.runtimeStats.Record(time.Since(start), req.NumRows()) }()
+	}
+	req.Reset()
+	if !e.fetched {
+		err := e.fetchRowChunks(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		e.initCompareFuncs()
+		e.allColumnExpr = e.buildKeyColumns()
+		if !e.allColumnExpr {
+			e.buildKeyExprsAndTypes()
+			err := e.buildKeyChunks()
+			if err != nil {
+				return err
+			}
+		}
+		e.finishedCh = make(chan struct{})
+		wg := &sync.WaitGroup{}
+		wg.Add(int(e.concurrency))
+		go e.wait4WorkerSort(wg, e.finishedCh)
+		avgLen := 0
+		avgLen = e.rowChunks.Len() / e.concurrency
+		//log.Infof("row count %d avgLen  %d", e.rowChunks.Len(), avgLen)
+
+		for i := 0; i < e.concurrency; i++ {
+			chkIdx := avgLen * i / e.maxChunkSize
+			rowIdx := avgLen * i % e.maxChunkSize
+			if i == e.concurrency-1 {
+				avgLen = e.rowChunks.Len()%e.concurrency + avgLen
+			}
+
+			sortWorker := e.newSortWorker(chkIdx, rowIdx, avgLen)
+			e.workerRowLen[i] = avgLen
+			e.workerRowIdx[i] = 0
+			e.workerRowPtrs[i] = &sortWorker.rowPtrs
+
+			go util.WithRecovery(func() {
+				defer wg.Done()
+				sortWorker.run()
+			}, nil)
+		}
+
+		e.fetched = true
+		<-e.finishedCh
+		for i := 0; i < e.concurrency; i++ {
+			//log.Infof("worker %d row count %d",i, len(*e.workerRowPtrs[i]))
+			for j := 0; j < len(*e.workerRowPtrs[i]); j++ {
+				//log.Infof("worker %d row %d ptr %v",i, j, (*e.workerRowPtrs[i])[j])
+			}
+		}
+	}
+	for req.NumRows() < e.maxChunkSize {
+		i := 0
+		j := 0
+		for; j < e.concurrency && e.workerRowIdx[j] >= e.workerRowLen[j];{
+			j++
+		}
+		//log.Infof("j %d", j)
+		if j >= e.concurrency {
+			break
+		}
+		minRowPtr := (*e.workerRowPtrs[j])[e.workerRowIdx[j]]
+
+		for i = j; i < e.concurrency; i++ {
+			if e.workerRowIdx[i] < e.workerRowLen[i] {
+				flag := false
+				if e.allColumnExpr {
+					keyRowI := e.rowChunks.GetRow(minRowPtr)
+					keyRowJ := e.rowChunks.GetRow((*e.workerRowPtrs[j])[e.workerRowIdx[j]])
+					flag = e.lessRow(keyRowI, keyRowJ)
+				} else {
+					keyRowI := e.keyChunks.GetRow(minRowPtr)
+					keyRowJ := e.keyChunks.GetRow((*e.workerRowPtrs[j])[e.workerRowIdx[j]])
+					flag = e.lessRow(keyRowI, keyRowJ)
+				}
+				if flag {
+					minRowPtr = (*e.workerRowPtrs[j])[e.workerRowIdx[j]]
+					j = i
+				}
+			}
+		}
+		e.workerRowIdx[j]++
+		//log.Infof("worker %d idx increase to %d", j, e.workerRowIdx[j])
+		req.AppendRow(e.rowChunks.GetRow(minRowPtr))
+	}
+	return nil
+}
+
+func (e *MergeSortExec) fetchRowChunks(ctx context.Context) error {
+	fields := e.retTypes()
+	e.rowChunks = chunk.NewList(fields, e.initCap, e.maxChunkSize)
+	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
+	e.rowChunks.GetMemTracker().SetLabel("rowChunks")
+	for {
+		chk := e.children[0].newFirstChunk()
+		err := e.children[0].Next(ctx, chunk.NewRecordBatch(chk))
+		if err != nil {
+			return errors.Trace(err)
+		}
+		rowCount := chk.NumRows()
+		if rowCount == 0 {
+			break
+		}
+		e.rowChunks.Add(chk)
+	}
+	return nil
+}
+
+//func (e *MergeSortExec) initPointers() {
+//	e.rowPtrs = make([]chunk.RowPtr, 0, e.rowChunks.Len())
+//	e.memTracker.Consume(int64(8 * e.rowChunks.Len()))
+//	for chkIdx := 0; chkIdx < e.rowChunks.NumChunks(); chkIdx++ {
+//		rowChk := e.rowChunks.GetChunk(chkIdx)
+//		for rowIdx := 0; rowIdx < rowChk.NumRows(); rowIdx++ {
+//			e.rowPtrs = append(e.rowPtrs, chunk.RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)})
+//		}
+//	}
+//}
+
+func (e *MergeSortExec) initCompareFuncs() {
+	e.keyCmpFuncs = make([]chunk.CompareFunc, len(e.ByItems))
+	for i := range e.ByItems {
+		keyType := e.ByItems[i].Expr.GetType()
+		e.keyCmpFuncs[i] = chunk.GetCompareFunc(keyType)
+	}
+}
+
+func (e *MergeSortExec) buildKeyColumns() (allColumnExpr bool) {
+	e.keyColumns = make([]int, 0, len(e.ByItems))
+	for _, by := range e.ByItems {
+		if col, ok := by.Expr.(*expression.Column); ok {
+			e.keyColumns = append(e.keyColumns, col.Index)
+		} else {
+			e.keyColumns = e.keyColumns[:0]
+			for i := range e.ByItems {
+				e.keyColumns = append(e.keyColumns, i)
+			}
+			return false
+		}
+	}
+	return true
+}
+
+func (e *MergeSortExec) buildKeyExprsAndTypes() {
+	keyLen := len(e.ByItems)
+	e.keyTypes = make([]*types.FieldType, keyLen)
+	e.keyExprs = make([]expression.Expression, keyLen)
+	for keyColIdx := range e.ByItems {
+		e.keyExprs[keyColIdx] = e.ByItems[keyColIdx].Expr
+		e.keyTypes[keyColIdx] = e.ByItems[keyColIdx].Expr.GetType()
+	}
+}
+
+func (e *MergeSortExec) buildKeyChunks() error {
+	e.keyChunks = chunk.NewList(e.keyTypes, e.initCap, e.maxChunkSize)
+	e.keyChunks.GetMemTracker().SetLabel("keyChunks")
+	e.keyChunks.GetMemTracker().AttachTo(e.memTracker)
+
+	for chkIdx := 0; chkIdx < e.rowChunks.NumChunks(); chkIdx++ {
+		keyChk := chunk.NewChunkWithCapacity(e.keyTypes, e.rowChunks.GetChunk(chkIdx).NumRows())
+		childIter := chunk.NewIterator4Chunk(e.rowChunks.GetChunk(chkIdx))
+		err := expression.VectorizedExecute(e.ctx, e.keyExprs, childIter, keyChk)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		e.keyChunks.Add(keyChk)
+	}
+	return nil
+}
+
+func (e *MergeSortExec) lessRow(rowI, rowJ chunk.Row) bool {
+	for i, colIdx := range e.keyColumns {
+		cmpFunc := e.keyCmpFuncs[i]
+		cmp := cmpFunc(rowI, colIdx, rowJ, colIdx)
+		if e.ByItems[i].Desc {
+			cmp = -cmp
+		}
+		if cmp < 0 {
+			return true
+		} else if cmp > 0 {
+			return false
+		}
+	}
+	return false
+}
+
+// keyColumnsLess is the less function for key columns.
+func (e *SortWorker) keyColumnsLess(i, j int) bool {
+	rowI := e.rowChunks.GetRow(e.rowPtrs[i])
+	rowJ := e.rowChunks.GetRow(e.rowPtrs[j])
+	return e.lessRow(rowI, rowJ)
+}
+
+// keyChunksLess is the less function for key chunk.
+func (e *SortWorker) keyChunksLess(i, j int) bool {
+	keyRowI := e.keyChunks.GetRow(e.rowPtrs[i])
+	keyRowJ := e.keyChunks.GetRow(e.rowPtrs[j])
+	return e.lessRow(keyRowI, keyRowJ)
+}

--- a/executor/merge_sort.go
+++ b/executor/merge_sort.go
@@ -43,8 +43,6 @@ type MergeSortExec struct {
 	keyColumns []int
 	// keyCmpFuncs is used to compare each ByItem.
 	keyCmpFuncs []chunk.CompareFunc
-	// keyChunks is used to store ByItems values when not all ByItems are column.
-	keyChunks *chunk.List
 	// rowChunks is the chunks to store row values.
 	rowChunks *chunk.List
 	// rowPointer store the chunk index and row index for each row.
@@ -283,4 +281,3 @@ func (sw *sortWorker) keyColumnsLess(i, j int) bool {
 	rowJ := sw.rowChunks.GetRow(sw.rowPtrs[j])
 	return sw.lessRow(rowI, rowJ)
 }
-

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -367,6 +367,7 @@ func NewSessionVars() *SessionVars {
 		DistSQLScanConcurrency:     DefDistSQLScanConcurrency,
 		HashAggPartialConcurrency:  DefTiDBHashAggPartialConcurrency,
 		HashAggFinalConcurrency:    DefTiDBHashAggFinalConcurrency,
+		MergeSortConcurrency:       DefTiDBMergeSortConcurrency,
 	}
 	vars.MemQuota = MemQuota{
 		MemQuotaQuery:             config.GetGlobalConfig().MemQuotaQuery,
@@ -763,6 +764,9 @@ type Concurrency struct {
 
 	// IndexSerialScanConcurrency is the number of concurrent index serial scan worker.
 	IndexSerialScanConcurrency int
+
+	//MergeSort is the number of concurrent sort worker
+	MergeSortConcurrency int
 }
 
 // MemQuota defines memory quota values.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -285,6 +285,7 @@ const (
 	DefTiDBForcePriority             = mysql.NoPriority
 	DefTiDBUseRadixJoin              = false
 	DefEnableWindowFunction          = false
+	DefTiDBMergeSortConcurrency      = 8
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -61,6 +61,7 @@ func (s *testVarsutilSuite) TestNewSessionVars(c *C) {
 	c.Assert(vars.IndexLookupSize, Equals, DefIndexLookupSize)
 	c.Assert(vars.IndexLookupConcurrency, Equals, DefIndexLookupConcurrency)
 	c.Assert(vars.IndexSerialScanConcurrency, Equals, DefIndexSerialScanConcurrency)
+	//c.Assert(vars.MergeSortConcurrency, Equals, DefTiDBMergeSortConcurrency)
 	c.Assert(vars.IndexLookupJoinConcurrency, Equals, DefIndexLookupJoinConcurrency)
 	c.Assert(vars.HashJoinConcurrency, Equals, DefTiDBHashJoinConcurrency)
 	c.Assert(vars.ProjectionConcurrency, Equals, int64(DefTiDBProjectionConcurrency))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?
make sort executor to parallel process
how it works:
1.get all rows from children executor
2.start several sort worker goroutine, average split rows to every sort worker, for every sort worker sort rows of itself
3.merge the sorted rows from every sort worker
 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
