### PR TITLE
*: improve plan cache param eval and insert const

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -677,15 +677,16 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
 	baseExec.initCap = chunk.ZeroCapacity
 
 	ivs := &InsertValues{
-		baseExecutor: baseExec,
-		Table:        v.Table,
-		Columns:      v.Columns,
-		Lists:        v.Lists,
-		SetList:      v.SetList,
-		GenColumns:   v.GenCols.Columns,
-		GenExprs:     v.GenCols.Exprs,
-		hasRefCols:   v.NeedFillDefaultValue,
-		SelectExec:   selectExec,
+		baseExecutor:              baseExec,
+		Table:                     v.Table,
+		Columns:                   v.Columns,
+		Lists:                     v.Lists,
+		SetList:                   v.SetList,
+		GenColumns:                v.GenCols.Columns,
+		GenExprs:                  v.GenCols.Exprs,
+		allAssignmentsAreConstant: v.AllAssignmentsAreConstant,
+		hasRefCols:                v.NeedFillDefaultValue,
+		SelectExec:                selectExec,
 	}
 	err := ivs.initInsertColumns()
 	if err != nil {
@@ -1399,10 +1400,11 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {
 	base := newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), selExec)
 	base.initCap = chunk.ZeroCapacity
 	updateExec := &UpdateExec{
-		baseExecutor:   base,
-		OrderedList:    v.OrderedList,
-		tblID2table:    tblID2table,
-		tblColPosInfos: v.TblColPosInfos,
+		baseExecutor:              base,
+		OrderedList:               v.OrderedList,
+		allAssignmentsAreConstant: v.AllAssignmentsAreConstant,
+		tblID2table:               tblID2table,
+		tblColPosInfos:            v.TblColPosInfos,
 	}
 	return updateExec
 }

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -166,7 +166,9 @@ func (e *InsertExec) Open(ctx context.Context) error {
 	if e.SelectExec != nil {
 		return e.SelectExec.Open(ctx)
 	}
-	e.initEvalBuffer()
+	if !e.allAssignmentsAreConstant {
+		e.initEvalBuffer()
+	}
 	return nil
 }
 

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -54,6 +54,8 @@ type InsertValues struct {
 
 	insertColumns []*table.Column
 
+	allAssignmentsAreConstant bool
+
 	// colDefaultVals is used to store casted default value.
 	// Because not every insert statement needs colDefaultVals, so we will init the buffer lazily.
 	colDefaultVals  []defaultVal
@@ -199,10 +201,16 @@ func insertRows(ctx context.Context, base insertCommon) (err error) {
 	batchInsert := sessVars.BatchInsert && !sessVars.InTxn()
 	batchSize := sessVars.DMLBatchSize
 
+	evalRowFunc := e.fastEvalRow
+	if !e.allAssignmentsAreConstant {
+		evalRowFunc = e.evalRow
+	}
+
 	rows := make([][]types.Datum, 0, len(e.Lists))
 	for i, list := range e.Lists {
 		e.rowCount++
-		row, err := e.evalRow(ctx, list, i)
+		var row []types.Datum
+		row, err = evalRowFunc(ctx, list, i)
 		if err != nil {
 			return err
 		}
@@ -275,6 +283,31 @@ func (e *InsertValues) evalRow(ctx context.Context, list []expression.Expression
 		e.evalBuffer.SetDatum(offset, val1)
 	}
 
+	return e.fillRow(ctx, row, hasValue)
+}
+
+var emptyRow chunk.Row
+
+func (e *InsertValues) fastEvalRow(ctx context.Context, list []expression.Expression, rowIdx int) ([]types.Datum, error) {
+	rowLen := len(e.Table.Cols())
+	if e.hasExtraHandle {
+		rowLen++
+	}
+	row := make([]types.Datum, rowLen)
+	hasValue := make([]bool, rowLen)
+	for i, expr := range list {
+		con := expr.(*expression.Constant)
+		val, err := con.Eval(emptyRow)
+		if err = e.handleErr(e.insertColumns[i], &val, rowIdx, err); err != nil {
+			return nil, err
+		}
+		val1, err := table.CastValue(e.ctx, val, e.insertColumns[i].ToInfo())
+		if err = e.handleErr(e.insertColumns[i], &val, rowIdx, err); err != nil {
+			return nil, err
+		}
+		offset := e.insertColumns[i].Offset
+		row[offset], hasValue[offset] = val1, true
+	}
 	return e.fillRow(ctx, row, hasValue)
 }
 

--- a/executor/update.go
+++ b/executor/update.go
@@ -47,8 +47,9 @@ type UpdateExec struct {
 	matched     uint64 // a counter of matched rows during update
 	// tblColPosInfos stores relationship between column ordinal to its table handle.
 	// the columns ordinals is present in ordinal range format, @see plannercore.TblColPosInfos
-	tblColPosInfos plannercore.TblColPosInfoSlice
-	evalBuffer     chunk.MutRow
+	tblColPosInfos            plannercore.TblColPosInfoSlice
+	evalBuffer                chunk.MutRow
+	allAssignmentsAreConstant bool
 }
 
 func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema) ([]types.Datum, error) {
@@ -165,7 +166,13 @@ func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
 	}
 	globalRowIdx := 0
 	chk := newFirstChunk(e.children[0])
-	e.evalBuffer = chunk.MutRowFromTypes(fields)
+	if !e.allAssignmentsAreConstant {
+		e.evalBuffer = chunk.MutRowFromTypes(fields)
+	}
+	composeFunc := e.fastComposeNewRow
+	if !e.allAssignmentsAreConstant {
+		composeFunc = e.composeNewRow
+	}
 	for {
 		err := Next(ctx, e.children[0], chk)
 		if err != nil {
@@ -175,11 +182,10 @@ func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
 		if chk.NumRows() == 0 {
 			break
 		}
-
 		for rowIdx := 0; rowIdx < chk.NumRows(); rowIdx++ {
 			chunkRow := chk.GetRow(rowIdx)
 			datumRow := chunkRow.GetDatumRow(fields)
-			newRow, err1 := e.composeNewRow(globalRowIdx, datumRow, colsInfo)
+			newRow, err1 := composeFunc(globalRowIdx, datumRow, colsInfo)
 			if err1 != nil {
 				return err1
 			}
@@ -206,6 +212,34 @@ func (e *UpdateExec) handleErr(colName model.CIStr, rowIdx int, err error) error
 	}
 
 	return err
+}
+
+func (e *UpdateExec) fastComposeNewRow(rowIdx int, oldRow []types.Datum, cols []*table.Column) ([]types.Datum, error) {
+	newRowData := types.CloneRow(oldRow)
+	for _, assign := range e.OrderedList {
+		handleIdx, handleFound := e.tblColPosInfos.FindHandle(assign.Col.Index)
+		if handleFound && e.canNotUpdate(oldRow[handleIdx]) {
+			continue
+		}
+
+		con := assign.Expr.(*expression.Constant)
+		val, err := con.Eval(emptyRow)
+		if err = e.handleErr(assign.Col.ColName, rowIdx, err); err != nil {
+			return nil, err
+		}
+
+		// info of `_tidb_rowid` column is nil.
+		// No need to cast `_tidb_rowid` column value.
+		if cols[assign.Col.Index] != nil {
+			val, err = table.CastValue(e.ctx, val, cols[assign.Col.Index].ColumnInfo)
+			if err = e.handleErr(assign.Col.ColName, rowIdx, err); err != nil {
+				return nil, err
+			}
+		}
+
+		newRowData[assign.Col.Index] = *val.Copy()
+	}
+	return newRowData, nil
 }
 
 func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*table.Column) ([]types.Datum, error) {

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1100,6 +1100,7 @@ func tryToConvertConstantInt(ctx sessionctx.Context, targetFieldType *types.Fiel
 		Value:        dt,
 		RetType:      targetFieldType,
 		DeferredExpr: con.DeferredExpr,
+		ParamMarker:  con.ParamMarker,
 	}, false
 }
 
@@ -1140,6 +1141,7 @@ func RefineComparedConstant(ctx sessionctx.Context, targetFieldType types.FieldT
 			Value:        intDatum,
 			RetType:      &targetFieldType,
 			DeferredExpr: con.DeferredExpr,
+			ParamMarker:  con.ParamMarker,
 		}, false
 	}
 	switch op {
@@ -1154,7 +1156,7 @@ func RefineComparedConstant(ctx sessionctx.Context, targetFieldType types.FieldT
 			return tryToConvertConstantInt(ctx, &targetFieldType, resultCon)
 		}
 	case opcode.NullEQ, opcode.EQ:
-		switch con.RetType.EvalType() {
+		switch con.GetType().EvalType() {
 		// An integer value equal or NULL-safe equal to a float value which contains
 		// non-zero decimal digits is definitely false.
 		// e.g.,
@@ -1181,6 +1183,7 @@ func RefineComparedConstant(ctx sessionctx.Context, targetFieldType types.FieldT
 				Value:        intDatum,
 				RetType:      &targetFieldType,
 				DeferredExpr: con.DeferredExpr,
+				ParamMarker:  con.ParamMarker,
 			}, false
 		}
 	}
@@ -1201,7 +1204,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon {
 		arg1, isExceptional = RefineComparedConstant(ctx, *arg0Type, arg1, c.op)
 		finalArg1 = arg1
-		if isExceptional && arg1.RetType.EvalType() == types.ETInt {
+		if isExceptional && arg1.GetType().EvalType() == types.ETInt {
 			// Judge it is inf or -inf
 			// For int:
 			//			inf:  01111111 & 1 == 1
@@ -1220,7 +1223,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon {
 		arg0, isExceptional = RefineComparedConstant(ctx, *arg1Type, arg0, symmetricOp[c.op])
 		finalArg0 = arg0
-		if isExceptional && arg0.RetType.EvalType() == types.ETInt {
+		if isExceptional && arg0.GetType().EvalType() == types.ETInt {
 			if arg0.Value.GetInt64()&1 == 1 {
 				isNegativeInfinite = true
 			} else {

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -112,7 +112,8 @@ func (c *Constant) GetType() *types.FieldType {
 	if c.ParamMarker != nil {
 		tp := &c.ParamMarker.tp
 		*tp = *unspecifiedTp
-		types.DefaultParamTypeForValue(c.ParamMarker.GetUserVar(), tp)
+		dt := c.ParamMarker.GetUserVar()
+		types.DefaultParamTypeForValue(dt.GetValue(), tp)
 		return tp
 	}
 	return c.RetType

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -50,15 +50,37 @@ var (
 
 // Constant stands for a constant value.
 type Constant struct {
-	Value        types.Datum
-	RetType      *types.FieldType
-	DeferredExpr Expression // parameter getter expression
-	hashcode     []byte
+	Value   types.Datum
+	RetType *types.FieldType
+	// DeferredExpr holds deferred function in PlanCache cached plan.
+	// it's only used to represent non-deterministic functions(see expression.DeferredFunctions)
+	// in PlanCache cached plan, so let them can be evaluated until cached item be used.
+	DeferredExpr Expression
+	// ParamMarker holds param index inside sessionVars.PreparedParams.
+	// It's only used to reference a user variable provided in the `EXECUTE` statement or `COM_EXECUTE` binary protocol.
+	ParamMarker *ParamMarker
+	hashcode    []byte
+}
+
+// ParamMarker indicates param provided by COM_STMT_EXECUTE.
+type ParamMarker struct {
+	ctx   sessionctx.Context
+	order int
+	tp    types.FieldType
+}
+
+// GetUserVar returns the corresponding user variable presented in the `EXECUTE` statement or `COM_EXECUTE` command.
+func (d *ParamMarker) GetUserVar() types.Datum {
+	sessionVars := d.ctx.GetSessionVars()
+	return sessionVars.PreparedParams[d.order]
 }
 
 // String implements fmt.Stringer interface.
 func (c *Constant) String() string {
-	if c.DeferredExpr != nil {
+	if c.ParamMarker != nil {
+		dt := c.ParamMarker.GetUserVar()
+		c.Value.SetValue(dt.GetValue())
+	} else if c.DeferredExpr != nil {
 		dt, err := c.Eval(chunk.Row{})
 		if err != nil {
 			logutil.BgLogger().Error("eval constant failed", zap.Error(err))
@@ -76,15 +98,23 @@ func (c *Constant) MarshalJSON() ([]byte, error) {
 
 // Clone implements Expression interface.
 func (c *Constant) Clone() Expression {
-	if c.DeferredExpr != nil {
+	if c.DeferredExpr != nil || c.ParamMarker != nil {
 		con := *c
 		return &con
 	}
 	return c
 }
 
+var unspecifiedTp = types.NewFieldType(mysql.TypeUnspecified)
+
 // GetType implements Expression interface.
 func (c *Constant) GetType() *types.FieldType {
+	if c.ParamMarker != nil {
+		tp := &c.ParamMarker.tp
+		*tp = *unspecifiedTp
+		types.DefaultParamTypeForValue(c.ParamMarker.GetUserVar(), tp)
+		return tp
+	}
 	return c.RetType
 }
 
@@ -144,32 +174,47 @@ func (c *Constant) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, resul
 	return c.DeferredExpr.VecEvalJSON(ctx, input, result)
 }
 
+func (c *Constant) getLazyDatum() (dt types.Datum, isLazy bool, err error) {
+	if c.ParamMarker != nil {
+		dt = c.ParamMarker.GetUserVar()
+		isLazy = true
+		return
+	} else if c.DeferredExpr != nil {
+		dt, err = c.DeferredExpr.Eval(chunk.Row{})
+		isLazy = true
+		return
+	}
+	return
+}
+
 // Eval implements Expression interface.
 func (c *Constant) Eval(_ chunk.Row) (types.Datum, error) {
-	if c.DeferredExpr != nil {
-		if sf, sfOK := c.DeferredExpr.(*ScalarFunction); sfOK {
-			dt, err := sf.Eval(chunk.Row{})
-			if err != nil {
-				return c.Value, err
-			}
-			if dt.IsNull() {
-				c.Value.SetNull()
-				return c.Value, nil
-			}
-			val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
-			if err != nil {
-				return dt, err
-			}
-			c.Value.SetValue(val.GetValue())
+	if dt, lazy, err := c.getLazyDatum(); lazy {
+		if err != nil {
+			return c.Value, err
 		}
+		if dt.IsNull() {
+			c.Value.SetNull()
+			return c.Value, nil
+		}
+		if c.DeferredExpr != nil {
+			sf, sfOk := c.DeferredExpr.(*ScalarFunction)
+			if sfOk {
+				val, err := dt.ConvertTo(sf.GetCtx().GetSessionVars().StmtCtx, c.RetType)
+				if err != nil {
+					return dt, err
+				}
+				return val, nil
+			}
+		}
+		return dt, nil
 	}
 	return c.Value, nil
 }
 
 // EvalInt returns int representation of Constant.
 func (c *Constant) EvalInt(ctx sessionctx.Context, _ chunk.Row) (int64, bool, error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return 0, true, err
 		}
@@ -195,8 +240,7 @@ func (c *Constant) EvalInt(ctx sessionctx.Context, _ chunk.Row) (int64, bool, er
 
 // EvalReal returns real representation of Constant.
 func (c *Constant) EvalReal(ctx sessionctx.Context, _ chunk.Row) (float64, bool, error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return 0, true, err
 		}
@@ -222,8 +266,7 @@ func (c *Constant) EvalReal(ctx sessionctx.Context, _ chunk.Row) (float64, bool,
 
 // EvalString returns string representation of Constant.
 func (c *Constant) EvalString(ctx sessionctx.Context, _ chunk.Row) (string, bool, error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return "", true, err
 		}
@@ -246,8 +289,7 @@ func (c *Constant) EvalString(ctx sessionctx.Context, _ chunk.Row) (string, bool
 
 // EvalDecimal returns decimal representation of Constant.
 func (c *Constant) EvalDecimal(ctx sessionctx.Context, _ chunk.Row) (*types.MyDecimal, bool, error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return nil, true, err
 		}
@@ -266,8 +308,7 @@ func (c *Constant) EvalDecimal(ctx sessionctx.Context, _ chunk.Row) (*types.MyDe
 
 // EvalTime returns DATE/DATETIME/TIMESTAMP representation of Constant.
 func (c *Constant) EvalTime(ctx sessionctx.Context, _ chunk.Row) (val types.Time, isNull bool, err error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return types.Time{}, true, err
 		}
@@ -293,8 +334,7 @@ func (c *Constant) EvalTime(ctx sessionctx.Context, _ chunk.Row) (val types.Time
 
 // EvalDuration returns Duration representation of Constant.
 func (c *Constant) EvalDuration(ctx sessionctx.Context, _ chunk.Row) (val types.Duration, isNull bool, err error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return types.Duration{}, true, err
 		}
@@ -320,8 +360,7 @@ func (c *Constant) EvalDuration(ctx sessionctx.Context, _ chunk.Row) (val types.
 
 // EvalJSON returns JSON representation of Constant.
 func (c *Constant) EvalJSON(ctx sessionctx.Context, _ chunk.Row) (json.BinaryJSON, bool, error) {
-	if c.DeferredExpr != nil {
-		dt, err := c.DeferredExpr.Eval(chunk.Row{})
+	if dt, lazy, err := c.getLazyDatum(); lazy {
 		if err != nil {
 			return json.BinaryJSON{}, true, err
 		}

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -201,7 +201,14 @@ func foldConstant(expr Expression) (Expression, bool) {
 		}
 		return &Constant{Value: value, RetType: x.RetType}, false
 	case *Constant:
-		if x.DeferredExpr != nil {
+		if x.ParamMarker != nil {
+			return &Constant{
+				Value:        x.ParamMarker.GetUserVar(),
+				RetType:      x.RetType,
+				DeferredExpr: x.DeferredExpr,
+				ParamMarker:  x.ParamMarker,
+			}, true
+		} else if x.DeferredExpr != nil {
 			value, err := x.DeferredExpr.Eval(chunk.Row{})
 			if err != nil {
 				logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -359,12 +359,39 @@ func (*testExpressionSuite) TestDeferredParamNotNull(c *C) {
 		types.NewTimeDatum(types.Time{Time: types.FromGoTime(testTime), Fsp: 6, Type: mysql.TypeTimestamp}),
 		types.NewDurationDatum(types.ZeroDuration),
 		types.NewStringDatum("{}"),
+		types.NewBinaryLiteralDatum(types.BinaryLiteral([]byte{1})),
+		types.NewBytesDatum([]byte{'b'}),
+		types.NewFloat32Datum(1.1),
+		types.NewFloat64Datum(2.1),
+		types.NewUintDatum(100),
+		types.NewMysqlBitDatum(types.BinaryLiteral([]byte{1})),
+		types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 	}
 	cstInt := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 0}, RetType: newIntFieldType()}
 	cstDec := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 1}, RetType: newDecimalFieldType()}
 	cstTime := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 2}, RetType: newDateFieldType()}
 	cstDuration := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 3}, RetType: newDurFieldType()}
 	cstJSON := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 4}, RetType: newJSONFieldType()}
+	cstBytes := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 6}, RetType: newBlobFieldType()}
+	cstBinary := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 5}, RetType: newBinaryLiteralFieldType()}
+	cstFloat32 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 7}, RetType: newFloatFieldType()}
+	cstFloat64 := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 8}, RetType: newFloatFieldType()}
+	cstUint := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 9}, RetType: newIntFieldType()}
+	cstBit := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 10}, RetType: newBinaryLiteralFieldType()}
+	cstEnum := &Constant{ParamMarker: &ParamMarker{ctx: ctx, order: 11}, RetType: newEnumFieldType()}
+
+	c.Assert(mysql.TypeVarString, Equals, cstJSON.GetType().Tp)
+	c.Assert(mysql.TypeNewDecimal, Equals, cstDec.GetType().Tp)
+	c.Assert(mysql.TypeLonglong, Equals, cstInt.GetType().Tp)
+	c.Assert(mysql.TypeLonglong, Equals, cstUint.GetType().Tp)
+	c.Assert(mysql.TypeTimestamp, Equals, cstTime.GetType().Tp)
+	c.Assert(mysql.TypeDuration, Equals, cstDuration.GetType().Tp)
+	c.Assert(mysql.TypeBlob, Equals, cstBytes.GetType().Tp)
+	c.Assert(mysql.TypeBit, Equals, cstBinary.GetType().Tp)
+	c.Assert(mysql.TypeBit, Equals, cstBit.GetType().Tp)
+	c.Assert(mysql.TypeVarString, Equals, cstFloat32.GetType().Tp)
+	c.Assert(mysql.TypeDouble, Equals, cstFloat64.GetType().Tp)
+	c.Assert(mysql.TypeEnum, Equals, cstEnum.GetType().Tp)
 
 	d, _, err := cstInt.EvalInt(ctx, chunk.Row{})
 	c.Assert(err, IsNil)

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -956,6 +956,46 @@ func newJSONFieldType() *types.FieldType {
 	}
 }
 
+func newFloatFieldType() *types.FieldType {
+	return &types.FieldType{
+		Tp:      mysql.TypeFloat,
+		Flen:    types.UnspecifiedLength,
+		Decimal: 0,
+		Charset: charset.CharsetBin,
+		Collate: charset.CollationBin,
+	}
+}
+
+func newBinaryLiteralFieldType() *types.FieldType {
+	return &types.FieldType{
+		Tp:      mysql.TypeBit,
+		Flen:    types.UnspecifiedLength,
+		Decimal: 0,
+		Charset: charset.CharsetBin,
+		Collate: charset.CollationBin,
+	}
+}
+
+func newBlobFieldType() *types.FieldType {
+	return &types.FieldType{
+		Tp:      mysql.TypeBlob,
+		Flen:    types.UnspecifiedLength,
+		Decimal: 0,
+		Charset: charset.CharsetBin,
+		Collate: charset.CollationBin,
+	}
+}
+
+func newEnumFieldType() *types.FieldType {
+	return &types.FieldType{
+		Tp:      mysql.TypeEnum,
+		Flen:    types.UnspecifiedLength,
+		Decimal: 0,
+		Charset: charset.CharsetBin,
+		Collate: charset.CollationBin,
+	}
+}
+
 func scalarFunctionExpr(sigCode tipb.ScalarFuncSig, retType *tipb.FieldType, args ...*tipb.Expr) *tipb.Expr {
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -194,7 +194,7 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 		}
 	case *driver.ParamMarkerExpr:
 		var value Expression
-		value, sr.err = GetParamExpression(sr.ctx, v)
+		value, sr.err = ParamMarkerExpression(sr.ctx, v)
 		if sr.err != nil {
 			return retNode, false
 		}

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -195,6 +195,14 @@ func (s *testUtilSuite) TestGetUint64FromConstant(c *check.C) {
 	con.DeferredExpr = &Constant{Value: types.NewIntDatum(1)}
 	num, _, _ = GetUint64FromConstant(con)
 	c.Assert(num, check.Equals, uint64(1))
+
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().PreparedParams = []types.Datum{
+		types.NewUintDatum(100),
+	}
+	con.ParamMarker = &ParamMarker{order: 0, ctx: ctx}
+	num, _, _ = GetUint64FromConstant(con)
+	c.Assert(num, check.Equals, uint64(100))
 }
 
 func (s *testUtilSuite) TestSetExprColumnInOperand(c *check.C) {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -451,6 +451,8 @@ type Insert struct {
 	GenCols InsertGeneratedColumns
 
 	SelectPlan PhysicalPlan
+
+	AllAssignmentsAreConstant bool
 }
 
 // Update represents Update plan.
@@ -458,6 +460,8 @@ type Update struct {
 	baseSchemaProducer
 
 	OrderedList []*expression.Assignment
+
+	AllAssignmentsAreConstant bool
 
 	SelectPlan PhysicalPlan
 

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -851,7 +851,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		er.ctxStack = append(er.ctxStack, value)
 	case *driver.ParamMarkerExpr:
 		var value expression.Expression
-		value, er.err = expression.GetParamExpression(er.sctx, v)
+		value, er.err = expression.ParamMarkerExpression(er.sctx, v)
 		if er.err != nil {
 			return retNode, false
 		}
@@ -999,8 +999,8 @@ func (er *expressionRewriter) rewriteVariable(v *ast.VariableExpr) {
 		return
 	}
 	e := expression.DatumToConstant(types.NewStringDatum(val), mysql.TypeVarString)
-	e.RetType.Charset, _ = er.sctx.GetSessionVars().GetSystemVar(variable.CharacterSetConnection)
-	e.RetType.Collate, _ = er.sctx.GetSessionVars().GetSystemVar(variable.CollationConnection)
+	e.GetType().Charset, _ = er.sctx.GetSessionVars().GetSystemVar(variable.CharacterSetConnection)
+	e.GetType().Collate, _ = er.sctx.GetSessionVars().GetSystemVar(variable.CollationConnection)
 	er.ctxStack = append(er.ctxStack, e)
 }
 

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -184,7 +184,7 @@ func (ds *DataSource) tryToGetMemTask(prop *property.PhysicalProperty) (task tas
 // tryToGetDualTask will check if the push down predicate has false constant. If so, it will return table dual.
 func (ds *DataSource) tryToGetDualTask() (task, error) {
 	for _, cond := range ds.pushedDownConds {
-		if con, ok := cond.(*expression.Constant); ok && con.DeferredExpr == nil {
+		if con, ok := cond.(*expression.Constant); ok && con.DeferredExpr == nil && con.ParamMarker == nil {
 			result, _, err := expression.EvalBool(ds.ctx, []expression.Expression{cond}, chunk.Row{})
 			if err != nil {
 				return nil, err

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -593,7 +593,7 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p LogicalPlan, where a
 		}
 		cnfItems := expression.SplitCNFItems(expr)
 		for _, item := range cnfItems {
-			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil {
+			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil && con.ParamMarker == nil {
 				ret, _, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
 				if err != nil || ret {
 					continue
@@ -1047,7 +1047,7 @@ func getUintFromNode(ctx sessionctx.Context, n ast.Node) (uVal uint64, isNull bo
 		if !v.InExecute {
 			return 0, false, true
 		}
-		param, err := expression.GetParamExpression(ctx, v)
+		param, err := expression.ParamMarkerExpression(ctx, v)
 		if err != nil {
 			return 0, false, false
 		}
@@ -2723,14 +2723,15 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 
 	var updateTableList []*ast.TableName
 	updateTableList = extractTableList(update.TableRefs.TableRefs, updateTableList, true)
-	orderedList, np, err := b.buildUpdateLists(ctx, updateTableList, update.List, p)
+	orderedList, np, allAssignmentsAreConstant, err := b.buildUpdateLists(ctx, updateTableList, update.List, p)
 	if err != nil {
 		return nil, err
 	}
 	p = np
 
 	updt := Update{
-		OrderedList: orderedList,
+		OrderedList:               orderedList,
+		AllAssignmentsAreConstant: allAssignmentsAreConstant,
 	}.Init(b.ctx)
 	// We cannot apply projection elimination when building the subplan, because
 	// columns in orderedList cannot be resolved.
@@ -2754,13 +2755,22 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 	return updt, err
 }
 
-func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.TableName, list []*ast.Assignment, p LogicalPlan) ([]*expression.Assignment, LogicalPlan, error) {
+func (b *PlanBuilder) buildUpdateLists(
+	ctx context.Context,
+	tableList []*ast.TableName,
+	list []*ast.Assignment,
+	p LogicalPlan,
+) (newList []*expression.Assignment,
+	po LogicalPlan,
+	allAssignmentsAreConstant bool,
+	error error,
+) {
 	b.curClause = fieldList
 	modifyColumns := make(map[string]struct{}, p.Schema().Len()) // Which columns are in set list.
 	for _, assign := range list {
 		col, _, err := p.findColumn(assign.Column)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		columnFullName := fmt.Sprintf("%s.%s.%s", col.DBName.L, col.TblName.L, col.ColName.L)
 		modifyColumns[columnFullName] = struct{}{}
@@ -2776,7 +2786,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 		tableInfo := tn.TableInfo
 		tableVal, found := b.is.TableByID(tableInfo.ID)
 		if !found {
-			return nil, nil, infoschema.ErrTableNotExists.GenWithStackByArgs(tn.DBInfo.Name.O, tableInfo.Name.O)
+			return nil, nil, false, infoschema.ErrTableNotExists.GenWithStackByArgs(tn.DBInfo.Name.O, tableInfo.Name.O)
 		}
 		for i, colInfo := range tableInfo.Columns {
 			if !colInfo.IsGenerated() {
@@ -2784,7 +2794,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 			}
 			columnFullName := fmt.Sprintf("%s.%s.%s", tn.Schema.L, tn.Name.L, colInfo.Name.L)
 			if _, ok := modifyColumns[columnFullName]; ok {
-				return nil, nil, ErrBadGeneratedColumn.GenWithStackByArgs(colInfo.Name.O, tableInfo.Name.O)
+				return nil, nil, false, ErrBadGeneratedColumn.GenWithStackByArgs(colInfo.Name.O, tableInfo.Name.O)
 			}
 			for _, asName := range tableAsName[tableInfo] {
 				virtualAssignments = append(virtualAssignments, &ast.Assignment{
@@ -2795,12 +2805,13 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 		}
 	}
 
-	newList := make([]*expression.Assignment, 0, p.Schema().Len())
+	allAssignmentsAreConstant = true
+	newList = make([]*expression.Assignment, 0, p.Schema().Len())
 	allAssignments := append(list, virtualAssignments...)
 	for i, assign := range allAssignments {
 		col, _, err := p.findColumn(assign.Column)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		var newExpr expression.Expression
 		var np LogicalPlan
@@ -2823,9 +2834,12 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 			newExpr, np, err = b.rewriteWithPreprocess(ctx, assign.Expr, p, nil, nil, false, rewritePreprocess)
 		}
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, false, err
 		}
 		newExpr = expression.BuildCastFunction(b.ctx, newExpr, col.GetType())
+		if _, isConst := newExpr.(*expression.Constant); !isConst {
+			allAssignmentsAreConstant = false
+		}
 		p = np
 		newList = append(newList, &expression.Assignment{Col: col, Expr: newExpr})
 	}
@@ -2847,7 +2861,7 @@ func (b *PlanBuilder) buildUpdateLists(ctx context.Context, tableList []*ast.Tab
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.UpdatePriv, dbName, col.OrigTblName.L, "", nil)
 	}
-	return newList, p, nil
+	return newList, p, allAssignmentsAreConstant, nil
 }
 
 // extractTableAsNameForUpdate extracts tables' alias names for update.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1722,11 +1722,17 @@ func (b *PlanBuilder) buildSetValuesOfInsert(ctx context.Context, insert *ast.In
 		}
 	}
 
+	insertPlan.AllAssignmentsAreConstant = true
 	for i, assign := range insert.Setlist {
 		expr, _, err := b.rewriteWithPreprocess(ctx, assign.Expr, mockTablePlan, nil, nil, true, checkRefColumn)
 		if err != nil {
 			return err
 		}
+		if insertPlan.AllAssignmentsAreConstant {
+			_, isConstant := expr.(*expression.Constant)
+			insertPlan.AllAssignmentsAreConstant = isConstant
+		}
+
 		insertPlan.SetList = append(insertPlan.SetList, &expression.Assignment{
 			Col:  exprCols[i],
 			Expr: expr,
@@ -1757,6 +1763,7 @@ func (b *PlanBuilder) buildValuesListOfInsert(ctx context.Context, insert *ast.I
 		}
 	}
 
+	insertPlan.AllAssignmentsAreConstant = true
 	totalTableCols := insertPlan.Table.Cols()
 	for i, valuesItem := range insert.Lists {
 		// The length of all the value_list should be the same.
@@ -1788,6 +1795,10 @@ func (b *PlanBuilder) buildValuesListOfInsert(ctx context.Context, insert *ast.I
 			}
 			if err != nil {
 				return err
+			}
+			if insertPlan.AllAssignmentsAreConstant {
+				_, isConstant := expr.(*expression.Constant)
+				insertPlan.AllAssignmentsAreConstant = isConstant
 			}
 			exprList = append(exprList, expr)
 		}

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -170,7 +170,7 @@ func (s *partitionProcessor) canBePruned(sctx sessionctx.Context, partCol *expre
 
 	if len(conds) == 1 {
 		// Constant false.
-		if con, ok := conds[0].(*expression.Constant); ok && con.DeferredExpr == nil {
+		if con, ok := conds[0].(*expression.Constant); ok && con.DeferredExpr == nil && con.ParamMarker == nil {
 			ret, _, err := expression.EvalBool(sctx, expression.CNFExprs{con}, chunk.Row{})
 			if err == nil && ret == false {
 				return true, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

-  prepare-plan-cache will generate `builtinGetParamStringSig` and interpreting running and also do cast from T to string then cast back to a string
- almost time `insert values .....`' s values just const, but we interpreted for each value

### What is changed and how it works?

- no expression eval, directly get param from session
- identity const value insert at parse phase and use the fast way to take the insert values

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Bench

Code changes

 - N/A
Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10746)
<!-- Reviewable:end -->
