### PR TITLE
expression: reuse tipb.Expr 'val' to push down expression implicit parameters

### DIFF
--- a/expression/aggregation/agg_to_pb.go
+++ b/expression/aggregation/agg_to_pb.go
@@ -56,7 +56,7 @@ func AggFuncToPBExpr(sc *stmtctx.StatementContext, client kv.Client, aggFunc *Ag
 
 	children := make([]*tipb.Expr, 0, len(aggFunc.Args))
 	for _, arg := range aggFunc.Args {
-		pbArg := pc.ExprToPB(arg)
+		pbArg := pc.ExprToPB(sc, arg)
 		if pbArg == nil {
 			return nil
 		}

--- a/expression/aggregation/agg_to_pb.go
+++ b/expression/aggregation/agg_to_pb.go
@@ -56,7 +56,7 @@ func AggFuncToPBExpr(sc *stmtctx.StatementContext, client kv.Client, aggFunc *Ag
 
 	children := make([]*tipb.Expr, 0, len(aggFunc.Args))
 	for _, arg := range aggFunc.Args {
-		pbArg := pc.ExprToPB(sc, arg)
+		pbArg := pc.ExprToPB(arg)
 		if pbArg == nil {
 			return nil
 		}

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -41,10 +41,10 @@ func (b *baseBuiltinFunc) PbCode() tipb.ScalarFuncSig {
 	return b.pbCode
 }
 
-// implicitParameters returns the implicit parameters of this function.
-// implicit parameters means some functions contain extra inner fields which will not
+// implicitArgs returns the implicit arguments of this function.
+// implicit arguments means some functions contain extra inner fields which will not
 // contain in `tipb.Expr.children` but must be pushed down to coprocessor
-func (b *baseBuiltinFunc) implicitParameters() []types.Datum {
+func (b *baseBuiltinFunc) implicitArgs() []types.Datum {
 	// We will not use a field to store them because of only
 	// a few functions contain implicit parameters
 	return nil
@@ -253,15 +253,15 @@ type baseBuiltinCastFunc struct {
 	inUnion bool
 }
 
-// implicitParameters returns the implicit parameters of cast functions
-func (b *baseBuiltinCastFunc) implicitParameters() []types.Datum {
-	params := b.baseBuiltinFunc.implicitParameters()
+// implicitArgs returns the implicit arguments of cast functions
+func (b *baseBuiltinCastFunc) implicitArgs() []types.Datum {
+	args := b.baseBuiltinFunc.implicitArgs()
 	if b.inUnion {
-		params = append(params, types.NewIntDatum(1))
+		args = append(args, types.NewIntDatum(1))
 	} else {
-		params = append(params, types.NewIntDatum(0))
+		args = append(args, types.NewIntDatum(0))
 	}
-	return params
+	return args
 }
 
 func (b *baseBuiltinCastFunc) cloneFrom(from *baseBuiltinCastFunc) {
@@ -304,10 +304,10 @@ type builtinFunc interface {
 	setPbCode(tipb.ScalarFuncSig)
 	// PbCode returns PbCode of this signature.
 	PbCode() tipb.ScalarFuncSig
-	// implicitParameters returns the implicit parameters of a function.
-	// implicit parameters means some functions contain extra inner fields which will not
+	// implicitArgs returns the implicit parameters of a function.
+	// implicit arguments means some functions contain extra inner fields which will not
 	// contain in `tipb.Expr.children` but must be pushed down to coprocessor
-	implicitParameters() []types.Datum
+	implicitArgs() []types.Datum
 	// Clone returns a copy of itself.
 	Clone() builtinFunc
 }

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -243,20 +243,20 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 		children = append(children, pbArg)
 	}
 
-	var implicitParameters []byte
-	if params := expr.Function.implicitParameters(); len(params) > 0 {
-		encoded, err := codec.EncodeValue(pc.sc, nil, params...)
+	var implicitArgs []byte
+	if args := expr.Function.implicitArgs(); len(args) > 0 {
+		encoded, err := codec.EncodeValue(pc.sc, nil, args...)
 		if err != nil {
 			logutil.Logger(context.Background()).Error("encode implicit parameters", zap.Any("datums", params), zap.Error(err))
 			return nil
 		}
-		implicitParameters = encoded
+		implicitArgs = encoded
 	}
 
 	// construct expression ProtoBuf.
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
-		Val:       implicitParameters,
+		Val:       implicitArgs,
 		Sig:       pbCode,
 		Children:  children,
 		FieldType: ToPBFieldType(expr.RetType),

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -45,7 +45,7 @@ func ExpressionsToPB(sc *stmtctx.StatementContext, exprs []Expression, client kv
 	}
 
 	for _, expr := range exprs {
-		pbExpr := pc.ExprToPB(expr)
+		pbExpr := pc.ExprToPB(sc, expr)
 		if pbExpr == nil {
 			remained = append(remained, expr)
 			continue
@@ -72,7 +72,7 @@ func ExpressionsToPB(sc *stmtctx.StatementContext, exprs []Expression, client kv
 func ExpressionsToPBList(sc *stmtctx.StatementContext, exprs []Expression, client kv.Client) (pbExpr []*tipb.Expr) {
 	pc := PbConverter{client: client, sc: sc}
 	for _, expr := range exprs {
-		v := pc.ExprToPB(expr)
+		v := pc.ExprToPB(sc, expr)
 		pbExpr = append(pbExpr, v)
 	}
 	return
@@ -90,14 +90,14 @@ func NewPBConverter(client kv.Client, sc *stmtctx.StatementContext) PbConverter 
 }
 
 // ExprToPB converts Expression to TiPB.
-func (pc PbConverter) ExprToPB(expr Expression) *tipb.Expr {
+func (pc PbConverter) ExprToPB(sc *stmtctx.StatementContext, expr Expression) *tipb.Expr {
 	switch x := expr.(type) {
 	case *Constant, *CorrelatedColumn:
 		return pc.conOrCorColToPBExpr(expr)
 	case *Column:
 		return pc.columnToPBExpr(x)
 	case *ScalarFunction:
-		return pc.scalarFuncToPBExpr(x)
+		return pc.scalarFuncToPBExpr(sc, x)
 	}
 	return nil
 }
@@ -221,7 +221,7 @@ func (pc PbConverter) columnToPBExpr(column *Column) *tipb.Expr {
 		Val: codec.EncodeInt(nil, id)}
 }
 
-func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
+func (pc PbConverter) scalarFuncToPBExpr(sc *stmtctx.StatementContext, expr *ScalarFunction) *tipb.Expr {
 	// check whether this function can be pushed.
 	if !pc.canFuncBePushed(expr) {
 		return nil
@@ -236,16 +236,27 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	// check whether all of its parameters can be pushed.
 	children := make([]*tipb.Expr, 0, len(expr.GetArgs()))
 	for _, arg := range expr.GetArgs() {
-		pbArg := pc.ExprToPB(arg)
+		pbArg := pc.ExprToPB(sc, arg)
 		if pbArg == nil {
 			return nil
 		}
 		children = append(children, pbArg)
 	}
 
+	var implicitParameters []byte
+	if params := expr.Function.implicitParameters(); len(params) > 0 {
+		encoded, err := codec.EncodeValue(sc, nil, params...)
+		if err != nil {
+			logutil.Logger(context.Background()).Error("encode implicit parameters", zap.Any("datums", params), zap.Error(err))
+			return nil
+		}
+		implicitParameters = encoded
+	}
+
 	// construct expression ProtoBuf.
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
+		Val:       implicitParameters,
 		Sig:       pbCode,
 		Children:  children,
 		FieldType: ToPBFieldType(expr.RetType),
@@ -255,7 +266,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 // GroupByItemToPB converts group by items to pb.
 func GroupByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression) *tipb.ByItem {
 	pc := PbConverter{client: client, sc: sc}
-	e := pc.ExprToPB(expr)
+	e := pc.ExprToPB(sc, expr)
 	if e == nil {
 		return nil
 	}
@@ -265,7 +276,7 @@ func GroupByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expres
 // SortByItemToPB converts order by items to pb.
 func SortByItemToPB(sc *stmtctx.StatementContext, client kv.Client, expr Expression, desc bool) *tipb.ByItem {
 	pc := PbConverter{client: client, sc: sc}
-	e := pc.ExprToPB(expr)
+	e := pc.ExprToPB(sc, expr)
 	if e == nil {
 		return nil
 	}

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -247,7 +247,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	if args := expr.Function.implicitArgs(); len(args) > 0 {
 		encoded, err := codec.EncodeValue(pc.sc, nil, args...)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("encode implicit parameters", zap.Any("datums", params), zap.Error(err))
+			logutil.Logger(context.Background()).Error("encode implicit parameters", zap.Any("datums", args), zap.Error(err))
 			return nil
 		}
 		implicitArgs = encoded

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -605,20 +605,30 @@ func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
 
 	pc := PbConverter{client: client, sc: sc}
 
-	// None flag
+	// InUnion flag is false in `BuildCastFunction` when `ScalarFuncSig_CastStringAsInt`
 	cast := BuildCastFunction(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
-	c.Assert(cast.(*ScalarFunction).Function.implicitParameters(), IsNil)
+	c.Assert(cast.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(0)})
 	expr := pc.ExprToPB(sc, cast)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
+	c.Assert(len(expr.Val), Greater, 0)
+	datums, err := codec.Decode(expr.Val, 1)
+	c.Assert(err, IsNil)
+	c.Assert(datums, DeepEquals, []types.Datum{types.NewIntDatum(0)})
+
+	// InUnion flag is nil in `BuildCastFunction4Union` when `ScalarFuncSig_CastIntAsString`
+	castInUnion := BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeLonglong, 1), types.NewFieldType(mysql.TypeString))
+	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), IsNil)
+	expr = pc.ExprToPB(sc, castInUnion)
+	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastIntAsString)
 	c.Assert(len(expr.Val), Equals, 0)
 
-	// InUnion flag
-	castInUnion := BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
+	// InUnion flag is true in `BuildCastFunction4Union` when `ScalarFuncSig_CastStringAsInt`
+	castInUnion = BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
 	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(1)})
 	expr = pc.ExprToPB(sc, castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)
-	datums, err := codec.Decode(expr.Val, 1)
+	datums, err = codec.Decode(expr.Val, 1)
 	c.Assert(err, IsNil)
 	c.Assert(datums, DeepEquals, []types.Datum{types.NewIntDatum(1)})
 }

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -595,7 +595,7 @@ func (s *testEvaluatorSuite) TestSortByItem2Pb(c *C) {
 	c.Assert(string(js), Equals, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":46,\"charset\":\"\"}},\"desc\":true}")
 }
 
-func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
+func (s *testEvaluatorSuite) TestImplicitArgs(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -607,7 +607,7 @@ func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
 
 	// InUnion flag is false in `BuildCastFunction` when `ScalarFuncSig_CastStringAsInt`
 	cast := BuildCastFunction(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
-	c.Assert(cast.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(0)})
+	c.Assert(cast.(*ScalarFunction).Function.implicitArgs(), DeepEquals, []types.Datum{types.NewIntDatum(0)})
 	expr := pc.ExprToPB(cast)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)
@@ -617,14 +617,14 @@ func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
 
 	// InUnion flag is nil in `BuildCastFunction4Union` when `ScalarFuncSig_CastIntAsString`
 	castInUnion := BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeLonglong, 1), types.NewFieldType(mysql.TypeString))
-	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), IsNil)
+	c.Assert(castInUnion.(*ScalarFunction).Function.implicitArgs(), IsNil)
 	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastIntAsString)
 	c.Assert(len(expr.Val), Equals, 0)
 
 	// InUnion flag is true in `BuildCastFunction4Union` when `ScalarFuncSig_CastStringAsInt`
 	castInUnion = BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
-	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(1)})
+	c.Assert(castInUnion.(*ScalarFunction).Function.implicitArgs(), DeepEquals, []types.Datum{types.NewIntDatum(1)})
 	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -608,7 +608,7 @@ func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
 	// InUnion flag is false in `BuildCastFunction` when `ScalarFuncSig_CastStringAsInt`
 	cast := BuildCastFunction(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
 	c.Assert(cast.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(0)})
