### PR TITLE
planner, executor: return TableDual when tryFastPlan is promised to be false

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3795,6 +3795,47 @@ func (s *testSuite) TestIssue10435(c *C) {
 	)
 }
 
+func (s *testSuite) TestIssue10448(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(pk int1 primary key)")
+	tk.MustExec("insert into t values(125)")
+	tk.MustQuery("desc select * from t where pk = 9223372036854775807").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551616").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775808").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551615").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 128").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(pk int8 primary key)")
+	tk.MustExec("insert into t values(9223372036854775807)")
+	tk.MustQuery("select * from t where pk = 9223372036854775807").Check(testkit.Rows("9223372036854775807"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775807").Check(testkit.Rows("Point_Get_1 1.00 root table:t, handle:9223372036854775807"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551616").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775808").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551615").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(pk int1 unsigned primary key)")
+	tk.MustExec("insert into t values(255)")
+	tk.MustQuery("select * from t where pk = 255").Check(testkit.Rows("255"))
+	tk.MustQuery("desc select * from t where pk = 256").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775807").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551616").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775808").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551615").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(pk int8 unsigned primary key)")
+	tk.MustExec("insert into t value(18446744073709551615)")
+	tk.MustQuery("desc select * from t where pk = 18446744073709551615").Check(testkit.Rows("Point_Get_1 1.00 root table:t, handle:18446744073709551615"))
+	tk.MustQuery("select * from t where pk = 18446744073709551615").Check(testkit.Rows("18446744073709551615"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775807").Check(testkit.Rows("Point_Get_1 1.00 root table:t, handle:9223372036854775807"))
+	tk.MustQuery("desc select * from t where pk = 18446744073709551616").Check(testkit.Rows("TableDual_2 0.00 root rows:0"))
+	tk.MustQuery("desc select * from t where pk = 9223372036854775808").Check(testkit.Rows("Point_Get_1 1.00 root table:t, handle:9223372036854775808"))
+}
+
 func (s *testSuite) TestUnsignedFeedback(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	oriProbability := statistics.FeedbackProbability.Load()

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -46,7 +46,6 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
 		idxVals: p.IndexValues,
 		handle:  p.Handle,
 		startTS: startTS,
-		done:    p.UnsignedHandle && p.Handle < 0,
 	}
 }
 

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -220,7 +220,8 @@ func (e *Execute) getPhysicalPlan(ctx sessionctx.Context, is infoschema.InfoSche
 	if err != nil {
 		return nil, err
 	}
-	if prepared.UseCache {
+	_, isTableDual := p.(*PhysicalTableDual)
+	if !isTableDual && prepared.UseCache {
 		ctx.PreparedPlanCache().Put(cacheKey, NewPSTMTPlanCacheValue(p))
 	}
 	return p, err

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -443,9 +443,7 @@ func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan
 		return nil
 	}
 	if fastSelect.IsTableDual {
-		return Update{
-			SelectPlan: &PhysicalTableDual{},
-		}.Init(ctx)
+		return PhysicalTableDual{}.Init(ctx, &property.StatsInfo{})
 	}
 	orderedList := buildOrderedList(ctx, fastSelect, updateStmt.List)
 	if orderedList == nil {
@@ -505,9 +503,7 @@ func tryDeletePointPlan(ctx sessionctx.Context, delStmt *ast.DeleteStmt) Plan {
 		return nil
 	}
 	if fastSelect.IsTableDual {
-		return Delete{
-			SelectPlan: &PhysicalTableDual{},
-		}.Init(ctx)
+		return PhysicalTableDual{}.Init(ctx, &property.StatsInfo{})
 	}
 	delPlan := Delete{
 		SelectPlan: fastSelect,

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/opcode"
+	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/privilege"
@@ -46,6 +47,7 @@ type PointGetPlan struct {
 	IndexValueParams []*driver.ParamMarkerExpr
 	expr             expression.Expression
 	ctx              sessionctx.Context
+	IsTableDual      bool
 }
 
 type nameValuePair struct {
@@ -84,7 +86,11 @@ func (p *PointGetPlan) ExplainInfo() string {
 			}
 		}
 	} else {
-		fmt.Fprintf(buffer, ", handle:%d", p.Handle)
+		if p.UnsignedHandle {
+			fmt.Fprintf(buffer, ", handle:%d", uint64(p.Handle))
+		} else {
+			fmt.Fprintf(buffer, ", handle:%d", p.Handle)
+		}
 	}
 	return buffer.String()
 }
@@ -129,6 +135,11 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 		if fp != nil {
 			if checkFastPlanPrivilege(ctx, fp, mysql.SelectPriv) != nil {
 				return nil
+			}
+			if fp.IsTableDual {
+				tableDual := PhysicalTableDual{}
+				tableDual.SetSchema(fp.Schema())
+				return tableDual.Init(ctx, &property.StatsInfo{})
 			}
 			return fp
 		}
@@ -186,19 +197,23 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 	if pairs == nil {
 		return nil
 	}
-	handlePair, unsigned := findPKHandle(tbl, pairs)
+	handlePair, fieldType := findPKHandle(tbl, pairs)
 	if handlePair.value.Kind() != types.KindNull && len(pairs) == 1 {
 		schema := buildSchemaFromFields(ctx, tblName.Schema, tbl, selStmt.Fields.Fields)
 		if schema == nil {
 			return nil
 		}
 		p := newPointGetPlan(ctx, schema, tbl)
-		var err error
-		p.Handle, err = handlePair.value.ToInt64(ctx.GetSessionVars().StmtCtx)
+		intDatum, err := handlePair.value.ConvertTo(ctx.GetSessionVars().StmtCtx, fieldType)
 		if err != nil {
+			if terror.ErrorEqual(types.ErrOverflow, err) {
+				p.IsTableDual = true
+				return p
+			}
 			return nil
 		}
-		p.UnsignedHandle = unsigned
+		p.Handle = intDatum.GetInt64()
+		p.UnsignedHandle = mysql.HasUnsignedFlag(fieldType.Flag)
 		p.HandleParam = handlePair.param
 		return p
 	}
@@ -364,20 +379,20 @@ func getNameValuePairs(nvPairs []nameValuePair, expr ast.ExprNode) []nameValuePa
 	return nil
 }
 
