### PR TITLE
*: fix 'db' and 'Info' column of 'show processlist'

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -546,7 +546,7 @@ var tableProcesslistCols = []columnInfo{
 	{"ID", mysql.TypeLonglong, 21, mysql.NotNullFlag, 0, nil},
 	{"USER", mysql.TypeVarchar, 16, mysql.NotNullFlag, "", nil},
 	{"HOST", mysql.TypeVarchar, 64, mysql.NotNullFlag, "", nil},
-	{"DB", mysql.TypeVarchar, 64, mysql.NotNullFlag, "", nil},
+	{"DB", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"COMMAND", mysql.TypeVarchar, 16, mysql.NotNullFlag, "", nil},
 	{"TIME", mysql.TypeLong, 7, mysql.NotNullFlag, 0, nil},
 	{"STATE", mysql.TypeVarchar, 7, 0, nil, nil},

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -306,6 +306,44 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s", "do something"),
 			fmt.Sprintf("2 user-2 localhost test Init DB 9223372036 2 %s", strings.Repeat("x", 101)),
 		))
+
+	sm = &mockSessionManager{make(map[uint64]*util.ProcessInfo, 2)}
+	sm.processInfoMap[1] = &util.ProcessInfo{
+		ID:      1,
+		User:    "user-1",
+		Host:    "localhost",
+		DB:      "information_schema",
+		Command: byte(1),
+		State:   1,
+		Info:    nil,
+		StmtCtx: tk.Se.GetSessionVars().StmtCtx,
+	}
+	sm.processInfoMap[2] = &util.ProcessInfo{
+		ID:      2,
+		User:    "user-2",
+		Host:    "localhost",
+		DB:      nil,
+		Command: byte(2),
+		State:   2,
+		Info:    strings.Repeat("x", 101),
+		StmtCtx: tk.Se.GetSessionVars().StmtCtx,
+	}
+	tk.Se.SetSessionManager(sm)
+	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Sort().Check(
+		testkit.Rows(
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0", "<nil>"),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0", strings.Repeat("x", 101)),
+		))
+	tk.MustQuery("SHOW PROCESSLIST;").Sort().Check(
+		testkit.Rows(
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s", "<nil>"),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s", strings.Repeat("x", 100)),
+		))
+	tk.MustQuery("SHOW FULL PROCESSLIST;").Sort().Check(
+		testkit.Rows(
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s", "<nil>"),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s", strings.Repeat("x", 101)),
+		))
 }
 
 func (s *testTableSuite) TestSchemataCharacterSet(c *C) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -344,6 +344,14 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s", "<nil>"),
 			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s", strings.Repeat("x", 101)),
 		))
+	tk.MustQuery("select * from information_schema.PROCESSLIST where db is null;").Sort().Check(
+		testkit.Rows(
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0", strings.Repeat("x", 101)),
+		))
+	tk.MustQuery("select * from information_schema.PROCESSLIST where Info is null;").Sort().Check(
+		testkit.Rows(
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0", "<nil>"),
+		))
 }
 
 func (s *testTableSuite) TestSchemataCharacterSet(c *C) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -329,7 +329,7 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 		StmtCtx: tk.Se.GetSessionVars().StmtCtx,
 	}
 	tk.Se.SetSessionManager(sm)
