### PR TITLE
add skip isolation level check variable

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -298,12 +298,12 @@ func (s *testSuite2) TestSetVar(c *C) {
 
 	// test skip isolation level check: error
 	_, err = tk.Exec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
-	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedValueForVar), IsTrue, Commentf("err %v", err))
+	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedIsolationLevel), IsTrue, Commentf("err %v", err))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("READ-COMMITTED"))
 
 	_, err = tk.Exec("SET GLOBAL TRANSACTION ISOLATION LEVEL SERIALIZABLE")
-	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedValueForVar), IsTrue, Commentf("err %v", err))
+	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedIsolationLevel), IsTrue, Commentf("err %v", err))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-COMMITTED"))
 
@@ -312,8 +312,8 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1105 variable 'tx_isolation' does not yet support value: SERIALIZABLE",
-		"Warning 1105 variable 'transaction_isolation' does not yet support value: SERIALIZABLE"))
+		"Warning 1105 The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error",
+		"Warning 1105 The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error"))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("SERIALIZABLE"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("SERIALIZABLE"))
 
@@ -322,8 +322,8 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1105 variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED",
-		"Warning 1105 variable 'transaction_isolation' does not yet support value: READ-UNCOMMITTED"))
+		"Warning 1105 The isolation level 'READ-UNCOMMITTED' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error",
+		"Warning 1105 The isolation level 'READ-UNCOMMITTED' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error"))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -312,7 +312,6 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1105 The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error",
 		"Warning 1105 The isolation level 'SERIALIZABLE' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error"))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("SERIALIZABLE"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("SERIALIZABLE"))
@@ -322,7 +321,6 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
-		"Warning 1105 The isolation level 'READ-UNCOMMITTED' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error",
 		"Warning 1105 The isolation level 'READ-UNCOMMITTED' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error"))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -313,7 +313,7 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
 		"Warning 1105 variable 'tx_isolation' does not yet support value: SERIALIZABLE",
-		"Warning 1105  variable 'transaction_isolation' does not yet support value: SERIALIZABLE"))
+		"Warning 1105 variable 'transaction_isolation' does not yet support value: SERIALIZABLE"))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("SERIALIZABLE"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("SERIALIZABLE"))
 
@@ -323,7 +323,7 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
 		"Warning 1105 variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED",
-		"Warning 1105  variable 'transaction_isolation' does not yet support value: READ-UNCOMMITTED"))
+		"Warning 1105 variable 'transaction_isolation' does not yet support value: READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -326,6 +326,10 @@ func (s *testSuite2) TestSetVar(c *C) {
 		"Warning 1105  variable 'transaction_isolation' does not yet support value: READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
+
+	// test skip isolation level check: reset
+	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
+	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")
 }
 
 func (s *testSuite2) TestSetCharset(c *C) {
@@ -625,6 +629,8 @@ func (s *testSuite2) TestValidateSetVar(c *C) {
 	result = tk.MustQuery("select @@tx_isolation;")
 	result.Check(testkit.Rows("REPEATABLE-READ"))
 
+	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
+	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")
 	_, err = tk.Exec("set @@tx_isolation='SERIALIZABLE'")
 	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedValueForVar), IsTrue, Commentf("err %v", err))
 }

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -286,9 +286,9 @@ func (s *testSuite2) TestSetVar(c *C) {
 	_, err = tk.Exec("set global tidb_batch_commit = 2")
 	c.Assert(err, NotNil)
 
-	// test strict compatibility: init
-	tk.MustExec("SET GLOBAL tidb_strict_compatibility = 0")
-	tk.MustExec("SET SESSION tidb_strict_compatibility = 0")
+	// test skip isolation level check: init
+	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
+	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ COMMITTED")
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED")
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
@@ -296,7 +296,7 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("READ-COMMITTED"))
 
-	// test strict compatibility: error
+	// test skip isolation level check: error
 	_, err = tk.Exec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 	c.Assert(terror.ErrorEqual(err, variable.ErrUnsupportedValueForVar), IsTrue, Commentf("err %v", err))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
@@ -307,16 +307,16 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-COMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-COMMITTED"))
 
-	// test strict compatibility: success
-	tk.MustExec("SET GLOBAL tidb_strict_compatibility = 1")
-	tk.MustExec("SET SESSION tidb_strict_compatibility = 1")
+	// test skip isolation level check: success
+	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 1")
+	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("SERIALIZABLE"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("SERIALIZABLE"))
 
