### PR TITLE
store/tikv: Refine metrics of RangeTaskRunner

### DIFF
--- a/store/tikv/range_task.go
+++ b/store/tikv/range_task.go
@@ -29,7 +29,8 @@ import (
 
 const (
 	rangeTaskDefaultStatLogInterval = time.Minute * 10
-	rangeTaskMetricsUpdateInterval  = time.Second * 10
+
+	lblCompletedRegions = "completed-regions"
 )
 
 // RangeTaskRunner splits a range into many ranges to process concurrently, and convenient to send requests to all
@@ -78,6 +79,7 @@ func (s *RangeTaskRunner) SetStatLogInterval(interval time.Duration) {
 // Empty startKey or endKey means unbounded.
 func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKey []byte) error {
 	s.completedRegions = 0
+	metrics.TiKVRangeTaskStats.WithLabelValues(s.name, lblCompletedRegions).Set(0)
 
 	if len(endKey) != 0 && bytes.Compare(startKey, endKey) >= 0 {
 		logutil.Logger(ctx).Info("empty range task executed. ignored",
@@ -95,8 +97,6 @@ func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKe
 
 	// Periodically log the progress
 	statLogTicker := time.NewTicker(s.statLogInterval)
-	// Periodically update metrics
-	metricsTicker := time.NewTicker(rangeTaskMetricsUpdateInterval)
 
 	ctx, cancel := context.WithCancel(ctx)
 	taskCh := make(chan *kv.KeyRange, s.concurrency)
@@ -121,8 +121,8 @@ func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKe
 			wg.Wait()
 		}
 		statLogTicker.Stop()
-		metricsTicker.Stop()
 		cancel()
+		metrics.TiKVRangeTaskStats.WithLabelValues(s.name, lblCompletedRegions).Set(0)
 	}()
 
 	// Iterate all regions and send each region's range as a task to the workers.
@@ -139,8 +139,6 @@ func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKe
 				zap.Int("concurrency", s.concurrency),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Int32("completed regions", s.CompletedRegions()))
-		case <-metricsTicker.C:
-			metrics.TiKVRangeTaskStats.WithLabelValues(s.name, "completed").Set(float64(s.CompletedRegions()))
 		default:
 		}
 
@@ -248,6 +246,7 @@ func (w *rangeTaskWorker) run(ctx context.Context, cancel context.CancelFunc) {
 
 		completedRegions, err := w.handler(ctx, *r)
 		atomic.AddInt32(w.completedRegions, int32(completedRegions))
+		metrics.TiKVRangeTaskStats.WithLabelValues(w.name, lblCompletedRegions).Add(float64(completedRegions))
 
 		if err != nil {
 			logutil.Logger(ctx).Info("canceling range task because of error",


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR refines `RangeTaskRunner`'s metrics. This PR removes the tick for metrics and updates it every time a subtask is finished. This is ok, especially after merging #10482 . After finishing the whole task, the metric `TiKVRangeTaskStats`, which shows the progress of the task, will be reset to 0; otherwise it will remains high after finishing, which looks terrible.

### What is changed and how it works?

Refined usage of `TiKVRangeTaskStats`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

![image](https://user-images.githubusercontent.com/9948422/58094193-a74b0080-7c02-11e9-94e9-07d3e69e5e35.png)

Related changes

 - Need to update the `tidb-ansible` repository (pingcap/tidb-ansible#761)
