### PR TITLE
infoschema, util: fix idle sessions in processlist

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -530,7 +530,7 @@ var tableProcesslistCols = []columnInfo{
 	{"COMMAND", mysql.TypeVarchar, 16, mysql.NotNullFlag, "", nil},
 	{"TIME", mysql.TypeLong, 7, mysql.NotNullFlag, 0, nil},
 	{"STATE", mysql.TypeVarchar, 7, 0, nil, nil},
-	{"Info", mysql.TypeString, 512, 0, nil, nil},
+	{"INFO", mysql.TypeString, 512, 0, nil, nil},
 }
 
 var tableTiDBIndexesCols = []columnInfo{

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -38,10 +38,7 @@ func (pi *ProcessInfo) ToRow(cmd2str map[byte]string, full bool) []interface{} {
 	} else {
 		info = fmt.Sprintf("%.100v", pi.Info)
 	}
-	var t uint64
-	if len(pi.Info) != 0 {
-		t = uint64(time.Since(pi.Time) / time.Second)
-	}
+	t := uint64(time.Since(pi.Time) / time.Second)
 	return []interface{}{
 		pi.ID,
 		pi.User,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes https://github.com/pingcap/tidb/issues/9853

Also fixes a bug where the column heading was not in caps.

### What is changed and how it works?

- Removed some code that always set the time to zero if the current command was empty.
- Test suite still seems to pass, and `show processlist` previously never had this check.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Removed code that seemed to not be required.  Manually verified with an idle session the time increases.  Also verified that without permissions the refactored code does not leak other sessions.

Code changes

 - Minimal

Side effects

 - Possible this check existed for a reason, but it only applied to `information_schema.processlist`.  Most users use `show processlist`.

Related changes

- None