### PR TITLE
types: provide a default slice capacity for result of ParseDateFormat

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -564,7 +564,11 @@ func ParseDateFormat(format string) []string {
 	format = strings.TrimSpace(format)
 
 	start := 0
-	var seps = make([]string, 0)
+	// Initialize `seps` with capacity of 6. The input `format` is typically
+	// a date time of the form "2006-01-02 15:04:05", which has 6 numeric parts
+	// (the fractional second part is usually removed by `splitDateTime`).
+	// Setting `seps`'s capacity to 6 avoids reallocation in this common case.
+	seps := make([]string, 0, 6)
 	for i := 0; i < len(format); i++ {
 		// Date format must start and end with number.
 		if i == 0 || i == len(format)-1 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In `types.ParseDateFormat()` a `sep` array was initialized with zero capacity, which will be populated by consecutive numerical substrings of the input. The input is typically correctly formatted datetime string such as `"2019-03-01 00:00:00"`, which has at most 6 parts. This means the capacity of `sep` needs to be unnecessarily grown 4 times (0 → 1 → 2 → 4 → 8).

### What is changed and how it works?

Create `sep` with an initial capacity of 6, so reallocation no longer happen.

On Lightning, after implementing this change, the performance of `ParseDateFormat` itself is improved from 1.34s to 0.50s for parsing ~4M datetimes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Replaced the `tidb` dependency of TiDB-Lightning, then capture a 10-second CPU profile, and compare with the previous result.

Code changes

Side effects

Related changes
