### PR TITLE
*: support drop session binding

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -286,5 +286,4 @@ func (s *testSuite) TestSessionBinding(c *C) {
 	c.Check(bindData.CreateTime, NotNil)
 	c.Check(bindData.UpdateTime, NotNil)
 
-
 }

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -278,12 +278,5 @@ func (s *testSuite) TestSessionBinding(c *C) {
 	bindData = handle.GetBindRecord("select * from t where i > ?", "test")
 	c.Check(bindData, NotNil)
 	c.Check(bindData.OriginalSQL, Equals, "select * from t where i > ?")
-	c.Check(bindData.BindSQL, Equals, "select * from t use index(index_t) where i>99")
-	c.Check(bindData.Db, Equals, "test")
 	c.Check(bindData.Status, Equals, "deleted")
-	c.Check(bindData.Charset, NotNil)
-	c.Check(bindData.Collation, NotNil)
-	c.Check(bindData.CreateTime, NotNil)
-	c.Check(bindData.UpdateTime, NotNil)
-
 }

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -256,4 +256,10 @@ func (s *testSuite) TestSessionBinding(c *C) {
 	err = rs.Next(context.TODO(), chk)
 	c.Check(err, IsNil)
 	c.Check(chk.NumRows(), Equals, 0)
+
+	_, err = tk.Exec("drop session binding for select * from t where i>99")
+	c.Assert(err, IsNil)
+	bindData = handle.GetBindRecord("select * from t where i > ?", "test")
+	c.Check(bindData, IsNil)
+
 }

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -260,6 +260,14 @@ func (s *testSuite) TestSessionBinding(c *C) {
 	_, err = tk.Exec("drop session binding for select * from t where i>99")
 	c.Assert(err, IsNil)
 	bindData = handle.GetBindRecord("select * from t where i > ?", "test")
-	c.Check(bindData, IsNil)
+	c.Check(bindData, NotNil)
+	c.Check(bindData.OriginalSQL, Equals, "select * from t where i > ?")
+	c.Check(bindData.BindSQL, Equals, "select * from t use index(index_t) where i>99")
+	c.Check(bindData.Db, Equals, "test")
+	c.Check(bindData.Status, Equals, "deleted")
+	c.Check(bindData.Charset, NotNil)
+	c.Check(bindData.Collation, NotNil)
+	c.Check(bindData.CreateTime, NotNil)
+	c.Check(bindData.UpdateTime, NotNil)
 
 }

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -196,7 +196,7 @@ func (h *BindHandle) DropBindRecord(record *BindRecord) (err error) {
 			return
 		}
 
-		hash, meta := h.newBindMetaWithoutAst(record)
+		hash, meta := newBindMetaWithoutAst(record)
 		h.removeBindMeta(hash, meta)
 	}()
 
@@ -259,7 +259,7 @@ func (h *BindHandle) newBindMeta(record *BindRecord) (hash string, meta *bindMet
 	return hash, meta, nil
 }
 
