### PR TITLE
store/helper: make test stable

### DIFF
--- a/store/helper/helper_test.go
+++ b/store/helper/helper_test.go
@@ -67,7 +67,7 @@ func (s *HelperTestSuite) SetUpSuite(c *C) {
 	mockTikvStore, err := mockstore.NewMockTikvStore(mockstore.WithMVCCStore(mvccStore))
 	s.store = &mockStore{
 		mockTikvStore.(tikv.Storage),
-		[]string{"127.0.0.1:10090/"},
+		[]string{"127.0.0.1:10100/"},
 	}
 	c.Assert(err, IsNil)
 }
@@ -87,7 +87,7 @@ func (s *HelperTestSuite) mockPDHTTPServer(c *C) {
 	router.HandleFunc("/pd/api/v1/hotspot/regions/read", s.mockHotRegionResponse)
 	serverMux := http.NewServeMux()
 	serverMux.Handle("/", router)
-	server := &http.Server{Addr: "127.0.0.1:10090", Handler: serverMux}
+	server := &http.Server{Addr: "127.0.0.1:10100", Handler: serverMux}
 	err := server.ListenAndServe()
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Port `10090` is used for more than one test.
Since tests between packages runs parallel. Use the same port may make test failed due to the `port already in use`.

### What is changed and how it works?

Use another port.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test