### PR TITLE
log: temporary remove recvTs from context log

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -585,7 +585,7 @@ func (cc *clientConn) Run(ctx context.Context) {
 		}
 
 		startTime := time.Now()
-		if err = cc.dispatch(logutil.WithRecvTs(ctx, startTime.UnixNano()/int64(time.Millisecond)), data); err != nil {
+		if err = cc.dispatch(ctx, data); err != nil {
 			if terror.ErrorEqual(err, io.EOF) {
 				cc.addMetrics(data[0], startTime, nil)
 				return

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -382,16 +382,3 @@ func WithConnID(ctx context.Context, connID uint32) context.Context {
 	}
 	return context.WithValue(ctx, ctxLogKey, logger.With(zap.Uint32("conn", connID)))
 }
-
-// WithRecvTs attaches current packet received timestamp to context.
-// it's common that each SQL has a packet receive timestamp in MySQL Protocol,
-// so we can use recvTs to gather log for some sql request on one connection.
-func WithRecvTs(ctx context.Context, recvTs int64) context.Context {
-	var logger *zap.Logger
-	if ctxLogger, ok := ctx.Value(ctxLogKey).(*zap.Logger); ok {
-		logger = ctxLogger
-	} else {
-		logger = zaplog.L()
-	}
-	return context.WithValue(ctx, ctxLogKey, logger.With(zap.Int64("recvTs", recvTs)))
-}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #9665 

current impl rely on zap's [Logger#With](https://github.com/uber-go/zap/blob/master/logger.go#L159) mechanism, but zap's current impl will encode during calling `With`,  this will reduce duplicate encode of those field for later log operation, but it also make every calling `With` must do a heavy copy and encode even if there no log for this request, so current `With` isn't suitable for fine grain contextual log, so this PR keep connection level contextual(every connection must have a log record) and temporary remove request level --- `WithRecvTs`

### What is changed and how it works?

remove calling with WithRecvTs.

maybe we can lazy call `Logger.With` to first log operation but it don't solve the root question(and lazy init root ctx value in lower level method will need some dirty code that break go's idiom)

this can be shipped again after improve log libary in future, before that we keep use connid+time to distinguish different request's log

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Remove code

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/9673)
<!-- Reviewable:end -->
