### PR TITLE
expression: fix issue that `TimeIsNull` is not compatible with MySQL

### DIFF
--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -920,10 +920,11 @@ func (b *builtinTimeIsNullSig) implicitArgs() []types.Datum {
 func (b *builtinTimeIsNullSig) Clone() builtinFunc {
 	newSig := &builtinTimeIsNullSig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)
+	newSig.isNotNull = b.isNotNull
 	return newSig
 }
 
 func (b *builtinTimeIsNullSig) evalInt(row chunk.Row) (int64, bool, error) {
-	_, isNull, err := b.args[0].EvalTime(b.ctx, row)
-	return evalIsNull(isNull, err)
+	t, isNull, err := b.args[0].EvalTime(b.ctx, row)
+	return evalIsNull(isNull || (b.isNotNull && t.IsZero()), err)
 }

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -925,6 +925,10 @@ func (b *builtinTimeIsNullSig) Clone() builtinFunc {
 }
 
 func (b *builtinTimeIsNullSig) evalInt(row chunk.Row) (int64, bool, error) {
+	//	Description below are from MySQL document:
+	//		For DATE and DATETIME columns that are declared as NOT NULL,
+	//		you can find the special date '0000-00-00' by using a statement like this:
+	//		"SELECT * FROM tbl_name WHERE date_column IS NULL"
 	t, isNull, err := b.args[0].EvalTime(b.ctx, row)
 	return evalIsNull(isNull || (b.isNotNull && t.IsZero()), err)
 }

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -907,16 +907,6 @@ type builtinTimeIsNullSig struct {
 	isNotNull bool
 }
 
