### PR TITLE
executor/aggfuncs: add test for aggregation functions

### DIFF
--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -62,7 +62,7 @@ func (s *testSuite) TearDownTest(c *C) {
 	s.ctx.GetSessionVars().StmtCtx.SetWarnings(nil)
 }
 
-type aggMergeTest struct {
+type aggTest struct {
 	dataType *types.FieldType
 	numRows  int
 	dataGen  func(i int) types.Datum
@@ -70,7 +70,7 @@ type aggMergeTest struct {
 	results  []types.Datum
 }
 
-func (s *testSuite) testMergePartialResult(c *C, p aggMergeTest) {
+func (s *testSuite) testMergePartialResult(c *C, p aggTest) {
 	srcChk := chunk.NewChunkWithCapacity([]*types.FieldType{p.dataType}, p.numRows)
 	for i := 0; i < p.numRows; i++ {
 		dt := p.dataGen(i)
@@ -132,12 +132,12 @@ func (s *testSuite) testMergePartialResult(c *C, p aggMergeTest) {
 	c.Assert(result, Equals, 0)
 }
 
-func buildAggMergeTester(funcName string, tp byte, numRows int, results ...interface{}) aggMergeTest {
-	return buildAggMergeTesterWithFieldType(funcName, types.NewFieldType(tp), numRows, results...)
+func buildAggTester(funcName string, tp byte, numRows int, results ...interface{}) aggTest {
+	return buildAggTesterWithFieldType(funcName, types.NewFieldType(tp), numRows, results...)
 }
 
-func buildAggMergeTesterWithFieldType(funcName string, ft *types.FieldType, numRows int, results ...interface{}) aggMergeTest {
-	pt := aggMergeTest{
+func buildAggTesterWithFieldType(funcName string, ft *types.FieldType, numRows int, results ...interface{}) aggTest {
+	pt := aggTest{
 		dataType: ft,
 		numRows:  numRows,
 		funcName: funcName,
@@ -157,11 +157,76 @@ func buildAggMergeTesterWithFieldType(funcName string, ft *types.FieldType, numR
 	case mysql.TypeString:
 		pt.dataGen = func(i int) types.Datum { return types.NewStringDatum(fmt.Sprintf("%d", i)) }
 	case mysql.TypeDate:
-		pt.dataGen = func(i int) types.Datum { return types.NewTimeDatum(types.TimeFromDays(int64(i))) }
+		pt.dataGen = func(i int) types.Datum { return types.NewTimeDatum(types.TimeFromDays(int64(i + 365))) }
 	case mysql.TypeDuration:
 		pt.dataGen = func(i int) types.Datum { return types.NewDurationDatum(types.Duration{Duration: time.Duration(i)}) }
 	case mysql.TypeJSON:
 		pt.dataGen = func(i int) types.Datum { return types.NewDatum(json.CreateBinary(int64(i))) }
 	}
 	return pt
+}
+
+func (s *testSuite) testAggFunc(c *C, p aggTest) {
+	srcChk := chunk.NewChunkWithCapacity([]*types.FieldType{p.dataType}, p.numRows)
+	for i := 0; i < p.numRows; i++ {
+		dt := p.dataGen(i)
+		srcChk.AppendDatum(0, &dt)
+	}
+	srcChk.AppendDatum(0, &types.Datum{})
+
+	args := []expression.Expression{&expression.Column{RetType: p.dataType, Index: 0}}
+	if p.funcName == ast.AggFuncGroupConcat {
+		args = append(args, &expression.Constant{Value: types.NewStringDatum(" "), RetType: types.NewFieldType(mysql.TypeString)})
+	}
+	desc := aggregation.NewAggFuncDesc(s.ctx, p.funcName, args, false)
+	finalFunc := aggfuncs.Build(s.ctx, desc, 0)
+	finalPr := finalFunc.AllocPartialResult()
+	resultChk := chunk.NewChunkWithCapacity([]*types.FieldType{desc.RetTp}, 1)
+
+	iter := chunk.NewIterator4Chunk(srcChk)
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt := resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err := dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[1])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the empty input
+	resultChk.Reset()
+	finalFunc.ResetPartialResult(finalPr)
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[0])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the agg func with distinct
+	desc = aggregation.NewAggFuncDesc(s.ctx, p.funcName, args, true)
+	finalFunc = aggfuncs.Build(s.ctx, desc, 0)
+	finalPr = finalFunc.AllocPartialResult()
+
+	resultChk.Reset()
+	iter = chunk.NewIterator4Chunk(srcChk)
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[1])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the empty input
+	resultChk.Reset()
+	finalFunc.ResetPartialResult(finalPr)
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[0])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
 }

--- a/executor/aggfuncs/func_avg_test.go
+++ b/executor/aggfuncs/func_avg_test.go
@@ -20,11 +20,21 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4Avg(c *C) {
-	tests := []aggMergeTest{
-		buildAggMergeTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5, 2.0, 3.0, 2.375),
-		buildAggMergeTester(ast.AggFuncAvg, mysql.TypeDouble, 5, 2.0, 3.0, 2.375),
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5, 2.0, 3.0, 2.375),
+		buildAggTester(ast.AggFuncAvg, mysql.TypeDouble, 5, 2.0, 3.0, 2.375),
 	}
 	for _, test := range tests {
 		s.testMergePartialResult(c, test)
+	}
+}
+
+func (s *testSuite) TestAvg(c *C) {
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5, nil, 2.0),
+		buildAggTester(ast.AggFuncAvg, mysql.TypeDouble, 5, nil, 2.0),
+	}
+	for _, test := range tests {
+		s.testAggFunc(c, test)
 	}
 }

--- a/executor/aggfuncs/func_bitfuncs_test.go
+++ b/executor/aggfuncs/func_bitfuncs_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4BitFuncs(c *C) {
-	tests := []aggMergeTest{
-		buildAggMergeTester(ast.AggFuncBitAnd, mysql.TypeLonglong, 5, 0, 0, 0),
-		buildAggMergeTester(ast.AggFuncBitOr, mysql.TypeLonglong, 5, 7, 7, 7),
-		buildAggMergeTester(ast.AggFuncBitXor, mysql.TypeLonglong, 5, 4, 5, 1),
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncBitAnd, mysql.TypeLonglong, 5, 0, 0, 0),
+		buildAggTester(ast.AggFuncBitOr, mysql.TypeLonglong, 5, 7, 7, 7),
+		buildAggTester(ast.AggFuncBitXor, mysql.TypeLonglong, 5, 4, 5, 1),
 	}
 	for _, test := range tests {
 		s.testMergePartialResult(c, test)

--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -20,6 +20,22 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4Count(c *C) {
-	tester := buildAggMergeTester(ast.AggFuncCount, mysql.TypeLonglong, 5, 5, 3, 8)
+	tester := buildAggTester(ast.AggFuncCount, mysql.TypeLonglong, 5, 5, 3, 8)
 	s.testMergePartialResult(c, tester)
+}
+
+func (s *testSuite) TestCount(c *C) {
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncCount, mysql.TypeLonglong, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeFloat, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeDouble, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeNewDecimal, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeString, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeDate, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeDuration, 5, 0, 5),
+		buildAggTester(ast.AggFuncCount, mysql.TypeJSON, 5, 0, 5),
+	}
+	for _, test := range tests {
+		s.testAggFunc(c, test)
+	}
 }

