### PR TITLE
executor: optimize UnionScanExec, try to use table/index access range to avoid execute buildAndSortAddedRows.

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -804,6 +804,10 @@ func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannerco
 		us.dirty = GetDirtyDB(b.ctx).GetDirtyTable(physicalTableID)
 		us.conditions = v.Conditions
 		us.columns = x.columns
+		err = us.buildAddedRowsFromIndexReader(x)
+		if err != nil {
+			return nil, err
+		}
 		err = us.buildAndSortAddedRows(x.table)
 	case *IndexLookUpExecutor:
 		us.desc = x.desc

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -16,21 +16,18 @@ package executor
 import (
 	"bytes"
 	"context"
-	"fmt"
-	"github.com/pingcap/tidb/distsql"
-	"github.com/pingcap/tidb/planner/core"
-	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/util/codec"
 	"sort"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/distsql"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -216,7 +213,6 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) ([]types.Datum, err
 				continue
 			}
 			if _, ok := us.dirty.addedRows[snapshotHandle]; ok {
-				fmt.Printf("\n\nhandle: %v\n--------\n-n", snapshotHandle)
 				// If src handle appears in added rows, it means there is conflict and the transaction will fail to
 				// commit, but for simplicity, we don't handle it here.
 				continue
@@ -300,52 +296,61 @@ func (us *UnionScanExec) rowWithColsInTxn(t table.Table, h int64, cols []*table.
 	return v, nil
 }
 
-func (us *UnionScanExec) buildAddedRowsFromIndexReader(e *IndexReaderExecutor) error {
-	condition := us.conditions
-	if len(e.plans) > 1 {
-		if sel, ok := e.plans[1].(*core.PhysicalSelection); ok {
-			condition = sel.Conditions
+func (us *UnionScanExec) checkBypassAddedRowsByTableReader(e *TableReaderExecutor) bool {
+	if len(e.ranges) == 0 {
+		return false
+	}
+	physicalTableID := getPhysicalTableID(e.table)
+	kvRanges := distsql.TableRangesToKVRanges(physicalTableID, e.ranges, nil)
+	txn, err := us.ctx.Txn(true)
+	if err != nil {
+		return false
+	}
+
+	prefix := tablecodec.GenTableRecordPrefix(physicalTableID)
+	for _, rg := range kvRanges {
+		iter, err := txn.GetMemBuffer().Iter(rg.StartKey, rg.EndKey)
+		if err != nil {
+			return false
+		}
+		for iter.Valid() {
+			if !bytes.Contains(iter.Key(), prefix) {
+				continue
+			}
+			return false
 		}
 	}
-	_ = condition
+	return true
+}
+
+func (us *UnionScanExec) checkBypassAddedRowsByIndexReader(e *IndexReaderExecutor) bool {
+	if len(e.ranges) == 0 {
+		return false
+	}
 	kvRanges, err := distsql.IndexRangesToKVRanges(e.ctx.GetSessionVars().StmtCtx, e.physicalTableID, e.index.ID, e.ranges, e.feedback)
 	if err != nil {
-		return err
+		return false
 	}
 
 	txn, err := us.ctx.Txn(true)
 	if err != nil {
-		return err
+		return false
 	}
 
 	prefix := tablecodec.EncodeTableIndexPrefix(e.physicalTableID, e.index.ID)
 	for _, rg := range kvRanges {
 		iter, err := txn.GetMemBuffer().Iter(rg.StartKey, rg.EndKey)
 		if err != nil {
-			return err
+			return false
 		}
 		for iter.Valid() {
-			key := iter.Key()
-			value := iter.Value()
-			if !bytes.Contains(key, prefix) {
+			if !bytes.Contains(iter.Key(), prefix) {
 				continue
 			}
-			key = key[len(prefix):]
-			fmt.Printf("\n\nkey: %v, value: %v\n\n------------------\n", key, value)
-
-			ds, err := codec.Decode(key, len(e.index.Columns)+1)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("\n\nds %#v\n\n------------------\n", ds)
-
-			err = iter.Next()
-			if err != nil {
-				return err
-			}
+			return false
 		}
 	}
-	return nil
+	return true
 }
 
 func (us *UnionScanExec) buildAndSortAddedRows(t table.Table) error {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In the case of big transaction, `buildAndSortAddedRows` function will spends too much time to decode and sort data.  

This PR try to avoid call `buildAndSortAddedRows` function in in some scenarios. here is a example:

```sql
 create table t (a int key, b int, index idx(b));
 insert into t values (1,1)
 begin
 insert into t values (2,2),(3,3),(4,4),(5,5)
 update t set b=b+1 where b=1;
 commit
```

In the upper transaction, execute `update t set b=b+1 where b=1;` will use `UnionScanExec` with `IndexReaderExecutor` and the index range is `range:[1,1]`.

Here is a trick, use the index `range:[1,1]` to check `MemBuffer` first, and if there is no row in `MemBuffer`, then we can avoid call `buildAndSortAddedRows`.

## benchmark

Below is a simple benchmark, Only 1 TiDB server, no pd/tikv.

**table schema**
```sql
create table t (a int key, b int,c varchar(100),d varchar(100), e decimal(60,10), f timestamp, g double, index idx(b));
```

***benchmark test***

**test insert 100 rows in transaction.**
```sql
begin
# insert 100 rows data.
insert into t2 values (0,0,'abcdefg', 'hijklmn', 123.456, '2019-05-29 20:16:59', 0.6046602879796196) ... # 100 rows data.
select * from t where a>5000; # do a benchmark of this select. the select result is null. 
rollback
```

In Master, the select avg spend time is **0.41ms**

In This PR, the select avg spend time is **0.22ms**

**test insert 1000 rows in transaction.**

In Master, the select avg spend time is **2ms**

In This PR, the select avg spend time is **0.22ms**

Here is the cpu-profile:
[cpu.profile-PR.txt](https://github.com/pingcap/tidb/files/3232594/cpu.profile-PR.txt)
[cpu.profile-master.txt](https://github.com/pingcap/tidb/files/3232600/cpu.profile-master.txt)




## Beter Idea

How about use `TableReaderExecutor` and `IndexReaderExecutor` to read `MemBuffer` and remove `buildAndSortAddedRows` function?



### What is changed and how it works?
* use table/index access range to avoid execute buildAndSortAddedRows.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Code changes

 - Has exported function/method change

Side effects


Related changes

