### PR TITLE
statistcs, executor: support history read for 'show stats_X' command

### DIFF
--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -111,10 +111,15 @@ func (hg *Histogram) GetUpper(idx int) *types.Datum {
 
 // AvgColSize is the average column size of the histogram.
 func (c *Column) AvgColSize(count int64) float64 {
+	return CalculateAvgColSize(c.Histogram.Tp.Tp, c.TotColSize, count)
+}
+
+// CalculateAvgColSize calculates the average column size of the histogram.
+func CalculateAvgColSize(tp byte, totColSize, count int64) float64 {
 	if count == 0 {
 		return 0
 	}
-	switch c.Histogram.Tp.Tp {
+	switch tp {
 	case mysql.TypeFloat:
 		return 4
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong,
@@ -126,7 +131,7 @@ func (c *Column) AvgColSize(count int64) float64 {
 		return types.MyDecimalStructSize
 	default:
 		// Keep two decimal place.
-		return math.Round(float64(c.TotColSize)/float64(count)*100) / 100
+		return math.Round(float64(totColSize)/float64(count)*100) / 100
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support read the historical statistics for `show stats_X` when `tidb_snapshot` is set.

Note:
This commit can *ONLY* fix the history read problem when we try to query the statistics manually, other 2 individual problems need to be fixed when we set `tidb_snapshot`:

1. When we dump stats using http-api, the data is the latest.
2. When we execute normal select_stmt, the statistics used is the latest. 

### What is changed and how it works?
Read from kv instead of the memory buffer when tidb_snapshot is set.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression
We need to read data from the network when `tidb_snapshot` is set.

Related changes

 - Need to cherry-pick to the release branch
