### PR TITLE
DDL:check stored when alter column

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1527,6 +1527,11 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 			if len(spec.NewColumns) != 1 {
 				return errRunMultiSchemaChanges
 			}
+			for _, v := range spec.NewColumns[0].Options {
+				if v.Stored {
+					return errUnsupportedAddColumn
+				}
+			}
 			err = d.AddColumn(ctx, ident, spec)
 		case ast.AlterTableAddPartitions:
 			err = d.AddTablePartitions(ctx, ident, spec)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #9453 

### What is changed and how it works?
When we exec `ALTER TABLE ADD COLUMN`, it will check it is stored column now.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test 
```SQL
mysql> create table t(a int );
Query OK, 0 rows affected (0.01 sec)

mysql> alter table t add column b int as (a+1) stored;
ERROR 1105 (HY000): unsupported add column
mysql> 
```
