### PR TITLE
executor: add coprocessor flag 'InUnion'

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -151,6 +151,9 @@ func statementContextToFlags(sc *stmtctx.StatementContext) uint64 {
 	if sc.PadCharToFullLength {
 		flags |= model.FlagPadCharToFullLength
 	}
+	if sc.InUnionStmt {
+		flags |= model.FlagInUnionStmt
+	}
 	return flags
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1376,6 +1376,20 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 			sc.NotFillCache = !opts.SQLCache
 		}
 		sc.PadCharToFullLength = ctx.GetSessionVars().SQLMode.HasPadCharToFullLengthMode()
+	case *ast.UnionStmt:
+		sc.InUnionStmt = true
+
+		// UNION is used to combine the result from multiple SELECT statements into a single result set.
+		// see https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#sql-mode-strict
+		// said "For statements such as SELECT that do not change data, invalid values
+		// generate a warning in strict mode, not an error."
+		// and https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
+		sc.OverflowAsWarning = true
+
+		// Return warning for truncate error in selection.
+		sc.TruncateAsWarning = true
+		sc.IgnoreZeroInDate = true
+		sc.PadCharToFullLength = ctx.GetSessionVars().SQLMode.HasPadCharToFullLengthMode()
 	case *ast.ExplainStmt:
 		sc.InExplainStmt = true
 	case *ast.ShowStmt:

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190528074401-b942b3f4108f
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190611090107-2bb2c0e8f340
+	github.com/pingcap/parser v0.0.0-20190612024153-939965d02d2e
 	github.com/pingcap/pd v2.1.11+incompatible
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3F
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/parser v0.0.0-20190611090107-2bb2c0e8f340 h1:WZGc0+xpKCnjuVdMX9YW7763/HO0Ey4Dn9nEbUfq5bc=
 github.com/pingcap/parser v0.0.0-20190611090107-2bb2c0e8f340/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190612024153-939965d02d2e h1:eyPhI46sWhK4Q4Mp7BtxWTZ0KO/mw5L1OVy3TSEfe/Y=
+github.com/pingcap/parser v0.0.0-20190612024153-939965d02d2e/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v2.1.11+incompatible h1:LHn92NDzkkpivZj+hyyuXIoSdyMMQbLRqQZg8ZQcz6o=
 github.com/pingcap/pd v2.1.11+incompatible/go.mod h1:nD3+EoYes4+aNNODO99ES59V83MZSI+dFbhyr667a0E=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -54,6 +54,7 @@ type StatementContext struct {
 	InUpdateStmt           bool
 	InDeleteStmt           bool
 	InSelectStmt           bool
+	InUnionStmt            bool
 	InLoadDataStmt         bool
 	InExplainStmt          bool
 	IgnoreTruncate         bool


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add a flag `InUnionStmt` which is useful to cover some corner case in CAST functions implementation in the coprocessor.

The `UnionAll` executor will infer its children's results type and add `CAST` function if necessary. The `CAST` functions in this scenario maybe have some different behaviors, so we should pushdown related `Flag` to the coprocessor.

### What is changed and how it works?

1. Add a flag to statement context.
2. Pushdown the flag to the coprocessor.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Related changes

 - Need to cherry-pick to the release branch
