### PR TITLE
*: support "add session binding"

### DIFF
--- a/bindinfo/cache.go
+++ b/bindinfo/cache.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	// using is the bind info's in use status.
-	using = "using"
-	// deleted is the bind info's deleted status.
-	deleted = "deleted"
+	// Using is the bind info's in use status.
+	Using = "using"
+	// Deleted is the bind info's Deleted status.
+	Deleted = "deleted"
 )
 
 // bindMeta stores the basic bind info and bindSql astNode.

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -20,6 +20,7 @@ import (
 	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/mysql"
@@ -129,6 +130,13 @@ func (h *GlobalBindHandle) Update(fullLoad bool) (err error) {
 
 // AddBindRecord new a BindRecord with bindMeta, add it to the cache.
 func (h *BindHandle) AddBindRecord(record *BindRecord) error {
+	record.CreateTime = types.Time{
+		Time: types.FromGoTime(time.Now()),
+		Type: mysql.TypeDatetime,
+		Fsp:  3,
+	}
+	record.UpdateTime = record.CreateTime
+
 	// update the bindMeta to the cache.
 	hash, meta, err := h.newBindMeta(record)
 	if err == nil {

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -74,7 +74,7 @@ type BindHandle struct {
 func NewBindHandle(parser *parser.Parser) *BindHandle {
 	handle := &BindHandle{}
 	handle.Parser = parser
-	handle.bindInfo.Value.Store(make(cache, 32))
+	handle.bindInfo.Value.Store(make(cache))
 	return handle
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -182,7 +182,7 @@ func (e *ShowExec) fetchShowBind() error {
 	if !e.GlobalScope {
 		return errors.New("show non-global bind sql is not supported")
 	}
-	bindRecords := domain.GetDomain(e.ctx).BindHandle().GetAllBindRecord()
+	bindRecords := domain.GetDomain(e.ctx).GlobalBindHandle().GetAllBindRecord()
 	for _, bindData := range bindRecords {
 		e.appendRow([]interface{}{
 			bindData.OriginalSQL,

--- a/session/session.go
+++ b/session/session.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
@@ -1311,6 +1312,9 @@ func CreateSession(store kv.Storage) (Session, error) {
 		Handle: do.PrivilegeHandle(),
 	}
 	privilege.BindPrivilegeManager(s, pm)
+
+	sessionBindHandle := bindinfo.NewBindHandle(s.parser)
+	s.SetValue(bindinfo.SessionBindInfoKeyType, sessionBindHandle)
 	// Add stats collector, and it will be freed by background stats worker
 	// which periodically updates stats using the collected data.
 	if do.StatsHandle() != nil && do.StatsUpdating() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
associated iusse: https://github.com/pingcap/tidb/issues/8935
feature: support add session binding
use case:
`
create table t(i int, s varchar(20))
`
`
create index index_t on t(i,s) 
`
if we want to create a binding for current session, then we execute such SQL:
`
create session binding for select * from t using select * from t use index for join(index_t)
`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes
N/A

Side effects
N/A

Related changes
N/A