### PR TITLE
chunk: change offset type to int64

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -139,7 +139,7 @@ func newVarLenColumn(cap int, old *column) *column {
 		estimatedElemLen = (len(old.data) + len(old.data)/8) / old.length
 	}
 	return &column{
-		offsets:    make([]int32, 1, cap+1),
+		offsets:    make([]int64, 1, cap+1),
 		data:       make([]byte, 0, cap*estimatedElemLen),
 		nullBitmap: make([]byte, 0, cap>>3),
 	}
@@ -318,7 +318,7 @@ func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
 		} else {
 			start, end := rowCol.offsets[row.idx], rowCol.offsets[row.idx+1]
 			chkCol.data = append(chkCol.data, rowCol.data[start:end]...)
-			chkCol.offsets = append(chkCol.offsets, int32(len(chkCol.data)))
+			chkCol.offsets = append(chkCol.offsets, int64(len(chkCol.data)))
 		}
 		chkCol.length++
 	}
@@ -342,7 +342,7 @@ func (c *Chunk) PreAlloc(row Row) (rowIdx uint32) {
 		elemLen := len(srcCol.elemBuf)
 		if !srcCol.isFixed() {
 			elemLen = int(srcCol.offsets[row.idx+1] - srcCol.offsets[row.idx])
-			dstCol.offsets = append(dstCol.offsets, int32(len(dstCol.data)+elemLen))
+			dstCol.offsets = append(dstCol.offsets, int64(len(dstCol.data)+elemLen))
 		}
 		dstCol.length++
 		needCap := len(dstCol.data) + elemLen

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -169,7 +169,7 @@ func (s *testChunkSuite) TestAppend(c *check.C) {
 	c.Assert(dst.columns[1].length, check.Equals, 12)
 	c.Assert(dst.columns[1].nullCount, check.Equals, 6)
 	c.Assert(string(dst.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
-	c.Assert(string(dst.columns[1].offsets), check.Equals, string([]int32{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
+	c.Assert(fmt.Sprintf("%v", dst.columns[1].offsets), check.Equals, fmt.Sprintf("%v", []int64{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
 	c.Assert(string(dst.columns[1].data), check.Equals, "abcabcabcabcabcabc")
 	c.Assert(len(dst.columns[1].elemBuf), check.Equals, 0)
 
@@ -222,7 +222,7 @@ func (s *testChunkSuite) TestTruncateTo(c *check.C) {
 	c.Assert(src.columns[1].length, check.Equals, 12)
 	c.Assert(src.columns[1].nullCount, check.Equals, 6)
 	c.Assert(string(src.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
-	c.Assert(string(src.columns[1].offsets), check.Equals, string([]int32{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
+	c.Assert(fmt.Sprintf("%v", src.columns[1].offsets), check.Equals, fmt.Sprintf("%v", []int64{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
 	c.Assert(string(src.columns[1].data), check.Equals, "abcabcabcabcabcabc")
 	c.Assert(len(src.columns[1].elemBuf), check.Equals, 0)
 

--- a/util/chunk/chunk_util.go
+++ b/util/chunk/chunk_util.go
@@ -64,7 +64,7 @@ func copySelectedInnerRows(innerColOffset, outerColOffset int, src *Chunk, selec
 
 				start, end := srcCol.offsets[i], srcCol.offsets[i+1]
 				dstCol.data = append(dstCol.data, srcCol.data[start:end]...)
-				dstCol.offsets = append(dstCol.offsets, int32(len(dstCol.data)))
+				dstCol.offsets = append(dstCol.offsets, int64(len(dstCol.data)))
 			}
 		}
 	}
@@ -99,7 +99,7 @@ func copyOuterRows(innerColOffset, outerColOffset int, src *Chunk, numRows int, 
 			offsets := dstCol.offsets
 			elemLen := srcCol.offsets[row.idx+1] - srcCol.offsets[row.idx]
 			for j := 0; j < numRows; j++ {
-				offsets = append(offsets, int32(offsets[len(offsets)-1]+elemLen))
+				offsets = append(offsets, int64(offsets[len(offsets)-1]+elemLen))
 			}
 			dstCol.offsets = offsets
 		}

--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -66,7 +66,7 @@ func (c *Codec) encodeColumn(buffer []byte, col *column) []byte {
 	// encode offsets.
 	if !col.isFixed() {
 		numOffsetBytes := (col.length + 1) * 4
-		offsetBytes := c.i32SliceToBytes(col.offsets)
+		offsetBytes := c.i64SliceToBytes(col.offsets)
 		buffer = append(buffer, offsetBytes[:numOffsetBytes]...)
 	}
 
@@ -75,14 +75,14 @@ func (c *Codec) encodeColumn(buffer []byte, col *column) []byte {
 	return buffer
 }
 
-func (c *Codec) i32SliceToBytes(i32s []int32) (b []byte) {
-	if len(i32s) == 0 {
+func (c *Codec) i64SliceToBytes(i64s []int64) (b []byte) {
+	if len(i64s) == 0 {
 		return nil
 	}
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(i32s) * 4
+	hdr.Len = len(i64s) * 4
 	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&i32s[0]))
+	hdr.Data = uintptr(unsafe.Pointer(&i64s[0]))
 	return b
 }
 
@@ -128,7 +128,7 @@ func (c *Codec) decodeColumn(buffer []byte, col *column, ordinal int) (remained 
 	numDataBytes := numFixedBytes * col.length
 	if numFixedBytes == -1 {
 		numOffsetBytes := (col.length + 1) * 4
-		col.offsets = append(col.offsets[:0], c.bytesToI32Slice(buffer[:numOffsetBytes])...)
+		col.offsets = append(col.offsets[:0], c.bytesToI64Slice(buffer[:numOffsetBytes])...)
 		buffer = buffer[numOffsetBytes:]
 		numDataBytes = int(col.offsets[col.length])
 	} else if cap(col.elemBuf) < numFixedBytes {
@@ -152,15 +152,15 @@ func (c *Codec) setAllNotNull(col *column) {
 	}
 }
 
-func (c *Codec) bytesToI32Slice(b []byte) (i32s []int32) {
+func (c *Codec) bytesToI64Slice(b []byte) (i64s []int64) {
 	if len(b) == 0 {
 		return nil
 	}
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&i32s))
-	hdr.Len = len(b) / 4
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&i64s))
+	hdr.Len = len(b) / 8
 	hdr.Cap = hdr.Len
 	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return i32s
+	return i64s
 }
 
 // varElemLen indicates this column is a variable length column.

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -47,7 +47,7 @@ type column struct {
 	length     int
 	nullCount  int
 	nullBitmap []byte
-	offsets    []int32
+	offsets    []int64
 	data       []byte
 	elemBuf    []byte
 }
@@ -158,7 +158,7 @@ func (c *column) appendFloat64(f float64) {
 
 func (c *column) finishAppendVar() {
 	c.appendNullBitmap(true)
-	c.offsets = append(c.offsets, int32(len(c.data)))
+	c.offsets = append(c.offsets, int64(len(c.data)))
 	c.length++
 }
 

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -13,7 +13,9 @@
 
 package chunk
 
-import "github.com/pingcap/check"
+import (
+	"github.com/pingcap/check"
+)
 
 func equalColumn(c1, c2 *column) bool {
 	if c1.length != c2.length ||
@@ -57,4 +59,11 @@ func (s *testChunkSuite) TestColumnCopy(c *check.C) {
 
 	c1 := col.copyConstruct()
 	c.Check(equalColumn(col, c1), check.IsTrue)
+}
+
+func (s *testChunkSuite) TestLargeStringColumnOffset(c *check.C) {
+	numRows := 1
+	col := newVarLenColumn(numRows, nil)
+	col.offsets[0] = 6 << 30
+	c.Check(col.offsets[0], check.Equals, int64(6<<30)) // test no overflow.
 }

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -178,7 +178,7 @@ func newMutRowVarLenColumn(valSize int) *column {
 	buf := make([]byte, valSize+1)
 	col := &column{
 		length:     1,
-		offsets:    []int32{0, int32(valSize)},
+		offsets:    []int64{0, int64(valSize)},
 		data:       buf[:valSize],
 		nullBitmap: buf[valSize:],
 	}
@@ -314,7 +314,7 @@ func setMutRowBytes(col *column, bin []byte) {
 		col.nullBitmap = buf[len(bin):]
 	}
 	copy(col.data, bin)
-	col.offsets[1] = int32(len(bin))
+	col.offsets[1] = int64(len(bin))
 }
 
 func setMutRowNameValue(col *column, name string, val uint64) {
@@ -328,7 +328,7 @@ func setMutRowNameValue(col *column, name string, val uint64) {
 	}
 	binary.LittleEndian.PutUint64(col.data, val)
 	copy(col.data[8:], name)
-	col.offsets[1] = int32(dataLen)
+	col.offsets[1] = int64(dataLen)
 }
 
 func setMutRowJSON(col *column, j json.BinaryJSON) {
@@ -344,7 +344,7 @@ func setMutRowJSON(col *column, j json.BinaryJSON) {
 	}
 	col.data[0] = j.TypeCode
 	copy(col.data[1:], j.Value)
-	col.offsets[1] = int32(dataLen)
+	col.offsets[1] = int64(dataLen)
 }
 
 // ShallowCopyPartialRow shallow copies the data of `row` to MutRow.
@@ -365,7 +365,7 @@ func (mr MutRow) ShallowCopyPartialRow(colIdx int, row Row) {
 		} else {
 			start, end := srcCol.offsets[row.idx], srcCol.offsets[row.idx+1]
 			dstCol.data = srcCol.data[start:end]
-			dstCol.offsets[1] = int32(len(dstCol.data))
+			dstCol.offsets[1] = int64(len(dstCol.data))
 		}
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The max-length of a string field can be 6M, a typical batch size for Chunk is 1024, which is 1K. That is to say, the memory offset of a string column can be 6GB, which exceeds int32

### What is changed and how it works?

change offset type from int32 to int64

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
