### PR TITLE
expression: fix issue that `TimeIsNull` is not compatible with MySQL 

### DIFF
--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -337,6 +337,8 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinRealIsNullSig{base}
 	case tipb.ScalarFuncSig_TimeIsNull:
 		f = &builtinTimeIsNullSig{base}
+	case tipb.ScalarFuncSig_TimeIsNullOnNotNullCol:
+		f = &builtinTimeIsNullSigOnNotNullCol{base}
 	case tipb.ScalarFuncSig_StringIsNull:
 		f = &builtinStringIsNullSig{base}
 	case tipb.ScalarFuncSig_IntIsNull:

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4398,3 +4398,28 @@ func (s *testIntegrationSuite) TestIssue10181(c *C) {
 	tk.MustExec(`insert into t values(9223372036854775807), (18446744073709551615)`)
 	tk.MustQuery(`select * from t where a > 9223372036854775807-0.5 order by a`).Check(testkit.Rows(`9223372036854775807`, `18446744073709551615`))
 }
+
+func (s *testIntegrationSuite) TestIssue9763(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`CREATE TABLE t1 (a datetime not null);`)
+	tk.MustExec(`insert ignore into t1 values (0);`)
+	tk.MustQuery(`select * from t1 where a is null;`).Check(testkit.Rows(`0000-00-00 00:00:00`))
+
+	tk.MustExec(`drop table if exists t2;`)
+	tk.MustExec(`CREATE TABLE t2 (a date not null);`)
+	tk.MustExec(`insert ignore into t2 values (0);`)
+	tk.MustQuery(`select * from t2 where a is null;`).Check(testkit.Rows(`0000-00-00`))
+
+	tk.MustExec(`drop table if exists t3;`)
+	tk.MustExec(`CREATE TABLE t3 (a datetime);`)
+	tk.MustExec(`insert ignore into t3 values (0);`)
+	c.Assert(len(tk.MustQuery(`select * from t3 where a is null;`).Rows()), Equals, 0)
+
+	tk.MustExec(`drop table if exists t4;`)
+	tk.MustExec(`CREATE TABLE t4 (a date);`)
+	tk.MustExec(`insert ignore into t4 values (0);`)
+	c.Assert(len(tk.MustQuery(`select * from t4 where a is null;`).Rows()), Equals, 0)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #9763.

`TimeIsNull` in TiDB doesn't check if these DATETIME columns are declared as NOT NULL.
But In MySQL:
```
For DATE and DATETIME columns that are declared as NOT NULL, 
you can find the special date '0000-00-00' by using a statement like this:
"SELECT * FROM tbl_name WHERE date_column IS NULL"
```

This PR needs to be merged after https://github.com/pingcap/tipb/pull/121.

For TiKV, since
1. `TimeIsNull` is not pushed down to TiKV, and
2. there is some problem(https://github.com/tikv/tikv/issues/4864) to let `tipb` can't be upgraded in TiKV, 

we don't fix `TimeIsNull` on TiKV.
### What is changed and how it works?
Check if these DATETIME columns are declared as NOT NULL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test