### PR TITLE
tikv: remove max grpc msg limitation for kv request

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -39,10 +39,6 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
-// MaxSendMsgSize set max gRPC request message size sent to server. If any request message size is larger than
-// current value, an error will be reported from gRPC.
-var MaxSendMsgSize = 10 * 1024 * 1024
-
 // MaxRecvMsgSize set max gRPC receive message size received from server. If any message size is larger than
 // current value, an error will be reported from gRPC.
 var MaxRecvMsgSize = math.MaxInt64
@@ -258,7 +254,6 @@ func (a *connArray) Init(addr string, security config.Security) error {
 			grpc.WithUnaryInterceptor(unaryInterceptor),
 			grpc.WithStreamInterceptor(streamInterceptor),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),
-			grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(MaxSendMsgSize)),
 			grpc.WithBackoffMaxDelay(time.Second*3),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{
 				Time:                time.Duration(keepAlive) * time.Second,


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

this pr works with https://github.com/tikv/tikv/pull/4992

grpc msg limitation is hard to pre-calculate and we already have 

https://github.com/pingcap/tidb/blob/c8d1ff7ca66f6e98d2002c429addf5ba34fd0416/store/tikv/2pc.go#L1035 to control commit msg size

and 

https://github.com/pingcap/tidb/commit/ef6590e1899a35515cf6a99353baf3d4d99db543#diff-c27388ffb48c6f6eaeefe07dd3243530R240 to control query msg size

in upper level.

### What is changed and how it works?

remove max grpc msg limitation for kv request

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - remove code

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11005)
<!-- Reviewable:end -->
