### PR TITLE
log: change slow log time format to compatible with pt-query-digest

### DIFF
--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -330,7 +330,11 @@ func (st *slowQueryTuple) convertToDatumRow() []types.Datum {
 func ParseTime(s string) (time.Time, error) {
 	t, err := time.Parse(logutil.SlowLogTimeFormat, s)
 	if err != nil {
-		err = errors.Errorf("string \"%v\" doesn't has a prefix that matches format \"%v\", err: %v", s, logutil.SlowLogTimeFormat, err)
+		// This is for compatibility.
+		t, err = time.Parse(logutil.OldSlowLogTimeFormat, s)
+		if err != nil {
+			err = errors.Errorf("string \"%v\" doesn't has a prefix that matches format \"%v\", err: %v", s, logutil.SlowLogTimeFormat, err)
+		}
 	}
 	return t, err
 }

--- a/infoschema/slow_log_test.go
+++ b/infoschema/slow_log_test.go
@@ -25,7 +25,7 @@ import (
 
 func (s *testSuite) TestParseSlowLogFile(c *C) {
 	slowLog := bytes.NewBufferString(
-		`# Time: 2019-01-24-22:32:29.313255 +0800
+		`# Time: 2019-04-28T15:24:04.309074+08:00
 # Txn_start_ts: 405888132465033227
 # Query_time: 0.216905
 # Process_time: 0.021 Request_count: 1 Total_keys: 637 Processed_keys: 436
@@ -51,14 +51,14 @@ select * from t;`)
 		}
 		recordString += str
 	}
-	expectRecordString := "2019-01-24 22:32:29.313255,405888132465033227,,0,0.216905,0.021,0,0,1,637,0,,,1,42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772,t1:1,t2:2,0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,select * from t;"
+	expectRecordString := "2019-04-28 15:24:04.309074,405888132465033227,,0,0.216905,0.021,0,0,1,637,0,,,1,42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772,t1:1,t2:2,0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,select * from t;"
 	c.Assert(expectRecordString, Equals, recordString)
 
 	// fix sql contain '# ' bug
 	slowLog = bytes.NewBufferString(
-		`# Time: 2019-01-24-22:32:29.313255 +0800
+		`# Time: 2019-04-28T15:24:04.309074+08:00
 select a# from t;
-# Time: 2019-01-24-22:32:29.313255 +0800
+# Time: 2019-01-24T22:32:29.313255+08:00
 # Txn_start_ts: 405888132465033227
 # Query_time: 0.216905
 # Process_time: 0.021 Request_count: 1 Total_keys: 637 Processed_keys: 436
@@ -70,16 +70,34 @@ select * from t;
 	scanner = bufio.NewScanner(slowLog)
 	_, err = infoschema.ParseSlowLog(loc, scanner)
 	c.Assert(err, IsNil)
+
+	// test for time format compatibility.
+	slowLog = bytes.NewBufferString(
+		`# Time: 2019-04-28T15:24:04.309074+08:00
+select * from t;
+# Time: 2019-04-24-19:41:21.716221 +0800
+select * from t;
+`)
+	scanner = bufio.NewScanner(slowLog)
+	rows, err = infoschema.ParseSlowLog(loc, scanner)
+	c.Assert(err, IsNil)
+	c.Assert(len(rows) == 2, IsTrue)
+	t0Str, err := rows[0][0].ToString()
+	c.Assert(err, IsNil)
+	c.Assert(t0Str, Equals, "2019-04-28 15:24:04.309074")
+	t1Str, err := rows[1][0].ToString()
+	c.Assert(err, IsNil)
+	c.Assert(t1Str, Equals, "2019-04-24 19:41:21.716221")
 }
 
 func (s *testSuite) TestSlowLogParseTime(c *C) {
-	t1Str := "2019-01-24-22:32:29.313255 +0800"
-	t2Str := "2019-01-24-22:32:29.313255"
+	t1Str := "2019-01-24T22:32:29.313255+08:00"
+	t2Str := "2019-01-24T22:32:29.313255"
 	t1, err := infoschema.ParseTime(t1Str)
 	c.Assert(err, IsNil)
 	loc, err := time.LoadLocation("Asia/Shanghai")
 	c.Assert(err, IsNil)
-	t2, err := time.ParseInLocation("2006-01-02-15:04:05.999999999", t2Str, loc)
+	t2, err := time.ParseInLocation("2006-01-02T15:04:05.999999999", t2Str, loc)
 	c.Assert(err, IsNil)
 	c.Assert(t1.Unix(), Equals, t2.Unix())
 	t1Format := t1.In(loc).Format(logutil.SlowLogTimeFormat)

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -329,7 +329,7 @@ func (s *testTableSuite) TestSlowQuery(c *C) {
 	f, err := os.OpenFile(slowLogFileName, os.O_CREATE|os.O_WRONLY, 0644)
 	c.Assert(err, IsNil)
 	defer os.Remove(slowLogFileName)
-	_, err = f.Write([]byte(`# Time: 2019-02-12-19:33:56.571953 +0800
+	_, err = f.Write([]byte(`# Time: 2019-02-12T19:33:56.571953+08:00
 # Txn_start_ts: 406315658548871171
 # User: root@127.0.0.1
 # Conn_ID: 6

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -945,7 +945,7 @@ const (
 
 // SlowLogFormat uses for formatting slow log.
 // The slow log output is like below:
-// # Time: 2019-02-12-19:33:56.571953 +0800
+// # Time: 2019-04-28T15:24:04.309074+08:00
 // # Txn_start_ts: 406315658548871171
 // # User: root@127.0.0.1
 // # Conn_ID: 6

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	zaplog "github.com/pingcap/log"
@@ -208,7 +209,9 @@ func (f *textFormatter) Format(entry *log.Entry) ([]byte, error) {
 
 const (
 	// SlowLogTimeFormat is the time format for slow log.
-	SlowLogTimeFormat = "2006-01-02-15:04:05.999999999 -0700"
+	SlowLogTimeFormat = time.RFC3339Nano
+	// OldSlowLogTimeFormat is the first version of the the time format for slow log, This is use for compatibility.
+	OldSlowLogTimeFormat = "2006-01-02-15:04:05.999999999 -0700"
 )
 
 type slowLogFormatter struct{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Exec below `pt-query-digest` with `--since`  command will got error in old tidb slow log. Because of the slow log time format is not compatible with pt-query-digest.
` pt-query-digest --type slowlog --output report --limit=100% --since "2019-04-28 15:26:06" tidb-slow.log` 

I try to find the MySQL slow log time format, But i got nothing in MySQL document or in google about the slow log time format. Then I check the MySQL slow log file, and find the most likely time format is `RFC3339Nano`, but not exactly the same.

Then I try to use `RFC3339Nano` time format, Then `pt-query-digest` with `--since` param will execute successfully. Then I chose `RFC3339Nano` format as the new slow log format.

### What is changed and how it works?
Change slow log time format from "2006-01-02-15:04:05.999999999 -0700" to `RFC3339Nano`(`"2006-01-02T15:04:05.999999999Z07:00"`).

And for `Slow_query` parse slow_log compatibility, I still keep the old time format. Because if user was upgrade from old version, then there maybe 2 different time format in the same slow log file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change


Side effects

Related changes

 - Need to cherry-pick to the release branch
