### PR TITLE
ddl: refine ddl change shard_rowid err msg

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2729,7 +2729,7 @@ func (s *testDBSuite2) TestAlterShardRowIDBits(c *C) {
 	// Test increase shard_row_id_bits failed by overflow global auto ID.
 	_, err := tk.Exec("alter table t1 SHARD_ROW_ID_BITS = 10;")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[autoid:1467]shard_row_id_bits 10 will cause next global auto ID overflow")
+	c.Assert(err.Error(), Equals, "[autoid:1467]shard_row_id_bits 10 will cause next global auto ID 72057594037932936 overflow")
 
 	// Test reduce shard_row_id_bits will be ok.
 	tk.MustExec("alter table t1 SHARD_ROW_ID_BITS = 3;")

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -607,7 +607,7 @@ func verifyNoOverflowShardBits(s *sessionPool, tbl table.Table, shardRowIDBits u
 		return errors.Trace(err)
 	}
 	if tables.OverflowShardBits(autoIncID, shardRowIDBits) {
-		return autoid.ErrAutoincReadFailed.GenWithStack("shard_row_id_bits %d will cause next global auto ID overflow", shardRowIDBits)
+		return autoid.ErrAutoincReadFailed.GenWithStack("shard_row_id_bits %d will cause next global auto ID %v overflow", shardRowIDBits, autoIncID)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 refine ddl change shard_rowid err msg. Print next global ID value if overflow.

### What is changed and how it works?
use to:

```go
shard_row_id_bits 6 will cause next global auto ID overflow
```

now

```go
shard_row_id_bits 6 will cause next global auto ID 576460752303423488 overflow.
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No Logical code
