### PR TITLE
executor: fix window function when order by item contain NULL

### DIFF
--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -79,6 +79,10 @@ func buildRowComparer(cols []*expression.Column) rowComparer {
 	rc.colIdx = make([]int, 0, len(cols))
 	rc.cmpFuncs = make([]chunk.CompareFunc, 0, len(cols))
 	for _, col := range cols {
+		cmpFunc := chunk.GetCompareFunc(col.RetType)
+		if cmpFunc == nil {
+			continue
+		}
 		rc.cmpFuncs = append(rc.cmpFuncs, chunk.GetCompareFunc(col.RetType))
 		rc.colIdx = append(rc.colIdx, col.Index)
 	}

--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -142,4 +142,7 @@ func (s *testSuite2) TestWindowFunctions(c *C) {
 	result.Check(testkit.Rows("1 1 1", "1 2 1", "2 2 1", "2 2 2"))
 	result = tk.MustQuery("select a, lead(a, 1, 'lead') over(), lag(a, 1, 'lag') over() from t")
 	result.Check(testkit.Rows("1 1 lag", "1 2 1", "2 2 1", "2 lead 2"))
+
+	result = tk.MustQuery("SELECT CUME_DIST() OVER (ORDER BY null);")
+	result.Check(testkit.Rows("1"))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

NULL cannot get compare func then panicked.

### What is changed and how it works?

Filter NULL out.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
