### PR TITLE
Add tidb_low_resolution_tso session scope variable

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -275,6 +275,10 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, sctx sessionctx.Co
 		if snapshotTS != 0 {
 			return nil, errors.New("can not execute write statement when 'tidb_snapshot' is set")
 		}
+		lowResolutionTSO := sctx.GetSessionVars().LowResolutionTSO
+		if lowResolutionTSO {
+			return nil, errors.New("can not execute write statement when 'tidb_low_resolution_tso' is set")
+		}
 	}
 
 	var err error

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2081,6 +2081,28 @@ func (s *testSuite) TestHistoryRead(c *C) {
 	tk.MustQuery("select * from history_read order by a").Check(testkit.Rows("2 <nil>", "4 <nil>", "8 8", "9 9"))
 }
 
+func (s *testSuite) TestLowResolutionTSORead(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set @@autocommit=1")
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists low_resolution_tso")
+	tk.MustExec("create table low_resolution_tso(a int)")
+	tk.MustExec("insert low_resolution_tso values (1)")
+
+	// enable low resolution tso
+	c.Assert(tk.Se.GetSessionVars().LowResolutionTSO, IsFalse)
+	tk.Exec("set @@tidb_low_resolution_tso = 'on'")
+	c.Assert(tk.Se.GetSessionVars().LowResolutionTSO, IsTrue)
+
+	time.Sleep(3 * time.Second)
+	tk.MustQuery("select * from low_resolution_tso").Check(testkit.Rows("1"))
+	_, err := tk.Exec("update low_resolution_tso set a = 2")
+	c.Assert(err, NotNil)
+	tk.MustExec("set @@tidb_low_resolution_tso = 'off'")
+	tk.MustExec("update low_resolution_tso set a = 2")
+	tk.MustQuery("select * from low_resolution_tso").Check(testkit.Rows("2"))
+}
+
 func (s *testSuite) TestScanControlSelection(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/session/txn.go
+++ b/session/txn.go
@@ -338,9 +338,8 @@ func mergeToDirtyDB(dirtyDB *executor.DirtyDB, op dirtyTableOperation) {
 
 // txnFuture is a promise, which promises to return a txn in future.
 type txnFuture struct {
-	future        oracle.Future
-	store         kv.Storage
-	lowResolution bool
+	future oracle.Future
+	store  kv.Storage
 }
 
 func (tf *txnFuture) wait() (kv.Transaction, error) {
@@ -356,15 +355,12 @@ func (tf *txnFuture) wait() (kv.Transaction, error) {
 func (s *session) getTxnFuture(ctx context.Context) *txnFuture {
 	oracleStore := s.store.GetOracle()
 	var tsFuture oracle.Future
-	var lowResolution bool
 	if s.sessionVars.LowResolutionTSO {
 		tsFuture = oracleStore.GetLowResolutionTimestampAsync(ctx)
-		lowResolution = true
 	} else {
 		tsFuture = oracleStore.GetTimestampAsync(ctx)
-		lowResolution = false
 	}
-	return &txnFuture{tsFuture, s.store, lowResolution}
+	return &txnFuture{tsFuture, s.store}
 }
 
 // StmtCommit implements the sessionctx.Context interface.

--- a/session/txn.go
+++ b/session/txn.go
@@ -338,8 +338,9 @@ func mergeToDirtyDB(dirtyDB *executor.DirtyDB, op dirtyTableOperation) {
 
 // txnFuture is a promise, which promises to return a txn in future.
 type txnFuture struct {
-	future oracle.Future
-	store  kv.Storage
+	future        oracle.Future
+	store         kv.Storage
+	lowResolution bool
 }
 
 func (tf *txnFuture) wait() (kv.Transaction, error) {
@@ -354,8 +355,16 @@ func (tf *txnFuture) wait() (kv.Transaction, error) {
 
 func (s *session) getTxnFuture(ctx context.Context) *txnFuture {
 	oracleStore := s.store.GetOracle()
-	tsFuture := oracleStore.GetTimestampAsync(ctx)
-	return &txnFuture{tsFuture, s.store}
+	var tsFuture oracle.Future
+	var lowResolution bool
+	if s.sessionVars.LowResolutionTSO {
+		tsFuture = oracleStore.GetLowResolutionTimestampAsync(ctx)
+		lowResolution = true
+	} else {
+		tsFuture = oracleStore.GetTimestampAsync(ctx)
+		lowResolution = false
+	}
+	return &txnFuture{tsFuture, s.store, lowResolution}
 }
 
 // StmtCommit implements the sessionctx.Context interface.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -319,6 +319,9 @@ type SessionVars struct {
 
 	// SlowQueryFile indicates which slow query log file for SLOW_QUERY table to parse.
 	SlowQueryFile string
+
+	// LowResolutionTSO is used for reading data with low resolution TSO which is updated once every two seconds
+	LowResolutionTSO bool
 }
 
 // ConnectionInfo present connection used by audit.
@@ -361,6 +364,7 @@ func NewSessionVars() *SessionVars {
 		DisableTxnAutoRetry:       DefTiDBDisableTxnAutoRetry,
 		DDLReorgPriority:          kv.PriorityLow,
 		SlowQueryFile:             config.GetGlobalConfig().Log.SlowQueryFile,
+		LowResolutionTSO:          false,
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,
@@ -643,6 +647,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		config.GetGlobalConfig().CheckMb4ValueInUTF8 = TiDBOptOn(val)
 	case TiDBSlowQueryFile:
 		s.SlowQueryFile = val
+	case TiDBLowResolutionTSO:
+		s.LowResolutionTSO = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -364,7 +364,6 @@ func NewSessionVars() *SessionVars {
 		DisableTxnAutoRetry:       DefTiDBDisableTxnAutoRetry,
 		DDLReorgPriority:          kv.PriorityLow,
 		SlowQueryFile:             config.GetGlobalConfig().Log.SlowQueryFile,
-		LowResolutionTSO:          false,
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -320,7 +320,7 @@ type SessionVars struct {
 	// SlowQueryFile indicates which slow query log file for SLOW_QUERY table to parse.
 	SlowQueryFile string
 
-	// LowResolutionTSO is used for reading data with low resolution TSO which is updated once every two seconds
+	// LowResolutionTSO is used for reading data with low resolution TSO which is updated once every two seconds.
 	LowResolutionTSO bool
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -676,6 +676,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBForcePriority, mysql.Priority2Str[DefTiDBForcePriority]},
 	{ScopeSession, TiDBCheckMb4ValueInUTF8, BoolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUTF8)},
 	{ScopeSession, TiDBSlowQueryFile, ""},
+	{ScopeSession, TiDBLowResolutionTSO, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -39,4 +39,7 @@ func (*testSysVarSuite) TestSysVar(c *C) {
 	f = GetSysVar("explicit_defaults_for_timestamp")
 	c.Assert(f, NotNil)
 	c.Assert(f.Value, Equals, "ON")
+
+	f = GetSysVar("tidb_low_resolution_tso")
+	c.Assert(f.Value, Equals, "0")
 }

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -121,6 +121,9 @@ const (
 
 	// TiDBCheckMb4ValueInUTF8 is used to control whether to enable the check wrong utf8 value.
 	TiDBCheckMb4ValueInUTF8 = "tidb_check_mb4_value_in_utf8"
+
+	// TiDBLowResolutionTSO is used for reading data with low resolution TSO which is updated once every two seconds
+	TiDBLowResolutionTSO = "tidb_low_resolution_tso"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -326,7 +326,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 	case AutocommitVar, TiDBSkipUTF8Check, TiDBOptAggPushDown,
 		TiDBOptInSubqUnFolding, TiDBEnableTablePartition,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
-		TiDBBatchDelete, TiDBCheckMb4ValueInUTF8:
+		TiDBBatchDelete, TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO:
 		if strings.EqualFold(value, "ON") || value == "1" || strings.EqualFold(value, "OFF") || value == "0" {
 			return value, nil
 		}

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -243,4 +243,15 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUTF8, Equals, false)
+
+	SetSessionSystemVar(v, TiDBLowResolutionTSO, types.NewStringDatum("1"))
+	val, err = GetSessionSystemVar(v, TiDBLowResolutionTSO)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "1")
+	c.Assert(v.LowResolutionTSO, Equals, true)
+	SetSessionSystemVar(v, TiDBLowResolutionTSO, types.NewStringDatum("0"))
+	val, err = GetSessionSystemVar(v, TiDBLowResolutionTSO)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "0")
+	c.Assert(v.LowResolutionTSO, Equals, false)
 }

--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -93,6 +93,16 @@ func (o *MockOracle) GetTimestampAsync(ctx context.Context) oracle.Future {
 	return &mockOracleFuture{o, ctx}
 }
 
+// GetLowResolutionTimestamp implements oracle.Oracle interface.
+func (o *MockOracle) GetLowResolutionTimestamp(ctx context.Context) (uint64, error) {
+	return o.GetTimestamp(ctx)
+}
+
+// GetLowResolutionTimestampAsync implements oracle.Oracle interface.
+func (o *MockOracle) GetLowResolutionTimestampAsync(ctx context.Context) oracle.Future {
+	return o.GetTimestampAsync(ctx)
+}
+
 // IsExpired implements oracle.Oracle interface.
 func (o *MockOracle) IsExpired(lockTimestamp uint64, TTL uint64) bool {
 	o.RLock()

--- a/store/tikv/oracle/oracle.go
+++ b/store/tikv/oracle/oracle.go
@@ -23,6 +23,8 @@ import (
 type Oracle interface {
 	GetTimestamp(ctx context.Context) (uint64, error)
 	GetTimestampAsync(ctx context.Context) Future
+	GetLowResolutionTimestamp(ctx context.Context) (uint64, error)
+	GetLowResolutionTimestampAsync(ctx context.Context) Future
 	IsExpired(lockTimestamp uint64, TTL uint64) bool
 	Close()
 }

--- a/store/tikv/oracle/oracles/local.go
+++ b/store/tikv/oracle/oracles/local.go
@@ -59,6 +59,14 @@ func (l *localOracle) GetTimestampAsync(ctx context.Context) oracle.Future {
 	}
 }
 
+func (l *localOracle) GetLowResolutionTimestamp(ctx context.Context) (uint64, error) {
+	return l.GetTimestamp(ctx)
+}
+
+func (l *localOracle) GetLowResolutionTimestampAsync(ctx context.Context) oracle.Future {
+	return l.GetTimestampAsync(ctx)
+}
+
 type future struct {
 	ctx context.Context
 	l   *localOracle

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -140,3 +140,21 @@ func (o *pdOracle) updateTS(ctx context.Context, interval time.Duration) {
 func (o *pdOracle) Close() {
 	close(o.quit)
 }
+
+type lowResolutionTsFuture uint64
+
+// Wait implements the oracle.Future interface.
+func (f lowResolutionTsFuture) Wait() (uint64, error) {
+	return uint64(f), nil
+}
+
+// GetLowResolutionTimestamp gets a new increasing time.
+func (o *pdOracle) GetLowResolutionTimestamp(ctx context.Context) (uint64, error) {
+	lastTS := atomic.LoadUint64(&o.lastTS)
+	return lastTS, nil
+}
+
+func (o *pdOracle) GetLowResolutionTimestampAsync(ctx context.Context) oracle.Future {
+	lastTS := atomic.LoadUint64(&o.lastTS)
+	return lowResolutionTsFuture(lastTS)
+}

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -141,6 +141,7 @@ func (o *pdOracle) Close() {
 	close(o.quit)
 }
 
+// A future that resolves immediately to a low resolution timestamp.
 type lowResolutionTsFuture uint64
 
 // Wait implements the oracle.Future interface.


### PR DESCRIPTION
Low resolution timestamp is updated once every two seconds which can be used if reading slightly old version of data is acceptable. Like tidb_snapshot read, transaction is readonly when tidb_low_resolution_tso is enabled.

Signed-off-by: Xiaoguang Sun <sunxiaoguang@zhihu.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduce a session scope variable tidb_low_resolution_tso which can use periodically updated
timestamp from TSO when transaction starts. This can save one TSO request roundtrip time per transaction which is beneficial for small readonly queries in terms of latency. As a side effect, there will be less TSO requests hence less pressure on PD.

### What is changed and how it works?
Add a new tidb_low_resolution_tso session scope variable. When transaction starts and about to get start timestamp from TSO, call low resolution timestamp interface when tidb_low_resolution_tso is enabled.   Like tidb_snapshot read, transaction is readonly when tidb_low_resolution_tso is enabled.

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Manual test (add detailed scripts or steps below)

Related changes
 - Need to update the documentation