### PR TITLE
executor: use EncodeBytes in countOriginDistinct (#10225)

### DIFF
--- a/executor/aggfuncs/func_count.go
+++ b/executor/aggfuncs/func_count.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/set"
 )
 
@@ -330,7 +332,7 @@ func (e *countOriginalWithDistinct) evalAndEncode(
 		if err != nil || isNull {
 			break
 		}
-		encodedBytes = appendString(encodedBytes, buf, val)
+		encodedBytes = codec.EncodeBytes(encodedBytes, hack.Slice(val))
 	default:
 		return nil, false, errors.Errorf("unsupported column type for encode %d", tp)
 	}

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -693,6 +693,14 @@ func (s *testSuite) TestAggJSON(c *C) {
 	))
 }
 
+func (s *testSuite) TestIssue10099(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a char(10), b char(10))")
+	tk.MustExec("insert into t values('1', '222'), ('12', '22')")
+	tk.MustQuery("select count(distinct a, b) from t").Check(testkit.Rows("2"))
+}
+
 func (s *testSuite) TestIssue10098(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec(`drop table if exists t;`)


### PR DESCRIPTION
cherry-pick #10225 