### PR TITLE
executor: support prepare DDL statements with no parameters

### DIFF
--- a/executor/errors.go
+++ b/executor/errors.go
@@ -34,7 +34,7 @@ var (
 	ErrGetStartTS      = terror.ClassExecutor.New(codeGetStartTS, "Can not get start ts")
 	ErrUnknownPlan     = terror.ClassExecutor.New(codeUnknownPlan, "Unknown plan")
 	ErrPrepareMulti    = terror.ClassExecutor.New(codePrepareMulti, "Can not prepare multiple statements")
-	ErrPrepareDDL      = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements")
+	ErrPrepareDDL      = terror.ClassExecutor.New(codePrepareDDL, "Can not prepare DDL statements with parameters")
 	ErrResultIsEmpty   = terror.ClassExecutor.New(codeResultIsEmpty, "result is empty")
 	ErrBuildExecutor   = terror.ClassExecutor.New(codeErrBuildExec, "Failed to build executor")
 	ErrBatchInsertFail = terror.ClassExecutor.New(codeBatchInsertFail, "Batch insert failed, please clean the table and try again.")

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -141,8 +141,7 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 	stmt.Accept(&extractor)
 
 	// DDL Statements can not accept parameters
-	_, ok := stmt.(ast.DDLNode)
-	if ok && len(extractor.markers) > 0 {
+	if _, ok := stmt.(ast.DDLNode); ok && len(extractor.markers) > 0 {
 		return ErrPrepareDDL
 	}
 

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -133,15 +133,18 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		return ErrPrepareMulti
 	}
 	stmt := stmts[0]
-	if _, ok := stmt.(ast.DDLNode); ok {
-		return ErrPrepareDDL
-	}
 	err = ResetContextOfStmt(e.ctx, stmt)
 	if err != nil {
 		return err
 	}
 	var extractor paramMarkerExtractor
 	stmt.Accept(&extractor)
+
+	// DDL Statements can not accept parameters
+	_, ok := stmt.(ast.DDLNode)
+	if ok && len(extractor.markers) > 0 {
+		return ErrPrepareDDL
+	}
 
 	// Prepare parameters should NOT over 2 bytes(MaxUint16)
 	// https://dev.mysql.com/doc/internals/en/com-stmt-prepare-response.html#packet-COM_STMT_PREPARE_OK.

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -30,3 +30,11 @@ func (s *testSuite1) TestPreparedNameResolver(c *C) {
 	_, err = tk.Exec("prepare stmt from '(select * FROM t) union all (select * FROM t) order by a limit ?'")
 	c.Assert(err.Error(), Equals, "[planner:1054]Unknown column 'a' in 'order clause'")
 }
+
+// a 'create table' DDL statement should be accepted if it has no parameters.
+func (s *testSuite1) TestPreparedDDL(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("prepare stmt from 'create table t (id int, KEY id (id))'")
+}

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -71,7 +71,6 @@ func (c *conditionPair) Err() error {
 // snapshot for read.
 type unionStore struct {
 	*BufferStore
-	snapshot           Snapshot                  // for read
 	lazyConditionPairs map[string]*conditionPair // for delay check
 	opts               options
 }
@@ -80,7 +79,6 @@ type unionStore struct {
 func NewUnionStore(snapshot Snapshot) UnionStore {
 	return &unionStore{
 		BufferStore:        NewBufferStore(snapshot, DefaultTxnMembufCap),
-		snapshot:           snapshot,
 		lazyConditionPairs: make(map[string]*conditionPair),
 		opts:               make(map[Option]interface{}),
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR improves compatibility with MySQL 5.7 by accepting some DDL as prepared statements.
Currently TiDB accepts no DDL as prepared statements (#9425). 
MySQL 5.7 lists some DDL statements in the accepted SQL for prepared statements: https://dev.mysql.com/doc/refman/5.7/en/sql-syntax-prepared-statements.html

### What is changed and how it works?

I removed the explicit check for DDL and relaxed the restriction from *no* DDL to *ddl without parameters*.  I don't believe parameters are used often for DDL and I am unable to test DDL with parameters so I left that restriction in.  Even so it's still useful; for example, Diesel's MySQL driver prepares all statements, including DDL, and with this change TiDB becomes more compatible with MySQL 5.7 and Diesel.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test in prepared_test.go TestPreparedNameResolver

Code changes

no function signatures have changed.  
The text of ErrPrepareDDL changed.

Side effects

- SQL that was illegal before becomes legal (DDL with no parameters in prepared statements).

Related changes

 - Need to be included in the release note
