### PR TITLE
store/tikv: collect exited goroutines when shutdown the server

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -291,16 +291,16 @@ func (a *connArray) Init(addr string, security config.Security) error {
 				idAlloc:                0,
 				tikvTransportLayerLoad: &a.tikvTransportLayerLoad,
 				closed:                 0,
-                                waitGroup: a.waitGroup,
+				waitGroup:              a.waitGroup,
 			}
 			a.batchCommandsClients = append(a.batchCommandsClients, batchClient)
-                        a.waitGroup.Add(1)
+			a.waitGroup.Add(1)
 			go batchClient.batchRecvLoop(cfg.TiKVClient)
 		}
 	}
 	go tikvrpc.CheckStreamTimeoutLoop(a.streamTimeout)
 	if allowBatch {
-                a.waitGroup.Add(1)
+		a.waitGroup.Add(1)
 		go a.batchSendLoop(cfg.TiKVClient)
 	}
 
@@ -327,7 +327,7 @@ func (a *connArray) Close() {
 			a.v[i] = nil
 		}
 	}
-        a.waitGroup.Wait()
+	a.waitGroup.Wait()
 	close(a.streamTimeout)
 }
 
@@ -425,9 +425,9 @@ func (a *connArray) batchSendLoop(cfg config.TiKVClient) {
 				zap.Stack("stack"))
 			logutil.Logger(context.Background()).Info("restart batchSendLoop")
 			go a.batchSendLoop(cfg)
-                        return
+			return
 		}
-                a.waitGroup.Done()
+		a.waitGroup.Done()
 	}()
 
 	entries := make([]*batchCommandsEntry, 0, cfg.MaxBatchSize)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Some internal schrodinger tests about groutine leak could fail without the patch, because when the tidb server is shutdown, the main goroutine won't wait all goroutines in `connArray` exit.

### What is changed and how it works?
This PR add a wait group in `connArray`, so now we can collect all exited goroutines in `connArray`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
A schrodinger test case in #10375 .