### PR TITLE
ddl: fix data race

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -583,7 +583,7 @@ func hasRootPrivilege() bool {
 }
 
 // TableLockEnabled uses to check whether enabled the table lock feature.
-func TableLockEnabled() bool {
+var TableLockEnabled = func() bool {
 	return GetGlobalConfig().EnableTableLock
 }
 

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -80,6 +80,14 @@ type testDBSuite struct {
 	autoIDStep int64
 }
 
+var tableLockEnabled uint32 = 0
+
+func init() {
+	config.TableLockEnabled = func() bool {
+		return atomic.LoadUint32(&tableLockEnabled) > 0
+	}
+}
+
 func setUpSuite(s *testDBSuite, c *C) {
 	var err error
 
@@ -90,7 +98,7 @@ func setUpSuite(s *testDBSuite, c *C) {
 	s.autoIDStep = autoid.GetStep()
 	ddl.WaitTimeWhenErrorOccured = 0
 	// Test for table lock.
-	config.GetGlobalConfig().EnableTableLock = true
+	atomic.StoreUint32(&tableLockEnabled, 1)
 
 	s.cluster = mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(s.cluster)

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -425,7 +425,7 @@ func (s *testSerialSuite) TestTableLocksEnable(c *C) {
 	}()
 
 	// Test for enable table lock config.
-	atomic.StoreUint32(&tableLockEnabled, 1)
+	atomic.StoreUint32(&tableLockEnabled, 0)
 	tk.MustExec("lock tables t1 write")
 	checkTableLock(c, tk.Se, "test", "t1", model.TableLockNone)
 }

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -25,7 +26,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
@@ -419,13 +419,13 @@ func (s *testSerialSuite) TestTableLocksEnable(c *C) {
 	defer tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (a int)")
 	// recover table lock config.
-	originValue := config.GetGlobalConfig().EnableTableLock
+	originValue := atomic.LoadUint32(&tableLockEnabled)
 	defer func() {
-		config.GetGlobalConfig().EnableTableLock = originValue
+		atomic.StoreUint32(&tableLockEnabled, originValue)
 	}()
 
 	// Test for enable table lock config.
-	config.GetGlobalConfig().EnableTableLock = false
+	atomic.StoreUint32(&tableLockEnabled, 1)
 	tk.MustExec("lock tables t1 write")
 	checkTableLock(c, tk.Se, "test", "t1", model.TableLockNone)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix ddl test data race

```
==================
WARNING: DATA RACE
Read at 0x00000402bcf2 by goroutine 195:
  github.com/pingcap/tidb/planner/core.CheckTableLock()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/config/config.go:587 +0x82
  github.com/pingcap/tidb/planner.Optimize()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:53 +0x4d5
  github.com/pingcap/tidb/executor.(*Compiler).compile()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:78 +0x268
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:55 +0x82f
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1015 +0xd4
  github.com/pingcap/tidb/session.execRestrictedSQL()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:794 +0xb2
  github.com/pingcap/tidb/session.(*session).ExecRestrictedSQL()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:749 +0x19a
  github.com/pingcap/tidb/bindinfo.(*BindHandle).Update()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/bindinfo/handle.go:102 +0xea
  github.com/pingcap/tidb/domain.(*Domain).loadBindInfoLoop.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:832 +0x201

Previous write at 0x00000402bcf2 by goroutine 259:
  github.com/pingcap/tidb/ddl_test.setUpSuite()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/db_test.go:93 +0x1b4
  github.com/pingcap/tidb/ddl_test.(*testDBSuite).SetUpSuite()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/db_test.go:123 +0x42
  github.com/pingcap/tidb/ddl_test.(*testDBSuite1).SetUpSuite()
      <autogenerated>:1 +0x63
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).runFixture.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x172
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Goroutine 195 (running) created at:
  github.com/pingcap/tidb/domain.(*Domain).loadBindInfoLoop()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:823 +0x6c
  github.com/pingcap/tidb/domain.(*Domain).LoadBindInfoLoop()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:816 +0x149
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1543 +0x3f7
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:895 +0x37f
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:893 +0x352
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:891 +0x325
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:889 +0x2f8
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:887 +0x2cb
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:885 +0x29e
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:883 +0x271
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:881 +0x244
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:879 +0x217
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:877 +0x1ea
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:875 +0x1bd
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:873 +0x190
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:872 +0x163
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:871 +0x136
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:869 +0x109
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:867 +0xdc
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:865 +0x5b
  github.com/pingcap/tidb/session.bootstrap()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:289 +0x1a3
  github.com/pingcap/tidb/session.runInBootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1577 +0x167
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1493 +0x97f
  github.com/pingcap/tidb/ddl_test.(*testStateChangeSuite).SetUpSuite()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/db_change_test.go:62 +0x1ed
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).runFixture.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:785 +0x172
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Goroutine 259 (running) created at:
  github.com/pingcap/check.(*suiteRunner).forkCall()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a7
  github.com/pingcap/check.(*suiteRunner).runFixture()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:737 +0x83
  github.com/pingcap/check.(*suiteRunner).asyncRun()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:639 +0x2db
  github.com/pingcap/check.parallelRun()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:135 +0x73
  github.com/pingcap/check.RunAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:118 +0x269
  github.com/pingcap/check.TestingT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:91 +0x770
  github.com/pingcap/tidb/ddl.TestT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_test.go:103 +0x1e8
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163
==================
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None