### PR TITLE
ranger: choose more prefix columns when building ranges

### DIFF
--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -457,6 +457,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	path.ranges = ranger.FullRange()
 	path.countAfterAccess = float64(ds.statisticTable.Count)
 	path.idxCols, path.idxColLens = expression.IndexInfo2Cols(ds.schema.Columns, path.index)
+	eqOrInCount := 0
 	if len(path.idxCols) != 0 {
 		res, err := ranger.DetachCondAndBuildRangeForIndex(ds.ctx, ds.pushedDownConds, path.idxCols, path.idxColLens)
 		if err != nil {
@@ -466,6 +467,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 		path.accessConds = res.AccessConds
 		path.tableFilters = res.RemainedConds
 		path.eqCondCount = res.EqCondCount
+		eqOrInCount = res.EqOrInCount
 		path.countAfterAccess, err = ds.stats.HistColl.GetRowCountByIndexRanges(sc, path.index.ID, path.ranges)
 		if err != nil {
 			return false, err
@@ -473,8 +475,8 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	} else {
 		path.tableFilters = ds.pushedDownConds
 	}
-	if path.eqCondCount == len(path.accessConds) {
-		accesses, remained := path.splitCorColAccessCondFromFilters()
+	if eqOrInCount == len(path.accessConds) {
+		accesses, remained := path.splitCorColAccessCondFromFilters(eqOrInCount)
 		path.accessConds = append(path.accessConds, accesses...)
 		path.tableFilters = remained
 		if len(accesses) > 0 && ds.statisticTable.Pseudo {
@@ -482,7 +484,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 		} else {
 			selectivity := path.countAfterAccess / float64(ds.statisticTable.Count)
 			for i := range accesses {
-				col := path.idxCols[path.eqCondCount+i]
+				col := path.idxCols[eqOrInCount+i]
 				ndv := ds.getColumnNDV(col.ID)
 				ndv *= selectivity
 				if ndv < 1 {
@@ -529,24 +531,24 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	return noIntervalRanges && !haveNullVal, nil
 }
 
-func (path *accessPath) splitCorColAccessCondFromFilters() (access, remained []expression.Expression) {
-	access = make([]expression.Expression, len(path.idxCols)-path.eqCondCount)
+func (path *accessPath) splitCorColAccessCondFromFilters(eqOrInCount int) (access, remained []expression.Expression) {
+	access = make([]expression.Expression, len(path.idxCols)-eqOrInCount)
 	used := make([]bool, len(path.tableFilters))
-	for i := path.eqCondCount; i < len(path.idxCols); i++ {
+	for i := eqOrInCount; i < len(path.idxCols); i++ {
 		matched := false
 		for j, filter := range path.tableFilters {
 			if used[j] || !isColEqCorColOrConstant(filter, path.idxCols[i]) {
 				continue
 			}
 			matched = true
-			access[i-path.eqCondCount] = filter
+			access[i-eqOrInCount] = filter
 			if path.idxColLens[i] == types.UnspecifiedLength {
 				used[j] = true
 			}
 			break
 		}
 		if !matched {
-			access = access[:i-path.eqCondCount]
+			access = access[:i-eqOrInCount]
 			break
 		}
 	}

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -189,7 +189,7 @@ func (s *testUnitTestSuit) TestIndexPathSplitCorColCond(c *C) {
 			idxColLens:   tt.idxColLens,
 		}
 
-		access, remained := path.splitCorColAccessCondFromFilters()
+		access, remained := path.splitCorColAccessCondFromFilters(path.eqCondCount)
 		c.Assert(fmt.Sprintf("%s", access), Equals, tt.access, comment)
 		c.Assert(fmt.Sprintf("%s", remained), Equals, tt.remained, comment)
 	}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -159,8 +159,9 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 	// We should remove all accessConds, so that they will not be added to filter conditions.
 	newConditions = removeAccessConditions(newConditions, accessConds)
 	eqOrInCount := len(accessConds)
+	res.EqCondCount = eqCount
+	res.EqOrInCount = eqOrInCount
 	if eqOrInCount == len(cols) {
-		// If curIndex equals to len of index columns, it means the rest conditions haven't been appended to filter conditions.
 		filterConds = append(filterConds, newConditions...)
 		ranges, err = buildCNFIndexRange(sctx.GetSessionVars().StmtCtx, cols, tpSlice, lengths, eqOrInCount, accessConds)
 		if err != nil {
@@ -169,7 +170,6 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 		res.Ranges = ranges
 		res.AccessConds = accessConds
 		res.RemainedConds = filterConds
-		res.EqCondCount = eqCount
 		return res, nil
 	}
 	checker := &conditionChecker{
@@ -194,7 +194,6 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 	res.Ranges = ranges
 	res.AccessConds = accessConds
 	res.RemainedConds = filterConds
-	res.EqCondCount = eqCount
 	return res, err
 }
 
@@ -319,6 +318,8 @@ type DetachRangeResult struct {
 	RemainedConds []expression.Expression
 	// EqCondCount is the number of equal conditions extracted.
 	EqCondCount int
+	// EqOrInCount is the number of equal/in conditions extracted.
+	EqOrInCount int
 	// IsDNFCond indicates if the top layer of conditions are in DNF.
 	IsDNFCond bool
 }

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -989,3 +989,35 @@ func (s *testRangerSuite) TestIndexRangeElimininatedProjection(c *C) {
 		"1 2",
 	))
 }
+
+func (s *testRangerSuite) TestCompIndexInExprCorrCol(c *C) {
+	defer testleak.AfterTest(c)()
+	dom, store, err := newDomainStoreWithBootstrap(c)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	c.Assert(err, IsNil)
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec("create table t(a int primary key, b int, c int, d int, e int, index idx(b,c,d))")
+	testKit.MustExec("insert into t values(1,1,1,1,2),(2,1,2,1,0)")
+	testKit.MustExec("analyze table t")
+	testKit.MustQuery("explain select t.e in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c in (1, 2) and s.d = t.a and s.a = t1.a) from t").Check(testkit.Rows(
+		"Projection_11 2.00 root 9_aux_0",
+		"└─Apply_13 2.00 root left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.e, 7_col_0)",
+		"  ├─TableReader_15 2.00 root data:TableScan_14",
+		"  │ └─TableScan_14 2.00 cop table:t, range:[-inf,+inf], keep order:false",
+		"  └─StreamAgg_20 1.00 root funcs:count(1)",
+		"    └─IndexJoin_32 2.00 root inner join, inner:TableReader_31, outer key:s.a, inner key:t1.a",
+		"      ├─IndexReader_27 2.00 root index:IndexScan_26",
+		"      │ └─IndexScan_26 2.00 cop table:s, index:b, c, d, range: decided by [eq(s.b, 1) in(s.c, 1, 2) eq(s.d, test.t.a)], keep order:false",
+		"      └─TableReader_31 1.00 root data:TableScan_30",
+		"        └─TableScan_30 1.00 cop table:t1, range: decided by [s.a], keep order:false",
+	))
+	testKit.MustQuery("select t.e in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c in (1, 2) and s.d = t.a and s.a = t1.a) from t").Check(testkit.Rows(
+		"1",
+		"1",
+	))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/10027

### What is changed and how it works?

Return `eqOrInCount` instead of `eqCount` in `detachCNFCondAndBuildRangeForIndex` for subsequent detach.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

N/A

Related changes

N/A
