### PR TITLE
session,executor: performance improvement in SetProcessInfo

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -69,7 +69,7 @@ func (s *testExecSuite) TestShowProcessList(c *C) {
 		User:    "test",
 		Host:    "127.0.0.1",
 		DB:      "test",
-		Command: "select * from t",
+		Command: 't',
 		State:   1,
 		Info:    "",
 	}

--- a/executor/show.go
+++ b/executor/show.go
@@ -249,7 +249,7 @@ func (e *ShowExec) fetchShowProcessList() error {
 			pi.User,
 			pi.Host,
 			pi.DB,
-			pi.Command,
+			mysql.Command2Str[pi.Command],
 			uint64(time.Since(pi.Time) / time.Second),
 			fmt.Sprintf("%d", pi.State),
 			info,

--- a/session/session.go
+++ b/session/session.go
@@ -865,7 +865,7 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 	pi := util.ProcessInfo{
 		ID:      s.sessionVars.ConnectionID,
 		DB:      s.sessionVars.CurrentDB,
-		Command: mysql.Command2Str[command],
+		Command: string(command),
 		Time:    t,
 		State:   s.Status(),
 		Info:    sql,
@@ -1628,6 +1628,8 @@ func (s *session) ShowProcess() util.ProcessInfo {
 	tmp := s.processInfo.Load()
 	if tmp != nil {
 		pi = tmp.(util.ProcessInfo)
+		byteCommand := []byte(pi.Command)
+		pi.Command = mysql.Command2Str[byteCommand[0]]
 	}
 	return pi
 }

--- a/session/session.go
+++ b/session/session.go
@@ -865,7 +865,7 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 	pi := util.ProcessInfo{
 		ID:      s.sessionVars.ConnectionID,
 		DB:      s.sessionVars.CurrentDB,
-		Command: string(command),
+		Command: mysql.Command2Str[command],
 		Time:    t,
 		State:   s.Status(),
 		Info:    sql,
@@ -1628,8 +1628,6 @@ func (s *session) ShowProcess() util.ProcessInfo {
 	tmp := s.processInfo.Load()
 	if tmp != nil {
 		pi = tmp.(util.ProcessInfo)
-		byteCommand := []byte(pi.Command)
-		pi.Command = mysql.Command2Str[byteCommand[0]]
 	}
 	return pi
 }

--- a/session/session.go
+++ b/session/session.go
@@ -865,7 +865,7 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 	pi := util.ProcessInfo{
 		ID:      s.sessionVars.ConnectionID,
 		DB:      s.sessionVars.CurrentDB,
-		Command: mysql.Command2Str[command],
+		Command: command,
 		Time:    t,
 		State:   s.Status(),
 		Info:    sql,

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -23,7 +23,7 @@ type ProcessInfo struct {
 	User    string
 	Host    string
 	DB      string
-	Command string
+	Command byte
 	Time    time.Time
 	State   uint16
 	Info    string


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Closes #9638 

### What is changed and how it works?

Search in the map only in `Showprocess`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - manual test
```sql
xiekeyi@ubuntu:~/main$ mysql -u root -P 4000 -h 127.0.0.1
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 3
Server version: 5.7.25-TiDB-v3.0.0-beta-210-g8fa2716dc-dirty MySQL Community Server (Apache License 2.0)

Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------+
| Id   | User | Host      | db   | Command | Time | State | Info             |
+------+------+-----------+------+---------+------+-------+------------------+
|    2 | root | 127.0.0.1 | test | Sleep   |    6 | 2     |                  |
|    3 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |
+------+------+-----------+------+---------+------+-------+------------------+
2 rows in set (0.00 sec)

mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------+
| Id   | User | Host      | db   | Command | Time | State | Info             |
+------+------+-----------+------+---------+------+-------+------------------+
|    3 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist |
|    2 | root | 127.0.0.1 | test | Sleep   |    0 | 2     |                  |
+------+------+-----------+------+---------+------+-------+------------------+
2 rows in set (0.00 sec)

mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------------------+
| Id   | User | Host      | db   | Command | Time | State | Info                         |
+------+------+-----------+------+---------+------+-------+------------------------------+
|    3 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist             |
|    2 | root | 127.0.0.1 | test | Sleep   |  171 | 2     |                              |
|   13 | root | 127.0.0.1 | test | Query   |    0 | 2     | CREATE TABLE aebcfd (ID int) |
|   14 | root | 127.0.0.1 |      | Sleep   |   10 | 2     |                              |
+------+------+-----------+------+---------+------+-------+------------------------------+
4 rows in set (0.00 sec)

mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------------------+
| Id   | User | Host      | db   | Command | Time | State | Info                         |
+------+------+-----------+------+---------+------+-------+------------------------------+
|    2 | root | 127.0.0.1 | test | Sleep   |  172 | 2     |                              |
|   13 | root | 127.0.0.1 | test | Query   |    0 | 2     | CREATE TABLE afcdbe (ID int) |
|   14 | root | 127.0.0.1 |      | Sleep   |   11 | 2     |                              |
|    3 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist             |
+------+------+-----------+------+---------+------+-------+------------------------------+
4 rows in set (0.01 sec)

mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------------------+
| Id   | User | Host      | db   | Command | Time | State | Info                         |
+------+------+-----------+------+---------+------+-------+------------------------------+
|    3 | root | 127.0.0.1 |      | Query   |    0 | 2     | show processlist             |
|    2 | root | 127.0.0.1 | test | Sleep   |  173 | 2     |                              |
|   13 | root | 127.0.0.1 | test | Query   |    0 | 2     | CREATE TABLE badfce (ID int) |
|   14 | root | 127.0.0.1 |      | Sleep   |   12 | 2     |                              |
+------+------+-----------+------+---------+------+-------+------------------------------+
4 rows in set (0.00 sec)

mysql> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v3.0.0-beta-210-g8fa2716dc-dirty
Git Commit Hash: 8fa2716dccaaeb1ecaddf8da69a2b366f3a78aeb
Git Branch: issue#9638
UTC Build Time: 2019-03-13 03:47:32
GoVersion: go version go1.12 linux/amd64
Race Enabled: false
TiKV Min Version: 2.1.0-alpha.1-ff3dd160846b7d1aed9079c389fc188f7f5ea13e
Check Table Before Drop: false
1 row in set (0.00 sec)

mysql> 
```
