### PR TITLE
pessimistic-txn: support deadlock detector in mocktikv

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65
+	github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-sql-driver/mysql v0.0.0-20170715192408-3955978caca4

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f h1:dDxpBYafY/GYpcl+LS4Bn3ziLPuEdGRkRjYAbSlWxSA=
+github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v0.0.0-20180421182945-02af3965c54e/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"sync"
 
+	"github.com/dgryski/go-farm"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/goleveldb/leveldb"
 	"github.com/pingcap/goleveldb/leveldb/iterator"
@@ -28,6 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/deadlock"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )
@@ -60,7 +62,8 @@ type MVCCLevelDB struct {
 	// mu used for lock
 	// leveldb can not guarantee multiple operations to be atomic, for example, read
 	// then write, another write may happen during it, so this lock is necessory.
-	mu sync.RWMutex
+	mu               sync.RWMutex
+	deadlockDetector *deadlock.Detector
 }
 
 const lockVer uint64 = math.MaxUint64
@@ -121,7 +124,7 @@ func NewMVCCLevelDB(path string) (*MVCCLevelDB, error) {
 		d, err = leveldb.OpenFile(path, &opt.Options{BlockCacheCapacity: 600 * 1024 * 1024})
 	}
 
-	return &MVCCLevelDB{db: d}, errors.Trace(err)
+	return &MVCCLevelDB{db: d, deadlockDetector: deadlock.NewDetector()}, errors.Trace(err)
 }
 
 // Iterator wraps iterator.Iterator to provide Valid() method.
