### PR TITLE
binlog: update config for backward compatibility

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -250,7 +250,8 @@ type TiKVClient struct {
 
 // Binlog is the config for binlog.
 type Binlog struct {
-	Enable       string `toml:"enable" json:"enable"`
+	Enable       bool   `toml:"enable" json:"enable"`
+	Mode         string `toml:"mode" json:"mode"`
 	WriteTimeout string `toml:"write-timeout" json:"write-timeout"`
 	// If IgnoreError is true, when writing binlog meets error, TiDB would
 	// ignore the error.
@@ -343,7 +344,6 @@ var defaultConf = Config{
 		BatchWaitSize:     8,
 	},
 	Binlog: Binlog{
-		Enable:       "auto",
 		WriteTimeout: "15s",
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -251,7 +251,7 @@ type TiKVClient struct {
 // Binlog is the config for binlog.
 type Binlog struct {
 	Enable       bool   `toml:"enable" json:"enable"`
-	Mode         string `toml:"mode" json:"mode"`
+	AutoMode     bool   `toml:"auto-mode" json:"auto-mode"`
 	WriteTimeout string `toml:"write-timeout" json:"write-timeout"`
 	// If IgnoreError is true, when writing binlog meets error, TiDB would
 	// ignore the error.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -258,9 +258,11 @@ enabled = true
 capacity = 2048000
 
 [binlog]
-# Enable to write binlog. Values can be "on", "off" or "auto".
-# If value is "auto", will enable binlog according to the system variables 'tidb_log_bin'.
-enable = "auto"
+# Enable to write binlog. This config will be disabled if mode is "auto".
+enable = false
+
+# If mode is "auto", will enable binlog according to the system variables 'tidb_log_bin'.
+# mode = "auto"
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.
 write-timeout = "15s"

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -262,7 +262,7 @@ capacity = 2048000
 enable = false
 
 # If mode is "auto", will enable binlog according to the system variables 'tidb_log_bin'.
-# mode = "auto"
+mode = ""
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.
 write-timeout = "15s"

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -258,11 +258,11 @@ enabled = true
 capacity = 2048000
 
 [binlog]
-# Enable to write binlog. This config will be disabled if mode is "auto".
+# Enable to write binlog. This config will be disabled if auto-mode is true.
 enable = false
 
-# If mode is "auto", will enable binlog according to the system variables 'tidb_log_bin'.
-mode = ""
+# If auto-mode is true, will enable binlog according to the system variables 'tidb_log_bin'.
+auto-mode = false
 
 # WriteTimeout specifies how long it will wait for writing binlog to pump.
 write-timeout = "15s"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestT(t *testing.T) {
 func (s *testConfigSuite) TestConfig(c *C) {
 	conf := new(Config)
 	conf.Binlog.Enable = true
+	conf.Binlog.Mode = "auto"
 	conf.Binlog.IgnoreError = true
 	conf.TiKVClient.CommitTimeout = "10s"
 	conf.CheckMb4ValueInUtf8 = true
@@ -55,6 +56,7 @@ max-batch-size=128
 
 	// Test that the original value will not be clear by load the config file that does not contain the option.
 	c.Assert(conf.Binlog.Enable, Equals, true)
+	c.Assert(conf.Binlog.Mode, Equals, "auto")
 
 	c.Assert(conf.TiKVClient.CommitTimeout, Equals, "41s")
 	c.Assert(conf.TiKVClient.MaxBatchSize, Equals, uint(128))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestT(t *testing.T) {
 func (s *testConfigSuite) TestConfig(c *C) {
 	conf := new(Config)
 	conf.Binlog.Enable = true
-	conf.Binlog.Mode = "auto"
+	conf.Binlog.AutoMode = true
 	conf.Binlog.IgnoreError = true
 	conf.TiKVClient.CommitTimeout = "10s"
 	conf.CheckMb4ValueInUtf8 = true
@@ -56,7 +56,7 @@ max-batch-size=128
 
 	// Test that the original value will not be clear by load the config file that does not contain the option.
 	c.Assert(conf.Binlog.Enable, Equals, true)
-	c.Assert(conf.Binlog.Mode, Equals, "auto")
+	c.Assert(conf.Binlog.AutoMode, Equals, true)
 
 	c.Assert(conf.TiKVClient.CommitTimeout, Equals, "41s")
 	c.Assert(conf.TiKVClient.MaxBatchSize, Equals, uint(128))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,7 @@ func TestT(t *testing.T) {
 
 func (s *testConfigSuite) TestConfig(c *C) {
 	conf := new(Config)
-	conf.Binlog.Enable = "auto"
+	conf.Binlog.Enable = true
 	conf.Binlog.IgnoreError = true
 	conf.TiKVClient.CommitTimeout = "10s"
 	conf.CheckMb4ValueInUtf8 = true
@@ -54,7 +54,7 @@ max-batch-size=128
 	c.Assert(conf.Load(configFile), IsNil)
 
 	// Test that the original value will not be clear by load the config file that does not contain the option.
-	c.Assert(conf.Binlog.Enable, Equals, "auto")
+	c.Assert(conf.Binlog.Enable, Equals, true)
 
 	c.Assert(conf.TiKVClient.CommitTimeout, Equals, "41s")
 	c.Assert(conf.TiKVClient.MaxBatchSize, Equals, uint(128))

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
@@ -239,8 +240,8 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("set @@sql_log_bin = on")
 	tk.MustQuery(`select @@session.sql_log_bin;`).Check(testkit.Rows("1"))
 
-	tk.MustQuery(`select @@global.log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig().Binlog.Enable == "on")))
-	tk.MustQuery(`select @@log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig().Binlog.Enable == "on")))
+	tk.MustQuery(`select @@global.log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(binloginfo.ShouldEnableBinlog())))
+	tk.MustQuery(`select @@log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(binloginfo.ShouldEnableBinlog())))
 
 	tk.MustExec("set global tidb_log_bin = on")
 	tk.MustQuery(`select @@global.tidb_log_bin;`).Check(testkit.Rows("1"))

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"

--- a/session/session.go
+++ b/session/session.go
@@ -1321,7 +1321,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 		return nil, errors.Trace(err)
 	}
 
-	// get global system tidb_log_bin from mysql.GLOBAL_VARIABLES
+	// get global system variable tidb_log_bin from mysql.GLOBAL_VARIABLES
 	tidbLogBin, err := se1.GetGlobalSysVar(variable.TiDBLogBin)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -95,9 +95,13 @@ func SetIgnoreError(on bool) {
 	}
 }
 
-// ShouldEnableBinlog returns true if binlog.enable is "on", or binlog.enable is "auto" and tidb_log_bin's value is "1"
+// ShouldEnableBinlog returns true if binlog.mode is not "auto" and binlog.enable is true, or binlog.mode is "auto" and tidb_log_bin's value is "1"
 func ShouldEnableBinlog() bool {
-	return config.GetGlobalConfig().Binlog.Enable == "on" || (config.GetGlobalConfig().Binlog.Enable == "auto" && variable.SysVars[variable.TiDBLogBin].Value == "1")
+	if config.GetGlobalConfig().Binlog.Mode == "auto" {
+		return variable.SysVars[variable.TiDBLogBin].Value == "1"
+	}
+
+	return config.GetGlobalConfig().Binlog.Enable
 }
 
 // WriteBinlog writes a binlog to Pump.

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -95,9 +95,9 @@ func SetIgnoreError(on bool) {
 	}
 }
 
-// ShouldEnableBinlog returns true if binlog.mode is not "auto" and binlog.enable is true, or binlog.mode is "auto" and tidb_log_bin's value is "1"
+// ShouldEnableBinlog returns true if Binlog.AutoMode is false and Binlog.Enable is true, or Binlog.AutoMode is true and tidb_log_bin's value is "1"
 func ShouldEnableBinlog() bool {
-	if config.GetGlobalConfig().Binlog.Mode == "auto" {
+	if config.GetGlobalConfig().Binlog.AutoMode {
 		return variable.SysVars[variable.TiDBLogBin].Value == "1"
 	}
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -100,7 +100,7 @@ var (
 	port             = flag.String(nmPort, "4000", "tidb server port")
 	cors             = flag.String(nmCors, "", "tidb server allow cors origin")
 	socket           = flag.String(nmSocket, "", "The socket file to use for connection.")
-	enableBinlog     = flag.String(nmEnableBinlog, "auto", "enable generate binlog")
+	enableBinlog     = flagBoolean(nmEnableBinlog, false, "enable generate binlog")
 	runDDL           = flagBoolean(nmRunDDL, true, "run ddl worker on this tidb-server")
 	ddlLease         = flag.String(nmDdlLease, "45s", "schema lease duration, very dangerous to change only if you know what you do")
 	tokenLimit       = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
pr https://github.com/pingcap/tidb/pull/9625  break the backward compatibility,
this pr fix it

### What is changed and how it works?
1. change binlog.enable's type to bool as before
2. add a new config binlog.automode, if automode is true, enable binlog by global system variable 'tidb_log_bin'

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (set binlog.enable and binlog.mode)


Related changes

 - Need to update the documentation
 - Need to be included in the release note
