### PR TITLE
server: fix `TestTLS` when use RSA-PSS

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -210,7 +210,7 @@ func (ts *TidbTestSuite) TestSocket(c *C) {
 // If parentCert and parentCertKey is specified, the new certificate will be signed by the parentCert.
 // Otherwise, the new certificate will be self-signed and is a CA.
 func generateCert(sn int, commonName string, parentCert *x509.Certificate, parentCertKey *rsa.PrivateKey, outKeyFile string, outCertFile string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 528)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
@@ -295,11 +295,6 @@ func registerTLSConfig(configName string, caCertPath string, clientCertPath stri
 }
 
 func (ts *TidbTestSuite) TestTLS(c *C) {
-	preEnv := os.Getenv("GODEBUG")
-	os.Setenv("GODEBUG", "tls13=0")
-	defer func() {
-		os.Setenv("GODEBUG", preEnv)
-	}()
 	// Generate valid TLS certificates.
 	caCert, caKey, err := generateCert(0, "TiDB CA", nil, nil, "/tmp/ca-key.pem", "/tmp/ca-cert.pem")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

closes https://github.com/pingcap/tidb/pull/10274

#10253 don't fix the root problem that makes test failure

 `tls13=1` and  `tls13=0` works well in go1.12, but in go1.13(or current go master) `tls13=0` cannot make "TLS" works like tls1.2 in go1.12

the root cause that makes the test fail isn't TLS, but the RSA alg change, in go1.12 it will use PKCS1WithSHA256([even if u use tls1.2](https://github.com/golang/go/blob/release-branch.go1.12/src/crypto/tls/common.go#L182, the relationship here is tls1.2 can use pss by opt but tls1.3 always use pss), https://github.com/golang/go/issues/30055), but in new go1.13, it use new RSA-PSS, even you disable tls1.2 and use tls1.3 it still uses PSS ---> `PSSWithSHA256`

and the question became simple PSSWithSHA256 require `(len(prikey)-1+7)/8 < 32 * 2 + 2 `, so we need generate key not smaller than `528`

### What is changed and how it works?

change generate key with `528`, so it will work well in

- go1.12 with tls12 or tls13
- go1.13 with tls13 unable or disable 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test test with master go and go1.12

Code changes

 - test

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10274)
<!-- Reviewable:end -->
