### PR TITLE
ddl: add recover for run ddl job

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -482,11 +482,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		}
 	}()
 
-	failpoint.Inject("mockPanicInRunDDLJob", func(val failpoint.Value) {
-		if val.(bool) {
-			panic("panic test")
-		}
-	})
+	failpoint.Inject("mockPanicInRunDDLJob", func(val failpoint.Value) {})
 
 	logutil.Logger(w.logCtx).Info("[ddl] run DDL job", zap.String("job", job.String()))
 	timeStart := time.Now()

--- a/ddl/failtest/fail_db_test.go
+++ b/ddl/failtest/fail_db_test.go
@@ -386,3 +386,17 @@ LOOP:
 	tk.MustExec("admin check table test_add_index")
 	tk.MustExec("drop table test_add_index")
 }
+
+// TestRunDDLJobPanic tests recover panic when run ddl job panic.
+func (s *testFailDBSuite) TestRunDDLJobPanic(c *C) {
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob"), IsNil)
+	}()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob", `1*return(true)`), IsNil)
+	_, err := tk.Exec("create table t(c1 int, c2 int)")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+}

--- a/ddl/failtest/fail_db_test.go
+++ b/ddl/failtest/fail_db_test.go
@@ -395,7 +395,7 @@ func (s *testFailDBSuite) TestRunDDLJobPanic(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob", `1*return(true)`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob", `1*panic("panic test")`), IsNil)
 	_, err := tk.Exec("create table t(c1 int, c2 int)")
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -429,17 +429,3 @@ func (s *testSerialSuite) TestTableLocksEnable(c *C) {
 	tk.MustExec("lock tables t1 write")
 	checkTableLock(c, tk.Se, "test", "t1", model.TableLockNone)
 }
