### PR TITLE
*: reduce tikvrpc request struct size

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -620,12 +620,9 @@ func (e *AnalyzeFastExec) getSampRegionsRowCount(bo *tikv.Backoffer, needRebuild
 		if !ok {
 			return
 		}
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdDebugGetRegionProperties,
-			DebugGetRegionProperties: &debugpb.GetRegionPropertiesRequest{
-				RegionId: loc.Region.GetID(),
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdDebugGetRegionProperties, &debugpb.GetRegionPropertiesRequest{
+			RegionId: loc.Region.GetID(),
+		})
 		var resp *tikvrpc.Response
 		var rpcCtx *tikv.RPCContext
 		rpcCtx, *err = e.cache.GetRPCContext(bo, loc.Region)

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -400,7 +400,7 @@ func (c *regionProperityClient) SendRequest(ctx context.Context, addr string, re
 		defer c.mu.Unlock()
 		c.mu.count++
 		// Mock failure once.
-		if req.DebugGetRegionProperties.RegionId == c.mu.regionID {
+		if req.DebugGetRegionProperties().RegionId == c.mu.regionID {
 			c.mu.regionID = 0
 			return &tikvrpc.Response{}, nil
 		}

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -151,12 +151,9 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 			return nil, errors.Trace(err)
 		}
 
-		tikvReq := &tikvrpc.Request{
-			Type: tikvrpc.CmdMvccGetByStartTs,
-			MvccGetByStartTs: &kvrpcpb.MvccGetByStartTsRequest{
-				StartTs: startTS,
-			},
-		}
+		tikvReq := tikvrpc.NewRequest(tikvrpc.CmdMvccGetByStartTs, &kvrpcpb.MvccGetByStartTsRequest{
+			StartTs: startTS,
+		})
 		tikvReq.Context.Priority = kvrpcpb.CommandPri_Low
 		kvResp, err := t.Store.SendReq(bo, tikvReq, curRegion.Region, time.Hour)
 		if err != nil {

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -50,12 +50,7 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 		return nil, errors.Trace(err)
 	}
 
-	tikvReq := &tikvrpc.Request{
-		Type: tikvrpc.CmdMvccGetByKey,
-		MvccGetByKey: &kvrpcpb.MvccGetByKeyRequest{
-			Key: encodedKey,
-		},
-	}
+	tikvReq := tikvrpc.NewRequest(tikvrpc.CmdMvccGetByKey, &kvrpcpb.MvccGetByKeyRequest{Key: encodedKey})
 	kvResp, err := h.Store.SendReq(tikv.NewBackoffer(context.Background(), 500), tikvReq, keyLocation.Region, time.Minute)
 	if err != nil {
 		logutil.BgLogger().Info("get MVCC by encoded key failed",

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -671,14 +671,14 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	resp.Type = req.Type
 	switch req.Type {
 	case tikvrpc.CmdGet:
-		r := req.Get
+		r := req.Get()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.Get = &kvrpcpb.GetResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.Get = handler.handleKvGet(r)
 	case tikvrpc.CmdScan:
-		r := req.Scan
+		r := req.Scan()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.Scan = &kvrpcpb.ScanResponse{RegionError: err}
 			return resp, nil
@@ -686,21 +686,21 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		resp.Scan = handler.handleKvScan(r)
 
 	case tikvrpc.CmdPrewrite:
-		r := req.Prewrite
+		r := req.Prewrite()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.Prewrite = &kvrpcpb.PrewriteResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.Prewrite = handler.handleKvPrewrite(r)
 	case tikvrpc.CmdPessimisticLock:
-		r := req.PessimisticLock
+		r := req.PessimisticLock()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.PessimisticLock = &kvrpcpb.PessimisticLockResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.PessimisticLock = handler.handleKvPessimisticLock(r)
 	case tikvrpc.CmdPessimisticRollback:
-		r := req.PessimisticRollback
+		r := req.PessimisticRollback()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.PessimisticRollback = &kvrpcpb.PessimisticRollbackResponse{RegionError: err}
 			return resp, nil
@@ -724,7 +724,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 			}
 		})
 
-		r := req.Commit
+		r := req.Commit()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.Commit = &kvrpcpb.CommitResponse{RegionError: err}
 			return resp, nil
@@ -736,104 +736,104 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 			}
 		})
 	case tikvrpc.CmdCleanup:
-		r := req.Cleanup
+		r := req.Cleanup()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.Cleanup = &kvrpcpb.CleanupResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.Cleanup = handler.handleKvCleanup(r)
 	case tikvrpc.CmdBatchGet:
-		r := req.BatchGet
+		r := req.BatchGet()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.BatchGet = &kvrpcpb.BatchGetResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.BatchGet = handler.handleKvBatchGet(r)
 	case tikvrpc.CmdBatchRollback:
-		r := req.BatchRollback
+		r := req.BatchRollback()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.BatchRollback = &kvrpcpb.BatchRollbackResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.BatchRollback = handler.handleKvBatchRollback(r)
 	case tikvrpc.CmdScanLock:
-		r := req.ScanLock
+		r := req.ScanLock()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.ScanLock = &kvrpcpb.ScanLockResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.ScanLock = handler.handleKvScanLock(r)
 	case tikvrpc.CmdResolveLock:
-		r := req.ResolveLock
+		r := req.ResolveLock()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.ResolveLock = &kvrpcpb.ResolveLockResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.ResolveLock = handler.handleKvResolveLock(r)
 	case tikvrpc.CmdGC:
-		r := req.GC
+		r := req.GC()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.GC = &kvrpcpb.GCResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.GC = &kvrpcpb.GCResponse{}
 	case tikvrpc.CmdDeleteRange:
-		r := req.DeleteRange
+		r := req.DeleteRange()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.DeleteRange = &kvrpcpb.DeleteRangeResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.DeleteRange = handler.handleKvDeleteRange(r)
 	case tikvrpc.CmdRawGet:
-		r := req.RawGet
+		r := req.RawGet()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawGet = &kvrpcpb.RawGetResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawGet = handler.handleKvRawGet(r)
 	case tikvrpc.CmdRawBatchGet:
-		r := req.RawBatchGet
+		r := req.RawBatchGet()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawBatchGet = &kvrpcpb.RawBatchGetResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawBatchGet = handler.handleKvRawBatchGet(r)
 	case tikvrpc.CmdRawPut:
