### PR TITLE
executor: log inconsistent handles when inconsistent-check fail in `IndexLookupReader`

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -845,10 +845,15 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 				obtainedHandlesMap[handle] = struct{}{}
 			}
 
+			logutil.Logger(ctx).Error("inconsistent index handles", zap.String("index", w.idxLookup.index.Name.O),
+				zap.Int("index_cnt", handleCnt), zap.Int("table_cnt", len(task.rows)),
+				zap.Any("missing_handles", GetLackHandles(task.handles, obtainedHandlesMap)),
+				zap.Any("total_handles", task.handles))
+
 			// table scan in double read can never has conditions according to convertToIndexScan.
 			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.
-			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v, total handles %v",
-				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap), task.handles)
+			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d",
+				w.idxLookup.index.Name.O, handleCnt, len(task.rows))
 		}
 	}
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -847,8 +847,8 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 
 			logutil.Logger(ctx).Error("inconsistent index handles", zap.String("index", w.idxLookup.index.Name.O),
 				zap.Int("index_cnt", handleCnt), zap.Int("table_cnt", len(task.rows)),
-				zap.Any("missing_handles", GetLackHandles(task.handles, obtainedHandlesMap)),
-				zap.Any("total_handles", task.handles))
+				zap.Int64s("missing_handles", GetLackHandles(task.handles, obtainedHandlesMap)),
+				zap.Int64s("total_handles", task.handles))
 
 			// table scan in double read can never has conditions according to convertToIndexScan.
 			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -848,7 +848,7 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 			// table scan in double read can never has conditions according to convertToIndexScan.
 			// if this table scan has no condition, the number of rows it returns must equal to the length of handles.
 			return errors.Errorf("inconsistent index %s handle count %d isn't equal to value count %d, missing handles %v, total handles %v",
-				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap), GetLackHandles(task.handles, obtainedHandlesMap), task.handles)
+				w.idxLookup.index.Name.O, handleCnt, len(task.rows), GetLackHandles(task.handles, obtainedHandlesMap), task.handles)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Log missing handles and total handles returned by `IndexScan` when inconsistent-check fail.

### What is changed and how it works?
Log when inconsistent-check fail.

