### PR TITLE
types: Fix checkMonthDay() to correctly handle leap year

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -1482,7 +1482,7 @@ func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
 		if month > 0 {
 			maxDay = maxDaysInMonth[month-1]
 		}
-		if month == 2 && (year%4 != 0 || (year%100 == 0 && year%400 != 0)) {
+		if month == 2 && !isLeapYear(uint16(year)) {
 			maxDay = 28
 		}
 	}

--- a/types/time.go
+++ b/types/time.go
@@ -1474,7 +1474,7 @@ func checkDateRange(t MysqlTime) error {
 
 func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
 	if month < 0 || month > 12 {
-		return errors.Trace(ErrInvalidTimeFormat.GenWithStackByArgs(month))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(month))
 	}
 
 	maxDay := 31
@@ -1482,13 +1482,13 @@ func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
 		if month > 0 {
 			maxDay = maxDaysInMonth[month-1]
 		}
-		if month == 2 && year%4 != 0 {
+		if month == 2 && (year%4 != 0 || (year%100 == 0 && year%400 != 0)) {
 			maxDay = 28
 		}
 	}
 
 	if day < 0 || day > maxDay {
-		return errors.Trace(ErrInvalidTimeFormat.GenWithStackByArgs(day))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(day))
 	}
 	return nil
 }

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -1455,3 +1455,43 @@ func (s *testTimeSuite) TestTimeSub(c *C) {
 		c.Assert(rec, Equals, dur)
 	}
 }
+
+func (s *testTimeSuite) TestCheckMonthDay(c *C) {
+	dates := []struct {
+		date        types.MysqlTime
+		isValidDate bool
+	}{
+		{types.FromDate(1900, 2, 29, 0, 0, 0, 0), false},
+		{types.FromDate(1900, 2, 28, 0, 0, 0, 0), true},
+		{types.FromDate(2000, 2, 29, 0, 0, 0, 0), true},
+		{types.FromDate(2000, 1, 1, 0, 0, 0, 0), true},
+		{types.FromDate(1900, 1, 1, 0, 0, 0, 0), true},
+		{types.FromDate(1900, 1, 31, 0, 0, 0, 0), true},
+		{types.FromDate(1900, 4, 1, 0, 0, 0, 0), true},
+		{types.FromDate(1900, 4, 31, 0, 0, 0, 0), false},
+		{types.FromDate(1900, 4, 30, 0, 0, 0, 0), true},
+		{types.FromDate(2000, 2, 30, 0, 0, 0, 0), false},
+		{types.FromDate(2000, 13, 1, 0, 0, 0, 0), false},
+		{types.FromDate(4000, 2, 29, 0, 0, 0, 0), true},
+		{types.FromDate(3200, 2, 29, 0, 0, 0, 0), true},
+	}
+
+	sc := &stmtctx.StatementContext{
+		TimeZone:         time.UTC,
+		AllowInvalidDate: false,
+	}
+
+	for _, t := range dates {
+		tt := types.Time{
+			Time: t.date,
+			Type: mysql.TypeDate,
+			Fsp:  types.DefaultFsp,
+		}
+		err := tt.Check(sc)
+		if t.isValidDate {
+			c.Check(err, IsNil)
+		} else {
+			c.Check(types.ErrIncorrectDatetimeValue.Equal(err), IsTrue)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1900-02-29 is not a valid date. However:

In TiDB:

```
mysql> insert into t1 values ("1900-02-29 00:00:00");
Query OK, 1 row affected (0.00 sec)
```


MySQL does not consider 1900 as a leap year. So this is not intended.

In MySQL:
```
mysql> insert into t1 values ("1900-02-29 00:00:00");
ERROR 1292 (22007): Incorrect datetime value: '1900-02-29 00:00:00' for column 't' at row 1
```

### What is changed and how it works?

```go
if month == 2 && !isLeapYear(uint16(year)) {
	maxDay = 28
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
