### PR TITLE
server: try to fix race

### DIFF
--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -330,7 +330,6 @@ func (ts ConnTestSuite) TestDispatch(c *C) {
 }
 
 func (ts ConnTestSuite) testGetSessionVarsWaitTimeout(c *C) {
-	c.Parallel()
 	var err error
 	ts.store, err = mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
@@ -370,7 +369,6 @@ func (ts ConnTestSuite) TestConnExecutionTimeout(c *C) {
 	//There is no underlying netCon, use failpoint to avoid panic
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/server/FakeClientConn", "return(1)"), IsNil)
 
-	c.Parallel()
 	var err error
 	ts.store, err = mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?
```sql
==================
WARNING: DATA RACE
Write at 0x00000447b0c0 by goroutine 17:
  github.com/pingcap/tidb/util/timeutil.SetSystemTZ.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/timeutil/time.go:125 +0x5a
  sync.(*Once).Do()
      /usr/local/go/src/sync/once.go:44 +0xde
  github.com/pingcap/tidb/util/timeutil.SetSystemTZ()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/timeutil/time.go:124 +0x75
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1510 +0x152
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:895 +0x37f
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:893 +0x352
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:891 +0x325
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:889 +0x2f8
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:887 +0x2cb
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:885 +0x29e
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:883 +0x271
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:881 +0x244
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:879 +0x217
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:877 +0x1ea
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:875 +0x1bd
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:873 +0x190
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:872 +0x163
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:871 +0x136
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:869 +0x109
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:867 +0xdc
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:865 +0x5b
  github.com/pingcap/tidb/session.bootstrap()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:289 +0x1a3
  github.com/pingcap/tidb/session.runInBootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1576 +0xe2
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1495 +0x9bd
  github.com/pingcap/tidb/server.ConnTestSuite.TestConnExecutionTimeout()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/server/conn_test.go:377 +0x20d
  github.com/pingcap/failpoint.enableAndLock()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20190512135322-30cc7431d99c/runtime.go:95 +0x11b
  github.com/pingcap/failpoint.Enable()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/failpoint@v0.0.0-20190512135322-30cc7431d99c/runtime.go:77 +0x5a
  github.com/pingcap/tidb/server.ConnTestSuite.TestConnExecutionTimeout()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/server/conn_test.go:371 +0x70
  github.com/pingcap/tidb/server.(*ConnTestSuite).TestConnExecutionTimeout()
      <autogenerated>:1 +0x85
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9fc
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Previous read at 0x00000447b0c0 by goroutine 18:
  github.com/pingcap/tidb/sessionctx/variable.parseTimeZone()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/timeutil/time.go:113 +0x91
  github.com/pingcap/tidb/sessionctx/variable.(*SessionVars).SetSystemVar()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/variable/session.go:673 +0x1c5
  github.com/pingcap/tidb/sessionctx/variable.SetSessionSystemVar()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/variable/varsutil.go:190 +0x1ad
  github.com/pingcap/tidb/session.(*session).loadCommonGlobalVariablesIfNeeded()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1788 +0x73b
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1033 +0xe0
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1024 +0xd4
  github.com/pingcap/tidb/session.loadSystemTZ()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1459 +0xa1
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1505 +0x127
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:895 +0x37f
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:893 +0x352
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:891 +0x325
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:889 +0x2f8
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:887 +0x2cb
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:885 +0x29e
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:883 +0x271
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:881 +0x244
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:879 +0x217
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:877 +0x1ea
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:875 +0x1bd
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:873 +0x190
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:872 +0x163
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:871 +0x136
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:869 +0x109
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:867 +0xdc
  github.com/pingcap/tidb/session.doDDLWorks()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:865 +0x5b
  github.com/pingcap/tidb/session.bootstrap()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:289 +0x1a3
  github.com/pingcap/tidb/session.runInBootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1576 +0xe2
  github.com/pingcap/tidb/session.BootstrapSession()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1495 +0x9bd
  github.com/pingcap/tidb/server.ConnTestSuite.TestDispatch()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/server/conn_test.go:284 +0xeb2
  github.com/pingcap/tidb/server.(*ConnTestSuite).TestDispatch()
      <autogenerated>:1 +0x85
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9fc
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Goroutine 17 (running) created at:
  github.com/pingcap/check.(*suiteRunner).forkCall()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a7
  github.com/pingcap/check.(*suiteRunner).forkTest()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
  github.com/pingcap/check.(*suiteRunner).doRun()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x12d
  github.com/pingcap/check.(*suiteRunner).run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:689 +0x176
  github.com/pingcap/check.Run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:142 +0x5a
  github.com/pingcap/check.RunAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:105 +0xf32
  github.com/pingcap/check.TestingT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:91 +0x770
  github.com/pingcap/tidb/server.TestT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/server/server_test.go:42 +0x210
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163

Goroutine 18 (running) created at:
  github.com/pingcap/check.(*suiteRunner).forkCall()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a7
  github.com/pingcap/check.(*suiteRunner).forkTest()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
  github.com/pingcap/check.(*suiteRunner).doRun()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x12d
  github.com/pingcap/check.(*suiteRunner).run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:689 +0x176
  github.com/pingcap/check.Run()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:142 +0x5a
  github.com/pingcap/check.RunAll()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:105 +0xf32
  github.com/pingcap/check.TestingT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/run.go:91 +0x770
  github.com/pingcap/tidb/server.TestT()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/server/server_test.go:42 +0x210
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:865 +0x163
==================
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

