### PR TITLE
tablecodec: improve package unit test code coverage to 85%

### DIFF
--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -14,7 +14,6 @@
 package tablecodec
 
 import (
-	"bytes"
 	"encoding/binary"
 	"math"
 	"time"
@@ -601,25 +600,6 @@ func GetTableIndexKeyRange(tableID, indexID int64) (startKey, endKey []byte) {
 	startKey = EncodeIndexSeekKey(tableID, indexID, nil)
 	endKey = EncodeIndexSeekKey(tableID, indexID, []byte{255})
 	return
-}
-
-type keyRangeSorter struct {
-	ranges []kv.KeyRange
-}
-
-func (r *keyRangeSorter) Len() int {
-	return len(r.ranges)
-}
-
-func (r *keyRangeSorter) Less(i, j int) bool {
-	a := r.ranges[i]
-	b := r.ranges[j]
-	cmp := bytes.Compare(a.StartKey, b.StartKey)
-	return cmp < 0
-}
-
-func (r *keyRangeSorter) Swap(i, j int) {
-	r.ranges[i], r.ranges[j] = r.ranges[j], r.ranges[i]
 }
 
 const (

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -64,31 +64,37 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	c1 := &column{id: 1, tp: types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &column{id: 2, tp: types.NewFieldType(mysql.TypeVarchar)}
 	c3 := &column{id: 3, tp: types.NewFieldType(mysql.TypeNewDecimal)}
-	cols := []*column{c1, c2, c3}
+	c4 := &column{id: 4, tp: &types.FieldType{Tp: mysql.TypeEnum, Elems: []string{"a"}}}
+	c5 := &column{id: 5, tp: &types.FieldType{Tp: mysql.TypeSet, Elems: []string{"a"}}}
+	c6 := &column{id: 6, tp: &types.FieldType{Tp: mysql.TypeBit, Flen: 8}}
+	cols := []*column{c1, c2, c3, c4, c5, c6}
 
-	row := make([]types.Datum, 3)
+	row := make([]types.Datum, 6)
 	row[0] = types.NewIntDatum(100)
 	row[1] = types.NewBytesDatum([]byte("abc"))
 	row[2] = types.NewDecimalDatum(types.NewDecFromInt(1))
+	row[3] = types.NewMysqlEnumDatum(types.Enum{Name: "a", Value: 0})
+	row[4] = types.NewDatum(types.Set{Name: "a", Value: 0})
+	row[5] = types.NewDatum(types.BinaryLiteral{100})
 	// Encode
-	colIDs := make([]int64, 0, 3)
+	colIDs := make([]int64, 0, len(row))
 	for _, col := range cols {
 		colIDs = append(colIDs, col.id)
 	}
-	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	bs, err := EncodeRow(sc, row, colIDs, nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(bs, NotNil)
 
 	// Decode
-	colMap := make(map[int64]*types.FieldType, 3)
+	colMap := make(map[int64]*types.FieldType, len(row))
 	for _, col := range cols {
 		colMap[col.id] = col.tp
 	}
 	r, err := DecodeRow(bs, colMap, time.UTC)
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
-	c.Assert(r, HasLen, 3)
+	c.Assert(r, HasLen, len(row))
 	// Compare decoded row and original row
 	for i, col := range cols {
 		v, ok := r[col.id]
@@ -103,7 +109,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	r, err = DecodeRow(bs, colMap, time.UTC)
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
-	c.Assert(r, HasLen, 3)
+	c.Assert(r, HasLen, len(row))
 	for i, col := range cols {
 		v, ok := r[col.id]
 		c.Assert(ok, IsTrue)
@@ -118,7 +124,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	r, err = DecodeRow(bs, colMap, time.UTC)
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
-	c.Assert(r, HasLen, 2)
+	c.Assert(r, HasLen, len(row)-2)
 	for i, col := range cols {
 		if i > 1 {
 			break
@@ -138,6 +144,36 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	r, err = DecodeRow(bs, colMap, time.UTC)
 	c.Assert(err, IsNil)
 	c.Assert(len(r), Equals, 0)
+}
+
+func (s *testTableCodecSuite) TestDecodeColumnValue(c *C) {
+	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	d := types.NewTimeDatum(types.Time{
+		Time: types.FromGoTime(time.Now()),
+		Type: mysql.TypeTimestamp,
+	})
+	bs, err := EncodeRow(sc, []types.Datum{d}, []int64{1}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(bs, NotNil)
+	_, bs, err = codec.CutOne(bs) // ignore colID
+	c.Assert(err, IsNil)
+
+	tp := types.NewFieldType(mysql.TypeTimestamp)
+	d1, err := DecodeColumnValue(bs, tp, sc.TimeZone)
+	c.Assert(err, IsNil)
+	cmp, err := d1.CompareDatum(sc, &d)
+	c.Assert(err, IsNil)
+	c.Assert(cmp, Equals, 0)
+}
+
+func (s *testTableCodecSuite) TestUnflattenDatums(c *C) {
+	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
+	input := types.MakeDatums(int64(1))
+	tps := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
+	output, err := UnflattenDatums(input, tps, sc.TimeZone)
+	c.Assert(err, IsNil)
+	cmp, err := input[0].CompareDatum(sc, &output[0])
+	c.Assert(cmp, Equals, 0)
 }
 
 func (s *testTableCodecSuite) TestTimeCodec(c *C) {
@@ -312,6 +348,49 @@ func (s *testTableCodecSuite) TestRecordKey(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tTableID, Equals, tableID)
 	c.Assert(isRecordKey, IsTrue)
+
+	encodedHandle := codec.EncodeInt(nil, math.MaxUint32)
+	rowKey := EncodeRowKey(tableID, encodedHandle)
+	c.Assert([]byte(tableKey), BytesEquals, []byte(rowKey))
+	tTableID, handle, err := DecodeRecordKey(rowKey)
+	c.Assert(err, IsNil)
+	c.Assert(tTableID, Equals, tableID)
+	c.Assert(handle, Equals, int64(math.MaxUint32))
+
+	recordPrefix := GenTableRecordPrefix(tableID)
+	rowKey = EncodeRecordKey(recordPrefix, math.MaxUint32)
+	c.Assert([]byte(tableKey), BytesEquals, []byte(rowKey))
+
+	_, _, err = DecodeRecordKey(nil)
+	c.Assert(err, NotNil)
+	_, _, err = DecodeRecordKey([]byte("abcdefghijklmnopqrstuvwxyz"))
+	c.Assert(err, NotNil)
+	c.Assert(DecodeTableID(nil), Equals, int64(0))
+}
+
+func (s *testTableCodecSuite) TestPrefix(c *C) {
+	const tableID int64 = 66
+	key := EncodeTablePrefix(tableID)
+	tTableID := DecodeTableID(key)
+	c.Assert(tTableID, Equals, int64(tableID))
+
+	c.Assert([]byte(TablePrefix()), BytesEquals, tablePrefix)
+
+	tablePrefix1 := GenTablePrefix(tableID)
+	c.Assert([]byte(tablePrefix1), BytesEquals, []byte(key))
+
+	indexPrefix := EncodeTableIndexPrefix(tableID, math.MaxUint32)
+	tTableID, indexID, isRecordKey, err := DecodeKeyHead(indexPrefix)
+	c.Assert(err, IsNil)
+	c.Assert(tTableID, Equals, tableID)
+	c.Assert(indexID, Equals, int64(math.MaxUint32))
+	c.Assert(isRecordKey, IsFalse)
+
+	prefixKey := GenTableIndexPrefix(tableID)
+	c.Assert(DecodeTableID(prefixKey), Equals, tableID)
+
+	c.Assert(TruncateToRowKeyLen(append(indexPrefix, "xyz"...)), HasLen, recordRowKeyLen)
+	c.Assert(TruncateToRowKeyLen(key), HasLen, len(key))
 }
 
 func (s *testTableCodecSuite) TestReplaceRecordKeyTableID(c *C) {
@@ -373,6 +452,28 @@ func (s *testTableCodecSuite) TestDecodeIndexKey(c *C) {
 	c.Assert(decodeTableID, Equals, tableID)
 	c.Assert(decodeIndexID, Equals, indexID)
 	c.Assert(decodeValues, DeepEquals, valueStrs)
+}
+
+func (s *testTableCodecSuite) TestCutPrefix(c *C) {
+	key := EncodeTableIndexPrefix(42, 666)
+	res := CutRowKeyPrefix(key)
+	c.Assert(res, BytesEquals, []byte{0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x9a})
+	res = CutIndexPrefix(key)
+	c.Assert(res, BytesEquals, []byte{})
+}
+
+func (s *testTableCodecSuite) TestRange(c *C) {
+	s1, e1 := GetTableHandleKeyRange(22)
+	s2, e2 := GetTableHandleKeyRange(23)
+	c.Assert([]byte(s1), Less, []byte(e1))
+	c.Assert([]byte(e1), Less, []byte(s2))
+	c.Assert([]byte(s2), Less, []byte(e2))
+
+	s1, e1 = GetTableIndexKeyRange(42, 666)
+	s2, e2 = GetTableIndexKeyRange(42, 667)
+	c.Assert([]byte(s1), Less, []byte(e1))
+	c.Assert([]byte(e1), Less, []byte(s2))
+	c.Assert([]byte(s2), Less, []byte(e2))
 }
 
 func BenchmarkHasTablePrefix(b *testing.B) {

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -173,6 +173,7 @@ func (s *testTableCodecSuite) TestUnflattenDatums(c *C) {
 	output, err := UnflattenDatums(input, tps, sc.TimeZone)
 	c.Assert(err, IsNil)
 	cmp, err := input[0].CompareDatum(sc, &output[0])
+	c.Assert(err, IsNil)
 	c.Assert(cmp, Equals, 0)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Improve test coverage

```
ok  	github.com/pingcap/tidb/tablecodec	0.016s	coverage: 85.8% of statements
```

### What is changed and how it works?

Add more test code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
