### PR TITLE
executor: close RecordSet to avoid leak test failure

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3433,9 +3433,9 @@ func (s *testSuite3) TestSelectPartition(c *C) {
 	tk.MustQuery("select b from tr partition (r1,R3) order by a").Check(testkit.Rows("4", "7", "8"))
 
 	// test select unknown partition error
-	_, err := tk.Exec("select b from th partition (p0,p4)")
+	err := tk.ExecToErr("select b from th partition (p0,p4)")
 	c.Assert(err.Error(), Equals, "[table:1735]Unknown partition 'p4' in table 'th'")
-	_, err = tk.Exec("select b from tr partition (r1,r4)")
+	err = tk.ExecToErr("select b from tr partition (r1,r4)")
 	c.Assert(err.Error(), Equals, "[table:1735]Unknown partition 'r4' in table 'tr'")
 }
 
@@ -3452,11 +3452,11 @@ func (s *testSuite) TestSelectView(c *C) {
 	tk.MustQuery("select * from view3;").Check(testkit.Rows("1 2"))
 	tk.MustExec("drop table view_t;")
 	tk.MustExec("create table view_t(c int,d int)")
-	_, err := tk.Exec("select * from view1")
+	err := tk.ExecToErr("select * from view1")
 	c.Assert(err.Error(), Equals, plannercore.ErrViewInvalid.GenWithStackByArgs("test", "view1").Error())
-	_, err = tk.Exec("select * from view2")
+	err = tk.ExecToErr("select * from view2")
 	c.Assert(err.Error(), Equals, plannercore.ErrViewInvalid.GenWithStackByArgs("test", "view2").Error())
-	_, err = tk.Exec("select * from view3")
+	err = tk.ExecToErr("select * from view3")
 	c.Assert(err.Error(), Equals, "[planner:1054]Unknown column 'a' in 'field list'")
 	tk.MustExec("drop table view_t;")
 	tk.MustExec("create table view_t(a int,b int,c int)")

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -602,8 +602,8 @@ func (s *testSuite2) TestSelectGlobalVar(c *C) {
 	tk.MustExec("set @@global.max_connections=151;")
 
 	// test for unknown variable.
-	_, err := tk.Exec("select @@invalid")
+	err := tk.ExecToErr("select @@invalid")
 	c.Assert(terror.ErrorEqual(err, variable.UnknownSystemVar), IsTrue, Commentf("err %v", err))
-	_, err = tk.Exec("select @@global.invalid")
+	err = tk.ExecToErr("select @@global.invalid")
 	c.Assert(terror.ErrorEqual(err, variable.UnknownSystemVar), IsTrue, Commentf("err %v", err))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix failure found in https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/2330/pipeline/

### What is changed and how it works?

Use `ExecToErr` instead of `Exec` if we do not care about the result, since `ExecToErr` would close `RecordSet`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

N/A

Side effects

N/A

Related changes

N/A
