### PR TITLE
ticlient: set max send/recv msg size match tikv's config

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -17,6 +17,7 @@ package tikv
 import (
 	"context"
 	"io"
+	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -42,11 +43,11 @@ import (
 
 // MaxSendMsgSize set max gRPC request message size sent to server. If any request message size is larger than
 // current value, an error will be reported from gRPC.
-var MaxSendMsgSize = 1<<31 - 1
+var MaxSendMsgSize = 10 * 1024 * 1024
 
-// MaxCallMsgSize set max gRPC receive message size received from server. If any message size is larger than
+// MaxRecvMsgSize set max gRPC receive message size received from server. If any message size is larger than
 // current value, an error will be reported from gRPC.
-var MaxCallMsgSize = 1<<31 - 1
+var MaxRecvMsgSize = math.MaxInt64
 
 // Timeout durations.
 const (
@@ -258,7 +259,7 @@ func (a *connArray) Init(addr string, security config.Security) error {
 			grpc.WithInitialConnWindowSize(grpcInitialConnWindowSize),
 			grpc.WithUnaryInterceptor(unaryInterceptor),
 			grpc.WithStreamInterceptor(streamInterceptor),
-			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxCallMsgSize)),
+			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),
 			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(MaxSendMsgSize)),
 			grpc.WithBackoffMaxDelay(time.Second*3),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Now TiDB and  TiKV use different max send/recv msg limit:

DB:

https://github.com/pingcap/tidb/blob/9b4940b735399bf2ad912d4acf61d00ef4cfe9ac/store/tikv/client.go#L56

KV:

https://github.com/tikv/tikv/blob/8dae71abe25cdcc511116f7d5b29312dffc2b152/src/server/server.rs#L108

### What is changed and how it works?

set TiDB's send to 10M and recv to ulimited(MaxInt)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10706)
<!-- Reviewable:end -->
