### PR TITLE
executor: fix the issue that `pb` memory cannot be released quickly

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1,4 +1,4 @@
- // Copyright 2018 PingCAP, Inc.
+// Copyright 2018 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 PingCAP, Inc.
+ // Copyright 2018 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -1,0 +1,119 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/testkit"
+	"runtime"
+	"strings"
+)
+
+var _ = SerialSuites(&testMemoryLeak{})
+
+type testMemoryLeak struct {
+	cluster   *mocktikv.Cluster
+	mvccStore mocktikv.MVCCStore
+	store     kv.Storage
+	domain    *domain.Domain
+	*parser.Parser
+	ctx *mock.Context
+}
+
+func (s *testMemoryLeak) SetUpSuite(c *C) {
+	s.Parser = parser.New()
+	flag.Lookup("mockTikv")
+	useMockTikv := *mockTikv
+	if useMockTikv {
+		s.cluster = mocktikv.NewCluster()
+		mocktikv.BootstrapWithSingleStore(s.cluster)
+		s.mvccStore = mocktikv.MustNewMVCCStore()
+		store, err := mockstore.NewMockTikvStore(
+			mockstore.WithCluster(s.cluster),
+			mockstore.WithMVCCStore(s.mvccStore),
+		)
+		c.Assert(err, IsNil)
+		s.store = store
+		session.SetSchemaLease(0)
+		session.SetStatsLease(0)
+	}
+	d, err := session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+	d.SetStatsUpdating(true)
+	s.domain = d
+}
+
+func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
+	se, err := session.CreateSession4Test(s.store)
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create database test_mem")
+	tk.MustExec("use test_mem")
+
+	// prepare data
+	totalSize := uint64(128 << 20) // 128MB
+	blockSize := uint64(8 << 10)   // 8KB
+	numRows := totalSize / blockSize
+	tk.MustExec(fmt.Sprintf("create table t (c varchar(%v))", blockSize))
+	defer tk.MustExec("drop table t")
+	randStr := strings.Repeat("x", int(blockSize))
+	sql := fmt.Sprintf("insert into t values ('%s')", randStr)
+	for i := uint64(0); i < numRows; i++ {
+		tk.MustExec(sql)
+	}
+
+	_, err = se.Execute(context.Background(), "use test_mem")
+	c.Assert(err, IsNil)
+	runtime.GC()
+	allocatedBegin, inUseBegin := s.readMem()
+	records, err := se.Execute(context.Background(), "select * from t")
+	c.Assert(err, IsNil)
+	record := records[0]
+	rowCnt := 0
+	chk := chunk.RecordBatch{new(chunk.Chunk)}
+	for {
+		c.Assert(record.Next(context.Background(), &chk), IsNil)
+		rowCnt += chk.NumRows()
+		if chk.NumRows() == 0 {
+			break
+		}
+	}
+	runtime.GC()
+	allocatedAfter, inUseAfter := s.readMem()
+
+	fmt.Println(">>> ", allocatedAfter-allocatedBegin, inUseAfter-inUseBegin)
+
+	c.Assert(allocatedAfter-allocatedBegin, GreaterEqual, totalSize)
+	fmt.Println(">>>>>>>>>>>>> ", inUseAfter-inUseBegin)
+
+	se.Close()
+	runtime.GC()
+}
+
+func (s *testMemoryLeak) readMem() (allocated, heapInUse uint64) {
+	var stat runtime.MemStats
+	runtime.ReadMemStats(&stat)
+	return stat.TotalAlloc, stat.HeapInuse
+}

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -15,52 +15,29 @@ package executor_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"runtime"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/parser"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
-	"github.com/pingcap/tidb/store/mockstore/mocktikv"
-	"github.com/pingcap/tidb/util/mock"
 )
 
 var _ = SerialSuites(&testMemoryLeak{})
 
 type testMemoryLeak struct {
-	cluster   *mocktikv.Cluster
-	mvccStore mocktikv.MVCCStore
-	store     kv.Storage
-	domain    *domain.Domain
-	*parser.Parser
-	ctx *mock.Context
+	store  kv.Storage
+	domain *domain.Domain
 }
 
 func (s *testMemoryLeak) SetUpSuite(c *C) {
-	s.Parser = parser.New()
-	flag.Lookup("mockTikv")
-	useMockTikv := *mockTikv
-	if useMockTikv {
-		s.cluster = mocktikv.NewCluster()
-		mocktikv.BootstrapWithSingleStore(s.cluster)
-		s.mvccStore = mocktikv.MustNewMVCCStore()
-		store, err := mockstore.NewMockTikvStore(
-			mockstore.WithCluster(s.cluster),
-			mockstore.WithMVCCStore(s.mvccStore),
-		)
-		c.Assert(err, IsNil)
-		s.store = store
-		session.SetSchemaLease(0)
-		session.SetStatsLease(0)
-	}
-	d, err := session.BootstrapSession(s.store)
+	var err error
+	s.store, err = mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
-	d.SetStatsUpdating(true)
-	s.domain = d
+	s.domain, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
 }
 
 func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -367,8 +367,8 @@ type copIteratorTaskSender struct {
 }
 
 type copResponse struct {
-	pbResp *coprocessor.Response
-	execdetails.ExecDetails
+	pbResp   *coprocessor.Response
+	detail   *execdetails.ExecDetails
 	startKey kv.Key
 	err      error
 	respSize int64
@@ -390,7 +390,7 @@ func (rs *copResponse) GetStartKey() kv.Key {
 }
 
 func (rs *copResponse) GetExecDetails() *execdetails.ExecDetails {
-	return &rs.ExecDetails
+	return rs.detail
 }
 
 // MemSize returns how many bytes of memory this response use
@@ -401,9 +401,11 @@ func (rs *copResponse) MemSize() int64 {
 
 	// ignore rs.err
 	rs.respSize += int64(cap(rs.startKey))
-	rs.respSize += int64(sizeofExecDetails)
-	if rs.CommitDetail != nil {
-		rs.respSize += int64(sizeofCommitDetails)
+	if rs.detail != nil {
+		rs.respSize += int64(sizeofExecDetails)
+		if rs.detail.CommitDetail != nil {
+			rs.respSize += int64(sizeofCommitDetails)
+		}
 	}
 	if rs.pbResp != nil {
 		// Using a approximate size since it's hard to get a accurate value.
@@ -768,19 +770,22 @@ func (worker *copIteratorWorker) handleCopResponse(bo *Backoffer, rpcCtx *RPCCon
 	} else {
 		resp.startKey = task.ranges.at(0).StartKey
 	}
-	resp.BackoffTime = time.Duration(bo.totalSleep) * time.Millisecond
+	if resp.detail == nil {
+		resp.detail = new(execdetails.ExecDetails)
+	}
+	resp.detail.BackoffTime = time.Duration(bo.totalSleep) * time.Millisecond
 	if rpcCtx != nil {
-		resp.CalleeAddress = rpcCtx.Addr
+		resp.detail.CalleeAddress = rpcCtx.Addr
 	}
 	if pbDetails := resp.pbResp.ExecDetails; pbDetails != nil {
 		if handleTime := pbDetails.HandleTime; handleTime != nil {
-			resp.WaitTime = time.Duration(handleTime.WaitMs) * time.Millisecond
-			resp.ProcessTime = time.Duration(handleTime.ProcessMs) * time.Millisecond
+			resp.detail.WaitTime = time.Duration(handleTime.WaitMs) * time.Millisecond
+			resp.detail.ProcessTime = time.Duration(handleTime.ProcessMs) * time.Millisecond
 		}
 		if scanDetail := pbDetails.ScanDetail; scanDetail != nil {
 			if scanDetail.Write != nil {
-				resp.TotalKeys += scanDetail.Write.Total
-				resp.ProcessedKeys += scanDetail.Write.Processed
+				resp.detail.TotalKeys += scanDetail.Write.Total
+				resp.detail.ProcessedKeys += scanDetail.Write.Processed
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the issue that `pb` memory cannot be released quickly.

### What is changed and how it works?
In this [PR](#10236)(stmtctx.go:296), we let `sc` hold `detail` until the query finish to get more coptask's execution information.

Because `detail` is nested in `copResponse`, if we hold its pointer, the Golang GC scanner will regard `copResponse` as active, and will not release until the query finish.

Then another field `pbResp` held by `copResonse` will not be released quickly.

Since `pbResp` is used to buffer `pb` data, it results in more memory consumption.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
