### PR TITLE
store/tikv/gc_worker: Add config to specify gc concurrency manually

### DIFF
--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -37,6 +37,7 @@ func TestT(t *testing.T) {
 
 type testGCWorkerSuite struct {
 	store    tikv.Storage
+	cluster  *mocktikv.Cluster
 	oracle   *mockoracle.MockOracle
 	gcWorker *GCWorker
 	dom      *domain.Domain
@@ -47,9 +48,9 @@ var _ = Suite(&testGCWorkerSuite{})
 func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	tikv.NewGCHandlerFunc = NewGCWorker
 
-	cluster := mocktikv.NewCluster()
-	mocktikv.BootstrapWithSingleStore(cluster)
-	store, err := mockstore.NewMockTikvStore(mockstore.WithCluster(cluster))
+	s.cluster = mocktikv.NewCluster()
+	mocktikv.BootstrapWithSingleStore(s.cluster)
+	store, err := mockstore.NewMockTikvStore(mockstore.WithCluster(s.cluster))
 
 	s.store = store.(tikv.Storage)
 	c.Assert(err, IsNil)
@@ -58,7 +59,7 @@ func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 
-	gcWorker, err := NewGCWorker(s.store, mocktikv.NewPDClient(cluster))
+	gcWorker, err := NewGCWorker(s.store, mocktikv.NewPDClient(s.cluster))
 	c.Assert(err, IsNil)
 	gcWorker.Start()
 	gcWorker.Close()
@@ -154,16 +155,28 @@ func (s *testGCWorkerSuite) TestPrepareGC(c *C) {
 
 	// Change GC enable status.
 	s.oracle.AddOffset(time.Minute * 40)
-	err = s.gcWorker.saveValueToSysTable(gcEnableKey, gcDisableValue)
+	err = s.gcWorker.saveValueToSysTable(gcEnableKey, booleanFalse)
 	c.Assert(err, IsNil)
 	ok, _, err = s.gcWorker.prepare()
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsFalse)
-	err = s.gcWorker.saveValueToSysTable(gcEnableKey, gcEnableValue)
+	err = s.gcWorker.saveValueToSysTable(gcEnableKey, booleanTrue)
 	c.Assert(err, IsNil)
 	ok, _, err = s.gcWorker.prepare()
 	c.Assert(err, IsNil)
 	c.Assert(ok, IsTrue)
+
+	// Change auto concurrency
+	err = s.gcWorker.saveValueToSysTable(gcAutoConcurrencyKey, booleanFalse)
+	c.Assert(err, IsNil)
+	useAutoConcurrency, err := s.gcWorker.checkUseAutoConcurrency()
+	c.Assert(err, IsNil)
+	c.Assert(useAutoConcurrency, IsFalse)
+	err = s.gcWorker.saveValueToSysTable(gcAutoConcurrencyKey, booleanTrue)
+	c.Assert(err, IsNil)
+	useAutoConcurrency, err = s.gcWorker.checkUseAutoConcurrency()
+	c.Assert(err, IsNil)
+	c.Assert(useAutoConcurrency, IsTrue)
 }
 
 func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
@@ -197,6 +210,28 @@ func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
 	c.Assert(regionErr.GetServerIsBusy(), NotNil)
 	c.Assert(err, IsNil)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/tikvStoreSendReqResult"), IsNil)
+}
+
+func (s *testGCWorkerSuite) TestGetGCConcurrency(c *C) {
+	// Pick a concurrency that doesn't equal to the number of stores.
+	concurrencyConfig := 25
+	c.Assert(concurrencyConfig, Not(Equals), len(s.cluster.GetAllStores()))
+	err := s.gcWorker.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(concurrencyConfig))
+	c.Assert(err, IsNil)
+
+	ctx := context.Background()
+
+	err = s.gcWorker.saveValueToSysTable(gcAutoConcurrencyKey, booleanFalse)
+	c.Assert(err, IsNil)
+	concurrency, err := s.gcWorker.getGCConcurrency(ctx)
+	c.Assert(err, IsNil)
+	c.Assert(concurrency, Equals, concurrencyConfig)
+
+	err = s.gcWorker.saveValueToSysTable(gcAutoConcurrencyKey, booleanTrue)
+	c.Assert(err, IsNil)
+	concurrency, err = s.gcWorker.getGCConcurrency(ctx)
+	c.Assert(err, IsNil)
+	c.Assert(concurrency, Equals, len(s.cluster.GetAllStores()))
 }
 
 func (s *testGCWorkerSuite) TestDoGC(c *C) {
@@ -236,17 +271,20 @@ func (s *testGCWorkerSuite) TestCheckGCMode(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(str, Equals, gcModeDistributed)
 
-	s.gcWorker.saveValueToSysTable(gcModeKey, gcModeCentral)
+	err = s.gcWorker.saveValueToSysTable(gcModeKey, gcModeCentral)
+	c.Assert(err, IsNil)
 	useDistributedGC, err = s.gcWorker.checkUseDistributedGC()
 	c.Assert(err, IsNil)
 	c.Assert(useDistributedGC, Equals, false)
 
-	s.gcWorker.saveValueToSysTable(gcModeKey, gcModeDistributed)
+	err = s.gcWorker.saveValueToSysTable(gcModeKey, gcModeDistributed)
+	c.Assert(err, IsNil)
 	useDistributedGC, err = s.gcWorker.checkUseDistributedGC()
 	c.Assert(err, IsNil)
 	c.Assert(useDistributedGC, Equals, true)
 
-	s.gcWorker.saveValueToSysTable(gcModeKey, "invalid_mode")
+	err = s.gcWorker.saveValueToSysTable(gcModeKey, "invalid_mode")
+	c.Assert(err, IsNil)
 	useDistributedGC, err = s.gcWorker.checkUseDistributedGC()
 	c.Assert(err, IsNil)
 	c.Assert(useDistributedGC, Equals, true)


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Now in master branch TiDB always uses number of up stores as the gc concurrency (now gc concurrency is used for ResolveLocks and will be used for notifying delete range too). However it's useful to make it still configurable. This PR makes it possible to fallback to use configured concurrency, rather than use number of up stores directly.

### What is changed and how it works?

This PR adds a new config `tikv_gc_auto_concurrency` to `mysql.tidb`. It's defalt value is `true`. When it's `true`, `tikv_gc_concurrency` will be ignored; and when it's `false`, `tikv_gc_concurrency`'s value will be used as the concurrency.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to update the documentation
