### PR TITLE
server: tiny update `ConnTestSuite`

### DIFF
--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -78,11 +78,6 @@ func (eqh *Handle) Run() {
 	}
 }
 
-// Close closes the handle and release the background goroutine.
-func (eqh *Handle) Close() {
-	close(eqh.exitCh)
-}
-
 // LogOnQueryExceedMemQuota prints a log when memory usage of connID is out of memory quota.
 func (eqh *Handle) LogOnQueryExceedMemQuota(connID uint64) {
 	if log.GetLevel() > zapcore.WarnLevel {


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`ConnTestSuite` does not call `domain.Close` and `store.Close` to release resource in the test code.

### What is changed and how it works?

Tiny update `ConnTestSuite`... and if `domain.Close` is called, the `expensive.Handle.Close()` is not necessary.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
This is the change of the unit test code itself.


