### PR TITLE
 *: replace 'logutil.Logger(context.Background())' with 'logutil.BgLogger()'

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -119,7 +119,7 @@ func (h *BindHandle) Update(fullLoad bool) (err error) {
 			h.lastUpdateTime = meta.UpdateTime
 		}
 		if err != nil {
-			logutil.Logger(context.Background()).Error("update bindinfo failed", zap.Error(err))
+			logutil.BgLogger().Error("update bindinfo failed", zap.Error(err))
 			continue
 		}
 
@@ -246,7 +246,7 @@ func (h *BindHandle) DropInvalidBindRecord() {
 		if invalidBindRecord.droppedTime.IsZero() {
 			err := h.DropBindRecord(invalidBindRecord.bindRecord)
 			if err != nil {
-				logutil.Logger(context.Background()).Error("DropInvalidBindRecord failed", zap.Error(err))
+				logutil.BgLogger().Error("DropInvalidBindRecord failed", zap.Error(err))
 			}
 			invalidBindRecord.droppedTime = time.Now()
 			continue

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,6 @@ package config
 
 import (
 	"bytes"
-	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"

--- a/config/config.go
+++ b/config/config.go
@@ -471,7 +471,7 @@ func ReloadGlobalConfig() error {
 
 	confReloader(nc, c)
 	globalConf.Store(nc)
-	logutil.Logger(context.Background()).Info("reload config changes" + formattedDiff.String())
+	logutil.BgLogger().Info("reload config changes" + formattedDiff.String())
 	return nil
 }
 

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -180,7 +180,7 @@ func onAddColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error)
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
-		logutil.Logger(ddlLogCtx).Info("[ddl] run add column job", zap.String("job", job.String()), zap.Reflect("columnInfo", *columnInfo), zap.Int("offset", offset))
+		logutil.BgLogger().Info("[ddl] run add column job", zap.String("job", job.String()), zap.Reflect("columnInfo", *columnInfo), zap.Int("offset", offset))
 		// Set offset arg to job.
 		if offset != 0 {
 			job.Args = []interface{}{columnInfo, pos, offset}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -452,7 +452,7 @@ func (d *ddl) start(ctx context.Context, ctxPool *pools.ResourcePool) {
 			func() { d.schemaSyncer.StartCleanWork() },
 			func(r interface{}) {
 				if r != nil {
-					logutil.Logger(ddlLogCtx).Error("[ddl] DDL syncer clean worker meet panic",
+					logutil.BgLogger().Error("[ddl] DDL syncer clean worker meet panic",
 						zap.String("ID", d.uuid), zap.Reflect("r", r), zap.Stack("stack trace"))
 					metrics.PanicCounter.WithLabelValues(metrics.LabelDDLSyncer).Inc()
 				}

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -71,9 +71,6 @@ var (
 	// a newly created table. It takes effect only if the Storage supports split
 	// region.
 	EnableSplitTableRegion = uint32(0)
-
-	// ddlLogCtx uses for log.
-	ddlLogCtx = context.Background()
 )
 
 var (
@@ -309,7 +306,7 @@ type ddlCtx struct {
 
 func (dc *ddlCtx) isOwner() bool {
 	isOwner := dc.ownerManager.IsOwner()
-	logutil.Logger(ddlLogCtx).Debug("[ddl] check whether is the DDL owner", zap.Bool("isOwner", isOwner), zap.String("selfID", dc.uuid))
+	logutil.BgLogger().Debug("[ddl] check whether is the DDL owner", zap.Bool("isOwner", isOwner), zap.String("selfID", dc.uuid))
 	if isOwner {
 		metrics.DDLCounter.WithLabelValues(metrics.DDLOwner + "_" + mysql.TiDBReleaseVersion).Inc()
 	}
@@ -338,7 +335,7 @@ func asyncNotifyEvent(d *ddlCtx, e *util.Event) {
 			case d.ddlEventCh <- e:
 				return
 			default:
-				logutil.Logger(ddlLogCtx).Warn("[ddl] fail to notify DDL event", zap.String("event", e.String()))
+				logutil.BgLogger().Warn("[ddl] fail to notify DDL event", zap.String("event", e.String()))
 				time.Sleep(time.Microsecond * 10)
 			}
 		}
@@ -399,7 +396,7 @@ func (d *ddl) Stop() error {
 	defer d.m.Unlock()
 
 	d.close()
-	logutil.Logger(ddlLogCtx).Info("[ddl] stop DDL", zap.String("ID", d.uuid))
+	logutil.BgLogger().Info("[ddl] stop DDL", zap.String("ID", d.uuid))
 	return nil
 }
 
@@ -407,7 +404,7 @@ func (d *ddl) newDeleteRangeManager(mock bool) delRangeManager {
 	var delRangeMgr delRangeManager
 	if !mock {
 		delRangeMgr = newDelRangeManager(d.store, d.sessPool)
-		logutil.Logger(ddlLogCtx).Info("[ddl] start delRangeManager OK", zap.Bool("is a emulator", !d.store.SupportDeleteRange()))
+		logutil.BgLogger().Info("[ddl] start delRangeManager OK", zap.Bool("is a emulator", !d.store.SupportDeleteRange()))
 	} else {
 		delRangeMgr = newMockDelRangeManager()
 	}
@@ -419,7 +416,7 @@ func (d *ddl) newDeleteRangeManager(mock bool) delRangeManager {
 // start campaigns the owner and starts workers.
 // ctxPool is used for the worker's delRangeManager and creates sessions.
 func (d *ddl) start(ctx context.Context, ctxPool *pools.ResourcePool) {
-	logutil.Logger(ddlLogCtx).Info("[ddl] start DDL", zap.String("ID", d.uuid), zap.Bool("runWorker", RunWorker))
+	logutil.BgLogger().Info("[ddl] start DDL", zap.String("ID", d.uuid), zap.Bool("runWorker", RunWorker))
 	d.quitCh = make(chan struct{})
 
 	// If RunWorker is true, we need campaign owner and do DDL job.
@@ -475,7 +472,7 @@ func (d *ddl) close() {
 	d.schemaSyncer.CloseCleanWork()
 	err := d.schemaSyncer.RemoveSelfVersionPath()
 	if err != nil {
-		logutil.Logger(ddlLogCtx).Error("[ddl] remove self version path failed", zap.Error(err))
+		logutil.BgLogger().Error("[ddl] remove self version path failed", zap.Error(err))
 	}
 
 	for _, worker := range d.workers {
@@ -490,7 +487,7 @@ func (d *ddl) close() {
 		d.sessPool.close()
 	}
 
-	logutil.Logger(ddlLogCtx).Info("[ddl] DDL closed", zap.String("ID", d.uuid), zap.Duration("take time", time.Since(startTime)))
+	logutil.BgLogger().Info("[ddl] DDL closed", zap.String("ID", d.uuid), zap.Duration("take time", time.Since(startTime)))
 }
 
 // GetLease implements DDL.GetLease interface.
@@ -586,7 +583,7 @@ func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 
 	// Notice worker that we push a new job and wait the job done.
 	d.asyncNotifyWorker(job.Type)
-	logutil.Logger(ddlLogCtx).Info("[ddl] start DDL job", zap.String("job", job.String()), zap.String("query", job.Query))
+	logutil.BgLogger().Info("[ddl] start DDL job", zap.String("job", job.String()), zap.String("query", job.Query))
 
 	var historyJob *model.Job
 	jobID := job.ID
@@ -609,16 +606,16 @@ func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 
 		historyJob, err = d.getHistoryDDLJob(jobID)
 		if err != nil {
-			logutil.Logger(ddlLogCtx).Error("[ddl] get history DDL job failed, check again", zap.Error(err))
+			logutil.BgLogger().Error("[ddl] get history DDL job failed, check again", zap.Error(err))
 			continue
 		} else if historyJob == nil {
-			logutil.Logger(ddlLogCtx).Debug("[ddl] DDL job is not in history, maybe not run", zap.Int64("jobID", jobID))
+			logutil.BgLogger().Debug("[ddl] DDL job is not in history, maybe not run", zap.Int64("jobID", jobID))
 			continue
 		}
 
 		// If a job is a history job, the state must be JobStateSynced or JobStateRollbackDone or JobStateCancelled.
 		if historyJob.IsSynced() {
-			logutil.Logger(ddlLogCtx).Info("[ddl] DDL job is finished", zap.Int64("jobID", jobID))
+			logutil.BgLogger().Info("[ddl] DDL job is finished", zap.Int64("jobID", jobID))
 			return nil
 		}
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -664,11 +664,11 @@ func setTimestampDefaultValue(c *table.Column, hasDefaultValue bool, setOnUpdate
 		if setOnUpdateNow {
 			if err := c.SetDefaultValue(types.ZeroDatetimeStr); err != nil {
 				context.Background()
-				logutil.Logger(ddlLogCtx).Error("set default value failed", zap.Error(err))
+				logutil.BgLogger().Error("set default value failed", zap.Error(err))
 			}
 		} else {
 			if err := c.SetDefaultValue(strings.ToUpper(ast.CurrentTimestamp)); err != nil {
-				logutil.Logger(ddlLogCtx).Error("set default value failed", zap.Error(err))
+				logutil.BgLogger().Error("set default value failed", zap.Error(err))
 			}
 		}
 	}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -174,7 +174,7 @@ func buildJobDependence(t *meta.Meta, curJob *model.Job) error {
 			return errors.Trace(err)
 		}
 		if isDependent {
-			logutil.Logger(ddlLogCtx).Info("[ddl] current DDL job depends on other job", zap.String("currentJob", curJob.String()), zap.String("dependentJob", job.String()))
+			logutil.BgLogger().Info("[ddl] current DDL job depends on other job", zap.String("currentJob", curJob.String()), zap.String("dependentJob", job.String()))
 			curJob.DependencyID = job.ID
 			break
 		}
@@ -335,7 +335,7 @@ func isDependencyJobDone(t *meta.Meta, job *model.Job) (bool, error) {
 	if historyJob == nil {
 		return false, nil
 	}
-	logutil.Logger(ddlLogCtx).Info("[ddl] current DDL job dependent job is finished", zap.String("currentJob", job.String()), zap.Int64("dependentJobID", job.DependencyID))
+	logutil.BgLogger().Info("[ddl] current DDL job dependent job is finished", zap.String("currentJob", job.String()), zap.Int64("dependentJobID", job.DependencyID))
 	job.DependencyID = noneDependencyJob
 	return true, nil
 }

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -95,7 +95,7 @@ func (dr *delRange) addDelRangeJob(job *model.Job) error {
 	if !dr.storeSupport {
 		dr.emulatorCh <- struct{}{}
 	}
-	logutil.Logger(ddlLogCtx).Info("[ddl] add job into delete-range table", zap.Int64("jobID", job.ID), zap.String("jobType", job.Type.String()))
+	logutil.BgLogger().Info("[ddl] add job into delete-range table", zap.Int64("jobID", job.ID), zap.String("jobType", job.Type.String()))
 	return nil
 }
 
@@ -120,7 +120,7 @@ func (dr *delRange) start() {
 
 // clear implements delRangeManager interface.
 func (dr *delRange) clear() {
-	logutil.Logger(ddlLogCtx).Info("[ddl] closing delRange")
+	logutil.BgLogger().Info("[ddl] closing delRange")
 	close(dr.quitCh)
 	dr.wait.Wait()
 }
@@ -130,7 +130,7 @@ func (dr *delRange) clear() {
 // deletes all keys in each DelRangeTask.
 func (dr *delRange) startEmulator() {
 	defer dr.wait.Done()
-	logutil.Logger(ddlLogCtx).Info("[ddl] start delRange emulator")
+	logutil.BgLogger().Info("[ddl] start delRange emulator")
 	for {
 		select {
 		case <-dr.emulatorCh:
@@ -162,20 +162,20 @@ func IsEmulatorGCEnable() bool {
 func (dr *delRange) doDelRangeWork() error {
 	ctx, err := dr.sessPool.get()
 	if err != nil {
-		logutil.Logger(ddlLogCtx).Error("[ddl] delRange emulator get session failed", zap.Error(err))
+		logutil.BgLogger().Error("[ddl] delRange emulator get session failed", zap.Error(err))
 		return errors.Trace(err)
 	}
 	defer dr.sessPool.put(ctx)
 
 	ranges, err := util.LoadDeleteRanges(ctx, math.MaxInt64)
 	if err != nil {
-		logutil.Logger(ddlLogCtx).Error("[ddl] delRange emulator load tasks failed", zap.Error(err))
+		logutil.BgLogger().Error("[ddl] delRange emulator load tasks failed", zap.Error(err))
 		return errors.Trace(err)
 	}
 
 	for _, r := range ranges {
 		if err := dr.doTask(ctx, r); err != nil {
-			logutil.Logger(ddlLogCtx).Error("[ddl] delRange emulator do task failed", zap.Error(err))
+			logutil.BgLogger().Error("[ddl] delRange emulator do task failed", zap.Error(err))
 			return errors.Trace(err)
 		}
 	}
@@ -221,14 +221,14 @@ func (dr *delRange) doTask(ctx sessionctx.Context, r util.DelRangeTask) error {
 		}
 		if finish {
 			if err := util.CompleteDeleteRange(ctx, r); err != nil {
-				logutil.Logger(ddlLogCtx).Error("[ddl] delRange emulator complete task failed", zap.Error(err))
+				logutil.BgLogger().Error("[ddl] delRange emulator complete task failed", zap.Error(err))
 				return errors.Trace(err)
 			}
-			logutil.Logger(ddlLogCtx).Info("[ddl] delRange emulator complete task", zap.Int64("jobID", r.JobID), zap.Int64("elementID", r.ElementID))
+			logutil.BgLogger().Info("[ddl] delRange emulator complete task", zap.Int64("jobID", r.JobID), zap.Int64("elementID", r.ElementID))
 			break
 		}
 		if err := util.UpdateDeleteRange(ctx, r, newStartKey, oldStartKey); err != nil {
-			logutil.Logger(ddlLogCtx).Error("[ddl] delRange emulator update task failed", zap.Error(err))
+			logutil.BgLogger().Error("[ddl] delRange emulator update task failed", zap.Error(err))
 		}
 		oldStartKey = newStartKey
 	}
@@ -334,7 +334,7 @@ func insertJobIntoDeleteRangeTable(ctx sessionctx.Context, job *model.Job) error
 }
 
 func doInsert(s sqlexec.SQLExecutor, jobID int64, elementID int64, startKey, endKey kv.Key, ts uint64) error {
-	logutil.Logger(ddlLogCtx).Info("[ddl] insert into delete-range table", zap.Int64("jobID", jobID), zap.Int64("elementID", elementID))
+	logutil.BgLogger().Info("[ddl] insert into delete-range table", zap.Int64("jobID", jobID), zap.Int64("elementID", elementID))
 	startKeyEncoded := hex.EncodeToString(startKey)
 	endKeyEncoded := hex.EncodeToString(endKey)
 	sql := fmt.Sprintf(insertDeleteRangeSQL, jobID, elementID, startKeyEncoded, endKeyEncoded, ts)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -275,7 +275,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int
 		indexInfo.Unique = unique
 		indexInfo.ID = allocateIndexID(tblInfo)
 		tblInfo.Indices = append(tblInfo.Indices, indexInfo)
-		logutil.Logger(ddlLogCtx).Info("[ddl] run add index job", zap.String("job", job.String()), zap.Reflect("indexInfo", indexInfo))
+		logutil.BgLogger().Info("[ddl] run add index job", zap.String("job", job.String()), zap.Reflect("indexInfo", indexInfo))
 	}
 	originalState := indexInfo.State
 	switch indexInfo.State {
@@ -317,7 +317,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int
 				r := recover()
 				if r != nil {
 					buf := util.GetStack()
-					logutil.Logger(ddlLogCtx).Error("[ddl] add table index panic", zap.Any("panic", r), zap.String("stack", string(buf)))
+					logutil.BgLogger().Error("[ddl] add table index panic", zap.Any("panic", r), zap.String("stack", string(buf)))
 					metrics.PanicCounter.WithLabelValues(metrics.LabelDDL).Inc()
 					addIndexErr = errCancelledDDLJob.GenWithStack("add table `%v` index `%v` panic", tblInfo.Name, indexInfo.Name)
 				}
@@ -330,7 +330,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int
 				return ver, nil
 			}
 			if kv.ErrKeyExists.Equal(err) || errCancelledDDLJob.Equal(err) || errCantDecodeIndex.Equal(err) {
-				logutil.Logger(ddlLogCtx).Warn("[ddl] run add index job failed, convert job to rollback", zap.String("job", job.String()), zap.Error(err))
+				logutil.BgLogger().Warn("[ddl] run add index job failed, convert job to rollback", zap.String("job", job.String()), zap.Error(err))
 				ver, err = convertAddIdxJob2RollbackJob(t, job, tblInfo, indexInfo, err)
 			}
 			// Clean up the channel of notifyCancelReorgJob. Make sure it can't affect other jobs.
@@ -684,7 +684,7 @@ func (w *addIndexWorker) fetchRowColVals(txn kv.Transaction, taskRange reorgInde
 		taskDone = true
 	}
 
-	logutil.Logger(ddlLogCtx).Debug("[ddl] txn fetches handle info", zap.Uint64("txnStartTS", txn.StartTS()), zap.String("taskRange", taskRange.String()), zap.Duration("takeTime", time.Since(startTime)))
+	logutil.BgLogger().Debug("[ddl] txn fetches handle info", zap.Uint64("txnStartTS", txn.StartTS()), zap.String("taskRange", taskRange.String()), zap.Duration("takeTime", time.Since(startTime)))
 	return w.idxRecords, w.getNextHandle(taskRange, taskDone), taskDone, errors.Trace(err)
 }
 
@@ -694,7 +694,7 @@ func (w *addIndexWorker) logSlowOperations(elapsed time.Duration, slowMsg string
 	}
 
 	if elapsed >= time.Duration(threshold)*time.Millisecond {
-		logutil.Logger(ddlLogCtx).Info("[ddl] slow operations", zap.Duration("takeTimes", elapsed), zap.String("msg", slowMsg))
+		logutil.BgLogger().Info("[ddl] slow operations", zap.Duration("takeTimes", elapsed), zap.String("msg", slowMsg))
 	}
 }
 
@@ -857,7 +857,7 @@ func (w *addIndexWorker) handleBackfillTask(d *ddlCtx, task *reorgIndexTask) *ad
 
 		if num := result.scanCount - lastLogCount; num >= 30000 {
 			lastLogCount = result.scanCount
-			logutil.Logger(ddlLogCtx).Info("[ddl] add index worker back fill index", zap.Int("workerID", w.id), zap.Int("addedCount", result.addedCount),
+			logutil.BgLogger().Info("[ddl] add index worker back fill index", zap.Int("workerID", w.id), zap.Int("addedCount", result.addedCount),
 				zap.Int("scanCount", result.scanCount), zap.Int64("nextHandle", taskCtx.nextHandle), zap.Float64("speed(rows/s)", float64(num)/time.Since(lastLogTime).Seconds()))
 			lastLogTime = time.Now()
 		}
@@ -867,18 +867,18 @@ func (w *addIndexWorker) handleBackfillTask(d *ddlCtx, task *reorgIndexTask) *ad
 			break
 		}
 	}
-	logutil.Logger(ddlLogCtx).Info("[ddl] add index worker finish task", zap.Int("workerID", w.id),
+	logutil.BgLogger().Info("[ddl] add index worker finish task", zap.Int("workerID", w.id),
 		zap.String("task", task.String()), zap.Int("addedCount", result.addedCount), zap.Int("scanCount", result.scanCount), zap.Int64("nextHandle", result.nextHandle), zap.String("takeTime", time.Since(startTime).String()))
 	return result
 }
 
 func (w *addIndexWorker) run(d *ddlCtx) {
-	logutil.Logger(ddlLogCtx).Info("[ddl] add index worker start", zap.Int("workerID", w.id))
+	logutil.BgLogger().Info("[ddl] add index worker start", zap.Int("workerID", w.id))
 	defer func() {
 		r := recover()
 		if r != nil {
 			buf := util.GetStack()
-			logutil.Logger(ddlLogCtx).Error("[ddl] add index worker panic", zap.Any("panic", r), zap.String("stack", string(buf)))
+			logutil.BgLogger().Error("[ddl] add index worker panic", zap.Any("panic", r), zap.String("stack", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelDDL).Inc()
 		}
 		w.resultCh <- &addIndexResult{err: errReorgPanic}
@@ -889,7 +889,7 @@ func (w *addIndexWorker) run(d *ddlCtx) {
 			break
 		}
 
-		logutil.Logger(ddlLogCtx).Debug("[ddl] add index worker got task", zap.Int("workerID", w.id), zap.String("task", task.String()))
+		logutil.BgLogger().Debug("[ddl] add index worker got task", zap.Int("workerID", w.id), zap.String("task", task.String()))
 		failpoint.Inject("mockAddIndexErr", func() {
 			if w.id == 0 {
 				result := &addIndexResult{addedCount: 0, nextHandle: 0, err: errors.Errorf("mock add index error")}
@@ -903,7 +903,7 @@ func (w *addIndexWorker) run(d *ddlCtx) {
 		result := w.handleBackfillTask(d, task)
 		w.resultCh <- result
 	}
-	logutil.Logger(ddlLogCtx).Info("[ddl] add index worker exit", zap.Int("workerID", w.id))
+	logutil.BgLogger().Info("[ddl] add index worker exit", zap.Int("workerID", w.id))
 }
 
 func makeupDecodeColMap(sessCtx sessionctx.Context, t table.Table, indexInfo *model.IndexInfo) (map[int64]decoder.Column, error) {
@@ -940,7 +940,7 @@ func splitTableRanges(t table.PhysicalTable, store kv.Storage, startHandle, endH
 	startRecordKey := t.RecordKey(startHandle)
 	endRecordKey := t.RecordKey(endHandle).Next()
 
-	logutil.Logger(ddlLogCtx).Info("[ddl] split table range from PD", zap.Int64("physicalTableID", t.GetPhysicalID()), zap.Int64("startHandle", startHandle), zap.Int64("endHandle", endHandle))
+	logutil.BgLogger().Info("[ddl] split table range from PD", zap.Int64("physicalTableID", t.GetPhysicalID()), zap.Int64("startHandle", startHandle), zap.Int64("endHandle", endHandle))
 	kvRange := kv.KeyRange{StartKey: startRecordKey, EndKey: endRecordKey}
 	s, ok := store.(tikv.Storage)
 	if !ok {
@@ -995,7 +995,7 @@ func (w *worker) waitTaskResults(workers []*addIndexWorker, taskCnt int, totalAd
 		}
 
 		if result.err != nil {
-			logutil.Logger(ddlLogCtx).Warn("[ddl] add index worker return error", zap.Int("workerID", worker.id), zap.Error(result.err))
+			logutil.BgLogger().Warn("[ddl] add index worker return error", zap.Int("workerID", worker.id), zap.Error(result.err))
 		}
 
 		if firstErr == nil {
@@ -1030,7 +1030,7 @@ func (w *worker) handleReorgTasks(reorgInfo *reorgInfo, totalAddedCount *int64, 
 			return errors.Trace(reorgInfo.UpdateReorgMeta(txn, nextHandle, reorgInfo.EndHandle, reorgInfo.PhysicalTableID))
 		})
 		metrics.BatchAddIdxHistogram.WithLabelValues(metrics.LblError).Observe(elapsedTime.Seconds())
-		logutil.Logger(ddlLogCtx).Warn("[ddl] add index worker handle batch tasks failed", zap.Int64("totalAddedCount", *totalAddedCount), zap.Int64("startHandle", startHandle), zap.Int64("nextHandle", nextHandle),
+		logutil.BgLogger().Warn("[ddl] add index worker handle batch tasks failed", zap.Int64("totalAddedCount", *totalAddedCount), zap.Int64("startHandle", startHandle), zap.Int64("nextHandle", nextHandle),
 			zap.Int64("batchAddedCount", taskAddedCount), zap.String("taskFailedError", err.Error()), zap.String("takeTime", elapsedTime.String()), zap.NamedError("updateHandleError", err1))
 		return errors.Trace(err)
 	}
@@ -1038,7 +1038,7 @@ func (w *worker) handleReorgTasks(reorgInfo *reorgInfo, totalAddedCount *int64, 
 	// nextHandle will be updated periodically in runReorgJob, so no need to update it here.
 	w.reorgCtx.setNextHandle(nextHandle)
 	metrics.BatchAddIdxHistogram.WithLabelValues(metrics.LblOK).Observe(elapsedTime.Seconds())
-	logutil.Logger(ddlLogCtx).Info("[ddl] add index worker handle batch tasks successful", zap.Int64("totalAddedCount", *totalAddedCount), zap.Int64("startHandle", startHandle),
+	logutil.BgLogger().Info("[ddl] add index worker handle batch tasks successful", zap.Int64("totalAddedCount", *totalAddedCount), zap.Int64("startHandle", startHandle),
 		zap.Int64("nextHandle", nextHandle), zap.Int64("batchAddedCount", taskAddedCount), zap.String("takeTime", elapsedTime.String()))
 	return nil
 }
@@ -1121,7 +1121,7 @@ func loadDDLReorgVars(w *worker) error {
 // Finally, update the concurrent processing of the total number of rows, and store the completed handle value.
 func (w *worker) addPhysicalTableIndex(t table.PhysicalTable, indexInfo *model.IndexInfo, reorgInfo *reorgInfo) error {
 	job := reorgInfo.Job
-	logutil.Logger(ddlLogCtx).Info("[ddl] start to add table index", zap.String("job", job.String()), zap.String("reorgInfo", reorgInfo.String()))
+	logutil.BgLogger().Info("[ddl] start to add table index", zap.String("job", job.String()), zap.String("reorgInfo", reorgInfo.String()))
 	totalAddedCount := job.GetRowCount()
 
 	startHandle, endHandle := reorgInfo.StartHandle, reorgInfo.EndHandle
@@ -1146,7 +1146,7 @@ func (w *worker) addPhysicalTableIndex(t table.PhysicalTable, indexInfo *model.I
 
 		// For dynamic adjust add index worker number.
 		if err := loadDDLReorgVars(w); err != nil {
-			logutil.Logger(ddlLogCtx).Error("[ddl] load DDL reorganization variable failed", zap.Error(err))
+			logutil.BgLogger().Error("[ddl] load DDL reorganization variable failed", zap.Error(err))
 		}
 		workerCnt = variable.GetDDLReorgWorkerCounter()
 		// If only have 1 range, we can only start 1 worker.
@@ -1184,7 +1184,7 @@ func (w *worker) addPhysicalTableIndex(t table.PhysicalTable, indexInfo *model.I
 			}
 		})
 
-		logutil.Logger(ddlLogCtx).Info("[ddl] start add index workers to reorg index", zap.Int("workerCnt", len(idxWorkers)), zap.Int("regionCnt", len(kvRanges)), zap.Int64("startHandle", startHandle), zap.Int64("endHandle", endHandle))
+		logutil.BgLogger().Info("[ddl] start add index workers to reorg index", zap.Int("workerCnt", len(idxWorkers)), zap.Int("regionCnt", len(kvRanges)), zap.Int64("startHandle", startHandle), zap.Int64("endHandle", endHandle))
 		remains, err := w.sendRangeTaskToWorkers(t, idxWorkers, reorgInfo, &totalAddedCount, kvRanges)
 		if err != nil {
 			return errors.Trace(err)
@@ -1238,7 +1238,7 @@ func (w *worker) updateReorgInfo(t table.PartitionedTable, reorg *reorgInfo) (bo
 	pid, err := findNextPartitionID(reorg.PhysicalTableID, pi.Definitions)
 	if err != nil {
 		// Fatal error, should not run here.
-		logutil.Logger(ddlLogCtx).Error("[ddl] find next partition ID failed", zap.Reflect("table", t), zap.Error(err))
+		logutil.BgLogger().Error("[ddl] find next partition ID failed", zap.Reflect("table", t), zap.Error(err))
 		return false, errors.Trace(err)
 	}
 	if pid == 0 {
@@ -1256,7 +1256,7 @@ func (w *worker) updateReorgInfo(t table.PartitionedTable, reorg *reorgInfo) (bo
 	err = kv.RunInNewTxn(reorg.d.store, true, func(txn kv.Transaction) error {
 		return errors.Trace(reorg.UpdateReorgMeta(txn, reorg.StartHandle, reorg.EndHandle, reorg.PhysicalTableID))
 	})
-	logutil.Logger(ddlLogCtx).Info("[ddl] job update reorgInfo", zap.Int64("jobID", reorg.Job.ID), zap.Int64("partitionTableID", pid), zap.Int64("startHandle", start), zap.Int64("endHandle", end), zap.Error(err))
+	logutil.BgLogger().Info("[ddl] job update reorgInfo", zap.Int64("jobID", reorg.Job.ID), zap.Int64("partitionTableID", pid), zap.Int64("startHandle", start), zap.Int64("endHandle", end), zap.Error(err))
 	return false, errors.Trace(err)
 }
 

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -137,13 +137,13 @@ func (w *worker) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, lease time.Dura
 	select {
 	case err := <-w.reorgCtx.doneCh:
 		rowCount, _ := w.reorgCtx.getRowCountAndHandle()
-		logutil.Logger(ddlLogCtx).Info("[ddl] run reorg job done", zap.Int64("handled rows", rowCount))
+		logutil.BgLogger().Info("[ddl] run reorg job done", zap.Int64("handled rows", rowCount))
 		// Update a job's RowCount.
 		job.SetRowCount(rowCount)
 		w.reorgCtx.clean()
 		return errors.Trace(err)
 	case <-w.quitCh:
-		logutil.Logger(ddlLogCtx).Info("[ddl] run reorg job quit")
+		logutil.BgLogger().Info("[ddl] run reorg job quit")
 		w.reorgCtx.setNextHandle(0)
 		w.reorgCtx.setRowCount(0)
 		// We return errWaitReorgTimeout here too, so that outer loop will break.
@@ -154,7 +154,7 @@ func (w *worker) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, lease time.Dura
 		job.SetRowCount(rowCount)
 		// Update a reorgInfo's handle.
 		err := t.UpdateDDLReorgStartHandle(job, doneHandle)
-		logutil.Logger(ddlLogCtx).Info("[ddl] run reorg job wait timeout", zap.Duration("waitTime", waitTimeout),
+		logutil.BgLogger().Info("[ddl] run reorg job wait timeout", zap.Duration("waitTime", waitTimeout),
 			zap.Int64("totalAddedRowCount", rowCount), zap.Int64("doneHandle", doneHandle), zap.Error(err))
 		// If timeout, we will return, check the owner and retry to wait job done again.
 		return errWaitReorgTimeout
@@ -174,7 +174,7 @@ func (w *worker) isReorgRunnable(d *ddlCtx) error {
 
 	if !d.isOwner() {
 		// If it's not the owner, we will try later, so here just returns an error.
-		logutil.Logger(ddlLogCtx).Info("[ddl] DDL worker is not the DDL owner", zap.String("ID", d.uuid))
+		logutil.BgLogger().Info("[ddl] DDL worker is not the DDL owner", zap.String("ID", d.uuid))
 		return errors.Trace(errNotOwner)
 	}
 	return nil
@@ -333,7 +333,7 @@ func getTableRange(d *ddlCtx, tbl table.PhysicalTable, snapshotVer uint64, prior
 		return 0, 0, errors.Trace(err)
 	}
 	if endHandle < startHandle || emptyTable {
-		logutil.Logger(ddlLogCtx).Info("[ddl] get table range, endHandle < startHandle", zap.String("table", fmt.Sprintf("%v", tbl.Meta())),
+		logutil.BgLogger().Info("[ddl] get table range, endHandle < startHandle", zap.String("table", fmt.Sprintf("%v", tbl.Meta())),
 			zap.Int64("partitionID", tbl.GetPhysicalID()), zap.Int64("endHandle", endHandle), zap.Int64("startHandle", startHandle))
 		endHandle = startHandle
 	}
@@ -372,7 +372,7 @@ func getReorgInfo(d *ddlCtx, t *meta.Meta, job *model.Job, tbl table.Table) (*re
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		logutil.Logger(ddlLogCtx).Info("[ddl] job get table range", zap.Int64("jobID", job.ID), zap.Int64("physicalTableID", pid), zap.Int64("startHandle", start), zap.Int64("endHandle", end))
+		logutil.BgLogger().Info("[ddl] job get table range", zap.Int64("jobID", job.ID), zap.Int64("physicalTableID", pid), zap.Int64("startHandle", start), zap.Int64("endHandle", end))
 
 		failpoint.Inject("errorUpdateReorgHandle", func() (*reorgInfo, error) {
 			return &info, errors.New("occur an error when update reorg handle")

--- a/ddl/session_pool.go
+++ b/ddl/session_pool.go
@@ -82,7 +82,7 @@ func (sg *sessionPool) close() {
 	if sg.mu.closed || sg.resPool == nil {
 		return
 	}
-	logutil.Logger(ddlLogCtx).Info("[ddl] closing sessionPool")
+	logutil.BgLogger().Info("[ddl] closing sessionPool")
 	sg.resPool.Close()
 	sg.mu.closed = true
 }

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -361,7 +361,7 @@ func splitTableRegion(store kv.Storage, tableID int64) {
 	tableStartKey := tablecodec.GenTablePrefix(tableID)
 	if err := s.SplitRegion(tableStartKey); err != nil {
 		// It will be automatically split by TiKV later.
-		logutil.Logger(ddlLogCtx).Warn("[ddl] split table region failed", zap.Error(err))
+		logutil.BgLogger().Warn("[ddl] split table region failed", zap.Error(err))
 	}
 }
 
@@ -406,7 +406,7 @@ func preSplitTableShardRowIDBitsRegion(store kv.Storage, tblInfo *model.TableInf
 		key := tablecodec.EncodeRecordKey(recordPrefix, recordID)
 		regionID, err := s.SplitRegionAndScatter(key)
 		if err != nil {
-			logutil.Logger(ddlLogCtx).Warn("[ddl] pre split table region failed", zap.Int64("recordID", recordID), zap.Error(err))
+			logutil.BgLogger().Warn("[ddl] pre split table region failed", zap.Int64("recordID", recordID), zap.Error(err))
 		} else {
 			regionIDs = append(regionIDs, regionID)
 		}
@@ -417,7 +417,7 @@ func preSplitTableShardRowIDBitsRegion(store kv.Storage, tblInfo *model.TableInf
 		indexPrefix := tablecodec.EncodeTableIndexPrefix(tblInfo.ID, idx.ID)
 		regionID, err := s.SplitRegionAndScatter(indexPrefix)
 		if err != nil {
-			logutil.Logger(ddlLogCtx).Warn("[ddl] pre split table index region failed", zap.String("index", idx.Name.L), zap.Error(err))
+			logutil.BgLogger().Warn("[ddl] pre split table index region failed", zap.String("index", idx.Name.L), zap.Error(err))
 		} else {
 			regionIDs = append(regionIDs, regionID)
 		}
@@ -428,7 +428,7 @@ func preSplitTableShardRowIDBitsRegion(store kv.Storage, tblInfo *model.TableInf
 	for _, regionID := range regionIDs {
 		err := s.WaitScatterRegionFinish(regionID)
 		if err != nil {
-			logutil.Logger(ddlLogCtx).Warn("[ddl] wait scatter region failed", zap.Uint64("regionID", regionID), zap.Error(err))
+			logutil.BgLogger().Warn("[ddl] wait scatter region failed", zap.Uint64("regionID", regionID), zap.Error(err))
 		}
 	}
 }

--- a/ddl/util/syncer.go
+++ b/ddl/util/syncer.go
@@ -435,7 +435,7 @@ func (s *schemaVersionSyncer) StartCleanWork() {
 				resp, err := s.etcdCli.Leases(childCtx)
 				cancelFunc()
 				if err != nil {
-					logutil.Logger(ddlLogCtx).Info("[ddl] syncer clean expired paths, failed to get leases.", zap.Error(err))
+					logutil.BgLogger().Info("[ddl] syncer clean expired paths, failed to get leases.", zap.Error(err))
 					continue
 				}
 
@@ -484,7 +484,7 @@ func (s *schemaVersionSyncer) doCleanExpirePaths(leases []clientv3.LeaseStatus) 
 		ttlResp, err := s.etcdCli.TimeToLive(childCtx, lease.ID)
 		cancelFunc()
 		if err != nil {
-			logutil.Logger(ddlLogCtx).Info("[ddl] syncer clean expired paths, failed to get one TTL.", zap.String("leaseID", leaseID), zap.Error(err))
+			logutil.BgLogger().Info("[ddl] syncer clean expired paths, failed to get one TTL.", zap.String("leaseID", leaseID), zap.Error(err))
 			failedGetIDs++
 			continue
 		}
@@ -501,11 +501,11 @@ func (s *schemaVersionSyncer) doCleanExpirePaths(leases []clientv3.LeaseStatus) 
 		_, err = s.etcdCli.Revoke(childCtx, lease.ID)
 		cancelFunc()
 		if err != nil && terror.ErrorEqual(err, rpctypes.ErrLeaseNotFound) {
-			logutil.Logger(ddlLogCtx).Warn("[ddl] syncer clean expired paths, failed to revoke lease.", zap.String("leaseID", leaseID),
+			logutil.BgLogger().Warn("[ddl] syncer clean expired paths, failed to revoke lease.", zap.String("leaseID", leaseID),
 				zap.Int64("TTL", ttlResp.TTL), zap.Error(err))
 			failedRevokeIDs++
 		}
-		logutil.Logger(ddlLogCtx).Warn("[ddl] syncer clean expired paths,", zap.String("leaseID", leaseID), zap.Int64("TTL", ttlResp.TTL))
+		logutil.BgLogger().Warn("[ddl] syncer clean expired paths,", zap.String("leaseID", leaseID), zap.Int64("TTL", ttlResp.TTL))
 		metrics.OwnerHandleSyncerHistogram.WithLabelValues(metrics.OwnerCleanOneExpirePath, metrics.RetLabel(err)).Observe(time.Since(st).Seconds())
 	}
 

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -202,7 +202,7 @@ func (r *selectResult) updateCopRuntimeStats(callee string) {
 		return
 	}
 	if len(r.selectResp.GetExecutionSummaries()) != len(r.copPlanIDs) {
-		logutil.Logger(context.Background()).Error("invalid cop task execution summaries length",
+		logutil.BgLogger().Error("invalid cop task execution summaries length",
 			zap.Int("expected", len(r.copPlanIDs)),
 			zap.Int("received", len(r.selectResp.GetExecutionSummaries())))
 

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -99,7 +99,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 		// 1. Failed to loading schema information.
 		// 2. When users use history read feature, the neededSchemaVersion isn't the latest schema version.
 		if err != nil || neededSchemaVersion < do.InfoSchema().SchemaMetaVersion() {
-			logutil.Logger(context.Background()).Info("do not update self schema version to etcd",
+			logutil.BgLogger().Info("do not update self schema version to etcd",
 				zap.Int64("usedSchemaVersion", usedSchemaVersion),
 				zap.Int64("neededSchemaVersion", neededSchemaVersion), zap.Error(err))
 			return
@@ -107,7 +107,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 
 		err = do.ddl.SchemaSyncer().UpdateSelfVersion(context.Background(), neededSchemaVersion)
 		if err != nil {
-			logutil.Logger(context.Background()).Info("update self version failed",
+			logutil.BgLogger().Info("update self version failed",
 				zap.Int64("usedSchemaVersion", usedSchemaVersion),
 				zap.Int64("neededSchemaVersion", neededSchemaVersion), zap.Error(err))
 		}
@@ -117,10 +117,10 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 	ok, tblIDs, err := do.tryLoadSchemaDiffs(m, usedSchemaVersion, neededSchemaVersion)
 	if err != nil {
 		// We can fall back to full load, don't need to return the error.
-		logutil.Logger(context.Background()).Error("failed to load schema diff", zap.Error(err))
+		logutil.BgLogger().Error("failed to load schema diff", zap.Error(err))
 	}
 	if ok {
-		logutil.Logger(context.Background()).Info("diff load InfoSchema success",
+		logutil.BgLogger().Info("diff load InfoSchema success",
 			zap.Int64("usedSchemaVersion", usedSchemaVersion),
 			zap.Int64("neededSchemaVersion", neededSchemaVersion),
 			zap.Duration("start time", time.Since(startTime)),
@@ -138,7 +138,7 @@ func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion in
 	if err != nil {
 		return 0, nil, fullLoad, err
 	}
-	logutil.Logger(context.Background()).Info("full load InfoSchema success",
+	logutil.BgLogger().Info("full load InfoSchema success",
 		zap.Int64("usedSchemaVersion", usedSchemaVersion),
 		zap.Int64("neededSchemaVersion", neededSchemaVersion),
 		zap.Duration("start time", time.Since(startTime)))
@@ -347,7 +347,7 @@ func (do *Domain) Reload() error {
 	metrics.LoadSchemaCounter.WithLabelValues("succ").Inc()
 
 	if fullLoad {
-		logutil.Logger(context.Background()).Info("full load and reset schema validator")
+		logutil.BgLogger().Info("full load and reset schema validator")
 		do.SchemaValidator.Reset()
 	}
 	do.SchemaValidator.Update(ver.Ver, schemaVersion, neededSchemaVersion, changedTableIDs)
@@ -357,7 +357,7 @@ func (do *Domain) Reload() error {
 	// Reload interval is lease / 2, if load schema time elapses more than this interval,
 	// some query maybe responded by ErrInfoSchemaExpired error.
 	if sub > (lease/2) && lease > 0 {
-		logutil.Logger(context.Background()).Warn("loading schema takes a long time", zap.Duration("take time", sub))
+		logutil.BgLogger().Warn("loading schema takes a long time", zap.Duration("take time", sub))
 	}
 
 	return nil
@@ -423,11 +423,11 @@ func (do *Domain) infoSyncerKeeper() {
 	for {
 		select {
 		case <-do.info.Done():
-			logutil.Logger(context.Background()).Info("server info syncer need to restart")
+			logutil.BgLogger().Info("server info syncer need to restart")
 			if err := do.info.Restart(context.Background()); err != nil {
-				logutil.Logger(context.Background()).Error("server restart failed", zap.Error(err))
+				logutil.BgLogger().Error("server restart failed", zap.Error(err))
 			}
-			logutil.Logger(context.Background()).Info("server info syncer restarted")
+			logutil.BgLogger().Info("server info syncer restarted")
 		case <-do.exit:
 			return
 		}
@@ -448,21 +448,21 @@ func (do *Domain) loadSchemaInLoop(lease time.Duration) {
 		case <-ticker.C:
 			err := do.Reload()
 			if err != nil {
-				logutil.Logger(context.Background()).Error("reload schema in loop failed", zap.Error(err))
+				logutil.BgLogger().Error("reload schema in loop failed", zap.Error(err))
 			}
 		case _, ok := <-syncer.GlobalVersionCh():
 			err := do.Reload()
 			if err != nil {
-				logutil.Logger(context.Background()).Error("reload schema in loop failed", zap.Error(err))
+				logutil.BgLogger().Error("reload schema in loop failed", zap.Error(err))
 			}
 			if !ok {
-				logutil.Logger(context.Background()).Warn("reload schema in loop, schema syncer need rewatch")
+				logutil.BgLogger().Warn("reload schema in loop, schema syncer need rewatch")
 				// Make sure the rewatch doesn't affect load schema, so we watch the global schema version asynchronously.
 				syncer.WatchGlobalSchemaVer(context.Background())
 			}
 		case <-syncer.Done():
 			// The schema syncer stops, we need stop the schema validator to synchronize the schema version.
-			logutil.Logger(context.Background()).Info("reload schema in loop, schema syncer need restart")
+			logutil.BgLogger().Info("reload schema in loop, schema syncer need restart")
 			// The etcd is responsible for schema synchronization, we should ensure there is at most two different schema version
 			// in the TiDB cluster, to make the data/schema be consistent. If we lost connection/session to etcd, the cluster
 			// will treats this TiDB as a down instance, and etcd will remove the key of `/tidb/ddl/all_schema_versions/tidb-id`.
@@ -472,18 +472,18 @@ func (do *Domain) loadSchemaInLoop(lease time.Duration) {
 			do.SchemaValidator.Stop()
 			err := do.mustRestartSyncer()
 			if err != nil {
-				logutil.Logger(context.Background()).Error("reload schema in loop, schema syncer restart failed", zap.Error(err))
+				logutil.BgLogger().Error("reload schema in loop, schema syncer restart failed", zap.Error(err))
 				break
 			}
 			// The schema maybe changed, must reload schema then the schema validator can restart.
 			exitLoop := do.mustReload()
 			// domain is cosed.
 			if exitLoop {
-				logutil.Logger(context.Background()).Error("domain is closed, exit loadSchemaInLoop")
+				logutil.BgLogger().Error("domain is closed, exit loadSchemaInLoop")
 				return
 			}
 			do.SchemaValidator.Restart()
-			logutil.Logger(context.Background()).Info("schema syncer restarted")
+			logutil.BgLogger().Info("schema syncer restarted")
 		case <-do.exit:
 			return
 		}
@@ -506,7 +506,7 @@ func (do *Domain) mustRestartSyncer() error {
 			return err
 		}
 		time.Sleep(time.Second)
-		logutil.Logger(context.Background()).Info("restart the schema syncer failed", zap.Error(err))
+		logutil.BgLogger().Info("restart the schema syncer failed", zap.Error(err))
 	}
 }
 
@@ -516,12 +516,12 @@ func (do *Domain) mustReload() (exitLoop bool) {
 	for {
 		err := do.Reload()
 		if err == nil {
-			logutil.Logger(context.Background()).Info("mustReload succeed")
+			logutil.BgLogger().Info("mustReload succeed")
 			return false
 		}
 
 		// If the domain is closed, we returns immediately.
-		logutil.Logger(context.Background()).Info("reload the schema failed", zap.Error(err))
+		logutil.BgLogger().Info("reload the schema failed", zap.Error(err))
 		if do.isClose() {
 			return true
 		}
@@ -532,7 +532,7 @@ func (do *Domain) mustReload() (exitLoop bool) {
 func (do *Domain) isClose() bool {
 	select {
 	case <-do.exit:
-		logutil.Logger(context.Background()).Info("domain is closed")
+		logutil.BgLogger().Info("domain is closed")
 		return true
 	default:
 	}
@@ -555,7 +555,7 @@ func (do *Domain) Close() {
 	do.sysSessionPool.Close()
 	do.slowQuery.Close()
 	do.wg.Wait()
-	logutil.Logger(context.Background()).Info("domain closed", zap.Duration("take time", time.Since(startTime)))
+	logutil.BgLogger().Info("domain closed", zap.Duration("take time", time.Since(startTime)))
 }
 
 type ddlCallback struct {
@@ -567,11 +567,11 @@ func (c *ddlCallback) OnChanged(err error) error {
 	if err != nil {
 		return err
 	}
-	logutil.Logger(context.Background()).Info("performing DDL change, must reload")
+	logutil.BgLogger().Info("performing DDL change, must reload")
 
 	err = c.do.Reload()
 	if err != nil {
-		logutil.Logger(context.Background()).Error("performing DDL change failed", zap.Error(err))
+		logutil.BgLogger().Error("performing DDL change failed", zap.Error(err))
 	}
 
 	return nil
@@ -637,7 +637,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 	failpoint.Inject("MockReplaceDDL", func(val failpoint.Value) {
 		if val.(bool) {
 			if err := do.ddl.Stop(); err != nil {
-				logutil.Logger(context.Background()).Error("stop DDL failed", zap.Error(err))
+				logutil.BgLogger().Error("stop DDL failed", zap.Error(err))
 			}
 			do.ddl = d
 		}
@@ -771,7 +771,7 @@ func (do *Domain) LoadPrivilegeLoop(ctx sessionctx.Context) error {
 			case <-time.After(duration):
 			}
 			if !ok {
-				logutil.Logger(context.Background()).Error("load privilege loop watch channel closed")
+				logutil.BgLogger().Error("load privilege loop watch channel closed")
 				watchCh = do.etcdClient.Watch(context.Background(), privilegeKey)
 				count++
 				if count > 10 {
@@ -784,9 +784,9 @@ func (do *Domain) LoadPrivilegeLoop(ctx sessionctx.Context) error {
 			err := do.privHandle.Update(ctx)
 			metrics.LoadPrivilegeCounter.WithLabelValues(metrics.RetLabel(err)).Inc()
 			if err != nil {
-				logutil.Logger(context.Background()).Error("load privilege failed", zap.Error(err))
+				logutil.BgLogger().Error("load privilege failed", zap.Error(err))
 			} else {
-				logutil.Logger(context.Background()).Debug("reload privilege success")
+				logutil.BgLogger().Debug("reload privilege success")
 			}
 		}
 	}()
@@ -831,7 +831,7 @@ func (do *Domain) loadBindInfoLoop() {
 			}
 			err := do.bindHandle.Update(false)
 			if err != nil {
-				logutil.Logger(context.Background()).Error("update bindinfo failed", zap.Error(err))
+				logutil.BgLogger().Error("update bindinfo failed", zap.Error(err))
 			}
 		}
 	}()
@@ -916,7 +916,7 @@ func (do *Domain) newStatsOwner() owner.Manager {
 	// TODO: Need to do something when err is not nil.
 	err := statsOwner.CampaignOwner(cancelCtx)
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("campaign owner failed", zap.Error(err))
+		logutil.BgLogger().Warn("campaign owner failed", zap.Error(err))
 	}
 	return statsOwner
 }
@@ -934,20 +934,20 @@ func (do *Domain) loadStatsWorker() {
 	t := time.Now()
 	err := statsHandle.InitStats(do.InfoSchema())
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("init stats info failed", zap.Error(err))
+		logutil.BgLogger().Debug("init stats info failed", zap.Error(err))
 	} else {
-		logutil.Logger(context.Background()).Info("init stats info time", zap.Duration("take time", time.Since(t)))
+		logutil.BgLogger().Info("init stats info time", zap.Duration("take time", time.Since(t)))
 	}
 	for {
 		select {
 		case <-loadTicker.C:
 			err = statsHandle.Update(do.InfoSchema())
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("update stats info failed", zap.Error(err))
+				logutil.BgLogger().Debug("update stats info failed", zap.Error(err))
 			}
 			err = statsHandle.LoadNeededHistograms()
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("load histograms failed", zap.Error(err))
+				logutil.BgLogger().Debug("load histograms failed", zap.Error(err))
 			}
 		case <-do.exit:
 			return
@@ -980,12 +980,12 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 		case t := <-statsHandle.DDLEventCh():
 			err := statsHandle.HandleDDLEvent(t)
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("handle ddl event failed", zap.Error(err))
+				logutil.BgLogger().Debug("handle ddl event failed", zap.Error(err))
 			}
 		case <-deltaUpdateTicker.C:
 			err := statsHandle.DumpStatsDeltaToKV(handle.DumpDelta)
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("dump stats delta failed", zap.Error(err))
+				logutil.BgLogger().Debug("dump stats delta failed", zap.Error(err))
 			}
 			statsHandle.UpdateErrorRate(do.InfoSchema())
 		case <-loadFeedbackTicker.C:
@@ -995,12 +995,12 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			}
 			err := statsHandle.HandleUpdateStats(do.InfoSchema())
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("update stats using feedback failed", zap.Error(err))
+				logutil.BgLogger().Debug("update stats using feedback failed", zap.Error(err))
 			}
 		case <-dumpFeedbackTicker.C:
 			err := statsHandle.DumpStatsFeedbackToKV()
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("dump stats feedback failed", zap.Error(err))
+				logutil.BgLogger().Debug("dump stats feedback failed", zap.Error(err))
 			}
 		case <-gcStatsTicker.C:
 			if !owner.IsOwner() {
@@ -1008,7 +1008,7 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 			}
 			err := statsHandle.GCStats(do.InfoSchema(), do.DDL().GetLease())
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("GC stats failed", zap.Error(err))
+				logutil.BgLogger().Debug("GC stats failed", zap.Error(err))
 			}
 		}
 	}
@@ -1053,13 +1053,13 @@ func (do *Domain) NotifyUpdatePrivilege(ctx sessionctx.Context) {
 		row := do.etcdClient.KV
 		_, err := row.Put(context.Background(), privilegeKey, "")
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("notify update privilege failed", zap.Error(err))
+			logutil.BgLogger().Warn("notify update privilege failed", zap.Error(err))
 		}
 	}
 	// update locally
 	_, _, err := ctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(ctx, `FLUSH PRIVILEGES`)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("unable to update privileges", zap.Error(err))
+		logutil.BgLogger().Error("unable to update privileges", zap.Error(err))
 	}
 }
 
@@ -1069,7 +1069,7 @@ func recoverInDomain(funcName string, quit bool) {
 		return
 	}
 	buf := util.GetStack()
-	logutil.Logger(context.Background()).Error("recover in domain failed", zap.String("funcName", funcName),
+	logutil.BgLogger().Error("recover in domain failed", zap.String("funcName", funcName),
 		zap.Any("error", r), zap.String("buffer", string(buf)))
 	metrics.PanicCounter.WithLabelValues(metrics.LabelDomain).Inc()
 	if quit {

--- a/domain/info.go
+++ b/domain/info.go
@@ -140,7 +140,7 @@ func (is *InfoSyncer) RemoveServerInfo() {
 	}
 	err := util.DeleteKeyFromEtcd(is.serverInfoPath, is.etcdCli, keyOpDefaultRetryCnt, keyOpDefaultTimeout)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("remove server info failed", zap.Error(err))
+		logutil.BgLogger().Error("remove server info failed", zap.Error(err))
 	}
 }
 
@@ -189,7 +189,7 @@ func getInfo(ctx context.Context, etcdCli *clientv3.Client, key string, retryCnt
 		resp, err = etcdCli.Get(childCtx, key, opts...)
 		cancel()
 		if err != nil {
-			logutil.Logger(context.Background()).Info("get key failed", zap.String("key", key), zap.Error(err))
+			logutil.BgLogger().Info("get key failed", zap.String("key", key), zap.Error(err))
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
@@ -197,7 +197,7 @@ func getInfo(ctx context.Context, etcdCli *clientv3.Client, key string, retryCnt
 			info := &ServerInfo{}
 			err = json.Unmarshal(kv.Value, info)
 			if err != nil {
-				logutil.Logger(context.Background()).Info("get key failed", zap.String("key", string(kv.Key)), zap.ByteString("value", kv.Value),
+				logutil.BgLogger().Info("get key failed", zap.String("key", string(kv.Key)), zap.ByteString("value", kv.Value),
 					zap.Error(err))
 				return nil, errors.Trace(err)
 			}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -171,7 +171,7 @@ func (a *ExecStmt) IsReadOnly(vars *variable.SessionVars) bool {
 	if execStmt, ok := a.StmtNode.(*ast.ExecuteStmt); ok {
 		s, err := getPreparedStmt(execStmt, vars)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("getPreparedStmt failed", zap.Error(err))
+			logutil.BgLogger().Error("getPreparedStmt failed", zap.Error(err))
 			return false
 		}
 		return ast.IsReadOnly(s)
@@ -510,7 +510,7 @@ func (a *ExecStmt) buildExecutor() (Executor, error) {
 			return nil, err
 		}
 		if useMaxTS {
-			logutil.Logger(context.Background()).Debug("init txnStartTS with MaxUint64", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.String("text", a.Text))
+			logutil.BgLogger().Debug("init txnStartTS with MaxUint64", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.String("text", a.Text))
 			err = ctx.InitTxnWithStartTS(math.MaxUint64)
 		} else if ctx.GetSessionVars().SnapshotTS != 0 {
 			if _, ok := a.Plan.(*plannercore.CheckTable); ok {

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -394,7 +394,7 @@ func (e *RecoverIndexExec) batchMarkDup(txn kv.Transaction, rows []recoverRows) 
 				}
 
 				if handle != rows[i].handle {
-					logutil.Logger(context.Background()).Warn("recover index: the constraint of unique index is broken, handle in index is not equal to handle in table",
+					logutil.BgLogger().Warn("recover index: the constraint of unique index is broken, handle in index is not equal to handle in table",
 						zap.String("index", e.index.Meta().Name.O), zap.ByteString("indexKey", key),
 						zap.Int64("handleInTable", rows[i].handle), zap.Int64("handleInIndex", handle))
 				}
@@ -522,7 +522,7 @@ func (e *CleanupIndexExec) deleteDanglingIdx(txn kv.Transaction, values map[stri
 				}
 				e.removeCnt++
 				if e.removeCnt%e.batchSize == 0 {
-					logutil.Logger(context.Background()).Info("clean up dangling index", zap.String("table", e.table.Meta().Name.String()),
+					logutil.BgLogger().Info("clean up dangling index", zap.String("table", e.table.Meta().Name.String()),
 						zap.String("index", e.index.Meta().Name.String()), zap.Uint64("count", e.removeCnt))
 				}
 			}

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -319,7 +319,7 @@ func (w *HashAggPartialWorker) getChildInput() bool {
 func recoveryHashAgg(output chan *AfFinalResult, r interface{}) {
 	err := errors.Errorf("%v", r)
 	output <- &AfFinalResult{err: errors.Errorf("%v", r)}
-	logutil.Logger(context.Background()).Error("parallel hash aggregation panicked", zap.Error(err))
+	logutil.BgLogger().Error("parallel hash aggregation panicked", zap.Error(err))
 }
 
 func (w *HashAggPartialWorker) run(ctx sessionctx.Context, waitGroup *sync.WaitGroup, finalConcurrency int) {
@@ -473,7 +473,7 @@ func (w *HashAggFinalWorker) getFinalResult(sctx sessionctx.Context) {
 		partialResults := w.getPartialResult(sctx.GetSessionVars().StmtCtx, []byte(groupKey), w.partialResultMap)
 		for i, af := range w.aggFuncs {
 			if err := af.AppendFinalResult2Chunk(sctx, partialResults[i], result); err != nil {
-				logutil.Logger(context.Background()).Error("HashAggFinalWorker failed to append final result to Chunk", zap.Error(err))
+				logutil.BgLogger().Error("HashAggFinalWorker failed to append final result to Chunk", zap.Error(err))
 			}
 		}
 		if len(w.aggFuncs) == 0 {

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -171,7 +171,7 @@ func (e *AnalyzeExec) analyzeWorker(taskCh <-chan *analyzeTask, resultCh chan<- 
 			buf := make([]byte, 4096)
 			stackSize := runtime.Stack(buf, false)
 			buf = buf[:stackSize]
-			logutil.Logger(context.Background()).Error("analyze worker panicked", zap.String("stack", string(buf)))
+			logutil.BgLogger().Error("analyze worker panicked", zap.String("stack", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelAnalyze).Inc()
 			resultCh <- analyzeResult{
 				Err: errAnalyzeWorkerPanic,

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -366,7 +366,7 @@ func GetInfoSchema(ctx sessionctx.Context) infoschema.InfoSchema {
 	var is infoschema.InfoSchema
 	if snap := sessVar.SnapshotInfoschema; snap != nil {
 		is = snap.(infoschema.InfoSchema)
-		logutil.Logger(context.Background()).Info("use snapshot schema", zap.Uint64("conn", sessVar.ConnectionID), zap.Int64("schemaVersion", is.SchemaMetaVersion()))
+		logutil.BgLogger().Info("use snapshot schema", zap.Uint64("conn", sessVar.ConnectionID), zap.Int64("schemaVersion", is.SchemaMetaVersion()))
 	} else {
 		is = sessVar.TxnCtx.InfoSchema.(infoschema.InfoSchema)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -61,7 +61,7 @@ func (e *DDLExec) toErr(err error) error {
 	checker := domain.NewSchemaChecker(dom, e.is.SchemaMetaVersion(), nil)
 	txn, err1 := e.ctx.Txn(true)
 	if err1 != nil {
-		logutil.Logger(context.Background()).Error("active txn failed", zap.Error(err))
+		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
 	schemaInfoErr := checker.Check(txn.StartTS())
@@ -266,7 +266,7 @@ func (e *DDLExec) executeDropTableOrView(s *ast.DropTableStmt) error {
 		}
 
 		if config.CheckTableBeforeDrop {
-			logutil.Logger(context.Background()).Warn("admin check table before drop",
+			logutil.BgLogger().Warn("admin check table before drop",
 				zap.String("database", fullti.Schema.O),
 				zap.String("table", fullti.Name.O),
 			)

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -165,7 +165,7 @@ func (e *InsertExec) Open(ctx context.Context) error {
 func (e *InsertExec) updateDupRow(row toBeCheckedRow, handle int64, onDuplicate []*expression.Assignment) error {
 	oldRow, err := e.getOldRow(e.ctx, e.Table, handle, e.GenExprs)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("get old row failed when insert on dup", zap.Int64("handle", handle), zap.String("toBeInsertedRow", types.DatumsToStrNoErr(row.row)))
+		logutil.BgLogger().Error("get old row failed when insert on dup", zap.Int64("handle", handle), zap.String("toBeInsertedRow", types.DatumsToStrNoErr(row.row)))
 		return err
 	}
 	// Do update row.

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -219,7 +219,7 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 	if types.ErrTruncated.Equal(err) {
 		valStr, err1 := val.ToString()
 		if err1 != nil {
-			logutil.Logger(context.Background()).Warn("truncate error", zap.Error(err1))
+			logutil.BgLogger().Warn("truncate error", zap.Error(err1))
 		}
 		return table.ErrTruncatedWrongValueForField.GenWithStackByArgs(types.TypeStr(col.Tp), valStr, col.Name.O, rowIdx+1)
 	}

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -256,7 +256,7 @@ func (e *LoadDataInfo) InsertData(prevData, curData []byte) ([]byte, bool, error
 		e.rowCount++
 		if e.maxRowsInBatch != 0 && e.rowCount%e.maxRowsInBatch == 0 {
 			reachLimit = true
-			logutil.Logger(context.Background()).Info("batch limit hit when inserting rows", zap.Int("maxBatchRows", e.maxChunkSize),
+			logutil.BgLogger().Info("batch limit hit when inserting rows", zap.Int("maxBatchRows", e.maxChunkSize),
 				zap.Uint64("totalRows", e.rowCount))
 			break
 		}

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -374,7 +374,7 @@ func recoveryProjection(output *projectionOutput, r interface{}) {
 		output.done <- errors.Errorf("%v", r)
 	}
 	buf := util.GetStack()
-	logutil.Logger(context.Background()).Error("projection executor panicked", zap.String("error", fmt.Sprintf("%v", r)), zap.String("stack", string(buf)))
+	logutil.BgLogger().Error("projection executor panicked", zap.String("error", fmt.Sprintf("%v", r)), zap.String("stack", string(buf)))
 }
 
 func readProjectionInput(inputCh <-chan *projectionInput, finishCh <-chan struct{}) *projectionInput {

--- a/executor/radix_hash_join.go
+++ b/executor/radix_hash_join.go
@@ -176,7 +176,7 @@ func (e *RadixHashJoinExec) preAlloc4InnerParts() (err error) {
 	if e.numNonEmptyPart < len(e.innerParts) {
 		numTotalPart := len(e.innerParts)
 		numEmptyPart := numTotalPart - e.numNonEmptyPart
-		logutil.Logger(context.Background()).Debug("empty partition in radix hash join", zap.Uint64("txnStartTS", e.ctx.GetSessionVars().TxnCtx.StartTS),
+		logutil.BgLogger().Debug("empty partition in radix hash join", zap.Uint64("txnStartTS", e.ctx.GetSessionVars().TxnCtx.StartTS),
 			zap.Int("numEmptyParts", numEmptyPart), zap.Int("numTotalParts", numTotalPart),
 			zap.Float64("emptyRatio", float64(numEmptyPart)/float64(numTotalPart)))
 	}

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -56,7 +56,7 @@ func (e *ReplaceExec) removeRow(handle int64, r toBeCheckedRow) (bool, error) {
 	newRow := r.row
 	oldRow, err := e.batchChecker.getOldRow(e.ctx, r.t, handle, e.GenExprs)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("get old row failed when replace", zap.Int64("handle", handle), zap.String("toBeInsertedRow", types.DatumsToStrNoErr(r.row)))
+		logutil.BgLogger().Error("get old row failed when replace", zap.Int64("handle", handle), zap.String("toBeInsertedRow", types.DatumsToStrNoErr(r.row)))
 		return false, err
 	}
 	rowUnchanged, err := types.EqualDatums(e.ctx.GetSessionVars().StmtCtx, oldRow, newRow)

--- a/executor/set.go
+++ b/executor/set.go
@@ -187,7 +187,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 			valStr, err = value.ToString()
 			terror.Log(err)
 		}
-		logutil.Logger(context.Background()).Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+		logutil.BgLogger().Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
 	}
 
 	return nil
@@ -238,7 +238,7 @@ func (e *SetExecutor) loadSnapshotInfoSchemaIfNeeded(name string) error {
 		vars.SnapshotInfoschema = nil
 		return nil
 	}
-	logutil.Logger(context.Background()).Info("load snapshot info schema", zap.Uint64("conn", vars.ConnectionID), zap.Uint64("SnapshotTS", vars.SnapshotTS))
+	logutil.BgLogger().Info("load snapshot info schema", zap.Uint64("conn", vars.ConnectionID), zap.Uint64("SnapshotTS", vars.SnapshotTS))
 	dom := domain.GetDomain(e.ctx)
 	snapInfo, err := dom.GetSnapshotInfoSchema(vars.SnapshotTS)
 	if err != nil {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -115,7 +115,7 @@ func (e *SimpleExec) setDefaultRoleNone(s *ast.SetDefaultRoleStmt) error {
 		}
 		sql := fmt.Sprintf("DELETE IGNORE FROM mysql.default_roles WHERE USER='%s' AND HOST='%s';", u.Username, u.Hostname)
 		if _, err := sqlExecutor.Execute(context.Background(), sql); err != nil {
-			logutil.Logger(context.Background()).Error(fmt.Sprintf("Error occur when executing %s", sql))
+			logutil.BgLogger().Error(fmt.Sprintf("Error occur when executing %s", sql))
 			if _, rollbackErr := sqlExecutor.Execute(context.Background(), "rollback"); rollbackErr != nil {
 				return rollbackErr
 			}
@@ -157,7 +157,7 @@ func (e *SimpleExec) setDefaultRoleRegular(s *ast.SetDefaultRoleStmt) error {
 		}
 		sql := fmt.Sprintf("DELETE IGNORE FROM mysql.default_roles WHERE USER='%s' AND HOST='%s';", user.Username, user.Hostname)
 		if _, err := sqlExecutor.Execute(context.Background(), sql); err != nil {
-			logutil.Logger(context.Background()).Error(fmt.Sprintf("Error occur when executing %s", sql))
+			logutil.BgLogger().Error(fmt.Sprintf("Error occur when executing %s", sql))
 			if _, rollbackErr := sqlExecutor.Execute(context.Background(), "rollback"); rollbackErr != nil {
 				return rollbackErr
 			}
@@ -169,7 +169,7 @@ func (e *SimpleExec) setDefaultRoleRegular(s *ast.SetDefaultRoleStmt) error {
 			ok := checker.FindEdge(e.ctx, role, user)
 			if ok {
 				if _, err := sqlExecutor.Execute(context.Background(), sql); err != nil {
-					logutil.Logger(context.Background()).Error(fmt.Sprintf("Error occur when executing %s", sql))
+					logutil.BgLogger().Error(fmt.Sprintf("Error occur when executing %s", sql))
 					if _, rollbackErr := sqlExecutor.Execute(context.Background(), "rollback"); rollbackErr != nil {
 						return rollbackErr
 					}
@@ -209,7 +209,7 @@ func (e *SimpleExec) setDefaultRoleAll(s *ast.SetDefaultRoleStmt) error {
 		}
 		sql := fmt.Sprintf("DELETE IGNORE FROM mysql.default_roles WHERE USER='%s' AND HOST='%s';", user.Username, user.Hostname)
 		if _, err := sqlExecutor.Execute(context.Background(), sql); err != nil {
-			logutil.Logger(context.Background()).Error(fmt.Sprintf("Error occur when executing %s", sql))
+			logutil.BgLogger().Error(fmt.Sprintf("Error occur when executing %s", sql))
 			if _, rollbackErr := sqlExecutor.Execute(context.Background(), "rollback"); rollbackErr != nil {
 				return rollbackErr
 			}
@@ -486,7 +486,7 @@ func (e *SimpleExec) executeCommit(s *ast.CommitStmt) {
 
 func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {
 	sessVars := e.ctx.GetSessionVars()
-	logutil.Logger(context.Background()).Debug("execute rollback statement", zap.Uint64("conn", sessVars.ConnectionID))
+	logutil.BgLogger().Debug("execute rollback statement", zap.Uint64("conn", sessVars.ConnectionID))
 	sessVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	txn, err := e.ctx.Txn(true)
 	if err != nil {
@@ -626,7 +626,7 @@ func (e *SimpleExec) executeGrantRole(s *ast.GrantRoleStmt) error {
 			sql := fmt.Sprintf(`INSERT IGNORE INTO %s.%s (FROM_HOST, FROM_USER, TO_HOST, TO_USER) VALUES ('%s','%s','%s','%s')`, mysql.SystemDB, mysql.RoleEdgeTable, role.Hostname, role.Username, user.Hostname, user.Username)
 			if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), sql); err != nil {
 				failedUsers = append(failedUsers, user.String())
-				logutil.Logger(context.Background()).Error(fmt.Sprintf("Error occur when executing %s", sql))
+				logutil.BgLogger().Error(fmt.Sprintf("Error occur when executing %s", sql))
 				if _, err := e.ctx.(sqlexec.SQLExecutor).Execute(context.Background(), "rollback"); err != nil {
 					return err
 				}

--- a/executor/split.go
+++ b/executor/split.go
@@ -69,7 +69,7 @@ func (e *SplitIndexRegionExec) Next(ctx context.Context, _ *chunk.RecordBatch) e
 	for _, idxKey := range splitIdxKeys {
 		regionID, err := s.SplitRegionAndScatter(idxKey)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("split table index region failed",
+			logutil.BgLogger().Warn("split table index region failed",
 				zap.String("table", e.tableInfo.Name.L),
 				zap.String("index", e.indexInfo.Name.L),
 				zap.Error(err))
@@ -87,7 +87,7 @@ func (e *SplitIndexRegionExec) Next(ctx context.Context, _ *chunk.RecordBatch) e
 	for _, regionID := range regionIDs {
 		err := s.WaitScatterRegionFinish(regionID)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("wait scatter region failed",
+			logutil.BgLogger().Warn("wait scatter region failed",
 				zap.Uint64("regionID", regionID),
 				zap.String("table", e.tableInfo.Name.L),
 				zap.String("index", e.indexInfo.Name.L),
@@ -247,7 +247,7 @@ func (e *SplitTableRegionExec) Next(ctx context.Context, _ *chunk.RecordBatch) e
 	for _, key := range splitKeys {
 		regionID, err := s.SplitRegionAndScatter(key)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("split table region failed",
+			logutil.BgLogger().Warn("split table region failed",
 				zap.String("table", e.tableInfo.Name.L),
 				zap.Error(err))
 			continue
@@ -270,7 +270,7 @@ func (e *SplitTableRegionExec) Next(ctx context.Context, _ *chunk.RecordBatch) e
 	for _, regionID := range regionIDs {
 		err := s.WaitScatterRegionFinish(regionID)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("wait scatter region failed",
+			logutil.BgLogger().Warn("wait scatter region failed",
 				zap.Uint64("regionID", regionID),
 				zap.String("table", e.tableInfo.Name.L),
 				zap.Error(err))

--- a/executor/write.go
+++ b/executor/write.go
@@ -172,7 +172,7 @@ func updateRecord(ctx sessionctx.Context, h int64, oldData, newData []types.Datu
 // so we reset the error msg here, and wrap old err with errors.Wrap.
 func resetErrDataTooLong(colName string, rowIdx int, err error) error {
 	newErr := types.ErrDataTooLong.GenWithStack("Data too long for column '%v' at row %v", colName, rowIdx)
-	logutil.Logger(context.Background()).Error("data too long for column", zap.String("colName", colName), zap.Int("rowIndex", rowIdx))
+	logutil.BgLogger().Error("data too long for column", zap.String("colName", colName), zap.Int("rowIndex", rowIdx))
 	return newErr
 }
 

--- a/executor/write.go
+++ b/executor/write.go
@@ -14,7 +14,6 @@
 package executor
 
 import (
-	"context"
 	"strings"
 
 	"github.com/pingcap/parser/ast"

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -266,7 +266,7 @@ func (c *concatFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 
 		if argType.Flen < 0 {
 			bf.tp.Flen = mysql.MaxBlobWidth
-			logutil.Logger(context.Background()).Warn("unexpected `Flen` value(-1) in CONCAT's args", zap.Int("arg's index", i))
+			logutil.BgLogger().Warn("unexpected `Flen` value(-1) in CONCAT's args", zap.Int("arg's index", i))
 		}
 		bf.tp.Flen += argType.Flen
 	}
@@ -324,7 +324,7 @@ func (c *concatWSFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 		if i != 0 {
 			if argType.Flen < 0 {
 				bf.tp.Flen = mysql.MaxBlobWidth
-				logutil.Logger(context.Background()).Warn("unexpected `Flen` value(-1) in CONCAT_WS's args", zap.Int("arg's index", i))
+				logutil.BgLogger().Warn("unexpected `Flen` value(-1) in CONCAT_WS's args", zap.Int("arg's index", i))
 			}
 			bf.tp.Flen += argType.Flen
 		}
@@ -1796,7 +1796,7 @@ func getFlen4LpadAndRpad(ctx sessionctx.Context, arg Expression) int {
 	if constant, ok := arg.(*Constant); ok {
 		length, isNull, err := constant.EvalInt(ctx, chunk.Row{})
 		if err != nil {
-			logutil.Logger(context.Background()).Error("eval `Flen` for LPAD/RPAD", zap.Error(err))
+			logutil.BgLogger().Error("eval `Flen` for LPAD/RPAD", zap.Error(err))
 		}
 		if isNull || err != nil || length > mysql.MaxBlobWidth {
 			return mysql.MaxBlobWidth
@@ -2176,7 +2176,7 @@ func (b *builtinCharSig) evalString(row chunk.Row) (string, bool, error) {
 	oldStr := result
 	result, _, err = transform.String(encoding.NewDecoder(), result)
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("change charset of string",
+		logutil.BgLogger().Warn("change charset of string",
 			zap.String("string", oldStr),
 			zap.String("charset", charsetName),
 			zap.Error(err))

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -19,7 +19,6 @@ package expression
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -18,7 +18,6 @@
 package expression
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"regexp"

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -5985,7 +5985,7 @@ func (b *builtinTimeFormatSig) evalString(row chunk.Row) (string, bool, error) {
 	dur, isNull, err := b.args[0].EvalDuration(b.ctx, row)
 	// if err != nil, then dur is ZeroDuration, outputs 00:00:00 in this case which follows the behavior of mysql.
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("time_format.args[0].EvalDuration failed", zap.Error(err))
+		logutil.BgLogger().Warn("time_format.args[0].EvalDuration failed", zap.Error(err))
 	}
 	if isNull {
 		return "", isNull, err

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -62,7 +62,7 @@ func (c *Constant) String() string {
 	if c.DeferredExpr != nil {
 		dt, err := c.Eval(chunk.Row{})
 		if err != nil {
-			logutil.Logger(context.Background()).Error("eval constant failed", zap.Error(err))
+			logutil.BgLogger().Error("eval constant failed", zap.Error(err))
 			return ""
 		}
 		c.Value.SetValue(dt.GetValue())

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/pingcap/parser/mysql"

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -47,7 +47,7 @@ func ifFoldHandler(expr *ScalarFunction) (Expression, bool) {
 			// Failed to fold this expr to a constant, print the DEBUG log and
 			// return the original expression to let the error to be evaluated
 			// again, in that time, the error is returned to the client.
-			logutil.Logger(context.Background()).Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
+			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
 			return expr, false
 		}
 		if !isNull0 && arg0 != 0 {
@@ -141,7 +141,7 @@ func foldConstant(expr Expression) (Expression, bool) {
 		}
 		value, err := x.Eval(chunk.Row{})
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
+			logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
 			return expr, isDeferredConst
 		}
 		if isDeferredConst {
@@ -152,7 +152,7 @@ func foldConstant(expr Expression) (Expression, bool) {
 		if x.DeferredExpr != nil {
 			value, err := x.DeferredExpr.Eval(chunk.Row{})
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
+				logutil.BgLogger().Debug("fold expression to constant", zap.String("expression", x.ExplainInfo()), zap.Error(err))
 				return expr, true
 			}
 			return &Constant{Value: value, RetType: x.RetType, DeferredExpr: x.DeferredExpr}, true

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -14,8 +14,6 @@
 package expression
 
 import (
-	"context"
-
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -14,8 +14,6 @@
 package expression
 
 import (
-	"context"
-
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -283,7 +283,7 @@ func (s *propConstSolver) solve(conditions []Expression) []Expression {
 		s.insertCol(col)
 	}
 	if len(s.columns) > MaxPropagateColsCnt {
-		logutil.Logger(context.Background()).Warn("too many columns in a single CNF",
+		logutil.BgLogger().Warn("too many columns in a single CNF",
 			zap.Int("numCols", len(s.columns)),
 			zap.Int("maxNumCols", MaxPropagateColsCnt),
 		)
@@ -534,7 +534,7 @@ func (s *propOuterJoinConstSolver) solve(joinConds, filterConds []Expression) ([
 		s.insertCol(col)
 	}
 	if len(s.columns) > MaxPropagateColsCnt {
-		logutil.Logger(context.Background()).Warn("too many columns",
+		logutil.BgLogger().Warn("too many columns",
 			zap.Int("numCols", len(s.columns)),
 			zap.Int("maxNumCols", MaxPropagateColsCnt),
 		)

--- a/expression/constraint_propagation.go
+++ b/expression/constraint_propagation.go
@@ -152,7 +152,7 @@ func ruleConstantFalse(ctx sessionctx.Context, i, j int, exprs *exprSet) {
 	if cons, ok := cond.(*Constant); ok {
 		v, isNull, err := cons.EvalInt(ctx, chunk.Row{})
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("eval constant", zap.Error(err))
+			logutil.BgLogger().Warn("eval constant", zap.Error(err))
 			return
 		}
 		if !isNull && v == 0 {
@@ -249,7 +249,7 @@ func ruleColumnOPConst(ctx sessionctx.Context, i, j int, exprs *exprSet) {
 		var err error
 		fc1, err = NewFunction(ctx, scalarFunc.FuncName.L, scalarFunc.RetType, con1)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("build new function in ruleColumnOPConst", zap.Error(err))
+			logutil.BgLogger().Warn("build new function in ruleColumnOPConst", zap.Error(err))
 			return
 		}
 	}
@@ -272,7 +272,7 @@ func ruleColumnOPConst(ctx sessionctx.Context, i, j int, exprs *exprSet) {
 	}
 	v, isNull, err := compareConstant(ctx, negOP(OP2), fc1, con2)
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("comparing constant in ruleColumnOPConst", zap.Error(err))
+		logutil.BgLogger().Warn("comparing constant in ruleColumnOPConst", zap.Error(err))
 		return
 	}
 	if !isNull && v > 0 {

--- a/expression/constraint_propagation.go
+++ b/expression/constraint_propagation.go
@@ -15,7 +15,6 @@ package expression
 
 import (
 	"bytes"
-	"context"
 
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -106,7 +106,7 @@ func (pc PbConverter) conOrCorColToPBExpr(expr Expression) *tipb.Expr {
 	ft := expr.GetType()
 	d, err := expr.Eval(chunk.Row{})
 	if err != nil {
-		logutil.Logger(context.Background()).Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
+		logutil.BgLogger().Error("eval constant or correlated column", zap.String("expression", expr.ExplainInfo()), zap.Error(err))
 		return nil
 	}
 	tp, val, ok := pc.encodeDatum(ft, d)
@@ -154,7 +154,7 @@ func (pc *PbConverter) encodeDatum(ft *types.FieldType, d types.Datum) (tipb.Exp
 		var err error
 		val, err = codec.EncodeDecimal(nil, d.GetMysqlDecimal(), d.Length(), d.Frac())
 		if err != nil {
-			logutil.Logger(context.Background()).Error("encode decimal", zap.Error(err))
+			logutil.BgLogger().Error("encode decimal", zap.Error(err))
 			return tp, nil, false
 		}
 	case types.KindMysqlTime:
@@ -162,7 +162,7 @@ func (pc *PbConverter) encodeDatum(ft *types.FieldType, d types.Datum) (tipb.Exp
 			tp = tipb.ExprType_MysqlTime
 			val, err := codec.EncodeMySQLTime(pc.sc, d, ft.Tp, nil)
 			if err != nil {
-				logutil.Logger(context.Background()).Error("encode mysql time", zap.Error(err))
+				logutil.BgLogger().Error("encode mysql time", zap.Error(err))
 				return tp, nil, false
 			}
 			return tp, val, true

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"context"
 	"strings"
 	"sync/atomic"
 

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -246,7 +246,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	if args := expr.Function.implicitArgs(); len(args) > 0 {
 		encoded, err := codec.EncodeValue(pc.sc, nil, args...)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("encode implicit parameters", zap.Any("datums", args), zap.Error(err))
+			logutil.BgLogger().Error("encode implicit parameters", zap.Any("datums", args), zap.Error(err))
 			return nil
 		}
 		implicitArgs = encoded

--- a/expression/util.go
+++ b/expression/util.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"context"
 	"strconv"
 	"strings"
 	"time"

--- a/expression/util.go
+++ b/expression/util.go
@@ -677,7 +677,7 @@ func RemoveDupExprs(ctx sessionctx.Context, exprs []Expression) []Expression {
 func GetUint64FromConstant(expr Expression) (uint64, bool, bool) {
 	con, ok := expr.(*Constant)
 	if !ok {
-		logutil.Logger(context.Background()).Warn("not a constant expression", zap.String("expression", expr.ExplainInfo()))
+		logutil.BgLogger().Warn("not a constant expression", zap.String("expression", expr.ExplainInfo()))
 		return 0, false, false
 	}
 	dt := con.Value
@@ -685,7 +685,7 @@ func GetUint64FromConstant(expr Expression) (uint64, bool, bool) {
 		var err error
 		dt, err = con.DeferredExpr.Eval(chunk.Row{})
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("eval deferred expr failed", zap.Error(err))
+			logutil.BgLogger().Warn("eval deferred expr failed", zap.Error(err))
 			return 0, false, false
 		}
 	}

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFd
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 h1:FUL3b97ZY2EPqg2NbXKuMHs5pXJB9hjj1fDHnF2vl28=
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -15,7 +15,6 @@ package infoschema
 
 import (
 	"bufio"
-	"context"
 	"io"
 	"os"
 	"strconv"

--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -77,7 +77,7 @@ func parseSlowLogFile(tz *time.Location, filePath string) ([][]types.Datum, erro
 	}
 	defer func() {
 		if err = file.Close(); err != nil {
-			logutil.Logger(context.Background()).Error("close slow log file failed.", zap.String("file", filePath), zap.Error(err))
+			logutil.BgLogger().Error("close slow log file failed.", zap.String("file", filePath), zap.Error(err))
 		}
 	}()
 	return ParseSlowLog(tz, bufio.NewReader(file))

--- a/kv/txn.go
+++ b/kv/txn.go
@@ -38,7 +38,7 @@ func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) e
 	for i := uint(0); i < maxRetryCnt; i++ {
 		txn, err = store.Begin()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("RunInNewTxn", zap.Error(err))
+			logutil.BgLogger().Error("RunInNewTxn", zap.Error(err))
 			return err
 		}
 
@@ -52,7 +52,7 @@ func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) e
 			err1 := txn.Rollback()
 			terror.Log(err1)
 			if retryable && IsTxnRetryableError(err) {
-				logutil.Logger(context.Background()).Warn("RunInNewTxn",
+				logutil.BgLogger().Warn("RunInNewTxn",
 					zap.Uint64("retry txn", txn.StartTS()),
 					zap.Uint64("original txn", originalTxnTS),
 					zap.Error(err))
@@ -66,7 +66,7 @@ func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) e
 			break
 		}
 		if retryable && IsTxnRetryableError(err) {
-			logutil.Logger(context.Background()).Warn("RunInNewTxn",
+			logutil.BgLogger().Warn("RunInNewTxn",
 				zap.Uint64("retry txn", txn.StartTS()),
 				zap.Uint64("original txn", originalTxnTS),
 				zap.Error(err))

--- a/kv/union_iter.go
+++ b/kv/union_iter.go
@@ -14,8 +14,6 @@
 package kv
 
 import (
-	"context"
-
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
 )

--- a/kv/union_iter.go
+++ b/kv/union_iter.go
@@ -122,7 +122,7 @@ func (iter *UnionIter) updateCur() error {
 			} else {
 				// record from dirty comes first
 				if len(iter.dirtyIt.Value()) == 0 {
-					logutil.Logger(context.Background()).Warn("delete a record not exists?",
+					logutil.BgLogger().Warn("delete a record not exists?",
 						zap.Binary("key", iter.dirtyIt.Key()))
 					// jump over this deletion
 					if err := iter.dirtyNext(); err != nil {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -14,7 +14,6 @@
 package autoid
 
 import (
-	"context"
 	"math"
 	"sync"
 	"sync/atomic"

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -237,7 +237,7 @@ func (alloc *allocator) alloc4Unsigned(tableID int64) (int64, error) {
 	}
 
 	alloc.base = int64(uint64(alloc.base) + 1)
-	logutil.Logger(context.Background()).Debug("alloc unsigned ID",
+	logutil.BgLogger().Debug("alloc unsigned ID",
 		zap.Uint64("ID", uint64(alloc.base)),
 		zap.Int64("table ID", tableID),
 		zap.Int64("database ID", alloc.dbID))
@@ -270,7 +270,7 @@ func (alloc *allocator) alloc4Signed(tableID int64) (int64, error) {
 	}
 
 	alloc.base++
-	logutil.Logger(context.Background()).Debug("alloc signed ID",
+	logutil.BgLogger().Debug("alloc signed ID",
 		zap.Uint64("ID", uint64(alloc.base)),
 		zap.Int64("table ID", tableID),
 		zap.Int64("database ID", alloc.dbID))

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -14,7 +14,6 @@
 package meta
 
 import (
-	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -726,10 +726,10 @@ func (m *Meta) RemoveDDLReorgHandle(job *model.Job) error {
 		return errors.Trace(err)
 	}
 	if err = m.txn.HDel(mDDLJobReorgKey, m.reorgJobEndHandle(job.ID)); err != nil {
-		logutil.Logger(context.Background()).Warn("remove DDL reorg end handle", zap.Error(err))
+		logutil.BgLogger().Warn("remove DDL reorg end handle", zap.Error(err))
 	}
 	if err = m.txn.HDel(mDDLJobReorgKey, m.reorgJobPhysicalTableID(job.ID)); err != nil {
-		logutil.Logger(context.Background()).Warn("remove DDL reorg physical ID", zap.Error(err))
+		logutil.BgLogger().Warn("remove DDL reorg physical ID", zap.Error(err))
 	}
 	return nil
 }
@@ -760,7 +760,7 @@ func (m *Meta) GetDDLReorgHandle(job *model.Job) (startHandle, endHandle, physic
 			endHandle = math.MaxInt64
 		}
 		physicalTableID = job.TableID
-		logutil.Logger(context.Background()).Warn("new TiDB binary running on old TiDB DDL reorg data",
+		logutil.BgLogger().Warn("new TiDB binary running on old TiDB DDL reorg data",
 			zap.Int64("partition ID", physicalTableID),
 			zap.Int64("startHandle", startHandle),
 			zap.Int64("endHandle", endHandle))

--- a/owner/manager.go
+++ b/owner/manager.go
@@ -167,7 +167,7 @@ func NewSession(ctx context.Context, logPrefix string, etcdCli *clientv3.Client,
 			break
 		}
 		if failedCnt%logIntervalCnt == 0 {
-			logutil.Logger(context.Background()).Warn("failed to new session to etcd", zap.String("ownerInfo", logPrefix), zap.Error(err))
+			logutil.BgLogger().Warn("failed to new session to etcd", zap.String("ownerInfo", logPrefix), zap.Error(err))
 		}
 
 		time.Sleep(newSessionRetryInterval)
@@ -221,7 +221,7 @@ func (m *ownerManager) campaignLoop(ctx context.Context, etcdSession *concurrenc
 		cancel()
 		if r := recover(); r != nil {
 			buf := util.GetStack()
-			logutil.Logger(context.Background()).Error("recover panic", zap.String("prompt", m.prompt), zap.Any("error", r), zap.String("buffer", string(buf)))
+			logutil.BgLogger().Error("recover panic", zap.String("prompt", m.prompt), zap.Any("error", r), zap.String("buffer", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelDDLOwner).Inc()
 		}
 	}()
@@ -325,7 +325,7 @@ func GetOwnerInfo(ctx, logCtx context.Context, elec *concurrency.Election, id st
 func (m *ownerManager) watchOwner(ctx context.Context, etcdSession *concurrency.Session, key string) {
 	logPrefix := fmt.Sprintf("[%s] ownerManager %s watch owner key %v", m.prompt, m.id, key)
 	logCtx := logutil.WithKeyValue(context.Background(), "owner info", logPrefix)
-	logutil.Logger(context.Background()).Debug(logPrefix)
+	logutil.BgLogger().Debug(logPrefix)
 	watchCh := m.etcdCli.Watch(ctx, key)
 	for {
 		select {
@@ -361,7 +361,7 @@ func (m *ownerManager) watchOwner(ctx context.Context, etcdSession *concurrency.
 func init() {
 	err := setManagerSessionTTL()
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("set manager session TTL failed", zap.Error(err))
+		logutil.BgLogger().Warn("set manager session TTL failed", zap.Error(err))
 	}
 }
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -442,7 +442,7 @@ func (p *LogicalJoin) getIndexJoinByOuterIdx(prop *property.PhysicalProperty, ou
 		indexInfo := path.index
 		err := helper.analyzeLookUpFilters(indexInfo, ds, innerJoinKeys)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("build index join failed", zap.Error(err))
+			logutil.BgLogger().Warn("build index join failed", zap.Error(err))
 		}
 	}
 	if helper.chosenIndexInfo != nil {
@@ -597,7 +597,7 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 	if len(indexConds) > 0 {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, indexConds)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("calculate selectivity failed, use selection factor", zap.Error(err))
+			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = selectionFactor
 		}
 		path.countAfterIndex = rowCount * selectivity

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -15,7 +15,6 @@ package core
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math"
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -537,7 +537,7 @@ func (ds *DataSource) deriveIndexPathStats(path *accessPath) (bool, error) {
 	if path.indexFilters != nil {
 		selectivity, _, err := ds.tableStats.HistColl.Selectivity(ds.ctx, path.indexFilters)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("calculate selectivity failed, use selection factor", zap.Error(err))
+			logutil.BgLogger().Debug("calculate selectivity failed, use selection factor", zap.Error(err))
 			selectivity = selectionFactor
 		}
 		path.countAfterIndex = math.Max(path.countAfterAccess*selectivity, ds.stats.RowCount)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -14,7 +14,6 @@
 package core
 
 import (
-	"context"
 	"math"
 
 	"github.com/pingcap/parser/ast"

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -106,7 +106,7 @@ func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs) {
 	ds.tableStats = tableStats
 	selectivity, nodes, err := tableStats.HistColl.Selectivity(ds.ctx, conds)
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("an error happened, use the default selectivity", zap.Error(err))
+		logutil.BgLogger().Debug("an error happened, use the default selectivity", zap.Error(err))
 		selectivity = selectionFactor
 	}
 	ds.stats = tableStats.Scale(selectivity)
@@ -201,7 +201,7 @@ func (lt *LogicalTopN) DeriveStats(childStats []*property.StatsInfo) (*property.
 func getCardinality(cols []*expression.Column, schema *expression.Schema, profile *property.StatsInfo) float64 {
 	indices := schema.ColumnsIndices(cols)
 	if indices == nil {
-		logutil.Logger(context.Background()).Error("column not found in schema", zap.Any("columns", cols), zap.String("schema", schema.String()))
+		logutil.BgLogger().Error("column not found in schema", zap.Any("columns", cols), zap.String("schema", schema.String()))
 		return 0
 	}
 	var cardinality = 1.0

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -14,7 +14,6 @@
 package core
 
 import (
-	"context"
 	"math"
 
 	"github.com/pingcap/tidb/expression"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -252,7 +252,7 @@ func (w *flushWatcher) watchLoop() {
 		case <-watchChan:
 			err := w.manifest.OnFlush(w.ctx, w.manifest)
 			if err != nil {
-				logutil.Logger(context.Background()).Error("notify plugin flush event failed", zap.String("plugin", w.manifest.Name), zap.Error(err))
+				logutil.BgLogger().Error("notify plugin flush event failed", zap.String("plugin", w.manifest.Name), zap.Error(err))
 			}
 		}
 	}

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -84,13 +84,13 @@ func (p *UserPrivileges) GetEncodedPassword(user, host string) string {
 	mysqlPriv := p.Handle.Get()
 	record := mysqlPriv.connectionVerification(user, host)
 	if record == nil {
-		logutil.Logger(context.Background()).Error("get user privilege record fail",
+		logutil.BgLogger().Error("get user privilege record fail",
 			zap.String("user", user), zap.String("host", host))
 		return ""
 	}
 	pwd := record.Password
 	if len(pwd) != 0 && len(pwd) != mysql.PWDHashLen+1 {
-		logutil.Logger(context.Background()).Error("user password from system DB not like sha1sum", zap.String("user", user))
+		logutil.BgLogger().Error("user password from system DB not like sha1sum", zap.String("user", user))
 		return ""
 	}
 	return pwd
@@ -108,7 +108,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, authenticatio
 	mysqlPriv := p.Handle.Get()
 	record := mysqlPriv.connectionVerification(user, host)
 	if record == nil {
-		logutil.Logger(context.Background()).Error("get user privilege record fail",
+		logutil.BgLogger().Error("get user privilege record fail",
 			zap.String("user", user), zap.String("host", host))
 		return
 	}
@@ -119,7 +119,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, authenticatio
 	// Login a locked account is not allowed.
 	locked := record.AccountLocked
 	if locked {
-		logutil.Logger(context.Background()).Error("try to login a locked account",
+		logutil.BgLogger().Error("try to login a locked account",
 			zap.String("user", user), zap.String("host", host))
 		success = false
 		return
@@ -127,7 +127,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, authenticatio
 
 	pwd := record.Password
 	if len(pwd) != 0 && len(pwd) != mysql.PWDHashLen+1 {
-		logutil.Logger(context.Background()).Error("user password from system DB not like sha1sum", zap.String("user", user))
+		logutil.BgLogger().Error("user password from system DB not like sha1sum", zap.String("user", user))
 		return
 	}
 
@@ -145,7 +145,7 @@ func (p *UserPrivileges) ConnectionVerification(user, host string, authenticatio
 
 	hpwd, err := auth.DecodePassword(pwd)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("decode password string failed", zap.Error(err))
+		logutil.BgLogger().Error("decode password string failed", zap.Error(err))
 		return
 	}
 
@@ -214,7 +214,7 @@ func (p *UserPrivileges) ActiveRoles(ctx sessionctx.Context, roleList []*auth.Ro
 	for _, r := range roleList {
 		ok := mysqlPrivilege.FindRole(u, h, r)
 		if !ok {
-			logutil.Logger(context.Background()).Error("find role failed", zap.Stringer("role", r))
+			logutil.BgLogger().Error("find role failed", zap.Stringer("role", r))
 			return false, r.String()
 		}
 	}
@@ -230,7 +230,7 @@ func (p *UserPrivileges) FindEdge(ctx sessionctx.Context, role *auth.RoleIdentit
 	mysqlPrivilege := p.Handle.Get()
 	ok := mysqlPrivilege.FindRole(user.Username, user.Hostname, role)
 	if !ok {
-		logutil.Logger(context.Background()).Error("find role failed", zap.Stringer("role", role))
+		logutil.BgLogger().Error("find role failed", zap.Stringer("role", role))
 		return false
 	}
 	return true

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -14,7 +14,6 @@
 package privileges
 
 import (
-	"context"
 	"strings"
 
 	"github.com/pingcap/parser/auth"

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -97,7 +97,7 @@ func writeData(w http.ResponseWriter, data interface{}) {
 		writeError(w, err)
 		return
 	}
-	logutil.Logger(context.Background()).Info(string(js))
+	logutil.BgLogger().Info(string(js))
 	// write response
 	w.Header().Set(headerContentType, contentTypeJSON)
 	w.WriteHeader(http.StatusOK)
@@ -148,7 +148,7 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 	for {
 		curRegion, err := t.RegionCache.LocateKey(bo, startKey)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("get MVCC by startTS failed", zap.Uint64("txnStartTS", startTS), zap.Binary("startKey", startKey), zap.Error(err))
+			logutil.BgLogger().Error("get MVCC by startTS failed", zap.Uint64("txnStartTS", startTS), zap.Binary("startKey", startKey), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 
@@ -161,7 +161,7 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		tikvReq.Context.Priority = kvrpcpb.CommandPri_Low
 		kvResp, err := t.Store.SendReq(bo, tikvReq, curRegion.Region, time.Hour)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("get MVCC by startTS failed",
+			logutil.BgLogger().Error("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
 				zap.Binary("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),
@@ -173,7 +173,7 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		}
 		data := kvResp.MvccGetByStartTS
 		if err := data.GetRegionError(); err != nil {
-			logutil.Logger(context.Background()).Warn("get MVCC by startTS failed",
+			logutil.BgLogger().Warn("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
 				zap.Binary("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),
@@ -185,7 +185,7 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		}
 
 		if len(data.GetError()) > 0 {
-			logutil.Logger(context.Background()).Error("get MVCC by startTS failed",
+			logutil.BgLogger().Error("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
 				zap.Binary("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -109,7 +109,7 @@ func (s *Server) startHTTPServer() {
 		router.HandleFunc("/web/trace", traceapp.HandleTiDB).Name("Trace Viewer")
 		sr := router.PathPrefix("/web/trace/").Subrouter()
 		if _, err := traceapp.New(traceapp.NewRouter(sr), baseURL); err != nil {
-			logutil.Logger(context.Background()).Error("new failed", zap.Error(err))
+			logutil.BgLogger().Error("new failed", zap.Error(err))
 		}
 		router.PathPrefix("/static/").Handler(http.StripPrefix("/static", http.FileServer(static.Data)))
 	}
@@ -230,7 +230,7 @@ func (s *Server) startHTTPServer() {
 	err = router.Walk(func(route *mux.Route, router *mux.Router, ancestors []*mux.Route) error {
 		pathTemplate, err = route.GetPathTemplate()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("get HTTP router path failed", zap.Error(err))
+			logutil.BgLogger().Error("get HTTP router path failed", zap.Error(err))
 		}
 		name := route.GetName()
 		// If the name attribute is not set, GetName returns "".
@@ -241,18 +241,18 @@ func (s *Server) startHTTPServer() {
 		return nil
 	})
 	if err != nil {
-		logutil.Logger(context.Background()).Error("generate root failed", zap.Error(err))
+		logutil.BgLogger().Error("generate root failed", zap.Error(err))
 	}
 	httpRouterPage.WriteString("<tr><td><a href='/debug/pprof/'>Debug</a><td></tr>")
 	httpRouterPage.WriteString("</table></body></html>")
 	router.HandleFunc("/", func(responseWriter http.ResponseWriter, request *http.Request) {
 		_, err = responseWriter.Write([]byte(httpRouterPage.String()))
 		if err != nil {
-			logutil.Logger(context.Background()).Error("write HTTP index page failed", zap.Error(err))
+			logutil.BgLogger().Error("write HTTP index page failed", zap.Error(err))
 		}
 	})
 
-	logutil.Logger(context.Background()).Info("for status and metrics report", zap.String("listening on addr", addr))
+	logutil.BgLogger().Info("for status and metrics report", zap.String("listening on addr", addr))
 	s.statusServer = &http.Server{Addr: addr, Handler: CorsHandler{handler: serverMux, cfg: s.cfg}}
 
 	if len(s.cfg.Security.ClusterSSLCA) != 0 {
@@ -262,7 +262,7 @@ func (s *Server) startHTTPServer() {
 	}
 
 	if err != nil {
-		logutil.Logger(context.Background()).Info("listen failed", zap.Error(err))
+		logutil.BgLogger().Info("listen failed", zap.Error(err))
 	}
 }
 
@@ -284,7 +284,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, req *http.Request) {
 	js, err := json.Marshal(st)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		logutil.Logger(context.Background()).Error("encode json failed", zap.Error(err))
+		logutil.BgLogger().Error("encode json failed", zap.Error(err))
 	} else {
 		_, err = w.Write(js)
 		terror.Log(errors.Trace(err))

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -16,7 +16,6 @@ package server
 import (
 	"archive/zip"
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net"

--- a/server/server.go
+++ b/server/server.go
@@ -147,7 +147,7 @@ func (s *Server) newConn(conn net.Conn) *clientConn {
 	if s.cfg.Performance.TCPKeepAlive {
 		if tcpConn, ok := conn.(*net.TCPConn); ok {
 			if err := tcpConn.SetKeepAlive(true); err != nil {
-				logutil.Logger(context.Background()).Error("failed to set tcp keep alive option", zap.Error(err))
+				logutil.BgLogger().Error("failed to set tcp keep alive option", zap.Error(err))
 			}
 		}
 	}
@@ -167,11 +167,11 @@ func (s *Server) forwardUnixSocketToTCP() {
 			return // server shutdown has started
 		}
 		if uconn, err := s.socket.Accept(); err == nil {
-			logutil.Logger(context.Background()).Info("server socket forwarding", zap.String("from", s.cfg.Socket), zap.String("to", addr))
+			logutil.BgLogger().Info("server socket forwarding", zap.String("from", s.cfg.Socket), zap.String("to", addr))
 			go s.handleForwardedConnection(uconn, addr)
 		} else {
 			if s.listener != nil {
-				logutil.Logger(context.Background()).Error("server failed to forward", zap.String("from", s.cfg.Socket), zap.String("to", addr), zap.Error(err))
+				logutil.BgLogger().Error("server failed to forward", zap.String("from", s.cfg.Socket), zap.String("to", addr), zap.Error(err))
 			}
 		}
 	}
@@ -182,14 +182,14 @@ func (s *Server) handleForwardedConnection(uconn net.Conn, addr string) {
 	if tconn, err := net.Dial("tcp", addr); err == nil {
 		go func() {
 			if _, err := io.Copy(uconn, tconn); err != nil {
-				logutil.Logger(context.Background()).Warn("copy server to socket failed", zap.Error(err))
+				logutil.BgLogger().Warn("copy server to socket failed", zap.Error(err))
 			}
 		}()
 		if _, err := io.Copy(tconn, uconn); err != nil {
-			logutil.Logger(context.Background()).Warn("socket forward copy failed", zap.Error(err))
+			logutil.BgLogger().Warn("socket forward copy failed", zap.Error(err))
 		}
 	} else {
-		logutil.Logger(context.Background()).Warn("socket forward failed: could not connect", zap.String("addr", addr), zap.Error(err))
+		logutil.BgLogger().Warn("socket forward failed: could not connect", zap.String("addr", addr), zap.Error(err))
 	}
 }
 
@@ -215,17 +215,17 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	if s.cfg.Host != "" && s.cfg.Port != 0 {
 		addr := fmt.Sprintf("%s:%d", s.cfg.Host, s.cfg.Port)
 		if s.listener, err = net.Listen("tcp", addr); err == nil {
-			logutil.Logger(context.Background()).Info("server is running MySQL protocol", zap.String("addr", addr))
+			logutil.BgLogger().Info("server is running MySQL protocol", zap.String("addr", addr))
 			if cfg.Socket != "" {
 				if s.socket, err = net.Listen("unix", s.cfg.Socket); err == nil {
-					logutil.Logger(context.Background()).Info("server redirecting", zap.String("from", s.cfg.Socket), zap.String("to", addr))
+					logutil.BgLogger().Info("server redirecting", zap.String("from", s.cfg.Socket), zap.String("to", addr))
 					go s.forwardUnixSocketToTCP()
 				}
 			}
 		}
 	} else if cfg.Socket != "" {
 		if s.listener, err = net.Listen("unix", cfg.Socket); err == nil {
-			logutil.Logger(context.Background()).Info("server is running MySQL protocol", zap.String("socket", cfg.Socket))
+			logutil.BgLogger().Info("server is running MySQL protocol", zap.String("socket", cfg.Socket))
 		}
 	} else {
 		err = errors.New("Server not configured to listen on either -socket or -host and -port")
@@ -235,10 +235,10 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		pplistener, errProxy := proxyprotocol.NewListener(s.listener, cfg.ProxyProtocol.Networks,
 			int(cfg.ProxyProtocol.HeaderTimeout))
 		if errProxy != nil {
-			logutil.Logger(context.Background()).Error("ProxyProtocol networks parameter invalid")
+			logutil.BgLogger().Error("ProxyProtocol networks parameter invalid")
 			return nil, errors.Trace(errProxy)
 		}
-		logutil.Logger(context.Background()).Info("server is running MySQL protocol (through PROXY protocol)", zap.String("host", s.cfg.Host))
+		logutil.BgLogger().Info("server is running MySQL protocol (through PROXY protocol)", zap.String("host", s.cfg.Host))
 		s.listener = pplistener
 	}
 
@@ -254,13 +254,13 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 func (s *Server) loadTLSCertificates() {
 	defer func() {
 		if s.tlsConfig != nil {
-			logutil.Logger(context.Background()).Info("secure connection is enabled", zap.Bool("client verification enabled", len(variable.SysVars["ssl_ca"].Value) > 0))
+			logutil.BgLogger().Info("secure connection is enabled", zap.Bool("client verification enabled", len(variable.SysVars["ssl_ca"].Value) > 0))
 			variable.SysVars["have_openssl"].Value = "YES"
 			variable.SysVars["have_ssl"].Value = "YES"
 			variable.SysVars["ssl_cert"].Value = s.cfg.Security.SSLCert
 			variable.SysVars["ssl_key"].Value = s.cfg.Security.SSLKey
 		} else {
-			logutil.Logger(context.Background()).Warn("secure connection is not enabled")
+			logutil.BgLogger().Warn("secure connection is not enabled")
 		}
 	}()
 
@@ -271,7 +271,7 @@ func (s *Server) loadTLSCertificates() {
 
 	tlsCert, err := tls.LoadX509KeyPair(s.cfg.Security.SSLCert, s.cfg.Security.SSLKey)
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("load x509 failed", zap.Error(err))
+		logutil.BgLogger().Warn("load x509 failed", zap.Error(err))
 		s.tlsConfig = nil
 		return
 	}
@@ -282,7 +282,7 @@ func (s *Server) loadTLSCertificates() {
 	if len(s.cfg.Security.SSLCA) > 0 {
 		caCert, err := ioutil.ReadFile(s.cfg.Security.SSLCA)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("read file failed", zap.Error(err))
+			logutil.BgLogger().Warn("read file failed", zap.Error(err))
 		} else {
 			certPool = x509.NewCertPool()
 			if certPool.AppendCertsFromPEM(caCert) {
@@ -318,11 +318,11 @@ func (s *Server) Run() error {
 
 			// If we got PROXY protocol error, we should continue accept.
 			if proxyprotocol.IsProxyProtocolError(err) {
-				logutil.Logger(context.Background()).Error("PROXY protocol failed", zap.Error(err))
+				logutil.BgLogger().Error("PROXY protocol failed", zap.Error(err))
 				continue
 			}
 
-			logutil.Logger(context.Background()).Error("accept failed", zap.Error(err))
+			logutil.BgLogger().Error("accept failed", zap.Error(err))
 			return errors.Trace(err)
 		}
 		if s.shouldStopListener() {
@@ -338,13 +338,13 @@ func (s *Server) Run() error {
 			if authPlugin.OnConnectionEvent != nil {
 				host, err := clientConn.PeerHost("")
 				if err != nil {
-					logutil.Logger(context.Background()).Error("get peer host failed", zap.Error(err))
+					logutil.BgLogger().Error("get peer host failed", zap.Error(err))
 					terror.Log(clientConn.Close())
 					return errors.Trace(err)
 				}
 				err = authPlugin.OnConnectionEvent(context.Background(), &auth.UserIdentity{Hostname: host}, plugin.PreAuth, nil)
 				if err != nil {
-					logutil.Logger(context.Background()).Info("do connection event failed", zap.Error(err))
+					logutil.BgLogger().Info("do connection event failed", zap.Error(err))
 					terror.Log(clientConn.Close())
 					return errors.Trace(err)
 				}
@@ -362,7 +362,7 @@ func (s *Server) Run() error {
 	s.listener = nil
 	for {
 		metrics.ServerEventCounter.WithLabelValues(metrics.EventHang).Inc()
-		logutil.Logger(context.Background()).Error("listener stopped, waiting for manual kill.")
+		logutil.BgLogger().Error("listener stopped, waiting for manual kill.")
 		time.Sleep(time.Minute)
 	}
 }
@@ -444,7 +444,7 @@ func (s *Server) onConn(conn *clientConn) {
 			connInfo.Duration = float64(time.Since(connectedTime)) / float64(time.Millisecond)
 			err := authPlugin.OnConnectionEvent(context.Background(), conn.ctx.GetSessionVars().User, plugin.Disconnect, connInfo)
 			if err != nil {
-				logutil.Logger(context.Background()).Warn("do connection event failed", zap.String("plugin", authPlugin.Name), zap.Error(err))
+				logutil.BgLogger().Warn("do connection event failed", zap.String("plugin", authPlugin.Name), zap.Error(err))
 			}
 		}
 		return nil
@@ -513,7 +513,7 @@ func (s *Server) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
 func (s *Server) Kill(connectionID uint64, query bool) {
 	s.rwlock.Lock()
 	defer s.rwlock.Unlock()
-	logutil.Logger(context.Background()).Info("kill", zap.Uint64("connID", connectionID), zap.Bool("query", query))
+	logutil.BgLogger().Info("kill", zap.Uint64("connID", connectionID), zap.Bool("query", query))
 	metrics.ServerEventCounter.WithLabelValues(metrics.EventKill).Inc()
 
 	conn, ok := s.clients[uint32(connectionID)]
@@ -538,7 +538,7 @@ func killConn(conn *clientConn) {
 func (s *Server) KillAllConnections() {
 	s.rwlock.Lock()
 	defer s.rwlock.Unlock()
-	logutil.Logger(context.Background()).Info("[server] kill all connections.")
+	logutil.BgLogger().Info("[server] kill all connections.")
 
 	for _, conn := range s.clients {
 		atomic.StoreInt32(&conn.status, connStatusShutdown)
@@ -606,7 +606,7 @@ func (s *Server) kickIdleConnection() {
 	for _, cc := range conns {
 		err := cc.Close()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("close connection", zap.Error(err))
+			logutil.BgLogger().Error("close connection", zap.Error(err))
 		}
 	}
 }

--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -37,16 +37,16 @@ var bigCount = 10000
 func prepareBenchSession() (Session, *domain.Domain, kv.Storage) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal(err.Error())
+		logutil.BgLogger().Fatal(err.Error())
 	}
 	domain, err := BootstrapSession(store)
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal(err.Error())
+		logutil.BgLogger().Fatal(err.Error())
 	}
 	log.SetLevel(zapcore.ErrorLevel)
 	se, err := CreateSession4Test(store)
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal(err.Error())
+		logutil.BgLogger().Fatal(err.Error())
 	}
 	mustExecute(se, "use test")
 	return se, domain, store

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -273,13 +273,13 @@ func bootstrap(s Session) {
 	for {
 		b, err := checkBootstrapped(s)
 		if err != nil {
-			logutil.Logger(context.Background()).Fatal("check bootstrap error",
+			logutil.BgLogger().Fatal("check bootstrap error",
 				zap.Error(err))
 		}
 		// For rolling upgrade, we can't do upgrade only in the owner.
 		if b {
 			upgrade(s)
-			logutil.Logger(context.Background()).Info("upgrade successful in bootstrap",
+			logutil.BgLogger().Info("upgrade successful in bootstrap",
 				zap.Duration("take time", time.Since(startTime)))
 			return
 		}
@@ -288,7 +288,7 @@ func bootstrap(s Session) {
 		if dom.DDL().OwnerManager().IsOwner() {
 			doDDLWorks(s)
 			doDMLWorks(s)
-			logutil.Logger(context.Background()).Info("bootstrap successful",
+			logutil.BgLogger().Info("bootstrap successful",
 				zap.Duration("take time", time.Since(startTime)))
 			return
 		}
@@ -348,7 +348,7 @@ func checkBootstrapped(s Session) (bool, error) {
 	//  Check if system db exists.
 	_, err := s.Execute(context.Background(), fmt.Sprintf("USE %s;", mysql.SystemDB))
 	if err != nil && infoschema.ErrDatabaseNotExists.NotEqual(err) {
-		logutil.Logger(context.Background()).Fatal("check bootstrap error",
+		logutil.BgLogger().Fatal("check bootstrap error",
 			zap.Error(err))
 	}
 	// Check bootstrapped variable value in TiDB table.
@@ -538,19 +538,19 @@ func upgrade(s Session) {
 
 	if err != nil {
 		sleepTime := 1 * time.Second
-		logutil.Logger(context.Background()).Info("update bootstrap ver failed",
+		logutil.BgLogger().Info("update bootstrap ver failed",
 			zap.Error(err), zap.Duration("sleeping time", sleepTime))
 		time.Sleep(sleepTime)
 		// Check if TiDB is already upgraded.
 		v, err1 := getBootstrapVersion(s)
 		if err1 != nil {
-			logutil.Logger(context.Background()).Fatal("upgrade failed", zap.Error(err1))
+			logutil.BgLogger().Fatal("upgrade failed", zap.Error(err1))
 		}
 		if v >= currentBootstrapVersion {
 			// It is already bootstrapped/upgraded by a higher version TiDB server.
 			return
 		}
-		logutil.Logger(context.Background()).Fatal("[Upgrade] upgrade failed",
+		logutil.BgLogger().Fatal("[Upgrade] upgrade failed",
 			zap.Int64("from", ver),
 			zap.Int("to", currentBootstrapVersion),
 			zap.Error(err))
@@ -625,7 +625,7 @@ func doReentrantDDL(s Session, sql string, ignorableErrs ...error) {
 		}
 	}
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal("doReentrantDDL error", zap.Error(err))
+		logutil.BgLogger().Fatal("doReentrantDDL error", zap.Error(err))
 	}
 }
 
@@ -643,7 +643,7 @@ func upgradeToVer11(s Session) {
 		if terror.ErrorEqual(err, infoschema.ErrColumnExists) {
 			return
 		}
-		logutil.Logger(context.Background()).Fatal("upgradeToVer11 error", zap.Error(err))
+		logutil.BgLogger().Fatal("upgradeToVer11 error", zap.Error(err))
 	}
 	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET References_priv='Y'")
 }
@@ -704,7 +704,7 @@ func upgradeToVer13(s Session) {
 			if terror.ErrorEqual(err, infoschema.ErrColumnExists) {
 				continue
 			}
-			logutil.Logger(context.Background()).Fatal("upgradeToVer13 error", zap.Error(err))
+			logutil.BgLogger().Fatal("upgradeToVer13 error", zap.Error(err))
 		}
 	}
 	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET Create_tmp_table_priv='Y',Lock_tables_priv='Y',Create_view_priv='Y',Show_view_priv='Y',Create_routine_priv='Y',Alter_routine_priv='Y',Event_priv='Y'")
@@ -729,7 +729,7 @@ func upgradeToVer14(s Session) {
 			if terror.ErrorEqual(err, infoschema.ErrColumnExists) {
 				continue
 			}
-			logutil.Logger(context.Background()).Fatal("upgradeToVer14 error", zap.Error(err))
+			logutil.BgLogger().Fatal("upgradeToVer14 error", zap.Error(err))
 		}
 	}
 }
@@ -738,7 +738,7 @@ func upgradeToVer15(s Session) {
 	var err error
 	_, err = s.Execute(context.Background(), CreateGCDeleteRangeTable)
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal("upgradeToVer15 error", zap.Error(err))
+		logutil.BgLogger().Fatal("upgradeToVer15 error", zap.Error(err))
 	}
 }
 
@@ -936,17 +936,17 @@ func doDMLWorks(s Session) {
 	_, err := s.Execute(context.Background(), "COMMIT")
 	if err != nil {
 		sleepTime := 1 * time.Second
-		logutil.Logger(context.Background()).Info("doDMLWorks failed", zap.Error(err), zap.Duration("sleeping time", sleepTime))
+		logutil.BgLogger().Info("doDMLWorks failed", zap.Error(err), zap.Duration("sleeping time", sleepTime))
 		time.Sleep(sleepTime)
 		// Check if TiDB is already bootstrapped.
 		b, err1 := checkBootstrapped(s)
 		if err1 != nil {
-			logutil.Logger(context.Background()).Fatal("doDMLWorks failed", zap.Error(err1))
+			logutil.BgLogger().Fatal("doDMLWorks failed", zap.Error(err1))
 		}
 		if b {
 			return
 		}
-		logutil.Logger(context.Background()).Fatal("doDMLWorks failed", zap.Error(err))
+		logutil.BgLogger().Fatal("doDMLWorks failed", zap.Error(err))
 	}
 }
 
@@ -954,7 +954,7 @@ func mustExecute(s Session, sql string) {
 	_, err := s.Execute(context.Background(), sql)
 	if err != nil {
 		debug.PrintStack()
-		logutil.Logger(context.Background()).Fatal("mustExecute error", zap.Error(err))
+		logutil.BgLogger().Fatal("mustExecute error", zap.Error(err))
 	}
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -349,13 +349,13 @@ func (s *session) StoreQueryFeedback(feedback interface{}) {
 	if s.statsCollector != nil {
 		do, err := GetDomain(s.store)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("domain not found", zap.Error(err))
+			logutil.BgLogger().Debug("domain not found", zap.Error(err))
 			metrics.StoreQueryFeedbackCounter.WithLabelValues(metrics.LblError).Inc()
 			return
 		}
 		err = s.statsCollector.StoreQueryFeedback(feedback, do.StatsHandle())
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("store query feedback", zap.Error(err))
+			logutil.BgLogger().Debug("store query feedback", zap.Error(err))
 			metrics.StoreQueryFeedbackCounter.WithLabelValues(metrics.LblError).Inc()
 			return
 		}
@@ -782,7 +782,7 @@ func (s *session) ExecRestrictedSQLWithSnapshot(sctx sessionctx.Context, sql str
 		}
 		defer func() {
 			if err := se.sessionVars.SetSystemVar(variable.TiDBSnapshot, ""); err != nil {
-				logutil.Logger(context.Background()).Error("set tidbSnapshot error", zap.Error(err))
+				logutil.BgLogger().Error("set tidbSnapshot error", zap.Error(err))
 			}
 		}()
 	}
@@ -1267,7 +1267,7 @@ func (s *session) Txn(active bool) (kv.Transaction, error) {
 		// If Txn() is called later, wait for the future to get a valid txn.
 		txnCap := s.getMembufCap()
 		if err := s.txn.changePendingToValid(txnCap); err != nil {
-			logutil.Logger(context.Background()).Error("active transaction fail",
+			logutil.BgLogger().Error("active transaction fail",
 				zap.Error(err))
 			s.txn.cleanup()
 			s.sessionVars.TxnCtx.StartTS = 0
@@ -1342,7 +1342,7 @@ func (s *session) Close() {
 		lockedTables := s.GetAllTableLocks()
 		err := domain.GetDomain(s).DDL().UnlockTables(s, lockedTables)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("release table lock failed", zap.Uint64("conn", s.sessionVars.ConnectionID))
+			logutil.BgLogger().Error("release table lock failed", zap.Uint64("conn", s.sessionVars.ConnectionID))
 		}
 	}
 	if s.statsCollector != nil {
@@ -1371,7 +1371,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication []byte, salt []by
 		s.sessionVars.ActiveRoles = pm.GetDefaultRoles(user.AuthUsername, user.AuthHostname)
 		return true
 	} else if user.Hostname == variable.DefHostname {
-		logutil.Logger(context.Background()).Error("user connection verification failed",
+		logutil.BgLogger().Error("user connection verification failed",
 			zap.Stringer("user", user))
 		return false
 	}
@@ -1391,7 +1391,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication []byte, salt []by
 		}
 	}
 
-	logutil.Logger(context.Background()).Error("user connection verification failed",
+	logutil.BgLogger().Error("user connection verification failed",
 		zap.Stringer("user", user))
 	return false
 }
@@ -1461,7 +1461,7 @@ func loadSystemTZ(se *session) (string, error) {
 	// the record of mysql.tidb under where condition: variable_name = "system_tz" should shall only be one.
 	defer func() {
 		if err := rss[0].Close(); err != nil {
-			logutil.Logger(context.Background()).Error("close result set error", zap.Error(err))
+			logutil.BgLogger().Error("close result set error", zap.Error(err))
 		}
 	}()
 	req := rss[0].NewRecordBatch()
@@ -1569,7 +1569,7 @@ func runInBootstrapSession(store kv.Storage, bootstrap func(Session)) {
 	s, err := createSession(store)
 	if err != nil {
 		// Bootstrap fail will cause program exit.
-		logutil.Logger(context.Background()).Fatal("createSession error", zap.Error(err))
+		logutil.BgLogger().Fatal("createSession error", zap.Error(err))
 	}
 	schemaLease = saveLease
 
@@ -1655,7 +1655,7 @@ func getStoreBootstrapVersion(store kv.Storage) int64 {
 	})
 
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal("check bootstrapped failed",
+		logutil.BgLogger().Fatal("check bootstrapped failed",
 			zap.Error(err))
 	}
 
@@ -1678,7 +1678,7 @@ func finishBootstrap(store kv.Storage) {
 		return err
 	})
 	if err != nil {
-		logutil.Logger(context.Background()).Fatal("finish bootstrap failed",
+		logutil.BgLogger().Fatal("finish bootstrap failed",
 			zap.Error(err))
 	}
 }
@@ -1776,7 +1776,7 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 		rows, fields, err = s.ExecRestrictedSQL(s, loadCommonGlobalVarsSQL)
 		if err != nil {
 			vars.CommonGlobalLoaded = false
-			logutil.Logger(context.Background()).Error("failed to load common global variables.")
+			logutil.BgLogger().Error("failed to load common global variables.")
 			return err
 		}
 		gvc.Update(rows, fields)
@@ -1888,13 +1888,13 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 		user := vars.User
 		schemaVersion := vars.TxnCtx.SchemaVersion
 		if ss, ok := node.(ast.SensitiveStmtNode); ok {
-			logutil.Logger(context.Background()).Info("CRUCIAL OPERATION",
+			logutil.BgLogger().Info("CRUCIAL OPERATION",
 				zap.Uint64("conn", vars.ConnectionID),
 				zap.Int64("schemaVersion", schemaVersion),
 				zap.String("secure text", ss.SecureText()),
 				zap.Stringer("user", user))
 		} else {
-			logutil.Logger(context.Background()).Info("CRUCIAL OPERATION",
+			logutil.BgLogger().Info("CRUCIAL OPERATION",
 				zap.Uint64("conn", vars.ConnectionID),
 				zap.Int64("schemaVersion", schemaVersion),
 				zap.String("cur_db", vars.CurrentDB),
@@ -1909,7 +1909,7 @@ func logStmt(node ast.StmtNode, vars *variable.SessionVars) {
 func logQuery(query string, vars *variable.SessionVars) {
 	if atomic.LoadUint32(&variable.ProcessGeneralLog) != 0 && !vars.InRestrictedSQL {
 		query = executor.QueryReplacer.Replace(query)
-		logutil.Logger(context.Background()).Info("GENERAL_LOG",
+		logutil.BgLogger().Info("GENERAL_LOG",
 			zap.Uint64("conn", vars.ConnectionID),
 			zap.Stringer("user", vars.User),
 			zap.Int64("schemaVersion", vars.TxnCtx.SchemaVersion),

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -68,7 +68,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	ddlLease = schemaLease
 	statisticLease = statsLease
 	err = util.RunWithRetry(util.DefaultMaxRetries, util.RetryInterval, func() (retry bool, err1 error) {
-		logutil.Logger(context.Background()).Info("new domain",
+		logutil.BgLogger().Info("new domain",
 			zap.String("store", store.UUID()),
 			zap.Stringer("ddl lease", ddlLease),
 			zap.Stringer("stats lease", statisticLease))
@@ -79,7 +79,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 		if err1 != nil {
 			// If we don't clean it, there are some dirty data when retrying the function of Init.
 			d.Close()
-			logutil.Logger(context.Background()).Error("[ddl] init domain failed",
+			logutil.BgLogger().Error("[ddl] init domain failed",
 				zap.Error(err1))
 		}
 		return true, err1
@@ -132,7 +132,7 @@ func SetStatsLease(lease time.Duration) {
 
 // Parse parses a query string to raw ast.StmtNode.
 func Parse(ctx sessionctx.Context, src string) ([]ast.StmtNode, error) {
-	logutil.Logger(context.Background()).Debug("compiling", zap.String("source", src))
+	logutil.BgLogger().Debug("compiling", zap.String("source", src))
 	charset, collation := ctx.GetSessionVars().GetCharsetInfo()
 	p := parser.New()
 	p.EnableWindowFunc(ctx.GetSessionVars().EnableWindowFunction)
@@ -142,7 +142,7 @@ func Parse(ctx sessionctx.Context, src string) ([]ast.StmtNode, error) {
 		ctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 	}
 	if err != nil {
-		logutil.Logger(context.Background()).Warn("compiling",
+		logutil.BgLogger().Warn("compiling",
 			zap.String("source", src),
 			zap.Error(err))
 		return nil, err
@@ -160,10 +160,10 @@ func Compile(ctx context.Context, sctx sessionctx.Context, stmtNode ast.StmtNode
 func finishStmt(ctx context.Context, sctx sessionctx.Context, se *session, sessVars *variable.SessionVars, meetsErr error) error {
 	if meetsErr != nil {
 		if !sessVars.InTxn() {
-			logutil.Logger(context.Background()).Info("rollbackTxn for ddl/autocommit error.")
+			logutil.BgLogger().Info("rollbackTxn for ddl/autocommit error.")
 			se.RollbackTxn(ctx)
 		} else if se.txn.Valid() && se.txn.IsPessimistic() && executor.ErrDeadlock.Equal(meetsErr) {
-			logutil.Logger(context.Background()).Info("rollbackTxn for deadlock error", zap.Uint64("txn", se.txn.StartTS()))
+			logutil.BgLogger().Info("rollbackTxn for deadlock error", zap.Uint64("txn", se.txn.StartTS()))
 			se.RollbackTxn(ctx)
 		}
 		return meetsErr
@@ -234,7 +234,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 				}
 			}
 		} else {
-			logutil.Logger(context.Background()).Error("get txn error", zap.Error(err1))
+			logutil.BgLogger().Error("get txn error", zap.Error(err1))
 		}
 	}
 

--- a/session/txn.go
+++ b/session/txn.go
@@ -167,14 +167,14 @@ func mockAutoIDRetry() bool {
 func (st *TxnState) Commit(ctx context.Context) error {
 	defer st.reset()
 	if len(st.mutations) != 0 || len(st.dirtyTableOP) != 0 || st.buf.Len() != 0 {
-		logutil.Logger(context.Background()).Error("the code should never run here",
+		logutil.BgLogger().Error("the code should never run here",
 			zap.String("TxnState", st.GoString()),
 			zap.Stack("something must be wrong"))
 		return errors.New("invalid transaction")
 	}
 	if st.doNotCommit != nil {
 		if err1 := st.Transaction.Rollback(); err1 != nil {
-			logutil.Logger(context.Background()).Error("rollback error", zap.Error(err1))
+			logutil.BgLogger().Error("rollback error", zap.Error(err1))
 		}
 		return errors.Trace(st.doNotCommit)
 	}

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -83,7 +83,7 @@ var ignoreError uint32
 // DisableSkipBinlogFlag disable the skipBinlog flag.
 func DisableSkipBinlogFlag() {
 	atomic.StoreUint32(&skipBinlog, 0)
-	logutil.Logger(context.Background()).Warn("[binloginfo] disable the skipBinlog flag")
+	logutil.BgLogger().Warn("[binloginfo] disable the skipBinlog flag")
 }
 
 // SetIgnoreError sets the ignoreError flag, this function called when TiDB start
@@ -111,9 +111,9 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 	// it will retry in PumpsClient if write binlog fail.
 	err := info.Client.WriteBinlog(info.Data)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("write binlog failed", zap.Error(err))
+		logutil.BgLogger().Error("write binlog failed", zap.Error(err))
 		if atomic.LoadUint32(&ignoreError) == 1 {
-			logutil.Logger(context.Background()).Error("write binlog fail but error ignored")
+			logutil.BgLogger().Error("write binlog fail but error ignored")
 			metrics.CriticalErrorCounter.Add(1)
 			// If error happens once, we'll stop writing binlog.
 			atomic.CompareAndSwapUint32(&skipBinlog, skip, skip+1)

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -14,7 +14,6 @@
 package binloginfo
 
 import (
-	"context"
 	"regexp"
 	"strings"
 	"sync"

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -158,12 +158,12 @@ func (q *QueryFeedback) DecodeIntValues() *QueryFeedback {
 	for _, fb := range q.Feedback {
 		_, lowInt, err := codec.DecodeInt(fb.Lower.GetBytes())
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("decode feedback lower bound value to integer failed", zap.Binary("value", fb.Lower.GetBytes()), zap.Error(err))
+			logutil.BgLogger().Debug("decode feedback lower bound value to integer failed", zap.Binary("value", fb.Lower.GetBytes()), zap.Error(err))
 			continue
 		}
 		_, highInt, err := codec.DecodeInt(fb.Upper.GetBytes())
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("decode feedback upper bound value to integer failed", zap.Binary("value", fb.Upper.GetBytes()), zap.Error(err))
+			logutil.BgLogger().Debug("decode feedback upper bound value to integer failed", zap.Binary("value", fb.Upper.GetBytes()), zap.Error(err))
 			continue
 		}
 		low, high := types.NewIntDatum(lowInt), types.NewIntDatum(highInt)
@@ -309,7 +309,7 @@ func buildBucketFeedback(h *Histogram, feedback *QueryFeedback) (map[int]*Bucket
 	for _, fb := range feedback.Feedback {
 		skip, err := fb.adjustFeedbackBoundaries(sc, &min, &max)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("adjust feedback boundaries failed", zap.Error(err))
+			logutil.BgLogger().Debug("adjust feedback boundaries failed", zap.Error(err))
 			continue
 		}
 		if skip {
@@ -337,7 +337,7 @@ func buildBucketFeedback(h *Histogram, feedback *QueryFeedback) (map[int]*Bucket
 		// Update the bound if necessary.
 		res, err := bkt.lower.CompareDatum(nil, fb.Lower)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("compare datum failed", zap.Any("value1", bkt.lower), zap.Any("value2", fb.Lower), zap.Error(err))
+			logutil.BgLogger().Debug("compare datum failed", zap.Any("value1", bkt.lower), zap.Any("value2", fb.Lower), zap.Error(err))
 			continue
 		}
 		if res > 0 {
@@ -345,7 +345,7 @@ func buildBucketFeedback(h *Histogram, feedback *QueryFeedback) (map[int]*Bucket
 		}
 		res, err = bkt.upper.CompareDatum(nil, fb.Upper)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("compare datum failed", zap.Any("value1", bkt.upper), zap.Any("value2", fb.Upper), zap.Error(err))
+			logutil.BgLogger().Debug("compare datum failed", zap.Any("value1", bkt.upper), zap.Any("value2", fb.Upper), zap.Error(err))
 			continue
 		}
 		if res < 0 {
@@ -365,7 +365,7 @@ func (b *BucketFeedback) getBoundaries(num int) []types.Datum {
 	vals = append(vals, *b.lower)
 	err := types.SortDatums(nil, vals)
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("sort datums failed", zap.Error(err))
+		logutil.BgLogger().Debug("sort datums failed", zap.Error(err))
 		return []types.Datum{*b.lower, *b.upper}
 	}
 	total, interval := 0, len(vals)/num
@@ -381,7 +381,7 @@ func (b *BucketFeedback) getBoundaries(num int) []types.Datum {
 	for i := 1; i < len(vals); i++ {
 		cmp, err := vals[total-1].CompareDatum(nil, &vals[i])
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("compare datum failed", zap.Any("value1", vals[total-1]), zap.Any("value2", vals[i]), zap.Error(err))
+			logutil.BgLogger().Debug("compare datum failed", zap.Any("value1", vals[total-1]), zap.Any("value2", vals[i]), zap.Error(err))
 			continue
 		}
 		if cmp == 0 {
@@ -932,7 +932,7 @@ func GetMaxValue(ft *types.FieldType) (max types.Datum) {
 		bytes, err := codec.EncodeKey(nil, nil, val)
 		// should not happen
 		if err != nil {
-			logutil.Logger(context.Background()).Error("encode key fail", zap.Error(err))
+			logutil.BgLogger().Error("encode key fail", zap.Error(err))
 		}
 		max.SetBytes(bytes)
 	case mysql.TypeNewDecimal:
@@ -967,7 +967,7 @@ func GetMinValue(ft *types.FieldType) (min types.Datum) {
 		bytes, err := codec.EncodeKey(nil, nil, val)
 		// should not happen
 		if err != nil {
-			logutil.Logger(context.Background()).Error("encode key fail", zap.Error(err))
+			logutil.BgLogger().Error("encode key fail", zap.Error(err))
 		}
 		min.SetBytes(bytes)
 	case mysql.TypeNewDecimal:

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -15,7 +15,6 @@ package statistics
 
 import (
 	"bytes"
-	"context"
 	"encoding/gob"
 	"math"
 	"math/rand"

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -36,7 +36,7 @@ func (h *Handle) initStatsMeta4Chunk(is infoschema.InfoSchema, tables StatsCache
 		physicalID := row.GetInt64(1)
 		table, ok := h.getTableByPhysicalID(is, physicalID)
 		if !ok {
-			logutil.Logger(context.Background()).Debug("unknown physical ID in stats meta table, maybe it has been dropped", zap.Int64("ID", physicalID))
+			logutil.BgLogger().Debug("unknown physical ID in stats meta table, maybe it has been dropped", zap.Int64("ID", physicalID))
 			continue
 		}
 		tableInfo := table.Meta()
@@ -192,14 +192,14 @@ func initStatsBuckets4Chunk(ctx sessionctx.Context, tables StatsCache, iter *chu
 			var err error
 			lower, err = d.ConvertTo(ctx.GetSessionVars().StmtCtx, &column.Info.FieldType)
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("decode bucket lower bound failed", zap.Error(err))
+				logutil.BgLogger().Debug("decode bucket lower bound failed", zap.Error(err))
 				delete(table.Columns, histID)
 				continue
 			}
 			d = types.NewBytesDatum(row.GetBytes(6))
 			upper, err = d.ConvertTo(ctx.GetSessionVars().StmtCtx, &column.Info.FieldType)
 			if err != nil {
-				logutil.Logger(context.Background()).Debug("decode bucket upper bound failed", zap.Error(err))
+				logutil.BgLogger().Debug("decode bucket upper bound failed", zap.Error(err))
 				delete(table.Columns, histID)
 				continue
 			}

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -167,7 +167,7 @@ func (h *Handle) Update(is infoschema.InfoSchema) error {
 		table, ok := h.getTableByPhysicalID(is, physicalID)
 		h.mu.Unlock()
 		if !ok {
-			logutil.Logger(context.Background()).Debug("unknown physical ID in stats meta table, maybe it has been dropped", zap.Int64("ID", physicalID))
+			logutil.BgLogger().Debug("unknown physical ID in stats meta table, maybe it has been dropped", zap.Int64("ID", physicalID))
 			deletedTableIDs = append(deletedTableIDs, physicalID)
 			continue
 		}
@@ -175,7 +175,7 @@ func (h *Handle) Update(is infoschema.InfoSchema) error {
 		tbl, err := h.tableStatsFromStorage(tableInfo, physicalID, false, nil)
 		// Error is not nil may mean that there are some ddl changes on this table, we will not update it.
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("error occurred when read table stats", zap.String("table", tableInfo.Name.O), zap.Error(err))
+			logutil.BgLogger().Debug("error occurred when read table stats", zap.String("table", tableInfo.Name.O), zap.Error(err))
 			continue
 		}
 		if tbl == nil {
@@ -317,14 +317,14 @@ func (h *Handle) FlushStats() {
 	for len(h.ddlEventCh) > 0 {
 		e := <-h.ddlEventCh
 		if err := h.HandleDDLEvent(e); err != nil {
-			logutil.Logger(context.Background()).Debug("[stats] handle ddl event fail", zap.Error(err))
+			logutil.BgLogger().Debug("[stats] handle ddl event fail", zap.Error(err))
 		}
 	}
 	if err := h.DumpStatsDeltaToKV(DumpAll); err != nil {
-		logutil.Logger(context.Background()).Debug("[stats] dump stats delta fail", zap.Error(err))
+		logutil.BgLogger().Debug("[stats] dump stats delta fail", zap.Error(err))
 	}
 	if err := h.DumpStatsFeedbackToKV(); err != nil {
-		logutil.Logger(context.Background()).Debug("[stats] dump stats feedback fail", zap.Error(err))
+		logutil.BgLogger().Debug("[stats] dump stats feedback fail", zap.Error(err))
 	}
 }
 
@@ -377,7 +377,7 @@ func (h *Handle) indexStatsFromStorage(row chunk.Row, table *statistics.Table, t
 	if idx != nil {
 		table.Indices[histID] = idx
 	} else {
-		logutil.Logger(context.Background()).Debug("we cannot find index id in table info. It may be deleted.", zap.Int64("indexID", histID), zap.String("table", tableInfo.Name.O))
+		logutil.BgLogger().Debug("we cannot find index id in table info. It may be deleted.", zap.Int64("indexID", histID), zap.String("table", tableInfo.Name.O))
 	}
 	return nil
 }
@@ -466,7 +466,7 @@ func (h *Handle) columnStatsFromStorage(row chunk.Row, table *statistics.Table, 
 		// If we didn't find a Column or Index in tableInfo, we won't load the histogram for it.
 		// But don't worry, next lease the ddl will be updated, and we will load a same table for two times to
 		// avoid error.
-		logutil.Logger(context.Background()).Debug("we cannot find column in table info now. It may be deleted", zap.Int64("colID", histID), zap.String("table", tableInfo.Name.O))
+		logutil.BgLogger().Debug("we cannot find column in table info now. It may be deleted", zap.Int64("colID", histID), zap.String("table", tableInfo.Name.O))
 	}
 	return nil
 }

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -385,7 +385,7 @@ func (h *Handle) DumpStatsFeedbackToKV() error {
 func (h *Handle) DumpFeedbackToKV(fb *statistics.QueryFeedback) error {
 	vals, err := statistics.EncodeFeedback(fb)
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("error occurred when encoding feedback", zap.Error(err))
+		logutil.BgLogger().Debug("error occurred when encoding feedback", zap.Error(err))
 		return nil
 	}
 	var isIndex int64
@@ -555,7 +555,7 @@ func (h *Handle) handleSingleHistogramUpdate(is infoschema.InfoSchema, rows []ch
 	for _, row := range rows {
 		err1 := statistics.DecodeFeedback(row.GetBytes(3), q, cms, hist.Tp)
 		if err1 != nil {
-			logutil.Logger(context.Background()).Debug("decode feedback failed", zap.Error(err))
+			logutil.BgLogger().Debug("decode feedback failed", zap.Error(err))
 		}
 	}
 	err = h.dumpStatsUpdateToKV(physicalTableID, isIndex, q, hist, cms)
@@ -695,7 +695,7 @@ func (h *Handle) HandleAutoAnalyze(is infoschema.InfoSchema) {
 	autoAnalyzeRatio := parseAutoAnalyzeRatio(parameters[variable.TiDBAutoAnalyzeRatio])
 	start, end, err := parseAnalyzePeriod(parameters[variable.TiDBAutoAnalyzeStartTime], parameters[variable.TiDBAutoAnalyzeEndTime])
 	if err != nil {
-		logutil.Logger(context.Background()).Error("[stats] parse auto analyze period failed", zap.Error(err))
+		logutil.BgLogger().Error("[stats] parse auto analyze period failed", zap.Error(err))
 		return
 	}
 	for _, db := range dbs {
@@ -732,14 +732,14 @@ func (h *Handle) autoAnalyzeTable(tblInfo *model.TableInfo, statsTbl *statistics
 		return false
 	}
 	if needAnalyze, reason := NeedAnalyzeTable(statsTbl, 20*h.Lease(), ratio, start, end, time.Now()); needAnalyze {
-		logutil.Logger(context.Background()).Info("[stats] auto analyze triggered", zap.String("sql", sql), zap.String("reason", reason))
+		logutil.BgLogger().Info("[stats] auto analyze triggered", zap.String("sql", sql), zap.String("reason", reason))
 		h.execAutoAnalyze(sql)
 		return true
 	}
 	for _, idx := range tblInfo.Indices {
 		if _, ok := statsTbl.Indices[idx.ID]; !ok && idx.State == model.StatePublic {
 			sql = fmt.Sprintf("%s index `%s`", sql, idx.Name.O)
-			logutil.Logger(context.Background()).Info("[stats] auto analyze for unanalyzed", zap.String("sql", sql))
+			logutil.BgLogger().Info("[stats] auto analyze for unanalyzed", zap.String("sql", sql))
 			h.execAutoAnalyze(sql)
 			return true
 		}
@@ -753,7 +753,7 @@ func (h *Handle) execAutoAnalyze(sql string) {
 	dur := time.Since(startTime)
 	metrics.AutoAnalyzeHistogram.Observe(dur.Seconds())
 	if err != nil {
-		logutil.Logger(context.Background()).Error("[stats] auto analyze failed", zap.String("sql", sql), zap.Duration("cost_time", dur), zap.Error(err))
+		logutil.BgLogger().Error("[stats] auto analyze failed", zap.String("sql", sql), zap.Duration("cost_time", dur), zap.Error(err))
 		metrics.AutoAnalyzeCounter.WithLabelValues("failed").Inc()
 	} else {
 		metrics.AutoAnalyzeCounter.WithLabelValues("succ").Inc()
@@ -808,7 +808,7 @@ func logForIndex(prefix string, t *statistics.Table, idx *statistics.Index, rang
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	if idx.CMSketch == nil || idx.StatsVer != statistics.Version1 {
 		for i, ran := range ranges {
-			logutil.Logger(context.Background()).Debug(prefix, zap.String("index", idx.Info.Name.O), zap.String("rangeStr", logForIndexRange(idx, ran, actual[i], factor)))
+			logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.String("rangeStr", logForIndexRange(idx, ran, actual[i], factor)))
 		}
 		return
 	}
@@ -816,7 +816,7 @@ func logForIndex(prefix string, t *statistics.Table, idx *statistics.Index, rang
 		rangePosition := statistics.GetOrdinalOfRangeCond(sc, ran)
 		// only contains range or equality query
 		if rangePosition == 0 || rangePosition == len(ran.LowVal) {
-			logutil.Logger(context.Background()).Debug(prefix, zap.String("index", idx.Info.Name.O), zap.String("rangeStr", logForIndexRange(idx, ran, actual[i], factor)))
+			logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.String("rangeStr", logForIndexRange(idx, ran, actual[i], factor)))
 			continue
 		}
 		equalityString, err := types.DatumsToString(ran.LowVal[:rangePosition], true)
@@ -836,21 +836,21 @@ func logForIndex(prefix string, t *statistics.Table, idx *statistics.Index, rang
 		// prefer index stats over column stats
 		if idxHist := t.IndexStartWithColumn(colName); idxHist != nil && idxHist.Histogram.Len() > 0 {
 			rangeString := logForIndexRange(idxHist, &rang, -1, factor)
-			logutil.Logger(context.Background()).Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
+			logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
 				zap.String("equality", equalityString), zap.Uint64("expected equality", equalityCount),
 				zap.String("range", rangeString))
 		} else if colHist := t.ColumnByName(colName); colHist != nil && colHist.Histogram.Len() > 0 {
 			err = convertRangeType(&rang, colHist.Tp, time.UTC)
 			if err == nil {
 				rangeString := colRangeToStr(colHist, &rang, -1, factor)
-				logutil.Logger(context.Background()).Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
+				logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
 					zap.String("equality", equalityString), zap.Uint64("expected equality", equalityCount),
 					zap.String("range", rangeString))
 			}
 		} else {
 			count, err := statistics.GetPseudoRowCountByColumnRanges(sc, float64(t.Count), []*ranger.Range{&rang}, 0)
 			if err == nil {
-				logutil.Logger(context.Background()).Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
+				logutil.BgLogger().Debug(prefix, zap.String("index", idx.Info.Name.O), zap.Int64("actual", actual[i]),
 					zap.String("equality", equalityString), zap.Uint64("expected equality", equalityCount),
 					zap.Stringer("range", &rang), zap.Float64("pseudo count", math.Round(count)))
 			}
@@ -866,7 +866,7 @@ func (h *Handle) logDetailedInfo(q *statistics.QueryFeedback) {
 	isIndex := q.Hist.IsIndexHist()
 	ranges, err := q.DecodeToRanges(isIndex)
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("decode to ranges failed", zap.Error(err))
+		logutil.BgLogger().Debug("decode to ranges failed", zap.Error(err))
 		return
 	}
 	actual := make([]int64, 0, len(q.Feedback))
@@ -894,7 +894,7 @@ func logForPK(prefix string, c *statistics.Column, ranges []*ranger.Range, actua
 		if ran.LowVal[0].GetInt64()+1 >= ran.HighVal[0].GetInt64() {
 			continue
 		}
-		logutil.Logger(context.Background()).Debug(prefix, zap.String("column", c.Info.Name.O), zap.String("rangeStr", colRangeToStr(c, ran, actual[i], factor)))
+		logutil.BgLogger().Debug(prefix, zap.String("column", c.Info.Name.O), zap.String("rangeStr", colRangeToStr(c, ran, actual[i], factor)))
 	}
 }
 
@@ -962,7 +962,7 @@ func (h *Handle) dumpRangeFeedback(sc *stmtctx.StatementContext, ran *ranger.Ran
 	}
 	ranges, ok := q.Hist.SplitRange(sc, []*ranger.Range{ran}, q.Tp == statistics.IndexType)
 	if !ok {
-		logutil.Logger(context.Background()).Debug("type of histogram and ranges mismatch")
+		logutil.BgLogger().Debug("type of histogram and ranges mismatch")
 		return nil
 	}
 	counts := make([]float64, 0, len(ranges))
@@ -1013,7 +1013,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 	}
 	ranges, err := q.DecodeToRanges(true)
 	if err != nil {
-		logutil.Logger(context.Background()).Debug("decode feedback ranges fail", zap.Error(err))
+		logutil.BgLogger().Debug("decode feedback ranges fail", zap.Error(err))
 		return nil
 	}
 	for i, ran := range ranges {
@@ -1025,7 +1025,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 
 		bytes, err := codec.EncodeKey(sc, nil, ran.LowVal[:rangePosition]...)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("encode keys fail", zap.Error(err))
+			logutil.BgLogger().Debug("encode keys fail", zap.Error(err))
 			continue
 		}
 		equalityCount := float64(idx.CMSketch.QueryBytes(bytes)) * idx.GetIncreaseFactor(t.Count)
@@ -1050,7 +1050,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 			continue
 		}
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("get row count by ranges fail", zap.Error(err))
+			logutil.BgLogger().Debug("get row count by ranges fail", zap.Error(err))
 			continue
 		}
 
@@ -1059,7 +1059,7 @@ func (h *Handle) DumpFeedbackForIndex(q *statistics.QueryFeedback, t *statistics
 		q.Feedback[i] = statistics.Feedback{Lower: &value, Upper: &value, Count: int64(equalityCount)}
 		err = h.dumpRangeFeedback(sc, rang, rangeCount, rangeFB)
 		if err != nil {
-			logutil.Logger(context.Background()).Debug("dump range feedback fail", zap.Error(err))
+			logutil.BgLogger().Debug("dump range feedback fail", zap.Error(err))
 			continue
 		}
 	}

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -966,7 +966,7 @@ func (coll *HistColl) NewHistCollBySelectivity(sc *stmtctx.StatementContext, sta
 			}
 			newIdxHist, err := idxHist.newIndexBySelectivity(sc, node)
 			if err != nil {
-				logutil.Logger(context.Background()).Warn("[Histogram-in-plan]: error happened when calculating row count, failed to build histogram for index %v of table %v",
+				logutil.BgLogger().Warn("[Histogram-in-plan]: error happened when calculating row count, failed to build histogram for index %v of table %v",
 					zap.String("index", idxHist.Info.Name.O), zap.String("table", idxHist.Info.Table.O), zap.Error(err))
 				continue
 			}
@@ -987,7 +987,7 @@ func (coll *HistColl) NewHistCollBySelectivity(sc *stmtctx.StatementContext, sta
 		var err error
 		splitRanges, ok := oldCol.Histogram.SplitRange(sc, node.Ranges, false)
 		if !ok {
-			logutil.Logger(context.Background()).Warn("[Histogram-in-plan]: the type of histogram and ranges mismatch")
+			logutil.BgLogger().Warn("[Histogram-in-plan]: the type of histogram and ranges mismatch")
 			continue
 		}
 		// Deal with some corner case.
@@ -1008,7 +1008,7 @@ func (coll *HistColl) NewHistCollBySelectivity(sc *stmtctx.StatementContext, sta
 			err = newHistogramBySelectivity(sc, node.ID, &oldCol.Histogram, &newCol.Histogram, splitRanges, coll.GetRowCountByColumnRanges)
 		}
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("[Histogram-in-plan]: error happened when calculating row count", zap.Error(err))
+			logutil.BgLogger().Warn("[Histogram-in-plan]: error happened when calculating row count", zap.Error(err))
 			continue
 		}
 		newColl.Columns[node.ID] = newCol

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -15,7 +15,6 @@ package statistics
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math"
 	"strings"

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -58,7 +58,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 	}
 	kvResp, err := h.Store.SendReq(tikv.NewBackoffer(context.Background(), 500), tikvReq, keyLocation.Region, time.Minute)
 	if err != nil {
-		logutil.Logger(context.Background()).Info("get MVCC by encoded key failed",
+		logutil.BgLogger().Info("get MVCC by encoded key failed",
 			zap.Binary("encodeKey", encodedKey),
 			zap.Reflect("region", keyLocation.Region),
 			zap.Binary("startKey", keyLocation.StartKey),
@@ -130,7 +130,7 @@ func (h *Helper) FetchHotRegion(rw string) (map[uint64]RegionMetric, error) {
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("close body failed", zap.Error(err))
+			logutil.BgLogger().Error("close body failed", zap.Error(err))
 		}
 	}()
 	var regionResp StoreHotRegionInfos
@@ -181,7 +181,7 @@ func (h *Helper) FetchRegionTableIndex(metrics map[uint64]RegionMetric, allSchem
 	for regionID, regionMetric := range metrics {
 		region, err := h.RegionCache.LocateRegionByID(tikv.NewBackoffer(context.Background(), 500), regionID)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("locate region failed", zap.Error(err))
+			logutil.BgLogger().Error("locate region failed", zap.Error(err))
 			continue
 		}
 
@@ -284,7 +284,7 @@ func NewFrameItemFromRegionKey(key []byte) (frame *FrameItem, err error) {
 		} else {
 			_, _, frame.IndexValues, err = tablecodec.DecodeIndexKey(key)
 		}
-		logutil.Logger(context.Background()).Warn("decode region key failed", zap.ByteString("key", key), zap.Error(err))
+		logutil.BgLogger().Warn("decode region key failed", zap.ByteString("key", key), zap.Error(err))
 		// Ignore decode errors.
 		err = nil
 		return
@@ -431,7 +431,7 @@ func (h *Helper) GetRegionsInfo() (*RegionsInfo, error) {
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("close body failed", zap.Error(err))
+			logutil.BgLogger().Error("close body failed", zap.Error(err))
 		}
 	}()
 	var regionsInfo RegionsInfo
@@ -510,7 +510,7 @@ func (h *Helper) GetStoresStat() (*StoresStat, error) {
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			logutil.Logger(context.Background()).Error("close body failed", zap.Error(err))
+			logutil.BgLogger().Error("close body failed", zap.Error(err))
 		}
 	}()
 	var storesStat StoresStat

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -342,7 +342,7 @@ func (mvcc *MVCCLevelDB) Scan(startKey, endKey []byte, limit int, startTS uint64
 	iter, currKey, err := newScanIterator(mvcc.db, startKey, endKey)
 	defer iter.Release()
 	if err != nil {
-		logutil.Logger(context.Background()).Error("scan new iterator fail", zap.Error(err))
+		logutil.BgLogger().Error("scan new iterator fail", zap.Error(err))
 		return nil
 	}
 
@@ -366,7 +366,7 @@ func (mvcc *MVCCLevelDB) Scan(startKey, endKey []byte, limit int, startTS uint64
 		skip := skipDecoder{currKey}
 		ok, err = skip.Decode(iter)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("seek to next key error", zap.Error(err))
+			logutil.BgLogger().Error("seek to next key error", zap.Error(err))
 			break
 		}
 		currKey = skip.currKey
@@ -421,7 +421,7 @@ func (mvcc *MVCCLevelDB) ReverseScan(startKey, endKey []byte, limit int, startTS
 			helper.entry.values = append(helper.entry.values, value)
 		}
 		if err != nil {
-			logutil.Logger(context.Background()).Error("unmarshal fail", zap.Error(err))
+			logutil.BgLogger().Error("unmarshal fail", zap.Error(err))
 			break
 		}
 		succ = iter.Prev()
@@ -713,7 +713,7 @@ func prewriteMutation(db *leveldb.DB, batch *leveldb.Batch, mutation *kvrpcpb.Mu
 	// Check assertions.
 	if (ok && mutation.Assertion == kvrpcpb.Assertion_NotExist) ||
 		(!ok && mutation.Assertion == kvrpcpb.Assertion_Exist) {
-		logutil.Logger(context.Background()).Error("ASSERTION FAIL!!!", zap.Stringer("mutation", mutation))
+		logutil.BgLogger().Error("ASSERTION FAIL!!!", zap.Stringer("mutation", mutation))
 	}
 
 	batch.Put(writeKey, writeValue)

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -15,7 +15,6 @@ package mocktikv
 
 import (
 	"bytes"
-	"context"
 	"math"
 	"sync"
 

--- a/store/store.go
+++ b/store/store.go
@@ -66,15 +66,15 @@ func newStoreWithRetry(path string, maxRetries int) (kv.Storage, error) {
 
 	var s kv.Storage
 	err = util.RunWithRetry(maxRetries, util.RetryInterval, func() (bool, error) {
-		logutil.Logger(context.Background()).Info("new store", zap.String("path", path))
+		logutil.BgLogger().Info("new store", zap.String("path", path))
 		s, err = d.Open(path)
 		return kv.IsTxnRetryableError(err), err
 	})
 
 	if err == nil {
-		logutil.Logger(context.Background()).Info("new store with retry success")
+		logutil.BgLogger().Info("new store with retry success")
 	} else {
-		logutil.Logger(context.Background()).Warn("new store with retry failed", zap.Error(err))
+		logutil.BgLogger().Warn("new store with retry failed", zap.Error(err))
 	}
 	return s, errors.Trace(err)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -14,7 +14,6 @@
 package store
 
 import (
-	"context"
 	"net/url"
 	"strings"
 

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -236,7 +236,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	const logSize = 4 * 1024 * 1024 // 4MB
 	if len(keys) > logEntryCount || size > logSize {
 		tableID := tablecodec.DecodeTableID(keys[0])
-		logutil.Logger(context.Background()).Info("[BIG_TXN]",
+		logutil.BgLogger().Info("[BIG_TXN]",
 			zap.Uint64("con", c.connID),
 			zap.Int64("table ID", tableID),
 			zap.Int("size", size),
@@ -253,7 +253,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	// Sanity check for startTS.
 	if txn.StartTS() == math.MaxUint64 {
 		err = errors.Errorf("try to commit with invalid txnStartTS: %d", txn.StartTS())
-		logutil.Logger(context.Background()).Error("commit failed",
+		logutil.BgLogger().Error("commit failed",
 			zap.Uint64("conn", c.connID),
 			zap.Error(err))
 		return errors.Trace(err)
@@ -350,7 +350,7 @@ func (c *twoPhaseCommitter) doActionOnKeys(bo *Backoffer, action twoPhaseCommitA
 		go func() {
 			e := c.doActionOnBatches(secondaryBo, action, batches)
 			if e != nil {
-				logutil.Logger(context.Background()).Debug("2PC async doActionOnBatches",
+				logutil.BgLogger().Debug("2PC async doActionOnBatches",
 					zap.Uint64("conn", c.connID),
 					zap.Stringer("action type", action),
 					zap.Error(e))
@@ -384,7 +384,7 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 	if len(batches) == 1 {
 		e := singleBatchActionFunc(bo, batches[0])
 		if e != nil {
-			logutil.Logger(context.Background()).Debug("2PC doActionOnBatches failed",
+			logutil.BgLogger().Debug("2PC doActionOnBatches failed",
 				zap.Uint64("conn", c.connID),
 				zap.Stringer("action type", action),
 				zap.Error(e),
@@ -427,14 +427,14 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 	var err error
 	for i := 0; i < len(batches); i++ {
 		if e := <-ch; e != nil {
-			logutil.Logger(context.Background()).Debug("2PC doActionOnBatches failed",
+			logutil.BgLogger().Debug("2PC doActionOnBatches failed",
 				zap.Uint64("conn", c.connID),
 				zap.Stringer("action type", action),
 				zap.Error(e),
 				zap.Uint64("txnStartTS", c.startTS))
 			// Cancel other requests and return the first error.
 			if cancel != nil {
-				logutil.Logger(context.Background()).Debug("2PC doActionOnBatches to cancel other actions",
+				logutil.BgLogger().Debug("2PC doActionOnBatches to cancel other actions",
 					zap.Uint64("conn", c.connID),
 					zap.Stringer("action type", action),
 					zap.Uint64("txnStartTS", c.startTS))
@@ -527,7 +527,7 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 				if conditionPair == nil {
 					return errors.Errorf("conn%d, conditionPair for key:%s should not be nil", c.connID, key)
 				}
-				logutil.Logger(context.Background()).Debug("key already exists",
+				logutil.BgLogger().Debug("key already exists",
 					zap.Uint64("conn", c.connID),
 					zap.Binary("key", key))
 				return errors.Trace(conditionPair.Err())
@@ -551,7 +551,7 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 					Primary:          lock.Primary,
 				})
 			}
-			logutil.Logger(context.Background()).Debug("prewrite encounters lock",
+			logutil.BgLogger().Debug("prewrite encounters lock",
 				zap.Uint64("conn", c.connID),
 				zap.Stringer("lock", lock))
 			locks = append(locks, lock)
@@ -781,13 +781,13 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 		if c.mu.committed {
 			// No secondary key could be rolled back after it's primary key is committed.
 			// There must be a serious bug somewhere.
-			logutil.Logger(context.Background()).Error("2PC failed commit key after primary key committed",
+			logutil.BgLogger().Error("2PC failed commit key after primary key committed",
 				zap.Error(err),
 				zap.Uint64("txnStartTS", c.startTS))
 			return errors.Trace(err)
 		}
 		// The transaction maybe rolled back by concurrent transactions.
-		logutil.Logger(context.Background()).Debug("2PC failed commit primary key",
+		logutil.BgLogger().Debug("2PC failed commit primary key",
 			zap.Error(err),
 			zap.Uint64("txnStartTS", c.startTS))
 		return err
@@ -831,7 +831,7 @@ func (c *twoPhaseCommitter) cleanupSingleBatch(bo *Backoffer, batch batchKeys) e
 	}
 	if keyErr := resp.BatchRollback.GetError(); keyErr != nil {
 		err = errors.Errorf("conn%d 2PC cleanup failed: %s", c.connID, keyErr)
-		logutil.Logger(context.Background()).Debug("2PC failed cleanup key",
+		logutil.BgLogger().Debug("2PC failed cleanup key",
 			zap.Error(err),
 			zap.Uint64("txnStartTS", c.startTS))
 		return errors.Trace(err)
@@ -930,7 +930,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) error {
 	if commitTS <= c.startTS {
 		err = errors.Errorf("conn%d Invalid transaction tso with txnStartTS=%v while txnCommitTS=%v",
 			c.connID, c.startTS, commitTS)
-		logutil.Logger(context.Background()).Error("invalid transaction", zap.Error(err))
+		logutil.BgLogger().Error("invalid transaction", zap.Error(err))
 		return errors.Trace(err)
 	}
 	c.commitTS = commitTS
@@ -1020,7 +1020,7 @@ func (c *twoPhaseCommitter) writeFinishBinlog(tp binlog.BinlogType, commitTS int
 	go func() {
 		err := binInfo.WriteBinlog(c.store.clusterID)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("failed to write binlog",
+			logutil.BgLogger().Error("failed to write binlog",
 				zap.Error(err))
 		}
 	}()

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -99,7 +99,7 @@ func NewBackoffFn(base, cap, jitter int) func(ctx context.Context, maxSleepMs in
 		case DecorrJitter:
 			sleep = int(math.Min(float64(cap), float64(base+rand.Intn(lastSleep*3-base))))
 		}
-		logutil.Logger(context.Background()).Debug("backoff",
+		logutil.BgLogger().Debug("backoff",
 			zap.Int("base", base),
 			zap.Int("sleep", sleep))
 
@@ -268,7 +268,7 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 // and never sleep more than maxSleepMs for each sleep.
 func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err error) error {
 	if strings.Contains(err.Error(), mismatchClusterID) {
-		logutil.Logger(context.Background()).Fatal("critical error", zap.Error(err))
+		logutil.BgLogger().Fatal("critical error", zap.Error(err))
 	}
 	select {
 	case <-b.ctx.Done():
@@ -294,7 +294,7 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 	if ts := b.ctx.Value(txnStartKey); ts != nil {
 		startTs = ts
 	}
-	logutil.Logger(context.Background()).Debug("retry later",
+	logutil.BgLogger().Debug("retry later",
 		zap.Error(err),
 		zap.Int("totalSleep", b.totalSleep),
 		zap.Int("maxSleep", b.maxSleep),
@@ -310,7 +310,7 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 				errMsg += "\n" + err.Error()
 			}
 		}
-		logutil.Logger(context.Background()).Warn(errMsg)
+		logutil.BgLogger().Warn(errMsg)
 		// Use the first backoff type to generate a MySQL error.
 		return b.types[0].TError()
 	}

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -124,10 +124,10 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 	defer func() {
 		if r := recover(); r != nil {
 			metrics.PanicCounter.WithLabelValues(metrics.LabelBatchRecvLoop).Inc()
-			logutil.Logger(context.Background()).Error("batchRecvLoop",
+			logutil.BgLogger().Error("batchRecvLoop",
 				zap.Reflect("r", r),
 				zap.Stack("stack"))
-			logutil.Logger(context.Background()).Info("restart batchRecvLoop")
+			logutil.BgLogger().Info("restart batchRecvLoop")
 			go c.batchRecvLoop(cfg)
 		}
 	}()
@@ -141,7 +141,7 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 				if c.isStopped() {
 					return
 				}
-				logutil.Logger(context.Background()).Error(
+				logutil.BgLogger().Error(
 					"batchRecvLoop error when receive",
 					zap.String("target", c.target),
 					zap.Error(err),
@@ -157,14 +157,14 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 				c.clientLock.Unlock()
 
 				if err == nil {
-					logutil.Logger(context.Background()).Info(
+					logutil.BgLogger().Info(
 						"batchRecvLoop re-create streaming success",
 						zap.String("target", c.target),
 					)
 					c.client = streamClient
 					break
 				}
-				logutil.Logger(context.Background()).Error(
+				logutil.BgLogger().Error(
 					"batchRecvLoop re-create streaming fail",
 					zap.String("target", c.target),
 					zap.Error(err),
@@ -433,10 +433,10 @@ func (a *connArray) batchSendLoop(cfg config.TiKVClient) {
 	defer func() {
 		if r := recover(); r != nil {
 			metrics.PanicCounter.WithLabelValues(metrics.LabelBatchSendLoop).Inc()
-			logutil.Logger(context.Background()).Error("batchSendLoop",
+			logutil.BgLogger().Error("batchSendLoop",
 				zap.Reflect("r", r),
 				zap.Stack("stack"))
-			logutil.Logger(context.Background()).Info("restart batchSendLoop")
+			logutil.BgLogger().Info("restart batchSendLoop")
 			go a.batchSendLoop(cfg)
 		}
 	}()
@@ -503,7 +503,7 @@ func (a *connArray) batchSendLoop(cfg config.TiKVClient) {
 		err := batchCommandsClient.client.Send(request)
 		batchCommandsClient.clientLock.Unlock()
 		if err != nil {
-			logutil.Logger(context.Background()).Error(
+			logutil.BgLogger().Error(
 				"batch commands send error",
 				zap.String("target", a.target),
 				zap.Error(err),
@@ -616,7 +616,7 @@ func sendBatchRequest(
 	select {
 	case connArray.batchCommandsCh <- entry:
 	case <-ctx1.Done():
-		logutil.Logger(context.Background()).Warn("send request is cancelled",
+		logutil.BgLogger().Warn("send request is cancelled",
 			zap.String("to", addr), zap.String("cause", ctx1.Err().Error()))
 		return nil, errors.Trace(ctx1.Err())
 	}
@@ -629,7 +629,7 @@ func sendBatchRequest(
 		return tikvrpc.FromBatchCommandsResponse(res), nil
 	case <-ctx1.Done():
 		atomic.StoreInt32(&entry.canceled, 1)
-		logutil.Logger(context.Background()).Warn("wait response is cancelled",
+		logutil.BgLogger().Warn("wait response is cancelled",
 			zap.String("to", addr), zap.String("cause", ctx1.Err().Error()))
 		return nil, errors.Trace(ctx1.Err())
 	}
@@ -698,7 +698,7 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		if errors.Cause(err) != io.EOF {
 			return nil, errors.Trace(err)
 		}
-		logutil.Logger(context.Background()).Debug("copstream returns nothing for the request.")
+		logutil.BgLogger().Debug("copstream returns nothing for the request.")
 	}
 	copStream.Response = first
 	return resp, nil
@@ -724,7 +724,7 @@ func (c *rpcClient) recycleIdleConnArray() {
 		conn, ok := c.conns[addr]
 		if ok {
 			delete(c.conns, addr)
-			logutil.Logger(context.Background()).Info("recycle idle connection",
+			logutil.BgLogger().Info("recycle idle connection",
 				zap.String("target", addr))
 		}
 		c.Unlock()

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -191,7 +191,7 @@ func createSession(store kv.Storage) session.Session {
 	for {
 		se, err := session.CreateSession(store)
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("[gc worker] create session", zap.Error(err))
+			logutil.BgLogger().Warn("[gc worker] create session", zap.Error(err))
 			continue
 		}
 		// Disable privilege check for gc worker session.
@@ -407,7 +407,7 @@ func (w *GCWorker) checkGCInterval(now time.Time) (bool, error) {
 	}
 
 	if lastRun != nil && lastRun.Add(*runInterval).After(now) {
-		logutil.Logger(context.Background()).Debug("[gc worker] skipping garbage collection because gc interval hasn't elapsed since last run",
+		logutil.BgLogger().Debug("[gc worker] skipping garbage collection because gc interval hasn't elapsed since last run",
 			zap.String("leaderTick on", w.uuid),
 			zap.Duration("interval", *runInterval),
 			zap.Time("last run", *lastRun))
@@ -430,7 +430,7 @@ func (w *GCWorker) calculateNewSafePoint(now time.Time) (*time.Time, error) {
 	safePoint := now.Add(-*lifeTime)
 	// We should never decrease safePoint.
 	if lastSafePoint != nil && safePoint.Before(*lastSafePoint) {
-		logutil.Logger(context.Background()).Info("[gc worker] last safe point is later than current one."+
+		logutil.BgLogger().Info("[gc worker] last safe point is later than current one."+
 			"No need to gc."+
 			"This might be caused by manually enlarging gc lifetime",
 			zap.String("leaderTick on", w.uuid),
@@ -703,7 +703,7 @@ func (w *GCWorker) checkUseDistributedGC() (bool, error) {
 	if strings.EqualFold(str, gcModeCentral) {
 		return false, nil
 	}
-	logutil.Logger(context.Background()).Warn("[gc worker] distributed mode will be used",
+	logutil.BgLogger().Warn("[gc worker] distributed mode will be used",
 		zap.String("invalid gc mode", str))
 	return true, nil
 }
@@ -891,7 +891,7 @@ func (w *gcTaskWorker) run() {
 	for task := range w.taskCh {
 		err := w.doGCForRange(task.startKey, task.endKey, task.safePoint)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("[gc worker] gc interrupted because get region error",
+			logutil.BgLogger().Error("[gc worker] gc interrupted because get region error",
 				zap.String("uuid", w.identifier),
 				zap.Binary("startKey", task.startKey),
 				zap.Binary("endKey", task.endKey),
@@ -930,7 +930,7 @@ func (w *gcTaskWorker) doGCForRange(startKey []byte, endKey []byte, safePoint ui
 		}
 
 		if err != nil {
-			logutil.Logger(context.Background()).Warn("[gc worker]",
+			logutil.BgLogger().Warn("[gc worker]",
 				zap.String("uuid", w.identifier),
 				zap.String("gc for range", fmt.Sprintf("[%d, %d)", startKey, endKey)),
 				zap.Uint64("safePoint", safePoint),
@@ -1086,7 +1086,7 @@ func (w *GCWorker) checkLeader() (bool, error) {
 		se.RollbackTxn(ctx)
 		return false, errors.Trace(err)
 	}
-	logutil.Logger(context.Background()).Debug("[gc worker] got leader", zap.String("uuid", leader))
+	logutil.BgLogger().Debug("[gc worker] got leader", zap.String("uuid", leader))
 	if leader == w.uuid {
 		err = w.saveTime(gcLeaderLeaseKey, time.Now().Add(gcWorkerLease))
 		if err != nil {
@@ -1111,7 +1111,7 @@ func (w *GCWorker) checkLeader() (bool, error) {
 		return false, errors.Trace(err)
 	}
 	if lease == nil || lease.Before(time.Now()) {
-		logutil.Logger(context.Background()).Debug("[gc worker] register as leader",
+		logutil.BgLogger().Debug("[gc worker] register as leader",
 			zap.String("uuid", w.uuid))
 		metrics.GCWorkerCounter.WithLabelValues("register_leader").Inc()
 
@@ -1144,7 +1144,7 @@ func (w *GCWorker) saveSafePoint(kv tikv.SafePointKV, key string, t uint64) erro
 	s := strconv.FormatUint(t, 10)
 	err := kv.Put(tikv.GcSavedSafePoint, s)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("save safepoint failed", zap.Error(err))
+		logutil.BgLogger().Error("save safepoint failed", zap.Error(err))
 		return errors.Trace(err)
 	}
 	return nil
@@ -1221,12 +1221,12 @@ func (w *GCWorker) loadValueFromSysTable(key string) (string, error) {
 		return "", errors.Trace(err)
 	}
 	if req.NumRows() == 0 {
-		logutil.Logger(context.Background()).Debug("[gc worker] load kv",
+		logutil.BgLogger().Debug("[gc worker] load kv",
 			zap.String("key", key))
 		return "", nil
 	}
 	value := req.GetRow(0).GetString(0)
-	logutil.Logger(context.Background()).Debug("[gc worker] load kv",
+	logutil.BgLogger().Debug("[gc worker] load kv",
 		zap.String("key", key),
 		zap.String("value", value))
 	return value, nil
@@ -1241,7 +1241,7 @@ func (w *GCWorker) saveValueToSysTable(key, value string) error {
 		return errors.New("[saveValueToSysTable session is nil]")
 	}
 	_, err := w.session.Execute(context.Background(), stmt)
-	logutil.Logger(context.Background()).Debug("[gc worker] save kv",
+	logutil.BgLogger().Debug("[gc worker] save kv",
 		zap.String("key", key),
 		zap.String("value", value),
 		zap.Error(err))
@@ -1317,7 +1317,7 @@ func NewMockGCWorker(store tikv.Storage) (*MockGCWorker, error) {
 	}
 	worker.session, err = session.CreateSession(worker.store)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("initialize MockGCWorker session fail", zap.Error(err))
+		logutil.BgLogger().Error("initialize MockGCWorker session fail", zap.Error(err))
 		return nil, errors.Trace(err)
 	}
 	privilege.BindPrivilegeManager(worker.session, nil)

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -243,7 +243,7 @@ func (s *tikvStore) runSafePointChecker() {
 				d = gcSafePointUpdateInterval
 			} else {
 				metrics.TiKVLoadSafepointCounter.WithLabelValues("fail").Inc()
-				logutil.Logger(context.Background()).Error("fail to load safepoint from pd", zap.Error(err))
+				logutil.BgLogger().Error("fail to load safepoint from pd", zap.Error(err))
 				d = gcSafePointQuickRepeatInterval
 			}
 		case <-s.Closed():
@@ -408,7 +408,7 @@ func parsePath(path string) (etcdAddrs []string, disableGC bool, err error) {
 	}
 	if strings.ToLower(u.Scheme) != "tikv" {
 		err = errors.Errorf("Uri scheme expected[tikv] but found [%s]", u.Scheme)
-		logutil.Logger(context.Background()).Error("parsePath error", zap.Error(err))
+		logutil.BgLogger().Error("parsePath error", zap.Error(err))
 		return
 	}
 	switch strings.ToLower(u.Query().Get("disableGC")) {

--- a/store/tikv/latch/latch.go
+++ b/store/tikv/latch/latch.go
@@ -290,7 +290,7 @@ func (latches *Latches) recycle(currentTS uint64) {
 		total += latch.recycle(currentTS)
 		latch.Unlock()
 	}
-	logutil.Logger(context.Background()).Debug("recycle",
+	logutil.BgLogger().Debug("recycle",
 		zap.Time("start at", time.Now()),
 		zap.Int("count", total))
 }

--- a/store/tikv/latch/latch.go
+++ b/store/tikv/latch/latch.go
@@ -15,7 +15,6 @@ package latch
 
 import (
 	"bytes"
-	"context"
 	"math/bits"
 	"sort"
 	"sync"

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -189,7 +189,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 		}
 	}
 	if len(expiredLocks) != len(locks) {
-		logutil.Logger(context.Background()).Error("BatchResolveLocks: maybe safe point is wrong!",
+		logutil.BgLogger().Error("BatchResolveLocks: maybe safe point is wrong!",
 			zap.Int("get locks", len(locks)),
 			zap.Int("expired locks", len(expiredLocks)))
 		return false, nil
@@ -208,7 +208,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 		}
 		txnInfos[l.TxnID] = uint64(status)
 	}
-	logutil.Logger(context.Background()).Info("BatchResolveLocks: lookup txn status",
+	logutil.BgLogger().Info("BatchResolveLocks: lookup txn status",
 		zap.Duration("cost time", time.Since(startTime)),
 		zap.Int("num of txn", len(txnInfos)))
 
@@ -253,7 +253,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 		return false, errors.Errorf("unexpected resolve err: %s", keyErr)
 	}
 
-	logutil.Logger(context.Background()).Info("BatchResolveLocks: resolve locks in a batch",
+	logutil.BgLogger().Info("BatchResolveLocks: resolve locks in a batch",
 		zap.Duration("cost time", time.Since(startTime)),
 		zap.Int("num of locks", len(expiredLocks)))
 	return true, nil
@@ -374,7 +374,7 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 		}
 		if keyErr := cmdResp.GetError(); keyErr != nil {
 			err = errors.Errorf("unexpected cleanup err: %s, tid: %v", keyErr, txnID)
-			logutil.Logger(context.Background()).Error("getTxnStatus error", zap.Error(err))
+			logutil.BgLogger().Error("getTxnStatus error", zap.Error(err))
 			return status, err
 		}
 		if cmdResp.CommitVersion != 0 {
@@ -435,7 +435,7 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, cl
 		}
 		if keyErr := cmdResp.GetError(); keyErr != nil {
 			err = errors.Errorf("unexpected resolve err: %s, lock: %v", keyErr, l)
-			logutil.Logger(context.Background()).Error("resolveLock error", zap.Error(err))
+			logutil.BgLogger().Error("resolveLock error", zap.Error(err))
 			return err
 		}
 		if cleanWholeRegion {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -168,7 +168,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 			// If we don't cancel, but the error code is Canceled, it must be from grpc remote.
 			// This may happen when tikv is killed and exiting.
 			// Backoff and retry in this case.
-			logutil.Logger(context.Background()).Warn("receive a grpc cancel signal from remote", zap.Error(err))
+			logutil.BgLogger().Warn("receive a grpc cancel signal from remote", zap.Error(err))
 		}
 	}
 
@@ -218,7 +218,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 	metrics.TiKVRegionErrorCounter.WithLabelValues(regionErrorToLabel(regionErr)).Inc()
 	if notLeader := regionErr.GetNotLeader(); notLeader != nil {
 		// Retry if error is `NotLeader`.
-		logutil.Logger(context.Background()).Debug("tikv reports `NotLeader` retry later",
+		logutil.BgLogger().Debug("tikv reports `NotLeader` retry later",
 			zap.String("notLeader", notLeader.String()),
 			zap.String("ctx", ctx.String()))
 		s.regionCache.UpdateLeader(ctx.Region, notLeader.GetLeader().GetStoreId(), ctx.PeerIdx)
@@ -239,7 +239,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 
 	if storeNotMatch := regionErr.GetStoreNotMatch(); storeNotMatch != nil {
 		// store not match
-		logutil.Logger(context.Background()).Warn("tikv reports `StoreNotMatch` retry later",
+		logutil.BgLogger().Warn("tikv reports `StoreNotMatch` retry later",
 			zap.Stringer("storeNotMatch", storeNotMatch),
 			zap.Stringer("ctx", ctx))
 		ctx.Store.markNeedCheck(s.regionCache.notifyCheckCh)
@@ -247,14 +247,14 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 	}
 
 	if epochNotMatch := regionErr.GetEpochNotMatch(); epochNotMatch != nil {
-		logutil.Logger(context.Background()).Debug("tikv reports `EpochNotMatch` retry later",
+		logutil.BgLogger().Debug("tikv reports `EpochNotMatch` retry later",
 			zap.Stringer("EpochNotMatch", epochNotMatch),
 			zap.Stringer("ctx", ctx))
 		err = s.regionCache.OnRegionEpochNotMatch(bo, ctx, epochNotMatch.CurrentRegions)
 		return false, errors.Trace(err)
 	}
 	if regionErr.GetServerIsBusy() != nil {
-		logutil.Logger(context.Background()).Warn("tikv reports `ServerIsBusy` retry later",
+		logutil.BgLogger().Warn("tikv reports `ServerIsBusy` retry later",
 			zap.String("reason", regionErr.GetServerIsBusy().GetReason()),
 			zap.Stringer("ctx", ctx))
 		err = bo.Backoff(boServerBusy, errors.Errorf("server is busy, ctx: %v", ctx))
@@ -264,16 +264,16 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, regi
 		return true, nil
 	}
 	if regionErr.GetStaleCommand() != nil {
-		logutil.Logger(context.Background()).Debug("tikv reports `StaleCommand`", zap.Stringer("ctx", ctx))
+		logutil.BgLogger().Debug("tikv reports `StaleCommand`", zap.Stringer("ctx", ctx))
 		return true, nil
 	}
 	if regionErr.GetRaftEntryTooLarge() != nil {
-		logutil.Logger(context.Background()).Warn("tikv reports `RaftEntryTooLarge`", zap.Stringer("ctx", ctx))
+		logutil.BgLogger().Warn("tikv reports `RaftEntryTooLarge`", zap.Stringer("ctx", ctx))
 		return false, errors.New(regionErr.String())
 	}
 	// For other errors, we only drop cache here.
 	// Because caller may need to re-split the request.
-	logutil.Logger(context.Background()).Debug("tikv reports region error",
+	logutil.BgLogger().Debug("tikv reports region error",
 		zap.Stringer("regionErr", regionErr),
 		zap.Stringer("ctx", ctx))
 	s.regionCache.InvalidateCachedRegion(ctx.Region)

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -117,7 +117,7 @@ func saveSafePoint(kv SafePointKV, key string, t uint64) error {
 	s := strconv.FormatUint(t, 10)
 	err := kv.Put(GcSavedSafePoint, s)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("save safepoint failed", zap.Error(err))
+		logutil.BgLogger().Error("save safepoint failed", zap.Error(err))
 		return errors.Trace(err)
 	}
 	return nil

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -153,7 +153,7 @@ func (s *Scanner) resolveCurrentLock(bo *Backoffer, current *pb.KvPair) error {
 }
 
 func (s *Scanner) getData(bo *Backoffer) error {
-	logutil.Logger(context.Background()).Debug("txn getData",
+	logutil.BgLogger().Debug("txn getData",
 		zap.Binary("nextStartKey", s.nextStartKey),
 		zap.Binary("nextEndKey", s.nextEndKey),
 		zap.Bool("reverse", s.reverse),
@@ -213,7 +213,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			logutil.Logger(context.Background()).Debug("scanner getData failed",
+			logutil.BgLogger().Debug("scanner getData failed",
 				zap.Stringer("regionErr", regionErr))
 			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
 			if err != nil {

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -140,7 +140,7 @@ func (s *tikvSnapshot) batchGetKeysByRegions(bo *Backoffer, keys [][]byte, colle
 	}
 	for i := 0; i < len(batches); i++ {
 		if e := <-ch; e != nil {
-			logutil.Logger(context.Background()).Debug("snapshot batchGet failed",
+			logutil.BgLogger().Debug("snapshot batchGet failed",
 				zap.Error(e),
 				zap.Uint64("txnStartTS", s.version.Ver))
 			err = e
@@ -328,7 +328,7 @@ func extractKeyErr(keyErr *pb.KeyError) error {
 	}
 	if keyErr.Abort != "" {
 		err := errors.Errorf("tikv aborts txn: %s", keyErr.GetAbort())
-		logutil.Logger(context.Background()).Warn("error", zap.Error(err))
+		logutil.BgLogger().Warn("error", zap.Error(err))
 		return errors.Trace(err)
 	}
 	return errors.Errorf("unexpected KeyError: %s", keyErr.String())
@@ -347,12 +347,12 @@ func prettyWriteKey(buf *bytes.Buffer, key []byte) {
 	if err == nil {
 		_, err1 := fmt.Fprintf(buf, "{tableID=%d, indexID=%d, indexValues={", tableID, indexID)
 		if err1 != nil {
-			logutil.Logger(context.Background()).Error("error", zap.Error(err1))
+			logutil.BgLogger().Error("error", zap.Error(err1))
 		}
 		for _, v := range indexValues {
 			_, err2 := fmt.Fprintf(buf, "%s, ", v)
 			if err2 != nil {
-				logutil.Logger(context.Background()).Error("error", zap.Error(err2))
+				logutil.BgLogger().Error("error", zap.Error(err2))
 			}
 		}
 		buf.WriteString("}}")
@@ -363,13 +363,13 @@ func prettyWriteKey(buf *bytes.Buffer, key []byte) {
 	if err == nil {
 		_, err3 := fmt.Fprintf(buf, "{tableID=%d, handle=%d}", tableID, handle)
 		if err3 != nil {
-			logutil.Logger(context.Background()).Error("error", zap.Error(err3))
+			logutil.BgLogger().Error("error", zap.Error(err3))
 		}
 		return
 	}
 
 	_, err4 := fmt.Fprintf(buf, "%#v", key)
 	if err4 != nil {
-		logutil.Logger(context.Background()).Error("error", zap.Error(err4))
+		logutil.BgLogger().Error("error", zap.Error(err4))
 	}
 }

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -100,7 +100,7 @@ func (s *testSnapshotSuite) deleteKeys(keys []kv.Key, c *C) {
 
 func (s *testSnapshotSuite) TestBatchGet(c *C) {
 	for _, rowNum := range s.rowNums {
-		logutil.Logger(context.Background()).Debug("test BatchGet",
+		logutil.BgLogger().Debug("test BatchGet",
 			zap.Int("length", rowNum))
 		txn := s.beginTxn(c)
 		for i := 0; i < rowNum; i++ {
@@ -119,7 +119,7 @@ func (s *testSnapshotSuite) TestBatchGet(c *C) {
 
 func (s *testSnapshotSuite) TestBatchGetNotExist(c *C) {
 	for _, rowNum := range s.rowNums {
-		logutil.Logger(context.Background()).Debug("test BatchGetNotExist",
+		logutil.BgLogger().Debug("test BatchGetNotExist",
 			zap.Int("length", rowNum))
 		txn := s.beginTxn(c)
 		for i := 0; i < rowNum; i++ {

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -35,7 +35,7 @@ func (s *tikvStore) SplitRegion(splitKey kv.Key) error {
 }
 
 func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
-	logutil.Logger(context.Background()).Info("start split region",
+	logutil.BgLogger().Info("start split region",
 		zap.Binary("at", splitKey))
 	bo := NewBackoffer(context.Background(), splitRegionBackoff)
 	sender := NewRegionRequestSender(s.regionCache, s.client)
@@ -52,7 +52,7 @@ func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
 			return nil, errors.Trace(err)
 		}
 		if bytes.Equal(splitKey, loc.StartKey) {
-			logutil.Logger(context.Background()).Info("skip split region",
+			logutil.BgLogger().Info("skip split region",
 				zap.Binary("at", splitKey))
 			return nil, nil
 		}
@@ -71,7 +71,7 @@ func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
 			}
 			continue
 		}
-		logutil.Logger(context.Background()).Info("split region complete",
+		logutil.BgLogger().Info("split region complete",
 			zap.Binary("at", splitKey),
 			zap.Stringer("new region left", res.SplitRegion.GetLeft()),
 			zap.Stringer("new region right", res.SplitRegion.GetRight()))
@@ -80,7 +80,7 @@ func (s *tikvStore) splitRegion(splitKey kv.Key) (*metapb.Region, error) {
 }
 
 func (s *tikvStore) scatterRegion(regionID uint64) error {
-	logutil.Logger(context.Background()).Info("start scatter region",
+	logutil.BgLogger().Info("start scatter region",
 		zap.Uint64("regionID", regionID))
 	bo := NewBackoffer(context.Background(), scatterRegionBackoff)
 	for {
@@ -94,13 +94,13 @@ func (s *tikvStore) scatterRegion(regionID uint64) error {
 		}
 		break
 	}
-	logutil.Logger(context.Background()).Info("scatter region complete",
+	logutil.BgLogger().Info("scatter region complete",
 		zap.Uint64("regionID", regionID))
 	return nil
 }
 
 func (s *tikvStore) WaitScatterRegionFinish(regionID uint64) error {
-	logutil.Logger(context.Background()).Info("wait scatter region",
+	logutil.BgLogger().Info("wait scatter region",
 		zap.Uint64("regionID", regionID))
 	bo := NewBackoffer(context.Background(), waitScatterRegionFinishBackoff)
 	logFreq := 0
@@ -108,12 +108,12 @@ func (s *tikvStore) WaitScatterRegionFinish(regionID uint64) error {
 		resp, err := s.pdClient.GetOperator(context.Background(), regionID)
 		if err == nil && resp != nil {
 			if !bytes.Equal(resp.Desc, []byte("scatter-region")) || resp.Status != pdpb.OperatorStatus_RUNNING {
-				logutil.Logger(context.Background()).Info("wait scatter region finished",
+				logutil.BgLogger().Info("wait scatter region finished",
 					zap.Uint64("regionID", regionID))
 				return nil
 			}
 			if logFreq%10 == 0 {
-				logutil.Logger(context.Background()).Info("wait scatter region",
+				logutil.BgLogger().Info("wait scatter region",
 					zap.Uint64("regionID", regionID),
 					zap.String("reverse", string(resp.Desc)),
 					zap.String("status", pdpb.OperatorStatus_name[int32(resp.Status)]))

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -329,11 +329,11 @@ func (txn *tikvTxn) Rollback() error {
 	if txn.IsPessimistic() && txn.committer != nil {
 		err := txn.rollbackPessimisticLocks()
 		if err != nil {
-			logutil.Logger(context.Background()).Error(err.Error())
+			logutil.BgLogger().Error(err.Error())
 		}
 	}
 	txn.close()
-	logutil.Logger(context.Background()).Debug("[kv] rollback txn", zap.Uint64("txnStartTS", txn.StartTS()))
+	logutil.BgLogger().Debug("[kv] rollback txn", zap.Uint64("txnStartTS", txn.StartTS()))
 	tikvTxnCmdCountWithRollback.Inc()
 
 	return nil

--- a/table/column.go
+++ b/table/column.go
@@ -141,7 +141,7 @@ func CastValues(ctx sessionctx.Context, rec []types.Datum, cols []*Column) (err 
 		if err != nil {
 			if sc.DupKeyAsWarning {
 				sc.AppendWarning(err)
-				logutil.Logger(context.Background()).Warn("CastValues failed", zap.Error(err))
+				logutil.BgLogger().Warn("CastValues failed", zap.Error(err))
 			} else {
 				return err
 			}
@@ -154,7 +154,7 @@ func CastValues(ctx sessionctx.Context, rec []types.Datum, cols []*Column) (err 
 func handleWrongUtf8Value(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
 	sc := ctx.GetSessionVars().StmtCtx
 	err := ErrTruncateWrongValue.FastGen("incorrect utf8 value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
-	logutil.Logger(context.Background()).Error("incorrect UTF-8 value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
+	logutil.BgLogger().Error("incorrect UTF-8 value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
 	// Truncate to valid utf8 string.
 	truncateVal := types.NewStringDatum(str[:i])
 	err = sc.HandleTruncate(err)

--- a/table/column.go
+++ b/table/column.go
@@ -18,7 +18,6 @@
 package table
 
 import (
-	"context"
 	"strings"
 	"time"
 	"unicode/utf8"

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -156,7 +156,7 @@ func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 		exprs, err := expression.ParseSimpleExprsWithSchema(ctx, buf.String(), schema)
 		if err != nil {
 			// If it got an error here, ddl may hang forever, so this error log is important.
-			logutil.Logger(context.Background()).Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
+			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		locateExprs = append(locateExprs, exprs[0])
@@ -174,14 +174,14 @@ func generatePartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 				}
 			}
 			if column == nil {
-				logutil.Logger(context.Background()).Warn("partition pruning not applicable", zap.String("expression", partStr))
+				logutil.BgLogger().Warn("partition pruning not applicable", zap.String("expression", partStr))
 			}
 		}
 
 		exprs, err = expression.ParseSimpleExprsWithSchema(ctx, buf.String(), schema)
 		if err != nil {
 			// If it got an error here, ddl may hang forever, so this error log is important.
-			logutil.Logger(context.Background()).Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
+			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		partitionPruneExprs = append(partitionPruneExprs, exprs[0])
@@ -209,7 +209,7 @@ func generateHashPartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error)
 		exprs, err := expression.ParseSimpleExprsWithSchema(ctx, buf.String(), schema)
 		if err != nil {
 			// If it got an error here, ddl may hang forever, so this error log is important.
-			logutil.Logger(context.Background()).Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
+			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", buf.String()), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 		partitionPruneExprs = append(partitionPruneExprs, exprs[0])
@@ -218,7 +218,7 @@ func generateHashPartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error)
 	exprs, err := expression.ParseSimpleExprsWithSchema(ctx, pi.Expr, schema)
 	if err != nil {
 		// If it got an error here, ddl may hang forever, so this error log is important.
-		logutil.Logger(context.Background()).Error("wrong table partition expression", zap.String("expression", pi.Expr), zap.Error(err))
+		logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", pi.Expr), zap.Error(err))
 		return nil, errors.Trace(err)
 	}
 	if col, ok := exprs[0].(*expression.Column); ok {
@@ -384,7 +384,7 @@ func (t *partitionedTable) UpdateRecord(ctx sessionctx.Context, h int64, currDat
 		// unlikely to happen in step2.
 		err = t.GetPartition(from).RemoveRecord(ctx, h, currData)
 		if err != nil {
-			logutil.Logger(context.Background()).Error("update partition record fails", zap.String("message", "new record inserted while old record is not removed"), zap.Error(err))
+			logutil.BgLogger().Error("update partition record fails", zap.String("message", "new record inserted while old record is not removed"), zap.Error(err))
 			return errors.Trace(err)
 		}
 		return nil

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -15,7 +15,6 @@ package tables
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"sort"
 	"strings"

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -106,7 +106,7 @@ func TableFromMeta(alloc autoid.Allocator, tblInfo *model.TableInfo) (table.Tabl
 
 		// Print some information when the column's offset isn't equal to i.
 		if colInfo.Offset != i {
-			logutil.Logger(context.Background()).Error("wrong table schema", zap.Any("table", tblInfo), zap.Any("column", colInfo), zap.Int("index", i), zap.Int("offset", colInfo.Offset), zap.Int("columnNumber", colsLen))
+			logutil.BgLogger().Error("wrong table schema", zap.Any("table", tblInfo), zap.Any("column", colInfo), zap.Int("index", i), zap.Int("offset", colInfo.Offset), zap.Int("columnNumber", colsLen))
 		}
 
 		col := table.ToColumn(colInfo)
@@ -780,14 +780,14 @@ func (t *tableCommon) removeRowIndices(ctx sessionctx.Context, h int64, rec []ty
 	for _, v := range t.DeletableIndices() {
 		vals, err := v.FetchValues(rec, nil)
 		if err != nil {
-			logutil.Logger(context.Background()).Info("remove row index failed", zap.Any("index", v.Meta()), zap.Uint64("txnStartTS", txn.StartTS()), zap.Int64("handle", h), zap.Any("record", rec), zap.Error(err))
+			logutil.BgLogger().Info("remove row index failed", zap.Any("index", v.Meta()), zap.Uint64("txnStartTS", txn.StartTS()), zap.Int64("handle", h), zap.Any("record", rec), zap.Error(err))
 			return err
 		}
 		if err = v.Delete(ctx.GetSessionVars().StmtCtx, txn, vals, h, txn); err != nil {
 			if v.Meta().State != model.StatePublic && kv.ErrNotExist.Equal(err) {
 				// If the index is not in public state, we may have not created the index,
 				// or already deleted the index, so skip ErrNotExist error.
-				logutil.Logger(context.Background()).Debug("row index not exists", zap.Any("index", v.Meta()), zap.Uint64("txnStartTS", txn.StartTS()), zap.Int64("handle", h))
+				logutil.BgLogger().Debug("row index not exists", zap.Any("index", v.Meta()), zap.Uint64("txnStartTS", txn.StartTS()), zap.Int64("handle", h))
 				continue
 			}
 			return err
@@ -838,7 +838,7 @@ func (t *tableCommon) IterRecords(ctx sessionctx.Context, startKey kv.Key, cols 
 		return nil
 	}
 
-	logutil.Logger(context.Background()).Debug("iterate records", zap.ByteString("startKey", startKey), zap.ByteString("key", it.Key()), zap.ByteString("value", it.Value()))
+	logutil.BgLogger().Debug("iterate records", zap.ByteString("startKey", startKey), zap.ByteString("key", it.Key()), zap.ByteString("value", it.Value()))
 
 	colMap := make(map[int64]*types.FieldType)
 	for _, col := range cols {

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -18,7 +18,6 @@
 package tables
 
 import (
-	"context"
 	"encoding/binary"
 	"math"
 	"strings"

--- a/types/datum.go
+++ b/types/datum.go
@@ -1245,7 +1245,7 @@ func (d *Datum) convertToMysqlEnum(sc *stmtctx.StatementContext, target *FieldTy
 		e, err = ParseEnumValue(target.Elems, uintDatum.GetUint64())
 	}
 	if err != nil {
-		logutil.Logger(context.Background()).Error("convert to MySQL enum failed", zap.Error(err))
+		logutil.BgLogger().Error("convert to MySQL enum failed", zap.Error(err))
 		err = errors.Trace(ErrTruncated)
 	}
 	ret.SetValue(e)

--- a/types/datum.go
+++ b/types/datum.go
@@ -14,7 +14,6 @@
 package types
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"sort"

--- a/types/time.go
+++ b/types/time.go
@@ -15,7 +15,6 @@ package types
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"math"
 	"regexp"

--- a/types/time.go
+++ b/types/time.go
@@ -305,7 +305,7 @@ func (t Time) ToNumber() *MyDecimal {
 
 	s, err := t.DateFormat(tfStr)
 	if err != nil {
-		logutil.Logger(context.Background()).Error("[fatal] never happen because we've control the format!")
+		logutil.BgLogger().Error("[fatal] never happen because we've control the format!")
 	}
 
 	if t.Fsp > 0 {

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -129,7 +129,7 @@ func CancelJobs(txn kv.Transaction, ids []int64) ([]error, error) {
 		found := false
 		for j, job := range jobs {
 			if id != job.ID {
-				logutil.Logger(context.Background()).Debug("the job that needs to be canceled isn't equal to current job",
+				logutil.BgLogger().Debug("the job that needs to be canceled isn't equal to current job",
 					zap.Int64("need to canceled job ID", id),
 					zap.Int64("current job ID", job.ID))
 				continue
@@ -688,7 +688,7 @@ func iterRecords(sessCtx sessionctx.Context, retriever kv.Retriever, t table.Tab
 		return nil
 	}
 
-	logutil.Logger(context.Background()).Debug("record",
+	logutil.BgLogger().Debug("record",
 		zap.Binary("startKey", startKey),
 		zap.Binary("key", it.Key()),
 		zap.Binary("value", it.Value()))

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -14,7 +14,6 @@
 package admin
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"sort"

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -150,5 +150,5 @@ func logExpensiveQuery(costTime time.Duration, info *util.ProcessInfo) {
 	}
 	logFields = append(logFields, zap.String("sql", sql))
 
-	logutil.Logger(context.Background()).Warn("expensive_query", logFields...)
+	logutil.BgLogger().Warn("expensive_query", logFields...)
 }

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -14,7 +14,6 @@
 package expensivequery
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"

--- a/util/kvencoder/kv_encoder.go
+++ b/util/kvencoder/kv_encoder.go
@@ -257,7 +257,7 @@ func initGlobal() error {
 
 	if storeGlobal != nil {
 		if err1 := storeGlobal.Close(); err1 != nil {
-			logutil.Logger(context.Background()).Error("storeGlobal close error", zap.Error(err1))
+			logutil.BgLogger().Error("storeGlobal close error", zap.Error(err1))
 		}
 	}
 	if domGlobal != nil {

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -245,8 +245,6 @@ var SlowQueryLogger = log.StandardLogger()
 // SlowQueryZapLogger is used to log slow query, InitZapLogger will modify it according to config file.
 var SlowQueryZapLogger = zaplog.L()
 
-var bgctxLogger = zaplog.L()
-
 // InitLogger initializes PD's logger.
 func InitLogger(cfg *LogConfig) error {
 	log.SetLevel(stringToLogLevel(cfg.Level))
@@ -284,7 +282,6 @@ func InitZapLogger(cfg *LogConfig) error {
 		return errors.Trace(err)
 	}
 	zaplog.ReplaceGlobals(gl, props)
-	bgctxLogger = gl
 
 	if len(cfg.SlowQueryFile) != 0 {
 		sqfCfg := zaplog.FileLogConfig{
@@ -335,7 +332,7 @@ func Logger(ctx context.Context) *zap.Logger {
 
 // BgLogger is alias of `logutil.BgLogger()`
 func BgLogger() *zap.Logger {
-	return bgctxLogger
+	return zaplog.L()
 }
 
 // WithConnID attaches connId to context.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -245,6 +245,8 @@ var SlowQueryLogger = log.StandardLogger()
 // SlowQueryZapLogger is used to log slow query, InitZapLogger will modify it according to config file.
 var SlowQueryZapLogger = zaplog.L()
 
+var bgctxLogger = zaplog.L()
+
 // InitLogger initializes PD's logger.
 func InitLogger(cfg *LogConfig) error {
 	log.SetLevel(stringToLogLevel(cfg.Level))
@@ -282,6 +284,7 @@ func InitZapLogger(cfg *LogConfig) error {
 		return errors.Trace(err)
 	}
 	zaplog.ReplaceGlobals(gl, props)
+	bgctxLogger = gl
 
 	if len(cfg.SlowQueryFile) != 0 {
 		sqfCfg := zaplog.FileLogConfig{
@@ -328,6 +331,11 @@ func Logger(ctx context.Context) *zap.Logger {
 		return ctxlogger
 	}
 	return zaplog.L()
+}
+
+// BgLogger is alias of `logutil.BgLogger()`
+func BgLogger() *zap.Logger {
+	return bgctxLogger
 }
 
 // WithConnID attaches connId to context.

--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -55,7 +55,7 @@ func (a *LogOnExceed) Action(t *Tracker) {
 	if !a.acted {
 		a.acted = true
 		if a.logHook == nil {
-			logutil.Logger(context.Background()).Warn("memory exceeds quota",
+			logutil.BgLogger().Warn("memory exceeds quota",
 				zap.Error(errMemExceedThreshold.GenWithStackByArgs(t.label, t.BytesConsumed(), t.bytesLimit, t.String())))
 			return
 		}

--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -14,7 +14,6 @@
 package memory
 
 import (
-	"context"
 	"fmt"
 	"sync"
 

--- a/util/misc.go
+++ b/util/misc.go
@@ -73,7 +73,7 @@ func WithRecovery(exec func(), recoverFn func(r interface{})) {
 			recoverFn(r)
 		}
 		if r != nil {
-			logutil.Logger(context.Background()).Error("panic in the recoverable goroutine",
+			logutil.BgLogger().Error("panic in the recoverable goroutine",
 				zap.Reflect("r", r),
 				zap.Stack("stack trace"))
 		}
@@ -111,7 +111,7 @@ func SyntaxError(err error) error {
 	if err == nil {
 		return nil
 	}
-	logutil.Logger(context.Background()).Error("syntax error", zap.Error(err))
+	logutil.BgLogger().Error("syntax error", zap.Error(err))
 
 	// If the error is already a terror with stack, pass it through.
 	if errors.HasStack(err) {

--- a/util/misc.go
+++ b/util/misc.go
@@ -14,7 +14,6 @@
 package util
 
 import (
-	"context"
 	"runtime"
 	"strings"
 	"time"

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -38,7 +38,7 @@ var (
 
 // PrintTiDBInfo prints the TiDB version information.
 func PrintTiDBInfo() {
-	logutil.Logger(context.Background()).Info("Welcome to TiDB.",
+	logutil.BgLogger().Info("Welcome to TiDB.",
 		zap.String("Release Version", mysql.TiDBReleaseVersion),
 		zap.String("Git Commit Hash", TiDBGitHash),
 		zap.String("Git Branch", TiDBGitBranch),
@@ -51,7 +51,7 @@ func PrintTiDBInfo() {
 	if err != nil {
 		panic(err)
 	}
-	logutil.Logger(context.Background()).Info("loaded config", zap.ByteString("config", configJSON))
+	logutil.BgLogger().Info("loaded config", zap.ByteString("config", configJSON))
 }
 
 // GetTiDBInfo returns the git hash and build time of this tidb-server binary.

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -15,7 +15,6 @@ package printer
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 

--- a/util/signal/signal_posix.go
+++ b/util/signal/signal_posix.go
@@ -51,7 +51,7 @@ func SetupSignalHandler(shudownFunc func(bool)) {
 
 	go func() {
 		sig := <-closeSignalChan
-		logutil.Logger(context.Background()).Info("got signal to exit", zap.Stringer("signal", sig))
+		logutil.BgLogger().Info("got signal to exit", zap.Stringer("signal", sig))
 		shudownFunc(sig == syscall.SIGQUIT)
 	}()
 }

--- a/util/signal/signal_posix.go
+++ b/util/signal/signal_posix.go
@@ -15,7 +15,6 @@
 package signal
 
 import (
-	"context"
 	"log"
 	"os"
 	"os/signal"

--- a/util/signal/signal_windows.go
+++ b/util/signal/signal_windows.go
@@ -34,7 +34,7 @@ func SetupSignalHandler(shudownFunc func(bool)) {
 
 	go func() {
 		sig := <-closeSignalChan
-		logutil.Logger(context.Background()).Info("got signal to exit", zap.Stringer("signal", sig))
+		logutil.BgLogger().Info("got signal to exit", zap.Stringer("signal", sig))
 		shudownFunc(sig == syscall.SIGQUIT)
 	}()
 }

--- a/util/systimemon/systime_mon.go
+++ b/util/systimemon/systime_mon.go
@@ -14,7 +14,6 @@
 package systimemon
 
 import (
-	"context"
 	"time"
 
 	"github.com/pingcap/tidb/util/logutil"

--- a/util/systimemon/systime_mon.go
+++ b/util/systimemon/systime_mon.go
@@ -23,7 +23,7 @@ import (
 
 // StartMonitor calls systimeErrHandler if system time jump backward.
 func StartMonitor(now func() time.Time, systimeErrHandler func(), successCallback func()) {
-	logutil.Logger(context.Background()).Info("start system time monitor")
+	logutil.BgLogger().Info("start system time monitor")
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()
 	tickCount := 0
@@ -31,7 +31,7 @@ func StartMonitor(now func() time.Time, systimeErrHandler func(), successCallbac
 		last := now().UnixNano()
 		<-tick.C
 		if now().UnixNano() < last {
-			logutil.Logger(context.Background()).Error("system time jump backward", zap.Int64("last", last))
+			logutil.BgLogger().Error("system time jump backward", zap.Int64("last", last))
 			systimeErrHandler()
 		}
 		// call sucessCallback per second.

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -14,7 +14,6 @@
 package timeutil
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -76,9 +76,9 @@ func InferSystemTZ() string {
 			if err2 == nil {
 				return name
 			}
-			logutil.Logger(context.Background()).Error("infer timezone failed", zap.Error(err2))
+			logutil.BgLogger().Error("infer timezone failed", zap.Error(err2))
 		}
-		logutil.Logger(context.Background()).Error("locate timezone files failed", zap.Error(err1))
+		logutil.BgLogger().Error("locate timezone files failed", zap.Error(err1))
 	case tz != "" && tz != "UTC":
 		for _, source := range zoneSources {
 			if _, err := os.Stat(source + tz); err == nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Lots of code snippets use `logutil.Logger(context.Background())'` to retrieve a logger and no necessary extra cost will consume in `logutil.Logger` function. 

This PR adds a simple function which returns a global logger directly.

1. The simple function will be inlined at the call site to eliminate the cost.
2. Eliminate the virtual function call cost of `ctx.Value()`

### What is changed and how it works?

1. Define the function `logutil.BgLogger()`
2. Replace 'logutil.Logger(context.Background())' with 'logutil.BgLogger()' 
3. Fix imports

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
