### PR TITLE
expression: fix timezone for timestamp constant when converting expression to pb

### DIFF
--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -14,8 +14,6 @@
 package expression
 
 import (
-	"fmt"
-
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
@@ -105,7 +103,6 @@ func (pc PbConverter) conOrCorColToPBExpr(expr Expression) *tipb.Expr {
 		log.Errorf("Fail to eval constant, err: %s", err.Error())
 		return nil
 	}
-	fmt.Printf("const to pb, expr = %s, d = %#v %s type = %v\n", expr, d, pc.sc.TimeZone, ft)
 	tp, val, ok := pc.encodeDatum(d)
 	if !ok {
 		return nil
@@ -234,24 +231,21 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 
 	// check whether all of its parameters can be pushed.
 	children := make([]*tipb.Expr, 0, len(expr.GetArgs()))
-	for i, arg := range expr.GetArgs() {
+	for _, arg := range expr.GetArgs() {
 		pbArg := pc.ExprToPB(arg)
 		if pbArg == nil {
 			return nil
 		}
-		fmt.Printf("scalar func argi = %d %#v AAADDD converted == %#v\n", i, arg, pbArg)
 		children = append(children, pbArg)
 	}
 
 	// construct expression ProtoBuf.
-	ret := &tipb.Expr{
+	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
 		Sig:       pbCode,
 		Children:  children,
 		FieldType: ToPBFieldType(expr.RetType),
 	}
-	fmt.Println("scalar func to pb expr", ret)
-	return ret
 }
 
 // GroupByItemToPB converts group by items to pb.

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3997,7 +3997,7 @@ func (s *testIntegrationSuite) TestIssue9325(c *C) {
 	tk.MustExec("create table t(a timestamp) partition by range(unix_timestamp(a)) (partition p0 values less than(unix_timestamp('2019-02-16 14:20:00')), partition p1 values less than (maxvalue))")
 	tk.MustExec("insert into t values('2019-02-16 14:19:59'), ('2019-02-16 14:20:01')")
 	result := tk.MustQuery("select * from t where a between timestamp'2019-02-16 14:19:00' and timestamp'2019-02-16 14:21:00'")
-	result.Check(testkit.Rows("2019-02-16 14:19:59", "2019-02-16 14:20:01"))
+	c.Assert(result.Rows(), HasLen, 2)
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a timestamp)")


### PR DESCRIPTION



<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/9325

TiDB does not need to convert the timezone of a timestamp constant when converting it to pb, because that coprocessor will do the timezone-convert-work when evaluating. 

### What is changed and how it works?

timestamp constant expression should not be converted in coprocessor push down.
The timezone info is already there.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch

