### PR TITLE
session: init expensiveQueryHandle immediately after domain be initiated

### DIFF
--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -296,3 +296,16 @@ func (s *testBootstrapSuite) TestOldPasswordUpgrade(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(newpwd, Equals, "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E")
 }
+
+func (s *testBootstrapSuite) TestBootstrapInitExpensiveQueryHandle(c *C) {
+	defer testleak.AfterTest(c)()
+	store := newStore(c, s.dbName)
+	defer store.Close()
+	se, err := createSession(store)
+	c.Assert(err, IsNil)
+	dom := domain.GetDomain(se)
+	c.Assert(dom, NotNil)
+	defer dom.Close()
+	dom.InitExpensiveQueryHandle()
+	c.Assert(dom.ExpensiveQueryHandle(), NotNil)
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1507,6 +1507,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 
 	timeutil.SetSystemTZ(tz)
 	dom := domain.GetDomain(se)
+	dom.InitExpensiveQueryHandle()
 
 	if !config.GetGlobalConfig().Security.SkipGrantTable {
 		err = dom.LoadPrivilegeLoop(se)
@@ -1543,7 +1544,6 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	if err != nil {
 		return nil, err
 	}
-	dom.InitExpensiveQueryHandle()
 	if raw, ok := store.(tikv.EtcdBackend); ok {
 		err = raw.StartGCWorker()
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the data race occurred when expensiveQueryHandle is initiated in main goroutine and be read in another goroutine.
``` go
==================
WARNING: DATA RACE
Write at 0x00c0002ae6a8 by goroutine 86:
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:1044 +0x3fb
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:895 +0x37f
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:893 +0x352
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:891 +0x325
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:889 +0x2f8
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:887 +0x2cb
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:885 +0x29e
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:883 +0x271
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:881 +0x244
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:879 +0x217
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:877 +0x1ea
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:875 +0x1bd
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:873 +0x190
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:872 +0x163
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:871 +0x136
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:869 +0x109
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:867 +0xdc
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:865 +0x5b
  github.com/pingcap/tidb/session.bootstrap()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:289 +0x1a3
  github.com/pingcap/tidb/session.runInBootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1577 +0x167
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1493 +0x989
  github.com/pingcap/tidb/util/admin_test.(*testSuite).TestScan()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/admin/admin_test.go:300 +0x72
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9fc
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7
Previous read at 0x00c0002ae6a8 by goroutine 145:
  github.com/pingcap/tidb/executor.ResetContextOfStmt()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:1039 +0x555
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1056 +0x7d1
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1015 +0xd4
  github.com/pingcap/tidb/statistics/handle.(*Handle).initStatsMeta()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/statistics/handle/bootstrap.go:64 +0x141
  github.com/pingcap/tidb/statistics/handle.(*Handle).InitStats()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/statistics/handle/bootstrap.go:256 +0x56
  github.com/pingcap/tidb/domain.(*Domain).loadStatsWorker()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:935 +0x1cd

```

### What is changed and how it works?
Init expensiveQueryHandle immediately after domain be initiated.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes
 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
