### PR TITLE
Makefile: add a 'make ddltest' target to generate ddltest binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ CHECK_LDFLAGS += $(LDFLAGS) ${TEST_LDFLAGS}
 
 TARGET = ""
 
-.PHONY: all build update clean todo test gotest interpreter server dev benchkv benchraw check checklist parser tidy
+.PHONY: all build update clean todo test gotest interpreter server dev benchkv benchraw check checklist parser tidy ddltest
 
 default: server buildsucc
 
@@ -115,6 +115,9 @@ test: checklist checkdep gotest explaintest
 
 explaintest: server
 	@cd cmd/explaintest && ./run-tests.sh -s ../../bin/tidb-server
+
+ddltest:
+	@cd cmd/ddltest && $(GO) test -o ddltest -c
 
 upload-coverage: SHELL:=/bin/bash
 upload-coverage:

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ explaintest: server
 	@cd cmd/explaintest && ./run-tests.sh -s ../../bin/tidb-server
 
 ddltest:
-	@cd cmd/ddltest && $(GO) test -o ddltest -c
+	@cd cmd/ddltest && $(GO) test -o ../../bin/ddltest -c
 
 upload-coverage: SHELL:=/bin/bash
 upload-coverage:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

It's easier to maintenance if we follow these rules:
tidb repo provides ddltest source code and binary 
tidb-test repo provides the CI script

### What is changed and how it works?

Provide `make ddltest` target in the Makefile


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

