### PR TITLE
executor: let flush privileges do nothing when `skip-grant-table` is configured

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -96,6 +96,7 @@ var _ = Suite(&testUpdateSuite{})
 var _ = Suite(&testOOMSuite{})
 var _ = Suite(&testPointGetSuite{})
 var _ = Suite(&testRecoverTable{})
+var _ = Suite(&testFlushSuite{})
 
 type testSuite struct {
 	cluster   *mocktikv.Cluster

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -812,6 +812,13 @@ func (e *SimpleExec) executeFlush(s *ast.FlushStmt) error {
 			return errors.New("FLUSH TABLES WITH READ LOCK is not supported.  Please use @@tidb_snapshot")
 		}
 	case ast.FlushPrivileges:
+		// If skip-grant-table is configured, do not flush privileges.
+		// Because LoadPrivilegeLoop does not run and the privilege Handle is nil,
+		// Call dom.PrivilegeHandle().Update would panic.
+		if config.GetGlobalConfig().Security.SkipGrantTable {
+			return nil
+		}
+
 		dom := domain.GetDomain(e.ctx)
 		sysSessionPool := dom.SysSessionPool()
 		ctx, err := sysSessionPool.Get()

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -16,15 +16,15 @@ package executor_test
 import (
 	"context"
 
-	"github.com/pingcap/tidb/planner/core"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
+	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testkit"
@@ -394,6 +394,10 @@ func (s *testSuite3) TestFlushPrivileges(c *C) {
 	// After flush.
 	_, err = se.Execute(ctx, `SELECT Password FROM mysql.User WHERE User="testflush" and Host="localhost"`)
 	c.Check(err, IsNil)
+
+	config.GetGlobalConfig().Security.SkipGrantTable = true
+	tk.MustExec("FLUSH PRIVILEGES")
+	config.GetGlobalConfig().Security.SkipGrantTable = false
 }
 
 func (s *testSuite3) TestDropStats(c *C) {


### PR DESCRIPTION



<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When skip-grant-table is enabled, privilege handle is not initialized, calling flush privileges
would meet nil pointer panic

```
mysql> flush privileges;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

```
github.com/pingcap/tidb/server.(*clientConn).Run.func1
	/root/go/src/github.com/pingcap/tidb/server/conn.go:593
runtime.gopanic
	/usr/local/go/src/runtime/panic.go:522
runtime.panicmem
	/usr/local/go/src/runtime/panic.go:82
runtime.sigpanic
	/usr/local/go/src/runtime/signal_unix.go:390
github.com/pingcap/tidb/privilege/privileges.(*Handle).Update
	/root/go/src/github.com/pingcap/tidb/privilege/privileges/cache.go:979
github.com/pingcap/tidb/executor.(*SimpleExec).executeFlush
	/root/go/src/github.com/pingcap/tidb/executor/simple.go:822
github.com/pingcap/tidb/executor.(*SimpleExec).Next
	/root/go/src/github.com/pingcap/tidb/executor/simple.go:74
github.com/pingcap/tidb/executor.Next
	/root/go/src/github.com/pingcap/tidb/executor/executor.go:190
github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor
	/root/go/src/github.com/pingcap/tidb/executor/adapter.go:388
github.com/pingcap/tidb/executor.(*ExecStmt).Exec
	/root/go/src/github.com/pingcap/tidb/executor/adapter.go:265
github.com/pingcap/tidb/session.runStmt
	/root/go/src/github.com/pingcap/tidb/session/tidb.go:219
github.com/pingcap/tidb/session.(*session).executeStatement
	/root/go/src/github.com/pingcap/tidb/session/session.go:939
github.com/pingcap/tidb/session.(*session).execute
	/root/go/src/github.com/pingcap/tidb/session/session.go:1037
github.com/pingcap/tidb/session.(*session).Execute
	/root/go/src/github.com/pingcap/tidb/session/session.go:966
github.com/pingcap/tidb/session.execRestrictedSQL
	/root/go/src/github.com/pingcap/tidb/session/session.go:745
github.com/pingcap/tidb/session.(*session).ExecRestrictedSQL
	/root/go/src/github.com/pingcap/tidb/session/session.go:700
github.com/pingcap/tidb/domain.(*Domain).NotifyUpdatePrivilege
	/root/go/src/github.com/pingcap/tidb/domain/domain.go:1047
github.com/pingcap/tidb/executor.(*SimpleExec).executeSetPwd
	/root/go/src/github.com/pingcap/tidb/executor/simple.go:789
github.com/pingcap/tidb/executor.(*SimpleExec).Next
	/root/go/src/github.com/pingcap/tidb/executor/simple.go:88
github.com/pingcap/tidb/executor.Next
	/root/go/src/github.com/pingcap/tidb/executor/executor.go:190
github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor
	/root/go/src/github.com/pingcap/tidb/executor/adapter.go:388
github.com/pingcap/tidb/executor.(*ExecStmt).Exec
	/root/go/src/github.com/pingcap/tidb/executor/adapter.go:265
github.com/pingcap/tidb/session.runStmt
	/root/go/src/github.com/pingcap/tidb/session/tidb.go:219
github.com/pingcap/tidb/session.(*session).executeStatement
	/root/go/src/github.com/pingcap/tidb/session/session.go:939
github.com/pingcap/tidb/session.(*session).execute
	/root/go/src/github.com/pingcap/tidb/session/session.go:1037
github.com/pingcap/tidb/session.(*session).Execute
	/root/go/src/github.com/pingcap/tidb/session/session.go:966
github.com/pingcap/tidb/server.(*TiDBContext).Execute
	/root/go/src/github.com/pingcap/tidb/server/driver_tidb.go:246
github.com/pingcap/tidb/server.(*clientConn).handleQuery
	/root/go/src/github.com/pingcap/tidb/server/conn.go:1158
github.com/pingcap/tidb/server.(*clientConn).dispatch
	/root/go/src/github.com/pingcap/tidb/server/conn.go:885
github.com/pingcap/tidb/server.(*clientConn).Run
	/root/go/src/github.com/pingcap/tidb/server/conn.go:644
github.com/pingcap/tidb/server.(*Server).onConn
	/root/go/src/github.com/pingcap/tidb/server/server.go:438
```

### What is changed and how it works?

Make `flush privileges` return directly if `skip-grant-table` is enabled.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch
