### PR TITLE
executor, types: fix char column not compatible with mysql

### DIFF
--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -458,6 +458,13 @@ func (s *seqTestSuite) TestShow(c *C) {
 	result = tk.MustQuery(`show plugins like '%'`)
 	result.Check(result.Rows())
 
+	//for issue #10392
+	testSQL = `drop table if exists vctt`
+	tk.MustExec(testSQL)
+	testSQL = `create table vctt (v varchar(4), c char(4))`
+	tk.MustExec(testSQL)
+	tk.MustExec(`insert into vctt values ("ab  ", "ab   ")`)
+
 	// for issue #4740
 	testSQL = `drop table if exists t`
 	tk.MustExec(testSQL)

--- a/types/datum.go
+++ b/types/datum.go
@@ -799,7 +799,7 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 	case KindString, KindBytes:
 		s = d.GetString()
 		if target.Tp == mysql.TypeString {
-			s=strings.TrimRight(s, " ")
+			s = strings.TrimRight(s, " ")
 		}
 	case KindMysqlTime:
 		s = d.GetMysqlTime().String()

--- a/types/datum.go
+++ b/types/datum.go
@@ -798,6 +798,9 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 		s = strconv.FormatFloat(d.GetFloat64(), 'f', -1, 64)
 	case KindString, KindBytes:
 		s = d.GetString()
+		if target.Tp == mysql.TypeString {
+			s=strings.TrimRight(s, " ")
+		}
 	case KindMysqlTime:
 		s = d.GetMysqlTime().String()
 	case KindMysqlDuration:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

for #10392 

### What is changed and how it works?

add condition in  types/datum.go


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)

```
create table vctt (v varchar(4), c char(4))
mysql> insert into vctt values ("ab  ", "  ab   ");
Query OK, 1 row affected (0.04 sec)
mysql> select * from vctt;
+------+------+
| v    | c    |
+------+------+
| ab   | NULL |
| ab   | NULL |
| NULL | ab   |
| NULL | ab   |
| ab   | ab   |
| ab   |   ab |
| ab   |   ab |
| ab   | ab   |
+------+------+
8 rows in set (0.00 sec)

```

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