-	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Sort().Check(
+	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Check(
 		testkit.Rows(
 			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0", "<nil>"),
 			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0", strings.Repeat("x", 101)),
@@ -344,11 +344,11 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s", "<nil>"),
 			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s", strings.Repeat("x", 101)),
 		))
-	tk.MustQuery("select * from information_schema.PROCESSLIST where db is null;").Sort().Check(
+	tk.MustQuery("select * from information_schema.PROCESSLIST where db is null;").Check(
 		testkit.Rows(
 			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0", strings.Repeat("x", 101)),
 		))
-	tk.MustQuery("select * from information_schema.PROCESSLIST where Info is null;").Sort().Check(
+	tk.MustQuery("select * from information_schema.PROCESSLIST where Info is null;").Check(
 		testkit.Rows(
 			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0", "<nil>"),
 		))

--- a/session/session.go
+++ b/session/session.go
@@ -965,14 +965,23 @@ func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) 
 }
 
 func (s *session) SetProcessInfo(sql string, t time.Time, command byte, maxExecutionTime uint64) {
+	var db interface{}
+	if len(s.sessionVars.CurrentDB) > 0 {
+		db = s.sessionVars.CurrentDB
+	}
+
+	var info interface{}
+	if len(sql) > 0 {
+		info = sql
+	}
 	pi := util.ProcessInfo{
 		ID:               s.sessionVars.ConnectionID,
-		DB:               s.sessionVars.CurrentDB,
+		DB:               db,
 		Command:          command,
 		Plan:             s.currentPlan,
 		Time:             t,
 		State:            s.Status(),
-		Info:             sql,
+		Info:             info,
 		CurTxnStartTS:    s.sessionVars.TxnCtx.StartTS,
 		StmtCtx:          s.sessionVars.StmtCtx,
 		StatsInfo:        plannercore.GetStatsInfo,

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -59,7 +59,7 @@ func (eqh *Handle) Run() {
 		case <-ticker.C:
 			processInfo := eqh.sm.ShowProcessList()
 			for _, info := range processInfo {
-				if len(info.Info) == 0 || info.ExceedExpensiveTimeThresh {
+				if info.Info == nil || info.ExceedExpensiveTimeThresh {
 					continue
 				}
 				costTime := time.Since(info.Time)
@@ -124,8 +124,8 @@ func logExpensiveQuery(costTime time.Duration, info *util.ProcessInfo) {
 	if len(info.User) > 0 {
 		logFields = append(logFields, zap.String("user", info.User))
 	}
-	if len(info.DB) > 0 {
-		logFields = append(logFields, zap.String("database", info.DB))
+	if info.DB != nil && len(info.DB.(string)) > 0 {
+		logFields = append(logFields, zap.String("database", info.DB.(string)))
 	}
 	var tableIDs, indexIDs string
 	if len(info.StmtCtx.TableIDs) > 0 {
@@ -142,7 +142,10 @@ func logExpensiveQuery(costTime time.Duration, info *util.ProcessInfo) {
 	}
 
 	const logSQLLen = 1024 * 8
-	sql := info.Info
+	var sql string
+	if info.Info != nil {
+		sql = info.Info.(string)
+	}
 	if len(sql) > logSQLLen {
 		sql = fmt.Sprintf("%s len(%d)", sql[:logSQLLen], len(sql))
 	}

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -26,12 +26,12 @@ type ProcessInfo struct {
 	ID                        uint64
 	User                      string
 	Host                      string
-	DB                        string
+	DB                        interface{}
 	Command                   byte
 	Plan                      interface{}
 	Time                      time.Time
 	State                     uint16
-	Info                      string
+	Info                      interface{}
 	CurTxnStartTS             uint64
 	StmtCtx                   *stmtctx.StatementContext
 	StatsInfo                 func(interface{}) map[string]uint64
@@ -43,11 +43,13 @@ type ProcessInfo struct {
 
 // ToRowForShow returns []interface{} for the row data of "SHOW [FULL] PROCESSLIST".
 func (pi *ProcessInfo) ToRowForShow(full bool) []interface{} {
-	var info string
-	if full {
-		info = pi.Info
-	} else {
-		info = fmt.Sprintf("%.100v", pi.Info)
+	var info interface{}
+	if pi.Info != nil {
+		if full {
+			info = pi.Info.(string)
+		} else {
+			info = fmt.Sprintf("%.100v", pi.Info.(string))
+		}
 	}
 	t := uint64(time.Since(pi.Time) / time.Second)
 	return []interface{}{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/pingcap/tidb/issues/10903
The Info column of `show processlist` should be NULL if it is not executing any statement.
The db column of `show processlist` should be NULL if it is not select one.

### What is changed and how it works?

open 2 mysql client and run `show processlist;` both.

Before this pr:
```
mysql> show processlist;
+------+------+-----------+----+---------+------+-------+------------------+
| Id   | User | Host      | db | Command | Time | State | Info             |
+------+------+-----------+----+---------+------+-------+------------------+
|    2 | root | 127.0.0.1 |    | Query   |    0 | 2     | show processlist |
|    1 | root | 127.0.0.1 |    | Sleep   |   10 | 2     |                  |
+------+------+-----------+----+---------+------+-------+------------------+
2 rows in set (0.00 sec)
```
This pr:
```
mysql> show processlist;
+------+------+-----------+------+---------+------+-------+------------------+
| Id   | User | Host      | db   | Command | Time | State | Info             |
+------+------+-----------+------+---------+------+-------+------------------+
|    3 | root | 127.0.0.1 | NULL | Sleep   |    3 | 2     | NULL             |
|    4 | root | 127.0.0.1 | NULL | Query   |    0 | 2     | show processlist |
+------+------+-----------+------+---------+------+-------+------------------+
2 rows in set (0.01 sec)
```




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes

