### PR TITLE
planner: allow queries on virtual columns to use index

### DIFF
--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -136,3 +136,42 @@ Union_13	23263.33	root
 └─TableReader_34	3323.33	root	data:Selection_33
   └─Selection_33	3323.33	cop	lt(test.sgc3.a, 7)
     └─TableScan_32	10000.00	cop	table:sgc3, partition:max, range:[-inf,+inf], keep order:false, stats:pseudo
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1(a INT, b INT AS (a+1) VIRTUAL, c INT AS (b+1) VIRTUAL, d INT AS (c+1) VIRTUAL, KEY(b), INDEX IDX(c, d));
+INSERT INTO t1 (a) VALUES (0);
+EXPLAIN SELECT b FROM t1 WHERE b=1;
+id	count	task	operator info
+IndexReader_6	10.00	root	index:IndexScan_5
+└─IndexScan_5	10.00	cop	table:t1, index:b, range:[1,1], keep order:false, stats:pseudo
+EXPLAIN SELECT b, c, d FROM t1 WHERE b=1;
+id	count	task	operator info
+Projection_11	10.00	root	cast(plus(test.t1.a, 1)), cast(plus(cast(plus(test.t1.a, 1)), 1)), cast(plus(cast(plus(cast(plus(test.t1.a, 1)), 1)), 1))
+└─IndexLookUp_12	10.00	root	
+  ├─IndexScan_9	10.00	cop	table:t1, index:b, range:[1,1], keep order:false, stats:pseudo
+  └─TableScan_10	10.00	cop	table:t1, keep order:false, stats:pseudo
+EXPLAIN SELECT * FROM t1 WHERE b=1;
+id	count	task	operator info
+Projection_11	10.00	root	test.t1.a, cast(plus(test.t1.a, 1)), cast(plus(cast(plus(test.t1.a, 1)), 1)), cast(plus(cast(plus(cast(plus(test.t1.a, 1)), 1)), 1))
+└─IndexLookUp_12	10.00	root	
+  ├─IndexScan_9	10.00	cop	table:t1, index:b, range:[1,1], keep order:false, stats:pseudo
+  └─TableScan_10	10.00	cop	table:t1, keep order:false, stats:pseudo
+EXPLAIN SELECT c FROM t1 WHERE c=2 AND d=3;
+id	count	task	operator info
+Projection_4	0.10	root	test.t1.c
+└─IndexReader_6	0.10	root	index:IndexScan_5
+  └─IndexScan_5	0.10	cop	table:t1, index:c, d, range:[2 3,2 3], keep order:false, stats:pseudo
+DROP TABLE IF EXISTS person;
+CREATE TABLE person (
+id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+name VARCHAR(255) NOT NULL,
+address_info JSON,
+city_no INT AS (JSON_EXTRACT(address_info, '$.city_no')) VIRTUAL,
+KEY(city_no));
+INSERT INTO person (name, address_info) VALUES ("John", CAST('{"city_no": 1}' AS JSON));
+EXPLAIN SELECT name FROM person where city_no=1;
+id	count	task	operator info
+Projection_4	10.00	root	test.person.name
+└─Projection_11	10.00	root	test.person.name, cast(json_extract(test.person.address_info, "$.city_no"))
+  └─IndexLookUp_12	10.00	root	
+    ├─IndexScan_9	10.00	cop	table:person, index:city_no, range:[1,1], keep order:false, stats:pseudo
+    └─TableScan_10	10.00	cop	table:person, keep order:false, stats:pseudo

--- a/cmd/explaintest/t/generated_columns.test
+++ b/cmd/explaintest/t/generated_columns.test
@@ -90,3 +90,24 @@ PARTITION max VALUES LESS THAN MAXVALUE);
 EXPLAIN SELECT * FROM sgc3 WHERE a <= 1;
 EXPLAIN SELECT * FROM sgc3 WHERE a < 7;
 
