### PR TITLE
executor: fix deadloop when exec replace with generated column

### DIFF
--- a/executor/replace.go
+++ b/executor/replace.go
@@ -142,6 +142,9 @@ func (e *ReplaceExec) removeIndexRow(r toBeCheckedRow) (bool, bool, error) {
 			if err != nil {
 				return false, found, err
 			}
+			if !rowUnchanged {
+				delete(e.dupKVs, string(uk.newKV.key))
+			}
 			return rowUnchanged, found, nil
 		}
 	}

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -898,6 +898,22 @@ func (s *testSuite2) TestReplace(c *C) {
 	tk.MustExec(`replace into t1 select * from (select 1, 2) as tmp;`)
 	c.Assert(int64(tk.Se.AffectedRows()), Equals, int64(2))
 	tk.CheckLastMessage("Records: 1  Duplicates: 1  Warnings: 0")
+
+	// Test Replace with generated column
+	// FIXME: this is not compatible with MySQL now, we don't support replace into
+	// duplicated value on generated column with unique key now.
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec("create table t1(id int, id_gen int as(`id` + 42), b int, unique key id_gen(`id_gen`));")
+	tk.MustExec(`insert into t1 (id, b) values(1,1),(2,2),(3,3),(4,4),(5,5);`)
+	_, err = tk.Exec(`replace into t1 (id, b) values(1,1);`)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[kv:1062]Duplicate entry '43' for key 'id_gen'")
+	_, err = tk.Exec(`replace into t1 (id, b) values(1,1),(2,2);`)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[kv:1062]Duplicate entry '43' for key 'id_gen'")
+	tk.MustExec(`replace into t1 (id, b) values(6,16),(7,17),(8,18);`)
+	c.Assert(int64(tk.Se.AffectedRows()), Equals, int64(3))
+	tk.CheckLastMessage("Records: 3  Duplicates: 0  Warnings: 0")
 }
 
 func (s *testSuite2) TestPartitionedTableReplace(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB will run into dead loop and exhausts large memory very soon if we execute `replace into values (...)` on a generated column.  The bug can be reproduced as following:
```
mysql> create table t3 (id int, id_gen int as (`id`+1), unique key id_gen(`id_gen`));
Query OK, 0 rows affected (0.04 sec)

mysql> insert into t3 (id) values (1);
Query OK, 1 row affected (0.00 sec)

mysql> replace into t3 (id) values (1);
```
The root cause of this is we fetched key value from store for duplicated kv checks, but did not apply generated column rule.

### What is changed and how it works?
Force remove duplicated key from `ReplaceExec.dupKVs`.

This pr is not a totally solution to this problem, it solves the deadloop, but a `replace into` operation having duplicated unique key conflict on a generated column still fail now.

I didn't find a suit method to calculate generated column value without building a logic planner,  if anyone points out a workaround way, I will have a try to make this pr better.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch
