### PR TITLE
planner: remove correlated column sort items

### DIFF
--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -189,3 +189,32 @@ id	count	task	operator info
 Projection_7	1.00	root	1
 └─Limit_8	1.00	root	offset:0, count:1
   └─TableDual_11	1.00	root	rows:1
+drop table if exists t1;
+drop table if exists t2;
+create table t1(a bigint, b bigint);
+create table t2(a bigint, b bigint);
+desc select * from t1 where t1.a in (select t2.a as a from t2 where t2.b > t1.b order by t1.b limit 1);
+id	count	task	operator info
+Apply_15	9990.00	root	semi join, inner:Selection_19, equal:[eq(test.t1.a, test.t2.a)]
+├─TableReader_18	9990.00	root	data:Selection_17
+│ └─Selection_17	9990.00	cop	not(isnull(test.t1.a))
+│   └─TableScan_16	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─Selection_19	0.80	root	not(isnull(test.t2.a))
+  └─Limit_20	1.00	root	offset:0, count:1
+    └─TableReader_26	1.00	root	data:Limit_25
+      └─Limit_25	1.00	cop	offset:0, count:1
+        └─Selection_24	1.00	cop	gt(test.t2.b, test.t1.b)
+          └─TableScan_23	1.25	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+desc select * from t1 where t1.a in (select a from (select t2.a as a, t1.b as b from t2 where t2.b > t1.b) x order by b limit 1);
+id	count	task	operator info
+Apply_17	9990.00	root	semi join, inner:Selection_21, equal:[eq(test.t1.a, x.a)]
+├─TableReader_20	9990.00	root	data:Selection_19
+│ └─Selection_19	9990.00	cop	not(isnull(test.t1.a))
+│   └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─Selection_21	0.80	root	not(isnull(x.a))
+  └─Projection_22	1.00	root	test.t2.a, test.t1.b
+    └─Limit_23	1.00	root	offset:0, count:1
+      └─TableReader_29	1.00	root	data:Limit_28
+        └─Limit_28	1.00	cop	offset:0, count:1
+          └─Selection_27	1.00	cop	gt(test.t2.b, test.t1.b)
+            └─TableScan_26	1.25	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/topn_push_down.test
+++ b/cmd/explaintest/t/topn_push_down.test
@@ -172,4 +172,13 @@ WHERE
 ORDER BY te.expect_time asc
 LIMIT 0, 5;
 
+-- test order by constant
 desc select 1 as a from dual order by a limit 1;
+
+-- test order by correlated column
+drop table if exists t1;
+drop table if exists t2;
+create table t1(a bigint, b bigint);
+create table t2(a bigint, b bigint);
+desc select * from t1 where t1.a in (select t2.a as a from t2 where t2.b > t1.b order by t1.b limit 1);
+desc select * from t1 where t1.a in (select a from (select t2.a as a, t1.b as b from t2 where t2.b > t1.b) x order by b limit 1);

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -99,8 +99,8 @@ func (p *LogicalProjection) pushDownTopN(topN *LogicalTopN) LogicalPlan {
 
 		// remove meaningless constant sort items.
 		for i := len(topN.ByItems) - 1; i >= 0; i-- {
-			_, isConst := topN.ByItems[i].Expr.(*expression.Constant)
-			if isConst {
+			switch topN.ByItems[i].Expr.(type) {
+			case *expression.Constant, *expression.CorrelatedColumn:
 				topN.ByItems = append(topN.ByItems[:i], topN.ByItems[i+1:]...)
 			}
 		}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix the issue that order by correlated column panic in the executor

### What is changed and how it works?

remove correlated column from sort items in sort/topn push down after column substitution.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Related changes

 - Need to cherry-pick to the release branch
