### PR TITLE
WIP:window function: Window with RANGE N PRECEDING/FOLLOWING frame requir…

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3182,7 +3182,7 @@ func (b *PlanBuilder) handleDefaultFrame(spec *ast.WindowSpec, windowFuncName st
 		return &newSpec, true
 	}
 	// For functions that operate on the entire partition, the frame clause will be ignored.
-	if !needFrame && spec.Frame != nil {
+	if !needFrame && spec.Frame != nil && spec.Frame.Type != ast.Ranges {
 		specName := spec.Name.O
 		b.ctx.GetSessionVars().StmtCtx.AppendNote(ErrWindowFunctionIgnoresFrame.GenWithStackByArgs(windowFuncName, getWindowName(specName)))
 		newSpec := *spec

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2274,6 +2274,10 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 			result: "TableReader(Table(t))->Window(sum(cast(test.t.a)) over(order by test.t.a asc range between 1.0 preceding and 1 following))->Projection",
 		},
 		{
+			sql:    "select sum(a) over(range between 1.0 preceding and 1 following) from t",
+			result: "[planner:3587]Window '<unnamed window>' with RANGE N PRECEDING/FOLLOWING frame requires exactly one ORDER BY expression, of numeric or temporal type",
+		},
+		{
 			sql:    "select row_number() over(rows between 1 preceding and 1 following) from t",
 			result: "TableReader(Table(t))->Window(row_number() over())->Projection",
 		},
@@ -2316,6 +2320,10 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 		{
 			sql:    "delete from t order by (sum(a) over())",
 			result: "[planner:3593]You cannot use the window function 'sum' in this context.'",
+		},
+		{
+			sql:    "SELECT DENSE_RANK() OVER w1 AS 'dense_rank', fieldA, fieldB FROM ( SELECT a AS fieldA, b AS fieldB FROM t ) as t WINDOW w1 AS (PARTITION BY fieldB ORDER BY fieldB DESC, fieldA DESC RANGE BETWEEN CURRENT ROW AND 1250951168 FOLLOWING);",
+			result: "[planner:3587]Window 'w1' with RANGE N PRECEDING/FOLLOWING frame requires exactly one ORDER BY expression, of numeric or temporal type",
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
window function: Window with RANGE N PRECEDING/FOLLOWING frame requires exactly one ORDER BY expression, of numeric or temporal type
Closes https://github.com/pingcap/tidb/issues/11010

### What is changed and how it works?
In the absence of a frame clause, `handleDefaultFrame` does not ignore the frame clause when `spec.Frame.Type` is `RANGE`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test