### PR TITLE
*: remove the transaction kv count limit

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,8 +37,6 @@ const (
 	MaxLogFileSize    = 4096 // MB
 	MinPessimisticTTL = time.Second * 15
 	MaxPessimisticTTL = time.Second * 120
-	// DefTxnEntryCountLimit is the default value of TxnEntryCountLimit.
-	DefTxnEntryCountLimit = 300 * 1000
 	// DefTxnTotalSizeLimit is the default value of TxnTxnTotalSizeLimit.
 	DefTxnTotalSizeLimit = 100 * 1024 * 1024
 )
@@ -198,7 +196,6 @@ type Performance struct {
 	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
 	ForcePriority       string  `toml:"force-priority" json:"force-priority"`
 	BindInfoLease       string  `toml:"bind-info-lease" json:"bind-info-lease"`
-	TxnEntryCountLimit  uint64  `toml:"txn-entry-count-limit" json:"txn-entry-count-limit"`
 	TxnTotalSizeLimit   uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
 }
 
@@ -369,7 +366,6 @@ var defaultConf = Config{
 		PseudoEstimateRatio: 0.8,
 		ForcePriority:       "NO_PRIORITY",
 		BindInfoLease:       "3s",
-		TxnEntryCountLimit:  DefTxnEntryCountLimit,
 		TxnTotalSizeLimit:   DefTxnTotalSizeLimit,
 	},
 	ProxyProtocol: ProxyProtocol{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -180,12 +180,6 @@ force-priority = "NO_PRIORITY"
 # Bind info lease duration, which influences the duration of loading bind info and handling invalid bind.
 bind-info-lease = "3s"
 
-# The limitation of the number for the entries in one transaction.
-# If using TiKV as the storage, the entry represents a key/value pair.
-# WARNING: Do not set the value too large, otherwise it will make a very large impact on the TiKV cluster.
-# Please adjust this configuration carefully.
-txn-entry-count-limit = 300000
-
 # The limitation of the size in byte for the entries in one transaction.
 # If using TiKV as the storage, the entry represents a key/value pair.
 # WARNING: Do not set the value too large, otherwise it will make a very large impact on the TiKV cluster.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,7 +38,6 @@ func (s *testConfigSuite) TestConfig(c *C) {
 	conf.Binlog.Enable = true
 	conf.Binlog.IgnoreError = true
 	conf.Binlog.Strategy = "hash"
-	conf.Performance.TxnEntryCountLimit = 1000
 	conf.Performance.TxnTotalSizeLimit = 1000
 	conf.TiKVClient.CommitTimeout = "10s"
 	configFile := "config.toml"
@@ -66,7 +65,6 @@ enable-table-lock = true
 delay-clean-table-lock = 5
 split-region-max-num=10000
 [performance]
-txn-entry-count-limit=2000
 txn-total-size-limit=2000
 [tikv-client]
 commit-timeout="41s"
@@ -83,7 +81,6 @@ max-batch-size=128
 	c.Assert(conf.Binlog.Strategy, Equals, "hash")
 
 	// Test that the value will be overwritten by the config file.
-	c.Assert(conf.Performance.TxnEntryCountLimit, Equals, uint64(2000))
 	c.Assert(conf.Performance.TxnTotalSizeLimit, Equals, uint64(2000))
 
 	c.Assert(conf.TiKVClient.CommitTimeout, Equals, "41s")

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -793,6 +793,8 @@ func (s *seqTestSuite) TestCartesianProduct(c *C) {
 	plannercore.AllowCartesianProduct.Store(true)
 }
 
+// the entry count is removed, so the batch insert/delete may not used anymore.
+/*
 func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	originLimit := atomic.LoadUint64(&kv.TxnEntryCountLimit)
 	defer func() {
@@ -909,6 +911,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("0"))
 }
+ */
 
 type checkPrioClient struct {
 	tikv.Client

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -911,7 +911,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("0"))
 }
- */
+*/
 
 type checkPrioClient struct {
 	tikv.Client

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -793,15 +793,13 @@ func (s *seqTestSuite) TestCartesianProduct(c *C) {
 	plannercore.AllowCartesianProduct.Store(true)
 }
 
-// the entry count is removed, so the batch insert/delete may not used anymore.
-/*
 func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
-	originLimit := atomic.LoadUint64(&kv.TxnEntryCountLimit)
+	originLimit := atomic.LoadUint64(&kv.TxnTotalSizeLimit)
 	defer func() {
-		atomic.StoreUint64(&kv.TxnEntryCountLimit, originLimit)
+		atomic.StoreUint64(&kv.TxnTotalSizeLimit, originLimit)
 	}()
 	// Set the limitation to a small value, make it easier to reach the limitation.
-	atomic.StoreUint64(&kv.TxnEntryCountLimit, 100)
+	atomic.StoreUint64(&kv.TxnTotalSizeLimit, 5000)
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -829,19 +827,22 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	tk.MustExec("insert into batch_insert (c) select * from batch_insert;")
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("160"))
+	tk.MustExec("insert into batch_insert (c) select * from batch_insert;")
+	r = tk.MustQuery("select count(*) from batch_insert;")
+	r.Check(testkit.Rows("320"))
 	// for on duplicate key
-	for i := 0; i < 160; i++ {
+	for i := 0; i < 320; i++ {
 		tk.MustExec(fmt.Sprintf("insert into batch_insert_on_duplicate values(%d, %d);", i, i))
 	}
 	r = tk.MustQuery("select count(*) from batch_insert_on_duplicate;")
-	r.Check(testkit.Rows("160"))
+	r.Check(testkit.Rows("320"))
 
 	// This will meet txn too large error.
 	_, err := tk.Exec("insert into batch_insert (c) select * from batch_insert;")
 	c.Assert(err, NotNil)
 	c.Assert(kv.ErrTxnTooLarge.Equal(err), IsTrue)
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("160"))
+	r.Check(testkit.Rows("320"))
 
 	// for on duplicate key
 	_, err = tk.Exec(`insert into batch_insert_on_duplicate select * from batch_insert_on_duplicate as tt
@@ -849,23 +850,23 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(kv.ErrTxnTooLarge.Equal(err), IsTrue, Commentf("%v", err))
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("160"))
+	r.Check(testkit.Rows("320"))
 
 	// Change to batch inset mode and batch size to 50.
 	tk.MustExec("set @@session.tidb_batch_insert=1;")
 	tk.MustExec("set @@session.tidb_dml_batch_size=50;")
 	tk.MustExec("insert into batch_insert (c) select * from batch_insert;")
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("320"))
+	r.Check(testkit.Rows("640"))
 
 	// Enlarge the batch size to 150 which is larger than the txn limitation (100).
 	// So the insert will meet error.
-	tk.MustExec("set @@session.tidb_dml_batch_size=150;")
+	tk.MustExec("set @@session.tidb_dml_batch_size=600;")
 	_, err = tk.Exec("insert into batch_insert (c) select * from batch_insert;")
 	c.Assert(err, NotNil)
 	c.Assert(kv.ErrTxnTooLarge.Equal(err), IsTrue)
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("320"))
+	r.Check(testkit.Rows("640"))
 	// Set it back to 50.
 	tk.MustExec("set @@session.tidb_dml_batch_size=50;")
 
@@ -874,7 +875,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 		on duplicate key update batch_insert_on_duplicate.id=batch_insert_on_duplicate.id+1000;`)
 	c.Assert(err, IsNil)
 	r = tk.MustQuery("select count(*) from batch_insert_on_duplicate;")
-	r.Check(testkit.Rows("160"))
+	r.Check(testkit.Rows("320"))
 
 	// Disable BachInsert mode in transition.
 	tk.MustExec("begin;")
@@ -883,7 +884,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	c.Assert(kv.ErrTxnTooLarge.Equal(err), IsTrue)
 	tk.MustExec("rollback;")
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("320"))
+	r.Check(testkit.Rows("640"))
 
 	tk.MustExec("drop table if exists com_batch_insert")
 	tk.MustExec("create table com_batch_insert (c int)")
@@ -902,7 +903,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(kv.ErrTxnTooLarge.Equal(err), IsTrue)
 	r = tk.MustQuery("select count(*) from batch_insert;")
-	r.Check(testkit.Rows("320"))
+	r.Check(testkit.Rows("640"))
 	// Enable batch delete and set batch size to 50.
 	tk.MustExec("set @@session.tidb_batch_delete=on;")
 	tk.MustExec("set @@session.tidb_dml_batch_size=50;")
@@ -911,7 +912,6 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("0"))
 }
-*/
 
 type checkPrioClient struct {
 	tikv.Client

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -73,8 +73,6 @@ const (
 var (
 	// TxnEntrySizeLimit is limit of single entry size (len(key) + len(value)).
 	TxnEntrySizeLimit = 6 * 1024 * 1024
-	// TxnEntryCountLimit  is limit of number of entries in the MemBuffer.
-	TxnEntryCountLimit uint64 = config.DefTxnEntryCountLimit
 	// TxnTotalSizeLimit is limit of the sum of all entry size.
 	TxnTotalSizeLimit uint64 = config.DefTxnTotalSizeLimit
 )

--- a/kv/mem_buffer_test.go
+++ b/kv/mem_buffer_test.go
@@ -223,15 +223,6 @@ func (s *testKVSuite) TestBufferLimit(c *C) {
 	c.Assert(err, IsNil)
 	err = buffer.Set([]byte("yz"), make([]byte, 499))
 	c.Assert(err, NotNil) // buffer size limit
-
-	buffer = NewMemDbBuffer(DefaultTxnMembufCap).(*memDbBuffer)
-	buffer.bufferLenLimit = 10
-	for i := 0; i < 10; i++ {
-		err = buffer.Set([]byte{byte(i)}, []byte{byte(i)})
-		c.Assert(err, IsNil)
-	}
-	err = buffer.Set([]byte("x"), []byte("y"))
-	c.Assert(err, NotNil) // buffer len limit
 }
 
 var opCnt = 100000

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -46,7 +46,6 @@ func NewMemDbBuffer(cap int) MemBuffer {
 	return &memDbBuffer{
 		db:              memdb.New(comparer.DefaultComparer, cap),
 		entrySizeLimit:  TxnEntrySizeLimit,
-		bufferLenLimit:  atomic.LoadUint64(&TxnEntryCountLimit),
 		bufferSizeLimit: atomic.LoadUint64(&TxnTotalSizeLimit),
 	}
 }
@@ -98,9 +97,6 @@ func (m *memDbBuffer) Set(k Key, v []byte) error {
 	err := m.db.Put(k, v)
 	if m.Size() > int(m.bufferSizeLimit) {
 		return ErrTxnTooLarge.GenWithStack("transaction too large, size:%d", m.Size())
-	}
-	if m.Len() > int(m.bufferLenLimit) {
-		return ErrTxnTooLarge.GenWithStack("transaction too large, len:%d", m.Len())
 	}
 	return errors.Trace(err)
 }

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -230,8 +230,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 		mutation.asserted = true
 	}
 
-	entrylimit := atomic.LoadUint64(&kv.TxnEntryCountLimit)
-	if len(keys) > int(entrylimit) || size > int(kv.TxnTotalSizeLimit) {
+	if size > int(kv.TxnTotalSizeLimit) {
 		return kv.ErrTxnTooLarge
 	}
 	const logEntryCount = 10000

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -486,7 +486,6 @@ func setGlobalVars() {
 	}
 	plannercore.AllowCartesianProduct.Store(cfg.Performance.CrossJoin)
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
-	kv.TxnEntryCountLimit = cfg.Performance.TxnEntryCountLimit
 	kv.TxnTotalSizeLimit = cfg.Performance.TxnTotalSizeLimit
 
 	priority := mysql.Str2Priority(cfg.Performance.ForcePriority)


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It is extremely easy to reach the transaction kv count limit for TiDB. Which make the user have to modify their applications.

### What is changed and how it works?
Remove the transaction kv count limit, though keep the transaction size limit.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported variable/fields change

