### PR TITLE
types: rename CopyRow and CopyDatum to Clone*

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -318,7 +318,7 @@ func (e *InsertValues) insertRowsFromSelect(ctx context.Context, exec func(ctx c
 		}
 
 		for innerChunkRow := iter.Begin(); innerChunkRow != iter.End(); innerChunkRow = iter.Next() {
-			innerRow := types.CopyRow(innerChunkRow.GetDatumRow(fields))
+			innerRow := types.CloneRow(innerChunkRow.GetDatumRow(fields))
 			e.rowCount++
 			row, err := e.getRow(innerRow)
 			if err != nil {

--- a/executor/update.go
+++ b/executor/update.go
@@ -223,7 +223,7 @@ func (e *UpdateExec) handleErr(colName model.CIStr, rowIdx int, err error) error
 }
 
 func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*table.Column) ([]types.Datum, error) {
-	newRowData := types.CopyRow(oldRow)
+	newRowData := types.CloneRow(oldRow)
 	e.evalBuffer.SetDatums(newRowData...)
 	for _, assign := range e.OrderedList {
 		handleIdx, handleFound := e.columns2Handle.findHandle(int32(assign.Col.Index))

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -36,7 +36,7 @@ func (ff *firstRowFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stat
 	if err != nil {
 		return err
 	}
-	evalCtx.Value = types.CopyDatum(value)
+	evalCtx.Value = types.CloneDatum(value)
 	evalCtx.GotFirstRow = true
 	return nil
 }

--- a/expression/aggregation/util.go
+++ b/expression/aggregation/util.go
@@ -68,7 +68,7 @@ func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.
 			data = types.NewDecimalDatum(d)
 		}
 	case types.KindMysqlDecimal:
-		data = types.CopyDatum(v)
+		data = types.CloneDatum(v)
 	default:
 		var f float64
 		f, err = v.ToFloat64(sc)

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -157,17 +157,17 @@ func (c *SampleCollector) collect(sc *stmtctx.StatementContext, d types.Datum) e
 		c.TotalSize += int64(len(d.GetBytes()) - 1)
 	}
 	c.seenValues++
-	// The following code use types.CopyDatum(d) because d may have a deep reference
+	// The following code use types.CloneDatum(d) because d may have a deep reference
 	// to the underlying slice, GC can't free them which lead to memory leak eventually.
 	// TODO: Refactor the proto to avoid copying here.
 	if len(c.Samples) < int(c.MaxSampleSize) {
-		newItem := &SampleItem{Value: types.CopyDatum(d)}
+		newItem := &SampleItem{Value: types.CloneDatum(d)}
 		c.Samples = append(c.Samples, newItem)
 	} else {
 		shouldAdd := rand.Int63n(c.seenValues) < c.MaxSampleSize
 		if shouldAdd {
 			idx := rand.Intn(int(c.MaxSampleSize))
-			newItem := &SampleItem{Value: types.CopyDatum(d)}
+			newItem := &SampleItem{Value: types.CloneDatum(d)}
 			// To keep the order of the elements, we use delete and append, not direct replacement.
 			c.Samples = append(c.Samples[:idx], c.Samples[idx+1:]...)
 			c.Samples = append(c.Samples, newItem)

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -267,7 +267,7 @@ func (e *streamAggExec) getPartialResult() ([][]byte, error) {
 		}
 		e.currGroupByValues = append(e.currGroupByValues, buf)
 	}
-	e.currGroupByRow = types.CopyRow(e.nextGroupByRow)
+	e.currGroupByRow = types.CloneRow(e.nextGroupByRow)
 	return append(value, e.currGroupByValues...), nil
 }
 
@@ -296,7 +296,7 @@ func (e *streamAggExec) meetNewGroup(row [][]byte) (bool, error) {
 		e.tmpGroupByRow = append(e.tmpGroupByRow, d)
 	}
 	if firstGroup {
-		e.currGroupByRow = types.CopyRow(e.tmpGroupByRow)
+		e.currGroupByRow = types.CloneRow(e.tmpGroupByRow)
 	}
 	if matched {
 		return false, nil

--- a/types/datum.go
+++ b/types/datum.go
@@ -1835,14 +1835,14 @@ func DatumsToStrNoErr(datums []Datum) string {
 	return str
 }
 
-// CopyDatum returns a new copy of the datum.
+// CloneDatum returns a new copy of the datum.
 // TODO: Abandon this function.
-func CopyDatum(datum Datum) Datum {
+func CloneDatum(datum Datum) Datum {
 	return *datum.Copy()
 }
 
-// CopyRow deep copies a Datum slice.
-func CopyRow(dr []Datum) []Datum {
+// CloneRow deep copies a Datum slice.
+func CloneRow(dr []Datum) []Datum {
 	c := make([]Datum, len(dr))
 	for i, d := range dr {
 		c[i] = *d.Copy()

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -351,7 +351,7 @@ func (ts *testDatumSuite) TestComputePlusAndMinus(c *C) {
 	}
 }
 
-func (ts *testDatumSuite) TestCopyDatum(c *C) {
+func (ts *testDatumSuite) TestCloneDatum(c *C) {
 	var raw Datum
 	raw.b = []byte("raw")
 	raw.k = KindRaw
@@ -366,7 +366,7 @@ func (ts *testDatumSuite) TestCopyDatum(c *C) {
 	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	for _, tt := range tests {
-		tt1 := CopyDatum(tt)
+		tt1 := CloneDatum(tt)
 		res, err := tt.CompareDatum(sc, &tt1)
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, 0)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tidb/issues/10252

### What is changed and how it works?

Search the whole project by `ag 'Copy[^r( ]'`

`CopyConstruct` need not to update, `CopySelectedJoinRows` and `ShallowCopyPartialRow` are really copy.

only rename `CopyRow` to `CloneRow`, `CopyDatum` to `CloneDatum`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

Related changes