-		r := req.RawPut
+		r := req.RawPut()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawPut = &kvrpcpb.RawPutResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawPut = handler.handleKvRawPut(r)
 	case tikvrpc.CmdRawBatchPut:
-		r := req.RawBatchPut
+		r := req.RawBatchPut()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawBatchPut = &kvrpcpb.RawBatchPutResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawBatchPut = handler.handleKvRawBatchPut(r)
 	case tikvrpc.CmdRawDelete:
-		r := req.RawDelete
+		r := req.RawDelete()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawDelete = &kvrpcpb.RawDeleteResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawDelete = handler.handleKvRawDelete(r)
 	case tikvrpc.CmdRawBatchDelete:
-		r := req.RawBatchDelete
+		r := req.RawBatchDelete()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawBatchDelete = &kvrpcpb.RawBatchDeleteResponse{RegionError: err}
 		}
 		resp.RawBatchDelete = handler.handleKvRawBatchDelete(r)
 	case tikvrpc.CmdRawDeleteRange:
-		r := req.RawDeleteRange
+		r := req.RawDeleteRange()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawDeleteRange = &kvrpcpb.RawDeleteRangeResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.RawDeleteRange = handler.handleKvRawDeleteRange(r)
 	case tikvrpc.CmdRawScan:
-		r := req.RawScan
+		r := req.RawScan()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.RawScan = &kvrpcpb.RawScanResponse{RegionError: err}
 			return resp, nil
@@ -842,7 +842,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	case tikvrpc.CmdUnsafeDestroyRange:
 		panic("unimplemented")
 	case tikvrpc.CmdCop:
-		r := req.Cop
+		r := req.Cop()
 		if err := handler.checkRequestContext(reqCtx); err != nil {
 			resp.Cop = &coprocessor.Response{RegionError: err}
 			return resp, nil
@@ -862,7 +862,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		}
 		resp.Cop = res
 	case tikvrpc.CmdCopStream:
-		r := req.Cop
+		r := req.Cop()
 		if err := handler.checkRequestContext(reqCtx); err != nil {
 			resp.CopStream = &tikvrpc.CopStreamResponse{
 				Tikv_CoprocessorStreamClient: &mockCopStreamErrClient{Error: err},
@@ -895,21 +895,21 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		streamResp.Response = first
 		resp.CopStream = streamResp
 	case tikvrpc.CmdMvccGetByKey:
-		r := req.MvccGetByKey
+		r := req.MvccGetByKey()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.MvccGetByKey = &kvrpcpb.MvccGetByKeyResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.MvccGetByKey = handler.handleMvccGetByKey(r)
 	case tikvrpc.CmdMvccGetByStartTs:
-		r := req.MvccGetByStartTs
+		r := req.MvccGetByStartTs()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.MvccGetByStartTS = &kvrpcpb.MvccGetByStartTsResponse{RegionError: err}
 			return resp, nil
 		}
 		resp.MvccGetByStartTS = handler.handleMvccGetByStartTS(r)
 	case tikvrpc.CmdSplitRegion:
-		r := req.SplitRegion
+		r := req.SplitRegion()
 		if err := handler.checkRequest(reqCtx, r.Size()); err != nil {
 			resp.SplitRegion = &kvrpcpb.SplitRegionResponse{RegionError: err}
 			return resp, nil
@@ -917,7 +917,7 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		resp.SplitRegion = handler.handleSplitRegion(r)
 	// DebugGetRegionProperties is for fast analyze in mock tikv.
 	case tikvrpc.CmdDebugGetRegionProperties:
-		r := req.DebugGetRegionProperties
+		r := req.DebugGetRegionProperties()
 		region, _ := c.Cluster.GetRegion(r.RegionId)
 		scanResp := handler.handleKvScan(&kvrpcpb.ScanRequest{StartKey: MvccKey(region.StartKey).Raw(), EndKey: MvccKey(region.EndKey).Raw(), Version: math.MaxUint64, Limit: math.MaxUint32})
 		resp.DebugGetRegionProperties = &debugpb.GetRegionPropertiesResponse{

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -237,13 +237,10 @@ func (s *testCommitterSuite) isKeyLocked(c *C, key []byte) bool {
 	ver, err := s.store.CurrentVersion()
 	c.Assert(err, IsNil)
 	bo := NewBackoffer(context.Background(), getMaxBackoff)
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdGet,
-		Get: &kvrpcpb.GetRequest{
-			Key:     key,
-			Version: ver.Ver,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{
+		Key:     key,
+		Version: ver.Ver,
+	})
 	loc, err := s.store.regionCache.LocateKey(bo, key)
 	c.Assert(err, IsNil)
 	resp, err := s.store.SendReq(bo, req, loc.Region, readTimeoutShort)
@@ -455,8 +452,8 @@ func (s *testCommitterSuite) TestPessimisticPrewriteRequest(c *C) {
 	batch.keys = append(batch.keys, []byte("t1"))
 	batch.region = RegionVerID{1, 1, 1}
 	req := commiter.buildPrewriteRequest(batch)
-	c.Assert(len(req.Prewrite.IsPessimisticLock), Greater, 0)
-	c.Assert(req.Prewrite.ForUpdateTs, Equals, uint64(100))
+	c.Assert(len(req.Prewrite().IsPessimisticLock), Greater, 0)
+	c.Assert(req.Prewrite().ForUpdateTs, Equals, uint64(100))
 }
 
 func (s *testCommitterSuite) TestUnsetPrimaryKey(c *C) {

--- a/store/tikv/client_fail_test.go
+++ b/store/tikv/client_fail_test.go
@@ -52,10 +52,7 @@ func (s *testClientSuite) TestPanicInRecvLoop(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/gotErrorInRecvLoop"), IsNil)
 	time.Sleep(time.Second)
 
-	req := &tikvrpc.Request{
-		Type:  tikvrpc.CmdEmpty,
-		Empty: &tikvpb.BatchCommandsEmptyRequest{},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdEmpty, &tikvpb.BatchCommandsEmptyRequest{})
 	_, err = rpcClient.SendRequest(context.Background(), addr, req, time.Second)
 	c.Assert(err, IsNil)
 	server.Stop()

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -612,21 +612,17 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 	})
 
 	sender := NewRegionRequestSender(worker.store.regionCache, worker.store.client)
-	req := &tikvrpc.Request{
-		Type: task.cmdType,
-		Cop: &coprocessor.Request{
-			Tp:     worker.req.Tp,
-			Data:   worker.req.Data,
-			Ranges: task.ranges.toPBRanges(),
-		},
-		Context: kvrpcpb.Context{
-			IsolationLevel: pbIsolationLevel(worker.req.IsolationLevel),
-			Priority:       kvPriorityToCommandPri(worker.req.Priority),
-			NotFillCache:   worker.req.NotFillCache,
-			HandleTime:     true,
-			ScanDetail:     true,
-		},
-	}
+	req := tikvrpc.NewRequest(task.cmdType, &coprocessor.Request{
+		Tp:     worker.req.Tp,
+		Data:   worker.req.Data,
+		Ranges: task.ranges.toPBRanges(),
+	}, kvrpcpb.Context{
+		IsolationLevel: pbIsolationLevel(worker.req.IsolationLevel),
+		Priority:       kvPriorityToCommandPri(worker.req.Priority),
+		NotFillCache:   worker.req.NotFillCache,
+		HandleTime:     true,
+		ScanDetail:     true,
+	})
 	startTime := time.Now()
 	resp, rpcCtx, err := sender.SendReqCtx(bo, req, task.region, ReadTimeoutMedium)
 	if err != nil {

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -104,14 +104,11 @@ func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (Ra
 			endKey = rangeEndKey
 		}
 
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdDeleteRange,
-			DeleteRange: &kvrpcpb.DeleteRangeRequest{
-				StartKey:   startKey,
-				EndKey:     endKey,
-				NotifyOnly: t.notifyOnly,
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdDeleteRange, &kvrpcpb.DeleteRangeRequest{
+			StartKey:   startKey,
+			EndKey:     endKey,
+			NotifyOnly: t.notifyOnly,
+		})
 
 		resp, err := t.store.SendReq(bo, req, loc.Region, ReadTimeoutMedium)
 		if err != nil {

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -402,7 +402,7 @@ func (s *testGCWorkerSuite) testDeleteRangesFailureImpl(c *C, failType int) {
 			Type:               tikvrpc.CmdUnsafeDestroyRange,
 			UnsafeDestroyRange: &kvrpcpb.UnsafeDestroyRangeResponse{},
 		}
-		if bytes.Equal(req.UnsafeDestroyRange.GetStartKey(), failKey) && addr == failStore.GetAddress() {
+		if bytes.Equal(req.UnsafeDestroyRange().GetStartKey(), failKey) && addr == failStore.GetAddress() {
 			if failType == failRPCErr {
 				return nil, errors.New("error")
 			} else if failType == failNilResp {
@@ -488,7 +488,7 @@ Loop:
 	}
 
 	sort.Slice(sentReq, func(i, j int) bool {
-		cmp := bytes.Compare(sentReq[i].req.UnsafeDestroyRange.StartKey, sentReq[j].req.UnsafeDestroyRange.StartKey)
+		cmp := bytes.Compare(sentReq[i].req.UnsafeDestroyRange().StartKey, sentReq[j].req.UnsafeDestroyRange().StartKey)
 		return cmp < 0 || (cmp == 0 && sentReq[i].addr < sentReq[j].addr)
 	})
 
@@ -501,8 +501,8 @@ Loop:
 		for storeIndex := range expectedStores {
 			i := rangeIndex*len(expectedStores) + storeIndex
 			c.Assert(sentReq[i].addr, Equals, expectedStores[storeIndex].Address)
-			c.Assert(sentReq[i].req.UnsafeDestroyRange.GetStartKey(), DeepEquals, sortedRanges[rangeIndex].StartKey)
-			c.Assert(sentReq[i].req.UnsafeDestroyRange.GetEndKey(), DeepEquals, sortedRanges[rangeIndex].EndKey)
+			c.Assert(sentReq[i].req.UnsafeDestroyRange().GetStartKey(), DeepEquals, sortedRanges[rangeIndex].StartKey)
+			c.Assert(sentReq[i].req.UnsafeDestroyRange().GetEndKey(), DeepEquals, sortedRanges[rangeIndex].EndKey)
 		}
 	}
 }

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -213,13 +213,10 @@ func (s *testLockSuite) mustGetLock(c *C, key []byte) *Lock {
 	ver, err := s.store.CurrentVersion()
 	c.Assert(err, IsNil)
 	bo := NewBackoffer(context.Background(), getMaxBackoff)
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdGet,
-		Get: &kvrpcpb.GetRequest{
-			Key:     key,
-			Version: ver.Ver,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{
+		Key:     key,
+		Version: ver.Ver,
+	})
 	loc, err := s.store.regionCache.LocateKey(bo, key)
 	c.Assert(err, IsNil)
 	resp, err := s.store.SendReq(bo, req, loc.Region, readTimeoutShort)

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -104,12 +104,7 @@ func (c *RawKVClient) Get(key []byte) ([]byte, error) {
 	start := time.Now()
 	defer func() { tikvRawkvCmdHistogramWithGet.Observe(time.Since(start).Seconds()) }()
 
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawGet,
-		RawGet: &kvrpcpb.RawGetRequest{
-			Key: key,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawGet, &kvrpcpb.RawGetRequest{Key: key})
 	resp, _, err := c.sendReq(key, req, false)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -168,13 +163,10 @@ func (c *RawKVClient) Put(key, value []byte) error {
 		return errors.New("empty value is not supported")
 	}
 
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   key,
-			Value: value,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   key,
+		Value: value,
+	})
 	resp, _, err := c.sendReq(key, req, false)
 	if err != nil {
 		return errors.Trace(err)
@@ -214,12 +206,9 @@ func (c *RawKVClient) Delete(key []byte) error {
 	start := time.Now()
 	defer func() { tikvRawkvCmdHistogramWithDelete.Observe(time.Since(start).Seconds()) }()
 
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawDelete,
-		RawDelete: &kvrpcpb.RawDeleteRequest{
-			Key: key,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawDelete, &kvrpcpb.RawDeleteRequest{
+		Key: key,
+	})
 	resp, _, err := c.sendReq(key, req, false)
 	if err != nil {
 		return errors.Trace(err)
@@ -303,14 +292,11 @@ func (c *RawKVClient) Scan(startKey, endKey []byte, limit int) (keys [][]byte, v
 	}
 
 	for len(keys) < limit {
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdRawScan,
-			RawScan: &kvrpcpb.RawScanRequest{
-				StartKey: startKey,
-				EndKey:   endKey,
-				Limit:    uint32(limit - len(keys)),
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdRawScan, &kvrpcpb.RawScanRequest{
+			StartKey: startKey,
+			EndKey:   endKey,
+			Limit:    uint32(limit - len(keys)),
+		})
 		resp, loc, err := c.sendReq(startKey, req, false)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
@@ -349,15 +335,12 @@ func (c *RawKVClient) ReverseScan(startKey, endKey []byte, limit int) (keys [][]
 	}
 
 	for len(keys) < limit {
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdRawScan,
-			RawScan: &kvrpcpb.RawScanRequest{
-				StartKey: startKey,
-				EndKey:   endKey,
-				Limit:    uint32(limit - len(keys)),
-				Reverse:  true,
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdRawScan, &kvrpcpb.RawScanRequest{
+			StartKey: startKey,
+			EndKey:   endKey,
+			Limit:    uint32(limit - len(keys)),
+			Reverse:  true,
+		})
 		resp, loc, err := c.sendReq(startKey, req, true)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
@@ -462,19 +445,13 @@ func (c *RawKVClient) doBatchReq(bo *Backoffer, batch batch, cmdType tikvrpc.Cmd
 	var req *tikvrpc.Request
 	switch cmdType {
 	case tikvrpc.CmdRawBatchGet:
-		req = &tikvrpc.Request{
-			Type: cmdType,
-			RawBatchGet: &kvrpcpb.RawBatchGetRequest{
-				Keys: batch.keys,
-			},
-		}
+		req = tikvrpc.NewRequest(cmdType, &kvrpcpb.RawBatchGetRequest{
+			Keys: batch.keys,
+		})
 	case tikvrpc.CmdRawBatchDelete:
-		req = &tikvrpc.Request{
-			Type: cmdType,
-			RawBatchDelete: &kvrpcpb.RawBatchDeleteRequest{
-				Keys: batch.keys,
-			},
-		}
+		req = tikvrpc.NewRequest(cmdType, &kvrpcpb.RawBatchDeleteRequest{
+			Keys: batch.keys,
+		})
 	}
 
 	sender := NewRegionRequestSender(c.regionCache, c.rpcClient)
@@ -538,13 +515,10 @@ func (c *RawKVClient) sendDeleteRangeReq(startKey []byte, endKey []byte) (*tikvr
 			actualEndKey = loc.EndKey
 		}
 
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdRawDeleteRange,
-			RawDeleteRange: &kvrpcpb.RawDeleteRangeRequest{
-				StartKey: startKey,
-				EndKey:   actualEndKey,
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdRawDeleteRange, &kvrpcpb.RawDeleteRangeRequest{
+			StartKey: startKey,
+			EndKey:   actualEndKey,
+		})
 
 		resp, err := sender.SendReq(bo, req, loc.Region, readTimeoutShort)
 		if err != nil {
@@ -648,12 +622,7 @@ func (c *RawKVClient) doBatchPut(bo *Backoffer, batch batch) error {
 		kvPair = append(kvPair, &kvrpcpb.KvPair{Key: key, Value: batch.values[i]})
 	}
 
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawBatchPut,
-		RawBatchPut: &kvrpcpb.RawBatchPutRequest{
-			Pairs: kvPair,
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawBatchPut, &kvrpcpb.RawBatchPutRequest{Pairs: kvPair})
 
 	sender := NewRegionRequestSender(c.regionCache, c.rpcClient)
 	resp, err := sender.SendReq(bo, req, batch.regionID, readTimeoutShort)

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -60,13 +60,10 @@ func (s *testRegionRequestSuite) TearDownTest(c *C) {
 }
 
 func (s *testRegionRequestSuite) TestOnSendFailedWithStoreRestart(c *C) {
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 	c.Assert(region, NotNil)
@@ -93,13 +90,10 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithStoreRestart(c *C) {
 }
 
 func (s *testRegionRequestSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOne(c *C) {
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 	c.Assert(region, NotNil)
@@ -131,13 +125,10 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOn
 }
 
 func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 	c.Assert(region, NotNil)
@@ -148,13 +139,10 @@ func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {
 }
 
 func (s *testRegionRequestSuite) TestOnSendFailedWithCancelled(c *C) {
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 	c.Assert(region, NotNil)
@@ -181,13 +169,10 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithCancelled(c *C) {
 }
 
 func (s *testRegionRequestSuite) TestNoReloadRegionWhenCtxCanceled(c *C) {
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 	c.Assert(region, NotNil)
@@ -340,13 +325,10 @@ func (s *testRegionRequestSuite) TestNoReloadRegionForGrpcWhenCtxCanceled(c *C) 
 
 	client := newRPCClient(config.Security{})
 	sender := NewRegionRequestSender(s.cache, client)
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdRawPut,
-		RawPut: &kvrpcpb.RawPutRequest{
-			Key:   []byte("key"),
-			Value: []byte("value"),
-		},
-	}
+	req := tikvrpc.NewRequest(tikvrpc.CmdRawPut, &kvrpcpb.RawPutRequest{
+		Key:   []byte("key"),
+		Value: []byte("value"),
+	})
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)
 	c.Assert(err, IsNil)
 

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -185,25 +185,22 @@ func (s *Scanner) getData(bo *Backoffer) error {
 			}
 		}
 
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdScan,
-			Scan: &pb.ScanRequest{
-				StartKey: s.nextStartKey,
-				EndKey:   reqEndKey,
-				Limit:    uint32(s.batchSize),
-				Version:  s.startTS(),
-				KeyOnly:  s.snapshot.keyOnly,
-			},
-			Context: pb.Context{
-				Priority:     s.snapshot.priority,
-				NotFillCache: s.snapshot.notFillCache,
-			},
+		sreq := &pb.ScanRequest{
+			StartKey: s.nextStartKey,
+			EndKey:   reqEndKey,
+			Limit:    uint32(s.batchSize),
+			Version:  s.startTS(),
+			KeyOnly:  s.snapshot.keyOnly,
 		}
 		if s.reverse {
-			req.Scan.StartKey = s.nextEndKey
-			req.Scan.EndKey = reqStartKey
-			req.Scan.Reverse = true
+			sreq.StartKey = s.nextEndKey
+			sreq.EndKey = reqStartKey
+			sreq.Reverse = true
 		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdScan, sreq, pb.Context{
+			Priority:     s.snapshot.priority,
+			NotFillCache: s.snapshot.notFillCache,
+		})
 		resp, err := sender.SendReq(bo, req, loc.Region, ReadTimeoutMedium)
 		if err != nil {
 			return errors.Trace(err)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -154,17 +154,13 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 
 	pending := batch.keys
 	for {
-		req := &tikvrpc.Request{
-			Type: tikvrpc.CmdBatchGet,
-			BatchGet: &pb.BatchGetRequest{
-				Keys:    pending,
-				Version: s.version.Ver,
-			},
-			Context: pb.Context{
-				Priority:     s.priority,
-				NotFillCache: s.notFillCache,
-			},
-		}
+		req := tikvrpc.NewRequest(tikvrpc.CmdBatchGet, &pb.BatchGetRequest{
+			Keys:    pending,
+			Version: s.version.Ver,
+		}, pb.Context{
+			Priority:     s.priority,
+			NotFillCache: s.notFillCache,
+		})
 		resp, err := sender.SendReq(bo, req, batch.region, ReadTimeoutMedium)
 		if err != nil {
 			return errors.Trace(err)
@@ -236,17 +232,14 @@ func (s *tikvSnapshot) Get(k kv.Key) ([]byte, error) {
 func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 	sender := NewRegionRequestSender(s.store.regionCache, s.store.client)
 
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdGet,
-		Get: &pb.GetRequest{
+	req := tikvrpc.NewRequest(tikvrpc.CmdGet,
+		&pb.GetRequest{
 			Key:     k,
 			Version: s.version.Ver,
-		},
-		Context: pb.Context{
+		}, pb.Context{
 			Priority:     s.priority,
 			NotFillCache: s.notFillCache,
-		},
-	}
+		})
 	for {
 		loc, err := s.store.regionCache.LocateKey(bo, k)
 		if err != nil {

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -33,13 +33,11 @@ func (s *tikvStore) SplitRegion(splitKey kv.Key, scatter bool) (regionID uint64,
 		zap.Binary("at", splitKey))
 	bo := NewBackoffer(context.Background(), splitRegionBackoff)
 	sender := NewRegionRequestSender(s.regionCache, s.client)
-	req := &tikvrpc.Request{
-		Type: tikvrpc.CmdSplitRegion,
-		SplitRegion: &kvrpcpb.SplitRegionRequest{
-			SplitKey: splitKey,
-		},
-	}
-	req.Context.Priority = kvrpcpb.CommandPri_Normal
+	req := tikvrpc.NewRequest(tikvrpc.CmdSplitRegion, &kvrpcpb.SplitRegionRequest{
+		SplitKey: splitKey,
+	}, kvrpcpb.Context{
+		Priority: kvrpcpb.CommandPri_Normal,
+	})
 	for {
 		loc, err := s.regionCache.LocateKey(bo, splitKey)
 		if err != nil {

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -134,90 +134,215 @@ func (t CmdType) String() string {
 
 // Request wraps all kv/coprocessor requests.
 type Request struct {
+	Type CmdType
+	req  interface{}
 	kvrpcpb.Context
-	Type               CmdType
-	Get                *kvrpcpb.GetRequest
-	Scan               *kvrpcpb.ScanRequest
-	Prewrite           *kvrpcpb.PrewriteRequest
-	Commit             *kvrpcpb.CommitRequest
-	Cleanup            *kvrpcpb.CleanupRequest
-	BatchGet           *kvrpcpb.BatchGetRequest
-	BatchRollback      *kvrpcpb.BatchRollbackRequest
-	ScanLock           *kvrpcpb.ScanLockRequest
-	ResolveLock        *kvrpcpb.ResolveLockRequest
-	GC                 *kvrpcpb.GCRequest
-	DeleteRange        *kvrpcpb.DeleteRangeRequest
-	RawGet             *kvrpcpb.RawGetRequest
-	RawBatchGet        *kvrpcpb.RawBatchGetRequest
-	RawPut             *kvrpcpb.RawPutRequest
-	RawBatchPut        *kvrpcpb.RawBatchPutRequest
-	RawDelete          *kvrpcpb.RawDeleteRequest
-	RawBatchDelete     *kvrpcpb.RawBatchDeleteRequest
-	RawDeleteRange     *kvrpcpb.RawDeleteRangeRequest
-	RawScan            *kvrpcpb.RawScanRequest
-	UnsafeDestroyRange *kvrpcpb.UnsafeDestroyRangeRequest
-	Cop                *coprocessor.Request
-	MvccGetByKey       *kvrpcpb.MvccGetByKeyRequest
-	MvccGetByStartTs   *kvrpcpb.MvccGetByStartTsRequest
-	SplitRegion        *kvrpcpb.SplitRegionRequest
+}
 
-	PessimisticLock     *kvrpcpb.PessimisticLockRequest
-	PessimisticRollback *kvrpcpb.PessimisticRollbackRequest
+// NewRequest returns new kv rpc request.
+func NewRequest(typ CmdType, pointer interface{}, ctxs ...kvrpcpb.Context) *Request {
+	if len(ctxs) > 0 {
+		return &Request{
+			Type:    typ,
+			req:     pointer,
+			Context: ctxs[0],
+		}
+	}
+	return &Request{
+		Type: typ,
+		req:  pointer,
+	}
+}
 
-	DebugGetRegionProperties *debugpb.GetRegionPropertiesRequest
+// Get returns GetRequest in request.
+func (req *Request) Get() *kvrpcpb.GetRequest {
+	return req.req.(*kvrpcpb.GetRequest)
+}
 
-	Empty *tikvpb.BatchCommandsEmptyRequest
+// Scan returns ScanRequest in request.
+func (req *Request) Scan() *kvrpcpb.ScanRequest {
+	return req.req.(*kvrpcpb.ScanRequest)
+}
+
+// Prewrite returns PrewriteRequest in request.
+func (req *Request) Prewrite() *kvrpcpb.PrewriteRequest {
+	return req.req.(*kvrpcpb.PrewriteRequest)
+}
+
+// Commit returns CommitRequest in request.
+func (req *Request) Commit() *kvrpcpb.CommitRequest {
+	return req.req.(*kvrpcpb.CommitRequest)
+}
+
+// Cleanup returns CleanupRequest in request.
+func (req *Request) Cleanup() *kvrpcpb.CleanupRequest {
+	return req.req.(*kvrpcpb.CleanupRequest)
+}
+
+// BatchGet returns BatchGetRequest in request.
+func (req *Request) BatchGet() *kvrpcpb.BatchGetRequest {
+	return req.req.(*kvrpcpb.BatchGetRequest)
+}
+
+// BatchRollback returns BatchRollbackRequest in request.
+func (req *Request) BatchRollback() *kvrpcpb.BatchRollbackRequest {
+	return req.req.(*kvrpcpb.BatchRollbackRequest)
+}
+
+// ScanLock returns ScanLockRequest in request.
+func (req *Request) ScanLock() *kvrpcpb.ScanLockRequest {
+	return req.req.(*kvrpcpb.ScanLockRequest)
+}
+
+// ResolveLock returns ResolveLockRequest in request.
+func (req *Request) ResolveLock() *kvrpcpb.ResolveLockRequest {
+	return req.req.(*kvrpcpb.ResolveLockRequest)
+}
+
+// GC returns GCRequest in request.
+func (req *Request) GC() *kvrpcpb.GCRequest {
+	return req.req.(*kvrpcpb.GCRequest)
+}
+
+// DeleteRange returns DeleteRangeRequest in request.
+func (req *Request) DeleteRange() *kvrpcpb.DeleteRangeRequest {
+	return req.req.(*kvrpcpb.DeleteRangeRequest)
+}
+
+// RawGet returns RawGetRequest in request.
+func (req *Request) RawGet() *kvrpcpb.RawGetRequest {
+	return req.req.(*kvrpcpb.RawGetRequest)
+}
+
+// RawBatchGet returns RawBatchGetRequest in request.
+func (req *Request) RawBatchGet() *kvrpcpb.RawBatchGetRequest {
+	return req.req.(*kvrpcpb.RawBatchGetRequest)
+}
+
+// RawPut returns RawPutRequest in request.
+func (req *Request) RawPut() *kvrpcpb.RawPutRequest {
+	return req.req.(*kvrpcpb.RawPutRequest)
+}
+
+// RawBatchPut returns RawBatchPutRequest in request.
+func (req *Request) RawBatchPut() *kvrpcpb.RawBatchPutRequest {
+	return req.req.(*kvrpcpb.RawBatchPutRequest)
+}
+
+// RawDelete returns PrewriteRequest in request.
+func (req *Request) RawDelete() *kvrpcpb.RawDeleteRequest {
+	return req.req.(*kvrpcpb.RawDeleteRequest)
+}
+
+// RawBatchDelete returns RawBatchDeleteRequest in request.
+func (req *Request) RawBatchDelete() *kvrpcpb.RawBatchDeleteRequest {
+	return req.req.(*kvrpcpb.RawBatchDeleteRequest)
+}
+
+// RawDeleteRange returns RawDeleteRangeRequest in request.
+func (req *Request) RawDeleteRange() *kvrpcpb.RawDeleteRangeRequest {
+	return req.req.(*kvrpcpb.RawDeleteRangeRequest)
+}
+
+// RawScan returns RawScanRequest in request.
+func (req *Request) RawScan() *kvrpcpb.RawScanRequest {
+	return req.req.(*kvrpcpb.RawScanRequest)
+}
+
+// UnsafeDestroyRange returns UnsafeDestroyRangeRequest in request.
+func (req *Request) UnsafeDestroyRange() *kvrpcpb.UnsafeDestroyRangeRequest {
+	return req.req.(*kvrpcpb.UnsafeDestroyRangeRequest)
+}
+
+// Cop returns coprocessor request in request.
+func (req *Request) Cop() *coprocessor.Request {
+	return req.req.(*coprocessor.Request)
+}
+
+// MvccGetByKey returns MvccGetByKeyRequest in request.
+func (req *Request) MvccGetByKey() *kvrpcpb.MvccGetByKeyRequest {
+	return req.req.(*kvrpcpb.MvccGetByKeyRequest)
+}
+
+// MvccGetByStartTs returns MvccGetByStartTsRequest in request.
+func (req *Request) MvccGetByStartTs() *kvrpcpb.MvccGetByStartTsRequest {
+	return req.req.(*kvrpcpb.MvccGetByStartTsRequest)
+}
+
+// SplitRegion returns SplitRegionRequest in request.
+func (req *Request) SplitRegion() *kvrpcpb.SplitRegionRequest {
+	return req.req.(*kvrpcpb.SplitRegionRequest)
+}
+
+// PessimisticLock returns PessimisticLockRequest in request.
+func (req *Request) PessimisticLock() *kvrpcpb.PessimisticLockRequest {
+	return req.req.(*kvrpcpb.PessimisticLockRequest)
+}
+
+// PessimisticRollback returns PessimisticRollbackRequest in request.
+func (req *Request) PessimisticRollback() *kvrpcpb.PessimisticRollbackRequest {
+	return req.req.(*kvrpcpb.PessimisticRollbackRequest)
+}
+
+// DebugGetRegionProperties returns GetRegionPropertiesRequest in request.
+func (req *Request) DebugGetRegionProperties() *debugpb.GetRegionPropertiesRequest {
+	return req.req.(*debugpb.GetRegionPropertiesRequest)
+}
+
+// Empty returns BatchCommandsEmptyRequest in request
+func (req *Request) Empty() *tikvpb.BatchCommandsEmptyRequest {
+	return req.req.(*tikvpb.BatchCommandsEmptyRequest)
 }
 
 // ToBatchCommandsRequest converts the request to an entry in BatchCommands request.
 func (req *Request) ToBatchCommandsRequest() *tikvpb.BatchCommandsRequest_Request {
 	switch req.Type {
 	case CmdGet:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Get{Get: req.Get}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Get{Get: req.Get()}}
 	case CmdScan:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Scan{Scan: req.Scan}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Scan{Scan: req.Scan()}}
 	case CmdPrewrite:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Prewrite{Prewrite: req.Prewrite}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Prewrite{Prewrite: req.Prewrite()}}
 	case CmdCommit:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Commit{Commit: req.Commit}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Commit{Commit: req.Commit()}}
 	case CmdCleanup:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Cleanup{Cleanup: req.Cleanup}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Cleanup{Cleanup: req.Cleanup()}}
 	case CmdBatchGet:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_BatchGet{BatchGet: req.BatchGet}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_BatchGet{BatchGet: req.BatchGet()}}
 	case CmdBatchRollback:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_BatchRollback{BatchRollback: req.BatchRollback}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_BatchRollback{BatchRollback: req.BatchRollback()}}
 	case CmdScanLock:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_ScanLock{ScanLock: req.ScanLock}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_ScanLock{ScanLock: req.ScanLock()}}
 	case CmdResolveLock:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_ResolveLock{ResolveLock: req.ResolveLock}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_ResolveLock{ResolveLock: req.ResolveLock()}}
 	case CmdGC:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_GC{GC: req.GC}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_GC{GC: req.GC()}}
 	case CmdDeleteRange:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_DeleteRange{DeleteRange: req.DeleteRange}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_DeleteRange{DeleteRange: req.DeleteRange()}}
 	case CmdRawGet:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawGet{RawGet: req.RawGet}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawGet{RawGet: req.RawGet()}}
 	case CmdRawBatchGet:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchGet{RawBatchGet: req.RawBatchGet}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchGet{RawBatchGet: req.RawBatchGet()}}
 	case CmdRawPut:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawPut{RawPut: req.RawPut}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawPut{RawPut: req.RawPut()}}
 	case CmdRawBatchPut:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchPut{RawBatchPut: req.RawBatchPut}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchPut{RawBatchPut: req.RawBatchPut()}}
 	case CmdRawDelete:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawDelete{RawDelete: req.RawDelete}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawDelete{RawDelete: req.RawDelete()}}
 	case CmdRawBatchDelete:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchDelete{RawBatchDelete: req.RawBatchDelete}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawBatchDelete{RawBatchDelete: req.RawBatchDelete()}}
 	case CmdRawDeleteRange:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawDeleteRange{RawDeleteRange: req.RawDeleteRange}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawDeleteRange{RawDeleteRange: req.RawDeleteRange()}}
 	case CmdRawScan:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawScan{RawScan: req.RawScan}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_RawScan{RawScan: req.RawScan()}}
 	case CmdCop:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Coprocessor{Coprocessor: req.Cop}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Coprocessor{Coprocessor: req.Cop()}}
 	case CmdPessimisticLock:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_PessimisticLock{PessimisticLock: req.PessimisticLock}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_PessimisticLock{PessimisticLock: req.PessimisticLock()}}
 	case CmdPessimisticRollback:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_PessimisticRollback{PessimisticRollback: req.PessimisticRollback}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_PessimisticRollback{PessimisticRollback: req.PessimisticRollback()}}
 	case CmdEmpty:
-		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Empty{Empty: req.Empty}}
+		return &tikvpb.BatchCommandsRequest_Request{Cmd: &tikvpb.BatchCommandsRequest_Request_Empty{Empty: req.Empty()}}
 	}
 	return nil
 }
