### PR TITLE
Add the superbatch-tester binary used to test correctness of the batch client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ all: dev server benchkv
 parser:
 	@echo "remove this command later, when our CI script doesn't call it"
 
-dev: checklist check test 
+dev: checklist check test
 
 build:
 	$(GOBUILD)
@@ -191,6 +191,9 @@ benchdb:
 
 importer:
 	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/importer ./cmd/importer
+
+superbatch-tester:
+	$(GOBUILD) -ldflags '$(LDFLAGS)' -o bin/superbatch-tester ./cmd/superbatch-tester
 
 checklist:
 	cat checklist.md

--- a/cmd/superbatch-tester/main.go
+++ b/cmd/superbatch-tester/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 )
 
-var testConfig tikv.BatchClientTestConfig
+var testConfig tikv.ClientTestConfig
 
 func init() {
 	flag.Uint64Var(&testConfig.Concurrent, "concurrent", 128, "The number of test RPC loops per tikv instance")
@@ -21,7 +21,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-	result := tikv.BatchTest(config.Security{}, flag.Args(), testConfig)
+	result := tikv.ClientTest(config.Security{}, flag.Args(), testConfig)
 	var exit int
 	if result {
 		exit = 255

--- a/cmd/superbatch-tester/main.go
+++ b/cmd/superbatch-tester/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"time"
+
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/store/tikv"
+)
+
+var testConfig tikv.BatchClientTestConfig
+
+func init() {
+	flag.Uint64Var(&testConfig.Concurrent, "concurrent", 128, "The number of test RPC loops per tikv instance")
+	flag.DurationVar(&testConfig.Timeout, "timeout", 10*time.Second, "The fail timeout")
+	flag.DurationVar(&testConfig.TestLength, "testLength", 20*time.Minute, "The full length of the test")
+	flag.Uint64Var(&testConfig.MinDelay, "minDelay", 1000, "The minimum delay in the test RPCs")
+	flag.Uint64Var(&testConfig.MaxDelay, "maxDelay", 10000, "The maximum delay in the test RPCs")
+}
+
+func main() {
+	flag.Parse()
+	result := tikv.BatchTest(config.Security{}, flag.Args(), testConfig)
+	var exit int
+	if result {
+		exit = 255
+	}
+	os.Exit(exit)
+}

--- a/cmd/superbatch-tester/main.go
+++ b/cmd/superbatch-tester/main.go
@@ -14,9 +14,9 @@ var testConfig tikv.BatchClientTestConfig
 func init() {
 	flag.Uint64Var(&testConfig.Concurrent, "concurrent", 128, "The number of test RPC loops per tikv instance")
 	flag.DurationVar(&testConfig.Timeout, "timeout", 10*time.Second, "The fail timeout")
-	flag.DurationVar(&testConfig.TestLength, "testLength", 20*time.Minute, "The full length of the test")
-	flag.Uint64Var(&testConfig.MinDelay, "minDelay", 1000, "The minimum delay in the test RPCs")
-	flag.Uint64Var(&testConfig.MaxDelay, "maxDelay", 10000, "The maximum delay in the test RPCs")
+	flag.DurationVar(&testConfig.TestLength, "time", 20*time.Minute, "The full running time of the test")
+	flag.Uint64Var(&testConfig.MinDelay, "minDelay", 10, "The minimum delay in the test RPCs, in milliseconds")
+	flag.Uint64Var(&testConfig.MaxDelay, "maxDelay", 1000, "The maximum delay in the test RPCs, in milliseconds")
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -74,4 +74,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/kvproto => ../kvproto
+replace github.com/pingcap/kvproto => github.com/benpigchu/kvproto v0.0.0-20190428082335-d88cadb633f1

--- a/go.mod
+++ b/go.mod
@@ -73,3 +73,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/kvproto => ../kvproto

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8DgGXC5B7ILL8y51fci/qYz2B4j8iLY=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/benpigchu/kvproto v0.0.0-20190428082335-d88cadb633f1 h1:WMgLf/Y4pqg3Sme6vsC2lELVAr/E8LLWhYkcW2koSzw=
+github.com/benpigchu/kvproto v0.0.0-20190428082335-d88cadb633f1/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3 h1:04yuCf5NMvLU8rB2
 github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3/go.mod h1:DazNTg0PTldtpsQiT9I5tVJwV1onHMKBBgXzmJUlMns=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rGrobssy1nVy2VaVpNCuLpCbr+FEaTA8=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d h1:LJYJl+cBhkkTWD79n+n9Bp4agQ85SdF9YKY4zEtL9Kw=
-github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -557,7 +557,7 @@ func (c *rpcClient) closeConns() {
 			array.Close()
 		}
 		for _, array := range c.conns {
-			array.waitGroup.Done()
+			array.waitGroup.Wait()
 		}
 	}
 	c.Unlock()

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -582,7 +582,7 @@ func sendBatchRequest(
 	select {
 	case connArray.batchCommandsCh <- entry:
 	case <-ctx1.Done():
-		logutil.Logger(context.Background()).Warn("send request is timeout", zap.String("to", addr))
+		logutil.Logger(context.Background()).Debug("send request is timeout", zap.String("to", addr))
 		return nil, errors.Trace(gstatus.Error(gcodes.DeadlineExceeded, "Canceled or timeout"))
 	}
 
@@ -594,7 +594,7 @@ func sendBatchRequest(
 		return tikvrpc.FromBatchCommandsResponse(res), nil
 	case <-ctx1.Done():
 		atomic.StoreInt32(&entry.canceled, 1)
-		logutil.Logger(context.Background()).Warn("send request is canceled", zap.String("to", addr))
+		logutil.Logger(context.Background()).Debug("send request is canceled", zap.String("to", addr))
 		return nil, errors.Trace(gstatus.Error(gcodes.DeadlineExceeded, "Canceled or timeout"))
 	}
 }

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -100,7 +100,7 @@ type batchCommandsClient struct {
 	closed int32
 	// clientLock protects client when re-create the streaming.
 	clientLock sync.Mutex
-	waitGroup              *sync.WaitGroup
+	waitGroup  *sync.WaitGroup
 }
 
 func (c *batchCommandsClient) isStopped() bool {
@@ -212,7 +212,7 @@ func newConnArray(maxSize uint, addr string, security config.Security) (*connArr
 		batchCommandsCh:        make(chan *batchCommandsEntry, cfg.TiKVClient.MaxBatchSize),
 		batchCommandsClients:   make([]*batchCommandsClient, 0, maxSize),
 		tikvTransportLayerLoad: 0,
-		waitGroup:				&sync.WaitGroup{},
+		waitGroup:              &sync.WaitGroup{},
 	}
 	if err := a.Init(addr, security); err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func (a *connArray) Init(addr string, security config.Security) error {
 				idAlloc:                0,
 				tikvTransportLayerLoad: &a.tikvTransportLayerLoad,
 				closed:                 0,
-				waitGroup:				a.waitGroup,
+				waitGroup:              a.waitGroup,
 			}
 			a.batchCommandsClients = append(a.batchCommandsClients, batchClient)
 			go batchClient.batchRecvLoop(cfg.TiKVClient)

--- a/store/tikv/test_batch.go
+++ b/store/tikv/test_batch.go
@@ -1,0 +1,170 @@
+package tikv
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/tikvpb"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
+)
+
+// batchClientTester is a thin wrap over the rpcClient used to test command batching
+type batchClientTester struct {
+	rpcClient Client
+	cfg       BatchClientTestConfig
+	failed    bool
+	failLock  sync.Mutex
+	ended     bool
+	endLock   sync.Mutex
+	wait      sync.WaitGroup
+}
+
+// BatchClientTestConfig is used to config batchClientTester
+type BatchClientTestConfig struct {
+	Interval   time.Duration
+	Timeout    time.Duration
+	MinDelay   uint64
+	MaxDelay   uint64
+	TestLength time.Duration
+}
+
+func (cfg *BatchClientTestConfig) genDelay() uint64 {
+	r := rand.Int63n(int64(cfg.MaxDelay - cfg.MinDelay))
+	return uint64(r) + cfg.MinDelay
+}
+
+// BatchTest start sending test messages to TiKV servers
+func BatchTest(security config.Security, addrs []string, config BatchClientTestConfig) {
+	c := &batchClientTester{
+		rpcClient: newRPCClient(security),
+		cfg:       config,
+		failed:    false,
+		ended:     false,
+	}
+	c.wait.Add(len(addrs))
+	for _, addr := range addrs {
+		go c.runTest(addr)
+	}
+	<-time.After(c.cfg.TestLength)
+	c.end()
+	c.wait.Wait()
+	//TODO: close the client
+}
+
+type sendRequestResult struct {
+	*tikvrpc.Response
+	error
+}
+
+// logger get default logger
+func logger() *zap.SugaredLogger {
+	return logutil.Logger(context.Background()).Sugar()
+}
+
+// fail make the test as failed
+func (c *batchClientTester) fail() {
+	c.failLock.Lock()
+	c.failed = true
+	c.failLock.Unlock()
+}
+
+// isFailed get is it failed
+func (c *batchClientTester) isFailed() bool {
+	c.failLock.Lock()
+	failed := c.failed
+	c.failLock.Unlock()
+	return failed
+}
+
+// end make the test end
+func (c *batchClientTester) end() {
+	c.endLock.Lock()
+	c.ended = true
+	c.endLock.Unlock()
+}
+
+// isEnded get is it ended
+func (c *batchClientTester) isEnded() bool {
+	c.endLock.Lock()
+	ended := c.ended
+	c.endLock.Unlock()
+	return ended
+}
+
+// unblockedSend invoke SendRequest, but returns a channel instead of blocking the current goroutine
+func (c *batchClientTester) unblockedSend(
+	ctx context.Context,
+	addr string,
+	req *tikvrpc.Request,
+	timeout time.Duration,
+) <-chan sendRequestResult {
+	done := make(chan sendRequestResult, 1)
+	go func() {
+		res, err := c.rpcClient.SendRequest(ctx, addr, req, timeout)
+		done <- sendRequestResult{res, err}
+	}()
+	return done
+}
+
+// test sends test messages to the server and process and check respond
+func (c *batchClientTester) test(addr string, id uint64) {
+	defer func() { c.wait.Done() }()
+	logger().Infof("Invoke test RPC %d at %v", id, addr)
+	req := &tikvrpc.Request{
+		Type: tikvrpc.CmdBatchTest,
+		BatchTest: &tikvpb.BatchCommandTestRequest{
+			TestId:    id,
+			DelayTime: c.cfg.genDelay(),
+		},
+	}
+	done := c.unblockedSend(context.Background(), addr, req, c.cfg.Timeout)
+	select {
+	case result := <-done:
+		err := result.error
+		if err != nil {
+			// detected conection error on time, success
+			logger().Infof("Test RPC %d at %v timeout", id, addr)
+			return
+		}
+		res := result.Response.Test
+		if res == nil {
+			// wrong response type
+			logger().Errorf("Test RPC %d at %v returned wrong type of response", id, addr)
+			c.fail()
+			return
+		}
+		if res.TestId != id {
+			// wrong id
+			logger().Errorf("Test RPC %d at %v returned wrong id %d", id, addr, res.TestId)
+			c.fail()
+			return
+		}
+		//TODO: check timing
+	case <-time.After(100*time.Millisecond + c.cfg.Timeout):
+		// do not finish in time
+		// better timing?
+		logger().Errorf("Test RPC %d at %v do not response or error on time", id, addr)
+		c.fail()
+	}
+}
+
+// runTest run test for one TiKV server
+func (c *batchClientTester) runTest(addr string) {
+	defer func() { c.wait.Done() }()
+	ticker := time.NewTicker(c.cfg.Interval)
+	defer func() { ticker.Stop() }()
+	var id uint64
+	for range ticker.C {
+		if c.isEnded() {
+			return
+		}
+		c.wait.Add(1)
+		go c.test(addr, id)
+		id++
+	}
+}

--- a/store/tikv/test_batch.go
+++ b/store/tikv/test_batch.go
@@ -123,7 +123,7 @@ func (c *batchClientTester) unblockedClose() <-chan struct{} {
 
 // test sends test messages to the server and process and check respond
 func (c *batchClientTester) test(addr string, id uint64) {
-	logger().Infof("Invoke test RPC %d at %v", id, addr)
+	logger().Debugf("Invoke test RPC %d at %v", id, addr)
 	req := &tikvrpc.Request{
 		Type: tikvrpc.CmdBatchTest,
 		BatchTest: &tikvpb.BatchCommandTestRequest{
@@ -137,7 +137,7 @@ func (c *batchClientTester) test(addr string, id uint64) {
 		err := result.error
 		if err != nil {
 			// detected conection error on time, success
-			logger().Infof("Test RPC %d at %v timeout", id, addr)
+			logger().Warnf("Test RPC %d at %v error: %v", id, addr, err)
 			return
 		}
 		res := result.Response.Test

--- a/store/tikv/test_client.go
+++ b/store/tikv/test_client.go
@@ -162,6 +162,12 @@ func (c *clientTester) test(addr string, id uint64) {
 		c.fail()
 		return
 	}
+	if result == nil {
+		// the tikv server do not support test command
+		logger().Errorf("Test RPC %d at %v was replied with a <nil>, the tikv instance do not support test command, please re-config the test", id, addr)
+		c.fail()
+		return
+	}
 	res := result.Test
 	if res == nil {
 		// wrong response type

--- a/store/tikv/test_client.go
+++ b/store/tikv/test_client.go
@@ -133,29 +133,29 @@ func (c *clientTester) test(addr string, id uint64) {
 			switch status.Code() {
 			case grpcCodes.DeadlineExceeded:
 				// just time out
-				logger().Warnf("Test RPC %d at %v timeout. error: %v", id, addr, err)
+				logger().Debugf("Test RPC %d at %v timeout. error: %v", id, addr, err)
 				return
 			case grpcCodes.Unavailable:
 				if strings.Contains(status.Message(), "all SubConns are in TransientFailure") {
 					// server not availiable
-					logger().Warnf("Test RPC %d at %v can not complete since connection to the server is not available. error: %v", id, addr, err)
+					logger().Debugf("Test RPC %d at %v can not complete since connection to the server is not available. error: %v", id, addr, err)
 					return
 				} else if strings.Contains(status.Message(), "transport is closing") {
 					// server is just killed, or panic (and the grpc thread killed)
-					logger().Warnf("Test RPC %d at %v can not complete since the connection is unexpected closed by server. error: %v", id, addr, err)
+					logger().Debugf("Test RPC %d at %v can not complete since the connection is unexpected closed by server. error: %v", id, addr, err)
 					return
 				}
 			case grpcCodes.Internal:
 				if strings.Contains(status.Message(), "RST_STREAM") {
 					// seems like the server gracefully reset the connection when manually exited?
-					logger().Warnf("Test RPC %d at %v is dropped since the stream is resetted. error: %v", id, addr, err)
+					logger().Debugf("Test RPC %d at %v is dropped since the stream is resetted. error: %v", id, addr, err)
 					return
 				}
 			}
 		}
 		if err == io.EOF {
 			// I have no idea why this happens in normal run, but it is returned when the connection is previously destroyed
-			logger().Warnf("Test RPC %d at %v is can not complete because of a previously error. error: %v", id, addr, err)
+			logger().Debugf("Test RPC %d at %v is can not complete because of a previously error. error: %v", id, addr, err)
 			return
 		}
 		logger().Errorf("Test RPC %d at %v have an unknown error: %v", id, addr, err)

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -298,7 +298,7 @@ func FromBatchCommandsResponse(res *tikvpb.BatchCommandsResponse_Response) *Resp
 	case *tikvpb.BatchCommandsResponse_Response_Coprocessor:
 		return &Response{Type: CmdCop, Cop: res.Coprocessor}
 	case *tikvpb.BatchCommandsResponse_Response_Test:
-		return &Response{Type: CmdBatchTest, Test:res.Test}
+		return &Response{Type: CmdBatchTest, Test: res.Test}
 	}
 	return nil
 }

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -64,6 +64,8 @@ const (
 	CmdSplitRegion
 
 	CmdDebugGetRegionProperties CmdType = 2048 + iota
+
+	CmdBatchTest CmdType = 4096 + iota
 )
 
 func (t CmdType) String() string {
@@ -120,6 +122,8 @@ func (t CmdType) String() string {
 		return "SplitRegion"
 	case CmdDebugGetRegionProperties:
 		return "DebugGetRegionProperties"
+	case CmdBatchTest:
+		return "BatchTest"
 	}
 	return "Unknown"
 }
@@ -154,6 +158,8 @@ type Request struct {
 	SplitRegion        *kvrpcpb.SplitRegionRequest
 
 	DebugGetRegionProperties *debugpb.GetRegionPropertiesRequest
+
+	BatchTest *tikvpb.BatchCommandTestRequest
 }
 
 // ToBatchCommandsRequest converts the request to an entry in BatchCommands request.
@@ -199,6 +205,8 @@ func (req *Request) ToBatchCommandsRequest() *tikvpb.BatchCommandsRequest_Reques
 		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawScan{RawScan: req.RawScan}}
 	case CmdCop:
 		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Coprocessor{Coprocessor: req.Cop}}
+	case CmdBatchTest:
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Test{Test: req.BatchTest}}
 	}
 	return nil
 }
@@ -242,6 +250,8 @@ type Response struct {
 	SplitRegion        *kvrpcpb.SplitRegionResponse
 
 	DebugGetRegionProperties *debugpb.GetRegionPropertiesResponse
+
+	Test *tikvpb.BatchCommandTestResponse
 }
 
 // FromBatchCommandsResponse converts a BatchCommands response to Response.
@@ -287,6 +297,8 @@ func FromBatchCommandsResponse(res *tikvpb.BatchCommandsResponse_Response) *Resp
 		return &Response{Type: CmdRawScan, RawScan: res.RawScan}
 	case *tikvpb.BatchCommandsResponse_Response_Coprocessor:
 		return &Response{Type: CmdCop, Cop: res.Coprocessor}
+	case *tikvpb.BatchCommandsResponse_Response_Test:
+		return &Response{Type: CmdBatchTest, Test:res.Test}
 	}
 	return nil
 }


### PR DESCRIPTION
### What problem does this PR solve? 

Testing of the batchCommand in the grpc

### What is changed and how it works?

Add a superbatch-tester binary to test the batchCommand in the grpc by repeatly sending the test RPCs. The test RPCs is defined in pingcap/kvproto#384 .

### Check List <!--REMOVE the items that are not applicable-->

**This part is not filled in yet**

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
