### PR TITLE
choose the last key as primary key

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -69,15 +69,14 @@ func (ca twoPhaseCommitAction) MetricsTag() string {
 
 // twoPhaseCommitter executes a two-phase commit protocol.
 type twoPhaseCommitter struct {
-	store      *tikvStore
-	txn        *tikvTxn
-	startTS    uint64
-	keys       [][]byte
-	primaryIdx uint64
-	mutations  map[string]*mutationEx
-	lockTTL    uint64
-	commitTS   uint64
-	mu         struct {
+	store     *tikvStore
+	txn       *tikvTxn
+	startTS   uint64
+	keys      [][]byte
+	mutations map[string]*mutationEx
+	lockTTL   uint64
+	commitTS  uint64
+	mu        struct {
 		sync.RWMutex
 		committed       bool
 		undeterminedErr error // undeterminedErr saves the rpc error we encounter when commit primary key.

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -231,7 +231,7 @@ func newTwoPhaseCommitter(txn *tikvTxn, connID uint64) (*twoPhaseCommitter, erro
 }
 
 func (c *twoPhaseCommitter) primary() []byte {
-	return c.keys[len(c.keys)]
+	return c.keys[len(c.keys)-1]
 }
 
 const bytesPerMiB = 1024 * 1024

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -249,23 +249,21 @@ func (c *RegionCache) LocateRegionByID(bo *Backoffer, regionID uint64) (*KeyLoca
 // 'PrimaryLockKey' and should be committed ahead of others.
 func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte) (map[RegionVerID][][]byte, RegionVerID, error) {
 	groups := make(map[RegionVerID][][]byte)
-	var first RegionVerID
+	var last RegionVerID
 	var lastLoc *KeyLocation
-	for i, k := range keys {
+	for _, k := range keys {
 		if lastLoc == nil || !lastLoc.Contains(k) {
 			var err error
 			lastLoc, err = c.LocateKey(bo, k)
 			if err != nil {
-				return nil, first, errors.Trace(err)
+				return nil, last, errors.Trace(err)
 			}
 		}
 		id := lastLoc.Region
-		if i == 0 {
-			first = id
-		}
+		last = id
 		groups[id] = append(groups[id], k)
 	}
-	return groups, first, nil
+	return groups, last, nil
 }
 
 // ListRegionIDsInKeyRange lists ids of regions in [start_key,end_key].


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

All the secondary keys will take a copy of primary key, currently the first key will be the priamry key, in TiDB it usally is an index key, is much longer than row key. And these data will replicated by raft. 

### What is changed and how it works?

This PR choose the last key as primary key to reduce total data flow.

