### PR TITLE
store/tikv: fix insert on dup update for pessimistic transaction

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -461,6 +461,11 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		}
 	}
 	txnCtx.SetForUpdateTS(newForUpdateTS)
+	txn, err := a.Ctx.Txn(true)
+	if err != nil {
+		return nil, err
+	}
+	txn.SetOption(kv.SnapshotTS, newForUpdateTS)
 	e, err := a.buildExecutor()
 	if err != nil {
 		return nil, err

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -47,6 +47,8 @@ const (
 	KeyOnly
 	// Pessimistic is defined for pessimistic lock
 	Pessimistic
+	// SnapshotTS is defined to set snapshot ts.
+	SnapshotTS
 )
 
 // Priority value for transaction priority.

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -19,6 +19,8 @@ type UnionStore interface {
 	MemBuffer
 	// Returns related condition pair
 	LookupConditionPair(k Key) *conditionPair
+	// DeleteConditionPair deletes a condition pair.
+	DeleteConditionPair(k Key)
 	// WalkBuffer iterates all buffered kv pairs.
 	WalkBuffer(f func(k Key, v []byte) error) error
 	// SetOption sets an option with a value, when val is nil, uses the default
@@ -215,6 +217,10 @@ func (us *unionStore) LookupConditionPair(k Key) *conditionPair {
 		return c
 	}
 	return nil
+}
+
+func (us *unionStore) DeleteConditionPair(k Key) {
+	delete(us.lazyConditionPairs, string(k))
 }
 
 // SetOption implements the UnionStore SetOption interface.

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -244,3 +244,16 @@ func (s *testPessimisticSuite) TestFirstStatementFail(c *C) {
 	tk.MustExec("insert first values (2)")
 	tk.MustExec("commit")
 }
+
+func (s *testPessimisticSuite) TestInsertOnDup(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists dup")
+	tk.MustExec("create table dup (id int primary key, c int)")
+	tk.MustExec("begin pessimistic")
+
+	tk2.MustExec("insert dup values (1, 1)")
+	tk.MustExec("insert dup values (1, 1) on duplicate key update c = c + 1")
+	tk.MustExec("commit")
+	tk.MustQuery("select * from dup").Check(testkit.Rows("1 2"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`INSERT ON DUPLICATE KEY UPDATE` returns duplicated key error in pessimistic transaction mode.

### What is changed and how it works?
- Update `SnapshotTS` when we get new `forUpdateTS`
- Remove condition pairs when we `LockKeys` failed.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change

Related changes

 - Need to cherry-pick to the release branch
