### PR TITLE
executor, ddl: get the correct result of "show create table" when add ing the first index to the table (#9388)

### DIFF
--- a/ddl/ddl_db_change_test.go
+++ b/ddl/ddl_db_change_test.go
@@ -78,24 +78,34 @@ func (s *testStateChangeSuite) TearDownSuite(c *C) {
 func (s *testStateChangeSuite) TestShowCreateTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("create table t (id int, index idx (id))")
+	tk.MustExec("create table t (id int)")
 
 	var checkErr error
+	testCases := []struct {
+		sql         string
+		expectedRet string
+	}{
+		{"alter table t add index idx(id)",
+			"CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"},
+		{"alter table t add index idx1(id)",
+			"CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"},
+		{"alter table t add column c int",
+			"CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`),\n  KEY `idx1` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"},
+	}
 	prevState := model.StateNone
 	callback := &ddl.TestDDLCallback{}
+	currTestCaseOffset := 0
 	callback.OnJobUpdatedExported = func(job *model.Job) {
 		if job.SchemaState == prevState || checkErr != nil {
 			return
 		}
+		if job.State == model.JobStateDone {
+			currTestCaseOffset++
+		}
 		if job.SchemaState != model.StatePublic {
 			result := tk.MustQuery("show create table t")
 			got := result.Rows()[0][1]
-			var expected string
-			if job.Type == model.ActionAddIndex {
-				expected = "CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
-			} else if job.Type == model.ActionAddColumn {
-				expected = "CREATE TABLE `t` (\n  `id` int(11) DEFAULT NULL,\n  KEY `idx` (`id`),\n  KEY `idx1` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"
-			}
+			expected := testCases[currTestCaseOffset].expectedRet
 			if got != expected {
 				checkErr = errors.Errorf("got %s, expected %s", got, expected)
 			}
@@ -105,10 +115,10 @@ func (s *testStateChangeSuite) TestShowCreateTable(c *C) {
 	originalCallback := d.GetHook()
 	defer d.SetHook(originalCallback)
 	d.SetHook(callback)
-	tk.MustExec("alter table t add index idx1(id)")
-	c.Assert(checkErr, IsNil)
-	tk.MustExec("alter table t add column c int")
-	c.Assert(checkErr, IsNil)
+	for _, tc := range testCases {
+		tk.MustExec(tc.sql)
+		c.Assert(checkErr, IsNil)
+	}
 }
 
 // TestDropNotNullColumn is used to test issue #8654.

--- a/executor/show.go
+++ b/executor/show.go
@@ -549,16 +549,16 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(fmt.Sprintf("  PRIMARY KEY (%s)", escape(pkCol.Name, sqlMode)))
 	}
 
-	if len(tb.Indices()) > 0 {
-		buf.WriteString(",\n")
-	}
-
 	publicIndices := make([]table.Index, 0, len(tb.Indices()))
 	for _, idx := range tb.Indices() {
 		if idx.Meta().State == model.StatePublic {
 			publicIndices = append(publicIndices, idx)
 		}
 	}
+	if len(publicIndices) > 0 {
+		buf.WriteString(",\n")
+	}
+
 	for i, idx := range publicIndices {
 		idxInfo := idx.Meta()
 		if idxInfo.Primary {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #9386, cherry-pick #9388 to v2.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
