### PR TITLE
remove an unnecessary argument

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -236,7 +236,7 @@ func (e *ShowExec) fetchShowProcessList() error {
 		if !hasProcessPriv && pi.User != loginUser.Username {
 			continue
 		}
-		row := pi.ToRow(mysql.Command2Str, e.Full)
+		row := pi.ToRow(e.Full)
 		e.appendRow(row)
 	}
 	return nil

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -640,7 +640,7 @@ func dataForProcesslist(ctx sessionctx.Context) [][]types.Datum {
 			continue
 		}
 
-		rows := pi.ToRow(mysql.Command2Str, true)
+		rows := pi.ToRow(true)
 		record := types.MakeDatums(rows...)
 		records = append(records, record)
 	}

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -16,6 +16,8 @@ package util
 import (
 	"fmt"
 	"time"
+
+	"github.com/pingcap/parser/mysql"
 )
 
 // ProcessInfo is a struct used for show processlist statement.
@@ -31,7 +33,7 @@ type ProcessInfo struct {
 }
 
 // ToRow returns []interface{} for the row data of "show processlist" and "select * from infoschema.processlist".
-func (pi *ProcessInfo) ToRow(cmd2str map[byte]string, full bool) []interface{} {
+func (pi *ProcessInfo) ToRow(full bool) []interface{} {
 	var info string
 	if full {
 		info = pi.Info
@@ -44,7 +46,7 @@ func (pi *ProcessInfo) ToRow(cmd2str map[byte]string, full bool) []interface{} {
 		pi.User,
 		pi.Host,
 		pi.DB,
-		cmd2str[pi.Command],
+		mysql.Command2Str[pi.Command],
 		t,
 		fmt.Sprintf("%d", pi.State),
 		info,


### PR DESCRIPTION
Remove an argument of ProcessInfo's ToRow method, which is always a constant map.