-	expr := pc.ExprToPB(sc, cast)
+	expr := pc.ExprToPB(cast)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)
 	datums, err := codec.Decode(expr.Val, 1)
@@ -618,14 +618,14 @@ func (s *testEvaluatorSuite) TestImplicitParameters(c *C) {
 	// InUnion flag is nil in `BuildCastFunction4Union` when `ScalarFuncSig_CastIntAsString`
 	castInUnion := BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeLonglong, 1), types.NewFieldType(mysql.TypeString))
 	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), IsNil)
-	expr = pc.ExprToPB(sc, castInUnion)
+	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastIntAsString)
 	c.Assert(len(expr.Val), Equals, 0)
 
 	// InUnion flag is true in `BuildCastFunction4Union` when `ScalarFuncSig_CastStringAsInt`
 	castInUnion = BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
 	c.Assert(castInUnion.(*ScalarFunction).Function.implicitParameters(), DeepEquals, []types.Datum{types.NewIntDatum(1)})
-	expr = pc.ExprToPB(sc, castInUnion)
+	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)
 	datums, err = codec.Decode(expr.Val, 1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- [x] Merge https://github.com/pingcap/tidb/pull/10786 first

Add an `implicitParameters` method to the `builtinFunc` interface, and provide a default implementation for `baseBuiltinFunc`. 

The `UnionAll` executor will infer its children's results type and add `CAST` function if necessary. The `CAST` functions in this scenario maybe have some different behaviors. The flag `InUnionStmt` which is useful to cover some corner case in CAST functions implementation in the coprocessor, so we should pushdown related `Flag` to the coprocessor.

### What is changed and how it works?

This PR overwrite the `implicitParameters` for `baseBuiltinCastFunc` to push the `inUnion` flag.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test