### PR TITLE
planner: skip virtual generated column in analyze push down

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -754,6 +754,10 @@ func (b *PlanBuilder) buildCheckIndexSchema(tn *ast.TableName, indexName string)
 func getColsInfo(tn *ast.TableName) (indicesInfo []*model.IndexInfo, colsInfo []*model.ColumnInfo, pkCol *model.ColumnInfo) {
 	tbl := tn.TableInfo
 	for _, col := range tbl.Columns {
+		// The virtual column will not store any data in TiKV, so it should be ignored when collect statistics
+		if col.IsGenerated() && !col.GeneratedStored {
+			continue
+		}
 		if tbl.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {
 			pkCol = col
 		} else {


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The virtual column will not store any data in TiKV, so it should be ignored in analyze.

### What is changed and how it works?

Filter virtual generated column when push down analyze.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manually test

- Before fix:

	```
	mysql> CREATE TABLE contacts2 (     id INT AUTO_INCREMENT PRIMARY KEY,     first_name VARCHAR(50) NOT NULL,     last_name VARCHAR(50) NOT NULL,     fullname varchar(101) GENERATED ALWAYS AS (CONCAT(first_name,' ',last_name)) virtual not null,     email VARCHAR(100) NOT NULL );
	Query OK, 0 rows affected (0.11 sec)
	
	mysql> INSERT INTO contacts2(first_name,last_name, email) VALUES('john','doe','john.doe@mysqltutorial.org');
	Query OK, 1 row affected (0.02 sec)
	
	mysql> analyze table contacts2;
	ERROR 1105 (HY000): other error: [src/coprocessor/dag/executor/mod.rs:161]: column 4 of 1 is missing
	```

- After fix:

	```
	mysql> CREATE TABLE contacts2 (     id INT AUTO_INCREMENT PRIMARY KEY,     first_name VARCHAR(50) NOT NULL,     last_name VARCHAR(50) NOT NULL,     fullname varchar(101) GENERATED ALWAYS AS (CONCAT(first_name,' ',last_name)) virtual not null,     email VARCHAR(100) NOT NULL );
	Query OK, 0 rows affected (0.11 sec)
	
	mysql> INSERT INTO contacts2(first_name,last_name, email) VALUES('john','doe','john.doe@mysqltutorial.org');
	Query OK, 1 row affected (0.02 sec)
	
	mysql> analyze table contacts2;
	Query OK, 0 rows affected (0.08 sec)
	```

Related changes

 - Need to cherry-pick to the release branch
