### PR TITLE
server: improve error message for connection close

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -413,7 +413,7 @@ func (s *Server) onConn(conn *clientConn) {
 	logutil.Logger(ctx).Info("new connection", zap.String("remoteAddr", conn.bufReadConn.RemoteAddr().String()))
 
 	defer func() {
-		logutil.Logger(ctx).Info("close connection")
+		logutil.Logger(ctx).Info("connection closed")
 	}()
 	s.rwlock.Lock()
 	s.clients[conn.connectionID] = conn


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Improves an error message

### What is changed and how it works?

The previous message could be interpreted as an action to close the connection.  This is now a passive statement, saying the connection was closed.

The previous wording could be misinterpreted that the server was taking action, when it could have been a client that closed the connection.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

- Minimal

Side effects

 - Breaking backward compatibility (in log file only)

Related changes

- None