### PR TITLE
executor: check inconsistent index in `IndexLookupExecutor`

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -829,8 +829,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 
 	if handleCnt != len(task.rows) {
 		if !w.isCheckOp {
-			return kv.ErrNotExist.GenWithStack("handle count %d isn't equal to value count %d",
-				handleCnt, len(task.rows))
+			return kv.ErrNotExist.GenWithStack("index %s handle count %d isn't equal to value count %d",
+				w.idxLookup.index.Name.O, handleCnt, len(task.rows))
 		}
 
 		obtainedHandlesMap := make(map[int64]struct{}, len(task.rows))
@@ -838,8 +838,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 			handle := row.GetInt64(w.handleIdx)
 			obtainedHandlesMap[handle] = struct{}{}
 		}
-		return kv.ErrNotExist.GenWithStack("handle count %d isn't equal to value count %d, missing handles %v in a batch",
-			handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
+		return kv.ErrNotExist.GenWithStack("index %s handle count %d isn't equal to value count %d, missing handles %v in a batch",
+			w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
 	}
 
 	return nil

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -834,8 +834,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 				handle := row.GetInt64(w.handleIdx)
 				obtainedHandlesMap[handle] = struct{}{}
 			}
-			return errors.Errorf("handle count %d isn't equal to value count %d, missing handles %v in a batch",
-				handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
+			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v in a batch",
+				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
 		}
 
 		if len(w.idxLookup.tblPlans) == 1 {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -839,7 +839,7 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 		}
 
 		if len(w.idxLookup.tblPlans) == 1 {
-			// if this table scan has no condition, the number or rows it returns must equal to the length of handles.
+			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.
 			tblScan, ok := w.idxLookup.tblPlans[0].(*plannercore.PhysicalTableScan)
 			if ok && tblScan.NoCondition() {
 				return kv.ErrNotExist.GenWithStack("inconsistent index %s handle count %d isn't equal to value count %d",

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -834,8 +834,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 				handle := row.GetInt64(w.handleIdx)
 				obtainedHandlesMap[handle] = struct{}{}
 			}
-			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v in a batch",
-				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
+			return errors.Errorf("handle count %d isn't equal to value count %d, missing handles %v in a batch",
+				handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
 		}
 
 		if len(w.idxLookup.tblPlans) == 1 {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -839,12 +839,10 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 		}
 
 		if len(w.idxLookup.tblPlans) == 1 {
+			// table scan in double read can never has conditions according to convertToIndexScan.
 			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.
-			tblScan, ok := w.idxLookup.tblPlans[0].(*plannercore.PhysicalTableScan)
-			if ok && tblScan.NoCondition() {
-				return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d",
-					w.idxLookup.index.Name.O, handleCnt, len(task.rows))
-			}
+			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d",
+				w.idxLookup.index.Name.O, handleCnt, len(task.rows))
 		}
 	}
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -834,7 +834,7 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 				handle := row.GetInt64(w.handleIdx)
 				obtainedHandlesMap[handle] = struct{}{}
 			}
-			return kv.ErrNotExist.GenWithStack("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v in a batch",
+			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v in a batch",
 				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap))
 		}
 
@@ -842,7 +842,7 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.
 			tblScan, ok := w.idxLookup.tblPlans[0].(*plannercore.PhysicalTableScan)
 			if ok && tblScan.NoCondition() {
-				return kv.ErrNotExist.GenWithStack("inconsistent index %s handle count %d isn't equal to value count %d",
+				return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d",
 					w.idxLookup.index.Name.O, handleCnt, len(task.rows))
 			}
 		}

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -192,6 +192,7 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
+	defer tk.MustExec("drop table t")
 	tk.MustExec("create table t(a int, b int, index idx_a(a))")
 	is := s.domain.InfoSchema()
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -202,9 +202,13 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 	s.ctx.Store = s.store
 
 	for i := 0; i < 10; i++ {
-		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i, i))
+		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i+10, i))
 		c.Assert(tk.QueryToErr("select * from t where a>=0"), IsNil)
+	}
 
+	for i := 0; i < 10; i++ {
+		tk.MustExec(fmt.Sprintf("update t set a=%d where a=%d", i, i+10))
+		c.Assert(tk.QueryToErr("select * from t where a>=0"), IsNil)
 	}
 
 	for i := 0; i < 10; i++ {

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -220,6 +220,6 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 		c.Assert(err, IsNil)
 
 		err = tk.QueryToErr("select * from t where a>=0")
-		c.Assert(err.Error(), Equals, fmt.Sprintf("[kv:2]handle count %d isn't equal to value count 10", i+11))
+		c.Assert(err.Error(), Equals, fmt.Sprintf("[kv:2]inconsistent index idx_a handle count %d isn't equal to value count 10", i+11))
 	}
 }

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -220,6 +220,10 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 		c.Assert(err, IsNil)
 
 		err = tk.QueryToErr("select * from t where a>=0")
