### PR TITLE
[experimental]planner: change semi join to inner join when decorrelaing

### DIFF
--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -31,11 +31,14 @@ create table t2(a int not null, b int not null, key a(a));
 set @@tidb_opt_insubq_to_join_and_agg=0;
 explain select /*+ TIDB_INLJ(t2) */ * from t1 where t1.a in (select t2.a from t2);
 id	count	task	operator info
-IndexJoin_10	8000.00	root	semi join, inner:IndexReader_9, outer key:test.t1.a, inner key:test.t2.a
-├─TableReader_12	10000.00	root	data:TableScan_11
-│ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-└─IndexReader_9	10.00	root	index:IndexScan_8
-  └─IndexScan_8	10.00	cop	table:t2, index:a, range: decided by [eq(test.t2.a, test.t1.a)], keep order:false, stats:pseudo
+Projection_9	10000.00	root	test.t1.a, test.t1.b
+└─HashLeftJoin_10	10000.00	root	inner join, inner:StreamAgg_25, equal:[eq(test.t1.a, test.t2.a)]
+  ├─TableReader_13	10000.00	root	data:TableScan_12
+  │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─StreamAgg_25	8000.00	root	group by:col_1, funcs:firstrow(col_0)
+    └─IndexReader_26	8000.00	root	index:StreamAgg_17
+      └─StreamAgg_17	8000.00	cop	group by:test.t2.a, funcs:firstrow(test.t2.a)
+        └─IndexScan_24	10000.00	cop	table:t2, index:a, range:[NULL,+inf], keep order:true, stats:pseudo
 show warnings;
 Level	Code	Message
 set @@tidb_opt_insubq_to_join_and_agg=1;

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -37,6 +37,7 @@ const (
 	flagPrunColumns uint64 = 1 << iota
 	flagBuildKeyInfo
 	flagDecorrelate
+	flagBuildKeyInfo2
 	flagEliminateAgg
 	flagEliminateProjection
 	flagMaxMinEliminate
@@ -52,6 +53,7 @@ var optRuleList = []logicalOptRule{
 	&columnPruner{},
 	&buildKeySolver{},
 	&decorrelateSolver{},
+	&buildKeySolver{},
 	&aggregationEliminator{},
 	&projectionEliminater{},
 	&maxMinEliminator{},
@@ -66,6 +68,7 @@ var optRuleList = []logicalOptRule{
 // logicalOptRule means a logical optimizing rule, which contains decorrelate, ppd, column pruning, etc.
 type logicalOptRule interface {
 	optimize(LogicalPlan) (LogicalPlan, error)
+	getFlag() uint64
 }
 
 // BuildLogicalPlan used to build logical plan from ast.Node.
@@ -133,6 +136,7 @@ func logicalOptimize(flag uint64, logic LogicalPlan) (LogicalPlan, error) {
 		if err != nil {
 			return nil, err
 		}
+		flag |= rule.getFlag()
 	}
 	return logic, err
 }

--- a/planner/core/partition_pruning_test.go
+++ b/planner/core/partition_pruning_test.go
@@ -28,6 +28,10 @@ type testPartitionPruningSuite struct {
 	partitionProcessor
 }
 
+func (s *testPartitionPruningSuite) getFlag() uint64 {
+	return 0
+}
+
 func (s *testPartitionPruningSuite) TestCanBePrune(c *C) {
 	p := parser.New()
 	stmt, err := p.ParseOneStmt("create table t (d datetime not null)", "", "")

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -296,7 +296,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderJoin(c *C) {
 		},
 		{
 			sql:  "select * from t where t.c in (select b from t s where s.a = t.a)",
-			best: "MergeSemiJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.s.a)",
+			best: "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.s.a)->Projection",
 		},
 		{
 			sql:  "select t.c in (select b from t s where s.a = t.a) from t",
@@ -503,7 +503,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSubquery(c *C) {
 		// Test Nested sub query.
 		{
 			sql:  "select * from t where exists (select s.a from t s where s.c in (select c from t as k where k.d = s.d) having sum(s.a) = t.a )",
-			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->IndexReader(Index(t.c_d_e)[[NULL,+inf]])}(test.s.c,test.k.c)(test.s.d,test.k.d)->Projection->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->LeftHashJoin{TableReader(Table(t))->IndexReader(Index(t.c_d_e)[[NULL,+inf]]->StreamAgg)->StreamAgg}(test.s.d,test.k.d)(test.s.c,test.k.c)->Projection->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
 		},
 		// Test Semi Join + Order by.
 		{

--- a/planner/core/rule_aggregation_elimination.go
+++ b/planner/core/rule_aggregation_elimination.go
@@ -28,6 +28,10 @@ type aggregationEliminator struct {
 	aggregationEliminateChecker
 }
 
+func (a *aggregationEliminator) getFlag() uint64 {
+	return 0
+}
+
 type aggregationEliminateChecker struct {
 }
 

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -28,6 +28,10 @@ type aggregationPushDownSolver struct {
 	aggregationEliminateChecker
 }
 
+func (a *aggregationPushDownSolver) getFlag() uint64 {
+	return 0
+}
+
 // isDecomposable checks if an aggregate function is decomposable. An aggregation function $F$ is decomposable
 // if there exist aggregation functions F_1 and F_2 such that F(S_1 union all S_2) = F_2(F_1(S_1),F_1(S_2)),
 // where S_1 and S_2 are two sets of values. We call S_1 and S_2 partial groups.

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -21,6 +21,10 @@ import (
 
 type buildKeySolver struct{}
 
+func (s *buildKeySolver) getFlag() uint64 {
+	return 0
+}
+
 func (s *buildKeySolver) optimize(lp LogicalPlan) (LogicalPlan, error) {
 	lp.buildKeyInfo()
 	return lp, nil

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -26,6 +26,10 @@ import (
 type columnPruner struct {
 }
 
+func (s *columnPruner) getFlag() uint64 {
+	return 0
+}
+
 func (s *columnPruner) optimize(lp LogicalPlan) (LogicalPlan, error) {
 	err := lp.PruneColumns(lp.Schema().Columns)
 	return lp, err

--- a/planner/core/rule_decorrelate.go
+++ b/planner/core/rule_decorrelate.go
@@ -158,7 +158,11 @@ func (s *decorrelateSolver) optimize(p LogicalPlan) (LogicalPlan, error) {
 			join := &apply.LogicalJoin
 			join.self = join
 
-			p = s.tryToTransSemiJoinToInnerJoin(join)
+			if p.context().GetSessionVars().AllowSemiJoinToInnerJoinAndAgg {
+				p = s.tryToTransSemiJoinToInnerJoin(join)
+			} else {
+				p = join
+			}
 		} else if sel, ok := innerPlan.(*LogicalSelection); ok {
 			// If the inner plan is a selection, we add this condition to join predicates.
 			// Notice that no matter what kind of join is, it's always right.

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -103,6 +103,10 @@ func eliminatePhysicalProjection(p PhysicalPlan) PhysicalPlan {
 type projectionEliminater struct {
 }
 
+func (pe *projectionEliminater) getFlag() uint64 {
+	return 0
+}
+
 // optimize implements the logicalOptRule interface.
 func (pe *projectionEliminater) optimize(lp LogicalPlan) (LogicalPlan, error) {
 	root := pe.eliminate(lp, make(map[string]*expression.Column), false)

--- a/planner/core/rule_join_elimination.go
+++ b/planner/core/rule_join_elimination.go
@@ -21,6 +21,10 @@ import (
 type outerJoinEliminator struct {
 }
 
+func (o *outerJoinEliminator) getFlag() uint64 {
+	return 0
+}
+
 // tryToEliminateOuterJoin will eliminate outer join plan base on the following rules
 // 1. outer join elimination: For example left outer join, if the parent only use the
 //    columns from left table and the join key of right table(the inner table) is a unique

--- a/planner/core/rule_join_reorder.go
+++ b/planner/core/rule_join_reorder.go
@@ -47,6 +47,10 @@ func extractJoinGroup(p LogicalPlan) (group []LogicalPlan, eqEdges []*expression
 type joinReOrderSolver struct {
 }
 
+func (s *joinReOrderSolver) getFlag() uint64 {
+	return 0
+}
+
 type jrNode struct {
 	p       LogicalPlan
 	cumCost float64

--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -25,6 +25,10 @@ import (
 type maxMinEliminator struct {
 }
 
+func (a *maxMinEliminator) getFlag() uint64 {
+	return 0
+}
+
 func (a *maxMinEliminator) optimize(p LogicalPlan) (LogicalPlan, error) {
 	a.eliminateMaxMin(p)
 	return p, nil

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -39,6 +39,10 @@ import (
 // partitionProcessor is here because it's easier to prune partition after predicate push down.
 type partitionProcessor struct{}
 
+func (s *partitionProcessor) getFlag() uint64 {
+	return 0
+}
+
 func (s *partitionProcessor) optimize(lp LogicalPlan) (LogicalPlan, error) {
 	return s.rewriteDataSource(lp)
 }

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -23,6 +23,10 @@ import (
 
 type ppdSolver struct{}
 
+func (s *ppdSolver) getFlag() uint64 {
+	return 0
+}
+
 func (s *ppdSolver) optimize(lp LogicalPlan) (LogicalPlan, error) {
 	_, p := lp.PredicatePushDown(nil)
 	return p, nil

--- a/planner/core/rule_topn_push_down.go
+++ b/planner/core/rule_topn_push_down.go
@@ -22,6 +22,10 @@ import (
 type pushDownTopNOptimizer struct {
 }
 
+func (s *pushDownTopNOptimizer) getFlag() uint64 {
+	return 0
+}
+
 func (s *pushDownTopNOptimizer) optimize(p LogicalPlan) (LogicalPlan, error) {
 	return p.pushDownTopN(nil), nil
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1659,6 +1659,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBDDLReorgBatchSize,
 	variable.TiDBDDLErrorCountLimit,
 	variable.TiDBOptInSubqToJoinAndAgg,
+	variable.TiDBOptSemiJoinToInnerJoinAndAgg,
 	variable.TiDBOptCorrelationThreshold,
 	variable.TiDBOptCorrelationExpFactor,
 	variable.TiDBDistSQLScanConcurrency,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -290,6 +290,8 @@ type SessionVars struct {
 	// AllowInSubqToJoinAndAgg can be set to false to forbid rewriting the semi join to inner join with agg.
 	AllowInSubqToJoinAndAgg bool
 
+	AllowSemiJoinToInnerJoinAndAgg bool
+
 	// CorrelationThreshold is the guard to enable row count estimation using column order correlation.
 	CorrelationThreshold float64
 
@@ -404,31 +406,32 @@ type ConnectionInfo struct {
 // NewSessionVars creates a session vars object.
 func NewSessionVars() *SessionVars {
 	vars := &SessionVars{
-		Users:                       make(map[string]string),
-		systems:                     make(map[string]string),
-		PreparedStmts:               make(map[uint32]*ast.Prepared),
-		PreparedStmtNameToID:        make(map[string]uint32),
-		PreparedParams:              make([]types.Datum, 0, 10),
-		TxnCtx:                      &TransactionContext{},
-		KVVars:                      kv.NewVariables(),
-		RetryInfo:                   &RetryInfo{},
-		ActiveRoles:                 make([]*auth.RoleIdentity, 0, 10),
-		StrictSQLMode:               true,
-		Status:                      mysql.ServerStatusAutocommit,
-		StmtCtx:                     new(stmtctx.StatementContext),
-		AllowAggPushDown:            false,
-		OptimizerSelectivityLevel:   DefTiDBOptimizerSelectivityLevel,
-		RetryLimit:                  DefTiDBRetryLimit,
-		DisableTxnAutoRetry:         DefTiDBDisableTxnAutoRetry,
-		DDLReorgPriority:            kv.PriorityLow,
-		AllowInSubqToJoinAndAgg:     DefOptInSubqToJoinAndAgg,
-		CorrelationThreshold:        DefOptCorrelationThreshold,
-		CorrelationExpFactor:        DefOptCorrelationExpFactor,
-		EnableRadixJoin:             false,
-		L2CacheSize:                 cpuid.CPU.Cache.L2,
-		CommandValue:                uint32(mysql.ComSleep),
-		TiDBOptJoinReorderThreshold: DefTiDBOptJoinReorderThreshold,
-		SlowQueryFile:               config.GetGlobalConfig().Log.SlowQueryFile,
+		Users:                          make(map[string]string),
+		systems:                        make(map[string]string),
+		PreparedStmts:                  make(map[uint32]*ast.Prepared),
+		PreparedStmtNameToID:           make(map[string]uint32),
+		PreparedParams:                 make([]types.Datum, 0, 10),
+		TxnCtx:                         &TransactionContext{},
+		KVVars:                         kv.NewVariables(),
+		RetryInfo:                      &RetryInfo{},
+		ActiveRoles:                    make([]*auth.RoleIdentity, 0, 10),
+		StrictSQLMode:                  true,
+		Status:                         mysql.ServerStatusAutocommit,
+		StmtCtx:                        new(stmtctx.StatementContext),
+		AllowAggPushDown:               false,
+		OptimizerSelectivityLevel:      DefTiDBOptimizerSelectivityLevel,
+		RetryLimit:                     DefTiDBRetryLimit,
+		DisableTxnAutoRetry:            DefTiDBDisableTxnAutoRetry,
+		DDLReorgPriority:               kv.PriorityLow,
+		AllowInSubqToJoinAndAgg:        DefOptInSubqToJoinAndAgg,
+		AllowSemiJoinToInnerJoinAndAgg: DefOptSemiJoinToInnerJoinAndAgg,
+		CorrelationThreshold:           DefOptCorrelationThreshold,
+		CorrelationExpFactor:           DefOptCorrelationExpFactor,
+		EnableRadixJoin:                false,
+		L2CacheSize:                    cpuid.CPU.Cache.L2,
+		CommandValue:                   uint32(mysql.ComSleep),
+		TiDBOptJoinReorderThreshold:    DefTiDBOptJoinReorderThreshold,
+		SlowQueryFile:                  config.GetGlobalConfig().Log.SlowQueryFile,
 	}
 	vars.Concurrency = Concurrency{
 		IndexLookupConcurrency:     DefIndexLookupConcurrency,
@@ -696,6 +699,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.AllowWriteRowID = TiDBOptOn(val)
 	case TiDBOptInSubqToJoinAndAgg:
 		s.AllowInSubqToJoinAndAgg = TiDBOptOn(val)
+	case TiDBOptSemiJoinToInnerJoinAndAgg:
+		s.AllowSemiJoinToInnerJoinAndAgg = TiDBOptOn(val)
 	case TiDBOptCorrelationThreshold:
 		s.CorrelationThreshold = tidbOptFloat64(val, DefOptCorrelationThreshold)
 	case TiDBOptCorrelationExpFactor:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -639,6 +639,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBChecksumTableConcurrency, strconv.Itoa(DefChecksumTableConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBDistSQLScanConcurrency, strconv.Itoa(DefDistSQLScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBOptInSubqToJoinAndAgg, BoolToIntStr(DefOptInSubqToJoinAndAgg)},
+	{ScopeGlobal | ScopeSession, TiDBOptSemiJoinToInnerJoinAndAgg, BoolToIntStr(DefOptSemiJoinToInnerJoinAndAgg)},
 	{ScopeGlobal | ScopeSession, TiDBOptCorrelationThreshold, strconv.FormatFloat(DefOptCorrelationThreshold, 'f', -1, 64)},
 	{ScopeGlobal | ScopeSession, TiDBOptCorrelationExpFactor, strconv.Itoa(DefOptCorrelationExpFactor)},
 	{ScopeGlobal | ScopeSession, TiDBIndexJoinBatchSize, strconv.Itoa(DefIndexJoinBatchSize)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -158,6 +158,8 @@ const (
 	// tidb_opt_insubquery_to_join_and_agg is used to enable/disable the optimizer rule of rewriting IN subquery.
 	TiDBOptInSubqToJoinAndAgg = "tidb_opt_insubq_to_join_and_agg"
 
+	TiDBOptSemiJoinToInnerJoinAndAgg = "tidb_opt_semijoin_to_innerjoin_and_agg"
+
 	// tidb_opt_correlation_threshold is a guard to enable row count estimation using column order correlation.
 	TiDBOptCorrelationThreshold = "tidb_opt_correlation_threshold"
 
@@ -296,6 +298,7 @@ const (
 	DefOptCorrelationThreshold         = 0.9
 	DefOptCorrelationExpFactor         = 1
 	DefOptInSubqToJoinAndAgg           = true
+	DefOptSemiJoinToInnerJoinAndAgg    = false
 	DefBatchInsert                     = false
 	DefBatchDelete                     = false
 	DefBatchCommit                     = false

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -419,7 +419,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
 		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction,
-		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO:
+		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBOptSemiJoinToInnerJoinAndAgg:
 		if strings.EqualFold(value, "ON") || value == "1" || strings.EqualFold(value, "OFF") || value == "0" {
 			return value, nil
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

open more probability for optimization.
A experimental feature.

### What is changed and how it works?

If the join is non-corrleated. Try to rewrite to inner join if it's a simple semi join.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes
Currently none.
<!--
 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note
-->