### PR TITLE
metrics: Fix a metrics that is not registered

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -139,4 +139,5 @@ func RegisterMetrics() {
 	prometheus.MustRegister(CPUUsagePercentageGauge)
 	prometheus.MustRegister(TiKVPendingBatchRequests)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
+	prometheus.MustRegister(TiKVBatchClientUnavailable)
 }


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The metrics TiKVBatchClientUnavailable is not registered `in metrics/metrics.go`, which seems to be a mistake. This PR registered it.

### What is changed and how it works?

register TiKVBatchClientUnavailable in `metrics/metrics.go`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - No

Side effects

 - No

Related changes

 - No
