### PR TITLE
executor: reset groupChecker for StreamAggExec when Close

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -789,6 +789,7 @@ func (e *StreamAggExec) Open(ctx context.Context) error {
 // Close implements the Executor Close interface.
 func (e *StreamAggExec) Close() error {
 	e.childResult = nil
+	e.groupChecker.reset()
 	return e.baseExecutor.Close()
 }
 
@@ -953,4 +954,13 @@ func (e *groupChecker) meetNewGroup(row chunk.Row) (bool, error) {
 		e.curGroupKey = append(e.curGroupKey, *((&v).Copy()))
 	}
 	return !firstGroup, nil
+}
+
+func (e *groupChecker) reset() {
+	if e.curGroupKey != nil {
+		e.curGroupKey = e.curGroupKey[:0]
+	}
+	if e.tmpGroupKey != nil {
+		e.tmpGroupKey = e.tmpGroupKey[:0]
+	}
 }

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -710,3 +710,14 @@ func (s *testSuite1) TestIssue10098(c *C) {
 	tk.MustExec("insert into t values('1', '222'), ('12', '22')")
 	tk.MustQuery("select group_concat(distinct a, b) from t").Check(testkit.Rows("1222,1222"))
 }
+
+func (s *testSuite1) TestIssue10608(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec(`drop table if exists t, s;`)
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("create table s(a int, b int)")
+	tk.MustExec("insert into s values(100292, 508931), (120002, 508932)")
+	tk.MustExec("insert into t values(508931), (508932)")
+	tk.MustQuery("select (select group_concat(concat(123,'-')) from t where t.a = s.b group by t.a) as t from s;").Check(testkit.Rows("123-", "123-"))
+
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #10608 

### What is changed and how it works?
Reset StreamAggExec.groupChecker when Close.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects
N/A

Related changes

 - Need to cherry-pick to the release branch

