### PR TITLE
session: make tidb_disable_txn_auto_retry disable retry for the explicit transactions

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -405,7 +405,7 @@ func (s *session) doCommitWithRetry(ctx context.Context) error {
 			// For autocommit single statement transactions, the history count is always 1.
 			// For explicit transactions, the statement count is more than 1.
 			history := GetHistory(s)
-			if history.Count() > 1 && strings.Contains(err.Error(), util.WriteConflictMarker) {
+			if history.Count() > 1 {
 				commitRetryLimit = 0
 			}
 		}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2421,12 +2421,12 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	tk2.MustExec("alter table no_retry add index idx(id)")
 	tk2.MustQuery("select * from no_retry").Check(testkit.Rows("8"))
 	tk1.MustExec("update no_retry set id = 10")
-	tk1.MustExec("commit")
-	tk2.MustQuery("select * from no_retry").Check(testkit.Rows("10"))
+	_, err = tk1.Se.Execute(context.Background(), "commit")
+	c.Assert(err, NotNil)
 
 	// set autocommit to begin and commit
 	tk1.MustExec("set autocommit = 0")
-	tk1.MustQuery("select * from no_retry").Check(testkit.Rows("10"))
+	tk1.MustQuery("select * from no_retry").Check(testkit.Rows("8"))
 	tk2.MustExec("update no_retry set id = 11")
 	tk1.MustExec("update no_retry set id = 12")
 	_, err = tk1.Se.Execute(context.Background(), "set autocommit = 1")


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It is not a good idea to make `tidb_disable_txn_auto_retry` deal with the write-conflict error only. Some rigorous tests e.g. jepsen will find that this will make the transaction behave abnormally. Although we can set `tidb_retry_limit = 0` to disable retry either.

### What is changed and how it works?
Make `tidb_disable_txn_auto_retry` work the same as before, it will disable retry for the explicit transactions, no matter what kind of error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

