### PR TITLE
executor: fix two data races in tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -435,6 +435,11 @@ func GetGlobalConfig() *Config {
 	return globalConf.Load().(*Config)
 }
 
+// StoreGlobalConfig stores a new config to the globalConf. It mostly uses in the test to avoid some data races.
+func StoreGlobalConfig(config *Config) {
+	globalConf.Store(config)
+}
+
 // ReloadGlobalConfig reloads global configuration for this server.
 func ReloadGlobalConfig() error {
 	confReloadLock.Lock()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4109,7 +4109,11 @@ func (s *testSuite) TestOOMPanicAction(c *C) {
 	}
 	tk.Se.SetSessionManager(sm)
 	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
+	orgAction := config.GetGlobalConfig().OOMAction
 	setOOMAction(config.OOMActionCancel)
+	defer func() {
+		setOOMAction(orgAction)
+	}()
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	c.Assert(err, NotNil)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -138,9 +138,15 @@ func (s *testSuite) TearDownSuite(c *C) {
 	s.store.Close()
 }
 
+func enablePessimisticTxn(enable bool) {
+	newConf := config.NewConfig()
+	newConf.PessimisticTxn.Enable = enable
+	config.StoreGlobalConfig(newConf)
+}
+
 func (s *testSuite) TestPessimisticSelectForUpdate(c *C) {
-	defer func() { config.GetGlobalConfig().PessimisticTxn.Enable = false }()
-	config.GetGlobalConfig().PessimisticTxn.Enable = true
+	defer func() { enablePessimisticTxn(false) }()
+	enablePessimisticTxn(true)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -4086,6 +4092,12 @@ func (s *testOOMSuite) TestDistSQLMemoryControl(c *C) {
 	tk.Se.GetSessionVars().MemQuotaDistSQL = -1
 }
 
+func setOOMAction(action string) {
+	newConf := config.NewConfig()
+	newConf.OOMAction = action
+	config.StoreGlobalConfig(newConf)
+}
+
 func (s *testSuite) TestOOMPanicAction(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -4097,7 +4109,7 @@ func (s *testSuite) TestOOMPanicAction(c *C) {
 	}
 	tk.Se.SetSessionManager(sm)
 	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
-	config.GetGlobalConfig().OOMAction = config.OOMActionCancel
+	setOOMAction(config.OOMActionCancel)
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	c.Assert(err, NotNil)

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -45,9 +45,6 @@ type testPessimisticSuite struct {
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	newConf := config.NewConfig()
-	newConf.PessimisticTxn.Enable = true
-	config.GetGlobalConfig()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
 	tikv.PessimisticLockTTL = 300

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -45,6 +45,9 @@ type testPessimisticSuite struct {
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
+	newConf := config.NewConfig()
+	newConf.PessimisticTxn.Enable = true
+	config.GetGlobalConfig()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
 	tikv.PessimisticLockTTL = 300


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix two data races in tests.

### What is changed and how it works?
Add atomic store for global variables.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
