### PR TITLE
tikv: fix `notLeader` in region cache 

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -657,14 +657,6 @@ func (c *RegionCache) getStoreByStoreID(storeID uint64) (store *Store) {
 	return
 }
 
-// OnSendRequestFail is used for clearing cache when a tikv server does not respond.
-func (c *RegionCache) OnSendRequestFail(ctx *RPCContext, err error) {
-	r := c.getCachedRegionWithRLock(ctx.Region)
-	if r == nil {
-		c.switchNextPeer(r, ctx.PeerIdx)
-	}
-}
-
 // OnRegionEpochNotMatch removes the old region and inserts new regions into the cache.
 func (c *RegionCache) OnRegionEpochNotMatch(bo *Backoffer, ctx *RPCContext, currentRegions []*metapb.Region) error {
 	// Find whether the region epoch in `ctx` is ahead of TiKV's. If so, backoff.

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -237,8 +237,8 @@ func (c *RPCContext) GetStoreID() uint64 {
 }
 
 func (c *RPCContext) String() string {
-	return fmt.Sprintf("region ID: %d, meta: %s, peer: %s, addr: %s, idx: %d, store: %v",
-		c.Region.GetID(), c.Meta, c.Peer, c.Addr, c.PeerIdx, c.Store)
+	return fmt.Sprintf("region ID: %d, meta: %s, peer: %s, addr: %s, idx: %d",
+		c.Region.GetID(), c.Meta, c.Peer, c.Addr, c.PeerIdx)
 }
 
 // GetRPCContext returns RPCContext for a region. If it returns nil, the region
@@ -977,11 +977,6 @@ func (s *Store) getResolveState() resolveState {
 
 func (s *Store) compareAndSwapState(oldState, newState resolveState) bool {
 	return atomic.CompareAndSwapUint64(&s.state, uint64(oldState), uint64(newState))
-}
-
-func (s *Store) storeState(newState resolveState) {
-	newValue := *(*uint64)(unsafe.Pointer(&newState))
-	atomic.StoreUint64(&s.state, newValue)
 }
 
 // markNeedCheck marks resolved store to be async resolve to check store addr change.

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -237,8 +237,8 @@ func (c *RPCContext) GetStoreID() uint64 {
 }
 
 func (c *RPCContext) String() string {
-	return fmt.Sprintf("region ID: %d, meta: %s, peer: %s, addr: %s",
-		c.Region.GetID(), c.Meta, c.Peer, c.Addr)
+	return fmt.Sprintf("region ID: %d, meta: %s, peer: %s, addr: %s, idx: %d, store: %v",
+		c.Region.GetID(), c.Meta, c.Peer, c.Addr, c.PeerIdx, c.Store)
 }
 
 // GetRPCContext returns RPCContext for a region. If it returns nil, the region
@@ -358,6 +358,7 @@ func (c *RegionCache) findRegionByKey(bo *Backoffer, key []byte, isEndKey bool) 
 	return r, nil
 }
 
+// OnSendFail handles send request fail logic.
 func (c *RegionCache) OnSendFail(bo *Backoffer, ctx *RPCContext, scheduleReload bool) {
 	r := c.getCachedRegionWithRLock(ctx.Region)
 	if r != nil {

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -15,7 +15,6 @@ package tikv
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -63,55 +62,29 @@ func (s *testRegionCacheSuite) storeAddr(id uint64) string {
 
 func (s *testRegionCacheSuite) checkCache(c *C, len int) {
 	ts := time.Now().Unix()
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, len)
-	c.Assert(workableRegionsInBtree(s.cache, s.cache.mu.sorted, ts), Equals, len)
-	for _, r := range s.cache.mu.regions {
-		if r.checkRegionCacheTTL(ts) {
-			bo := NewBackoffer(context.Background(), 100)
-			if store, _, _, _ := s.cache.routeStoreInRegion(bo, r, ts); store != nil {
-				c.Assert(r, DeepEquals, s.cache.searchCachedRegion(r.StartKey(), false))
-			}
-		}
-	}
+	c.Assert(validRegions(s.cache.mu.regions, ts), Equals, len)
+	c.Assert(validRegionsInBtree(s.cache.mu.sorted, ts), Equals, len)
 }
 
-func workableRegions(cache *RegionCache, regions map[RegionVerID]*Region, ts int64) (len int) {
+func validRegions(regions map[RegionVerID]*Region, ts int64) (len int) {
 	for _, region := range regions {
 		if !region.checkRegionCacheTTL(ts) {
 			continue
 		}
-		bo := NewBackoffer(context.Background(), 100)
-		store, _, _, _ := cache.routeStoreInRegion(bo, region, ts)
-		if store != nil {
-			len++
-		}
+		len++
 	}
 	return
 }
 
-func workableRegionsInBtree(cache *RegionCache, t *btree.BTree, ts int64) (len int) {
+func validRegionsInBtree(t *btree.BTree, ts int64) (len int) {
 	t.Descend(func(item btree.Item) bool {
 		r := item.(*btreeItem).cachedRegion
 		if !r.checkRegionCacheTTL(ts) {
 			return true
 		}
-		bo := NewBackoffer(context.Background(), 100)
-		store, _, _, _ := cache.routeStoreInRegion(bo, r, ts)
-		if store != nil {
-			len++
-		}
+		len++
 		return true
 	})
-	return
-}
-
-func reachableStore(stores map[uint64]*Store, ts int64) (cnt int) {
-	for _, store := range stores {
-		state := store.getState()
-		if state.Available(ts) {
-			cnt++
-		}
-	}
 	return
 }
 
@@ -182,7 +155,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// tikv-server reports `NotLeader`
-	s.cache.UpdateLeader(loc.Region, s.store2)
+	s.cache.UpdateLeader(loc.Region, &metapb.Peer{StoreId: s.store2}, 0)
 
 	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
@@ -204,7 +177,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	s.cluster.AddStore(store3, s.storeAddr(store3))
 	s.cluster.AddPeer(s.region1, store3, peer3)
 	// tikv-server reports `NotLeader`
-	s.cache.UpdateLeader(loc.Region, store3)
+	s.cache.UpdateLeader(loc.Region, &metapb.Peer{StoreId: store3}, 0)
 
 	// Store3 does not exist in cache, causes a reload from PD.
 	r := s.getRegion(c, []byte("a"))
@@ -215,7 +188,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	// tikv-server notifies new leader to pd-server.
 	s.cluster.ChangeLeader(s.region1, peer3)
 	// tikv-server reports `NotLeader` again.
-	s.cache.UpdateLeader(r.VerID(), store3)
+	s.cache.UpdateLeader(r.VerID(), &metapb.Peer{StoreId: store3}, 0)
 	r = s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
@@ -236,7 +209,7 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	// tikv-server notifies new leader to pd-server.
 	s.cluster.ChangeLeader(s.region1, peer3)
 	// tikv-server reports `NotLeader`(store2 is the leader)
-	s.cache.UpdateLeader(loc.Region, s.store2)
+	s.cache.UpdateLeader(loc.Region, &metapb.Peer{StoreId: s.store2}, 0)
 
 	// Store2 does not exist any more, causes a reload from PD.
 	r := s.getRegion(c, []byte("a"))
@@ -248,6 +221,10 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	s.getRegion(c, []byte("a"))
 	// pd-server should return the new leader.
 	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(store3))
+}
+
+func (s *testRegionCacheSuite) TestUpdateLeader4(c *C) {
+
 }
 
 func (s *testRegionCacheSuite) TestSplit(c *C) {
@@ -311,86 +288,6 @@ func (s *testRegionCacheSuite) TestReconnect(c *C) {
 	s.checkCache(c, 1)
 }
 
-func (s *testRegionCacheSuite) TestSendFailBlackout(c *C) {
-	ts := time.Now().Unix()
-	region := s.getRegion(c, []byte("a"))
-
-	// init with 1 region 2 stores
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 1)
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
-
-	// for each stores has 20 chance to retry, and still have chance to access store for 21
-	for i := 0; i < 38; i++ {
-		ctx, _ := s.cache.GetRPCContext(s.bo, region.VerID())
-		if ctx == nil {
-			fmt.Println()
-		}
-		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
-
-	}
-	ts = time.Now().Unix()
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 1)
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
-
-	// 21 fail attempts will start blackout store in 1 second
-	for i := 0; i < 2; i++ {
-		// first fail request make 1st store' failAttempt + 1
-		ctx, _ := s.cache.GetRPCContext(s.bo, region.VerID())
-		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
-	}
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 0)
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 0)
-
-	// after 1 second blackout, 2 store can be access again.
-	time.Sleep(1 * time.Second)
-	ts = time.Now().Unix()
-	s.getRegion(c, []byte("a"))
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 1)
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
-}
-
-func (s *testRegionCacheSuite) TestSendFailBlackTwoRegion(c *C) {
-	ts := time.Now().Unix()
-	// key range: ['' - 'm' - 'z']
-	region2 := s.cluster.AllocID()
-	newPeers := s.cluster.AllocIDs(2)
-	s.cluster.Split(s.region1, region2, []byte("m"), newPeers, newPeers[0])
-
-	// Check the two regions.
-	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
-	c.Assert(err, IsNil)
-	c.Assert(loc1.Region.id, Equals, s.region1)
-	loc2, err := s.cache.LocateKey(s.bo, []byte("x"))
-	c.Assert(err, IsNil)
-	c.Assert(loc2.Region.id, Equals, region2)
-
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
-	s.checkCache(c, 2)
-
-	// send request fail in 2 regions backed by same 2 stores.
-	for i := 0; i < startBlackoutAfterAttempt; i++ {
-		ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
-		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
-	}
-	for i := 0; i < startBlackoutAfterAttempt; i++ {
-		ctx, _ := s.cache.GetRPCContext(s.bo, loc2.Region)
-		s.cache.OnSendRequestFail(ctx, errors.New("test error"))
-	}
-
-	// both 2 region are invalidate and both 2 store are available.
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 0)
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 0)
-
-	// after sleep 1 second, region recover
-	time.Sleep(1 * time.Second)
-	ts = time.Now().Unix()
-	c.Assert(reachableStore(s.cache.storeMu.stores, ts), Equals, 2)
-	s.getRegion(c, []byte("a"))
-	s.getRegion(c, []byte("x"))
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 2)
-	c.Assert(workableRegions(s.cache, s.cache.mu.regions, ts), Equals, 2)
-}
-
 func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 	// Create a separated region cache to do this test.
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
@@ -412,31 +309,6 @@ func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 	err = cache.OnRegionEpochNotMatch(bo, &RPCContext{Region: region.VerID()}, []*metapb.Region{&r2})
 	c.Assert(err, IsNil)
 	c.Assert(len(bo.errors), Equals, 2)
