### PR TITLE
executor: forbid batch insert for ignore/on duplicate key update

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1080,7 +1080,7 @@ func batchGetInsertKeys(ctx sessionctx.Context, t table.Table, newRows [][]types
 // checkBatchLimit check the batchSize limitation.
 func (e *InsertExec) checkBatchLimit() error {
 	sessVars := e.ctx.GetSessionVars()
-	batchInsert := sessVars.BatchInsert && !sessVars.InTxn()
+	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && len(e.OnDuplicate) == 0 && !e.IgnoreErr
 	batchSize := sessVars.DMLBatchSize
 	if batchInsert && e.rowCount >= batchSize {
 		if err := e.ctx.StmtCommit(); err != nil {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1473,7 +1473,7 @@ func (s *testSuite) TestBatchInsertDelete(c *C) {
 	// for on duplicate key
 	_, err = tk.Exec(`insert into batch_insert_on_duplicate select * from batch_insert_on_duplicate as tt
 		on duplicate key update batch_insert_on_duplicate.id=batch_insert_on_duplicate.id+1000;`)
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 	r = tk.MustQuery("select count(*) from batch_insert_on_duplicate;")
 	r.Check(testkit.Rows("160"))
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This is a draft PR. It is used for test only now.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Breaking backward compatibility