### PR TITLE
*: reduce useless `promtheus.WithLabelValues` call

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ type Config struct {
 	// TreatOldVersionUTF8AsUTF8MB4 is use to treat old version table/column UTF8 charset as UTF8MB4. This is for compatibility.
 	// Currently not support dynamic modify, because this need to reload all old version schema.
 	TreatOldVersionUTF8AsUTF8MB4 bool `toml:"treat-old-version-utf8-as-utf8mb4" json:"treat-old-version-utf8-as-utf8mb4"`
+	DebugMode                    int
 }
 
 // Log is the log section of config.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -872,9 +872,11 @@ func (b *executorBuilder) buildMergeJoin(v *plannercore.PhysicalMergeJoin) Execu
 		return nil
 	}
 
-	metrics.ExecutorCounter.WithLabelValues("MergeJoinExec").Inc()
+	executorCounterMergeJoinExec.Inc()
 	return e
 }
+
+var executorCounterMergeJoinExec = metrics.ExecutorCounter.WithLabelValues("MergeJoinExec")
 
 func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) Executor {
 	leftHashKey := make([]*expression.Column, 0, len(v.EqualConditions))
@@ -938,12 +940,14 @@ func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) Executo
 		e.joiners[i] = newJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues,
 			v.OtherConditions, lhsTypes, rhsTypes)
 	}
-	metrics.ExecutorCounter.WithLabelValues("HashJoinExec").Inc()
+	executorCountHashJoinExec.Inc()
 	if e.ctx.GetSessionVars().EnableRadixJoin {
 		return &RadixHashJoinExec{HashJoinExec: e}
 	}
 	return e
 }
+
+var executorCountHashJoinExec = metrics.ExecutorCounter.WithLabelValues("HashJoinExec")
 
 func (b *executorBuilder) buildHashAgg(v *plannercore.PhysicalHashAgg) Executor {
 	src := b.build(v.Children()[0])
@@ -1021,9 +1025,11 @@ func (b *executorBuilder) buildHashAgg(v *plannercore.PhysicalHashAgg) Executor 
 		}
 	}
 
-	metrics.ExecutorCounter.WithLabelValues("HashAggExec").Inc()
+	executorCounterHashAggExec.Inc()
 	return e
 }
+
+var executorCounterHashAggExec = metrics.ExecutorCounter.WithLabelValues("HashAggExec")
 
 func (b *executorBuilder) buildStreamAgg(v *plannercore.PhysicalStreamAgg) Executor {
 	src := b.build(v.Children()[0])
@@ -1049,9 +1055,11 @@ func (b *executorBuilder) buildStreamAgg(v *plannercore.PhysicalStreamAgg) Execu
 		}
 	}
 
-	metrics.ExecutorCounter.WithLabelValues("StreamAggExec").Inc()
+	executorStreamAggExec.Inc()
 	return e
 }
+
+var executorStreamAggExec = metrics.ExecutorCounter.WithLabelValues("StreamAggExec")
 
 func (b *executorBuilder) buildSelection(v *plannercore.PhysicalSelection) Executor {
 	childExec := b.build(v.Children()[0])
@@ -1143,9 +1151,11 @@ func (b *executorBuilder) buildSort(v *plannercore.PhysicalSort) Executor {
 		ByItems:      v.ByItems,
 		schema:       v.Schema(),
 	}
-	metrics.ExecutorCounter.WithLabelValues("SortExec").Inc()
+	executorCounterSortExec.Inc()
 	return &sortExec
 }
+
+var executorCounterSortExec = metrics.ExecutorCounter.WithLabelValues("SortExec")
 
 func (b *executorBuilder) buildTopN(v *plannercore.PhysicalTopN) Executor {
 	childExec := b.build(v.Children()[0])
@@ -1157,12 +1167,14 @@ func (b *executorBuilder) buildTopN(v *plannercore.PhysicalTopN) Executor {
 		ByItems:      v.ByItems,
 		schema:       v.Schema(),
 	}
-	metrics.ExecutorCounter.WithLabelValues("TopNExec").Inc()
+	executorCounterTopNExec.Inc()
 	return &TopNExec{
 		SortExec: sortExec,
 		limit:    &plannercore.PhysicalLimit{Count: v.Count, Offset: v.Offset},
 	}
 }
+
+var executorCounterTopNExec = metrics.ExecutorCounter.WithLabelValues("TopNExec")
 
 func (b *executorBuilder) buildApply(apply *plannercore.PhysicalApply) *NestedLoopApplyExec {
 	v := apply.PhysicalJoin
@@ -1197,9 +1209,11 @@ func (b *executorBuilder) buildApply(apply *plannercore.PhysicalApply) *NestedLo
 		joiner:       tupleJoiner,
 		outerSchema:  apply.OuterSchema,
 	}
-	metrics.ExecutorCounter.WithLabelValues("NestedLoopApplyExec").Inc()
+	executorCounterNestedLoopApplyExec.Inc()
 	return e
 }
+
+var executorCounterNestedLoopApplyExec = metrics.ExecutorCounter.WithLabelValues("NestedLoopApplyExec")
 
 func (b *executorBuilder) buildMaxOneRow(v *plannercore.PhysicalMaxOneRow) Executor {
 	childExec := b.build(v.Children()[0])
@@ -1608,9 +1622,11 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 	}
 	e.innerCtx.keyCols = innerKeyCols
 	e.joinResult = e.newFirstChunk()
-	metrics.ExecutorCounter.WithLabelValues("IndexLookUpJoin").Inc()
+	executorCounterIndexLookUpJoin.Inc()
 	return e
 }
+
+var executorCounterIndexLookUpJoin = metrics.ExecutorCounter.WithLabelValues("IndexLookUpJoin")
 
 // containsLimit tests if the execs contains Limit because we do not know whether `Limit` has consumed all of its' source,
 // so the feedback may not be accurate.
@@ -1815,12 +1831,14 @@ func (b *executorBuilder) buildIndexLookUpReader(v *plannercore.PhysicalIndexLoo
 	ts := v.TablePlans[0].(*plannercore.PhysicalTableScan)
 
 	ret.ranges = is.Ranges
-	metrics.ExecutorCounter.WithLabelValues("IndexLookUpExecutor").Inc()
+	executorCounterIndexLookUpExecutor.Inc()
 	sctx := b.ctx.GetSessionVars().StmtCtx
 	sctx.IndexIDs = append(sctx.IndexIDs, is.Index.ID)
 	sctx.TableIDs = append(sctx.TableIDs, ts.Table.ID)
 	return ret
 }
+
+var executorCounterIndexLookUpExecutor = metrics.ExecutorCounter.WithLabelValues("IndexLookUpExecutor")
 
 // dataReaderBuilder build an executor.
 // The executor can be used to read data in the ranges which are constructed by datums.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -117,6 +117,19 @@ func isPhysicalPlanExpensive(p plannercore.PhysicalPlan) bool {
 	return false
 }
 
