### PR TITLE
distsql: tiny refactor to make the code more robust

### DIFF
--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -112,7 +112,7 @@ func (r *selectResult) fetch(ctx context.Context) {
 		}
 
 		select {
-		case r.results <- resultWithErr{result: resultSubset}:
+		case r.results <- result:
 		case <-r.closed:
 			// If selectResult called Close() already, make fetch goroutine exit.
 			return


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

There is a potential goroutine leak found here:

```
goroutine 2190640781 [chan send, 217 minutes]:
github.com/pingcap/tidb/distsql.(*selectResult).fetch(0xc000c26d10, 0x2189000, 0xc0de519300)
/home/jenkins/workspace/build_tidb_release-3.0/go/src/github.com/pingcap/tidb/distsql/select_result.go:97 +0x2e8
created by github.com/pingcap/tidb/distsql.(*selectResult).Fetch
/home/jenkins/workspace/build_tidb_release-3.0/go/src/github.com/pingcap/tidb/distsql/select_result.go:84 +0x53
```

### What is changed and how it works?

https://github.com/pingcap/tidb/compare/master...tiancaiamao:leak?expand=1#diff-7492d01b7aac81533194642850a45b8eL103

This line only listen for one exit condition.
If multiple error arrive and caller call `Close`, without calling `selectResult.Next()` any more,
nobody would drain from `r.results` so the fetch goroutine blocks sending here forever (leak).

I'm not quite sure that's the case, but this tiny refactor would make the code more robust.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
