### PR TITLE
go.mod: update parser's version

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -177,7 +177,7 @@ func (s *testIntegrationSuite) TestCreateTableWithKeyWord(c *C) {
 	tk.MustExec("USE test;")
 
 	_, err := tk.Exec("create table t1(pump varchar(20), drainer varchar(20), node_id varchar(20), node_state varchar(20));")
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }
 
 func (s *testIntegrationSuite) TestUniqueKeyNullValue(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -170,6 +170,16 @@ func (s *testIntegrationSuite) TestCreateTableIfNotExists(c *C) {
 	c.Assert(terror.ErrorEqual(infoschema.ErrTableExists, lastWarn.Err), IsTrue)
 }
 
+// for issue #9910
+func (s *testIntegrationSuite) TestCreateTableWithKeyWord(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("USE test;")
+
+	_, err := tk.Exec("create table t1(pump varchar(20), drainer varchar(20), node_id varchar(20), node_state varchar(20));")
+	c.Assert(err, NotNil)
+}
+
 func (s *testIntegrationSuite) TestUniqueKeyNullValue(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("USE test")

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190325012055-cc0fa08f99ca
+	github.com/pingcap/parser v0.0.0-20190327115014-cc00dafe38cf
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562 h1:32oF1/8lVnBR2JV
 github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190325012055-cc0fa08f99ca h1:ylsmsndeqq4NUE3EvL+TIvZKTlv8Qrth6CFPxDpm570=
-github.com/pingcap/parser v0.0.0-20190325012055-cc0fa08f99ca/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190327115014-cc00dafe38cf h1:QOpAuCYJYl710Ox0D0bCHQKU0HfAMRv/q/XVpOnWTqg=
+github.com/pingcap/parser v0.0.0-20190327115014-cc00dafe38cf/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
parser's pr https://github.com/pingcap/parser/pull/263 fix issue  https://github.com/pingcap/tidb/issues/9910
need update parser's version

### What is changed and how it works?
update parser's version in go.mod

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (create table, with column named `node_id` and `node_state`)



Related changes

 - Need to cherry-pick to the release branch