### PR TITLE
executor, test: skip `TestPBMemoryLeak` to reduce unit test time cost

### DIFF
--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -42,6 +42,8 @@ func (s *testMemoryLeak) SetUpSuite(c *C) {
 }
 
 func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
+	c.Skip("decrease test time")
+
 	se, err := session.CreateSession4Test(s.store)
 	c.Assert(err, IsNil)
 	_, err = se.Execute(context.Background(), "create database test_mem")

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -42,8 +42,6 @@ func (s *testMemoryLeak) SetUpSuite(c *C) {
 }
 
 func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
-	c.Skip("decrease test time")
-
 	se, err := session.CreateSession4Test(s.store)
 	c.Assert(err, IsNil)
 	_, err = se.Execute(context.Background(), "create database test_mem")

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -16,13 +16,14 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"runtime"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"runtime"
+	"strings"
+	"sync"
 )
 
 var _ = SerialSuites(&testMemoryLeak{})
@@ -59,11 +60,37 @@ func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
 		_, err = se.Execute(context.Background(), "drop table t")
 		c.Assert(err, IsNil)
 	}()
-	sql := fmt.Sprintf("insert into t values (space(%v))", blockSize)
-	for i := uint64(0); i < numRows; i++ {
-		_, err = se.Execute(context.Background(), sql)
-		c.Assert(err, IsNil)
+
+	sqlCh := make(chan string)
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			se, err := session.CreateSession4Test(s.store)
+			c.Assert(err, IsNil)
+			_, err = se.Execute(context.Background(), "use test_mem")
+			c.Assert(err, IsNil)
+
+			for {
+				sql, ok := <-sqlCh
+				if !ok {
+					return
+				}
+				_, err = se.Execute(context.Background(), sql)
+				c.Assert(err, IsNil)
+			}
+		}()
 	}
+
+	batchSize := 16
+	for i := uint64(0); i < numRows; i += uint64(batchSize) {
+		val := fmt.Sprintf("(space(%v))", blockSize)
+		sql := "insert into t values " + val + strings.Repeat(","+val, batchSize-1)
+		sqlCh <- sql
+	}
+	close(sqlCh)
+	wg.Wait()
 
 	// read data
 	runtime.GC()

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -51,7 +51,7 @@ func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
 
 	// prepare data
 	totalSize := uint64(64 << 20) // 64MB
-	blockSize := uint64(8 << 10)   // 8KB
+	blockSize := uint64(8 << 10)  // 8KB
 	delta := totalSize / 5
 	numRows := totalSize / blockSize
 	_, err = se.Execute(context.Background(), fmt.Sprintf("create table t (c varchar(%v))", blockSize))

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -16,14 +16,15 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
-	"runtime"
-	"strings"
-	"sync"
 )
 
 var _ = SerialSuites(&testMemoryLeak{})

--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -50,7 +50,7 @@ func (s *testMemoryLeak) TestPBMemoryLeak(c *C) {
 	c.Assert(err, IsNil)
 
 	// prepare data
-	totalSize := uint64(256 << 20) // 256MB
+	totalSize := uint64(64 << 20) // 64MB
 	blockSize := uint64(8 << 10)   // 8KB
 	delta := totalSize / 5
 	numRows := totalSize / blockSize


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The unit test `TestPBMemoryLeak` is too slow.

### What is changed and how it works?
Have tried two ways to accelerate this unit test:
1. insert records concurrently,
2. reduce the size of data to insert;

The effect of the first method is not obvious since we set a parallel limit(5) when running unit tests.
The second method lets this unit test unstable.

So I decide to skip this unit test now...
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
