### PR TITLE
kv: remove the useless field of `snapshot`

### DIFF
--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -71,7 +71,6 @@ func (c *conditionPair) Err() error {
 // snapshot for read.
 type unionStore struct {
 	*BufferStore
-	snapshot           Snapshot                  // for read
 	lazyConditionPairs map[string]*conditionPair // for delay check
 	opts               options
 }
@@ -80,7 +79,6 @@ type unionStore struct {
 func NewUnionStore(snapshot Snapshot) UnionStore {
 	return &unionStore{
 		BufferStore:        NewBufferStore(snapshot, DefaultTxnMembufCap),
-		snapshot:           snapshot,
 		lazyConditionPairs: make(map[string]*conditionPair),
 		opts:               make(map[Option]interface{}),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`snapshot` isn't being used.

### What is changed and how it works?
Remove the useless field in kv.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code
