### PR TITLE
session: skip loading privilege when "skip-grant-table" is enabled

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1303,11 +1303,13 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	}
 
 	timeutil.SetSystemTZ(tz)
-
 	dom := domain.GetDomain(se)
-	err = dom.LoadPrivilegeLoop(se)
-	if err != nil {
-		return nil, errors.Trace(err)
+
+	if !config.GetGlobalConfig().Security.SkipGrantTable {
+		err = dom.LoadPrivilegeLoop(se)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 
 	se1, err := createSession(store)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Skip loading privilege when "skip-grant-table" is enabled, which helps users to bootstrap tidb-server and recreate the `mysql.user` table correctly.

### What is changed and how it works?

only load privilege when "skip-grant-table" is false

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - **TODO** Unit test
 - **TODO** Integration test
 - Manual test steps:
	- drop mysql.users
	- config `skip-grant-table = true`
	- start tidb-server with root privilege
	- tidb-server can be successfully started

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
