### PR TITLE
mocktikv: fix key exists check for pessimistic transaction

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -244,3 +244,24 @@ func (s *testPessimisticSuite) TestFirstStatementFail(c *C) {
 	tk.MustExec("insert first values (2)")
 	tk.MustExec("commit")
 }
+
+func (s *testPessimisticSuite) TestKeyExistsCheck(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists chk")
+	tk.MustExec("create table chk (k int primary key)")
+	tk.MustExec("insert chk values (1)")
+	tk.MustExec("delete from chk where k = 1")
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert chk values (1)")
+	tk.MustExec("commit")
+
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("begin optimistic")
+	tk1.MustExec("insert chk values (1), (2), (3)")
+	_, err := tk1.Exec("commit")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert chk values (2)")
+	tk.MustExec("commit")
+}

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -652,6 +652,19 @@ func checkConflictValue(iter *Iterator, m *kvrpcpb.Mutation, startTS uint64) err
 		}
 	}
 	if m.Op == kvrpcpb.Op_PessimisticLock && m.Assertion == kvrpcpb.Assertion_NotExist {
+		// Skip rollback keys.
+		for dec.value.valueType == typeRollback {
+			ok, err = dec.Decode(iter)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if !ok {
+				return nil
+			}
+		}
+		if dec.value.valueType == typeDelete {
+			return nil
+		}
 		return &ErrKeyAlreadyExist{
 			Key: m.Key,
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
mocktikv returns unexpected `ErrKeyAlreadyExists`.
TiKV doesn't have this issue.

### What is changed and how it works?
Check value type before return `ErrKeyAlreadyExists` error.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
