### PR TITLE
*: fix oom action cancel bug

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/gcutil"
@@ -4082,6 +4083,24 @@ func (s *testOOMSuite) TestDistSQLMemoryControl(c *C) {
 	tk.MustQuery("select * from t use index(idx_a)")
 	c.Assert(s.oom.tracker, Equals, "IndexLookupDistSQLTracker")
 	tk.Se.GetSessionVars().MemQuotaDistSQL = -1
+}
+
+func (s *testSuite) TestOOMPanicAction(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b double);")
+	tk.MustExec("insert into t values (1,1)")
+	sm := &mockSessionManager1{
+		PS: make([]*util.ProcessInfo, 0),
+	}
+	tk.Se.SetSessionManager(sm)
+	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
+	config.GetGlobalConfig().OOMAction = config.OOMActionCancel
+	tk.MustExec("set @@tidb_mem_quota_query=1;")
+	err := tk.QueryToErr("select sum(b) from t group by a;")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Matches, "Out Of Memory Quota!.*")
 }
 
 type oomCapturer struct {

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -583,7 +583,7 @@ func (worker *copIteratorWorker) handleTask(bo *Backoffer, task *copTask, respCh
 				zap.Stack("stack trace"))
 			resp := &copResponse{err: errors.Errorf("%v", r)}
 			// if panic has happened, set checkOOM to false to avoid another panic.
-			worker.sendToRespCh(resp, task.respChan, false)
+			worker.sendToRespCh(resp, respCh, false)
 		}
 	}()
 	remainTasks := []*copTask{task}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
set config.OOMAction = "cancel"
before this PR:
```sql
create table t1(a int primary key, b double);
insert into t1 values(3,2);

test> select sum(a) from t1 group by b;
+--------+
| sum(a) |
+--------+
| 3      |
+--------+
1 row in set
test> set @@tidb_mem_quota_query=1;
Query OK, 0 rows affected
test> select sum(a) from t1 group by b;
+--------+
| sum(a) |
+--------+
0 rows in set
```

After This PR:

```sql 
test> select sum(a) from t1 group by b;
+--------+
| sum(a) |
+--------+
| 3      |
+--------+
1 row in set
Time: 0.006s
test> set @@tidb_mem_quota_query=1;
Query OK, 0 rows affected
Time: 0.001s
test> select sum(a) from t1 group by b;
(1105, u'Out Of Memory Quota![conn_id=1]')
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
