### PR TITLE
executor: remove a redundant `GetInfoSchema` call

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -271,7 +271,7 @@ func CompileExecutePreparedStmt(ctx sessionctx.Context, ID uint32, args ...inter
 	}
 
 	stmt := &ExecStmt{
-		InfoSchema: GetInfoSchema(ctx),
+		InfoSchema: is,
 		Plan:       execPlan,
 		StmtNode:   execStmt,
 		Ctx:        ctx,


### PR DESCRIPTION
Calling GetInfoSchema twice is not necessary, so i remove the second calling.