### PR TITLE
executor: uses `memzero` to reset StatementContext to avoid allocating memory.

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1302,10 +1302,13 @@ func (e *UnionExec) Close() error {
 // Before every execution, we must clear statement context.
 func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	vars := ctx.GetSessionVars()
-	sc := &stmtctx.StatementContext{
-		TimeZone:   vars.Location(),
-		MemTracker: memory.NewTracker(stringutil.MemoizeStr(s.Text), vars.MemQuotaQuery),
-	}
+	sc := vars.StmtCtx
+
+	// Reset StatementContext
+	*sc = stmtctx.StatementContext{}
+	sc.TimeZone = vars.Location()
+	sc.MemTracker = memory.NewTracker(stringutil.MemoizeStr(s.Text), vars.MemQuotaQuery)
+
 	switch config.GetGlobalConfig().OOMAction {
 	case config.OOMActionCancel:
 		action := &memory.PanicOnExceed{ConnID: ctx.GetSessionVars().ConnectionID}


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR uses `memzero` to reset StatementContext to avoid allocating memory.

See: https://godbolt.org/z/dUdzWa

### What is changed and how it works?

See diff.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

