### PR TITLE
expression: deep copy the string when assigning it to a user variable

### DIFF
--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -420,7 +421,7 @@ func (b *builtinSetVarSig) evalString(row chunk.Row) (res string, isNull bool, e
 	}
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.Lock()
-	sessionVars.Users[varName] = res
+	sessionVars.Users[varName] = stringutil.Copy(res)
 	sessionVars.UsersLock.Unlock()
 	return res, false, nil
 }


### PR DESCRIPTION
Signed-off-by: Zhang Jian <zjsariel@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

At present, the builtin `SetVar` function might refer to the content of an underlying Chunk. The problem is, when the content of that Chunk is changed, the value of the corresponding user variable is changed as well.

### What is changed and how it works?

To address this issue, we should make a deep copy of that string value before assigning it to a user variable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