-	// test strict compatibility: success
-	tk.MustExec("SET GLOBAL tidb_strict_compatibility = 0")
-	tk.MustExec("SET SESSION tidb_strict_compatibility = 1")
+	// test skip isolation level check: success
+	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
+	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -311,6 +311,9 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET SESSION TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+	tk.MustQuery("show warnings").Check(testkit.Rows(
+		"Warning 1105 variable 'tx_isolation' does not yet support value: SERIALIZABLE",
+		"Warning 1105  variable 'transaction_isolation' does not yet support value: SERIALIZABLE"))
 	tk.MustQuery("select @@session.tx_isolation").Check(testkit.Rows("SERIALIZABLE"))
 	tk.MustQuery("select @@session.transaction_isolation").Check(testkit.Rows("SERIALIZABLE"))
 
@@ -318,6 +321,9 @@ func (s *testSuite2) TestSetVar(c *C) {
 	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 1")
 	tk.MustExec("SET GLOBAL TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+	tk.MustQuery("show warnings").Check(testkit.Rows(
+		"Warning 1105 variable 'tx_isolation' does not yet support value: READ-UNCOMMITTED",
+		"Warning 1105  variable 'transaction_isolation' does not yet support value: READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.tx_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 	tk.MustQuery("select @@global.transaction_isolation").Check(testkit.Rows("READ-UNCOMMITTED"))
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -611,7 +611,13 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
 				return returnErr
 			}
-			s.StmtCtx.AppendWarning(returnErr)
+			//SET TRANSACTION ISOLATION LEVEL will affect two internal variables:
+			// 1. tx_isolation
+			// 2. transaction_isolation
+			// The following if condition is used to deduplicate two same warnings.
+			if name == "transaction_isolation" {
+				s.StmtCtx.AppendWarning(returnErr)
+			}
 		}
 		s.TxnIsolationLevelOneShot.State = 1
 		s.TxnIsolationLevelOneShot.Value = val

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -601,9 +601,12 @@ func (s *SessionVars) WithdrawAllPreparedStmt() {
 func (s *SessionVars) SetSystemVar(name string, val string) error {
 	switch name {
 	case TxnIsolationOneShot:
-		switch val {
-		case "SERIALIZABLE", "READ-UNCOMMITTED":
-			return ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)
+		strictCompatibility, e := GetSessionSystemVar(s, TiDBStrictCompatibility)
+		if !TiDBOptOn(strictCompatibility) || e != nil {
+			switch val {
+			case "SERIALIZABLE", "READ-UNCOMMITTED":
+				return ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)
+			}
 		}
 		s.TxnIsolationLevelOneShot.State = 1
 		s.TxnIsolationLevelOneShot.Value = val

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -17,8 +17,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
 	"strconv"
 	"strings"
 	"sync"
@@ -610,7 +608,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
 				return unSupportedValueForVarErr
 			}
-			log.Warn("", zap.Error(unSupportedValueForVarErr))
+			s.StmtCtx.AppendWarning(unSupportedValueForVarErr)
 		}
 		s.TxnIsolationLevelOneShot.State = 1
 		s.TxnIsolationLevelOneShot.Value = val

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -604,11 +604,14 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		switch val {
 		case "SERIALIZABLE", "READ-UNCOMMITTED":
 			skipIsolationLevelCheck, err := GetSessionSystemVar(s, TiDBSkipIsolationLevelCheck)
-			unSupportedValueForVarErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)
-			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
-				return unSupportedValueForVarErr
+			returnErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)
+			if err != nil {
+				returnErr = err
 			}
