### PR TITLE
Revert "ddl: prohibit modification decimal precision to avoid inconsistency problem (#10433)"

### DIFF
--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -934,8 +934,6 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 		{"varchar(10)", "varchar(8)", errUnsupportedModifyColumn.GenWithStackByArgs("length 8 is less than origin 10")},
 		{"varchar(10)", "varchar(11)", nil},
 		{"varchar(10) character set utf8 collate utf8_bin", "varchar(10) character set utf8", nil},
-		{"decimal(2,1)", "decimal(3,2)", errUnsupportedModifyColumn.GenWithStack("unsupported modify decimal column precision")},
-		{"decimal(2,1)", "decimal(2,1)", nil},
 	}
 	for _, tt := range tests {
 		ftA := s.colDefStrToFieldType(c, tt.origin)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2180,10 +2180,6 @@ func modifiableCharsetAndCollation(toCharset, toCollate, origCharset, origCollat
 // It returns true if the two types has the same Charset and Collation, the same sign, both are
 // integer types or string types, and new Flen and Decimal must be greater than or equal to origin.
 func modifiable(origin *types.FieldType, to *types.FieldType) error {
-	// The root cause is modifying decimal precision needs to rewrite binary representation of that decimal.
-	if origin.Tp == mysql.TypeNewDecimal && (to.Flen != origin.Flen || to.Decimal != origin.Decimal) {
-		return errUnsupportedModifyColumn.GenWithStack("unsupported modify decimal column precision")
-	}
 	if to.Flen > 0 && to.Flen < origin.Flen {
 		msg := fmt.Sprintf("length %d is less than origin %d", to.Flen, origin.Flen)
 		return errUnsupportedModifyColumn.GenWithStackByArgs(msg)

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -505,16 +505,6 @@ func (s *testSuite1) TestAdminCheckTable(c *C) {
 	tk.MustExec(`alter table t1 add column b timestamp not null;`)
 	tk.MustExec(`alter table t1 add index(b);`)
 	tk.MustExec(`admin check table t1;`)
-
-	// Test for index with change decimal precision.
-	tk.MustExec(`drop table if exists t1`)
-	tk.MustExec(`create table t1 (a decimal(2,1), index(a))`)
-	tk.MustExec(`insert into t1 set a='1.9'`)
-	_, err = tk.Exec(`alter table t1 modify column a decimal(3,2);`)
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify decimal column precision")
-	tk.MustExec(`delete from t1;`)
-	tk.MustExec(`admin check table t1;`)
 }
 
 func (s *testSuite1) TestAdminCheckPrimaryIndex(c *C) {


### PR DESCRIPTION

This reverts commit 0e9a6bf3a75b94ec0eda7daf2e3f18a8a6c159f5.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Revert a mis-operation commit in release-3.0 branch.
I will fill another PR to do this #10433  cherry-pick.
Sorry for my mistake.