### PR TITLE
Fix incorrect "Internal" display in admin show slow output

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -617,9 +617,9 @@ func (e *ShowSlowExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		req.AppendString(9, slow.TableIDs)
 		req.AppendString(10, slow.IndexIDs)
 		if slow.Internal {
-			req.AppendInt64(11, 0)
-		} else {
 			req.AppendInt64(11, 1)
+		} else {
+			req.AppendInt64(11, 0)
 		}
 		req.AppendString(12, slow.Digest)
 		e.cursor++


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fixes the incorrect output for "Internal" in admin show slow output

### What is changed and how it works?
Just the output was inverted

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None exist

Code changes

 - Has exported function/method change
No
 - Has exported variable/fields change
No
 - Has interface methods change
No
 - Has persistent data change
No

Side effects

 - Possible performance regression
No
 - Increased code complexity
No
 - Breaking backward compatibility
Possibly for someone depending on incorrect output

Related changes

 - Need to cherry-pick to the release branch
No
 - Need to update the documentation
No
 - Need to update the `tidb-ansible` repository
No
 - Need to be included in the release note
No
