### PR TITLE
[DNM]build: add GolangCi Configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+run:
+  deadline: 3m
+  issues-exit-code: 1
+  tests: true
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true
+linters:
+  disable-all: true
+  enable:
+    - misspell
+    - ineffassign
+linters-settings:
+  lll:
+    line-length: 120
+    tab-width: 1
+    #  misspell:
+    #    locale: US
+issues:
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing
+  # large codebase. It's not practical to fix all existing issues at the moment
+  # of integration: much better don't allow issues in new code.
+  # Default is false.
+  new: true


### PR DESCRIPTION
### What problem does this PR solve?

I would like to propose [GolangCI](https://golangci.com/) in the weekly meeting.
This PR should be reviewed after the weekly meeting.
**Now, the configuration has the checks as little as possible. ( Avoid to the CI failed).**
Only check the ineffassign and misspell.
When GolangCI opened, this configuration will be added more configs.

### What is changed and how it works?
Add GolangCI Configuration.
F.Y.R: https://github.com/golangci/golangci-lint#configuration

### Check List
Tests
 - No code

Side effects
 - GolangCI may failed.

![image](https://user-images.githubusercontent.com/7782671/55155188-b3ca5400-5191-11e9-8bac-e852ab2cd5af.png)

