### PR TITLE
util: Fixed TestSlowQueryZapLogger to work with negative UTC offset timezones

### DIFF
--- a/util/logutil/log_test.go
+++ b/util/logutil/log_test.go
@@ -33,7 +33,7 @@ const (
 	logPattern = `\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d\.\d\d\d ([\w_%!$@.,+~-]+|\\.)+:\d+: \[(fatal|error|warning|info|debug)\] .*?\n`
 	// zapLogPatern is used to match the zap log format, such as the following log:
 	// [2019/02/13 15:56:05.385 +08:00] [INFO] [log_test.go:167] ["info message"] ["str key"=val] ["int key"=123]
-	zapLogPattern = `\[\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d\ \+\d\d:\d\d\] \[(FATAL|ERROR|WARN|INFO|DEBUG)\] \[([\w_%!$@.,+~-]+|\\.)+:\d+\] \[.*\] (\[.*=.*\]).*\n`
+	zapLogPattern = `\[\d\d\d\d/\d\d/\d\d \d\d:\d\d:\d\d.\d\d\d\ (\+|-)\d\d:\d\d\] \[(FATAL|ERROR|WARN|INFO|DEBUG)\] \[([\w_%!$@.,+~-]+|\\.)+:\d+\] \[.*\] (\[.*=.*\]).*\n`
 )
 
 func Test(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fixed TestSlowQueryZapLogger to work with negative UTC offset timezones

testLogSuite.TestSlowQueryZapLogger failed on a machine with a timezone offset from UTC by a negative number of hours. The regular expression matched only a "+" where a "-" must also be allowed. 
```
----------------------------------------------------------------------
FAIL: log_test.go:161: testLogSuite.TestSlowQueryZapLogger

log_test.go:184:
    c.Assert(str, Matches, zapLogPattern)
... value string = "[2019/03/18 14:50:33.399 -07:00] [INFO] [log_test.go:169] [\"info message\"] [\"str key\"=val]\n"
... regex string = "\\[\\d\\d\\d\\d/\\d\\d/\\d\\d \\d\\d:\\d\\d:\\d\\d.\\d\\d\\d\\ \\+\\d\\d:\\d\\d\\] \\[(FATAL|ERROR|WARN|INFO|DEBUG)\\] \\[([\\w_%!$@.,+~-]
+|\\\\.)+:\\d+\\] \\[.*\\] (\\[.*=.*\\]).*\\n"
```

### What is changed and how it works?
This commit simply adjusts the regex to allow either a "+" or a "-" for the timezone offset in the log message.

Where the regex previously had `\+`, I changed that to `(\+|-)`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

My system timezone is typically US/Pacific (presently Pacific Standard Time, with a UTC offset of -0700). I tested after making the change described above and the test passed. I changed my system time to Iran Standard Time (+0330) to verify that I hadn't broken the behavior for positive-offset timezones and the test still passed.

Code changes
n/a

Side effects
n/a

Related changes
n/a
