### PR TITLE
executor,privilege: fix "show grants" result for RBAC

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -550,7 +550,12 @@ func (b *executorBuilder) buildShow(v *plannercore.Show) Executor {
 		is:           b.is,
 	}
 	if e.Tp == ast.ShowGrants && e.User == nil {
-		e.User = e.ctx.GetSessionVars().User
+		// The input is a "show grants" statement, fulfill the user and roles field.
+		// Note: "show grants" result are different from "show grants for current_user",
+		// The former determine privileges with roles, while the later doesn't.
+		vars := e.ctx.GetSessionVars()
+		e.User = vars.User
+		e.Roles = vars.ActiveRoles
 	}
 	if e.Tp == ast.ShowMasterStatus {
 		// show master status need start ts.

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -221,17 +221,20 @@ func (e *SimpleExec) setDefaultRoleAll(s *ast.SetDefaultRoleStmt) error {
 	return nil
 }
 
-func (e *SimpleExec) executeSetDefaultRole(s *ast.SetDefaultRoleStmt) error {
+func (e *SimpleExec) executeSetDefaultRole(s *ast.SetDefaultRoleStmt) (err error) {
 	switch s.SetRoleOpt {
 	case ast.SetRoleAll:
-		return e.setDefaultRoleAll(s)
+		err = e.setDefaultRoleAll(s)
 	case ast.SetRoleNone:
-		return e.setDefaultRoleNone(s)
+		err = e.setDefaultRoleNone(s)
 	case ast.SetRoleRegular:
-		return e.setDefaultRoleRegular(s)
+		err = e.setDefaultRoleRegular(s)
 	}
-	err := domain.GetDomain(e.ctx).PrivilegeHandle().Update(e.ctx.(sessionctx.Context))
-	return err
+	if err != nil {
+		return
+	}
+	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)
+	return
 }
 
 func (e *SimpleExec) setRoleRegular(s *ast.SetRoleStmt) error {

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -474,7 +474,6 @@ func (s *testPrivilegeSuite) TestUseDB(c *C) {
 	mustExec(c, se, `CREATE USER 'dev'@'localhost'`)
 	mustExec(c, se, `GRANT 'app_developer' TO 'dev'@'localhost'`)
 	mustExec(c, se, `SET DEFAULT ROLE 'app_developer' TO 'dev'@'localhost'`)
-	mustExec(c, se, `FLUSH PRIVILEGES`)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "dev", Hostname: "localhost", AuthUsername: "dev", AuthHostname: "localhost"}, nil, nil), IsTrue)
 	_, err = se.Execute(context.Background(), "use app_db")
 	c.Assert(err, IsNil)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/10549

### What is changed and how it works?

1. "show grants" returns the privileges including current active rule, while "show grants for current_user" doesn't
2. "set default role for" should flush privilege

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

