### PR TITLE
ddl: add an error about unsupported adding index to generated columns

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -547,7 +547,13 @@ func (s *testIntegrationSuite2) TestNullGeneratedColumn(c *C) {
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
 
 	tk.MustExec("insert into t values()")
-	tk.MustExec("alter table t add index idx_c(c)")
+
+	// Currently TiDB not support adding an index on the virtual generated column.
+	// Tests below should be uncommented in the future.
+	// tk.MustExec("alter table t add index idx_c(c)")
+	_, err := tk.Exec("alter table t add index idx_c(c)")
+	c.Assert(err.Error(), Equals, "[ddl:3106]'adding index' is not supported for generated columns.")
+
 	tk.MustExec("drop table t")
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add an error about unsupported adding index to generated columns by `alter table` or `create index`.

We don't support this operation, but It is only mentioned in the [documentation](https://github.com/pingcap/docs/blob/master/v2.1/sql/generated-columns.md#limitations).

### What is changed and how it works?
- Add a check to the `createIndex()` function
- Modify existing tests. For those successful, invert the assertion; for those failed, change the error asserting into a proper type.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
