### PR TITLE
executor: split unit tests to speedup execution time

### DIFF
--- a/executor/metrics_test.go
+++ b/executor/metrics_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testSuite2) TestStmtLabel(c *C) {
+func (s *testSuite4) TestStmtLabel(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table label (c1 int primary key, c2 int, c3 int, index (c2))")

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testSuite2) TestSortRand(c *C) {
+func (s *testSuite4) TestSortRand(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testSuite2) TestDirtyTransaction(c *C) {
+func (s *testSuite4) TestDirtyTransaction(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -94,7 +94,7 @@ func (s *testSuite2) TestDirtyTransaction(c *C) {
 	tk.MustExec("commit")
 }
 
-func (s *testSuite2) TestUnionScanWithCastCondition(c *C) {
+func (s *testSuite4) TestUnionScanWithCastCondition(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table ta (a varchar(20))")

--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testSuite2) TestWindowFunctions(c *C) {
+func (s *testSuite4) TestWindowFunctions(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -40,7 +40,7 @@ type testBypassSuite struct{}
 func (s *testBypassSuite) SetUpSuite(c *C) {
 }
 
-func (s *testSuite2) TestInsert(c *C) {
+func (s *testSuite4) TestInsert(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	testSQL := `drop table if exists insert_test;create table insert_test (id int PRIMARY KEY AUTO_INCREMENT, c1 int, c2 int, c3 int default 1);`
@@ -314,7 +314,7 @@ func (s *testSuite) TestMultiBatch(c *C) {
 	tk.MustExec("admin check table t")
 }
 
-func (s *testSuite2) TestInsertAutoInc(c *C) {
+func (s *testSuite4) TestInsertAutoInc(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	createSQL := `drop table if exists insert_autoinc_test; create table insert_autoinc_test (id int primary key auto_increment, c1 int);`
@@ -447,7 +447,7 @@ func (s *testSuite2) TestInsertAutoInc(c *C) {
 	r.Check(testkit.Rows(rowStr4, rowStr1, rowStr2, rowStr3, rowStr5, rowStr6, rowStr7, rowStr8))
 }
 
-func (s *testSuite2) TestInsertIgnore(c *C) {
+func (s *testSuite4) TestInsertIgnore(c *C) {
 	var cfg kv.InjectionConfig
 	tk := testkit.NewTestKit(c, kv.NewInjectedStore(s.store, &cfg))
 	tk.MustExec("use test")
@@ -561,7 +561,7 @@ commit;`
 	tk.MustQuery(testSQL).Check(testkit.Rows("0"))
 }
 
-func (s *testSuite2) TestInsertOnDup(c *C) {
+func (s *testSuite4) TestInsertOnDup(c *C) {
 	var cfg kv.InjectionConfig
 	tk := testkit.NewTestKit(c, kv.NewInjectedStore(s.store, &cfg))
 	tk.MustExec("use test")
@@ -726,7 +726,7 @@ commit;`
 	tk.MustQuery(`SELECT * FROM t1 order by f1;`).Check(testkit.Rows("1 0", "2 2"))
 }
 
-func (s *testSuite2) TestInsertIgnoreOnDup(c *C) {
+func (s *testSuite4) TestInsertIgnoreOnDup(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	testSQL := `drop table if exists t;
@@ -749,7 +749,7 @@ func (s *testSuite2) TestInsertIgnoreOnDup(c *C) {
 	r.Check(testkit.Rows("1 1", "2 2"))
 }
 
-func (s *testSuite2) TestReplace(c *C) {
+func (s *testSuite4) TestReplace(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	testSQL := `drop table if exists replace_test;
@@ -900,7 +900,7 @@ func (s *testSuite2) TestReplace(c *C) {
 	tk.CheckLastMessage("Records: 1  Duplicates: 1  Warnings: 0")
 }
 
-func (s *testSuite2) TestPartitionedTableReplace(c *C) {
+func (s *testSuite4) TestPartitionedTableReplace(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	testSQL := `drop table if exists replace_test;
@@ -1039,7 +1039,7 @@ func (s *testSuite2) TestPartitionedTableReplace(c *C) {
 	r.Check(testkit.Rows("111 2"))
 }
 
-func (s *testSuite2) TestHashPartitionedTableReplace(c *C) {
+func (s *testSuite4) TestHashPartitionedTableReplace(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("set @@session.tidb_enable_table_partition = '1';")
@@ -1356,7 +1356,7 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("drop view v")
 }
 
-func (s *testSuite2) TestPartitionedTableUpdate(c *C) {
+func (s *testSuite4) TestPartitionedTableUpdate(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -1464,7 +1464,7 @@ func (s *testSuite2) TestPartitionedTableUpdate(c *C) {
 }
 
 // TestUpdateCastOnlyModifiedValues for issue #4514.
-func (s *testSuite2) TestUpdateCastOnlyModifiedValues(c *C) {
+func (s *testSuite4) TestUpdateCastOnlyModifiedValues(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table update_modified (col_1 int, col_2 enum('a', 'b'))")
@@ -1499,7 +1499,7 @@ func (s *testSuite2) TestUpdateCastOnlyModifiedValues(c *C) {
 	r.Check(testkit.Rows(`{"a": "测试"}`))
 }
 
-func (s *testSuite2) fillMultiTableForUpdate(tk *testkit.TestKit) {
+func (s *testSuite4) fillMultiTableForUpdate(tk *testkit.TestKit) {
 	// Create and fill table items
 	tk.MustExec("CREATE TABLE items (id int, price TEXT);")
 	tk.MustExec(`insert into items values (11, "items_price_11"), (12, "items_price_12"), (13, "items_price_13");`)
@@ -1510,7 +1510,7 @@ func (s *testSuite2) fillMultiTableForUpdate(tk *testkit.TestKit) {
 	tk.CheckExecResult(3, 0)
 }
 
-func (s *testSuite2) TestMultipleTableUpdate(c *C) {
+func (s *testSuite4) TestMultipleTableUpdate(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	s.fillMultiTableForUpdate(tk)
@@ -1618,7 +1618,7 @@ func (s *testSuite) TestDelete(c *C) {
 	tk.MustExec("drop view v")
 }
 
-func (s *testSuite2) TestPartitionedTableDelete(c *C) {
+func (s *testSuite4) TestPartitionedTableDelete(c *C) {
 	createTable := `CREATE TABLE test.t (id int not null default 1, name varchar(255), index(id))
 			  PARTITION BY RANGE ( id ) (
 			  PARTITION p0 VALUES LESS THAN (6),
@@ -1671,7 +1671,7 @@ func (s *testSuite2) TestPartitionedTableDelete(c *C) {
 	tk.MustExec(`drop table t1;`)
 }
 
-func (s *testSuite2) fillDataMultiTable(tk *testkit.TestKit) {
+func (s *testSuite4) fillDataMultiTable(tk *testkit.TestKit) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1, t2, t3")
 	// Create and fill table t1
@@ -1688,7 +1688,7 @@ func (s *testSuite2) fillDataMultiTable(tk *testkit.TestKit) {
 	tk.CheckExecResult(3, 0)
 }
 
-func (s *testSuite2) TestMultiTableDelete(c *C) {
+func (s *testSuite4) TestMultiTableDelete(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	s.fillDataMultiTable(tk)
 
@@ -1700,7 +1700,7 @@ func (s *testSuite2) TestMultiTableDelete(c *C) {
 	c.Assert(r.Rows(), HasLen, 3)
 }
 
-func (s *testSuite2) TestQualifiedDelete(c *C) {
+func (s *testSuite4) TestQualifiedDelete(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1")
@@ -1736,7 +1736,7 @@ func (s *testSuite2) TestQualifiedDelete(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *testSuite2) TestLoadData(c *C) {
+func (s *testSuite4) TestLoadData(c *C) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -1902,7 +1902,7 @@ func (s *testSuite2) TestLoadData(c *C) {
 	checkCases(tests, ld, c, tk, ctx, selectSQL, deleteSQL)
 }
 
-func (s *testSuite2) TestLoadDataEscape(c *C) {
+func (s *testSuite4) TestLoadDataEscape(c *C) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
@@ -1931,7 +1931,7 @@ func (s *testSuite2) TestLoadDataEscape(c *C) {
 }
 
 // TestLoadDataSpecifiedColumns reuse TestLoadDataEscape's test case :-)
-func (s *testSuite2) TestLoadDataSpecifiedColumns(c *C) {
+func (s *testSuite4) TestLoadDataSpecifiedColumns(c *C) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
@@ -1958,7 +1958,7 @@ func (s *testSuite2) TestLoadDataSpecifiedColumns(c *C) {
 	checkCases(tests, ld, c, tk, ctx, selectSQL, deleteSQL)
 }
 
-func (s *testSuite2) TestLoadDataIgnoreLines(c *C) {
+func (s *testSuite4) TestLoadDataIgnoreLines(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
 	tk.MustExec("CREATE TABLE load_data_test (id INT NOT NULL PRIMARY KEY, value TEXT NOT NULL) CHARACTER SET utf8")
@@ -1978,7 +1978,7 @@ func (s *testSuite2) TestLoadDataIgnoreLines(c *C) {
 }
 
 // related to issue 6360
-func (s *testSuite2) TestLoadDataOverflowBigintUnsigned(c *C) {
+func (s *testSuite4) TestLoadDataOverflowBigintUnsigned(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists load_data_test;")
 	tk.MustExec("CREATE TABLE load_data_test (a bigint unsigned);")
@@ -1997,7 +1997,7 @@ func (s *testSuite2) TestLoadDataOverflowBigintUnsigned(c *C) {
 	checkCases(tests, ld, c, tk, ctx, selectSQL, deleteSQL)
 }
 
-func (s *testSuite2) TestBatchInsertDelete(c *C) {
+func (s *testSuite4) TestBatchInsertDelete(c *C) {
 	originLimit := atomic.LoadUint64(&kv.TxnEntryCountLimit)
 	defer func() {
 		atomic.StoreUint64(&kv.TxnEntryCountLimit, originLimit)
@@ -2114,7 +2114,7 @@ func (s *testSuite2) TestBatchInsertDelete(c *C) {
 	r.Check(testkit.Rows("0"))
 }
 
-func (s *testSuite2) TestNullDefault(c *C) {
+func (s *testSuite4) TestNullDefault(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists test_null_default;")
 	tk.MustExec("set timestamp = 1234")
@@ -2126,7 +2126,7 @@ func (s *testSuite2) TestNullDefault(c *C) {
 	tk.MustQuery("select * from test_null_default").Check(testkit.Rows("<nil>", "1970-01-01 08:20:34"))
 }
 
-func (s *testSuite2) TestNotNullDefault(c *C) {
+func (s *testSuite4) TestNotNullDefault(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test; drop table if exists t1,t2;")
 	defer tk.MustExec("drop table t1,t2")
@@ -2180,7 +2180,7 @@ func (s *testBypassSuite) TestLatch(c *C) {
 }
 
 // TestIssue4067 Test issue https://github.com/pingcap/tidb/issues/4067
-func (s *testSuite2) TestIssue4067(c *C) {
+func (s *testSuite4) TestIssue4067(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1, t2")
@@ -2194,7 +2194,7 @@ func (s *testSuite2) TestIssue4067(c *C) {
 	tk.MustQuery("select * from t1").Check(nil)
 }
 
-func (s *testSuite2) TestInsertCalculatedValue(c *C) {
+func (s *testSuite4) TestInsertCalculatedValue(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 
@@ -2310,7 +2310,7 @@ func (s *testSuite2) TestInsertCalculatedValue(c *C) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("4 0 2"))
 }
 
-func (s *testSuite2) TestDataTooLongErrMsg(c *C) {
+func (s *testSuite4) TestDataTooLongErrMsg(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a varchar(2));")
@@ -2323,7 +2323,7 @@ func (s *testSuite2) TestDataTooLongErrMsg(c *C) {
 	c.Assert(err.Error(), Equals, "[types:1406]Data too long for column 'a' at row 1")
 }
 
-func (s *testSuite2) TestUpdateSelect(c *C) {
+func (s *testSuite4) TestUpdateSelect(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table msg (id varchar(8), b int, status int, primary key (id, b))")
@@ -2335,7 +2335,7 @@ func (s *testSuite2) TestUpdateSelect(c *C) {
 	tk.MustExec("admin check table msg")
 }
 
-func (s *testSuite2) TestUpdateDelete(c *C) {
+func (s *testSuite4) TestUpdateDelete(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE ttt (id bigint(20) NOT NULL, host varchar(30) NOT NULL, PRIMARY KEY (id), UNIQUE KEY i_host (host));")
@@ -2355,7 +2355,7 @@ func (s *testSuite2) TestUpdateDelete(c *C) {
 	tk.MustExec("drop table ttt")
 }
 
-func (s *testSuite2) TestUpdateAffectRowCnt(c *C) {
+func (s *testSuite4) TestUpdateAffectRowCnt(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table a(id int auto_increment, a int default null, primary key(id))")
@@ -2374,7 +2374,7 @@ func (s *testSuite2) TestUpdateAffectRowCnt(c *C) {
 	tk.CheckLastMessage("Rows matched: 2  Changed: 2  Warnings: 0")
 }
 
-func (s *testSuite2) TestReplaceLog(c *C) {
+func (s *testSuite4) TestReplaceLog(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec(`create table testLog (a int not null primary key, b int unique key);`)
@@ -2409,7 +2409,7 @@ func (s *testSuite2) TestReplaceLog(c *C) {
 // TestRebaseIfNeeded is for issue 7422.
 // There is no need to do the rebase when updating a record if the auto-increment ID not changed.
 // This could make the auto ID increasing speed slower.
-func (s *testSuite2) TestRebaseIfNeeded(c *C) {
+func (s *testSuite4) TestRebaseIfNeeded(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec(`create table t (a int not null primary key auto_increment, b int unique key);`)
@@ -2441,7 +2441,7 @@ func (s *testSuite2) TestRebaseIfNeeded(c *C) {
 	tk.MustQuery(`select a from t where b = 6;`).Check(testkit.Rows("30003"))
 }
 
-func (s *testSuite2) TestDeferConstraintCheckForInsert(c *C) {
+func (s *testSuite4) TestDeferConstraintCheckForInsert(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
 	tk.MustExec(`drop table if exists t;create table t (i int key);`)
@@ -2455,7 +2455,7 @@ func (s *testSuite2) TestDeferConstraintCheckForInsert(c *C) {
 	tk.MustQuery(`select * from t;`).Check(testkit.Rows("2"))
 }
 
-func (s *testSuite2) TestDefEnumInsert(c *C) {
+func (s *testSuite4) TestDefEnumInsert(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table test (id int, prescription_type enum('a','b','c','d','e','f') NOT NULL, primary key(id));")
@@ -2463,7 +2463,7 @@ func (s *testSuite2) TestDefEnumInsert(c *C) {
 	tk.MustQuery("select prescription_type from test").Check(testkit.Rows("a"))
 }
 
-func (s *testSuite2) TestAutoIDInRetry(c *C) {
+func (s *testSuite4) TestAutoIDInRetry(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int not null auto_increment primary key)")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Try to speedup unit test execution time.

### What is changed and how it works?

Split tests in testSuite2 into 2 separate suites, and run them in parallel.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

N/A

Side effects

N/A

Related changes

N/A
