### PR TITLE
docs: change all the MySQL version from 5.7.10 to 5.7.25

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -13,7 +13,7 @@
     {
         "connections": 0,
         "git_hash": "f572e33854e1c0f942f031e9656d0004f99995c6",
-        "version": "5.7.10-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
+        "version": "5.7.25-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
     }
     ```
 
@@ -288,7 +288,7 @@ timezone.*
         "lease": "45s",
         "listening_port": 4000,
         "status_port": 10080,
-        "version": "5.7.10-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
+        "version": "5.7.25-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
     }
     ```
 
@@ -309,7 +309,7 @@ timezone.*
                 "lease": "45s",
                 "listening_port": 4001,
                 "status_port": 10081,
-                "version": "5.7.10-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
+                "version": "5.7.25-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
             },
             "f7e73ed5-63b4-4cb4-ba7c-42b32dc74e77": {
                 "ddl_id": "f7e73ed5-63b4-4cb4-ba7c-42b32dc74e77",
@@ -318,7 +318,7 @@ timezone.*
                 "lease": "45s",
                 "listening_port": 4000,
                 "status_port": 10080,
-                "version": "5.7.10-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
+                "version": "5.7.25-TiDB-v2.1.0-rc.3-355-gf572e3385-dirty"
             }
         },
         "is_all_server_version_consistent": true,

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562
 	github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7
-	github.com/pingcap/parser v0.0.0-20190228070002-74e8cffabf28
+	github.com/pingcap/parser v0.0.0-20190305083139-b478256a6451
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7 h1:kOHAMalwF69bJrtWrOd
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/parser v0.0.0-20190228070002-74e8cffabf28 h1:pOOCEgCZHvY4H3kZNZjzru6nZfpbw54QA5EuZWjH/TE=
 github.com/pingcap/parser v0.0.0-20190228070002-74e8cffabf28/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190305083139-b478256a6451 h1:aB0QkNXn7nCnx0FY4/w4kgsIenj9hWNJueTJ55wBDSw=
+github.com/pingcap/parser v0.0.0-20190305083139-b478256a6451/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible h1:e9Gi/LP9181HT3gBfSOeSBA+5JfemuE4aEAhqNgoE4k=

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,6 @@ github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562 h1:32oF1/8lVnBR2JV
 github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7 h1:kOHAMalwF69bJrtWrOdVaCSvZjLucrJhP4NQKIu6uM4=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
-github.com/pingcap/parser v0.0.0-20190228070002-74e8cffabf28 h1:pOOCEgCZHvY4H3kZNZjzru6nZfpbw54QA5EuZWjH/TE=
-github.com/pingcap/parser v0.0.0-20190228070002-74e8cffabf28/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20190305083139-b478256a6451 h1:aB0QkNXn7nCnx0FY4/w4kgsIenj9hWNJueTJ55wBDSw=
 github.com/pingcap/parser v0.0.0-20190305083139-b478256a6451/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Change all the MySQL version from 5.7.10 to 5.7.25.
related PR: https://github.com/pingcap/parser/pull/231

### What is changed and how it works?
N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
Start a new tidb-server and connect to it from MySQL-client:
```
Reading table information for completion of table and column names
You can turn off this feature to get a quicker startup with -A

Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2
Server version: 5.7.25-TiDB-v3.0.0-beta-152-g5ad33c88d-dirty MySQL Community Server
(Apache License 2.0)
...
```

Code changes

N/A

Side effects

Related changes

N/A