### PR TITLE
planner: fix wrong selectivity for inner selection in index join

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -156,9 +156,9 @@ Projection_10	0.00	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test.d
     ├─TableReader_41	0.00	root	data:Selection_40
     │ └─Selection_40	0.00	cop	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
     │   └─TableScan_39	10000.00	cop	table:dt, range:[0,+inf], keep order:false, stats:pseudo
-    └─IndexLookUp_18	3.33	root	
+    └─IndexLookUp_18	0.00	root	
       ├─IndexScan_15	10.00	cop	table:rr, index:aid, dic, range: decided by [eq(test.rr.aid, test.dt.aid) eq(test.rr.dic, test.dt.dic)], keep order:false, stats:pseudo
-      └─Selection_17	3.33	cop	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
+      └─Selection_17	0.00	cop	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
         └─TableScan_16	10.00	cop	table:rr, keep order:false, stats:pseudo
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	count	task	operator info

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -132,9 +132,9 @@ Projection_13	424.00	root	test.gad.id, test.dd.id, test.gad.aid, test.gad.cm, te
       ├─TableReader_29	424.00	root	data:Selection_28
       │ └─Selection_28	424.00	cop	eq(test.gad.bm, 0), eq(test.gad.pt, "android"), gt(test.gad.t, 1478143908), not(isnull(test.gad.ip))
       │   └─TableScan_27	1999.00	cop	table:gad, range:[0,+inf], keep order:false
-      └─IndexLookUp_23	455.80	root	
+      └─IndexLookUp_23	0.23	root	
         ├─IndexScan_20	1.00	cop	table:dd, index:aid, dic, range: decided by [eq(test.dd.aid, test.gad.aid)], keep order:false
-        └─Selection_22	455.80	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
+        └─Selection_22	0.23	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
           └─TableScan_21	1.00	cop	table:dd, keep order:false
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	count	task	operator info
@@ -144,9 +144,9 @@ Projection_10	170.34	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, t
     ├─TableReader_23	170.34	root	data:Selection_22
     │ └─Selection_22	170.34	cop	eq(test.gad.bm, 0), eq(test.gad.dit, "mac"), eq(test.gad.pt, "ios"), gt(test.gad.t, 1477971479), not(isnull(test.gad.dic))
     │   └─TableScan_21	1999.00	cop	table:gad, range:[0,+inf], keep order:false
-    └─IndexLookUp_17	509.04	root	
+    └─IndexLookUp_17	0.25	root	
       ├─IndexScan_14	1.00	cop	table:sdk, index:aid, dic, range: decided by [eq(test.sdk.aid, test.gad.aid)], keep order:false
-      └─Selection_16	509.04	cop	eq(test.sdk.bm, 0), eq(test.sdk.pt, "ios"), gt(test.sdk.t, 1477971479), not(isnull(test.sdk.mac)), not(isnull(test.sdk.t))
+      └─Selection_16	0.25	cop	eq(test.sdk.bm, 0), eq(test.sdk.pt, "ios"), gt(test.sdk.t, 1477971479), not(isnull(test.sdk.mac)), not(isnull(test.sdk.t))
         └─TableScan_15	1.00	cop	table:dd, keep order:false
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	count	task	operator info
@@ -164,9 +164,9 @@ Projection_10	428.32	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test
     ├─TableReader_41	428.32	root	data:Selection_40
     │ └─Selection_40	428.32	cop	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
     │   └─TableScan_39	2000.00	cop	table:dt, range:[0,+inf], keep order:false
-    └─IndexLookUp_18	970.00	root	
+    └─IndexLookUp_18	0.48	root	
       ├─IndexScan_15	1.00	cop	table:rr, index:aid, dic, range: decided by [eq(test.rr.aid, test.dt.aid) eq(test.rr.dic, test.dt.dic)], keep order:false
