### PR TITLE
type/compatibility: check `KEY` option for generated column.

### DIFF
--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -75,6 +75,7 @@ const (
 	codeWindowRangeBoundNotConstant     = mysql.ErrWindowRangeBoundNotConstant
 	codeWindowRowsIntervalUse           = mysql.ErrWindowRowsIntervalUse
 	codeWindowFunctionIgnoresFrame      = mysql.ErrWindowFunctionIgnoresFrame
+	codeUnsupportedOnGeneratedColumn    = mysql.ErrUnsupportedOnGeneratedColumn
 )
 
 // error definitions.
@@ -136,6 +137,7 @@ var (
 	ErrWindowRangeBoundNotConstant     = terror.ClassOptimizer.New(codeWindowRangeBoundNotConstant, mysql.MySQLErrName[mysql.ErrWindowRangeBoundNotConstant])
 	ErrWindowRowsIntervalUse           = terror.ClassOptimizer.New(codeWindowRowsIntervalUse, mysql.MySQLErrName[mysql.ErrWindowRowsIntervalUse])
 	ErrWindowFunctionIgnoresFrame      = terror.ClassOptimizer.New(codeWindowFunctionIgnoresFrame, mysql.MySQLErrName[mysql.ErrWindowFunctionIgnoresFrame])
+	ErrUnsupportedOnGeneratedColumn    = terror.ClassOptimizer.New(codeUnsupportedOnGeneratedColumn, mysql.MySQLErrName[mysql.ErrUnsupportedOnGeneratedColumn])
 	ErrNoSuchThread                    = terror.ClassOptimizer.New(mysql.ErrNoSuchThread, mysql.MySQLErrName[mysql.ErrNoSuchThread])
 	// Since we cannot know if user loggined with a password, use message of ErrAccessDeniedNoPassword instead
 	ErrAccessDenied = terror.ClassOptimizer.New(mysql.ErrAccessDenied, mysql.MySQLErrName[mysql.ErrAccessDeniedNoPassword])
@@ -190,6 +192,7 @@ func init() {
 		codeWindowRangeBoundNotConstant:     mysql.ErrWindowRangeBoundNotConstant,
 		codeWindowRowsIntervalUse:           mysql.ErrWindowRowsIntervalUse,
 		codeWindowFunctionIgnoresFrame:      mysql.ErrWindowFunctionIgnoresFrame,
+		codeUnsupportedOnGeneratedColumn:    mysql.ErrUnsupportedOnGeneratedColumn,
 
 		mysql.ErrNoSuchThread: mysql.ErrNoSuchThread,
 		mysql.ErrAccessDenied: mysql.ErrAccessDenied,

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -333,7 +333,7 @@ func (p *preprocessor) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 		}
 		isPrimary, err := checkColumnOptions(colDef.Options)
 		if err != nil {
-			p.err = errors.Trace(err)
+			p.err = err
 			return
 		}
 		countPrimaryKey += isPrimary

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -434,7 +434,7 @@ func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[string]inter
 }
 
 func checkColumnOptions(ops []*ast.ColumnOption) (int, error) {
-	isPrimary, isGenerated := 0, 0
+	isPrimary, isGenerated, isStored := 0, 0, false
 
 	for _, op := range ops {
 		switch op.Tp {
@@ -442,10 +442,11 @@ func checkColumnOptions(ops []*ast.ColumnOption) (int, error) {
 			isPrimary = 1
 		case ast.ColumnOptionGenerated:
 			isGenerated = 1
+			isStored = op.Stored
 		}
 	}
 
-	if isPrimary > 0 && isGenerated > 0 {
+	if isPrimary > 0 && isGenerated > 0 && !isStored {
 		return isPrimary, ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("Defining a virtual generated column as primary key")
 	}
 

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -434,8 +434,7 @@ func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[string]inter
 }
 
 func checkColumnOptions(ops []*ast.ColumnOption) (int, error) {
-	isPrimary := 0
-	isGenerated := 0
+	isPrimary, isGenerated := 0, 0
 
 	for _, op := range ops {
 		switch op.Tp {

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -331,7 +331,12 @@ func (p *preprocessor) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 			p.err = err
 			return
 		}
-		countPrimaryKey += isPrimary(colDef.Options)
+		isPrimary, err := checkColumnOptions(colDef.Options)
+		if err != nil {
+			p.err = errors.Trace(err)
+			return
+		}
+		countPrimaryKey += isPrimary
 		if countPrimaryKey > 1 {
 			p.err = infoschema.ErrMultiplePriKey
 			return
@@ -428,13 +433,24 @@ func isTableAliasDuplicate(node ast.ResultSetNode, tableAliases map[string]inter
 	return nil
 }
 
-func isPrimary(ops []*ast.ColumnOption) int {
+func checkColumnOptions(ops []*ast.ColumnOption) (int, error) {
+	isPrimary := 0
+	isGenerated := 0
+
 	for _, op := range ops {
-		if op.Tp == ast.ColumnOptionPrimaryKey {
-			return 1
+		switch op.Tp {
+		case ast.ColumnOptionPrimaryKey:
+			isPrimary = 1
+		case ast.ColumnOptionGenerated:
+			isGenerated = 1
 		}
 	}
-	return 0
+
+	if isPrimary > 0 && isGenerated > 0 {
+		return isPrimary, ErrUnsupportedOnGeneratedColumn.GenWithStackByArgs("Defining a virtual generated column as primary key")
+	}
+
+	return isPrimary, nil
 }
 
 func (p *preprocessor) checkCreateIndexGrammar(stmt *ast.CreateIndexStmt) {

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -198,6 +198,10 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"select * from (select 1 ) a , (select 2) b, (select * from (select 3) a join (select 4) b) c;", false, nil},
 
 		{"CREATE VIEW V (a,b,c) AS SELECT 1,1,3;", false, nil},
+
+		// issue 9464
+		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));", false, errors.New("[planner:3106]'Defining a virtual generated column as primary key' is not supported for generated columns.")},
+		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));", false, errors.New("[planner:3106]'Defining a virtual generated column as primary key' is not supported for generated columns.")},
 	}
 
 	store, dom, err := newStoreWithBootstrap()

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -202,6 +202,7 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		// issue 9464
 		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));", false, core.ErrUnsupportedOnGeneratedColumn},
 		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));", false, core.ErrUnsupportedOnGeneratedColumn},
