### PR TITLE
tikvclient: refine region-cache

### DIFF
--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -79,7 +79,7 @@ func checkRegionStartWithTableID(c *C, id int64, store kvStore) {
 		c.Assert(err, IsNil)
 
 		// Region cache may be out of date, so we need to drop this expired region and load it again.
-		cache.DropRegion(loc.Region)
+		cache.InvalidateCachedRegion(loc.Region)
 		if bytes.Equal(loc.StartKey, []byte(regionStartKey)) {
 			return
 		}

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -161,7 +161,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	regionIDs = append(regionIDs, cluster.AllocID())
 	peerIDs = append(peerIDs, cluster.AllocID())
 	cluster.Split(regionIDs[1], regionIDs[2], []byte("q"), []uint64{peerIDs[2]}, storeID)
-	cache.DropRegion(tasks[1].region)
+	cache.InvalidateCachedRegion(tasks[1].region)
 
 	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "z"), true, false)
 	c.Assert(err, IsNil)

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -34,6 +34,7 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 	_, regionIDs, _ := mocktikv.BootstrapWithMultiRegions(cluster, []byte("g"), []byte("n"), []byte("t"))
 	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	cache := NewRegionCache(pdCli)
+	defer cache.Close()
 
 	bo := NewBackoffer(context.Background(), 3000)
 
