### PR TITLE
session: don't change the DDL lease when doing bootstrap

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1405,13 +1405,6 @@ func getHostByIP(ip string) []string {
 	return addrs
 }
 
-func chooseMinLease(n1 time.Duration, n2 time.Duration) time.Duration {
-	if n1 <= n2 {
-		return n1
-	}
-	return n2
-}
-
 // CreateSession4Test creates a new session environment for test.
 func CreateSession4Test(store kv.Storage) (Session, error) {
 	s, err := CreateSession(store)
@@ -1564,14 +1557,11 @@ func GetDomain(store kv.Storage) (*domain.Domain, error) {
 // bootstrap quickly, after bootstrapped, we will reset the lease time.
 // TODO: Using a bootstrap tool for doing this may be better later.
 func runInBootstrapSession(store kv.Storage, bootstrap func(Session)) {
-	saveLease := schemaLease
-	schemaLease = chooseMinLease(schemaLease, 100*time.Millisecond)
 	s, err := createSession(store)
 	if err != nil {
 		// Bootstrap fail will cause program exit.
 		logutil.Logger(context.Background()).Fatal("createSession error", zap.Error(err))
 	}
-	schemaLease = saveLease
 
 	s.SetValue(sessionctx.Initing, true)
 	bootstrap(s)

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -63,10 +63,8 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 		return
 	}
 
-	ddlLease := time.Duration(0)
-	statisticLease := time.Duration(0)
-	ddlLease = schemaLease
-	statisticLease = statsLease
+	ddlLease := schemaLease
+	statisticLease := statsLease
 	err = util.RunWithRetry(util.DefaultMaxRetries, util.RetryInterval, func() (retry bool, err1 error) {
 		logutil.Logger(context.Background()).Info("new domain",
 			zap.String("store", store.UUID()),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In the case of a rolling upgrade, in general, the old TiDB is owner, but if all the old TiDBs are not the owner because of network problems with the PD. Then the new TiDB is owner, and at this point it needs to do bootstrap, and the lease for bootstrap is 100ms. If the DDL operation that needs to be done at this time encounters a situation of downgrading to 2*lease, there may be a problem.

### What is changed and how it works?
We don't change the DDL lease when doing bootstrap.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. --> 

 - No code

Related changes

 - Need to cherry-pick to the release branch