-func findPKHandle(tblInfo *model.TableInfo, pairs []nameValuePair) (handlePair nameValuePair, unsigned bool) {
+func findPKHandle(tblInfo *model.TableInfo, pairs []nameValuePair) (handlePair nameValuePair, fieldType *types.FieldType) {
 	if !tblInfo.PKIsHandle {
-		return handlePair, unsigned
+		return handlePair, nil
 	}
 	for _, col := range tblInfo.Columns {
 		if mysql.HasPriKeyFlag(col.Flag) {
 			i := findInPairs(col.Name.L, pairs)
 			if i == -1 {
-				return handlePair, unsigned
+				return handlePair, nil
 			}
-			return pairs[i], mysql.HasUnsignedFlag(col.Flag)
+			return pairs[i], &col.FieldType
 		}
 	}
-	return handlePair, unsigned
+	return handlePair, nil
 }
 
 func getIndexValues(idxInfo *model.IndexInfo, pairs []nameValuePair) ([]types.Datum, []*driver.ParamMarkerExpr) {
@@ -426,6 +441,11 @@ func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan
 	}
 	if checkFastPlanPrivilege(ctx, fastSelect, mysql.SelectPriv, mysql.UpdatePriv) != nil {
 		return nil
+	}
+	if fastSelect.IsTableDual {
+		return Update{
+			SelectPlan: &PhysicalTableDual{},
+		}.Init(ctx)
 	}
 	orderedList := buildOrderedList(ctx, fastSelect, updateStmt.List)
 	if orderedList == nil {
@@ -483,6 +503,11 @@ func tryDeletePointPlan(ctx sessionctx.Context, delStmt *ast.DeleteStmt) Plan {
 	}
 	if checkFastPlanPrivilege(ctx, fastSelect, mysql.SelectPriv, mysql.DeletePriv) != nil {
 		return nil
+	}
+	if fastSelect.IsTableDual {
+		return Delete{
+			SelectPlan: &PhysicalTableDual{},
+		}.Init(ctx)
 	}
 	delPlan := Delete{
 		SelectPlan: fastSelect,

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -150,5 +150,5 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 	tk.MustQuery("execute stmt7 using @p2").Check(testkit.Rows("1"))
 	counter.Write(pb)
 	hit = pb.GetCounter().GetValue()
-	c.Check(hit, Equals, float64(3))
+	c.Check(hit, Equals, float64(2))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #10678 .
Before this commit:
``` sql
CREATE TABLE `t` (
  `pk` bigint(11) signed NOT NULL,
  PRIMARY KEY (`pk`)
);
tidb> SELECT `pk` FROM `t` WHERE `pk` = 18446744073709551615;
ERROR 1690 (22003): constant 18446744073709551615 overflows bigint

tidb> SELECT `pk` FROM `t` WHERE `pk` = 18446744073709551616;
Empty set (0.00 sec)
```

``` sql
drop table t;
CREATE TABLE `t` (
  `pk` bigint(20) unsigned NOT NULL,
  PRIMARY KEY (`pk`)
);

tidb> desc select * from t where pk = 18446744073709551615;
+-------------------+-------+------+----------------------------------------------------------------------------+
| id                | count | task | operator info                                                              |
+-------------------+-------+------+----------------------------------------------------------------------------+
| TableReader_6     | 0.33  | root | data:TableScan_5                                                           |
| └─TableScan_5     | 0.33  | cop  | table:t, range:[18446744073709551615,+inf], keep order:false, stats:pseudo |
+-------------------+-------+------+----------------------------------------------------------------------------+
2 rows in set (0.00 sec)



```
After this commit:
``` sql
CREATE TABLE `t` (
  `pk` bigint(11) signed NOT NULL,
  PRIMARY KEY (`pk`)
);
tidb> SELECT `pk` FROM `t` WHERE `pk` = 18446744073709551615;
Empty set (0.00 sec)
tidb> SELECT `pk` FROM `t` WHERE `pk` = 18446744073709551616;
Empty set (0.00 sec)
```

``` sql
drop table t;
CREATE TABLE `t` (
  `pk` bigint(20) unsigned NOT NULL,
  PRIMARY KEY (`pk`)
);
tidb> desc select * from t where pk = 18446744073709551615;
+-------------+-------+------+--------------------------------------+
| id          | count | task | operator info                        |
+-------------+-------+------+--------------------------------------+
| Point_Get_1 | 1.00  | root | table:t, handle:18446744073709551615 |
+-------------+-------+------+--------------------------------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?
1. Return TableDual when the constant overflows the range of the primary key type .
2. Do not cache the prepared plan when the plan is TableDual.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

