### PR TITLE
executor: refine point get failpoint injection logic

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -67,7 +67,6 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
-	"github.com/tiancaiamao/debugger"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -1876,9 +1875,6 @@ func (s *testSuite) TestIsPointGet(c *C) {
 }
 
 func (s *testSuite) TestPointGetRepeatableRead(c *C) {
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/pointGetRepeatableReadTest", `return(true)`), IsNil)
-	defer failpoint.Disable("github.com/pingcap/tidb/executor/pointGetRepeatableReadTest")
-
 	tk1 := testkit.NewTestKit(c, s.store)
 	tk1.MustExec("use test")
 	tk1.MustExec(`create table point_get (a int, b int, c int,
@@ -1888,19 +1884,24 @@ func (s *testSuite) TestPointGetRepeatableRead(c *C) {
 	tk2 := testkit.NewTestKit(c, s.store)
 	tk2.MustExec("use test")
 
+	// Create a failpoint to block `POINT GET` until `UPDATE` finished
+	const pointGet1Pause = "github.com/pingcap/tidb/executor/pointGetQuery1Pause"
+	c.Assert(failpoint.Enable(pointGet1Pause, `return`), IsNil)
+	defer func() { c.Assert(failpoint.Disable(pointGet1Pause), IsNil) }()
+	pointGetWaitCh := make(chan struct{})
+	updateWaitCh := make(chan struct{})
 	go func() {
-		ctx := context.WithValue(context.Background(), "pointGetRepeatableReadTest", true)
+		chs := []chan struct{}{updateWaitCh, pointGetWaitCh}
+		ctx := context.WithValue(context.Background(), "pointGetRepeatableReadTest", chs)
 		rs, err := tk1.Se.Execute(ctx, "select c from point_get where b = 1")
 		c.Assert(err, IsNil)
 		result := tk1.ResultSetToResultWithCtx(ctx, rs[0], Commentf("execute sql fail"))
 		result.Check(testkit.Rows("1"))
 	}()
 
-	label := debugger.Bind("point-get-g2")
-	debugger.Continue("point-get-g1")
-	debugger.Breakpoint(label)
+	<-updateWaitCh
 	tk2.MustExec("update point_get set b = 2, c = 2 where a = 1")
-	debugger.Continue("point-get-g1")
+	close(pointGetWaitCh) // Make `POINT GET` continue
 }
 
 func (s *testSuite) TestRow(c *C) {

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
-	"github.com/tiancaiamao/debugger"
 )
 
 func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
@@ -91,10 +90,15 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.RecordBatch) err
 			return err1
 		}
 
-		failpoint.Inject("pointGetRepeatableReadTest", func(val failpoint.Value) {
-			if val.(bool) && ctx.Value("pointGetRepeatableReadTest") != nil {
-				label := debugger.Bind("point-get-g1")
-				debugger.Breakpoint(label)
+		// The injection is used to simulate following scenario:
+		// 1. Session A create a point get query but pause before `GET` kv from backend
+		// 2. Session B create an UPDATE query to update the record that will be obtained in step 1
+		// 3. Then point get retrieve data from backend after step 2 finished
+		// 4. Check the result
+		failpoint.InjectContext(ctx, "pointGetQuery1Pause", func() {
+			if chs, ok := ctx.Value("pointGetRepeatableReadTest").([]chan struct{}); ok {
+				close(chs[0]) // Make `UPDATE` query continue
+				<-chs[1]      // Wait `UPDATE` finished
 			}
 		})
 
@@ -109,14 +113,6 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.RecordBatch) err
 		if err1 != nil {
 			return err1
 		}
-
-		failpoint.Inject("pointGetRepeatableReadTest", func(val failpoint.Value) {
-			if val.(bool) && ctx.Value("pointGetRepeatableReadTest") != nil {
-				label := debugger.Bind("point-get-g1")
-				debugger.Continue("point-get-g2")
-				debugger.Breakpoint(label)
-			}
-		})
 	}
 
 	key := tablecodec.EncodeRowKeyWithHandle(e.tblInfo.ID, e.handle)

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72
 	github.com/struCoder/pidusage v0.1.2
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tiancaiamao/debugger v0.0.0-20190428065433-3a10ffa41d22
 	github.com/twinj/uuid v1.0.0
 	github.com/uber-go/atomic v1.3.2 // indirect
 	github.com/uber/jaeger-client-go v2.15.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,6 @@ github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d h1:4J9HCZVpvDmj2t
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tiancaiamao/debugger v0.0.0-20190428065433-3a10ffa41d22 h1:P4sgavMKEdqNOws2VfR2c/Bye9nYFgV8gHyiW1wpQhE=
-github.com/tiancaiamao/debugger v0.0.0-20190428065433-3a10ffa41d22/go.mod h1:qaShs3uDBYnvaQZJAJ6PjPg8kuAHR9zUJ8ilSLK1y/w=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6 h1:lYIiVDtZnyTWlNwiAxLj0bbpTcx1BWCFhXjfsvmPdNc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Signed-off-by: Lonng <chris@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Refine point get fault injection logic

### What is changed and how it works?

1. Change the failpoint expression from `return(true)` to `return` and remove `debugger`
2. Refine the failpoint closure.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

N/A

Side effects


Related changes

