### PR TITLE
support 'tidb_txn_mode' session variable.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190517030054-ff2e03f6fdfe
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190521133604-4afa585be9a4
+	github.com/pingcap/parser v0.0.0-20190522123204-4628ac31ee47
 	github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/pingcap/kvproto v0.0.0-20190517030054-ff2e03f6fdfe/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190521133604-4afa585be9a4 h1:y2rXJis8je4II6I5pAs57dzvaqISSI8L/oZUVCeuPgI=
-github.com/pingcap/parser v0.0.0-20190521133604-4afa585be9a4/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190522123204-4628ac31ee47 h1:dEGqJ89QHTj1bfSbV9e8A9TtOiwaTEVkrR7VQLa7mTQ=
+github.com/pingcap/parser v0.0.0-20190522123204-4628ac31ee47/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669/go.mod h1:MUCxRzOkYiWZtlyi4MhxjCIj9PgQQ/j+BLNGm7aUsnM=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -14,6 +14,7 @@
 package session_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -71,7 +72,7 @@ func (s *testPessimisticSuite) TestPessimisticTxn(c *C) {
 	tk.MustExec("insert into pessimistic values (1, 1)")
 
 	// t1 lock, t2 update, t1 update and retry statement.
-	tk1.MustExec("begin lock")
+	tk1.MustExec("begin pessimistic")
 
 	tk.MustExec("update pessimistic set v = 2 where v = 1")
 
@@ -92,7 +93,7 @@ func (s *testPessimisticSuite) TestPessimisticTxn(c *C) {
 	tk1.MustQuery("select * from pessimistic").Check(testkit.Rows("1 3"))
 
 	// t1 lock, t1 select for update, t2 wait t1.
-	tk1.MustExec("begin lock")
+	tk1.MustExec("begin pessimistic")
 	tk1.MustExec("select * from pessimistic where k = 1 for update")
 	finishCh := make(chan struct{})
 	go func() {
@@ -104,4 +105,63 @@ func (s *testPessimisticSuite) TestPessimisticTxn(c *C) {
 	tk1.MustExec("commit")
 	<-finishCh
 	tk.MustQuery("select * from pessimistic").Check(testkit.Rows("1 5"))
+}
+
+func (s *testPessimisticSuite) TestTxnMode(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tests := []struct {
+		beginStmt     string
+		txnMode       string
+		configDefault bool
+		isPessimistic bool
+	}{
+		{"pessimistic", "pessimistic", false, true},
+		{"pessimistic", "pessimistic", true, true},
+		{"pessimistic", "optimistic", false, true},
+		{"pessimistic", "optimistic", true, true},
+		{"pessimistic", "", false, true},
+		{"pessimistic", "", true, true},
+		{"optimistic", "pessimistic", false, false},
+		{"optimistic", "pessimistic", true, false},
+		{"optimistic", "optimistic", false, false},
+		{"optimistic", "optimistic", true, false},
+		{"optimistic", "", false, false},
+		{"optimistic", "", true, false},
+		{"", "pessimistic", false, true},
+		{"", "pessimistic", true, true},
+		{"", "optimistic", false, false},
+		{"", "optimistic", true, false},
+		{"", "", false, false},
+		{"", "", true, true},
+	}
+	for _, tt := range tests {
+		config.GetGlobalConfig().PessimisticTxn.Default = tt.configDefault
+		tk.MustExec(fmt.Sprintf("set @@tidb_txn_mode = '%s'", tt.txnMode))
+		tk.MustExec("begin " + tt.beginStmt)
+		c.Check(tk.Se.GetSessionVars().TxnCtx.IsPessimistic, Equals, tt.isPessimistic)
+		tk.MustExec("rollback")
+	}
+
+	tk.MustExec("set @@autocommit = 0")
+	tk.MustExec("create table if not exists txn_mode (a int)")
+	tests2 := []struct {
+		txnMode       string
+		configDefault bool
+		isPessimistic bool
+	}{
+		{"pessimistic", false, true},
+		{"pessimistic", true, true},
+		{"optimistic", false, false},
+		{"optimistic", true, false},
+		{"", false, false},
+		{"", true, true},
+	}
+	for _, tt := range tests2 {
+		config.GetGlobalConfig().PessimisticTxn.Default = tt.configDefault
+		tk.MustExec(fmt.Sprintf("set @@tidb_txn_mode = '%s'", tt.txnMode))
+		tk.MustExec("rollback")
+		tk.MustExec("insert txn_mode values (1)")
+		c.Check(tk.Se.GetSessionVars().TxnCtx.IsPessimistic, Equals, tt.isPessimistic)
+		tk.MustExec("rollback")
+	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1739,10 +1739,10 @@ func (s *session) PrepareTxnCtx(ctx context.Context) {
 		CreateTime:    time.Now(),
 	}
 	if !s.sessionVars.IsAutocommit() {
-		txnConf := config.GetGlobalConfig().PessimisticTxn
-		if txnConf.Enable {
+		pessTxnConf := config.GetGlobalConfig().PessimisticTxn
+		if pessTxnConf.Enable {
 			txnMode := s.sessionVars.TxnMode
-			if txnMode == "" && txnConf.Default {
+			if txnMode == "" && pessTxnConf.Default {
 				txnMode = ast.Pessimistic
 			}
 			if txnMode == ast.Pessimistic {

--- a/session/session.go
+++ b/session/session.go
@@ -1740,8 +1740,14 @@ func (s *session) PrepareTxnCtx(ctx context.Context) {
 	}
 	if !s.sessionVars.IsAutocommit() {
 		txnConf := config.GetGlobalConfig().PessimisticTxn
-		if txnConf.Enable && (txnConf.Default || s.sessionVars.PessimisticLock) {
-			s.sessionVars.TxnCtx.IsPessimistic = true
+		if txnConf.Enable {
+			txnMode := s.sessionVars.TxnMode
+			if txnMode == "" && txnConf.Default {
+				txnMode = ast.Pessimistic
+			}
+			if txnMode == ast.Pessimistic {
+				s.sessionVars.TxnCtx.IsPessimistic = true
+			}
 		}
 	}
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -374,8 +374,8 @@ type SessionVars struct {
 	// EnableFastAnalyze indicates whether to take fast analyze.
 	EnableFastAnalyze bool
 
-	// PessimisticLock indicates whether new transaction should be pessimistic .
-	PessimisticLock bool
+	// TxnMode indicates should be pessimistic or optimistic.
+	TxnMode string
 }
 
 // ConnectionInfo present connection used by audit.
@@ -791,10 +791,26 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.EnableFastAnalyze = TiDBOptOn(val)
 	case TiDBWaitTableSplitFinish:
 		s.WaitTableSplitFinish = TiDBOptOn(val)
-	case TiDBPessimisticLock:
-		s.PessimisticLock = TiDBOptOn(val)
+	case TiDBTxnMode:
+		if err := s.setTxnMode(val); err != nil {
+			return err
+		}
 	}
 	s.systems[name] = val
+	return nil
+}
+
+func (s *SessionVars) setTxnMode(val string) error {
+	switch strings.ToUpper(val) {
+	case ast.Pessimistic:
+		s.TxnMode = ast.Pessimistic
+	case ast.Optimistic:
+		s.TxnMode = ast.Optimistic
+	case "":
+		s.TxnMode = ""
+	default:
+		return ErrWrongValueForVar.FastGenByArgs(TiDBTxnMode, val)
+	}
 	return nil
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -675,7 +675,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeGlobal | ScopeSession, TiDBDisableTxnAutoRetry, BoolToIntStr(DefTiDBDisableTxnAutoRetry)},
 	{ScopeGlobal | ScopeSession, TiDBConstraintCheckInPlace, BoolToIntStr(DefTiDBConstraintCheckInPlace)},
-	{ScopeSession, TiDBPessimisticLock, strconv.Itoa(DefTiDBPessimisticLock)},
+	{ScopeSession, TiDBTxnMode, DefTiDBTxnMode},
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},
 	{ScopeGlobal | ScopeSession, TiDBEnableWindowFunction, BoolToIntStr(DefEnableWindowFunction)},
 	{ScopeGlobal | ScopeSession, TiDBEnableFastAnalyze, BoolToIntStr(DefTiDBUseFastAnalyze)},

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -45,3 +45,17 @@ func (*testSysVarSuite) TestSysVar(c *C) {
 	c.Assert(f.Value, Equals, "4000")
 
 }
+
+func (*testSysVarSuite) TestTxnMode(c *C) {
+	seVar := NewSessionVars()
+	c.Assert(seVar, NotNil)
+	c.Assert(seVar.TxnMode, Equals, "")
+	err := seVar.setTxnMode("pessimistic")
+	c.Assert(err, IsNil)
+	err = seVar.setTxnMode("optimistic")
+	c.Assert(err, IsNil)
+	err = seVar.setTxnMode("")
+	c.Assert(err, IsNil)
+	err = seVar.setTxnMode("something else")
+	c.Assert(err, NotNil)
+}

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -122,8 +122,8 @@ const (
 	// tidb_optimizer_selectivity_level is used to control the selectivity estimation level.
 	TiDBOptimizerSelectivityLevel = "tidb_optimizer_selectivity_level"
 
-	// tidb_pessimistic_lock is used to control the transactin behavior.
-	TiDBPessimisticLock = "tidb_pessimistic_lock"
+	// tidb_txn_mode is used to control the transaction behavior.
+	TiDBTxnMode = "tidb_txn_mode"
 
 	// tidb_enable_table_partition is used to control table partition feature.
 	// The valid value include auto/on/off:
@@ -314,7 +314,7 @@ const (
 	DefTiDBHashJoinConcurrency       = 5
 	DefTiDBProjectionConcurrency     = 4
 	DefTiDBOptimizerSelectivityLevel = 0
-	DefTiDBPessimisticLock           = 0
+	DefTiDBTxnMode                   = ""
 	DefTiDBDDLReorgWorkerCount       = 16
 	DefTiDBDDLReorgBatchSize         = 1024
 	DefTiDBDDLErrorCountLimit        = 512


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The old variable `tidb_pessimistic_lock` can only set the transaction to pessimistic mode.
The new variable `tidb_txn_mode` can set transaction mode to either pessimistic or optimistic.
Which is useful when the config file sets pessimistic mode as default.

### What is changed and how it works?
- Remove `tidb_pessimistic_lock` variable.
- Add `tidb_txn_mode` variable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
