### PR TITLE
planner: keep unfoldable exprs when pruning columns for ORDER BY items

### DIFF
--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -194,16 +194,16 @@ create table t1(a bigint, b bigint);
 create table t2(a bigint, b bigint);
 desc select * from t1 where t1.a in (select t2.a as a from t2 where t2.b > t1.b order by t1.b limit 1);
 id	count	task	operator info
-Apply_15	9990.00	root	semi join, inner:Selection_19, equal:[eq(test.t1.a, test.t2.a)]
-├─TableReader_18	9990.00	root	data:Selection_17
-│ └─Selection_17	9990.00	cop	not(isnull(test.t1.a))
-│   └─TableScan_16	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-└─Selection_19	0.80	root	not(isnull(test.t2.a))
-  └─Limit_20	1.00	root	offset:0, count:1
-    └─TableReader_26	1.00	root	data:Limit_25
-      └─Limit_25	1.00	cop	offset:0, count:1
-        └─Selection_24	1.00	cop	gt(test.t2.b, test.t1.b)
-          └─TableScan_23	1.25	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+Apply_14	9990.00	root	semi join, inner:Selection_18, equal:[eq(test.t1.a, test.t2.a)]
+├─TableReader_17	9990.00	root	data:Selection_16
+│ └─Selection_16	9990.00	cop	not(isnull(test.t1.a))
+│   └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─Selection_18	0.80	root	not(isnull(test.t2.a))
+  └─TopN_19	1.00	root	test.t1.b:asc, offset:0, count:1
+    └─TableReader_25	1.00	root	data:TopN_24
+      └─TopN_24	1.00	cop	test.t1.b:asc, offset:0, count:1
+        └─Selection_23	8000.00	cop	gt(test.t2.b, test.t1.b)
+          └─TableScan_22	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 desc select * from t1 where t1.a in (select a from (select t2.a as a, t1.b as b from t2 where t2.b > t1.b) x order by b limit 1);
 id	count	task	operator info
 Apply_17	9990.00	root	semi join, inner:Selection_21, equal:[eq(test.t1.a, x.a)]

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -194,16 +194,16 @@ create table t1(a bigint, b bigint);
 create table t2(a bigint, b bigint);
 desc select * from t1 where t1.a in (select t2.a as a from t2 where t2.b > t1.b order by t1.b limit 1);
 id	count	task	operator info
-Apply_14	9990.00	root	semi join, inner:Selection_18, equal:[eq(test.t1.a, test.t2.a)]
-├─TableReader_17	9990.00	root	data:Selection_16
-│ └─Selection_16	9990.00	cop	not(isnull(test.t1.a))
-│   └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-└─Selection_18	0.80	root	not(isnull(test.t2.a))
-  └─TopN_19	1.00	root	test.t1.b:asc, offset:0, count:1
-    └─TableReader_25	1.00	root	data:TopN_24
-      └─TopN_24	1.00	cop	test.t1.b:asc, offset:0, count:1
-        └─Selection_23	8000.00	cop	gt(test.t2.b, test.t1.b)
-          └─TableScan_22	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+Apply_15	9990.00	root	semi join, inner:Selection_19, equal:[eq(test.t1.a, test.t2.a)]
+├─TableReader_18	9990.00	root	data:Selection_17
+│ └─Selection_17	9990.00	cop	not(isnull(test.t1.a))
+│   └─TableScan_16	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─Selection_19	0.80	root	not(isnull(test.t2.a))
+  └─Limit_20	1.00	root	offset:0, count:1
+    └─TableReader_26	1.00	root	data:Limit_25
+      └─Limit_25	1.00	cop	offset:0, count:1
+        └─Selection_24	1.00	cop	gt(test.t2.b, test.t1.b)
+          └─TableScan_23	1.25	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 desc select * from t1 where t1.a in (select a from (select t2.a as a, t1.b as b from t2 where t2.b > t1.b) x order by b limit 1);
 id	count	task	operator info
 Apply_17	9990.00	root	semi join, inner:Selection_21, equal:[eq(test.t1.a, x.a)]

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -35,4 +35,12 @@ func (s *testSuite2) TestSortRand(c *C) {
 	tk.MustQuery("explain select a, b from t order by abs(2)").Check(testkit.Rows(
 		"TableReader_8 10000.00 root data:TableScan_7",
 		"└─TableScan_7 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain select a from t order by abs(rand())+1").Check(testkit.Rows(
+		"Projection_8 10000.00 root test.t.a",
+		"└─Sort_4 10000.00 root col_1:asc",
+		"  └─Projection_9 10000.00 root test.t.a, plus(abs(rand()), 1)",
+		"    └─TableReader_7 10000.00 root data:TableScan_6",
+		"      └─TableScan_6 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
+	))
 }

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -1,0 +1,38 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+func (s *testSuite2) TestSortRand(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int);")
+
+	tk.MustQuery("explain select a from t order by rand()").Check(testkit.Rows(
+		"Projection_8 10000.00 root test.t.a",
+		"└─Sort_4 10000.00 root col_1:asc",
+		"  └─Projection_9 10000.00 root test.t.a, rand()",
+		"    └─TableReader_7 10000.00 root data:TableScan_6",
+		"      └─TableScan_6 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
+	))
+
+	tk.MustQuery("explain select a, b from t order by abs(2)").Check(testkit.Rows(
+		"TableReader_8 10000.00 root data:TableScan_7",
+		"└─TableScan_7 10000.00 cop table:t, range:[-inf,+inf], keep order:false, stats:pseudo"))
+}

