### PR TITLE
executor: locks key in point get executor for pessimistic transaction

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -433,6 +433,9 @@ id	count	task	operator info
 Projection_3	10000.00	root	or(NULL, gt(test.t.a, 1))
 └─TableReader_5	10000.00	root	data:TableScan_4
   └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain select * from t where a = 1 for update;
+id	count	task	operator info
+Point_Get_1	1.00	root	table:t, handle:1
 drop table if exists ta, tb;
 create table ta (a varchar(20));
 create table tb (a varchar(20));

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -79,6 +79,7 @@ drop table if exists t;
 create table t(a bigint primary key);
 explain select * from t where a = 1 and a = 2;
 explain select null or a > 1 from t;
+explain select * from t where a = 1 for update;
 
 drop table if exists ta, tb;
 create table ta (a varchar(20));

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -411,7 +411,12 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 	for {
 		_, err = a.handleNoDelayExecutor(ctx, e)
 		if err != nil {
-			return err
+			// It is possible the DML has point get plan that locks the key.
+			e, err = a.handlePessimisticLockError(ctx, err)
+			if err != nil {
+				return err
+			}
+			continue
 		}
 		keys, err1 := txn.(pessimisticTxn).KeysNeedToLock()
 		if err1 != nil {
@@ -422,21 +427,18 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 		}
 		forUpdateTS := txnCtx.GetForUpdateTS()
 		err = txn.LockKeys(ctx, forUpdateTS, keys...)
+		if err == nil {
+			return nil
+		}
 		e, err = a.handlePessimisticLockError(ctx, err)
 		if err != nil {
 			return err
-		}
-		if e == nil {
-			return nil
 		}
 	}
 }
 
 // handlePessimisticLockError updates TS and rebuild executor if the err is write conflict.
 func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (Executor, error) {
-	if err == nil {
-		return nil, nil
-	}
 	txnCtx := a.Ctx.GetSessionVars().TxnCtx
 	var newForUpdateTS uint64
 	if deadlock, ok := errors.Cause(err).(*tikv.ErrDeadlock); ok {

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -48,6 +48,8 @@ type PointGetPlan struct {
 	expr             expression.Expression
 	ctx              sessionctx.Context
 	IsTableDual      bool
+	Lock             bool
+	IsForUpdate      bool
 }
 
 type nameValuePair struct {
@@ -141,6 +143,10 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 				tableDual.SetSchema(fp.Schema())
 				return tableDual.Init(ctx, &property.StatsInfo{})
 			}
+			if x.LockTp == ast.SelectLockForUpdate {
+				fp.Lock = true
+				fp.IsForUpdate = true
+			}
 			return fp
 		}
 	case *ast.UpdateStmt:
@@ -159,7 +165,7 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 // 3. All the columns must be public and generated.
 // 4. The condition is an access path that the range is a unique key.
 func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetPlan {
-	if selStmt.Having != nil || selStmt.LockTp != ast.SelectLockNone {
+	if selStmt.Having != nil {
 		return nil
 	} else if selStmt.Limit != nil {
 		count, offset, err := extractLimitCountOffset(ctx, selStmt.Limit)
@@ -452,6 +458,9 @@ func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan
 	if fastSelect.IsTableDual {
 		return PhysicalTableDual{}.Init(ctx, &property.StatsInfo{})
 	}
+	if ctx.GetSessionVars().TxnCtx.IsPessimistic {
+		fastSelect.Lock = true
+	}
 	orderedList := buildOrderedList(ctx, fastSelect, updateStmt.List)
 	if orderedList == nil {
 		return nil
@@ -511,6 +520,9 @@ func tryDeletePointPlan(ctx sessionctx.Context, delStmt *ast.DeleteStmt) Plan {
 	}
 	if fastSelect.IsTableDual {
 		return PhysicalTableDual{}.Init(ctx, &property.StatsInfo{})
+	}
+	if ctx.GetSessionVars().TxnCtx.IsPessimistic {
+		fastSelect.Lock = true
 	}
 	delPlan := Delete{
 		SelectPlan: fastSelect,

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -278,3 +278,47 @@ func (s *testPessimisticSuite) TestInsertOnDup(c *C) {
 	tk.MustExec("commit")
 	tk.MustQuery("select * from dup").Check(testkit.Rows("1 2"))
 }
+
+func (s *testPessimisticSuite) TestPointGetKeyLock(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists point")
+	tk.MustExec("create table point (id int primary key, u int unique, c int)")
+	syncCh := make(chan struct{})
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("update point set c = c + 1 where id = 1")
+	tk.MustExec("delete from point where u = 2")
+	go func() {
+		tk2.MustExec("begin pessimistic")
+		_, err1 := tk2.Exec("insert point values (1, 1, 1)")
+		c.Check(kv.ErrKeyExists.Equal(err1), IsTrue)
+		_, err1 = tk2.Exec("insert point values (2, 2, 2)")
+		c.Check(kv.ErrKeyExists.Equal(err1), IsTrue)
+		tk2.MustExec("rollback")
+		<-syncCh
+	}()
+	time.Sleep(time.Millisecond * 10)
+	tk.MustExec("insert point values (1, 1, 1)")
+	tk.MustExec("insert point values (2, 2, 2)")
+	tk.MustExec("commit")
+	syncCh <- struct{}{}
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("select * from point where id = 3 for update")
+	tk.MustExec("select * from point where u = 4 for update")
+	go func() {
+		tk2.MustExec("begin pessimistic")
+		_, err1 := tk2.Exec("insert point values (3, 3, 3)")
+		c.Check(kv.ErrKeyExists.Equal(err1), IsTrue)
+		_, err1 = tk2.Exec("insert point values (4, 4, 4)")
+		c.Check(kv.ErrKeyExists.Equal(err1), IsTrue)
+		tk2.MustExec("rollback")
+		<-syncCh
+	}()
+	time.Sleep(time.Millisecond * 10)
+	tk.MustExec("insert point values (3, 3, 3)")
+	tk.MustExec("insert point values (4, 4, 4)")
+	tk.MustExec("commit")
+	syncCh <- struct{}{}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When a pessimistic transaction uses a primary key or unique key to lock read or update/delete a row, if the result is empty, the key will not be locked, the next insert may return duplicated key error.

### What is changed and how it works?
Locks the key in point get plan, even if the value is empty.
It prevents phantom read if the read is a point get.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Related changes

 - Need to cherry-pick to the release branch