-func (h *BindHandle) newBindMetaWithoutAst(record *BindRecord) (hash string, meta *bindMeta) {
+func newBindMetaWithoutAst(record *BindRecord) (hash string, meta *bindMeta) {
 	hash = parser.DigestHash(record.OriginalSQL)
 	meta = &bindMeta{BindRecord: record}
 	return hash, meta

--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -228,16 +228,7 @@ func (h *BindHandle) Size() int {
 
 // GetBindRecord return the bindMeta of the (normdOrigSQL,db) if bindMeta exist.
 func (h *BindHandle) GetBindRecord(normdOrigSQL, db string) *bindMeta {
-	hash := parser.DigestHash(normdOrigSQL)
-	bindRecords := h.bindInfo.Load().(cache)[hash]
-	if bindRecords != nil {
-		for _, bindRecord := range bindRecords {
-			if bindRecord.OriginalSQL == normdOrigSQL && bindRecord.Db == db {
-				return bindRecord
-			}
-		}
-	}
-	return nil
+	return h.bindInfo.Load().(cache).getBindRecord(normdOrigSQL, db)
 }
 
 // GetAllBindRecord return all bind record in cache.
@@ -335,6 +326,19 @@ func (c cache) copy() cache {
 		newCache[k] = v
 	}
 	return newCache
+}
+
+func (c cache) getBindRecord(normdOrigSQL, db string) *bindMeta {
+	hash := parser.DigestHash(normdOrigSQL)
+	bindRecords := c[hash]
+	if bindRecords != nil {
+		for _, bindRecord := range bindRecords {
+			if bindRecord.OriginalSQL == normdOrigSQL && bindRecord.Db == db {
+				return bindRecord
+			}
+		}
+	}
+	return nil
 }
 
 // isStale checks whether this bindMeta is stale compared with the other bindMeta.

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -70,6 +70,12 @@ func (h *SessionHandle) AddBindRecord(record *BindRecord) error {
 	return err
 }
 
+// DropBindRecord drops a BindRecord in the cache.
+func (h *SessionHandle) DropBindRecord(record *BindRecord) {
+	hash, meta := newBindMetaWithoutAst(record)
+	h.ch.removeDeletedBindMeta(hash, meta)
+}
+
 // GetBindRecord return the bindMeta of the (normdOrigSQL,db) if bindMeta exist.
 func (h *SessionHandle) GetBindRecord(normdOrigSQL, db string) *bindMeta {
 	hash := parser.DigestHash(normdOrigSQL)

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -72,8 +72,10 @@ func (h *SessionHandle) AddBindRecord(record *BindRecord) error {
 
 // DropBindRecord drops a BindRecord in the cache.
 func (h *SessionHandle) DropBindRecord(record *BindRecord) {
-	hash, meta := newBindMetaWithoutAst(record)
-	h.ch.removeDeletedBindMeta(hash, meta)
+	meta := h.ch.getBindRecord(record.OriginalSQL, record.Db)
+	if meta != nil {
+		meta.Status = deleted
+	}
 }
 
 // GetBindRecord return the bindMeta of the (normdOrigSQL,db) if bindMeta exist.

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -72,10 +72,11 @@ func (h *SessionHandle) AddBindRecord(record *BindRecord) error {
 
 // DropBindRecord drops a BindRecord in the cache.
 func (h *SessionHandle) DropBindRecord(record *BindRecord) {
-	meta := h.ch.getBindRecord(record.OriginalSQL, record.Db)
-	if meta != nil {
-		meta.Status = deleted
-	}
+	meta := &BindMeta{BindRecord: record}
+	meta.Status = deleted
+	hash := parser.DigestHash(record.OriginalSQL)
+	h.ch.removeDeletedBindMeta(hash, meta)
+	h.appendBindMeta(hash, meta)
 }
 
 // GetBindRecord return the BindMeta of the (normdOrigSQL,db) if BindMeta exist.

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -78,7 +78,6 @@ func (h *SessionHandle) DropBindRecord(record *BindRecord) {
 	}
 }
 
-
 // GetBindRecord return the BindMeta of the (normdOrigSQL,db) if BindMeta exist.
 func (h *SessionHandle) GetBindRecord(normdOrigSQL, db string) *BindMeta {
 	hash := parser.DigestHash(normdOrigSQL)

--- a/executor/bind.go
+++ b/executor/bind.go
@@ -57,13 +57,14 @@ func (e *SQLBindExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 }
 
 func (e *SQLBindExec) dropSQLBind() error {
-	if !e.isGlobal {
-		return errors.New("drop non-global sql bind is not supported")
-	}
-
 	record := &bindinfo.BindRecord{
 		OriginalSQL: e.normdOrigSQL,
 		Db:          e.ctx.GetSessionVars().CurrentDB,
+	}
+	if !e.isGlobal {
+		handle := e.ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
+		handle.DropBindRecord(record)
+		return nil
 	}
 	return domain.GetDomain(e.ctx).BindHandle().DropBindRecord(record)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
associated iusse: https://github.com/pingcap/tidb/issues/8935
feature: support add session binding
use case:
`
create table t(i int, s varchar(20))
`
`
create index index_t on t(i,s) 
`
if we want to create a binding for current session, then we execute such SQL:
`
create session binding for select * from t using select * from t use index for join(index_t)
`
if we want to drop this session binding,we execute SQL:
`
drop session binding for select * from t
`
### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes
N/A

Side effects
N/A

Related changes
N/A