### PR TITLE
util: fix issue #9532, quote database name before running SQL with it

### DIFF
--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -224,13 +224,15 @@ func (e *kvEncoder) initial(dbName string, idAlloc autoid.Allocator) (err error)
 		return
 	}
 
+	dbName = strings.Replace(dbName, "`", "``", -1)
+
 	se.SetConnectionID(atomic.AddUint64(&mockConnID, 1))
-	_, err = se.Execute(context.Background(), fmt.Sprintf("create database if not exists %s", dbName))
+	_, err = se.Execute(context.Background(), fmt.Sprintf("create database if not exists `%s`", dbName))
 	if err != nil {
 		err = errors.Trace(err)
 		return
 	}
-	_, err = se.Execute(context.Background(), fmt.Sprintf("use %s", dbName))
+	_, err = se.Execute(context.Background(), fmt.Sprintf("use `%s`", dbName))
 	if err != nil {
 		err = errors.Trace(err)
 		return

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -684,3 +684,15 @@ func (s *testKvEncoderSuite) TestRefCount(c *C) {
 	tmp.Close()
 	c.Assert(refCount, Equals, int64(0))
 }
+
+// TestExoticDatabaseName checks if https://github.com/pingcap/tidb/issues/9532
+// is fixed.
+func (s *testKvEncoderSuite) TestExoticDatabaseName(c *C) {
+	encoder1, err := New("pay-service_micro_db", nil)
+	c.Assert(err, IsNil)
+	encoder1.Close()
+
+	encoder2, err := New("㎩¥`𝕊ℯ®Ⅵ₠—🎤肉 ㏈", nil)
+	c.Assert(err, IsNil)
+	encoder2.Close()
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixed #9532.

### What is changed and how it works?

Add quotation marks around the database name, to ensure it is already interpreted as an identifier even if it contains exotic characters or keywords.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
    * Needs to backport to 2.1, so that Lightning 2.1.x can pick up this bug fix.
