### PR TITLE
*: support `select`/ `explain select` using bind info

### DIFF
--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -83,6 +83,16 @@ func exprBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
 		if v.Sel != nil {
 			v.Sel.(*ast.SubqueryExpr).Query = resultSetNodeBind(v.Sel.(*ast.SubqueryExpr).Query, hintedWhere.(*ast.PatternInExpr).Sel.(*ast.SubqueryExpr).Query)
 		}
+	case *ast.BinaryOperationExpr:
+		if v.L != nil {
+			switch v.L.(type) {
+			case *ast.BinaryOperationExpr:
+				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
+				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
+			case *ast.PatternInExpr:
+				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
+			}
+		}
 	}
 	return where
 }

--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -85,20 +85,10 @@ func exprBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
 		}
 	case *ast.BinaryOperationExpr:
 		if v.L != nil {
-			switch v.L.(type) {
-			case *ast.BinaryOperationExpr:
-				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
-			case *ast.PatternInExpr:
-				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
-			}
+			v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
 		}
 		if v.R != nil {
-			switch v.R.(type) {
-			case *ast.BinaryOperationExpr:
-				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
-			case *ast.PatternInExpr:
-				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
-			}
+			v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
 		}
 	case *ast.IsNullExpr:
 		if v.Expr != nil {

--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -88,9 +88,16 @@ func exprBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
 			switch v.L.(type) {
 			case *ast.BinaryOperationExpr:
 				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
-				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
 			case *ast.PatternInExpr:
 				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
+			}
+		}
+		if v.R != nil{
+			switch v.R.(type) {
+			case *ast.BinaryOperationExpr:
+				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
+			case *ast.PatternInExpr:
+				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
 			}
 		}
 	}

--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -1,0 +1,107 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bindinfo
+
+import "github.com/pingcap/parser/ast"
+
+// BindHint will add hints for originStmt according to hintedStmt' hints.
+func BindHint(originStmt, hintedStmt ast.StmtNode) ast.StmtNode {
+	switch x := originStmt.(type) {
+	case *ast.SelectStmt:
+		return selectBind(x, hintedStmt.(*ast.SelectStmt))
+	default:
+		return originStmt
+	}
+}
+
+func selectBind(originalNode, hintedNode *ast.SelectStmt) *ast.SelectStmt {
+	if hintedNode.TableHints != nil {
+		originalNode.TableHints = hintedNode.TableHints
+	}
+	if originalNode.From != nil {
+		originalNode.From.TableRefs = resultSetNodeBind(originalNode.From.TableRefs, hintedNode.From.TableRefs).(*ast.Join)
+	}
+	if originalNode.Where != nil {
+		originalNode.Where = selectionBind(originalNode.Where, hintedNode.Where).(ast.ExprNode)
+	}
+	return originalNode
+}
+
+func selectionBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
+	switch v := where.(type) {
+	case *ast.SubqueryExpr:
+		if v.Query != nil {
+			v.Query = resultSetNodeBind(v.Query, hintedWhere.(*ast.SubqueryExpr).Query)
+		}
+	case *ast.ExistsSubqueryExpr:
+		if v.Sel != nil {
+			v.Sel.(*ast.SubqueryExpr).Query = resultSetNodeBind(v.Sel.(*ast.SubqueryExpr).Query, hintedWhere.(*ast.ExistsSubqueryExpr).Sel.(*ast.SubqueryExpr).Query)
+		}
+	case *ast.PatternInExpr:
+		if v.Sel != nil {
+			v.Sel.(*ast.SubqueryExpr).Query = resultSetNodeBind(v.Sel.(*ast.SubqueryExpr).Query, hintedWhere.(*ast.PatternInExpr).Sel.(*ast.SubqueryExpr).Query)
+		}
+	}
+	return where
+}
+
+func resultSetNodeBind(originalNode, hintedNode ast.ResultSetNode) ast.ResultSetNode {
+	switch x := originalNode.(type) {
+	case *ast.Join:
+		return joinBind(x, hintedNode.(*ast.Join))
+	case *ast.TableSource:
+		ts, _ := hintedNode.(*ast.TableSource)
+		switch v := x.Source.(type) {
+		case *ast.SelectStmt:
+			x.Source = selectBind(v, ts.Source.(*ast.SelectStmt))
+		case *ast.UnionStmt:
+			x.Source = unionSelectBind(v, hintedNode.(*ast.TableSource).Source.(*ast.UnionStmt))
+		case *ast.TableName:
+			x.Source = dataSourceBind(v, ts.Source.(*ast.TableName))
+		}
+		return x
+	case *ast.SelectStmt:
+		return selectBind(x, hintedNode.(*ast.SelectStmt))
+	case *ast.UnionStmt:
+		return unionSelectBind(x, hintedNode.(*ast.UnionStmt))
+	default:
+		return x
+	}
+}
+
+func dataSourceBind(originalNode, hintedNode *ast.TableName) *ast.TableName {
+	originalNode.IndexHints = hintedNode.IndexHints
+	return originalNode
+}
+
+func joinBind(originalNode, hintedNode *ast.Join) *ast.Join {
+	if originalNode.Left != nil {
+		originalNode.Left = resultSetNodeBind(originalNode.Left, hintedNode.Left)
+	}
+
+	if hintedNode.Right != nil {
+		originalNode.Right = resultSetNodeBind(originalNode.Right, hintedNode.Right)
+	}
+
+	return originalNode
+}
+
+func unionSelectBind(originalNode, hintedNode *ast.UnionStmt) ast.ResultSetNode {
+	selects := originalNode.SelectList.Selects
+	for i := len(selects) - 1; i >= 0; i-- {
+		originalNode.SelectList.Selects[i] = selectBind(selects[i], hintedNode.SelectList.Selects[i])
+	}
+
+	return originalNode
+}

--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -92,13 +92,32 @@ func exprBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
 				v.L = exprBind(v.L, hintedWhere.(*ast.BinaryOperationExpr).L)
 			}
 		}
-		if v.R != nil{
+		if v.R != nil {
 			switch v.R.(type) {
 			case *ast.BinaryOperationExpr:
 				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
 			case *ast.PatternInExpr:
 				v.R = exprBind(v.R, hintedWhere.(*ast.BinaryOperationExpr).R)
 			}
+		}
+	case *ast.IsNullExpr:
+		if v.Expr != nil {
+			v.Expr = exprBind(v.Expr, hintedWhere.(*ast.IsNullExpr).Expr)
+		}
+	case *ast.IsTruthExpr:
+		if v.Expr != nil {
+			v.Expr = exprBind(v.Expr, hintedWhere.(*ast.IsTruthExpr).Expr)
+		}
+	case *ast.PatternLikeExpr:
+		if v.Pattern != nil {
+			v.Pattern = exprBind(v.Pattern, hintedWhere.(*ast.PatternLikeExpr).Pattern)
+		}
+	case *ast.CompareSubqueryExpr:
+		if v.L != nil {
+			v.L = exprBind(v.L, hintedWhere.(*ast.CompareSubqueryExpr).L)
+		}
+		if v.R != nil {
+			v.R = exprBind(v.R, hintedWhere.(*ast.CompareSubqueryExpr).R)
 		}
 	}
 	return where

