### PR TITLE
ddl: refine error messages in unsupported column options

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -770,6 +770,20 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 
 }
 
+func (s *testIntegrationSuite5) TestChangingColumnCollation(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create database if not exists test")
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (b char(1) default null) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_general_ci")
+	tk.MustExec("alter table t1 modify column b char(1) character set utf8mb4 collate utf8mb4_general_ci")
+
+	tk.MustExec("drop table t1")
+	tk.MustExec("create table t1 (b char(1) collate utf8mb4_general_ci)")
+	tk.MustExec("alter table t1 modify b char(1) character set utf8mb4 collate utf8mb4_general_ci")
+}
+
 func (s *testIntegrationSuite2) TestCaseInsensitiveCharsetAndCollate(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -775,8 +775,7 @@ func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 	tk.MustExec("create database if not exists test")
 	tk.MustExec("use test")
 
-	errCodeStr1 := "[ddl:210]" // unsupported modify collate from utf8mb4_bin to utf8mb4_general_ci"
-	errCodeStr2 := "[ddl:203]" // unsupported modify column with references
+	errMsg := "[ddl:203]" // unsupported modify column with references
 	assertErrCode := func(sql string, errCodeStr string) {
 		_, err := tk.Exec(sql)
 		c.Assert(err, NotNil)
@@ -785,7 +784,7 @@ func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (b char(1) default null) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_general_ci")
-	assertErrCode("alter table t1 modify column b char(1) character set utf8mb4 collate utf8mb4_general_ci", errCodeStr1)
+	tk.MustExec("alter table t1 modify column b char(1) character set utf8mb4 collate utf8mb4_general_ci")
 
 	tk.MustExec("drop table t1")
 	tk.MustExec("create table t1 (b char(1) collate utf8mb4_general_ci)")
@@ -795,7 +794,7 @@ func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1 (a int)")
 	tk.MustExec("create table t2 (b int, c int)")
-	assertErrCode("alter table t2 modify column c int references t1(a)", errCodeStr2)
+	assertErrCode("alter table t2 modify column c int references t1(a)", errMsg)
 }
 
 func (s *testIntegrationSuite2) TestCaseInsensitiveCharsetAndCollate(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -770,18 +770,32 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 
 }
 
-func (s *testIntegrationSuite5) TestChangingColumnCollation(c *C) {
+func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create database if not exists test")
 	tk.MustExec("use test")
 
+	errCodeStr1 := "[ddl:210]" // unsupported modify collate from utf8mb4_bin to utf8mb4_general_ci"
+	errCodeStr2 := "[ddl:203]" // unsupported modify column with references
+	assertErrCode := func(sql string, errCodeStr string) {
+		_, err := tk.Exec(sql)
+		c.Assert(err, NotNil)
+		c.Assert(err.Error()[:len(errCodeStr)], Equals, errCodeStr)
+	}
+
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1 (b char(1) default null) engine=InnoDB default charset=utf8mb4 collate=utf8mb4_general_ci")
-	tk.MustExec("alter table t1 modify column b char(1) character set utf8mb4 collate utf8mb4_general_ci")
+	assertErrCode("alter table t1 modify column b char(1) character set utf8mb4 collate utf8mb4_general_ci", errCodeStr1)
 
 	tk.MustExec("drop table t1")
 	tk.MustExec("create table t1 (b char(1) collate utf8mb4_general_ci)")
 	tk.MustExec("alter table t1 modify b char(1) character set utf8mb4 collate utf8mb4_general_ci")
+
+	tk.MustExec("drop table t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (a int)")
+	tk.MustExec("create table t2 (b int, c int)")
+	assertErrCode("alter table t2 modify column c int references t1(a)", errCodeStr2)
 }
 
 func (s *testIntegrationSuite2) TestCaseInsensitiveCharsetAndCollate(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2527,7 +2527,7 @@ func processColumnOptions(ctx sessionctx.Context, col *table.Column, options []*
 		case ast.ColumnOptionFulltext:
 			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("with full text"))
 		default:
-			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("unknown column option type"))
+			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs(fmt.Sprintf("unknown column option type: %d", opt.Tp)))
 		}
 	}
 

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2527,7 +2527,7 @@ func processColumnOptions(ctx sessionctx.Context, col *table.Column, options []*
 		case ast.ColumnOptionFulltext:
 			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("with full text"))
 		default:
-			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs(opt.Tp))
+			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("unknown column option type"))
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #10731 and fix #11052.

### What is changed and how it works?

1.  Add more cases in `switch` in `processColumnOptions()`, avoiding the obscure error message in #10731. 

2.  `getModifiableColumnJob()` is used to build a `ActionModifyColumn` DDL job. It contains two methods:
    - `modifiable()`, check whether the FieldType of the origin column can be changed into the new column. The checks include charset, collation, types, Flen/Decimal, etc.
    - `processColumnOptions()`, set FieldType of the new column, according to `Option` in `ColumnDef`, which is filled by SQL parser.

    Obviously, we should first set the FieldType and then check it. So `processColumnOptions()` should come first.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

