### PR TITLE
test: fix go vet and run go vet regularly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ build:
 # Install the check tools.
 check-setup:tools/bin/revive tools/bin/goword tools/bin/gometalinter tools/bin/gosec
 
-check: fmt errcheck lint tidy check-static
+check: fmt errcheck lint tidy check-static vet
 
 # These need to be fixed before they can be ran regularly
 check-fail: goword check-slow

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ lint:tools/bin/revive
 
 vet:
 	@echo "vet"
-	$(GO) vet -all -shadow $(PACKAGES) 2>&1 | $(FAIL_ON_STDOUT)
+	$(GO) vet -all $(PACKAGES) 2>&1 | $(FAIL_ON_STDOUT)
 
 tidy:
 	@echo "go mod tidy"

--- a/plugin/conn_ip_example/conn_ip_example_test.go
+++ b/plugin/conn_ip_example/conn_ip_example_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 )
 
-func ExampleLoadRunShutdownPlugin() {
+func LoadRunShutdownPluginExample() {
 	ctx := context.Background()
 	var pluginVarNames []string
 	cfg := plugin.Config{

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -53,7 +53,8 @@ func TestString(t *testing.T) {
 }
 
 func mockExecutorExecutionSummary(TimeProcessedNs, NumProducedRows, NumIterations uint64) *tipb.ExecutorExecutionSummary {
-	return &tipb.ExecutorExecutionSummary{&TimeProcessedNs, &NumProducedRows, &NumIterations, nil}
+	return &tipb.ExecutorExecutionSummary{TimeProcessedNs: &TimeProcessedNs, NumProducedRows: &NumProducedRows,
+		NumIterations: &NumIterations, XXX_unrecognized: nil}
 }
 
 func TestCopRuntimeStats(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
There is something wrong in `govet`
```
xiekeyi@ubuntu:~/gopath/src/github.com/pingcap/tidb$ make vet
vet
GO111MODULE=on go vet -all $(go list ./...) 2>&1 | awk '{ print } END { if (NR > 0) { exit 1 } }'
# github.com/pingcap/tidb/plugin/conn_ip_example_test
plugin/conn_ip_example/conn_ip_example_test.go:23:1: ExampleLoadRunShutdownPlugin refers to unknown identifier: LoadRunShutdownPlugin
# github.com/pingcap/tidb/util/execdetails
util/execdetails/execdetails_test.go:56:10: github.com/pingcap/tipb/go-tipb.ExecutorExecutionSummary composite literal uses unkeyed fields
Makefile:102: recipe for target 'vet' failed
make: *** [vet] Error 1
```
### What is changed and how it works?

fix `go vet` and run `go vet` regularly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test



Side effects

 - **Make CI slower than slower**