-
-// TestRunDDLJobPanic tests recover panic when run ddl job panic.
-func (s *testSerialSuite) TestRunDDLJobPanic(c *C) {
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob"), IsNil)
-	}()
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob", `1*return(true)`), IsNil)
-	_, err := tk.Exec("create table t(c1 int, c2 int)")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
-}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -773,7 +773,7 @@ func onModifyTableCharsetAndCollate(t *meta.Meta, job *model.Job) (ver int64, _ 
 
 func checkTableNotExists(d *ddlCtx, t *meta.Meta, schemaID int64, tableName string) error {
 	// d.infoHandle maybe nil in some test.
-	if d.infoHandle == nil || d.infoHandle.IsValid() {
+	if d.infoHandle == nil || !d.infoHandle.IsValid() {
 		return checkTableNotExistsFromStore(t, schemaID, tableName)
 	}
 	// Try to use memory schema info to check first.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -773,7 +773,7 @@ func onModifyTableCharsetAndCollate(t *meta.Meta, job *model.Job) (ver int64, _ 
 
 func checkTableNotExists(d *ddlCtx, t *meta.Meta, schemaID int64, tableName string) error {
 	// d.infoHandle maybe nil in some test.
-	if d.infoHandle == nil {
+	if d.infoHandle == nil || d.infoHandle.IsNil() {
 		return checkTableNotExistsFromStore(t, schemaID, tableName)
 	}
 	// Try to use memory schema info to check first.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -773,7 +773,7 @@ func onModifyTableCharsetAndCollate(t *meta.Meta, job *model.Job) (ver int64, _ 
 
 func checkTableNotExists(d *ddlCtx, t *meta.Meta, schemaID int64, tableName string) error {
 	// d.infoHandle maybe nil in some test.
-	if d.infoHandle == nil || d.infoHandle.IsNil() {
+	if d.infoHandle == nil || d.infoHandle.IsValid() {
 		return checkTableNotExistsFromStore(t, schemaID, tableName)
 	}
 	// Try to use memory schema info to check first.

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -303,6 +303,11 @@ func (h *Handle) Get() InfoSchema {
 	return schema
 }
 
+// IsNil uses to check whether handle value is nil.
+func (h *Handle) IsNil() bool {
+	return h.value.Load() == nil
+}
+
 // EmptyClone creates a new Handle with the same store and memSchema, but the value is not set.
 func (h *Handle) EmptyClone() *Handle {
 	newHandle := &Handle{

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -303,8 +303,8 @@ func (h *Handle) Get() InfoSchema {
 	return schema
 }
 
-// IsNil uses to check whether handle value is nil.
-func (h *Handle) IsNil() bool {
+// IsValid uses to check whether handle value is nil.
+func (h *Handle) IsValid() bool {
 	return h.value.Load() == nil
 }
 

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -303,9 +303,9 @@ func (h *Handle) Get() InfoSchema {
 	return schema
 }
 
-// IsValid uses to check whether handle value is nil.
+// IsValid uses to check whether handle value is valid.
 func (h *Handle) IsValid() bool {
-	return h.value.Load() == nil
+	return h.value.Load() != nil
 }
 
 // EmptyClone creates a new Handle with the same store and memSchema, but the value is not set.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix ddl worker run ddl job panic.

```sql
[2019/06/28 15:21:54.379 +08:00] [INFO] [ddl_worker.go:474] ["[ddl] run DDL job"] [worker="worker 1, tp general"] [job="ID:48, Type:create table, State:none, SchemaState:none, SchemaID:1, TableID:47, RowCount:0, ArgLen:0, start time: 2019-06-28 15:19:12.653 +0800 CST, Err:<nil>, ErrCount:0, SnapshotVersion:0"]
[2019/06/28 15:21:54.379 +08:00] [ERROR] [ddl.go:441] ["[ddl] DDL worker meet panic"] [worker="worker 1, tp general"] [ID=8c8b0d58-4238-4f21-bd15-6915af71a983] [stack="github.com/pingcap/tidb/ddl.(*ddl).start.func2
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:441
github.com/pingcap/tidb/util.WithRecovery.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:72
runtime.gopanic
	/usr/local/go1.12/src/runtime/panic.go:522
runtime.panicmem
	/usr/local/go1.12/src/runtime/panic.go:82
runtime.sigpanic
	/usr/local/go1.12/src/runtime/signal_unix.go:390
github.com/pingcap/tidb/infoschema.(*Handle).Get
	/Users/cs/code/goread/src/github.com/pingcap/tidb/infoschema/infoschema.go:302
github.com/pingcap/tidb/ddl.onCreateTable
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/table.go:56
github.com/pingcap/tidb/ddl.(*worker).runDDLJob
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:499
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:402
github.com/pingcap/tidb/kv.RunInNewTxn
	/Users/cs/code/goread/src/github.com/pingcap/tidb/kv/txn.go:50
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:365
github.com/pingcap/tidb/ddl.(*worker).start
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:137
github.com/pingcap/tidb/ddl.(*ddl).start.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:438
github.com/pingcap/tidb/util.WithRecovery
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:80"]
[2019/06/28 15:21:54.380 +08:00] [ERROR] [misc.go:75] ["panic in the recoverable goroutine"] [r="\"invalid memory address or nil pointer dereference\""] ["stack trace"="github.com/pingcap/tidb/util.WithRecovery.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:77
runtime.gopanic
	/usr/local/go1.12/src/runtime/panic.go:522
runtime.panicmem
	/usr/local/go1.12/src/runtime/panic.go:82
runtime.sigpanic
	/usr/local/go1.12/src/runtime/signal_unix.go:390
github.com/pingcap/tidb/infoschema.(*Handle).Get
	/Users/cs/code/goread/src/github.com/pingcap/tidb/infoschema/infoschema.go:302
github.com/pingcap/tidb/ddl.onCreateTable
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/table.go:56
github.com/pingcap/tidb/ddl.(*worker).runDDLJob
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:499
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:402
github.com/pingcap/tidb/kv.RunInNewTxn
	/Users/cs/code/goread/src/github.com/pingcap/tidb/kv/txn.go:50
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:365
github.com/pingcap/tidb/ddl.(*worker).start
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:137
github.com/pingcap/tidb/ddl.(*ddl).start.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:438
github.com/pingcap/tidb/util.WithRecovery
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:80"] [stack="github.com/pingcap/tidb/util.WithRecovery.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:75
runtime.gopanic
	/usr/local/go1.12/src/runtime/panic.go:522
runtime.panicmem
	/usr/local/go1.12/src/runtime/panic.go:82
runtime.sigpanic
	/usr/local/go1.12/src/runtime/signal_unix.go:390
github.com/pingcap/tidb/infoschema.(*Handle).Get
	/Users/cs/code/goread/src/github.com/pingcap/tidb/infoschema/infoschema.go:302
github.com/pingcap/tidb/ddl.onCreateTable
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/table.go:56
github.com/pingcap/tidb/ddl.(*worker).runDDLJob
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:499
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:402
github.com/pingcap/tidb/kv.RunInNewTxn
	/Users/cs/code/goread/src/github.com/pingcap/tidb/kv/txn.go:50
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:365
github.com/pingcap/tidb/ddl.(*worker).start
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl_worker.go:137
github.com/pingcap/tidb/ddl.(*ddl).start.func1
	/Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:438
github.com/pingcap/tidb/util.WithRecovery
	/Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:80"]
```

### What is changed and how it works?
* Add a recover in `runDDLJob` function.
* check nil point.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