--- a/expression/column.go
+++ b/expression/column.go
@@ -125,7 +125,7 @@ func (col *CorrelatedColumn) IsCorrelated() bool {
 
 // ConstItem implements Expression interface.
 func (col *CorrelatedColumn) ConstItem() bool {
-	return false
+	return true
 }
 
 // Decorrelate implements Expression interface.

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -43,7 +43,7 @@ func (s *testEvaluatorSuite) TestColumn(c *C) {
 	c.Assert(corCol.Equal(nil, corCol), IsTrue)
 	c.Assert(corCol.Equal(nil, invalidCorCol), IsFalse)
 	c.Assert(corCol.IsCorrelated(), IsTrue)
-	c.Assert(corCol.ConstItem(), IsFalse)
+	c.Assert(corCol.ConstItem(), IsTrue)
 	c.Assert(corCol.Decorrelate(schema).Equal(nil, col), IsTrue)
 	c.Assert(invalidCorCol.Decorrelate(schema).Equal(nil, invalidCorCol), IsTrue)
 

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -139,6 +139,11 @@ func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) error {
 	for i := len(ls.ByItems) - 1; i >= 0; i-- {
 		cols := expression.ExtractColumns(ls.ByItems[i].Expr)
 		if len(cols) == 0 {
+			if sf, ok := ls.ByItems[i].Expr.(*expression.ScalarFunction); ok {
+				if sf.FuncName.L == "rand" {
+					continue
+				}
+			}
 			ls.ByItems = append(ls.ByItems[:i], ls.ByItems[i+1:]...)
 		} else {
 			parentUsedCols = append(parentUsedCols, cols...)

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -139,10 +139,8 @@ func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) error {
 	for i := len(ls.ByItems) - 1; i >= 0; i-- {
 		cols := expression.ExtractColumns(ls.ByItems[i].Expr)
 		if len(cols) == 0 {
-			if sf, ok := ls.ByItems[i].Expr.(*expression.ScalarFunction); ok {
-				if sf.FuncName.L == "rand" {
-					continue
-				}
+			if !ls.ByItems[i].Expr.ConstItem() {
+				continue
 			}
 			ls.ByItems = append(ls.ByItems[:i], ls.ByItems[i+1:]...)
 		} else {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #9033 

### What is changed and how it works?

pruning column logic will do prune if order by expression with zero columns(it's right for sql like `order by abs(1)`), but `rand()` shouldn't be pruned, so do skip logic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - implement change

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10064)
<!-- Reviewable:end -->
