### PR TITLE
store/tikv: fix performance issue under mixed transaction mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,9 @@ import (
 
 // Config number limitations
 const (
-	MaxLogFileSize = 4096 // MB
+	MaxLogFileSize    = 4096 // MB
+	MinPessimisticTTL = time.Second * 15
+	MaxPessimisticTTL = time.Second * 60
 )
 
 // Valid config maps
@@ -568,10 +570,9 @@ func (c *Config) Valid() error {
 		if err != nil {
 			return err
 		}
-		minDur := time.Second * 15
-		maxDur := time.Second * 60
-		if dur < minDur || dur > maxDur {
-			return fmt.Errorf("pessimistic transaction ttl %s out of range [%s, %s]", dur, minDur, maxDur)
+		if dur < MinPessimisticTTL || dur > MaxPessimisticTTL {
+			return fmt.Errorf("pessimistic transaction ttl %s out of range [%s, %s]",
+				dur, MinPessimisticTTL, MaxPessimisticTTL)
 		}
 	}
 	return nil

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
+	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/testkit"
@@ -52,6 +53,7 @@ func (s *testPessimisticSuite) SetUpSuite(c *C) {
 		mockstore.WithCluster(s.cluster),
 		mockstore.WithMVCCStore(s.mvccStore),
 	)
+	tikv.PessimisticLockTTL = uint64(config.MinPessimisticTTL / time.Millisecond)
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -37,12 +37,9 @@ type testCommitterSuite struct {
 
 var _ = Suite(&testCommitterSuite{})
 
-func (s *testCommitterSuite) SetUpSuite(c *C) {
-	PessimisticLockTTL = uint64(config.MinPessimisticTTL / time.Millisecond)
-}
-
 func (s *testCommitterSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster()
+	PessimisticLockTTL = uint64(config.MinPessimisticTTL / time.Millisecond)
 	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("a"), []byte("b"), []byte("c"))
 	mvccStore, err := mocktikv.NewMVCCLevelDB("")
 	c.Assert(err, IsNil)

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -138,17 +138,12 @@ func (l *Lock) String() string {
 
 // NewLock creates a new *Lock.
 func NewLock(l *kvrpcpb.LockInfo) *Lock {
-	ttl := l.GetLockTtl()
-	if ttl == 0 {
-		ttl = defaultLockTTL
-	}
-	txnSize := l.GetTxnSize()
 	return &Lock{
 		Key:     l.GetKey(),
 		Primary: l.GetPrimaryLock(),
 		TxnID:   l.GetLockVersion(),
-		TTL:     ttl,
-		TxnSize: txnSize,
+		TTL:     l.GetLockTtl(),
+		TxnSize: l.GetTxnSize(),
 	}
 }
 

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -277,6 +277,11 @@ func (s *testLockSuite) TestLockTTL(c *C) {
 	s.ttlEquals(c, l.TTL, defaultLockTTL+uint64(time.Since(start)/time.Millisecond))
 }
 
+func (s *testLockSuite) TestNewLockZeroTTL(c *C) {
+	l := NewLock(&kvrpcpb.LockInfo{})
+	c.Assert(l.TTL, Equals, uint64(0))
+}
+
 func init() {
 	// Speed up tests.
 	defaultLockTTL = 3


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- When optimistic transaction and pessimistic transactions conflicts, the performance was terribly low.
The reason is that if an optimistic wait for a pessimistic lock during prewrite, the other successfully written prewrite locks blocks all the reads.
- When tikv returns a lock with zero TTL, we don't respect it but set it to a default 3000 value which causes an undesired wait, can lead to transaction failure.

### What is changed and how it works?
- Return ErrWriteConflict when optimistic prewrite meets a pessimistic lock.
- Don't modify the TTL value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch