### PR TITLE
ddl: make add index test stable by change ddl reorg batch size

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -289,6 +289,10 @@ func (s *testDBSuite3) TestCancelAddIndex(c *C) {
 
 	var c3IdxInfo *model.IndexInfo
 	hook := &ddl.TestDDLCallback{}
+	originBatchSize := s.tk.MustQuery("select @@global.tidb_ddl_reorg_batch_size")
+	// Set batch size to lower try to slow down add-index reorganization, This if for hook to cancel this ddl job.
+	s.tk.MustExec("set @@global.tidb_ddl_reorg_batch_size = 32")
+	defer s.tk.MustExec(fmt.Sprintf("set @@global.tidb_ddl_reorg_batch_size = %v", originBatchSize.Rows()[0][0]))
 	// let hook.OnJobUpdatedExported has chance to cancel the job.
 	// the hook.OnJobUpdatedExported is called when the job is updated, runReorgJob will wait ddl.ReorgWaitTimeout, then return the ddl.runDDLJob.
 	// After that ddl call d.hook.OnJobUpdated(job), so that we can canceled the job in this test case.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```go
----------------------------------------------------------------------
FAIL: db_test.go:277: testDBSuite3.TestCancelAddIndex

db_test.go:310:
   c.Assert(err, NotNil)
... value = nil
```

Related PR: https://github.com/pingcap/tidb/pull/10387

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
