### PR TITLE
executor: fix a bug for 'int column <cmp> non-int constant'

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1198,7 +1198,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	isAlways, finalArg0, finalArg1 := false, args[0], args[1]
 	isPositiveInfinite, isNegativeInfinite := false, false
 	// int non-constant [cmp] non-int constant
-	if arg0IsInt && !arg0IsCon && arg1IsCon {
+	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon {
 		finalArg1, arg1, isAlways = RefineComparedConstant(ctx, arg0Type, arg1, c.op)
 		if isAlways && arg1.RetType.EvalType() == types.ETInt {
 			// Judge it is inf or -inf
@@ -1216,7 +1216,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 		}
 	}
 	// non-int constant [cmp] int non-constant
-	if arg1IsInt && !arg1IsCon && arg0IsCon {
+	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon {
 		finalArg0, arg0, isAlways = RefineComparedConstant(ctx, arg1Type, arg0, symmetricOp[c.op])
 		if isAlways && arg0.RetType.EvalType() == types.ETInt {
 			if arg0.Value.GetInt64()&1 == 1 {

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -63,6 +63,10 @@ func (s *testEvaluatorSuite) TestCompareFunctionWithRefine(c *C) {
 		{"'1.1' != a", "ne(1.1, cast(a))"},
 		{"'123456789123456711111189' = a", "0"},
 		{"123456789123456789.12345 = a", "0"},
+		{"123456789123456789123456789.12345 > a", "1"},
+		{"-123456789123456789123456789.12345 > a", "0"},
+		{"123456789123456789123456789.12345 < a", "0"},
+		{"-123456789123456789123456789.12345 < a", "1"},
 		// This cast can not be eliminated,
 		// since converting "aaaa" to an int will cause DataTruncate error.
 		{"'aaaa'=a", "eq(cast(aaaa), cast(a))"},

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4435,3 +4435,17 @@ func (s *testIntegrationSuite) TestInvalidEndingStatement(c *C) {
 	assertParseErr(`drop table if exists t'`)
 	assertParseErr(`drop table if exists t"`)
 }
+
+func (s *testIntegrationSuite) TestIssue10675(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t(a int);`)
+	tk.MustExec(`insert into t values(1);`)
+	tk.MustQuery(`select * from t where a < -184467440737095516167.1;`).Check(testkit.Rows())
+	tk.MustQuery(`select * from t where a > -184467440737095516167.1;`).Check(
+		testkit.Rows("1"))
+	tk.MustQuery(`select * from t where a < 184467440737095516167.1;`).Check(
+		testkit.Rows("1"))
+	tk.MustQuery(`select * from t where a > 184467440737095516167.1;`).Check(testkit.Rows())
+}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/parser/opcode"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util"
 )
 
@@ -471,7 +471,7 @@ func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType
 	if leftEt == types.ETInt {
 		for i := 0; i < len(elems); i++ {
 			if c, ok := elems[i].(*Constant); ok {
-				elems[i], _ = RefineComparedConstant(sr.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
+				elems[i], _, _ = RefineComparedConstant(sr.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
 			}
 		}
 	}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -472,8 +472,8 @@ func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType
 	if leftEt == types.ETInt {
 		for i := 0; i < len(elems); i++ {
 			if c, ok := elems[i].(*Constant); ok {
-				isExceptional := false
-				elems[i], isExceptional = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
+				var isExceptional bool
+				elems[i], isExceptional = RefineComparedConstant(sr.ctx, *leftFt, c, opcode.EQ)
 				if isExceptional {
 					elems[i] = c
 				}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -468,10 +468,15 @@ func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType
 		return
 	}
 	leftEt := leftFt.EvalType()
+
 	if leftEt == types.ETInt {
 		for i := 0; i < len(elems); i++ {
 			if c, ok := elems[i].(*Constant); ok {
-				elems[i], _ = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
+				isExceptional := false
+				elems[i], isExceptional = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
+				if isExceptional {
+					elems[i] = c
+				}
 			}
 		}
 	}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -471,7 +471,7 @@ func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType
 	if leftEt == types.ETInt {
 		for i := 0; i < len(elems); i++ {
 			if c, ok := elems[i].(*Constant); ok {
-				elems[i], _, _ = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
+				elems[i], _ = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
 			}
 		}
 	}

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -471,7 +471,7 @@ func (sr *simpleRewriter) inToExpression(lLen int, not bool, tp *types.FieldType
 	if leftEt == types.ETInt {
 		for i := 0; i < len(elems); i++ {
 			if c, ok := elems[i].(*Constant); ok {
-				elems[i], _, _ = RefineComparedConstant(sr.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
+				elems[i], _, _ = RefineComparedConstant(sr.ctx, leftFt, c, opcode.EQ)
 			}
 		}
 	}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1127,8 +1127,8 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 	if leftEt == types.ETInt {
 		for i := 1; i < len(args); i++ {
 			if c, ok := args[i].(*expression.Constant); ok {
-				isExceptional := false
-				args[i], isExceptional = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
+				var isExceptional bool
+				args[i], isExceptional = expression.RefineComparedConstant(er.ctx, *leftFt, c, opcode.EQ)
 				if isExceptional {
 					args[i] = c
 				}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/stringutil"
 )
@@ -1127,7 +1127,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 	if leftEt == types.ETInt {
 		for i := 1; i < len(args); i++ {
 			if c, ok := args[i].(*expression.Constant); ok {
-				args[i], _ = expression.RefineComparedConstant(er.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
+				args[i], _, _ = expression.RefineComparedConstant(er.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
 			}
 		}
 	}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1127,7 +1127,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 	if leftEt == types.ETInt {
 		for i := 1; i < len(args); i++ {
 			if c, ok := args[i].(*expression.Constant); ok {
-				args[i], _, _ = expression.RefineComparedConstant(er.ctx, mysql.HasUnsignedFlag(leftFt.Flag), c, opcode.EQ)
+				args[i], _, _ = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
 			}
 		}
 	}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1127,7 +1127,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 	if leftEt == types.ETInt {
 		for i := 1; i < len(args); i++ {
 			if c, ok := args[i].(*expression.Constant); ok {
-				args[i], _, _ = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
+				args[i], _ = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
 			}
 		}
 	}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1127,7 +1127,11 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 	if leftEt == types.ETInt {
 		for i := 1; i < len(args); i++ {
 			if c, ok := args[i].(*expression.Constant); ok {
-				args[i], _ = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
+				isExceptional := false
+				args[i], isExceptional = expression.RefineComparedConstant(er.ctx, leftFt, c, opcode.EQ)
+				if isExceptional {
+					args[i] = c
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#10675 
Wrong result for `int column <cmp> non-int constant`  when the constant is  `inf` or `-inf`
```
CREATE TABLE `t` (
  `a` int(11) DEFAULT NULL
);
insert into t values(1);
select * from t where a < -184467440737095516167.1;
```
Before this pr:
```
select * from t where a < -184467440737095516167.1;
+------+
| a    |
+------+
|    1 |
+------+
```
This pr:
```
select * from t where a < -184467440737095516167.1;
Empty set (0.00 sec)
```

## What is changed and how it works?

When the compare expression is `int column <cmp> non-int constant` or `non-int constant <cmp> int column`, TiDB will refine the constant to the int column type.
E.g., `a < 1.1` will be rewritten to `a < 2`.

Before this pr, the logic of refine function is wrong. It is only judged whether the constant is Overflow. 
`a < -184467440737095516167.1` will be rewritten to `a < inf`
`a > 184467440737095516167.1` will be rewritten to `a > -inf`

This pr, I use the leading sing and Overflow flag to decide the constant is 'inf' or '-inf'
`a < -184467440737095516167.1` will be rewritten to `a < -inf`
`a > 184467440737095516167.1` will be rewritten to `a > inf`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes

