### PR TITLE
planner: chose outer table based on cost when both tables are specified in TIDB_INLJ

### DIFF
--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -1,0 +1,27 @@
+drop table if exists t1, t2;
+create table t1(a bigint, b bigint, index idx(a));
+create table t2(a bigint, b bigint, index idx(a));
+insert into t1 values(1, 1), (1, 1), (1, 1), (1, 1), (1, 1);
+insert into t2 values(1, 1);
+analyze table t1, t2;
+explain select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;
+id	count	task	operator info
+IndexJoin_16	5.00	root	inner join, inner:IndexLookUp_15, outer key:test.t2.a, inner key:test.t1.a
+├─IndexLookUp_15	0.00	root	
+│ ├─Selection_14	0.00	cop	not(isnull(test.t1.a))
+│ │ └─IndexScan_12	5.00	cop	table:t1, index:a, range: decided by [test.t2.a], keep order:false
+│ └─TableScan_13	0.00	cop	table:t1, keep order:false
+└─TableReader_19	1.00	root	data:Selection_18
+  └─Selection_18	1.00	cop	not(isnull(test.t2.a))
+    └─TableScan_17	1.00	cop	table:t2, range:[-inf,+inf], keep order:false
+explain select * from t1 join t2 on t1.a=t2.a;
+id	count	task	operator info
+Projection_6	5.00	root	test.t1.a, test.t1.b, test.t2.a, test.t2.b
+└─IndexJoin_12	5.00	root	inner join, inner:IndexLookUp_11, outer key:test.t2.a, inner key:test.t1.a
+  ├─TableReader_32	1.00	root	data:Selection_31
+  │ └─Selection_31	1.00	cop	not(isnull(test.t2.a))
+  │   └─TableScan_30	1.00	cop	table:t2, range:[-inf,+inf], keep order:false
+  └─IndexLookUp_11	0.00	root	
+    ├─Selection_10	0.00	cop	not(isnull(test.t1.a))
+    │ └─IndexScan_8	5.00	cop	table:t1, index:a, range: decided by [test.t2.a], keep order:false
+    └─TableScan_9	0.00	cop	table:t1, keep order:false

--- a/cmd/explaintest/t/index_join.test
+++ b/cmd/explaintest/t/index_join.test
@@ -1,0 +1,12 @@
+drop table if exists t1, t2;
+create table t1(a bigint, b bigint, index idx(a));
+create table t2(a bigint, b bigint, index idx(a));
+insert into t1 values(1, 1), (1, 1), (1, 1), (1, 1), (1, 1);
+insert into t2 values(1, 1);
+
+analyze table t1, t2;
+
+-- Test https://github.com/pingcap/tidb/issues/9577
+-- we expect the following two SQL chose t2 as the outer table
+explain select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;
+explain select * from t1 join t2 on t1.a=t2.a;

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -124,3 +124,22 @@ func (s *testSuite1) TestBatchIndexJoinUnionScan(c *C) {
 	))
 	tk.MustExec("rollback")
 }
+
+func (s *testSuite1) TestInapplicableIndexJoinHint(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec(`drop table if exists t1, t2;`)
+	tk.MustExec(`create table t1(a bigint, b bigint);`)
+	tk.MustExec(`create table t2(a bigint, b bigint);`)
+	tk.MustQuery(`select /*+ TIDB_INLJ(t1, t2) */ * from t1, t2;`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings;`).Check(testkit.Rows(`Warning 1815 Optimizer Hint /*+ TIDB_INLJ(t1, t2) */ is inapplicable without column equal ON condition`))
+	tk.MustQuery(`select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings;`).Check(testkit.Rows(`Warning 1815 Optimizer Hint /*+ TIDB_INLJ(t1, t2) */ is inapplicable`))
+
+	tk.MustExec(`drop table if exists t1, t2;`)
+	tk.MustExec(`create table t1(a bigint, b bigint, index idx_a(a));`)
+	tk.MustExec(`create table t2(a bigint, b bigint);`)
+	tk.MustQuery(`select /*+ TIDB_INLJ(t1) */ * from t1 left join t2 on t1.a=t2.a;`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings;`).Check(testkit.Rows(`Warning 1815 Optimizer Hint /*+ TIDB_INLJ(t1) */ is inapplicable`))
+	tk.MustQuery(`select /*+ TIDB_INLJ(t2) */ * from t1 right join t2 on t1.a=t2.a;`).Check(testkit.Rows())
+	tk.MustQuery(`show warnings;`).Check(testkit.Rows(`Warning 1815 Optimizer Hint /*+ TIDB_INLJ(t2) */ is inapplicable`))
+}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -614,7 +614,7 @@ func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) ([]Phys
 		join := p.getIndexJoinByOuterIdx(prop, 0)
 		if join != nil {
 			// If the plan is not nil and matches the hint, return it directly.
-			if leftOuter {
+			if leftOuter && !rightOuter {
 				return join, true
 			}
 			plans = append(plans, join...)
@@ -623,7 +623,7 @@ func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) ([]Phys
 		join := p.getIndexJoinByOuterIdx(prop, 1)
 		if join != nil {
 			// If the plan is not nil and matches the hint, return it directly.
-			if rightOuter {
+			if rightOuter && !leftOuter {
 				return join, true
 			}
 			plans = append(plans, join...)
@@ -633,12 +633,12 @@ func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) ([]Phys
 		rhsCardinality := p.Children()[1].statsInfo().Count()
 
 		leftJoins := p.getIndexJoinByOuterIdx(prop, 0)
-		if leftOuter && leftJoins != nil {
+		if leftOuter && !rightOuter && leftJoins != nil {
 			return leftJoins, true
 		}
 
 		rightJoins := p.getIndexJoinByOuterIdx(prop, 1)
-		if rightOuter && rightJoins != nil {
+		if rightOuter && !leftOuter && rightJoins != nil {
 			return rightJoins, true
 		}
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -602,9 +602,10 @@ func (p *LogicalJoin) buildFakeEqCondsForIndexJoin(keys, idxCols []*expression.C
 func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) (indexJoins []PhysicalPlan, forced bool) {
 	rightOuter := (p.preferJoinType & preferLeftAsIndexInner) > 0
 	leftOuter := (p.preferJoinType & preferRightAsIndexInner) > 0
+	hasIndexJoinHint := leftOuter || rightOuter
 
 	defer func() {
-		if !forced && (leftOuter || rightOuter) {
+		if !forced && hasIndexJoinHint {
 			// Construct warning message prefix.
 			errMsg := "Optimizer Hint TIDB_INLJ is inapplicable"
 			if p.hintInfo != nil {
@@ -647,7 +648,6 @@ func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) (indexJ
 			return rightJoins, true
 		}
 
-		hasIndexJoinHint := leftOuter || rightOuter
 		if leftJoins != nil && lhsCardinality < rhsCardinality {
 			return leftJoins, hasIndexJoinHint
 		}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/pingcap/parser/ast"
@@ -598,62 +599,68 @@ func (p *LogicalJoin) buildFakeEqCondsForIndexJoin(keys, idxCols []*expression.C
 
 // tryToGetIndexJoin will get index join by hints. If we can generate a valid index join by hint, the second return value
 // will be true, which means we force to choose this index join. Otherwise we will select a join algorithm with min-cost.
-func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) ([]PhysicalPlan, bool) {
-	plans := make([]PhysicalPlan, 0, 2)
+func (p *LogicalJoin) tryToGetIndexJoin(prop *property.PhysicalProperty) (indexJoins []PhysicalPlan, forced bool) {
 	rightOuter := (p.preferJoinType & preferLeftAsIndexInner) > 0
 	leftOuter := (p.preferJoinType & preferRightAsIndexInner) > 0
-	if len(p.EqualConditions) == 0 {
-		if leftOuter || rightOuter {
-			warning := ErrInternal.GenWithStack("TIDB_INLJ hint is inapplicable without column equal ON condition")
+
+	defer func() {
+		if !forced && (leftOuter || rightOuter) {
+			// Construct warning message prefix.
+			errMsg := "Optimizer Hint TIDB_INLJ is inapplicable"
+			if p.hintInfo != nil {
+				errMsg = fmt.Sprintf("Optimizer Hint %s is inapplicable", p.hintInfo.restore2IndexJoinHint())
+			}
+
+			// Append inapplicable reason.
+			if len(p.EqualConditions) == 0 {
+				errMsg += " without column equal ON condition"
+			}
+
+			// Generate warning message to client.
+			warning := ErrInternal.GenWithStack(errMsg)
 			p.ctx.GetSessionVars().StmtCtx.AppendWarning(warning)
 		}
+	}()
+
+	if len(p.EqualConditions) == 0 {
 		return nil, false
 	}
+
 	switch p.JoinType {
 	case SemiJoin, AntiSemiJoin, LeftOuterSemiJoin, AntiLeftOuterSemiJoin, LeftOuterJoin:
 		join := p.getIndexJoinByOuterIdx(prop, 0)
-		if join != nil {
-			// If the plan is not nil and matches the hint, return it directly.
-			if leftOuter && !rightOuter {
-				return join, true
-			}
-			plans = append(plans, join...)
-		}
+		return join, join != nil && leftOuter
 	case RightOuterJoin:
 		join := p.getIndexJoinByOuterIdx(prop, 1)
-		if join != nil {
-			// If the plan is not nil and matches the hint, return it directly.
-			if rightOuter && !leftOuter {
-				return join, true
-			}
-			plans = append(plans, join...)
-		}
+		return join, join != nil && rightOuter
 	case InnerJoin:
 		lhsCardinality := p.Children()[0].statsInfo().Count()
 		rhsCardinality := p.Children()[1].statsInfo().Count()
 
 		leftJoins := p.getIndexJoinByOuterIdx(prop, 0)
-		if leftOuter && !rightOuter && leftJoins != nil {
+		if leftJoins != nil && leftOuter && !rightOuter {
 			return leftJoins, true
 		}
 
 		rightJoins := p.getIndexJoinByOuterIdx(prop, 1)
-		if rightOuter && !leftOuter && rightJoins != nil {
+		if rightJoins != nil && rightOuter && !leftOuter {
 			return rightJoins, true
 		}
 
+		hasIndexJoinHint := leftOuter || rightOuter
 		if leftJoins != nil && lhsCardinality < rhsCardinality {
-			return leftJoins, leftOuter
+			return leftJoins, hasIndexJoinHint
 		}
 
 		if rightJoins != nil && rhsCardinality < lhsCardinality {
-			return rightJoins, rightOuter
+			return rightJoins, hasIndexJoinHint
 		}
 
-		plans = append(plans, leftJoins...)
-		plans = append(plans, rightJoins...)
+		joins := append(leftJoins, rightJoins...)
+		return joins, hasIndexJoinHint && len(joins) != 0
 	}
-	return plans, false
+
+	return nil, false
 }
 
 // LogicalJoin can generates hash join, index join and sort merge join.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -295,6 +295,11 @@ func (p *LogicalJoin) setPreferredJoinType(hintInfo *tableHintInfo) error {
 		p.preferJoinType |= preferRightAsIndexInner
 	}
 
+	// set hintInfo for further usage if this hint info can be used.
+	if p.preferJoinType != 0 {
+		p.hintInfo = hintInfo
+	}
+
 	// If there're multiple join types and one of them is not index join hint,
 	// then there is a conflict of join types.
 	if bits.OnesCount(p.preferJoinType) > 1 && (p.preferJoinType^preferRightAsIndexInner^preferLeftAsIndexInner) > 0 {

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -97,10 +97,13 @@ const (
 type LogicalJoin struct {
 	logicalSchemaProducer
 
-	JoinType       JoinType
-	reordered      bool
-	cartesianJoin  bool
-	StraightJoin   bool
+	JoinType      JoinType
+	reordered     bool
+	cartesianJoin bool
+	StraightJoin  bool
+
+	// hintInfo stores the join algorithm hint information specified by client.
+	hintInfo       *tableHintInfo
 	preferJoinType uint
 
 	EqualConditions []*expression.ScalarFunction

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -1355,7 +1355,7 @@ func (s *testPlanSuite) TestIndexJoinUnionScan(c *C) {
 		txn.Set(kv.Key("AAA"), []byte("BBB"))
 		c.Assert(se.StmtCommit(), IsNil)
 		p, err := planner.Optimize(se, stmt, tt.is)
-		c.Assert(err, IsNil)
+		c.Assert(err, IsNil, comment)
 		c.Assert(core.ToString(p), Equals, tt.best, comment)
 	}
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 
@@ -82,6 +83,18 @@ func (info *tableHintInfo) matchTableName(tables []*model.CIStr, tablesInHints [
 		}
 	}
 	return false
+}
+
+func (info *tableHintInfo) restore2IndexJoinHint() string {
+	buffer := bytes.NewBufferString("/*+ TIDB_INLJ(")
+	for i, tableName := range info.indexNestedLoopJoinTables {
+		buffer.WriteString(tableName.O)
+		if i < len(info.indexNestedLoopJoinTables)-1 {
+			buffer.WriteString(", ")
+		}
+	}
+	buffer.WriteString(") */")
+	return buffer.String()
 }
 
 // clauseCode indicates in which clause the column is currently.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

fix https://github.com/pingcap/tidb/issues/9577

### What is changed and how it works?

only short circuit when only one table is specified in the Index Join Hint.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
