### PR TITLE
domain, store/tikv: enable etcd client auto sync

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -605,8 +605,9 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 		if addrs := ebd.EtcdAddrs(); addrs != nil {
 			cfg := config.GetGlobalConfig()
 			cli, err := clientv3.New(clientv3.Config{
-				Endpoints:   addrs,
-				DialTimeout: 5 * time.Second,
+				Endpoints:        addrs,
+				AutoSyncInterval: 30 * time.Second,
+				DialTimeout:      5 * time.Second,
 				DialOptions: []grpc.DialOption{
 					grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 					grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -51,8 +51,9 @@ type Driver struct {
 
 func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, error) {
 	cli, err := clientv3.New(clientv3.Config{
-		Endpoints:   addrs,
-		DialTimeout: 5 * time.Second,
+		Endpoints:        addrs,
+		AutoSyncInterval: 30 * time.Second,
+		DialTimeout:      5 * time.Second,
 		DialOptions: []grpc.DialOption{
 			grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
 			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
When all PD nodes are replaced by new PD nodes, etcd clients (used by DDL worker and safepoint syncer) in tidb will lost connection with PD cluster.

### What is changed and how it works?
Enable etcd's `AutoSync` feature so it will automatically update member list.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Manual test (add detailed scripts or steps below)
1. start a cluster with 3 PDs, 1 TiKV, 1TiDB
2. Join 3 more PDs then `member delete` original 3 PDs.
3. Wait 100s and check if there are any 'safePoint out of sync' errors (TRUE for `master`, FALSE for `auto-sync`)
4. Run some DDL and check if it succeds (FALSE for `master`, TRUE for `auto-sync`)

Note: No unit test case included, it will be more suitable to add a integration test in schrodinger later. This bug is kind urgent and the fix is straightforward so I guess we can merge it ahead.

Related changes
 - Need to cherry-pick to the release branch
 - Need to be included in the release note
