### PR TITLE
cmd/ddltest: fix build using 'go test -c'

### DIFF
--- a/cmd/ddltest/ddl_test.go
+++ b/cmd/ddltest/ddl_test.go
@@ -32,13 +32,14 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/store"
+	zaplog "github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
@@ -92,7 +93,7 @@ type TestDDLSuite struct {
 }
 
 func (s *TestDDLSuite) SetUpSuite(c *C) {
-	logutil.InitLogger(&logutil.LogConfig{Level: *logLevel})
+	logutil.InitLogger(&logutil.LogConfig{Config: zaplog.Config{Level: *logLevel}})
 
 	s.quit = make(chan struct{})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
➜  tidb git:(master) ✗ cd cmd/ddltest 
➜  ddltest git:(master) ✗ go test -c
# github.com/pingcap/tidb/cmd/ddltest [github.com/pingcap/tidb/cmd/ddltest.test]
./ddl_test.go:95:40: cannot use promoted field Config.Level in struct literal of type logutil.LogConfig
```

### What is changed and how it works?

Fix build ddltest for https://github.com/pingcap/tidb-test/pull/719

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
go test -c success
