### PR TITLE
types: use switch table to save memory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ TiDB is written in [Go](http://golang.org).
 If you don't have a Go development environment,
 please [set one up](http://golang.org/doc/code.html).
 
-The version of GO should be **1.11** or above.
+The version of GO should be **1.12** or above.
 
 After installation, there are two ways to build TiDB binary.
 
@@ -215,12 +215,22 @@ mysql -h127.0.0.1 -P4000 -uroot test --default-character-set utf8
 
 #### Run Test
 
+Run all tests
+
 ```sh
 # Run unit test to make sure all test passed.
 make dev
 
 # Check checklist before you move on.
 make checklist
+```
+
+You can also run a single test in a file. For example, if you want to run
+test `TestToInt64` in file `types/datum.go`, you can do something like
+
+```sh
+cd types
+GO111MODULE=on go test -check.f TestToInt64
 ```
 
 ### Step 5: Keep your branch in sync

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -465,7 +465,7 @@ func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull b
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		res = float64(uVal)
 	}
 	return res, false, err
@@ -493,7 +493,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		if err != nil {
 			return res, false, err
 		}
@@ -523,7 +523,7 @@ func (b *builtinCastIntAsStringSig) evalString(row chunk.Row) (res string, isNul
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		if err != nil {
 			return res, false, err
 		}
@@ -748,13 +748,13 @@ func (b *builtinCastRealAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool
 		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
-		res, err = types.ConvertFloatToInt(val, types.SignedLowerBound[mysql.TypeLonglong], types.SignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
+		res, err = types.ConvertFloatToInt(val, types.ByteToSignedLowerBound(mysql.TypeLonglong), types.ByteToSignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
 	} else if b.inUnion && val < 0 {
 		res = 0
 	} else {
 		var uintVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uintVal, err = types.ConvertFloatToUint(sc, val, types.UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeDouble)
+		uintVal, err = types.ConvertFloatToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
 		res = int64(uintVal)
 	}
 	return res, isNull, err

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -465,7 +465,7 @@ func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull b
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		res = float64(uVal)
 	}
 	return res, false, err
@@ -493,7 +493,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		if err != nil {
 			return res, false, err
 		}
@@ -523,7 +523,7 @@ func (b *builtinCastIntAsStringSig) evalString(row chunk.Row) (res string, isNul
 	} else {
 		var uVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uVal, err = types.ConvertIntToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
+		uVal, err = types.ConvertIntToUint(sc, val, types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		if err != nil {
 			return res, false, err
 		}
@@ -748,13 +748,13 @@ func (b *builtinCastRealAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool
 		return res, isNull, err
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) {
-		res, err = types.ConvertFloatToInt(val, types.ByteToSignedLowerBound(mysql.TypeLonglong), types.ByteToSignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
+		res, err = types.ConvertFloatToInt(val, types.IntergerSignedLowerBound(mysql.TypeLonglong), types.IntergerSignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
 	} else if b.inUnion && val < 0 {
 		res = 0
 	} else {
 		var uintVal uint64
 		sc := b.ctx.GetSessionVars().StmtCtx
-		uintVal, err = types.ConvertFloatToUint(sc, val, types.ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
+		uintVal, err = types.ConvertFloatToUint(sc, val, types.IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeDouble)
 		res = int64(uintVal)
 	}
 	return res, isNull, err

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -1152,9 +1152,9 @@ func getMaxValue(ft *types.FieldType) (max types.Datum) {
 	switch ft.Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		if mysql.HasUnsignedFlag(ft.Flag) {
-			max.SetUint64(types.ByteToUnsignedUpperBound(ft.Tp))
+			max.SetUint64(types.IntergerUnsignedUpperBound(ft.Tp))
 		} else {
-			max.SetInt64(types.ByteToSignedUpperBound(ft.Tp))
+			max.SetInt64(types.IntergerSignedUpperBound(ft.Tp))
 		}
 	case mysql.TypeFloat:
 		max.SetFloat32(float32(types.GetMaxFloat(ft.Flen, ft.Decimal)))
@@ -1188,7 +1188,7 @@ func getMinValue(ft *types.FieldType) (min types.Datum) {
 		if mysql.HasUnsignedFlag(ft.Flag) {
 			min.SetUint64(0)
 		} else {
-			min.SetInt64(types.ByteToSignedLowerBound(ft.Tp))
+			min.SetInt64(types.IntergerSignedLowerBound(ft.Tp))
 		}
 	case mysql.TypeFloat:
 		min.SetFloat32(float32(-types.GetMaxFloat(ft.Flen, ft.Decimal)))

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -1152,9 +1152,9 @@ func getMaxValue(ft *types.FieldType) (max types.Datum) {
 	switch ft.Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		if mysql.HasUnsignedFlag(ft.Flag) {
-			max.SetUint64(types.UnsignedUpperBound[ft.Tp])
+			max.SetUint64(types.ByteToUnsignedUpperBound(ft.Tp))
 		} else {
-			max.SetInt64(types.SignedUpperBound[ft.Tp])
+			max.SetInt64(types.ByteToSignedUpperBound(ft.Tp))
 		}
 	case mysql.TypeFloat:
 		max.SetFloat32(float32(types.GetMaxFloat(ft.Flen, ft.Decimal)))
@@ -1188,7 +1188,7 @@ func getMinValue(ft *types.FieldType) (min types.Datum) {
 		if mysql.HasUnsignedFlag(ft.Flag) {
 			min.SetUint64(0)
 		} else {
-			min.SetInt64(types.SignedLowerBound[ft.Tp])
+			min.SetInt64(types.ByteToSignedLowerBound(ft.Tp))
 		}
 	case mysql.TypeFloat:
 		min.SetFloat32(float32(-types.GetMaxFloat(ft.Flen, ft.Decimal)))

--- a/types/convert.go
+++ b/types/convert.go
@@ -67,6 +67,42 @@ var SignedLowerBound = map[byte]int64{
 	mysql.TypeLonglong: math.MinInt64,
 }
 
+// ByteToSignedUpperBound indicates the max int64 values of different mysql types.
+func ByteToSignedUpperBound(b byte) int64 {
+	switch b {
+	case mysql.TypeTiny:
+		return math.MaxInt8
+	case mysql.TypeShort:
+		return math.MaxInt16
+	case mysql.TypeInt24:
+		return mysql.MaxInt24
+	case mysql.TypeLong:
+		return math.MaxInt32
+	case mysql.TypeLonglong:
+		return math.MaxInt64
+	default:
+		panic("Input byte is not a mysql type")
+	}
+}
+
+// ByteToSignedLowerBound indicates the min int64 values of different mysql types.
+func ByteToSignedLowerBound(b byte) int64 {
+	switch b {
+	case mysql.TypeTiny:
+		return math.MinInt8
+	case mysql.TypeShort:
+		return math.MinInt16
+	case mysql.TypeInt24:
+		return mysql.MinInt24
+	case mysql.TypeLong:
+		return math.MinInt32
+	case mysql.TypeLonglong:
+		return math.MinInt64
+	default:
+		panic("Input byte is not a mysql type")
+	}
+}
+
 // ConvertFloatToInt converts a float64 value to a int value.
 func ConvertFloatToInt(fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
 	val := RoundFloat(fval)

--- a/types/convert.go
+++ b/types/convert.go
@@ -37,34 +37,28 @@ func truncateStr(str string, flen int) string {
 	return str
 }
 
-// UnsignedUpperBound indicates the max uint64 values of different mysql types.
-var UnsignedUpperBound = map[byte]uint64{
-	mysql.TypeTiny:     math.MaxUint8,
-	mysql.TypeShort:    math.MaxUint16,
-	mysql.TypeInt24:    mysql.MaxUint24,
-	mysql.TypeLong:     math.MaxUint32,
-	mysql.TypeLonglong: math.MaxUint64,
-	mysql.TypeBit:      math.MaxUint64,
-	mysql.TypeEnum:     math.MaxUint64,
-	mysql.TypeSet:      math.MaxUint64,
-}
-
-// SignedUpperBound indicates the max int64 values of different mysql types.
-var SignedUpperBound = map[byte]int64{
-	mysql.TypeTiny:     math.MaxInt8,
-	mysql.TypeShort:    math.MaxInt16,
-	mysql.TypeInt24:    mysql.MaxInt24,
-	mysql.TypeLong:     math.MaxInt32,
-	mysql.TypeLonglong: math.MaxInt64,
-}
-
-// SignedLowerBound indicates the min int64 values of different mysql types.
-var SignedLowerBound = map[byte]int64{
-	mysql.TypeTiny:     math.MinInt8,
-	mysql.TypeShort:    math.MinInt16,
-	mysql.TypeInt24:    mysql.MinInt24,
-	mysql.TypeLong:     math.MinInt32,
-	mysql.TypeLonglong: math.MinInt64,
+// ByteToUnsignedUpperBound indicates the max uint64 values of different mysql types.
+func ByteToUnsignedUpperBound(b byte) uint64 {
+	switch b {
+	case mysql.TypeTiny:
+		return math.MaxUint8
+	case mysql.TypeShort:
+		return math.MaxUint16
+	case mysql.TypeInt24:
+		return mysql.MaxUint24
+	case mysql.TypeLong:
+		return math.MaxUint32
+	case mysql.TypeLonglong:
+		return math.MaxUint64
+	case mysql.TypeBit:
+		return math.MaxUint64
+	case mysql.TypeEnum:
+		return math.MaxUint64
+	case mysql.TypeSet:
+		return math.MaxUint64
+	default:
+		panic("Input byte is not a mysql type")
+	}
 }
 
 // ByteToSignedUpperBound indicates the max int64 values of different mysql types.
@@ -436,11 +430,11 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 	case json.TypeCodeFloat64:
 		f := j.GetFloat64()
 		if !unsigned {
-			lBound := SignedLowerBound[mysql.TypeLonglong]
-			uBound := SignedUpperBound[mysql.TypeLonglong]
+			lBound := ByteToSignedLowerBound(mysql.TypeLonglong)
+			uBound := ByteToSignedUpperBound(mysql.TypeLonglong)
 			return ConvertFloatToInt(f, lBound, uBound, mysql.TypeDouble)
 		}
-		bound := UnsignedUpperBound[mysql.TypeLonglong]
+		bound := ByteToUnsignedUpperBound(mysql.TypeLonglong)
 		u, err := ConvertFloatToUint(sc, f, bound, mysql.TypeDouble)
 		return int64(u), errors.Trace(err)
 	case json.TypeCodeString:
@@ -465,7 +459,7 @@ func ConvertJSONToFloat(sc *stmtctx.StatementContext, j json.BinaryJSON) (float6
 	case json.TypeCodeInt64:
 		return float64(j.GetInt64()), nil
 	case json.TypeCodeUint64:
-		u, err := ConvertIntToUint(sc, j.GetInt64(), UnsignedUpperBound[mysql.TypeLonglong], mysql.TypeLonglong)
+		u, err := ConvertIntToUint(sc, j.GetInt64(), ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		return float64(u), errors.Trace(err)
 	case json.TypeCodeFloat64:
 		return j.GetFloat64(), nil

--- a/types/convert.go
+++ b/types/convert.go
@@ -37,9 +37,9 @@ func truncateStr(str string, flen int) string {
 	return str
 }
 
-// ByteToUnsignedUpperBound indicates the max uint64 values of different mysql types.
-func ByteToUnsignedUpperBound(b byte) uint64 {
-	switch b {
+// IntergerUnsignedUpperBound indicates the max uint64 values of different mysql types.
+func IntergerUnsignedUpperBound(intType byte) uint64 {
+	switch intType {
 	case mysql.TypeTiny:
 		return math.MaxUint8
 	case mysql.TypeShort:
@@ -61,9 +61,9 @@ func ByteToUnsignedUpperBound(b byte) uint64 {
 	}
 }
 
-// ByteToSignedUpperBound indicates the max int64 values of different mysql types.
-func ByteToSignedUpperBound(b byte) int64 {
-	switch b {
+// IntergerSignedUpperBound indicates the max int64 values of different mysql types.
+func IntergerSignedUpperBound(intType byte) int64 {
+	switch intType {
 	case mysql.TypeTiny:
 		return math.MaxInt8
 	case mysql.TypeShort:
@@ -79,9 +79,9 @@ func ByteToSignedUpperBound(b byte) int64 {
 	}
 }
 
-// ByteToSignedLowerBound indicates the min int64 values of different mysql types.
-func ByteToSignedLowerBound(b byte) int64 {
-	switch b {
+// IntergerSignedLowerBound indicates the min int64 values of different mysql types.
+func IntergerSignedLowerBound(intType byte) int64 {
+	switch intType {
 	case mysql.TypeTiny:
 		return math.MinInt8
 	case mysql.TypeShort:
@@ -430,11 +430,11 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 	case json.TypeCodeFloat64:
 		f := j.GetFloat64()
 		if !unsigned {
-			lBound := ByteToSignedLowerBound(mysql.TypeLonglong)
-			uBound := ByteToSignedUpperBound(mysql.TypeLonglong)
+			lBound := IntergerSignedLowerBound(mysql.TypeLonglong)
+			uBound := IntergerSignedUpperBound(mysql.TypeLonglong)
 			return ConvertFloatToInt(f, lBound, uBound, mysql.TypeDouble)
 		}
-		bound := ByteToUnsignedUpperBound(mysql.TypeLonglong)
+		bound := IntergerUnsignedUpperBound(mysql.TypeLonglong)
 		u, err := ConvertFloatToUint(sc, f, bound, mysql.TypeDouble)
 		return int64(u), errors.Trace(err)
 	case json.TypeCodeString:
@@ -459,7 +459,7 @@ func ConvertJSONToFloat(sc *stmtctx.StatementContext, j json.BinaryJSON) (float6
 	case json.TypeCodeInt64:
 		return float64(j.GetInt64()), nil
 	case json.TypeCodeUint64:
-		u, err := ConvertIntToUint(sc, j.GetInt64(), ByteToUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
+		u, err := ConvertIntToUint(sc, j.GetInt64(), IntergerUnsignedUpperBound(mysql.TypeLonglong), mysql.TypeLonglong)
 		return float64(u), errors.Trace(err)
 	case json.TypeCodeFloat64:
 		return j.GetFloat64(), nil

--- a/types/datum.go
+++ b/types/datum.go
@@ -867,7 +867,7 @@ func (d *Datum) convertToInt(sc *stmtctx.StatementContext, target *FieldType) (D
 
 func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {
 	tp := target.Tp
-	upperBound := UnsignedUpperBound[tp]
+	upperBound := ByteToUnsignedUpperBound(tp)
 	var (
 		val uint64
 		err error

--- a/types/datum.go
+++ b/types/datum.go
@@ -1409,8 +1409,8 @@ func (d *Datum) ToInt64(sc *stmtctx.StatementContext) (int64, error) {
 }
 
 func (d *Datum) toSignedInteger(sc *stmtctx.StatementContext, tp byte) (int64, error) {
-	lowerBound := SignedLowerBound[tp]
-	upperBound := SignedUpperBound[tp]
+	lowerBound := ByteToSignedLowerBound(tp)
+	upperBound := ByteToSignedUpperBound(tp)
 	switch d.Kind() {
 	case KindInt64:
 		return ConvertIntToInt(d.GetInt64(), lowerBound, upperBound, tp)

--- a/types/datum.go
+++ b/types/datum.go
@@ -867,7 +867,7 @@ func (d *Datum) convertToInt(sc *stmtctx.StatementContext, target *FieldType) (D
 
 func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {
 	tp := target.Tp
-	upperBound := ByteToUnsignedUpperBound(tp)
+	upperBound := IntergerUnsignedUpperBound(tp)
 	var (
 		val uint64
 		err error
@@ -1409,8 +1409,8 @@ func (d *Datum) ToInt64(sc *stmtctx.StatementContext) (int64, error) {
 }
 
 func (d *Datum) toSignedInteger(sc *stmtctx.StatementContext, tp byte) (int64, error) {
-	lowerBound := ByteToSignedLowerBound(tp)
-	upperBound := ByteToSignedUpperBound(tp)
+	lowerBound := IntergerSignedLowerBound(tp)
+	upperBound := IntergerSignedUpperBound(tp)
 	switch d.Kind() {
 	case KindInt64:
 		return ConvertIntToInt(d.GetInt64(), lowerBound, upperBound, tp)


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To deal with this one:
https://github.com/pingcap/tidb/issues/9642

### What is changed and how it works?
Instead of defining a map, some witch tables in functions are used, and Go compiler will inline it. With this way, there is no memory allocation at all.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

