### PR TITLE
types:change Map to switch in `GetFormatType`

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -2205,7 +2205,7 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 		}
 		var durationTokens bool
 		var dateTokens bool
-		if len(token) >= 2 && token[0] != '%' {
+		if len(token) >= 2 && token[0] == '%' {
 			switch token[1] {
 			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
 				durationTokens = true

--- a/types/time.go
+++ b/types/time.go
@@ -2204,12 +2204,12 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 			break
 		}
 		var durationTokens bool
-		if len(token >= 2) {
+		var dateTokens bool
+		if len(token) >= 2 {
 			switch token[1] {
 			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
 				durationTokens = true
 			}
-			var dateTokens bool
 			switch token[1] {
 			case 'y', 'Y', 'm', 'M', 'c', 'b', 'D', 'd', 'e':
 				dateTokens = true

--- a/types/time.go
+++ b/types/time.go
@@ -2191,28 +2191,6 @@ var dateFormatParserTable = map[string]dateFormatParser{
 
 // GetFormatType checks the type(Duration, Date or Datetime) of a format string.
 func GetFormatType(format string) (isDuration, isDate bool) {
-	durationTokens := map[string]struct{}{
-		"%h": {},
-		"%H": {},
-		"%i": {},
-		"%I": {},
-		"%s": {},
-		"%S": {},
-		"%k": {},
-		"%l": {},
-	}
-	dateTokens := map[string]struct{}{
-		"%y": {},
-		"%Y": {},
-		"%m": {},
-		"%M": {},
-		"%c": {},
-		"%b": {},
-		"%D": {},
-		"%d": {},
-		"%e": {},
-	}
-
 	format = skipWhiteSpace(format)
 	var token string
 	var succ bool
@@ -2225,9 +2203,19 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 			isDuration, isDate = false, false
 			break
 		}
-		if _, ok := durationTokens[token]; ok {
+		var durationTokens bool
+		switch token {
+		case "%h", "%H", "%i", "%I", "%s", "%S", "%k", "%l":
+			durationTokens = true
+		}
+		var dateTokens bool
+		switch token {
+		case "%y", "%Y", "%m", "%M", "%c", "%b", "%D", "%d", "%e":
+			dateTokens = true
+		}
+		if durationTokens {
 			isDuration = true
-		} else if _, ok := dateTokens[token]; ok {
+		} else if dateTokens {
 			isDate = true
 		}
 		if isDuration && isDate {

--- a/types/time.go
+++ b/types/time.go
@@ -2204,14 +2204,16 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 			break
 		}
 		var durationTokens bool
-		switch token {
-		case "%h", "%H", "%i", "%I", "%s", "%S", "%k", "%l":
-			durationTokens = true
-		}
-		var dateTokens bool
-		switch token {
-		case "%y", "%Y", "%m", "%M", "%c", "%b", "%D", "%d", "%e":
-			dateTokens = true
+		if len(token >= 2) {
+			switch token[1] {
+			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
+				durationTokens = true
+			}
+			var dateTokens bool
+			switch token[1] {
+			case 'y', 'Y', 'm', 'M', 'c', 'b', 'D', 'd', 'e':
+				dateTokens = true
+			}
 		}
 		if durationTokens {
 			isDuration = true

--- a/types/time.go
+++ b/types/time.go
@@ -2209,8 +2209,6 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 			switch token[1] {
 			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
 				durationTokens = true
-			}
-			switch token[1] {
 			case 'y', 'Y', 'm', 'M', 'c', 'b', 'D', 'd', 'e':
 				dateTokens = true
 			}

--- a/types/time.go
+++ b/types/time.go
@@ -2205,7 +2205,7 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 		}
 		var durationTokens bool
 		var dateTokens bool
-		if len(token) >= 2 {
+		if len(token) >= 2 && token[0] != '%' {
 			switch token[1] {
 			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
 				durationTokens = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make performance up.
Use switch will speed up more than map.

### What is changed and how it works?

Replace map with switch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```
xiekeyi@ubuntu:~$ cat a_test.go 
package types

import (
	"math/rand"
	"testing"
)

func testMap(format string) (a, b bool) {
	a, b = false, false
	durationTokens := map[string]struct{}{
		"%h": {},
		"%H": {},
		"%i": {},
		"%I": {},
		"%s": {},
		"%S": {},
		"%k": {},
		"%l": {},
	}
	if _, ok := durationTokens[format]; ok {
		a, b = true, true
	}
	return a, b

}
func testSwitch(format string) (a, b bool) {
	a, b = false, false
	var ok bool
	switch format {
	case "%h", "%H", "%i", "%I", "%s", "%S", "%k", "%l":
		ok = true
	}

	if ok {
		a, b = true, true
	}
	return a, b

}
func BenchmarkMap(b *testing.B) {
	s := []string{"%h", "%H", "%i", "%a", "%s", "%S"}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = testMap(s[rand.Intn(6)])
	}
}

func BenchmarkSwitch(b *testing.B) {
	s := []string{"%h", "%H", "%i", "%a", "%s", "%S"}
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _ = testSwitch(s[rand.Intn(6)])
	}
}
xiekeyi@ubuntu:~$ go test -bench=. -benchtime=3s -count=5 a_test.go 
goos: linux
goarch: amd64
BenchmarkMap-4      	20000000	       405 ns/op
BenchmarkMap-4      	10000000	       515 ns/op
BenchmarkMap-4      	10000000	       486 ns/op
BenchmarkMap-4      	10000000	       423 ns/op
BenchmarkMap-4      	20000000	       434 ns/op
BenchmarkSwitch-4   	50000000	        88.1 ns/op
BenchmarkSwitch-4   	50000000	        85.2 ns/op
BenchmarkSwitch-4   	50000000	        90.9 ns/op
BenchmarkSwitch-4   	50000000	        89.7 ns/op
BenchmarkSwitch-4   	50000000	        86.8 ns/op
PASS
ok  	command-line-arguments	55.801s
xiekeyi@ubuntu:~$ go test -bench=. -benchmem -benchtime=5s -count=3 a_test.go 
goos: linux
goarch: amd64
BenchmarkMap-4      	20000000	       444 ns/op	       0 B/op	       0 allocs/op
BenchmarkMap-4      	20000000	       401 ns/op	       0 B/op	       0 allocs/op
BenchmarkMap-4      	20000000	       432 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwitch-4   	100000000	        94.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwitch-4   	100000000	        90.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkSwitch-4   	100000000	        93.7 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	command-line-arguments	55.227s
xiekeyi@ubuntu:~$ go version
go version go1.12.1 linux/amd64

```