### PR TITLE
domain: make schema validator test more stable and fix planner test leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 ![](docs/logo_with_text.png)
 
+[![LICENSE](https://img.shields.io/github/license/pingcap/tidb.svg)](https://github.com/pingcap/tidb/blob/master/LICENSE)
+[![Language](https://img.shields.io/badge/Language-Go-blue.svg)](https://golang.org/)
 [![Build Status](https://travis-ci.org/pingcap/tidb.svg?branch=master)](https://travis-ci.org/pingcap/tidb)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pingcap/tidb)](https://goreportcard.com/report/github.com/pingcap/tidb)
-![GitHub release](https://img.shields.io/github/tag/pingcap/tidb.svg?label=release)
+[![GitHub release](https://img.shields.io/github/tag/pingcap/tidb.svg?label=release)](https://github.com/pingcap/tidb/releases)
+[![GitHub release date](https://img.shields.io/github/release-date/pingcap/tidb.svg)](https://github.com/pingcap/tidb/releases)
 [![CircleCI Status](https://circleci.com/gh/pingcap/tidb.svg?style=shield)](https://circleci.com/gh/pingcap/tidb)
 [![Coverage Status](https://codecov.io/gh/pingcap/tidb/branch/master/graph/badge.svg)](https://codecov.io/gh/pingcap/tidb)
 

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -95,7 +95,7 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 
 	// All schema versions is expired.
-	ts = uint64(time.Now().Add(lease).UnixNano())
+	ts = uint64(time.Now().Add(2 * lease).UnixNano())
 	valid = validator.Check(ts, newItem.schemaVer, nil)
 	c.Assert(valid, Equals, ResultUnknown)
 

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -144,8 +144,6 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 	// behavior would not be effected by the uncertain memory utilization.
 	core.PreparedPlanCacheMaxMemory = math.MaxUint64
 
-	defer testleak.AfterTest(c)()
-
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (id int PRIMARY KEY, c1 TIMESTAMP(3) NOT NULL DEFAULT '2019-01-14 10:43:20', KEY idx1 (c1))")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
make test more stable.
sometime will faild as below.
```go
schema_validator_test.go:100:
    c.Assert(valid, Equals, ResultUnknown)
... obtained domain.checkResult = 0
... expected domain.checkResult = 2
```

and 
```go
----------------------------------------------------------------------
FAIL: prepare_test.go:123: testPlanSuite.TestPrepareCacheDeferredFunction

prepare_test.go:182:
    ...
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:123:
    c.Errorf("Test check-count %d appears to have leaked: %v", cnt, g)
... Error: Test check-count 50 appears to have leaked: github.com/pingcap/tidb/domain.(*Domain).LoadBindInfoLoop.func1(0xc0086706c0, 0xb2d05e00, 0xc00ba48e60, 0xc0000bbe70)
	/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:810 +0x145
created by github.com/pingcap/tidb/domain.(*Domain).LoadBindInfoLoop
	/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:806 +0x1a3
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->
