### PR TITLE
types: fix insert hex values overflow for unsigned column types

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -915,7 +915,12 @@ func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (
 		val, err = ConvertFloatToUint(sc, d.GetMysqlEnum().ToNumber(), upperBound, tp)
 	case KindMysqlSet:
 		val, err = ConvertFloatToUint(sc, d.GetMysqlSet().ToNumber(), upperBound, tp)
-	case KindBinaryLiteral, KindMysqlBit:
+	case KindBinaryLiteral:
+		val, err = d.GetBinaryLiteral().ToInt(sc)
+		if err == nil && val > upperBound {
+			err = overflow(val, tp)
+		}
+	case KindMysqlBit:
 		val, err = d.GetBinaryLiteral().ToInt(sc)
 	case KindMysqlJSON:
 		var i64 int64

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -200,9 +200,6 @@ func (ts *testTypeConvertSuite) TestConvertBinaryLiteralToUnsigned(c *C) {
 		sc = new(stmtctx.StatementContext)
 		_, err = datum.ConvertTo(sc, ft)
 		c.Assert(err.Error(), Equals, fmt.Sprintf("[types:1690]constant %d overflows %s", v, ast.TypeStr(t)))
-
-		ft = NewFieldType(mysql.TypeTiny)
-		ft.Flag = mysql.UnsignedFlag
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/11064

fix hex values overflow bug for unsigned field types

### What is changed and how it works?
compare hex value with unsigned field type's upperboud 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