+		{"create table t (a DOUBLE NULL, b_sto DOUBLE GENERATED ALWAYS AS (a + 2) STORED UNIQUE KEY NOT NULL PRIMARY KEY);", false, nil},
 	}
 
 	store, dom, err := newStoreWithBootstrap()

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -200,8 +200,8 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"CREATE VIEW V (a,b,c) AS SELECT 1,1,3;", false, nil},
 
 		// issue 9464
-		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));", false, errors.New("[planner:3106]'Defining a virtual generated column as primary key' is not supported for generated columns.")},
-		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));", false, errors.New("[planner:3106]'Defining a virtual generated column as primary key' is not supported for generated columns.")},
+		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));", false, core.ErrUnsupportedOnGeneratedColumn},
+		{"CREATE TABLE t1 (id INT NOT NULL, c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));", false, core.ErrUnsupportedOnGeneratedColumn},
 	}
 
 	store, dom, err := newStoreWithBootstrap()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
check `KEY` option for generated column in `create table`

TiDB:
```sql
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));
ERROR 1068 (42000): Multiple primary key defined
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));
ERROR 1068 (42000): Multiple primary key defined
```

MySQL:
```sql
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));
ERROR 3106 (HY000): 'Defining a virtual generated column as primary key' is not supported for generated columns.
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));
ERROR 3106 (HY000): 'Defining a virtual generated column as primary key' is not supported for generated columns.
mysql> select version();
+-------------------------+
| version()               |
+-------------------------+
| 5.7.25-0ubuntu0.18.04.2 |
+-------------------------+
1 row in set (0.00 sec)

mysql> 
```

related issue: #9464 

### What is changed and how it works?
add checking of `KEY` option on generated column for `CREATE TABLE`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual Test
```sql
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NULL, PRIMARY KEY (id));
ERROR 3106 (HY000): 'Defining a virtual generated column as primary key' is not supported for generated columns.
mysql> CREATE TABLE t1 (id INT NOT NULL,
    ->   c1 VARCHAR(20) AS ('foo') VIRTUAL KEY NOT NULL, PRIMARY KEY (id));
ERROR 3106 (HY000): 'Defining a virtual generated column as primary key' is not supported for generated columns.
mysql> select TiDB_version();
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| TiDB_version()                                                                                                                                                                                                                                                                                                                             |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Release Version: v3.0.0-beta-144-g560e8cfe5-dirty
Git Commit Hash: 560e8cfe57d102d52918fd609e4e865ebdfb7159
Git Branch: master
UTC Build Time: 2019-03-03 05:20:02
GoVersion: go version go1.11.2 darwin/amd64
Race Enabled: false
TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
Check Table Before Drop: false |
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

mysql> 
```

 - Unit test
