### PR TITLE
store/tikv: revert the optimization for optimistic conflicts pessimistic

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -47,7 +47,7 @@ func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
-	tikv.PessimisticLockTTL = 100
+	tikv.PessimisticLockTTL = 300
 	s.cluster = mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(s.cluster)
 	s.mvccStore = mocktikv.MustNewMVCCStore()

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -372,7 +372,7 @@ func (s *testPessimisticSuite) TestOptimisticConflicts(c *C) {
 	syncCh <- struct{}{}
 	tk.MustQuery("select c from conflict where id = 1").Check(testkit.Rows("3"))
 
-	// Check utdated pessimistic lock is resolved.
+	// Check outdated pessimistic lock is resolved.
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("update conflict set c = 4 where id = 1")
 	time.Sleep(300 * time.Millisecond)

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -46,6 +46,8 @@ type testPessimisticSuite struct {
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
+	// Set it to 300ms for testing lock resolve.
+	tikv.PessimisticLockTTL = 100
 	s.cluster = mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(s.cluster)
 	s.mvccStore = mocktikv.MustNewMVCCStore()
@@ -53,7 +55,6 @@ func (s *testPessimisticSuite) SetUpSuite(c *C) {
 		mockstore.WithCluster(s.cluster),
 		mockstore.WithMVCCStore(s.mvccStore),
 	)
-	tikv.PessimisticLockTTL = uint64(config.MinPessimisticTTL / time.Millisecond)
 	c.Assert(err, IsNil)
 	s.store = store
 	session.SetSchemaLease(0)
@@ -350,4 +351,34 @@ func (s *testPessimisticSuite) TestBankTransfer(c *C) {
 	tk.MustExec("commit")
 	syncCh <- struct{}{}
 	tk.MustQuery("select sum(c) from accounts").Check(testkit.Rows("300"))
+}
+
+func (s *testPessimisticSuite) TestOptimisticConflicts(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists conflict")
+	tk.MustExec("create table conflict (id int primary key, c int)")
+	tk.MustExec("insert conflict values (1, 1)")
+	tk.MustExec("begin pessimistic")
+	tk.MustQuery("select * from conflict where id = 1 for update")
+	syncCh := make(chan struct{})
+	go func() {
+		tk2.MustExec("update conflict set c = 3 where id = 1")
+		<-syncCh
+	}()
+	time.Sleep(time.Millisecond * 10)
+	tk.MustExec("update conflict set c = 2 where id = 1")
+	tk.MustExec("commit")
+	syncCh <- struct{}{}
+	tk.MustQuery("select c from conflict where id = 1").Check(testkit.Rows("3"))
+
+	// Check utdated pessimistic lock is resolved.
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("update conflict set c = 4 where id = 1")
+	time.Sleep(300 * time.Millisecond)
+	tk2.MustExec("begin optimistic")
+	tk2.MustExec("update conflict set c = 5 where id = 1")
+	tk2.MustExec("commit")
+	_, err := tk.Exec("commit")
+	c.Check(err, NotNil)
 }

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -538,19 +538,6 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
-			if !c.isPessimistic && c.lockTTL < lock.TTL && lock.TTL >= uint64(config.MinPessimisticTTL/time.Millisecond) {
-				// An optimistic prewrite meets a pessimistic or large transaction lock.
-				// If we wait for the lock, other written optimistic locks would block reads for long time.
-				// And it is very unlikely this transaction would succeed after wait for the long TTL lock.
-				// Return write conflict error to cleanup locks.
-				return newWriteConflictError(&pb.WriteConflict{
-					StartTs:          c.startTS,
-					ConflictTs:       lock.TxnID,
-					ConflictCommitTs: 0,
-					Key:              lock.Key,
-					Primary:          lock.Primary,
-				})
-			}
 			logutil.BgLogger().Debug("prewrite encounters lock",
 				zap.Uint64("conn", c.connID),
 				zap.Stringer("lock", lock))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The previous optimization return WriteConflict error when an optimistic transaction meets a pessimistic lock, this has the problem that optimistic transaction may reach retry limit soon and failed to resolve lock when pessimistic lock ttl is reached.

### What is changed and how it works?
Revert the optimization.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch