### PR TITLE
executor: fix group_concat for cases like group_concat(123,null)

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -409,7 +409,7 @@ func (s *testSuite1) TestGroupConcatAggr(c *C) {
 	result = tk.MustQuery("select id, group_concat(name SEPARATOR '123') from test group by id order by id")
 	result.Check(testkit.Rows("1 101232012330", "2 20", "3 200123500"))
 
-	// #issue 9920
+	// issue #9920
 	tk.MustQuery("select group_concat(123, null)").Check(testkit.Rows("<nil>"))
 }
 

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -408,6 +408,9 @@ func (s *testSuite1) TestGroupConcatAggr(c *C) {
 
 	result = tk.MustQuery("select id, group_concat(name SEPARATOR '123') from test group by id order by id")
 	result.Check(testkit.Rows("1 101232012330", "2 20", "3 200123500"))
+
+	// #issue 9920
+	tk.MustQuery("select group_concat(123, null)").Check(testkit.Rows("<nil>"))
 }
 
 func (s *testSuite) TestSelectDistinct(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #9920 

### What is changed and how it works?
Make the behavior of group_concat be compatible with the MySQL manual:
> It returns NULL if there are no non-NULL values

Before this commit, we regard **every** argument as an item of the result of group_concat.
But actually, **all the arguments value in one row** should be regarded as one item. If any one of the arguments is null, the group_concat result of **this row** is null.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