@@ -340,60 +465,61 @@ func SetContext(req *Request, region *metapb.Region, peer *metapb.Peer) error {
 
 	switch req.Type {
 	case CmdGet:
-		req.Get.Context = ctx
+		req.Get().Context = ctx
 	case CmdScan:
-		req.Scan.Context = ctx
+		req.Scan().Context = ctx
 	case CmdPrewrite:
-		req.Prewrite.Context = ctx
+		req.Prewrite().Context = ctx
 	case CmdPessimisticLock:
-		req.PessimisticLock.Context = ctx
+		req.PessimisticLock().Context = ctx
 	case CmdPessimisticRollback:
-		req.PessimisticRollback.Context = ctx
+		req.PessimisticRollback().Context = ctx
 	case CmdCommit:
-		req.Commit.Context = ctx
+		req.Commit().Context = ctx
 	case CmdCleanup:
-		req.Cleanup.Context = ctx
+		req.Cleanup().Context = ctx
 	case CmdBatchGet:
-		req.BatchGet.Context = ctx
+		req.BatchGet().Context = ctx
 	case CmdBatchRollback:
-		req.BatchRollback.Context = ctx
+		req.BatchRollback().Context = ctx
 	case CmdScanLock:
-		req.ScanLock.Context = ctx
+		req.ScanLock().Context = ctx
 	case CmdResolveLock:
-		req.ResolveLock.Context = ctx
+		req.ResolveLock().Context = ctx
 	case CmdGC:
-		req.GC.Context = ctx
+		req.GC().Context = ctx
 	case CmdDeleteRange:
-		req.DeleteRange.Context = ctx
+		req.DeleteRange().Context = ctx
 	case CmdRawGet:
-		req.RawGet.Context = ctx
+		req.RawGet().Context = ctx
 	case CmdRawBatchGet:
-		req.RawBatchGet.Context = ctx
+		req.RawBatchGet().Context = ctx
 	case CmdRawPut:
-		req.RawPut.Context = ctx
+		req.RawPut().Context = ctx
 	case CmdRawBatchPut:
-		req.RawBatchPut.Context = ctx
+		req.RawBatchPut().Context = ctx
 	case CmdRawDelete:
-		req.RawDelete.Context = ctx
+		req.RawDelete().Context = ctx
 	case CmdRawBatchDelete:
-		req.RawBatchDelete.Context = ctx
+		req.RawBatchDelete().Context = ctx
 	case CmdRawDeleteRange:
-		req.RawDeleteRange.Context = ctx
+		req.RawDeleteRange().Context = ctx
 	case CmdRawScan:
-		req.RawScan.Context = ctx
+		req.RawScan().Context = ctx
 	case CmdUnsafeDestroyRange:
-		req.UnsafeDestroyRange.Context = ctx
+		req.UnsafeDestroyRange().Context = ctx
 	case CmdCop:
-		req.Cop.Context = ctx
+		req.Cop().Context = ctx
 	case CmdCopStream:
-		req.Cop.Context = ctx
+		req.Cop().Context = ctx
 	case CmdMvccGetByKey:
-		req.MvccGetByKey.Context = ctx
+		req.MvccGetByKey().Context = ctx
 	case CmdMvccGetByStartTs:
-		req.MvccGetByStartTs.Context = ctx
+		req.MvccGetByStartTs().Context = ctx
 	case CmdSplitRegion:
-		req.SplitRegion.Context = ctx
+		req.SplitRegion().Context = ctx
 	case CmdEmpty:
+		req.SplitRegion().Context = ctx
 	default:
 		return fmt.Errorf("invalid request type %v", req.Type)
 	}
@@ -597,63 +723,63 @@ func CallRPC(ctx context.Context, client tikvpb.TikvClient, req *Request) (*Resp
 	var err error
 	switch req.Type {
 	case CmdGet:
-		resp.Get, err = client.KvGet(ctx, req.Get)
+		resp.Get, err = client.KvGet(ctx, req.Get())
 	case CmdScan:
-		resp.Scan, err = client.KvScan(ctx, req.Scan)
+		resp.Scan, err = client.KvScan(ctx, req.Scan())
 	case CmdPrewrite:
-		resp.Prewrite, err = client.KvPrewrite(ctx, req.Prewrite)
+		resp.Prewrite, err = client.KvPrewrite(ctx, req.Prewrite())
 	case CmdPessimisticLock:
-		resp.PessimisticLock, err = client.KvPessimisticLock(ctx, req.PessimisticLock)
+		resp.PessimisticLock, err = client.KvPessimisticLock(ctx, req.PessimisticLock())
 	case CmdPessimisticRollback:
-		resp.PessimisticRollback, err = client.KVPessimisticRollback(ctx, req.PessimisticRollback)
+		resp.PessimisticRollback, err = client.KVPessimisticRollback(ctx, req.PessimisticRollback())
 	case CmdCommit:
-		resp.Commit, err = client.KvCommit(ctx, req.Commit)
+		resp.Commit, err = client.KvCommit(ctx, req.Commit())
 	case CmdCleanup:
-		resp.Cleanup, err = client.KvCleanup(ctx, req.Cleanup)
+		resp.Cleanup, err = client.KvCleanup(ctx, req.Cleanup())
 	case CmdBatchGet:
-		resp.BatchGet, err = client.KvBatchGet(ctx, req.BatchGet)
+		resp.BatchGet, err = client.KvBatchGet(ctx, req.BatchGet())
 	case CmdBatchRollback:
-		resp.BatchRollback, err = client.KvBatchRollback(ctx, req.BatchRollback)
+		resp.BatchRollback, err = client.KvBatchRollback(ctx, req.BatchRollback())
 	case CmdScanLock:
-		resp.ScanLock, err = client.KvScanLock(ctx, req.ScanLock)
+		resp.ScanLock, err = client.KvScanLock(ctx, req.ScanLock())
 	case CmdResolveLock:
-		resp.ResolveLock, err = client.KvResolveLock(ctx, req.ResolveLock)
+		resp.ResolveLock, err = client.KvResolveLock(ctx, req.ResolveLock())
 	case CmdGC:
-		resp.GC, err = client.KvGC(ctx, req.GC)
+		resp.GC, err = client.KvGC(ctx, req.GC())
 	case CmdDeleteRange:
-		resp.DeleteRange, err = client.KvDeleteRange(ctx, req.DeleteRange)
+		resp.DeleteRange, err = client.KvDeleteRange(ctx, req.DeleteRange())
 	case CmdRawGet:
-		resp.RawGet, err = client.RawGet(ctx, req.RawGet)
+		resp.RawGet, err = client.RawGet(ctx, req.RawGet())
 	case CmdRawBatchGet:
-		resp.RawBatchGet, err = client.RawBatchGet(ctx, req.RawBatchGet)
+		resp.RawBatchGet, err = client.RawBatchGet(ctx, req.RawBatchGet())
 	case CmdRawPut:
-		resp.RawPut, err = client.RawPut(ctx, req.RawPut)
+		resp.RawPut, err = client.RawPut(ctx, req.RawPut())
 	case CmdRawBatchPut:
-		resp.RawBatchPut, err = client.RawBatchPut(ctx, req.RawBatchPut)
+		resp.RawBatchPut, err = client.RawBatchPut(ctx, req.RawBatchPut())
 	case CmdRawDelete:
-		resp.RawDelete, err = client.RawDelete(ctx, req.RawDelete)
+		resp.RawDelete, err = client.RawDelete(ctx, req.RawDelete())
 	case CmdRawBatchDelete:
-		resp.RawBatchDelete, err = client.RawBatchDelete(ctx, req.RawBatchDelete)
+		resp.RawBatchDelete, err = client.RawBatchDelete(ctx, req.RawBatchDelete())
 	case CmdRawDeleteRange:
-		resp.RawDeleteRange, err = client.RawDeleteRange(ctx, req.RawDeleteRange)
+		resp.RawDeleteRange, err = client.RawDeleteRange(ctx, req.RawDeleteRange())
 	case CmdRawScan:
-		resp.RawScan, err = client.RawScan(ctx, req.RawScan)
+		resp.RawScan, err = client.RawScan(ctx, req.RawScan())
 	case CmdUnsafeDestroyRange:
-		resp.UnsafeDestroyRange, err = client.UnsafeDestroyRange(ctx, req.UnsafeDestroyRange)
+		resp.UnsafeDestroyRange, err = client.UnsafeDestroyRange(ctx, req.UnsafeDestroyRange())
 	case CmdCop:
-		resp.Cop, err = client.Coprocessor(ctx, req.Cop)
+		resp.Cop, err = client.Coprocessor(ctx, req.Cop())
 	case CmdCopStream:
 		var streamClient tikvpb.Tikv_CoprocessorStreamClient
-		streamClient, err = client.CoprocessorStream(ctx, req.Cop)
+		streamClient, err = client.CoprocessorStream(ctx, req.Cop())
 		resp.CopStream = &CopStreamResponse{
 			Tikv_CoprocessorStreamClient: streamClient,
 		}
 	case CmdMvccGetByKey:
-		resp.MvccGetByKey, err = client.MvccGetByKey(ctx, req.MvccGetByKey)
+		resp.MvccGetByKey, err = client.MvccGetByKey(ctx, req.MvccGetByKey())
 	case CmdMvccGetByStartTs:
-		resp.MvccGetByStartTS, err = client.MvccGetByStartTs(ctx, req.MvccGetByStartTs)
+		resp.MvccGetByStartTS, err = client.MvccGetByStartTs(ctx, req.MvccGetByStartTs())
 	case CmdSplitRegion:
-		resp.SplitRegion, err = client.SplitRegion(ctx, req.SplitRegion)
+		resp.SplitRegion, err = client.SplitRegion(ctx, req.SplitRegion())
 	case CmdEmpty:
 		resp.Empty, err = &tikvpb.BatchCommandsEmptyResponse{}, nil
 	default:
@@ -672,7 +798,7 @@ func CallDebugRPC(ctx context.Context, client debugpb.DebugClient, req *Request)
 	var err error
 	switch req.Type {
 	case CmdDebugGetRegionProperties:
-		resp.DebugGetRegionProperties, err = client.GetRegionProperties(ctx, req.DebugGetRegionProperties)
+		resp.DebugGetRegionProperties, err = client.GetRegionProperties(ctx, req.DebugGetRegionProperties())
 	default:
 		return nil, errors.Errorf("invalid request type: %v", req.Type)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

ref #9641, try to reduce tikvrpc request struct size

### What is changed and how it works?

reduce multiple request field into one `interface{}`, no switch cast from/to interface{} is fast and more clear

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

performance test with https://github.com/pingcap/tidb/pull/11056

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release 3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11055)
<!-- Reviewable:end -->
