### PR TITLE
 cmd/pluginpkg: support relative path

### DIFF
--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -99,8 +99,19 @@ func main() {
 	if pkgDir == "" || outDir == "" {
 		flag.Usage()
 	}
+	pkgDir, err := filepath.Abs(pkgDir)
+	if err != nil {
+		log.Printf("unable to resolve absolute representation of package path , %+v\n", err)
+		flag.Usage()
+	}
+	outDir, err := filepath.Abs(outDir)
+	if err != nil {
+		log.Printf("unable to resolve absolute representation of output path , %+v\n", err)
+		flag.Usage()
+	}
+
 	var manifest map[string]interface{}
-	_, err := toml.DecodeFile(filepath.Join(pkgDir, "manifest.toml"), &manifest)
+	_, err = toml.DecodeFile(filepath.Join(pkgDir, "manifest.toml"), &manifest)
 	if err != nil {
 		log.Printf("read pkg %s's manifest failure, %+v\n", pkgDir, err)
 		os.Exit(1)
@@ -150,6 +161,7 @@ func main() {
 		"-ldflags", pluginPath,
 		"-buildmode=plugin",
 		"-o", outputFile, pkgDir)
+	buildCmd.Dir = pkgDir
 	buildCmd.Stderr = os.Stderr
 	buildCmd.Stdout = os.Stdout
 	buildCmd.Env = append(os.Environ(), "GO111MODULE=on")

--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -89,7 +89,7 @@ func init() {
 }
 
 func usage() {
-	log.Printf("Usage: %s --pkg-dir [plugin source pkg folder] --outDir-dir [outDir-dir]\n", path.Base(os.Args[0]))
+	log.Printf("Usage: %s --pkg-dir [plugin source pkg folder] --out-dir [plugin packaged folder path]\n", path.Base(os.Args[0]))
 	flag.PrintDefaults()
 	os.Exit(1)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make pluginpkg support relative path,  now if we don't run pluginpkg in the plugin package  , will be failed with  "outside available modules" or "go: cannot find main module; see 'go help modules' message.

With this patch, now we can run pluginpkg like this
`
./pluginpkg --pkg-dir ../../../enterprise-plugin/whitelist/ --out-dir ./
`


### What is changed and how it works?
 Resolve the out-dir and pkg-dir command line arguments to the absolute path

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
   
   1.  build the pluginpkg
   2. use pluginpkg to build the whitelist plugin 
    `
    ./pluginpkg --pkg-dir ../../../enterprise-plugin/whitelist/ --out-dir ./
   `
    3. run TiDB with whitelist plugin enabled
   4. show  tables in mysql database, and check if there is a writelist table .


Code changes


Side effects


Related changes

