### PR TITLE
planner, executor: group_concat(multiple cols) should not be converted to proj

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -581,6 +581,7 @@ func (s *testSuite1) TestAggEliminator(c *C) {
 	tk.MustQuery("select min(b) from t").Check(testkit.Rows("-2"))
 	tk.MustQuery("select max(b*b) from t").Check(testkit.Rows("4"))
 	tk.MustQuery("select min(b*b) from t").Check(testkit.Rows("1"))
+	tk.MustQuery("select group_concat(b, b) from t group by a").Check(testkit.Rows("-1-1", "-2-2", "11", "<nil>"))
 }
 
 func (s *testSuite1) TestMaxMinFloatScalaFunc(c *C) {

--- a/planner/core/rule_aggregation_elimination.go
+++ b/planner/core/rule_aggregation_elimination.go
@@ -16,6 +16,7 @@ package core
 import (
 	"math"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -25,64 +26,84 @@ import (
 )
 
 type aggregationEliminator struct {
-	aggregationEliminateChecker
 }
 
-type aggregationEliminateChecker struct {
-}
-
-// tryToEliminateAggregation will eliminate aggregation grouped by unique key.
-// e.g. select min(b) from t group by a. If a is a unique key, then this sql is equal to `select b from t group by a`.
-// For count(expr), sum(expr), avg(expr), count(distinct expr, [expr...]) we may need to rewrite the expr. Details are shown below.
-// If we can eliminate agg successful, we return a projection. Else we return a nil pointer.
-func (a *aggregationEliminateChecker) tryToEliminateAggregation(agg *LogicalAggregation) *LogicalProjection {
+func (a *aggregationEliminator) canEliminate(agg *LogicalAggregation) (ok bool) {
 	schemaByGroupby := expression.NewSchema(agg.groupByCols...)
-	coveredByUniqueKey := false
 	for _, key := range agg.children[0].Schema().Keys {
 		if schemaByGroupby.ColumnsIndices(key) != nil {
-			coveredByUniqueKey = true
+			ok = true
 			break
 		}
 	}
-	if coveredByUniqueKey {
-		// GroupByCols has unique key, so this aggregation can be removed.
-		proj := a.convertAggToProj(agg)
-		proj.SetChildren(agg.children[0])
-		return proj
+	if !ok {
+		return false
 	}
-	return nil
+	for _, af := range agg.AggFuncs {
+		if af.Name == ast.AggFuncGroupConcat && len(af.Args) > 1 {
+			return false
+		}
+	}
+	return true
 }
 
-func (a *aggregationEliminateChecker) convertAggToProj(agg *LogicalAggregation) *LogicalProjection {
+// tryEliminateAgg will eliminate aggregation if `groupByCols` contains at lease
+// one unique key. Else, it will do nothing.
+// e.g. select min(b) from `t` group by `non-unique-col`, `unique-col`.
+// Suppose `unique-col` is an unique key, this sql is equal to `select b from t
+// group by a`.
+// For count(expr), sum(expr), avg(expr), count(distinct expr, [expr...]) we may
+// need to rewrite the expr. Details are shown below.
+// If we can eliminate agg successfully, we return a projection. Else we return
+// a nil pointer.
+func (a *aggregationEliminator) tryEliminateAgg(agg *LogicalAggregation) (LogicalPlan, error) {
+	if !a.canEliminate(agg) {
+		return nil, nil
+	}
+	proj, err := a.convertAggToProj(agg)
+	if err != nil {
+		return nil, err
+	}
+	proj.SetChildren(agg.children[0])
+	return proj, nil
+}
+
+func (a *aggregationEliminator) convertAggToProj(agg *LogicalAggregation) (*LogicalProjection, error) {
 	proj := LogicalProjection{
 		Exprs: make([]expression.Expression, 0, len(agg.AggFuncs)),
 	}.Init(agg.ctx)
 	for _, fun := range agg.AggFuncs {
-		expr := a.rewriteExpr(agg.ctx, fun)
+		expr, err := a.rewriteExpr(agg.ctx, fun)
+		if err != nil {
+			return nil, err
+		}
 		proj.Exprs = append(proj.Exprs, expr)
 	}
 	proj.SetSchema(agg.schema.Clone())
-	return proj
+	return proj, nil
 }
 
 // rewriteExpr will rewrite the aggregate function to expression doesn't contain aggregate function.
-func (a *aggregationEliminateChecker) rewriteExpr(ctx sessionctx.Context, aggFunc *aggregation.AggFuncDesc) expression.Expression {
+func (a *aggregationEliminator) rewriteExpr(ctx sessionctx.Context, aggFunc *aggregation.AggFuncDesc) (expr expression.Expression, err error) {
 	switch aggFunc.Name {
 	case ast.AggFuncCount:
 		if aggFunc.Mode == aggregation.FinalMode {
-			return a.wrapCastFunction(ctx, aggFunc.Args[0], aggFunc.RetTp)
+			// The input value is promised to be int type if it's FinalMode.
+			expr = aggFunc.Args[0]
+		} else {
+			expr = a.rewriteCount(ctx, aggFunc.Args, aggFunc.RetTp)
 		}
-		return a.rewriteCount(ctx, aggFunc.Args, aggFunc.RetTp)
 	case ast.AggFuncSum, ast.AggFuncAvg, ast.AggFuncFirstRow, ast.AggFuncMax, ast.AggFuncMin, ast.AggFuncGroupConcat:
-		return a.wrapCastFunction(ctx, aggFunc.Args[0], aggFunc.RetTp)
+		expr = a.wrapCastFunction(ctx, aggFunc.Args[0], aggFunc.RetTp)
 	case ast.AggFuncBitAnd, ast.AggFuncBitOr, ast.AggFuncBitXor:
-		return a.rewriteBitFunc(ctx, aggFunc.Name, aggFunc.Args[0], aggFunc.RetTp)
+		expr = a.rewriteBitFunc(ctx, aggFunc.Name, aggFunc.Args[0], aggFunc.RetTp)
 	default:
-		panic("Unsupported function")
+		err = errors.Errorf("unsupported function when doing aggEliminate")
 	}
+	return
 }
 
-func (a *aggregationEliminateChecker) rewriteCount(ctx sessionctx.Context, exprs []expression.Expression, targetTp *types.FieldType) expression.Expression {
+func (a *aggregationEliminator) rewriteCount(ctx sessionctx.Context, exprs []expression.Expression, targetTp *types.FieldType) expression.Expression {
 	// If is count(expr), we will change it to if(isnull(expr), 0, 1).
 	// If is count(distinct x, y, z) we will change it to if(isnull(x) or isnull(y) or isnull(z), 0, 1).
 	// If is count(expr not null), we will change it to constant 1.
@@ -101,7 +122,7 @@ func (a *aggregationEliminateChecker) rewriteCount(ctx sessionctx.Context, exprs
 	return newExpr
 }
 
-func (a *aggregationEliminateChecker) rewriteBitFunc(ctx sessionctx.Context, funcType string, arg expression.Expression, targetTp *types.FieldType) expression.Expression {
+func (a *aggregationEliminator) rewriteBitFunc(ctx sessionctx.Context, funcType string, arg expression.Expression, targetTp *types.FieldType) expression.Expression {
 	// For not integer type. We need to cast(cast(arg as signed) as unsigned) to make the bit function work.
 	innerCast := expression.WrapWithCastAsInt(ctx, arg)
 	outerCast := a.wrapCastFunction(ctx, innerCast, targetTp)
@@ -115,7 +136,7 @@ func (a *aggregationEliminateChecker) rewriteBitFunc(ctx sessionctx.Context, fun
 }
 
 // wrapCastFunction will wrap a cast if the targetTp is not equal to the arg's.
-func (a *aggregationEliminateChecker) wrapCastFunction(ctx sessionctx.Context, arg expression.Expression, targetTp *types.FieldType) expression.Expression {
+func (a *aggregationEliminator) wrapCastFunction(ctx sessionctx.Context, arg expression.Expression, targetTp *types.FieldType) expression.Expression {
 	if arg.GetType() == targetTp {
 		return arg
 	}
@@ -136,8 +157,9 @@ func (a *aggregationEliminator) optimize(p LogicalPlan) (LogicalPlan, error) {
 	if !ok {
 		return p, nil
 	}
-	if proj := a.tryToEliminateAggregation(agg); proj != nil {
-		return proj, nil
+	proj, err := a.tryEliminateAgg(agg)
+	if proj != nil || err != nil {
+		return proj, err
 	}
 	return p, nil
 }

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -315,8 +315,7 @@ func (a *aggregationPushDownSolver) optimize(p LogicalPlan) (LogicalPlan, error)
 	if !p.context().GetSessionVars().AllowAggPushDown {
 		return p, nil
 	}
-	a.aggPushDown(p)
-	return p, nil
+	return a.aggPushDown(p)
 }
 
 // aggPushDown tries to push down aggregate functions to join paths.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #9922 

### What is changed and how it works?
Check whether an aggregation function is group_concat with multiple columns,
if so, do not eliminate it during aggregation eliminating.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects

 - Possible performance regression


Related changes

 - Need to cherry-pick to the release branch

