### PR TITLE
.github: automatically include labels when creating issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F41B Bug Report"
 about: Something isn't working as expected
-
+labels: type/bug
 ---
 
 ## Bug Report

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F680 Feature Request"
 about: I have a suggestion
-
+labels: type/enhancement
 ---
 
 ## Feature Request

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,7 +1,7 @@
 ---
 name: "\U0001F914 General Question"
 about: Usage question that isn't answered in docs or discussion
-
+labels: question
 ---
 
 ## General Question

--- a/.github/ISSUE_TEMPLATE/performance-questions.md
+++ b/.github/ISSUE_TEMPLATE/performance-questions.md
@@ -1,6 +1,7 @@
 ---
 name: "\U0001F947 Performance Questions"
 about: Performance question about TiDB which is not caused by bug.
+labels: question, type/performance
 ---
 
 ## Performance Questions


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Automatically apply some labels when a user creates an issue.

### What is changed and how it works?

Added the `labels` field the issue templates' headers according to https://help.github.com/en/articles/manually-creating-a-single-issue-template-for-your-repository.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

Side effects

Related changes
