### PR TITLE
planner, executor: support range framed window functions

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1918,12 +1918,25 @@ func (b *executorBuilder) buildWindow(v *plannercore.PhysicalWindow) *WindowExec
 			windowFunc:    agg,
 			partialResult: agg.AllocPartialResult(),
 		}
-	} else {
+	} else if v.Frame.Type == ast.Rows {
 		processor = &rowFrameWindowProcessor{
 			windowFunc:    agg,
 			partialResult: agg.AllocPartialResult(),
 			start:         v.Frame.Start,
 			end:           v.Frame.End,
+		}
+	} else {
+		cmpResult := int64(-1)
+		if v.OrderBy[0].Desc {
+			cmpResult = 1
+		}
+		processor = &rangeFrameWindowProcessor{
+			windowFunc:        agg,
+			partialResult:     agg.AllocPartialResult(),
+			start:             v.Frame.Start,
+			end:               v.Frame.End,
+			col:               v.OrderBy[0].Col,
+			expectedCmpResult: cmpResult,
 		}
 	}
 	return &WindowExec{baseExecutor: base,

--- a/executor/window.go
+++ b/executor/window.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/executor/aggfuncs"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"
@@ -304,4 +305,98 @@ func (p *rowFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, row
 func (p *rowFrameWindowProcessor) resetPartialResult() {
 	p.windowFunc.ResetPartialResult(p.partialResult)
 	p.curRowIdx = 0
+}
+
+type rangeFrameWindowProcessor struct {
+	windowFunc      aggfuncs.AggFunc
+	partialResult   aggfuncs.PartialResult
+	start           *core.FrameBound
+	end             *core.FrameBound
+	curRowIdx       uint64
+	lastStartOffset uint64
+	lastEndOffset   uint64
+	col             *expression.Column
+	// expectedCmpResult is used to decide if one value is included in the frame.
+	expectedCmpResult int64
+}
+
+func (p *rangeFrameWindowProcessor) getStartOffset(ctx sessionctx.Context, rows []chunk.Row) (uint64, error) {
+	if p.start.UnBounded {
+		return 0, nil
+	}
+	numRows := uint64(len(rows))
+	for ; p.lastStartOffset < numRows; p.lastStartOffset++ {
+		res, _, err := p.start.CmpFunc(ctx, p.col, p.start.CalcFunc, rows[p.lastStartOffset], rows[p.curRowIdx])
+		if err != nil {
+			return 0, err
+		}
+		// For asc, break when the current value is greater or equal to the calculated result;
+		// For desc, break when the current value is less or equal to the calculated result.
+		if res != p.expectedCmpResult {
+			break
+		}
+	}
+	return p.lastStartOffset, nil
+}
+
+func (p *rangeFrameWindowProcessor) getEndOffset(ctx sessionctx.Context, rows []chunk.Row) (uint64, error) {
+	numRows := uint64(len(rows))
+	if p.end.UnBounded {
+		return numRows, nil
+	}
+	for ; p.lastEndOffset < numRows; p.lastEndOffset++ {
+		res, _, err := p.end.CmpFunc(ctx, p.end.CalcFunc, p.col, rows[p.curRowIdx], rows[p.lastEndOffset])
+		if err != nil {
+			return 0, err
+		}
+		// For asc, break when the calculated result is greater than the current value.
+		// For desc, break when the calculated result is less than the current value.
+		if res == p.expectedCmpResult {
+			break
+		}
+	}
+	return p.lastEndOffset, nil
+}
+
+func (p *rangeFrameWindowProcessor) appendResult2Chunk(ctx sessionctx.Context, rows []chunk.Row, chk *chunk.Chunk, remained int) ([]chunk.Row, error) {
+	for remained > 0 {
+		start, err := p.getStartOffset(ctx, rows)
+		if err != nil {
+			return nil, err
+		}
+		end, err := p.getEndOffset(ctx, rows)
+		if err != nil {
+			return nil, err
+		}
+		p.curRowIdx++
+		remained--
+		if start >= end {
+			err := p.windowFunc.AppendFinalResult2Chunk(ctx, p.partialResult, chk)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		err = p.windowFunc.UpdatePartialResult(ctx, rows[start:end], p.partialResult)
+		if err != nil {
+			return nil, err
+		}
+		err = p.windowFunc.AppendFinalResult2Chunk(ctx, p.partialResult, chk)
+		if err != nil {
+			return nil, err
+		}
+		p.windowFunc.ResetPartialResult(p.partialResult)
+	}
+	return rows, nil
+}
+
+func (p *rangeFrameWindowProcessor) consumeGroupRows(ctx sessionctx.Context, rows []chunk.Row) ([]chunk.Row, error) {
+	return rows, nil
+}
+
+func (p *rangeFrameWindowProcessor) resetPartialResult() {
+	p.windowFunc.ResetPartialResult(p.partialResult)
+	p.curRowIdx = 0
+	p.lastStartOffset = 0
+	p.lastEndOffset = 0
 }

--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -52,4 +52,16 @@ func (s *testSuite2) TestWindowFunctions(c *C) {
 	result.Check(testkit.Rows("1 5", "4 7", "2 6"))
 	result = tk.MustQuery("select a, sum(a) over(rows between unbounded preceding and 1 preceding) from t")
 	result.Check(testkit.Rows("1 <nil>", "4 1", "2 5"))
+
+	tk.MustExec("drop table t")
+	tk.MustExec("create table t(a int, b date)")
+	tk.MustExec("insert into t values (null,null),(1,20190201),(2,20190202),(3,20190203),(5,20190205)")
+	result = tk.MustQuery("select a, sum(a) over(order by a range between 1 preceding and 2 following) from t")
+	result.Check(testkit.Rows("<nil> <nil>", "1 6", "2 6", "3 10", "5 5"))
+	result = tk.MustQuery("select a, sum(a) over(order by a desc range between 1 preceding and 2 following) from t")
+	result.Check(testkit.Rows("5 8", "3 6", "2 6", "1 3", "<nil> <nil>"))
+	result = tk.MustQuery("select a, b, sum(a) over(order by b range between interval 1 day preceding and interval 2 day following) from t")
+	result.Check(testkit.Rows("<nil> <nil> <nil>", "1 2019-02-01 6", "2 2019-02-02 6", "3 2019-02-03 10", "5 2019-02-05 5"))
+	result = tk.MustQuery("select a, b, sum(a) over(order by b desc range between interval 1 day preceding and interval 2 day following) from t")
+	result.Check(testkit.Rows("5 2019-02-05 8", "3 2019-02-03 6", "2 2019-02-02 6", "1 2019-02-01 3", "<nil> <nil> <nil>"))
 }

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1035,6 +1035,27 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 	return cmpType
 }
 
+// GetCmpFunction get the compare function according to two arguments.
+func GetCmpFunction(lhs, rhs Expression) CompareFunc {
+	switch GetAccurateCmpType(lhs, rhs) {
+	case types.ETInt:
+		return CompareInt
+	case types.ETReal:
+		return CompareReal
+	case types.ETDecimal:
+		return CompareDecimal
+	case types.ETString:
+		return CompareString
+	case types.ETDuration:
+		return CompareDuration
+	case types.ETDatetime, types.ETTimestamp:
+		return CompareTime
+	case types.ETJson:
+		return CompareJSON
+	}
+	return nil
+}
+
 // isTemporalColumn checks if a expression is a temporal column,
 // temporal column indicates time column or duration column.
 func isTemporalColumn(expr Expression) bool {

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -236,22 +236,7 @@ func (p *LogicalJoin) getEnforcedMergeJoin(prop *property.PhysicalProperty) []Ph
 func (p *PhysicalMergeJoin) initCompareFuncs() {
 	p.CompareFuncs = make([]expression.CompareFunc, 0, len(p.LeftKeys))
 	for i := range p.LeftKeys {
-		switch expression.GetAccurateCmpType(p.LeftKeys[i], p.RightKeys[i]) {
-		case types.ETInt:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareInt)
-		case types.ETReal:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareReal)
-		case types.ETDecimal:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareDecimal)
-		case types.ETString:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareString)
-		case types.ETDuration:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareDuration)
-		case types.ETDatetime, types.ETTimestamp:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareTime)
-		case types.ETJson:
-			p.CompareFuncs = append(p.CompareFuncs, expression.CompareJSON)
-		}
+		p.CompareFuncs = append(p.CompareFuncs, expression.GetCmpFunction(p.LeftKeys[i], p.RightKeys[i]))
 	}
 }
 

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2189,7 +2189,7 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 		},
 		{
 			sql:    "select sum(a) over(order by a range between 1.0 preceding and 1 following) from t",
-			result: "[planner:3586]Window '<unnamed window>': frame start or end is negative, NULL or of non-integral type",
+			result: "TableReader(Table(t))->Window(sum(cast(test.t.a)) over(order by test.t.a asc range between 1.0 preceding and 1 following))->Projection",
 		},
 	}
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -663,8 +663,12 @@ type FrameBound struct {
 	Type      ast.BoundType
 	UnBounded bool
 	Num       uint64
-	// For `INTERVAL '2:30' MINUTE_SECOND FOLLOWING`, we will build the date_add or date_sub functions.
-	DateCalcFunc expression.Expression
+	// CalcFunc is used for range framed windows.
+	// We will build the date_add or date_sub functions for frames like `INTERVAL '2:30' MINUTE_SECOND FOLLOWING`,
+	// and plus or minus for frames like `1 preceding`.
+	CalcFunc expression.Expression
+	// CmpFunc is used to decide whether one row is included in the current frame.
+	CmpFunc expression.CompareFunc
 }
 
 // LogicalWindow represents a logical window function plan.

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -336,6 +336,20 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 			return err
 		}
 	}
+	if p.Frame != nil {
+		if p.Frame.Start.CalcFunc != nil {
+			p.Frame.Start.CalcFunc, err = p.Frame.Start.CalcFunc.ResolveIndices(p.children[0].Schema())
+			if err != nil {
+				return err
+			}
+		}
+		if p.Frame.End.CalcFunc != nil {
+			p.Frame.End.CalcFunc, err = p.Frame.End.CalcFunc.ResolveIndices(p.children[0].Schema())
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Support range framed window functions.
Refer https://dev.mysql.com/doc/refman/8.0/en/window-functions-frames.html

### What is changed and how it works?

- Add one proecessor in executor to process range framed windows.
- Unify the calculation of frame end points for numeric and temporal types.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