-func (b *builtinTimeIsNullSig) implicitArgs() []types.Datum {
-	args := b.baseBuiltinFunc.implicitArgs()
-	if b.isNotNull {
-		args = append(args, types.NewIntDatum(1))
-	} else {
-		args = append(args, types.NewIntDatum(0))
-	}
-	return args
-}
-
 func (b *builtinTimeIsNullSig) Clone() builtinFunc {
 	newSig := &builtinTimeIsNullSig{}
 	newSig.cloneFrom(&b.baseBuiltinFunc)

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -800,7 +800,8 @@ func (c *isNullFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 		sig.setPbCode(tipb.ScalarFuncSig_RealIsNull)
 	case types.ETDatetime:
 		isNotNull := false
-		if mysql.HasNotNullFlag(args[0].GetType().Flag) {
+		_, isCol := args[0].(*Column)
+		if isCol && mysql.HasNotNullFlag(args[0].GetType().Flag) {
 			isNotNull = true
 		}
 		sig = &builtinTimeIsNullSig{bf, isNotNull}

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -337,7 +337,7 @@ func getSignatureByPB(ctx sessionctx.Context, expr *tipb.Expr, args []Expression
 		f = &builtinRealIsNullSig{base}
 	case tipb.ScalarFuncSig_TimeIsNull:
 		isNotNull := false
-		if len(expr.Children) > 0 && mysql.HasNotNullFlag(uint(expr.Children[0].FieldType.Flag)) {
+		if len(expr.Children) > 0 && expr.Children[0].Tp == tipb.ExprType_ColumnRef && mysql.HasNotNullFlag(uint(expr.Children[0].FieldType.Flag)) {
 			isNotNull = true
 		}
 

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -39,7 +39,7 @@ func pbTypeToFieldType(tp *tipb.FieldType) *types.FieldType {
 	}
 }
 
-func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression, impArgs []types.Datum) (f builtinFunc, e error) {
+func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression) (f builtinFunc, e error) {
 	fieldTp := pbTypeToFieldType(tp)
 	base := newBaseBuiltinFunc(ctx, args)
 	base.tp = fieldTp
@@ -336,11 +336,7 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 	case tipb.ScalarFuncSig_RealIsNull:
 		f = &builtinRealIsNullSig{base}
 	case tipb.ScalarFuncSig_TimeIsNull:
-		isNotNull := false
-		if len(impArgs) > 0 && impArgs[0].GetInt64() > 0 {
-			isNotNull = true
-		}
-		f = &builtinTimeIsNullSig{base, isNotNull}
+		f = &builtinTimeIsNullSig{base, false}
 	case tipb.ScalarFuncSig_StringIsNull:
 		f = &builtinStringIsNullSig{base}
 	case tipb.ScalarFuncSig_IntIsNull:
@@ -476,10 +472,10 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 	return f, nil
 }
 
-func newDistSQLFunctionBySig(sc *stmtctx.StatementContext, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression, impArgs []types.Datum) (Expression, error) {
+func newDistSQLFunctionBySig(sc *stmtctx.StatementContext, sigCode tipb.ScalarFuncSig, tp *tipb.FieldType, args []Expression) (Expression, error) {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx = sc
-	f, err := getSignatureByPB(ctx, sigCode, tp, args, impArgs)
+	f, err := getSignatureByPB(ctx, sigCode, tp, args)
 	if err != nil {
 		return nil, err
 	}
@@ -546,16 +542,7 @@ func PBToExpr(expr *tipb.Expr, tps []*types.FieldType, sc *stmtctx.StatementCont
 		args = append(args, arg)
 	}
 
-	// decode implicit arguments
-	var impArgs []types.Datum
-	var err error
-	if len(expr.Val) > 0 {
-		if impArgs, err = codec.Decode(expr.Val, 1); err != nil {
-			return nil, err
-		}
-	}
-
-	return newDistSQLFunctionBySig(sc, expr.Sig, expr.FieldType, args, impArgs)
+	return newDistSQLFunctionBySig(sc, expr.Sig, expr.FieldType, args)
 }
 
 func convertTime(data []byte, ftPB *tipb.FieldType, tz *time.Location) (*Constant, error) {

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -337,7 +337,7 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 		f = &builtinRealIsNullSig{base}
 	case tipb.ScalarFuncSig_TimeIsNull:
 		isNotNull := false
-		if len(impArgs) > 0 && impArgs[0].GetInt64()> 0 {
+		if len(impArgs) > 0 && impArgs[0].GetInt64() > 0 {
 			isNotNull = true
 		}
 		f = &builtinTimeIsNullSig{base, isNotNull}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4404,6 +4404,31 @@ func (s *testIntegrationSuite) TestExprPushdownBlacklist(c *C) {
 	tk.MustQuery(`select * from mysql.expr_pushdown_blacklist`).Check(testkit.Rows())
 }
 
+func (s *testIntegrationSuite) TestIssue9763(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`CREATE TABLE t1 (a datetime not null);`)
+	tk.MustExec(`insert ignore into t1 values (0);`)
+	tk.MustQuery(`select * from t1 where a is null;`).Check(testkit.Rows(`0000-00-00 00:00:00`))
+
+	tk.MustExec(`drop table if exists t2;`)
+	tk.MustExec(`CREATE TABLE t2 (a date not null);`)
+	tk.MustExec(`insert ignore into t2 values (0);`)
+	tk.MustQuery(`select * from t2 where a is null;`).Check(testkit.Rows(`0000-00-00`))
+
+	tk.MustExec(`drop table if exists t3;`)
+	tk.MustExec(`CREATE TABLE t3 (a datetime);`)
+	tk.MustExec(`insert ignore into t3 values (0);`)
+	c.Assert(len(tk.MustQuery(`select * from t3 where a is null;`).Rows()), Equals, 0)
+
+	tk.MustExec(`drop table if exists t4;`)
+	tk.MustExec(`CREATE TABLE t4 (a date);`)
+	tk.MustExec(`insert ignore into t4 values (0);`)
+	c.Assert(len(tk.MustQuery(`select * from t4 where a is null;`).Rows()), Equals, 0)
+}
+
 func (s *testIntegrationSuite) TestIssue10804(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustQuery(`SELECT @@information_schema_stats_expiry`).Check(testkit.Rows(`86400`))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/9763.

### What is changed and how it works?
Introduce a new variable `isNotNull` to `builtinTimeIsNullSig` to judge if this column has a `NotNull` attribution and push it down to `TiKV`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test