### PR TITLE
planner/core: fix a bug that check update privilege use wrong `AsName` and DBName (#9003)

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1602,6 +1602,13 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 			},
 		},
 		{
+			sql: "update t a1 set a1.a = a1.a + 1",
+			ans: []visitInfo{
+				{mysql.UpdatePriv, "test", "t", "", nil},
+				{mysql.SelectPriv, "test", "t", "", nil},
+			},
+		},
+		{
 			sql: "select a, sum(e) from t group by a",
 			ans: []visitInfo{
 				{mysql.SelectPriv, "test", "t", ""},

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1604,8 +1604,8 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 		{
 			sql: "update t a1 set a1.a = a1.a + 1",
 			ans: []visitInfo{
-				{mysql.UpdatePriv, "test", "t", "", nil},
-				{mysql.SelectPriv, "test", "t", "", nil},
+				{mysql.UpdatePriv, "test", "t", ""},
+				{mysql.SelectPriv, "test", "t", ""},
 			},
 		},
 		{

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2350,29 +2350,6 @@ func (s *testSessionSuite) TestSetGroupConcatMaxLen(c *C) {
 
 func (s *testSessionSuite) TestUpdatePrivilege(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("drop table if exists t1, t2;")
-	tk.MustExec("create table t1 (id int);")
-	tk.MustExec("create table t2 (id int);")
-	tk.MustExec("insert into t1 values (1);")
-	tk.MustExec("insert into t2 values (2);")
-	tk.MustExec("create user xxx;")
-	tk.MustExec("grant all on test.t1 to xxx;")
-	tk.MustExec("grant select on test.t2 to xxx;")
-	tk.MustExec("flush privileges;")
-
-	tk1 := testkit.NewTestKitWithInit(c, s.store)
-	c.Assert(tk1.Se.Auth(&auth.UserIdentity{Username: "xxx", Hostname: "localhost"},
-		[]byte(""),
-		[]byte("")), IsTrue)
-
-	_, err := tk1.Exec("update t2 set id = 666 where id = 1;")
-	c.Assert(err, NotNil)
-	c.Assert(strings.Contains(err.Error(), "privilege check fail"), IsTrue)
-
-	// Cover a bug that t1 and t2 both require update privilege.
-	// In fact, the privlege check for t1 should be update, and for t2 should be select.
-	_, err = tk1.Exec("update t1,t2 set t1.id = t2.id;")
-	c.Assert(err, IsNil)
 
 	// Fix issue 8911
 	tk.MustExec("create database weperk")
@@ -2380,6 +2357,9 @@ func (s *testSessionSuite) TestUpdatePrivilege(c *C) {
 	tk.MustExec("create table tb_wehub_server (id int, active_count int, used_count int)")
 	tk.MustExec("create user 'weperk'")
 	tk.MustExec("grant all privileges on weperk.* to 'weperk'@'%'")
+	tk.MustExec("flush privileges;")
+
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	c.Assert(tk1.Se.Auth(&auth.UserIdentity{Username: "weperk", Hostname: "%"},
 		[]byte(""), []byte("")), IsTrue)
 	tk1.MustExec("use weperk")


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/9003