### PR TITLE
meta: make auto increment id can be adjust.

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2181,7 +2181,7 @@ func (s *testDBSuite5) TestRebaseAutoID(c *C) {
 	s.tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1"))
 	s.tk.MustExec("alter table tidb.test auto_increment = 6000;")
 	s.tk.MustExec("insert tidb.test values (null, 1);")
-	s.tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1", "6000 1"))
+	s.tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1", "1500001 1"))
 	s.tk.MustExec("alter table tidb.test auto_increment = 5;")
 	s.tk.MustExec("insert tidb.test values (null, 1);")
 	s.tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1", "6000 1", "11000 1"))
@@ -2869,7 +2869,7 @@ func (s *testDBSuite4) TestAlterShardRowIDBits(c *C) {
 	// Test increase shard_row_id_bits failed by overflow global auto ID.
 	_, err := tk.Exec("alter table t1 SHARD_ROW_ID_BITS = 10;")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[autoid:1467]shard_row_id_bits 10 will cause next global auto ID 72057594037932936 overflow")
+	c.Assert(err.Error(), Equals, "[autoid:1467]shard_row_id_bits 10 will cause next global auto ID 72057594039427936 overflow")
 
 	// Test reduce shard_row_id_bits will be ok.
 	tk.MustExec("alter table t1 SHARD_ROW_ID_BITS = 3;")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2170,7 +2170,7 @@ func (s *testDBSuite4) TestComment(c *C) {
 	s.tk.MustExec("drop table if exists ct, ct1")
 }
 
-func (s *testDBSuite5) TestRebaseAutoID(c *C) {
+func (s *testDBSuite4) TestRebaseAutoID(c *C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
 	defer func() {
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -26,8 +26,8 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	tmysql "github.com/pingcap/parser/mysql"

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -356,7 +356,7 @@ func (s *testSuite3) TestRenameTable(c *C) {
 	tk.MustExec("insert rename2.t values ()")
 	tk.MustExec("rename table rename2.t to rename3.t")
 	tk.MustExec("insert rename3.t values ()")
-	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "5001", "10001"))
+	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "1500001", "2000001"))
 	// Make sure the drop old database doesn't affect the rename3.t's operations.
 	tk.MustExec("drop database rename2")
 	tk.MustExec("insert rename3.t values ()")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
@@ -343,6 +344,10 @@ func (s *testSuite3) TestDefaultDBAfterDropCurDB(c *C) {
 }
 
 func (s *testSuite3) TestRenameTable(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("create database rename1")
@@ -356,7 +361,7 @@ func (s *testSuite3) TestRenameTable(c *C) {
 	tk.MustExec("insert rename2.t values ()")
 	tk.MustExec("rename table rename2.t to rename3.t")
 	tk.MustExec("insert rename3.t values ()")
-	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "1500001", "2000001"))
+	tk.MustQuery("select * from rename3.t").Check(testkit.Rows("1", "5001", "10001"))
 	// Make sure the drop old database doesn't affect the rename3.t's operations.
 	tk.MustExec("drop database rename2")
 	tk.MustExec("insert rename3.t values ()")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4209,7 +4209,7 @@ func (s *testRecoverTable) TestRecoverTable(c *C) {
 	tk.MustExec("insert into t_recover values (4),(5),(6)")
 	tk.MustQuery("select * from t_recover;").Check(testkit.Rows("1", "2", "3", "4", "5", "6"))
 	// check rebase auto id.
-	tk.MustQuery("select a,_tidb_rowid from t_recover;").Check(testkit.Rows("1 1", "2 2", "3 3", "4 5001", "5 5002", "6 5003"))
+	tk.MustQuery("select a,_tidb_rowid from t_recover;").Check(testkit.Rows("1 1", "2 2", "3 3", "4 1500001", "5 1500002", "6 1500003"))
 
 	// recover table by none exits job.
 	_, err = tk.Exec(fmt.Sprintf("recover table by job %d", 10000000))

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4141,6 +4141,10 @@ func (s *testRecoverTable) SetUpSuite(c *C) {
 }
 
 func (s *testRecoverTable) TestRecoverTable(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create database if not exists test_recover")
 	tk.MustExec("use test_recover")
@@ -4209,7 +4213,7 @@ func (s *testRecoverTable) TestRecoverTable(c *C) {
 	tk.MustExec("insert into t_recover values (4),(5),(6)")
 	tk.MustQuery("select * from t_recover;").Check(testkit.Rows("1", "2", "3", "4", "5", "6"))
 	// check rebase auto id.
-	tk.MustQuery("select a,_tidb_rowid from t_recover;").Check(testkit.Rows("1 1", "2 2", "3 3", "4 1500001", "5 1500002", "6 1500003"))
+	tk.MustQuery("select a,_tidb_rowid from t_recover;").Check(testkit.Rows("1 1", "2 2", "3 3", "4 5001", "5 5002", "6 5003"))
 
 	// recover table by none exits job.
 	_, err = tk.Exec(fmt.Sprintf("recover table by job %d", 10000000))

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -708,6 +708,10 @@ func checkGoroutineExists(keyword string) bool {
 }
 
 func (s *seqTestSuite) TestAdminShowNextID(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
 	step := int64(10)
 	autoIDStep := autoid.GetStep()
 	autoid.SetStep(step)
@@ -727,7 +731,7 @@ func (s *seqTestSuite) TestAdminShowNextID(c *C) {
 		tk.MustExec("insert into t values(10000, 1)")
 	}
 	r = tk.MustQuery("admin show t next_row_id")
-	r.Check(testkit.Rows("test t _tidb_rowid 10011"))
+	r.Check(testkit.Rows("test t _tidb_rowid 21"))
 
 	// test for a table with the primary key
 	tk.MustExec("create table tt(id int primary key auto_increment, c int)")

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -727,7 +727,7 @@ func (s *seqTestSuite) TestAdminShowNextID(c *C) {
 		tk.MustExec("insert into t values(10000, 1)")
 	}
 	r = tk.MustQuery("admin show t next_row_id")
-	r.Check(testkit.Rows("test t _tidb_rowid 21"))
+	r.Check(testkit.Rows("test t _tidb_rowid 10011"))
 
 	// test for a table with the primary key
 	tk.MustExec("create table tt(id int primary key auto_increment, c int)")

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -315,8 +315,8 @@ func NextStep(curStep int64, consumeDur time.Duration) int64 {
 	if consumeDur.Nanoseconds() == 0 {
 		return curStep
 	}
-	y := defaultComsumeTime.Nanoseconds() / consumeDur.Nanoseconds()
-	res := curStep * y
+	y := defaultComsumeTime.Seconds() / consumeDur.Seconds()
+	res := int64(float64(curStep) * y)
 	if res < minStep {
 		return minStep
 	} else if res > maxStep {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -303,6 +303,7 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 	return alloc.alloc4Signed(tableID)
 }
 
+// NextStep return new auto id step according to previous step and consuming time.
 func NextStep(curStep int64, consumeDur time.Duration) int64 {
 	x, y := consumeDur.Nanoseconds()/1000000, defaultComsumeTime.Nanoseconds()/1000000
 	if x == 0 {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -311,9 +311,9 @@ func NextStep(curStep int64, consumeDur time.Duration) int64 {
 			failpoint.Return(step)
 		}
 	})
-	
-	y := defaultComsumeTime.Seconds() / consumeDur.Seconds()
-	res := int64(float64(curStep) * y)
+
+	consumeRate := defaultComsumeTime.Seconds() / consumeDur.Seconds()
+	res := int64(float64(curStep) * consumeRate)
 	if res < minStep {
 		return minStep
 	} else if res > maxStep {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -311,10 +311,7 @@ func NextStep(curStep int64, consumeDur time.Duration) int64 {
 			failpoint.Return(step)
 		}
 	})
-
-	if consumeDur.Nanoseconds() == 0 {
-		return curStep
-	}
+	
 	y := defaultComsumeTime.Seconds() / consumeDur.Seconds()
 	res := int64(float64(curStep) * y)
 	if res < minStep {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -33,7 +33,7 @@ import (
 const (
 	minStep            = 1000
 	maxStep            = 2000000
-	defaultComsumeTime = 10 * time.Second
+	defaultConsumeTime = 10 * time.Second
 )
 
 // Test needs to change it, so it's a variable.

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -19,9 +19,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pingcap/failpoint"
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -312,7 +312,7 @@ func NextStep(curStep int64, consumeDur time.Duration) int64 {
 		}
 	})
 
-	consumeRate := defaultComsumeTime.Seconds() / consumeDur.Seconds()
+	consumeRate := defaultConsumeTime.Seconds() / consumeDur.Seconds()
 	res := int64(float64(curStep) * consumeRate)
 	if res < minStep {
 		return minStep

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	minStep            = 5000
-	maxStep            = 1500000
+	minStep            = 1000
+	maxStep            = 2000000
 	defaultComsumeTime = 10 * time.Second
 )
 
@@ -225,7 +225,6 @@ func (alloc *allocator) alloc4Unsigned(tableID int64) (int64, error) {
 		startTime := time.Now()
 		consumeDur := startTime.Sub(alloc.lastAllocTime)
 		alloc.step = NextStep(alloc.step, consumeDur)
-		alloc.lastAllocTime = startTime
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
@@ -241,6 +240,7 @@ func (alloc *allocator) alloc4Unsigned(tableID int64) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
+		alloc.lastAllocTime = time.Now()
 		if uint64(newBase) == math.MaxUint64 {
 			return 0, ErrAutoincReadFailed
 		}
@@ -261,7 +261,6 @@ func (alloc *allocator) alloc4Signed(tableID int64) (int64, error) {
 		startTime := time.Now()
 		consumeDur := startTime.Sub(alloc.lastAllocTime)
 		alloc.step = NextStep(alloc.step, consumeDur)
-		alloc.lastAllocTime = startTime
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
@@ -277,6 +276,7 @@ func (alloc *allocator) alloc4Signed(tableID int64) (int64, error) {
 		if err != nil {
 			return 0, err
 		}
+		alloc.lastAllocTime = time.Now()
 		if newBase == math.MaxInt64 {
 			return 0, ErrAutoincReadFailed
 		}

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -304,7 +304,7 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 }
 
 func NextStep(curStep int64, consumeDur time.Duration) int64 {
-	x, y := consumeDur.Nanoseconds() / 1000000, defaultComsumeTime.Nanoseconds() / 1000000
+	x, y := consumeDur.Nanoseconds()/1000000, defaultComsumeTime.Nanoseconds()/1000000
 	if x == 0 {
 		return curStep
 	}

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -29,6 +29,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	minStep            = 5000
+	maxStep            = 1500000
+	defaultComsumeTime = 10 * time.Second
+)
+
 // Test needs to change it, so it's a variable.
 var step = int64(30000)
 
@@ -58,8 +64,10 @@ type allocator struct {
 	end   int64
 	store kv.Storage
 	// dbID is current database's ID.
-	dbID       int64
-	isUnsigned bool
+	dbID          int64
+	isUnsigned    bool
+	lastAllocTime time.Time
+	step          int64
 }
 
 // GetStep is only used by tests
@@ -123,7 +131,7 @@ func (alloc *allocator) rebase4Unsigned(tableID int64, requiredBase uint64, allo
 		uCurrentEnd := uint64(currentEnd)
 		if allocIDs {
 			newBase = mathutil.MaxUint64(uCurrentEnd, requiredBase)
-			newEnd = mathutil.MinUint64(math.MaxUint64-uint64(step), newBase) + uint64(step)
+			newEnd = mathutil.MinUint64(math.MaxUint64-uint64(alloc.step), newBase) + uint64(alloc.step)
 		} else {
 			if uCurrentEnd >= requiredBase {
 				newBase = uCurrentEnd
@@ -168,7 +176,7 @@ func (alloc *allocator) rebase4Signed(tableID, requiredBase int64, allocIDs bool
 		}
 		if allocIDs {
 			newBase = mathutil.MaxInt64(currentEnd, requiredBase)
-			newEnd = mathutil.MinInt64(math.MaxInt64-step, newBase) + step
+			newEnd = mathutil.MinInt64(math.MaxInt64-alloc.step, newBase) + alloc.step
 		} else {
 			if currentEnd >= requiredBase {
 				newBase = currentEnd
@@ -214,6 +222,9 @@ func (alloc *allocator) alloc4Unsigned(tableID int64) (int64, error) {
 	if alloc.base == alloc.end { // step
 		var newBase, newEnd int64
 		startTime := time.Now()
+		consumeDur := startTime.Sub(alloc.lastAllocTime)
+		alloc.step = NextStep(alloc.step, consumeDur)
+		alloc.lastAllocTime = startTime
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
@@ -221,7 +232,7 @@ func (alloc *allocator) alloc4Unsigned(tableID int64) (int64, error) {
 			if err1 != nil {
 				return err1
 			}
-			tmpStep := int64(mathutil.MinUint64(math.MaxUint64-uint64(newBase), uint64(step)))
+			tmpStep := int64(mathutil.MinUint64(math.MaxUint64-uint64(newBase), uint64(alloc.step)))
 			newEnd, err1 = m.GenAutoTableID(alloc.dbID, tableID, tmpStep)
 			return err1
 		})
@@ -247,6 +258,9 @@ func (alloc *allocator) alloc4Signed(tableID int64) (int64, error) {
 	if alloc.base == alloc.end { // step
 		var newBase, newEnd int64
 		startTime := time.Now()
+		consumeDur := startTime.Sub(alloc.lastAllocTime)
+		alloc.step = NextStep(alloc.step, consumeDur)
+		alloc.lastAllocTime = startTime
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
@@ -254,7 +268,7 @@ func (alloc *allocator) alloc4Signed(tableID int64) (int64, error) {
 			if err1 != nil {
 				return err1
 			}
-			tmpStep := mathutil.MinInt64(math.MaxInt64-newBase, step)
+			tmpStep := mathutil.MinInt64(math.MaxInt64-newBase, alloc.step)
 			newEnd, err1 = m.GenAutoTableID(alloc.dbID, tableID, tmpStep)
 			return err1
 		})
@@ -289,12 +303,28 @@ func (alloc *allocator) Alloc(tableID int64) (int64, error) {
 	return alloc.alloc4Signed(tableID)
 }
 
+func NextStep(curStep int64, consumeDur time.Duration) int64 {
+	x, y := consumeDur.Nanoseconds() / 1000000, defaultComsumeTime.Nanoseconds() / 1000000
+	if x == 0 {
+		return curStep
+	}
+	res := (curStep / x) * y
+	if res < minStep {
+		return minStep
+	} else if res > maxStep {
+		return maxStep
+	}
+	return res
+}
+
 // NewAllocator returns a new auto increment id generator on the store.
 func NewAllocator(store kv.Storage, dbID int64, isUnsigned bool) Allocator {
 	return &allocator{
-		store:      store,
-		dbID:       dbID,
-		isUnsigned: isUnsigned,
+		store:         store,
+		dbID:          dbID,
+		isUnsigned:    isUnsigned,
+		step:          step,
+		lastAllocTime: time.Now(),
 	}
 }
 

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -326,3 +326,13 @@ func (*testSuite) TestRollbackAlloc(c *C) {
 	c.Assert(alloc.Base(), Equals, int64(0))
 	c.Assert(alloc.End(), Equals, int64(0))
 }
+
+// TestNextStep tests generate next auto id step.
+func (*testSuite) TestNextStep(c *C) {
+	nextStep := autoid.NextStep(2000000, 1*time.Nanosecond)
+	c.Assert(nextStep, Equals, int64(2000000))
+	nextStep = autoid.NextStep(678910, 10*time.Second)
+	c.Assert(nextStep, Equals, int64(678910))
+	nextStep = autoid.NextStep(50000, 10*time.Minute)
+	c.Assert(nextStep, Equals, int64(1000))
+}

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -39,6 +40,11 @@ type testSuite struct {
 }
 
 func (*testSuite) TestT(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
+
 	store, err := mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
 	defer store.Close()
@@ -130,6 +136,11 @@ func (*testSuite) TestT(c *C) {
 }
 
 func (*testSuite) TestUnsignedAutoid(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
+
 	store, err := mockstore.NewMockTikvStore()
 	c.Assert(err, IsNil)
 	defer store.Close()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make auto increment id step can be adjust automatically according to auto id request speed.

### What is changed and how it works?
add function `NextStep` which can produce the next auto id step according to previous step.

There are still many test need to be change, so do not merge.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change


Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
