### PR TITLE
infoschema, domain, ddl: fix upper cased charset names

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -764,7 +764,6 @@ func (s *testIntegrationSuite7) TestCaseInsensitiveCharsetAndCollate(c *C) {
 
 	tblInfo.Version = model.TableInfoVersion2
 	tblInfo.Charset = "UTF8MB4"
-	// colInfo := tblInfo.Columns[0].Clone()
 
 	updateTableInfo := func(tblInfo *model.TableInfo) {
 		mockCtx := mock.NewContext()

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -751,6 +751,52 @@ func (s *testIntegrationSuite7) TestCaseInsensitiveCharsetAndCollate(c *C) {
 	tk.MustExec("create table t2(id int) ENGINE=InnoDB DEFAULT CHARSET=Utf8 COLLATE=utf8_BIN;")
 	tk.MustExec("create table t3(id int) ENGINE=InnoDB DEFAULT CHARSET=Utf8mb4 COLLATE=utf8MB4_BIN;")
 	tk.MustExec("create table t4(id int) ENGINE=InnoDB DEFAULT CHARSET=Utf8mb4 COLLATE=utf8MB4_general_ci;")
+
+	tk.MustExec("create table t5(a varchar(20)) ENGINE=InnoDB DEFAULT CHARSET=UTF8MB4 COLLATE=UTF8MB4_GENERAL_CI;")
+	tk.MustExec("insert into t5 values ('特克斯和凯科斯群岛')")
+
+	db, ok := domain.GetDomain(s.ctx).InfoSchema().SchemaByName(model.NewCIStr("test_charset_collate"))
+	c.Assert(ok, IsTrue)
+	tbl := testGetTableByName(c, s.ctx, "test_charset_collate", "t5")
+	tblInfo := tbl.Meta().Clone()
+	c.Assert(tblInfo.Charset, Equals, "utf8mb4")
+	c.Assert(tblInfo.Columns[0].Charset, Equals, "utf8mb4")
+
+	tblInfo.Version = model.TableInfoVersion2
+	tblInfo.Charset = "UTF8MB4"
+	// colInfo := tblInfo.Columns[0].Clone()
+
+	updateTableInfo := func(tblInfo *model.TableInfo) {
+		mockCtx := mock.NewContext()
+		mockCtx.Store = s.store
+		err := mockCtx.NewTxn(context.Background())
+		c.Assert(err, IsNil)
+		txn, err := mockCtx.Txn(true)
+		c.Assert(err, IsNil)
+		mt := meta.NewMeta(txn)
+		c.Assert(ok, IsTrue)
+		err = mt.UpdateTable(db.ID, tblInfo)
+		c.Assert(err, IsNil)
+		err = txn.Commit(context.Background())
+		c.Assert(err, IsNil)
+	}
+	updateTableInfo(tblInfo)
+	tk.MustExec("alter table t5 add column b varchar(10);") //  load latest schema.
+
+	tblInfo = testGetTableByName(c, s.ctx, "test_charset_collate", "t5").Meta()
+	c.Assert(tblInfo.Charset, Equals, "utf8mb4")
+	c.Assert(tblInfo.Columns[0].Charset, Equals, "utf8mb4")
+
+	// For model.TableInfoVersion3, it is believed that all charsets / collations are lower-cased, do not do case-convert
+	tblInfo = tblInfo.Clone()
+	tblInfo.Version = model.TableInfoVersion3
+	tblInfo.Charset = "UTF8MB4"
+	updateTableInfo(tblInfo)
+	tk.MustExec("alter table t5 add column c varchar(10);") //  load latest schema.
+
+	tblInfo = testGetTableByName(c, s.ctx, "test_charset_collate", "t5").Meta()
+	c.Assert(tblInfo.Charset, Equals, "UTF8MB4")
+	c.Assert(tblInfo.Columns[0].Charset, Equals, "utf8mb4")
 }
 
 func (s *testIntegrationSuite3) TestZeroFillCreateTable(c *C) {

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2292,7 +2292,7 @@ func (s *testDBSuite4) TestCheckTooBigFieldLength(c *C) {
 	assertErrorCode(c, s.tk, "alter table tr_04 add column b varchar(20000) charset utf8mb4;", tmysql.ErrTooBigFieldlength)
 	assertErrorCode(c, s.tk, "alter table tr_04 convert to character set utf8mb4;", tmysql.ErrTooBigFieldlength)
 	assertErrorCode(c, s.tk, "create table tr (id int, name varchar(30000), purchased date )  default charset=utf8 collate=utf8_bin;", tmysql.ErrTooBigFieldlength)
-	assertErrorCode(c, s.tk, "create table tr (id int, name varchar(20000) charset utf8mb4, purchased date ) default charset=utf8 collate=utf8;", tmysql.ErrTooBigFieldlength)
+	assertErrorCode(c, s.tk, "create table tr (id int, name varchar(20000) charset utf8mb4, purchased date ) default charset=utf8 collate=utf8_bin;", tmysql.ErrTooBigFieldlength)
 	assertErrorCode(c, s.tk, "create table tr (id int, name varchar(65536), purchased date ) default charset=latin1;", tmysql.ErrTooBigFieldlength)
 
 	s.tk.MustExec("drop table if exists tr_05;")

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -194,6 +194,7 @@ func (do *Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, 
 				// schema is not public, can't be used outside.
 				continue
 			}
+			infoschema.ConvertCharsetCollateToLowerCaseIfNeed(tbl)
 			di.Tables = append(di.Tables, tbl)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190427000002-f3ecae036b23
+	github.com/pingcap/parser v0.0.0-20190429074050-34bcb57d11a6
 	github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330
@@ -74,5 +74,3 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-
-replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20190425062935-f0bd8dbd4cea

--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20190425062935-f0bd8dbd4cea

--- a/go.sum
+++ b/go.sum
@@ -292,7 +292,6 @@ google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/gometalinter.v2 v2.0.12/go.mod h1:NDRytsqEZyolNuAgTzJkZMkSQM7FIKyzVzGhjB/qfYo=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mod h1:3HH7i1SgMqlzxCcBmUHW657sD4Kvv9sC3HpL3YukzwA=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190427000002-f3ecae036b23 h1:9RUvFHNfDplW4KZ90FMOC7QEDLORa15AlozhX0P8cCg=
-github.com/pingcap/parser v0.0.0-20190427000002-f3ecae036b23/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190429074050-34bcb57d11a6 h1:m35H8yhrMcATKp8yUVUHAmvuzIT8xjL+ialXyBrBWHU=
+github.com/pingcap/parser v0.0.0-20190429074050-34bcb57d11a6/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669/go.mod h1:MUCxRzOkYiWZtlyi4MhxjCIj9PgQQ/j+BLNGm7aUsnM=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -16,6 +16,7 @@ package infoschema
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"
@@ -172,6 +173,7 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 			fmt.Sprintf("(Table ID %d)", tableID),
 		)
 	}
+	ConvertCharsetCollateToLowerCaseIfNeed(tblInfo)
 	ConvertOldVersionUTF8ToUTF8MB4IfNeed(tblInfo)
 
 	if alloc == nil {
@@ -195,6 +197,20 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 		dbInfo.Tables = append(dbInfo.Tables, newTbl.Meta())
 	}
 	return nil
+}
+
+// ConvertCharsetCollateToLowerCaseIfNeed convert the charset / collation of table and its columns to lower case,
+// if the table's version is prior to TableInfoVersion3.
+func ConvertCharsetCollateToLowerCaseIfNeed(tbInfo *model.TableInfo) {
+	if tbInfo.Version >= model.TableInfoVersion3 {
+		return
+	}
+	tbInfo.Charset = strings.ToLower(tbInfo.Charset)
+	tbInfo.Collate = strings.ToLower(tbInfo.Collate)
+	for _, col := range tbInfo.Columns {
+		col.Charset = strings.ToLower(col.Charset)
+		col.Collate = strings.ToLower(col.Collate)
+	}
 }
 
 // ConvertOldVersionUTF8ToUTF8MB4IfNeed convert old version UTF8 to UTF8MB4 if config.TreatOldVersionUTF8AsUTF8MB4 is enable.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This version aims to deal with upper-cased charset name in `TableInfo` stored by previous versions of TiDB.

TiDB always supposes that all charsets / collations are lower-cased and try to convert them if they're not. However, the convert is missed in some scenarios, some upper-cased charsets / collations are kept and stored, leading to some potential issues:

```
mysql> create table t1(a varchar(20)) default charset=utf8;
Query OK, 0 rows affected (0.03 sec)
mysql> insert into t1 values ('特克斯和凯科斯群岛');
Query OK, 1 row affected (0.01 sec)

mysql> create table t2(a varchar(20)) default charset=UTF8;
Query OK, 0 rows affected (0.03 sec)
mysql> insert into t2 values ('特克斯和凯科斯群岛');
ERROR 1406 (22001): Data too long for column 'a' at row 1

mysql> select version();
+------------------------------------------+
| version()                                |
+------------------------------------------+
| 5.7.25-TiDB-v3.0.0-beta.1-104-g0a9569af4 |
+------------------------------------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?
With the help of https://github.com/pingcap/parser/pull/301, a new `TableInfoVersion3` is added as `CurrLatestTableInfoVersion`. All tables with version prior to `TableInfoVersion3` will do the charset / collation name convert when loaded.

Also, https://github.com/pingcap/parser/pull/301 validates all charset / collation names and convert them to lower-case in parser.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - (Potentially) Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
