### PR TITLE
Revert "ddl: fix race in table lock config"

### DIFF
--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
@@ -410,22 +409,4 @@ func (s *testSerialSuite) TestCanceledJobTakeTime(c *C) {
 	assertErrorCode(c, tk, "alter table t_cjtt add column b int", mysql.ErrNoSuchTable)
 	sub := time.Since(startTime)
 	c.Assert(sub, Less, ddl.WaitTimeWhenErrorOccured)
-}
-
-func (s *testSerialSuite) TestTableLocksEnable(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1")
-	defer tk.MustExec("drop table if exists t1")
-	tk.MustExec("create table t1 (a int)")
-	// recover table lock config.
-	originValue := config.GetGlobalConfig().EnableTableLock
-	defer func() {
-		config.GetGlobalConfig().EnableTableLock = originValue
-	}()
-
-	// Test for enable table lock config.
-	config.GetGlobalConfig().EnableTableLock = false
-	tk.MustExec("lock tables t1 write")
-	checkTableLock(c, tk.Se, "test", "t1", model.TableLockNone)
 }


### PR DESCRIPTION
Reverts pingcap/tidb#10848
The pingcap/tidb#10855 fixes this data race, and pingcap/tidb#10848 may cause the data race that was previously repaired by pingcap/tidb#10855.