### PR TITLE
expression: fix panic when wrap cast for window func

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2211,6 +2211,10 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 			sql:    "select avg(a) over w from t window w as(partition by b)",
 			result: "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a)) over(partition by test.t.b))->Projection",
 		},
+		{
+			sql:    "select nth_value(i_date, 1) over() from t",
+			result: "TableReader(Table(t))->Window(nth_value(test.t.i_date, 1) over())->Projection",
+		},
 	}
 
 	s.Parser.EnableWindowFunc(true)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/9675

### What is changed and how it works?

Previously, the `WrapCastForAggArgs` only handle part of eval types. This PR changes it to let it handle all the eval types.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
