### PR TITLE
executor: fix data race in testChunkSizeControlSuite

### DIFF
--- a/executor/chunk_size_control_test.go
+++ b/executor/chunk_size_control_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -39,20 +40,30 @@ var (
 )
 
 type testSlowClient struct {
+	sync.RWMutex
 	tikv.Client
 	regionDelay map[uint64]time.Duration
 }
 
 func (c *testSlowClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
 	regionID := req.RegionId
-	if req.Type == tikvrpc.CmdCop && c.regionDelay[regionID] > 0 {
-		time.Sleep(c.regionDelay[regionID])
+	delay := c.GetDelay(regionID)
+	if req.Type == tikvrpc.CmdCop && delay > 0 {
+		time.Sleep(delay)
 	}
 	return c.Client.SendRequest(ctx, addr, req, timeout)
 }
 
 func (c *testSlowClient) SetDelay(regionID uint64, dur time.Duration) {
+	c.Lock()
+	defer c.Unlock()
 	c.regionDelay[regionID] = dur
+}
+
+func (c *testSlowClient) GetDelay(regionID uint64) time.Duration {
+	c.RLock()
+	defer c.RUnlock()
+	return c.regionDelay[regionID]
 }
 
 // manipulateCluster splits this cluster's region by splitKeys and returns regionIDs after split


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Data race problem in `testChunkSizeControlSuite`.
```
WARNING: DATA RACE
Write at 0x00c00027b3b0 by goroutine 154:
  runtime.mapassign_fast64()
      /usr/local/go/src/runtime/map_fast64.go:92 +0x0
  github.com/pingcap/tidb/executor_test.(*testChunkSizeControlSuite).TestLimitAndIndexScan()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/chunk_size_control_test.go:55 +0x4f9
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9fc
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Previous read at 0x00c00027b3b0 by goroutine 150:
  runtime.mapaccess1_fast64()
      /usr/local/go/src/runtime/map_fast64.go:12 +0x0
  github.com/pingcap/tidb/executor_test.(*testSlowClient).SendRequest()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/chunk_size_control_test.go:48 +0x19e
  github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).sendReqToRegion()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:136 +0x193
  github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).SendReqCtx()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:107 +0x1cd
  github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTaskOnce()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:618 +0x6f3
  github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTask()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:578 +0x114
  github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:427 +0x257
```

### What is changed and how it works?
Introduce a `RWMutex`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test