### PR TITLE
expression:  a tiny cleanup of relocating getSystemTimestamp() not to be called unnecessarily

### DIFF
--- a/expression/helper.go
+++ b/expression/helper.go
@@ -49,15 +49,15 @@ func GetTimeValue(ctx sessionctx.Context, v interface{}, tp byte, fsp int) (d ty
 		Fsp:  fsp,
 	}
 
-	defaultTime, err := getSystemTimestamp(ctx)
-	if err != nil {
-		return d, err
-	}
 	sc := ctx.GetSessionVars().StmtCtx
 	switch x := v.(type) {
 	case string:
 		upperX := strings.ToUpper(x)
 		if upperX == strings.ToUpper(ast.CurrentTimestamp) {
+			defaultTime, err := getSystemTimestamp(ctx)
+			if err != nil {
+				return d, err
+			}
 			value.Time = types.FromGoTime(defaultTime.Truncate(time.Duration(math.Pow10(9-fsp)) * time.Nanosecond))
 			if tp == mysql.TypeTimestamp || tp == mysql.TypeDatetime {
 				err = value.ConvertTimeZone(time.Local, ctx.GetSessionVars().Location())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Tiny cleanup for removing the unnecessary function call of getSystemTimestamp()

### What is changed and how it works?
Relocate getSystemTimestamp() to be called only where it is used.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
