### PR TITLE
ddl: fix 'create table like' for partitioned table

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1678,6 +1678,13 @@ func (s *testDBSuite5) TestCreateTableWithLike(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tbl1.Meta().ForeignKeys, IsNil)
 
+	// for table partition
+	s.tk.MustExec("use ctwl_db")
+	s.tk.MustExec("create table pt1 (id int) partition by range columns (id) (partition p0 values less than (10))")
+	s.tk.MustExec("insert into pt1 values (1),(2),(3),(4);")
+	s.tk.MustExec("create table ctwl_db1.pt1 like ctwl_db.pt1;")
+	s.tk.MustQuery("select * from ctwl_db1.pt1").Check(testkit.Rows())
+
 	// for failure cases
 	failSQL := fmt.Sprintf("create table t1 like test_not_exist.t")
 	assertErrorCode(c, s.tk, failSQL, tmysql.ErrNoSuchTable)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -495,8 +495,8 @@ func (d *ddl) GetInfoSchemaWithInterceptor(ctx sessionctx.Context) infoschema.In
 	return d.mu.interceptor.OnGetInfoSchema(ctx, is)
 }
 
-func (d *ddl) genGlobalID() (int64, error) {
-	var globalID int64
+func (d *ddl) genGlobalID(count int) ([]int64, error) {
+	ret := make([]int64, count)
 	err := kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
 		var err error
 
@@ -506,11 +506,17 @@ func (d *ddl) genGlobalID() (int64, error) {
 			}
 		})
 
-		globalID, err = meta.NewMeta(txn).GenGlobalID()
-		return errors.Trace(err)
+		m := meta.NewMeta(txn)
+		for i := 0; i < count; i++ {
+			ret[i], err = m.GenGlobalID()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 
-	return globalID, errors.Trace(err)
+	return ret, err
 }
 
 // SchemaSyncer implements DDL.SchemaSyncer interface.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -495,14 +495,14 @@ func (d *ddl) GetInfoSchemaWithInterceptor(ctx sessionctx.Context) infoschema.In
 	return d.mu.interceptor.OnGetInfoSchema(ctx, is)
 }
 
