### PR TITLE
store/tikv: always set `isPessimisticLock` in request for pessimistic transaction.

### DIFF
--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -15,7 +15,6 @@ package tikv
 
 import (
 	"context"
-	"github.com/pingcap/tidb/kv"
 	"math"
 	"math/rand"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+	"github.com/pingcap/tidb/kv"
 	"math"
 	"math/rand"
 	"strings"
@@ -439,4 +440,19 @@ func (s *testCommitterSuite) TestWrittenKeysOnConflict(c *C) {
 		txn3.Commit(context.Background())
 	}
 	c.Assert(totalTime, Less, time.Millisecond*200)
+}
+
+func (s *testCommitterSuite) TestPessimisticPrewriteRequest(c *C) {
+	// This test checks that the isPessimisticLock field is set in the request even when no keys are pessimistic lock.
+	txn := s.begin(c)
+	txn.SetOption(kv.Pessimistic, true)
+	err := txn.Set([]byte("t1"), []byte("v1"))
+	c.Assert(err, IsNil)
+	commiter, err := newTwoPhaseCommitterWithInit(txn, 0)
+	c.Assert(err, IsNil)
+	var batch batchKeys
+	batch.keys = append(batch.keys, []byte("t1"))
+	batch.region = RegionVerID{1, 1, 1}
+	req := commiter.buildPrewriteRequest(batch)
+	c.Assert(len(req.Prewrite.IsPessimisticLock), Greater, 0)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 `isPessimisticLock` in the prewrite request is used to determine if this transaction is pessimistic.
Fail to set it causing tikv return WriteConflict error.

### What is changed and how it works?
always set `isPessimisticLock` in the request for pessimistic transaction

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
