### PR TITLE
ddl: fix canceling model.ActionRebaseAutoID and model.ActionShardRowID ddl jobs (#9226)

### DIFF
--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -88,6 +88,14 @@ func cancelOnlyNotHandledJob(job *model.Job) (ver int64, err error) {
 	return ver, nil
 }
 
+func rollingbackRebaseAutoID(t *meta.Meta, job *model.Job) (ver int64, err error) {
+	return cancelOnlyNotHandledJob(job)
+}
+
+func rollingbackShardRowID(t *meta.Meta, job *model.Job) (ver int64, err error) {
+	return cancelOnlyNotHandledJob(job)
+}
+
 func rollingbackAddColumn(t *meta.Meta, job *model.Job) (ver int64, err error) {
 	job.State = model.JobStateRollingback
 	col := &model.ColumnInfo{}
@@ -266,6 +274,10 @@ func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) 
 		ver, err = rollingbackTruncateTable(t, job)
 	case model.ActionDropIndex:
 		ver, err = rollingbackDropIndex(t, job)
+	case model.ActionRebaseAutoID:
+		ver, err = rollingbackRebaseAutoID(t, job)
+	case model.ActionShardRowID:
+		ver, err = rollingbackShardRowID(t, job)
 	default:
 		job.State = model.JobStateCancelled
 		err = errCancelledDDLJob

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -107,6 +107,10 @@ func isJobRollbackable(job *model.Job, id int64) error {
 			job.SchemaState == model.StateDeleteReorganization {
 			return ErrCannotCancelDDLJob.GenWithStackByArgs(id)
 		}
+	case model.ActionRebaseAutoID, model.ActionShardRowID:
+		if job.SchemaState != model.StateNone {
+			return ErrCannotCancelDDLJob.GenWithStackByArgs(id)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Cherry-pick from #9226 