### PR TITLE
bindinfo: reduce duplicate DigestHash call

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -284,8 +284,8 @@ func (h *BindHandle) Size() int {
 }
 
 // GetBindRecord return the bindMeta of the (normdOrigSQL,db) if bindMeta exist.
-func (h *BindHandle) GetBindRecord(normdOrigSQL, db string) *BindMeta {
-	return h.bindInfo.Load().(cache).getBindRecord(normdOrigSQL, db)
+func (h *BindHandle) GetBindRecord(hash, normdOrigSQL, db string) *BindMeta {
+	return h.bindInfo.Load().(cache).getBindRecord(hash, normdOrigSQL, db)
 }
 
 // GetAllBindRecord return all bind record in cache.
@@ -387,8 +387,7 @@ func copyInvalidBindRecordMap(oldMap map[string]*invalidBindRecordMap) map[strin
 	return newMap
 }
 
-func (c cache) getBindRecord(normdOrigSQL, db string) *BindMeta {
-	hash := parser.DigestHash(normdOrigSQL)
+func (c cache) getBindRecord(hash, normdOrigSQL, db string) *BindMeta {
 	bindRecords := c[hash]
 	if bindRecords != nil {
 		for _, bindRecord := range bindRecords {

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -396,17 +396,19 @@ func addHint(ctx sessionctx.Context, stmtNode ast.StmtNode) ast.StmtNode {
 			normalizeExplainSQL := parser.Normalize(x.Text())
 			idx := strings.Index(normalizeExplainSQL, "select")
 			normalizeSQL := normalizeExplainSQL[idx:]
-			x.Stmt = addHintForSelect(normalizeSQL, ctx, x.Stmt)
+			hash := parser.DigestHash(normalizeSQL)
+			x.Stmt = addHintForSelect(hash, normalizeSQL, ctx, x.Stmt)
 		}
 		return x
 	case *ast.SelectStmt:
-		return addHintForSelect(parser.Normalize(x.Text()), ctx, x)
+		normalizeSQL, hash := parser.NormalizeDigest(x.Text())
+		return addHintForSelect(hash, normalizeSQL, ctx, x)
 	default:
 		return stmtNode
 	}
 }
 
-func addHintForSelect(normdOrigSQL string, ctx sessionctx.Context, stmt ast.StmtNode) ast.StmtNode {
+func addHintForSelect(hash, normdOrigSQL string, ctx sessionctx.Context, stmt ast.StmtNode) ast.StmtNode {
 	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
 	bindRecord := sessionHandle.GetBindRecord(normdOrigSQL, ctx.GetSessionVars().CurrentDB)
 	if bindRecord != nil {
@@ -418,9 +420,9 @@ func addHintForSelect(normdOrigSQL string, ctx sessionctx.Context, stmt ast.Stmt
 		}
 	}
 	globalHandle := domain.GetDomain(ctx).BindHandle()
-	bindRecord = globalHandle.GetBindRecord(normdOrigSQL, ctx.GetSessionVars().CurrentDB)
+	bindRecord = globalHandle.GetBindRecord(hash, normdOrigSQL, ctx.GetSessionVars().CurrentDB)
 	if bindRecord == nil {
-		bindRecord = globalHandle.GetBindRecord(normdOrigSQL, "")
+		bindRecord = globalHandle.GetBindRecord(hash, normdOrigSQL, "")
 	}
 	if bindRecord != nil {
 		return bindinfo.BindHint(stmt, bindRecord.Ast)

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190429120706-c378059f7f42
+	github.com/pingcap/parser v0.0.0-20190505092803-4542e963c7f1
 	github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190429120706-c378059f7f42 h1:iuZ/y1DLC/4gLTxw/xtEbo9R2SMRq7CKzLXhffff/kc=
-github.com/pingcap/parser v0.0.0-20190429120706-c378059f7f42/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20190505092803-4542e963c7f1 h1:YvxFABfyD5Pnp80FUVV4w3zdlmkcwRhQbn7xpTjBwwU=
 github.com/pingcap/parser v0.0.0-20190505092803-4542e963c7f1/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=

--- a/go.sum
+++ b/go.sum
@@ -162,6 +162,8 @@ github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3F
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/parser v0.0.0-20190429120706-c378059f7f42 h1:iuZ/y1DLC/4gLTxw/xtEbo9R2SMRq7CKzLXhffff/kc=
 github.com/pingcap/parser v0.0.0-20190429120706-c378059f7f42/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190505092803-4542e963c7f1 h1:YvxFABfyD5Pnp80FUVV4w3zdlmkcwRhQbn7xpTjBwwU=
+github.com/pingcap/parser v0.0.0-20190505092803-4542e963c7f1/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669/go.mod h1:MUCxRzOkYiWZtlyi4MhxjCIj9PgQQ/j+BLNGm7aUsnM=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/session/session.go
+++ b/session/session.go
@@ -1046,7 +1046,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 }
 
 func (s *session) handleInvalidBindRecord(ctx context.Context, stmtNode ast.StmtNode) {
-	var normdOrigSQL string
+	var normdOrigSQL, hash string
 	switch x := stmtNode.(type) {
 	case *ast.ExplainStmt:
 		switch x.Stmt.(type) {
@@ -1054,11 +1054,12 @@ func (s *session) handleInvalidBindRecord(ctx context.Context, stmtNode ast.Stmt
 			normalizeExplainSQL := parser.Normalize(x.Text())
 			idx := strings.Index(normalizeExplainSQL, "select")
 			normdOrigSQL = normalizeExplainSQL[idx:]
+			hash = parser.DigestHash(normdOrigSQL)
 		default:
 			return
 		}
 	case *ast.SelectStmt:
-		normdOrigSQL = parser.Normalize(x.Text())
+		normdOrigSQL, hash = parser.NormalizeDigest(x.Text())
 	default:
 		return
 	}
@@ -1070,9 +1071,9 @@ func (s *session) handleInvalidBindRecord(ctx context.Context, stmtNode ast.Stmt
 	}
 
 	globalHandle := domain.GetDomain(s).BindHandle()
-	bindMeta = globalHandle.GetBindRecord(normdOrigSQL, s.GetSessionVars().CurrentDB)
+	bindMeta = globalHandle.GetBindRecord(hash, normdOrigSQL, s.GetSessionVars().CurrentDB)
 	if bindMeta == nil {
-		bindMeta = globalHandle.GetBindRecord(normdOrigSQL, "")
+		bindMeta = globalHandle.GetBindRecord(hash, normdOrigSQL, "")
 	}
 	if bindMeta != nil {
 		record := &bindinfo.BindRecord{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes (3) of https://github.com/pingcap/parser/pull/313, we can lex once when stmt isn't `explain ...`

this PR will also update parser version after https://github.com/pingcap/parser/pull/313 be merged

### What is changed and how it works?

use `NormalizeDigest` to generate normalize sql and hash at once

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - impl change

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10352)
<!-- Reviewable:end -->
