### PR TITLE
executor: fix slow log output format

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -391,10 +391,10 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 	execDetail := sessVars.StmtCtx.GetExecDetails()
 	if costTime < threshold {
 		_, digest := sessVars.StmtCtx.SQLDigest()
-		logutil.SlowQueryZapLogger.Debug(sessVars.SlowLogFormat(txnTS, costTime, execDetail, indexIDs, digest, sql))
+		logutil.SlowQueryLogger.Debug(sessVars.SlowLogFormat(txnTS, costTime, execDetail, indexIDs, digest, sql))
 	} else {
 		_, digest := sessVars.StmtCtx.SQLDigest()
-		logutil.SlowQueryZapLogger.Warn(sessVars.SlowLogFormat(txnTS, costTime, execDetail, indexIDs, digest, sql))
+		logutil.SlowQueryLogger.Warn(sessVars.SlowLogFormat(txnTS, costTime, execDetail, indexIDs, digest, sql))
 		metrics.TotalQueryProcHistogram.Observe(costTime.Seconds())
 		metrics.TotalCopProcHistogram.Observe(execDetail.ProcessTime.Seconds())
 		metrics.TotalCopWaitHistogram.Observe(execDetail.WaitTime.Seconds())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The slow log should use `logru` to format slow log temporary. 
After I find how custom log format in zap, I will change slow log output to zap.

Before this PR, slow log output use `zap`. It's a wrong format for slow-log format.
```log
[2019/03/18 11:46:22.477 +08:00] [WARN] [adapter.go:397] ["# Txn_start_ts: 407078378792812544\n# User: root@127.0.0.1\n# Conn_ID: 27\n# Query_time: 1.262702571\n# Prewrite_time: 0.750106471 Commit_time: 0.511245612 Get_commit_ts_time: 1.615e-06 Local_latch_wait_time: 0.000482302 Write_keys: 474 Write_size: 2866278 Prewrite_region: 1\n# DB: test\n# Is_internal: false\n# Digest: 9505cacb7c710ed17125fcc6cb3669e8ddca6c8cd8af6a31f6b3cd64604c3098\ncommitTxn;"]
```
### What is changed and how it works?
After this PR:
```sql
# Time: 2019-03-18-11:56:27.990947 +0800
# Txn_start_ts: 407078538554114048
# Query_time: 0.072932683
# Request_count: 1
# Is_internal: true
# Digest: 9b185535408ec48f7d7f4019503896cb7c6d2af3ed6a24e1330c81377c48f6f5
select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, correlation from mysql.stats_histograms;

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes


Side effects