### PR TITLE
planner/core: force first column used if no columns required (#9125)

### DIFF
--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -105,6 +105,13 @@ func (la *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) 
 		return err
 	}
 
+	if len(parentUsedCols) == 0 && len(used) > 0 {
+		// For sql like `select count(1) from (select count(1) from t)`, no column used.
+		// tikv's response will be empty if the inner aggr is pushed down.
+		// We should force some column to be used.
+		used[0] = true
+	}
+
 	for i := len(used) - 1; i >= 0; i-- {
 		if !used[i] {
 			la.schema.Columns = append(la.schema.Columns[:i], la.schema.Columns[i+1:]...)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix issue #9125 

### What is changed and how it works?

For sql like `select count(1) from (select count(1) from t)`, no column used for the inner Aggregation. TiKV's response will be empty if the inner Aggregation is pushed down. So force some column to be used for the inner Aggregation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test (a new test case TestIssue9125 in cbo_test.go)


Code changes

 - None

Side effects

 - None

Related changes

 - None
