### PR TITLE
table:modify 'desc' and 'show columns' statement is compatible with MySQL

### DIFF
--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -586,7 +586,7 @@ func (s *seqTestSuite) TestShow(c *C) {
 		"c5|varchar(6)|YES||'C6'|",
 		"c6|enum('s','m','l','xl')|YES||xl|",
 		"c7|set('a','b','c','d')|YES||a,c,c|",
-		"c8|datetime|YES||CURRENT_TIMESTAMP|on update CURRENT_TIMESTAMP",
+		"c8|datetime|YES||CURRENT_TIMESTAMP|DEFAULT_GENERATED on update CURRENT_TIMESTAMP",
 		"c9|year(4)|YES||2014|",
 	))
 }

--- a/table/column.go
+++ b/table/column.go
@@ -262,7 +262,9 @@ func NewColDesc(col *Column) *ColDesc {
 	if mysql.HasAutoIncrementFlag(col.Flag) {
 		extra = "auto_increment"
 	} else if mysql.HasOnUpdateNowFlag(col.Flag) {
-		extra = "on update CURRENT_TIMESTAMP"
+		//in order to match the rules of mysql 8.0.16 version
+		//see https://github.com/pingcap/tidb/issues/10337
+		extra = "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
 	} else if col.IsGenerated() {
 		if col.GeneratedStored {
 			extra = "STORED GENERATED"

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -117,7 +117,7 @@ func (t *testTableSuite) TestDesc(c *C) {
 	NewColDesc(col)
 	col.Flag = mysql.UniqueKeyFlag | mysql.OnUpdateNowFlag
 	desc := NewColDesc(col)
-	c.Assert(desc.Extra, Equals, "on update CURRENT_TIMESTAMP")
+	c.Assert(desc.Extra, Equals, "DEFAULT_GENERATED on update CURRENT_TIMESTAMP")
 	col.Flag = 0
 	col.GeneratedExprString = "test"
 	col.GeneratedStored = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
[the issue 10337](https://github.com/pingcap/tidb/issues/10337)

### What is changed and how it works?
when we use statements such as desc, show columns, etc., the value of the returned column 'Extra' is determined by the method in column.go: NewColDesc. 
after the codes commit,when the type of the column is timestamp and is set to update according to the current timestamp, the return value of the statement such as desc for extra: DEFAULT_GENERATED on update CURRENT_TIMESTAMP.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
