### PR TITLE
executor: control Chunk size for StreamAgg&HashAgg

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -470,12 +470,14 @@ func (w *HashAggFinalWorker) getFinalResult(sctx sessionctx.Context) {
 		return
 	}
 	for groupKey := range w.groupSet {
+		//fmt.Println("----------1>  ", result.NumRows(), len(w.aggFuncs))
 		partialResults := w.getPartialResult(sctx.GetSessionVars().StmtCtx, []byte(groupKey), w.partialResultMap)
 		for i, af := range w.aggFuncs {
 			if err := af.AppendFinalResult2Chunk(sctx, partialResults[i], result); err != nil {
 				log.Error(errors.ErrorStack(err))
 			}
 		}
+		//fmt.Println("----------2> ", result.NumRows())
 		if len(w.aggFuncs) == 0 {
 			result.SetNumVirtualRows(result.NumRows() + 1)
 		}
@@ -485,7 +487,6 @@ func (w *HashAggFinalWorker) getFinalResult(sctx sessionctx.Context) {
 			if finished {
 				return
 			}
-			result.Reset()
 		}
 	}
 	w.outputCh <- &AfFinalResult{chk: result}

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -470,14 +470,12 @@ func (w *HashAggFinalWorker) getFinalResult(sctx sessionctx.Context) {
 		return
 	}
 	for groupKey := range w.groupSet {
-		//fmt.Println("----------1>  ", result.NumRows(), len(w.aggFuncs))
 		partialResults := w.getPartialResult(sctx.GetSessionVars().StmtCtx, []byte(groupKey), w.partialResultMap)
 		for i, af := range w.aggFuncs {
 			if err := af.AppendFinalResult2Chunk(sctx, partialResults[i], result); err != nil {
 				log.Error(errors.ErrorStack(err))
 			}
 		}
-		//fmt.Println("----------2> ", result.NumRows())
 		if len(w.aggFuncs) == 0 {
 			result.SetNumVirtualRows(result.NumRows() + 1)
 		}
@@ -665,11 +663,11 @@ func (e *HashAggExec) unparallelExec(ctx context.Context, chk *chunk.Chunk) erro
 			chk.SetNumVirtualRows(chk.NumRows() + 1)
 		}
 		for i, af := range e.PartialAggFuncs {
-			if err := (af.AppendFinalResult2Chunk(e.ctx, partialResults[i], chk)); err != nil {
+			if err := af.AppendFinalResult2Chunk(e.ctx, partialResults[i], chk); err != nil {
 				return err
 			}
 		}
-		if chk.NumRows() == e.maxChunkSize {
+		if chk.IsFull() {
 			e.cursor4GroupKey++
 			return nil
 		}

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -626,7 +626,7 @@ func (e *HashAggExec) parallelExec(ctx context.Context, chk *chunk.Chunk) error 
 			return nil
 		}
 		if result.err != nil {
-			return errors.Trace(result.err)
+			return result.err
 		}
 		if chk.NumRows() > 0 {
 			e.isChildReturnEmpty = false

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -18,7 +18,7 @@ import (
 	"sync"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
@@ -805,7 +805,7 @@ func (e *StreamAggExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 		defer func() { e.runtimeStats.Record(time.Since(start), req.NumRows()) }()
 	}
 	req.Reset()
-	for !e.executed && req.NumRows() < e.maxChunkSize {
+	for !e.executed && !req.IsFull() {
 		err := e.consumeOneGroup(ctx, req.Chunk)
 		if err != nil {
 			e.executed = true

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -667,3 +667,66 @@ func (s *testExecSuite) TestStreamAggRequiredRows(c *C) {
 		c.Assert(ds.checkNumNextCalled(), IsNil)
 	}
 }
+
+func (s *testExecSuite) TestHashAggParallelRequiredRows(c *C) {
+	genByDiv := func(factor int) func(valType *types.FieldType) interface{} {
+		closureCountInt := 0
+		closureCountDouble := 0
+		return func(valType *types.FieldType) interface{} {
+			switch valType.Tp {
+			case mysql.TypeLong, mysql.TypeLonglong:
+				ret := int64(closureCountInt / factor)
+				closureCountInt++
+				return ret
+			case mysql.TypeDouble:
+				ret := float64(closureCountInt / factor)
+				closureCountDouble++
+				return ret
+			default:
+				panic("not implement")
+			}
+		}
+	}
+
+	maxChunkSize := defaultCtx().GetSessionVars().MaxChunkSize
+	testCases := []struct {
+		totalRows      int
+		aggFunc        string
+		requiredRows   []int
+		expectedRows   []int
+		expectedRowsDS []int
+		gen            func(valType *types.FieldType) interface{}
+	}{
+		{
+			totalRows:      maxChunkSize,
+			aggFunc:        ast.AggFuncSum,
+			requiredRows:   []int{1, 2, 3, 4, 5, 6, 7},
+			expectedRows:   []int{1, 2, 3, 4, 5, 6, 7},
+			expectedRowsDS: []int{maxChunkSize, 0},
+			gen:            genByDiv(1),
+		},
+	}
+
+	for _, hasDistinct := range []bool{false} {
+		for _, testCase := range testCases {
+			sctx := defaultCtx()
+			ctx := context.Background()
+			ds := newRequiredRowsDataSourceWithGenerator(sctx, testCase.totalRows, testCase.expectedRowsDS, testCase.gen)
+			childCols := ds.Schema().Columns
+			schema := expression.NewSchema(childCols...)
+			groupBy := []expression.Expression{childCols[1]}
+			aggFunc := aggregation.NewAggFuncDesc(sctx, testCase.aggFunc, []expression.Expression{childCols[0]}, hasDistinct)
+			aggFuncs := []*aggregation.AggFuncDesc{aggFunc}
+			exec := buildHashAggExecutor(sctx, ds, schema, aggFuncs, groupBy)
+			c.Assert(exec.Open(ctx), IsNil)
+			chk := exec.newFirstChunk()
+			for i := range testCase.requiredRows {
+				chk.SetRequiredRows(testCase.requiredRows[i], maxChunkSize)
+				c.Assert(exec.Next(ctx, chunk.NewRecordBatch(chk)), IsNil)
+				c.Assert(chk.NumRows(), Equals, testCase.expectedRows[i])
+			}
+			c.Assert(exec.Close(), IsNil)
+			c.Assert(ds.checkNumNextCalled(), IsNil)
+		}
+	}
+}

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/expression/aggregation"
 	"math"
 	"math/rand"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -583,6 +583,14 @@ func (s *testExecSuite) TestProjectionParallelRequiredRows(c *C) {
 	}
 }
 
+func buildProjectionExec(ctx sessionctx.Context, exprs []expression.Expression, src Executor, numWorkers int) Executor {
+	return &ProjectionExec{
+		baseExecutor:  newBaseExecutor(ctx, src.Schema(), "", src),
+		numWorkers:    int64(numWorkers),
+		evaluatorSuit: expression.NewEvaluatorSuite(exprs, false),
+	}
+}
+
 func divGenerator(factor int) func(valType *types.FieldType) interface{} {
 	closureCountInt := 0
 	closureCountDouble := 0
@@ -599,14 +607,6 @@ func divGenerator(factor int) func(valType *types.FieldType) interface{} {
 		default:
 			panic("not implement")
 		}
-	}
-}
-
-func buildProjectionExec(ctx sessionctx.Context, exprs []expression.Expression, src Executor, numWorkers int) Executor {
-	return &ProjectionExec{
-		baseExecutor:  newBaseExecutor(ctx, src.Schema(), "", src),
-		numWorkers:    int64(numWorkers),
-		evaluatorSuit: expression.NewEvaluatorSuite(exprs, false),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Control the number of rows in chunks returned by `TableReader` & `IndexReader` & `IndexLookup`.
Following up #9452, this PR is a subtask of #9166.

### What is changed and how it works?
1. make `StreamAgg` and `HashAgg` support chunk size control.
2. add some unit tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test