### PR TITLE
expression: length(binary(m)) should return 'm' instead of the concrete string length

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -253,7 +253,7 @@ func (col *Column) EvalString(ctx sessionctx.Context, row chunk.Row) (string, bo
 	// See #3644.
 	// Binary type column value will changed after modify the column length.
 	if (ctx.GetSessionVars().StmtCtx.PadCharToFullLength || (mysql.HasBinaryFlag(uint(col.GetType().Tp)) && col.GetType().Charset == charset.CharsetBin)) && col.GetType().Tp == mysql.TypeString {
-		valLen := len([]rune(val))
+		valLen := len(val)
 		if valLen < col.RetType.Flen {
 			val = val + strings.Repeat(" ", col.RetType.Flen-valLen)
 		}

--- a/expression/column.go
+++ b/expression/column.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
@@ -252,7 +251,7 @@ func (col *Column) EvalString(ctx sessionctx.Context, row chunk.Row) (string, bo
 	val := row.GetString(col.Index)
 	// See #3644.
 	// Binary type column value will changed after modify the column length.
-	if (ctx.GetSessionVars().StmtCtx.PadCharToFullLength || (mysql.HasBinaryFlag(uint(col.GetType().Tp)) && col.GetType().Charset == charset.CharsetBin)) && col.GetType().Tp == mysql.TypeString {
+	if (ctx.GetSessionVars().StmtCtx.PadCharToFullLength && col.GetType().Tp == mysql.TypeString) || col.GetType().IsBinaryStr() {
 		valLen := len(val)
 		if valLen < col.RetType.Flen {
 			val = val + strings.Repeat(" ", col.RetType.Flen-valLen)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -148,6 +148,10 @@ func (s *testIntegrationSuite) TestModifyBinaryLength(c *C) {
 	tk.MustExec("alter table t modify c varbinary(20);")
 	tk.MustQuery("select length(b), length(c) from t;").Check(testkit.Rows("33 4"))
 	tk.MustQuery("select length(concat(b, '|')), length(concat(c, '|')) from t;").Check(testkit.Rows("34 5"))
+
+	// for chinese characters
+	tk.MustExec("insert into t set b='中文', c='中文';")
+	tk.MustQuery("select length(concat(b, '|')), length(concat(c, '|')) from t;").Check(testkit.Rows("34 5", "34 7"))
 }
 
 func (s *testIntegrationSuite) TestMiscellaneousBuiltin(c *C) {

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/parser => github.com/miraclesu/parser v0.0.0-20190609130231-314580b9fc47

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/matttproud/golang_protobuf_extensions v1.0.0/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/miraclesu/parser v0.0.0-20190609130231-314580b9fc47 h1:RQQtd/cPr5KJCzF2JRCQ6aTBBy92eiFfUIVFFF8r6ZQ=
+github.com/miraclesu/parser v0.0.0-20190609130231-314580b9fc47/go.mod h1:wj5/O4OVI+PCLFKto4jhsxAzqVjCCmQpzaKjSe+kbm4=
 github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808 h1:pmpDGKLw4n82EtrNiLqB+xSz/JQwFOaZuMALYUHwX5s=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
@@ -165,8 +167,6 @@ github.com/pingcap/kvproto v0.0.0-20190528074401-b942b3f4108f/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190605085902-82be48fe0267 h1:LAR69Ocf7MIxHuh0uxr4JjRfPiFpKHq6aqEkvD63Z/k=
-github.com/pingcap/parser v0.0.0-20190605085902-82be48fe0267/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669 h1:ZoKjndm/Ig7Ru/wojrQkc/YLUttUdQXoH77gtuWCvL4=
 github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669/go.mod h1:MUCxRzOkYiWZtlyi4MhxjCIj9PgQQ/j+BLNGm7aUsnM=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #3644.

### What is changed and how it works?

Right-padded with the pad value to the specified length.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