-		c.Assert(err.Error(), Equals, fmt.Sprintf("[kv:2]inconsistent index idx_a handle count %d isn't equal to value count 10", i+11))
+		c.Assert(err.Error(), Equals, fmt.Sprintf("inconsistent index idx_a handle count %d isn't equal to value count 10", i+11))
+
+		// if has other conditions, the inconsistent index check doesn't work.
+		err = tk.QueryToErr("select * from t where a>=0 and b<10")
+		c.Assert(err, IsNil)
 	}
 }

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -17,9 +17,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/table/tables"
-	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/mock"
 	"runtime/pprof"
 	"strings"
 
@@ -28,7 +25,10 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
 )
 

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -198,8 +198,8 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 	c.Assert(err, IsNil)
 	idx := tbl.Meta().FindIndexByName("idx_a")
 	idxOp := tables.NewIndex(tbl.Meta().ID, tbl.Meta(), idx)
-	s.ctx = mock.NewContext()
-	s.ctx.Store = s.store
+	ctx := mock.NewContext()
+	ctx.Store = s.store
 
 	for i := 0; i < 10; i++ {
 		tk.MustExec(fmt.Sprintf("insert into t values (%d, %d)", i+10, i))
@@ -214,7 +214,7 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 	for i := 0; i < 10; i++ {
 		txn, err := s.store.Begin()
 		c.Assert(err, IsNil)
-		_, err = idxOp.Create(s.ctx, txn, types.MakeDatums(i+10), int64(100+i))
+		_, err = idxOp.Create(ctx, txn, types.MakeDatums(i+10), int64(100+i))
 		c.Assert(err, IsNil)
 		err = txn.Commit(context.Background())
 		c.Assert(err, IsNil)

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -216,6 +216,6 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 		c.Assert(err, IsNil)
 
 		err = tk.QueryToErr("select * from t where a>=0")
-		c.Assert(err.Error(), Equals, fmt.Sprintf("[kv:2]inconsistent extra index idx_a, %d handles got 10 rows", i+11))
+		c.Assert(err.Error(), Equals, fmt.Sprintf("[kv:2]handle count %d isn't equal to value count 10", i+11))
 	}
 }

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -219,7 +219,7 @@ func (s *testSuite3) TestInconsistentIndex(c *C) {
 		err = txn.Commit(context.Background())
 		c.Assert(err, IsNil)
 
-		err = tk.QueryToErr("select * from t where a>=0")
+		err = tk.QueryToErr("select * from t use index(idx_a) where a >= 0")
 		c.Assert(err.Error(), Equals, fmt.Sprintf("inconsistent index idx_a handle count %d isn't equal to value count 10", i+11))
 
 		// if has other conditions, the inconsistent index check doesn't work.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -163,6 +163,11 @@ type PhysicalTableScan struct {
 	rangeDecidedBy []*expression.Column
 }
 
+// NoCondition returns if this table scan has any condition or filter
+func (ts *PhysicalTableScan) NoCondition() bool {
+	return len(ts.AccessCondition) == 0 && len(ts.filterCondition) == 0
+}
+
 // IsPartition returns true and partition ID if it's actually a partition.
 func (ts *PhysicalTableScan) IsPartition() (bool, int64) {
 	return ts.isPartition, ts.physicalTableID

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -163,11 +163,6 @@ type PhysicalTableScan struct {
 	rangeDecidedBy []*expression.Column
 }
 
-// NoCondition returns if this table scan has any condition or filter
-func (ts *PhysicalTableScan) NoCondition() bool {
-	return len(ts.AccessCondition) == 0 && len(ts.filterCondition) == 0
-}
-
 // IsPartition returns true and partition ID if it's actually a partition.
 func (ts *PhysicalTableScan) IsPartition() (bool, int64) {
 	return ts.isPartition, ts.physicalTableID


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Check inconsistent index in `IndexLookupExecutor`.

### What is changed and how it works?
1. Check if the length of handles and the number rows of results are equal in `IndexLookupExecutor`;
2. Add an UT `TestInconsistentIndex`;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test