### PR TITLE
planner,executor: relax the restrictions of `trace format='row'`

### DIFF
--- a/executor/trace_test.go
+++ b/executor/trace_test.go
@@ -39,6 +39,8 @@ func (s *testSuite1) TestTraceExec(c *C) {
 	// |   └─recordSet.Next        | 22:08:38.249340 | 155.317µs  |
 	// +---------------------------+-----------------+------------+
 	rows = tk.MustQuery("trace format='row' select * from trace where id = 0;").Rows()
+	c.Assert(len(rows) > 1, IsTrue)
 
+	rows = tk.MustQuery("trace format='row' delete from trace where id = 0").Rows()
 	c.Assert(len(rows) > 1, IsTrue)
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1984,12 +1984,7 @@ func (b *PlanBuilder) buildDDL(node ast.DDLNode) (Plan, error) {
 // underlying query and then constructs a schema, which will be used to constructs
 // rows result.
 func (b *PlanBuilder) buildTrace(trace *ast.TraceStmt) (Plan, error) {
-	if _, ok := trace.Stmt.(*ast.SelectStmt); !ok && trace.Format == "row" {
-		return nil, errors.New("trace only supports select query when format is row")
-	}
-
 	p := &Trace{StmtNode: trace.Stmt, Format: trace.Format}
-
 	switch trace.Format {
 	case "row":
 		retFields := []string{"operation", "duration", "spanID"}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before:

```
mysql> trace  format = 'row' delete from t1 where b > 188 and a > 70000 and a < 110000 limit 6000;
ERROR 1105 (HY000): trace only supports select query when format is row
```

After:

```
mysql> trace  format = 'row' delete from t1 where b > 188 and a > 70000 and a < 110000 limit 6000;
+--------------------------------------------+-----------------+-------------+
| operation                                  | startTS         | duration    |
+--------------------------------------------+-----------------+-------------+
| session.getTxnFuture                       | 15:44:52.505747 | 24.853µs    |
|   ├─session.Execute                        | 15:44:52.505740 | 57.30648ms  |
|   ├─session.ParseSQL                       | 15:44:52.505865 | 96.449µs    |
|   ├─executor.Compile                       | 15:44:52.506090 | 630.772µs   |
|   ├─session.runStmt                        | 15:44:52.506789 | 56.189145ms |
|   ├─executor.handleNoDelayExecutor         | 15:44:52.509336 | 29.912158ms |
|   ├─*executor.DeleteExec.Next              | 15:44:52.509362 | 29.866858ms |
|   ├─*executor.LimitExec.Next               | 15:44:52.509390 | 27.584511ms |
|   ├─*executor.TableReaderExecutor.Next     | 15:44:52.509397 | 27.557925ms |
|   ├─*executor.LimitExec.Next               | 15:44:52.538084 | 125.436µs   |
|   ├─*executor.TableReaderExecutor.Next     | 15:44:52.538092 | 80.23µs     |
|   ├─*executor.LimitExec.Next               | 15:44:52.539201 | 21.681µs    |
|   ├─*executor.TableReaderExecutor.Next     | 15:44:52.539204 | 2.073µs     |
|   └─session.CommitTxn                      | 15:44:52.540510 | 22.43159ms  |
+--------------------------------------------+-----------------+-------------+
14 rows in set (0.06 sec)
```

### What is changed and how it works?

In fact, `trace format='row' delete from t where ...` is supported, we can relax the restrictions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
