### PR TITLE
planner, executor: handle default frame for window functions

### DIFF
--- a/cmd/explaintest/r/window_function.result
+++ b/cmd/explaintest/r/window_function.result
@@ -17,7 +17,7 @@ Projection_7	10000.00	root	sum(a) over(partition by a)
 explain select sum(a) over(partition by a order by b) from t;
 id	count	task	operator info
 Projection_7	10000.00	root	sum(a) over(partition by a order by b)
-└─Window_8	10000.00	root	sum(cast(test.t.a)) over(partition by test.t.a order by test.t.b asc)
+└─Window_8	10000.00	root	sum(cast(test.t.a)) over(partition by test.t.a order by test.t.b asc range between unbounded preceding and current row)
   └─Sort_12	10000.00	root	test.t.a:asc, test.t.b:asc
     └─TableReader_11	10000.00	root	data:TableScan_10
       └─TableScan_10	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1942,7 +1942,7 @@ func (b *executorBuilder) buildWindow(v *plannercore.PhysicalWindow) *WindowExec
 			partialResult:     agg.AllocPartialResult(),
 			start:             v.Frame.Start,
 			end:               v.Frame.End,
-			col:               v.OrderBy[0].Col,
+			orderByCols:       orderByCols,
 			expectedCmpResult: cmpResult,
 		}
 	}

--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -81,4 +81,16 @@ func (s *testSuite2) TestWindowFunctions(c *C) {
 	result.Check(testkit.Rows("1 1 1", "1 2 1", "2 1 2", "2 2 2"))
 	result = tk.MustQuery("select a, b, dense_rank() over(order by a, b) from t")
 	result.Check(testkit.Rows("1 1 1", "1 2 2", "2 1 3", "2 2 4"))
+
+	result = tk.MustQuery("select row_number() over(rows between 1 preceding and 1 following) from t")
+	result.Check(testkit.Rows("1", "2", "3", "4"))
+	result = tk.MustQuery("show warnings")
+	result.Check(testkit.Rows("Note 3599 Window function 'row_number' ignores the frame clause of window '<unnamed window>' and aggregates over the whole partition"))
+
+	result = tk.MustQuery("select a, sum(a) over() from t")
+	result.Check(testkit.Rows("1 6", "1 6", "2 6", "2 6"))
+	result = tk.MustQuery("select a, sum(a) over(order by a) from t")
+	result.Check(testkit.Rows("1 2", "1 2", "2 6", "2 6"))
+	result = tk.MustQuery("select a, sum(a) over(order by a, b) from t")
+	result.Check(testkit.Rows("1 1", "1 2", "2 4", "2 6"))
 }

