### PR TITLE
stats: restrict the adjust factor for index feedback

### DIFF
--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -991,6 +991,10 @@ func (q *QueryFeedback) logDetailedInfo(h *Handle) {
 	}
 }
 
+// minAdjustFactor is the minimum adjust factor of each index feedback.
+// We use it to avoid adjusting too much when the assumption of independence failed.
+const minAdjustFactor = 0.7
+
 // getNewCount adjust the estimated `eqCount` and `rangeCount` according to the real count.
 // We assumes that `eqCount` and `rangeCount` contribute the same error rate.
 func getNewCountForIndex(eqCount, rangeCount, totalCount, realCount float64) (float64, float64) {
@@ -999,6 +1003,7 @@ func getNewCountForIndex(eqCount, rangeCount, totalCount, realCount float64) (fl
 		return eqCount, rangeCount
 	}
 	adjustFactor := math.Sqrt(realCount / estimate)
+	adjustFactor = math.Max(adjustFactor, minAdjustFactor)
 	return eqCount * adjustFactor, rangeCount * adjustFactor
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When estimating the row count for `a = 1 and b < 1` using an index, we will split it into two parts: one is `a = 1` using the cm sketch of the index, and another one is `b < 1` using the histogram of `b`, and assumes that they are independent.
When the query feedback indicates that the real count of `a = 1 and b < 1` is 0, we actually do not know where the estimation error comes from, so adjusting them to 0 may cause big changes to the stats.

### What is changed and how it works?

Limit the minimum adjusting factor in this pr to avoid big changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has unexported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