-}
-
-func (s *testRegionCacheSuite) TestDropStoreOnSendRequestFail(c *C) {
-	ts := time.Now().Unix()
-	regionCnt, storeCount := 8, 3
-	cluster := createClusterWithStoresAndRegions(regionCnt, storeCount)
-
-	cache := NewRegionCache(mocktikv.NewPDClient(cluster))
-	defer cache.Close()
-	loadRegionsToCache(cache, regionCnt)
-	c.Assert(workableRegions(cache, cache.mu.regions, ts), Equals, regionCnt)
-
-	bo := NewBackoffer(context.Background(), 1)
-	loc, err := cache.LocateKey(bo, []byte{})
-	c.Assert(err, IsNil)
-
-	// fail on one region make all stores be unavailable.
-	for j := 0; j < 20; j++ {
-		for i := 0; i < storeCount; i++ {
-			rpcCtx, err := cache.GetRPCContext(bo, loc.Region)
-			c.Assert(err, IsNil)
-			cache.OnSendRequestFail(rpcCtx, errors.New("test error"))
-		}
-	}
-	c.Assert(workableRegions(cache, cache.mu.regions, ts), Equals, 0)
 }
 
 const regionSplitKeyFormat = "t%08d"
@@ -563,14 +435,15 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	region := cache.getRegionByIDFromCache(loc.Region.id)
 	b.ResetTimer()
 	regionStore := region.getStore()
