### PR TITLE
executor: forbid batchInsert for insert ignore in 2.0

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -1080,7 +1080,7 @@ func batchGetInsertKeys(ctx sessionctx.Context, t table.Table, newRows [][]types
 // checkBatchLimit check the batchSize limitation.
 func (e *InsertExec) checkBatchLimit() error {
 	sessVars := e.ctx.GetSessionVars()
-	batchInsert := sessVars.BatchInsert && !sessVars.InTxn()
+	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && len(e.OnDuplicate) == 0 && !e.IgnoreErr
 	batchSize := sessVars.DMLBatchSize
 	if batchInsert && e.rowCount >= batchSize {
 		if err := e.ctx.StmtCommit(); err != nil {

--- a/executor/write_concurrent_test.go
+++ b/executor/write_concurrent_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"context"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+func (s *testSuite) TestBatchInsertIgnore(c *C) {
+	tk := testkit.NewCTestKit(c, s.store)
+	// prepare schema.
+	ctx := tk.OpenSessionWithDB(context.Background(), "test")
+	defer tk.CloseSession(ctx)
+	tk.MustExec(ctx, "drop table if exists duplicate_test")
+	tk.MustExec(ctx, "create table duplicate_test(id int auto_increment, k1 int, primary key(id), unique key uk(k1))")
+	tk.MustExec(ctx, "insert into duplicate_test(k1) values(?),(?),(?),(?),(?)", tk.PermInt(5)...)
+
+	tk.ConcurrentRun(c, 3, 2, // concurrent: 3, loops: 2,
+		// prepare data for each loop.
+		func(ctx context.Context, tk *testkit.CTestKit, concurrent int, currentLoop int) [][][]interface{} {
+			var ii [][][]interface{}
+			for i := 0; i < concurrent; i++ {
+				ii = append(ii, [][]interface{}{tk.PermInt(7)})
+			}
+			return ii
+		},
+		// concurrent execute logic.
+		func(ctx context.Context, tk *testkit.CTestKit, input [][]interface{}) {
+			tk.MustExec(ctx, "set @@session.tidb_batch_insert=1")
+			tk.MustExec(ctx, "set @@session.tidb_dml_batch_size=1")
+			_, err := tk.Exec(ctx, "insert ignore into duplicate_test(k1) values (?),(?),(?),(?),(?),(?),(?)", input[0]...)
+			tk.IgnoreError(err)
+		},
+		// check after all done.
+		func(ctx context.Context, tk *testkit.CTestKit) {
+			tk.MustExec(ctx, "admin check table duplicate_test")
+			tk.MustQuery(ctx, "select d1.id, d1.k1 from duplicate_test d1 ignore index(uk), duplicate_test d2 use index (uk) where d1.id = d2.id and d1.k1 <> d2.k1").
+				Check(testkit.Rows())
+		})
+}

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1473,7 +1473,7 @@ func (s *testSuite) TestBatchInsertDelete(c *C) {
 	// for on duplicate key
 	_, err = tk.Exec(`insert into batch_insert_on_duplicate select * from batch_insert_on_duplicate as tt
 		on duplicate key update batch_insert_on_duplicate.id=batch_insert_on_duplicate.id+1000;`)
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 	r = tk.MustQuery("select count(*) from batch_insert_on_duplicate;")
 	r.Check(testkit.Rows("160"))
 

--- a/util/testkit/ctestkit.go
+++ b/util/testkit/ctestkit.go
@@ -1,0 +1,237 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testkit
+
+import (
+	"context"
+	"github.com/pingcap/tidb/ast"
+	"math/rand"
+	"sync/atomic"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/check"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/util"
+)
+
+type contextKeyType int
+
+const sessionKey contextKeyType = iota
+
+func getSession(ctx context.Context) session.Session {
+	s := ctx.Value(sessionKey)
+	if s == nil {
+		return nil
+	}
+	return s.(session.Session)
+}
+
+func setSession(ctx context.Context, se session.Session) context.Context {
+	return context.WithValue(ctx, sessionKey, se)
+}
+
+// CTestKit is a utility to run sql test with concurrent execution support.
+type CTestKit struct {
+	c     *check.C
+	store kv.Storage
+}
+
+// NewCTestKit returns a new *CTestKit.
+func NewCTestKit(c *check.C, store kv.Storage) *CTestKit {
+	return &CTestKit{
+		c:     c,
+		store: store,
+	}
+}
+
+// OpenSession opens new session ctx if no exists one.
+func (tk *CTestKit) OpenSession(ctx context.Context) context.Context {
+	if getSession(ctx) == nil {
+		se, err := session.CreateSession4Test(tk.store)
+		tk.c.Assert(err, check.IsNil)
+		id := atomic.AddUint64(&connectionID, 1)
+		se.SetConnectionID(id)
+		ctx = setSession(ctx, se)
+	}
+	return ctx
+}
+
+// OpenSessionWithDB opens new session ctx if no exists one and use db.
+func (tk *CTestKit) OpenSessionWithDB(ctx context.Context, db string) context.Context {
+	ctx = tk.OpenSession(ctx)
+	tk.MustExec(ctx, "use "+db)
+	return ctx
+}
+
+// CloseSession closes exists session from ctx.
+func (tk *CTestKit) CloseSession(ctx context.Context) {
+	se := getSession(ctx)
+	if se == nil {
+		return
+	}
+	se.Close()
+}
+
+// Exec executes a sql statement.
+func (tk *CTestKit) Exec(ctx context.Context, sql string, args ...interface{}) (ast.RecordSet, error) {
+	var err error
+	tk.c.Assert(getSession(ctx), check.NotNil)
+	if len(args) == 0 {
+		var rss []ast.RecordSet
+		rss, err = getSession(ctx).Execute(ctx, sql)
+		if err == nil && len(rss) > 0 {
+			return rss[0], nil
+		}
+		return nil, errors.Trace(err)
+	}
+	stmtID, _, _, err := getSession(ctx).PrepareStmt(sql)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	rs, err := getSession(ctx).ExecutePreparedStmt(ctx, stmtID, args...)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	err = getSession(ctx).DropPreparedStmt(stmtID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return rs, nil
+}
+
+// CheckExecResult checks the affected rows and the insert id after executing MustExec.
+func (tk *CTestKit) CheckExecResult(ctx context.Context, affectedRows, insertID int64) {
+	tk.c.Assert(getSession(ctx), check.NotNil)
+	tk.c.Assert(affectedRows, check.Equals, int64(getSession(ctx).AffectedRows()))
+	tk.c.Assert(insertID, check.Equals, int64(getSession(ctx).LastInsertID()))
+}
+
+// MustExec executes a sql statement and asserts nil error.
+func (tk *CTestKit) MustExec(ctx context.Context, sql string, args ...interface{}) {
+	res, err := tk.Exec(ctx, sql, args...)
+	tk.c.Assert(err, check.IsNil, check.Commentf("sql:%s, %v, error stack %v", sql, args, errors.ErrorStack(err)))
+	if res != nil {
+		tk.c.Assert(res.Close(), check.IsNil)
+	}
+}
+
+// MustQuery query the statements and returns result rows.
+// If expected result is set it asserts the query result equals expected result.
+func (tk *CTestKit) MustQuery(ctx context.Context, sql string, args ...interface{}) *Result {
+	comment := check.Commentf("sql:%s, args:%v", sql, args)
+	rs, err := tk.Exec(ctx, sql, args...)
+	tk.c.Assert(errors.ErrorStack(err), check.Equals, "", comment)
+	tk.c.Assert(rs, check.NotNil, comment)
+	return tk.resultSetToResult(ctx, rs, comment)
+}
+
+// resultSetToResult converts ast.RecordSet to testkit.Result.
+// It is used to check results of execute statement in binary mode.
+func (tk *CTestKit) resultSetToResult(ctx context.Context, rs ast.RecordSet, comment check.CommentInterface) *Result {
+	rows, err := session.GetRows4Test(context.Background(), getSession(ctx), rs)
+	tk.c.Assert(errors.ErrorStack(err), check.Equals, "", comment)
+	err = rs.Close()
+	tk.c.Assert(errors.ErrorStack(err), check.Equals, "", comment)
+	sRows := make([][]string, len(rows))
+	for i := range rows {
+		row := rows[i]
+		iRow := make([]string, row.Len())
+		for j := 0; j < row.Len(); j++ {
+			if row.IsNull(j) {
+				iRow[j] = "<nil>"
+			} else {
+				d := row.GetDatum(j, &rs.Fields()[j].Column.FieldType)
+				iRow[j], err = d.ToString()
+				tk.c.Assert(err, check.IsNil)
+			}
+		}
+		sRows[i] = iRow
+	}
+	return &Result{rows: sRows, c: tk.c, comment: comment}
+}
+
+// ConcurrentRun run test in current.
+// - concurrent: controls the concurrent worker count.
+// - loops: controls run test how much times.
+// - prepareFunc: provide test data and will be called for every loop.
+// - checkFunc: used to do some check after all workers done.
+// works like create table better be put in front of this method calling.
+// see more example at TestBatchInsertWithOnDuplicate
+func (tk *CTestKit) ConcurrentRun(c *check.C, concurrent int, loops int,
+	prepareFunc func(ctx context.Context, tk *CTestKit, concurrent int, currentLoop int) [][][]interface{},
+	writeFunc func(ctx context.Context, tk *CTestKit, input [][]interface{}),
+	checkFunc func(ctx context.Context, tk *CTestKit)) {
+	var (
+		channel = make([]chan [][]interface{}, concurrent)
+		ctxs    = make([]context.Context, concurrent)
+		dones   = make([]context.CancelFunc, concurrent)
+	)
+	for i := 0; i < concurrent; i++ {
+		w := i
+		channel[w] = make(chan [][]interface{}, 1)
+		ctxs[w], dones[w] = context.WithCancel(context.Background())
+		ctxs[w] = tk.OpenSessionWithDB(ctxs[w], "test")
+		go func() {
+			defer func() {
+				r := recover()
+				if r != nil {
+					c.Fatal(r, string(util.GetStack()))
+				}
+				dones[w]()
+			}()
+			for input := range channel[w] {
+				writeFunc(ctxs[w], tk, input)
+			}
+		}()
+	}
+	defer func() {
+		for i := 0; i < concurrent; i++ {
+			tk.CloseSession(ctxs[i])
+		}
+	}()
+
+	ctx := tk.OpenSessionWithDB(context.Background(), "test")
+	defer tk.CloseSession(ctx)
+	tk.MustExec(ctx, "use test")
+
+	for j := 0; j < loops; j++ {
+		datas := prepareFunc(ctx, tk, concurrent, j)
+		for i := 0; i < concurrent; i++ {
+			channel[i] <- datas[i]
+		}
+	}
+
+	for i := 0; i < concurrent; i++ {
+		close(channel[i])
+	}
+
+	for i := 0; i < concurrent; i++ {
+		<-ctxs[i].Done()
+	}
+	checkFunc(ctx, tk)
+}
+
+// PermInt returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n).
+func (tk *CTestKit) PermInt(n int) []interface{} {
+	var v []interface{}
+	for _, i := range rand.Perm(n) {
+		v = append(v, i)
+	}
+	return v
+}
+
+// IgnoreError ignores error and make errcheck tool happy.
+// Deprecated: it's normal to ignore some error in concurrent test, but please don't use this method in other place.
+func (tk *CTestKit) IgnoreError(_ error) {}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Insert  ignore/on duplicate  with `BatchInsert` in 2.0.11 only check the first batch and have potential to write wrong data.

this question is fixed in 2.1 but 2.0's code base is too hard to support that.

### What is changed and how it works?

ignore BatchInsert for insert ignore/on duplicate key update to keep data consistent

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Disable BatchInsert for insert ignore/duplicate

Side effects

 - Breaking backward compatibility, old user use batchInsert + insert ignore are recommend upgrade to 2.1+

Related changes

 - Need to be included in the release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/9677)
<!-- Reviewable:end -->
