### PR TITLE
util/codec: improve package test code coverage above 85%

### DIFF
--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -192,7 +192,8 @@ func EncodeValue(sc *stmtctx.StatementContext, b []byte, v ...types.Datum) ([]by
 	return encode(sc, b, v, false, false)
 }
 
-func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTypes []*types.FieldType, colIdx []int, comparable, hash bool) (_ []byte, err error) {
+func encodeHashChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTypes []*types.FieldType, colIdx []int) (_ []byte, err error) {
+	const comparable = false
 	for _, i := range colIdx {
 		if row.IsNull(i) {
 			b = append(b, NilFlag)
@@ -205,15 +206,11 @@ func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTy
 				break
 			}
 			// encode unsigned integers.
-			if hash {
-				integer := row.GetInt64(i)
-				if integer < 0 {
-					b = encodeUnsignedInt(b, uint64(integer), comparable)
-				} else {
-					b = encodeSignedInt(b, integer, comparable)
-				}
+			integer := row.GetInt64(i)
+			if integer < 0 {
+				b = encodeUnsignedInt(b, uint64(integer), comparable)
 			} else {
-				b = encodeUnsignedInt(b, row.GetUint64(i), comparable)
+				b = encodeSignedInt(b, integer, comparable)
 			}
 		case mysql.TypeFloat:
 			b = append(b, floatFlag)
@@ -246,20 +243,13 @@ func encodeChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTy
 			b = EncodeInt(b, int64(row.GetDuration(i, 0).Duration))
 		case mysql.TypeNewDecimal:
 			b = append(b, decimalFlag)
-			if hash {
-				// If hash is true, we only consider the original value of this decimal and ignore it's precision.
-				dec := row.GetMyDecimal(i)
-				bin, err := dec.ToHashKey()
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				b = append(b, bin...)
-			} else {
-				b, err = EncodeDecimal(b, row.GetMyDecimal(i), allTypes[i].Flen, allTypes[i].Decimal)
-				if terror.ErrorEqual(err, types.ErrTruncated) {
-					err = sc.HandleTruncate(err)
-				}
+			// If hash is true, we only consider the original value of this decimal and ignore it's precision.
+			dec := row.GetMyDecimal(i)
+			bin, err := dec.ToHashKey()
+			if err != nil {
+				return nil, errors.Trace(err)
 			}
+			b = append(b, bin...)
 		case mysql.TypeEnum:
 			b = encodeUnsignedInt(b, uint64(row.GetEnum(i).ToNumber()), comparable)
 		case mysql.TypeSet:
@@ -291,7 +281,7 @@ func HashValues(sc *stmtctx.StatementContext, b []byte, v ...types.Datum) ([]byt
 // HashChunkRow appends the encoded values to byte slice "b", returning the appended slice.
 // If two rows are equal, it will generate the same bytes.
 func HashChunkRow(sc *stmtctx.StatementContext, b []byte, row chunk.Row, allTypes []*types.FieldType, colIdx []int) ([]byte, error) {
-	return encodeChunkRow(sc, b, row, allTypes, colIdx, false, true)
+	return encodeHashChunkRow(sc, b, row, allTypes, colIdx)
 }
 
 // Decode decodes values from a byte slice generated with EncodeKey or EncodeValue
@@ -480,7 +470,7 @@ func peek(b []byte) (length int, err error) {
 		// Those types are stored in 8 bytes.
 		l = 8
 	case bytesFlag:
-		l, err = peekBytes(b, false)
+		l, err = peekBytes(b)
 	case compactBytesFlag:
 		l, err = peekCompactBytes(b)
 	case decimalFlag:
@@ -501,7 +491,7 @@ func peek(b []byte) (length int, err error) {
 	return
 }
 
-func peekBytes(b []byte, reverse bool) (int, error) {
+func peekBytes(b []byte) (int, error) {
 	offset := 0
 	for {
 		if len(b) < offset+encGroupSize+1 {
@@ -510,12 +500,7 @@ func peekBytes(b []byte, reverse bool) (int, error) {
 		// The byte slice is encoded into many groups.
 		// For each group, there are 8 bytes for data and 1 byte for marker.
 		marker := b[offset+encGroupSize]
-		var padCount byte
-		if reverse {
-			padCount = marker
-		} else {
-			padCount = encMarker - marker
-		}
+		padCount := encMarker - marker
 		offset += encGroupSize + 1
 		// When padCount is not zero, it means we get the end of the byte slice.
 		if padCount != 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After this commit:

```
ok  	github.com/pingcap/tidb/util/codec	0.054s	coverage: 85.4% of statements
```

### What is changed and how it works?

Add test to cover more code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