-      └─Selection_17	970.00	cop	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
+      └─Selection_17	0.48	cop	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
         └─TableScan_16	1.00	cop	table:rr, keep order:false
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	count	task	operator info

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -45,10 +45,10 @@ id	count	task	operator info
 IndexJoin_12	4166.67	root	left outer join, inner:IndexLookUp_11, outer key:test.t1.c2, inner key:test.t2.c1
 ├─TableReader_24	3333.33	root	data:TableScan_23
 │ └─TableScan_23	3333.33	cop	table:t1, range:(1,+inf], keep order:false, stats:pseudo
-└─IndexLookUp_11	0.00	root	
-  ├─Selection_10	0.00	cop	not(isnull(test.t2.c1))
+└─IndexLookUp_11	9.99	root	
+  ├─Selection_10	9.99	cop	not(isnull(test.t2.c1))
   │ └─IndexScan_8	10.00	cop	table:t2, index:c1, range: decided by [eq(test.t2.c1, test.t1.c2)], keep order:false, stats:pseudo
-  └─TableScan_9	0.00	cop	table:t2, keep order:false, stats:pseudo
+  └─TableScan_9	9.99	cop	table:t2, keep order:false, stats:pseudo
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	count	task	operator info
 Point_Get_1	1.00	root	table:t1, handle:1

--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -72,10 +72,10 @@ ANALYZE TABLE sgc1, sgc2;
 EXPLAIN SELECT /*+ TIDB_INLJ(sgc1, sgc2) */ * from sgc1 join sgc2 on sgc1.a=sgc2.a;
 id	count	task	operator info
 IndexJoin_17	5.00	root	inner join, inner:IndexLookUp_16, outer key:test.sgc2.a, inner key:test.sgc1.a
-├─IndexLookUp_16	0.00	root	
-│ ├─Selection_15	0.00	cop	not(isnull(test.sgc1.a))
+├─IndexLookUp_16	5.00	root	
+│ ├─Selection_15	5.00	cop	not(isnull(test.sgc1.a))
 │ │ └─IndexScan_13	5.00	cop	table:sgc1, index:a, range: decided by [eq(test.sgc1.a, test.sgc2.a)], keep order:false
-│ └─TableScan_14	0.00	cop	table:sgc1, keep order:false, stats:pseudo
+│ └─TableScan_14	5.00	cop	table:sgc1, keep order:false, stats:pseudo
 └─TableReader_20	1.00	root	data:Selection_19
   └─Selection_19	1.00	cop	not(isnull(test.sgc2.a))
     └─TableScan_18	1.00	cop	table:sgc2, range:[-inf,+inf], keep order:false
@@ -86,10 +86,10 @@ Projection_6	5.00	root	test.sgc1.j1, test.sgc1.j2, test.sgc1.a, test.sgc1.b, tes
   ├─TableReader_39	1.00	root	data:Selection_38
   │ └─Selection_38	1.00	cop	not(isnull(test.sgc2.a))
   │   └─TableScan_37	1.00	cop	table:sgc2, range:[-inf,+inf], keep order:false
-  └─IndexLookUp_12	0.00	root	
-    ├─Selection_11	0.00	cop	not(isnull(test.sgc1.a))
+  └─IndexLookUp_12	5.00	root	
+    ├─Selection_11	5.00	cop	not(isnull(test.sgc1.a))
     │ └─IndexScan_9	5.00	cop	table:sgc1, index:a, range: decided by [eq(test.sgc1.a, test.sgc2.a)], keep order:false