+-- Virtual generated columns as indices
+
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1(a INT, b INT AS (a+1) VIRTUAL, c INT AS (b+1) VIRTUAL, d INT AS (c+1) VIRTUAL, KEY(b), INDEX IDX(c, d));
+INSERT INTO t1 (a) VALUES (0);
+
+EXPLAIN SELECT b FROM t1 WHERE b=1;
+EXPLAIN SELECT b, c, d FROM t1 WHERE b=1;
+EXPLAIN SELECT * FROM t1 WHERE b=1;
+EXPLAIN SELECT c FROM t1 WHERE c=2 AND d=3;
+
+DROP TABLE IF EXISTS person;
+CREATE TABLE person (
+id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+name VARCHAR(255) NOT NULL,
+address_info JSON,
+city_no INT AS (JSON_EXTRACT(address_info, '$.city_no')) VIRTUAL,
+KEY(city_no));
+
+INSERT INTO person (name, address_info) VALUES ("John", CAST('{"city_no": 1}' AS JSON));
+EXPLAIN SELECT name FROM person where city_no=1;

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -78,6 +78,10 @@ func (e *ProjectionExec) Open(ctx context.Context) error {
 		return err
 	}
 
+	return e.open(ctx)
+}
+
+func (e *ProjectionExec) open(ctx context.Context) error {
 	e.prepared = false
 	e.parentReqRows = int64(e.maxChunkSize)
 

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -964,10 +964,10 @@ func (s *testAnalyzeSuite) TestIssue9805(c *C) {
 	//+----------------------------+-------+------+-------------------------------------------------------------------------------------------------+----------------------------------+
 	//| Projection_7               | 0.12  | root | test.t1.id, test.t2.a                                                                           | time:3.844593ms, loops:1, rows:0 |
 	//| └─IndexJoin_11             | 0.12  | root | inner join, inner:IndexLookUp_10, outer key:test.t1.a, inner key:test.t2.d                      | time:3.830714ms, loops:1, rows:0 |
-	//|   ├─Projection_20          | 0.10  | root | test.t1.id, test.t1.a, test.t1.b, cast(mod(test.t1.a, 30))                                      | time:3.735174ms, loops:1, rows:0 |
-	//|   │ └─IndexLookUp_21       | 0.10  | root |                                                                                                 | time:3.569946ms, loops:1, rows:0 |
-	//|   │   ├─IndexScan_18       | 0.10  | cop  | table:t1, index:d, b, c, range:[4 "t2",4 "t2"], keep order:false, stats:pseudo                  | time:50.542µs, loops:1, rows:0   |
-	//|   │   └─TableScan_19       | 0.10  | cop  | table:t1, keep order:false, stats:pseudo                                                        | time:0s, loops:0, rows:0         |
+	//|   ├─Projection_21          | 0.10  | root | test.t1.id, test.t1.a, test.t1.b, cast(mod(test.t1.a, 30))                                      | time:3.735174ms, loops:1, rows:0 |
+	//|   │ └─IndexLookUp_22       | 0.10  | root |                                                                                                 | time:3.569946ms, loops:1, rows:0 |
+	//|   │   ├─IndexScan_19       | 0.10  | cop  | table:t1, index:d, b, c, range:[4 "t2",4 "t2"], keep order:false, stats:pseudo                  | time:50.542µs, loops:1, rows:0   |
+	//|   │   └─TableScan_20       | 0.10  | cop  | table:t1, keep order:false, stats:pseudo                                                        | time:0s, loops:0, rows:0         |
 	//|   └─IndexLookUp_10         | 10.00 | root |                                                                                                 | time:0ns, loops:0, rows:0        |
 	//|     ├─IndexScan_8          | 10.00 | cop  | table:t2, index:d, range: decided by [eq(test.t2.d, test.t1.a)], keep order:false, stats:pseudo | time:0ns, loops:0, rows:0        |
 	//|     └─TableScan_9          | 10.00 | cop  | table:t2, keep order:false, stats:pseudo                                                        | time:0ns, loops:0, rows:0        |
@@ -976,19 +976,19 @@ func (s *testAnalyzeSuite) TestIssue9805(c *C) {
 	//
 	c.Assert(rs.Rows(), HasLen, 9)
 	hasIndexLookUp10 := false
-	hasIndexLookUp21 := false
+	hasIndexLookUp22 := false
 	for _, row := range rs.Rows() {
 		c.Assert(row, HasLen, 5)
-		if strings.HasSuffix(row[0].(string), "IndexLookUp_10") {
+		if strings.Contains(row[0].(string), "IndexLookUp_10") {
 			hasIndexLookUp10 = true
 			c.Assert(row[4], Equals, "time:0ns, loops:0, rows:0")
 		}
-		if strings.HasSuffix(row[0].(string), "IndexLookUp_21") {
-			hasIndexLookUp21 = true
+		if strings.Contains(row[0].(string), "IndexLookUp_22") {
+			hasIndexLookUp22 = true
 		}
 	}
 	c.Assert(hasIndexLookUp10, IsTrue)
-	c.Assert(hasIndexLookUp21, IsTrue)
+	c.Assert(hasIndexLookUp22, IsTrue)
 }
 
 func (s *testAnalyzeSuite) TestVirtualGeneratedColumn(c *C) {

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -978,7 +978,7 @@ func (s *testAnalyzeSuite) TestIssue9805(c *C) {
 	hasIndexLookUp10 := false
 	hasIndexLookUp22 := false
 	for _, row := range rs.Rows() {
-		c.Assert(row, HasLen, 5)
+		c.Assert(row, HasLen, 6)
 		if strings.Contains(row[0].(string), "IndexLookUp_10") {
 			hasIndexLookUp10 = true
 			c.Assert(row[4], Equals, "time:0ns, loops:0, rows:0")

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -908,7 +908,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(indexInfo *model.Inde
 }
 
 func (ijHelper *indexJoinBuildHelper) updateBestChoice(ranges []*ranger.Range, idxInfo *model.IndexInfo, accesses,
-remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
+	remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
 	// We choose the index by the number of used columns of the range, the much the better.
 	// Notice that there may be the cases like `t1.a=t2.a and b > 2 and b < 1`. So ranges can be nil though the conditions are valid.
 	// But obviously when the range is nil, we don't need index join.

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -894,7 +894,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(indexInfo *model.Inde
 }
 
 func (ijHelper *indexJoinBuildHelper) updateBestChoice(ranges []*ranger.Range, idxInfo *model.IndexInfo, accesses,
-remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
+	remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
 	// We choose the index by the number of used columns of the range, the much the better.
 	// Notice that there may be the cases like `t1.a=t2.a and b > 2 and b < 1`. So ranges can be nil though the conditions are valid.
 	// But obviously when the range is nil, we don't need index join.

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -538,7 +538,7 @@ func (p *LogicalJoin) constructInnerTableScan(ds *DataSource, pk *expression.Col
 		indexPlanFinished: true,
 	}
 	selStats := ts.stats.Scale(selectionFactor)
-	t := ds.resolveVirtualColumns(copTask, selStats)
+	t := ds.pushDownSelAndResolveVirtualCols(copTask, nil, selStats)
 	t = finishCopTask(ds.ctx, copTask)
 	reader := t.plan()
 	return p.constructInnerUnionScan(us, reader)
@@ -611,8 +611,8 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 	}
 	selectivity := ds.stats.RowCount / ds.tableStats.RowCount
 	finalStats := ds.stats.ScaleByExpectCnt(selectivity * rowCount)
-	is.addPushedDownSelection(cop, ds, path, finalStats)
-	t := finishCopTask(ds.ctx, cop)
+	t := ds.pushDownSelAndResolveVirtualCols(cop, path, finalStats)
+	t = finishCopTask(ds.ctx, t)
 	reader := t.plan()
 	return p.constructInnerUnionScan(us, reader)
 }

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -538,8 +538,8 @@ func (p *LogicalJoin) constructInnerTableScan(ds *DataSource, pk *expression.Col
 		indexPlanFinished: true,
 	}
 	selStats := ts.stats.Scale(selectionFactor)
-	ts.addPushedDownSelection(copTask, selStats)
-	t := finishCopTask(ds.ctx, copTask)
+	t := ds.resolveVirtualColumns(copTask, selStats)
+	t = finishCopTask(ds.ctx, copTask)
 	reader := t.plan()
 	return p.constructInnerUnionScan(us, reader)
 }
@@ -894,7 +894,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(indexInfo *model.Inde
 }
 
 func (ijHelper *indexJoinBuildHelper) updateBestChoice(ranges []*ranger.Range, idxInfo *model.IndexInfo, accesses,
-	remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
+remained []expression.Expression, lastColManager *ColWithCmpFuncManager) {
 	// We choose the index by the number of used columns of the range, the much the better.
 	// Notice that there may be the cases like `t1.a=t2.a and b > 2 and b < 1`. So ranges can be nil though the conditions are valid.
 	// But obviously when the range is nil, we don't need index join.

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -501,6 +501,10 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 		}.Init(ds.ctx)
 		ts.SetSchema(ds.schema.Clone())
 		cop.tablePlan = ts
+
+		// TODO:
+		//  1. 检查是否有需要处理的虚拟列
+		//  2. 如果有, 加一个root Projection
 	}
 	is.initSchema(ds.id, idx, cop.tablePlan != nil)
 	// Only use expectedCnt when it's smaller than the count we calculated.
@@ -840,6 +844,14 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 		ts.KeepOrder = true
 		copTask.keepOrder = true
 	}
+
+	// TODO:
+	//  1. 检查是否需要处理虚拟列
+	//  2. 替换table filter内的虚拟列
+	//  3. 区分table filter中能够下推和不能下推的conditions
+	//  4. 如果有不能下推的conditions, 加一个root Selection
+	//  5. 再加一个root Projection
+
 	ts.addPushedDownSelection(copTask, ds.stats.ScaleByExpectCnt(prop.ExpectedCnt))
 	if prop.TaskTp == property.RootTaskType {
 		task = finishCopTask(ds.ctx, task)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -870,8 +870,8 @@ func (ds *DataSource) resolveVirtualColumns(copTask *copTask, stats *property.St
 	virSchema := ts.Schema().Clone()
 	for i := 0; i < len(ts.Columns); i++ {
 		if ts.Columns[i].IsGenerated() && !ts.Columns[i].GeneratedStored {
-			ts.Columns = append(ts.Columns[i:], ts.Columns[i+1:]...)
-			ts.schema.Columns = append(ts.schema.Columns[i:], ts.schema.Columns[i+1:]...)
+			ts.Columns = append(ts.Columns[:i], ts.Columns[i+1:]...)
+			ts.schema.Columns = append(ts.schema.Columns[:i], ts.schema.Columns[i+1:]...)
 		}
 	}
 

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -884,7 +884,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	if !ok {
 		return invalidTask, errors.Trace(fmt.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan)))
 	}
-	if len(ds.virtualColExprs) > 0 {
+	if len(ds.virtualColExprs) == 0 {
 		ds.addPushedDownTableScan(copTask, ts, stats)
 		return
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -574,7 +574,7 @@ func (is *PhysicalIndexScan) initSchema(id int, idx *model.IndexInfo, isDoubleRe
 	is.SetSchema(expression.NewSchema(indexCols...))
 }
 
-func (ds *DataSource) addPushedDownIndexScan(copTask *copTask, path *accessPath) {
+func (ds *DataSource) addPushedDownSelection(copTask *copTask, path *accessPath) {
 	// Add filter condition to table plan now.
 	is := copTask.indexPlan.(*PhysicalIndexScan)
 	indexConds, tableConds := path.indexFilters, path.tableFilters
@@ -857,7 +857,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	// step 1
 	t = copTask
 	if copTask.indexPlan != nil {
-		ds.addPushedDownIndexScan(copTask, path)
+		ds.addPushedDownSelection(copTask, path)
 	}
 	if copTask.tablePlan == nil { // don't need to handle virtual columns in IndexScan
 		return

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -848,7 +848,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 	return task, nil
 }
 
-// TODO: more comments
+// pushDownSelAndResolveVirtualCols push some filters down to coprocessor and resolve virtual columns
 //	1. check if there are some virtual generated columns to handle;
 //	2. substitute virtual columns in this table plan;
 //	3. substitute table filters in this table plan;

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -14,9 +14,6 @@
 package core
 
 import (
-	"math"
-	"reflect"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -30,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/set"
 	"golang.org/x/tools/container/intsets"
+	"math"
 )
 
 const (
@@ -583,7 +581,7 @@ func (ds *DataSource) addIndexScanSelection(copTask *copTask, path *accessPath) 
 	// Add filter condition to table plan now.
 	is, ok := copTask.indexPlan.(*PhysicalIndexScan)
 	if !ok {
-		return errors.Errorf("type assertion fail, expect PhysicalIndexScan, but got %v", reflect.TypeOf(copTask.indexPlan))
+		return errors.Errorf("type assertion fail, expect PhysicalIndexScan, but got %T", copTask.indexPlan)
 	}
 	indexConds, tableConds := path.indexFilters, path.tableFilters
 	if indexConds != nil {
@@ -602,7 +600,7 @@ func (ds *DataSource) addIndexScanSelection(copTask *copTask, path *accessPath) 
 		copTask.finishIndexPlan()
 		ts, ok := copTask.tablePlan.(*PhysicalTableScan)
 		if !ok {
-			return errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan))
+			return errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %T", copTask.tablePlan)
 		}
 		ts.filterCondition = append(ts.filterCondition, tableConds...)
 	}
@@ -881,7 +879,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	}
 	ts, ok := copTask.tablePlan.(*PhysicalTableScan)
 	if !ok {
-		return invalidTask, errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan))
+		return invalidTask, errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %T", copTask.tablePlan)
 	}
 	if len(ds.virtualColExprs) == 0 {
 		ds.addTableScanSelection(copTask, ts, stats)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -875,8 +875,8 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	for i, expr := range ts.filterCondition {
 		ts.filterCondition[i] = expression.ColumnSubstitute(expr, ds.virtualColSchema, ds.virtualColExprs)
 	}
-	cantBePushed := ts.filterCondition // all Cast cannot be pushed down now
-	ts.filterCondition = ts.filterCondition[:0]
+	var cantBePushed []expression.Expression
+	_, ts.filterCondition, cantBePushed = expression.ExpressionsToPB(ds.ctx.GetSessionVars().StmtCtx, ts.filterCondition, ds.ctx.GetClient())
 	ds.addPushedDownTableScan(copTask, ts, stats)
 	if len(cantBePushed) > 0 { // for filters cannot be pushed down, we add a root Selection to handle them
 		sel := PhysicalSelection{Conditions: cantBePushed}.Init(ds.ctx, stats)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -14,7 +14,6 @@
 package core
 
 import (
-	"fmt"
 	"github.com/pingcap/errors"
 	"math"
 	"reflect"
@@ -584,7 +583,7 @@ func (ds *DataSource) addPushedDownSelection(copTask *copTask, path *accessPath)
 	// Add filter condition to table plan now.
 	is, ok := copTask.indexPlan.(*PhysicalIndexScan)
 	if !ok {
-		return errors.Trace(fmt.Errorf("type assertion fail, expect PhysicalIndexScan, but got %v", reflect.TypeOf(copTask.indexPlan)))
+		return errors.Errorf("type assertion fail, expect PhysicalIndexScan, but got %v", reflect.TypeOf(copTask.indexPlan))
 	}
 	indexConds, tableConds := path.indexFilters, path.tableFilters
 	if indexConds != nil {
@@ -603,7 +602,7 @@ func (ds *DataSource) addPushedDownSelection(copTask *copTask, path *accessPath)
 		copTask.finishIndexPlan()
 		ts, ok := copTask.tablePlan.(*PhysicalTableScan)
 		if !ok {
-			return errors.Trace(fmt.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan)))
+			return errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan))
 		}
 		ts.filterCondition = append(ts.filterCondition, tableConds...)
 	}
@@ -882,7 +881,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	}
 	ts, ok := copTask.tablePlan.(*PhysicalTableScan)
 	if !ok {
-		return invalidTask, errors.Trace(fmt.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan)))
+		return invalidTask, errors.Errorf("type assertion fail, expect PhysicalTableScan, but got %v", reflect.TypeOf(copTask.tablePlan))
 	}
 	if len(ds.virtualColExprs) == 0 {
 		ds.addPushedDownTableScan(copTask, ts, stats)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -863,7 +863,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 		return
 	}
 	ts := copTask.tablePlan.(*PhysicalTableScan)
-	if !ds.hasVirtualCol {
+	if len(ds.virtualColExprs) > 0 {
 		ds.addPushedDownTableScan(copTask, ts, stats)
 		return
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -574,7 +574,7 @@ func (is *PhysicalIndexScan) initSchema(id int, idx *model.IndexInfo, isDoubleRe
 	is.SetSchema(expression.NewSchema(indexCols...))
 }
 
-func (ds *DataSource) addPushedDownIndexScan(copTask *copTask, path *accessPath, finalStats *property.StatsInfo) {
+func (ds *DataSource) addPushedDownIndexScan(copTask *copTask, path *accessPath) {
 	// Add filter condition to table plan now.
 	is := copTask.indexPlan.(*PhysicalIndexScan)
 	indexConds, tableConds := path.indexFilters, path.tableFilters
@@ -857,7 +857,7 @@ func (ds *DataSource) pushDownSelAndResolveVirtualCols(copTask *copTask, path *a
 	// step 1
 	t = copTask
 	if copTask.indexPlan != nil {
-		ds.addPushedDownIndexScan(copTask, path, stats)
+		ds.addPushedDownIndexScan(copTask, path)
 	}
 	if copTask.tablePlan == nil { // don't need to handle virtual columns in IndexScan
 		return

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2377,13 +2377,8 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName model.
 // prepareVirtualColumns is only for DataSource.
 // It prepares virtualColExprs and virtualColSchema for table which has virtual generated columns.
 // virtualColExprs and virtualColSchema are used to rewrite virtual columns in pushDownSelAndResolveVirtualCols.
-//<<<<<<< HEAD
-//func (b *PlanBuilder) prepareVirtualColumns(ctx context.Context, ds *DataSource, columns []*table.Column) error {
-//	ds.hasVirtualCol = false
-//=======
 func (b *PlanBuilder) prepareVirtualColumns(ctx context.Context, ds *DataSource, columns []*table.Column) error {
 	hasVirtualCol := false
-	//>>>>>>> address comments
 	for _, column := range columns {
 		if column.IsGenerated() && !column.GeneratedStored {
 			hasVirtualCol = true

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2377,15 +2377,20 @@ func (b *PlanBuilder) BuildDataSourceFromView(ctx context.Context, dbName model.
 // prepareVirtualColumns is only for DataSource.
 // It prepares virtualColExprs and virtualColSchema for table which has virtual generated columns.
 // virtualColExprs and virtualColSchema are used to rewrite virtual columns in pushDownSelAndResolveVirtualCols.
+//<<<<<<< HEAD
+//func (b *PlanBuilder) prepareVirtualColumns(ctx context.Context, ds *DataSource, columns []*table.Column) error {
+//	ds.hasVirtualCol = false
+//=======
 func (b *PlanBuilder) prepareVirtualColumns(ctx context.Context, ds *DataSource, columns []*table.Column) error {
-	ds.hasVirtualCol = false
+	hasVirtualCol := false
+	//>>>>>>> address comments
 	for _, column := range columns {
 		if column.IsGenerated() && !column.GeneratedStored {
-			ds.hasVirtualCol = true
+			hasVirtualCol = true
 			break
 		}
 	}
-	if !ds.hasVirtualCol {
+	if !hasVirtualCol {
 		return nil
 	}
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -355,7 +355,6 @@ type DataSource struct {
 	handleCol *expression.Column
 
 	// fields for virtual generated columns
-	hasVirtualCol    bool
 	virtualColSchema *expression.Schema
 	virtualColExprs  []expression.Expression
 }

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -353,6 +353,11 @@ type DataSource struct {
 	// handleCol represents the handle column for the datasource, either the
 	// int primary key column or extra handle column.
 	handleCol *expression.Column
+
+	// fields for virtual generated columns
+	hasVirtualCol    bool
+	virtualColSchema *expression.Schema
+	virtualColExprs  []expression.Expression
 }
 
 // accessPath indicates the way we access a table: by using single index, or by using multiple indexes,

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -187,16 +187,24 @@ func (tk *TestKit) MustExec(sql string, args ...interface{}) {
 
 // MustIndexLookup checks whether the plan for the sql is Point_Get.
 func (tk *TestKit) MustIndexLookup(sql string, args ...interface{}) *Result {
+	return tk.MustPlan("IndexLookUp", sql, args...)
+}
+
+func (tk *TestKit) MustPlan(plan, sql string, args ...interface{}) *Result {
 	rs := tk.MustQuery("explain "+sql, args...)
 	hasIndexLookup := false
 	for i := range rs.rows {
-		if strings.Contains(rs.rows[i][0], "IndexLookUp") {
+		if strings.Contains(rs.rows[i][0], plan) {
 			hasIndexLookup = true
 			break
 		}
 	}
 	tk.c.Assert(hasIndexLookup, check.IsTrue)
 	return tk.MustQuery(sql, args...)
+}
+
+func (tk *TestKit) MustIndexRead(sql string, args ...interface{}) *Result {
+	return tk.MustPlan("IndexReader", sql, args...)
 }
 
 // MustPointGet checks whether the plan for the sql is Point_Get.

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -185,7 +185,7 @@ func (tk *TestKit) MustExec(sql string, args ...interface{}) {
 	}
 }
 
-// MustIndexLookup checks whether the plan for the sql is Point_Get.
+// MustIndexLookup checks whether the plan for the sql is IndexLookUp.
 func (tk *TestKit) MustIndexLookup(sql string, args ...interface{}) *Result {
 	return tk.MustPlan("IndexLookUp", sql, args...)
 }

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -211,10 +211,7 @@ func (tk *TestKit) MustIndexRead(sql string, args ...interface{}) *Result {
 
 // MustPointGet checks whether the plan for the sql is Point_Get.
 func (tk *TestKit) MustPointGet(sql string, args ...interface{}) *Result {
-	rs := tk.MustQuery("explain "+sql, args...)
-	tk.c.Assert(len(rs.rows), check.Equals, 1)
-	tk.c.Assert(strings.Contains(rs.rows[0][0], "Point_Get"), check.IsTrue)
-	return tk.MustQuery(sql, args...)
+	return tk.MustPlan("Point_Get", sql, args...)
 }
 
 // MustQuery query the statements and returns result rows.

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -190,6 +190,7 @@ func (tk *TestKit) MustIndexLookup(sql string, args ...interface{}) *Result {
 	return tk.MustPlan("IndexLookUp", sql, args...)
 }
 
+// MustPlan checks whether the plan for the sql is the specific plan.
 func (tk *TestKit) MustPlan(plan, sql string, args ...interface{}) *Result {
 	rs := tk.MustQuery("explain "+sql, args...)
 	hasIndexLookup := false
@@ -203,6 +204,7 @@ func (tk *TestKit) MustPlan(plan, sql string, args ...interface{}) *Result {
 	return tk.MustQuery(sql, args...)
 }
 
+// MustIndexRead checks whether the plan for this sql is IndexReader.
 func (tk *TestKit) MustIndexRead(sql string, args ...interface{}) *Result {
 	return tk.MustPlan("IndexReader", sql, args...)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #5189, allow queries on virtual columns to use index.

### What is changed and how it works?
Before this PR, virtual columns are replaced with corresponding physical columns when building the basic logical plan, which happens before the optimization. 

Therefore, when the optimizer gets the replaced logical plan, there is no virtual column in it, so the optimizer will not use the corresponding virtual index to optimize this plan.

In this PR, we postpone replacing the virtual column until the optimization is finished, so the optimizer will take virtual columns into account and virtual indices will be used.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

