### PR TITLE
planner: correct estimated row count for inner plan of index join

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -61,8 +61,8 @@ explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	count	task	operator info
 Projection_11	9990.00	root	cast(join_agg_0)
 └─IndexJoin_14	9990.00	root	inner join, inner:TableReader_13, outer key:b.c2, inner key:a.c1
-  ├─TableReader_13	10.00	root	data:TableScan_12
-  │ └─TableScan_12	10.00	cop	table:a, range: decided by [b.c2], keep order:false, stats:pseudo
+  ├─TableReader_13	1.00	root	data:TableScan_12
+  │ └─TableScan_12	1.00	cop	table:a, range: decided by [b.c2], keep order:false, stats:pseudo
   └─HashAgg_22	7992.00	root	group by:col_2, funcs:count(col_0), firstrow(col_1)
     └─TableReader_23	7992.00	root	data:HashAgg_17
       └─HashAgg_17	7992.00	cop	group by:b.c2, funcs:count(b.c2), firstrow(b.c2)
@@ -99,8 +99,8 @@ explain select c1 from t1 where c1 in (select c2 from t2);
 id	count	task	operator info
 Projection_9	9990.00	root	test.t1.c1
 └─IndexJoin_12	9990.00	root	inner join, inner:TableReader_11, outer key:test.t2.c2, inner key:test.t1.c1
-  ├─TableReader_11	10.00	root	data:TableScan_10
-  │ └─TableScan_10	10.00	cop	table:t1, range: decided by [test.t2.c2], keep order:false, stats:pseudo
+  ├─TableReader_11	1.00	root	data:TableScan_10
+  │ └─TableScan_10	1.00	cop	table:t1, range: decided by [test.t2.c2], keep order:false, stats:pseudo
   └─HashAgg_20	7992.00	root	group by:col_1, funcs:firstrow(col_0)
     └─TableReader_21	7992.00	root	data:HashAgg_15
       └─HashAgg_15	7992.00	cop	group by:test.t2.c2, funcs:firstrow(test.t2.c2)
@@ -291,9 +291,9 @@ Projection_11	10000.00	root	9_aux_0
     └─IndexJoin_44	12.50	root	inner join, inner:TableReader_43, outer key:s.a, inner key:t1.a
       ├─TableReader_37	1.00	root	data:TableScan_36
       │ └─TableScan_36	1.00	cop	table:s, range: decided by [eq(s.a, test.t.a)], keep order:false, stats:pseudo
-      └─TableReader_43	10.00	root	data:Selection_42
-        └─Selection_42	10.00	cop	eq(t1.a, test.t.a)
-          └─TableScan_41	10.00	cop	table:t1, range: decided by [s.a], keep order:false, stats:pseudo
+      └─TableReader_43	0.80	root	data:Selection_42
+        └─Selection_42	0.80	cop	eq(t1.a, test.t.a)
+          └─TableScan_41	1.00	cop	table:t1, range: decided by [s.a], keep order:false, stats:pseudo
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
@@ -304,8 +304,8 @@ Projection_11	10000.00	root	9_aux_0
     └─IndexJoin_32	12.50	root	inner join, inner:TableReader_31, outer key:s.a, inner key:t1.a
       ├─IndexReader_27	10.00	root	index:IndexScan_26
       │ └─IndexScan_26	10.00	cop	table:s, index:b, range: decided by [eq(s.b, test.t.a)], keep order:false, stats:pseudo
-      └─TableReader_31	10.00	root	data:TableScan_30
-        └─TableScan_30	10.00	cop	table:t1, range: decided by [s.a], keep order:false, stats:pseudo
+      └─TableReader_31	1.00	root	data:TableScan_30
+        └─TableScan_30	1.00	cop	table:t1, range: decided by [s.a], keep order:false, stats:pseudo
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
@@ -318,8 +318,8 @@ Projection_11	10000.00	root	9_aux_0
       │ ├─IndexScan_26	10.00	cop	table:s, index:b, range: decided by [eq(s.b, test.t.a)], keep order:false, stats:pseudo
       │ └─Selection_28	9.99	cop	not(isnull(s.c))
       │   └─TableScan_27	10.00	cop	table:t, keep order:false, stats:pseudo
-      └─TableReader_33	10.00	root	data:TableScan_32
-        └─TableScan_32	10.00	cop	table:t1, range: decided by [s.c], keep order:false, stats:pseudo
+      └─TableReader_33	1.00	root	data:TableScan_32
+        └─TableScan_32	1.00	cop	table:t1, range: decided by [s.c], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int unsigned);
 explain select t.a = '123455' from t;

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -360,8 +360,8 @@ Sort_23	5.00	root	revenue:desc
         │ │ │   └─TableScan_56	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
         │ │ └─TableReader_59	300005811.00	root	data:TableScan_58
         │ │   └─TableScan_58	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        │ └─TableReader_37	11822812.50	root	data:Selection_36
-        │   └─Selection_36	11822812.50	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
+        │ └─TableReader_37	0.80	root	data:Selection_36
+        │   └─Selection_36	0.80	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
         │     └─TableScan_35	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:false
         └─TableReader_30	1.00	root	data:TableScan_29
           └─TableScan_29	1.00	cop	table:customer, range: decided by [tpch.supplier.s_nationkey tpch.orders.o_custkey], keep order:false
@@ -1096,8 +1096,8 @@ StreamAgg_13	1.00	root	funcs:sum(col_0)
     ├─TableReader_22	6286493.79	root	data:Selection_21
     │ └─Selection_21	6286493.79	cop	eq(tpch.lineitem.l_shipinstruct, "DELIVER IN PERSON"), in(tpch.lineitem.l_shipmode, "AIR", "AIR REG"), or(and(ge(tpch.lineitem.l_quantity, 4), le(tpch.lineitem.l_quantity, 14)), or(and(ge(tpch.lineitem.l_quantity, 18), le(tpch.lineitem.l_quantity, 28)), and(ge(tpch.lineitem.l_quantity, 29), le(tpch.lineitem.l_quantity, 39))))
     │   └─TableScan_20	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-    └─TableReader_28	8000000.00	root	data:Selection_27
-      └─Selection_27	8000000.00	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
+    └─TableReader_28	0.80	root	data:Selection_27
+      └─Selection_27	0.80	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
         └─TableScan_26	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:false
 /*
 Q20 Potential Part Promotion Query
@@ -1235,8 +1235,8 @@ Projection_25	1.00	root	tpch.supplier.s_name, 17_col_0
       │ │ │ └─TableReader_80	240004648.80	root	data:Selection_79
       │ │ │   └─Selection_79	240004648.80	cop	gt(l1.l_receiptdate, l1.l_commitdate)
       │ │ │     └─TableScan_78	300005811.00	cop	table:l1, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_61	36517371.00	root	data:Selection_60
-      │ │   └─Selection_60	36517371.00	cop	eq(tpch.orders.o_orderstatus, "F")
+      │ │ └─TableReader_61	0.80	root	data:Selection_60
+      │ │   └─Selection_60	0.80	cop	eq(tpch.orders.o_orderstatus, "F")
       │ │     └─TableScan_59	1.00	cop	table:orders, range: decided by [l1.l_orderkey], keep order:false
       │ └─IndexLookUp_55	1.00	root	
       │   ├─IndexScan_53	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [l1.l_orderkey], keep order:false

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -53,9 +53,9 @@ func (s *testSuite1) TestIndexJoinUnionScan(c *C) {
 		"│ └─TableReader_15 9990.00 root data:Selection_14",
 		"│   └─Selection_14 9990.00 cop not(isnull(test.t1.a))",
 		"│     └─TableScan_13 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"└─UnionScan_10 10.00 root ",
-		"  └─TableReader_9 10.00 root data:TableScan_8",
-		"    └─TableScan_8 10.00 cop table:t2, range: decided by [test.t1.a], keep order:false, stats:pseudo",
+		"└─UnionScan_10 1.00 root ",
+		"  └─TableReader_9 1.00 root data:TableScan_8",
+		"    └─TableScan_8 1.00 cop table:t2, range: decided by [test.t1.a], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("select /*+ TIDB_INLJ(t1, t2)*/ * from t1 join t2 on t1.a = t2.id").Check(testkit.Rows(
 		"2 2 2 2 2",

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -461,22 +461,15 @@ func (p *LogicalJoin) constructInnerTableScan(ds *DataSource, pk *expression.Col
 	}.Init(ds.ctx)
 	ts.SetSchema(ds.schema)
 
-	var rowCount float64
-	pkHist, ok := ds.statisticTable.Columns[pk.ID]
-	if ok && !ds.statisticTable.Pseudo {
-		rowCount = pkHist.AvgCountPerNotNullValue(ds.statisticTable.Count)
-	} else {
-		rowCount = ds.statisticTable.PseudoAvgCountPerValue()
-	}
-
-	ts.stats = property.NewSimpleStats(rowCount)
+	ts.stats = property.NewSimpleStats(1)
 	ts.stats.UsePseudoStats = ds.statisticTable.Pseudo
 
 	copTask := &copTask{
 		tablePlan:         ts,
 		indexPlanFinished: true,
 	}
-	ts.addPushedDownSelection(copTask, ds.stats)
+	selStats := ts.stats.Scale(selectionFactor)
+	ts.addPushedDownSelection(copTask, selStats)
 	t := finishCopTask(ds.ctx, copTask)
 	reader := t.plan()
 	return p.constructInnerUnionScan(us, reader)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For index join, if inner plan is table scan, i.e, handle is index join key, and if there is selection above table scan, the estimated row count is wrong. This should has no impact on the final plan chosen, but the explain output is confusing, so I fix it.

### What is changed and how it works?

Use stats of table scan instead of datasource as the stats of selection.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test: existing UT covers this fix
 - Integration test: existing integration test covers this fix

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
