### PR TITLE
kvcache: fix unit test by avoiding lru OOM.

### DIFF
--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -56,7 +56,7 @@ func (s *testLRUCacheSuite) TestPut(c *C) {
 	maxMem, err := memory.MemTotal()
 	c.Assert(err, IsNil)
 
-	lru := NewSimpleLRUCache(3, 0.1, maxMem)
+	lru := NewSimpleLRUCache(3, 0, maxMem)
 	c.Assert(lru.capacity, Equals, uint(3))
 
 	keys := make([]*mockCacheKey, 5)
@@ -135,7 +135,7 @@ func (s *testLRUCacheSuite) TestGet(c *C) {
 	maxMem, err := memory.MemTotal()
 	c.Assert(err, IsNil)
 
-	lru := NewSimpleLRUCache(3, 0.1, maxMem)
+	lru := NewSimpleLRUCache(3, 0, maxMem)
 
 	keys := make([]*mockCacheKey, 5)
 	vals := make([]int64, 5)
@@ -178,7 +178,7 @@ func (s *testLRUCacheSuite) TestDelete(c *C) {
 	maxMem, err := memory.MemTotal()
 	c.Assert(err, IsNil)
 
-	lru := NewSimpleLRUCache(3, 0.1, maxMem)
+	lru := NewSimpleLRUCache(3, 0, maxMem)
 
 	keys := make([]*mockCacheKey, 3)
 	vals := make([]int64, 3)
@@ -207,7 +207,7 @@ func (s *testLRUCacheSuite) TestDeleteAll(c *C) {
 	maxMem, err := memory.MemTotal()
 	c.Assert(err, IsNil)
 
-	lru := NewSimpleLRUCache(3, 0.1, maxMem)
+	lru := NewSimpleLRUCache(3, 0, maxMem)
 
 	keys := make([]*mockCacheKey, 3)
 	vals := make([]int64, 3)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The test fails if my laptop memory is almost full.

```bash
----------------------------------------------------------------------
FAIL: simple_lru_test.go:177: testLRUCacheSuite.TestDelete

simple_lru_test.go:191:
    c.Assert(int(lru.size), Equals, 3)
... obtained int = 0
... expected int = 3

----------------------------------------------------------------------
FAIL: simple_lru_test.go:206: testLRUCacheSuite.TestDeleteAll

simple_lru_test.go:220:
    c.Assert(int(lru.size), Equals, 3)
... obtained int = 0
... expected int = 3

----------------------------------------------------------------------
FAIL: simple_lru_test.go:134: testLRUCacheSuite.TestGet

simple_lru_test.go:158:
    c.Assert(exists, IsTrue)
... obtained bool = false

----------------------------------------------------------------------
PASS: simple_lru_test.go:109: testLRUCacheSuite.TestOOMGuard	0.000s

----------------------------------------------------------------------
FAIL: simple_lru_test.go:55: testLRUCacheSuite.TestPut

simple_lru_test.go:70:
    c.Assert(lru.size, Equals, lru.capacity)
... obtained uint = 0x0
... expected uint = 0x3

OOPS: 1 passed, 4 FAILED
--- FAIL: TestT (0.01s)
FAIL
exit status 1
FAIL	github.com/pingcap/tidb/util/kvcache	0.029s

[sunrunaway:...m/pingcap/tidb/util/kvcache]$ GO111MODULE=on go test                                           (master)

----------------------------------------------------------------------
FAIL: simple_lru_test.go:177: testLRUCacheSuite.TestDelete

simple_lru_test.go:191:
    c.Assert(int(lru.size), Equals, 3)
... obtained int = 0
... expected int = 3

----------------------------------------------------------------------
FAIL: simple_lru_test.go:206: testLRUCacheSuite.TestDeleteAll

simple_lru_test.go:220:
    c.Assert(int(lru.size), Equals, 3)
... obtained int = 0
... expected int = 3

----------------------------------------------------------------------
FAIL: simple_lru_test.go:134: testLRUCacheSuite.TestGet

simple_lru_test.go:158:
    c.Assert(exists, IsTrue)
... obtained bool = false

----------------------------------------------------------------------
PASS: simple_lru_test.go:109: testLRUCacheSuite.TestOOMGuard	0.000s

----------------------------------------------------------------------
FAIL: simple_lru_test.go:55: testLRUCacheSuite.TestPut

simple_lru_test.go:70:
    c.Assert(lru.size, Equals, lru.capacity)
... obtained uint = 0x0
... expected uint = 0x3

OOPS: 1 passed, 4 FAILED
--- FAIL: TestT (0.01s)
FAIL
exit status 1
FAIL	github.com/pingcap/tidb/util/kvcache	0.029s
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None