### PR TITLE
store/tikv: add sanity check for startTS in 2pc (#9555)

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -142,6 +142,13 @@ func newTwoPhaseCommitter(txn *tikvTxn, connID uint64) (*twoPhaseCommitter, erro
 			connID, tableID, size, len(keys), putCnt, delCnt, lockCnt, txn.startTS)
 	}
 
+	// Sanity check for startTS.
+	if txn.StartTS() == math.MaxUint64 {
+		err = errors.Errorf("try to commit with invalid startTS: %d", txn.StartTS())
+		log.Errorf("con:%d 2PC commit err: %v", connID, err)
+		return nil, errors.Trace(err)
+	}
+
 	commitDetail := &execdetails.CommitDetails{WriteSize: size, WriteKeys: len(keys)}
 	metrics.TiKVTxnWriteKVCountHistogram.Observe(float64(commitDetail.WriteKeys))
 	metrics.TiKVTxnWriteSizeHistogram.Observe(float64(commitDetail.WriteSize))

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -319,6 +319,7 @@ func (s *testCommitterSuite) TestIllegalTso(c *C) {
 	txn.startTS = uint64(math.MaxUint64)
 	err := txn.Commit(context.Background())
 	c.Assert(err, NotNil)
+	errMsgMustContain(c, err, "invalid startTS")
 }
 
 func errMsgMustContain(c *C, err error, msg string) {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To avoid committing a transaction with MAX_UINT64 unexpectedly.
Sometimes (PointGet, Analyze) TiDB uses special startTS (MAX_UINT64) to initialize a transaction. This is dangerous because `txn.Commit()` may be called unexpectedly.

### What is changed and how it works?
cherry-pick #9555 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test