### PR TITLE
planner: decrease the level of confusing log raised during plan building

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,7 @@ var defaultConf = Config{
 	},
 	LowerCaseTableNames: 2,
 	Log: Log{
-		Level:              "debug",
+		Level:              "info",
 		Format:             "text",
 		File:               logutil.NewFileLogConfig(true, logutil.DefaultLogMaxSize),
 		SlowQueryFile:      "tidb-slow.log",

--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,7 @@ var defaultConf = Config{
 	},
 	LowerCaseTableNames: 2,
 	Log: Log{
-		Level:              "info",
+		Level:              "debug",
 		Format:             "text",
 		File:               logutil.NewFileLogConfig(true, logutil.DefaultLogMaxSize),
 		SlowQueryFile:      "tidb-slow.log",

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -17,17 +17,19 @@ import (
 	"fmt"
 	"math"
 
+	"context"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/set"
+	"go.uber.org/zap"
 )
 
 func (p *LogicalUnionScan) exhaustPhysicalPlans(prop *property.PhysicalProperty) []PhysicalPlan {
@@ -574,7 +576,7 @@ func (p *LogicalJoin) buildRangeForIndexJoin(indexInfo *model.IndexInfo, innerPl
 	// So the equal conditions we built can be successfully used to build a range if they can be used. They won't be affected by the existing filters.
 	res, err := ranger.DetachCondAndBuildRangeForIndex(p.ctx, access, idxCols, colLengths)
 	if err != nil {
-		terror.Log(err)
+		logutil.Logger(context.Background()).Debug("build range for index join", zap.Error(err))
 		return nil, nil, nil
 	}
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -14,10 +14,10 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"math"
 
-	"context"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This commit decreases the level of the log raised during plan building which is mentioned in #8244 

### What is changed and how it works?
Decrease the log level from error to debug.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Manual test (add detailed scripts or steps below)
1. Keep the default config, and run the case in #8244 , error message will not be printed.
2. Set the log level to debug, and run the case again, error message will be printed.

Code changes

 - Has exported function/method change


Side effects

N/A

Related changes

N/A