### PR TITLE
domain: add a config to control updating stats

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -176,7 +176,7 @@ type Performance struct {
 	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
 	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
 	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
-	UpdateStats         bool    `toml:"update-stats" json:"update-stats"`
+	EnableUpdateStats   bool    `toml:"enable-update-stats" json:"enable-update-stats"`
 	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
@@ -322,7 +322,7 @@ var defaultConf = Config{
 		TCPKeepAlive:        true,
 		CrossJoin:           true,
 		StatsLease:          "3s",
-		UpdateStats:         true,
+		EnableUpdateStats:   true,
 		RunAutoAnalyze:      true,
 		StmtCountLimit:      5000,
 		FeedbackProbability: 0.05,

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ type Performance struct {
 	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
 	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
 	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
+	UpdateStats         bool    `toml:"update-stats" json:"update-stats"`
 	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
 	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
@@ -321,6 +322,7 @@ var defaultConf = Config{
 		TCPKeepAlive:        true,
 		CrossJoin:           true,
 		StatsLease:          "3s",
+		UpdateStats:         true,
 		RunAutoAnalyze:      true,
 		StmtCountLimit:      5000,
 		FeedbackProbability: 0.05,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,7 +143,7 @@ cross-join = true
 # Stats lease duration, which influences the time of analyze and stats load.
 stats-lease = "3s"
 
-# Whether run stats updates on this tidb-server. It will only updates stats when stats-lease is non-zero.
+# Whether run stats updates on this tidb-server. It will updates stats only when stats-lease is non-zero.
 enable-update-stats = true
 
 # Run auto analyze worker on this tidb-server.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,6 +143,9 @@ cross-join = true
 # Stats lease duration, which influences the time of analyze and stats load.
 stats-lease = "3s"
 
+# Whether run stats updates on this tidb-server.
+update-stats = true
+
 # Run auto analyze worker on this tidb-server.
 run-auto-analyze = true
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,7 +143,7 @@ cross-join = true
 # Stats lease duration, which influences the time of analyze and stats load.
 stats-lease = "3s"
 
-# Whether run stats updates on this tidb-server. It will updates stats only when stats-lease is non-zero.
+# Whether run stats updates on this tidb-server. It will use the value of `stats-lease` to set its tickers' values, so it won't work when `stats-lease` is zero.
 enable-update-stats = true
 
 # Run auto analyze worker on this tidb-server.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -143,8 +143,8 @@ cross-join = true
 # Stats lease duration, which influences the time of analyze and stats load.
 stats-lease = "3s"
 
-# Whether run stats updates on this tidb-server.
-update-stats = true
+# Whether run stats updates on this tidb-server. It will only updates stats when stats-lease is non-zero.
+enable-update-stats = true
 
 # Run auto analyze worker on this tidb-server.
 run-auto-analyze = true

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -839,7 +839,7 @@ func (do *Domain) UpdateTableStatsLoop(ctx sessionctx.Context) error {
 	}
 	do.wg.Add(1)
 	go do.loadStatsWorker()
-	if !config.GetGlobalConfig().Performance.UpdateStats {
+	if !config.GetGlobalConfig().Performance.EnableUpdateStats {
 		return nil
 	}
 	owner := do.newStatsOwner()

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -837,6 +837,11 @@ func (do *Domain) UpdateTableStatsLoop(ctx sessionctx.Context) error {
 	if do.statsLease <= 0 {
 		return nil
 	}
+	do.wg.Add(1)
+	go do.loadStatsWorker()
+	if !config.GetGlobalConfig().Performance.UpdateStats {
+		return nil
+	}
 	owner := do.newStatsOwner()
 	do.wg.Add(1)
 	do.SetStatsUpdating(true)
@@ -865,22 +870,12 @@ func (do *Domain) newStatsOwner() owner.Manager {
 	return statsOwner
 }
 
-func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager) {
-	defer recoverInDomain("updateStatsWorker", false)
+func (do *Domain) loadStatsWorker() {
+	defer recoverInDomain("loadStatsWorker", false)
+	defer do.wg.Done()
 	lease := do.statsLease
-	deltaUpdateDuration := lease * 20
 	loadTicker := time.NewTicker(lease)
 	defer loadTicker.Stop()
-	deltaUpdateTicker := time.NewTicker(deltaUpdateDuration)
-	defer deltaUpdateTicker.Stop()
-	loadHistogramTicker := time.NewTicker(lease)
-	defer loadHistogramTicker.Stop()
-	gcStatsTicker := time.NewTicker(100 * lease)
-	defer gcStatsTicker.Stop()
-	dumpFeedbackTicker := time.NewTicker(200 * lease)
-	defer dumpFeedbackTicker.Stop()
-	loadFeedbackTicker := time.NewTicker(5 * lease)
-	defer loadFeedbackTicker.Stop()
 	statsHandle := do.StatsHandle()
 	t := time.Now()
 	err := statsHandle.InitStats(do.InfoSchema())
@@ -889,10 +884,6 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 	} else {
 		logutil.Logger(context.Background()).Info("init stats info time", zap.Duration("take time", time.Since(t)))
 	}
-	defer func() {
-		do.SetStatsUpdating(false)
-		do.wg.Done()
-	}()
 	for {
 		select {
 		case <-loadTicker.C:
@@ -900,37 +891,60 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("update stats info failed", zap.Error(err))
 			}
+			err = statsHandle.LoadNeededHistograms()
+			if err != nil {
+				logutil.Logger(context.Background()).Debug("load histograms failed", zap.Error(err))
+			}
+		case <-do.exit:
+			return
+		}
+	}
+}
+
+func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager) {
+	defer recoverInDomain("updateStatsWorker", false)
+	lease := do.statsLease
+	deltaUpdateTicker := time.NewTicker(20 * lease)
+	defer deltaUpdateTicker.Stop()
+	gcStatsTicker := time.NewTicker(100 * lease)
+	defer gcStatsTicker.Stop()
+	dumpFeedbackTicker := time.NewTicker(200 * lease)
+	defer dumpFeedbackTicker.Stop()
+	loadFeedbackTicker := time.NewTicker(5 * lease)
+	defer loadFeedbackTicker.Stop()
+	statsHandle := do.StatsHandle()
+	defer func() {
+		do.SetStatsUpdating(false)
+		do.wg.Done()
+	}()
+	for {
+		select {
 		case <-do.exit:
 			statsHandle.FlushStats()
 			return
 			// This channel is sent only by ddl owner.
 		case t := <-statsHandle.DDLEventCh():
-			err = statsHandle.HandleDDLEvent(t)
+			err := statsHandle.HandleDDLEvent(t)
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("handle ddl event failed", zap.Error(err))
 			}
 		case <-deltaUpdateTicker.C:
-			err = statsHandle.DumpStatsDeltaToKV(statistics.DumpDelta)
+			err := statsHandle.DumpStatsDeltaToKV(statistics.DumpDelta)
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("dump stats delta failed", zap.Error(err))
 			}
 			statsHandle.UpdateErrorRate(do.InfoSchema())
-		case <-loadHistogramTicker.C:
-			err = statsHandle.LoadNeededHistograms()
-			if err != nil {
-				logutil.Logger(context.Background()).Debug("load histograms failed", zap.Error(err))
-			}
 		case <-loadFeedbackTicker.C:
 			statsHandle.UpdateStatsByLocalFeedback(do.InfoSchema())
 			if !owner.IsOwner() {
 				continue
 			}
-			err = statsHandle.HandleUpdateStats(do.InfoSchema())
+			err := statsHandle.HandleUpdateStats(do.InfoSchema())
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("update stats using feedback failed", zap.Error(err))
 			}
 		case <-dumpFeedbackTicker.C:
-			err = statsHandle.DumpStatsFeedbackToKV()
+			err := statsHandle.DumpStatsFeedbackToKV()
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("dump stats feedback failed", zap.Error(err))
 			}
@@ -938,7 +952,7 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			if !owner.IsOwner() {
 				continue
 			}
-			err = statsHandle.GCStats(do.InfoSchema(), do.DDL().GetLease())
+			err := statsHandle.GCStats(do.InfoSchema(), do.DDL().GetLease())
 			if err != nil {
 				logutil.Logger(context.Background()).Debug("GC stats failed", zap.Error(err))
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

We need to disable the updating of stats while still can load the stats.

### What is changed and how it works?

Add a bool config `update-stats` to control the updating stats.

StatsLease|EnableUpdateStats|Effects
--|--|--
0 | 0 | disable stats
0|1 | disable stats
1|0 | only load stats
1|1 | load stats and update stats

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
     Change `update-stats` to false, the log still shows ["init stats info time"] ["take time"=2.834524ms] but there is no stats update anymore.

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to be included in the release note
