### PR TITLE
tikv: fix backoff stop early

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -112,7 +112,7 @@ func NewBackoffFn(base, cap, jitter int) func(ctx context.Context, maxSleepMs in
 		case <-time.After(time.Duration(realSleep) * time.Millisecond):
 			attempts++
 			lastSleep = sleep
-			return lastSleep
+			return realSleep
 		case <-ctx.Done():
 			return 0
 		}

--- a/store/tikv/backoff_test.go
+++ b/store/tikv/backoff_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"context"
+	"errors"
+	. "github.com/pingcap/check"
+)
+
+type testBackoffSuite struct {
+	OneByOneSuite
+	store *tikvStore
+}
+
+var _ = Suite(&testLockSuite{})
+
+func (s *testBackoffSuite) SetUpTest(c *C) {
+	s.store = NewTestStore(c).(*tikvStore)
+}
+
+func (s *testBackoffSuite) TearDownTest(c *C) {
+	s.store.Close()
+}
+
+func (s *testBackoffSuite) TestBackoffWithMax(c *C) {
+	b := NewBackoffer(context.TODO(), 2000)
+	err := b.BackoffWithMaxSleep(boTxnLockFast, 30, errors.New("test"))
+	c.Assert(err, NotNil)
+	c.Assert(b.totalSleep, Equals, 30)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when backoff sleep over than maxSleep, we should count realSleep time into totalSleep

### What is changed and how it works?

count realSleep

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - imple change

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release 3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/10809)
<!-- Reviewable:end -->
