### PR TITLE
executor: fix show create table for partitioned table

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -784,9 +784,6 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		fmt.Fprintf(&buf, " COMPRESSION='%s'", tb.Meta().Compression)
 	}
 
-	// add partition info here.
-	appendPartitionInfo(tb.Meta().Partition, &buf)
-
 	if hasAutoIncID {
 		autoIncID, err := tb.Allocator(e.ctx).NextGlobalAutoID(tb.Meta().ID)
 		if err != nil {
@@ -809,6 +806,9 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	if len(tb.Meta().Comment) > 0 {
 		fmt.Fprintf(&buf, " COMMENT='%s'", format.OutputFormat(tb.Meta().Comment))
 	}
+	// add partition info here.
+	appendPartitionInfo(tb.Meta().Partition, &buf)
+
 	e.appendRow([]interface{}{tb.Meta().Name.O, buf.String()})
 	return nil
 }

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -470,6 +470,61 @@ func (s *testSuite2) TestShowCreateTable(c *C) {
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin/*!90000 SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=3 */",
 	))
 	tk.MustExec("drop table t")
+
+	tk.MustExec("CREATE TABLE `log` (" +
+		"`LOG_ID` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT," +
+		"`ROUND_ID` bigint(20) UNSIGNED NOT NULL," +
+		"`USER_ID` int(10) UNSIGNED NOT NULL," +
+		"`USER_IP` int(10) UNSIGNED DEFAULT NULL," +
+		"`END_TIME` datetime NOT NULL," +
+		"`USER_TYPE` int(11) DEFAULT NULL," +
+		"`APP_ID` int(11) DEFAULT NULL," +
+		"PRIMARY KEY (`LOG_ID`,`END_TIME`)," +
+		"KEY `IDX_EndTime` (`END_TIME`)," +
+		"KEY `IDX_RoundId` (`ROUND_ID`)," +
+		"KEY `IDX_UserId_EndTime` (`USER_ID`,`END_TIME`)" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=505488 " +
+		"PARTITION BY RANGE ( month(`end_time`) ) (" +
+		"PARTITION p1 VALUES LESS THAN (2)," +
+		"PARTITION p2 VALUES LESS THAN (3)," +
+		"PARTITION p3 VALUES LESS THAN (4)," +
+		"PARTITION p4 VALUES LESS THAN (5)," +
+		"PARTITION p5 VALUES LESS THAN (6)," +
+		"PARTITION p6 VALUES LESS THAN (7)," +
+		"PARTITION p7 VALUES LESS THAN (8)," +
+		"PARTITION p8 VALUES LESS THAN (9)," +
+		"PARTITION p9 VALUES LESS THAN (10)," +
+		"PARTITION p10 VALUES LESS THAN (11)," +
+		"PARTITION p11 VALUES LESS THAN (12)," +
+		"PARTITION p12 VALUES LESS THAN (MAXVALUE))")
+	tk.MustQuery("show create table log").Check(testutil.RowsWithSep("|",
+		"log CREATE TABLE `log` (\n"+
+			"  `LOG_ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n"+
+			"  `ROUND_ID` bigint(20) unsigned NOT NULL,\n"+
+			"  `USER_ID` int(10) unsigned NOT NULL,\n"+
+			"  `USER_IP` int(10) unsigned DEFAULT NULL,\n"+
+			"  `END_TIME` datetime NOT NULL,\n"+
+			"  `USER_TYPE` int(11) DEFAULT NULL,\n"+
+			"  `APP_ID` int(11) DEFAULT NULL,\n"+
+			"  PRIMARY KEY (`LOG_ID`,`END_TIME`),\n"+
+			"  KEY `IDX_EndTime` (`END_TIME`),\n"+
+			"  KEY `IDX_RoundId` (`ROUND_ID`),\n"+
+			"  KEY `IDX_UserId_EndTime` (`USER_ID`,`END_TIME`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=505488\n"+
+			"PARTITION BY RANGE ( month(`end_time`) ) (\n"+
+			"  PARTITION p1 VALUES LESS THAN (2),\n"+
+			"  PARTITION p2 VALUES LESS THAN (3),\n"+
+			"  PARTITION p3 VALUES LESS THAN (4),\n"+
+			"  PARTITION p4 VALUES LESS THAN (5),\n"+
+			"  PARTITION p5 VALUES LESS THAN (6),\n"+
+			"  PARTITION p6 VALUES LESS THAN (7),\n"+
+			"  PARTITION p7 VALUES LESS THAN (8),\n"+
+			"  PARTITION p8 VALUES LESS THAN (9),\n"+
+			"  PARTITION p9 VALUES LESS THAN (10),\n"+
+			"  PARTITION p10 VALUES LESS THAN (11),\n"+
+			"  PARTITION p11 VALUES LESS THAN (12),\n"+
+			"  PARTITION p12 VALUES LESS THAN (MAXVALUE)\n"+
+			")"))
 }
 
 func (s *testSuite2) TestShowEscape(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Show create table result:

```
CREATE TABLE `log` (
  `LOG_ID` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
  `ROUND_ID` bigint(20) unsigned NOT NULL,
  `USER_ID` int(10) unsigned NOT NULL,
  `USER_IP` int(10) unsigned DEFAULT NULL,
  `END_TIME` datetime NOT NULL,
  `USER_TYPE` int(11) DEFAULT NULL,
  `APP_ID` int(11) DEFAULT NULL,
  PRIMARY KEY (`LOG_ID`,`END_TIME`),
  KEY `IDX_EndTime` (`END_TIME`),
  KEY `IDX_RoundId` (`ROUND_ID`),
  KEY `IDX_UserId_EndTime` (`USER_ID`,`END_TIME`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin
PARTITION BY RANGE ( month(`end_time`) ) (
  PARTITION p1 VALUES LESS THAN (2),
  PARTITION p2 VALUES LESS THAN (3),
  PARTITION p3 VALUES LESS THAN (4),
  PARTITION p4 VALUES LESS THAN (5),
  PARTITION p5 VALUES LESS THAN (6),
  PARTITION p6 VALUES LESS THAN (7),
  PARTITION p7 VALUES LESS THAN (8),
  PARTITION p8 VALUES LESS THAN (9),
  PARTITION p9 VALUES LESS THAN (10),
  PARTITION p10 VALUES LESS THAN (11),
  PARTITION p11 VALUES LESS THAN (12),
  PARTITION p12 VALUES LESS THAN (MAXVALUE)
) AUTO_INCREMENT=505488
```

`AUTO_INCREMENT=505488` should not be after PARTITION definitions.
If there is a `COMMENT=xxx`, it would meet the same problem as `AUTO_INCREMENT=xxx`.

### What is changed and how it works?

Fix the order, let the PARTITION definitions come last

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

