### PR TITLE
expressio: fix data race of rand function

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -552,7 +552,7 @@ func (s *testIntegrationSuite) TestMathBuiltin(c *C) {
 	tk.MustExec("create table t(a int)")
 	tk.MustExec("insert into t values(1),(2),(3)")
 	tk.Se.GetSessionVars().MaxChunkSize = 1
-	tk.MustQuery("select rand() from t")
+	tk.MustQuery("select rand(1) from t").Sort().Check(testkit.Rows("0.6046602879796196", "0.6645600532184904", "0.9405090880450124"))
 	tk.MustQuery("select rand(a) from t").Check(testkit.Rows("0.6046602879796196", "0.16729663442585624", "0.7199826688373036"))
 	tk.MustQuery("select rand(1), rand(2), rand(3)").Check(testkit.Rows("0.6046602879796196 0.16729663442585624 0.7199826688373036"))
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -551,6 +551,8 @@ func (s *testIntegrationSuite) TestMathBuiltin(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int)")
 	tk.MustExec("insert into t values(1),(2),(3)")
+	tk.Se.GetSessionVars().MaxChunkSize = 1
+	tk.MustQuery("select rand() from t")
 	tk.MustQuery("select rand(a) from t").Check(testkit.Rows("0.6046602879796196", "0.16729663442585624", "0.7199826688373036"))
 	tk.MustQuery("select rand(1), rand(2), rand(3)").Check(testkit.Rows("0.6046602879796196 0.16729663442585624 0.7199826688373036"))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
WARNING: DATA RACE
Read at 0x00c000345508 by goroutine 81:
  math/rand.(*rngSource).Int63()
      /usr/lib/go/src/math/rand/rng.go:244 +0x8f
  github.com/pingcap/tidb/expression.(*builtinRandSig).evalReal()
      /usr/lib/go/src/math/rand/rand.go:85 +0x7a
  github.com/pingcap/tidb/expression.(*ScalarFunction).EvalReal()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/scalar_function.go:239 +0x73
  github.com/pingcap/tidb/expression.executeToReal()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/chunk_executor.go:143 +0x79
  github.com/pingcap/tidb/expression.evalOneColumn()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/chunk_executor.go:75 +0x2c0
  github.com/pingcap/tidb/expression.(*defaultEvaluator).run()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/evaluator.go:47 +0x664
  github.com/pingcap/tidb/expression.(*EvaluatorSuite).Run()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/evaluator.go:113 +0x113
  github.com/pingcap/tidb/executor.(*projectionWorker).run()
      /home/aliv/go/src/github.com/pingcap/tidb/executor/projection.go:356 +0x246

Previous write at 0x00c000345508 by goroutine 116:
  math/rand.(*rngSource).Int63()
      /usr/lib/go/src/math/rand/rng.go:244 +0xab
  github.com/pingcap/tidb/expression.(*builtinRandSig).evalReal()
      /usr/lib/go/src/math/rand/rand.go:85 +0x7a
  github.com/pingcap/tidb/expression.(*ScalarFunction).EvalReal()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/scalar_function.go:239 +0x73
  github.com/pingcap/tidb/expression.executeToReal()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/chunk_executor.go:143 +0x79
  github.com/pingcap/tidb/expression.evalOneColumn()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/chunk_executor.go:75 +0x2c0
  github.com/pingcap/tidb/expression.(*defaultEvaluator).run()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/evaluator.go:47 +0x664
  github.com/pingcap/tidb/expression.(*EvaluatorSuite).Run()
      /home/aliv/go/src/github.com/pingcap/tidb/expression/evaluator.go:113 +0x113
  github.com/pingcap/tidb/executor.(*projectionWorker).run()
      /home/aliv/go/src/github.com/pingcap/tidb/executor/projection.go:356 +0x246
```
### What is changed and how it works?

Add a mutex for `rand` to prevent data race.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
