### PR TITLE
 *: remove all the "errors.Trace()" function calls

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -17,10 +17,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"go.uber.org/zap"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/mysql"

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -83,7 +83,7 @@ func Init() {
 
 	go func() {
 		err1 := http.ListenAndServe(":9191", nil)
-		terror.Log(errors.Trace(err1))
+		terror.Log(err1)
 	}()
 }
 
@@ -105,7 +105,7 @@ func batchRW(value []byte) {
 				}
 				key := fmt.Sprintf("key_%d", k)
 				err = txn.Set([]byte(key), value)
-				terror.Log(errors.Trace(err))
+				terror.Log(err)
 				err = txn.Commit(context.Background())
 				if err != nil {
 					txnRolledbackCounter.WithLabelValues("txn").Inc()
@@ -132,7 +132,7 @@ func main() {
 
 	defer terror.Call(resp.Body.Close)
 	text, err1 := ioutil.ReadAll(resp.Body)
-	terror.Log(errors.Trace(err1))
+	terror.Log(err1)
 
 	fmt.Println(string(text))
 

--- a/cmd/benchraw/main.go
+++ b/cmd/benchraw/main.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"

--- a/cmd/benchraw/main.go
+++ b/cmd/benchraw/main.go
@@ -76,7 +76,7 @@ func main() {
 	log.SetLevel(zap.WarnLevel)
 	go func() {
 		err := http.ListenAndServe(":9191", nil)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}()
 
 	value := make([]byte, *valueSize)

--- a/cmd/ddltest/ddl_test.go
+++ b/cmd/ddltest/ddl_test.go
@@ -198,12 +198,12 @@ func (s *TestDDLSuite) startServers() (err error) {
 		// Open log file.
 		logFP, err := os.OpenFile(fmt.Sprintf("%s%d", logFilePrefix, i), os.O_RDWR, 0766)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		s.procs[i], err = s.startServer(i, logFP)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
@@ -215,12 +215,12 @@ func (s *TestDDLSuite) killServer(proc *os.Process) error {
 	err := proc.Kill()
 	if err != nil {
 		log.Errorf("kill server failed err %v", err)
-		return errors.Trace(err)
+		return err
 	}
 	_, err = proc.Wait()
 	if err != nil {
 		log.Errorf("kill server, wait failed err %v", err)
-		return errors.Trace(err)
+		return err
 	}
 
 	time.Sleep(1 * time.Second)
@@ -235,7 +235,7 @@ func (s *TestDDLSuite) stopServers() error {
 		if s.procs[i] != nil {
 			err := s.killServer(s.procs[i].Process)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			s.procs[i] = nil
 		}
@@ -268,7 +268,7 @@ func (s *TestDDLSuite) startServer(i int, fp *os.File) (*server, error) {
 	cmd.Stdout = fp
 	err := cmd.Start()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	time.Sleep(500 * time.Millisecond)
 
@@ -302,13 +302,13 @@ func (s *TestDDLSuite) startServer(i int, fp *os.File) (*server, error) {
 	}
 	if err != nil {
 		log.Errorf("restart server addr %v failed %v, take time %v", addr, err, time.Since(startTime))
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	db.SetMaxOpenConns(10)
 
 	_, err = db.Exec("use test_ddl")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	log.Infof("start server %s ok %v", addr, err)
@@ -336,11 +336,11 @@ func (s *TestDDLSuite) restartServerRand() error {
 	log.Warnf("begin to restart %s", server.addr)
 	err := s.killServer(server.Process)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	s.procs[i], err = s.startServer(i, server.logFP)
-	return errors.Trace(err)
+	return err
 }
 
 func isRetryError(err error) bool {

--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -96,11 +96,11 @@ func newTester(name string) *tester {
 func (t *tester) Run() error {
 	queries, err := t.loadQueries()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	if err = t.openResult(); err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	var s string
@@ -214,7 +214,7 @@ func (t *tester) parserErrorHandle(query query, err error) error {
 	}
 
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// clear expected errors after we execute the first query
@@ -226,15 +226,15 @@ func (t *tester) parserErrorHandle(query query, err error) error {
 		gotBuf := t.buf.Bytes()[offset:]
 		buf := make([]byte, t.buf.Len()-offset)
 		if _, err = t.resultFD.ReadAt(buf, int64(offset)); err != nil {
-			return errors.Trace(errors.Errorf("run \"%v\" at line %d err, we got \n%s\nbut read result err %s", query.Query, query.Line, gotBuf, err))
+			return errors.Errorf("run \"%v\" at line %d err, we got \n%s\nbut read result err %s", query.Query, query.Line, gotBuf, err)
 		}
 
 		if !bytes.Equal(gotBuf, buf) {
-			return errors.Trace(errors.Errorf("run \"%v\" at line %d err, we need(%v):\n%s\nbut got(%v):\n%s\n", query.Query, query.Line, len(buf), buf, len(gotBuf), gotBuf))
+			return errors.Errorf("run \"%v\" at line %d err, we need(%v):\n%s\nbut got(%v):\n%s\n", query.Query, query.Line, len(buf), buf, len(gotBuf), gotBuf)
 		}
 	}
 
-	return errors.Trace(err)
+	return err
 }
 
 func (t *tester) executeDefault(qText string) (err error) {
@@ -349,7 +349,7 @@ func (t *tester) execute(query query) error {
 		t.singleQuery = false
 
 		if err != nil {
-			return errors.Trace(errors.Errorf("run \"%v\" at line %d err %v", st.Text(), query.Line, err))
+			return errors.Errorf("run \"%v\" at line %d err %v", st.Text(), query.Line, err)
 		}
 
 		if !record && !create {
@@ -358,15 +358,15 @@ func (t *tester) execute(query query) error {
 
 			buf := make([]byte, t.buf.Len()-offset)
 			if _, err = t.resultFD.ReadAt(buf, int64(offset)); err != nil {
-				return errors.Trace(errors.Errorf("run \"%v\" at line %d err, we got \n%s\nbut read result err %s", st.Text(), query.Line, gotBuf, err))
+				return errors.Errorf("run \"%v\" at line %d err, we got \n%s\nbut read result err %s", st.Text(), query.Line, gotBuf, err)
 			}
 
 			if !bytes.Equal(gotBuf, buf) {
-				return errors.Trace(errors.Errorf("run \"%v\" at line %d err, we need:\n%s\nbut got:\n%s\n", query.Query, query.Line, buf, gotBuf))
+				return errors.Errorf("run \"%v\" at line %d err, we need:\n%s\nbut got:\n%s\n", query.Query, query.Line, buf, gotBuf)
 			}
 		}
 	}
-	return errors.Trace(err)
+	return err
 }
 
 func filterWarning(err error) error {
@@ -397,7 +397,7 @@ func (t *tester) create(tableName string, qText string) error {
 	stderr := io.MultiWriter(os.Stderr, &stderrBuf)
 
 	if err = cmd.Start(); err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	go func() {
@@ -413,11 +413,11 @@ func (t *tester) create(tableName string, qText string) error {
 	}
 
 	if errStdout != nil {
-		return errors.Trace(errStdout)
+		return errStdout
 	}
 
 	if errStderr != nil {
-		return errors.Trace(errStderr)
+		return errStderr
 	}
 
 	if err = t.analyze(tableName); err != nil {
@@ -463,11 +463,11 @@ func (t *tester) executeStmt(query string) error {
 	if session.IsQuery(query) {
 		rows, err := t.tx.Query(query)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		cols, err := rows.Columns()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		for i, c := range cols {
@@ -487,7 +487,7 @@ func (t *tester) executeStmt(query string) error {
 		for rows.Next() {
 			err = rows.Scan(scanArgs...)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 
 			var value string
@@ -507,13 +507,13 @@ func (t *tester) executeStmt(query string) error {
 		}
 		err = rows.Err()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	} else {
 		// TODO: rows affected and last insert id
 		_, err := t.tx.Exec(query)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil
@@ -617,7 +617,7 @@ func openDBWithRetry(driverName, dataSourceName string) (mdb *sql.DB, err error)
 	}
 	if err != nil {
 		log.Error("open Db failed", zap.Duration("take time", time.Since(startTime)), zap.Error(err))
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return

--- a/cmd/importer/config.go
+++ b/cmd/importer/config.go
@@ -112,21 +112,21 @@ func (c *Config) Parse(arguments []string) error {
 	// Parse first to get config file.
 	err := c.FlagSet.Parse(arguments)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// Load config file if specified.
 	if c.configFile != "" {
 		err = c.configFromFile(c.configFile)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
 	// Parse again to replace with command line options.
 	err = c.FlagSet.Parse(arguments)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	if len(c.FlagSet.Args()) != 0 {
@@ -146,5 +146,5 @@ func (c *Config) String() string {
 // configFromFile loads config from file.
 func (c *Config) configFromFile(path string) error {
 	_, err := toml.DecodeFile(path, c)
-	return errors.Trace(err)
+	return err
 }

--- a/cmd/importer/db.go
+++ b/cmd/importer/db.go
@@ -107,7 +107,7 @@ func genRowDatas(table *table, count int) ([]string, error) {
 	for i := 0; i < count; i++ {
 		data, err := genRowData(table)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		datas = append(datas, data)
 	}
@@ -120,7 +120,7 @@ func genRowData(table *table) (string, error) {
 	for _, column := range table.columns {
 		data, err := genColumnData(table, column)
 		if err != nil {
-			return "", errors.Trace(err)
+			return "", err
 		}
 		values = append(values, []byte(data)...)
 		values = append(values, ',')
@@ -309,7 +309,7 @@ func execSQL(db *sql.DB, sql string) error {
 
 	_, err := db.Exec(sql)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	return nil
@@ -319,14 +319,14 @@ func createDB(cfg DBConfig) (*sql.DB, error) {
 	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name)
 	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return db, nil
 }
 
 func closeDB(db *sql.DB) error {
-	return errors.Trace(db.Close())
+	return db.Close()
 }
 
 func createDBs(cfg DBConfig, count int) ([]*sql.DB, error) {
@@ -334,7 +334,7 @@ func createDBs(cfg DBConfig, count int) ([]*sql.DB, error) {
 	for i := 0; i < count; i++ {
 		db, err := createDB(cfg)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 
 		dbs = append(dbs, db)

--- a/cmd/importer/parser.go
+++ b/cmd/importer/parser.go
@@ -237,7 +237,7 @@ func parseTable(t *table, stmt *ast.CreateTableStmt) error {
 
 	mockTbl, err := ddl.MockTableInfo(mock.NewContext(), stmt, 1)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	t.tblInfo = mockTbl
 
@@ -258,7 +258,7 @@ func parseTable(t *table, stmt *ast.CreateTableStmt) error {
 func parseTableSQL(table *table, sql string) error {
 	stmt, err := parser.New().ParseOneStmt(sql, "", "")
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	switch node := stmt.(type) {
@@ -268,7 +268,7 @@ func parseTableSQL(table *table, sql string) error {
 		err = errors.Errorf("invalid statement - %v", stmt.Text())
 	}
 
-	return errors.Trace(err)
+	return err
 }
 
 func parseIndex(table *table, stmt *ast.CreateIndexStmt) error {
@@ -295,7 +295,7 @@ func parseIndexSQL(table *table, sql string) error {
 
 	stmt, err := parser.New().ParseOneStmt(sql, "", "")
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	switch node := stmt.(type) {
@@ -305,5 +305,5 @@ func parseIndexSQL(table *table, sql string) error {
 		err = errors.Errorf("invalid statement - %v", stmt.Text())
 	}
 
-	return errors.Trace(err)
+	return err
 }

--- a/cmd/importer/stats.go
+++ b/cmd/importer/stats.go
@@ -33,12 +33,12 @@ import (
 func loadStats(tblInfo *model.TableInfo, path string) (*stats.Table, error) {
 	data, err := ioutil.ReadFile(path)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	jsTable := &handle.JSONTable{}
 	err = json.Unmarshal(data, jsTable)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return handle.TableStatsFromJSON(tblInfo, tblInfo.ID, jsTable)
 }

--- a/cmd/importer/stats.go
+++ b/cmd/importer/stats.go
@@ -19,7 +19,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
 	stats "github.com/pingcap/tidb/statistics"

--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -49,7 +49,7 @@ func (s *testColumnChangeSuite) SetUpSuite(c *C) {
 	}
 	err := kv.RunInNewTxn(s.store, true, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
-		return errors.Trace(t.CreateDatabase(s.dbInfo))
+		return t.CreateDatabase(s.dbInfo)
 	})
 	c.Check(err, IsNil)
 }
@@ -96,42 +96,42 @@ func (s *testColumnChangeSuite) TestColumnChange(c *C) {
 		prevState = job.SchemaState
 		err := hookCtx.NewTxn(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 		switch job.SchemaState {
 		case model.StateDeleteOnly:
 			deleteOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StateWriteOnly:
 			writeOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkAddWriteOnly(hookCtx, d, deleteOnlyTable, writeOnlyTable, h)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StatePublic:
 			mu.Lock()
 			publicTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkAddPublic(hookCtx, d, writeOnlyTable, publicTable)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			mu.Unlock()
 		}
 		txn, err := hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 		err = txn.Commit(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 	}
 	d.SetHook(tc)
@@ -162,31 +162,31 @@ func (s *testColumnChangeSuite) testAddColumnNoDefault(c *C, ctx sessionctx.Cont
 		prevState = job.SchemaState
 		err := hookCtx.NewTxn(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 		switch job.SchemaState {
 		case model.StateWriteOnly:
 			writeOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StatePublic:
 			_, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			_, err = writeOnlyTable.AddRecord(hookCtx, types.MakeDatums(10, 10))
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		}
 		txn, err := hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 		err = txn.Commit(context.TODO())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 	}
 	d.SetHook(tc)
@@ -210,7 +210,7 @@ func (s *testColumnChangeSuite) testColumnDrop(c *C, ctx sessionctx.Context, d *
 		prevState = job.SchemaState
 		currentTbl, err := getCurrentTable(d, s.dbInfo.ID, tbl.Meta().ID)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 		for _, col := range currentTbl.Cols() {
 			if col.ID == dropCol.ID {
@@ -228,25 +228,25 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(ctx sessionctx.Context, d *ddl
 	// WriteOnlyTable: insert t values (2, 3)
 	err := ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	_, err = writeOnlyTable.AddRecord(ctx, types.MakeDatums(2, 3))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(),
 		testutil.RowsWithSep(" ", "1 2 <nil>", "2 3 3"))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// This test is for RowWithCols when column state is StateWriteOnly.
 	row, err := writeOnlyTable.RowWithCols(ctx, h, writeOnlyTable.WritableCols())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	got := fmt.Sprintf("%v", row)
 	expect := fmt.Sprintf("%v", []types.Datum{types.NewDatum(1), types.NewDatum(2), types.NewDatum(nil)})
@@ -256,38 +256,38 @@ func (s *testColumnChangeSuite) checkAddWriteOnly(ctx sessionctx.Context, d *ddl
 	// DeleteOnlyTable: select * from t
 	err = checkResult(ctx, deleteOnlyTable, deleteOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "1 2", "2 3"))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// WriteOnlyTable: update t set c1 = 2 where c1 = 1
 	h, _, err = writeOnlyTable.Seek(ctx, 0)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = writeOnlyTable.UpdateRecord(ctx, h, types.MakeDatums(1, 2, 3), types.MakeDatums(2, 2, 3), touchedSlice(writeOnlyTable))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// After we update the first row, its default value is also set.
 	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "2 2 3", "2 3 3"))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// DeleteOnlyTable: delete from t where c2 = 2
 	err = deleteOnlyTable.RemoveRecord(ctx, h, types.MakeDatums(2, 2))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// After delete table has deleted the first row, check the WriteOnly table records.
 	err = checkResult(ctx, writeOnlyTable, writeOnlyTable.WritableCols(), testutil.RowsWithSep(" ", "2 3 3"))
-	return errors.Trace(err)
+	return err
 }
 
 func touchedSlice(t table.Table) []bool {
@@ -303,20 +303,20 @@ func (s *testColumnChangeSuite) checkAddPublic(sctx sessionctx.Context, d *ddl, 
 	// publicTable Insert t values (4, 4, 4)
 	err := sctx.NewTxn(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	h, err := publicTable.AddRecord(sctx, types.MakeDatums(4, 4, 4))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = sctx.NewTxn(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// writeOnlyTable update t set c1 = 3 where c1 = 4
 	oldRow, err := writeOnlyTable.RowWithCols(sctx, h, writeOnlyTable.WritableCols())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if len(oldRow) != 3 {
 		return errors.Errorf("%v", oldRow)
@@ -324,16 +324,16 @@ func (s *testColumnChangeSuite) checkAddPublic(sctx sessionctx.Context, d *ddl, 
 	newRow := types.MakeDatums(3, 4, oldRow[2].GetValue())
 	err = writeOnlyTable.UpdateRecord(sctx, h, oldRow, newRow, touchedSlice(writeOnlyTable))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = sctx.NewTxn(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// publicTable select * from t, make sure the new c3 value 4 is not overwritten to default value 3.
 	err = checkResult(sctx, publicTable, publicTable.WritableCols(), testutil.RowsWithSep(" ", "2 3 3", "3 4 4"))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -345,17 +345,17 @@ func getCurrentTable(d *ddl, schemaID, tableID int64) (table.Table, error) {
 		var err error
 		tblInfo, err = t.GetTable(schemaID, tableID)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	alloc := autoid.NewAllocator(d.store, schemaID, false)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return tbl, err
 }

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -324,11 +324,11 @@ func (t *testExecInfo) createSessions(store kv.Storage, useDB string) error {
 		for j, c := range info.cases {
 			c.session, err = session.CreateSession4Test(store)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			_, err = c.session.Execute(context.Background(), "use "+useDB)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			// It's used to debug.
 			c.session.SetConnectionID(uint64(i*10 + j))
@@ -348,7 +348,7 @@ func (t *testExecInfo) parseSQLs(p *parser.Parser) error {
 		for j := 0; j < t.execCases; j++ {
 			sqlInfo.cases[j].rawStmt, err = p.ParseOneStmt(sqlInfo.sql, charset, collation)
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 	}
@@ -364,7 +364,7 @@ func (t *testExecInfo) compileSQL(idx int) (err error) {
 		se.PrepareTxnCtx(ctx)
 		sctx := se.(sessionctx.Context)
 		if err = executor.ResetContextOfStmt(sctx, c.rawStmt); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		c.stmt, err = compiler.Compile(ctx, c.rawStmt)
 		if c.expectedCompileErr != nil {
@@ -375,7 +375,7 @@ func (t *testExecInfo) compileSQL(idx int) (err error) {
 			}
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil
@@ -396,11 +396,11 @@ func (t *testExecInfo) execSQL(idx int) error {
 			}
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		err = c.session.CommitTxn(context.TODO())
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1108,10 +1108,10 @@ func (s *testIntegrationSuite) getHistoryDDLJob(id int64) (*model.Job, error) {
 		t := meta.NewMeta(txn)
 		var err1 error
 		job, err1 = t.GetHistoryDDLJob(id)
-		return errors.Trace(err1)
+		return err1
 	})
 
-	return job, errors.Trace(err)
+	return job, err
 }
 
 func (s *testIntegrationSuite1) TestCreateTableTooLarge(c *C) {

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1239,33 +1239,33 @@ func backgroundExecOnJobUpdatedExported(c *C, store kv.Storage, ctx sessionctx.C
 		hookCtx.Store = store
 		err := hookCtx.NewTxn(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		jobIDs := []int64{job.ID}
 		txn, err := hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		errs, err := admin.CancelJobs(txn, jobIDs)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		// It only tests cancel one DDL job.
 		if errs[0] != nil {
-			checkErr = errors.Trace(errs[0])
+			checkErr = errs[0]
 			return
 		}
 		txn, err = hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		err = txn.Commit(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 	}
 	return hook.OnJobUpdatedExported, c3IdxInfo, checkErr

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -202,17 +202,17 @@ func (s *testDBSuite) testGetTable(c *C, name string) table.Table {
 func backgroundExec(s kv.Storage, sql string, done chan error) {
 	se, err := session.CreateSession4Test(s)
 	if err != nil {
-		done <- errors.Trace(err)
+		done <- err
 		return
 	}
 	defer se.Close()
 	_, err = se.Execute(context.Background(), "use test_db")
 	if err != nil {
-		done <- errors.Trace(err)
+		done <- err
 		return
 	}
 	_, err = se.Execute(context.Background(), sql)
-	done <- errors.Trace(err)
+	done <- err
 }
 
 func (s *testDBSuite2) TestAddUniqueIndexRollback(c *C) {
@@ -360,22 +360,22 @@ func (s *testDBSuite4) TestCancelAddIndex1(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.Background())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 
@@ -435,21 +435,21 @@ func (s *testDBSuite5) TestCancelDropIndex(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.TODO())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -504,21 +504,21 @@ func (s *testDBSuite5) TestCancelTruncateTable(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.Background())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -554,21 +554,21 @@ func (s *testDBSuite1) TestCancelRenameIndex(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.Background())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -624,21 +624,21 @@ func (s *testDBSuite2) TestCancelDropTableAndSchema(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.TODO())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -985,21 +985,21 @@ func (s *testDBSuite1) TestCancelAddTableAndDropTablePartition(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.Background())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -1134,21 +1134,21 @@ func (s *testDBSuite3) TestCancelDropColumn(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.TODO())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			checkErr = txn.Commit(context.Background())
@@ -2353,35 +2353,35 @@ func (s *testDBSuite5) TestModifyColumnRollBack(c *C) {
 		hookCtx.Store = s.store
 		err := hookCtx.NewTxn(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 
 		jobIDs := []int64{job.ID}
 		txn, err := hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		errs, err := admin.CancelJobs(txn, jobIDs)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		// It only tests cancel one DDL job.
 		if errs[0] != nil {
-			checkErr = errors.Trace(errs[0])
+			checkErr = errs[0]
 			return
 		}
 
 		txn, err = hookCtx.Txn(true)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return
 		}
 		err = txn.Commit(context.Background())
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 		}
 	}
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -429,7 +429,7 @@ func (d *ddl) start(ctx context.Context, ctxPool *pools.ResourcePool) {
 	// Otherwise, we needn't do that.
 	if RunWorker {
 		err := d.ownerManager.CampaignOwner(ctx)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 
 		d.workers = make(map[workerType]*worker, 2)
 		d.sessPool = newSessionPool(ctxPool)
@@ -515,10 +515,10 @@ func (d *ddl) genGlobalID() (int64, error) {
 		})
 
 		globalID, err = meta.NewMeta(txn).GenGlobalID()
-		return errors.Trace(err)
+		return err
 	})
 
-	return globalID, errors.Trace(err)
+	return globalID, err
 }
 
 // SchemaSyncer implements DDL.SchemaSyncer interface.
@@ -565,7 +565,7 @@ func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 	// Get a global job ID and put the DDL job in the queue.
 	err := d.addDDLJob(ctx, job)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	ctx.GetSessionVars().StmtCtx.IsDDLJobInQueue = true
 
@@ -608,7 +608,7 @@ func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 		}
 
 		if historyJob.Error != nil {
-			return errors.Trace(historyJob.Error)
+			return historyJob.Error
 		}
 		panic("When the state is JobStateRollbackDone or JobStateCancelled, historyJob.Error should never be nil")
 	}
@@ -619,7 +619,7 @@ func (d *ddl) callHookOnChanged(err error) error {
 	defer d.mu.RUnlock()
 
 	err = d.mu.hook.OnChanged(err)
-	return errors.Trace(err)
+	return err
 }
 
 // SetBinlogClient implements DDL.SetBinlogClient interface.

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -41,7 +41,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1597,10 +1597,7 @@ func (d *ddl) handleAutoIncID(tbInfo *model.TableInfo, schemaID int64) error {
 	// The operation of the minus 1 to make sure that the current value doesn't be used,
 	// the next Alloc operation will get this value.
 	// Its behavior is consistent with MySQL.
-	if err = tb.RebaseAutoID(nil, tbInfo.AutoIncID-1, false); err != nil {
-		return err
-	}
-	return nil
+	return tb.RebaseAutoID(nil, tbInfo.AutoIncID-1, false)
 }
 
 func resolveDefaultTableCharsetAndCollation(tbInfo *model.TableInfo, dbCharset string) (err error) {

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -340,12 +340,12 @@ func checkCancelState(txn kv.Transaction, job *model.Job, test *testCancelJob) e
 	if test.cancelState == job.SchemaState && !addIndexFirstReorg {
 		errs, err := admin.CancelJobs(txn, test.jobIDs)
 		if err != nil {
-			checkErr = errors.Trace(err)
+			checkErr = err
 			return checkErr
 		}
 		// It only tests cancel one DDL job.
 		if !terror.ErrorEqual(errs[0], test.cancelRetErrs[0]) {
-			checkErr = errors.Trace(errs[0])
+			checkErr = errs[0]
 			return checkErr
 		}
 	}
@@ -502,12 +502,12 @@ func (s *testDDLSuite) TestCancelJob(c *C) {
 		hookCtx.Store = store
 		err1 := hookCtx.NewTxn(context.Background())
 		if err1 != nil {
-			checkErr = errors.Trace(err1)
+			checkErr = err1
 			return
 		}
 		txn, err1 = hookCtx.Txn(true)
 		if err1 != nil {
-			checkErr = errors.Trace(err1)
+			checkErr = err1
 			return
 		}
 		mu.Lock()
@@ -518,7 +518,7 @@ func (s *testDDLSuite) TestCancelJob(c *C) {
 		}
 		err1 = txn.Commit(context.Background())
 		if err1 != nil {
-			checkErr = errors.Trace(err1)
+			checkErr = err1
 			return
 		}
 	}

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/ddl/util"

--- a/ddl/foreign_key.go
+++ b/ddl/foreign_key.go
@@ -14,7 +14,6 @@
 package ddl
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/meta"

--- a/ddl/foreign_key.go
+++ b/ddl/foreign_key.go
@@ -24,14 +24,14 @@ func onCreateForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
 	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, schemaID)
 	if err != nil {
-		return ver, errors.Trace(err)
+		return ver, err
 	}
 
 	var fkInfo model.FKInfo
 	err = job.DecodeArgs(&fkInfo)
 	if err != nil {
 		job.State = model.JobStateCancelled
-		return ver, errors.Trace(err)
+		return ver, err
 	}
 	fkInfo.ID = allocateIndexID(tblInfo)
 	tblInfo.ForeignKeys = append(tblInfo.ForeignKeys, &fkInfo)
@@ -44,7 +44,7 @@ func onCreateForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		fkInfo.State = model.StatePublic
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != fkInfo.State)
 		if err != nil {
-			return ver, errors.Trace(err)
+			return ver, err
 		}
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
@@ -58,7 +58,7 @@ func onDropForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	schemaID := job.SchemaID
 	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, schemaID)
 	if err != nil {
-		return ver, errors.Trace(err)
+		return ver, err
 	}
 
 	var (
@@ -69,7 +69,7 @@ func onDropForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	err = job.DecodeArgs(&fkName)
 	if err != nil {
 		job.State = model.JobStateCancelled
-		return ver, errors.Trace(err)
+		return ver, err
 	}
 
 	for _, fk := range tblInfo.ForeignKeys {
@@ -100,7 +100,7 @@ func onDropForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		fkInfo.State = model.StateNone
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != fkInfo.State)
 		if err != nil {
-			return ver, errors.Trace(err)
+			return ver, err
 		}
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -144,7 +144,7 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 		var t table.Table
 		t, err = testGetTableWithError(d, s.dbInfo.ID, tblInfo.ID)
 		if err != nil {
-			hookErr = errors.Trace(err)
+			hookErr = err
 			return
 		}
 		fk := getForeignKey(t, "c1_fk")
@@ -189,7 +189,7 @@ func (s *testForeighKeySuite) TestForeignKey(c *C) {
 		var t table.Table
 		t, err = testGetTableWithError(d, s.dbInfo.ID, tblInfo.ID)
 		if err != nil {
-			hookErr = errors.Trace(err)
+			hookErr = err
 			return
 		}
 		fk := getForeignKey(t, "c1_fk")

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -38,11 +38,11 @@ func verifyColumnGeneration(colName2Generation map[string]columnGenerationInDDL,
 					// A generated column definition can refer to other
 					// generated columns occurring earilier in the table.
 					err := errGeneratedColumnNonPrior.GenWithStackByArgs()
-					return errors.Trace(err)
+					return err
 				}
 			} else {
 				err := errBadField.GenWithStackByArgs(depCol, "generated column function")
-				return errors.Trace(err)
+				return err
 			}
 		}
 	}
@@ -151,14 +151,14 @@ func checkModifyGeneratedColumn(originCols []*table.Column, oldCol, newCol *tabl
 			colName = column.Name.L
 		}
 		if err := verifyColumnGeneration(colName2Generation, colName); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
 	// rule 3
 	if newCol.IsGenerated() {
 		if err := checkIllegalFn4GeneratedColumn(newCol.Name.L, newCol.GeneratedExpr); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -14,7 +14,6 @@
 package ddl
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/rowDecoder"
+	decoder "github.com/pingcap/tidb/util/rowDecoder"
 	"github.com/pingcap/tidb/util/timeutil"
 	"go.uber.org/zap"
 )

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -42,7 +42,7 @@ func (s *testIndexChangeSuite) SetUpSuite(c *C) {
 	}
 	err := kv.RunInNewTxn(s.store, true, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
-		return errors.Trace(t.CreateDatabase(s.dbInfo))
+		return t.CreateDatabase(s.dbInfo)
 	})
 	c.Check(err, IsNil, Commentf("err %v", errors.ErrorStack(err)))
 }
@@ -96,16 +96,16 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 		case model.StateDeleteOnly:
 			deleteOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StateWriteOnly:
 			writeOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkAddWriteOnly(d, ctx1, deleteOnlyTable, writeOnlyTable)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StatePublic:
 			if job.GetRowCount() != 3 {
@@ -113,11 +113,11 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 			}
 			publicTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkAddPublic(d, ctx1, writeOnlyTable, publicTable)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		}
 	}
@@ -141,25 +141,25 @@ func (s *testIndexChangeSuite) TestIndexChange(c *C) {
 		case model.StateWriteOnly:
 			writeOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkDropWriteOnly(d, ctx1, publicTable, writeOnlyTable)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StateDeleteOnly:
 			deleteOnlyTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			err = s.checkDropDeleteOnly(d, ctx1, writeOnlyTable, deleteOnlyTable)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 		case model.StateNone:
 			noneTable, err = getCurrentTable(d, s.dbInfo.ID, tblInfo.ID)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 			}
 			if len(noneTable.Indices()) != 0 {
 				checkErr = errors.New("index should have been dropped")
@@ -175,11 +175,11 @@ func checkIndexExists(ctx sessionctx.Context, tbl table.Table, indexValue interf
 	idx := tbl.Indices()[0]
 	txn, err := ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	doesExist, _, err := idx.Exist(ctx.GetSessionVars().StmtCtx, txn, types.MakeDatums(indexValue), handle)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if exists != doesExist {
 		if exists {
@@ -194,71 +194,71 @@ func (s *testIndexChangeSuite) checkAddWriteOnly(d *ddl, ctx sessionctx.Context,
 	// DeleteOnlyTable: insert t values (4, 4);
 	err := ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	_, err = delOnlyTbl.AddRecord(ctx, types.MakeDatums(4, 4))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, writeOnlyTbl, 4, 4, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable: insert t values (5, 5);
 	_, err = writeOnlyTbl.AddRecord(ctx, types.MakeDatums(5, 5))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, writeOnlyTbl, 5, 5, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable: update t set c2 = 1 where c1 = 4 and c2 = 4
 	err = writeOnlyTbl.UpdateRecord(ctx, 4, types.MakeDatums(4, 4), types.MakeDatums(4, 1), touchedSlice(writeOnlyTbl))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, writeOnlyTbl, 1, 4, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// DeleteOnlyTable: update t set c2 = 3 where c1 = 4 and c2 = 1
 	err = delOnlyTbl.UpdateRecord(ctx, 4, types.MakeDatums(4, 1), types.MakeDatums(4, 3), touchedSlice(writeOnlyTbl))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// old value index not exists.
 	err = checkIndexExists(ctx, writeOnlyTbl, 1, 4, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// new value index not exists.
 	err = checkIndexExists(ctx, writeOnlyTbl, 3, 4, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable: delete t where c1 = 4 and c2 = 3
 	err = writeOnlyTbl.RemoveRecord(ctx, 4, types.MakeDatums(4, 3))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, writeOnlyTbl, 3, 4, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// DeleteOnlyTable: delete t where c1 = 5
 	err = delOnlyTbl.RemoveRecord(ctx, 5, types.MakeDatums(5, 5))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, writeOnlyTbl, 5, 5, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -267,47 +267,47 @@ func (s *testIndexChangeSuite) checkAddPublic(d *ddl, ctx sessionctx.Context, wr
 	// WriteOnlyTable: insert t values (6, 6)
 	err := ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	_, err = writeTbl.AddRecord(ctx, types.MakeDatums(6, 6))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, publicTbl, 6, 6, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// PublicTable: insert t values (7, 7)
 	_, err = publicTbl.AddRecord(ctx, types.MakeDatums(7, 7))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, publicTbl, 7, 7, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable: update t set c2 = 5 where c1 = 7 and c2 = 7
 	err = writeTbl.UpdateRecord(ctx, 7, types.MakeDatums(7, 7), types.MakeDatums(7, 5), touchedSlice(writeTbl))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, publicTbl, 5, 7, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, publicTbl, 7, 7, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	// WriteOnlyTable: delete t where c1 = 6
 	err = writeTbl.RemoveRecord(ctx, 6, types.MakeDatums(6, 6))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = checkIndexExists(ctx, publicTbl, 6, 6, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	var rows [][]types.Datum
@@ -324,12 +324,12 @@ func (s *testIndexChangeSuite) checkAddPublic(d *ddl, ctx sessionctx.Context, wr
 		handle := row[0].GetInt64()
 		err = checkIndexExists(ctx, publicTbl, idxVal, handle, true)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	txn, err := ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return txn.Commit(context.Background())
 }
@@ -338,42 +338,42 @@ func (s *testIndexChangeSuite) checkDropWriteOnly(d *ddl, ctx sessionctx.Context
 	// WriteOnlyTable insert t values (8, 8)
 	err := ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	_, err = writeTbl.AddRecord(ctx, types.MakeDatums(8, 8))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, publicTbl, 8, 8, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable update t set c2 = 7 where c1 = 8 and c2 = 8
 	err = writeTbl.UpdateRecord(ctx, 8, types.MakeDatums(8, 8), types.MakeDatums(8, 7), touchedSlice(writeTbl))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, publicTbl, 7, 8, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// WriteOnlyTable delete t where c1 = 8
 	err = writeTbl.RemoveRecord(ctx, 8, types.MakeDatums(8, 7))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, publicTbl, 7, 8, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	txn, err := ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return txn.Commit(context.Background())
 }
@@ -382,47 +382,47 @@ func (s *testIndexChangeSuite) checkDropDeleteOnly(d *ddl, ctx sessionctx.Contex
 	// WriteOnlyTable insert t values (9, 9)
 	err := ctx.NewTxn(context.Background())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	_, err = writeTbl.AddRecord(ctx, types.MakeDatums(9, 9))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, writeTbl, 9, 9, true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// DeleteOnlyTable insert t values (10, 10)
 	_, err = delTbl.AddRecord(ctx, types.MakeDatums(10, 10))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, writeTbl, 10, 10, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// DeleteOnlyTable update t set c2 = 10 where c1 = 9
 	err = delTbl.UpdateRecord(ctx, 9, types.MakeDatums(9, 9), types.MakeDatums(9, 10), touchedSlice(delTbl))
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, writeTbl, 9, 9, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = checkIndexExists(ctx, writeTbl, 10, 9, false)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	txn, err := ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return txn.Commit(context.Background())
 }

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -103,7 +103,7 @@ func (s *MockSchemaSyncer) OwnerCheckAllVersions(ctx context.Context, latestVer 
 	for {
 		select {
 		case <-ctx.Done():
-			return errors.Trace(ctx.Err())
+			return ctx.Err()
 		case <-ticker.C:
 			ver := atomic.LoadInt64(&s.selfSchemaVersion)
 			if ver == latestVer {
@@ -141,21 +141,21 @@ func (dr *mockDelRange) clear() {}
 func MockTableInfo(ctx sessionctx.Context, stmt *ast.CreateTableStmt, tableID int64) (*model.TableInfo, error) {
 	cols, newConstraints, err := buildColumnsAndConstraints(ctx, stmt.Cols, stmt.Constraints, "", "")
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tbl, err := buildTableInfo(ctx, nil, stmt.Table.Name, cols, newConstraints)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tbl.ID = tableID
 
 	// The specified charset will be handled in handleTableOptions
 	if err = handleTableOptions(stmt.Options, tbl); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if err = resolveDefaultTableCharsetAndCollation(tbl, ""); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return tbl, nil

--- a/ddl/mock.go
+++ b/ddl/mock.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/sessionctx"

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -14,7 +14,6 @@
 package ddl
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -271,12 +271,12 @@ func testGetSchemaInfoWithError(d *ddl, schemaID int64) (*model.DBInfo, error) {
 		var err1 error
 		dbInfo, err1 = t.GetDatabase(schemaID)
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return dbInfo, nil
 }

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/infoschema"

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -93,26 +93,26 @@ func (s *testSerialSuite) TestCancelAddIndexPanic(c *C) {
 			hookCtx.Store = s.store
 			err := hookCtx.NewTxn(context.Background())
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			txn, err := hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			errs, err := admin.CancelJobs(txn, jobIDs)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			if errs[0] != nil {
-				checkErr = errors.Trace(errs[0])
+				checkErr = errs[0]
 				return
 			}
 			txn, err = hookCtx.Txn(true)
 			if err != nil {
-				checkErr = errors.Trace(err)
+				checkErr = err
 				return
 			}
 			checkErr = txn.Commit(context.Background())

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/ddl/session_pool.go
+++ b/ddl/session_pool.go
@@ -54,7 +54,7 @@ func (sg *sessionPool) get() (sessionctx.Context, error) {
 	// no need to protect sg.resPool
 	resource, err := sg.resPool.Get()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	ctx := resource.(sessionctx.Context)

--- a/ddl/stat.go
+++ b/ddl/stat.go
@@ -55,12 +55,12 @@ func (d *ddl) Stats(vars *variable.SessionVars) (map[string]interface{}, error) 
 		var err1 error
 		ddlInfo, err1 = admin.GetDDLInfo(txn)
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
-		return errors.Trace(err1)
+		return err1
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	m[ddlSchemaVersion] = ddlInfo.SchemaVer

--- a/ddl/stat.go
+++ b/ddl/stat.go
@@ -14,7 +14,6 @@
 package ddl
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/admin"

--- a/ddl/syncer.go
+++ b/ddl/syncer.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/clientv3/concurrency"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/util/logutil"

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -244,12 +244,12 @@ func testGetTableWithError(d *ddl, schemaID, tableID int64) (table.Table, error)
 		var err1 error
 		tblInfo, err1 = t.GetTable(schemaID, tableID)
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if tblInfo == nil {
 		return nil, errors.New("table not found")
@@ -257,7 +257,7 @@ func testGetTableWithError(d *ddl, schemaID, tableID int64) (table.Table, error)
 	alloc := autoid.NewAllocator(d.store, schemaID, false)
 	tbl, err := table.TableFromMeta(alloc, tblInfo)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return tbl, nil
 }

--- a/ddl/testutil/testutil.go
+++ b/ddl/testutil/testutil.go
@@ -32,19 +32,19 @@ func ExecMultiSQLInGoroutine(c *check.C, s kv.Storage, dbName string, multiSQL [
 	go func() {
 		se, err := session.CreateSession4Test(s)
 		if err != nil {
-			done <- errors.Trace(err)
+			done <- err
 			return
 		}
 		defer se.Close()
 		_, err = se.Execute(context.Background(), "use "+dbName)
 		if err != nil {
-			done <- errors.Trace(err)
+			done <- err
 			return
 		}
 		for _, sql := range multiSQL {
 			rs, err := se.Execute(context.Background(), sql)
 			if err != nil {
-				done <- errors.Trace(err)
+				done <- err
 				return
 			}
 			if rs != nil {

--- a/ddl/util/util.go
+++ b/ddl/util/util.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -159,7 +159,7 @@ func (r *selectResult) getSelectResp() error {
 	for {
 		re := <-r.results
 		if re.err != nil {
-			return errors.Trace(re.err)
+			return re.err
 		}
 		if r.memTracker != nil && r.selectResp != nil {
 			r.memTracker.Consume(-int64(r.selectResp.Size()))
@@ -174,7 +174,7 @@ func (r *selectResult) getSelectResp() error {
 		r.selectResp = new(tipb.SelectResponse)
 		err := r.selectResp.Unmarshal(re.result.GetData())
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if r.memTracker != nil && r.selectResp != nil {
 			r.memTracker.Consume(int64(r.selectResp.Size()))

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -75,7 +75,7 @@ func (r *streamResult) readDataFromResponse(ctx context.Context, resp kv.Respons
 	var stream tipb.StreamResponse
 	err = stream.Unmarshal(resultSubset.GetData())
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	if stream.Error != nil {
 		return false, errors.Errorf("stream response error: [%d]%s\n", stream.Error.Code, stream.Error.Msg)
@@ -86,7 +86,7 @@ func (r *streamResult) readDataFromResponse(ctx context.Context, resp kv.Respons
 
 	err = result.Unmarshal(stream.Data)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	r.feedback.Update(resultSubset.GetStartKey(), stream.OutputCounts)
 	r.partialCount++

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -546,7 +546,7 @@ func (do *Domain) Close() {
 	}
 	close(do.exit)
 	if do.etcdClient != nil {
-		terror.Log(errors.Trace(do.etcdClient.Close()))
+		terror.Log(do.etcdClient.Close())
 	}
 	do.sysSessionPool.Close()
 	do.slowQuery.Close()
@@ -610,7 +610,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 				TLS: ebd.TLSConfig(),
 			})
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			do.etcdClient = cli
 		}

--- a/domain/info.go
+++ b/domain/info.go
@@ -126,7 +126,7 @@ func (is *InfoSyncer) storeServerInfo(ctx context.Context) error {
 	}
 	infoBuf, err := json.Marshal(is.info)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	str := string(hack.String(infoBuf))
 	err = ddl.PutKVToEtcd(ctx, is.etcdCli, keyOpDefaultRetryCnt, is.serverInfoPath, str, clientv3.WithLease(is.session.Lease()))
@@ -181,7 +181,7 @@ func getInfo(ctx context.Context, etcdCli *clientv3.Client, key string, retryCnt
 	for i := 0; i < retryCnt; i++ {
 		select {
 		case <-ctx.Done():
-			err = errors.Trace(ctx.Err())
+			err = ctx.Err()
 			return nil, err
 		default:
 		}
@@ -199,13 +199,13 @@ func getInfo(ctx context.Context, etcdCli *clientv3.Client, key string, retryCnt
 			if err != nil {
 				logutil.Logger(context.Background()).Info("get key failed", zap.String("key", string(kv.Key)), zap.ByteString("value", kv.Value),
 					zap.Error(err))
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			allInfo[info.ID] = info
 		}
 		return allInfo, nil
 	}
-	return nil, errors.Trace(err)
+	return nil, err
 }
 
 // getServerInfo gets self tidb server information.

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -543,7 +543,7 @@ func (a *ExecStmt) buildExecutor() (Executor, error) {
 	b := newExecutorBuilder(ctx, a.InfoSchema)
 	e := b.build(a.Plan)
 	if b.err != nil {
-		return nil, errors.Trace(b.err)
+		return nil, b.err
 	}
 
 	// ExecuteExec is not a real Executor, we only use it to build another Executor from a prepared statement.

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1151,7 +1151,7 @@ func (b *executorBuilder) getStartTS() (uint64, error) {
 	}
 	b.startTS = startTS
 	if b.startTS == 0 {
-		return 0, errors.Trace(ErrGetStartTS)
+		return 0, ErrGetStartTS
 	}
 	return startTS, nil
 }
@@ -2092,7 +2092,7 @@ func buildKvRangesForIndexJoin(ctx sessionctx.Context, tableID, indexID int64, l
 				}
 				tmpKvRanges, err := distsql.IndexRangesToKVRanges(sc, tableID, indexID, ranges, nil)
 				if err != nil {
-					return nil, errors.Trace(err)
+					return nil, err
 				}
 				kvRanges = append(kvRanges, tmpKvRanges...)
 			}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -66,7 +66,7 @@ func (e *DDLExec) toErr(err error) error {
 	}
 	schemaInfoErr := checker.Check(txn.StartTS())
 	if schemaInfoErr != nil {
-		return errors.Trace(schemaInfoErr)
+		return schemaInfoErr
 	}
 	return err
 }
@@ -389,7 +389,7 @@ func (e *DDLExec) getRecoverTableByTableName(s *ast.RecoverTableStmt, t *meta.Me
 		schemaName = e.ctx.GetSessionVars().CurrentDB
 	}
 	if schemaName == "" {
-		return nil, nil, errors.Trace(core.ErrNoDB)
+		return nil, nil, core.ErrNoDB
 	}
 	// TODO: only search recent `e.JobNum` DDL jobs.
 	for i := len(jobs) - 1; i > 0; i-- {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -119,7 +119,7 @@ func closeAll(objs ...Closeable) error {
 		}
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -661,7 +661,7 @@ func (w *indexWorker) fetchHandles(ctx context.Context, result distsql.SelectRes
 				doneCh: doneCh,
 			}
 			if err != nil {
-				err = errors.Trace(err4Panic)
+				err = err4Panic
 			}
 		}
 	}()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1273,7 +1273,7 @@ func (e *UnionExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		return nil
 	}
 	if result.err != nil {
-		return errors.Trace(result.err)
+		return result.err
 	}
 
 	req.SwapColumns(result.chk)

--- a/executor/grant.go
+++ b/executor/grant.go
@@ -75,7 +75,7 @@ func (e *GrantExec) Next(ctx context.Context, req *chunk.RecordBatch) error {
 		} else if !exists {
 			pwd, ok := user.EncodedPassword()
 			if !ok {
-				return errors.Trace(ErrPasswordFormat)
+				return ErrPasswordFormat
 			}
 			user := fmt.Sprintf(`('%s', '%s', '%s')`, user.User.Hostname, user.User.Username, pwd)
 			sql := fmt.Sprintf(`INSERT INTO %s.%s (Host, User, Password) VALUES %s;`, mysql.SystemDB, mysql.UserTable, user)

--- a/executor/load_stats.go
+++ b/executor/load_stats.go
@@ -78,7 +78,7 @@ func (e *LoadStatsExec) Open(ctx context.Context) error {
 func (e *LoadStatsInfo) Update(data []byte) error {
 	jsonTbl := &handle.JSONTable{}
 	if err := json.Unmarshal(data, jsonTbl); err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	do := domain.GetDomain(e.Ctx)
 	h := do.StatsHandle()

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"sort"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -232,7 +232,7 @@ func (e *ExecuteExec) Build(b *executorBuilder) error {
 	stmtExec := b.build(e.plan)
 	if b.err != nil {
 		log.Warn("rebuild plan in EXECUTE statement failed", zap.String("labelName of PREPARE statement", e.name))
-		return errors.Trace(b.err)
+		return b.err
 	}
 	e.stmtExec = stmtExec
 	CountStmtNode(e.stmt, e.ctx.GetSessionVars().InRestrictedSQL)
@@ -252,7 +252,7 @@ func (e *DeallocateExec) Next(ctx context.Context, req *chunk.RecordBatch) error
 	vars := e.ctx.GetSessionVars()
 	id, ok := vars.PreparedStmtNameToID[e.Name]
 	if !ok {
-		return errors.Trace(plannercore.ErrStmtNotFound)
+		return plannercore.ErrStmtNotFound
 	}
 	delete(vars.PreparedStmtNameToID, e.Name)
 	if plannercore.PreparedPlanCacheEnabled() {

--- a/executor/set.go
+++ b/executor/set.go
@@ -160,7 +160,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 		}
 		oldSnapshotTS := sessionVars.SnapshotTS
 		if name == variable.TxnIsolationOneShot && sessionVars.InTxn() {
-			return errors.Trace(ErrCantChangeTxCharacteristics)
+			return ErrCantChangeTxCharacteristics
 		}
 		err = variable.SetSessionSystemVar(sessionVars, name, value)
 		if err != nil {

--- a/executor/show_stats.go
+++ b/executor/show_stats.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"

--- a/executor/show_stats.go
+++ b/executor/show_stats.go
@@ -143,13 +143,13 @@ func (e *ShowExec) appendTableForStatsBuckets(dbName, tblName, partitionName str
 	for _, col := range statsTbl.Columns {
 		err := e.bucketsToRows(dbName, tblName, partitionName, col.Info.Name.O, 0, col.Histogram)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	for _, idx := range statsTbl.Indices {
 		err := e.bucketsToRows(dbName, tblName, partitionName, idx.Info.Name.O, len(idx.Info.Columns), idx.Histogram)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return nil
@@ -165,11 +165,11 @@ func (e *ShowExec) bucketsToRows(dbName, tblName, partitionName, colName string,
 	for i := 0; i < hist.Len(); i++ {
 		lowerBoundStr, err := statistics.ValueToString(hist.GetLower(i), numOfCols)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		upperBoundStr, err := statistics.ValueToString(hist.GetUpper(i), numOfCols)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		e.appendRow([]interface{}{
 			dbName,

--- a/executor/trace.go
+++ b/executor/trace.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/opentracing/basictracer-go"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/chunk"

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -326,7 +326,7 @@ func (us *UnionScanExec) buildAndSortAddedRows(t table.Table) error {
 		sort.Sort(us)
 	}
 	if us.sortErr != nil {
-		return errors.Trace(us.sortErr)
+		return us.sortErr
 	}
 	return nil
 }
@@ -340,7 +340,7 @@ func (us *UnionScanExec) Len() int {
 func (us *UnionScanExec) Less(i, j int) bool {
 	cmp, err := us.compare(us.addedRows[i], us.addedRows[j])
 	if err != nil {
-		us.sortErr = errors.Trace(err)
+		us.sortErr = err
 		return true
 	}
 	return cmp < 0

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"

--- a/executor/window.go
+++ b/executor/window.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/cznic/mathutil"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 	"github.com/pingcap/tidb/expression"

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
 func boolToInt64(v bool) int64 {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util"
 )
 

--- a/expression/util.go
+++ b/expression/util.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/config"

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -97,7 +97,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 		// All types except DropTableOrView.
 		err := b.applyCreateTable(m, dbInfo, newTableID, alloc)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	return tblIDs, nil
@@ -116,7 +116,7 @@ func (b *Builder) copySortedTables(oldTableID, newTableID int64) {
 func (b *Builder) applyCreateSchema(m *meta.Meta, diff *model.SchemaDiff) error {
 	di, err := m.GetDatabase(diff.SchemaID)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if di == nil {
 		// When we apply an old schema diff, the database may has been dropped already, so we need to fall back to
@@ -132,7 +132,7 @@ func (b *Builder) applyCreateSchema(m *meta.Meta, diff *model.SchemaDiff) error 
 func (b *Builder) applyModifySchemaCharsetAndCollate(m *meta.Meta, diff *model.SchemaDiff) error {
 	di, err := m.GetDatabase(diff.SchemaID)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if di == nil {
 		// This should never happen.
@@ -182,7 +182,7 @@ func (b *Builder) copySortedTablesBucket(bucketIdx int) {
 func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID int64, alloc autoid.Allocator) error {
 	tblInfo, err := m.GetTable(dbInfo.ID, tableID)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if tblInfo == nil {
 		// When we apply an old schema diff, the table may has been dropped already, so we need to fall back to
@@ -201,7 +201,7 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 	}
 	tbl, err := tables.TableFromMeta(alloc, tblInfo)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	tableNames := b.is.schemaMap[dbInfo.Name.L]
 	tableNames.tables[tblInfo.Name.L] = tbl
@@ -312,7 +312,7 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 	for _, di := range dbInfos {
 		err := b.createSchemaTablesForDB(di, tables.TableFromMeta)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 
@@ -320,7 +320,7 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 	for _, driver := range drivers {
 		err := b.createSchemaTablesForDB(driver.DBInfo, driver.TableFromMeta)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	// TODO: Update INFORMATION_SCHEMA schema to use virtual table.
@@ -345,7 +345,7 @@ func (b *Builder) createSchemaTablesForDB(di *model.DBInfo, tableFromMeta tableF
 		var tbl table.Table
 		tbl, err := tableFromMeta(alloc, t)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		schTbls.tables[t.Name.L] = tbl
 		sortedTbls := b.is.sortedTablesBuckets[tableBucketIdx(t.ID)]

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -105,7 +105,7 @@ func (*testSuite) TestT(c *C) {
 	dbInfos := []*model.DBInfo{dbInfo}
 	err = kv.RunInNewTxn(store, true, func(txn kv.Transaction) error {
 		meta.NewMeta(txn).CreateDatabase(dbInfo)
-		return errors.Trace(err)
+		return err
 	})
 	c.Assert(err, IsNil)
 
@@ -194,7 +194,7 @@ func (*testSuite) TestT(c *C) {
 
 	err = kv.RunInNewTxn(store, true, func(txn kv.Transaction) error {
 		meta.NewMeta(txn).CreateTableOrView(dbID, tblInfo)
-		return errors.Trace(err)
+		return err
 	})
 	c.Assert(err, IsNil)
 	txn, err = store.Begin()
@@ -331,7 +331,7 @@ func genGlobalID(store kv.Storage) (int64, error) {
 	err := kv.RunInNewTxn(store, true, func(txn kv.Transaction) error {
 		var err error
 		globalID, err = meta.NewMeta(txn).GenGlobalID()
-		return errors.Trace(err)
+		return err
 	})
-	return globalID, errors.Trace(err)
+	return globalID, err
 }

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/infoschema"

--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -73,7 +73,7 @@ func dataForSlowLog(ctx sessionctx.Context) ([][]types.Datum, error) {
 func parseSlowLogFile(tz *time.Location, filePath string) ([][]types.Datum, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	defer func() {
 		if err = file.Close(); err != nil {

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -88,7 +88,7 @@ func (m *memDbBuffer) Get(k Key) ([]byte, error) {
 // Set associates key with value.
 func (m *memDbBuffer) Set(k Key, v []byte) error {
 	if len(v) == 0 {
-		return errors.Trace(ErrCannotSetNilValue)
+		return ErrCannotSetNilValue
 	}
 	if len(k)+len(v) > m.entrySizeLimit {
 		return ErrEntryTooLarge.GenWithStackByArgs(m.entrySizeLimit, len(k)+len(v))
@@ -101,13 +101,13 @@ func (m *memDbBuffer) Set(k Key, v []byte) error {
 	if m.Len() > int(m.bufferLenLimit) {
 		return ErrTxnTooLarge.GenWithStack("transaction too large, len:%d", m.Len())
 	}
-	return errors.Trace(err)
+	return err
 }
 
 // Delete removes the entry from buffer with provided key.
 func (m *memDbBuffer) Delete(k Key) error {
 	err := m.db.Put(k, nil)
-	return errors.Trace(err)
+	return err
 }
 
 // Size returns sum of keys and values length.
@@ -159,17 +159,17 @@ func (i *memDbIter) Close() {
 func WalkMemBuffer(memBuf MemBuffer, f func(k Key, v []byte) error) error {
 	iter, err := memBuf.Iter(nil, nil)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	defer iter.Close()
 	for iter.Valid() {
 		if err = f(iter.Key(), iter.Value()); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		err = iter.Next()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -18,7 +18,6 @@ package kv
 import (
 	"sync/atomic"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/goleveldb/leveldb"
 	"github.com/pingcap/goleveldb/leveldb/comparer"
 	"github.com/pingcap/goleveldb/leveldb/iterator"

--- a/kv/utils.go
+++ b/kv/utils.go
@@ -15,8 +15,6 @@ package kv
 
 import (
 	"strconv"
-
-	"github.com/pingcap/errors"
 )
 
 // IncInt64 increases the value for key k in kv store by step.

--- a/kv/utils.go
+++ b/kv/utils.go
@@ -35,7 +35,7 @@ func IncInt64(rm RetrieverMutator, k Key, step int64) (int64, error) {
 
 	intVal, err := strconv.ParseInt(string(val), 10, 0)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 
 	intVal += step
@@ -57,7 +57,7 @@ func GetInt64(r Retriever, k Key) (int64, error) {
 	}
 	intVal, err := strconv.ParseInt(string(val), 10, 0)
 	if err != nil {
-		return intVal, errors.Trace(err)
+		return intVal, err
 	}
 	return intVal, nil
 }

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -92,7 +92,7 @@ func (alloc *allocator) NextGlobalAutoID(tableID int64) (int64, error) {
 		m := meta.NewMeta(txn)
 		autoID, err1 = m.GetAutoTableID(alloc.dbID, tableID)
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
 		return nil
 	})

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -282,11 +282,7 @@ func (m *Meta) DropDatabase(dbID int64) error {
 		return err
 	}
 
-	if err := m.txn.HDel(mDBs, dbKey); err != nil {
-		return err
-	}
-
-	return nil
+	return m.txn.HDel(mDBs, dbKey)
 }
 
 // DropTableOrView drops table in database.

--- a/planner/core/cacheable_checker.go
+++ b/planner/core/cacheable_checker.go
@@ -16,7 +16,7 @@ package core
 import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
 // Cacheable checks whether the input ast is cacheable.

--- a/planner/core/cacheable_checker_test.go
+++ b/planner/core/cacheable_checker_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
 var _ = Suite(&testCacheableSuite{})

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -751,7 +751,7 @@ func (s *testAnalyzeSuite) TestInconsistentEstimation(c *C) {
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 
 	session.SetSchemaLease(0)
@@ -763,7 +763,7 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	}
 
 	dom.SetStatsUpdating(true)
-	return store, dom, errors.Trace(err)
+	return store, dom, err
 }
 
 func BenchmarkOptimize(b *testing.B) {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -161,11 +161,11 @@ func (e *Execute) OptimizePreparedPlan(ctx sessionctx.Context, is infoschema.Inf
 	}
 	prepared, ok := vars.PreparedStmts[e.ExecID]
 	if !ok {
-		return errors.Trace(ErrStmtNotFound)
+		return ErrStmtNotFound
 	}
 
 	if len(prepared.Params) != len(e.UsingVars) {
-		return errors.Trace(ErrWrongParamCount)
+		return ErrWrongParamCount
 	}
 
 	for i, usingVar := range e.UsingVars {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -138,7 +138,7 @@ func (b *PlanBuilder) getExpressionRewriter(p LogicalPlan) (rewriter *expression
 func (b *PlanBuilder) rewriteExprNode(rewriter *expressionRewriter, exprNode ast.ExprNode, asScalar bool) (expression.Expression, LogicalPlan, error) {
 	exprNode.Accept(rewriter)
 	if rewriter.err != nil {
-		return nil, nil, errors.Trace(rewriter.err)
+		return nil, nil, rewriter.err
 	}
 	if !asScalar && len(rewriter.ctxStack) == 0 {
 		return nil, rewriter.p, nil
@@ -148,7 +148,7 @@ func (b *PlanBuilder) rewriteExprNode(rewriter *expressionRewriter, exprNode ast
 	}
 	rewriter.err = expression.CheckArgsNotMultiColumnRow(rewriter.ctxStack[0])
 	if rewriter.err != nil {
-		return nil, nil, errors.Trace(rewriter.err)
+		return nil, nil, rewriter.err
 	}
 	return rewriter.ctxStack[0], rewriter.p, nil
 }

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/stringutil"
 )

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -40,7 +40,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 )
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1318,7 +1318,7 @@ func (b *PlanBuilder) resolveHavingAndOrderBy(sel *ast.SelectStmt, p LogicalPlan
 		extractor.curClause = havingClause
 		n, ok := sel.Having.Expr.Accept(extractor)
 		if !ok {
-			return nil, nil, errors.Trace(extractor.err)
+			return nil, nil, extractor.err
 		}
 		sel.Having.Expr = n.(ast.ExprNode)
 	}
@@ -1335,7 +1335,7 @@ func (b *PlanBuilder) resolveHavingAndOrderBy(sel *ast.SelectStmt, p LogicalPlan
 			}
 			n, ok := item.Expr.Accept(extractor)
 			if !ok {
-				return nil, nil, errors.Trace(extractor.err)
+				return nil, nil, extractor.err
 			}
 			item.Expr = n.(ast.ExprNode)
 		}
@@ -1851,7 +1851,7 @@ func (b *PlanBuilder) resolveGbyExprs(p LogicalPlan, gby *ast.GroupByClause, fie
 		resolver.inExpr = false
 		retExpr, _ := item.Expr.Accept(resolver)
 		if resolver.err != nil {
-			return nil, nil, errors.Trace(resolver.err)
+			return nil, nil, resolver.err
 		}
 		if !resolver.isParam {
 			item.Expr = retExpr.(ast.ExprNode)
@@ -3235,7 +3235,7 @@ func (b *PlanBuilder) groupWindowFuncs(windowFuncs []*ast.WindowFuncExpr) (map[*
 // We need to resolve the referenced window to get the definition of current window spec.
 func resolveWindowSpec(spec *ast.WindowSpec, specs map[string]*ast.WindowSpec, inStack map[string]bool) error {
 	if inStack[spec.Name.L] {
-		return errors.Trace(ErrWindowCircularityInWindowGraph)
+		return ErrWindowCircularityInWindowGraph
 	}
 	if spec.Ref.L == "" {
 		return nil
@@ -3264,7 +3264,7 @@ func mergeWindowSpec(spec, ref *ast.WindowSpec) error {
 		spec.OrderBy = ref.OrderBy
 	}
 	if spec.PartitionBy != nil {
-		return errors.Trace(ErrWindowNoChildPartitioning)
+		return ErrWindowNoChildPartitioning
 	}
 	spec.PartitionBy = ref.PartitionBy
 	spec.Ref = model.NewCIStr("")

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -50,12 +50,12 @@ func (s *testUnitTestSuit) SubstituteCol2CorCol(expr expression.Expression, colI
 		for _, arg := range x.GetArgs() {
 			newArg, err := s.SubstituteCol2CorCol(arg, colIDs)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			newArgs = append(newArgs, newArg)
 		}
 		newSf, err := expression.NewFunction(x.GetCtx(), x.FuncName.L, x.GetType(), newArgs...)
-		return newSf, errors.Trace(err)
+		return newSf, err
 	case *expression.Column:
 		if _, ok := colIDs[x.UniqueID]; ok {
 			return &expression.CorrelatedColumn{Column: *x}, nil

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -16,7 +16,6 @@ package core
 import (
 	"math"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/tidb/expression"

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -104,7 +104,7 @@ func DoOptimize(flag uint64, logic LogicalPlan) (PhysicalPlan, error) {
 		return nil, err
 	}
 	if !AllowCartesianProduct.Load() && existsCartesianProduct(logic) {
-		return nil, errors.Trace(ErrCartesianProductUnsupported)
+		return nil, ErrCartesianProductUnsupported
 	}
 	physical, err := physicalOptimize(logic)
 	if err != nil {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -777,7 +777,7 @@ func getPhysicalIDsAndPartitionNames(tblInfo *model.TableInfo, partitionNames []
 	pi := tblInfo.GetPartitionInfo()
 	if pi == nil {
 		if len(partitionNames) != 0 {
-			return nil, nil, errors.Trace(ddl.ErrPartitionMgmtOnNonpartitioned)
+			return nil, nil, ddl.ErrPartitionMgmtOnNonpartitioned
 		}
 		return []int64{tblInfo.ID}, []string{""}, nil
 	}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tipb/go-tipb"
 )
 

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
 // PreprocessOpt presents optional parameters to `Preprocess` method.

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -51,7 +51,7 @@ func Preprocess(ctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema,
 		optFn(&v)
 	}
 	node.Accept(&v)
-	return errors.Trace(v.err)
+	return v.err
 }
 
 type preprocessorFlag uint8
@@ -690,7 +690,7 @@ func (p *preprocessor) handleTableName(tn *ast.TableName) {
 	if tn.Schema.L == "" {
 		currentDB := p.ctx.GetSessionVars().CurrentDB
 		if currentDB == "" {
-			p.err = errors.Trace(ErrNoDB)
+			p.err = ErrNoDB
 			return
 		}
 		tn.Schema = model.NewCIStr(currentDB)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -168,7 +168,7 @@ func Load(ctx context.Context, cfg Config) (err error) {
 		var pName string
 		pName, _, err = ID(pluginID).Decode()
 		if err != nil {
-			err = errors.Trace(err)
+			err = err
 			return
 		}
 		// Check duplicate.
@@ -288,12 +288,12 @@ func loadOne(dir string, pluginID ID) (plugin Plugin, err error) {
 	plugin.Path = filepath.Join(dir, string(pluginID)+LibrarySuffix)
 	plugin.library, err = gplugin.Open(plugin.Path)
 	if err != nil {
-		err = errors.Trace(err)
+		err = err
 		return
 	}
 	manifestSym, err := plugin.library.Lookup(ManifestSymbol)
 	if err != nil {
-		err = errors.Trace(err)
+		err = err
 		return
 	}
 	manifest, ok := manifestSym.(func() *Manifest)
@@ -303,7 +303,7 @@ func loadOne(dir string, pluginID ID) (plugin Plugin, err error) {
 	}
 	pName, pVersion, err := pluginID.Decode()
 	if err != nil {
-		err = errors.Trace(err)
+		err = err
 		return
 	}
 	plugin.Manifest = manifest()

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -287,6 +287,6 @@ func (s *Server) handleStatus(w http.ResponseWriter, req *http.Request) {
 		logutil.Logger(context.Background()).Error("encode json failed", zap.Error(err))
 	} else {
 		_, err = w.Write(js)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}
 }

--- a/server/packetio.go
+++ b/server/packetio.go
@@ -39,7 +39,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 )

--- a/server/packetio.go
+++ b/server/packetio.go
@@ -77,7 +77,7 @@ func (p *packetIO) readOnePacket() ([]byte, error) {
 		}
 	}
 	if _, err := io.ReadFull(p.bufReadConn, header[:]); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	sequence := header[3]
@@ -96,7 +96,7 @@ func (p *packetIO) readOnePacket() ([]byte, error) {
 		}
 	}
 	if _, err := io.ReadFull(p.bufReadConn, data); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return data, nil
 }
@@ -104,7 +104,7 @@ func (p *packetIO) readOnePacket() ([]byte, error) {
 func (p *packetIO) readPacket() ([]byte, error) {
 	data, err := p.readOnePacket()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if len(data) < mysql.MaxPayloadLen {
@@ -115,7 +115,7 @@ func (p *packetIO) readPacket() ([]byte, error) {
 	for {
 		buf, err := p.readOnePacket()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 
 		data = append(data, buf...)
@@ -140,9 +140,9 @@ func (p *packetIO) writePacket(data []byte) error {
 		data[3] = p.sequence
 
 		if n, err := p.bufWriter.Write(data[:4+mysql.MaxPayloadLen]); err != nil {
-			return errors.Trace(mysql.ErrBadConn)
+			return mysql.ErrBadConn
 		} else if n != (4 + mysql.MaxPayloadLen) {
-			return errors.Trace(mysql.ErrBadConn)
+			return mysql.ErrBadConn
 		} else {
 			p.sequence++
 			length -= mysql.MaxPayloadLen
@@ -156,10 +156,10 @@ func (p *packetIO) writePacket(data []byte) error {
 	data[3] = p.sequence
 
 	if n, err := p.bufWriter.Write(data); err != nil {
-		terror.Log(errors.Trace(err))
-		return errors.Trace(mysql.ErrBadConn)
+		terror.Log(err)
+		return mysql.ErrBadConn
 	} else if n != len(data) {
-		return errors.Trace(mysql.ErrBadConn)
+		return mysql.ErrBadConn
 	} else {
 		p.sequence++
 		return nil
@@ -169,7 +169,7 @@ func (p *packetIO) writePacket(data []byte) error {
 func (p *packetIO) flush() error {
 	err := p.bufWriter.Flush()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return err
 }

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -212,7 +212,7 @@ func (ts *TidbTestSuite) TestSocket(c *C) {
 func generateCert(sn int, commonName string, parentCert *x509.Certificate, parentCertKey *rsa.PrivateKey, outKeyFile string, outCertFile string) (*x509.Certificate, *rsa.PrivateKey, error) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 528)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	notBefore := time.Now().Add(-10 * time.Minute).UTC()
 	notAfter := notBefore.Add(1 * time.Hour).UTC()
@@ -242,24 +242,24 @@ func generateCert(sn int, commonName string, parentCert *x509.Certificate, paren
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, parent, &privateKey.PublicKey, priv)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 
 	cert, err := x509.ParseCertificate(derBytes)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 
 	certOut, err := os.Create(outCertFile)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	certOut.Close()
 
 	keyOut, err := os.OpenFile(outKeyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
 	keyOut.Close()

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -15,7 +15,6 @@ package server
 
 import (
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -31,11 +31,11 @@ var _ = Suite(&testUtilSuite{})
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	session.SetSchemaLease(0)
 	dom, err := session.BootstrapSession(store)
-	return store, dom, errors.Trace(err)
+	return store, dom, err
 }
 
 type testUtilSuite struct {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -351,13 +351,13 @@ func checkBootstrapped(s Session) (bool, error) {
 		if infoschema.ErrTableNotExists.Equal(err) {
 			return false, nil
 		}
-		return false, errors.Trace(err)
+		return false, err
 	}
 	isBootstrapped := sVal == bootstrappedVarTrue
 	if isBootstrapped {
 		// Make sure that doesn't affect the following operations.
 		if err = s.CommitTxn(context.Background()); err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 	}
 	return isBootstrapped, nil
@@ -371,7 +371,7 @@ func getTiDBVar(s Session, name string) (sVal string, isNull bool, e error) {
 	ctx := context.Background()
 	rs, err := s.Execute(ctx, sql)
 	if err != nil {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	if len(rs) != 1 {
 		return "", true, errors.New("Wrong number of Recordset")
@@ -381,7 +381,7 @@ func getTiDBVar(s Session, name string) (sVal string, isNull bool, e error) {
 	req := r.NewRecordBatch()
 	err = r.Next(ctx, req)
 	if err != nil || req.NumRows() == 0 {
-		return "", true, errors.Trace(err)
+		return "", true, err
 	}
 	row := req.GetRow(0)
 	if row.IsNull(0) {
@@ -837,7 +837,7 @@ func updateBootstrapVer(s Session) {
 func getBootstrapVersion(s Session) (int64, error) {
 	sVal, isNull, err := getTiDBVar(s, tidbServerVersionVar)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	if isNull {
 		return 0, nil
@@ -946,7 +946,7 @@ func mustExecute(s Session, sql string) {
 func oldPasswordUpgrade(pass string) (string, error) {
 	hash1, err := hex.DecodeString(pass)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 
 	hash2 := auth.Sha1Hash(hash1)

--- a/session/session.go
+++ b/session/session.go
@@ -367,7 +367,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		if prewriteValue != nil {
 			prewriteData, err := prewriteValue.Marshal()
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			info := &binloginfo.BinlogInfo{
 				Data: &binlog.Binlog{
@@ -521,7 +521,7 @@ func (s *session) String() string {
 		data["preparedStmtCount"] = len(sessVars.PreparedStmts)
 	}
 	b, err := json.MarshalIndent(data, "", "  ")
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return string(b)
 }
 
@@ -1342,7 +1342,7 @@ func getHostByIP(ip string) []string {
 		return []string{variable.DefHostname}
 	}
 	addrs, err := net.LookupAddr(ip)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return addrs
 }
 

--- a/session/txn.go
+++ b/session/txn.go
@@ -176,7 +176,7 @@ func (st *TxnState) Commit(ctx context.Context) error {
 		if err1 := st.Transaction.Rollback(); err1 != nil {
 			logutil.Logger(context.Background()).Error("rollback error", zap.Error(err1))
 		}
-		return errors.Trace(st.doNotCommit)
+		return st.doNotCommit
 	}
 
 	// mockCommitError8942 is used for PR #8942.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -672,7 +672,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		// Modes is a list of different modes separated by commas.
 		sqlMode, err2 := mysql.GetSQLMode(val)
 		if err2 != nil {
-			return errors.Trace(err2)
+			return err2
 		}
 		s.StrictSQLMode = sqlMode.HasStrictMode()
 		s.SQLMode = sqlMode

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/klauspost/cpuid"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -14,7 +14,6 @@
 package statistics
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"

--- a/statistics/builder.go
+++ b/statistics/builder.go
@@ -56,7 +56,7 @@ func (b *SortedBuilder) Iterate(data types.Datum) error {
 	}
 	cmp, err := b.hist.GetUpper(int(b.bucketIdx)).CompareDatum(b.sc, &data)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if cmp == 0 {
 		// The new item has the same value as current bucket value, to ensure that
@@ -135,7 +135,7 @@ func BuildColumnHist(ctx sessionctx.Context, numBuckets, id int64, collector *Sa
 		corrXYSum += float64(i) * float64(samples[i].Ordinal)
 		cmp, err := hg.GetUpper(bucketIdx).CompareDatum(sc, &samples[i].Value)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		totalCount := float64(i+1) * sampleFactor
 		if cmp == 0 {

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -240,7 +240,7 @@ func (c *CMSketch) setValue(h1, h2 uint64, count uint64) {
 func (c *CMSketch) queryValue(sc *stmtctx.StatementContext, val types.Datum) (uint64, error) {
 	bytes, err := codec.EncodeValue(sc, nil, val)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	return c.QueryBytes(bytes), nil
 }
@@ -386,7 +386,7 @@ func decodeCMSketch(data []byte, topN []*TopNMeta) (*CMSketch, error) {
 	p := &tipb.CMSketch{}
 	err := p.Unmarshal(data)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if len(p.Rows) == 0 && len(topN) == 0 {
 		return nil, nil

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -30,7 +30,7 @@ import (
 func (c *CMSketch) insert(val *types.Datum) error {
 	bytes, err := codec.EncodeValue(nil, nil, *val)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	c.InsertBytes(bytes)
 	return nil
@@ -41,7 +41,7 @@ func prepareCMSWithTopN(d, w int32, vals []*types.Datum, n uint32, total uint64)
 	for _, v := range vals {
 		bytes, err := codec.EncodeValue(nil, nil, *v)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		data = append(data, bytes)
 	}
@@ -57,7 +57,7 @@ func buildCMSketchAndMap(d, w int32, seed int64, total, imax uint64, s float64) 
 		val := types.NewIntDatum(int64(zipf.Uint64()))
 		err := cms.insert(&val)
 		if err != nil {
-			return nil, nil, errors.Trace(err)
+			return nil, nil, err
 		}
 		mp[val.GetInt64()]++
 	}
@@ -85,7 +85,7 @@ func averageAbsoluteError(cms *CMSketch, mp map[int64]uint32) (uint64, error) {
 	for num, count := range mp {
 		estimate, err := cms.queryValue(sc, types.NewIntDatum(num))
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		var diff uint64
 		if uint64(count) > estimate {

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"

--- a/statistics/fmsketch.go
+++ b/statistics/fmsketch.go
@@ -16,7 +16,6 @@ package statistics
 import (
 	"hash"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"

--- a/statistics/fmsketch.go
+++ b/statistics/fmsketch.go
@@ -65,12 +65,12 @@ func (s *FMSketch) insertHashValue(hashVal uint64) {
 func (s *FMSketch) InsertValue(sc *stmtctx.StatementContext, value types.Datum) error {
 	bytes, err := codec.EncodeValue(sc, nil, value)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	s.hashFunc.Reset()
 	_, err = s.hashFunc.Write(bytes)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	s.insertHashValue(s.hashFunc.Sum64())
 	return nil
@@ -81,7 +81,7 @@ func buildFMSketch(sc *stmtctx.StatementContext, values []types.Datum, maxSize i
 	for _, value := range values {
 		err := s.InsertValue(sc, value)
 		if err != nil {
-			return nil, 0, errors.Trace(err)
+			return nil, 0, err
 		}
 	}
 	return s, s.NDV(), nil

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -66,7 +66,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (StatsCache, error) {
 		defer terror.Call(rc[0].Close)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	tables := StatsCache{}
 	req := rc[0].NewRecordBatch()
@@ -74,7 +74,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (StatsCache, error) {
 	for {
 		err := rc[0].Next(context.TODO(), req)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		if req.NumRows() == 0 {
 			break
@@ -106,7 +106,7 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, tables Stat
 			cms, err := statistics.LoadCMSketchWithTopN(h.restrictedExec, row.GetInt64(0), row.GetInt64(1), row.GetInt64(2), row.GetBytes(6))
 			if err != nil {
 				cms = nil
-				terror.Log(errors.Trace(err))
+				terror.Log(err)
 			}
 			hist := statistics.NewHistogram(id, ndv, nullCount, version, types.NewFieldType(mysql.TypeBlob), chunk.InitialCapacity, 0)
 			table.Indices[hist.ID] = &statistics.Index{Histogram: *hist, CMSketch: cms, Info: idxInfo, StatsVer: row.GetInt64(8), Flag: row.GetInt64(10), LastAnalyzePos: row.GetDatum(11, types.NewFieldType(mysql.TypeBlob))}
@@ -145,14 +145,14 @@ func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, tables StatsCache
 		defer terror.Call(rc[0].Close)
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	req := rc[0].NewRecordBatch()
 	iter := chunk.NewIterator4Chunk(req.Chunk)
 	for {
 		err := rc[0].Next(context.TODO(), req)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if req.NumRows() == 0 {
 			break
@@ -217,14 +217,14 @@ func (h *Handle) initStatsBuckets(tables StatsCache) error {
 		defer terror.Call(rc[0].Close)
 	}
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	req := rc[0].NewRecordBatch()
 	iter := chunk.NewIterator4Chunk(req.Chunk)
 	for {
 		err := rc[0].Next(context.TODO(), req)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if req.NumRows() == 0 {
 			break
@@ -255,15 +255,15 @@ func (h *Handle) initStatsBuckets(tables StatsCache) error {
 func (h *Handle) InitStats(is infoschema.InfoSchema) error {
 	tables, err := h.initStatsMeta(is)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = h.initStatsHistograms(is, tables)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	err = h.initStatsBuckets(tables)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	h.StatsCache.Store(tables)
 	return nil

--- a/statistics/handle/ddl.go
+++ b/statistics/handle/ddl.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/statistics/handle/ddl.go
+++ b/statistics/handle/ddl.go
@@ -72,14 +72,14 @@ func (h *Handle) insertTableStats2KV(info *model.TableInfo, physicalID int64) (e
 	exec := h.mu.ctx.(sqlexec.SQLExecutor)
 	_, err = exec.Execute(context.Background(), "begin")
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	defer func() {
 		err = finishTransaction(context.Background(), exec, err)
 	}()
 	txn, err := h.mu.ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	startTS := txn.StartTS()
 	_, err = exec.Execute(context.Background(), fmt.Sprintf("insert into mysql.stats_meta (version, table_id) values(%d, %d)", startTS, physicalID))
@@ -110,14 +110,14 @@ func (h *Handle) insertColStats2KV(physicalID int64, colInfo *model.ColumnInfo) 
 	exec := h.mu.ctx.(sqlexec.SQLExecutor)
 	_, err = exec.Execute(context.Background(), "begin")
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	defer func() {
 		err = finishTransaction(context.Background(), exec, err)
 	}()
 	txn, err := h.mu.ctx.Txn(true)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	startTS := txn.StartTS()
 	// First of all, we update the version.
@@ -180,7 +180,7 @@ func finishTransaction(ctx context.Context, exec sqlexec.SQLExecutor, err error)
 		_, err = exec.Execute(ctx, "commit")
 	} else {
 		_, err1 := exec.Execute(ctx, "rollback")
-		terror.Log(errors.Trace(err1))
+		terror.Log(err1)
 	}
-	return errors.Trace(err)
+	return err
 }

--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/util/sqlexec"
 )

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -434,14 +434,14 @@ func (s *testStatsSuite) TestLoadStats(c *C) {
 func newStoreWithBootstrap(statsLease time.Duration) (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	session.SetSchemaLease(0)
 	session.SetStatsLease(statsLease)
 	domain.RunAutoAnalyze = false
 	do, err := session.BootstrapSession(store)
 	do.SetStatsUpdating(true)
-	return store, do, errors.Trace(err)
+	return store, do, err
 }
 
 func (s *testStatsSuite) TestCorrelation(c *C) {

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -92,11 +92,11 @@ func (c *SampleCollector) MergeSampleCollector(sc *stmtctx.StatementContext, rc 
 	c.FMSketch.mergeFMSketch(rc.FMSketch)
 	if rc.CMSketch != nil {
 		err := c.CMSketch.MergeCMSketch(rc.CMSketch)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}
 	for _, item := range rc.Samples {
 		err := c.collect(sc, item.Value)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 	}
 }
 
@@ -148,7 +148,7 @@ func (c *SampleCollector) collect(sc *stmtctx.StatementContext, d types.Datum) e
 		}
 		c.Count++
 		if err := c.FMSketch.InsertValue(sc, d); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if c.CMSketch != nil {
 			c.CMSketch.InsertBytes(d.GetBytes())
@@ -222,7 +222,7 @@ func (s SampleBuilder) CollectColumnStats() ([]*SampleCollector, *SortedBuilder,
 	for {
 		err := s.RecordSet.Next(ctx, req)
 		if err != nil {
-			return nil, nil, errors.Trace(err)
+			return nil, nil, err
 		}
 		if req.NumRows() == 0 {
 			return collectors, s.PkBuilder, nil
@@ -235,14 +235,14 @@ func (s SampleBuilder) CollectColumnStats() ([]*SampleCollector, *SortedBuilder,
 			if s.PkBuilder != nil {
 				err = s.PkBuilder.Iterate(datums[0])
 				if err != nil {
-					return nil, nil, errors.Trace(err)
+					return nil, nil, err
 				}
 				datums = datums[1:]
 			}
 			for i, val := range datums {
 				err = collectors[i].collect(s.Sc, val)
 				if err != nil {
-					return nil, nil, errors.Trace(err)
+					return nil, nil, err
 				}
 			}
 		}

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -191,7 +191,7 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 		if col != nil {
 			maskCovered, ranges, _, err := getMaskAndRanges(ctx, remainedExprs, ranger.ColumnRangeType, nil, col)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, nil, err
 			}
 			nodes = append(nodes, &StatsNode{Tp: ColType, ID: id, mask: maskCovered, Ranges: ranges, numCols: 1})
 			if colInfo.IsHandle {
@@ -199,14 +199,14 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 				var cnt float64
 				cnt, err = coll.GetRowCountByIntColumnRanges(sc, id, ranges)
 				if err != nil {
-					return 0, nil, errors.Trace(err)
+					return 0, nil, err
 				}
 				nodes[len(nodes)-1].Selectivity = cnt / float64(coll.Count)
 				continue
 			}
 			cnt, err := coll.GetRowCountByColumnRanges(sc, id, ranges)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, nil, err
 			}
 			nodes[len(nodes)-1].Selectivity = cnt / float64(coll.Count)
 		}
@@ -220,11 +220,11 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 			}
 			maskCovered, ranges, partCover, err := getMaskAndRanges(ctx, remainedExprs, ranger.IndexRangeType, lengths, idxCols...)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, nil, err
 			}
 			cnt, err := coll.GetRowCountByIndexRanges(sc, id, ranges)
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, nil, err
 			}
 			selectivity := cnt / float64(coll.Count)
 			nodes = append(nodes, &StatsNode{

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -16,7 +16,6 @@ package statistics
 import (
 	"math"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -118,14 +118,14 @@ func (h *logHook) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.Chec
 func newStoreWithBootstrap(statsLease time.Duration) (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	session.SetSchemaLease(0)
 	session.SetStatsLease(statsLease)
 	domain.RunAutoAnalyze = false
 	do, err := session.BootstrapSession(store)
 	do.SetStatsUpdating(true)
-	return store, do, errors.Trace(err)
+	return store, do, err
 }
 
 func cleanEnv(c *C, store kv.Storage, do *domain.Domain) {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -180,7 +180,7 @@ func buildPK(sctx sessionctx.Context, numBuckets, id int64, records sqlexec.Reco
 		req := records.NewRecordBatch()
 		err := records.Next(ctx, req)
 		if err != nil {
-			return 0, nil, errors.Trace(err)
+			return 0, nil, err
 		}
 		if req.NumRows() == 0 {
 			break
@@ -190,7 +190,7 @@ func buildPK(sctx sessionctx.Context, numBuckets, id int64, records sqlexec.Reco
 			datums := RowToDatums(row, records.Fields())
 			err = b.Iterate(datums[0])
 			if err != nil {
-				return 0, nil, errors.Trace(err)
+				return 0, nil, err
 			}
 		}
 	}
@@ -206,7 +206,7 @@ func buildIndex(sctx sessionctx.Context, numBuckets, id int64, records sqlexec.R
 	for {
 		err := records.Next(ctx, req)
 		if err != nil {
-			return 0, nil, nil, errors.Trace(err)
+			return 0, nil, nil, err
 		}
 		if req.NumRows() == 0 {
 			break
@@ -215,12 +215,12 @@ func buildIndex(sctx sessionctx.Context, numBuckets, id int64, records sqlexec.R
 			datums := RowToDatums(row, records.Fields())
 			buf, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, datums...)
 			if err != nil {
-				return 0, nil, nil, errors.Trace(err)
+				return 0, nil, nil, err
 			}
 			data := types.NewBytesDatum(buf)
 			err = b.Iterate(data)
 			if err != nil {
-				return 0, nil, nil, errors.Trace(err)
+				return 0, nil, nil, err
 			}
 			cms.InsertBytes(buf)
 		}

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -221,7 +221,7 @@ func (t *Table) ColumnEqualRowCount(sc *stmtctx.StatementContext, value types.Da
 	}
 	result, err := c.equalRowCount(sc, value, t.ModifyCount)
 	result *= c.GetIncreaseFactor(t.Count)
-	return result, errors.Trace(err)
+	return result, err
 }
 
 // GetRowCountByIntColumnRanges estimates the row count by a slice of IntColumnRange.
@@ -238,7 +238,7 @@ func (coll *HistColl) GetRowCountByIntColumnRanges(sc *stmtctx.StatementContext,
 	}
 	result, err := c.GetColumnRowCount(sc, intRanges, coll.ModifyCount)
 	result *= c.GetIncreaseFactor(coll.Count)
-	return result, errors.Trace(err)
+	return result, err
 }
 
 // GetRowCountByColumnRanges estimates the row count by a slice of Range.
@@ -249,7 +249,7 @@ func (coll *HistColl) GetRowCountByColumnRanges(sc *stmtctx.StatementContext, co
 	}
 	result, err := c.GetColumnRowCount(sc, colRanges, coll.ModifyCount)
 	result *= c.GetIncreaseFactor(coll.Count)
-	return result, errors.Trace(err)
+	return result, err
 }
 
 // GetRowCountByIndexRanges estimates the row count by a slice of Range.
@@ -270,7 +270,7 @@ func (coll *HistColl) GetRowCountByIndexRanges(sc *stmtctx.StatementContext, idx
 		result, err = idx.GetRowCount(sc, indexRanges, coll.ModifyCount)
 	}
 	result *= idx.GetIncreaseFactor(coll.Count)
-	return result, errors.Trace(err)
+	return result, err
 }
 
 // PseudoAvgCountPerValue gets a pseudo average count if histogram not exists.
@@ -372,7 +372,7 @@ func (coll *HistColl) getIndexRowCount(sc *stmtctx.StatementContext, idxID int64
 		if rangePosition == 0 || isSingleColIdxNullRange(idx, ran) {
 			count, err := idx.GetRowCount(sc, []*ranger.Range{ran}, coll.ModifyCount)
 			if err != nil {
-				return 0, errors.Trace(err)
+				return 0, err
 			}
 			totalCount += count
 			continue
@@ -381,7 +381,7 @@ func (coll *HistColl) getIndexRowCount(sc *stmtctx.StatementContext, idxID int64
 		// use CM Sketch to estimate the equal conditions
 		bytes, err := codec.EncodeKey(sc, nil, ran.LowVal[:rangePosition]...)
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		val := types.NewBytesDatum(bytes)
 		if idx.outOfRange(val) {
@@ -421,7 +421,7 @@ func (coll *HistColl) getIndexRowCount(sc *stmtctx.StatementContext, idxID int64
 				count, err = coll.GetRowCountByColumnRanges(sc, colID, []*ranger.Range{&rang})
 			}
 			if err != nil {
-				return 0, errors.Trace(err)
+				return 0, err
 			}
 			selectivity = selectivity * count / float64(idx.TotalRowCount())
 		}
@@ -475,7 +475,7 @@ func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []
 		count := tableRowCount
 		i, err := indexRange.PrefixEqualLen(sc)
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		if i == colsLen && !indexRange.LowExclude && !indexRange.HighExclude {
 			totalCount += 1.0
@@ -486,7 +486,7 @@ func getPseudoRowCountByIndexRanges(sc *stmtctx.StatementContext, indexRanges []
 		}
 		rowCount, err := GetPseudoRowCountByColumnRanges(sc, tableRowCount, []*ranger.Range{indexRange}, i)
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		count = count / tableRowCount * rowCount
 		// If the condition is a = 1, b = 1, c = 1, d = 1, we think every a=1, b=1, c=1 only filtrate 1/100 data,
@@ -522,7 +522,7 @@ func GetPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount
 		} else {
 			compare, err1 := ran.LowVal[colIdx].CompareDatum(sc, &ran.HighVal[colIdx])
 			if err1 != nil {
-				return 0, errors.Trace(err1)
+				return 0, err1
 			}
 			if compare == 0 {
 				rowCount += tableRowCount / pseudoEqualRate
@@ -531,7 +531,7 @@ func GetPseudoRowCountByColumnRanges(sc *stmtctx.StatementContext, tableRowCount
 			}
 		}
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 	}
 	if rowCount > tableRowCount {

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -47,7 +47,7 @@ type Helper struct {
 func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyResponse, error) {
 	keyLocation, err := h.RegionCache.LocateKey(tikv.NewBackoffer(context.Background(), 500), encodedKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	tikvReq := &tikvrpc.Request{
@@ -65,7 +65,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 			zap.Binary("endKey", keyLocation.EndKey),
 			zap.Reflect("kvResp", kvResp),
 			zap.Error(err))
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return kvResp.MvccGetByKey, nil
 }
@@ -119,13 +119,13 @@ func (h *Helper) FetchHotRegion(rw string) (map[uint64]RegionMetric, error) {
 	}
 	req, err := http.NewRequest("GET", protocol+pdHosts[0]+rw, nil)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	timeout, cancelFunc := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	resp, err := http.DefaultClient.Do(req.WithContext(timeout))
 	cancelFunc()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	defer func() {
 		err = resp.Body.Close()
@@ -136,7 +136,7 @@ func (h *Helper) FetchHotRegion(rw string) (map[uint64]RegionMetric, error) {
 	var regionResp StoreHotRegionInfos
 	err = json.NewDecoder(resp.Body).Decode(&regionResp)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	metric := make(map[uint64]RegionMetric)
 	for _, hotRegions := range regionResp.AsLeader {
@@ -295,7 +295,7 @@ func NewFrameItemFromRegionKey(key []byte) (frame *FrameItem, err error) {
 			frame.TableID = tablecodec.DecodeTableID(key)
 			return frame, nil
 		}
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	// key start with tablePrefix must be either record key or index key
@@ -420,13 +420,13 @@ func (h *Helper) GetRegionsInfo() (*RegionsInfo, error) {
 	}
 	req, err := http.NewRequest("GET", protocol+pdHosts[0]+pdapi.Regions, nil)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	timeout, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
 	resp, err := http.DefaultClient.Do(req.WithContext(timeout))
 	defer cancelFunc()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	defer func() {
 		err = resp.Body.Close()
@@ -437,7 +437,7 @@ func (h *Helper) GetRegionsInfo() (*RegionsInfo, error) {
 	var regionsInfo RegionsInfo
 	err = json.NewDecoder(resp.Body).Decode(&regionsInfo)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &regionsInfo, nil
 }
@@ -499,13 +499,13 @@ func (h *Helper) GetStoresStat() (*StoresStat, error) {
 	}
 	req, err := http.NewRequest("GET", protocol+pdHosts[0]+pdapi.Stores, nil)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	timeout, cancelFunc := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	resp, err := http.DefaultClient.Do(req.WithContext(timeout))
 	defer cancelFunc()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	defer func() {
 		err = resp.Body.Close()
@@ -516,7 +516,7 @@ func (h *Helper) GetStoresStat() (*StoresStat, error) {
 	var storesStat StoresStat
 	err = json.NewDecoder(resp.Body).Decode(&storesStat)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &storesStat, nil
 }

--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -67,7 +67,7 @@ func (o *MockOracle) GetTimestamp(context.Context) (uint64, error) {
 	defer o.Unlock()
 
 	if o.stop {
-		return 0, errors.Trace(errStopped)
+		return 0, errStopped
 	}
 	physical := oracle.GetPhysical(time.Now().Add(o.offset))
 	ts := oracle.ComposeTS(physical, 0)

--- a/store/mockstore/mocktikv/aggregate.go
+++ b/store/mockstore/mocktikv/aggregate.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/types"

--- a/store/mockstore/mocktikv/analyze.go
+++ b/store/mockstore/mocktikv/analyze.go
@@ -17,7 +17,6 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"

--- a/store/mockstore/mocktikv/mock.go
+++ b/store/mockstore/mocktikv/mock.go
@@ -29,7 +29,7 @@ func NewTiKVAndPDClient(cluster *Cluster, mvccStore MVCCStore, path string) (*RP
 		var err error
 		mvccStore, err = NewMVCCLevelDB(path)
 		if err != nil {
-			return nil, nil, errors.Trace(err)
+			return nil, nil, err
 		}
 	}
 

--- a/store/mockstore/mocktikv/mock.go
+++ b/store/mockstore/mocktikv/mock.go
@@ -14,8 +14,7 @@
 package mocktikv
 
 import (
-	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 )
 
 // NewTiKVAndPDClient creates a TiKV client and PD client from options.

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -786,10 +786,7 @@ func commitKey(db *leveldb.DB, batch *leveldb.Batch, key []byte, startTS, commit
 		return ErrRetryable("txn not found")
 	}
 
-	if err = commitLock(batch, dec.lock, key, startTS, commitTS); err != nil {
-		return err
-	}
-	return nil
+	return commitLock(batch, dec.lock, key, startTS, commitTS)
 }
 
 func commitLock(batch *leveldb.Batch, lock mvccLock, key []byte, startTS, commitTS uint64) error {
@@ -852,10 +849,7 @@ func rollbackKey(db *leveldb.DB, batch *leveldb.Batch, key []byte, startTS uint6
 		}
 		// If current transaction's lock exist.
 		if ok && dec.lock.startTS == startTS {
-			if err = rollbackLock(batch, dec.lock, key, startTS); err != nil {
-				return err
-			}
-			return nil
+			return rollbackLock(batch, dec.lock, key, startTS)
 		}
 
 		// If current transaction's lock not exist.

--- a/store/mockstore/mocktikv/pd.go
+++ b/store/mockstore/mocktikv/pd.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 )
 
 // Use global variables to prevent pdClients from creating duplicate timestamps.

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -878,7 +878,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		copStream, err := handler.handleCopStream(ctx1, r)
 		if err != nil {
 			cancel()
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 
 		streamResp := &tikvrpc.CopStreamResponse{
@@ -890,7 +890,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 		first, err := streamResp.Recv()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		streamResp.Response = first
 		resp.CopStream = streamResp

--- a/store/mockstore/mocktikv/topn.go
+++ b/store/mockstore/mocktikv/topn.go
@@ -50,7 +50,7 @@ func (t *topNSorter) Less(i, j int) bool {
 
 		ret, err := v1.CompareDatum(t.sc, &v2)
 		if err != nil {
-			t.err = errors.Trace(err)
+			t.err = err
 			return true
 		}
 
@@ -99,7 +99,7 @@ func (t *topNHeap) Less(i, j int) bool {
 
 		ret, err := v1.CompareDatum(t.sc, &v2)
 		if err != nil {
-			t.err = errors.Trace(err)
+			t.err = err
 			return true
 		}
 

--- a/store/mockstore/mocktikv/topn.go
+++ b/store/mockstore/mocktikv/topn.go
@@ -16,7 +16,6 @@ package mocktikv
 import (
 	"container/heap"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tipb/go-tipb"

--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -33,7 +33,7 @@ type MockDriver struct {
 func (d MockDriver) Open(path string) (kv.Storage, error) {
 	u, err := url.Parse(path)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if !strings.EqualFold(u.Scheme, "mocktikv") {
 		return nil, errors.Errorf("Uri scheme expected(mocktikv) but found (%s)", u.Scheme)
@@ -105,7 +105,7 @@ func NewMockTikvStore(options ...MockTiKVStoreOption) (kv.Storage, error) {
 
 	client, pdClient, err := mocktikv.NewTiKVAndPDClient(opt.cluster, opt.mvccStore, opt.path)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return tikv.NewTestTiKVStore(client, pdClient, opt.clientHijack, opt.pdClientHijack, opt.txnLocalLatches)

--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"

--- a/store/store.go
+++ b/store/store.go
@@ -76,5 +76,5 @@ func newStoreWithRetry(path string, maxRetries int) (kv.Storage, error) {
 	} else {
 		logutil.Logger(context.Background()).Warn("new store with retry failed", zap.Error(err))
 	}
-	return s, errors.Trace(err)
+	return s, err
 }

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -330,10 +330,10 @@ func errMsgMustContain(c *C, err error, msg string) {
 func newTwoPhaseCommitterWithInit(txn *tikvTxn, connID uint64) (*twoPhaseCommitter, error) {
 	c, err := newTwoPhaseCommitter(txn, connID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if err = c.initKeysAndMutations(); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return c, nil
 }

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -272,7 +272,7 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 	}
 	select {
 	case <-b.ctx.Done():
-		return errors.Trace(err)
+		return err
 	default:
 	}
 

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	grpc_opentracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/debugpb"

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -60,7 +60,7 @@ func (t *DeleteRangeTask) Execute() error {
 		bo := NewBackoffer(t.ctx, deleteRangeOneRegionMaxBackoff)
 		loc, err := t.store.GetRegionCache().LocateKey(bo, startKey)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		// Delete to the end of the region, except if it's the last region overlapping the range
@@ -80,22 +80,22 @@ func (t *DeleteRangeTask) Execute() error {
 
 		resp, err := t.store.SendReq(bo, req, loc.Region, ReadTimeoutMedium)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if regionErr != nil {
 			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			continue
 		}
 		deleteRangeResp := resp.DeleteRange
 		if deleteRangeResp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return ErrBodyMissing
 		}
 		if err := deleteRangeResp.GetError(); err != "" {
 			return errors.Errorf("unexpected delete range err: %v", err)

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -62,7 +62,7 @@ type GCWorker struct {
 func NewGCWorker(store tikv.Storage, pdClient pd.Client) (tikv.GCHandler, error) {
 	ver, err := store.CurrentVersion()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	hostName, err := os.Hostname()
 	if err != nil {
@@ -229,7 +229,7 @@ func (w *GCWorker) storeIsBootstrapped() bool {
 		var err error
 		t := meta.NewMeta(txn)
 		ver, err = t.GetBootstrapVersion()
-		return errors.Trace(err)
+		return err
 	})
 	if err != nil {
 		logutil.Logger(context.Background()).Error("[gc worker] check bootstrapped", zap.Error(err))
@@ -252,7 +252,7 @@ func (w *GCWorker) leaderTick(ctx context.Context) error {
 			metrics.GCJobFailureCounter.WithLabelValues("prepare").Inc()
 		}
 		w.gcIsRunning = false
-		return errors.Trace(err)
+		return err
 	}
 	// When the worker is just started, or an old GC job has just finished,
 	// wait a while before starting a new job.
@@ -268,7 +268,7 @@ func (w *GCWorker) leaderTick(ctx context.Context) error {
 		logutil.Logger(ctx).Info("[gc worker] failed to get gc concurrency.",
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
-		return errors.Trace(err)
+		return err
 	}
 
 	w.gcIsRunning = true
@@ -292,25 +292,25 @@ func (w *GCWorker) prepare() (bool, uint64, error) {
 	ctx := context.Background()
 	_, err := w.session.Execute(ctx, "BEGIN")
 	if err != nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	doGC, safePoint, err := w.checkPrepare(ctx)
 	if doGC {
 		_, err = w.session.Execute(ctx, "COMMIT")
 		if err != nil {
-			return false, 0, errors.Trace(err)
+			return false, 0, err
 		}
 	} else {
 		_, err1 := w.session.Execute(ctx, "ROLLBACK")
-		terror.Log(errors.Trace(err1))
+		terror.Log(err1)
 	}
-	return doGC, safePoint, errors.Trace(err)
+	return doGC, safePoint, err
 }
 
 func (w *GCWorker) checkPrepare(ctx context.Context) (bool, uint64, error) {
 	enable, err := w.checkGCEnable()
 	if err != nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	if !enable {
 		logutil.Logger(ctx).Warn("[gc worker] gc status is disabled.")
@@ -318,23 +318,23 @@ func (w *GCWorker) checkPrepare(ctx context.Context) (bool, uint64, error) {
 	}
 	now, err := w.getOracleTime()
 	if err != nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	ok, err := w.checkGCInterval(now)
 	if err != nil || !ok {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	newSafePoint, err := w.calculateNewSafePoint(now)
 	if err != nil || newSafePoint == nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	err = w.saveTime(gcLastRunTimeKey, now)
 	if err != nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	err = w.saveTime(gcSafePointKey, *newSafePoint)
 	if err != nil {
-		return false, 0, errors.Trace(err)
+		return false, 0, err
 	}
 	return true, oracle.ComposeTS(oracle.GetPhysical(*newSafePoint), 0), nil
 }
@@ -342,7 +342,7 @@ func (w *GCWorker) checkPrepare(ctx context.Context) (bool, uint64, error) {
 func (w *GCWorker) getOracleTime() (time.Time, error) {
 	currentVer, err := w.store.CurrentVersion()
 	if err != nil {
-		return time.Time{}, errors.Trace(err)
+		return time.Time{}, err
 	}
 	physical := oracle.ExtractPhysical(currentVer.Ver)
 	sec, nsec := physical/1e3, (physical%1e3)*1e6
@@ -360,7 +360,7 @@ func (w *GCWorker) checkUseAutoConcurrency() (bool, error) {
 func (w *GCWorker) loadBooleanWithDefault(key string, defaultValue bool) (bool, error) {
 	str, err := w.loadValueFromSysTable(key)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	if str == "" {
 		// Save default value for gc enable key. The default value is always true.
@@ -370,7 +370,7 @@ func (w *GCWorker) loadBooleanWithDefault(key string, defaultValue bool) (bool, 
 		}
 		err = w.saveValueToSysTable(key, defaultValueStr)
 		if err != nil {
-			return defaultValue, errors.Trace(err)
+			return defaultValue, err
 		}
 		return defaultValue, nil
 	}
@@ -417,12 +417,12 @@ func (w *GCWorker) getGCConcurrency(ctx context.Context) (int, error) {
 func (w *GCWorker) checkGCInterval(now time.Time) (bool, error) {
 	runInterval, err := w.loadDurationWithDefault(gcRunIntervalKey, gcDefaultRunInterval)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	metrics.GCConfigGauge.WithLabelValues(gcRunIntervalKey).Set(runInterval.Seconds())
 	lastRun, err := w.loadTime(gcLastRunTimeKey)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 
 	if lastRun != nil && lastRun.Add(*runInterval).After(now) {
@@ -439,12 +439,12 @@ func (w *GCWorker) checkGCInterval(now time.Time) (bool, error) {
 func (w *GCWorker) calculateNewSafePoint(now time.Time) (*time.Time, error) {
 	lifeTime, err := w.loadDurationWithDefault(gcLifeTimeKey, gcDefaultLifeTime)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	metrics.GCConfigGauge.WithLabelValues(gcLifeTimeKey).Set(lifeTime.Seconds())
 	lastSafePoint, err := w.loadTime(gcSafePointKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	safePoint := now.Add(-*lifeTime)
 	// We should never decrease safePoint.
@@ -468,7 +468,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
 		metrics.GCJobFailureCounter.WithLabelValues("resolve_lock").Inc()
-		w.done <- errors.Trace(err)
+		w.done <- err
 		return
 	}
 	err = w.deleteRanges(ctx, safePoint)
@@ -477,7 +477,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
 		metrics.GCJobFailureCounter.WithLabelValues("delete_range").Inc()
-		w.done <- errors.Trace(err)
+		w.done <- err
 		return
 	}
 	err = w.redoDeleteRanges(ctx, safePoint)
@@ -486,7 +486,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
 		metrics.GCJobFailureCounter.WithLabelValues("redo_delete_range").Inc()
-		w.done <- errors.Trace(err)
+		w.done <- err
 		return
 	}
 
@@ -507,7 +507,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 				zap.Error(err))
 			w.gcIsRunning = false
 			metrics.GCJobFailureCounter.WithLabelValues("upload_safe_point").Inc()
-			w.done <- errors.Trace(err)
+			w.done <- err
 			return
 		}
 	} else {
@@ -518,7 +518,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 				zap.Error(err))
 			w.gcIsRunning = false
 			metrics.GCJobFailureCounter.WithLabelValues("gc").Inc()
-			w.done <- errors.Trace(err)
+			w.done <- err
 			return
 		}
 	}
@@ -534,7 +534,7 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64) error {
 	ranges, err := util.LoadDeleteRanges(se, safePoint)
 	se.Close()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	logutil.Logger(ctx).Info("[gc worker] start delete",
@@ -546,14 +546,14 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64) error {
 
 		err = w.sendUnsafeDestroyRangeRequest(ctx, startKey, endKey)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		se := createSession(w.store)
 		err = util.CompleteDeleteRange(se, r)
 		se.Close()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	logutil.Logger(ctx).Info("[gc worker] finish delete ranges",
@@ -575,7 +575,7 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64) error
 	ranges, err := util.LoadDoneDeleteRanges(se, redoDeleteRangesTs)
 	se.Close()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	logutil.Logger(ctx).Info("[gc worker] start redo-delete ranges",
@@ -587,14 +587,14 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64) error
 
 		err = w.sendUnsafeDestroyRangeRequest(ctx, startKey, endKey)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		se := createSession(w.store)
 		err := util.DeleteDoneRecord(se, r)
 		se.Close()
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	logutil.Logger(ctx).Info("[gc worker] finish redo-delete ranges",
@@ -612,7 +612,7 @@ func (w *GCWorker) sendUnsafeDestroyRangeRequest(ctx context.Context, startKey [
 		logutil.Logger(ctx).Error("[gc worker] delete ranges: got an error while trying to get store list from PD",
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
-		return errors.Trace(err)
+		return err
 	}
 
 	req := &tikvrpc.Request{
@@ -644,13 +644,13 @@ func (w *GCWorker) sendUnsafeDestroyRangeRequest(ctx context.Context, startKey [
 
 	wg.Wait()
 
-	return errors.Trace(err)
+	return err
 }
 
 func (w *GCWorker) getUpStores(ctx context.Context) ([]*metapb.Store, error) {
 	stores, err := w.pdClient.GetAllStores(ctx)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	upStores := make([]*metapb.Store, 0, len(stores))
@@ -665,12 +665,12 @@ func (w *GCWorker) getUpStores(ctx context.Context) ([]*metapb.Store, error) {
 func (w *GCWorker) loadGCConcurrencyWithDefault() (int, error) {
 	str, err := w.loadValueFromSysTable(gcConcurrencyKey)
 	if err != nil {
-		return gcDefaultConcurrency, errors.Trace(err)
+		return gcDefaultConcurrency, err
 	}
 	if str == "" {
 		err = w.saveValueToSysTable(gcConcurrencyKey, strconv.Itoa(gcDefaultConcurrency))
 		if err != nil {
-			return gcDefaultConcurrency, errors.Trace(err)
+			return gcDefaultConcurrency, err
 		}
 		return gcDefaultConcurrency, nil
 	}
@@ -694,12 +694,12 @@ func (w *GCWorker) loadGCConcurrencyWithDefault() (int, error) {
 func (w *GCWorker) checkUseDistributedGC() (bool, error) {
 	str, err := w.loadValueFromSysTable(gcModeKey)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	if str == "" {
 		err = w.saveValueToSysTable(gcModeKey, gcModeDefault)
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 		str = gcModeDefault
 	}
@@ -734,7 +734,7 @@ func (w *GCWorker) resolveLocks(ctx context.Context, safePoint uint64, concurren
 			zap.String("uuid", w.uuid),
 			zap.Uint64("safePoint", safePoint),
 			zap.Error(err))
-		return errors.Trace(err)
+		return err
 	}
 
 	logutil.Logger(ctx).Info("[gc worker] finish resolve locks",
@@ -776,26 +776,26 @@ func (w *GCWorker) resolveLocksForRange(
 		req.ScanLock.StartKey = key
 		loc, err := w.store.GetRegionCache().LocateKey(bo, key)
 		if err != nil {
-			return regions, errors.Trace(err)
+			return regions, err
 		}
 		resp, err := w.store.SendReq(bo, req, loc.Region, tikv.ReadTimeoutMedium)
 		if err != nil {
-			return regions, errors.Trace(err)
+			return regions, err
 		}
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return regions, errors.Trace(err)
+			return regions, err
 		}
 		if regionErr != nil {
 			err = bo.Backoff(tikv.BoRegionMiss, errors.New(regionErr.String()))
 			if err != nil {
-				return regions, errors.Trace(err)
+				return regions, err
 			}
 			continue
 		}
 		locksResp := resp.ScanLock
 		if locksResp == nil {
-			return regions, errors.Trace(tikv.ErrBodyMissing)
+			return regions, tikv.ErrBodyMissing
 		}
 		if locksResp.GetError() != nil {
 			return regions, errors.Errorf("unexpected scanlock error: %s", locksResp)
@@ -808,12 +808,12 @@ func (w *GCWorker) resolveLocksForRange(
 
 		ok, err1 := w.store.GetLockResolver().BatchResolveLocks(bo, locks, loc.Region)
 		if err1 != nil {
-			return regions, errors.Trace(err1)
+			return regions, err1
 		}
 		if !ok {
 			err = bo.Backoff(tikv.BoTxnLock, errors.Errorf("remain locks: %d", len(locks)))
 			if err != nil {
-				return regions, errors.Trace(err)
+				return regions, err
 			}
 			continue
 		}
@@ -846,11 +846,11 @@ func (w *GCWorker) uploadSafePointToPD(ctx context.Context, safePoint uint64) er
 		newSafePoint, err = w.pdClient.UpdateGCSafePoint(ctx, safePoint)
 		if err != nil {
 			if errors.Cause(err) == context.Canceled {
-				return errors.Trace(err)
+				return err
 			}
 			err = bo.Backoff(tikv.BoPDRPC, errors.Errorf("failed to upload safe point to PD, err: %v", err))
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			continue
 		}
@@ -925,7 +925,7 @@ func (w *gcTaskWorker) doGCForRange(startKey []byte, endKey []byte, safePoint ui
 		bo := tikv.NewBackoffer(context.Background(), tikv.GcOneRegionMaxBackoff)
 		loc, err := w.store.GetRegionCache().LocateKey(bo, key)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		var regionErr *errorpb.Error
@@ -972,11 +972,11 @@ func (w *gcTaskWorker) doGCForRegion(bo *tikv.Backoffer, safePoint uint64, regio
 
 	resp, err := w.store.SendReq(bo, req, region, tikv.GCTimeout)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	regionErr, err := resp.GetRegionError()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if regionErr != nil {
 		return regionErr, nil
@@ -984,7 +984,7 @@ func (w *gcTaskWorker) doGCForRegion(bo *tikv.Backoffer, safePoint uint64, regio
 
 	gcResp := resp.GC
 	if gcResp == nil {
-		return nil, errors.Trace(tikv.ErrBodyMissing)
+		return nil, tikv.ErrBodyMissing
 	}
 	if gcResp.GetError() != nil {
 		return nil, errors.Errorf("unexpected gc error: %s", gcResp.GetError())
@@ -996,7 +996,7 @@ func (w *gcTaskWorker) doGCForRegion(bo *tikv.Backoffer, safePoint uint64, regio
 func (w *GCWorker) genNextGCTask(bo *tikv.Backoffer, safePoint uint64, key kv.Key) (*gcTask, error) {
 	loc, err := w.store.GetRegionCache().LocateKey(bo, key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	task := &gcTask{
@@ -1012,7 +1012,7 @@ func (w *GCWorker) doGC(ctx context.Context, safePoint uint64, concurrency int) 
 
 	err := w.saveSafePoint(w.store.GetSafePointKV(), tikv.GcSavedSafePoint, safePoint)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	// Sleep to wait for all other tidb instances update their safepoint cache.
@@ -1068,7 +1068,7 @@ func (w *GCWorker) doGC(ctx context.Context, safePoint uint64, concurrency int) 
 		bo := tikv.NewBackoffer(ctx, tikv.GcOneRegionMaxBackoff)
 		task, err := w.genNextGCTask(bo, safePoint, key)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		if task != nil {
 			gcTaskCh <- task
@@ -1089,40 +1089,40 @@ func (w *GCWorker) checkLeader() (bool, error) {
 	ctx := context.Background()
 	_, err := se.Execute(ctx, "BEGIN")
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	w.session = se
 	leader, err := w.loadValueFromSysTable(gcLeaderUUIDKey)
 	if err != nil {
 		_, err1 := se.Execute(ctx, "ROLLBACK")
-		terror.Log(errors.Trace(err1))
-		return false, errors.Trace(err)
+		terror.Log(err1)
+		return false, err
 	}
 	logutil.Logger(context.Background()).Debug("[gc worker] got leader", zap.String("uuid", leader))
 	if leader == w.uuid {
 		err = w.saveTime(gcLeaderLeaseKey, time.Now().Add(gcWorkerLease))
 		if err != nil {
 			_, err1 := se.Execute(ctx, "ROLLBACK")
-			terror.Log(errors.Trace(err1))
-			return false, errors.Trace(err)
+			terror.Log(err1)
+			return false, err
 		}
 		_, err = se.Execute(ctx, "COMMIT")
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 		return true, nil
 	}
 
 	_, err = se.Execute(ctx, "ROLLBACK")
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 
 	_, err = se.Execute(ctx, "BEGIN")
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	lease, err := w.loadTime(gcLeaderLeaseKey)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	if lease == nil || lease.Before(time.Now()) {
 		logutil.Logger(context.Background()).Debug("[gc worker] register as leader",
@@ -1132,29 +1132,29 @@ func (w *GCWorker) checkLeader() (bool, error) {
 		err = w.saveValueToSysTable(gcLeaderUUIDKey, w.uuid)
 		if err != nil {
 			_, err1 := se.Execute(ctx, "ROLLBACK")
-			terror.Log(errors.Trace(err1))
-			return false, errors.Trace(err)
+			terror.Log(err1)
+			return false, err
 		}
 		err = w.saveValueToSysTable(gcLeaderDescKey, w.desc)
 		if err != nil {
 			_, err1 := se.Execute(ctx, "ROLLBACK")
-			terror.Log(errors.Trace(err1))
-			return false, errors.Trace(err)
+			terror.Log(err1)
+			return false, err
 		}
 		err = w.saveTime(gcLeaderLeaseKey, time.Now().Add(gcWorkerLease))
 		if err != nil {
 			_, err1 := se.Execute(ctx, "ROLLBACK")
-			terror.Log(errors.Trace(err1))
-			return false, errors.Trace(err)
+			terror.Log(err1)
+			return false, err
 		}
 		_, err = se.Execute(ctx, "COMMIT")
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 		return true, nil
 	}
 	_, err1 := se.Execute(ctx, "ROLLBACK")
-	terror.Log(errors.Trace(err1))
+	terror.Log(err1)
 	return false, nil
 }
 
@@ -1163,47 +1163,47 @@ func (w *GCWorker) saveSafePoint(kv tikv.SafePointKV, key string, t uint64) erro
 	err := kv.Put(tikv.GcSavedSafePoint, s)
 	if err != nil {
 		logutil.Logger(context.Background()).Error("save safepoint failed", zap.Error(err))
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
 
 func (w *GCWorker) saveTime(key string, t time.Time) error {
 	err := w.saveValueToSysTable(key, t.Format(tidbutil.GCTimeFormat))
-	return errors.Trace(err)
+	return err
 }
 
 func (w *GCWorker) loadTime(key string) (*time.Time, error) {
 	str, err := w.loadValueFromSysTable(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if str == "" {
 		return nil, nil
 	}
 	t, err := tidbutil.CompatibleParseGCTime(str)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &t, nil
 }
 
 func (w *GCWorker) saveDuration(key string, d time.Duration) error {
 	err := w.saveValueToSysTable(key, d.String())
-	return errors.Trace(err)
+	return err
 }
 
 func (w *GCWorker) loadDuration(key string) (*time.Duration, error) {
 	str, err := w.loadValueFromSysTable(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if str == "" {
 		return nil, nil
 	}
 	d, err := time.ParseDuration(str)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &d, nil
 }
@@ -1211,12 +1211,12 @@ func (w *GCWorker) loadDuration(key string) (*time.Duration, error) {
 func (w *GCWorker) loadDurationWithDefault(key string, def time.Duration) (*time.Duration, error) {
 	d, err := w.loadDuration(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if d == nil {
 		err = w.saveDuration(key, def)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		return &def, nil
 	}
@@ -1231,12 +1231,12 @@ func (w *GCWorker) loadValueFromSysTable(key string) (string, error) {
 		defer terror.Call(rs[0].Close)
 	}
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	req := rs[0].NewRecordBatch()
 	err = rs[0].Next(ctx, req)
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	if req.NumRows() == 0 {
 		logutil.Logger(context.Background()).Debug("[gc worker] load kv",
@@ -1263,7 +1263,7 @@ func (w *GCWorker) saveValueToSysTable(key, value string) error {
 		zap.String("key", key),
 		zap.String("value", value),
 		zap.Error(err))
-	return errors.Trace(err)
+	return err
 }
 
 // RunGCJob sends GC command to KV. It is exported for kv api, do not use it with GCWorker at the same time.
@@ -1275,7 +1275,7 @@ func RunGCJob(ctx context.Context, s tikv.Storage, safePoint uint64, identifier 
 
 	err := gcWorker.resolveLocks(ctx, safePoint, concurrency)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	if concurrency <= 0 {
@@ -1283,7 +1283,7 @@ func RunGCJob(ctx context.Context, s tikv.Storage, safePoint uint64, identifier 
 	}
 	err = gcWorker.doGC(ctx, safePoint, concurrency)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -1307,12 +1307,12 @@ func RunDistributedGCJob(
 
 	err := gcWorker.resolveLocks(ctx, safePoint, concurrency)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	err = gcWorker.uploadSafePointToPD(ctx, safePoint)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -1326,7 +1326,7 @@ type MockGCWorker struct {
 func NewMockGCWorker(store tikv.Storage) (*MockGCWorker, error) {
 	ver, err := store.CurrentVersion()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	hostName, err := os.Hostname()
 	if err != nil {
@@ -1343,7 +1343,7 @@ func NewMockGCWorker(store tikv.Storage) (*MockGCWorker, error) {
 	worker.session, err = session.CreateSession(worker.store)
 	if err != nil {
 		logutil.Logger(context.Background()).Error("initialize MockGCWorker session fail", zap.Error(err))
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	privilege.BindPrivilegeManager(worker.session, nil)
 	worker.session.GetSessionVars().InRestrictedSQL = true

--- a/store/tikv/interface.go
+++ b/store/tikv/interface.go
@@ -16,7 +16,7 @@ package tikv
 import (
 	"time"
 
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -53,7 +53,7 @@ func NewPdOracle(pdClient pd.Client, updateInterval time.Duration) (oracle.Oracl
 	_, err := o.GetTimestamp(ctx)
 	if err != nil {
 		o.Close()
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return o, nil
 }
@@ -69,7 +69,7 @@ func (o *pdOracle) IsExpired(lockTS, TTL uint64) bool {
 func (o *pdOracle) GetTimestamp(ctx context.Context) (uint64, error) {
 	ts, err := o.getTimestamp(ctx)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	o.setLastTS(ts)
 	return ts, nil
@@ -86,7 +86,7 @@ func (f *tsFuture) Wait() (uint64, error) {
 	physical, logical, err := f.TSFuture.Wait()
 	metrics.TSFutureWaitDuration.Observe(time.Since(now).Seconds())
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	ts := oracle.ComposeTS(physical, logical)
 	f.o.setLastTS(ts)
@@ -102,7 +102,7 @@ func (o *pdOracle) getTimestamp(ctx context.Context) (uint64, error) {
 	now := time.Now()
 	physical, logical, err := o.c.GetTS(ctx)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	dist := time.Since(now)
 	if dist > slowDist {

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -18,8 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/logutil"

--- a/store/tikv/pd_codec.go
+++ b/store/tikv/pd_codec.go
@@ -16,9 +16,8 @@ package tikv
 import (
 	"context"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/util/codec"
 )
 

--- a/store/tikv/pd_codec.go
+++ b/store/tikv/pd_codec.go
@@ -49,14 +49,14 @@ func (c *codecPDClient) GetRegionByID(ctx context.Context, regionID uint64) (*me
 
 func processRegionResult(region *metapb.Region, peer *metapb.Peer, err error) (*metapb.Region, *metapb.Peer, error) {
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	if region == nil {
 		return nil, nil, nil
 	}
 	err = decodeRegionMetaKey(region)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	return region, peer, nil
 }
@@ -65,14 +65,14 @@ func decodeRegionMetaKey(r *metapb.Region) error {
 	if len(r.StartKey) != 0 {
 		_, decoded, err := codec.DecodeBytes(r.StartKey, nil)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		r.StartKey = decoded
 	}
 	if len(r.EndKey) != 0 {
 		_, decoded, err := codec.DecodeBytes(r.EndKey, nil)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		r.EndKey = decoded
 	}

--- a/store/tikv/range_task.go
+++ b/store/tikv/range_task.go
@@ -150,7 +150,7 @@ func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKe
 				zap.Binary("endKey", endKey),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Error(err))
-			return errors.Trace(err)
+			return err
 		}
 		task := &kv.KeyRange{
 			StartKey: key,
@@ -190,7 +190,7 @@ func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKe
 				zap.Binary("endKey", endKey),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Error(w.err))
-			return errors.Trace(w.err)
+			return w.err
 		}
 	}
 

--- a/store/tikv/range_task.go
+++ b/store/tikv/range_task.go
@@ -20,7 +20,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util/logutil"

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -405,7 +405,7 @@ func (c *RegionCache) LocateRegionByID(bo *Backoffer, regionID uint64) (*KeyLoca
 
 	r, err := c.loadRegionByID(bo, regionID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	c.mu.Lock()
@@ -430,7 +430,7 @@ func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte) (map[Regio
 			var err error
 			lastLoc, err = c.LocateKey(bo, k)
 			if err != nil {
-				return nil, first, errors.Trace(err)
+				return nil, first, err
 			}
 		}
 		id := lastLoc.Region
@@ -447,7 +447,7 @@ func (c *RegionCache) ListRegionIDsInKeyRange(bo *Backoffer, startKey, endKey []
 	for {
 		curRegion, err := c.LocateKey(bo, startKey)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		regionIDs = append(regionIDs, curRegion.Region.id)
 		if curRegion.Contains(endKey) {
@@ -556,7 +556,7 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 		if backoffErr != nil {
 			err := bo.Backoff(BoPDRPC, backoffErr)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 		}
 		var meta *metapb.Region
@@ -603,7 +603,7 @@ func (c *RegionCache) loadRegionByID(bo *Backoffer, regionID uint64) (*Region, e
 		if backoffErr != nil {
 			err := bo.Backoff(BoPDRPC, backoffErr)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 		}
 		meta, leader, err := c.pdClient.GetRegionByID(bo.ctx, regionID)

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/btree"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -83,7 +83,7 @@ type EtcdSafePointKV struct {
 func NewEtcdSafePointKV(addrs []string, tlsConfig *tls.Config) (*EtcdSafePointKV, error) {
 	etcdCli, err := createEtcdKV(addrs, tlsConfig)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return &EtcdSafePointKV{cli: etcdCli}, nil
 }
@@ -94,7 +94,7 @@ func (w *EtcdSafePointKV) Put(k string, v string) error {
 	_, err := w.cli.Put(ctx, k, v)
 	cancel()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -105,7 +105,7 @@ func (w *EtcdSafePointKV) Get(k string) (string, error) {
 	resp, err := w.cli.Get(ctx, k)
 	cancel()
 	if err != nil {
-		return "", errors.Trace(err)
+		return "", err
 	}
 	if len(resp.Kvs) > 0 {
 		return string(resp.Kvs[0].Value), nil
@@ -118,7 +118,7 @@ func saveSafePoint(kv SafePointKV, key string, t uint64) error {
 	err := kv.Put(GcSavedSafePoint, s)
 	if err != nil {
 		logutil.Logger(context.Background()).Error("save safepoint failed", zap.Error(err))
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -127,7 +127,7 @@ func loadSafePoint(kv SafePointKV, key string) (uint64, error) {
 	str, err := kv.Get(GcSavedSafePoint)
 
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 
 	if str == "" {
@@ -136,7 +136,7 @@ func loadSafePoint(kv SafePointKV, key string) (uint64, error) {
 
 	t, err := strconv.ParseUint(str, 10, 64)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	return t, nil
 }

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -49,7 +49,7 @@ func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
 	for {
 		loc, err := s.regionCache.LocateKey(bo, splitKey)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		if bytes.Equal(splitKey, loc.StartKey) {
 			logutil.Logger(context.Background()).Info("skip split region",
@@ -58,16 +58,16 @@ func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
 		}
 		res, err := sender.SendReq(bo, req, loc.Region, readTimeoutShort)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		regionErr, err := res.GetRegionError()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		if regionErr != nil {
 			err := bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			continue
 		}
@@ -88,7 +88,7 @@ func (s *tikvStore) scatterRegion(regionID uint64) error {
 		if err != nil {
 			err = bo.Backoff(BoRegionMiss, errors.New(err.Error()))
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 			continue
 		}
@@ -126,7 +126,7 @@ func (s *tikvStore) WaitScatterRegionFinish(regionID uint64) error {
 			err = bo.Backoff(BoRegionMiss, errors.New("wait scatter region timeout"))
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -23,7 +23,7 @@ import (
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -120,7 +120,7 @@ func (c *mockPDClient) GetTS(ctx context.Context) (int64, int64, error) {
 	defer c.RUnlock()
 
 	if c.stop {
-		return 0, 0, errors.Trace(errStopped)
+		return 0, 0, errStopped
 	}
 	return c.client.GetTS(ctx)
 }
@@ -134,7 +134,7 @@ func (c *mockPDClient) GetRegion(ctx context.Context, key []byte) (*metapb.Regio
 	defer c.RUnlock()
 
 	if c.stop {
-		return nil, nil, errors.Trace(errStopped)
+		return nil, nil, errStopped
 	}
 	return c.client.GetRegion(ctx, key)
 }
@@ -144,7 +144,7 @@ func (c *mockPDClient) GetPrevRegion(ctx context.Context, key []byte) (*metapb.R
 	defer c.RUnlock()
 
 	if c.stop {
-		return nil, nil, errors.Trace(errStopped)
+		return nil, nil, errStopped
 	}
 	return c.client.GetPrevRegion(ctx, key)
 }
@@ -154,7 +154,7 @@ func (c *mockPDClient) GetRegionByID(ctx context.Context, regionID uint64) (*met
 	defer c.RUnlock()
 
 	if c.stop {
-		return nil, nil, errors.Trace(errStopped)
+		return nil, nil, errStopped
 	}
 	return c.client.GetRegionByID(ctx, regionID)
 }
@@ -164,7 +164,7 @@ func (c *mockPDClient) GetStore(ctx context.Context, storeID uint64) (*metapb.St
 	defer c.RUnlock()
 
 	if c.stop {
-		return nil, errors.Trace(errStopped)
+		return nil, errStopped
 	}
 	return c.client.GetStore(ctx, storeID)
 }
@@ -174,7 +174,7 @@ func (c *mockPDClient) GetAllStores(ctx context.Context, opts ...pd.GetStoreOpti
 	defer c.Unlock()
 
 	if c.stop {
-		return nil, errors.Trace(errStopped)
+		return nil, errStopped
 	}
 	return c.client.GetAllStores(ctx)
 }

--- a/store/tikv/test_util.go
+++ b/store/tikv/test_util.go
@@ -14,8 +14,7 @@
 package tikv
 
 import (
-	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	"github.com/pingcap/tidb/kv"
 	"github.com/twinj/uuid"
 )

--- a/store/tikv/test_util.go
+++ b/store/tikv/test_util.go
@@ -41,5 +41,5 @@ func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Clien
 	}
 
 	tikvStore.mock = true
-	return tikvStore, errors.Trace(err)
+	return tikvStore, err
 }

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/codec"

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -59,16 +59,16 @@ func NewTestStore(c *C) kv.Storage {
 func clearStorage(store kv.Storage) error {
 	txn, err := store.Begin()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	iter, err := txn.Iter(nil, nil)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	for iter.Valid() {
 		txn.Delete(iter.Key())
 		if err := iter.Next(); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 	return txn.Commit(context.Background())

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -645,7 +645,7 @@ func CallRPC(ctx context.Context, client tikvpb.TikvClient, req *Request) (*Resp
 		return nil, errors.Errorf("invalid request type: %v", req.Type)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return resp, nil
 }
@@ -678,7 +678,7 @@ func (resp *CopStreamResponse) Recv() (*coprocessor.Response, error) {
 	ret, err := resp.Tikv_CoprocessorStreamClient.Recv()
 
 	atomic.StoreInt64(&resp.Lease.deadline, 0) // Stop the lease check.
-	return ret, errors.Trace(err)
+	return ret, err
 }
 
 // Close closes the CopStreamResponse object.

--- a/structure/hash.go
+++ b/structure/hash.go
@@ -18,7 +18,6 @@ import (
 	"encoding/binary"
 	"strconv"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 )
 

--- a/structure/list.go
+++ b/structure/list.go
@@ -16,7 +16,6 @@ package structure
 import (
 	"encoding/binary"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 )
 

--- a/structure/list.go
+++ b/structure/list.go
@@ -57,7 +57,7 @@ func (t *TxStructure) listPush(key []byte, left bool, values ...[]byte) error {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	var index int64
@@ -72,7 +72,7 @@ func (t *TxStructure) listPush(key []byte, left bool, values ...[]byte) error {
 
 		dataKey := t.encodeListDataKey(key, index)
 		if err = t.readWriter.Set(dataKey, v); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
@@ -96,7 +96,7 @@ func (t *TxStructure) listPop(key []byte, left bool) ([]byte, error) {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil || meta.IsEmpty() {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	var index int64
@@ -113,11 +113,11 @@ func (t *TxStructure) listPop(key []byte, left bool) ([]byte, error) {
 	var data []byte
 	data, err = t.reader.Get(dataKey)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if err = t.readWriter.Delete(dataKey); err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	if !meta.IsEmpty() {
@@ -126,14 +126,14 @@ func (t *TxStructure) listPop(key []byte, left bool) ([]byte, error) {
 		err = t.readWriter.Delete(metaKey)
 	}
 
-	return data, errors.Trace(err)
+	return data, err
 }
 
 // LLen gets the length of a list.
 func (t *TxStructure) LLen(key []byte) (int64, error) {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
-	return meta.RIndex - meta.LIndex, errors.Trace(err)
+	return meta.RIndex - meta.LIndex, err
 }
 
 // LGetAll gets all elements of this list in order from right to left.
@@ -141,7 +141,7 @@ func (t *TxStructure) LGetAll(key []byte) ([][]byte, error) {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil || meta.IsEmpty() {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	length := int(meta.RIndex - meta.LIndex)
@@ -149,7 +149,7 @@ func (t *TxStructure) LGetAll(key []byte) ([][]byte, error) {
 	for index := meta.RIndex - 1; index >= meta.LIndex; index-- {
 		e, err := t.reader.Get(t.encodeListDataKey(key, index))
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		elements = append(elements, e)
 	}
@@ -161,7 +161,7 @@ func (t *TxStructure) LIndex(key []byte, index int64) ([]byte, error) {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil || meta.IsEmpty() {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	index = adjustIndex(index, meta.LIndex, meta.RIndex)
@@ -180,7 +180,7 @@ func (t *TxStructure) LSet(key []byte, index int64, value []byte) error {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil || meta.IsEmpty() {
-		return errors.Trace(err)
+		return err
 	}
 
 	index = adjustIndex(index, meta.LIndex, meta.RIndex)
@@ -199,13 +199,13 @@ func (t *TxStructure) LClear(key []byte) error {
 	metaKey := t.encodeListMetaKey(key)
 	meta, err := t.loadListMeta(metaKey)
 	if err != nil || meta.IsEmpty() {
-		return errors.Trace(err)
+		return err
 	}
 
 	for index := meta.LIndex; index < meta.RIndex; index++ {
 		dataKey := t.encodeListDataKey(key, index)
 		if err = t.readWriter.Delete(dataKey); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
@@ -218,7 +218,7 @@ func (t *TxStructure) loadListMeta(metaKey []byte) (listMeta, error) {
 		err = nil
 	}
 	if err != nil {
-		return listMeta{}, errors.Trace(err)
+		return listMeta{}, err
 	}
 
 	meta := listMeta{0, 0}

--- a/structure/string.go
+++ b/structure/string.go
@@ -16,7 +16,6 @@ package structure
 import (
 	"strconv"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 )
 

--- a/structure/string.go
+++ b/structure/string.go
@@ -36,18 +36,18 @@ func (t *TxStructure) Get(key []byte) ([]byte, error) {
 	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
-	return value, errors.Trace(err)
+	return value, err
 }
 
 // GetInt64 gets the int64 value of a key.
 func (t *TxStructure) GetInt64(key []byte) (int64, error) {
 	v, err := t.Get(key)
 	if err != nil || v == nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 
 	n, err := strconv.ParseInt(string(v), 10, 64)
-	return n, errors.Trace(err)
+	return n, err
 }
 
 // Inc increments the integer value of a key by step, returns
@@ -62,7 +62,7 @@ func (t *TxStructure) Inc(key []byte, step int64) (int64, error) {
 	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
-	return n, errors.Trace(err)
+	return n, err
 }
 
 // Clear removes the string value of the key.
@@ -75,5 +75,5 @@ func (t *TxStructure) Clear(key []byte) error {
 	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}
-	return errors.Trace(err)
+	return err
 }

--- a/structure/type.go
+++ b/structure/type.go
@@ -84,18 +84,18 @@ func (t *TxStructure) decodeHashDataKey(ek kv.Key) ([]byte, []byte, error) {
 
 	ek, key, err = codec.DecodeBytes(ek, nil)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 
 	ek, tp, err = codec.DecodeUint(ek)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	} else if TypeFlag(tp) != HashData {
 		return nil, nil, errInvalidHashKeyFlag.GenWithStack("invalid encoded hash data key flag %c", byte(tp))
 	}
 
 	_, field, err = codec.DecodeBytes(ek, nil)
-	return key, field, errors.Trace(err)
+	return key, field, err
 }
 
 func (t *TxStructure) hashDataKeyPrefix(key []byte) kv.Key {

--- a/table/tables/gen_expr.go
+++ b/table/tables/gen_expr.go
@@ -73,7 +73,7 @@ func parseExpression(expr string) (node ast.ExprNode, err error) {
 func simpleResolveName(node ast.ExprNode, tblInfo *model.TableInfo) (ast.ExprNode, error) {
 	nr := nameResolver{tblInfo, nil}
 	if _, ok := node.Accept(&nr); !ok {
-		return nil, errors.Trace(nr.err)
+		return nil, nr.err
 	}
 	return node, nil
 }

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"unicode/utf8"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -67,10 +67,10 @@ func (c *indexIter) Close() {
 // Next returns current key and moves iterator to the next step.
 func (c *indexIter) Next() (val []types.Datum, h int64, err error) {
 	if !c.it.Valid() {
-		return nil, 0, errors.Trace(io.EOF)
+		return nil, 0, io.EOF
 	}
 	if !c.it.Key().HasPrefix(c.prefix) {
-		return nil, 0, errors.Trace(io.EOF)
+		return nil, 0, io.EOF
 	}
 	// get indexedValues
 	buf := c.it.Key()[len(c.prefix):]

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -20,7 +20,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -163,7 +163,7 @@ func countEntriesWithPrefix(ctx sessionctx.Context, prefix []byte) (int, error) 
 	cnt := 0
 	txn, err := ctx.Txn(true)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	err = util.ScanMetaWithPrefix(txn, prefix, func(k kv.Key, v []byte) bool {
 		cnt++

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -573,7 +573,7 @@ func closeDomainAndStorage() {
 	atomic.StoreUint32(&tikv.ShuttingDown, 1)
 	dom.Close()
 	err := storage.Close()
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 }
 
 func cleanup() {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -24,11 +24,10 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/pd/client"
+	pd "github.com/pingcap/pd/client"
 	pumpcli "github.com/pingcap/tidb-tools/tidb-binlog/pump_client"
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"

--- a/types/binary_literal.go
+++ b/types/binary_literal.go
@@ -166,7 +166,7 @@ func ParseBitStr(s string) (BinaryLiteral, error) {
 		strPosition := i << 3
 		val, err := strconv.ParseUint(s[strPosition:strPosition+8], 2, 8)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		buf[i] = byte(val)
 	}
@@ -212,7 +212,7 @@ func ParseHexStr(s string) (BinaryLiteral, error) {
 	}
 	buf, err := hex.DecodeString(s)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return buf, nil
 }

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -44,7 +44,7 @@ func Convert(val interface{}, target *FieldType) (v interface{}, err error) {
 	sc.TimeZone = time.UTC
 	ret, err := d.ConvertTo(sc, target)
 	if err != nil {
-		return ret.GetValue(), errors.Trace(err)
+		return ret.GetValue(), err
 	}
 	return ret.GetValue(), nil
 }

--- a/types/datum_eval.go
+++ b/types/datum_eval.go
@@ -15,7 +15,6 @@ package types
 
 import (
 	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/opcode"
 )
 

--- a/types/datum_eval.go
+++ b/types/datum_eval.go
@@ -27,22 +27,22 @@ func ComputePlus(a, b Datum) (d Datum, err error) {
 		case KindInt64:
 			r, err1 := AddInt64(a.GetInt64(), b.GetInt64())
 			d.SetInt64(r)
-			return d, errors.Trace(err1)
+			return d, err1
 		case KindUint64:
 			r, err1 := AddInteger(b.GetUint64(), a.GetInt64())
 			d.SetUint64(r)
-			return d, errors.Trace(err1)
+			return d, err1
 		}
 	case KindUint64:
 		switch b.Kind() {
 		case KindInt64:
 			r, err1 := AddInteger(a.GetUint64(), b.GetInt64())
 			d.SetUint64(r)
-			return d, errors.Trace(err1)
+			return d, err1
 		case KindUint64:
 			r, err1 := AddUint64(a.GetUint64(), b.GetUint64())
 			d.SetUint64(r)
-			return d, errors.Trace(err1)
+			return d, err1
 		}
 	case KindFloat64:
 		switch b.Kind() {

--- a/types/etc.go
+++ b/types/etc.go
@@ -148,7 +148,7 @@ func EOFAsNil(err error) error {
 	if terror.ErrorEqual(err, io.EOF) {
 		return nil
 	}
-	return errors.Trace(err)
+	return err
 }
 
 // InvOp2 returns an invalid operation error.

--- a/types/fsp.go
+++ b/types/fsp.go
@@ -54,13 +54,13 @@ func ParseFrac(s string, fsp int) (v int, overflow bool, err error) {
 
 	fsp, err = CheckFsp(fsp)
 	if err != nil {
-		return 0, false, errors.Trace(err)
+		return 0, false, err
 	}
 
 	if fsp >= len(s) {
 		tmp, e := strconv.ParseInt(s, 10, 64)
 		if e != nil {
-			return 0, false, errors.Trace(e)
+			return 0, false, e
 		}
 		v = int(float64(tmp) * math.Pow10(MaxFsp-len(s)))
 		return
@@ -69,7 +69,7 @@ func ParseFrac(s string, fsp int) (v int, overflow bool, err error) {
 	// Round when fsp < string length.
 	tmp, e := strconv.ParseInt(s[:fsp+1], 10, 64)
 	if e != nil {
-		return 0, false, errors.Trace(e)
+		return 0, false, e
 	}
 	tmp = (tmp + 5) / 10
 

--- a/types/helper.go
+++ b/types/helper.go
@@ -17,8 +17,6 @@ import (
 	"math"
 	"strings"
 	"unicode"
-
-	"github.com/pingcap/errors"
 )
 
 // RoundFloat rounds float val to the nearest integer value with float64 format, like MySQL Round function.

--- a/types/helper.go
+++ b/types/helper.go
@@ -90,7 +90,7 @@ func TruncateFloat(f float64, flen int, decimal int) (float64, error) {
 		err = ErrOverflow.GenWithStackByArgs("DOUBLE", "")
 	}
 
-	return f, errors.Trace(err)
+	return f, err
 }
 
 func isSpace(c byte) bool {
@@ -163,7 +163,7 @@ func strToInt(str string) (int64, error) {
 		hasNum = true
 		if r >= uintCutOff {
 			r = 0
-			err = errors.Trace(ErrBadNumber)
+			err = ErrBadNumber
 			break
 		}
 		r = r * uint64(10)
@@ -171,7 +171,7 @@ func strToInt(str string) (int64, error) {
 		r1 := r + uint64(str[i]-'0')
 		if r1 < r || r1 > maxUint {
 			r = 0
-			err = errors.Trace(ErrBadNumber)
+			err = ErrBadNumber
 			break
 		}
 		r = r1
@@ -181,11 +181,11 @@ func strToInt(str string) (int64, error) {
 	}
 
 	if !negative && r >= intCutOff {
-		return math.MaxInt64, errors.Trace(ErrBadNumber)
+		return math.MaxInt64, ErrBadNumber
 	}
 
 	if negative && r > intCutOff {
-		return math.MinInt64, errors.Trace(ErrBadNumber)
+		return math.MinInt64, ErrBadNumber
 	}
 
 	if negative {

--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -261,7 +261,7 @@ func (bj BinaryJSON) marshalArrayTo(buf []byte) ([]byte, error) {
 		var err error
 		buf, err = bj.arrayGetElem(i).marshalTo(buf)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	return append(buf, ']'), nil
@@ -279,7 +279,7 @@ func (bj BinaryJSON) marshalObjTo(buf []byte) ([]byte, error) {
 		var err error
 		buf, err = bj.objectGetVal(i).marshalTo(buf)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	return append(buf, '}'), nil
@@ -368,7 +368,7 @@ func (bj BinaryJSON) marshalValueEntryTo(buf []byte, entryOff int) ([]byte, erro
 		var err error
 		buf, err = tmp.marshalTo(buf)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	return buf, nil
@@ -410,13 +410,13 @@ func (bj *BinaryJSON) UnmarshalJSON(data []byte) error {
 	var in interface{}
 	err := decoder.Decode(&in)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	buf := make([]byte, 0, len(data))
 	var typeCode TypeCode
 	typeCode, buf, err = appendBinary(buf, in)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	bj.TypeCode = typeCode
 	bj.Value = buf
@@ -458,7 +458,7 @@ func appendBinary(buf []byte, in interface{}) (TypeCode, []byte, error) {
 	case json.Number:
 		typeCode, buf, err = appendBinaryNumber(buf, x)
 		if err != nil {
-			return typeCode, nil, errors.Trace(err)
+			return typeCode, nil, err
 		}
 	case string:
 		typeCode = TypeCodeString
@@ -470,13 +470,13 @@ func appendBinary(buf []byte, in interface{}) (TypeCode, []byte, error) {
 		typeCode = TypeCodeArray
 		buf, err = appendBinaryArray(buf, x)
 		if err != nil {
-			return typeCode, nil, errors.Trace(err)
+			return typeCode, nil, err
 		}
 	case map[string]interface{}:
 		typeCode = TypeCodeObject
 		buf, err = appendBinaryObject(buf, x)
 		if err != nil {
-			return typeCode, nil, errors.Trace(err)
+			return typeCode, nil, err
 		}
 	default:
 		msg := fmt.Sprintf(unknownTypeErrorMsg, reflect.TypeOf(in))
@@ -510,7 +510,7 @@ func appendBinaryNumber(buf []byte, x json.Number) (TypeCode, []byte, error) {
 		typeCode = TypeCodeFloat64
 		f64, err := x.Float64()
 		if err != nil {
-			return typeCode, nil, errors.Trace(err)
+			return typeCode, nil, err
 		}
 		buf = appendBinaryFloat64(buf, f64)
 	} else {
@@ -520,7 +520,7 @@ func appendBinaryNumber(buf []byte, x json.Number) (TypeCode, []byte, error) {
 			typeCode = TypeCodeFloat64
 			f64, err := x.Float64()
 			if err != nil {
-				return typeCode, nil, errors.Trace(err)
+				return typeCode, nil, err
 			}
 			buf = appendBinaryFloat64(buf, f64)
 		} else {
@@ -563,7 +563,7 @@ func appendBinaryArray(buf []byte, array []interface{}) ([]byte, error) {
 		var err error
 		buf, err = appendBinaryValElem(buf, docOff, valEntryBegin+i*valEntrySize, val)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	docSize := len(buf) - docOff
@@ -577,7 +577,7 @@ func appendBinaryValElem(buf []byte, docOff, valEntryOff int, val interface{}) (
 	elemDocOff := len(buf)
 	typeCode, buf, err = appendBinary(buf, val)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	switch typeCode {
 	case TypeCodeLiteral:
@@ -626,7 +626,7 @@ func appendBinaryObject(buf []byte, x map[string]interface{}) ([]byte, error) {
 		var err error
 		buf, err = appendBinaryValElem(buf, docOff, valEntryBegin+i*valEntrySize, field.val)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 	}
 	docSize := len(buf) - docOff

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -68,7 +68,7 @@ func (bj BinaryJSON) Unquote() (string, error) {
 		tmp := string(hack.String(bj.GetString()))
 		s, err := unquoteString(tmp)
 		if err != nil {
-			return "", errors.Trace(err)
+			return "", err
 		}
 		// Remove prefix and suffix '"'.
 		slen := len(s)
@@ -115,7 +115,7 @@ func unquoteString(s string) (string, error) {
 				}
 				char, size, err := decodeEscapedUnicode(hack.Slice(s[i+1 : i+5]))
 				if err != nil {
-					return "", errors.Trace(err)
+					return "", err
 				}
 				ret.Write(char[0:size])
 				i += 4
@@ -137,12 +137,12 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 	size, err = hex.Decode(char[0:2], s)
 	if err != nil || size != 2 {
 		// The unicode must can be represented in 2 bytes.
-		return char, 0, errors.Trace(err)
+		return char, 0, err
 	}
 	var unicode uint16
 	err = binary.Read(bytes.NewReader(char[0:2]), binary.BigEndian, &unicode)
 	if err != nil {
-		return char, 0, errors.Trace(err)
+		return char, 0, err
 	}
 	size = utf8.RuneLen(rune(unicode))
 	utf8.EncodeRune(char[0:size], rune(unicode))

--- a/types/json/path_expr.go
+++ b/types/json/path_expr.go
@@ -196,7 +196,7 @@ func ParseJSONPathExpr(pathExpr string) (pe PathExpression, err error) {
 				index = arrayIndexAsterisk
 			} else {
 				if index, err = strconv.Atoi(indexStr); err != nil {
-					err = errors.Trace(err)
+					err = err
 					return
 				}
 			}

--- a/types/json/path_expr.go
+++ b/types/json/path_expr.go
@@ -17,8 +17,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/pingcap/errors"
 )
 
 /*

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -246,7 +246,7 @@ func (d *MyDecimal) GetDigitsFrac() int8 {
 func (d *MyDecimal) String() string {
 	tmp := *d
 	err := tmp.Round(&tmp, int(tmp.resultFrac), ModeHalfEven)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return string(tmp.ToString())
 }
 
@@ -561,7 +561,7 @@ func (d *MyDecimal) Shift(shift int) error {
 		diff := digitsFrac - wordsFrac*digitsPerWord
 		err1 := d.Round(d, digitEnd-point-diff, ModeHalfEven)
 		if err1 != nil {
-			return errors.Trace(err1)
+			return err1
 		}
 		digitEnd -= diff
 		digitsFrac = wordsFrac * digitsPerWord
@@ -1454,7 +1454,7 @@ func writeWord(b []byte, word int32, size int) {
 func (d *MyDecimal) Compare(to *MyDecimal) int {
 	if d.negative == to.negative {
 		cmp, err := doSub(d, to, nil)
-		terror.Log(errors.Trace(err))
+		terror.Log(err)
 		return cmp
 	}
 	if d.negative {
@@ -2251,7 +2251,7 @@ func NewDecFromUint(i uint64) *MyDecimal {
 func NewDecFromFloatForTest(f float64) *MyDecimal {
 	dec := new(MyDecimal)
 	err := dec.FromFloat64(f)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return dec
 }
 
@@ -2259,7 +2259,7 @@ func NewDecFromFloatForTest(f float64) *MyDecimal {
 func NewDecFromStringForTest(s string) *MyDecimal {
 	dec := new(MyDecimal)
 	err := dec.FromString([]byte(s))
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return dec
 }
 
@@ -2277,6 +2277,6 @@ func NewMaxOrMinDec(negative bool, prec, frac int) *MyDecimal {
 	str[1+prec-frac] = '.'
 	dec := new(MyDecimal)
 	err := dec.FromString(str)
-	terror.Log(errors.Trace(err))
+	terror.Log(err)
 	return dec
 }

--- a/types/mytime.go
+++ b/types/mytime.go
@@ -15,8 +15,6 @@ package types
 
 import (
 	gotime "time"
-
-	"github.com/pingcap/errors"
 )
 
 // MysqlTime is the internal struct type for Time.

--- a/types/mytime.go
+++ b/types/mytime.go
@@ -112,7 +112,7 @@ func (t MysqlTime) GoTime(loc *gotime.Location) (gotime.Time, error) {
 	if year != t.Year() || int(month) != t.Month() || day != t.Day() ||
 		hour != t.Hour() || minute != t.Minute() || second != t.Second() ||
 		microsec != t.Microsecond() {
-		return tm, errors.Trace(ErrInvalidTimeFormat.GenWithStackByArgs(t))
+		return tm, ErrInvalidTimeFormat.GenWithStackByArgs(t)
 	}
 	return tm, nil
 }

--- a/types/overflow.go
+++ b/types/overflow.go
@@ -117,7 +117,7 @@ func MulInt64(a int64, b int64) (int64, error) {
 	}
 
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 
 	if negative {

--- a/types/overflow.go
+++ b/types/overflow.go
@@ -16,8 +16,6 @@ package types
 import (
 	"fmt"
 	"math"
-
-	"github.com/pingcap/errors"
 )
 
 // AddUint64 adds uint64 a and b if no overflow, else returns error.

--- a/types/time.go
+++ b/types/time.go
@@ -1449,11 +1449,7 @@ func checkDateType(t MysqlTime, allowZeroInDate, allowInvalidDate bool) error {
 		return err
 	}
 
-	if err := checkMonthDay(year, month, day, allowInvalidDate); err != nil {
-		return err
-	}
-
-	return nil
+	return checkMonthDay(year, month, day, allowInvalidDate)
 }
 
 func checkDateRange(t MysqlTime) error {

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -35,7 +35,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/rowDecoder"
+	decoder "github.com/pingcap/tidb/util/rowDecoder"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"go.uber.org/zap"
 )

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -16,7 +16,6 @@ package chunk
 import (
 	"fmt"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/stringutil"

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -186,7 +186,7 @@ func (l *List) Walk(walkFunc ListWalkFunc) error {
 		for j := 0; j < chk.NumRows(); j++ {
 			err := walkFunc(chk.GetRow(j))
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		}
 	}

--- a/util/codec/bytes.go
+++ b/util/codec/bytes.go
@@ -152,7 +152,7 @@ func EncodeCompactBytes(b []byte, data []byte) []byte {
 func DecodeCompactBytes(b []byte) ([]byte, []byte, error) {
 	b, n, err := DecodeVarint(b)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	if int64(len(b)) < n {
 		return nil, nil, errors.Errorf("insufficient bytes to decode value, expected length: %v", n)

--- a/util/codec/decimal.go
+++ b/util/codec/decimal.go
@@ -27,7 +27,7 @@ func EncodeDecimal(b []byte, dec *types.MyDecimal, precision, frac int) ([]byte,
 	b = append(b, byte(precision), byte(frac))
 	bin, err := dec.ToBin(precision, frac)
 	b = append(b, bin...)
-	return b, errors.Trace(err)
+	return b, err
 }
 
 // DecodeDecimal decodes bytes to decimal.
@@ -48,7 +48,7 @@ func DecodeDecimal(b []byte) ([]byte, *types.MyDecimal, int, int, error) {
 	binSize, err := dec.FromBin(b, precision, frac)
 	b = b[binSize:]
 	if err != nil {
-		return b, nil, precision, frac, errors.Trace(err)
+		return b, nil, precision, frac, err
 	}
 	return b, dec, precision, frac, nil
 }

--- a/util/codec/float.go
+++ b/util/codec/float.go
@@ -48,7 +48,7 @@ func EncodeFloat(b []byte, v float64) []byte {
 // DecodeFloat decodes a float from a byte slice generated with EncodeFloat before.
 func DecodeFloat(b []byte) ([]byte, float64, error) {
 	b, u, err := DecodeUint(b)
-	return b, decodeCmpUintToFloat(u), errors.Trace(err)
+	return b, decodeCmpUintToFloat(u), err
 }
 
 // EncodeFloatDesc encodes a float v into a byte slice which can be sorted lexicographically later.
@@ -61,5 +61,5 @@ func EncodeFloatDesc(b []byte, v float64) []byte {
 // DecodeFloatDesc decodes a float from a byte slice generated with EncodeFloatDesc before.
 func DecodeFloatDesc(b []byte) ([]byte, float64, error) {
 	b, u, err := DecodeUintDesc(b)
-	return b, decodeCmpUintToFloat(u), errors.Trace(err)
+	return b, decodeCmpUintToFloat(u), err
 }

--- a/util/codec/float.go
+++ b/util/codec/float.go
@@ -15,8 +15,6 @@ package codec
 
 import (
 	"math"
-
-	"github.com/pingcap/errors"
 )
 
 func encodeFloatToCmpUint64(f float64) uint64 {

--- a/util/codec/number.go
+++ b/util/codec/number.go
@@ -235,14 +235,14 @@ func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
 	first := b[0]
 	b = b[1:]
 	if first < negativeTagEnd {
-		return nil, 0, errors.Trace(errDecodeInvalid)
+		return nil, 0, errDecodeInvalid
 	}
 	if first <= positiveTagStart {
 		return b, uint64(first) - negativeTagEnd, nil
 	}
 	length := int(first) - positiveTagStart
 	if len(b) < length {
-		return nil, 0, errors.Trace(errDecodeInsufficient)
+		return nil, 0, errDecodeInsufficient
 	}
 	var v uint64
 	for _, c := range b[:length] {
@@ -254,7 +254,7 @@ func DecodeComparableUvarint(b []byte) ([]byte, uint64, error) {
 // DecodeComparableVarint decodes mem-comparable varint.
 func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 	if len(b) == 0 {
-		return nil, 0, errors.Trace(errDecodeInsufficient)
+		return nil, 0, errDecodeInsufficient
 	}
 	first := b[0]
 	if first >= negativeTagEnd && first <= positiveTagStart {
@@ -270,15 +270,15 @@ func DecodeComparableVarint(b []byte) ([]byte, int64, error) {
 		length = int(first) - positiveTagStart
 	}
 	if len(b) < length {
-		return nil, 0, errors.Trace(errDecodeInsufficient)
+		return nil, 0, errDecodeInsufficient
 	}
 	for _, c := range b[:length] {
 		v = (v << 8) | uint64(c)
 	}
 	if first > positiveTagStart && v > math.MaxInt64 {
-		return nil, 0, errors.Trace(errDecodeInvalid)
+		return nil, 0, errDecodeInvalid
 	} else if first < negativeTagEnd && v <= math.MaxInt64 {
-		return nil, 0, errors.Trace(errDecodeInvalid)
+		return nil, 0, errDecodeInvalid
 	}
 	return b[length:], int64(v), nil
 }

--- a/util/encrypt/aes.go
+++ b/util/encrypt/aes.go
@@ -122,7 +122,7 @@ func PKCS7Unpad(data []byte, blockSize int) ([]byte, error) {
 func AESEncryptWithECB(str, key []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := newECBEncrypter(cb)
 	return aesEncrypt(str, mode)
@@ -132,7 +132,7 @@ func AESEncryptWithECB(str, key []byte) ([]byte, error) {
 func AESDecryptWithECB(cryptStr, key []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := newECBDecrypter(cb)
 	return aesDecrypt(cryptStr, mode)
@@ -157,7 +157,7 @@ func DeriveKeyMySQL(key []byte, blockSize int) []byte {
 func AESEncryptWithCBC(str, key []byte, iv []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := cipher.NewCBCEncrypter(cb, iv)
 	return aesEncrypt(str, mode)
@@ -167,7 +167,7 @@ func AESEncryptWithCBC(str, key []byte, iv []byte) ([]byte, error) {
 func AESDecryptWithCBC(cryptStr, key []byte, iv []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := cipher.NewCBCDecrypter(cb, iv)
 	return aesDecrypt(cryptStr, mode)
@@ -177,7 +177,7 @@ func AESDecryptWithCBC(cryptStr, key []byte, iv []byte) ([]byte, error) {
 func AESEncryptWithOFB(plainStr []byte, key []byte, iv []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := cipher.NewOFB(cb, iv)
 	crypted := make([]byte, len(plainStr))
@@ -189,7 +189,7 @@ func AESEncryptWithOFB(plainStr []byte, key []byte, iv []byte) ([]byte, error) {
 func AESDecryptWithOFB(cipherStr []byte, key []byte, iv []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	mode := cipher.NewOFB(cb, iv)
 	plainStr := make([]byte, len(cipherStr))
@@ -213,7 +213,7 @@ func AESEncryptWithCFB(cryptStr, key []byte, iv []byte) ([]byte, error) {
 func AESDecryptWithCFB(cryptStr, key []byte, iv []byte) ([]byte, error) {
 	cb, err := aes.NewCipher(key)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	cfb := cipher.NewCFBDecrypter(cb, []byte(iv))
 	dst := make([]byte, len(cryptStr))

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -60,7 +60,7 @@ func lessThan(sc *stmtctx.StatementContext, i []types.Datum, j []types.Datum, by
 
 		ret, err := v1.CompareDatum(sc, &v2)
 		if err != nil {
-			return false, errors.Trace(err)
+			return false, err
 		}
 
 		if byDesc[k] {
@@ -221,7 +221,7 @@ func (b *Builder) Build() (*FileSorter, error) {
 		if os.IsNotExist(err) {
 			return nil, errors.New("tmpDir does not exist")
 		}
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	ws := make([]*Worker, b.nWorkers)
@@ -291,7 +291,7 @@ func (fs *FileSorter) closeAllFiles() error {
 		reportErr = err
 	}
 	if reportErr != nil {
-		return errors.Trace(reportErr)
+		return reportErr
 	}
 	return nil
 }
@@ -303,7 +303,7 @@ func (fs *FileSorter) internalSort() (*comparableRow, error) {
 	if !fs.fetched {
 		sort.Sort(w)
 		if w.err != nil {
-			return nil, errors.Trace(w.err)
+			return nil, w.err
 		}
 		fs.fetched = true
 	}
@@ -332,7 +332,7 @@ func (fs *FileSorter) externalSort() (*comparableRow, error) {
 		// check errors from workers
 		for _, w := range fs.workers {
 			if w.err != nil {
-				return nil, errors.Trace(w.err)
+				return nil, w.err
 			}
 			if w.rowSize > fs.maxRowSize {
 				fs.maxRowSize = w.rowSize
@@ -341,20 +341,20 @@ func (fs *FileSorter) externalSort() (*comparableRow, error) {
 
 		heap.Init(fs.rowHeap)
 		if fs.rowHeap.err != nil {
-			return nil, errors.Trace(fs.rowHeap.err)
+			return nil, fs.rowHeap.err
 		}
 
 		fs.rowBytes = make([]byte, fs.maxRowSize)
 
 		err := fs.openAllFiles()
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 
 		for id := range fs.fds {
 			row, err := fs.fetchNextRow(id)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, err
 			}
 			if row == nil {
 				return nil, errors.New("file is empty")
@@ -367,7 +367,7 @@ func (fs *FileSorter) externalSort() (*comparableRow, error) {
 
 			heap.Push(fs.rowHeap, im)
 			if fs.rowHeap.err != nil {
-				return nil, errors.Trace(fs.rowHeap.err)
+				return nil, fs.rowHeap.err
 			}
 		}
 
@@ -377,12 +377,12 @@ func (fs *FileSorter) externalSort() (*comparableRow, error) {
 	if fs.rowHeap.Len() > 0 {
 		im := heap.Pop(fs.rowHeap).(*item)
 		if fs.rowHeap.err != nil {
-			return nil, errors.Trace(fs.rowHeap.err)
+			return nil, fs.rowHeap.err
 		}
 
 		row, err := fs.fetchNextRow(im.index)
 		if err != nil {
-			return nil, errors.Trace(err)
+			return nil, err
 		}
 		if row != nil {
 			nextIm := &item{
@@ -392,7 +392,7 @@ func (fs *FileSorter) externalSort() (*comparableRow, error) {
 
 			heap.Push(fs.rowHeap, nextIm)
 			if fs.rowHeap.err != nil {
-				return nil, errors.Trace(fs.rowHeap.err)
+				return nil, fs.rowHeap.err
 			}
 		}
 
@@ -406,7 +406,7 @@ func (fs *FileSorter) openAllFiles() error {
 	for _, fname := range fs.files {
 		fd, err := os.Open(fname)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		fs.fds = append(fs.fds, fd)
 	}
@@ -420,7 +420,7 @@ func (fs *FileSorter) fetchNextRow(index int) (*comparableRow, error) {
 		return nil, nil
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if n != headSize {
 		return nil, errors.New("incorrect header")
@@ -429,7 +429,7 @@ func (fs *FileSorter) fetchNextRow(index int) (*comparableRow, error) {
 
 	n, err = fs.fds[index].Read(fs.rowBytes)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	if n != rowSize {
 		return nil, errors.New("incorrect row")
@@ -437,7 +437,7 @@ func (fs *FileSorter) fetchNextRow(index int) (*comparableRow, error) {
 
 	fs.dcod, err = codec.Decode(fs.rowBytes, fs.keySize+fs.valSize+1)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 
 	return &comparableRow{
@@ -511,7 +511,7 @@ func (fs *FileSorter) Output() ([]types.Datum, []types.Datum, int64, error) {
 	}
 
 	if err != nil {
-		return nil, nil, 0, errors.Trace(err)
+		return nil, nil, 0, err
 	} else if r != nil {
 		return r.key, r.val, r.handle, nil
 	} else {
@@ -531,7 +531,7 @@ func (fs *FileSorter) Close() error {
 	fs.closed = true
 	err := fs.closeAllFiles()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	return nil
 }
@@ -545,7 +545,7 @@ func (w *Worker) Less(i, j int) bool {
 	r := w.buf[j].key
 	ret, err := lessThan(w.ctx.sc, l, r, w.ctx.byDesc)
 	if w.err == nil {
-		w.err = errors.Trace(err)
+		w.err = err
 	}
 	return ret
 }
@@ -578,7 +578,7 @@ func (w *Worker) flushToFile() {
 
 	outputFile, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		w.err = errors.Trace(err)
+		w.err = err
 		return
 	}
 	defer terror.Call(outputFile.Close)
@@ -588,17 +588,17 @@ func (w *Worker) flushToFile() {
 		outputByte = append(outputByte, w.head...)
 		outputByte, err = codec.EncodeKey(sc, outputByte, row.key...)
 		if err != nil {
-			w.err = errors.Trace(err)
+			w.err = err
 			return
 		}
 		outputByte, err = codec.EncodeKey(sc, outputByte, row.val...)
 		if err != nil {
-			w.err = errors.Trace(err)
+			w.err = err
 			return
 		}
 		outputByte, err = codec.EncodeKey(sc, outputByte, types.NewIntDatum(row.handle))
 		if err != nil {
-			w.err = errors.Trace(err)
+			w.err = err
 			return
 		}
 
@@ -613,7 +613,7 @@ func (w *Worker) flushToFile() {
 
 	_, err = outputFile.Write(outputByte)
 	if err != nil {
-		w.err = errors.Trace(err)
+		w.err = err
 		return
 	}
 

--- a/util/gcutil/gcutil.go
+++ b/util/gcutil/gcutil.go
@@ -36,7 +36,7 @@ func CheckGCEnable(ctx sessionctx.Context) (enable bool, err error) {
 	sql := fmt.Sprintf(selectVariableValueSQL, "tikv_gc_enable")
 	rows, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, sql)
 	if err != nil {
-		return false, errors.Trace(err)
+		return false, err
 	}
 	if len(rows) != 1 {
 		return false, errors.New("can not get 'tikv_gc_enable'")
@@ -48,21 +48,21 @@ func CheckGCEnable(ctx sessionctx.Context) (enable bool, err error) {
 func DisableGC(ctx sessionctx.Context) error {
 	sql := fmt.Sprintf(insertVariableValueSQL, "tikv_gc_enable", "false", "Current GC enable status")
 	_, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, sql)
-	return errors.Trace(err)
+	return err
 }
 
 // EnableGC will enable GC enable variable.
 func EnableGC(ctx sessionctx.Context) error {
 	sql := fmt.Sprintf(insertVariableValueSQL, "tikv_gc_enable", "true", "Current GC enable status")
 	_, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, sql)
-	return errors.Trace(err)
+	return err
 }
 
 // ValidateSnapshot checks that the newly set snapshot time is after GC safe point time.
 func ValidateSnapshot(ctx sessionctx.Context, snapshotTS uint64) error {
 	safePointTS, err := GetGCSafePoint(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	if safePointTS > snapshotTS {
 		return variable.ErrSnapshotTooOld.GenWithStackByArgs(model.TSConvert2Time(safePointTS).String())
@@ -83,7 +83,7 @@ func GetGCSafePoint(ctx sessionctx.Context) (uint64, error) {
 	sql := fmt.Sprintf(selectVariableValueSQL, "tikv_gc_safe_point")
 	rows, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, sql)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	if len(rows) != 1 {
 		return 0, errors.New("can not get 'tikv_gc_safe_point'")
@@ -91,7 +91,7 @@ func GetGCSafePoint(ctx sessionctx.Context) (uint64, error) {
 	safePointString := rows[0].GetString(0)
 	safePointTime, err := util.CompatibleParseGCTime(safePointString)
 	if err != nil {
-		return 0, errors.Trace(err)
+		return 0, err
 	}
 	ts := variable.GoTimeToTS(safePointTime)
 	return ts, nil

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -46,12 +46,12 @@ func TestT(t *testing.T) {
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	session.SetSchemaLease(0)
 	session.SetStatsLease(0)
 	dom, err := session.BootstrapSession(store)
-	return store, dom, errors.Trace(err)
+	return store, dom, err
 }
 
 type testKvEncoderSuite struct {

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -258,7 +258,7 @@ func InitLogger(cfg *LogConfig) error {
 
 	if len(cfg.File.Filename) != 0 {
 		if err := initFileLog(&cfg.File, nil); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
@@ -267,7 +267,7 @@ func InitLogger(cfg *LogConfig) error {
 		tmp := cfg.File
 		tmp.Filename = cfg.SlowQueryFile
 		if err := initFileLog(&tmp, SlowQueryLogger); err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		SlowQueryLogger.Formatter = &slowLogFormatter{}
 	}
@@ -279,7 +279,7 @@ func InitLogger(cfg *LogConfig) error {
 func InitZapLogger(cfg *LogConfig) error {
 	gl, props, err := zaplog.InitLogger(&cfg.Config)
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	zaplog.ReplaceGlobals(gl, props)
 
@@ -297,7 +297,7 @@ func InitZapLogger(cfg *LogConfig) error {
 		}
 		sqLogger, _, err := zaplog.InitLogger(sqCfg)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		SlowQueryZapLogger = sqLogger
 	} else {
@@ -311,7 +311,7 @@ func InitZapLogger(cfg *LogConfig) error {
 func SetLevel(level string) error {
 	l := zap.NewAtomicLevel()
 	if err := l.UnmarshalText([]byte(level)); err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	zaplog.SetLevel(l.Level())
 	return nil

--- a/util/misc.go
+++ b/util/misc.go
@@ -45,12 +45,12 @@ func RunWithRetry(retryCnt int, backoff uint64, f func() (bool, error)) (err err
 		var retryAble bool
 		retryAble, err = f()
 		if err == nil || !retryAble {
-			return errors.Trace(err)
+			return err
 		}
 		sleepTime := time.Duration(backoff*uint64(i)) * time.Millisecond
 		time.Sleep(sleepTime)
 	}
-	return errors.Trace(err)
+	return err
 }
 
 // GetStack gets the stacktrace.

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -132,13 +132,13 @@ func (c *Context) NewTxn(context.Context) error {
 	if c.txn.Valid() {
 		err := c.txn.Commit(c.ctx)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 
 	txn, err := c.Store.Begin()
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	c.txn.Transaction = txn
 	return nil
@@ -146,7 +146,7 @@ func (c *Context) NewTxn(context.Context) error {
 
 // RefreshTxnCtx implements the sessionctx.Context interface.
 func (c *Context) RefreshTxnCtx(ctx context.Context) error {
-	return errors.Trace(c.NewTxn(ctx))
+	return c.NewTxn(ctx)
 }
 
 // InitTxnWithStartTS implements the sessionctx.Context interface with startTS.
@@ -161,7 +161,7 @@ func (c *Context) InitTxnWithStartTS(startTS uint64) error {
 		}
 		txn, err := c.Store.BeginWithStartTS(startTS)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 		txn.SetCap(membufCap)
 		c.txn.Transaction = txn

--- a/util/prefix_helper.go
+++ b/util/prefix_helper.go
@@ -28,13 +28,13 @@ import (
 func ScanMetaWithPrefix(retriever kv.Retriever, prefix kv.Key, filter func(kv.Key, []byte) bool) error {
 	iter, err := retriever.Iter(prefix, prefix.PrefixNext())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 	defer iter.Close()
 
 	for {
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		if iter.Valid() && iter.Key().HasPrefix(prefix) {
@@ -43,7 +43,7 @@ func ScanMetaWithPrefix(retriever kv.Retriever, prefix kv.Key, filter func(kv.Ke
 			}
 			err = iter.Next()
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		} else {
 			break
@@ -58,20 +58,20 @@ func DelKeyWithPrefix(rm kv.RetrieverMutator, prefix kv.Key) error {
 	var keys []kv.Key
 	iter, err := rm.Iter(prefix, prefix.PrefixNext())
 	if err != nil {
-		return errors.Trace(err)
+		return err
 	}
 
 	defer iter.Close()
 	for {
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 
 		if iter.Valid() && iter.Key().HasPrefix(prefix) {
 			keys = append(keys, iter.Key().Clone())
 			err = iter.Next()
 			if err != nil {
-				return errors.Trace(err)
+				return err
 			}
 		} else {
 			break
@@ -81,7 +81,7 @@ func DelKeyWithPrefix(rm kv.RetrieverMutator, prefix kv.Key) error {
 	for _, key := range keys {
 		err := rm.Delete(key)
 		if err != nil {
-			return errors.Trace(err)
+			return err
 		}
 	}
 

--- a/util/prefix_helper.go
+++ b/util/prefix_helper.go
@@ -20,7 +20,6 @@ package util
 import (
 	"bytes"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 )
 

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -297,7 +297,7 @@ func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expr
 			points := rb.build(item)
 			ranges, err := points2Ranges(sc, points, newTpSlice[0])
 			if err != nil {
-				return nil, nil, false, errors.Trace(err)
+				return nil, nil, false, err
 			}
 			totalRanges = append(totalRanges, ranges...)
 			newAccessItems = append(newAccessItems, item)
@@ -308,7 +308,7 @@ func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expr
 
 	totalRanges, err := unionRanges(sc, totalRanges)
 	if err != nil {
-		return nil, nil, false, errors.Trace(err)
+		return nil, nil, false, err
 	}
 
 	return totalRanges, []expression.Expression{expression.ComposeDNFCondition(sctx, newAccessItems...)}, hasResidual, nil
@@ -343,7 +343,7 @@ func DetachCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expre
 		if sf, ok := conditions[0].(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicOr {
 			ranges, accesses, hasResidual, err := detachDNFCondAndBuildRangeForIndex(sctx, sf, cols, newTpSlice, lengths)
 			if err != nil {
-				return res, errors.Trace(err)
+				return res, err
 			}
 			res.Ranges = ranges
 			res.AccessConds = accesses

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -14,7 +14,6 @@
 package ranger
 
 import (
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -104,7 +104,7 @@ func rangePointLess(sc *stmtctx.StatementContext, a, b point) (bool, error) {
 	if cmp != 0 {
 		return cmp < 0, nil
 	}
-	return rangePointEqualValueLess(a, b), errors.Trace(err)
+	return rangePointEqualValueLess(a, b), err
 }
 
 func rangePointEqualValueLess(a, b point) bool {
@@ -455,12 +455,12 @@ func (r *builder) buildFromIn(expr *expression.ScalarFunction) ([]point, bool) {
 func (r *builder) newBuildFromPatternLike(expr *expression.ScalarFunction) []point {
 	pdt, err := expr.GetArgs()[1].(*expression.Constant).Eval(chunk.Row{})
 	if err != nil {
-		r.err = errors.Trace(err)
+		r.err = err
 		return fullRange
 	}
 	pattern, err := pdt.ToString()
 	if err != nil {
-		r.err = errors.Trace(err)
+		r.err = err
 		return fullRange
 	}
 	if pattern == "" {
@@ -471,7 +471,7 @@ func (r *builder) newBuildFromPatternLike(expr *expression.ScalarFunction) []poi
 	lowValue := make([]byte, 0, len(pattern))
 	edt, err := expr.GetArgs()[2].(*expression.Constant).Eval(chunk.Row{})
 	if err != nil {
-		r.err = errors.Trace(err)
+		r.err = err
 		return fullRange
 	}
 	escape := byte(edt.GetInt64())

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"unicode/utf8"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -61,10 +61,10 @@ func newDomainStoreWithBootstrap(c *C) (*domain.Domain, kv.Storage, error) {
 	session.SetSchemaLease(0)
 	session.SetStatsLease(0)
 	if err != nil {
-		return nil, nil, errors.Trace(err)
+		return nil, nil, err
 	}
 	dom, err := session.BootstrapSession(store)
-	return dom, store, errors.Trace(err)
+	return dom, store, err
 }
 
 func (s *testRangerSuite) TestTableRange(c *C) {

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -124,7 +124,7 @@ func (ran *Range) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) {
 	for i := 0; i < len(ran.LowVal); i++ {
 		cmp, err := ran.LowVal[i].CompareDatum(sc, &ran.HighVal[i])
 		if err != nil {
-			return 0, errors.Trace(err)
+			return 0, err
 		}
 		if cmp != 0 {
 			return i, nil

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -18,7 +18,6 @@ import (
 	"math"
 	"strings"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"

--- a/util/signal/signal_windows.go
+++ b/util/signal/signal_windows.go
@@ -15,10 +15,12 @@
 package signal
 
 import (
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
 
+	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )
 

--- a/util/stringutil/string_util.go
+++ b/util/stringutil/string_util.go
@@ -44,7 +44,7 @@ func UnquoteChar(s string, quote byte) (value []byte, tail string, err error) {
 	// easy cases
 	switch c := s[0]; {
 	case c == quote:
-		err = errors.Trace(ErrSyntax)
+		err = ErrSyntax
 		return
 	case c >= utf8.RuneSelf:
 		r, size := utf8.DecodeRuneInString(s)
@@ -60,7 +60,7 @@ func UnquoteChar(s string, quote byte) (value []byte, tail string, err error) {
 	}
 	// hard case: c is backslash
 	if len(s) <= 1 {
-		err = errors.Trace(ErrSyntax)
+		err = ErrSyntax
 		return
 	}
 	c := s[1]
@@ -99,15 +99,15 @@ func UnquoteChar(s string, quote byte) (value []byte, tail string, err error) {
 func Unquote(s string) (t string, err error) {
 	n := len(s)
 	if n < 2 {
-		return "", errors.Trace(ErrSyntax)
+		return "", ErrSyntax
 	}
 	quote := s[0]
 	if quote != s[n-1] {
-		return "", errors.Trace(ErrSyntax)
+		return "", ErrSyntax
 	}
 	s = s[1 : n-1]
 	if quote != '"' && quote != '\'' {
-		return "", errors.Trace(ErrSyntax)
+		return "", ErrSyntax
 	}
 	// Avoid allocation. No need to convert if there is no '\'
 	if strings.IndexByte(s, '\\') == -1 && strings.IndexByte(s, quote) == -1 {
@@ -117,7 +117,7 @@ func Unquote(s string) (t string, err error) {
 	for len(s) > 0 {
 		mb, ss, err := UnquoteChar(s, quote)
 		if err != nil {
-			return "", errors.Trace(err)
+			return "", err
 		}
 		s = ss
 		buf = append(buf, mb...)

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -141,19 +141,19 @@ func (tk *TestKit) Exec(sql string, args ...interface{}) (sqlexec.RecordSet, err
 		if err == nil && len(rss) > 0 {
 			return rss[0], nil
 		}
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	stmtID, _, _, err := tk.Se.PrepareStmt(sql)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	rs, err := tk.Se.ExecutePreparedStmt(ctx, stmtID, args...)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	err = tk.Se.DropPreparedStmt(stmtID)
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, err
 	}
 	return rs, nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Removing all the `errors.Trace()` function calls. 

### What is changed and how it works?


```sh
# 1. remove `errors.Trace`:
find . -name "*.go" | xargs sed -i '' -e 's/errors.Trace(\(.*\))/\1/g'

# 2. fix go imports:
goimports -w .
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
