### PR TITLE
ddl: fix modify column null to not null bug

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -380,15 +380,10 @@ func (w *worker) doModifyColumn(t *meta.Meta, job *model.Job, newCol *model.Colu
 	// }
 	// }
 
-	if !mysql.HasNotNullFlag(oldCol.Flag) && mysql.HasNotNullFlag(newCol.Flag) {
-		ver, err = modifyColumnFromNull2NotNull(w, t, dbInfo, tblInfo, job, oldCol, newCol)
-		if err != nil {
-			return ver, errors.Trace(err)
-		}
+	if !mysql.HasNotNullFlag(oldCol.Flag) && mysql.HasNotNullFlag(newCol.Flag) && !mysql.HasPreventNullInsertFlag(oldCol.Flag) {
 		// Introduce the `mysql.HasPreventNullInsertFlag` flag to prevent users from inserting or updating null values.
-		if !mysql.HasPreventNullInsertFlag(oldCol.Flag) {
-			return ver, nil
-		}
+		ver, err = modifyColumnFromNull2NotNull(w, t, dbInfo, tblInfo, job, oldCol, newCol)
+		return ver, errors.Trace(err)
 	}
 
 	// We need the latest column's offset and state. This information can be obtained from the store.

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2222,6 +2222,7 @@ func (s *testDBSuite) TestCheckConvertToCharacter(c *C) {
 	}
 	c.Assert(t.Cols()[0].Charset, Equals, "binary")
 }
+
 func (s *testDBSuite) TestModifyColumnRollBack(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.mustExec(c, "use test_db")
@@ -2307,6 +2308,54 @@ LOOP:
 		}
 	}
 	c.Assert(mysql.HasNotNullFlag(c2.Flag), IsFalse)
+	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
+	s.mustExec(c, "drop table t1")
+}
+
+func (s *testDBSuite) TestModifyColumnNullToNotNull(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.mustExec(c, "use test_db")
+	s.mustExec(c, "drop table if exists t1")
+	s.mustExec(c, "create table t1 (c1 int, c2 int);")
+
+	tbl := s.testGetTable(c, "t1")
+	var insertErr error
+	hook := &ddl.TestDDLCallback{}
+	hook.OnJobRunBeforeExported = func(job *model.Job) {
+		if tbl.Meta().ID != job.TableID {
+			return
+		}
+		var c2 *table.Column
+		t := s.testGetTable(c, "t1")
+		for _, col := range t.Cols() {
+			if col.Name.L == "c2" {
+				c2 = col
+			}
+		}
+		if mysql.HasPreventNullInsertFlag(c2.Flag) {
+			_, insertErr = s.tk.Exec("insert into t1 values ();")
+		}
+	}
+
+	originalHook := s.dom.DDL().GetHook()
+	s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
+	done := make(chan error, 1)
+	go backgroundExec(s.store, "alter table t1 change c2 c2 bigint not null;", done)
+	err := <-done
+	c.Assert(err, IsNil)
+
+	var c2 *table.Column
+	t := s.testGetTable(c, "t1")
+	for _, col := range t.Cols() {
+		if col.Name.L == "c2" {
+			c2 = col
+		}
+	}
+	c.Assert(mysql.HasNotNullFlag(c2.Flag), IsTrue)
+	c.Assert(mysql.HasPreventNullInsertFlag(c2.Flag), IsFalse)
+	c.Assert(insertErr.Error(), Equals, "[table:1048]Column 'c2' cannot be null")
+	_, insertErr = s.tk.Exec("insert into t1 values ();")
+	c.Assert(insertErr.Error(), Equals, "[table:1364]Field 'c2' doesn't have a default value")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 	s.mustExec(c, "drop table t1")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When modify column from null to not null, the normal state should be:
```
column null -> check null value and set column prevent not null -> column not null
```

But there is something wrong that `set column prevent not null` does not take effect, so the problem is:
```
column null -> check null value and change column not null
```
there is only 2 state. here is the problem.

This PR will fix this.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch
