### PR TITLE
expression: add a failpoint switch to control expr push down in integration test

### DIFF
--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -15,14 +15,18 @@ package expression
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 type dataGen4Expr2PbTest struct {
@@ -411,6 +415,61 @@ func (s *testEvaluatorSuite) TestBitwiseFunc2Pb(c *C) {
 		js, err := json.Marshal(pbExpr)
 		c.Assert(err, IsNil)
 		c.Assert(string(js), Equals, "null")
+	}
+}
+
+func (s *testEvaluatorSuite) TestPushDownSwitcher(c *C) {
+	var funcs = make([]Expression, 0)
+	sc := new(stmtctx.StatementContext)
+	client := new(mock.Client)
+	dg := new(dataGen4Expr2PbTest)
+
+	cases := []struct {
+		name   string
+		sig    tipb.ScalarFuncSig
+		enable bool
+	}{
+		{ast.And, tipb.ScalarFuncSig_BitAndSig, true},
+		{ast.Or, tipb.ScalarFuncSig_BitOrSig, false},
+		{ast.UnaryNot, tipb.ScalarFuncSig_UnaryNot, true},
+	}
+	var enabled []string
+	for i, funcName := range cases {
+		args := []Expression{dg.genColumn(mysql.TypeLong, 1)}
+		if i+1 < len(cases) {
+			args = append(args, dg.genColumn(mysql.TypeLong, 2))
+		}
+		fc, err := NewFunction(
+			mock.NewContext(),
+			funcName.name,
+			types.NewFieldType(mysql.TypeUnspecified),
+			args...,
+		)
+		c.Assert(err, IsNil)
+		funcs = append(funcs, fc)
+		if funcName.enable {
+			enabled = append(enabled, funcName.name)
+		}
+	}
+
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/expression/PushDownTestSwitcher", `return("all")`), IsNil)
+	defer func() { c.Assert(failpoint.Disable("github.com/pingcap/tidb/expression/PushDownTestSwitcher"), IsNil) }()
+
+	pbExprs := ExpressionsToPBList(sc, funcs, client)
+	c.Assert(len(pbExprs), Equals, len(cases))
+	for i, pbExpr := range pbExprs {
+		c.Assert(pbExpr.Sig, Equals, cases[i].sig, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))
+	}
+
+	// Partial enable
+	fpexpr := fmt.Sprintf(`return("%s")`, strings.Join(enabled, ","))
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/expression/PushDownTestSwitcher", fpexpr), IsNil)
+	c.Assert(len(pbExprs), Equals, len(cases))
+	for i, pbExpr := range pbExprs {
+		if !cases[i].enable {
+			continue
+		}
+		c.Assert(pbExpr.Sig, Equals, cases[i].sig, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))
 	}
 }
 

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -461,12 +461,22 @@ func (s *testEvaluatorSuite) TestPushDownSwitcher(c *C) {
 		c.Assert(pbExpr.Sig, Equals, cases[i].sig, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))
 	}
 
-	// Partial enable
+	// All disabled
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/expression/PushDownTestSwitcher", `return("")`), IsNil)
+	pbExprs = ExpressionsToPBList(sc, funcs, client)
+	c.Assert(len(pbExprs), Equals, len(cases))
+	for i, pbExpr := range pbExprs {
+		c.Assert(pbExpr, IsNil, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))
+	}
+
+	// Partial enabled
 	fpexpr := fmt.Sprintf(`return("%s")`, strings.Join(enabled, ","))
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/expression/PushDownTestSwitcher", fpexpr), IsNil)
+	pbExprs = ExpressionsToPBList(sc, funcs, client)
 	c.Assert(len(pbExprs), Equals, len(cases))
 	for i, pbExpr := range pbExprs {
 		if !cases[i].enable {
+			c.Assert(pbExpr, IsNil, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))
 			continue
 		}
 		c.Assert(pbExpr.Sig, Equals, cases[i].sig, Commentf("function: %s, sig: %v", cases[i].name, cases[i].sig))

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLM
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d h1:rQlvB2AYWme2bIB18r/SipGiMEVJYE9U0z+MGoU/LtQ=
 github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d/go.mod h1:VKt7CNAQxpFpSDz3sXyj9hY/GbVsQCr0sB3w59nE7lU=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=

--- a/kv/checker.go
+++ b/kv/checker.go
@@ -1,0 +1,56 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv
+
+import "github.com/pingcap/tipb/go-tipb"
+
+// RequestTypeSupportedChecker is used to check expression can be pushed down.
+type RequestTypeSupportedChecker struct{}
+
+// IsRequestTypeSupported checks whether reqType is supported.
+func (d RequestTypeSupportedChecker) IsRequestTypeSupported(reqType, subType int64) bool {
+	switch reqType {
+	case ReqTypeSelect, ReqTypeIndex:
+		switch subType {
+		case ReqSubTypeGroupBy, ReqSubTypeBasic, ReqSubTypeTopN:
+			return true
+		default:
+			return d.supportExpr(tipb.ExprType(subType))
+		}
+	case ReqTypeDAG:
+		return d.supportExpr(tipb.ExprType(subType))
+	case ReqTypeAnalyze:
+		return true
+	}
+	return false
+}
+
+func (d RequestTypeSupportedChecker) supportExpr(exprType tipb.ExprType) bool {
+	switch exprType {
+	case tipb.ExprType_Null, tipb.ExprType_Int64, tipb.ExprType_Uint64, tipb.ExprType_String, tipb.ExprType_Bytes,
+		tipb.ExprType_MysqlDuration, tipb.ExprType_MysqlTime, tipb.ExprType_MysqlDecimal,
+		tipb.ExprType_Float32, tipb.ExprType_Float64, tipb.ExprType_ColumnRef:
+		return true
+	// aggregate functions.
+	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg,
+		tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr:
+		return true
+	case ReqSubTypeDesc:
+		return true
+	case ReqSubTypeSignature:
+		return true
+	default:
+		return false
+	}
+}

--- a/kv/checker_test.go
+++ b/kv/checker_test.go
@@ -1,0 +1,40 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kv_test
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/kv"
+)
+
+type checkerSuite struct{}
+
+func TestIsRequestTypeSupported(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&checkerSuite{})
+
+func (s checkerSuite) TestIsRequestTypeSupported(c *C) {
+	checker := kv.RequestTypeSupportedChecker{}.IsRequestTypeSupported
+	c.Assert(checker(kv.ReqTypeSelect, kv.ReqSubTypeGroupBy), IsTrue)
+	c.Assert(checker(kv.ReqTypeDAG, kv.ReqSubTypeSignature), IsTrue)
+	c.Assert(checker(kv.ReqTypeDAG, kv.ReqSubTypeDesc), IsTrue)
+	c.Assert(checker(kv.ReqTypeDAG, kv.ReqSubTypeSignature), IsTrue)
+	c.Assert(checker(kv.ReqTypeDAG, kv.ReqSubTypeAnalyzeIdx), IsFalse)
+	c.Assert(checker(kv.ReqTypeAnalyze, 0), IsTrue)
+	c.Assert(checker(kv.ReqTypeChecksum, 0), IsFalse)
+}

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/memory"
-	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 )
 
@@ -44,44 +43,8 @@ var tikvTxnRegionsNumHistogramWithCoprocessor = metrics.TiKVTxnRegionsNumHistogr
 
 // CopClient is coprocessor client.
 type CopClient struct {
+	kv.RequestTypeSupportedChecker
 	store *tikvStore
-}
-
-// IsRequestTypeSupported checks whether reqType is supported.
-func (c *CopClient) IsRequestTypeSupported(reqType, subType int64) bool {
-	switch reqType {
-	case kv.ReqTypeSelect, kv.ReqTypeIndex:
-		switch subType {
-		case kv.ReqSubTypeGroupBy, kv.ReqSubTypeBasic, kv.ReqSubTypeTopN:
-			return true
-		default:
-			return c.supportExpr(tipb.ExprType(subType))
-		}
-	case kv.ReqTypeDAG:
-		return c.supportExpr(tipb.ExprType(subType))
-	case kv.ReqTypeAnalyze:
-		return true
-	}
-	return false
-}
-
-func (c *CopClient) supportExpr(exprType tipb.ExprType) bool {
-	switch exprType {
-	case tipb.ExprType_Null, tipb.ExprType_Int64, tipb.ExprType_Uint64, tipb.ExprType_String, tipb.ExprType_Bytes,
-		tipb.ExprType_MysqlDuration, tipb.ExprType_MysqlTime, tipb.ExprType_MysqlDecimal,
-		tipb.ExprType_Float32, tipb.ExprType_Float64, tipb.ExprType_ColumnRef:
-		return true
-	// aggregate functions.
-	case tipb.ExprType_Count, tipb.ExprType_First, tipb.ExprType_Max, tipb.ExprType_Min, tipb.ExprType_Sum, tipb.ExprType_Avg,
-		tipb.ExprType_Agg_BitXor, tipb.ExprType_Agg_BitAnd, tipb.ExprType_Agg_BitOr:
-		return true
-	case kv.ReqSubTypeDesc:
-		return true
-	case kv.ReqSubTypeSignature:
-		return true
-	default:
-		return false
-	}
 }
 
 // Send builds the request and gets the coprocessor iterator response.


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Use the failpoint to control whether to push down an expression in the integration test. Push down all expression if the `failpoint expression` is `all`, otherwise, check whether scalar function's name is contained in the enabled expression list (e.g.`ne,eq,lt`).

Additional: Abstract `IsRequestTypeSupported` to reduce duplicated code in `util/mock/client.go`

### What is changed and how it works?

Add a failpoint to `canFuncBePushed` function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
