### PR TITLE
expression: fix `unix_timestamp` function which is not compatible with Mysql 

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -3528,6 +3528,19 @@ func (c *unixTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []
 					retDecimal = len(tmpStr) - dotIdx - 1
 				}
 			}
+			if sf, ok := args[0].(*ScalarFunction); ok {
+				_, isGetVarSig := sf.Function.(*builtinGetVarSig)
+				if isGetVarSig {
+					tmpStr, _, err := sf.EvalString(ctx, chunk.Row{})
+					if err != nil {
+						return nil, err
+					}
+					retDecimal = 0
+					if dotIdx := strings.LastIndex(tmpStr, "."); dotIdx >= 0 {
+						retDecimal = len(tmpStr) - dotIdx - 1
+					}
+				}
+			}
 		} else {
 			retDecimal = argType.Decimal
 		}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -3521,13 +3521,13 @@ func (c *unixTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []
 			retDecimal = types.UnspecifiedLength
 			var tmpStr string
 			var err error
-			o := false
+			o := true
 			if cnst, ok := args[0].(*Constant); ok {
 				tmpStr, _, err = cnst.EvalString(ctx, chunk.Row{})
-				o = true
 			} else if sf, ok := args[0].(*ScalarFunction); ok && sf.FuncName.L == ast.GetVar {
 				tmpStr, _, err = sf.EvalString(ctx, chunk.Row{})
-				o = true
+			} else {
+				o = false
 			}
 			if o {
 				if err != nil {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #9729 

### What is changed and how it works?
The implement of the original only considers the case of `Constant`. We need to consider the case such as `select unix_timestamp(@1)` 

I found that it's hard to build a test for such sistuation, maybe some one could tell we how to add the test?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Code changes



Side effects



Related changes


