### PR TITLE
domain: make leaktest happy 

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -734,7 +734,9 @@ func (do *Domain) LoadPrivilegeLoop(ctx sessionctx.Context) error {
 		duration = 10 * time.Minute
 	}
 
+	do.wg.Add(1)
 	go func() {
+		defer do.wg.Done()
 		defer recoverInDomain("loadPrivilegeInLoop", false)
 		var count int
 		for {
@@ -791,7 +793,9 @@ func (do *Domain) LoadBindInfoLoop(ctx sessionctx.Context, parser *parser.Parser
 	}
 
 	duration := 3 * time.Second
+	do.wg.Add(1)
 	go func() {
+		defer do.wg.Done()
 		defer recoverInDomain("loadBindInfoLoop", false)
 		for {
 			select {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:123:
5935     c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
5936 ... Error: Test check-count 50 appears to have leaked: github.com/pingcap/tidb/domain.(*Domain).LoadBindInfoLoop.func1(0xc0059fd7a0, 0xb2d05e00, 0xc009f7bf90, 0xc0094b81e0)^M
5937         /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:797 +0x10f
5938 created by github.com/pingcap/tidb/domain.(*Domain).LoadBindInfoLoop
5939         /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:794 +0x180
```

### What is changed and how it works?
Do `wg.Add` before running a goroutine.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code
