### PR TITLE
domain: fix updating the self schema version and update log

### DIFF
--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -82,14 +82,14 @@ func (*testSuite) TestT(c *C) {
 	lease := 100 * time.Millisecond
 
 	// for updating the self schema version
-	goCtx, cancel := context.WithTimeout(context.Background(), 3*time.Millisecond)
+	goCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	err = dd.SchemaSyncer().OwnerCheckAllVersions(goCtx, is.SchemaMetaVersion())
 	cancel()
 	c.Assert(err, IsNil)
 	_, err = dom.GetSnapshotInfoSchema(snapTS)
 	c.Assert(err, IsNil)
 	// Make sure that the self schema version doesn't be changed.
-	goCtx, cancel = context.WithTimeout(context.Background(), 3*time.Millisecond)
+	goCtx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
 	err = dd.SchemaSyncer().OwnerCheckAllVersions(goCtx, is.SchemaMetaVersion())
 	cancel()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Updating the self-schema version to etcd is wrong when executing GetSnapshotInfoSchema.

### What is changed and how it works?
If the neededSchemaVersion isn't the latest schema version.
Update the logs and rename ”latestSchemaVersion“ to ” neededSchemaVersion“

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