-	store, peer, _ := region.WorkStorePeer(regionStore)
+	store, peer, idx := region.WorkStorePeer(regionStore)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			rpcCtx := &RPCContext{
-				Region: loc.Region,
-				Meta:   region.meta,
-				Peer:   peer,
-				Store:  store,
+				Region:  loc.Region,
+				Meta:    region.meta,
+				PeerIdx: idx,
+				Peer:    peer,
+				Store:   store,
 			}
 			cache.OnSendRequestFail(rpcCtx, nil)
 		}

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -149,13 +149,7 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, ctx *RPCContext, re
 		}
 		return nil, true, nil
 	}
-	s.onSendSuccess(ctx)
 	return
-}
-
-func (s *RegionRequestSender) onSendSuccess(ctx *RPCContext) {
-	store := s.regionCache.getStoreByStoreID(ctx.Store.storeID)
-	store.markAccess(s.regionCache.notifyCheckCh, true)
 }
 
 func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
@@ -213,7 +207,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 		logutil.Logger(context.Background()).Debug("tikv reports `NotLeader` retry later",
 			zap.String("notLeader", notLeader.String()),
 			zap.String("ctx", ctx.String()))
-		s.regionCache.UpdateLeader(ctx.Region, notLeader.GetLeader().GetStoreId())
+		s.regionCache.UpdateLeader(ctx.Region, notLeader.GetLeader(), ctx.PeerIdx)
 
 		var boType backoffType
 		if notLeader.GetLeader() != nil {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -172,9 +172,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 		}
 	}
 
-	needReloadRegion := s.needReloadRegion(ctx)
-
-	s.regionCache.OnSendFail(bo, ctx, needReloadRegion)
+	s.regionCache.OnSendFail(bo, ctx, s.needReloadRegion(ctx))
 
 	// Retry on send request failure when it's not canceled.
 	// When a store is not available, the leader of related region should be elected quickly.

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -89,6 +90,44 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithStoreRestart(c *C) {
 	resp, err = s.regionRequestSender.SendReq(s.bo, req, region.Region, time.Second)
 	c.Assert(err, IsNil)
 	c.Assert(resp.RawPut, NotNil)
+}
+
+func (s *testRegionRequestSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOne(c *C) {
+	req := &tikvrpc.Request{
+		Type: tikvrpc.CmdRawPut,
+		RawPut: &kvrpcpb.RawPutRequest{
+			Key:   []byte("key"),
+			Value: []byte("value"),
+		},
+	}
+	region, err := s.cache.LocateRegionByID(s.bo, s.region)
+	c.Assert(err, IsNil)
+	c.Assert(region, NotNil)
+	resp, err := s.regionRequestSender.SendReq(s.bo, req, region.Region, time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(resp.RawPut, NotNil)
+
+	// add new unknown region
+	store2 := s.cluster.AllocID()
+	peer2 := s.cluster.AllocID()
+	s.cluster.AddStore(store2, fmt.Sprintf("store%d", store2))
+	s.cluster.AddPeer(region.Region.id, store2, peer2)
+
+	// stop known region
+	s.cluster.StopStore(s.store)
+
+	// send to failed store
+	resp, err = s.regionRequestSender.SendReq(NewBackoffer(context.Background(), 100), req, region.Region, time.Second)
+	c.Assert(err, NotNil)
+
+	// retry to send store by old region info
+	region, err = s.cache.LocateRegionByID(s.bo, s.region)
+	c.Assert(region, NotNil)
+	c.Assert(err, IsNil)
+
+	// retry again, reload region info and send to new store.
+	resp, err = s.regionRequestSender.SendReq(NewBackoffer(context.Background(), 100), req, region.Region, time.Second)
+	c.Assert(err, NotNil)
 }
 
 func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes bug introduced by  #10256

```
not leader: region_id:8 leader:<id:9 store_id:1 > , ctx: region ID: 8, meta: id:8 end_key:\"t\\200\\000\\000\\000\\000\\000\\000\\005\" region_epoch:<conf_ver:5 version:2 > peers:<id:9 store_id:1 > peers:<id:10 store_id:5 > peers:<id:11 store_id:4 > , peer: id:10 store_id:5 , ad
dr: tidb-cluster-tikv-1.tidb-cluster-tikv-peer.dm-refactor-full-exp328-cat0-tidb-cluster.svc:20160 at 2019-05-22T06:42:46.764390748Z\nnot leader: region_id:8 leader:<id:9 store_id:1 > , ctx: region ID
: 8, meta: id:8 end_key:\"t\\200\\000\\000\\000\\000\\000\\000\\005\" region_epoch:<conf_ver:5 version:2 > peers:<id:9 store_id:1 > peers:<id:10 store_id:5 > peers:<id:11 store_id:4 > , peer: id:10 st
ore_id:5 , addr: tidb-cluster-tikv-1.tidb-cluster-tikv-peer.dm-refactor-full-exp328-cat0-tidb-cluster.svc:20160 at 2019-05-22T06:42:46.775362301Z\nnot leader: region_id:8 leader:<id:9 store_id:1 > , c
tx: region ID: 8, meta: id:8 end_key:\"t\\200\\000\\000\\000\\000\\000\\000\\005\" region_epoch:<conf_ver:5 version:2 > peers:<id:9 store_id:1 > peers:<id:10 store_id:5 > peers:<id:11 store_id:4 > , p
eer: id:10 store_id:5 , addr: tidb-cluster-tikv-1.tidb-cluster-tikv-peer.dm-refactor-full-exp328-cat0-tidb-cluster.svc:20160 at 2019-05-22T06:42:46.786329643Z"
```

the question is NotLeader response told A1 is leader, but  A1 maybe meet other error(e.g. network error) and be marked as `failed`, when next request arrival, TiDB will try round-robin try other nodes, so request will send to A2, and A2 told NotLeader(A1 is leader) again.

### What is changed and how it works?

when recieve NotLeader, not only switch currentPeer to A1 but also clear up A1's failed marker.

then next request will try A1, until Ax return a NotLeader with NULL is leader.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

manual running tpcc/sysbench with write leader change test..

schrodinger boxdetail?boxid=15585290796895

Code changes

 - impl change

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10572)
<!-- Reviewable:end -->