-			s.StmtCtx.AppendWarning(unSupportedValueForVarErr)
+			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
+				return returnErr
+			}
+			s.StmtCtx.AppendWarning(returnErr)
 		}
 		s.TxnIsolationLevelOneShot.State = 1
 		s.TxnIsolationLevelOneShot.Value = val

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -601,8 +601,8 @@ func (s *SessionVars) WithdrawAllPreparedStmt() {
 func (s *SessionVars) SetSystemVar(name string, val string) error {
 	switch name {
 	case TxnIsolationOneShot:
-		strictCompatibility, e := GetSessionSystemVar(s, TiDBStrictCompatibility)
-		if !TiDBOptOn(strictCompatibility) || e != nil {
+		strictCompatibility, err := GetSessionSystemVar(s, TiDBStrictCompatibility)
+		if !TiDBOptOn(strictCompatibility) || err != nil {
 			switch val {
 			case "SERIALIZABLE", "READ-UNCOMMITTED":
 				return ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -604,7 +604,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		switch val {
 		case "SERIALIZABLE", "READ-UNCOMMITTED":
 			skipIsolationLevelCheck, err := GetSessionSystemVar(s, TiDBSkipIsolationLevelCheck)
-			returnErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, val)
+			returnErr := ErrUnsupportedIsolationLevel.GenWithStackByArgs(val)
 			if err != nil {
 				returnErr = err
 			}

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -673,7 +673,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},
 	{ScopeGlobal | ScopeSession, TiDBEnableWindowFunction, BoolToIntStr(DefEnableWindowFunction)},
 	{ScopeGlobal | ScopeSession, TiDBEnableFastAnalyze, BoolToIntStr(DefTiDBUseFastAnalyze)},
-	{ScopeGlobal | ScopeSession, TiDBStrictCompatibility, BoolToIntStr(DefTiDBStrictCompatibility)},
+	{ScopeGlobal | ScopeSession, TiDBSkipIsolationLevelCheck, BoolToIntStr(DefTiDBSkipIsolationLevelCheck)},
 	/* The following variable is defined as session scope but is actually server scope. */
 	{ScopeSession, TiDBGeneralLog, strconv.Itoa(DefTiDBGeneralLog)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -673,6 +673,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},
 	{ScopeGlobal | ScopeSession, TiDBEnableWindowFunction, BoolToIntStr(DefEnableWindowFunction)},
 	{ScopeGlobal | ScopeSession, TiDBEnableFastAnalyze, BoolToIntStr(DefTiDBUseFastAnalyze)},
+	{ScopeGlobal | ScopeSession, TiDBStrictCompatibility, BoolToIntStr(DefTiDBStrictCompatibility)},
 	/* The following variable is defined as session scope but is actually server scope. */
 	{ScopeSession, TiDBGeneralLog, strconv.Itoa(DefTiDBGeneralLog)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -85,6 +85,7 @@ var (
 	ErrTruncatedWrongValue         = terror.ClassVariable.New(CodeTruncatedWrongValue, mysql.MySQLErrName[mysql.ErrTruncatedWrongValue])
 	ErrMaxPreparedStmtCountReached = terror.ClassVariable.New(CodeMaxPreparedStmtCountReached, mysql.MySQLErrName[mysql.ErrMaxPreparedStmtCountReached])
 	ErrUnsupportedValueForVar      = terror.ClassVariable.New(CodeUnknownStatusVar, "variable '%s' does not yet support value: %s")
+	ErrUnsupportedIsolationLevel   = terror.ClassVariable.New(CodeUnknownStatusVar, "The isolation level '%s' is not supported. Set tidb_skip_isolation_level_check=1 to skip this error")
 )
 
 func init() {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -131,6 +131,10 @@ const (
 
 	// TiDBCheckMb4ValueInUTF8 is used to control whether to enable the check wrong utf8 value.
 	TiDBCheckMb4ValueInUTF8 = "tidb_check_mb4_value_in_utf8"
+
+	// tidb_strict_compatibility is used to control whether to return error when set unsupported transaction
+	// isolation level.
+	TiDBStrictCompatibility = "tidb_strict_compatibility"
 )
 
 // TiDB system variable names that both in session and global scope.
@@ -295,6 +299,7 @@ const (
 	DefEnableWindowFunction          = false
 	DefTiDBDDLSlowOprThreshold       = 300
 	DefTiDBUseFastAnalyze            = false
+	DefTiDBStrictCompatibility 	     = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -299,7 +299,7 @@ const (
 	DefEnableWindowFunction          = false
 	DefTiDBDDLSlowOprThreshold       = 300
 	DefTiDBUseFastAnalyze            = false
-	DefTiDBStrictCompatibility 	     = false
+	DefTiDBStrictCompatibility       = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -132,9 +132,9 @@ const (
 	// TiDBCheckMb4ValueInUTF8 is used to control whether to enable the check wrong utf8 value.
 	TiDBCheckMb4ValueInUTF8 = "tidb_check_mb4_value_in_utf8"
 
-	// tidb_strict_compatibility is used to control whether to return error when set unsupported transaction
+	// tidb_skip_isolation_level_check is used to control whether to return error when set unsupported transaction
 	// isolation level.
-	TiDBStrictCompatibility = "tidb_strict_compatibility"
+	TiDBSkipIsolationLevelCheck = "tidb_skip_isolation_level_check"
 )
 
 // TiDB system variable names that both in session and global scope.
@@ -299,7 +299,7 @@ const (
 	DefEnableWindowFunction          = false
 	DefTiDBDDLSlowOprThreshold       = 300
 	DefTiDBUseFastAnalyze            = false
-	DefTiDBStrictCompatibility       = false
+	DefTiDBSkipIsolationLevelCheck   = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -428,8 +428,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "", ErrWrongValueForVar.GenWithStackByArgs(name, value)
 		}
 
-		strictCompatibility, e := GetSessionSystemVar(vars, TiDBStrictCompatibility)
-		if !TiDBOptOn(strictCompatibility) || e != nil {
+		strictCompatibility, err := GetSessionSystemVar(vars, TiDBStrictCompatibility)
+		if !TiDBOptOn(strictCompatibility) || err != nil {
 			switch upVal {
 			case "SERIALIZABLE", "READ-UNCOMMITTED":
 				return "", ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -430,11 +430,14 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		switch upVal {
 		case "SERIALIZABLE", "READ-UNCOMMITTED":
 			skipIsolationLevelCheck, err := GetSessionSystemVar(vars, TiDBSkipIsolationLevelCheck)
-			unSupportedValueForVarErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)
-			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
-				return "", unSupportedValueForVarErr
+			returnErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)
+			if err != nil {
+				returnErr = err
 			}
-			vars.StmtCtx.AppendWarning(unSupportedValueForVarErr)
+			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
+				return "", returnErr
+			}
+			vars.StmtCtx.AppendWarning(returnErr)
 		}
 		return upVal, nil
 	case TiDBInitChunkSize:

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -16,8 +16,6 @@ package variable
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/log"
-	"go.uber.org/zap"
 	"math"
 	"strconv"
 	"strings"
@@ -436,7 +434,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
 				return "", unSupportedValueForVarErr
 			}
-			log.Warn("", zap.Error(unSupportedValueForVarErr))
+			vars.StmtCtx.AppendWarning(unSupportedValueForVarErr)
 		}
 		return upVal, nil
 	case TiDBInitChunkSize:

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -427,9 +427,13 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		if !exists {
 			return "", ErrWrongValueForVar.GenWithStackByArgs(name, value)
 		}
-		switch upVal {
-		case "SERIALIZABLE", "READ-UNCOMMITTED":
-			return "", ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)
+
+		strictCompatibility, e := GetSessionSystemVar(vars, TiDBStrictCompatibility)
+		if !TiDBOptOn(strictCompatibility) || e != nil {
+			switch upVal {
+			case "SERIALIZABLE", "READ-UNCOMMITTED":
+				return "", ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)
+			}
 		}
 		return upVal, nil
 	case TiDBInitChunkSize:

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -437,7 +437,13 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			if !TiDBOptOn(skipIsolationLevelCheck) || err != nil {
 				return "", returnErr
 			}
-			vars.StmtCtx.AppendWarning(returnErr)
+			//SET TRANSACTION ISOLATION LEVEL will affect two internal variables:
+			// 1. tx_isolation
+			// 2. transaction_isolation
+			// The following if condition is used to deduplicate two same warnings.
+			if name == "transaction_isolation" {
+				vars.StmtCtx.AppendWarning(returnErr)
+			}
 		}
 		return upVal, nil
 	case TiDBInitChunkSize:

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -430,7 +430,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		switch upVal {
 		case "SERIALIZABLE", "READ-UNCOMMITTED":
 			skipIsolationLevelCheck, err := GetSessionSystemVar(vars, TiDBSkipIsolationLevelCheck)
-			returnErr := ErrUnsupportedValueForVar.GenWithStackByArgs(name, value)
+			returnErr := ErrUnsupportedIsolationLevel.GenWithStackByArgs(value)
 			if err != nil {
 				returnErr = err
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This patch (https://github.com/pingcap/tidb/pull/8625/files) breaks backward compatible.
When using tidb as hive's metastore, hive will set  transaction isolation level  to serializable, which will cause the following error:
```
ERROR 1105 (HY000): variable 'tx_isolation' does not yet support value: SERIALIZABLE
```

### What is changed and how it works?
This PR provide a variable ```tidb_skip_isolation_level_check```. 
If ```tidb_skip_isolation_level_check == ON```, tidb will not throw an error if hive call ```set session transaction isolation level serializable;```. ```tidb_skip_isolation_level_check```'s default value is ```OFF```.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test

Related changes
 - Need to be included in the release note
 - Need to cherry-pick to the release branch