-    └─TableScan_10	0.00	cop	table:sgc1, keep order:false, stats:pseudo
+    └─TableScan_10	5.00	cop	table:sgc1, keep order:false, stats:pseudo
 DROP TABLE IF EXISTS sgc3;
 CREATE TABLE sgc3 (
 j JSON,

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -7,10 +7,10 @@ analyze table t1, t2;
 explain select /*+ TIDB_INLJ(t1, t2) */ * from t1 join t2 on t1.a=t2.a;
 id	count	task	operator info
 IndexJoin_16	5.00	root	inner join, inner:IndexLookUp_15, outer key:test.t2.a, inner key:test.t1.a
-├─IndexLookUp_15	0.00	root	
-│ ├─Selection_14	0.00	cop	not(isnull(test.t1.a))
+├─IndexLookUp_15	5.00	root	
+│ ├─Selection_14	5.00	cop	not(isnull(test.t1.a))
 │ │ └─IndexScan_12	5.00	cop	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false
-│ └─TableScan_13	0.00	cop	table:t1, keep order:false, stats:pseudo
+│ └─TableScan_13	5.00	cop	table:t1, keep order:false, stats:pseudo
 └─TableReader_19	1.00	root	data:Selection_18
   └─Selection_18	1.00	cop	not(isnull(test.t2.a))
     └─TableScan_17	1.00	cop	table:t2, range:[-inf,+inf], keep order:false
@@ -21,10 +21,10 @@ Projection_6	5.00	root	test.t1.a, test.t1.b, test.t2.a, test.t2.b
   ├─TableReader_30	1.00	root	data:Selection_29
   │ └─Selection_29	1.00	cop	not(isnull(test.t2.a))
   │   └─TableScan_28	1.00	cop	table:t2, range:[-inf,+inf], keep order:false
-  └─IndexLookUp_11	0.00	root	
-    ├─Selection_10	0.00	cop	not(isnull(test.t1.a))
+  └─IndexLookUp_11	5.00	root	
+    ├─Selection_10	5.00	cop	not(isnull(test.t1.a))
     │ └─IndexScan_8	5.00	cop	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false
-    └─TableScan_9	0.00	cop	table:t1, keep order:false, stats:pseudo
+    └─TableScan_9	5.00	cop	table:t1, keep order:false, stats:pseudo
 drop table if exists t1, t2;
 create table t1(a int not null, b int not null);
 create table t2(a int not null, b int not null, key a(a));

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -181,8 +181,8 @@ Projection_13	0.00	root	test.te.expect_time
     │     ├─IndexScan_32	10.00	cop	table:te, index:trade_id, range: decided by [eq(test.te.trade_id, test.tr.id)], keep order:false, stats:pseudo
     │     └─Selection_34	250.00	cop	ge(test.te.expect_time, 2018-04-23 00:00:00.000000), le(test.te.expect_time, 2018-04-23 23:59:59.000000)
     │       └─TableScan_33	10.00	cop	table:te, keep order:false, stats:pseudo
-    └─IndexReader_91	0.00	root	index:Selection_90
-      └─Selection_90	0.00	cop	not(isnull(test.p.relate_id))
+    └─IndexReader_91	9.99	root	index:Selection_90
+      └─Selection_90	9.99	cop	not(isnull(test.p.relate_id))
         └─IndexScan_89	10.00	cop	table:p, index:relate_id, range: decided by [eq(test.p.relate_id, test.tr.id)], keep order:false, stats:pseudo
 desc select 1 as a from dual order by a limit 1;
 id	count	task	operator info

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -177,9 +177,9 @@ Projection_13	0.00	root	test.te.expect_time
     │   │ │ └─IndexScan_70	10.00	cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false, stats:pseudo
     │   │ └─Selection_73	0.00	cop	eq(test.tr.brand_identy, 32314), eq(test.tr.domain_type, 2)
     │   │   └─TableScan_71	0.00	cop	table:tr, keep order:false, stats:pseudo
-    │   └─IndexLookUp_35	250.00	root	
+    │   └─IndexLookUp_35	0.25	root	
     │     ├─IndexScan_32	10.00	cop	table:te, index:trade_id, range: decided by [eq(test.te.trade_id, test.tr.id)], keep order:false, stats:pseudo
-    │     └─Selection_34	250.00	cop	ge(test.te.expect_time, 2018-04-23 00:00:00.000000), le(test.te.expect_time, 2018-04-23 23:59:59.000000)
+    │     └─Selection_34	0.25	cop	ge(test.te.expect_time, 2018-04-23 00:00:00.000000), le(test.te.expect_time, 2018-04-23 23:59:59.000000)
     │       └─TableScan_33	10.00	cop	table:te, keep order:false, stats:pseudo
     └─IndexReader_91	9.99	root	index:Selection_90
       └─Selection_90	9.99	cop	not(isnull(test.p.relate_id))

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -260,9 +260,9 @@ Projection_14	10.00	root	tpch.lineitem.l_orderkey, 7_col_0, tpch.orders.o_orderd
         │ └─TableReader_52	36870000.00	root	data:Selection_51
         │   └─Selection_51	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
         │     └─TableScan_50	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─IndexLookUp_28	162945114.27	root	
+        └─IndexLookUp_28	0.54	root	
           ├─IndexScan_25	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:false
-          └─Selection_27	162945114.27	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
+          └─Selection_27	0.54	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
             └─TableScan_26	1.00	cop	table:lineitem, keep order:false
 /*
 Q4 Order Priority Checking Query
@@ -301,9 +301,9 @@ Sort_10	1.00	root	tpch.orders.o_orderpriority:asc
       ├─TableReader_33	2925937.50	root	data:Selection_32
       │ └─Selection_32	2925937.50	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-04-01)
       │   └─TableScan_31	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_20	240004648.80	root	
+      └─IndexLookUp_20	0.80	root	
         ├─IndexScan_17	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:false
-        └─Selection_19	240004648.80	cop	lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate)
+        └─Selection_19	0.80	cop	lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate)
           └─TableScan_18	1.00	cop	table:lineitem, keep order:false
 /*
 Q5 Local Supplier Volume Query
@@ -672,9 +672,9 @@ Projection_17	20.00	root	tpch.customer.c_custkey, tpch.customer.c_name, 9_col_0,
         │ └─TableReader_48	3017307.69	root	data:Selection_47
         │   └─Selection_47	3017307.69	cop	ge(tpch.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1993-11-01)
         │     └─TableScan_46	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─IndexLookUp_31	73916005.00	root	
+        └─IndexLookUp_31	0.25	root	
           ├─IndexScan_28	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:false
-          └─Selection_30	73916005.00	cop	eq(tpch.lineitem.l_returnflag, "R")
+          └─Selection_30	0.25	cop	eq(tpch.lineitem.l_returnflag, "R")
             └─TableScan_29	1.00	cop	table:lineitem, keep order:false
 /*
 Q11 Important Stock Identification Query
@@ -1241,9 +1241,9 @@ Projection_25	1.00	root	tpch.supplier.s_name, 17_col_0
       │ └─IndexLookUp_55	1.00	root	
       │   ├─IndexScan_53	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l2.l_orderkey, tpch.l1.l_orderkey)], keep order:false
       │   └─TableScan_54	1.00	cop	table:lineitem, keep order:false
-      └─IndexLookUp_39	240004648.80	root	
+      └─IndexLookUp_39	0.80	root	
         ├─IndexScan_36	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l3.l_orderkey, tpch.l1.l_orderkey)], keep order:false
-        └─Selection_38	240004648.80	cop	gt(tpch.l3.l_receiptdate, tpch.l3.l_commitdate)
+        └─Selection_38	0.80	cop	gt(tpch.l3.l_receiptdate, tpch.l3.l_commitdate)
           └─TableScan_37	1.00	cop	table:lineitem, keep order:false
 /*
 Q22 Global Sales Opportunity Query

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -85,9 +85,9 @@ func (s *testSuite1) TestIndexJoinUnionScan(c *C) {
 		"  │ └─TableReader_16 9990.00 root data:Selection_15",
 		"  │   └─Selection_15 9990.00 cop not(isnull(test.t1.a))",
 		"  │     └─TableScan_14 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"  └─UnionScan_11 0.00 root not(isnull(test.t2.a))",
-		"    └─IndexReader_10 0.00 root index:Selection_9",
-		"      └─Selection_9 0.00 cop not(isnull(test.t2.a))",
+		"  └─UnionScan_11 9.99 root not(isnull(test.t2.a))",
+		"    └─IndexReader_10 9.99 root index:Selection_9",
+		"      └─Selection_9 9.99 cop not(isnull(test.t2.a))",
 		"        └─IndexScan_8 10.00 cop table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("select /*+ TIDB_INLJ(t1, t2)*/ t1.a, t2.a from t1 join t2 on t1.a = t2.a").Check(testkit.Rows(
@@ -114,7 +114,7 @@ func (s *testSuite1) TestBatchIndexJoinUnionScan(c *C) {
 		"  │ └─TableReader_22 9990.00 root data:Selection_21",
 		"  │   └─Selection_21 9990.00 cop not(isnull(test.t1.a))",
 		"  │     └─TableScan_20 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"  └─UnionScan_26 0.00 root not(isnull(test.t2.a))",
+		"  └─UnionScan_26 9.99 root not(isnull(test.t2.a))",
 		"    └─IndexReader_25 9.99 root index:Selection_24",
 		"      └─Selection_24 9.99 cop not(isnull(test.t2.a))",
 		"        └─IndexScan_23 10.00 cop table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -67,11 +67,11 @@ func (s *testSuite1) TestIndexJoinUnionScan(c *C) {
 		"│ └─TableReader_17 9990.00 root data:Selection_16",
 		"│   └─Selection_16 9990.00 cop not(isnull(test.t1.a))",
 		"│     └─TableScan_15 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"└─UnionScan_12 0.00 root not(isnull(test.t2.a))",
-		"  └─IndexLookUp_11 0.00 root ",
-		"    ├─Selection_10 0.00 cop not(isnull(test.t2.a))",
+		"└─UnionScan_12 9.99 root not(isnull(test.t2.a))",
+		"  └─IndexLookUp_11 9.99 root ",
+		"    ├─Selection_10 9.99 cop not(isnull(test.t2.a))",
 		"    │ └─IndexScan_8 10.00 cop table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
-		"    └─TableScan_9 0.00 cop table:t2, keep order:false, stats:pseudo",
+		"    └─TableScan_9 9.99 cop table:t2, keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("select /*+ TIDB_INLJ(t1, t2)*/ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows(
 		"2 2 2 2 2",
@@ -115,8 +115,8 @@ func (s *testSuite1) TestBatchIndexJoinUnionScan(c *C) {
 		"  │   └─Selection_21 9990.00 cop not(isnull(test.t1.a))",
 		"  │     └─TableScan_20 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"  └─UnionScan_26 0.00 root not(isnull(test.t2.a))",
-		"    └─IndexReader_25 0.00 root index:Selection_24",
-		"      └─Selection_24 0.00 cop not(isnull(test.t2.a))",
+		"    └─IndexReader_25 9.99 root index:Selection_24",
+		"      └─Selection_24 9.99 cop not(isnull(test.t2.a))",
 		"        └─IndexScan_23 10.00 cop table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("select /*+ TIDB_INLJ(t1, t2)*/ count(*) from t1 join t2 on t1.a = t2.id").Check(testkit.Rows(

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -908,8 +908,8 @@ func (s *testAnalyzeSuite) TestIssue9562(c *C) {
 		"├─TableReader_12 9980.01 root data:Selection_11",
 		"│ └─Selection_11 9980.01 cop not(isnull(test.t1.a)), not(isnull(test.t1.c))",
 		"│   └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
-		"└─IndexReader_8 0.00 root index:Selection_7",
-		"  └─Selection_7 0.00 cop not(isnull(test.t2.a)), not(isnull(test.t2.c))",
+		"└─IndexReader_8 9.98 root index:Selection_7",
+		"  └─Selection_7 9.98 cop not(isnull(test.t2.a)), not(isnull(test.t2.c))",
 		"    └─IndexScan_6 10.00 cop table:t2, index:a, b, c, range: decided by [eq(test.t2.a, test.t1.a) gt(test.t2.b, minus(test.t1.b, 1)) lt(test.t2.b, plus(test.t1.b, 1))], keep order:false, stats:pseudo",
 	))
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -594,7 +594,7 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 		countAfterAccess: rowCount,
 	}
 	if len(indexConds) > 0 {
-		selectivity, _, err := ds.stats.HistColl.Selectivity(ds.ctx, indexConds)
+		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, indexConds)
 		if err != nil {
 			logutil.Logger(context.Background()).Warn("calculate selectivity faild, use selection factor", zap.Error(err))
 			selectivity = selectionFactor

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -597,7 +597,7 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 	if len(indexConds) > 0 {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, indexConds)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("calculate selectivity failed, use selection factor", zap.Error(err))
+			logutil.Logger(context.Background()).Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = selectionFactor
 		}
 		path.countAfterIndex = rowCount * selectivity

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -575,11 +575,11 @@ func (is *PhysicalIndexScan) addPushedDownSelection(copTask *copTask, p *DataSou
 	indexConds, tableConds := path.indexFilters, path.tableFilters
 	if indexConds != nil {
 		copTask.cst += copTask.count() * cpuFactor
-		count := path.countAfterAccess
-		if count >= 1.0 {
-			selectivity := path.countAfterIndex / path.countAfterAccess
-			count = is.stats.RowCount * selectivity
+		var selectivity float64
+		if path.countAfterAccess > 0 {
+			selectivity = path.countAfterIndex / path.countAfterAccess
 		}
+		count := is.stats.RowCount * selectivity
 		stats := &property.StatsInfo{RowCount: count}
 		indexSel := PhysicalSelection{Conditions: indexConds}.Init(is.ctx, stats)
 		indexSel.SetChildren(is)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -537,7 +537,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	if path.indexFilters != nil {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, path.indexFilters)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("calculate selectivity failed, use selection factor", zap.Error(err))
+			logutil.Logger(context.Background()).Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = selectionFactor
 		}
 		path.countAfterIndex = math.Max(path.countAfterAccess*selectivity, ds.stats.RowCount)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -337,6 +337,7 @@ type DataSource struct {
 	allConds []expression.Expression
 
 	statisticTable *statistics.Table
+	tableStats     *property.StatsInfo
 
 	// possibleAccessPaths stores all the possible access path for physical plan, including table scan.
 	possibleAccessPaths []*accessPath
@@ -501,7 +502,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 		path.tableFilters = res.RemainedConds
 		path.eqCondCount = res.EqCondCount
 		eqOrInCount = res.EqOrInCount
-		path.countAfterAccess, err = ds.stats.HistColl.GetRowCountByIndexRanges(sc, path.index.ID, path.ranges)
+		path.countAfterAccess, err = ds.tableStats.HistColl.GetRowCountByIndexRanges(sc, path.index.ID, path.ranges)
 		if err != nil {
 			return false, err
 		}
@@ -534,7 +535,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 		path.countAfterAccess = math.Min(ds.stats.RowCount/selectionFactor, float64(ds.statisticTable.Count))
 	}
 	if path.indexFilters != nil {
-		selectivity, _, err := ds.stats.HistColl.Selectivity(ds.ctx, path.indexFilters)
+		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, path.indexFilters)
 		if err != nil {
 			logutil.Logger(context.Background()).Warn("calculate selectivity faild, use selection factor", zap.Error(err))
 			selectivity = selectionFactor

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -537,7 +537,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	if path.indexFilters != nil {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, path.indexFilters)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("calculate selectivity faild, use selection factor", zap.Error(err))
+			logutil.Logger(context.Background()).Warn("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = selectionFactor
 		}
 		path.countAfterIndex = math.Max(path.countAfterAccess*selectivity, ds.stats.RowCount)

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -106,7 +106,7 @@ func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs) {
 	ds.tableStats = tableStats
 	selectivity, nodes, err := tableStats.HistColl.Selectivity(ds.ctx, conds)
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("an error happened, use the default selectivity", zap.Error(err))
+		logutil.Logger(context.Background()).Debug("an error happened, use the default selectivity", zap.Error(err))
 		selectivity = selectionFactor
 	}
 	ds.stats = tableStats.Scale(selectivity)

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -90,8 +90,8 @@ func (ds *DataSource) getColumnNDV(colID int64) (ndv float64) {
 	return ndv
 }
 
-func (ds *DataSource) getStatsByFilter(conds expression.CNFExprs) (*property.StatsInfo, *statistics.HistColl) {
-	profile := &property.StatsInfo{
+func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs) {
+	tableStats := &property.StatsInfo{
 		RowCount:     float64(ds.statisticTable.Count),
 		Cardinality:  make([]float64, len(ds.Columns)),
 		HistColl:     ds.statisticTable.GenerateHistCollFromColumnInfo(ds.Columns, ds.schema.Columns),
@@ -100,21 +100,19 @@ func (ds *DataSource) getStatsByFilter(conds expression.CNFExprs) (*property.Sta
 	if ds.statisticTable.Pseudo {
 		profile.StatsVersion = statistics.PseudoVersion
 	}
-
 	for i, col := range ds.Columns {
 		profile.Cardinality[i] = ds.getColumnNDV(col.ID)
 	}
-	ds.stats = profile
-	selectivity, nodes, err := profile.HistColl.Selectivity(ds.ctx, conds)
+	ds.tableStats = tableStats
+	selectivity, nodes, err := tableStats.HistColl.Selectivity(ds.ctx, conds)
 	if err != nil {
 		logutil.Logger(context.Background()).Warn("an error happened, use the default selectivity", zap.Error(err))
 		selectivity = selectionFactor
 	}
-	if ds.ctx.GetSessionVars().OptimizerSelectivityLevel >= 1 && ds.stats.HistColl != nil {
-		finalHist := ds.stats.HistColl.NewHistCollBySelectivity(ds.ctx.GetSessionVars().StmtCtx, nodes)
-		return profile, finalHist
+	ds.stats = tableStats.Scale(selectivity)
+	if ds.ctx.GetSessionVars().OptimizerSelectivityLevel >= 1 {
+		ds.stats.HistColl = ds.stats.HistColl.NewHistCollBySelectivity(ds.ctx.GetSessionVars().StmtCtx, nodes)
 	}
-	return profile.Scale(selectivity), nil
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
@@ -123,8 +121,7 @@ func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo) (*property.S
 	for i, expr := range ds.pushedDownConds {
 		ds.pushedDownConds[i] = expression.PushDownNot(nil, expr, false)
 	}
-	var finalHist *statistics.HistColl
-	ds.stats, finalHist = ds.getStatsByFilter(ds.pushedDownConds)
+	ds.deriveStatsByFilter(ds.pushedDownConds)
 	for _, path := range ds.possibleAccessPaths {
 		if path.isTablePath {
 			noIntervalRanges, err := ds.deriveTablePathStats(path)
@@ -149,9 +146,6 @@ func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo) (*property.S
 			ds.possibleAccessPaths = ds.possibleAccessPaths[:1]
 			break
 		}
-	}
-	if ds.ctx.GetSessionVars().OptimizerSelectivityLevel >= 1 {
-		ds.stats.HistColl = finalHist
 	}
 	return ds.stats, nil
 }

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -98,10 +98,10 @@ func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs) {
 		StatsVersion: ds.statisticTable.Version,
 	}
 	if ds.statisticTable.Pseudo {
-		profile.StatsVersion = statistics.PseudoVersion
+		tableStats.StatsVersion = statistics.PseudoVersion
 	}
 	for i, col := range ds.Columns {
-		profile.Cardinality[i] = ds.getColumnNDV(col.ID)
+		tableStats.Cardinality[i] = ds.getColumnNDV(col.ID)
 	}
 	ds.tableStats = tableStats
 	selectivity, nodes, err := tableStats.HistColl.Selectivity(ds.ctx, conds)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/10630

### What is changed and how it works?

- recompute selectivity for index filters of index scan which is inner child of index join;
- do not use `ds.stats` as table plan's stats when it is double read in index join's inner side, because for inner child of index join, we are building new stats using average row count from scratch, so it is different from normal `DataSource::DeriveStats`;

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