@@ -96,6 +97,7 @@ func (s *testCoprocessorSuite) TestSplitRegionRanges(c *C) {
 	mocktikv.BootstrapWithMultiRegions(cluster, []byte("g"), []byte("n"), []byte("t"))
 	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	cache := NewRegionCache(pdCli)
+	defer cache.Close()
 
 	bo := NewBackoffer(context.Background(), 3000)
 
@@ -148,6 +150,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	storeID, regionIDs, peerIDs := mocktikv.BootstrapWithMultiRegions(cluster, []byte("m"))
 	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	cache := NewRegionCache(pdCli)
+	defer cache.Close()
 	bo := NewBackoffer(context.Background(), 3000)
 
 	tasks, err := buildCopTasks(bo, cache, buildCopRanges("a", "z"), false, false)

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -296,6 +296,7 @@ func (s *tikvStore) Close() error {
 	if s.txnLatches != nil {
 		s.txnLatches.Close()
 	}
+	s.regionCache.Close()
 	return nil
 }
 

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -83,6 +83,7 @@ func NewRawKVClient(pdAddrs []string, security config.Security) (*RawKVClient, e
 // Close closes the client.
 func (c *RawKVClient) Close() error {
 	c.pdClient.Close()
+	c.regionCache.Close()
 	return c.rpcClient.Close()
 }
 

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -82,8 +82,15 @@ func NewRawKVClient(pdAddrs []string, security config.Security) (*RawKVClient, e
 
 // Close closes the client.
 func (c *RawKVClient) Close() error {
-	c.pdClient.Close()
-	c.regionCache.Close()
+	if c.pdClient != nil {
+		c.pdClient.Close()
+	}
+	if c.regionCache != nil {
+		c.regionCache.Close()
+	}
+	if c.rpcClient == nil {
+		return nil
+	}
 	return c.rpcClient.Close()
 }
 

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -841,16 +841,16 @@ func (r *Region) EndKey() []byte {
 
 // switchWorkStore switches current store to the one on specific store. It returns
 // false if no peer matches the storeID.
-func (c *RegionCache) switchWorkStore(r *Region, storeID uint64) (foundLeader bool) {
+func (c *RegionCache) switchWorkStore(r *Region, targetStoreID uint64) (switchToTarget bool) {
 	if len(r.meta.Peers) == 0 {
 		return
 	}
 
 	leaderIdx := 0
 	for i, p := range r.meta.Peers {
-		if p.GetStoreId() == storeID {
+		if p.GetStoreId() == targetStoreID {
 			leaderIdx = i
-			foundLeader = true
+			switchToTarget = true
 		}
 	}
 
@@ -880,9 +880,6 @@ func (r *Region) ContainsByEnd(key []byte) bool {
 	return bytes.Compare(r.meta.GetStartKey(), key) < 0 &&
 		(bytes.Compare(key, r.meta.GetEndKey()) <= 0 || len(r.meta.GetEndKey()) == 0)
 }
-
-// fn loads the Store info given by storeId.
-type resolveFunc func(ctx context.Context, id uint64) (*metapb.Store, error)
 
 // Store contains a kv process's address.
 type Store struct {

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -910,9 +910,10 @@ type storeState struct {
 	lastFailedTime uint32
 	failedAttempt  uint16
 	resolveState   resolveState
+	_Align         int8
 }
 
-type resolveState uint16
+type resolveState uint8
 
 const (
 	unresolved resolveState = iota

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -854,6 +854,9 @@ func (c *RegionCache) switchWorkStore(r *Region, targetStoreID uint64) (switchTo
 retry:
 	// switch to new leader.
 	oldRegionStore := r.getStore()
+	if oldRegionStore.workStoreIdx == int32(leaderIdx) && oldRegionStore.startingLineIdx == int32(leaderIdx) {
+		return
+	}
 	newRegionStore := oldRegionStore.clone()
 	newRegionStore.workStoreIdx = int32(leaderIdx)
 	newRegionStore.startingLineIdx = int32(leaderIdx)

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -599,7 +599,7 @@ retry:
 	regionStore := region.getStore()
 	cachedStore, cachedPeer, cachedIdx := region.WorkStorePeer(regionStore)
 
-	// almost time requests be directly routed to stable leader.
+	// Most of the time, requests are directly routed to stable leader.
 	// returns if store is stable leader and no need retry other node.
 	state := cachedStore.getState()
 	if cachedStore != nil && state.failedAttempt == 0 && state.lastFailedTime == 0 {
@@ -844,7 +844,7 @@ func (r *Region) EndKey() []byte {
 
 // switchWorkStore switches current store to the one on specific store. It returns
 // false if no peer matches the storeID.
-func (c *RegionCache) switchWorkStore(r *Region, targetStoreID uint64) (switchToTarget bool) {
+func (c *RegionCache) switchWorkStore(r *Region, targetStoreID uint64) {
 	if len(r.meta.Peers) == 0 {
 		return
 	}
@@ -853,7 +853,7 @@ func (c *RegionCache) switchWorkStore(r *Region, targetStoreID uint64) (switchTo
 	for i, p := range r.meta.Peers {
 		if p.GetStoreId() == targetStoreID {
 			leaderIdx = i
-			switchToTarget = true
+			break
 		}
 	}
 

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/btree"
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/backoffutils"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"
@@ -700,13 +699,6 @@ func (r *Region) WorkStorePeer() (store *Store, peer *metapb.Peer, idx int) {
 	return
 }
 
-// workPeer returns current work peer.
-func (r *Region) workPeer() (peer *metapb.Peer) {
-	idx := int(atomic.LoadInt32(&r.workStoreIdx))
-	peer = r.meta.Peers[idx]
-	return
-}
-
 // RegionVerID is a unique ID that can identify a Region at a specific version.
 type RegionVerID struct {
 	id      uint64
@@ -736,15 +728,6 @@ func (r *Region) StartKey() []byte {
 // EndKey returns EndKey.
 func (r *Region) EndKey() []byte {
 	return r.meta.EndKey
-}
-
-// GetContext constructs kvprotopb.Context from region info.
-func (r *Region) GetContext() *kvrpcpb.Context {
-	return &kvrpcpb.Context{
-		RegionId:    r.meta.Id,
-		RegionEpoch: r.meta.RegionEpoch,
-		Peer:        r.workPeer(),
-	}
 }
 
 // switchWorkStore switches current store to the one on specific store. It returns

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -977,10 +977,6 @@ func (s *Store) reResolve(c *RegionCache) {
 		tikvRegionCacheCounterWithGetStoreOK.Inc()
 	}
 	if err != nil {
-		// TODO: more refine PD error status handle.
-		if errors.Cause(err) == context.Canceled {
-			return
-		}
 		logutil.Logger(context.Background()).Error("loadStore from PD failed", zap.Uint64("id", s.storeID), zap.Error(err))
 		// we cannot do backoff in reResolve loop but try check other store and wait tick.
 		return

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -368,11 +368,11 @@ func (s *testRegionCacheSuite) TestSendFailBlackTwoRegion(c *C) {
 	s.checkCache(c, 2)
 
 	// send request fail in 2 regions backed by same 2 stores.
-	for i := 0; i < 20; i++ {
+	for i := 0; i < startBlackoutAfterAttempt; i++ {
 		ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
 		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
 	}
-	for i := 0; i < 20; i++ {
+	for i := 0; i < startBlackoutAfterAttempt; i++ {
 		ctx, _ := s.cache.GetRPCContext(s.bo, loc2.Region)
 		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
 	}

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -378,8 +378,8 @@ func (s *testRegionCacheSuite) TestSendFailBlackTwoRegion(c *C) {
 	ts = time.Now().Unix()
 	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
 	s.getRegion(c, []byte("a"))
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 1)
 	s.getRegion(c, []byte("x"))
+	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 2)
 	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 2)
 }
 

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -351,6 +351,7 @@ func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 	// Create a separated region cache to do this test.
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	cache := NewRegionCache(pdCli)
+	defer cache.Close()
 
 	region := createSampleRegion([]byte("k1"), []byte("k2"))
 	region.meta.Id = 1
@@ -375,6 +376,7 @@ func (s *testRegionCacheSuite) TestDropStoreOnSendRequestFail(c *C) {
 	cluster := createClusterWithStoresAndRegions(regionCnt, storeCount)
 
 	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
+	defer cache.Close()
 	loadRegionsToCache(cache, regionCnt)
 	c.Assert(workableRegions(cache, cache.mu.regions, ts), Equals, regionCnt)
 
@@ -514,6 +516,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	regionCnt, storeCount := 998, 3
 	cluster := createClusterWithStoresAndRegions(regionCnt, storeCount)
 	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
+	defer cache.Close()
 	loadRegionsToCache(cache, regionCnt)
 	bo := NewBackoffer(context.Background(), 1)
 	loc, err := cache.LocateKey(bo, []byte{})

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -334,7 +334,7 @@ func (s *testRegionCacheSuite) TestRequestFail2(c *C) {
 
 	// Request should fail on region1.
 	ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
-	c.Assert(s.cache.storeMu.stores, HasLen, 1)
+	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
 	s.checkCache(c, 2)
 	s.cache.OnSendRequestFail(ctx, errors.New("test error"))
 	// Both region2 and store should be dropped from cache.
@@ -522,12 +522,13 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	}
 	region := cache.getRegionByIDFromCache(loc.Region.id)
 	b.ResetTimer()
+	store, _ := region.WorkStore()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			rpcCtx := &RPCContext{
 				Region: loc.Region,
 				Meta:   region.meta,
-				Store:  region.WorkStore(),
+				Store:  store,
 			}
 			cache.OnSendRequestFail(rpcCtx, nil)
 		}

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -195,33 +195,6 @@ func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
 	c.Assert(s.getAddr(c, []byte("z")), Equals, s.storeAddr(s.store2))
 }
 
-func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
-	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
-	// new store3 becomes leader
-	store3 := s.cluster.AllocID()
-	peer3 := s.cluster.AllocID()
-	s.cluster.AddStore(store3, s.storeAddr(store3))
-	s.cluster.AddPeer(s.region1, store3, peer3)
-	// tikv-server reports `NotLeader`
-	s.cache.UpdateLeader(loc.Region, store3)
-
-	// Store3 does not exist in cache, causes a reload from PD.
-	r := s.getRegion(c, []byte("a"))
-	c.Assert(r, NotNil)
-	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(s.store1))
-
-	// tikv-server notifies new leader to pd-server.
-	s.cluster.ChangeLeader(s.region1, peer3)
-	// tikv-server reports `NotLeader` again.
-	s.cache.UpdateLeader(r.VerID(), store3)
-	r = s.getRegion(c, []byte("a"))
-	c.Assert(r, NotNil)
-	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(store3))
-}
-
 func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -261,14 +261,14 @@ func (s *testRegionCacheSuite) TestReconnect(c *C) {
 
 func (s *testRegionCacheSuite) TestRequestFail(c *C) {
 	region := s.getRegion(c, []byte("a"))
-
+	c.Assert(region.backupPeers, HasLen, len(region.meta.Peers)-1)
 	ctx, _ := s.cache.GetRPCContext(s.bo, region.VerID())
-	s.cache.DropStoreOnSendRequestFail(ctx, errors.New("test error"))
-	c.Assert(s.cache.mu.regions, HasLen, 0)
+	s.cache.OnSendRequestFail(ctx, errors.New("test error"))
+	c.Assert(region.backupPeers, HasLen, len(region.meta.Peers)-2)
 	region = s.getRegion(c, []byte("a"))
 	c.Assert(s.cache.mu.regions, HasLen, 1)
 	ctx, _ = s.cache.GetRPCContext(s.bo, region.VerID())
-	s.cache.DropStoreOnSendRequestFail(ctx, errors.New("test error"))
+	s.cache.OnSendRequestFail(ctx, errors.New("test error"))
 	c.Assert(len(s.cache.mu.regions), Equals, 0)
 	s.getRegion(c, []byte("a"))
 	c.Assert(s.cache.mu.regions, HasLen, 1)
@@ -292,10 +292,13 @@ func (s *testRegionCacheSuite) TestRequestFail2(c *C) {
 	ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
 	c.Assert(s.cache.storeMu.stores, HasLen, 1)
 	s.checkCache(c, 2)
-	s.cache.DropStoreOnSendRequestFail(ctx, errors.New("test error"))
+	s.cache.OnSendRequestFail(ctx, errors.New("test error"))
 	// Both region2 and store should be dropped from cache.
 	c.Assert(s.cache.storeMu.stores, HasLen, 0)
-	c.Assert(s.cache.searchCachedRegion([]byte("x"), true), IsNil)
+	ctx2, _ := s.cache.GetRPCContext(s.bo, loc2.Region)
+	s.cache.OnSendRequestFail(ctx2, errors.New("test error"))
+	r := s.cache.searchCachedRegion([]byte("x"), true)
+	c.Assert(r, IsNil)
 	s.checkCache(c, 0)
 }
 
@@ -322,8 +325,8 @@ func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestDropStoreOnSendRequestFail(c *C) {
-	regionCnt := 999
-	cluster := createClusterWithStoresAndRegions(regionCnt)
+	regionCnt, storeCount := 999, 3
+	cluster := createClusterWithStoresAndRegions(regionCnt, storeCount)
 
 	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
 	loadRegionsToCache(cache, regionCnt)
@@ -333,11 +336,20 @@ func (s *testRegionCacheSuite) TestDropStoreOnSendRequestFail(c *C) {
 	loc, err := cache.LocateKey(bo, []byte{})
 	c.Assert(err, IsNil)
 
-	// Drop the regions on one store, should drop only 1/3 of the regions.
+	// First two drop attempts just switch peer.
+	for i := 0; i < storeCount-1; i++ {
+		rpcCtx, err := cache.GetRPCContext(bo, loc.Region)
+		c.Assert(err, IsNil)
+		cache.OnSendRequestFail(rpcCtx, errors.New("test error"))
+		c.Assert(len(cache.mu.regions), Equals, regionCnt+1)
+	}
+
+	// Drop the regions on one store, all region will be drop because they are in three stores.
+	// and fail 3 times hit at each stores.
 	rpcCtx, err := cache.GetRPCContext(bo, loc.Region)
 	c.Assert(err, IsNil)
-	cache.DropStoreOnSendRequestFail(rpcCtx, errors.New("test error"))
-	c.Assert(len(cache.mu.regions), Equals, regionCnt*2/3)
+	cache.OnSendRequestFail(rpcCtx, errors.New("test error"))
+	c.Assert(len(cache.mu.regions), Equals, 0)
 
 	loadRegionsToCache(cache, regionCnt)
 	c.Assert(len(cache.mu.regions), Equals, regionCnt)
@@ -345,9 +357,9 @@ func (s *testRegionCacheSuite) TestDropStoreOnSendRequestFail(c *C) {
 
 const regionSplitKeyFormat = "t%08d"
 
-func createClusterWithStoresAndRegions(regionCnt int) *mocktikv.Cluster {
+func createClusterWithStoresAndRegions(regionCnt, storeCount int) *mocktikv.Cluster {
 	cluster := mocktikv.NewCluster()
-	_, _, regionID, _ := mocktikv.BootstrapWithMultiStores(cluster, 3)
+	_, _, regionID, _ := mocktikv.BootstrapWithMultiStores(cluster, storeCount)
 	for i := 0; i < regionCnt; i++ {
 		rawKey := []byte(fmt.Sprintf(regionSplitKeyFormat, i))
 		ids := cluster.AllocIDs(4)
@@ -449,12 +461,12 @@ func (s *testRegionCacheSuite) TestContainsByEnd(c *C) {
 
 func BenchmarkOnRequestFail(b *testing.B) {
 	/*
-			This benchmark simulate many concurrent requests call DropStoreOnSendRequestFail method
+			This benchmark simulate many concurrent requests call OnSendRequestFail method
 			after failed on a store, validate that on this scene, requests don't get blocked on the
 		    RegionCache lock.
 	*/
-	regionCnt := 999
-	cluster := createClusterWithStoresAndRegions(regionCnt)
+	regionCnt, storeCount := 998, 3
+	cluster := createClusterWithStoresAndRegions(regionCnt, storeCount)
 	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
 	loadRegionsToCache(cache, regionCnt)
 	bo := NewBackoffer(context.Background(), 1)
@@ -471,7 +483,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 				Meta:   region.meta,
 				Peer:   region.peer,
 			}
-			cache.DropStoreOnSendRequestFail(rpcCtx, nil)
+			cache.OnSendRequestFail(rpcCtx, nil)
 		}
 	})
 	if len(cache.mu.regions) != regionCnt*2/3 {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -132,7 +132,7 @@ func (s *RegionRequestSender) SendReqCtx(bo *Backoffer, req *tikvrpc.Request, re
 }
 
 func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, retry bool, err error) {
-	if e := tikvrpc.SetContext(req, ctx.Meta, ctx.Store.peer); e != nil {
+	if e := tikvrpc.SetContext(req, ctx.Meta, ctx.Peer); e != nil {
 		return nil, false, errors.Trace(e)
 	}
 	resp, err = s.client.SendRequest(bo.ctx, ctx.Addr, req, timeout)
@@ -148,7 +148,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 }
 
 func (s *RegionRequestSender) onSendSuccess(ctx *RPCContext) {
-	store := s.regionCache.getStoreByStoreID(ctx.Store.peer)
+	store := s.regionCache.getStoreByStoreID(ctx.Store.storeID)
 	store.markAccess(true)
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -149,7 +149,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 
 func (s *RegionRequestSender) onSendSuccess(ctx *RPCContext) {
 	store := s.regionCache.getStoreByStoreID(ctx.Store.storeID)
-	store.markAccess(s.regionCache, true)
+	store.markAccess(s.regionCache.notifyCheckCh, true)
 }
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
@@ -226,7 +226,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 		logutil.Logger(context.Background()).Warn("tikv reports `StoreNotMatch` retry later",
 			zap.Stringer("storeNotMatch", storeNotMatch),
 			zap.Stringer("ctx", ctx))
-		ctx.Store.markNeedCheck(s.regionCache)
+		ctx.Store.markNeedCheck(s.regionCache.notifyCheckCh)
 		return true, nil
 	}
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -143,7 +143,13 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 		}
 		return nil, true, nil
 	}
+	s.onSendSuccess(ctx)
 	return
+}
+
+func (s *RegionRequestSender) onSendSuccess(ctx *RPCContext) {
+	store := s.regionCache.getStoreByStoreID(ctx.Peer.StoreId)
+	store.Mark(true)
 }
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
@@ -254,7 +260,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 	logutil.Logger(context.Background()).Debug("tikv reports region error",
 		zap.Stringer("regionErr", regionErr),
 		zap.Stringer("ctx", ctx))
-	s.regionCache.DropRegion(ctx.Region)
+	s.regionCache.InvalidateCachedRegion(ctx.Region)
 	return false, nil
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -149,7 +149,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 
 func (s *RegionRequestSender) onSendSuccess(ctx *RPCContext) {
 	store := s.regionCache.getStoreByStoreID(ctx.Store.storeID)
-	store.markAccess(true)
+	store.markAccess(s.regionCache, true)
 }
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
@@ -226,7 +226,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 		logutil.Logger(context.Background()).Warn("tikv reports `StoreNotMatch` retry later",
 			zap.Stringer("storeNotMatch", storeNotMatch),
 			zap.Stringer("ctx", ctx))
-		ctx.Store.markNeedCheck()
+		ctx.Store.markNeedCheck(s.regionCache)
 		return true, nil
 	}
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -163,7 +163,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 		}
 	}
 
-	s.regionCache.DropStoreOnSendRequestFail(ctx, err)
+	s.regionCache.OnSendRequestFail(ctx, err)
 
 	// Retry on send request failure when it's not canceled.
 	// When a store is not available, the leader of related region should be elected quickly.

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -226,7 +226,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 		logutil.Logger(context.Background()).Warn("tikv reports `StoreNotMatch` retry later",
 			zap.Stringer("storeNotMatch", storeNotMatch),
 			zap.Stringer("ctx", ctx))
-		ctx.Store.markResolved(false)
+		ctx.Store.markNeedCheck()
 		return true, nil
 	}
 

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -54,6 +54,10 @@ func (s *testRegionRequestSuite) SetUpTest(c *C) {
 	s.regionRequestSender = NewRegionRequestSender(s.cache, client)
 }
 
+func (s *testRegionRequestSuite) TearDownTest(c *C) {
+	s.cache.Close()
+}
+
 func (s *testRegionRequestSuite) TestOnSendFailedWithStoreRestart(c *C) {
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdRawPut,

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -69,7 +69,7 @@ func (s *testSplitSuite) TestSplitBatchGet(c *C) {
 	}
 
 	s.split(c, loc.Region.id, []byte("b"))
-	s.store.regionCache.DropRegion(loc.Region)
+	s.store.regionCache.InvalidateCachedRegion(loc.Region)
 
 	// mocktikv will panic if it meets a not-in-region key.
 	err = snapshot.batchGetSingleRegion(s.bo, batch, func([]byte, []byte) {})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

try to fixes #10037, keep retry region's other stores

- meet hibernate region feature in tikv
- keep using old data when tidb can not connect to pd

### What is changed and how it works?

#### What region-cache can hold?

- region: region maintains a range of data,  one region has multiple stores, it will be created/deleted frequently(region split, region merge, leader change,  schedule from one store to another)
- stores: store is kv process, one machine can hold multiple stores,  one store can hold multiple regions,  it will be infrequent change(copy old kv to new machine, change network interface...)

#### What fails or data outdated region-cache will meet?

1) send data failure

normally, it happens when **machine down or network partition between tidb and kv or process crash**.
for TiDB side, it will see **send data failure event** to identify the store failure.

but sometimes, this will be caused by someone to **replace a new machine or change network interface**, but people don't often do that.

2) send success but got the error response

this means the store is working well, but info is miss matched.
for TiDB side, send data will success, but will **get fail response** from kv.

normally, it's the region info be changed, seldom it's store info changed.

#### How current running

on send fail,  it will drop region cache and remove store info, it will trigger reload region and store info.

but have 2 problems:

- re-fetch region info will get the old leader when kv doesn't trigger new election, but hibernate region need trigger other peer to start new election
- fetch region from pd maybe failure if pd have network partition.

#### how this PR change

1) mark store after send

- mark store be failed when sending data failure, it let tidb blackout this store in following in a period(continue fail count + last fail timestamp).
- mark store as success when sending data success.

"blackout store when failure" keep the chance that failure peer can be used again but doesn't make retry flood.

2) invalidate region cache

cache item never be deleted and only invalidate it to trigger pd re-fetch
it will make it validate again to keep use old data if fetch failure caused by pd down. 

review this PR maybe need to take look at https://github.com/pingcap/tidb/pull/6880 and https://github.com/pingcap/tidb/pull/2792, also `GetRPCContext` method which isn't modified but vital to this logic.

3) main focus

- fast & lock-free for cache-hit code path?
- when to try other peers when the current leader unreachable? 
- when to invalidate a region and trigger reload region?
- when & how long to blackout a store when it continues failed?
- when to trigger stores info to be reloaded?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test(WIP add more)
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Increased code complexity

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10256)
<!-- Reviewable:end -->