@@ -507,7 +510,7 @@ func (mvcc *MVCCLevelDB) PessimisticLock(mutations []*kvrpcpb.Mutation, primary 
 	batch := &leveldb.Batch{}
 	errs := make([]error, 0, len(mutations))
 	for _, m := range mutations {
-		err := pessimisticLockMutation(mvcc.db, batch, m, startTS, forUpdateTS, primary, ttl)
+		err := mvcc.pessimisticLockMutation(batch, m, startTS, forUpdateTS, primary, ttl)
 		errs = append(errs, err)
 		if err != nil {
 			anyError = true
@@ -523,9 +526,9 @@ func (mvcc *MVCCLevelDB) PessimisticLock(mutations []*kvrpcpb.Mutation, primary 
 	return errs
 }
 
-func pessimisticLockMutation(db *leveldb.DB, batch *leveldb.Batch, mutation *kvrpcpb.Mutation, startTS, forUpdateTS uint64, primary []byte, ttl uint64) error {
+func (mvcc *MVCCLevelDB) pessimisticLockMutation(batch *leveldb.Batch, mutation *kvrpcpb.Mutation, startTS, forUpdateTS uint64, primary []byte, ttl uint64) error {
 	startKey := mvccEncode(mutation.Key, lockVer)
-	iter := newIterator(db, &util.Range{
+	iter := newIterator(mvcc.db, &util.Range{
 		Start: startKey,
 	})
 	defer iter.Release()
@@ -539,6 +542,10 @@ func pessimisticLockMutation(db *leveldb.DB, batch *leveldb.Batch, mutation *kvr
 	}
 	if ok {
 		if dec.lock.startTS != startTS {
+			errDeadlock := mvcc.deadlockDetector.Detect(startTS, dec.lock.startTS, farm.Fingerprint64(mutation.Key))
+			if errDeadlock != nil {
+				return errDeadlock
+			}
 			return dec.lock.lockErr(mutation.Key)
 		}
 		return nil
@@ -684,7 +691,10 @@ func prewriteMutation(db *leveldb.DB, batch *leveldb.Batch, mutation *kvrpcpb.Mu
 // Commit implements the MVCCStore interface.
 func (mvcc *MVCCLevelDB) Commit(keys [][]byte, startTS, commitTS uint64) error {
 	mvcc.mu.Lock()
-	defer mvcc.mu.Unlock()
+	defer func() {
+		mvcc.mu.Unlock()
+		mvcc.deadlockDetector.CleanUp(startTS)
+	}()
 
 	batch := &leveldb.Batch{}
 	for _, k := range keys {
@@ -758,7 +768,10 @@ func commitLock(batch *leveldb.Batch, lock mvccLock, key []byte, startTS, commit
 // Rollback implements the MVCCStore interface.
 func (mvcc *MVCCLevelDB) Rollback(keys [][]byte, startTS uint64) error {
 	mvcc.mu.Lock()
-	defer mvcc.mu.Unlock()
+	defer func() {
+		mvcc.mu.Unlock()
+		mvcc.deadlockDetector.CleanUp(startTS)
+	}()
 
 	batch := &leveldb.Batch{}
 	for _, k := range keys {
@@ -860,13 +873,17 @@ func getTxnCommitInfo(iter *Iterator, expectKey []byte, startTS uint64) (mvccVal
 // Cleanup implements the MVCCStore interface.
 func (mvcc *MVCCLevelDB) Cleanup(key []byte, startTS uint64) error {
 	mvcc.mu.Lock()
-	defer mvcc.mu.Unlock()
+	defer func() {
+		mvcc.mu.Unlock()
+		mvcc.deadlockDetector.CleanUp(startTS)
+	}()
 
 	batch := &leveldb.Batch{}
 	err := rollbackKey(mvcc.db, batch, key, startTS)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	mvcc.deadlockDetector.CleanUp(startTS)
 	return mvcc.db.Write(batch, nil)
 }
 

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -883,7 +883,6 @@ func (mvcc *MVCCLevelDB) Cleanup(key []byte, startTS uint64) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	mvcc.deadlockDetector.CleanUp(startTS)
 	return mvcc.db.Write(batch, nil)
 }
 

--- a/util/deadlock/deadlock.go
+++ b/util/deadlock/deadlock.go
@@ -1,0 +1,130 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deadlock
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Detector detects deadlock.
+type Detector struct {
+	waitForMap map[uint64]*txnList
+	lock       sync.Mutex
+}
+
+type txnList struct {
+	txns []txnKeyHashPair
+}
+
+type txnKeyHashPair struct {
+	txn     uint64
+	keyHash uint64
+}
+
+// NewDetector creates a new Detector.
+func NewDetector() *Detector {
+	return &Detector{
+		waitForMap: map[uint64]*txnList{},
+	}
+}
+
+// ErrDeadlock is returned when deadlock is detected.
+type ErrDeadlock struct {
+	keyHash uint64
+}
+
+func (e *ErrDeadlock) Error() string {
+	return fmt.Sprintf("deadlock(%d)", e.keyHash)
+}
+
+// Detect detects deadlock for the sourceTxn on a locked key.
+func (d *Detector) Detect(sourceTxn, waitForTxn, keyHash uint64) *ErrDeadlock {
+	d.lock.Lock()
+	err := d.doDetect(sourceTxn, waitForTxn)
+	if err == nil {
+		d.register(sourceTxn, waitForTxn, keyHash)
+	}
+	d.lock.Unlock()
+	return err
+}
+
+func (d *Detector) doDetect(sourceTxn, waitForTxn uint64) *ErrDeadlock {
+	list := d.waitForMap[waitForTxn]
+	if list == nil {
+		return nil
+	}
+	for _, nextTarget := range list.txns {
+		if nextTarget.txn == sourceTxn {
+			return &ErrDeadlock{keyHash: nextTarget.keyHash}
+		}
+		if err := d.doDetect(sourceTxn, nextTarget.txn); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Detector) register(sourceTxn, waitForTxn, keyHash uint64) {
+	list := d.waitForMap[sourceTxn]
+	pair := txnKeyHashPair{txn: waitForTxn, keyHash: keyHash}
+	if list == nil {
+		d.waitForMap[sourceTxn] = &txnList{txns: []txnKeyHashPair{pair}}
+		return
+	}
+	for _, tar := range list.txns {
+		if tar.txn == waitForTxn && tar.keyHash == keyHash {
+			return
+		}
+	}
+	list.txns = append(list.txns, pair)
+}
+
+// CleanUp removes the wait for entry for the transaction.
+func (d *Detector) CleanUp(txn uint64) {
+	d.lock.Lock()
+	delete(d.waitForMap, txn)
+	d.lock.Unlock()
+}
+
+// CleanUpWaitFor removes a key in the wait for entry for the transaction.
+func (d *Detector) CleanUpWaitFor(txn, waitForTxn, keyHash uint64) {
+	pair := txnKeyHashPair{txn: waitForTxn, keyHash: keyHash}
+	d.lock.Lock()
+	l := d.waitForMap[txn]
+	if l != nil {
+		for i, tar := range l.txns {
+			if tar == pair {
+				l.txns = append(l.txns[:i], l.txns[i+1:]...)
+				break
+			}
+		}
+		if len(l.txns) == 0 {
+			delete(d.waitForMap, txn)
+		}
+	}
+	d.lock.Unlock()
+
+}
+
+// Expire removes entries with TS smaller than minTS.
+func (d *Detector) Expire(minTS uint64) {
+	d.lock.Lock()
+	for ts := range d.waitForMap {
+		if ts < minTS {
+			delete(d.waitForMap, ts)
+		}
+	}
+	d.lock.Unlock()
+}

--- a/util/deadlock/deadlock_test.go
+++ b/util/deadlock/deadlock_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deadlock
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testDeadlockSuite{})
+
+type testDeadlockSuite struct{}
+
+func (s *testDeadlockSuite) TestDeadlock(c *C) {
+	detector := NewDetector()
+	err := detector.Detect(1, 2, 100)
+	c.Assert(err, IsNil)
+	err = detector.Detect(2, 3, 200)
+	c.Assert(err, IsNil)
+	err = detector.Detect(3, 1, 300)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, fmt.Sprintf("deadlock(200)"))
+	detector.CleanUp(2)
+	list2 := detector.waitForMap[2]
+	c.Assert(list2, IsNil)
+
+	// After cycle is broken, no deadlock now.
+	err = detector.Detect(3, 1, 300)
+	c.Assert(err, IsNil)
+	list3 := detector.waitForMap[3]
+	c.Assert(list3.txns, HasLen, 1)
+
+	// Different keyHash grows the list.
+	err = detector.Detect(3, 1, 400)
+	c.Assert(err, IsNil)
+	c.Assert(list3.txns, HasLen, 2)
+
+	// Same waitFor and key hash doesn't grow the list.
+	err = detector.Detect(3, 1, 400)
+	c.Assert(err, IsNil)
+	c.Assert(list3.txns, HasLen, 2)
+
+	detector.CleanUpWaitFor(3, 1, 300)
+	c.Assert(list3.txns, HasLen, 1)
+	detector.CleanUpWaitFor(3, 1, 400)
+	list3 = detector.waitForMap[3]
+	c.Assert(list3, IsNil)
+	detector.Expire(1)
+	c.Assert(detector.waitForMap, HasLen, 1)
+	detector.Expire(2)
+	c.Assert(detector.waitForMap, HasLen, 0)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support deadlock detector in mocktikv for pessimistic transaction.

### What is changed and how it works?
add 'util/deadlock' package and use it in mocktikv.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
