### PR TITLE
session: do not add history for pessimistic transaction

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -84,6 +84,7 @@ func (s *testPessimisticSuite) TestPessimisticTxn(c *C) {
 	// Update can see the change, so this statement affects 0 roews.
 	tk1.MustExec("update pessimistic set v = 3 where v = 1")
 	c.Assert(tk1.Se.AffectedRows(), Equals, uint64(0))
+	c.Assert(session.GetHistory(tk1.Se).Count(), Equals, 0)
 	// select for update can see the change of another transaction.
 	tk1.MustQuery("select * from pessimistic for update").Check(testkit.Rows("1 2"))
 	// plain select can not see the change of another transaction.

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -223,7 +223,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 	// All the history should be added here.
 	sessVars.TxnCtx.StatementCount++
 	if !s.IsReadOnly(sessVars) {
-		if err == nil {
+		if err == nil && !sessVars.TxnCtx.IsPessimistic {
 			GetHistory(sctx).Add(0, s, se.sessionVars.StmtCtx)
 		}
 		if txn, err1 := sctx.Txn(false); err1 == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We never retry pessimistic transactions, so adding statement history for pessimistic transaction wastes memory.

### What is changed and how it works?
Do not add statement history for pessimistic transactions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
