### PR TITLE
planner: fix wrong `DATE/DATETIME` comparison in `BETWEEN` function (#10313)

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -380,8 +380,8 @@ func temporalWithDateAsNumEvalType(argTp *types.FieldType) (argEvalType types.Ev
 	return
 }
 
-// getCmpTp4MinMax gets compare type for GREATEST and LEAST.
-func getCmpTp4MinMax(args []Expression) (argTp types.EvalType) {
+// GetCmpTp4MinMax gets compare type for GREATEST and LEAST and BETWEEN (mainly for datetime).
+func GetCmpTp4MinMax(args []Expression) (argTp types.EvalType) {
 	datetimeFound, isAllStr := false, true
 	cmpEvalType, isStr, isTemporalWithDate := temporalWithDateAsNumEvalType(args[0].GetType())
 	if !isStr {
@@ -422,7 +422,7 @@ func (c *greatestFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	if err = c.verifyArgs(args); err != nil {
 		return nil, errors.Trace(err)
 	}
-	tp, cmpAsDatetime := getCmpTp4MinMax(args), false
+	tp, cmpAsDatetime := GetCmpTp4MinMax(args), false
 	if tp == types.ETDatetime {
 		cmpAsDatetime = true
 		tp = types.ETString
@@ -616,7 +616,7 @@ func (c *leastFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	if err = c.verifyArgs(args); err != nil {
 		return nil, errors.Trace(err)
 	}
-	tp, cmpAsDatetime := getCmpTp4MinMax(args), false
+	tp, cmpAsDatetime := GetCmpTp4MinMax(args), false
 	if tp == types.ETDatetime {
 		cmpAsDatetime = true
 		tp = types.ETString

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1208,9 +1208,9 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 
 	var op string
 	var l, r expression.Expression
-	l, er.err = expression.NewFunction(ast.GE, &v.Type, expr, lexp)
+	l, er.err = expression.NewFunction(er.ctx, ast.GE, &v.Type, expr, lexp)
 	if er.err == nil {
-		r, er.err = expression.NewFunction(ast.LE, &v.Type, expr, rexp)
+		r, er.err = expression.NewFunction(er.ctx, ast.LE, &v.Type, expr, rexp)
 	}
 	op = ast.LogicAnd
 	if er.err != nil {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1208,9 +1208,9 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 
 	var op string
 	var l, r expression.Expression
-	l, er.err = er.newFunction(ast.GE, &v.Type, expr, lexp)
+	l, er.err = expression.NewFunction(ast.GE, &v.Type, expr, lexp)
 	if er.err == nil {
-		r, er.err = er.newFunction(ast.LE, &v.Type, expr, rexp)
+		r, er.err = expression.NewFunction(ast.LE, &v.Type, expr, rexp)
 	}
 	op = ast.LogicAnd
 	if er.err != nil {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -1197,11 +1197,20 @@ func (er *expressionRewriter) betweenToExpression(v *ast.BetweenExpr) {
 	if er.err != nil {
 		return
 	}
+
+	expr, lexp, rexp := er.ctxStack[stkLen-3], er.ctxStack[stkLen-2], er.ctxStack[stkLen-1]
+
+	if expression.GetCmpTp4MinMax([]expression.Expression{expr, lexp, rexp}) == types.ETDatetime {
+		expr = expression.WrapWithCastAsTime(er.ctx, expr, types.NewFieldType(mysql.TypeDatetime))
+		lexp = expression.WrapWithCastAsTime(er.ctx, lexp, types.NewFieldType(mysql.TypeDatetime))
+		rexp = expression.WrapWithCastAsTime(er.ctx, rexp, types.NewFieldType(mysql.TypeDatetime))
+	}
+
 	var op string
 	var l, r expression.Expression
-	l, er.err = expression.NewFunction(er.ctx, ast.GE, &v.Type, er.ctxStack[stkLen-3], er.ctxStack[stkLen-2])
+	l, er.err = er.newFunction(ast.GE, &v.Type, expr, lexp)
 	if er.err == nil {
-		r, er.err = expression.NewFunction(er.ctx, ast.LE, &v.Type, er.ctxStack[stkLen-3], er.ctxStack[stkLen-1])
+		r, er.err = er.newFunction(ast.LE, &v.Type, expr, rexp)
 	}
 	op = ast.LogicAnd
 	if er.err != nil {

--- a/planner/core/expression_test.go
+++ b/planner/core/expression_test.go
@@ -70,6 +70,8 @@ func (s *testExpressionSuite) TestBetween(c *C) {
 	tests := []testCase{
 		{exprStr: "1 between 2 and 3", resultStr: "0"},
 		{exprStr: "1 not between 2 and 3", resultStr: "1"},
+		{exprStr: "'2001-04-10 12:34:56' between cast('2001-01-01 01:01:01' as datetime) and '01-05-01'", resultStr: "1"},
+		{exprStr: "20010410123456 between cast('2001-01-01 01:01:01' as datetime) and 010501", resultStr: "0"},
 	}
 	s.runTests(c, tests)
 }


### PR DESCRIPTION
Cherry pick #10313 to 2.1