### PR TITLE
server: change the conn-killed error to `ErrQueryInterrupted` to let this behavior be compatible with MySQL

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1178,7 +1178,7 @@ func (cc *clientConn) handleQuery(ctx context.Context, sql string) (err error) {
 	status := atomic.LoadInt32(&cc.status)
 	if status == connStatusShutdown || status == connStatusWaitShutdown {
 		killConn(cc)
-		return errors.New("killed by another connection")
+		return executor.ErrQueryInterrupted
 	}
 	if rs != nil {
 		if len(rs) == 1 {

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -38,7 +38,7 @@ type ConnTestSuite struct {
 	store kv.Storage
 }
 
-var _ = Suite(new(ConnTestSuite))
+var _ = Suite(ConnTestSuite{})
 
 func (ts *ConnTestSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
@@ -371,29 +371,6 @@ func mapBelong(m1, m2 map[string]string) bool {
 		}
 	}
 	return true
-}
-
-func (ts *ConnTestSuite) TestConnKillError(c *C) {
-	connID := 1
-	se, err := session.CreateSession4Test(ts.store)
-	c.Assert(err, IsNil)
-	tc := &TiDBContext{
-		session: se,
-		stmts:   make(map[int]*TiDBStatement),
-	}
-	sv := &Server{
-		capability: defaultCapability,
-	}
-	cc := &clientConn{
-		connectionID: uint32(connID),
-		server:       sv,
-		ctx:          tc,
-		alloc:        arena.NewAllocator(32 * 1024),
-	}
-	sv.KillAllConnections()
-
-	err = cc.handleQuery(context.Background(), "use test")
-	fmt.Println(err)
 }
 
 func (ts *ConnTestSuite) TestConnExecutionTimeout(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Now, when a connection is killed by another, it returns a `Killed By Another` error, which is not compatible with MySQL.

### What is changed and how it works?
Change this error to `ErrQueryInterrupted`.

