### PR TITLE
executor: using ToHashKey to check equality of decimal when count(distinct)

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1135,6 +1135,7 @@ func (s *testSuite) TestUnion(c *C) {
 	_, err = tk.Exec("(select a,b from t1 limit 2) union all (select a,b from t2 order by a limit 1) order by t1.b")
 	c.Assert(err.Error(), Equals, "[planner:1250]Table 't1' from one of the SELECTs cannot be used in global ORDER clause")
 
+	// #issue 9900
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b decimal(6, 3))")
 	tk.MustExec("insert into t values(1, 1.000)")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1134,6 +1134,11 @@ func (s *testSuite) TestUnion(c *C) {
 	tk.MustExec("analyze table t2")
 	_, err = tk.Exec("(select a,b from t1 limit 2) union all (select a,b from t2 order by a limit 1) order by t1.b")
 	c.Assert(err.Error(), Equals, "[planner:1250]Table 't1' from one of the SELECTs cannot be used in global ORDER clause")
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b decimal(6, 3))")
+	tk.MustExec("insert into t values(1, 1.000)")
+	tk.MustQuery("select count(distinct a) from (select a from t union select b from t) tmp;").Check(testkit.Rows("1"))
 }
 
 func (s *testSuite) TestNeighbouringProj(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #9900 

### What is changed and how it works?
Using MyDecimal.ToHashKey to check the equality of decimal when in when count(distinct).

Before this commit, we wrap a `cast as decimal(52, 31)` for both children of union.
After the cast, the value from the int column becomes `{9 3 3 false [1 0 0 0 0 0 0 0 0]}`
the value from the decimal column becomes `{3 3 3 false [1 0 0 0 0 0 0 0 0]}`.
Which is thought as in-equal when compared directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects

 - Possible performance regression

Before this commit, we use the value as a hash-key without evaluating.
This commit may cause some performance regression since we evaluating invoke MyDecimal.ToHashKey for every decimal.

Related changes

 - Need to cherry-pick to the release branch

