### PR TITLE
executor: handle missing timestamp value for load data

### DIFF
--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -297,11 +297,9 @@ func (e *LoadDataInfo) colsToRow(ctx context.Context, cols []field) []types.Datu
 	for i := 0; i < len(e.row); i++ {
 		if i >= len(cols) {
 			// If some columns is missing and their type is time and has not null flag, they should be set as current time.
-			if totalCols[i].Tp == mysql.TypeTimestamp || totalCols[i].Tp == mysql.TypeDate || totalCols[i].Tp == mysql.TypeDatetime {
-				if mysql.HasNotNullFlag(totalCols[i].Flag) {
-					e.row[i].SetMysqlTime(types.CurrentTime(totalCols[i].Tp))
-					continue
-				}
+			if types.IsTypeTime(totalCols[i].Tp) && mysql.HasNotNullFlag(totalCols[i].Flag) {
+				e.row[i].SetMysqlTime(types.CurrentTime(totalCols[i].Tp))
+				continue
 			}
 			e.row[i].SetNull()
 			continue

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/planner/core"
@@ -31,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
@@ -1780,7 +1780,7 @@ func (s *testSuite4) TestQualifiedDelete(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s * testSuite3) TestLoadDataMissingColumn(c *C) {
+func (s *testSuite3) TestLoadDataMissingColumn(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	createSQL := `create table load_data_missing (id int, t timestamp not null)`

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1780,7 +1780,7 @@ func (s *testSuite4) TestQualifiedDelete(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *testSuite3) TestLoadDataMissingColumn(c *C) {
+func (s *testSuite4) TestLoadDataMissingColumn(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	createSQL := `create table load_data_missing (id int, t timestamp not null)`

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1794,7 +1794,7 @@ func (s *testSuite4) TestLoadDataMissingColumn(c *C) {
 
 	deleteSQL := "delete from load_data_missing"
 	selectSQL := "select * from load_data_missing;"
-	_, reachLimit, err := ld.InsertData(nil, nil)
+	_, reachLimit, err := ld.InsertData(context.Background(), nil, nil)
 	c.Assert(err, IsNil)
 	c.Assert(reachLimit, IsFalse)
 	r := tk.MustQuery(selectSQL)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #10504 
`LOAD DATA` has different behavior with MySQL when handling missing timestamp/datetime value.

For example:
If we create a table:
```
create table t_default(id int, t timestamp null);
load data local infile "~/1.csv" into table t_default;
```
```
// 1.csv
12
```
The result for MySQL and TiDB are same:
```
mysql> select * from t_default;
+------+------+
| id   | t    |
+------+------+
|   12 | NULL |
+------+------+
1 row in set (0.00 sec)
```
But if `t` is `NOT NULL`, things are different.
```
create table t_default(id int, t timestamp not null default current_timestamp);
load data local infile "~/1.csv" into table t_default;
```
TiDB:
```
mysql> select * from t_default;
+------+---------------------+
| id   | t                   |
+------+---------------------+
|   12 | 0000-00-00 00:00:00 |
+------+---------------------+
1 row in set (0.00 sec)
```
MySQL:
```
mysql> select * from test.t_default;
+------+---------------------+
| id   | t                   |
+------+---------------------+
|   12 | 2019-07-05 13:27:05 |
+------+---------------------+
1 row in set (0.00 sec)
```
### What is changed and how it works?
Add check for missing timestamp columns when insert load data.
If these columns have `NOT NULL` flag, set them to `CURRENT_TIMESTAMP`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch