### PR TITLE
*: add a config item for load stats interval

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -73,7 +73,7 @@ func (s *testSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/cmd/explaintest/config.toml
+++ b/cmd/explaintest/config.toml
@@ -8,4 +8,5 @@ level = "error"
 status-port = 10081
 
 [performance]
-stats-lease = "0"
+update-stats-lease = "0"
+load-stats-lease = "0"

--- a/config/config.go
+++ b/config/config.go
@@ -180,7 +180,8 @@ type Performance struct {
 	MaxMemory           uint64  `toml:"max-memory" json:"max-memory"`
 	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
 	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
-	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
+	UpdateStatsLease    string  `toml:"update-stats-lease" json:"update-stats-lease"`
+	LoadStatsLease      string  `toml:"load-stats-lease" json:"load-stats-lease"`
 	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
@@ -346,7 +347,8 @@ var defaultConf = Config{
 		MaxMemory:           0,
 		TCPKeepAlive:        true,
 		CrossJoin:           true,
-		StatsLease:          "3s",
+		UpdateStatsLease:    "3s",
+		LoadStatsLease:      "3s",
 		RunAutoAnalyze:      true,
 		StmtCountLimit:      5000,
 		FeedbackProbability: 0.05,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -148,8 +148,11 @@ tcp-keep-alive = true
 # Whether support cartesian product.
 cross-join = true
 
-# Stats lease duration, which influences the time of analyze and stats load.
-stats-lease = "3s"
+# Update stats lease duration, which influences the interval of updating stats.
+update-stats-lease = "3s"
+
+# Load stats duration, which is the interval of loading stats.
+load-stats-lease = "3s"
 
 # Run auto analyze worker on this tidb-server.
 run-auto-analyze = true

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -77,7 +77,7 @@ func setupIntegrationSuite(s *testIntegrationSuite, c *C) {
 	)
 	c.Assert(err, IsNil)
 	session.SetSchemaLease(s.lease)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -83,7 +83,7 @@ func setUpSuite(s *testDBSuite, c *C) {
 
 	s.lease = 100 * time.Millisecond
 	session.SetSchemaLease(s.lease)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.schemaName = "test_db"
 	s.autoIDStep = autoid.GetStep()
 	ddl.WaitTimeWhenErrorOccured = 0

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -47,7 +47,7 @@ type testSerialSuite struct {
 
 func (s *testSerialSuite) SetUpSuite(c *C) {
 	session.SetSchemaLease(200 * time.Millisecond)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 
 	ddl.WaitTimeWhenErrorOccured = 1 * time.Microsecond
 	var err error

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -38,7 +38,7 @@ func (s *testDDLTableSplitSuite) TestTableSplit(c *C) {
 	c.Assert(err, IsNil)
 	defer store.Close()
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
 	dom, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -56,7 +56,7 @@ func (*testSuite) TestT(c *C) {
 	store, err := mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
 	ddlLease := 80 * time.Millisecond
-	dom := NewDomain(store, ddlLease, 0, mockFactory)
+	dom := NewDomain(store, ddlLease, 0, 0, mockFactory)
 	err = dom.Init(ddlLease, sysMockFactory)
 	c.Assert(err, IsNil)
 	defer func() {

--- a/domain/global_vars_cache_test.go
+++ b/domain/global_vars_cache_test.go
@@ -39,7 +39,7 @@ func (gvcSuite *testGVCSuite) TestSimple(c *C) {
 	c.Assert(err, IsNil)
 	defer store.Close()
 	ddlLease := 50 * time.Millisecond
-	dom := NewDomain(store, ddlLease, 0, mockFactory)
+	dom := NewDomain(store, ddlLease, 0, 0, mockFactory)
 	err = dom.Init(ddlLease, sysMockFactory)
 	c.Assert(err, IsNil)
 	defer dom.Close()

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -992,7 +992,7 @@ func (e *AnalyzeFastExec) buildHist(ID int64, collector *statistics.SampleCollec
 	}
 	stats := domain.GetDomain(e.ctx).StatsHandle()
 	rowCount := int64(e.rowCount)
-	if stats.Lease > 0 {
+	if stats.LoadLease > 0 {
 		rowCount = mathutil.MinInt64(stats.GetTableStats(e.tblInfo).Count, rowCount)
 	}
 	// build CMSketch

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -153,7 +153,7 @@ func (s *testSuite1) TestAnalyzeFastSample(c *C) {
 	)
 	c.Assert(err, IsNil)
 	var dom *domain.Domain
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	session.SetSchemaLease(0)
 	dom, err = session.BootstrapSession(store)
 	c.Assert(err, IsNil)
@@ -224,7 +224,7 @@ func (s *testSuite1) TestFastAnalyze(c *C) {
 	)
 	c.Assert(err, IsNil)
 	var dom *domain.Domain
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	session.SetSchemaLease(0)
 	dom, err = session.BootstrapSession(store)
 	c.Assert(err, IsNil)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -120,7 +120,8 @@ func (s *testSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
+		session.SetLoadStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
@@ -3605,7 +3606,7 @@ func (s *testSuite2) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
@@ -3656,7 +3657,7 @@ func (s *testSuite3) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
@@ -3707,7 +3708,7 @@ func (s *testSuite4) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -91,7 +91,7 @@ func (s *seqTestSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -412,12 +412,12 @@ func (s *testSuite3) TestDropStats(c *C) {
 	statsTbl = h.GetTableStats(tableInfo)
 	c.Assert(statsTbl.Pseudo, IsFalse)
 
-	h.Lease = 1
+	h.LoadLease = 1
 	testKit.MustExec("drop stats t")
 	h.Update(is)
 	statsTbl = h.GetTableStats(tableInfo)
 	c.Assert(statsTbl.Pseudo, IsTrue)
-	h.Lease = 0
+	h.LoadLease = 0
 }
 
 func (s *testSuite3) TestFlushTables(c *C) {

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -52,7 +52,7 @@ func (s *testUpdateSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -47,7 +47,7 @@ func (s *testTableSuite) SetUpSuite(c *C) {
 	var err error
 	s.store, err = mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 }

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -658,8 +658,8 @@ func (s *testAnalyzeSuite) TestNullCount(c *C) {
 	))
 	h := dom.StatsHandle()
 	h.Clear()
-	h.Lease = 1
-	defer func() { h.Lease = 0 }()
+	h.LoadLease = 1
+	defer func() { h.LoadLease = 0 }()
 	c.Assert(h.Update(dom.InfoSchema()), IsNil)
 	testKit.MustQuery("explain select * from t where b = 1").Check(testkit.Rows(
 		"TableReader_7 0.00 root data:Selection_6",
@@ -755,7 +755,8 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	}
 
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
+	session.SetLoadStatsLease(0)
 
 	dom, err := session.BootstrapSession(store)
 	if err != nil {

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -35,7 +35,7 @@ type testCacheSuite struct {
 func (s *testCacheSuite) SetUpSuite(c *C) {
 	store, err := mockstore.NewMockTikvStore()
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	c.Assert(err, IsNil)
 	s.domain, err = session.BootstrapSession(store)
 	c.Assert(err, IsNil)
@@ -276,7 +276,7 @@ func (s *testCacheSuite) TestAbnormalMySQLTable(c *C) {
 	c.Assert(err, IsNil)
 	defer store.Close()
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 
 	dom, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -658,7 +658,7 @@ func mustExec(c *C, se session.Session, sql string) {
 func newStore(c *C, dbPath string) (*domain.Domain, kv.Storage) {
 	store, err := mockstore.NewMockTikvStore()
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	c.Assert(err, IsNil)
 	dom, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)

--- a/server/statistics_handler_test.go
+++ b/server/statistics_handler_test.go
@@ -47,7 +47,7 @@ func (ds *testDumpStatsSuite) startServer(c *C) {
 	var err error
 	ds.store, err = mockstore.NewMockTikvStore(mockstore.WithMVCCStore(mvccStore))
 	c.Assert(err, IsNil)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	ds.domain, err = session.BootstrapSession(ds.store)
 	c.Assert(err, IsNil)
 	ds.domain.SetStatsUpdating(true)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -53,7 +53,7 @@ func (ts *TidbTestSuite) SetUpSuite(c *C) {
 	metrics.RegisterMetrics()
 	var err error
 	ts.store, err = mockstore.NewMockTikvStore()
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	c.Assert(err, IsNil)
 	ts.domain, err = session.BootstrapSession(ts.store)
 	c.Assert(err, IsNil)

--- a/session/isolation_test.go
+++ b/session/isolation_test.go
@@ -47,7 +47,7 @@ func (s *testIsolationSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -55,7 +55,7 @@ func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -72,7 +72,7 @@ func (s *testSessionSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 }
@@ -1703,7 +1703,7 @@ func (s *testSchemaSuite) SetUpSuite(c *C) {
 	s.store = store
 	s.lease = 20 * time.Millisecond
 	session.SetSchemaLease(s.lease)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	dom, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 	s.dom = dom

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -105,9 +105,9 @@ func (s *testStatsSuite) TestDumpAlteredTable(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	h := s.do.StatsHandle()
-	oriLease := h.Lease
-	h.Lease = 1
-	defer func() { h.Lease = oriLease }()
+	oriLease := h.LoadLease
+	h.LoadLease = 1
+	defer func() { h.LoadLease = oriLease }()
 	tk.MustExec("create table t(a int, b int)")
 	tk.MustExec("analyze table t")
 	tk.MustExec("alter table t drop column a")

--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -29,7 +29,7 @@ import (
 func (h *Handle) GCStats(is infoschema.InfoSchema, ddlLease time.Duration) error {
 	// To make sure that all the deleted tables' schema and stats info have been acknowledged to all tidb,
 	// we only garbage collect version before 10 lease.
-	lease := mathutil.MaxInt64(int64(h.Lease), int64(ddlLease))
+	lease := mathutil.MaxInt64(int64(h.LoadLease), int64(ddlLease))
 	offset := DurationToTS(10 * time.Duration(lease))
 	if h.LastUpdateVersion() < offset {
 		return nil

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -740,7 +740,7 @@ func (h *Handle) autoAnalyzeTable(tblInfo *model.TableInfo, statsTbl *statistics
 	if statsTbl.Pseudo || statsTbl.Count < AutoAnalyzeMinCnt {
 		return false
 	}
-	if needAnalyze, reason := NeedAnalyzeTable(statsTbl, 20*h.Lease, ratio, start, end, time.Now()); needAnalyze {
+	if needAnalyze, reason := NeedAnalyzeTable(statsTbl, 20*h.LoadLease, ratio, start, end, time.Now()); needAnalyze {
 		logutil.Logger(context.Background()).Info("[stats] auto analyze triggered", zap.String("sql", sql), zap.String("reason", reason))
 		h.execAutoAnalyze(sql)
 		return true

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -408,8 +408,8 @@ func (s *testStatsSuite) TestAutoUpdate(c *C) {
 	}
 
 	// Test that even if the table is recently modified, we can still analyze the table.
-	h.Lease = time.Second
-	defer func() { h.Lease = 0 }()
+	h.LoadLease = time.Second
+	defer func() { h.LoadLease = 0 }()
 	_, err = testKit.Exec("insert into t values ('fff')")
 	c.Assert(err, IsNil)
 	c.Assert(h.DumpStatsDeltaToKV(handle.DumpAll), IsNil)
@@ -523,11 +523,11 @@ func (s *testStatsSuite) TestTableAnalyzed(c *C) {
 	c.Assert(handle.TableAnalyzed(statsTbl), IsTrue)
 
 	h.Clear()
-	oriLease := h.Lease
+	oriLease := h.LoadLease
 	// set it to non-zero so we will use load by need strategy
-	h.Lease = 1
+	h.LoadLease = 1
 	defer func() {
-		h.Lease = oriLease
+		h.LoadLease = oriLease
 	}()
 	h.Update(is)
 	statsTbl = h.GetTableStats(tableInfo)
@@ -538,7 +538,7 @@ func (s *testStatsSuite) TestUpdateErrorRate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	h := s.do.StatsHandle()
 	is := s.do.InfoSchema()
-	h.Lease = 0
+	h.LoadLease = 0
 	h.Update(is)
 
 	oriProbability := statistics.FeedbackProbability
@@ -608,7 +608,7 @@ func (s *testStatsSuite) TestUpdatePartitionErrorRate(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	h := s.do.StatsHandle()
 	is := s.do.InfoSchema()
-	h.Lease = 0
+	h.LoadLease = 0
 	h.Update(is)
 
 	oriProbability := statistics.FeedbackProbability
@@ -1086,18 +1086,18 @@ func (s *testStatsSuite) TestLogDetailedInfo(c *C) {
 	oriMinLogCount := handle.MinLogScanCount
 	oriMinError := handle.MinLogErrorRate
 	oriLevel := log.GetLevel()
-	oriLease := s.do.StatsHandle().Lease
+	oriLease := s.do.StatsHandle().LoadLease
 	defer func() {
 		statistics.FeedbackProbability = oriProbability
 		handle.MinLogScanCount = oriMinLogCount
 		handle.MinLogErrorRate = oriMinError
-		s.do.StatsHandle().Lease = oriLease
+		s.do.StatsHandle().LoadLease = oriLease
 		log.SetLevel(oriLevel)
 	}()
 	statistics.FeedbackProbability.Store(1)
 	handle.MinLogScanCount = 0
 	handle.MinLogErrorRate = 0
-	s.do.StatsHandle().Lease = 1
+	s.do.StatsHandle().LoadLease = 1
 
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
@@ -1555,9 +1555,9 @@ func (s *testStatsSuite) TestLoadHistCorrelation(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	h := s.do.StatsHandle()
-	origLease := h.Lease
-	h.Lease = time.Second
-	defer func() { h.Lease = origLease }()
+	origLease := h.LoadLease
+	h.LoadLease = time.Second
+	defer func() { h.LoadLease = origLease }()
 	testKit.MustExec("use test")
 	testKit.MustExec("create table t(c int)")
 	testKit.MustExec("insert into t values(1),(2),(3),(4),(5)")

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -121,7 +121,8 @@ func newStoreWithBootstrap(statsLease time.Duration) (kv.Storage, *domain.Domain
 		return nil, nil, errors.Trace(err)
 	}
 	session.SetSchemaLease(0)
-	session.SetStatsLease(statsLease)
+	session.SetUpdateStatsLease(statsLease)
+	session.SetLoadStatsLease(statsLease)
 	domain.RunAutoAnalyze = false
 	do, err := session.BootstrapSession(store)
 	do.SetStatsUpdating(true)

--- a/store/mockstore/mocktikv/mvcc.go
+++ b/store/mockstore/mocktikv/mvcc.go
@@ -48,6 +48,7 @@ type mvccLock struct {
 	op          kvrpcpb.Op
 	ttl         uint64
 	forUpdateTS uint64
+	txnSize     uint64
 }
 
 type mvccEntry struct {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -482,6 +482,7 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchKeys) *tikvrpc.Reque
 			LockTtl:           c.lockTTL,
 			IsPessimisticLock: isPessimisticLock,
 			ForUpdateTs:       c.forUpdateTS,
+			TxnSize:           uint64(len(batch.keys)),
 		},
 		Context: pb.Context{
 			Priority: c.priority,

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -33,6 +33,9 @@ import (
 // ResolvedCacheSize is max number of cached txn status.
 const ResolvedCacheSize = 2048
 
+// bigTxnThreshold : transaction involves keys exceed this threshold can be treated as `big transaction`.
+const bigTxnThreshold = 16
+
 var (
 	tikvLockResolverCountWithBatchResolve             = metrics.TiKVLockResolverCounter.WithLabelValues("batch_resolve")
 	tikvLockResolverCountWithExpired                  = metrics.TiKVLockResolverCounter.WithLabelValues("expired")
@@ -43,6 +46,7 @@ var (
 	tikvLockResolverCountWithQueryTxnStatusCommitted  = metrics.TiKVLockResolverCounter.WithLabelValues("query_txn_status_committed")
 	tikvLockResolverCountWithQueryTxnStatusRolledBack = metrics.TiKVLockResolverCounter.WithLabelValues("query_txn_status_rolled_back")
 	tikvLockResolverCountWithResolveLocks             = metrics.TiKVLockResolverCounter.WithLabelValues("query_resolve_locks")
+	tikvLockResolverCountWithResolveLockLite          = metrics.TiKVLockResolverCounter.WithLabelValues("query_resolve_lock_lite")
 )
 
 // LockResolver resolves locks and also caches resolved txn status.
@@ -125,6 +129,7 @@ type Lock struct {
 	Primary []byte
 	TxnID   uint64
 	TTL     uint64
+	TxnSize uint64
 }
 
 func (l *Lock) String() string {
@@ -137,11 +142,13 @@ func NewLock(l *kvrpcpb.LockInfo) *Lock {
 	if ttl == 0 {
 		ttl = defaultLockTTL
 	}
+	txnSize := l.GetTxnSize()
 	return &Lock{
 		Key:     l.GetKey(),
 		Primary: l.GetPrimaryLock(),
 		TxnID:   l.GetLockVersion(),
 		TTL:     ttl,
+		TxnSize: txnSize,
 	}
 }
 
@@ -388,6 +395,7 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 
 func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, cleanRegions map[RegionVerID]struct{}) error {
 	tikvLockResolverCountWithResolveLocks.Inc()
+	cleanWholeRegion := l.TxnSize >= bigTxnThreshold
 	for {
 		loc, err := lr.store.GetRegionCache().LocateKey(bo, l.Key)
 		if err != nil {
@@ -404,6 +412,12 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, cl
 		}
 		if status.IsCommitted() {
 			req.ResolveLock.CommitVersion = status.CommitTS()
+		}
+		if l.TxnSize < bigTxnThreshold {
+			// Only resolve specified keys when it is a small transaction,
+			// prevent from scanning the whole region in this case.
+			tikvLockResolverCountWithResolveLockLite.Inc()
+			req.ResolveLock.Keys = [][]byte{l.Key}
 		}
 		resp, err := lr.store.SendReq(bo, req, loc.Region, readTimeoutShort)
 		if err != nil {
@@ -429,7 +443,9 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, cl
 			logutil.Logger(context.Background()).Error("resolveLock error", zap.Error(err))
 			return err
 		}
-		cleanRegions[loc.Region] = struct{}{}
+		if cleanWholeRegion {
+			cleanRegions[loc.Region] = struct{}{}
+		}
 		return nil
 	}
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -447,8 +447,9 @@ func setGlobalVars() {
 	ddlLeaseDuration := parseDuration(cfg.Lease)
 	session.SetSchemaLease(ddlLeaseDuration)
 	runtime.GOMAXPROCS(int(cfg.Performance.MaxProcs))
-	statsLeaseDuration := parseDuration(cfg.Performance.StatsLease)
-	session.SetStatsLease(statsLeaseDuration)
+	statsLeaseDuration := parseDuration(cfg.Performance.UpdateStatsLease)
+	session.SetUpdateStatsLease(statsLeaseDuration)
+	session.SetLoadStatsLease(parseDuration(cfg.Performance.LoadStatsLease))
 	bindinfo.Lease = parseDuration(cfg.Performance.BindInfoLease)
 	domain.RunAutoAnalyze = cfg.Performance.RunAutoAnalyze
 	statistics.FeedbackProbability.Store(cfg.Performance.FeedbackProbability)

--- a/types/const_test.go
+++ b/types/const_test.go
@@ -56,7 +56,7 @@ func (s *testMySQLConstSuite) SetUpSuite(c *C) {
 		c.Assert(err, IsNil)
 		s.store = store
 		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
+		session.SetUpdateStatsLease(0)
 	}
 	var err error
 	s.dom, err = session.BootstrapSession(s.store)

--- a/util/admin/admin_integration_test.go
+++ b/util/admin/admin_integration_test.go
@@ -43,7 +43,7 @@ func (s *testAdminSuite) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	d, err := session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 	d.SetStatsUpdating(true)

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -248,7 +248,7 @@ func (e *kvEncoder) initial(dbName string, idAlloc autoid.Allocator) (err error)
 // initGlobal modify the global domain and store
 func initGlobal() error {
 	// disable stats update.
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	var err error
 	storeGlobal, domGlobal, err = newMockTikvWithBootstrap()
 	if err == nil {

--- a/util/kvencoder/kv_encoder_test.go
+++ b/util/kvencoder/kv_encoder_test.go
@@ -49,7 +49,7 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 		return nil, nil, errors.Trace(err)
 	}
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
 	dom, err := session.BootstrapSession(store)
 	return store, dom, errors.Trace(err)
 }

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -59,7 +59,8 @@ func newDomainStoreWithBootstrap(c *C) (*domain.Domain, kv.Storage, error) {
 	)
 	c.Assert(err, IsNil)
 	session.SetSchemaLease(0)
-	session.SetStatsLease(0)
+	session.SetUpdateStatsLease(0)
+	session.SetLoadStatsLease(0)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Sometimes, we need to automatically load stats even if the stats lease is 0.

### What is changed and how it works?

Let stats lease only controls the update stats lease, and add another config item for load stats lease, so we can control the load and update separately.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
      Change the stats lease to 0, verifies that it could load the latest stats.

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
