### PR TITLE
*: refine transaction retry error messages

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1051,7 +1051,7 @@ var (
 	// ErrInfoSchemaExpired returns the error that information schema is out of date.
 	ErrInfoSchemaExpired = terror.ClassDomain.New(codeInfoSchemaExpired, "Information schema is out of date.")
 	// ErrInfoSchemaChanged returns the error that information schema is changed.
-	ErrInfoSchemaChanged = terror.ClassDomain.New(codeInfoSchemaChanged, "Information schema is changed.")
+	ErrInfoSchemaChanged = terror.ClassDomain.New(codeInfoSchemaChanged, "Information schema is changed."+kv.TxnRetryableMark)
 )
 
 func init() {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1051,7 +1051,8 @@ var (
 	// ErrInfoSchemaExpired returns the error that information schema is out of date.
 	ErrInfoSchemaExpired = terror.ClassDomain.New(codeInfoSchemaExpired, "Information schema is out of date.")
 	// ErrInfoSchemaChanged returns the error that information schema is changed.
-	ErrInfoSchemaChanged = terror.ClassDomain.New(codeInfoSchemaChanged, "Information schema is changed."+kv.TxnRetryableMark)
+	ErrInfoSchemaChanged = terror.ClassDomain.New(codeInfoSchemaChanged,
+		"Information schema is changed. "+kv.TxnRetryableMark)
 )
 
 func init() {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -40,7 +40,6 @@ import (
 	"github.com/pingcap/tidb/plugin"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -424,7 +423,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 	if err == nil {
 		return nil, nil
 	}
-	if !terror.ErrorEqual(tikv.ErrWriteConflict, err) {
+	if !terror.ErrorEqual(kv.ErrWriteConflict, err) {
 		return nil, err
 	}
 	if a.retryCount >= config.GetGlobalConfig().PessimisticTxn.MaxRetryCount {

--- a/go.mod
+++ b/go.mod
@@ -34,12 +34,12 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8
-	github.com/pingcap/errors v0.11.1
+	github.com/pingcap/errors v0.11.4
 	github.com/pingcap/failpoint v0.0.0-20190422094118-d8535965f59b
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190425131531-4ed0aa16f7ea
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190509110453-7a8657e6052b
+	github.com/pingcap/parser v0.0.0-20190515092550-ea671bdadc9d
 	github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9 h1:KH4f4Si9XK6/IW5
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
 github.com/pingcap/errors v0.10.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
-github.com/pingcap/errors v0.11.1 h1:BXFZ6MdDd2U1uJUa2sRAWTmm+nieEzuyYM0R4aUTcC8=
-github.com/pingcap/errors v0.11.1/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
+github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/failpoint v0.0.0-20190422094118-d8535965f59b h1:gFQVlQbthX4C2WKV/zqGBF3bZFr7oceKK9jGOVNkfws=
 github.com/pingcap/failpoint v0.0.0-20190422094118-d8535965f59b/go.mod h1:fdAkVXuIXHAPZ7a280nj9bRORfK9NuSsOguvBH0+W6c=
 github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3 h1:04yuCf5NMvLU8rB2m4Qs3rynH7EYpMno3lHkewIOdMo=
@@ -161,8 +161,8 @@ github.com/pingcap/kvproto v0.0.0-20190425131531-4ed0aa16f7ea/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190509110453-7a8657e6052b h1:IC1S/ZfKdQRccGJG7C3IkWB6S+d0OkYj8vnmNrMCu2c=
-github.com/pingcap/parser v0.0.0-20190509110453-7a8657e6052b/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190515092550-ea671bdadc9d h1:LGBHFQ3C9sDcqSLLk+CTZmjhGmKtI5jWt6lzoUVYmIE=
+github.com/pingcap/parser v0.0.0-20190515092550-ea671bdadc9d/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669/go.mod h1:MUCxRzOkYiWZtlyi4MhxjCIj9PgQQ/j+BLNGm7aUsnM=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/kv/error.go
+++ b/kv/error.go
@@ -14,44 +14,33 @@
 package kv
 
 import (
-	"strings"
-
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 )
 
 // KV error codes.
 const (
-	codeClosed                     terror.ErrCode = 1
-	codeNotExist                                  = 2
-	codeConditionNotMatch                         = 3
-	codeLockConflict                              = 4
-	codeLazyConditionPairsNotMatch                = 5
-	codeRetryable                                 = 6
-	codeCantSetNilValue                           = 7
-	codeInvalidTxn                                = 8
-	codeNotCommitted                              = 9
-	codeNotImplemented                            = 10
-	codeTxnTooLarge                               = 11
-	codeEntryTooLarge                             = 12
-
-	codeKeyExists = 1062
+	codeClosed          terror.ErrCode = 1
+	codeNotExist                       = 2
+	codeRetryable                      = 6
+	codeCantSetNilValue                = 7
+	codeInvalidTxn                     = 8
+	codeNotImplemented                 = 10
+	codeTxnTooLarge                    = 11
+	codeEntryTooLarge                  = 12
+	codeKeyExists                      = 1062
 )
+
+// TxnRetryableMark is used to uniform the commit error messages which could retry the transaction.
+const TxnRetryableMark = " [try again later]"
 
 var (
 	// ErrClosed is used when close an already closed txn.
 	ErrClosed = terror.ClassKV.New(codeClosed, "Error: Transaction already closed")
 	// ErrNotExist is used when try to get an entry with an unexist key from KV store.
 	ErrNotExist = terror.ClassKV.New(codeNotExist, "Error: key not exist")
-	// ErrConditionNotMatch is used when condition is not met.
-	ErrConditionNotMatch = terror.ClassKV.New(codeConditionNotMatch, "Error: Condition not match")
-	// ErrLockConflict is used when try to lock an already locked key.
-	ErrLockConflict = terror.ClassKV.New(codeLockConflict, "Error: Lock conflict")
-	// ErrLazyConditionPairsNotMatch is used when value in store differs from expect pairs.
-	ErrLazyConditionPairsNotMatch = terror.ClassKV.New(codeLazyConditionPairsNotMatch, "Error: Lazy condition pairs not match")
-	// ErrRetryable is used when KV store occurs RPC error or some other
-	// errors which SQL layer can safely retry.
-	ErrRetryable = terror.ClassKV.New(codeRetryable, "Error: KV error safe to retry")
+	// ErrRetryable is used when KV store occurs RPC error or some other errors which SQL layer can safely retry.
+	ErrRetryable = terror.ClassKV.New(codeRetryable, "Error: KV error safe to retry %s"+TxnRetryableMark)
 	// ErrCannotSetNilValue is the error when sets an empty value.
 	ErrCannotSetNilValue = terror.ClassKV.New(codeCantSetNilValue, "can not set nil value")
 	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.
@@ -60,22 +49,20 @@ var (
 	ErrTxnTooLarge = terror.ClassKV.New(codeTxnTooLarge, "transaction is too large")
 	// ErrEntryTooLarge is the error when a key value entry is too large.
 	ErrEntryTooLarge = terror.ClassKV.New(codeEntryTooLarge, "entry too large, the max entry size is %d, the size of data is %d")
-
-	// ErrNotCommitted is the error returned by CommitVersion when this
-	// transaction is not committed.
-	ErrNotCommitted = terror.ClassKV.New(codeNotCommitted, "this transaction has not committed")
-
 	// ErrKeyExists returns when key is already exist.
 	ErrKeyExists = terror.ClassKV.New(codeKeyExists, "key already exist")
 	// ErrNotImplemented returns when a function is not implemented yet.
 	ErrNotImplemented = terror.ClassKV.New(codeNotImplemented, "not implemented")
+	// ErrWriteConflict is the error when the commit meets an write conflict error.
+	ErrWriteConflict = terror.ClassKV.New(mysql.ErrWriteConflict, mysql.MySQLErrName[mysql.ErrWriteConflict]+TxnRetryableMark)
 )
 
 func init() {
 	kvMySQLErrCodes := map[terror.ErrCode]uint16{
-		codeKeyExists:     mysql.ErrDupEntry,
-		codeEntryTooLarge: mysql.ErrTooBigRowsize,
-		codeTxnTooLarge:   mysql.ErrTxnTooLarge,
+		codeKeyExists:          mysql.ErrDupEntry,
+		codeEntryTooLarge:      mysql.ErrTooBigRowsize,
+		codeTxnTooLarge:        mysql.ErrTxnTooLarge,
+		mysql.ErrWriteConflict: mysql.ErrWriteConflict,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassKV] = kvMySQLErrCodes
 }
@@ -86,11 +73,7 @@ func IsRetryableError(err error) bool {
 		return false
 	}
 
-	if ErrRetryable.Equal(err) ||
-		ErrLockConflict.Equal(err) ||
-		ErrConditionNotMatch.Equal(err) ||
-		// TiKV exception message will tell you if you should retry or not
-		strings.Contains(err.Error(), "try again later") {
+	if ErrRetryable.Equal(err) || ErrWriteConflict.Equal(err) {
 		return true
 	}
 

--- a/kv/error.go
+++ b/kv/error.go
@@ -22,7 +22,7 @@ import (
 const (
 	codeClosed          terror.ErrCode = 1
 	codeNotExist                       = 2
-	codeRetryable                      = 6
+	codeTxnRetryable                   = 6
 	codeCantSetNilValue                = 7
 	codeInvalidTxn                     = 8
 	codeNotImplemented                 = 10
@@ -43,7 +43,7 @@ var (
 	// ErrTxnRetryable is used when KV store occurs retryable error which SQL layer can safely retry the transaction.
 	// When using TiKV as the storage node, the error is returned ONLY when lock not found (txnLockNotFound) in Commit,
 	// subject to change it in the future.
-	ErrTxnRetryable = terror.ClassKV.New(codeRetryable, "Error: KV error safe to retry %s "+TxnRetryableMark)
+	ErrTxnRetryable = terror.ClassKV.New(codeTxnRetryable, "Error: KV error safe to retry %s "+TxnRetryableMark)
 	// ErrCannotSetNilValue is the error when sets an empty value.
 	ErrCannotSetNilValue = terror.ClassKV.New(codeCantSetNilValue, "can not set nil value")
 	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.

--- a/kv/error.go
+++ b/kv/error.go
@@ -42,7 +42,7 @@ var (
 	ErrNotExist = terror.ClassKV.New(codeNotExist, "Error: key not exist")
 	// ErrTxnRetryable is used when KV store occurs retryable error which SQL layer can safely retry the transaction.
 	// When using TiKV as the storage node, the error is returned ONLY when lock not found (txnLockNotFound) in Commit,
-	// subjective to change it in the future.
+	// subject to change it in the future.
 	ErrTxnRetryable = terror.ClassKV.New(codeRetryable, "Error: KV error safe to retry %s "+TxnRetryableMark)
 	// ErrCannotSetNilValue is the error when sets an empty value.
 	ErrCannotSetNilValue = terror.ClassKV.New(codeCantSetNilValue, "can not set nil value")

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -27,7 +27,7 @@ type mockTxn struct {
 
 // Commit always returns a retryable error.
 func (t *mockTxn) Commit(ctx context.Context) error {
-	return ErrRetryable
+	return ErrTxnRetryable
 }
 
 func (t *mockTxn) Rollback() error {

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -51,7 +51,7 @@ func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) e
 		if err != nil {
 			err1 := txn.Rollback()
 			terror.Log(err1)
-			if retryable && IsRetryableError(err) {
+			if retryable && IsTxnRetryableError(err) {
 				logutil.Logger(context.Background()).Warn("RunInNewTxn",
 					zap.Uint64("retry txn", txn.StartTS()),
 					zap.Uint64("original txn", originalTxnTS),
@@ -65,7 +65,7 @@ func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) e
 		if err == nil {
 			break
 		}
-		if retryable && IsRetryableError(err) {
+		if retryable && IsTxnRetryableError(err) {
 			logutil.Logger(context.Background()).Warn("RunInNewTxn",
 				zap.Uint64("retry txn", txn.StartTS()),
 				zap.Uint64("original txn", originalTxnTS),

--- a/session/session.go
+++ b/session/session.go
@@ -358,7 +358,7 @@ func (s *session) doCommit(ctx context.Context) error {
 	failpoint.Inject("mockCommitError", func(val failpoint.Value) {
 		if val.(bool) && kv.IsMockCommitErrorEnable() {
 			kv.MockCommitErrorDisable()
-			failpoint.Return(kv.ErrRetryable)
+			failpoint.Return(kv.ErrTxnRetryable)
 		}
 	})
 
@@ -543,9 +543,9 @@ func (s *session) isInternal() bool {
 
 func (s *session) isRetryableError(err error) bool {
 	if SchemaChangedWithoutRetry {
-		return kv.IsRetryableError(err)
+		return kv.IsTxnRetryableError(err)
 	}
-	return kv.IsRetryableError(err) || domain.ErrInfoSchemaChanged.Equal(err)
+	return kv.IsTxnRetryableError(err) || domain.ErrInfoSchemaChanged.Equal(err)
 }
 
 func (s *session) checkTxnAborted(stmt sqlexec.Statement) error {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2404,7 +2404,7 @@ func (s *testSessionSuite) TestTxnRetryErrMsg(c *C) {
 	_, err := tk1.Se.Execute(context.Background(), "commit")
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/ErrMockRetryableOnly"), IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(kv.ErrRetryable.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(kv.ErrTxnRetryable.Equal(err), IsTrue, Commentf("error: %s", err))
 	c.Assert(strings.Contains(err.Error(), "mock retryable error"), IsTrue, Commentf("error: %s", err))
 	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2392,6 +2392,23 @@ func (s *testSessionSuite) TestCommitRetryCount(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *testSessionSuite) TestTxnRetryErrMsg(c *C) {
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("create table no_retry (id int)")
+	tk1.MustExec("insert into no_retry values (1)")
+	tk1.MustExec("begin")
+	tk2.MustExec("update no_retry set id = id + 1")
+	tk1.MustExec("update no_retry set id = id + 1")
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/ErrMockRetryableOnly", `return(true)`), IsNil)
+	_, err := tk1.Se.Execute(context.Background(), "commit")
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/ErrMockRetryableOnly"), IsNil)
+	c.Assert(err, NotNil)
+	c.Assert(kv.ErrRetryable.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), "mock retryable error"), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
+}
+
 func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)
@@ -2438,9 +2455,10 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 
 	_, err = tk1.Se.Execute(context.Background(), "commit")
 	c.Assert(err, NotNil)
+	c.Assert(kv.ErrWriteConflict.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
 	tk1.MustExec("rollback")
 
-	// other errors could retry
 	config.GetGlobalConfig().TxnLocalLatches.Enabled = true
 	tk1.MustExec("begin")
 	tk2.MustExec("alter table no_retry add index idx(id)")
@@ -2448,6 +2466,8 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	tk1.MustExec("update no_retry set id = 10")
 	_, err = tk1.Se.Execute(context.Background(), "commit")
 	c.Assert(err, NotNil)
+	c.Assert(domain.ErrInfoSchemaChanged.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
 
 	// set autocommit to begin and commit
 	tk1.MustExec("set autocommit = 0")
@@ -2456,6 +2476,8 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	tk1.MustExec("update no_retry set id = 12")
 	_, err = tk1.Se.Execute(context.Background(), "set autocommit = 1")
 	c.Assert(err, NotNil)
+	c.Assert(kv.ErrWriteConflict.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
 	tk1.MustExec("rollback")
 	tk2.MustQuery("select * from no_retry").Check(testkit.Rows("11"))
 
@@ -2465,6 +2487,8 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	tk1.MustExec("update no_retry set id = 14")
 	_, err = tk1.Se.Execute(context.Background(), "commit")
 	c.Assert(err, NotNil)
+	c.Assert(kv.ErrWriteConflict.Equal(err), IsTrue, Commentf("error: %s", err))
+	c.Assert(strings.Contains(err.Error(), kv.TxnRetryableMark), IsTrue, Commentf("error: %s", err))
 	tk1.MustExec("rollback")
 	tk2.MustQuery("select * from no_retry").Check(testkit.Rows("13"))
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -182,7 +182,7 @@ func (st *TxnState) Commit(ctx context.Context) error {
 	// mockCommitError8942 is used for PR #8942.
 	failpoint.Inject("mockCommitError8942", func(val failpoint.Value) {
 		if val.(bool) {
-			failpoint.Return(kv.ErrRetryable)
+			failpoint.Return(kv.ErrTxnRetryable)
 		}
 	})
 
@@ -190,7 +190,7 @@ func (st *TxnState) Commit(ctx context.Context) error {
 	failpoint.Inject("mockCommitRetryForAutoID", func(val failpoint.Value) {
 		if val.(bool) && !mockAutoIDRetry() {
 			enableMockAutoIDRetry()
-			failpoint.Return(kv.ErrRetryable)
+			failpoint.Return(kv.ErrTxnRetryable)
 		}
 	})
 

--- a/store/store.go
+++ b/store/store.go
@@ -68,7 +68,7 @@ func newStoreWithRetry(path string, maxRetries int) (kv.Storage, error) {
 	err = util.RunWithRetry(maxRetries, util.RetryInterval, func() (bool, error) {
 		logutil.Logger(context.Background()).Info("new store", zap.String("path", path))
 		s, err = d.Open(path)
-		return kv.IsRetryableError(err), err
+		return kv.IsTxnRetryableError(err), err
 	})
 
 	if err == nil {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -39,7 +39,7 @@ const (
 type brokenStore struct{}
 
 func (s *brokenStore) Open(schema string) (kv.Storage, error) {
-	return nil, kv.ErrRetryable
+	return nil, kv.ErrTxnRetryable
 }
 
 func TestT(t *testing.T) {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -224,7 +224,7 @@ func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
 	c.Assert(err, IsNil)
 	err = txn2.Commit(context.Background())
 	c.Assert(err, NotNil)
-	c.Assert(strings.Contains(err.Error(), txnRetryableMark), IsTrue, Commentf("err: %s", err))
+	c.Assert(kv.ErrWriteConflict.Equal(err), IsTrue, Commentf("err: %s", err))
 }
 
 func (s *testCommitterSuite) mustGetRegionID(c *C, key []byte) uint64 {

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -27,14 +27,6 @@ var (
 // mismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
 const mismatchClusterID = "mismatch cluster id"
 
-// TiDB decides whether to retry transaction by checking if error message contains
-// string "try again later" literally.
-// In TiClient we use `errors.Annotate(err, txnRetryableMark)` to direct TiDB to
-// restart a transaction.
-// Note that it should be only used if i) the error occurs inside a transaction
-// and ii) the error is not totally unexpected and hopefully will recover soon.
-const txnRetryableMark = "[try again later]"
-
 // MySQL error instances.
 var (
 	ErrTiKVServerTimeout  = terror.ClassTiKV.New(mysql.ErrTiKVServerTimeout, mysql.MySQLErrName[mysql.ErrTiKVServerTimeout])
@@ -43,7 +35,6 @@ var (
 	ErrRegionUnavailable  = terror.ClassTiKV.New(mysql.ErrRegionUnavailable, mysql.MySQLErrName[mysql.ErrRegionUnavailable])
 	ErrTiKVServerBusy     = terror.ClassTiKV.New(mysql.ErrTiKVServerBusy, mysql.MySQLErrName[mysql.ErrTiKVServerBusy])
 	ErrGCTooEarly         = terror.ClassTiKV.New(mysql.ErrGCTooEarly, mysql.MySQLErrName[mysql.ErrGCTooEarly])
-	ErrWriteConflict      = terror.ClassTiKV.New(mysql.ErrWriteConflict, mysql.MySQLErrName[mysql.ErrWriteConflict])
 )
 
 func init() {
@@ -55,7 +46,6 @@ func init() {
 		mysql.ErrTiKVServerBusy:      mysql.ErrTiKVServerBusy,
 		mysql.ErrGCTooEarly:          mysql.ErrGCTooEarly,
 		mysql.ErrTruncatedWrongValue: mysql.ErrTruncatedWrongValue,
-		mysql.ErrWriteConflict:       mysql.ErrWriteConflict,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassTiKV] = tikvMySQLErrCodes
 }

--- a/store/tikv/isolation_test.go
+++ b/store/tikv/isolation_test.go
@@ -72,7 +72,7 @@ func (s *testIsolationSuite) SetWithRetry(c *C, k, v []byte) writeRecord {
 				commitTS: txn.(*tikvTxn).commitTS,
 			}
 		}
-		c.Assert(kv.IsRetryableError(err) || terror.ErrorEqual(err, terror.ErrResultUndetermined), IsTrue)
+		c.Assert(kv.IsTxnRetryableError(err) || terror.ErrorEqual(err, terror.ErrResultUndetermined), IsTrue)
 	}
 }
 
@@ -99,7 +99,7 @@ func (s *testIsolationSuite) GetWithRetry(c *C, k []byte) readRecord {
 				value:   val,
 			}
 		}
-		c.Assert(kv.IsRetryableError(err), IsTrue)
+		c.Assert(kv.IsTxnRetryableError(err), IsTrue)
 	}
 }
 

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -323,7 +323,7 @@ func extractKeyErr(keyErr *pb.KeyError) error {
 		return newWriteConflictError(keyErr.Conflict)
 	}
 	if keyErr.Retryable != "" {
-		return kv.ErrRetryable.GenWithStackByArgs("tikv restarts txn: " + keyErr.GetRetryable())
+		return kv.ErrTxnRetryable.GenWithStackByArgs("tikv restarts txn: " + keyErr.GetRetryable())
 	}
 	if keyErr.Abort != "" {
 		err := errors.Errorf("tikv aborts txn: %s", keyErr.GetAbort())

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -22,6 +22,7 @@ import (
 	"unsafe"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
@@ -311,14 +312,18 @@ func extractLockFromKeyErr(keyErr *pb.KeyError) (*Lock, error) {
 }
 
 func extractKeyErr(keyErr *pb.KeyError) error {
+	failpoint.Inject("ErrMockRetryableOnly", func(val failpoint.Value) {
+		if val.(bool) {
+			keyErr.Conflict = nil
+			keyErr.Retryable = "mock retryable error"
+		}
+	})
+
 	if keyErr.Conflict != nil {
-		err := newWriteConflictError(keyErr.Conflict)
-		return errors.Annotate(err, txnRetryableMark)
+		return newWriteConflictError(keyErr.Conflict)
 	}
 	if keyErr.Retryable != "" {
-		err := errors.Errorf("tikv restarts txn: %s", keyErr.GetRetryable())
-		logutil.Logger(context.Background()).Debug("error", zap.Error(err))
-		return errors.Annotate(err, txnRetryableMark)
+		return kv.ErrRetryable.GenWithStackByArgs("tikv restarts txn: " + keyErr.GetRetryable())
 	}
 	if keyErr.Abort != "" {
 		err := errors.Errorf("tikv aborts txn: %s", keyErr.GetAbort())
@@ -330,15 +335,10 @@ func extractKeyErr(keyErr *pb.KeyError) error {
 
 func newWriteConflictError(conflict *pb.WriteConflict) error {
 	var buf bytes.Buffer
-	_, err := fmt.Fprintf(&buf, "txnStartTS=%d, conflictTS=%d, key=",
-		conflict.StartTs, conflict.ConflictTs)
-	if err != nil {
-		logutil.Logger(context.Background()).Error("error", zap.Error(err))
-	}
 	prettyWriteKey(&buf, conflict.Key)
 	buf.WriteString(" primary=")
 	prettyWriteKey(&buf, conflict.Primary)
-	return ErrWriteConflict.FastGen(buf.String())
+	return kv.ErrWriteConflict.GenWithStackByArgs(conflict.StartTs, conflict.ConflictTs, buf.String())
 }
 
 func prettyWriteKey(buf *bytes.Buffer, key []byte) {

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -323,7 +323,7 @@ func extractKeyErr(keyErr *pb.KeyError) error {
 		return newWriteConflictError(keyErr.Conflict)
 	}
 	if keyErr.Retryable != "" {
-		return kv.ErrTxnRetryable.GenWithStackByArgs("tikv restarts txn: " + keyErr.GetRetryable())
+		return kv.ErrTxnRetryable.FastGenByArgs("tikv restarts txn: " + keyErr.GetRetryable())
 	}
 	if keyErr.Abort != "" {
 		err := errors.Errorf("tikv aborts txn: %s", keyErr.GetAbort())
@@ -338,7 +338,7 @@ func newWriteConflictError(conflict *pb.WriteConflict) error {
 	prettyWriteKey(&buf, conflict.Key)
 	buf.WriteString(" primary=")
 	prettyWriteKey(&buf, conflict.Primary)
-	return kv.ErrWriteConflict.GenWithStackByArgs(conflict.StartTs, conflict.ConflictTs, buf.String())
+	return kv.ErrWriteConflict.FastGenByArgs(conflict.StartTs, conflict.ConflictTs, buf.String())
 }
 
 func prettyWriteKey(buf *bytes.Buffer, key []byte) {

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -154,6 +154,10 @@ func (s *testSnapshotSuite) TestWriteConflictPrettyFormat(c *C) {
 		Primary:    []byte{116, 128, 0, 0, 0, 0, 0, 1, 155, 95, 105, 128, 0, 0, 0, 0, 0, 0, 1, 1, 82, 87, 48, 49, 0, 0, 0, 0, 251, 1, 55, 54, 56, 50, 50, 49, 49, 48, 255, 57, 0, 0, 0, 0, 0, 0, 0, 248, 1, 0, 0, 0, 0, 0, 0, 0, 0, 247},
 	}
 
-	expectedStr := `[kv:9007]Write conflict, txnStartTS=399402937522847774, conflictTS=399402937719455772, key={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} primary={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} [try again later]`
+	expectedStr := "[kv:9007]Write conflict, " +
+		"txnStartTS=399402937522847774, conflictTS=399402937719455772, " +
+		"key={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} " +
+		"primary={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} " +
+		kv.TxnRetryableMark
 	c.Assert(newWriteConflictError(conflict).Error(), Equals, expectedStr)
 }

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -154,6 +154,6 @@ func (s *testSnapshotSuite) TestWriteConflictPrettyFormat(c *C) {
 		Primary:    []byte{116, 128, 0, 0, 0, 0, 0, 1, 155, 95, 105, 128, 0, 0, 0, 0, 0, 0, 1, 1, 82, 87, 48, 49, 0, 0, 0, 0, 251, 1, 55, 54, 56, 50, 50, 49, 49, 48, 255, 57, 0, 0, 0, 0, 0, 0, 0, 248, 1, 0, 0, 0, 0, 0, 0, 0, 0, 247},
 	}
 
-	expectedStr := `[tikv:9007]txnStartTS=399402937522847774, conflictTS=399402937719455772, key={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} primary={tableID=411, indexID=1, indexValues={RW01, 768221109, , }}`
+	expectedStr := `[kv:9007]Write conflict, txnStartTS=399402937522847774, conflictTS=399402937719455772, key={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} primary={tableID=411, indexID=1, indexValues={RW01, 768221109, , }} [try again later]`
 	c.Assert(newWriteConflictError(conflict).Error(), Equals, expectedStr)
 }

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -176,7 +176,7 @@ func (s *testTiclientSuite) TestLargeRequest(c *C) {
 	c.Assert(err, NotNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	c.Assert(kv.IsRetryableError(err), IsFalse)
+	c.Assert(kv.IsTxnRetryableError(err), IsFalse)
 }
 
 func encodeKey(prefix, s string) []byte {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -304,7 +304,6 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 	}
 	defer txn.store.txnLatches.UnLock(lock)
 	if lock.IsStale() {
-		err = errors.Errorf("txnStartTS %d is stale", txn.startTS)
 		return kv.ErrWriteConflict.GenWithStackByArgs(txn.startTS, 0, "is stale")
 	}
 	err = committer.executeAndWriteFinishBinlog(ctx)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -305,7 +305,7 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 	defer txn.store.txnLatches.UnLock(lock)
 	if lock.IsStale() {
 		err = errors.Errorf("txnStartTS %d is stale", txn.startTS)
-		return errors.Annotate(err, txnRetryableMark)
+		return kv.ErrWriteConflict.GenWithStackByArgs(txn.startTS, 0, "is stale")
 	}
 	err = committer.executeAndWriteFinishBinlog(ctx)
 	if err == nil {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -304,7 +304,7 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 	}
 	defer txn.store.txnLatches.UnLock(lock)
 	if lock.IsStale() {
-		return kv.ErrWriteConflict.GenWithStackByArgs(txn.startTS, 0, "is stale")
+		return kv.ErrWriteConflict.FastGenByArgs(txn.startTS, 0, "is stale")
 	}
 	err = committer.executeAndWriteFinishBinlog(ctx)
 	if err == nil {


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Using `[try again later]` as the transaction retry marker is not suitable. It costs too many resources to search the error messages `strings.Contrains(err.Error(), "[try again later]")` when the error stack is very long.
1. Some tests, e.g. jepsen have to use the error message to determine whether the transaction is aborted as expected.
1. `errors.Annotate` sometimes only set the message in the full stack error, that means it could not be used by jepsen.

### What is changed and how it works?

1. Do not use a string to determine whether should retry the transaction.
1. Add "[try again later]" for ErrWriteConflict, ErrRetryable, and ErrInfoSchemaChanged, then they will be used by some test to know the transaction is safe to retry.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - Increased code complexity

