### PR TITLE
plugin:modify conn_ip_example's method parameters and return values

### DIFF
--- a/plugin/conn_ip_example/conn_ip_example.go
+++ b/plugin/conn_ip_example/conn_ip_example.go
@@ -41,9 +41,9 @@ func OnShutdown(ctx context.Context, manifest *plugin.Manifest) error {
 }
 
 // OnGeneralEvent implements TiDB Audit plugin's OnGeneralEvent SPI.
-func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd byte, stmt string) error {
+func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd string) {
 	fmt.Println("conn_ip_example notifiy called")
 	fmt.Println("variable test: ", variable.GetSysVar("conn_ip_example_test_variable").Value)
 	fmt.Printf("new connection by %s\n", ctx.Value("ip"))
-	return nil
+	return
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
I recently researched TiDB's plugin mechanism, using the example provided by the official website (conn_id_example) to compile and generate plugins, but in the process of generating plugins, the following error message appears:
```
cannot use OnGeneralEvent (type func(context.Context, *variable.SessionVars, "github.com/pingcap/tidb/plugin".GeneralEvent, byte, string) error) as type func(context.Context, *variable.SessionVars, "github.com/pingcap/tidb/plugin".GeneralEvent, string) in field value
```
### What is changed and how it works?
I checked and found that the OnGeneralEvent method in conn_id_example.go is different from the OnGeneralEvent method parameter and return value in plugin/audit.go. Therefore, this pull request modifies the conn_id_example.go method parameter and return value, so that it can be normal. Generate plugin: conn_ip_example-1.so.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Code changes
no

Side effects
no

