### PR TITLE
config: update pessimistic lock ttl.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -300,8 +300,8 @@ type PessimisticTxn struct {
 	Default bool `toml:"default" json:"default"`
 	// The max count of retry for a single statement in a pessimistic transaction.
 	MaxRetryCount uint `toml:"max-retry-count" json:"max-retry-count"`
-	// The pessimistic lock ttl in milliseconds.
-	TTL uint64 `toml:"ttl" json:"ttl"`
+	// The pessimistic lock ttl.
+	TTL string `toml:"ttl" json:"ttl"`
 }
 
 var defaultConf = Config{
@@ -391,7 +391,7 @@ var defaultConf = Config{
 		Enable:        false,
 		Default:       false,
 		MaxRetryCount: 256,
-		TTL:           60 * 1000,
+		TTL:           "30s",
 	},
 }
 
@@ -553,6 +553,17 @@ func (c *Config) Valid() error {
 	}
 	if c.TiKVClient.MaxTxnTimeUse == 0 {
 		return fmt.Errorf("max-txn-time-use should be greater than 0")
+	}
+	if c.PessimisticTxn.TTL != "" {
+		dur, err := time.ParseDuration(c.PessimisticTxn.TTL)
+		if err != nil {
+			return err
+		}
+		minDur := time.Second * 15
+		maxDur := time.Second * 60
+		if dur < minDur || dur > maxDur {
+			return fmt.Errorf("pessimistic transaction ttl %s out of range [%s, %s]", dur, minDur, maxDur)
+		}
 	}
 	return nil
 }

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -295,4 +295,5 @@ default = false
 max-retry-count = 256
 
 # default TTL in milliseconds for pessimistic lock.
-ttl = 60000
+# The value must between "15s" and "60s".
+ttl = "30s"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,3 +194,20 @@ func (s *testConfigSuite) TestConfigDiff(c *C) {
 	c.Assert(diffs["Performance.FeedbackProbability"][0], Equals, float64(2333))
 	c.Assert(diffs["Performance.FeedbackProbability"][1], Equals, float64(23.33))
 }
+
+func (s *testConfigSuite) TestValid(c *C) {
+	c1 := NewConfig()
+	tests := []struct {
+		ttl   string
+		valid bool
+	}{
+		{"14s", false},
+		{"15s", true},
+		{"60s", true},
+		{"61s", false},
+	}
+	for _, tt := range tests {
+		c1.PessimisticTxn.TTL = tt.ttl
+		c.Assert(c1.Valid() == nil, Equals, tt.valid)
+	}
+}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -52,6 +52,11 @@ var (
 	tikvSecondaryLockCleanupFailureCounterRollback = metrics.TiKVSecondaryLockCleanupFailureCounter.WithLabelValues("rollback")
 )
 
+// Global variable set by config file.
+var (
+	PessimisticLockTTL uint64
+)
+
 func (ca twoPhaseCommitAction) String() string {
 	switch ca {
 	case actionPrewrite:
@@ -567,7 +572,7 @@ func (c *twoPhaseCommitter) pessimisticLockSingleBatch(bo *Backoffer, batch batc
 			PrimaryLock:  c.primary(),
 			StartVersion: c.startTS,
 			ForUpdateTs:  c.forUpdateTS,
-			LockTtl:      config.GetGlobalConfig().PessimisticTxn.TTL,
+			LockTtl:      PessimisticLockTTL,
 			IsFirstLock:  c.isFirstLock,
 		},
 		Context: pb.Context{

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -489,6 +489,7 @@ func setGlobalVars() {
 	}
 
 	tikv.CommitMaxBackoff = int(parseDuration(cfg.TiKVClient.CommitTimeout).Seconds() * 1000)
+	tikv.PessimisticLockTTL = uint64(parseDuration(cfg.PessimisticTxn.TTL).Seconds() * 1000)
 }
 
 func setupLog() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make the config easier to set and validate the value.

### What is changed and how it works?
- change the type of `PessimisticTTL` to `string`.
- parse and validate the value is between 15s and 60s.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

