### PR TITLE
executor,planner: make the output from partition table stable

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1255,6 +1255,7 @@ func (b *executorBuilder) buildUnionAll(v *plannercore.PhysicalUnionAll) Executo
 	}
 	e := &UnionExec{
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), childExecs...),
+		keepOrder:    v.KeepOrder,
 	}
 	return e
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3466,6 +3466,8 @@ func (s *testSuite3) TestSelectPartition(c *C) {
 	// select multi partition.
 	tk.MustQuery("select b from th partition (P2,p0) order by a").Check(testkit.Rows("-8", "-6", "-5", "-3", "-2", "0", "2", "3", "5", "6", "8"))
 	tk.MustQuery("select b from tr partition (r1,R3) order by a").Check(testkit.Rows("4", "7", "8"))
+	// No order by.
+	tk.MustQuery("select a from th").Check(testkit.Rows("0", "3", "6", "-3", "-6", "1", "4", "7", "-1", "-4", "-7", "2", "5", "8", "-2", "-5", "-8"))
 
 	// test select unknown partition error
 	_, err := tk.Exec("select b from th partition (p0,p4)")

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -954,7 +954,7 @@ func (p *LogicalUnionAll) exhaustPhysicalPlans(prop *property.PhysicalProperty) 
 	for range p.children {
 		chReqProps = append(chReqProps, &property.PhysicalProperty{ExpectedCnt: prop.ExpectedCnt})
 	}
-	ua := PhysicalUnionAll{}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), chReqProps...)
+	ua := PhysicalUnionAll{KeepOrder: p.keepOrder}.Init(p.ctx, p.stats.ScaleByExpectCnt(prop.ExpectedCnt), chReqProps...)
 	ua.SetSchema(p.Schema())
 	return []PhysicalPlan{ua}
 }

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -613,6 +613,7 @@ func (ds *DataSource) TableInfo() *model.TableInfo {
 // LogicalUnionAll represents LogicalUnionAll plan.
 type LogicalUnionAll struct {
 	logicalSchemaProducer
+	keepOrder bool
 }
 
 // LogicalSort stands for the order by plan.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -272,6 +272,7 @@ type PhysicalLimit struct {
 // PhysicalUnionAll is the physical operator of UnionAll.
 type PhysicalUnionAll struct {
 	physicalSchemaProducer
+	KeepOrder bool
 }
 
 // AggregationType stands for the mode of aggregation plan.

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -146,7 +146,7 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 		// No need for the union all.
 		return children[0], nil
 	}
-	unionAll := LogicalUnionAll{}.Init(ds.context())
+	unionAll := LogicalUnionAll{keepOrder: true}.Init(ds.context())
 	unionAll.SetChildren(children...)
 	unionAll.SetSchema(ds.schema)
 	return unionAll, nil


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This change will keep the result data in the partition order, so it's more
convenient to write tests.

### What is changed and how it works?

If 'keep order' is set in `UnionExec`, `Next()` will receive data from the children executors one by one.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
