### PR TITLE
metrics: adjust the parse & compile duration metrics

### DIFF
--- a/metrics/session.go
+++ b/metrics/session.go
@@ -23,7 +23,7 @@ var (
 			Subsystem: "session",
 			Name:      "parse_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) in parse SQL.",
-			Buckets:   prometheus.LinearBuckets(0.00004, 0.00001, 13),
+			Buckets:   prometheus.ExponentialBuckets(0.00004, 1.6, 13), // 40us ~ 18ms
 		}, []string{LblSQLType})
 	SessionExecuteCompileDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -31,7 +31,8 @@ var (
 			Subsystem: "session",
 			Name:      "compile_duration_seconds",
 			Help:      "Bucketed histogram of processing time (s) in query optimize.",
-			Buckets:   prometheus.LinearBuckets(0.00004, 0.00001, 13),
+			// Build plan may execute the statement, or allocate table ID, so it might take a long time.
+			Buckets: prometheus.ExponentialBuckets(0.00004, 2, 13), // 40us ~ 327ms
 		}, []string{LblSQLType})
 	SessionExecuteRunDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

From current obserevation, parse cost more than 160us on general,
and compile may takes long if it involves subquery or alloc table ID.
Adjust those metrics to be more accurate.

### What is changed and how it works?

Tiny update

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Related changes

 - Need to cherry-pick to the release branch
