### PR TITLE
store/tikv: Notify affected regions after sending UnsafeDestroyRange (#10069)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/errors v0.11.4
 	github.com/pingcap/failpoint v0.0.0-20190422094118-d8535965f59b
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
-	github.com/pingcap/kvproto v0.0.0-20190528074401-b942b3f4108f
+	github.com/pingcap/kvproto v0.0.0-20190619024611-a4759dfe3753
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
 	github.com/pingcap/parser v0.0.0-20190613045206-37cc370a20a4
 	github.com/pingcap/pd v0.0.0-20190424024702-bd1e2496a669

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/pingcap/gofail v0.0.0-20181217135706-6a951c1e42c3/go.mod h1:DazNTg0PT
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e h1:P73/4dPCL96rGrobssy1nVy2VaVpNCuLpCbr+FEaTA8=
 github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
 github.com/pingcap/kvproto v0.0.0-20190327032727-3d8cb3a30d5d/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
-github.com/pingcap/kvproto v0.0.0-20190528074401-b942b3f4108f h1:EXZvZmZl+n4PGSRD8fykjHGzXS8QarWYx7KgIBBa7rg=
-github.com/pingcap/kvproto v0.0.0-20190528074401-b942b3f4108f/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
+github.com/pingcap/kvproto v0.0.0-20190619024611-a4759dfe3753 h1:92t0y430CJF0tN1lvUhP5fhnYTFmssATJqwxQtvixYU=
+github.com/pingcap/kvproto v0.0.0-20190619024611-a4759dfe3753/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -16,9 +16,9 @@ package tikv
 import (
 	"bytes"
 	"context"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
 
@@ -27,40 +27,74 @@ import (
 // if the task was canceled or not.
 type DeleteRangeTask struct {
 	completedRegions int
-	canceled         bool
 	store            Storage
-	ctx              context.Context
 	startKey         []byte
 	endKey           []byte
+	notifyOnly       bool
+	concurrency      int
 }
 
-// NewDeleteRangeTask creates a DeleteRangeTask. Deleting will not be performed right away.
-// WARNING: Currently, this API may leave some waste key-value pairs uncleaned in TiKV. Be careful while using it.
-func NewDeleteRangeTask(ctx context.Context, store Storage, startKey []byte, endKey []byte) *DeleteRangeTask {
+// NewDeleteRangeTask creates a DeleteRangeTask. Deleting will be performed when `Execute` method is invoked.
+// Be careful while using this API. This API doesn't keep recent MVCC versions, but will delete all versions of all keys
+// in the range immediately. Also notice that frequent invocation to this API may cause performance problems to TiKV.
+func NewDeleteRangeTask(store Storage, startKey []byte, endKey []byte, concurrency int) *DeleteRangeTask {
 	return &DeleteRangeTask{
 		completedRegions: 0,
-		canceled:         false,
 		store:            store,
-		ctx:              ctx,
 		startKey:         startKey,
 		endKey:           endKey,
+		notifyOnly:       false,
+		concurrency:      concurrency,
 	}
 }
 
+// NewNotifyDeleteRangeTask creates a task that sends delete range requests to all regions in the range, but with the
+// flag `notifyOnly` set. TiKV will not actually delete the range after receiving request, but it will be replicated via
+// raft. This is used to notify the involved regions before sending UnsafeDestroyRange requests.
+func NewNotifyDeleteRangeTask(store Storage, startKey []byte, endKey []byte, concurrency int) *DeleteRangeTask {
+	task := NewDeleteRangeTask(store, startKey, endKey, concurrency)
+	task.notifyOnly = true
+	return task
+}
+
+// getRunnerName returns a name for RangeTaskRunner.
+func (t *DeleteRangeTask) getRunnerName() string {
+	if t.notifyOnly {
+		return "delete-range-notify"
+	}
+	return "delete-range"
+}
+
 // Execute performs the delete range operation.
-func (t *DeleteRangeTask) Execute() error {
-	startKey, rangeEndKey := t.startKey, t.endKey
+func (t *DeleteRangeTask) Execute(ctx context.Context) error {
+	runnerName := t.getRunnerName()
+
+	runner := NewRangeTaskRunner(runnerName, t.store, t.concurrency, t.sendReqOnRange)
+	err := runner.RunOnRange(ctx, t.startKey, t.endKey)
+	t.completedRegions = int(runner.CompletedRegions())
+
+	return err
+}
+
+// Execute performs the delete range operation.
+func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (int, error) {
+	startKey, rangeEndKey := r.StartKey, r.EndKey
+	completedRegions := 0
 	for {
 		select {
-		case <-t.ctx.Done():
-			t.canceled = true
-			return nil
+		case <-ctx.Done():
+			return completedRegions, errors.Trace(ctx.Err())
 		default:
 		}
-		bo := NewBackoffer(t.ctx, deleteRangeOneRegionMaxBackoff)
+
+		if bytes.Compare(startKey, rangeEndKey) >= 0 {
+			break
+		}
+
+		bo := NewBackoffer(ctx, deleteRangeOneRegionMaxBackoff)
 		loc, err := t.store.GetRegionCache().LocateKey(bo, startKey)
 		if err != nil {
-			return errors.Trace(err)
+			return completedRegions, errors.Trace(err)
 		}
 
 		// Delete to the end of the region, except if it's the last region overlapping the range
@@ -73,49 +107,42 @@ func (t *DeleteRangeTask) Execute() error {
 		req := &tikvrpc.Request{
 			Type: tikvrpc.CmdDeleteRange,
 			DeleteRange: &kvrpcpb.DeleteRangeRequest{
-				StartKey: startKey,
-				EndKey:   endKey,
+				StartKey:   startKey,
+				EndKey:     endKey,
+				NotifyOnly: t.notifyOnly,
 			},
 		}
 
 		resp, err := t.store.SendReq(bo, req, loc.Region, ReadTimeoutMedium)
 		if err != nil {
-			return errors.Trace(err)
+			return completedRegions, errors.Trace(err)
 		}
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return errors.Trace(err)
+			return completedRegions, errors.Trace(err)
 		}
 		if regionErr != nil {
 			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
 			if err != nil {
-				return errors.Trace(err)
+				return completedRegions, errors.Trace(err)
 			}
 			continue
 		}
 		deleteRangeResp := resp.DeleteRange
 		if deleteRangeResp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return completedRegions, errors.Trace(ErrBodyMissing)
 		}
 		if err := deleteRangeResp.GetError(); err != "" {
-			return errors.Errorf("unexpected delete range err: %v", err)
+			return completedRegions, errors.Errorf("unexpected delete range err: %v", err)
 		}
-		t.completedRegions++
-		if bytes.Equal(endKey, rangeEndKey) {
-			break
-		}
+		completedRegions++
 		startKey = endKey
 	}
 
-	return nil
+	return completedRegions, nil
 }
 
 // CompletedRegions returns the number of regions that are affected by this delete range task
 func (t *DeleteRangeTask) CompletedRegions() int {
 	return t.completedRegions
-}
-
-// IsCanceled returns true if the delete range operation was canceled on the half way
-func (t *DeleteRangeTask) IsCanceled() bool {
-	return t.canceled
 }

--- a/store/tikv/delete_range_test.go
+++ b/store/tikv/delete_range_test.go
@@ -33,7 +33,7 @@ var _ = Suite(&testDeleteRangeSuite{})
 
 func (s *testDeleteRangeSuite) SetUpTest(c *C) {
 	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("a"), []byte("b"), []byte("c"))
+	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("b"), []byte("c"), []byte("d"))
 	client, pdClient, err := mocktikv.NewTiKVAndPDClient(s.cluster, nil, "")
 	c.Assert(err, IsNil)
 
@@ -81,12 +81,13 @@ func (s *testDeleteRangeSuite) checkData(c *C, expectedData map[string]string) {
 	c.Assert(data, DeepEquals, expectedData)
 }
 
-func (s *testDeleteRangeSuite) deleteRange(c *C, startKey []byte, endKey []byte) {
-	ctx := context.Background()
-	task := NewDeleteRangeTask(ctx, s.store, startKey, endKey)
+func (s *testDeleteRangeSuite) deleteRange(c *C, startKey []byte, endKey []byte) int {
+	task := NewDeleteRangeTask(s.store, startKey, endKey, 1)
 
-	err := task.Execute()
+	err := task.Execute(context.Background())
 	c.Assert(err, IsNil)
+
+	return task.CompletedRegions()
 }
 
 // deleteRangeFromMap deletes all keys in a given range from a map
@@ -100,10 +101,11 @@ func deleteRangeFromMap(m map[string]string, startKey []byte, endKey []byte) {
 }
 
 // mustDeleteRange does delete range on both the map and the storage, and assert they are equal after deleting
-func (s *testDeleteRangeSuite) mustDeleteRange(c *C, startKey []byte, endKey []byte, expected map[string]string) {
-	s.deleteRange(c, startKey, endKey)
+func (s *testDeleteRangeSuite) mustDeleteRange(c *C, startKey []byte, endKey []byte, expected map[string]string, regions int) {
+	completedRegions := s.deleteRange(c, startKey, endKey)
 	deleteRangeFromMap(expected, startKey, endKey)
 	s.checkData(c, expected)
+	c.Assert(completedRegions, Equals, regions)
 }
 
 func (s *testDeleteRangeSuite) TestDeleteRange(c *C) {
@@ -119,7 +121,8 @@ func (s *testDeleteRangeSuite) TestDeleteRange(c *C) {
 			key := []byte{byte(i), byte(j)}
 			value := []byte{byte(rand.Intn(256)), byte(rand.Intn(256))}
 			testData[string(key)] = string(value)
-			txn.Set(key, value)
+			err := txn.Set(key, value)
+			c.Assert(err, IsNil)
 		}
 	}
 
@@ -128,10 +131,10 @@ func (s *testDeleteRangeSuite) TestDeleteRange(c *C) {
 
 	s.checkData(c, testData)
 
-	s.mustDeleteRange(c, []byte("b"), []byte("c0"), testData)
-	s.mustDeleteRange(c, []byte("c11"), []byte("c12"), testData)
-	s.mustDeleteRange(c, []byte("d0"), []byte("d0"), testData)
-	s.mustDeleteRange(c, []byte("d0\x00"), []byte("d1\x00"), testData)
-	s.mustDeleteRange(c, []byte("c5"), []byte("d5"), testData)
-	s.mustDeleteRange(c, []byte("a"), []byte("z"), testData)
+	s.mustDeleteRange(c, []byte("b"), []byte("c0"), testData, 2)
+	s.mustDeleteRange(c, []byte("c11"), []byte("c12"), testData, 1)
+	s.mustDeleteRange(c, []byte("d0"), []byte("d0"), testData, 0)
+	s.mustDeleteRange(c, []byte("d0\x00"), []byte("d1\x00"), testData, 1)
+	s.mustDeleteRange(c, []byte("c5"), []byte("d5"), testData, 2)
+	s.mustDeleteRange(c, []byte("a"), []byte("z"), testData, 4)
 }

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -471,7 +471,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 		w.done <- errors.Trace(err)
 		return
 	}
-	err = w.deleteRanges(ctx, safePoint)
+	err = w.deleteRanges(ctx, safePoint, concurrency)
 	if err != nil {
 		logutil.Logger(ctx).Error("[gc worker] delete range returns an error",
 			zap.String("uuid", w.uuid),
@@ -480,7 +480,7 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 		w.done <- errors.Trace(err)
 		return
 	}
-	err = w.redoDeleteRanges(ctx, safePoint)
+	err = w.redoDeleteRanges(ctx, safePoint, concurrency)
 	if err != nil {
 		logutil.Logger(ctx).Error("[gc worker] redo-delete range returns an error",
 			zap.String("uuid", w.uuid),
@@ -527,7 +527,8 @@ func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency i
 }
 
 // deleteRanges processes all delete range records whose ts < safePoint in table `gc_delete_range`
-func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64) error {
+// `concurrency` specifies the concurrency to send NotifyDeleteRange.
+func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64, concurrency int) error {
 	metrics.GCWorkerCounter.WithLabelValues("delete_range").Inc()
 
 	se := createSession(w.store)
@@ -544,7 +545,7 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64) error {
 	for _, r := range ranges {
 		startKey, endKey := r.Range()
 
-		err = w.sendUnsafeDestroyRangeRequest(ctx, startKey, endKey)
+		err = w.doUnsafeDestroyRangeRequest(ctx, startKey, endKey, concurrency)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -565,7 +566,8 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64) error {
 }
 
 // redoDeleteRanges checks all deleted ranges whose ts is at least `lifetime + 24h` ago. See TiKV RFC #2.
-func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64) error {
+// `concurrency` specifies the concurrency to send NotifyDeleteRange.
+func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64, concurrency int) error {
 	metrics.GCWorkerCounter.WithLabelValues("redo_delete_range").Inc()
 
 	// We check delete range records that are deleted about 24 hours ago.
@@ -585,7 +587,7 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64) error
 	for _, r := range ranges {
 		startKey, endKey := r.Range()
 
-		err = w.sendUnsafeDestroyRangeRequest(ctx, startKey, endKey)
+		err = w.doUnsafeDestroyRangeRequest(ctx, startKey, endKey, concurrency)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -605,7 +607,7 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64) error
 	return nil
 }
 
-func (w *GCWorker) sendUnsafeDestroyRangeRequest(ctx context.Context, startKey []byte, endKey []byte) error {
+func (w *GCWorker) doUnsafeDestroyRangeRequest(ctx context.Context, startKey []byte, endKey []byte, concurrency int) error {
 	// Get all stores every time deleting a region. So the store list is less probably to be stale.
 	stores, err := w.getUpStores(ctx)
 	if err != nil {
@@ -643,6 +645,17 @@ func (w *GCWorker) sendUnsafeDestroyRangeRequest(ctx context.Context, startKey [
 	}
 
 	wg.Wait()
+
+	// Notify all affected regions in the range that UnsafeDestroyRange occurs.
+	notifyTask := tikv.NewNotifyDeleteRangeTask(w.store, startKey, endKey, concurrency)
+	err = notifyTask.Execute(ctx)
+	if err != nil {
+		logutil.Logger(ctx).Error("[gc worker] failed notifying regions affected by UnsafeDestroyRange",
+			zap.String("uuid", w.uuid),
+			zap.Binary("startKey", startKey),
+			zap.Binary("endKey", endKey),
+			zap.Error(err))
+	}
 
 	return errors.Trace(err)
 }
@@ -1353,5 +1366,5 @@ func NewMockGCWorker(store tikv.Storage) (*MockGCWorker, error) {
 // DeleteRanges calls deleteRanges internally, just for test.
 func (w *MockGCWorker) DeleteRanges(ctx context.Context, safePoint uint64) error {
 	logutil.Logger(ctx).Error("deleteRanges is called")
-	return w.worker.deleteRanges(ctx, safePoint)
+	return w.worker.deleteRanges(ctx, safePoint, 1)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR cherry-picks #10069 to reelase-3.0 branch.

- [x] Requires https://github.com/tikv/tikv/pull/4931 to be merged first

### What is changed and how it works?

#10069 sends a message to all affected regions after unsafe_destroy_range. This PR cherry-picks it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - Tested in #10069 .

Code changes

 - No

Side effects

 - Increased code complexity