### PR TITLE
infoschema/slow_query: fix slow log parser bug when sql contain #

### DIFF
--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -94,7 +94,7 @@ func ParseSlowLog(tz *time.Location, scanner *bufio.Scanner) ([][]types.Datum, e
 
 		if startFlag {
 			// Parse slow log field.
-			if strings.Contains(line, variable.SlowLogRowPrefixStr) {
+			if strings.HasPrefix(line, variable.SlowLogRowPrefixStr) {
 				line = line[len(variable.SlowLogRowPrefixStr):]
 				fieldValues := strings.Split(line, " ")
 				for i := 0; i < len(fieldValues)-1; i += 2 {

--- a/infoschema/slow_log_test.go
+++ b/infoschema/slow_log_test.go
@@ -50,6 +50,23 @@ select * from t;`)
 	}
 	expectRecordString := "2019-01-24 22:32:29.313255,405888132465033227,,0,0.216905,0.021,0,0,1,637,0,,,1,42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772,t1:1,t2:2,select * from t;"
 	c.Assert(expectRecordString, Equals, recordString)
+
+	// fix sql contain '# ' bug
+	slowLog = bytes.NewBufferString(
+		`# Time: 2019-01-24-22:32:29.313255 +0800
+select a# from t;
+# Time: 2019-01-24-22:32:29.313255 +0800
+# Txn_start_ts: 405888132465033227
+# Query_time: 0.216905
+# Process_time: 0.021 Request_count: 1 Total_keys: 637 Processed_keys: 436
+# Is_internal: true
+# Digest: 42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772
+# Stats: t1:1,t2:2
+select * from t;
+`)
+	scanner = bufio.NewScanner(slowLog)
+	_, err = infoschema.ParseSlowLog(loc, scanner)
+	c.Assert(err, IsNil)
 }
 
 func (s *testSuite) TestSlowLogParseTime(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix slow log parser bug when sql contain '# '.

### What is changed and how it works?
Change parser function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
