### PR TITLE
executor: fix a data race in `TestOOMPanicAction`

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+	"sync/atomic"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
@@ -234,4 +235,8 @@ func assertEqualStrings(c *C, got []field, expect []string) {
 	for i := 0; i < len(got); i++ {
 		c.Assert(string(got[i].str), Equals, expect[i])
 	}
+}
+
+func SetOOMActionForTest(v uint32) {
+	atomic.StoreUint32(&testingOOMAction, v)
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4097,9 +4097,10 @@ func (s *testSuite) TestOOMPanicAction(c *C) {
 	}
 	tk.Se.SetSessionManager(sm)
 	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
-	config.GetGlobalConfig().OOMAction = config.OOMActionCancel
+	executor.SetOOMActionForTest(1)
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
+	executor.SetOOMActionForTest(0)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Matches, "Out Of Memory Quota!.*")
 }


### PR DESCRIPTION
Change config.GetGlobalConfig().OOMAction is not thread safe

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a data race here:

```
==================
WARNING: DATA RACE
Write at 0x0000040ffbc8 by goroutine 74:
  github.com/pingcap/tidb/executor_test.(*testSuite).TestOOMPanicAction()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:4100 +0x30c
  github.com/pingcap/tidb/executor_test.(*testSuite).TestOOMPanicAction()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor_test.go:4093 +0x164
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
  reflect.Value.Call()
      /usr/local/go/src/reflect/value.go:308 +0xc0
  github.com/pingcap/check.(*suiteRunner).forkTest.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9fc
  github.com/pingcap/check.(*suiteRunner).forkCall.func1()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xb7

Previous read at 0x0000040ffbc8 by goroutine 354:
  github.com/pingcap/tidb/executor.ResetContextOfStmt()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:1270 +0x3c6
  github.com/pingcap/tidb/session.(*session).execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1074 +0x7d1
  github.com/pingcap/tidb/session.(*session).Execute()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1033 +0xd4
  github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:141 +0x103
  github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:179 +0x91
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1466 +0xace
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1460 +0xa97
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1459 +0xa60
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1440 +0x6d6
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1439 +0x69f
  github.com/pingcap/tidb/executor_test.(*testSuite4).TestPartitionedTableUpdate()
      /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/write_test.go:1405 +0x167
  runtime.call32()
      /usr/local/go/src/runtime/asm_amd64.s:519 +0x3a
```

### What is changed and how it works?

Use an atomic variable

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