--- a/executor/aggfuncs/func_first_row_test.go
+++ b/executor/aggfuncs/func_first_row_test.go
@@ -24,15 +24,15 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4FirstRow(c *C) {
-	tests := []aggMergeTest{
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeLonglong, 5, 0, 2, 0),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeFloat, 5, 0.0, 2.0, 0.0),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeDouble, 5, 0.0, 2.0, 0.0),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeNewDecimal, 5, types.NewDecFromInt(0), types.NewDecFromInt(2), types.NewDecFromInt(0)),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeString, 5, "0", "2", "0"),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeDate, 5, types.TimeFromDays(0), types.TimeFromDays(2), types.TimeFromDays(0)),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(0)}, types.Duration{Duration: time.Duration(2)}, types.Duration{Duration: time.Duration(0)}),
-		buildAggMergeTester(ast.AggFuncFirstRow, mysql.TypeJSON, 5, json.CreateBinary(int64(0)), json.CreateBinary(int64(2)), json.CreateBinary(int64(0))),
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeLonglong, 5, 0, 2, 0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeFloat, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDouble, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeNewDecimal, 5, types.NewDecFromInt(0), types.NewDecFromInt(2), types.NewDecFromInt(0)),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeString, 5, "0", "2", "0"),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDate, 5, types.TimeFromDays(365), types.TimeFromDays(367), types.TimeFromDays(365)),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(0)}, types.Duration{Duration: time.Duration(2)}, types.Duration{Duration: time.Duration(0)}),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeJSON, 5, json.CreateBinary(int64(0)), json.CreateBinary(int64(2)), json.CreateBinary(int64(0))),
 	}
 	for _, test := range tests {
 		s.testMergePartialResult(c, test)

--- a/executor/aggfuncs/func_group_concat_test.go
+++ b/executor/aggfuncs/func_group_concat_test.go
@@ -20,6 +20,11 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4GroupConcat(c *C) {
-	test := buildAggMergeTester(ast.AggFuncGroupConcat, mysql.TypeString, 5, "0 1 2 3 4", "2 3 4", "0 1 2 3 4 2 3 4")
+	test := buildAggTester(ast.AggFuncGroupConcat, mysql.TypeString, 5, "0 1 2 3 4", "2 3 4", "0 1 2 3 4 2 3 4")
 	s.testMergePartialResult(c, test)
+}
+
+func (s *testSuite) TestGroupConcat(c *C) {
+	test := buildAggTester(ast.AggFuncGroupConcat, mysql.TypeString, 5, nil, "0 1 2 3 4", "0 1 2 3 4 2 3 4")
+	s.testAggFunc(c, test)
 }

--- a/executor/aggfuncs/func_max_min_test.go
+++ b/executor/aggfuncs/func_max_min_test.go
@@ -26,28 +26,57 @@ import (
 func (s *testSuite) TestMergePartialResult4MaxMin(c *C) {
 	unsignedType := types.NewFieldType(mysql.TypeLonglong)
 	unsignedType.Flag |= mysql.UnsignedFlag
-	tests := []aggMergeTest{
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeLonglong, 5, 4, 4, 4),
-		buildAggMergeTesterWithFieldType(ast.AggFuncMax, unsignedType, 5, 4, 4, 4),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeFloat, 5, 4.0, 4.0, 4.0),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeDouble, 5, 4.0, 4.0, 4.0),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeNewDecimal, 5, types.NewDecFromInt(4), types.NewDecFromInt(4), types.NewDecFromInt(4)),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeString, 5, "4", "4", "4"),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeDate, 5, types.TimeFromDays(4), types.TimeFromDays(4), types.TimeFromDays(4)),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(4)}, types.Duration{Duration: time.Duration(4)}, types.Duration{Duration: time.Duration(4)}),
-		buildAggMergeTester(ast.AggFuncMax, mysql.TypeJSON, 5, json.CreateBinary(int64(4)), json.CreateBinary(int64(4)), json.CreateBinary(int64(4))),
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncMax, mysql.TypeLonglong, 5, 4, 4, 4),
+		buildAggTesterWithFieldType(ast.AggFuncMax, unsignedType, 5, 4, 4, 4),
+		buildAggTester(ast.AggFuncMax, mysql.TypeFloat, 5, 4.0, 4.0, 4.0),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDouble, 5, 4.0, 4.0, 4.0),
+		buildAggTester(ast.AggFuncMax, mysql.TypeNewDecimal, 5, types.NewDecFromInt(4), types.NewDecFromInt(4), types.NewDecFromInt(4)),
+		buildAggTester(ast.AggFuncMax, mysql.TypeString, 5, "4", "4", "4"),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDate, 5, types.TimeFromDays(369), types.TimeFromDays(369), types.TimeFromDays(369)),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(4)}, types.Duration{Duration: time.Duration(4)}, types.Duration{Duration: time.Duration(4)}),
+		buildAggTester(ast.AggFuncMax, mysql.TypeJSON, 5, json.CreateBinary(int64(4)), json.CreateBinary(int64(4)), json.CreateBinary(int64(4))),
 
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeLonglong, 5, 0, 2, 0),
-		buildAggMergeTesterWithFieldType(ast.AggFuncMin, unsignedType, 5, 0, 2, 0),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeFloat, 5, 0.0, 2.0, 0.0),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeDouble, 5, 0.0, 2.0, 0.0),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeNewDecimal, 5, types.NewDecFromInt(0), types.NewDecFromInt(2), types.NewDecFromInt(0)),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeString, 5, "0", "2", "0"),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeDate, 5, types.TimeFromDays(0), types.TimeFromDays(2), types.TimeFromDays(0)),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(0)}, types.Duration{Duration: time.Duration(2)}, types.Duration{Duration: time.Duration(0)}),
-		buildAggMergeTester(ast.AggFuncMin, mysql.TypeJSON, 5, json.CreateBinary(int64(0)), json.CreateBinary(int64(2)), json.CreateBinary(int64(0))),
+		buildAggTester(ast.AggFuncMin, mysql.TypeLonglong, 5, 0, 2, 0),
+		buildAggTesterWithFieldType(ast.AggFuncMin, unsignedType, 5, 0, 2, 0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeFloat, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDouble, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeNewDecimal, 5, types.NewDecFromInt(0), types.NewDecFromInt(2), types.NewDecFromInt(0)),
+		buildAggTester(ast.AggFuncMin, mysql.TypeString, 5, "0", "2", "0"),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDate, 5, types.TimeFromDays(365), types.TimeFromDays(367), types.TimeFromDays(365)),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(0)}, types.Duration{Duration: time.Duration(2)}, types.Duration{Duration: time.Duration(0)}),
+		buildAggTester(ast.AggFuncMin, mysql.TypeJSON, 5, json.CreateBinary(int64(0)), json.CreateBinary(int64(2)), json.CreateBinary(int64(0))),
 	}
 	for _, test := range tests {
 		s.testMergePartialResult(c, test)
+	}
+}
+
+func (s *testSuite) TestMaxMin(c *C) {
+	unsignedType := types.NewFieldType(mysql.TypeLonglong)
+	unsignedType.Flag |= mysql.UnsignedFlag
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncMax, mysql.TypeLonglong, 5, nil, 4),
+		buildAggTesterWithFieldType(ast.AggFuncMax, unsignedType, 5, nil, 4),
+		buildAggTester(ast.AggFuncMax, mysql.TypeFloat, 5, nil, 4.0),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDouble, 5, nil, 4.0),
+		buildAggTester(ast.AggFuncMax, mysql.TypeNewDecimal, 5, nil, types.NewDecFromInt(4)),
+		buildAggTester(ast.AggFuncMax, mysql.TypeString, 5, nil, "4", "4"),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDate, 5, nil, types.TimeFromDays(369)),
+		buildAggTester(ast.AggFuncMax, mysql.TypeDuration, 5, nil, types.Duration{Duration: time.Duration(4)}),
+		buildAggTester(ast.AggFuncMax, mysql.TypeJSON, 5, nil, json.CreateBinary(int64(4))),
+
+		buildAggTester(ast.AggFuncMin, mysql.TypeLonglong, 5, nil, 0),
+		buildAggTesterWithFieldType(ast.AggFuncMin, unsignedType, 5, nil, 0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeFloat, 5, nil, 0.0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDouble, 5, nil, 0.0),
+		buildAggTester(ast.AggFuncMin, mysql.TypeNewDecimal, 5, nil, types.NewDecFromInt(0)),
+		buildAggTester(ast.AggFuncMin, mysql.TypeString, 5, nil, "0"),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDate, 5, nil, types.TimeFromDays(365)),
+		buildAggTester(ast.AggFuncMin, mysql.TypeDuration, 5, nil, types.Duration{Duration: time.Duration(0)}),
+		buildAggTester(ast.AggFuncMin, mysql.TypeJSON, 5, nil, json.CreateBinary(int64(0))),
+	}
+	for _, test := range tests {
+		s.testAggFunc(c, test)
 	}
 }

--- a/executor/aggfuncs/func_sum_test.go
+++ b/executor/aggfuncs/func_sum_test.go
@@ -21,11 +21,21 @@ import (
 )
 
 func (s *testSuite) TestMergePartialResult4Sum(c *C) {
-	tests := []aggMergeTest{
-		buildAggMergeTester(ast.AggFuncSum, mysql.TypeNewDecimal, 5, types.NewDecFromInt(10), types.NewDecFromInt(9), types.NewDecFromInt(19)),
-		buildAggMergeTester(ast.AggFuncSum, mysql.TypeDouble, 5, 10.0, 9.0, 19.0),
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncSum, mysql.TypeNewDecimal, 5, types.NewDecFromInt(10), types.NewDecFromInt(9), types.NewDecFromInt(19)),
+		buildAggTester(ast.AggFuncSum, mysql.TypeDouble, 5, 10.0, 9.0, 19.0),
 	}
 	for _, test := range tests {
 		s.testMergePartialResult(c, test)
+	}
+}
+
+func (s *testSuite) TestSum(c *C) {
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncSum, mysql.TypeNewDecimal, 5, nil, types.NewDecFromInt(10)),
+		buildAggTester(ast.AggFuncSum, mysql.TypeDouble, 5, nil, 10.0),
+	}
+	for _, test := range tests {
+		s.testAggFunc(c, test)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add unit test for agg funcs.

### What is changed and how it works?

- Introduce one general test for agg funcs.
- Add new tests under the general test.

It increases the unit test coverage of aggfuncs from 47.7% to 70%

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - None

Side effects

 - None

Related changes

 - None