### PR TITLE
executor: fix two data races in tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -432,6 +432,11 @@ func GetGlobalConfig() *Config {
 	return globalConf.Load().(*Config)
 }
 
+// StoreGlobalConfig stores a new config to the globalConf. It mostly uses in the test to avoid some data races.
+func StoreGlobalConfig(config *Config) {
+	globalConf.Store(config)
+}
+
 // ReloadGlobalConfig reloads global configuration for this server.
 func ReloadGlobalConfig() error {
 	confReloadLock.Lock()

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3998,7 +3998,11 @@ func (s *testSuite) TestOOMPanicAction(c *C) {
 	}
 	tk.Se.SetSessionManager(sm)
 	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
+	orgAction := config.GetGlobalConfig().OOMAction
 	setOOMAction(config.OOMActionCancel)
+	defer func() {
+		setOOMAction(orgAction)
+	}()
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	c.Assert(err, NotNil)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -135,6 +135,27 @@ func (s *testSuite) TearDownSuite(c *C) {
 	s.store.Close()
 }
 
+func enablePessimisticTxn(enable bool) {
+	newConf := config.NewConfig()
+	newConf.PessimisticTxn.Enable = enable
+	config.StoreGlobalConfig(newConf)
+}
+
+func (s *testSuite) TestPessimisticSelectForUpdate(c *C) {
+	defer func() { enablePessimisticTxn(false) }()
+	enablePessimisticTxn(true)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int primary key, a int)")
+	tk.MustExec("insert into t values(1, 1)")
+	tk.MustExec("begin PESSIMISTIC")
+	tk.MustQuery("select a from t where id=1 for update").Check(testkit.Rows("1"))
+	tk.MustExec("update t set a=a+1 where id=1")
+	tk.MustExec("commit")
+	tk.MustQuery("select a from t where id=1").Check(testkit.Rows("2"))
+}
+
 func (s *testSuite) TearDownTest(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -3960,6 +3981,12 @@ func (s *testOOMSuite) TestDistSQLMemoryControl(c *C) {
 	tk.Se.GetSessionVars().MemQuotaDistSQL = -1
 }
 
+func setOOMAction(action string) {
+	newConf := config.NewConfig()
+	newConf.OOMAction = action
+	config.StoreGlobalConfig(newConf)
+}
+
 func (s *testSuite) TestOOMPanicAction(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -3971,7 +3998,7 @@ func (s *testSuite) TestOOMPanicAction(c *C) {
 	}
 	tk.Se.SetSessionManager(sm)
 	s.domain.ExpensiveQueryHandle().SetSessionManager(sm)
-	config.GetGlobalConfig().OOMAction = config.OOMActionCancel
+	setOOMAction(config.OOMActionCancel)
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	c.Assert(err, NotNil)

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -45,9 +45,6 @@ type testPessimisticSuite struct {
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	newConf := config.NewConfig()
-	newConf.PessimisticTxn.Enable = true
-	config.GetGlobalConfig()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
 	tikv.PessimisticLockTTL = 300

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -45,6 +45,9 @@ type testPessimisticSuite struct {
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
+	newConf := config.NewConfig()
+	newConf.PessimisticTxn.Enable = true
+	config.GetGlobalConfig()
 	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
 	tikv.PessimisticLockTTL = 300


### PR DESCRIPTION
Cherry pick of #11062 on release-3.0.

fix two races