### PR TITLE
config: fix config toml file `check-mb4-value-in-utf8` problem.

### DIFF
--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -48,6 +48,9 @@ lower-case-table-names = 2
 # turn on this option when TiDB server is behind a proxy.
 compatible-kill-query = false
 
+# check mb4 value in utf8 is used to control whether to check the mb4 characters when the charset is utf8.
+check-mb4-value-in-utf8 = true
+
 [log]
 # Log level: debug, info, warn, error, fatal.
 level = "info"
@@ -273,6 +276,3 @@ ignore-error = false
 
 # use socket file to write binlog, for compatible with kafka version tidb-binlog.
 binlog-socket = ""
-
-# check mb4 value in utf8 is used to control whether to check the mb4 characters when the charset is utf8.
-check-mb4-value-in-utf8 = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently in `config/config.toml.example` file,  variable  `check-mb4-value-in-utf8` is belong to the `[binlog]` scope,  but It should be  the global scope correspond to the `Config` struct.

### What is changed and how it works?
Move `check-mb4-value-in-utf8` to global scope in `config/config.toml.example` file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

