### PR TITLE
table: add an http api to control whether the check is enabled when the inserted column data is 4-byte utf-8 characters

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -578,7 +578,17 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 				atomic.StoreUint32(&variable.DDLSlowOprThreshold, uint32(threshold))
 			}
 		}
-
+		if checkMb4ValueInUtf8 := req.Form.Get("check_mb4_value_in_utf8"); checkMb4ValueInUtf8 != "" {
+			switch checkMb4ValueInUtf8 {
+			case "0":
+				config.GetGlobalConfig().CheckMb4ValueInUtf8 = false
+			case "1":
+				config.GetGlobalConfig().CheckMb4ValueInUtf8 = true
+			default:
+				writeError(w, errors.New("illegal argument"))
+				return
+			}
+		}
 	} else {
 		writeData(w, config.GetGlobalConfig())
 	}

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -641,6 +641,36 @@ func (ts *HTTPHandlerTestSuite) TestPostSettings(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	c.Assert(atomic.LoadUint32(&variable.DDLSlowOprThreshold), Equals, uint32(200))
+
+	// test check_mb4_value_in_utf8
+	db, err := sql.Open("mysql", getDSN())
+	c.Assert(err, IsNil, Commentf("Error connecting"))
+	defer db.Close()
+	dbt := &DBTest{c, db}
+
+	dbt.mustExec("create database tidb_test;")
+	dbt.mustExec("use tidb_test;")
+	dbt.mustExec("drop table if exists t2;")
+	dbt.mustExec("create table t2(a varchar(100) charset utf8);")
+	form.Set("check_mb4_value_in_utf8", "1")
+	resp, err = http.PostForm("http://127.0.0.1:10090/settings", form)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUtf8, Equals, true)
+	txn1, err := dbt.db.Begin()
+	c.Assert(err, IsNil)
+	_, err = txn1.Exec("insert t2 values (unhex('F0A48BAE'));")
+	c.Assert(err, NotNil)
+	txn1.Commit()
+
+	// Disable CheckMb4ValueInUtf8.
+	form = make(url.Values)
+	form.Set("check_mb4_value_in_utf8", "0")
+	resp, err = http.PostForm("http://127.0.0.1:10090/settings", form)
+	c.Assert(err, IsNil)
+	c.Assert(resp.StatusCode, Equals, http.StatusOK)
+	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUtf8, Equals, false)
+	dbt.mustExec("insert t2 values (unhex('f09f8c80'));")
 }
 
 func (ts *HTTPHandlerTestSuite) TestPprof(c *C) {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -606,6 +606,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.setDDLReorgPriority(val)
 	case TiDBForcePriority:
 		atomic.StoreInt32(&ForcePriority, int32(mysql.Str2Priority(val)))
+	case TiDBCheckMb4ValueInUtf8:
+		config.GetGlobalConfig().CheckMb4ValueInUtf8 = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -669,6 +669,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, TiDBDDLReorgBatchSize, strconv.Itoa(DefTiDBDDLReorgBatchSize)},
 	{ScopeSession, TiDBDDLReorgPriority, "PRIORITY_LOW"},
 	{ScopeSession, TiDBForcePriority, mysql.Priority2Str[DefTiDBForcePriority]},
+	{ScopeSession, TiDBCheckMb4ValueInUtf8, boolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUtf8)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -118,6 +118,9 @@ const (
 
 	// tidb_enable_table_partition is used to enable table partition feature.
 	TiDBEnableTablePartition = "tidb_enable_table_partition"
+
+	// TiDBCheckMb4ValueInUtf8 is used to control whether to enable the check wrong utf8 value.
+	TiDBCheckMb4ValueInUtf8 = "tidb_check_mb4_value_in_utf8"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -106,6 +106,8 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.SlowThreshold), 10), true, nil
 	case TiDBQueryLogMaxLen:
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.QueryLogMaxLen), 10), true, nil
+	case TiDBCheckMb4ValueInUtf8:
+		return boolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUtf8), true, nil
 	}
 	sVal, ok := s.systems[key]
 	if ok {
@@ -316,7 +318,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 	case AutocommitVar, TiDBSkipUTF8Check, TiDBOptAggPushDown,
 		TiDBOptInSubqUnFolding, TiDBEnableTablePartition,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
-		TiDBBatchDelete:
+		TiDBBatchDelete, TiDBCheckMb4ValueInUtf8:
 		if strings.EqualFold(value, "ON") || value == "1" || strings.EqualFold(value, "OFF") || value == "0" {
 			return value, nil
 		}

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -220,4 +220,15 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "1")
 	c.Assert(v.EnableTablePartition, IsTrue)
+
+	SetSessionSystemVar(v, TiDBCheckMb4ValueInUtf8, types.NewStringDatum("1"))
+	val, err = GetSessionSystemVar(v, TiDBCheckMb4ValueInUtf8)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "1")
+	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUtf8, Equals, true)
+	SetSessionSystemVar(v, TiDBCheckMb4ValueInUtf8, types.NewStringDatum("0"))
+	val, err = GetSessionSystemVar(v, TiDBCheckMb4ValueInUtf8)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "0")
+	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUtf8, Equals, false)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry pick #9024


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
