### PR TITLE
privilege: fix update privilege error

### DIFF
--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -2410,7 +2410,7 @@ func extractTableListForUpdate(refTables []*ast.TableName, sets []*ast.Assignmen
 	if len(refTables) == 1 {
 		return refTables
 	}
-	tbls := make([]*ast.TableName, len(sets))
+	tbls := make([]*ast.TableName, 0, len(sets))
 	var tblsMap map[string]*ast.TableName
 
 	for _, a := range sets {

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -2410,7 +2410,7 @@ func extractTableListForUpdate(refTables []*ast.TableName, sets []*ast.Assignmen
 	if len(refTables) == 1 {
 		return refTables
 	}
-	var tbls []*ast.TableName
+	tbls := make([]*ast.TableName, len(sets))
 	var tblsMap map[string]*ast.TableName
 
 	for _, a := range sets {
@@ -2419,7 +2419,7 @@ func extractTableListForUpdate(refTables []*ast.TableName, sets []*ast.Assignmen
 		if c.Table.L != "" {
 			for _, tbl := range refTables {
 				if strings.EqualFold(tbl.Name.L, c.Name.L) {
-					tblsMap[fmt.Sprintf("`%s`.`%s`", tbl.Schema.L, tbl.Name.L)] = tbl
+					tblsMap["`"+tbl.Schema.L+"`.`"+tbl.Name.L+"`"] = tbl
 				}
 			}
 		}

--- a/plan/logical_plan_builder.go
+++ b/plan/logical_plan_builder.go
@@ -2063,7 +2063,8 @@ func (b *planBuilder) buildUpdate(update *ast.UpdateStmt) Plan {
 
 	var tableList []*ast.TableName
 	tableList = extractTableList(sel.From.TableRefs, tableList)
-	for _, t := range tableList {
+	tableListForUpdate := extractTableListForUpdate(tableList, update.List)
+	for _, t := range tableListForUpdate {
 		dbName := t.Schema.L
 		if dbName == "" {
 			dbName = b.ctx.GetSessionVars().CurrentDB
@@ -2402,4 +2403,31 @@ func getInnerFromParentheses(expr ast.ExprNode) ast.ExprNode {
 		return getInnerFromParentheses(pexpr.Expr)
 	}
 	return expr
+}
+
+func extractTableListForUpdate(refTables []*ast.TableName, sets []*ast.Assignment) []*ast.TableName {
+	// if there's only one tbl , we won't bother
+	if len(refTables) == 1 {
+		return refTables
+	}
+	var tbls []*ast.TableName
+	var tblsMap map[string]*ast.TableName
+
+	for _, a := range sets {
+		c := a.Column
+
+		if c.Table.L != "" {
+			for _, tbl := range refTables {
+				if strings.EqualFold(tbl.Name.L, c.Name.L) {
+					tblsMap[fmt.Sprintf("`%s`.`%s`", tbl.Schema.L, tbl.Name.L)] = tbl
+				}
+			}
+		}
+	}
+
+	for _, tbl := range tblsMap {
+		tbls = append(tbls, tbl)
+	}
+
+	return tbls
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2118,3 +2118,26 @@ func (s *testSessionSuite) TestDisableTxnAutoRetry(c *C) {
 	tk1.MustExec("update no_retry set id = 7")
 	tk1.MustExec("commit")
 }
+
+func (s *testSessionSuite) TestUpdatePrivilege(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create user xxx;")
+
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+
+	// Fix issue 10028
+	tk.MustExec("create database ap")
+	tk.MustExec("create database tp")
+	tk.MustExec("grant all privileges on ap.* to xxx")
+	tk.MustExec("grant select on tp.* to xxx")
+	tk.MustExec("flush privileges")
+	tk.MustExec("create table tp.record( id int,name varchar(128),age int)")
+	tk.MustExec("insert into tp.record (id,name,age) values (1,'john',18),(2,'lary',19),(3,'lily',18)")
+	tk.MustExec("create table ap.record( id int,name varchar(128),age int)")
+	tk.MustExec("insert into ap.record(id) values(1)")
+	c.Assert(tk1.Se.Auth(&auth.UserIdentity{Username: "xxx", Hostname: "localhost"},
+		[]byte(""),
+		[]byte("")), IsTrue)
+	_, err2 := tk1.Exec("update ap.record t inner join tp.record tt on t.id=tt.id  set t.name=tt.name")
+	c.Assert(err2, IsNil)
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
[issue10028](https://github.com/pingcap/tidb/issues/10028)
```sql
update ap.record t inner join tp.record tt on t.id=tt.id  set t.name=tt.name;
```

```
ERROR 1105 (HY000): privilege check fail
```

### What is changed and how it works?

only use modified table name for update privilege check in planner/logical_plan_builder.go#buildUpdate

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes


Side effects

Related changes

