### PR TITLE
executor: explain analyze panic when processing `explain analyze insert ... select ...` 

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -253,17 +253,8 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		return a.handlePessimisticSelectForUpdate(ctx, e)
 	}
 
-	// If the executor doesn't return any result to the client, we execute it without delay.
-	if e.Schema().Len() == 0 {
-		if isPessimistic {
-			return nil, a.handlePessimisticDML(ctx, e)
-		}
-		return a.handleNoDelayExecutor(ctx, e)
-	} else if proj, ok := e.(*ProjectionExec); ok && proj.calculateNoDelay {
-		// Currently this is only for the "DO" statement. Take "DO 1, @a=2;" as an example:
-		// the Projection has two expressions and two columns in the schema, but we should
-		// not return the result of the two expressions.
-		return a.handleNoDelayExecutor(ctx, e)
+	if result, err := a.handleNoDelay(ctx, e, isPessimistic); result != nil || err != nil {
+		return result, err
 	}
 
 	var txnStartTS uint64
@@ -279,6 +270,30 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		stmt:       a,
 		txnStartTS: txnStartTS,
 	}, nil
+}
+
+func (a *ExecStmt) handleNoDelay(ctx context.Context, e Executor, isPessimistic bool) (sqlexec.RecordSet, error) {
+	toCheck := e
+	if explain, ok := e.(*ExplainExec); ok {
+		if explain.analyzeExec != nil {
+			toCheck = explain.analyzeExec
+		}
+	}
+
+	// If the executor doesn't return any result to the client, we execute it without delay.
+	if toCheck.Schema().Len() == 0 {
+		if isPessimistic {
+			return nil, a.handlePessimisticDML(ctx, e)
+		}
+		return a.handleNoDelayExecutor(ctx, e)
+	} else if proj, ok := toCheck.(*ProjectionExec); ok && proj.calculateNoDelay {
+		// Currently this is only for the "DO" statement. Take "DO 1, @a=2;" as an example:
+		// the Projection has two expressions and two columns in the schema, but we should
+		// not return the result of the two expressions.
+		return a.handleNoDelayExecutor(ctx, e)
+	}
+
+	return nil, nil
 }
 
 // getMaxExecutionTime get the max execution timeout value.

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -63,11 +63,14 @@ func (s *testSuite1) TestExplainPriviliges(c *C) {
 
 func (s *testSuite1) TestExplainWrite(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int)")
-	tk.MustExec("explain analyze insert into t values (1)")
+	tk.MustExec("explain analyze insert into t select 1")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
 	tk.MustExec("explain analyze update t set a=2 where a=1")
 	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
-	tk.MustExec("explain analyze insert into t values (1)")
+	tk.MustExec("explain insert into t select 1")
 	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
+	tk.MustExec("explain analyze insert into t select 1")
+	tk.MustQuery("select * from t order by a").Check(testkit.Rows("1", "2"))
 }

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -60,3 +60,14 @@ func (s *testSuite1) TestExplainPriviliges(c *C) {
 	err = tk1.ExecToErr("explain select * from v")
 	c.Assert(err.Error(), Equals, plannercore.ErrTableaccessDenied.GenWithStackByArgs("SELECT", "explain", "%", "v").Error())
 }
+
+func (s *testSuite1) TestExplainWrite(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("explain analyze insert into t values (1)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
+	tk.MustExec("explain analyze update t set a=2 where a=1")
+	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
+	tk.MustExec("explain analyze insert into t values (1)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
+}

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb
+	github.com/pingcap/parser v0.0.0-20190710072914-6cd203114f2d
 	github.com/pingcap/pd v0.0.0-20190617100349-293d4b5189bf
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,6 @@ github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb h1:jfhJo/D1bWMF+zVaVdmixWG5EnxbnFt99GS2pdxuToo=
-github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20190710072914-6cd203114f2d h1:vOZjn1ami1LIjtIj0i5QunGh/sHawbhiBCb1qPx373w=
 github.com/pingcap/parser v0.0.0-20190710072914-6cd203114f2d/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190617100349-293d4b5189bf h1:vmlN6DpZI5LtHd8r9YRAsyCeTU2pxRq+WlWn5CZ+ax4=

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,8 @@ github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3F
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb h1:jfhJo/D1bWMF+zVaVdmixWG5EnxbnFt99GS2pdxuToo=
 github.com/pingcap/parser v0.0.0-20190708123555-29973f7a22eb/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20190710072914-6cd203114f2d h1:vOZjn1ami1LIjtIj0i5QunGh/sHawbhiBCb1qPx373w=
+github.com/pingcap/parser v0.0.0-20190710072914-6cd203114f2d/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190617100349-293d4b5189bf h1:vmlN6DpZI5LtHd8r9YRAsyCeTU2pxRq+WlWn5CZ+ax4=
 github.com/pingcap/pd v0.0.0-20190617100349-293d4b5189bf/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #11036;
Panic when processing `explain analyze insert ... select ...`;

### What is changed and how it works?
SQLs like `explain analyze insert ...` should be handled in a no-delayed manner, since there is write operation in it. 

But All explain statements are handled in a delayed manner now because we don't check `ExplainExec` rightly when handing no delayed executors.

In this PR, we check:
1. if the explain-executor has an analyze flag, and
2. if the internal executor of the explain-executor should be handled in a no-delayed manner;

If all conditions 1) and 2) are true, we should handle this explain without delay. 

This PR should be merged after https://github.com/pingcap/parser/pull/381.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test