### PR TITLE
executor: refine HashAgg.Close when unparallelExec

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -197,7 +197,7 @@ func (e *HashAggExec) Close() error {
 		e.childResult = nil
 		e.groupSet = nil
 		e.partialResultMap = nil
-		return nil
+		return e.baseExecutor.Close()
 	}
 	// `Close` may be called after `Open` without calling `Next` in test.
 	if !e.prepared {
@@ -214,7 +214,7 @@ func (e *HashAggExec) Close() error {
 	}
 	for range e.finalOutputCh {
 	}
-	return errors.Trace(e.baseExecutor.Close())
+	return e.baseExecutor.Close()
 }
 
 // Open implements the Executor Open interface.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1019,6 +1019,7 @@ func (b *executorBuilder) buildProjBelowAgg(aggFuncs []*aggregation.AggFuncDesc,
 
 	return &ProjectionExec{
 		baseExecutor:  newBaseExecutor(b.ctx, expression.NewSchema(projSchemaCols...), projFromID, src),
+		numWorkers:    b.ctx.GetSessionVars().ProjectionConcurrency,
 		evaluatorSuit: expression.NewEvaluatorSuite(projExprs, false),
 	}
 }


### PR DESCRIPTION
Cherry pick https://github.com/pingcap/tidb/pull/8810

Only the bug fix, without the test code, because the file struct has changed dramaticly and there is no seqtest/seq_executor_test.go in release-2.1

@XuHuaiyu @zz-jason @eurekaka 