--- a/expression/aggregation/window_func.go
+++ b/expression/aggregation/window_func.go
@@ -14,6 +14,9 @@
 package aggregation
 
 import (
+	"strings"
+
+	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 )
@@ -26,4 +29,23 @@ type WindowFuncDesc struct {
 // NewWindowFuncDesc creates a window function signature descriptor.
 func NewWindowFuncDesc(ctx sessionctx.Context, name string, args []expression.Expression) *WindowFuncDesc {
 	return &WindowFuncDesc{newBaseFuncDesc(ctx, name, args)}
+}
+
+// partitionWindowFuncs is the functions that operate on the entire partition,
+// they should not have frame specifications.
+var partitionWindowFuncs = map[string]struct{}{
+	ast.WindowFuncCumeDist:    {},
+	ast.WindowFuncDenseRank:   {},
+	ast.WindowFuncLag:         {},
+	ast.WindowFuncLead:        {},
+	ast.WindowFuncNtile:       {},
+	ast.WindowFuncPercentRank: {},
+	ast.WindowFuncRank:        {},
+	ast.WindowFuncRowNumber:   {},
+}
+
+// NeedFrame checks if the function need frame specification.
+func NeedFrame(name string) bool {
+	_, ok := partitionWindowFuncs[strings.ToLower(name)]
+	return !ok
 }

--- a/expression/aggregation/window_func.go
+++ b/expression/aggregation/window_func.go
@@ -31,9 +31,9 @@ func NewWindowFuncDesc(ctx sessionctx.Context, name string, args []expression.Ex
 	return &WindowFuncDesc{newBaseFuncDesc(ctx, name, args)}
 }
 
-// partitionWindowFuncs is the functions that operate on the entire partition,
+// noFrameWindowFuncs is the functions that operate on the entire partition,
 // they should not have frame specifications.
-var partitionWindowFuncs = map[string]struct{}{
+var noFrameWindowFuncs = map[string]struct{}{
 	ast.WindowFuncCumeDist:    {},
 	ast.WindowFuncDenseRank:   {},
 	ast.WindowFuncLag:         {},
@@ -46,6 +46,6 @@ var partitionWindowFuncs = map[string]struct{}{
 
 // NeedFrame checks if the function need frame specification.
 func NeedFrame(name string) bool {
-	_, ok := partitionWindowFuncs[strings.ToLower(name)]
+	_, ok := noFrameWindowFuncs[strings.ToLower(name)]
 	return !ok
 }

--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -73,6 +73,7 @@ const (
 	codeWindowRangeFrameNumericType     = mysql.ErrWindowRangeFrameNumericType
 	codeWindowRangeBoundNotConstant     = mysql.ErrWindowRangeBoundNotConstant
 	codeWindowRowsIntervalUse           = mysql.ErrWindowRowsIntervalUse
+	codeWindowFunctionIgnoresFrame      = mysql.ErrWindowFunctionIgnoresFrame
 )
 
 // error definitions.
@@ -132,6 +133,7 @@ var (
 	ErrWindowRangeFrameNumericType     = terror.ClassOptimizer.New(codeWindowRangeFrameNumericType, mysql.MySQLErrName[mysql.ErrWindowRangeFrameNumericType])
 	ErrWindowRangeBoundNotConstant     = terror.ClassOptimizer.New(codeWindowRangeBoundNotConstant, mysql.MySQLErrName[mysql.ErrWindowRangeBoundNotConstant])
 	ErrWindowRowsIntervalUse           = terror.ClassOptimizer.New(codeWindowRowsIntervalUse, mysql.MySQLErrName[mysql.ErrWindowRowsIntervalUse])
+	ErrWindowFunctionIgnoresFrame      = terror.ClassOptimizer.New(codeWindowFunctionIgnoresFrame, mysql.MySQLErrName[mysql.ErrWindowFunctionIgnoresFrame])
 )
 
 func init() {
@@ -181,6 +183,7 @@ func init() {
 		codeWindowRangeFrameNumericType:     mysql.ErrWindowRangeFrameNumericType,
 		codeWindowRangeBoundNotConstant:     mysql.ErrWindowRangeBoundNotConstant,
 		codeWindowRowsIntervalUse:           mysql.ErrWindowRowsIntervalUse,
+		codeWindowFunctionIgnoresFrame:      mysql.ErrWindowFunctionIgnoresFrame,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassOptimizer] = mysqlErrCodeMap
 }

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -306,8 +306,8 @@ func (p *PhysicalWindow) formatFrameBound(buffer *bytes.Buffer, bound *FrameBoun
 	}
 	if bound.UnBounded {
 		buffer.WriteString("unbounded")
-	} else if bound.CalcFunc != nil {
-		sf := bound.CalcFunc.(*expression.ScalarFunction)
+	} else if len(bound.CalcFuncs) > 0 {
+		sf := bound.CalcFuncs[0].(*expression.ScalarFunction)
 		switch sf.FuncName.L {
 		case ast.DateAdd, ast.DateSub:
 			// For `interval '2:30' minute_second`.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
-	driver "github.com/pingcap/tidb/types/parser_driver"
+	"github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -2805,14 +2805,19 @@ func (b *PlanBuilder) buildWindowFunctionFrameBound(spec *ast.WindowSpec, orderB
 		return bound, nil
 	}
 
-	if len(orderByItems) != 1 {
-		return nil, ErrWindowRangeFrameOrderType.GenWithStackByArgs(spec.Name)
+	bound.CalcFuncs = make([]expression.Expression, len(orderByItems))
+	bound.CmpFuncs = make([]expression.CompareFunc, len(orderByItems))
+	if bound.Type == ast.CurrentRow {
+		for i, item := range orderByItems {
+			col := item.Col
+			bound.CalcFuncs[i] = col
+			bound.CmpFuncs[i] = expression.GetCmpFunction(col, col)
+		}
+		return bound, nil
 	}
 
-	if bound.Type == ast.CurrentRow {
-		bound.CalcFunc = orderByItems[0].Col
-		bound.CmpFunc = expression.GetCmpFunction(orderByItems[0].Col, orderByItems[0].Col)
-		return bound, nil
+	if len(orderByItems) != 1 {
+		return nil, ErrWindowRangeFrameOrderType.GenWithStackByArgs(spec.Name)
 	}
 	col := orderByItems[0].Col
 	isNumeric, isTemporal := types.IsTypeNumeric(col.RetType.Tp), types.IsTypeTemporal(col.RetType.Tp)
@@ -2857,11 +2862,11 @@ func (b *PlanBuilder) buildWindowFunctionFrameBound(spec *ast.WindowSpec, orderB
 		if (!desc && bound.Type == ast.Preceding) || (desc && bound.Type == ast.Following) {
 			funcName = ast.DateSub
 		}
-		bound.CalcFunc, err = expression.NewFunctionBase(b.ctx, funcName, col.RetType, col, &expr, &unit)
+		bound.CalcFuncs[0], err = expression.NewFunctionBase(b.ctx, funcName, col.RetType, col, &expr, &unit)
 		if err != nil {
 			return nil, err
 		}
-		bound.CmpFunc = expression.GetCmpFunction(orderByItems[0].Col, bound.CalcFunc)
+		bound.CmpFuncs[0] = expression.GetCmpFunction(orderByItems[0].Col, bound.CalcFuncs[0])
 		return bound, nil
 	}
 	// When the order is asc:
@@ -2871,11 +2876,11 @@ func (b *PlanBuilder) buildWindowFunctionFrameBound(spec *ast.WindowSpec, orderB
 	if (!desc && bound.Type == ast.Preceding) || (desc && bound.Type == ast.Following) {
 		funcName = ast.Minus
 	}
-	bound.CalcFunc, err = expression.NewFunctionBase(b.ctx, funcName, col.RetType, col, &expr)
+	bound.CalcFuncs[0], err = expression.NewFunctionBase(b.ctx, funcName, col.RetType, col, &expr)
 	if err != nil {
 		return nil, err
 	}
-	bound.CmpFunc = expression.GetCmpFunction(orderByItems[0].Col, bound.CalcFunc)
+	bound.CmpFuncs[0] = expression.GetCmpFunction(orderByItems[0].Col, bound.CalcFuncs[0])
 	return bound, nil
 }
 
@@ -2915,6 +2920,26 @@ func (b *PlanBuilder) buildWindowFunction(p LogicalPlan, expr *ast.WindowFuncExp
 	p, partitionBy, orderBy, args, err := b.buildProjectionForWindow(p, expr, aggMap)
 	if err != nil {
 		return nil, err
+	}
+
+	needFrame := aggregation.NeedFrame(expr.F)
+	// According to MySQL, In the absence of a frame clause, the default frame depends on whether an ORDER BY clause is present:
+	//   (1) With order by, the default frame is equivalent to "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW";
+	//   (2) Without order by, the default frame is equivalent to "RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING",
+	//       which is the same as an empty frame.
+	if needFrame && expr.Spec.Frame == nil && len(orderBy) > 0 {
+		expr.Spec.Frame = &ast.FrameClause{
+			Type: ast.Ranges,
+			Extent: ast.FrameExtent{
+				Start: ast.FrameBound{Type: ast.Preceding, UnBounded: true},
+				End:   ast.FrameBound{Type: ast.CurrentRow},
+			},
+		}
+	}
+	// For functions that operate on the entire partition, the frame clause will be ignored.
+	if !needFrame && expr.Spec.Frame != nil {
+		b.ctx.GetSessionVars().StmtCtx.AppendNote(ErrWindowFunctionIgnoresFrame.GenWithStackByArgs(expr.F, expr.Spec.Name.O))
+		expr.Spec.Frame = nil
 	}
 	frame, err := b.buildWindowFunctionFrame(&expr.Spec, orderBy)
 	if err != nil {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2065,7 +2065,7 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 		},
 		{
 			sql:    "select a, avg(a) over(order by a asc, b desc) from t order by a asc, b desc",
-			result: "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a)) over(order by test.t.a asc, test.t.b desc))->Projection",
+			result: "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a)) over(order by test.t.a asc, test.t.b desc range between unbounded preceding and current row))->Projection",
 		},
 		{
 			sql:    "select a, b as a, avg(a) over(partition by a) from t",
@@ -2190,6 +2190,10 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 		{
 			sql:    "select sum(a) over(order by a range between 1.0 preceding and 1 following) from t",
 			result: "TableReader(Table(t))->Window(sum(cast(test.t.a)) over(order by test.t.a asc range between 1.0 preceding and 1 following))->Projection",
+		},
+		{
+			sql:    "select row_number() over(rows between 1 preceding and 1 following) from t",
+			result: "TableReader(Table(t))->Window(row_number() over())->Projection",
 		},
 	}
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -663,12 +663,12 @@ type FrameBound struct {
 	Type      ast.BoundType
 	UnBounded bool
 	Num       uint64
-	// CalcFunc is used for range framed windows.
+	// CalcFuncs is used for range framed windows.
 	// We will build the date_add or date_sub functions for frames like `INTERVAL '2:30' MINUTE_SECOND FOLLOWING`,
 	// and plus or minus for frames like `1 preceding`.
-	CalcFunc expression.Expression
-	// CmpFunc is used to decide whether one row is included in the current frame.
-	CmpFunc expression.CompareFunc
+	CalcFuncs []expression.Expression
+	// CmpFuncs is used to decide whether one row is included in the current frame.
+	CmpFuncs []expression.CompareFunc
 }
 
 // LogicalWindow represents a logical window function plan.

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -337,14 +337,14 @@ func (p *PhysicalWindow) ResolveIndices() (err error) {
 		}
 	}
 	if p.Frame != nil {
-		if p.Frame.Start.CalcFunc != nil {
-			p.Frame.Start.CalcFunc, err = p.Frame.Start.CalcFunc.ResolveIndices(p.children[0].Schema())
+		for i := range p.Frame.Start.CalcFuncs {
+			p.Frame.Start.CalcFuncs[i], err = p.Frame.Start.CalcFuncs[i].ResolveIndices(p.children[0].Schema())
 			if err != nil {
 				return err
 			}
 		}
-		if p.Frame.End.CalcFunc != nil {
-			p.Frame.End.CalcFunc, err = p.Frame.End.CalcFunc.ResolveIndices(p.children[0].Schema())
+		for i := range p.Frame.End.CalcFuncs {
+			p.Frame.End.CalcFuncs[i], err = p.Frame.End.CalcFuncs[i].ResolveIndices(p.children[0].Schema())
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When there is no frame specification, we need to add default frames to the window.

### What is changed and how it works?

- When there is no frame specification and the function needs frame,
    - if it has order by clause, we will use `RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` as default frame.
    - Otherwise, we will leave it as empty, which is the same as `RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING`.

- For functions that cannot have frame but a frame specification presents, we will remove that frame and raise a note.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
