### PR TITLE
planner: tidy code more go style

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2084,7 +2084,7 @@ func (b *PlanBuilder) buildDataSource(tn *ast.TableName) (LogicalPlan, error) {
 	}
 
 	tableInfo := tbl.Meta()
-	var authErr error = nil
+	var authErr error
 	if b.ctx.GetSessionVars().User != nil {
 		authErr = ErrTableaccessDenied.GenWithStackByArgs("SELECT", b.ctx.GetSessionVars().User.Hostname, b.ctx.GetSessionVars().User.Username, tableInfo.Name.L)
 	}


### PR DESCRIPTION
Golang will auto-init the variable.
We do not need it.
`warning: should drop = nil from the declaration of var authErr; it is the zero value (golint)`

Signed-off-by: Keyi Xie <xiekeyi98@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make the code more like go style.

### What is changed and how it works?

Remove useless init.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
