### PR TITLE
executor: fix wrong row count in fast analyze

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -996,6 +996,7 @@ func (e *AnalyzeFastExec) buildHist(ID int64, collector *statistics.SampleCollec
 	if handle.Lease() > 0 && !tblStats.Pseudo {
 		rowCount = mathutil.MinInt64(tblStats.Count, rowCount)
 	}
+	// Adjust the row count in case of too small table row count.
 	rowCount = mathutil.MaxInt64(rowCount, int64(len(collector.Samples)))
 	// build CMSketch
 	var ndv, scaleRatio uint64

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -995,6 +995,7 @@ func (e *AnalyzeFastExec) buildHist(ID int64, collector *statistics.SampleCollec
 	if stats.Lease() > 0 {
 		rowCount = mathutil.MinInt64(stats.GetTableStats(e.tblInfo).Count, rowCount)
 	}
+	rowCount = mathutil.MaxInt64(rowCount, int64(len(collector.Samples)))
 	// build CMSketch
 	var ndv, scaleRatio uint64
 	collector.CMSketch, ndv, scaleRatio = statistics.NewCMSketchWithTopN(defaultCMSketchDepth, defaultCMSketchWidth, data, 20, uint64(rowCount))

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -996,7 +996,7 @@ func (e *AnalyzeFastExec) buildHist(ID int64, collector *statistics.SampleCollec
 	if handle.Lease() > 0 && !tblStats.Pseudo {
 		rowCount = mathutil.MinInt64(tblStats.Count, rowCount)
 	}
-	// Adjust the row count in case of too small table row count.
+	// Adjust the row count in case the count of `tblStats` is not accurate and too small.
 	rowCount = mathutil.MaxInt64(rowCount, int64(len(collector.Samples)))
 	// build CMSketch
 	var ndv, scaleRatio uint64

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -990,10 +990,11 @@ func (e *AnalyzeFastExec) buildHist(ID int64, collector *statistics.SampleCollec
 		}
 		data = append(data, bytes)
 	}
-	stats := domain.GetDomain(e.ctx).StatsHandle()
+	handle := domain.GetDomain(e.ctx).StatsHandle()
+	tblStats := handle.GetTableStats(e.tblInfo)
 	rowCount := int64(e.rowCount)
-	if stats.Lease() > 0 {
-		rowCount = mathutil.MinInt64(stats.GetTableStats(e.tblInfo).Count, rowCount)
+	if handle.Lease() > 0 && !tblStats.Pseudo {
+		rowCount = mathutil.MinInt64(tblStats.Count, rowCount)
 	}
 	rowCount = mathutil.MaxInt64(rowCount, int64(len(collector.Samples)))
 	// build CMSketch

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -402,6 +402,7 @@ func (s *testFastAnalyze) TestFastAnalyzeRetryRowCount(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key)")
+	c.Assert(s.dom.StatsHandle().Update(s.dom.InfoSchema()), IsNil)
 	tk.MustExec("set @@session.tidb_enable_fast_analyze=1")
 	tk.MustExec("set @@session.tidb_build_stats_concurrency=1")
 	tblInfo, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
FAIL: analyze_test.go:400: testFastAnalyze.TestFastAnalyzeRetryRowCount
analyze_test.go:421:
    c.Assert(row[5], Equals, "30")
... obtained string = "0"
... expected string = "30"
```

### What is changed and how it works?

When stats lease is not 0, the row count of fast analyze result is `mathutil.MinInt64(stats.GetTableStats(e.tblInfo).Count, rowCount)`

- If the test runs fast, the stats cache has not been updated, so the `Count` will be pseudo row count 10000, so we can get the expected result.
- If the test runs slow, newly added rows are not dumped to stats table yet, so the `Count` in stats cache will be `0`, and the test will fail.

This PR fixes it by also consider the sampled count when calculating the result count.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
