### PR TITLE
executor: control Chunk size for Joiners

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -914,6 +914,7 @@ func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) Executo
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), leftExec, rightExec),
 		concurrency:  v.Concurrency,
 		joinType:     v.JoinType,
+		isOuterJoin:  IsOuterJoiner(v.JoinType),
 		innerIdx:     v.InnerChildIdx,
 	}
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -67,6 +67,13 @@ func newExecutorBuilder(ctx sessionctx.Context, is infoschema.InfoSchema) *execu
 	}
 }
 
+// MockPhysicalPlan is used to return a specified executor in when build.
+// It is mainly used for testing.
+type MockPhysicalPlan interface {
+	plannercore.PhysicalPlan
+	GetExecutor() Executor
+}
+
 func (b *executorBuilder) build(p plannercore.Plan) Executor {
 	switch v := p.(type) {
 	case nil:
@@ -172,6 +179,10 @@ func (b *executorBuilder) build(p plannercore.Plan) Executor {
 	case *plannercore.PhysicalWindow:
 		return b.buildWindow(v)
 	default:
+		if mp, ok := p.(MockPhysicalPlan); ok {
+			return mp.GetExecutor()
+		}
+
 		b.err = ErrUnknownPlan.GenWithStack("Unknown Plan %T", p)
 		return nil
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -846,7 +846,7 @@ func (b *executorBuilder) buildMergeJoin(v *plannercore.PhysicalMergeJoin) Execu
 			leftExec.retTypes(),
 			rightExec.retTypes(),
 		),
-		isOuterJoin: IsOuterJoiner(v.JoinType),
+		isOuterJoin: v.JoinType.IsOuterJoin(),
 	}
 
 	leftKeys := v.LeftKeys
@@ -914,7 +914,7 @@ func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) Executo
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), leftExec, rightExec),
 		concurrency:  v.Concurrency,
 		joinType:     v.JoinType,
-		isOuterJoin:  IsOuterJoiner(v.JoinType),
+		isOuterJoin:  v.JoinType.IsOuterJoin(),
 		innerIdx:     v.InnerChildIdx,
 	}
 
@@ -1554,7 +1554,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 		},
 		workerWg:      new(sync.WaitGroup),
 		joiner:        newJoiner(b.ctx, v.JoinType, v.OuterIndex == 1, defaultValues, v.OtherConditions, leftTypes, rightTypes),
-		isOuterJoin:   IsOuterJoiner(v.JoinType),
+		isOuterJoin:   v.JoinType.IsOuterJoin(),
 		indexRanges:   v.Ranges,
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -846,6 +846,7 @@ func (b *executorBuilder) buildMergeJoin(v *plannercore.PhysicalMergeJoin) Execu
 			leftExec.retTypes(),
 			rightExec.retTypes(),
 		),
+		isOuterJoin: IsOuterJoiner(v.JoinType),
 	}
 
 	leftKeys := v.LeftKeys
@@ -1552,6 +1553,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 		},
 		workerWg:      new(sync.WaitGroup),
 		joiner:        newJoiner(b.ctx, v.JoinType, v.OuterIndex == 1, defaultValues, v.OtherConditions, leftTypes, rightTypes),
+		isOuterJoin:   IsOuterJoiner(v.JoinType),
 		indexRanges:   v.Ranges,
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 	}

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -68,12 +68,14 @@ func newRequiredRowsDataSource(ctx sessionctx.Context, totalRows int, expectedRo
 
 func (r *requiredRowsDataSource) Next(ctx context.Context, req *chunk.RecordBatch) error {
 	defer func() {
-		if r.expectedRowsRet != nil {
-			rowsRet := req.NumRows()
-			expected := r.expectedRowsRet[r.numNextCalled]
-			if rowsRet != expected {
-				panic(fmt.Sprintf("unexpected number of rows returned, obtain: %v, expected: %v", rowsRet, expected))
-			}
+		if r.expectedRowsRet == nil {
+			r.numNextCalled++
+			return
+		}
+		rowsRet := req.NumRows()
+		expected := r.expectedRowsRet[r.numNextCalled]
+		if rowsRet != expected {
+			panic(fmt.Sprintf("unexpected number of rows returned, obtain: %v, expected: %v", rowsRet, expected))
 		}
 		r.numNextCalled++
 	}()

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -370,10 +370,11 @@ func (ow *outerWorker) buildTask(ctx context.Context) (*lookUpJoinTask, error) {
 	task.memTracker.AttachTo(ow.parentMemTracker)
 
 	ow.increaseBatchSize()
-	task.outerResult.SetRequiredRows(ow.batchSize, ow.maxBatchSize)
 	if ow.lookup.isOuterJoin { // if is outerJoin, push the requiredRows down
 		requiredRows := int(atomic.LoadInt64(&ow.lookup.requiredRows))
 		task.outerResult.SetRequiredRows(requiredRows, ow.maxBatchSize)
+	} else {
+		task.outerResult.SetRequiredRows(ow.batchSize, ow.maxBatchSize)
 	}
 
 	task.memTracker.Consume(task.outerResult.MemoryUsage())

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -251,7 +251,7 @@ func (e *IndexLookUpJoin) Next(ctx context.Context, req *chunk.RecordBatch) erro
 			task.hasMatch = false
 			task.hasNull = false
 		}
-		if req.NumRows() == e.maxChunkSize {
+		if req.IsFull() {
 			return nil
 		}
 	}

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -63,9 +63,9 @@ type IndexLookUpJoin struct {
 	joinResult *chunk.Chunk
 	innerIter  chunk.Iterator
 
-	joiner joiner
+	joiner      joiner
+	isOuterJoin bool
 
-	isOuterJoin  bool
 	requiredRows int64
 
 	indexRanges   []*ranger.Range
@@ -171,8 +171,6 @@ func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 }
 
 func (e *IndexLookUpJoin) startWorkers(ctx context.Context) {
-	e.isOuterJoin = IsOuterJoiner(e.joiner)
-	e.requiredRows = int64(e.maxChunkSize)
 	concurrency := e.ctx.GetSessionVars().IndexLookupJoinConcurrency
 	resultCh := make(chan *lookUpJoinTask, concurrency)
 	e.resultCh = resultCh

--- a/executor/join.go
+++ b/executor/join.go
@@ -427,7 +427,7 @@ func (e *HashJoinExec) joinMatchedOuterRow2Chunk(workerID uint, outerRow chunk.R
 		hasMatch = hasMatch || matched
 		hasNull = hasNull || isNull
 
-		if joinResult.chk.NumRows() == e.maxChunkSize {
+		if joinResult.chk.IsFull() {
 			e.joinResultCh <- joinResult
 			ok, joinResult := e.getNewJoinResult(workerID)
 			if !ok {
@@ -471,7 +471,7 @@ func (e *HashJoinExec) join2Chunk(workerID uint, outerChk *chunk.Chunk, joinResu
 				return false, joinResult
 			}
 		}
-		if joinResult.chk.NumRows() == e.maxChunkSize {
+		if joinResult.chk.IsFull() {
 			e.joinResultCh <- joinResult
 			ok, joinResult = e.getNewJoinResult(workerID)
 			if !ok {
@@ -649,7 +649,7 @@ func (e *NestedLoopApplyExec) fetchSelectedOuterRow(ctx context.Context, chk *ch
 			return &outerRow, nil
 		} else if e.outer {
 			e.joiner.onMissMatch(false, outerRow, chk)
-			if chk.NumRows() == e.maxChunkSize {
+			if chk.IsFull() {
 				return nil, nil
 			}
 		}
@@ -720,7 +720,7 @@ func (e *NestedLoopApplyExec) Next(ctx context.Context, req *chunk.RecordBatch) 
 		e.hasMatch = e.hasMatch || matched
 		e.hasNull = e.hasNull || isNull
 
-		if err != nil || req.NumRows() == e.maxChunkSize {
+		if err != nil || req.IsFull() {
 			return errors.Trace(err)
 		}
 	}

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -461,6 +461,7 @@ func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *ch
 func (j *innerJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }
 
+// IsOuterJoiner returns if this joiner is a outer joiner
 func IsOuterJoiner(j joiner) bool {
 	switch j.(type) {
 	case *leftOuterSemiJoiner, *leftOuterJoiner, *rightOuterJoiner, *antiLeftOuterSemiJoiner:

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -460,13 +460,3 @@ func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *ch
 
 func (j *innerJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }
-
-// IsOuterJoiner returns if this joiner is a outer joiner
-func IsOuterJoiner(j plannercore.JoinType) bool {
-	switch j {
-	case plannercore.LeftOuterSemiJoin, plannercore.LeftOuterJoin, plannercore.RightOuterJoin, plannercore.AntiLeftOuterSemiJoin:
-		return true
-	default:
-		return false
-	}
-}

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -462,9 +462,9 @@ func (j *innerJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }
 
 // IsOuterJoiner returns if this joiner is a outer joiner
-func IsOuterJoiner(j joiner) bool {
-	switch j.(type) {
-	case *leftOuterSemiJoiner, *leftOuterJoiner, *rightOuterJoiner, *antiLeftOuterSemiJoiner:
+func IsOuterJoiner(j plannercore.JoinType) bool {
+	switch j {
+	case plannercore.LeftOuterSemiJoin, plannercore.LeftOuterJoin, plannercore.RightOuterJoin, plannercore.AntiLeftOuterSemiJoin:
 		return true
 	default:
 		return false

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -460,3 +460,12 @@ func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *ch
 
 func (j *innerJoiner) onMissMatch(_ bool, outer chunk.Row, chk *chunk.Chunk) {
 }
+
+func IsOuterJoiner(j joiner) bool {
+	switch j.(type) {
+	case *leftOuterSemiJoiner, *leftOuterJoiner, *rightOuterJoiner, *antiLeftOuterSemiJoiner:
+		return true
+	default:
+		return false
+	}
+}

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -365,7 +365,7 @@ func (j *leftOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk
 		chkForJoin = chk
 	}
 
-	numToAppend := j.maxChunkSize - chk.NumRows()
+	numToAppend := chk.RequiredRows() - chk.NumRows()
 	for ; inners.Current() != inners.End() && numToAppend > 0; numToAppend-- {
 		j.makeJoinRowToChunk(chkForJoin, outer, inners.Current())
 		inners.Next()
@@ -403,7 +403,7 @@ func (j *rightOuterJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, ch
 		chkForJoin = chk
 	}
 
-	numToAppend := j.maxChunkSize - chk.NumRows()
+	numToAppend := chk.RequiredRows() - chk.NumRows()
 	for ; inners.Current() != inners.End() && numToAppend > 0; numToAppend-- {
 		j.makeJoinRowToChunk(chkForJoin, inners.Current(), outer)
 		inners.Next()
@@ -438,7 +438,7 @@ func (j *innerJoiner) tryToMatch(outer chunk.Row, inners chunk.Iterator, chk *ch
 	if len(j.conditions) == 0 {
 		chkForJoin = chk
 	}
-	inner, numToAppend := inners.Current(), j.maxChunkSize-chk.NumRows()
+	inner, numToAppend := inners.Current(), chk.RequiredRows()-chk.NumRows()
 	for ; inner != inners.End() && numToAppend > 0; inner, numToAppend = inners.Next(), numToAppend-1 {
 		if j.outerIsRight {
 			j.makeJoinRowToChunk(chkForJoin, inner, outer)

--- a/executor/joiner_test.go
+++ b/executor/joiner_test.go
@@ -1,0 +1,100 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"math/rand"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+var _ = Suite(&testSuiteJoiner{})
+
+type testSuiteJoiner struct{}
+
+func (s *testSuiteJoiner) SetUpSuite(c *C) {
+}
+
+func (s *testSuiteJoiner) TestRequiredRows(c *C) {
+	joinTypes := []core.JoinType{core.InnerJoin, core.LeftOuterJoin, core.RightOuterJoin}
+	lTypes := [][]byte{
+		{mysql.TypeLong},
+		{mysql.TypeFloat},
+		{mysql.TypeLong, mysql.TypeFloat},
+	}
+	rTypes := lTypes
+
+	convertTypes := func(mysqlTypes []byte) []*types.FieldType {
+		fieldTypes := make([]*types.FieldType, 0, len(mysqlTypes))
+		for _, t := range mysqlTypes {
+			fieldTypes = append(fieldTypes, types.NewFieldType(t))
+		}
+		return fieldTypes
+	}
+
+	for _, joinType := range joinTypes {
+		for _, ltype := range lTypes {
+			for _, rtype := range rTypes {
+				maxChunkSize := defaultCtx().GetSessionVars().MaxChunkSize
+				lfields := convertTypes(ltype)
+				rfields := convertTypes(rtype)
+				outerRow := genTestChunk(maxChunkSize, 1, lfields).GetRow(0)
+				innerChk := genTestChunk(maxChunkSize, maxChunkSize, rfields)
+				var defaultInner []types.Datum
+				for i, f := range rfields {
+					defaultInner = append(defaultInner, innerChk.GetRow(0).GetDatum(i, f))
+				}
+				joiner := newJoiner(defaultCtx(), joinType, false, defaultInner, nil, lfields, rfields)
+
+				fields := make([]*types.FieldType, 0, len(lfields)+len(rfields))
+				fields = append(fields, rfields...)
+				fields = append(fields, lfields...)
+				result := chunk.New(fields, maxChunkSize, maxChunkSize)
+
+				for i := 0; i < 10; i++ {
+					required := rand.Int()%maxChunkSize + 1
+					result.SetRequiredRows(required, maxChunkSize)
+					result.Reset()
+					it := chunk.NewIterator4Chunk(innerChk)
+					it.Begin()
+					_, _, err := joiner.tryToMatch(outerRow, it, result)
+					c.Assert(err, IsNil)
+					c.Assert(result.NumRows(), Equals, required)
+				}
+			}
+		}
+	}
+}
+
+func genTestChunk(maxChunkSize int, numRows int, fields []*types.FieldType) *chunk.Chunk {
+	chk := chunk.New(fields, maxChunkSize, maxChunkSize)
+	for numRows > 0 {
+		numRows--
+		for col, field := range fields {
+			switch field.Tp {
+			case mysql.TypeLong:
+				chk.AppendInt64(col, 0)
+			case mysql.TypeFloat:
+				chk.AppendFloat32(col, 0)
+			default:
+				panic("not support")
+			}
+		}
+	}
+	return chk
+}

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -317,7 +317,7 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 			e.outerTable.hasMatch = false
 			e.outerTable.hasNull = false
 
-			if chk.NumRows() == e.maxChunkSize {
+			if chk.IsFull() {
 				return true, nil
 			}
 			continue

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -274,7 +274,7 @@ func (e *MergeJoinExec) Next(ctx context.Context, req *chunk.RecordBatch) error 
 		}
 	}
 
-	for req.NumRows() < e.maxChunkSize {
+	for !req.IsFull() {
 		hasMore, err := e.joinToChunk(ctx, req.Chunk)
 		if err != nil || !hasMore {
 			return errors.Trace(err)
@@ -340,7 +340,7 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 			e.innerIter4Row.Begin()
 		}
 
-		if chk.NumRows() >= e.maxChunkSize {
+		if chk.IsFull() {
 			return true, errors.Trace(err)
 		}
 	}

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -37,6 +37,7 @@ type MergeJoinExec struct {
 	stmtCtx      *stmtctx.StatementContext
 	compareFuncs []expression.CompareFunc
 	joiner       joiner
+	isOuterJoin  bool
 
 	prepared bool
 	outerIdx int
@@ -380,7 +381,7 @@ func (e *MergeJoinExec) fetchNextInnerRows() (err error) {
 func (e *MergeJoinExec) fetchNextOuterRows(ctx context.Context, requiredRows int) (err error) {
 	// It's hard to calculate selectivity if there is any filter or it's inner join,
 	// so we just push the requiredRows down when it's outer join and has no filter.
-	if IsOuterJoiner(e.joiner) && len(e.outerTable.filter) == 0 {
+	if e.isOuterJoin && len(e.outerTable.filter) == 0 {
 		e.outerTable.chk.SetRequiredRows(requiredRows, e.maxChunkSize)
 	}
 

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -379,7 +379,7 @@ func (e *MergeJoinExec) fetchNextInnerRows() (err error) {
 // according to the join key.
 func (e *MergeJoinExec) fetchNextOuterRows(ctx context.Context, requiredRows int) (err error) {
 	// It's hard to calculate selectivity if there is any filter or it's inner join,
-	// so we just set the requiredRows when it's outer join and has no filter.
+	// so we just push the requiredRows down when it's outer join and has no filter.
 	if IsOuterJoiner(e.joiner) && len(e.outerTable.filter) == 0 {
 		e.outerTable.chk.SetRequiredRows(requiredRows, e.maxChunkSize)
 	}

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -68,6 +68,12 @@ const (
 	AntiLeftOuterSemiJoin
 )
 
+// IsOuterJoiner returns if this joiner is a outer joiner
+func (tp JoinType) IsOuterJoin() bool {
+	return tp == LeftOuterJoin || tp == RightOuterJoin ||
+		tp == LeftOuterSemiJoin || tp == AntiLeftOuterSemiJoin
+}
+
 func (tp JoinType) String() string {
 	switch tp {
 	case InnerJoin:

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -68,7 +68,7 @@ const (
 	AntiLeftOuterSemiJoin
 )
 
-// IsOuterJoiner returns if this joiner is a outer joiner
+// IsOuterJoin returns if this joiner is a outer joiner
 func (tp JoinType) IsOuterJoin() bool {
 	return tp == LeftOuterJoin || tp == RightOuterJoin ||
 		tp == LeftOuterSemiJoin || tp == AntiLeftOuterSemiJoin


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Control the number of rows in chunks returned by `joiner` and join-like executors.
Following up #9452, this PR is a subtask of #9166.

### What is changed and how it works?
For `MergeJoin`, `HashJoin` and `IndexLookupJoin`, support `requiredRows` from parents and push `requiredRows` down to its outer child if it is outer join.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test