### PR TITLE
planner, cmd: correct the behavior of IndexJoin hint for SemiJoin

### DIFF
--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -38,3 +38,4 @@ IndexJoin_10	8000.00	root	semi join, inner:IndexReader_9, outer key:test.t1.a, i
   └─IndexScan_8	10.00	cop	table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo
 show warnings;
 Level	Code	Message
+set @@tidb_opt_insubq_to_join_and_agg=1;

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -39,3 +39,17 @@ IndexJoin_10	8000.00	root	semi join, inner:IndexReader_9, outer key:test.t1.a, i
 show warnings;
 Level	Code	Message
 set @@tidb_opt_insubq_to_join_and_agg=1;
+drop table if exists t1, t2;
+create table t1(a int not null, b int not null, key a(a));
+create table t2(a int not null, b int not null, key a(a));
+explain select /*+ TIDB_INLJ(t1) */ * from t1 where t1.a in (select t2.a from t2);
+id	count	task	operator info
+Projection_8	10000.00	root	test.t1.a, test.t1.b
+└─IndexJoin_12	10000.00	root	inner join, inner:IndexLookUp_11, outer key:test.t2.a, inner key:test.t1.a
+  ├─IndexLookUp_11	10.00	root	
+  │ ├─IndexScan_9	10.00	cop	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo
+  │ └─TableScan_10	10.00	cop	table:t1, keep order:false, stats:pseudo
+  └─StreamAgg_24	8000.00	root	group by:col_1, funcs:firstrow(col_0)
+    └─IndexReader_25	8000.00	root	index:StreamAgg_16
+      └─StreamAgg_16	8000.00	cop	group by:test.t2.a, funcs:firstrow(test.t2.a)
+        └─IndexScan_23	10000.00	cop	table:t2, index:a, range:[NULL,+inf], keep order:true, stats:pseudo

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -25,3 +25,16 @@ Projection_6	5.00	root	test.t1.a, test.t1.b, test.t2.a, test.t2.b
     ├─Selection_10	0.00	cop	not(isnull(test.t1.a))
     │ └─IndexScan_8	5.00	cop	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false
     └─TableScan_9	0.00	cop	table:t1, keep order:false, stats:pseudo
+drop table if exists t1, t2;
+create table t1(a int not null, b int not null);
+create table t2(a int not null, b int not null, key a(a));
+set @@tidb_opt_insubq_to_join_and_agg=0;
+explain select /*+ TIDB_INLJ(t2) */ * from t1 where t1.a in (select t2.a from t2);
+id	count	task	operator info
+IndexJoin_10	8000.00	root	semi join, inner:IndexReader_9, outer key:test.t1.a, inner key:test.t2.a
+├─TableReader_12	10000.00	root	data:TableScan_11
+│ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─IndexReader_9	10.00	root	index:IndexScan_8
+  └─IndexScan_8	10.00	cop	table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo
+show warnings;
+Level	Code	Message

--- a/cmd/explaintest/t/index_join.test
+++ b/cmd/explaintest/t/index_join.test
@@ -20,3 +20,8 @@ set @@tidb_opt_insubq_to_join_and_agg=0;
 explain select /*+ TIDB_INLJ(t2) */ * from t1 where t1.a in (select t2.a from t2);
 show warnings;
 set @@tidb_opt_insubq_to_join_and_agg=1;
+
+drop table if exists t1, t2;
+create table t1(a int not null, b int not null, key a(a));
+create table t2(a int not null, b int not null, key a(a));
+explain select /*+ TIDB_INLJ(t1) */ * from t1 where t1.a in (select t2.a from t2);

--- a/cmd/explaintest/t/index_join.test
+++ b/cmd/explaintest/t/index_join.test
@@ -10,3 +10,12 @@ analyze table t1, t2;
 -- we expect the following two SQL chose t2 as the outer table
 explain select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;
 explain select * from t1 join t2 on t1.a=t2.a;
+
+-- Test https://github.com/pingcap/tidb/issues/10516
+drop table if exists t1, t2;
+create table t1(a int not null, b int not null);
+create table t2(a int not null, b int not null, key a(a));
+
+set @@tidb_opt_insubq_to_join_and_agg=0;
+explain select /*+ TIDB_INLJ(t2) */ * from t1 where t1.a in (select t2.a from t2);
+show warnings;

--- a/cmd/explaintest/t/index_join.test
+++ b/cmd/explaintest/t/index_join.test
@@ -19,3 +19,4 @@ create table t2(a int not null, b int not null, key a(a));
 set @@tidb_opt_insubq_to_join_and_agg=0;
 explain select /*+ TIDB_INLJ(t2) */ * from t1 where t1.a in (select t2.a from t2);
 show warnings;
+set @@tidb_opt_insubq_to_join_and_agg=1;

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2483,7 +2483,7 @@ func (b *PlanBuilder) buildSemiJoin(outerPlan, innerPlan LogicalPlan, onConditio
 			joinPlan.preferJoinType |= preferHashJoin
 		}
 		if b.TableHints().ifPreferINLJ(innerAlias) {
-			joinPlan.preferJoinType = preferLeftAsIndexInner
+			joinPlan.preferJoinType = preferRightAsIndexInner
 		}
 		// If there're multiple join hints, they're conflict.
 		if bits.OnesCount(joinPlan.preferJoinType) > 1 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #10516 

### What is changed and how it works?
Set `preferRightAsIndexInner` as preferJoinType instead of `preferLeftAsIndexInner` for SemiJoin.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

