### PR TITLE
planner: fix point get with PK and UK

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -581,7 +581,7 @@ Sort_13	2.00	root	a:asc
     └─HashAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
       └─Projection_27	1.00	root	1
         └─TableDual_28	1.00	root	rows:1
-explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a)
+explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a);
 id	count	task	operator info
 HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
 └─Union_16	2.00	root	
@@ -591,3 +591,11 @@ HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
   └─StreamAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
     └─Projection_31	1.00	root	1
       └─TableDual_32	1.00	root	rows:1
+create table t (i int key, j int, unique key (i, j));
+begin;
+insert into t values (1, 1);
+explain update t set j = -j where i = 1 and j = 1;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:t, index:i j
+rollback;
+drop table if exists t;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -123,4 +123,11 @@ explain select * from (select * from t order by c) t order by a, b;
 drop table if exists t;
 set @@session.tidb_opt_insubq_to_join_and_agg=1;
 explain SELECT 0 AS a FROM dual UNION SELECT 1 AS a FROM dual ORDER BY a;
-explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a)
+explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a);
+
+create table t (i int key, j int, unique key (i, j));
+begin;
+insert into t values (1, 1);
+explain update t set j = -j where i = 1 and j = 1;
+rollback;
+drop table if exists t;

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -186,10 +186,7 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 		return nil
 	}
 	handlePair := findPKHandle(tbl, pairs)
-	if handlePair.value.Kind() != types.KindNull {
-		if len(pairs) != 1 {
-			goto CheckUK
-		}
+	if handlePair.value.Kind() != types.KindNull && len(pairs) == 1 {
 		schema := buildSchemaFromFields(ctx, tblName.Schema, tbl, selStmt.Fields.Fields)
 		if schema == nil {
 			return nil
@@ -203,7 +200,7 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 		p.HandleParam = handlePair.param
 		return p
 	}
-CheckUK:
+
 	for _, idxInfo := range tbl.Indices {
 		if !idxInfo.Unique {
 			continue

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -188,7 +188,7 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 	handlePair := findPKHandle(tbl, pairs)
 	if handlePair.value.Kind() != types.KindNull {
 		if len(pairs) != 1 {
-			return nil
+			goto CheckUK
 		}
 		schema := buildSchemaFromFields(ctx, tblName.Schema, tbl, selStmt.Fields.Fields)
 		if schema == nil {
@@ -203,6 +203,7 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 		p.HandleParam = handlePair.param
 		return p
 	}
+CheckUK:
 	for _, idxInfo := range tbl.Indices {
 		if !idxInfo.Unique {
 			continue


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Point get will miss the unique key if the primary key is also in the condition.

### What is changed and how it works?
If check the primary key failed, go to check the unique key.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change


Related changes

 - Need to cherry-pick to the release branch
