### PR TITLE
server: add `/debug/zip` api to get useful debuginfo at once

### DIFF
--- a/docs/tidb_http_api.md
+++ b/docs/tidb_http_api.md
@@ -377,4 +377,17 @@ timezone.*
     curl http://{TiDBIP}:10080/ddl/history?limit={number}
     ```
 
-    **Note**: If you request a tidb that is not ddl owner, the response will be `This node is not a ddl owner, can't be resigned.`
+    **Note**: If you request a tidb that is not ddl owner, the response will be `This node is not a ddl owner, can't be resigned.` 
+
+1. Download TiDB debug info
+
+    ```shell
+    curl http://{TiDBIP}:10080/debug/zip
+    ```
+    zip file will include:
+    
+    - Go heap pprof(after GC)
+    - Go cpu pprof(10s)
+    - Go mutex pprof
+    - Full goroutine
+    - TiDB config and version

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -124,7 +124,8 @@ func (s *Server) startHTTPServer() {
 		w.Header().Set("X-Go-Pprof", "1")
 		w.Header().Del("Content-Disposition")
 		w.WriteHeader(status)
-		fmt.Fprintln(w, txt)
+		_, err := fmt.Fprintln(w, txt)
+		terror.Log(err)
 	}
 
 	sleep := func(w http.ResponseWriter, d time.Duration) {
@@ -167,7 +168,8 @@ func (s *Server) startHTTPServer() {
 				serveError(w, http.StatusInternalServerError, fmt.Sprintf("Create zipped %s fail: %v", item.name, err))
 				return
 			}
-			p.WriteTo(fw, item.debug)
+			err = p.WriteTo(fw, item.debug)
+			terror.Log(err)
 		}
 
 		// dump profile
@@ -199,7 +201,8 @@ func (s *Server) startHTTPServer() {
 			serveError(w, http.StatusInternalServerError, fmt.Sprintf("get config info fail%v", err))
 			return
 		}
-		fw.Write(js)
+		_, err = fw.Write(js)
+		terror.Log(err)
 
 		// dump version
 		fw, err = zw.Create("version")
@@ -207,9 +210,11 @@ func (s *Server) startHTTPServer() {
 			serveError(w, http.StatusInternalServerError, fmt.Sprintf("Create zipped %s fail: %v", "version", err))
 			return
 		}
-		fw.Write([]byte(printer.GetTiDBInfo()))
+		_, err = fw.Write([]byte(printer.GetTiDBInfo()))
+		terror.Log(err)
 
-		zw.Close()
+		err = zw.Close()
+		terror.Log(err)
 	})
 
 	var (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when we do troubleshooting often need multiple round-trips to get info from our custom.

to save time we need the ability to get more info at once, just curl or access

http://0.0.0.0:10080/debug/zip

### What is changed and how it works?

get go pprof info in one file and maybe we can add more info in future, now after unzip we will got:

- heap pprof(after gc)
- mutex pprof
- cpu pprof (default 10s)
- full goroutine
- tidb config info
- tidb version info

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

can be curl and unzip and be `go pprof` or `cat` without error

Code changes

 - New code

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release 2.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/9651)
<!-- Reviewable:end -->