--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -37,7 +37,7 @@ func selectBind(originalNode, hintedNode *ast.SelectStmt) *ast.SelectStmt {
 	}
 
 	if originalNode.Having != nil {
-		originalNode.Having = havingBind(originalNode.Having, hintedNode.Having)
+		originalNode.Having.Expr = exprBind(originalNode.Having.Expr, hintedNode.Having.Expr)
 	}
 
 	if originalNode.OrderBy != nil {
@@ -58,11 +58,6 @@ func orderByBind(originalNode, hintedNode *ast.OrderByClause) *ast.OrderByClause
 	for idx := 0; idx < len(originalNode.Items); idx++ {
 		originalNode.Items[idx].Expr = exprBind(originalNode.Items[idx].Expr, hintedNode.Items[idx].Expr)
 	}
-	return originalNode
-}
-
-func havingBind(originalNode, hintedNode *ast.HavingClause) *ast.HavingClause {
-	originalNode.Expr = exprBind(originalNode.Expr, hintedNode.Expr)
 	return originalNode
 }
 

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -299,6 +299,7 @@ func (s *testSuite) TestGlobalAndSessionBindingBothExist(c *C) {
 		"  └─Selection_14 9990.00 cop not(isnull(test.t2.id))",
 		"    └─TableScan_13 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
+
 	tk.MustQuery("explain SELECT  /*+ TIDB_SMJ(t1, t2) */  * from t1,t2 where t1.id = t2.id").Check(testkit.Rows(
 		"MergeJoin_7 12487.50 root inner join, left key:test.t1.id, right key:test.t2.id",
 		"├─Sort_11 9990.00 root test.t1.id:asc",
@@ -346,6 +347,16 @@ func (s *testSuite) TestExplain(c *C) {
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1(id int)")
 	tk.MustExec("create table t2(id int)")
+
+	tk.MustQuery("explain SELECT * from t1,t2 where t1.id = t2.id").Check(testkit.Rows(
+		"HashLeftJoin_8 12487.50 root inner join, inner:TableReader_15, equal:[eq(test.t1.id, test.t2.id)]",
+		"├─TableReader_12 9990.00 root data:Selection_11",
+		"│ └─Selection_11 9990.00 cop not(isnull(test.t1.id))",
+		"│   └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
+		"└─TableReader_15 9990.00 root data:Selection_14",
+		"  └─Selection_14 9990.00 cop not(isnull(test.t2.id))",
+		"    └─TableScan_13 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
+	))
 
 	tk.MustQuery("explain SELECT  /*+ TIDB_SMJ(t1, t2) */  * from t1,t2 where t1.id = t2.id").Check(testkit.Rows(
 		"MergeJoin_7 12487.50 root inner join, left key:test.t1.id, right key:test.t2.id",

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -415,7 +415,7 @@ func (s *testSuite) TestErrorBind(c *C) {
 	_, err = tk.Exec("select * from t where i > 10")
 	c.Check(err, IsNil)
 
-	s.domain.BindHandle().HandleDropBindRecord()
+	s.domain.BindHandle().DropInvalidBindRecord()
 
 	rs, err := tk.Exec("show global bindings")
 	c.Assert(err, IsNil)

--- a/bindinfo/cache.go
+++ b/bindinfo/cache.go
@@ -20,16 +20,18 @@ import (
 )
 
 const (
-	// using is the bind info's in use status.
-	using = "using"
+	// Using is the bind info's in use status.
+	Using = "using"
 	// deleted is the bind info's deleted status.
 	deleted = "deleted"
+	// Invalid is the bind info's invalid status.
+	Invalid = "invalid"
 )
 
 // bindMeta stores the basic bind info and bindSql astNode.
 type bindMeta struct {
 	*BindRecord
-	ast ast.StmtNode //ast will be used to do query sql bind check
+	Ast ast.StmtNode //ast will be used to do query sql bind check
 }
 
 // cache is a k-v map, key is original sql, value is a slice of bindMeta.

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -231,8 +231,6 @@ func (h *BindHandle) DropBindRecord(record *BindRecord) (err error) {
 
 // HandleDropBindRecord execute the drop bindRecord task.
 func (h *BindHandle) HandleDropBindRecord() {
-	h.dropBindRecordMap.Lock()
-	defer h.dropBindRecordMap.Unlock()
 	dropBindRecordMap := copyDroppedBindRecordMap(h.dropBindRecordMap.Load().(map[string]*droppedBindRecord))
 	for key, droppedBindRecord := range dropBindRecordMap {
 		if droppedBindRecord.droppedTime.IsZero() {

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -258,6 +258,7 @@ func (h *BindHandle) AddDropBindRecordTask(dropBindRecord *BindRecord) {
 		return
 	}
 	h.dropBindRecordMap.Lock()
+	defer h.dropBindRecordMap.Unlock()
 	if _, ok := h.dropBindRecordMap.Value.Load().(map[string]*droppedBindRecord)[key]; ok {
 		return
 	}
@@ -266,7 +267,6 @@ func (h *BindHandle) AddDropBindRecordTask(dropBindRecord *BindRecord) {
 		bindRecord: dropBindRecord,
 	}
 	h.dropBindRecordMap.Store(newMap)
-	h.dropBindRecordMap.Unlock()
 }
 
 // Size return the size of bind info cache.

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -232,6 +232,7 @@ func (h *BindHandle) DropBindRecord(record *BindRecord) (err error) {
 // HandleDropBindRecord execute the drop bindRecord task.
 func (h *BindHandle) HandleDropBindRecord() {
 	h.dropBindRecordMap.Lock()
+	defer h.dropBindRecordMap.Unlock()
 	dropBindRecordMap := copyDroppedBindRecordMap(h.dropBindRecordMap.Load().(map[string]*droppedBindRecord))
 	for key, droppedBindRecord := range dropBindRecordMap {
 		if droppedBindRecord.droppedTime.IsZero() {
@@ -248,7 +249,6 @@ func (h *BindHandle) HandleDropBindRecord() {
 		}
 	}
 	h.dropBindRecordMap.Store(dropBindRecordMap)
-	h.dropBindRecordMap.Unlock()
 }
 
 // AddDropBindRecordTask add bindRecord to dropBindRecordMap when the bindRecord need to be deleted.

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -48,13 +48,12 @@ func (h *SessionHandle) newBindMeta(record *BindRecord) (hash string, meta *bind
 	if err != nil {
 		return "", nil, err
 	}
-	meta = &bindMeta{BindRecord: record, ast: stmtNodes[0]}
+	meta = &bindMeta{BindRecord: record, Ast: stmtNodes[0]}
 	return hash, meta, nil
 }
 
 // AddBindRecord new a BindRecord with bindMeta, add it to the cache.
 func (h *SessionHandle) AddBindRecord(record *BindRecord) error {
-	record.Status = using
 	record.CreateTime = types.Time{
 		Time: types.FromGoTime(time.Now()),
 		Type: mysql.TypeDatetime,
@@ -82,6 +81,17 @@ func (h *SessionHandle) GetBindRecord(normdOrigSQL, db string) *bindMeta {
 		}
 	}
 	return nil
+}
+
+// DropBindRecord remove the bindRecord from session cache.
+func (h *SessionHandle) DropBindRecord(normdOrigSQL, db string) {
+	hash := parser.DigestHash(normdOrigSQL)
+	record := &BindRecord{
+		OriginalSQL: normdOrigSQL,
+		Db:          db,
+	}
+	meta := &bindMeta{BindRecord: record}
+	h.ch.removeDeletedBindMeta(hash, meta)
 }
 
 // sessionBindInfoKeyType is a dummy type to avoid naming collision in context.

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -828,7 +828,7 @@ func (do *Domain) handleInvalidBindTaskLoop() {
 				return
 			case <-time.After(handleInvalidTaskDuration):
 			}
-			do.bindHandle.HandleDropBindRecord()
+			do.bindHandle.DropInvalidBindRecord()
 		}
 	}()
 }

--- a/executor/bind.go
+++ b/executor/bind.go
@@ -75,6 +75,7 @@ func (e *SQLBindExec) createSQLBind() error {
 		Db:          e.ctx.GetSessionVars().CurrentDB,
 		Charset:     e.charset,
 		Collation:   e.collation,
+		Status:      bindinfo.Using,
 	}
 	if !e.isGlobal {
 		handle := e.ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -416,7 +416,7 @@ func addHintForSelect(normdOrigSQL string, ctx sessionctx.Context, stmt ast.Stmt
 			return stmt
 		}
 		if bindRecord.Status == bindinfo.Using {
-			return bindHint(stmt, bindRecord.Ast)
+			return bindinfo.BindHint(stmt, bindRecord.Ast)
 		}
 	}
 	globalHandle := domain.GetDomain(ctx).BindHandle()
@@ -425,97 +425,7 @@ func addHintForSelect(normdOrigSQL string, ctx sessionctx.Context, stmt ast.Stmt
 		bindRecord = globalHandle.GetBindRecord(normdOrigSQL, "")
 	}
 	if bindRecord != nil {
-		return bindHint(stmt, bindRecord.Ast)
+		return bindinfo.BindHint(stmt, bindRecord.Ast)
 	}
 	return stmt
-}
-
-func bindHint(originStmt, hintedStmt ast.StmtNode) ast.StmtNode {
-	switch x := originStmt.(type) {
-	case *ast.SelectStmt:
-		return selectBind(x, hintedStmt.(*ast.SelectStmt))
-	default:
-		return originStmt
-	}
-}
-
-func selectBind(originalNode, hintedNode *ast.SelectStmt) *ast.SelectStmt {
-	if hintedNode.TableHints != nil {
-		originalNode.TableHints = hintedNode.TableHints
-	}
-	if originalNode.From != nil {
-		originalNode.From.TableRefs = resultSetNodeBind(originalNode.From.TableRefs, hintedNode.From.TableRefs).(*ast.Join)
-	}
-	if originalNode.Where != nil {
-		originalNode.Where = selectionBind(originalNode.Where, hintedNode.Where).(ast.ExprNode)
-	}
-	return originalNode
-}
-
-func selectionBind(where ast.ExprNode, hintedWhere ast.ExprNode) ast.ExprNode {
-	switch v := where.(type) {
-	case *ast.SubqueryExpr:
-		if v.Query != nil {
-			v.Query = resultSetNodeBind(v.Query, hintedWhere.(*ast.SubqueryExpr).Query)
-		}
-	case *ast.ExistsSubqueryExpr:
-		if v.Sel != nil {
-			v.Sel.(*ast.SubqueryExpr).Query = resultSetNodeBind(v.Sel.(*ast.SubqueryExpr).Query, hintedWhere.(*ast.ExistsSubqueryExpr).Sel.(*ast.SubqueryExpr).Query)
-		}
-	case *ast.PatternInExpr:
-		if v.Sel != nil {
-			v.Sel.(*ast.SubqueryExpr).Query = resultSetNodeBind(v.Sel.(*ast.SubqueryExpr).Query, hintedWhere.(*ast.PatternInExpr).Sel.(*ast.SubqueryExpr).Query)
-		}
-	}
-	return where
-}
-
-func resultSetNodeBind(originalNode, hintedNode ast.ResultSetNode) ast.ResultSetNode {
-	switch x := originalNode.(type) {
-	case *ast.Join:
-		return joinBind(x, hintedNode.(*ast.Join))
-	case *ast.TableSource:
-		ts, _ := hintedNode.(*ast.TableSource)
-		switch v := x.Source.(type) {
-		case *ast.SelectStmt:
-			x.Source = selectBind(v, ts.Source.(*ast.SelectStmt))
-		case *ast.UnionStmt:
-			x.Source = unionSelectBind(v, hintedNode.(*ast.TableSource).Source.(*ast.UnionStmt))
-		case *ast.TableName:
-			x.Source = dataSourceBind(v, ts.Source.(*ast.TableName))
-		}
-		return x
-	case *ast.SelectStmt:
-		return selectBind(x, hintedNode.(*ast.SelectStmt))
-	case *ast.UnionStmt:
-		return unionSelectBind(x, hintedNode.(*ast.UnionStmt))
-	default:
-		return x
-	}
-}
-
-func dataSourceBind(originalNode, hintedNode *ast.TableName) *ast.TableName {
-	originalNode.IndexHints = hintedNode.IndexHints
-	return originalNode
-}
-
-func joinBind(originalNode, hintedNode *ast.Join) *ast.Join {
-	if originalNode.Left != nil {
-		originalNode.Left = resultSetNodeBind(originalNode.Left, hintedNode.Left)
-	}
-
-	if hintedNode.Right != nil {
-		originalNode.Right = resultSetNodeBind(originalNode.Right, hintedNode.Right)
-	}
-
-	return originalNode
-}
-
-func unionSelectBind(originalNode, hintedNode *ast.UnionStmt) ast.ResultSetNode {
-	selects := originalNode.SelectList.Selects
-	for i := len(selects) - 1; i >= 0; i-- {
-		originalNode.SelectList.Selects[i] = selectBind(selects[i], hintedNode.SelectList.Selects[i])
-	}
-
-	return originalNode
 }

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -95,46 +95,6 @@ func (c *Compiler) compile(ctx context.Context, stmtNode ast.StmtNode, skipBind 
 	}, nil
 }
 
-// GetSelectTextFromStmtNode return stmtNode's select text if select text exist.
-func (c *Compiler) GetSelectTextFromStmtNode(stmtNode ast.StmtNode) string {
-	switch x := stmtNode.(type) {
-	case *ast.ExplainStmt:
-		switch x.Stmt.(type) {
-		case *ast.SelectStmt:
-			normalizeExplainSQL := parser.Normalize(x.Text())
-			idx := strings.Index(normalizeExplainSQL, "select")
-			return normalizeExplainSQL[idx:]
-		}
-	case *ast.SelectStmt:
-		return parser.Normalize(x.Text())
-	}
-	return ""
-}
-
-// GetBindMeta return normdOriginSQL's bindMeta in session bind cache or global bind cache.
-func (c *Compiler) GetBindMeta(ctx sessionctx.Context, normalizeSQL string) *bindinfo.BindMeta {
-	if ctx.Value(bindinfo.SessionBindInfoKeyType) == nil { //when the domain is initializing, the bind will be nil.
-		return nil
-	}
-	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-	bindMeta := sessionHandle.GetBindRecord(normalizeSQL, ctx.GetSessionVars().CurrentDB)
-	if bindMeta != nil {
-		if bindMeta.Status == bindinfo.Invalid {
-			return nil
-		}
-		if bindMeta.Status == bindinfo.Using {
-			return bindMeta
-		}
-	}
-
-	globalHandle := domain.GetDomain(ctx).BindHandle()
-	bindMeta = globalHandle.GetBindRecord(normalizeSQL, ctx.GetSessionVars().CurrentDB)
-	if bindMeta == nil {
-		bindMeta = globalHandle.GetBindRecord(normalizeSQL, "")
-	}
-	return bindMeta
-}
-
 func logExpensiveQuery(stmtNode ast.StmtNode, finalPlan plannercore.Plan) (expensive bool) {
 	expensive = isExpensiveQuery(finalPlan)
 	if !expensive {

--- a/session/session.go
+++ b/session/session.go
@@ -1010,7 +1010,8 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 		}
 		stmt, err := compiler.Compile(ctx, stmtNode)
 		if err != nil {
-			if tempStmtNodes == nil {
+			normolizedSQL := compiler.GetSelectTextFromStmtNode(stmtNode)
+			if tempStmtNodes == nil && normolizedSQL != "" && compiler.GetBindMeta(s, normolizedSQL) != nil {
 				tempStmtNodes, warns, err = s.ParseSQL(ctx, sql, charsetInfo, collation)
 				if err != nil || warns != nil {
 					//just skip errcheck, because parse will not return an error.
@@ -1058,8 +1059,7 @@ func (s *session) handleInValidBindRecord(ctx context.Context, stmtNode ast.Stmt
 		switch x.Stmt.(type) {
 		case *ast.SelectStmt:
 			normalizeExplainSQL := parser.Normalize(x.Text())
-			lowerSQL := strings.ToLower(normalizeExplainSQL)
-			idx := strings.Index(lowerSQL, "select")
+			idx := strings.Index(normalizeExplainSQL, "select")
 			normdOrigSQL = normalizeExplainSQL[idx:]
 		default:
 			return

--- a/session/session.go
+++ b/session/session.go
@@ -1025,7 +1025,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 					zap.String("sql", sql))
 				return nil, err
 			}
-			s.handleInValidBindRecord(ctx, stmtNode)
+			s.handleInvalidBindRecord(ctx, stmtNode)
 		}
 		if isInternal {
 			sessionExecuteCompileDurationInternal.Observe(time.Since(startTS).Seconds())
@@ -1051,7 +1051,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 	return recordSets, nil
 }
 
-func (s *session) handleInValidBindRecord(ctx context.Context, stmtNode ast.StmtNode) {
+func (s *session) handleInvalidBindRecord(ctx context.Context, stmtNode ast.StmtNode) {
 	var normdOrigSQL string
 	switch x := stmtNode.(type) {
 	case *ast.ExplainStmt:
@@ -1092,7 +1092,7 @@ func (s *session) handleInValidBindRecord(ctx context.Context, stmtNode ast.Stmt
 
 		err := sessionHandle.AddBindRecord(record)
 		if err != nil {
-			logutil.Logger(ctx).Warn("handleInValidBindRecord failed", zap.Error(err))
+			logutil.Logger(ctx).Warn("handleInvalidBindRecord failed", zap.Error(err))
 		}
 
 		globalHandle := domain.GetDomain(s).BindHandle()
@@ -1100,7 +1100,7 @@ func (s *session) handleInValidBindRecord(ctx context.Context, stmtNode ast.Stmt
 			OriginalSQL: bindMeta.OriginalSQL,
 			Db:          bindMeta.Db,
 		}
-		globalHandle.AddDropBindRecordTask(dropBindRecord)
+		globalHandle.AddDropInvalidBindTask(dropBindRecord)
 	}
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -1012,7 +1012,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 		if err != nil {
 			if tempStmtNodes == nil {
 				tempStmtNodes, warns, err = s.ParseSQL(ctx, sql, charsetInfo, collation)
-				if err != nil || warns != nil{
+				if err != nil || warns != nil {
 					//just skip errcheck, because parse will not return an error.
 				}
 			}

--- a/session/session.go
+++ b/session/session.go
@@ -1011,7 +1011,10 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 		stmt, err := compiler.Compile(ctx, stmtNode)
 		if err != nil {
 			if tempStmtNodes == nil {
-				tempStmtNodes, _, _ = s.ParseSQL(ctx, sql, charsetInfo, collation)
+				tempStmtNodes, warns, err = s.ParseSQL(ctx, sql, charsetInfo, collation)
+				if err != nil || warns != nil{
+					//just skip errcheck, because parse will not return an error.
+				}
 			}
 			stmtNode = tempStmtNodes[idx]
 			stmt, err = compiler.SkipBindCompile(ctx, stmtNode)

--- a/session/session.go
+++ b/session/session.go
@@ -1010,8 +1010,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 		}
 		stmt, err := compiler.Compile(ctx, stmtNode)
 		if err != nil {
-			normolizedSQL := compiler.GetSelectTextFromStmtNode(stmtNode)
-			if tempStmtNodes == nil && normolizedSQL != "" && compiler.GetBindMeta(s, normolizedSQL) != nil {
+			if tempStmtNodes == nil {
 				tempStmtNodes, warns, err = s.ParseSQL(ctx, sql, charsetInfo, collation)
 				if err != nil || warns != nil {
 					//just skip errcheck, because parse will not return an error.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
associated iusse: https://github.com/pingcap/tidb/issues/8935
feature: support add session binding
use case:
`
create table t(i int, s varchar(20))
`
`
create index index_t on t(i,s) 
`
`
create session binding for select * from t using select * from t use index for join(index_t)
`
then when we execute `select * from t`, we will execute `select * from t use index for join(index_t)` in actually.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes
N/A

Side effects
N/A

Related changes
N/A