### PR TITLE
variable: validate setting read_only variable

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -286,7 +286,6 @@ func (s *testSuite2) TestSetVar(c *C) {
 	_, err = tk.Exec("set global tidb_batch_commit = 2")
 	c.Assert(err, NotNil)
 
-<<<<<<< HEAD
 	// test skip isolation level check: init
 	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -286,6 +286,7 @@ func (s *testSuite2) TestSetVar(c *C) {
 	_, err = tk.Exec("set global tidb_batch_commit = 2")
 	c.Assert(err, NotNil)
 
+<<<<<<< HEAD
 	// test skip isolation level check: init
 	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")
@@ -328,6 +329,17 @@ func (s *testSuite2) TestSetVar(c *C) {
 	// test skip isolation level check: reset
 	tk.MustExec("SET GLOBAL tidb_skip_isolation_level_check = 0")
 	tk.MustExec("SET SESSION tidb_skip_isolation_level_check = 0")
+
+	tk.MustExec("set global read_only = 0")
+	tk.MustQuery("select @@global.read_only;").Check(testkit.Rows("0"))
+	tk.MustExec("set global read_only = off")
+	tk.MustQuery("select @@global.read_only;").Check(testkit.Rows("0"))
+	tk.MustExec("set global read_only = 1")
+	tk.MustQuery("select @@global.read_only;").Check(testkit.Rows("1"))
+	tk.MustExec("set global read_only = on")
+	tk.MustQuery("select @@global.read_only;").Check(testkit.Rows("1"))
+	_, err = tk.Exec("set global read_only = abc")
+	c.Assert(err, NotNil)
 }
 
 func (s *testSuite2) TestSetCharset(c *C) {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -775,6 +775,7 @@ const (
 )
 
 // these variables are useless for TiDB, but still need to validate their values for some compatible issues.
+// TODO: some more variables need to be added here.
 const (
 	serverReadOnly = "read_only"
 )

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -774,6 +774,11 @@ const (
 	TxnIsolationOneShot  = "tx_isolation_one_shot"
 )
 
+// these variables are useless for TiDB, but still need to validate their values for some compatible issues.
+const (
+	serverReadOnly = "read_only"
+)
+
 var (
 	// TxIsolationNames are the valid values of the variable "tx_isolation" or "transaction_isolation".
 	TxIsolationNames = map[string]struct{}{

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -434,7 +434,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "log_bin_trust_function_creators", "OFF"},
 	{ScopeNone, "innodb_write_io_threads", "4"},
 	{ScopeGlobal, "mysql_native_password_proxy_users", ""},
-	{ScopeGlobal, "read_only", "OFF"},
+	{ScopeGlobal, serverReadOnly, "0"},
 	{ScopeNone, "large_page_size", "0"},
 	{ScopeNone, "table_open_cache_instances", "1"},
 	{ScopeGlobal, "innodb_stats_persistent", "ON"},

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -351,7 +351,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return value, ErrReadOnly.GenWithStackByArgs(name)
 	case GeneralLog, TiDBGeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
 		CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode, PseudoSlaveMode, LowPriorityUpdates,
-		SkipNameResolve, SQLSafeUpdates, TiDBConstraintCheckInPlace:
+		SkipNameResolve, SQLSafeUpdates, TiDBConstraintCheckInPlace, serverReadOnly:
 		if strings.EqualFold(value, "ON") || value == "1" {
 			return "1", nil
 		} else if strings.EqualFold(value, "OFF") || value == "0" {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
set global read_only = abc;
```
then 
```
select @@read_only;
```
will get `abc`, which does not make sense.

### What is changed and how it works?
Fix it, only 1/0/on/off will be the valid values.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change
