### PR TITLE
go.mod: update parser version and add unit test

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -160,9 +160,9 @@ func (s *testIntegrationSuite) TestCreateTableIfNotExists(c *C) {
 func (s *testIntegrationSuite) TestCreateTableWithKeyWord(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
-	 tk.MustExec("USE test;")
+	tk.MustExec("USE test;")
 
-	 _, err := tk.Exec("create table t1(pump varchar(20), drainer varchar(20), node_id varchar(20), node_state varchar(20));")
+	_, err := tk.Exec("create table t1(pump varchar(20), drainer varchar(20), node_id varchar(20), node_state varchar(20));")
 	c.Assert(err, IsNil)
 }
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -157,6 +157,15 @@ func (s *testIntegrationSuite) TestCreateTableIfNotExists(c *C) {
 	c.Assert(terror.ErrorEqual(infoschema.ErrTableExists, lastWarn.Err), IsTrue)
 }
 
+func (s *testIntegrationSuite) TestCreateTableWithKeyWord(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	 tk.MustExec("USE test;")
+
+	 _, err := tk.Exec("create table t1(pump varchar(20), drainer varchar(20), node_id varchar(20), node_state varchar(20));")
+	c.Assert(err, IsNil)
+}
+
 func (s *testIntegrationSuite) TestUniquekeyNullValue(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3
 	github.com/pingcap/goleveldb v0.0.0-20171020084629-8d44bfdf1030
 	github.com/pingcap/kvproto v0.0.0-20190226063853-f6c0b7ffff11
-	github.com/pingcap/parser v0.0.0-20190326083041-06045580997a
+	github.com/pingcap/parser v0.0.0-20190328044348-9945885931bb
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible
 	github.com/pingcap/tipb v0.0.0-20180910045846-371b48b15d93

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/pingcap/goleveldb v0.0.0-20171020084629-8d44bfdf1030 h1:XJLuW0lsP7vAt
 github.com/pingcap/goleveldb v0.0.0-20171020084629-8d44bfdf1030/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20190226063853-f6c0b7ffff11 h1:iGNfAHgK0VHJobW4bPTlFmdnt3YWsEHdSTIcjut6ffk=
 github.com/pingcap/kvproto v0.0.0-20190226063853-f6c0b7ffff11/go.mod h1:0gwbe1F2iBIjuQ9AH0DbQhL+Dpr5GofU8fgYyXk+ykk=
-github.com/pingcap/parser v0.0.0-20190326083041-06045580997a h1:4trGl3lvogZnelwJSF8ELqeS/5+RUVZte84bVmKT8+w=
-github.com/pingcap/parser v0.0.0-20190326083041-06045580997a/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190328044348-9945885931bb h1:JCc0MMW4fqfhbaI8LS1dXRmql1PbpoKLxoYq6GUlSaQ=
+github.com/pingcap/parser v0.0.0-20190328044348-9945885931bb/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.3-0.20190116051332-34c808eef588+incompatible h1:e9Gi/LP9181HT3gBfSOeSBA+5JfemuE4aEAhqNgoE4k=


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
parser's pr pingcap/parser#264 fix issue #9910
need update parser's version
same with https://github.com/pingcap/tidb/pull/9917

### What is changed and how it works?
update parser's version in go.mod

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (Manual test (create table, with column named node_id and node_state))
