### PR TITLE
planner: the expression field name disappears when there's window function

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2017,6 +2017,7 @@ func (s *testSuite) TestColumnName(c *C) {
 	c.Assert(fields[1].Column.Name.L, Equals, "num")
 	c.Assert(fields[1].ColumnAsName.L, Equals, "num")
 	tk.MustExec("set @@tidb_enable_window_function = 0")
+	rs.Close()
 }
 
 func (s *testSuite) TestSelectVar(c *C) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -672,11 +672,15 @@ func (b *PlanBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 				expr = p.Schema().Columns[i]
 			}
 			proj.Exprs = append(proj.Exprs, expr)
-			col, err := b.buildProjectionField(proj.id, schema.Len()+1, field, expr)
-			if err != nil {
-				return nil, 0, errors.Trace(err)
+			if isWindowFuncField {
+				col, err := b.buildProjectionField(proj.id, schema.Len()+1, field, expr)
+				if err != nil {
+					return nil, 0, errors.Trace(err)
+				}
+				schema.Append(col)
+			} else {
+				schema.Append(p.Schema().Columns[i])
 			}
-			schema.Append(col)
 			continue
 		}
 		newExpr, np, err := b.rewrite(field.Expr, p, mapper, true)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

To fix #9639 

### What is changed and how it works?

The final projection field name depends on the rewriting result. After we build first projection, all expression's output become column. Then we get empty name of the expression field.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
