### PR TITLE
types: function `extract` is incompatible with Mysql 

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4032,3 +4032,32 @@ func (s *testIntegrationSuite) TestIssue9325(c *C) {
 	result = tk.MustQuery("select * from t where a < timestamp'2019-02-16 14:21:00'")
 	result.Check(testkit.Rows("2019-02-16 14:19:59", "2019-02-16 14:20:01"))
 }
+
+func (s *testIntegrationSuite) TestTimeExtract(c *C) {
+	testCases := []struct {
+		SQL string
+		Res string
+	}{
+		{
+			SQL: "select extract(DAY_HOUR FROM '01 23:45:56.89')",
+			Res: "47",
+		},
+		{
+			SQL: "select extract(DAY_MINUTE FROM '01 23:45:56.89')",
+			Res: "4745",
+		},
+		{
+			SQL: "select extract(DAY_SECOND FROM '01 23:45:56.89')",
+			Res: "474556",
+		},
+		{
+			SQL: "select extract(DAY_MICROSECOND FROM '01 23:45:56.89')",
+			Res: "474556890000",
+		},
+	}
+
+	tk := testkit.NewTestKit(c, s.store)
+	for _, testCase := range testCases {
+		tk.MustQuery(testCase.SQL).Check(testkit.Rows(testCase.Res))
+	}
+}

--- a/types/time.go
+++ b/types/time.go
@@ -690,8 +690,13 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		// YYYY-MM-DD
 		err = scanTimeArgs(seps, &year, &month, &day)
 	case 4:
-		// YYYY-MM-DD HH
-		err = scanTimeArgs(seps, &year, &month, &day, &hour)
+		if strings.Contains(str, "-") {
+			// YYYY-MM-DD HH
+			err = scanTimeArgs(seps, &year, &month, &day, &hour)
+		} else {
+			// DD HH:MM:SS
+			err = scanTimeArgs(seps, &day, &hour, &minute, &second)
+		}
 	case 5:
 		// YYYY-MM-DD HH-MM
 		err = scanTimeArgs(seps, &year, &month, &day, &hour, &minute)
@@ -1482,19 +1487,19 @@ func ExtractDatetimeNum(t *Time, unit string) (int64, error) {
 	case "DAY_MICROSECOND":
 		h, m, s := t.Clock()
 		d := t.Time.Day()
-		return int64(d*1000000+h*10000+m*100+s)*1000000 + int64(t.Time.Microsecond()), nil
+		return int64(d*240000+h*10000+m*100+s)*1000000 + int64(t.Time.Microsecond()), nil
 	case "DAY_SECOND":
 		h, m, s := t.Clock()
 		d := t.Time.Day()
-		return int64(d)*1000000 + int64(h)*10000 + int64(m)*100 + int64(s), nil
+		return int64(d)*240000 + int64(h)*10000 + int64(m)*100 + int64(s), nil
 	case "DAY_MINUTE":
 		h, m, _ := t.Clock()
 		d := t.Time.Day()
-		return int64(d)*10000 + int64(h)*100 + int64(m), nil
+		return int64(d)*2400 + int64(h)*100 + int64(m), nil
 	case "DAY_HOUR":
 		h, _, _ := t.Clock()
 		d := t.Time.Day()
-		return int64(d)*100 + int64(h), nil
+		return int64(d)*24 + int64(h), nil
 	case "YEAR_MONTH":
 		y, m := t.Time.Year(), t.Time.Month()
 		return int64(y)*100 + int64(m), nil

--- a/types/time.go
+++ b/types/time.go
@@ -57,7 +57,7 @@ const (
 	// MaxDuration is the maximum for duration.
 	MaxDuration int64 = 838*10000 + 59*100 + 59
 	// MinTime is the minimum for mysql time type.
-	MinTime = -gotime.Duration(838*3600+59*60+59) * gotime.Second
+	MinTime = -gotime.Duration(838*3600 + 59*60 + 59) * gotime.Second
 	// MaxTime is the maximum for mysql time type.
 	MaxTime = gotime.Duration(838*3600+59*60+59) * gotime.Second
 	// ZeroDatetimeStr is the string representation of a zero datetime.
@@ -696,6 +696,7 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 		} else {
 			// DD HH:MM:SS
 			err = scanTimeArgs(seps, &day, &hour, &minute, &second)
+			hhmmss = true
 		}
 	case 5:
 		// YYYY-MM-DD HH-MM

--- a/types/time.go
+++ b/types/time.go
@@ -57,7 +57,7 @@ const (
 	// MaxDuration is the maximum for duration.
 	MaxDuration int64 = 838*10000 + 59*100 + 59
 	// MinTime is the minimum for mysql time type.
-	MinTime = -gotime.Duration(838*3600 + 59*60 + 59) * gotime.Second
+	MinTime = -gotime.Duration(838*3600+59*60+59) * gotime.Second
 	// MaxTime is the maximum for mysql time type.
 	MaxTime = gotime.Duration(838*3600+59*60+59) * gotime.Second
 	// ZeroDatetimeStr is the string representation of a zero datetime.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #9716 

### What is changed and how it works?
1. Update formulas of calculating `DAY_HOUR`, `DAY_MINUTE`, `DAY_SECOND`, `DAY_MICROSECOND`.
2. Add pattern `DD HH:MM:SS` when parsing datetime.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test