-func (d *ddl) genGlobalID(count int) ([]int64, error) {
+func (d *ddl) genGlobalIDs(count int) ([]int64, error) {
 	ret := make([]int64, count)
 	err := kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
 		var err error
 
 		failpoint.Inject("mockGenGlobalIDFail", func(val failpoint.Value) {
 			if val.(bool) {
-				failpoint.Return(errors.New("gofail genGlobalID error"))
+				failpoint.Return(errors.New("gofail genGlobalIDs error"))
 			}
 		})
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -60,10 +60,11 @@ func (d *ddl) CreateSchema(ctx sessionctx.Context, schema model.CIStr, charsetIn
 		return errors.Trace(err)
 	}
 
-	schemaID, err := d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	schemaID := genIDs[0]
 	dbInfo := &model.DBInfo{
 		Name: schema,
 	}
@@ -967,10 +968,11 @@ func buildTableInfo(ctx sessionctx.Context, d *ddl, tableName model.CIStr, cols 
 	// When this function is called by MockTableInfo, we should set a particular table id.
 	// So the `ddl` structure may be nil.
 	if d != nil {
-		tbInfo.ID, err = d.genGlobalID()
+		genIDs, err := d.genGlobalID(1)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		tbInfo.ID = genIDs[0]
 	}
 	for _, v := range cols {
 		v.ID = allocateColumnID(tbInfo)
@@ -1097,10 +1099,22 @@ func (d *ddl) CreateTableWithLike(ctx sessionctx.Context, ident, referIdent ast.
 	}
 
 	tblInfo := buildTableInfoWithLike(ident, referTbl.Meta())
-	tblInfo.ID, err = d.genGlobalID()
+	count := 1
+	if tblInfo.Partition != nil {
+		count += len(tblInfo.Partition.Definitions)
+	}
+	var genIDs []int64
+	genIDs, err = d.genGlobalID(count)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	tblInfo.ID = genIDs[0]
+	if tblInfo.Partition != nil {
+		for i := 0; i < len(tblInfo.Partition.Definitions); i++ {
+			tblInfo.Partition.Definitions[i].ID = genIDs[i+1]
+		}
+	}
+
 	job := &model.Job{
 		SchemaID:   schema.ID,
 		TableID:    tblInfo.ID,
@@ -1135,6 +1149,12 @@ func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) mode
 	tblInfo.Name = ident.Name
 	tblInfo.AutoIncID = 0
 	tblInfo.ForeignKeys = nil
+	if referTblInfo.Partition != nil {
+		pi := *referTblInfo.Partition
+		pi.Definitions = make([]model.PartitionDefinition, len(referTblInfo.Partition.Definitions))
+		copy(pi.Definitions, referTblInfo.Partition.Definitions)
+		tblInfo.Partition = &pi
+	}
 	return tblInfo
 }
 
@@ -2870,10 +2890,11 @@ func (d *ddl) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	newTableID, err := d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	if err != nil {
 		return errors.Trace(err)
 	}
+	newTableID := genIDs[0]
 	job := &model.Job{
 		SchemaID:   schema.ID,
 		TableID:    tb.Meta().ID,
@@ -3168,8 +3189,12 @@ func buildPartitionInfo(meta *model.TableInfo, d *ddl, spec *ast.AlterTableSpec)
 		Columns: meta.Partition.Columns,
 		Enable:  meta.Partition.Enable,
 	}
+	genIDs, err := d.genGlobalID(len(spec.PartDefinitions))
+	if err != nil {
+		return nil, err
+	}
 	buf := new(bytes.Buffer)
-	for _, def := range spec.PartDefinitions {
+	for ith, def := range spec.PartDefinitions {
 		if err := def.Clause.Validate(part.Type, len(part.Columns)); err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -3190,14 +3215,10 @@ func buildPartitionInfo(meta *model.TableInfo, d *ddl, spec *ast.AlterTableSpec)
 			}
 			// Partition by range columns if len(part.Columns) != 0.
 		}
-		pid, err1 := d.genGlobalID()
-		if err1 != nil {
-			return nil, errors.Trace(err1)
-		}
 		comment, _ := def.Comment()
 		piDef := model.PartitionDefinition{
 			Name:    def.Name,
-			ID:      pid,
+			ID:      genIDs[ith],
 			Comment: comment,
 		}
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -60,7 +60,7 @@ func (d *ddl) CreateSchema(ctx sessionctx.Context, schema model.CIStr, charsetIn
 		return errors.Trace(err)
 	}
 
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -968,7 +968,7 @@ func buildTableInfo(ctx sessionctx.Context, d *ddl, tableName model.CIStr, cols 
 	// When this function is called by MockTableInfo, we should set a particular table id.
 	// So the `ddl` structure may be nil.
 	if d != nil {
-		genIDs, err := d.genGlobalID(1)
+		genIDs, err := d.genGlobalIDs(1)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -1104,7 +1104,7 @@ func (d *ddl) CreateTableWithLike(ctx sessionctx.Context, ident, referIdent ast.
 		count += len(tblInfo.Partition.Definitions)
 	}
 	var genIDs []int64
-	genIDs, err = d.genGlobalID(count)
+	genIDs, err = d.genGlobalIDs(count)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -2890,7 +2890,7 @@ func (d *ddl) TruncateTable(ctx sessionctx.Context, ti ast.Ident) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -3189,7 +3189,7 @@ func buildPartitionInfo(meta *model.TableInfo, d *ddl, spec *ast.AlterTableSpec)
 		Columns: meta.Partition.Columns,
 		Enable:  meta.Partition.Enable,
 	}
-	genIDs, err := d.genGlobalID(len(spec.PartDefinitions))
+	genIDs, err := d.genGlobalIDs(len(spec.PartDefinitions))
 	if err != nil {
 		return nil, err
 	}

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -115,7 +115,7 @@ func buildTablePartitionInfo(ctx sessionctx.Context, d *ddl, s *ast.CreateTableS
 }
 
 func buildHashPartitionDefinitions(ctx sessionctx.Context, d *ddl, s *ast.CreateTableStmt, pi *model.PartitionInfo) error {
-	genIDs, err := d.genGlobalID(int(pi.Num))
+	genIDs, err := d.genGlobalIDs(int(pi.Num))
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -135,7 +135,7 @@ func buildHashPartitionDefinitions(ctx sessionctx.Context, d *ddl, s *ast.Create
 }
 
 func buildRangePartitionDefinitions(ctx sessionctx.Context, d *ddl, s *ast.CreateTableStmt, pi *model.PartitionInfo) error {
-	genIDs, err := d.genGlobalID(len(s.Partition.Definitions))
+	genIDs, err := d.genGlobalIDs(len(s.Partition.Definitions))
 	if err != nil {
 		return err
 	}

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -40,13 +40,12 @@ func (s *testSchemaSuite) TearDownSuite(c *C) {
 }
 
 func testSchemaInfo(c *C, d *ddl, name string) *model.DBInfo {
-	var err error
 	dbInfo := &model.DBInfo{
 		Name: model.NewCIStr(name),
 	}
-
-	dbInfo.ID, err = d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	c.Assert(err, IsNil)
+	dbInfo.ID = genIDs[0]
 	return dbInfo
 }
 
@@ -206,8 +205,9 @@ func (s *testSchemaSuite) TestSchemaWaitJob(c *C) {
 	// d2 must not be owner.
 	c.Assert(d2.ownerManager.IsOwner(), IsFalse)
 
-	schemaID, err := d2.genGlobalID()
+	genIDs, err := d2.genGlobalID(1)
 	c.Assert(err, IsNil)
+	schemaID := genIDs[0]
 	doDDLJobErr(c, schemaID, 0, model.ActionCreateSchema, []interface{}{dbInfo}, ctx, d2)
 }
 

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -43,7 +43,7 @@ func testSchemaInfo(c *C, d *ddl, name string) *model.DBInfo {
 	dbInfo := &model.DBInfo{
 		Name: model.NewCIStr(name),
 	}
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	dbInfo.ID = genIDs[0]
 	return dbInfo
@@ -205,7 +205,7 @@ func (s *testSchemaSuite) TestSchemaWaitJob(c *C) {
 	// d2 must not be owner.
 	c.Assert(d2.ownerManager.IsOwner(), IsFalse)
 
-	genIDs, err := d2.genGlobalID(1)
+	genIDs, err := d2.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	schemaID := genIDs[0]
 	doDDLJobErr(c, schemaID, 0, model.ActionCreateSchema, []interface{}{dbInfo}, ctx, d2)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -42,12 +42,12 @@ type testTableSuite struct {
 
 // testTableInfo creates a test table with num int columns and with no index.
 func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
-	var err error
 	tblInfo := &model.TableInfo{
 		Name: model.NewCIStr(name),
 	}
-	tblInfo.ID, err = d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	c.Assert(err, IsNil)
+	tblInfo.ID = genIDs[0]
 
 	cols := make([]*model.ColumnInfo, num)
 	for i := range cols {
@@ -71,8 +71,9 @@ func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 // testTableInfo creates a test table with num int columns and with no index.
 func testTableInfoWithPartition(c *C, d *ddl, name string, num int) *model.TableInfo {
 	tblInfo := testTableInfo(c, d, name, num)
-	pid, err := d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	c.Assert(err, IsNil)
+	pid := genIDs[0]
 	tblInfo.Partition = &model.PartitionInfo{
 		Type:   model.PartitionTypeRange,
 		Expr:   tblInfo.Columns[0].Name.L,
@@ -89,12 +90,12 @@ func testTableInfoWithPartition(c *C, d *ddl, name string, num int) *model.Table
 
 // testViewInfo creates a test view with num int columns.
 func testViewInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
-	var err error
 	tblInfo := &model.TableInfo{
 		Name: model.NewCIStr(name),
 	}
-	tblInfo.ID, err = d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	c.Assert(err, IsNil)
+	tblInfo.ID = genIDs[0]
 
 	cols := make([]*model.ColumnInfo, num)
 	viewCols := make([]model.CIStr, num)
@@ -196,8 +197,9 @@ func testDropTable(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, t
 }
 
 func testTruncateTable(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo) *model.Job {
-	newTableID, err := d.genGlobalID()
+	genIDs, err := d.genGlobalID(1)
 	c.Assert(err, IsNil)
+	newTableID := genIDs[0]
 	job := &model.Job{
 		SchemaID:   dbInfo.ID,
 		TableID:    tblInfo.ID,

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -45,7 +45,7 @@ func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 	tblInfo := &model.TableInfo{
 		Name: model.NewCIStr(name),
 	}
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	tblInfo.ID = genIDs[0]
 
@@ -71,7 +71,7 @@ func testTableInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 // testTableInfo creates a test table with num int columns and with no index.
 func testTableInfoWithPartition(c *C, d *ddl, name string, num int) *model.TableInfo {
 	tblInfo := testTableInfo(c, d, name, num)
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	pid := genIDs[0]
 	tblInfo.Partition = &model.PartitionInfo{
@@ -93,7 +93,7 @@ func testViewInfo(c *C, d *ddl, name string, num int) *model.TableInfo {
 	tblInfo := &model.TableInfo{
 		Name: model.NewCIStr(name),
 	}
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	tblInfo.ID = genIDs[0]
 
@@ -197,7 +197,7 @@ func testDropTable(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, t
 }
 
 func testTruncateTable(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo) *model.Job {
-	genIDs, err := d.genGlobalID(1)
+	genIDs, err := d.genGlobalIDs(1)
 	c.Assert(err, IsNil)
 	newTableID := genIDs[0]
 	job := &model.Job{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/10784

### What is changed and how it works?

"create table like" should not shadow copy the partition info from the original table, it should use new tableID.

`genGlobal` is updated so we can get a batch of tableID in one call

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch
