### PR TITLE
*: let baseFuncDesc.typeInfer return error instead of panic(#10910)

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/util/testkit"
@@ -338,6 +339,15 @@ func (s *testSuite) TestAggregation(c *C) {
 	tk.MustExec("insert into t value(0), (-0.9871), (-0.9871)")
 	tk.MustQuery("select 10 from t group by a").Check(testkit.Rows("10", "10"))
 	tk.MustQuery("select sum(a) from (select a from t union all select a from t) tmp").Check(testkit.Rows("-3.9484"))
+	_, err = tk.Exec("select std(a) from t")
+	c.Assert(errors.Cause(err).Error(), Equals, "unsupported agg function: std")
+	_, err = tk.Exec("select stddev(a) from t")
+	c.Assert(errors.Cause(err).Error(), Equals, "unsupported agg function: stddev")
+	_, err = tk.Exec("select stddev_pop(a) from t")
+	c.Assert(errors.Cause(err).Error(), Equals, "unsupported agg function: stddev_pop")
+	_, err = tk.Exec("select std_samp(a) from t")
+	// TODO: Fix this error message.
+	c.Assert(errors.Cause(err).Error(), Equals, "[expression:1305]FUNCTION std_samp does not exist")
 }
 
 func (s *testSuite) TestStreamAggPushDown(c *C) {

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -685,7 +685,8 @@ func (s *testExecSuite) TestStreamAggRequiredRows(c *C) {
 		childCols := ds.Schema().Columns
 		schema := expression.NewSchema(childCols...)
 		groupBy := []expression.Expression{childCols[1]}
-		aggFunc := aggregation.NewAggFuncDesc(sctx, testCase.aggFunc, []expression.Expression{childCols[0]}, true)
+		aggFunc, err := aggregation.NewAggFuncDesc(sctx, testCase.aggFunc, []expression.Expression{childCols[0]}, true)
+		c.Assert(err, IsNil)
 		aggFuncs := []*aggregation.AggFuncDesc{aggFunc}
 		exec := buildStreamAggExecutor(sctx, ds, schema, aggFuncs, groupBy)
 		c.Assert(exec.Open(ctx), IsNil)
@@ -744,7 +745,8 @@ func (s *testExecSuite) TestHashAggParallelRequiredRows(c *C) {
 			childCols := ds.Schema().Columns
 			schema := expression.NewSchema(childCols...)
 			groupBy := []expression.Expression{childCols[1]}
-			aggFunc := aggregation.NewAggFuncDesc(sctx, testCase.aggFunc, []expression.Expression{childCols[0]}, hasDistinct)
+			aggFunc, err := aggregation.NewAggFuncDesc(sctx, testCase.aggFunc, []expression.Expression{childCols[0]}, hasDistinct)
+			c.Assert(err, IsNil)
 			aggFuncs := []*aggregation.AggFuncDesc{aggFunc}
 			exec := buildHashAggExecutor(sctx, ds, schema, aggFuncs, groupBy)
 			c.Assert(exec.Open(ctx), IsNil)

--- a/expression/aggregation/aggregation_test.go
+++ b/expression/aggregation/aggregation_test.go
@@ -58,7 +58,9 @@ func (s *testAggFuncSuit) TestAvg(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	avgFunc := NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	avgFunc := desc.GetAggFunc(ctx)
 	evalCtx := avgFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := avgFunc.GetResult(evalCtx)
@@ -71,12 +73,14 @@ func (s *testAggFuncSuit) TestAvg(c *C) {
 	result = avgFunc.GetResult(evalCtx)
 	needed := types.NewDecFromStringForTest("67.000000000000000000000000000000")
 	c.Assert(result.GetMysqlDecimal().Compare(needed) == 0, IsTrue)
-	err := avgFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
+	err = avgFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
 	c.Assert(err, IsNil)
 	result = avgFunc.GetResult(evalCtx)
 	c.Assert(result.GetMysqlDecimal().Compare(needed) == 0, IsTrue)
 
-	distinctAvgFunc := NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{col}, true).GetAggFunc(ctx)
+	desc, err = NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{col}, true)
+	c.Assert(err, IsNil)
+	distinctAvgFunc := desc.GetAggFunc(ctx)
 	evalCtx = distinctAvgFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 	for _, row := range s.rows {
 		err := distinctAvgFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
@@ -105,7 +109,8 @@ func (s *testAggFuncSuit) TestAvgFinalMode(c *C) {
 		Index:   1,
 		RetType: types.NewFieldType(mysql.TypeNewDecimal),
 	}
-	aggFunc := NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{cntCol, sumCol}, false)
+	aggFunc, err := NewAggFuncDesc(s.ctx, ast.AggFuncAvg, []expression.Expression{cntCol, sumCol}, false)
+	c.Assert(err, IsNil)
 	aggFunc.Mode = FinalMode
 	avgFunc := aggFunc.GetAggFunc(ctx)
 	evalCtx := avgFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
@@ -125,7 +130,9 @@ func (s *testAggFuncSuit) TestSum(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	sumFunc := NewAggFuncDesc(s.ctx, ast.AggFuncSum, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncSum, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	sumFunc := desc.GetAggFunc(ctx)
 	evalCtx := sumFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := sumFunc.GetResult(evalCtx)
@@ -138,14 +145,16 @@ func (s *testAggFuncSuit) TestSum(c *C) {
 	result = sumFunc.GetResult(evalCtx)
 	needed := types.NewDecFromStringForTest("338350")
 	c.Assert(result.GetMysqlDecimal().Compare(needed) == 0, IsTrue)
-	err := sumFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
+	err = sumFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
 	c.Assert(err, IsNil)
 	result = sumFunc.GetResult(evalCtx)
 	c.Assert(result.GetMysqlDecimal().Compare(needed) == 0, IsTrue)
 	partialResult := sumFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetMysqlDecimal().Compare(needed) == 0, IsTrue)
 
-	distinctSumFunc := NewAggFuncDesc(s.ctx, ast.AggFuncSum, []expression.Expression{col}, true).GetAggFunc(ctx)
+	desc, err = NewAggFuncDesc(s.ctx, ast.AggFuncSum, []expression.Expression{col}, true)
+	c.Assert(err, IsNil)
+	distinctSumFunc := desc.GetAggFunc(ctx)
 	evalCtx = distinctSumFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 	for _, row := range s.rows {
 		err := distinctSumFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
@@ -162,14 +171,16 @@ func (s *testAggFuncSuit) TestBitAnd(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	bitAndFunc := NewAggFuncDesc(s.ctx, ast.AggFuncBitAnd, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncBitAnd, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	bitAndFunc := desc.GetAggFunc(ctx)
 	evalCtx := bitAndFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := bitAndFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(math.MaxUint64))
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(1)).ToRow()
-	err := bitAndFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
+	err = bitAndFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
 	c.Assert(err, IsNil)
 	result = bitAndFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(1))
@@ -238,14 +249,16 @@ func (s *testAggFuncSuit) TestBitOr(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	bitOrFunc := NewAggFuncDesc(s.ctx, ast.AggFuncBitOr, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncBitOr, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	bitOrFunc := desc.GetAggFunc(ctx)
 	evalCtx := bitOrFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := bitOrFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(0))
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(1)).ToRow()
-	err := bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
+	err = bitOrFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
 	c.Assert(err, IsNil)
 	result = bitOrFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(1))
@@ -322,14 +335,16 @@ func (s *testAggFuncSuit) TestBitXor(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	bitXorFunc := NewAggFuncDesc(s.ctx, ast.AggFuncBitXor, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncBitXor, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	bitXorFunc := desc.GetAggFunc(ctx)
 	evalCtx := bitXorFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := bitXorFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(0))
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(1)).ToRow()
-	err := bitXorFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
+	err = bitXorFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
 	c.Assert(err, IsNil)
 	result = bitXorFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(1))
@@ -398,7 +413,9 @@ func (s *testAggFuncSuit) TestCount(c *C) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	countFunc := NewAggFuncDesc(s.ctx, ast.AggFuncCount, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncCount, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	countFunc := desc.GetAggFunc(ctx)
 	evalCtx := countFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := countFunc.GetResult(evalCtx)
@@ -410,14 +427,16 @@ func (s *testAggFuncSuit) TestCount(c *C) {
 	}
 	result = countFunc.GetResult(evalCtx)
 	c.Assert(result.GetInt64(), Equals, int64(5050))
-	err := countFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
+	err = countFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, s.nullRow)
 	c.Assert(err, IsNil)
 	result = countFunc.GetResult(evalCtx)
 	c.Assert(result.GetInt64(), Equals, int64(5050))
 	partialResult := countFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetInt64(), Equals, int64(5050))
 
-	distinctCountFunc := NewAggFuncDesc(s.ctx, ast.AggFuncCount, []expression.Expression{col}, true).GetAggFunc(ctx)
+	desc, err = NewAggFuncDesc(s.ctx, ast.AggFuncCount, []expression.Expression{col}, true)
+	c.Assert(err, IsNil)
+	distinctCountFunc := desc.GetAggFunc(ctx)
 	evalCtx = distinctCountFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	for _, row := range s.rows {
@@ -438,14 +457,16 @@ func (s *testAggFuncSuit) TestConcat(c *C) {
 		RetType: types.NewFieldType(mysql.TypeVarchar),
 	}
 	ctx := mock.NewContext()
-	concatFunc := NewAggFuncDesc(s.ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep}, false)
+	c.Assert(err, IsNil)
+	concatFunc := desc.GetAggFunc(ctx)
 	evalCtx := concatFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	result := concatFunc.GetResult(evalCtx)
 	c.Assert(result.IsNull(), IsTrue)
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(1, "x"))
-	err := concatFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row.ToRow())
+	err = concatFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row.ToRow())
 	c.Assert(err, IsNil)
 	result = concatFunc.GetResult(evalCtx)
 	c.Assert(result.GetString(), Equals, "1")
@@ -464,7 +485,9 @@ func (s *testAggFuncSuit) TestConcat(c *C) {
 	partialResult := concatFunc.GetPartialResult(evalCtx)
 	c.Assert(partialResult[0].GetString(), Equals, "1x2")
 
-	distinctConcatFunc := NewAggFuncDesc(s.ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep}, true).GetAggFunc(ctx)
+	desc, err = NewAggFuncDesc(s.ctx, ast.AggFuncGroupConcat, []expression.Expression{col, sep}, true)
+	c.Assert(err, IsNil)
+	distinctConcatFunc := desc.GetAggFunc(ctx)
 	evalCtx = distinctConcatFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	row.SetDatum(0, types.NewIntDatum(1))
@@ -487,11 +510,13 @@ func (s *testAggFuncSuit) TestFirstRow(c *C) {
 	}
 
 	ctx := mock.NewContext()
-	firstRowFunc := NewAggFuncDesc(s.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	firstRowFunc := desc.GetAggFunc(ctx)
 	evalCtx := firstRowFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(1)).ToRow()
-	err := firstRowFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
+	err = firstRowFunc.Update(evalCtx, s.ctx.GetSessionVars().StmtCtx, row)
 	c.Assert(err, IsNil)
 	result := firstRowFunc.GetResult(evalCtx)
 	c.Assert(result.GetUint64(), Equals, uint64(1))
