### PR TITLE
planner: make WindowFunction uncacheable in prepare

### DIFF
--- a/planner/core/cacheable_checker.go
+++ b/planner/core/cacheable_checker.go
@@ -82,6 +82,11 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 				return in, true
 			}
 		}
+	case *ast.FrameBound:
+		if _, ok := node.Expr.(*driver.ParamMarkerExpr); ok {
+			checker.cacheable = false
+			return in, true
+		}
 	}
 	return in, false
 }

--- a/planner/core/cacheable_checker_test.go
+++ b/planner/core/cacheable_checker_test.go
@@ -191,4 +191,7 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		OrderBy: orderByClause,
 	}
 	c.Assert(Cacheable(stmt), IsTrue)
+
+	boundExpr := &ast.FrameBound{Expr: &driver.ParamMarkerExpr{}}
+	c.Assert(Cacheable(boundExpr), IsFalse)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`FrameBound` is pre-calculated when building logical plan. So it will cause error if we cache it.

But it's safe to evaluate it later in execution phase. We'll make it cacheable in the future.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch