### PR TITLE
executor: introduce `Allocator` to manage memory used by executors

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -544,6 +544,12 @@ func (e *HashAggExec) fetchChildData(ctx context.Context) {
 		for i := range e.partialInputChs {
 			close(e.partialInputChs[i])
 		}
+		for len(e.inputCh) > 0 {
+			if p := <-e.inputCh; p.chk != nil {
+				p.chk.Release()
+				p.chk = nil
+			}
+		}
 	}()
 	for {
 		select {
@@ -788,6 +794,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 
 // Close implements the Executor Close interface.
 func (e *StreamAggExec) Close() error {
+	e.childResult.Release()
 	e.childResult = nil
 	return e.baseExecutor.Close()
 }

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -259,5 +259,5 @@ func (e *PointGetExecutor) retTypes() []*types.FieldType {
 }
 
 func (e *PointGetExecutor) newFirstChunk() *chunk.Chunk {
-	return chunk.New(e.retTypes(), 1, 1)
+	return chunk.NewChunkWithAllocator(e.ctx.GetSessionVars().MemoryAllocator, e.retTypes(), 1, 1)
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -1295,6 +1295,7 @@ func (cc *clientConn) writeColumnInfo(columns []*ColumnInfo, serverStatus uint16
 func (cc *clientConn) writeChunks(ctx context.Context, rs ResultSet, binary bool, serverStatus uint16) error {
 	data := cc.alloc.AllocWithLen(4, 1024)
 	req := rs.NewRecordBatch()
+	defer req.Release()
 	gotColumnInfo := false
 	for {
 		// Here server.tidbResultSet implements Next method.
@@ -1343,6 +1344,7 @@ func (cc *clientConn) writeChunksWithFetchSize(ctx context.Context, rs ResultSet
 
 	// if fetchedRows is not enough, getting data from recordSet.
 	req := rs.NewRecordBatch()
+	defer req.Release()
 	for len(fetchedRows) < fetchSize {
 		// Here server.tidbResultSet implements Next method.
 		err := rs.Next(ctx, req)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -274,6 +274,9 @@ type SessionVars struct {
 	// GlobalVarsAccessor is used to set and get global variables.
 	GlobalVarsAccessor GlobalVarAccessor
 
+	// MemoryAllocator is used to alloc memory.
+	MemoryAllocator chunk.Allocator
+
 	// LastFoundRows is the number of found rows of last query statement
 	LastFoundRows uint64
 

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -39,7 +39,7 @@ type Chunk struct {
 	// requiredRows indicates how many rows the parent executor want.
 	requiredRows int
 
-	a        Allocator
+	a Allocator
 }
 
 // Capacity constants.

--- a/util/chunk/chunk_allocator.go
+++ b/util/chunk/chunk_allocator.go
@@ -1,0 +1,247 @@
+package chunk
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/tidb/types"
+)
+
+var (
+	// GlobalAllocator is the root allocator of all allocators.
+	GlobalAllocator = NewMultiBufAllocator(uint(runtime.NumCPU()), 15, 64)
+)
+
+// Allocator is used to manage byte slices.
+type Allocator interface {
+	Alloc(l, c int) []byte
+	Free(buf []byte)
+	SetParent(a Allocator)
+	Close()
+}
+
+type multiBufChan struct {
+	allocIndex    uint32
+	freeIndex     uint32
+	numAllocators uint32
+	maxCap        int
+	allocators    []Allocator
+}
+
+// NewMultiBufAllocator creates a multiBufChan.
+func NewMultiBufAllocator(numAllocators, bitN, bufSize uint) Allocator {
+	m := &multiBufChan{0, 0, uint32(numAllocators), 1 << bitN, make([]Allocator, 0, numAllocators)}
+	for i := 0; i < int(numAllocators); i++ {
+		m.allocators = append(m.allocators, NewBufAllocator(bitN, bufSize))
+	}
+	return m
+}
+
+// Alloc alloc memory.
+func (b *multiBufChan) Alloc(l, c int) []byte {
+	return b.allocators[atomic.AddUint32(&b.allocIndex, 1)%b.numAllocators].Alloc(l, c)
+}
+
+// Free releases memory.
+func (b *multiBufChan) Free(buf []byte) {
+	b.allocators[atomic.AddUint32(&b.freeIndex, 1)%b.numAllocators].Free(buf)
+}
+
+// SetParent sets a parent for this allocator.
+func (b *multiBufChan) SetParent(a Allocator) {
+	for _, x := range b.allocators {
+		x.SetParent(a)
+	}
+}
+
+// Close closes this allocator.
+func (b *multiBufChan) Close() {
+	for _, x := range b.allocators {
+		x.Close()
+	}
+}
+
+var (
+	capIndexBit           = 15
+	allocIndex, freeIndex = getCapIndex(uint(capIndexBit))
+	pad                   = make([]byte, (1<<uint(capIndexBit))+1)
+)
+
+func getCapIndex(bitN uint) ([]int, []int) {
+	allocIndex := make([]int, int(1<<bitN)+1)
+	freeIndex := make([]int, int(1<<bitN)+1)
+	for i := uint(1); i <= bitN; i++ {
+		left := 1 << (i - 1)
+		right := 1 << i
+		for j := left + 1; j <= right; j++ {
+			allocIndex[j] = int(i)
+		}
+		for j := left; j < right; j++ {
+			freeIndex[j] = int(i - 1)
+		}
+	}
+	allocIndex[1] = 0
+	freeIndex[1<<bitN] = int(bitN)
+	return allocIndex, freeIndex
+}
+
+type bufChan struct {
+	maxCap     int
+	bufList    []chan []byte
+	allocIndex []int
+	freeIndex  []int
+	pad        []byte
+	parent     Allocator
+}
+
+// NewBufAllocator creates a bufChan.
+func NewBufAllocator(bitN, bufSize uint) Allocator {
+	b := &bufChan{
+		maxCap:  1 << bitN,
+		bufList: make([]chan []byte, bitN+1),
+	}
+
+	if int(bitN) <= capIndexBit {
+		b.allocIndex = allocIndex
+		b.freeIndex = freeIndex
+		b.pad = pad
+	} else {
+		b.allocIndex, b.freeIndex = getCapIndex(bitN)
+		b.pad = make([]byte, (1<<bitN)+1)
+	}
+
+	for i := uint(1); i <= bitN; i++ {
+		b.bufList[i] = make(chan []byte, bufSize)
+	}
+	return b
+}
+
+// Alloc alloc memory.
+func (b *bufChan) Alloc(l, c int) []byte {
+	if c > b.maxCap {
+		return make([]byte, l, c)
+	}
+	idx := b.allocIndex[c]
+	select {
+	case buf := <-b.bufList[idx]:
+		if len(buf) > l {
+			buf = buf[:l]
+		} else if len(buf) < l {
+			// TODO: remove this copy or make it faster
+			buf = append(buf, b.pad[:l-len(buf)]...)
+		}
+		return buf
+	default:
+		if b.parent != nil {
+			return b.parent.Alloc(l, c)
+		}
+		return make([]byte, l, c)
+	}
+}
+
+// Free releases memory.
+func (b *bufChan) Free(buf []byte) {
+	if cap(buf) > b.maxCap {
+		return
+	}
+	idx := b.freeIndex[cap(buf)]
+	select {
+	case b.bufList[idx] <- buf:
+	default:
+		if b.parent != nil {
+			b.parent.Free(buf)
+		}
+	}
+}
+
+// SetParent sets a parent for this allocator.
+func (b *bufChan) SetParent(pb Allocator) {
+	b.parent = pb
+}
+
+// Close closes this allocator.
+func (b *bufChan) Close() {
+	for _, ch := range b.bufList {
+		for len(ch) > 0 {
+			buf := <-ch
+			b.parent.Free(buf)
+		}
+	}
+}
+
+var (
+	chunkPool = sync.Pool{
+		New: func() interface{} {
+			return new(Chunk)
+		},
+	}
+	columnPool = sync.Pool{
+		New: func() interface{} {
+			return new(column)
+		},
+	}
+)
+
+// NewChunkWithAllocator creates a chunk with a specific allocator.
+func NewChunkWithAllocator(a Allocator, fields []*types.FieldType, cap, maxChunkSize int) *Chunk {
+	if a == nil {
+		return New(fields, cap, maxChunkSize)
+	}
+
+	cap = mathutil.Min(cap, maxChunkSize)
+	chk := chunkPool.Get().(*Chunk)
+	chk.columns = make([]*column, 0, len(fields))
+	for _, f := range fields {
+		elemLen := getFixedLen(f)
+		col := columnPool.Get().(*column)
+		if elemLen == varElemLen {
+			estimatedElemLen := 8
+			// TODO: make a buffer pool for offsets
+			//col.offsets = *(*[]int64)(unsafe.Pointer(&a.Alloc(8, (cap+1)*8)))
+			col.offsets = make([]int64, 1, cap+1)
+			col.data = a.Alloc(0, cap*estimatedElemLen)
+			col.nullBitmap = a.Alloc(0, cap>>3)
+			col.elemBuf = nil
+		} else {
+			col.elemBuf = a.Alloc(elemLen, elemLen)
+			col.data = a.Alloc(0, cap*elemLen)
+			col.nullBitmap = a.Alloc(0, cap>>3)
+			col.offsets = nil
+		}
+		col.length = 0
+		col.nullCount = 0
+		chk.columns = append(chk.columns, col)
+	}
+	chk.capacity = cap
+	chk.numVirtualRows = 0
+	chk.requiredRows = maxChunkSize
+	chk.a = a
+	return chk
+}
+
+// ReleaseChunk releases this chunk.
+func ReleaseChunk(chk *Chunk) {
+	if chk.a == nil {
+		return
+	}
+	for _, c := range chk.columns {
+		if c.cantReuse {
+			continue
+		}
+		if c.offsets != nil { // varElemLen
+			c.offsets = nil
+		} else {
+			chk.a.Free(c.elemBuf)
+			c.elemBuf = nil
+		}
+		chk.a.Free(c.data)
+		c.data = nil
+		chk.a.Free(c.nullBitmap)
+		c.nullBitmap = nil
+		columnPool.Put(c)
+	}
+	chk.columns = nil
+	chunkPool.Put(chk)
+}

--- a/util/chunk/chunk_allocator_test.go
+++ b/util/chunk/chunk_allocator_test.go
@@ -1,0 +1,64 @@
+package chunk
+
+import (
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pingcap/parser/charset"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+)
+
+func prepareChunkType() ([]int, []*types.FieldType) {
+	return []int{32, 64, 128, 256, 512, 1024, 4096}, []*types.FieldType{
+		{
+			Tp:      mysql.TypeLonglong,
+			Flen:    mysql.MaxIntWidth,
+			Decimal: 0,
+			Flag:    mysql.BinaryFlag,
+			Charset: charset.CharsetBin,
+			Collate: charset.CollationBin,
+		},
+	}
+}
+
+func BenchmarkNewChunkWithAllocator(b *testing.B) {
+	bufSize, colTypes := prepareChunkType()
+	m := NewMultiBufAllocator(8, 15, 32)
+	runtime.GC()
+	b.ResetTimer()
+	var k uint32
+	for i := 0; i < b.N; i++ {
+		c := bufSize[int(atomic.AddUint32(&k, 1))%len(bufSize)]
+		chk := NewChunkWithAllocator(m, colTypes, c, c)
+		chk.Release()
+	}
+}
+
+func BenchmarkNewChunk(b *testing.B) {
+	bufSize, colTypes := prepareChunkType()
+	runtime.GC()
+	b.ResetTimer()
+	var k uint32
+	for i := 0; i < b.N; i++ {
+		c := bufSize[int(atomic.AddUint32(&k, 1))%len(bufSize)]
+		chk := New(colTypes, c, c)
+		chk.Release()
+	}
+}
+
+func TestCapIndex(t *testing.T) {
+	for i := 1; i < len(allocIndex); i++ {
+		b := allocIndex[i]
+		if !(i <= (1<<uint(b)) && i > (1<<uint(b-1))) {
+			t.Fatal("alloc", i)
+		}
+	}
+	for i := 1; i < len(freeIndex); i++ {
+		b := freeIndex[i]
+		if !(i >= (1<<uint(b)) && i < (1<<uint(b+1))) {
+			t.Fatal("free", i)
+		}
+	}
+}

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -44,6 +44,7 @@ func (c *column) appendJSON(j json.BinaryJSON) {
 }
 
 type column struct {
+	cantReuse  bool // if this column can be reused.
 	length     int
 	nullCount  int
 	nullBitmap []byte

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -125,6 +125,7 @@ func (l *List) allocChunk() (chk *Chunk) {
 	if len(l.chunks) > 0 {
 		return Renew(l.chunks[len(l.chunks)-1], l.maxChunkSize)
 	}
+	// TODO: new chunk with allocator
 	return New(l.fieldTypes, l.initChunkSize, l.maxChunkSize)
 }
 

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -362,10 +362,12 @@ func (mr MutRow) ShallowCopyPartialRow(colIdx int, row Row) {
 			elemLen := len(srcCol.elemBuf)
 			offset := row.idx * elemLen
 			dstCol.data = srcCol.data[offset : offset+elemLen]
+			dstCol.cantReuse = true
 		} else {
 			start, end := srcCol.offsets[row.idx], srcCol.offsets[row.idx+1]
 			dstCol.data = srcCol.data[start:end]
 			dstCol.offsets[1] = int64(len(dstCol.data))
+			dstCol.cantReuse = true
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The first step to fix #9396.
Introduce an `Allocator` to manage memory used by chunk in executors.

### What is changed and how it works?
1. Introduce an interface `Allocator`.
2. Introduce two structs which implement `Allocator`.
3. Add `Release` method to `Chunk`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Increased code complexity