+var (
+	stmtNodeCounterUse      = metrics.StmtNodeCounter.WithLabelValues("Use")
+	stmtNodeCounterShow     = metrics.StmtNodeCounter.WithLabelValues("Show")
+	stmtNodeCounterBegin    = metrics.StmtNodeCounter.WithLabelValues("Begin")
+	stmtNodeCounterCommit   = metrics.StmtNodeCounter.WithLabelValues("Commit")
+	stmtNodeCounterRollback = metrics.StmtNodeCounter.WithLabelValues("Rollback")
+	stmtNodeCounterInsert   = metrics.StmtNodeCounter.WithLabelValues("Insert")
+	stmtNodeCounterReplace  = metrics.StmtNodeCounter.WithLabelValues("Replace")
+	stmtNodeCounterDelete   = metrics.StmtNodeCounter.WithLabelValues("Delete")
+	stmtNodeCounterUpdate   = metrics.StmtNodeCounter.WithLabelValues("Update")
+	stmtNodeCounterSelect   = metrics.StmtNodeCounter.WithLabelValues("Select")
+)
+
 // CountStmtNode records the number of statements with the same type.
 func CountStmtNode(stmtNode ast.StmtNode, inRestrictedSQL bool) {
 	if inRestrictedSQL {
@@ -124,7 +137,30 @@ func CountStmtNode(stmtNode ast.StmtNode, inRestrictedSQL bool) {
 	}
 
 	typeLabel := GetStmtLabel(stmtNode)
-	metrics.StmtNodeCounter.WithLabelValues(typeLabel).Inc()
+	switch typeLabel {
+	case "Use":
+		stmtNodeCounterUse.Inc()
+	case "Show":
+		stmtNodeCounterShow.Inc()
+	case "Begin":
+		stmtNodeCounterBegin.Inc()
+	case "Commit":
+		stmtNodeCounterCommit.Inc()
+	case "Rollback":
+		stmtNodeCounterRollback.Inc()
+	case "Insert":
+		stmtNodeCounterInsert.Inc()
+	case "Replace":
+		stmtNodeCounterReplace.Inc()
+	case "Delete":
+		stmtNodeCounterDelete.Inc()
+	case "Update":
+		stmtNodeCounterUpdate.Inc()
+	case "Select":
+		stmtNodeCounterSelect.Inc()
+	default:
+		metrics.StmtNodeCounter.WithLabelValues(typeLabel).Inc()
+	}
 
 	if !config.GetGlobalConfig().Status.RecordQPSbyDB {
 		return

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1395,18 +1395,17 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	} else if vars.StmtCtx.InSelectStmt {
 		sc.PrevAffectedRows = -1
 	}
-	err = vars.SetSystemVar("warning_count", fmt.Sprintf("%d", vars.StmtCtx.NumWarnings(false)))
+	errCount, warnCount := vars.StmtCtx.NumErrorWarnings()
+	err = vars.SetSystemVar("warning_count", warnCount)
 	if err != nil {
 		return err
 	}
-	err = vars.SetSystemVar("error_count", fmt.Sprintf("%d", vars.StmtCtx.NumWarnings(true)))
+	err = vars.SetSystemVar("error_count", errCount)
 	if err != nil {
 		return err
 	}
-	if s != nil {
-		// execute missed stmtID uses empty sql
-		sc.OriginalSQL = s.Text()
-	}
+	// execute missed stmtID uses empty sql
+	sc.OriginalSQL = s.Text()
 	vars.StmtCtx = sc
 	return
 }

--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -428,6 +428,7 @@ func (s *seqTestSuite) TestPreparedInsert(c *C) {
 		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
 		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
+	metrics.PlanCacheCounterTest = true
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
 	pb := &dto.Metric{}
@@ -510,6 +511,7 @@ func (s *seqTestSuite) TestPreparedUpdate(c *C) {
 		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
 		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
+	metrics.PlanCacheCounterTest = true
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
 	pb := &dto.Metric{}
@@ -569,6 +571,7 @@ func (s *seqTestSuite) TestPreparedDelete(c *C) {
 		plannercore.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
 		plannercore.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
+	metrics.PlanCacheCounterTest = true
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
 	pb := &dto.Metric{}

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190409044748-a0b301443a30
+	github.com/pingcap/parser v0.0.0-20190412041648-99e6a7a6a525
 	github.com/pingcap/pd v2.1.0-rc.4+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190107072121-abbec73437b7

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,6 @@ github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562 h1:32oF1/8lVnBR2JV
 github.com/pingcap/kvproto v0.0.0-20190215154024-7f2fc73ef562/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190409044748-a0b301443a30 h1:Cu+VJBHLUqI0TFj/0Kya4L1iHIJZ3VbtZcEwv+3zOxQ=
-github.com/pingcap/parser v0.0.0-20190409044748-a0b301443a30/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20190412041648-99e6a7a6a525 h1:01hhDf1GWpRWZvuGWHQwns/zN7LjZhYSNpqDT+Nm3lk=
 github.com/pingcap/parser v0.0.0-20190412041648-99e6a7a6a525/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3F
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/parser v0.0.0-20190409044748-a0b301443a30 h1:Cu+VJBHLUqI0TFj/0Kya4L1iHIJZ3VbtZcEwv+3zOxQ=
 github.com/pingcap/parser v0.0.0-20190409044748-a0b301443a30/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190412041648-99e6a7a6a525 h1:01hhDf1GWpRWZvuGWHQwns/zN7LjZhYSNpqDT+Nm3lk=
+github.com/pingcap/parser v0.0.0-20190412041648-99e6a7a6a525/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible h1:/buwGk04aHO5odk/+O8ZOXGs4qkUjYTJ2UpCJXna8NE=
 github.com/pingcap/pd v2.1.0-rc.4+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -102,6 +102,8 @@ var (
 			Help:      "Counter of TiDB keep alive.",
 		})
 
+	PlanCacheCounterTest = false
+
 	PlanCacheCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "tidb",

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -68,6 +68,7 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	tk.MustQuery("explain delete from t where a = 1").Check(testkit.Rows(
 		"Point_Get_1 1.00 root table:t, handle:1",
 	))
+	metrics.PlanCacheCounterTest = true
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
 	pb := &dto.Metric{}

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -154,6 +154,7 @@ func (s *testPlanSuite) TestPrepareCacheDeferredFunction(c *C) {
 
 	var cnt [2]float64
 	var planStr [2]string
+	metrics.PlanCacheCounterTest = true
 	metrics.PlanCacheCounter.Reset()
 	counter := metrics.PlanCacheCounter.WithLabelValues("prepare")
 	for i := 0; i < 2; i++ {

--- a/server/conn.go
+++ b/server/conn.go
@@ -668,55 +668,175 @@ func errStrForLog(err error) string {
 	return errors.ErrorStack(err)
 }
 
+var (
+	queryTotalCounterComSleepOK           = metrics.QueryTotalCounter.WithLabelValues("Sleep", "OK")
+	queryTotalCounterComSleepError        = metrics.QueryTotalCounter.WithLabelValues("Sleep", "Error")
+	queryTotalCounterComQuitOK            = metrics.QueryTotalCounter.WithLabelValues("Quit", "OK")
+	queryTotalCounterComQuitError         = metrics.QueryTotalCounter.WithLabelValues("Quit", "Error")
+	queryTotalCounterComInitDBOK          = metrics.QueryTotalCounter.WithLabelValues("InitDB", "OK")
+	queryTotalCounterComInitDBError       = metrics.QueryTotalCounter.WithLabelValues("InitDB", "Error")
+	queryTotalCounterComQueryOK           = metrics.QueryTotalCounter.WithLabelValues("Query", "OK")
+	queryTotalCounterComQueryError        = metrics.QueryTotalCounter.WithLabelValues("Query", "Error")
+	queryTotalCounterComPingOK            = metrics.QueryTotalCounter.WithLabelValues("Ping", "OK")
+	queryTotalCounterComPingError         = metrics.QueryTotalCounter.WithLabelValues("Ping", "Error")
+	queryTotalCounterComFieldListOK       = metrics.QueryTotalCounter.WithLabelValues("FieldList", "OK")
+	queryTotalCounterComFieldListError    = metrics.QueryTotalCounter.WithLabelValues("FieldList", "Error")
+	queryTotalCounterComPrepareOK         = metrics.QueryTotalCounter.WithLabelValues("StmtPrepare", "OK")
+	queryTotalCounterComPrepareError      = metrics.QueryTotalCounter.WithLabelValues("StmtPrepare", "Error")
+	queryTotalCounterComExecuteOK         = metrics.QueryTotalCounter.WithLabelValues("StmtExecute", "OK")
+	queryTotalCounterComExecuteError      = metrics.QueryTotalCounter.WithLabelValues("StmtExecute", "Error")
+	queryTotalCounterComFetchOK           = metrics.QueryTotalCounter.WithLabelValues("StmtFetch", "OK")
+	queryTotalCounterComFetchError        = metrics.QueryTotalCounter.WithLabelValues("StmtFetch", "Error")
+	queryTotalCounterComCloseOK           = metrics.QueryTotalCounter.WithLabelValues("StmtClose", "OK")
+	queryTotalCounterComCloseError        = metrics.QueryTotalCounter.WithLabelValues("StmtClose", "Error")
+	queryTotalCounterComSendLongDataOK    = metrics.QueryTotalCounter.WithLabelValues("StmtSendLongData", "OK")
+	queryTotalCounterComSendLongDataError = metrics.QueryTotalCounter.WithLabelValues("StmtSendLongData", "Error")
+	queryTotalCounterComResetOK           = metrics.QueryTotalCounter.WithLabelValues("StmtReset", "OK")
+	queryTotalCounterComResetError        = metrics.QueryTotalCounter.WithLabelValues("StmtReset", "Error")
+	queryTotalCounterComSetOptionOK       = metrics.QueryTotalCounter.WithLabelValues("SetOption", "OK")
+	queryTotalCounterComSetOptionError    = metrics.QueryTotalCounter.WithLabelValues("SetOption", "Error")
+)
+
 func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
-	var label string
 	switch cmd {
 	case mysql.ComSleep:
-		label = "Sleep"
+		if err != nil {
+			queryTotalCounterComSleepError.Inc()
+		} else {
+			queryTotalCounterComSleepOK.Inc()
+		}
 	case mysql.ComQuit:
-		label = "Quit"
+		if err != nil {
+			queryTotalCounterComQuitError.Inc()
+		} else {
+			queryTotalCounterComQuitOK.Inc()
+		}
 	case mysql.ComQuery:
 		if cc.ctx.Value(sessionctx.LastExecuteDDL) != nil {
 			// Don't take DDL execute time into account.
 			// It's already recorded by other metrics in ddl package.
 			return
 		}
-		label = "Query"
+		if err != nil {
+			queryTotalCounterComQueryError.Inc()
+		} else {
+			queryTotalCounterComQueryOK.Inc()
+		}
 	case mysql.ComPing:
-		label = "Ping"
+		if err != nil {
+			queryTotalCounterComPingError.Inc()
+		} else {
+			queryTotalCounterComPingOK.Inc()
+		}
 	case mysql.ComInitDB:
-		label = "InitDB"
+		if err != nil {
+			queryTotalCounterComInitDBError.Inc()
+		} else {
+			queryTotalCounterComInitDBOK.Inc()
+		}
 	case mysql.ComFieldList:
-		label = "FieldList"
+		if err != nil {
+			queryTotalCounterComFieldListError.Inc()
+		} else {
+			queryTotalCounterComFieldListOK.Inc()
+		}
 	case mysql.ComStmtPrepare:
-		label = "StmtPrepare"
+		if err != nil {
+			queryTotalCounterComPrepareError.Inc()
+		} else {
+			queryTotalCounterComPrepareOK.Inc()
+		}
 	case mysql.ComStmtExecute:
-		label = "StmtExecute"
+		if err != nil {
+			queryTotalCounterComExecuteError.Inc()
+		} else {
+			queryTotalCounterComExecuteOK.Inc()
+		}
 	case mysql.ComStmtFetch:
-		label = "StmtFetch"
+		if err != nil {
+			queryTotalCounterComFetchError.Inc()
+		} else {
+			queryTotalCounterComFetchOK.Inc()
+		}
 	case mysql.ComStmtClose:
-		label = "StmtClose"
+		if err != nil {
+			queryTotalCounterComCloseError.Inc()
+		} else {
+			queryTotalCounterComCloseOK.Inc()
+		}
 	case mysql.ComStmtSendLongData:
-		label = "StmtSendLongData"
+		if err != nil {
+			queryTotalCounterComSendLongDataError.Inc()
+		} else {
+			queryTotalCounterComSendLongDataOK.Inc()
+		}
 	case mysql.ComStmtReset:
-		label = "StmtReset"
+		if err != nil {
+			queryTotalCounterComResetError.Inc()
+		} else {
+			queryTotalCounterComResetOK.Inc()
+		}
 	case mysql.ComSetOption:
-		label = "SetOption"
+		if err != nil {
+			queryTotalCounterComSetOptionError.Inc()
+		} else {
+			queryTotalCounterComSetOptionOK.Inc()
+		}
 	default:
-		label = strconv.Itoa(int(cmd))
-	}
-	if err != nil {
-		metrics.QueryTotalCounter.WithLabelValues(label, "Error").Inc()
-	} else {
-		metrics.QueryTotalCounter.WithLabelValues(label, "OK").Inc()
+		label := strconv.Itoa(int(cmd))
+		if err != nil {
+			metrics.QueryTotalCounter.WithLabelValues(label, "ERROR").Inc()
+		} else {
+			metrics.QueryTotalCounter.WithLabelValues(label, "OK").Inc()
+		}
 	}
 	stmtType := cc.ctx.GetSessionVars().StmtCtx.StmtType
 	sqlType := metrics.LblGeneral
 	if stmtType != "" {
 		sqlType = stmtType
 	}
-	metrics.QueryDurationHistogram.WithLabelValues(sqlType).Observe(time.Since(startTime).Seconds())
+
+	switch sqlType {
+	case "Use":
+		queryDurationHistogramUse.Observe(time.Since(startTime).Seconds())
+	case "Show":
+		queryDurationHistogramShow.Observe(time.Since(startTime).Seconds())
+	case "Begin":
+		queryDurationHistogramBegin.Observe(time.Since(startTime).Seconds())
+	case "Commit":
+		queryDurationHistogramCommit.Observe(time.Since(startTime).Seconds())
+	case "Rollback":
+		queryDurationHistogramRollback.Observe(time.Since(startTime).Seconds())
+	case "Insert":
+		queryDurationHistogramInsert.Observe(time.Since(startTime).Seconds())
+	case "Replace":
+		queryDurationHistogramReplace.Observe(time.Since(startTime).Seconds())
+	case "Delete":
+		queryDurationHistogramDelete.Observe(time.Since(startTime).Seconds())
+	case "Update":
+		queryDurationHistogramUpdate.Observe(time.Since(startTime).Seconds())
+	case "Select":
+		queryDurationHistogramSelect.Observe(time.Since(startTime).Seconds())
+	case metrics.LblGeneral:
+		queryDurationHistogramGeneral.Observe(time.Since(startTime).Seconds())
+	default:
+		metrics.QueryDurationHistogram.WithLabelValues(sqlType).Observe(time.Since(startTime).Seconds())
+	}
 }
+
+var (
+	queryDurationHistogramUse      = metrics.QueryDurationHistogram.WithLabelValues("Use")
+	queryDurationHistogramShow     = metrics.QueryDurationHistogram.WithLabelValues("Show")
+	queryDurationHistogramBegin    = metrics.QueryDurationHistogram.WithLabelValues("Begin")
+	queryDurationHistogramCommit   = metrics.QueryDurationHistogram.WithLabelValues("Commit")
+	queryDurationHistogramRollback = metrics.QueryDurationHistogram.WithLabelValues("Rollback")
+	queryDurationHistogramInsert   = metrics.QueryDurationHistogram.WithLabelValues("Insert")
+	queryDurationHistogramReplace  = metrics.QueryDurationHistogram.WithLabelValues("Replace")
+	queryDurationHistogramDelete   = metrics.QueryDurationHistogram.WithLabelValues("Delete")
+	queryDurationHistogramUpdate   = metrics.QueryDurationHistogram.WithLabelValues("Update")
+	queryDurationHistogramSelect   = metrics.QueryDurationHistogram.WithLabelValues("Select")
+	queryDurationHistogramGeneral  = metrics.QueryDurationHistogram.WithLabelValues(metrics.LblGeneral)
+)
 
 // dispatch handles client request based on command which is the first byte of the data.
 // It also gets a token from server which is used to limit the concurrently handling clients.

--- a/session/session.go
+++ b/session/session.go
@@ -361,6 +361,37 @@ func (s *session) doCommit(ctx context.Context) error {
 	return s.txn.Commit(sessionctx.SetCommitCtx(ctx, s))
 }
 
+var (
+	statementPerTransactionInternalOK    = metrics.StatementPerTransaction.WithLabelValues(metrics.LblInternal, "ok")
+	statementPerTransactionInternalError = metrics.StatementPerTransaction.WithLabelValues(metrics.LblInternal, "error")
+	statementPerTransactionGeneralOK     = metrics.StatementPerTransaction.WithLabelValues(metrics.LblGeneral, "ok")
+	statementPerTransactionGeneralError  = metrics.StatementPerTransaction.WithLabelValues(metrics.LblGeneral, "error")
+	transactionDurationInternalOK        = metrics.TransactionDuration.WithLabelValues(metrics.LblInternal, "ok")
+	transactionDurationInternalError     = metrics.TransactionDuration.WithLabelValues(metrics.LblInternal, "error")
+	transactionDurationGeneralOK         = metrics.TransactionDuration.WithLabelValues(metrics.LblGeneral, "ok")
+	transactionDurationGeneralError      = metrics.TransactionDuration.WithLabelValues(metrics.LblGeneral, "error")
+)
+
+func (s *session) recordTransactionFinishMetric(err error, counter int, duration float64) {
+	if s.isInternal() {
+		if err != nil {
+			statementPerTransactionInternalError.Observe(float64(counter))
+			transactionDurationInternalError.Observe(duration)
+		} else {
+			statementPerTransactionInternalOK.Observe(float64(counter))
+			transactionDurationInternalOK.Observe(duration)
+		}
+	} else {
+		if err != nil {
+			statementPerTransactionGeneralError.Observe(float64(counter))
+			transactionDurationGeneralError.Observe(duration)
+		} else {
+			statementPerTransactionGeneralOK.Observe(float64(counter))
+			transactionDurationGeneralOK.Observe(duration)
+		}
+	}
+}
+
 func (s *session) doCommitWithRetry(ctx context.Context) error {
 	var txnSize int
 	if s.txn.Valid() {
@@ -393,11 +424,9 @@ func (s *session) doCommitWithRetry(ctx context.Context) error {
 			err = s.retry(ctx, uint(maxRetryCount))
 		}
 	}
-	label := s.getSQLLabel()
 	counter := s.sessionVars.TxnCtx.StatementCount
 	duration := time.Since(s.GetSessionVars().TxnCtx.CreateTime).Seconds()
-	metrics.StatementPerTransaction.WithLabelValues(label, metrics.RetLabel(err)).Observe(float64(counter))
-	metrics.TransactionDuration.WithLabelValues(label, metrics.RetLabel(err)).Observe(float64(duration))
+	s.recordTransactionFinishMetric(err, counter, duration)
 	s.cleanRetryInfo()
 
 	if isoLevelOneShot := &s.sessionVars.TxnIsolationLevelOneShot; isoLevelOneShot.State != 0 {
@@ -443,14 +472,38 @@ func (s *session) CommitTxn(ctx context.Context) error {
 		s.sessionVars.StmtCtx.MergeExecDetails(nil, commitDetail)
 	}
 	stmt.LogSlowQuery(s.sessionVars.TxnCtx.StartTS, err == nil)
-	label := metrics.LblOK
-	if err != nil {
-		label = metrics.LblError
-	}
 	s.sessionVars.TxnCtx.Cleanup()
-	metrics.TransactionCounter.WithLabelValues(s.getSQLLabel(), label).Inc()
+	s.recordTransactionCounter(err)
 	return err
 }
+
+var (
+	transactionCounterInternalOK  = metrics.TransactionCounter.WithLabelValues(metrics.LblInternal, metrics.LblOK)
+	transactionCounterInternalErr = metrics.TransactionCounter.WithLabelValues(metrics.LblInternal, metrics.LblError)
+	transactionCounterGeneralOK   = metrics.TransactionCounter.WithLabelValues(metrics.LblGeneral, metrics.LblOK)
+	transactionCounterGeneralErr  = metrics.TransactionCounter.WithLabelValues(metrics.LblGeneral, metrics.LblError)
+)
+
+func (s *session) recordTransactionCounter(err error) {
+	if s.isInternal() {
+		if err != nil {
+			transactionCounterInternalErr.Inc()
+		} else {
+			transactionCounterInternalOK.Inc()
+		}
+	} else {
+		if err != nil {
+			transactionCounterGeneralErr.Inc()
+		} else {
+			transactionCounterGeneralOK.Inc()
+		}
+	}
+}
+
+var (
+	transactionRollbackCounterInternal = metrics.TransactionCounter.WithLabelValues(metrics.LblInternal, metrics.LblRollback)
+	transactionRollbackCounterGeneral  = metrics.TransactionCounter.WithLabelValues(metrics.LblGeneral, metrics.LblRollback)
+)
 
 func (s *session) RollbackTxn(ctx context.Context) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
@@ -460,7 +513,11 @@ func (s *session) RollbackTxn(ctx context.Context) {
 
 	if s.txn.Valid() {
 		terror.Log(s.txn.Rollback())
-		metrics.TransactionCounter.WithLabelValues(s.getSQLLabel(), metrics.LblRollback).Inc()
+		if s.isInternal() {
+			transactionRollbackCounterInternal.Inc()
+		} else {
+			transactionRollbackCounterGeneral.Inc()
+		}
 	}
 	s.cleanRetryInfo()
 	s.txn.changeToInvalid()
@@ -510,6 +567,10 @@ func (s *session) getSQLLabel() string {
 		return metrics.LblInternal
 	}
 	return metrics.LblGeneral
+}
+
+func (s *session) isInternal() bool {
+	return s.sessionVars.InRestrictedSQL
 }
 
 func (s *session) isRetryableError(err error) bool {
@@ -895,6 +956,11 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte) {
 	s.processInfo.Store(pi)
 }
 
+var (
+	sessionExecuteRunDurationInternal = metrics.SessionExecuteRunDuration.WithLabelValues(metrics.LblInternal)
+	sessionExecuteRunDurationGeneral  = metrics.SessionExecuteRunDuration.WithLabelValues(metrics.LblGeneral)
+)
+
 func (s *session) executeStatement(ctx context.Context, connID uint64, stmtNode ast.StmtNode, stmt sqlexec.Statement, recordSets []sqlexec.RecordSet) ([]sqlexec.RecordSet, error) {
 	s.SetValue(sessionctx.QueryString, stmt.OriginText())
 	if _, ok := stmtNode.(ast.DDLNode); ok {
@@ -914,7 +980,11 @@ func (s *session) executeStatement(ctx context.Context, connID uint64, stmtNode 
 		}
 		return nil, err
 	}
-	metrics.SessionExecuteRunDuration.WithLabelValues(s.getSQLLabel()).Observe(time.Since(startTime).Seconds())
+	if s.isInternal() {
+		sessionExecuteRunDurationInternal.Observe(time.Since(startTime).Seconds())
+	} else {
+		sessionExecuteRunDurationGeneral.Observe(time.Since(startTime).Seconds())
+	}
 
 	if recordSet != nil {
 		recordSets = append(recordSets, recordSet)
@@ -932,6 +1002,13 @@ func (s *session) Execute(ctx context.Context, sql string) (recordSets []sqlexec
 	}
 	return
 }
+
+var (
+	sessionExecuteCompileDurationInternal = metrics.SessionExecuteCompileDuration.WithLabelValues(metrics.LblInternal)
+	sessionExecuteCompileDurationGeneral  = metrics.SessionExecuteCompileDuration.WithLabelValues(metrics.LblGeneral)
+	sessionExecuteParseDurationInternal   = metrics.SessionExecuteParseDuration.WithLabelValues(metrics.LblInternal)
+	sessionExecuteParseDurationGeneral    = metrics.SessionExecuteParseDuration.WithLabelValues(metrics.LblGeneral)
+)
 
 func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec.RecordSet, err error) {
 	s.PrepareTxnCtx(ctx)
@@ -953,8 +1030,12 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 			zap.String("sql", sql))
 		return nil, util.SyntaxError(err)
 	}
-	label := s.getSQLLabel()
-	metrics.SessionExecuteParseDuration.WithLabelValues(label).Observe(time.Since(startTS).Seconds())
+	isInternal := s.isInternal()
+	if isInternal {
+		sessionExecuteParseDurationInternal.Observe(time.Since(startTS).Seconds())
+	} else {
+		sessionExecuteParseDurationGeneral.Observe(time.Since(startTS).Seconds())
+	}
 
 	compiler := executor.Compiler{Ctx: s}
 	for _, stmtNode := range stmtNodes {
@@ -974,7 +1055,11 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 				zap.String("sql", sql))
 			return nil, err
 		}
-		metrics.SessionExecuteCompileDuration.WithLabelValues(label).Observe(time.Since(startTS).Seconds())
+		if isInternal {
+			sessionExecuteCompileDurationInternal.Observe(time.Since(startTS).Seconds())
+		} else {
+			sessionExecuteCompileDurationGeneral.Observe(time.Since(startTS).Seconds())
+		}
 		s.currentPlan = stmt.Plan
 
 		// Step3: Execute the physical plan.

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -269,7 +269,7 @@ func (sc *StatementContext) WarningCount() uint16 {
 
 const zero = "0"
 
-// NumWarnings gets warning and error count.
+// NumErrorWarnings gets warning and error count.
 // is set).
 func (sc *StatementContext) NumErrorWarnings() (ec, wc string) {
 	var (

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -689,6 +689,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBEnableRadixJoin, BoolToIntStr(DefTiDBUseRadixJoin)},
 	{ScopeSession, TiDBCheckMb4ValueInUTF8, BoolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUTF8)},
 	{ScopeSession, TiDBSlowQueryFile, ""},
+	{ScopeSession, TiDBDebugMode, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -246,6 +246,9 @@ const (
 
 	// TiDBEnableFastAnalyze indicates to use fast analyze.
 	TiDBEnableFastAnalyze = "tidb_enable_fast_analyze"
+
+	// TiDBDebugMode indicates whether running in diagnosis mode which will log more metrics.
+	TiDBDebugMode = "tidb_debug_mode"
 )
 
 // Default TiDB system variable values.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -124,6 +124,8 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 		return config.GetGlobalConfig().Plugin.Load, true, nil
 	case TiDBCheckMb4ValueInUTF8:
 		return BoolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUTF8), true, nil
+	case TiDBDebugMode:
+		return strconv.Itoa(config.GetGlobalConfig().DebugMode), true, nil
 	}
 	sVal, ok := s.systems[key]
 	if ok {

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -207,7 +207,6 @@ func (a *connArray) Init(addr string, security config.Security) error {
 
 	var unaryInterceptor grpc.UnaryClientInterceptor
 	var streamInterceptor grpc.StreamClientInterceptor
-
 	if config.GetGlobalConfig().DebugMode > 0 {
 		unaryInterceptor = grpc_prometheus.UnaryClientInterceptor
 		streamInterceptor = grpc_prometheus.StreamClientInterceptor

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -205,8 +205,13 @@ func (a *connArray) Init(addr string, security config.Security) error {
 		opt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	unaryInterceptor := grpc_prometheus.UnaryClientInterceptor
-	streamInterceptor := grpc_prometheus.StreamClientInterceptor
+	var unaryInterceptor grpc.UnaryClientInterceptor
+	var streamInterceptor grpc.StreamClientInterceptor
+
+	if config.GetGlobalConfig().DebugMode > 0 {
+		unaryInterceptor = grpc_prometheus.UnaryClientInterceptor
+		streamInterceptor = grpc_prometheus.StreamClientInterceptor
+	}
 	cfg := config.GetGlobalConfig()
 	if cfg.OpenTracing.Enable {
 		unaryInterceptor = grpc_middleware.ChainUnaryClient(

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -566,12 +566,14 @@ func sendBatchRequest(
 
 // SendRequest sends a Request to server and receives Response.
 func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
-	start := time.Now()
-	reqType := req.Type.String()
-	storeID := strconv.FormatUint(req.Context.GetPeer().GetStoreId(), 10)
-	defer func() {
-		metrics.TiKVSendReqHistogram.WithLabelValues(reqType, storeID).Observe(time.Since(start).Seconds())
-	}()
+	if config.GetGlobalConfig().DebugMode > 0 {
+		start := time.Now()
+		reqType := req.Type.String()
+		storeID := strconv.FormatUint(req.Context.GetPeer().GetStoreId(), 10)
+		defer func() {
+			metrics.TiKVSendReqHistogram.WithLabelValues(reqType, storeID).Observe(time.Since(start).Seconds())
+		}()
+	}
 
 	connArray, err := c.getConnArray(addr)
 	if err != nil {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -279,9 +279,11 @@ func buildCopTasks(bo *Backoffer, cache *RegionCache, ranges *copRanges, desc bo
 			zap.Int("range len", rangesLen),
 			zap.Int("task len", len(tasks)))
 	}
-	metrics.TiKVTxnRegionsNumHistogram.WithLabelValues("coprocessor").Observe(float64(len(tasks)))
+	tikvTxnRegionsNumHistogramWithCoprocessor.Observe(float64(len(tasks)))
 	return tasks, nil
 }
+
+var tikvTxnRegionsNumHistogramWithCoprocessor = metrics.TiKVTxnRegionsNumHistogram.WithLabelValues("coprocessor")
 
 func splitRanges(bo *Backoffer, cache *RegionCache, ranges *copRanges, fn func(region RegionVerID, ranges *copRanges)) error {
 	for ranges.len() > 0 {

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -51,13 +51,19 @@ type Driver struct {
 }
 
 func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, error) {
+	var unaryInterceptor grpc.UnaryClientInterceptor
+	var streamInterceptor grpc.StreamClientInterceptor
+	if config.GetGlobalConfig().DebugMode > 0 {
+		unaryInterceptor = grpc_prometheus.UnaryClientInterceptor
+		streamInterceptor = grpc_prometheus.StreamClientInterceptor
+	}
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:        addrs,
 		AutoSyncInterval: 30 * time.Second,
 		DialTimeout:      5 * time.Second,
 		DialOptions: []grpc.DialOption{
-			grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
-			grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+			grpc.WithUnaryInterceptor(unaryInterceptor),
+			grpc.WithStreamInterceptor(streamInterceptor),
 		},
 		TLS: tlsConfig,
 	})

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -78,10 +78,20 @@ func (c *RawKVClient) ClusterID() uint64 {
 	return c.clusterID
 }
 
+var (
+	tikvRawkvCmdHistogramWithGet           = metrics.TiKVRawkvCmdHistogram.WithLabelValues("get")
+	tikvRawkvCmdHistogramWithBatchGet      = metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_get")
+	tikvRawkvCmdHistogramWithBatchPut      = metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_put")
+	tikvRawkvCmdHistogramWithDelete        = metrics.TiKVRawkvCmdHistogram.WithLabelValues("delete")
+	tikvRawkvCmdHistogramWithBatchDelete   = metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_delete")
+	tikvRawkvCmdHistogramWithRawScan       = metrics.TiKVRawkvCmdHistogram.WithLabelValues("raw_scan")
+	tikvRawkvCmdHistogramWithRawReversScan = metrics.TiKVRawkvCmdHistogram.WithLabelValues("raw_reverse_scan")
+)
+
 // Get queries value with the key. When the key does not exist, it returns `nil, nil`.
 func (c *RawKVClient) Get(key []byte) ([]byte, error) {
 	start := time.Now()
-	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("get").Observe(time.Since(start).Seconds()) }()
+	defer func() { tikvRawkvCmdHistogramWithGet.Observe(time.Since(start).Seconds()) }()
 
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawGet,
@@ -110,7 +120,7 @@ func (c *RawKVClient) Get(key []byte) ([]byte, error) {
 func (c *RawKVClient) BatchGet(keys [][]byte) ([][]byte, error) {
 	start := time.Now()
 	defer func() {
-		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_get").Observe(time.Since(start).Seconds())
+		tikvRawkvCmdHistogramWithBatchGet.Observe(time.Since(start).Seconds())
 	}()
 
 	bo := NewBackoffer(context.Background(), rawkvMaxBackoff)
@@ -136,12 +146,17 @@ func (c *RawKVClient) BatchGet(keys [][]byte) ([][]byte, error) {
 	return values, nil
 }
 
+var (
+	tikvRawkvSizeHistogramWithKey   = metrics.TiKVRawkvSizeHistogram.WithLabelValues("key")
+	tikvRawkvSizeHistogramWithValue = metrics.TiKVRawkvSizeHistogram.WithLabelValues("value")
+)
+
 // Put stores a key-value pair to TiKV.
 func (c *RawKVClient) Put(key, value []byte) error {
 	start := time.Now()
-	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("put").Observe(time.Since(start).Seconds()) }()
-	metrics.TiKVRawkvSizeHistogram.WithLabelValues("key").Observe(float64(len(key)))
-	metrics.TiKVRawkvSizeHistogram.WithLabelValues("value").Observe(float64(len(value)))
+	defer func() { tikvRawkvCmdHistogramWithBatchPut.Observe(time.Since(start).Seconds()) }()
+	tikvRawkvSizeHistogramWithKey.Observe(float64(len(key)))
+	tikvRawkvSizeHistogramWithValue.Observe(float64(len(value)))
 
 	if len(value) == 0 {
 		return errors.New("empty value is not supported")
@@ -172,7 +187,7 @@ func (c *RawKVClient) Put(key, value []byte) error {
 func (c *RawKVClient) BatchPut(keys, values [][]byte) error {
 	start := time.Now()
 	defer func() {
-		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_put").Observe(time.Since(start).Seconds())
+		tikvRawkvCmdHistogramWithBatchPut.Observe(time.Since(start).Seconds())
 	}()
 
 	if len(keys) != len(values) {
@@ -191,7 +206,7 @@ func (c *RawKVClient) BatchPut(keys, values [][]byte) error {
 // Delete deletes a key-value pair from TiKV.
 func (c *RawKVClient) Delete(key []byte) error {
 	start := time.Now()
-	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("delete").Observe(time.Since(start).Seconds()) }()
+	defer func() { tikvRawkvCmdHistogramWithDelete.Observe(time.Since(start).Seconds()) }()
 
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawDelete,
@@ -217,7 +232,7 @@ func (c *RawKVClient) Delete(key []byte) error {
 func (c *RawKVClient) BatchDelete(keys [][]byte) error {
 	start := time.Now()
 	defer func() {
-		metrics.TiKVRawkvCmdHistogram.WithLabelValues("batch_delete").Observe(time.Since(start).Seconds())
+		tikvRawkvCmdHistogramWithBatchDelete.Observe(time.Since(start).Seconds())
 	}()
 
 	bo := NewBackoffer(context.Background(), rawkvMaxBackoff)
@@ -275,7 +290,7 @@ func (c *RawKVClient) DeleteRange(startKey []byte, endKey []byte) error {
 // `Scan(append(startKey, '\0'), append(endKey, '\0'), limit)`.
 func (c *RawKVClient) Scan(startKey, endKey []byte, limit int) (keys [][]byte, values [][]byte, err error) {
 	start := time.Now()
-	defer func() { metrics.TiKVRawkvCmdHistogram.WithLabelValues("raw_scan").Observe(time.Since(start).Seconds()) }()
+	defer func() { tikvRawkvCmdHistogramWithRawScan.Observe(time.Since(start).Seconds()) }()
 
 	if limit > MaxRawKVScanLimit {
 		return nil, nil, errors.Trace(ErrMaxScanLimitExceeded)
@@ -320,7 +335,7 @@ func (c *RawKVClient) Scan(startKey, endKey []byte, limit int) (keys [][]byte, v
 func (c *RawKVClient) ReverseScan(startKey, endKey []byte, limit int) (keys [][]byte, values [][]byte, err error) {
 	start := time.Now()
 	defer func() {
-		metrics.TiKVRawkvCmdHistogram.WithLabelValues("raw_reverse_scan").Observe(time.Since(start).Seconds())
+		tikvRawkvCmdHistogramWithRawReversScan.Observe(time.Since(start).Seconds())
 	}()
 
 	if limit > MaxRawKVScanLimit {

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -363,12 +363,22 @@ func (c *RegionCache) getRegionByIDFromCache(regionID uint64) *Region {
 	return nil
 }
 
+var (
+	tikvRegionCacheCounterWithDropRegionFromCacheOK = metrics.TiKVRegionCacheCounter.WithLabelValues("drop_region_from_cache", "ok")
+	tikvRegionCacheCounterWithGetRegionByIDOK       = metrics.TiKVRegionCacheCounter.WithLabelValues("get_region_by_id", "ok")
+	tikvRegionCacheCounterWithGetRegionByIDError    = metrics.TiKVRegionCacheCounter.WithLabelValues("get_region_by_id", "err")
+	tikvRegionCacheCounterWithGetRegionOK           = metrics.TiKVRegionCacheCounter.WithLabelValues("get_region", "ok")
+	tikvRegionCacheCounterWithGetRegionError        = metrics.TiKVRegionCacheCounter.WithLabelValues("get_region", "err")
+	tikvRegionCacheCounterWithGetStoreOK            = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "ok")
+	tikvRegionCacheCounterWithGetStoreError         = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "err")
+)
+
 func (c *RegionCache) dropRegionFromCache(verID RegionVerID) {
 	r, ok := c.mu.regions[verID]
 	if !ok {
 		return
 	}
-	metrics.TiKVRegionCacheCounter.WithLabelValues("drop_region_from_cache", metrics.RetLabel(nil)).Inc()
+	tikvRegionCacheCounterWithDropRegionFromCacheOK.Inc()
 	c.mu.sorted.Delete(newBtreeItem(r.region))
 	delete(c.mu.regions, verID)
 }
@@ -393,7 +403,11 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 		} else {
 			meta, leader, err = c.pdClient.GetRegion(bo.ctx, key)
 		}
-		metrics.TiKVRegionCacheCounter.WithLabelValues("get_region", metrics.RetLabel(err)).Inc()
+		if err != nil {
+			tikvRegionCacheCounterWithGetRegionError.Inc()
+		} else {
+			tikvRegionCacheCounterWithGetRegionOK.Inc()
+		}
 		if err != nil {
 			backoffErr = errors.Errorf("loadRegion from PD failed, key: %q, err: %v", key, err)
 			continue
@@ -431,7 +445,11 @@ func (c *RegionCache) loadRegionByID(bo *Backoffer, regionID uint64) (*Region, e
 			}
 		}
 		meta, leader, err := c.pdClient.GetRegionByID(bo.ctx, regionID)
-		metrics.TiKVRegionCacheCounter.WithLabelValues("get_region_by_id", metrics.RetLabel(err)).Inc()
+		if err != nil {
+			tikvRegionCacheCounterWithGetRegionByIDError.Inc()
+		} else {
+			tikvRegionCacheCounterWithGetRegionByIDOK.Inc()
+		}
 		if err != nil {
 			backoffErr = errors.Errorf("loadRegion from PD failed, regionID: %v, err: %v", regionID, err)
 			continue
@@ -492,7 +510,11 @@ func (c *RegionCache) ClearStoreByID(id uint64) {
 func (c *RegionCache) loadStoreAddr(bo *Backoffer, id uint64) (string, error) {
 	for {
 		store, err := c.pdClient.GetStore(bo.ctx, id)
-		metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", metrics.RetLabel(err)).Inc()
+		if err != nil {
+			tikvRegionCacheCounterWithGetStoreError.Inc()
+		} else {
+			tikvRegionCacheCounterWithGetStoreOK.Inc()
+		}
 		if err != nil {
 			if errors.Cause(err) == context.Canceled {
 				return "", errors.Trace(err)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -66,6 +66,12 @@ func (s *tikvSnapshot) SetPriority(priority int) {
 	s.priority = pb.CommandPri(priority)
 }
 
+var (
+	tikvTxnCmdCounterWithBatchGet          = metrics.TiKVTxnCmdCounter.WithLabelValues("batch_get")
+	tikvTxnCmdHistogramWithBatchGet        = metrics.TiKVTxnCmdHistogram.WithLabelValues("batch_get")
+	tikvTxnRegionsNumHistogramWithSnapshot = metrics.TiKVTxnRegionsNumHistogram.WithLabelValues("snapshot")
+)
+
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
 // The map will not contain nonexistent keys.
 func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
@@ -73,9 +79,9 @@ func (s *tikvSnapshot) BatchGet(keys []kv.Key) (map[string][]byte, error) {
 	if len(keys) == 0 {
 		return m, nil
 	}
-	metrics.TiKVTxnCmdCounter.WithLabelValues("batch_get").Inc()
+	tikvTxnCmdCounterWithBatchGet.Inc()
 	start := time.Now()
-	defer func() { metrics.TiKVTxnCmdHistogram.WithLabelValues("batch_get").Observe(time.Since(start).Seconds()) }()
+	defer func() { tikvTxnCmdHistogramWithBatchGet.Observe(time.Since(start).Seconds()) }()
 
 	// We want [][]byte instead of []kv.Key, use some magic to save memory.
 	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
@@ -110,7 +116,7 @@ func (s *tikvSnapshot) batchGetKeysByRegions(bo *Backoffer, keys [][]byte, colle
 		return errors.Trace(err)
 	}
 
-	metrics.TiKVTxnRegionsNumHistogram.WithLabelValues("snapshot").Observe(float64(len(groups)))
+	tikvTxnRegionsNumHistogramWithSnapshot.Observe(float64(len(groups)))
 
 	var batches []batchKeys
 	for id, g := range groups {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -24,7 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/mysql"
@@ -86,6 +86,7 @@ const (
 	nmTokenLimit       = "token-limit"
 	nmPluginDir        = "plugin-dir"
 	nmPluginLoad       = "plugin-load"
+	nmDebugMode        = "debug-mode"
 
 	nmProxyProtocolNetworks      = "proxy-protocol-networks"
 	nmProxyProtocolHeaderTimeout = "proxy-protocol-header-timeout"
@@ -111,6 +112,7 @@ var (
 	tokenLimit       = flag.Int(nmTokenLimit, 1000, "the limit of concurrent executed sessions")
 	pluginDir        = flag.String(nmPluginDir, "/data/deploy/plugin", "the folder that hold plugin")
 	pluginLoad       = flag.String(nmPluginLoad, "", "wait load plugin name(separated by comma)")
+	debugMode        = flag.String(nmDebugMode, "0", "tidb debug mode.")
 
 	// Log
 	logLevel     = flag.String(nmLogLevel, "info", "log level: info, debug, warn, error, fatal")
@@ -367,6 +369,11 @@ func overrideConfig() {
 	}
 	if actualFlags[nmPluginDir] {
 		cfg.Plugin.Dir = *pluginDir
+	}
+	if actualFlags[nmDebugMode] {
+		d, err := strconv.Atoi(*debugMode)
+		terror.MustNil(err)
+		cfg.DebugMode = d
 	}
 
 	// Log


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- prometheus's `WithLabelValues` will require heavy mutex/hash operation in pprof 
- opentracing stack exists in pprof even if we doesn't run sql with `trace select ...`
- grpc run with prometheus's wrapper by default but our grafana don't use them

### What is changed and how it works?

- prev with fixed label value and assgin to local at once
- remove opentracing call when we run sql without `trace sql`
- remove grpc client's prometheus's wrapper when it's not `debug mode`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
-  sysbench point-get

run sysbench point-get with 1 tidb , 1pd, 1 unionstore(master) in my laptop

before this pr:

```
sysbench --config-file=tidb-config oltp_point_select --tables=32 --threads=32 --table-size=100000 run   
Unknown argument type: 0Unknown argument type: 0sysbench 1.1.0-c0bbed6 (using bundled LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 32
Report intermediate results every 5 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 5s ] thds: 32 tps: 37192.07 qps: 37192.07 (r/w/o: 37192.07/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 32 tps: 36009.02 qps: 36009.02 (r/w/o: 36009.02/0.00/0.00) lat (ms,95%): 1.76 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 32 tps: 37087.25 qps: 37087.25 (r/w/o: 37087.25/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 32 tps: 36230.77 qps: 36230.77 (r/w/o: 36230.77/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 32 tps: 36506.36 qps: 36506.36 (r/w/o: 36506.36/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 32 tps: 36427.74 qps: 36427.74 (r/w/o: 36427.74/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 32 tps: 36623.29 qps: 36623.29 (r/w/o: 36623.29/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 32 tps: 36370.51 qps: 36370.51 (r/w/o: 36370.51/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 32 tps: 36492.56 qps: 36492.56 (r/w/o: 36492.56/0.00/0.00) lat (ms,95%): 1.76 err/s: 0.00 reconn/s: 0.00
[ 50s ] thds: 32 tps: 35857.27 qps: 35857.27 (r/w/o: 35857.27/0.00/0.00) lat (ms,95%): 1.79 err/s: 0.00 reconn/s: 0.00
[ 55s ] thds: 32 tps: 36534.97 qps: 36534.97 (r/w/o: 36534.97/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 60s ] thds: 32 tps: 36695.14 qps: 36695.14 (r/w/o: 36695.14/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 65s ] thds: 32 tps: 36360.68 qps: 36360.68 (r/w/o: 36360.68/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 70s ] thds: 32 tps: 35787.92 qps: 35787.92 (r/w/o: 35787.92/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 75s ] thds: 32 tps: 36527.31 qps: 36527.31 (r/w/o: 36527.31/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 80s ] thds: 32 tps: 36316.72 qps: 36316.72 (r/w/o: 36316.72/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 85s ] thds: 32 tps: 36236.60 qps: 36236.60 (r/w/o: 36236.60/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 90s ] thds: 32 tps: 36512.32 qps: 36512.32 (r/w/o: 36512.32/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 95s ] thds: 32 tps: 36766.68 qps: 36766.68 (r/w/o: 36766.68/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 100s ] thds: 32 tps: 37001.98 qps: 37001.98 (r/w/o: 37001.98/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 105s ] thds: 32 tps: 37152.54 qps: 37152.54 (r/w/o: 37152.54/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 110s ] thds: 32 tps: 37147.89 qps: 37147.89 (r/w/o: 37147.89/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 115s ] thds: 32 tps: 37132.60 qps: 37132.60 (r/w/o: 37132.60/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 120s ] thds: 32 tps: 36888.23 qps: 36888.23 (r/w/o: 36888.23/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 125s ] thds: 32 tps: 36449.69 qps: 36449.69 (r/w/o: 36449.69/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 130s ] thds: 32 tps: 36820.11 qps: 36820.11 (r/w/o: 36820.11/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 135s ] thds: 32 tps: 36670.81 qps: 36670.81 (r/w/o: 36670.81/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 140s ] thds: 32 tps: 36791.14 qps: 36791.14 (r/w/o: 36791.14/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 145s ] thds: 32 tps: 36319.64 qps: 36319.64 (r/w/o: 36319.64/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 150s ] thds: 32 tps: 36910.19 qps: 36910.19 (r/w/o: 36910.19/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 155s ] thds: 32 tps: 36434.97 qps: 36434.97 (r/w/o: 36434.97/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 160s ] thds: 32 tps: 36446.83 qps: 36446.83 (r/w/o: 36446.83/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 165s ] thds: 32 tps: 37179.51 qps: 37179.51 (r/w/o: 37179.51/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 170s ] thds: 32 tps: 37430.92 qps: 37430.92 (r/w/o: 37430.92/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 175s ] thds: 32 tps: 37292.76 qps: 37292.76 (r/w/o: 37292.76/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 180s ] thds: 32 tps: 37335.57 qps: 37335.57 (r/w/o: 37335.57/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 185s ] thds: 32 tps: 35354.86 qps: 35354.86 (r/w/o: 35354.86/0.00/0.00) lat (ms,95%): 1.73 err/s: 0.00 reconn/s: 0.00
[ 190s ] thds: 32 tps: 36876.84 qps: 36876.84 (r/w/o: 36876.84/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 195s ] thds: 32 tps: 37123.33 qps: 37123.33 (r/w/o: 37123.33/0.00/0.00) lat (ms,95%): 1.61 err/s: 0.00 reconn/s: 0.00
[ 200s ] thds: 32 tps: 37001.36 qps: 37001.36 (r/w/o: 37001.36/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 205s ] thds: 32 tps: 37001.62 qps: 37001.62 (r/w/o: 37001.62/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 210s ] thds: 32 tps: 36687.51 qps: 36687.51 (r/w/o: 36687.51/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 215s ] thds: 32 tps: 36897.51 qps: 36897.51 (r/w/o: 36897.51/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 220s ] thds: 32 tps: 36460.74 qps: 36460.74 (r/w/o: 36460.74/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 225s ] thds: 32 tps: 36807.67 qps: 36807.67 (r/w/o: 36807.67/0.00/0.00) lat (ms,95%): 1.61 err/s: 0.00 reconn/s: 0.00
[ 230s ] thds: 32 tps: 36907.49 qps: 36907.49 (r/w/o: 36907.49/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 235s ] thds: 32 tps: 36627.26 qps: 36627.26 (r/w/o: 36627.26/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 240s ] thds: 32 tps: 36593.21 qps: 36593.21 (r/w/o: 36593.21/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 245s ] thds: 32 tps: 36789.74 qps: 36789.74 (r/w/o: 36789.74/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 250s ] thds: 32 tps: 36879.52 qps: 36879.52 (r/w/o: 36879.52/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 255s ] thds: 32 tps: 36554.33 qps: 36554.33 (r/w/o: 36554.33/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 260s ] thds: 32 tps: 36529.86 qps: 36529.86 (r/w/o: 36529.86/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 265s ] thds: 32 tps: 36711.03 qps: 36711.03 (r/w/o: 36711.03/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 270s ] thds: 32 tps: 36862.05 qps: 36862.05 (r/w/o: 36862.05/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 275s ] thds: 32 tps: 36332.89 qps: 36332.89 (r/w/o: 36332.89/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 280s ] thds: 32 tps: 36360.91 qps: 36360.91 (r/w/o: 36360.91/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 285s ] thds: 32 tps: 36873.78 qps: 36873.78 (r/w/o: 36873.78/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
[ 290s ] thds: 32 tps: 36196.82 qps: 36196.82 (r/w/o: 36196.82/0.00/0.00) lat (ms,95%): 1.70 err/s: 0.00 reconn/s: 0.00
[ 295s ] thds: 32 tps: 36508.55 qps: 36508.55 (r/w/o: 36508.55/0.00/0.00) lat (ms,95%): 1.67 err/s: 0.00 reconn/s: 0.00
[ 300s ] thds: 32 tps: 36547.64 qps: 36547.64 (r/w/o: 36547.64/0.00/0.00) lat (ms,95%): 1.64 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            10997248
        write:                           0
        other:                           0
        total:                           10997248
    transactions:                        10997248 (36656.71 per sec.)
    queries:                             10997248 (36656.71 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

Throughput:
    events/s (eps):                      36656.7142
    time elapsed:                        300.0064s
    total number of events:              10997248

Latency (ms):
         min:                                    0.14
         avg:                                    0.87
         max:                                   28.64
         95th percentile:                        1.70
         sum:                              9592300.25

Threads fairness:
    events (avg/stddev):           343664.0000/349.44
    execution time (avg/stddev):   299.7594/0.01

```

after this 

```
sysbench --config-file=tidb-config oltp_point_select --tables=32 --threads=32 --table-size=100000 run   
Unknown argument type: 0Unknown argument type: 0sysbench 1.1.0-c0bbed6 (using bundled LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 32
Report intermediate results every 5 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 5s ] thds: 32 tps: 41333.86 qps: 41333.86 (r/w/o: 41333.86/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 32 tps: 40846.79 qps: 40846.79 (r/w/o: 40846.79/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 32 tps: 41019.58 qps: 41019.58 (r/w/o: 41019.58/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 32 tps: 40536.73 qps: 40536.73 (r/w/o: 40536.73/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 32 tps: 40711.61 qps: 40711.61 (r/w/o: 40711.61/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 32 tps: 40799.22 qps: 40799.22 (r/w/o: 40799.22/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 32 tps: 40573.79 qps: 40573.79 (r/w/o: 40573.79/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 32 tps: 40571.52 qps: 40571.52 (r/w/o: 40571.52/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 32 tps: 40942.46 qps: 40942.46 (r/w/o: 40942.46/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 50s ] thds: 32 tps: 40533.36 qps: 40533.36 (r/w/o: 40533.36/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 55s ] thds: 32 tps: 40448.16 qps: 40448.16 (r/w/o: 40448.16/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 60s ] thds: 32 tps: 40663.91 qps: 40663.91 (r/w/o: 40663.91/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 65s ] thds: 32 tps: 40557.97 qps: 40557.97 (r/w/o: 40557.97/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 70s ] thds: 32 tps: 39962.69 qps: 39962.69 (r/w/o: 39962.69/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 75s ] thds: 32 tps: 40248.64 qps: 40248.64 (r/w/o: 40248.64/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 80s ] thds: 32 tps: 40497.06 qps: 40497.06 (r/w/o: 40497.06/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 85s ] thds: 32 tps: 40080.60 qps: 40080.60 (r/w/o: 40080.60/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 90s ] thds: 32 tps: 40403.85 qps: 40403.85 (r/w/o: 40403.85/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 95s ] thds: 32 tps: 40542.22 qps: 40542.22 (r/w/o: 40542.22/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 100s ] thds: 32 tps: 40773.42 qps: 40773.42 (r/w/o: 40773.42/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 105s ] thds: 32 tps: 40909.28 qps: 40909.28 (r/w/o: 40909.28/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 110s ] thds: 32 tps: 40455.26 qps: 40455.26 (r/w/o: 40455.26/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 115s ] thds: 32 tps: 40387.26 qps: 40387.26 (r/w/o: 40387.26/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 120s ] thds: 32 tps: 40977.52 qps: 40977.52 (r/w/o: 40977.52/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 125s ] thds: 32 tps: 40734.28 qps: 40734.28 (r/w/o: 40734.28/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 130s ] thds: 32 tps: 40318.51 qps: 40318.51 (r/w/o: 40318.51/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 135s ] thds: 32 tps: 40345.74 qps: 40345.74 (r/w/o: 40345.74/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 140s ] thds: 32 tps: 40609.52 qps: 40609.52 (r/w/o: 40609.52/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 145s ] thds: 32 tps: 40253.38 qps: 40253.38 (r/w/o: 40253.38/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 150s ] thds: 32 tps: 40720.80 qps: 40720.80 (r/w/o: 40720.80/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 155s ] thds: 32 tps: 40543.30 qps: 40543.30 (r/w/o: 40543.30/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 160s ] thds: 32 tps: 40050.42 qps: 40050.42 (r/w/o: 40050.42/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 165s ] thds: 32 tps: 40896.46 qps: 40896.46 (r/w/o: 40896.46/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 170s ] thds: 32 tps: 39034.16 qps: 39034.16 (r/w/o: 39034.16/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 175s ] thds: 32 tps: 38965.23 qps: 38965.23 (r/w/o: 38965.23/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 180s ] thds: 32 tps: 40076.24 qps: 40076.24 (r/w/o: 40076.24/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 185s ] thds: 32 tps: 39873.56 qps: 39873.56 (r/w/o: 39873.56/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 190s ] thds: 32 tps: 40225.93 qps: 40225.93 (r/w/o: 40225.93/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 195s ] thds: 32 tps: 39978.25 qps: 39978.25 (r/w/o: 39978.25/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 200s ] thds: 32 tps: 39060.11 qps: 39060.11 (r/w/o: 39060.11/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 205s ] thds: 32 tps: 39789.40 qps: 39789.40 (r/w/o: 39789.40/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 210s ] thds: 32 tps: 40095.31 qps: 40095.31 (r/w/o: 40095.31/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 215s ] thds: 32 tps: 40090.20 qps: 40090.20 (r/w/o: 40090.20/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 220s ] thds: 32 tps: 40010.11 qps: 40010.11 (r/w/o: 40010.11/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 225s ] thds: 32 tps: 40140.50 qps: 40140.50 (r/w/o: 40140.50/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 230s ] thds: 32 tps: 39594.73 qps: 39594.73 (r/w/o: 39594.73/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 235s ] thds: 32 tps: 39474.16 qps: 39474.16 (r/w/o: 39474.16/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 240s ] thds: 32 tps: 39745.96 qps: 39745.96 (r/w/o: 39745.96/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 245s ] thds: 32 tps: 40217.78 qps: 40217.78 (r/w/o: 40217.78/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 250s ] thds: 32 tps: 39946.98 qps: 39946.98 (r/w/o: 39946.98/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 255s ] thds: 32 tps: 40228.24 qps: 40228.24 (r/w/o: 40228.24/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 260s ] thds: 32 tps: 39640.51 qps: 39640.51 (r/w/o: 39640.51/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 265s ] thds: 32 tps: 39914.15 qps: 39914.15 (r/w/o: 39914.15/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 270s ] thds: 32 tps: 39161.59 qps: 39161.59 (r/w/o: 39161.59/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 275s ] thds: 32 tps: 40124.40 qps: 40124.40 (r/w/o: 40124.40/0.00/0.00) lat (ms,95%): 1.47 err/s: 0.00 reconn/s: 0.00
[ 280s ] thds: 32 tps: 40120.86 qps: 40120.86 (r/w/o: 40120.86/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 285s ] thds: 32 tps: 39865.57 qps: 39865.57 (r/w/o: 39865.57/0.00/0.00) lat (ms,95%): 1.52 err/s: 0.00 reconn/s: 0.00
[ 290s ] thds: 32 tps: 39086.00 qps: 39086.00 (r/w/o: 39086.00/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
[ 295s ] thds: 32 tps: 40042.72 qps: 40042.72 (r/w/o: 40042.72/0.00/0.00) lat (ms,95%): 1.50 err/s: 0.00 reconn/s: 0.00
[ 300s ] thds: 32 tps: 38923.58 qps: 38923.58 (r/w/o: 38923.58/0.00/0.00) lat (ms,95%): 1.55 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            12063493
        write:                           0
        other:                           0
        total:                           12063493
    transactions:                        12063493 (40210.99 per sec.)
    queries:                             12063493 (40210.99 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

Throughput:
    events/s (eps):                      40210.9893
    time elapsed:                        300.0049s
    total number of events:              12063493

Latency (ms):
         min:                                    0.12
         avg:                                    0.80
         max:                                   27.31
         95th percentile:                        1.52
         sum:                              9591690.90

Threads fairness:
    events (avg/stddev):           376984.1562/300.90
    execution time (avg/stddev):   299.7403/0.01

```

Code changes

 - implement change

Side effects

 - Increased code complexity

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10158)
<!-- Reviewable:end -->