@@ -512,8 +537,12 @@ func (s *testAggFuncSuit) TestMaxMin(c *C) {
 	}
 
 	ctx := mock.NewContext()
-	maxFunc := NewAggFuncDesc(s.ctx, ast.AggFuncMax, []expression.Expression{col}, false).GetAggFunc(ctx)
-	minFunc := NewAggFuncDesc(s.ctx, ast.AggFuncMin, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(s.ctx, ast.AggFuncMax, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	maxFunc := desc.GetAggFunc(ctx)
+	desc, err = NewAggFuncDesc(s.ctx, ast.AggFuncMin, []expression.Expression{col}, false)
+	c.Assert(err, IsNil)
+	minFunc := desc.GetAggFunc(ctx)
 	maxEvalCtx := maxFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 	minEvalCtx := minFunc.CreateContext(s.ctx.GetSessionVars().StmtCtx)
 
@@ -523,7 +552,7 @@ func (s *testAggFuncSuit) TestMaxMin(c *C) {
 	c.Assert(result.IsNull(), IsTrue)
 
 	row := chunk.MutRowFromDatums(types.MakeDatums(2))
-	err := maxFunc.Update(maxEvalCtx, s.ctx.GetSessionVars().StmtCtx, row.ToRow())
+	err = maxFunc.Update(maxEvalCtx, s.ctx.GetSessionVars().StmtCtx, row.ToRow())
 	c.Assert(err, IsNil)
 	result = maxFunc.GetResult(maxEvalCtx)
 	c.Assert(result.GetInt64(), Equals, int64(2))

--- a/expression/aggregation/bench_test.go
+++ b/expression/aggregation/bench_test.go
@@ -29,7 +29,11 @@ func BenchmarkCreateContext(b *testing.B) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fun := desc.GetAggFunc(ctx)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		fun.CreateContext(ctx.GetSessionVars().StmtCtx)
@@ -43,7 +47,11 @@ func BenchmarkResetContext(b *testing.B) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, false)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fun := desc.GetAggFunc(ctx)
 	evalCtx := fun.CreateContext(ctx.GetSessionVars().StmtCtx)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
@@ -58,7 +66,11 @@ func BenchmarkCreateDistinctContext(b *testing.B) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fun := desc.GetAggFunc(ctx)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		fun.CreateContext(ctx.GetSessionVars().StmtCtx)
@@ -72,7 +84,11 @@ func BenchmarkResetDistinctContext(b *testing.B) {
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
 	ctx := mock.NewContext()
-	fun := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true).GetAggFunc(ctx)
+	desc, err := NewAggFuncDesc(ctx, ast.AggFuncAvg, []expression.Expression{col}, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fun := desc.GetAggFunc(ctx)
 	evalCtx := fun.CreateContext(ctx.GetSessionVars().StmtCtx)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -415,7 +415,11 @@ func (er *expressionRewriter) handleOtherComparableSubq(lexpr, rexpr expression.
 	if useMin {
 		funcName = ast.AggFuncMin
 	}
-	funcMaxOrMin := aggregation.NewAggFuncDesc(er.ctx, funcName, []expression.Expression{rexpr}, false)
+	funcMaxOrMin, err := aggregation.NewAggFuncDesc(er.ctx, funcName, []expression.Expression{rexpr}, false)
+	if err != nil {
+		er.err = err
+		return
+	}
 
 	// Create a column and append it to the schema of that aggregation.
 	colMaxOrMin := &expression.Column{
@@ -437,7 +441,11 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 	innerIsNull := expression.NewFunctionInternal(er.ctx, ast.IsNull, types.NewFieldType(mysql.TypeTiny), rexpr)
 	outerIsNull := expression.NewFunctionInternal(er.ctx, ast.IsNull, types.NewFieldType(mysql.TypeTiny), lexpr)
 
-	funcSum := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncSum, []expression.Expression{innerIsNull}, false)
+	funcSum, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncSum, []expression.Expression{innerIsNull}, false)
+	if err != nil {
+		er.err = err
+		return
+	}
 	colSum := &expression.Column{
 		ColName:  model.NewCIStr("agg_col_sum"),
 		UniqueID: er.ctx.GetSessionVars().AllocPlanColumnID(),
@@ -448,7 +456,11 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 	innerHasNull := expression.NewFunctionInternal(er.ctx, ast.NE, types.NewFieldType(mysql.TypeTiny), colSum, expression.Zero)
 
 	// Build `count(1)` aggregation to check if subquery is empty.
-	funcCount := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{expression.One}, false)
+	funcCount, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{expression.One}, false)
+	if err != nil {
+		er.err = err
+		return
+	}
 	colCount := &expression.Column{
 		ColName:  model.NewCIStr("agg_col_cnt"),
 		UniqueID: er.ctx.GetSessionVars().AllocPlanColumnID(),
@@ -509,8 +521,16 @@ func (er *expressionRewriter) buildQuantifierPlan(plan4Agg *LogicalAggregation, 
 // t.id != s.id or count(distinct s.id) > 1 or [any checker]. If there are two different values in s.id ,
 // there must exist a s.id that doesn't equal to t.id.
 func (er *expressionRewriter) handleNEAny(lexpr, rexpr expression.Expression, np LogicalPlan) {
-	firstRowFunc := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncFirstRow, []expression.Expression{rexpr}, false)
-	countFunc := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{rexpr}, true)
+	firstRowFunc, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncFirstRow, []expression.Expression{rexpr}, false)
+	if err != nil {
+		er.err = err
+		return
+	}
+	countFunc, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{rexpr}, true)
+	if err != nil {
+		er.err = err
+		return
+	}
 	plan4Agg := LogicalAggregation{
 		AggFuncs: []*aggregation.AggFuncDesc{firstRowFunc, countFunc},
 	}.init(er.ctx)
@@ -535,8 +555,16 @@ func (er *expressionRewriter) handleNEAny(lexpr, rexpr expression.Expression, np
 // handleEQAll handles the case of = all. For example, if the query is t.id = all (select s.id from s), it will be rewrote to
 // t.id = (select s.id from s having count(distinct s.id) <= 1 and [all checker]).
 func (er *expressionRewriter) handleEQAll(lexpr, rexpr expression.Expression, np LogicalPlan) {
-	firstRowFunc := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncFirstRow, []expression.Expression{rexpr}, false)
-	countFunc := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{rexpr}, true)
+	firstRowFunc, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncFirstRow, []expression.Expression{rexpr}, false)
+	if err != nil {
+		er.err = err
+		return
+	}
+	countFunc, err := aggregation.NewAggFuncDesc(er.ctx, ast.AggFuncCount, []expression.Expression{rexpr}, true)
+	if err != nil {
+		er.err = err
+		return
+	}
 	plan4Agg := LogicalAggregation{
 		AggFuncs: []*aggregation.AggFuncDesc{firstRowFunc, countFunc},
 	}.init(er.ctx)

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -92,7 +92,10 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 			p = np
 			newArgList = append(newArgList, newArg)
 		}
-		newFunc := aggregation.NewAggFuncDesc(b.ctx, aggFunc.F, newArgList, aggFunc.Distinct)
+		newFunc, err := aggregation.NewAggFuncDesc(b.ctx, aggFunc.F, newArgList, aggFunc.Distinct)
+		if err != nil {
+			return nil, nil, err
+		}
 		combined := false
 		for j, oldFunc := range plan4Agg.AggFuncs {
 			if oldFunc.Equal(b.ctx, newFunc) {
@@ -114,7 +117,10 @@ func (b *planBuilder) buildAggregation(p LogicalPlan, aggFuncList []*ast.Aggrega
 		}
 	}
 	for _, col := range p.Schema().Columns {
-		newFunc := aggregation.NewAggFuncDesc(b.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+		newFunc, err := aggregation.NewAggFuncDesc(b.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+		if err != nil {
+			return nil, nil, err
+		}
 		plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, newFunc)
 		newCol, _ := col.Clone().(*expression.Column)
 		newCol.RetType = newFunc.RetTp
@@ -649,7 +655,7 @@ func (b *planBuilder) buildProjection(p LogicalPlan, fields []*ast.SelectField, 
 	return proj, oldLen, nil
 }
 
-func (b *planBuilder) buildDistinct(child LogicalPlan, length int) *LogicalAggregation {
+func (b *planBuilder) buildDistinct(child LogicalPlan, length int) (*LogicalAggregation, error) {
 	b.optFlag = b.optFlag | flagBuildKeyInfo
 	b.optFlag = b.optFlag | flagAggregationOptimize
 	plan4Agg := LogicalAggregation{
@@ -658,7 +664,10 @@ func (b *planBuilder) buildDistinct(child LogicalPlan, length int) *LogicalAggre
 	}.init(b.ctx)
 	plan4Agg.collectGroupByColumns()
 	for _, col := range child.Schema().Columns {
-		aggDesc := aggregation.NewAggFuncDesc(b.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+		aggDesc, err := aggregation.NewAggFuncDesc(b.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+		if err != nil {
+			return nil, err
+		}
 		plan4Agg.AggFuncs = append(plan4Agg.AggFuncs, aggDesc)
 	}
 	plan4Agg.SetChildren(child)
@@ -668,7 +677,7 @@ func (b *planBuilder) buildDistinct(child LogicalPlan, length int) *LogicalAggre
 	for i, col := range plan4Agg.schema.Columns {
 		col.RetType = plan4Agg.AggFuncs[i].RetTp
 	}
-	return plan4Agg
+	return plan4Agg, nil
 }
 
 // unionJoinFieldType finds the type which can carry the given types in Union.
@@ -740,7 +749,10 @@ func (b *planBuilder) buildUnion(union *ast.UnionStmt) (LogicalPlan, error) {
 
 	unionDistinctPlan := b.buildUnionAll(distinctSelectPlans)
 	if unionDistinctPlan != nil {
-		unionDistinctPlan = b.buildDistinct(unionDistinctPlan, unionDistinctPlan.Schema().Len())
+		unionDistinctPlan, err = b.buildDistinct(unionDistinctPlan, unionDistinctPlan.Schema().Len())
+		if err != nil {
+			return nil, err
+		}
 		if len(allSelectPlans) > 0 {
 			// Can't change the statements order in order to get the correct column info.
 			allSelectPlans = append([]LogicalPlan{unionDistinctPlan}, allSelectPlans...)
@@ -1791,7 +1803,10 @@ func (b *planBuilder) buildSelect(sel *ast.SelectStmt) (p LogicalPlan, err error
 	}
 
 	if sel.Distinct {
-		p = b.buildDistinct(p, oldLen)
+		p, err = b.buildDistinct(p, oldLen)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if sel.OrderBy != nil {

--- a/planner/core/rule_decorrelate.go
+++ b/planner/core/rule_decorrelate.go
@@ -185,7 +185,10 @@ func (s *decorrelateSolver) optimize(p LogicalPlan) (LogicalPlan, error) {
 
 				outerColsInSchema := make([]*expression.Column, 0, outerPlan.Schema().Len())
 				for i, col := range outerPlan.Schema().Columns {
-					first := aggregation.NewAggFuncDesc(agg.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+					first, err := aggregation.NewAggFuncDesc(agg.ctx, ast.AggFuncFirstRow, []expression.Expression{col}, false)
+					if err != nil {
+						return nil, err
+					}
 					newAggFuncs = append(newAggFuncs, first)
 
 					outerCol, _ := outerPlan.Schema().Columns[i].Clone().(*expression.Column)
@@ -232,7 +235,10 @@ func (s *decorrelateSolver) optimize(p LogicalPlan) (LogicalPlan, error) {
 							clonedCol := eqCond.GetArgs()[1]
 							// If the join key is not in the aggregation's schema, add first row function.
 							if agg.schema.ColumnIndex(eqCond.GetArgs()[1].(*expression.Column)) == -1 {
-								newFunc := aggregation.NewAggFuncDesc(apply.ctx, ast.AggFuncFirstRow, []expression.Expression{clonedCol}, false)
+								newFunc, err := aggregation.NewAggFuncDesc(apply.ctx, ast.AggFuncFirstRow, []expression.Expression{clonedCol}, false)
+								if err != nil {
+									return nil, err
+								}
 								agg.AggFuncs = append(agg.AggFuncs, newFunc)
 								agg.schema.Append(clonedCol.(*expression.Column))
 								agg.schema.Columns[agg.schema.Len()-1].RetType = newFunc.RetTp


### PR DESCRIPTION
cherry-pick #10910 

```
# Conflicts:
#       cmd/explaintest/r/explain_easy.result
#       executor/aggfuncs/aggfunc_test.go
#       executor/aggfuncs/window_func_test.go
#       executor/benchmark_test.go
#       executor/builder.go
#       expression/aggregation/agg_to_pb_test.go
#       expression/aggregation/base_func.go
#       expression/aggregation/base_func_test.go
#       expression/aggregation/descriptor.go
#       expression/aggregation/window_func.go
#       planner/core/expression_rewriter.go
#       planner/core/logical_plan_builder.go
#       planner/core/rule_aggregation_push_down.go
#       planner/core/rule_inject_extra_projection_test.go
```