### PR TITLE
tikvclient: fix a bug that recreate connection forever

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -126,13 +126,13 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 		// When `conn.Close()` is called, `client.Recv()` will return an error.
 		resp, err := c.client.Recv()
 		if err != nil {
-			if c.isStopped() {
-				return
-			}
 			logutil.Logger(context.Background()).Error("batchRecvLoop error when receive", zap.Error(err))
 
 			now := time.Now()
 			for { // try to re-create the streaming in the loop.
+				if c.isStopped() {
+					return
+				}
 				// Hold the lock to forbid batchSendLoop using the old client.
 				c.clientLock.Lock()
 				c.failPendingRequests(err) // fail all pending requests.


### PR DESCRIPTION
### What problem does this PR solve?
When TiDB trys to re-create the connection to one TiKV, it just checks itself is shutdown or not for the first time. After that TiDB will keep retry if the re-create always fail. 

### What is changed and how it works?
With this PR TiDB will check it's shutdown or not for every retry, so it can exit successfully.