### PR TITLE
planner: fix union scan on partition table bug

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3664,6 +3664,13 @@ func (s *testSuite3) TestSelectPartition(c *C) {
 	c.Assert(err.Error(), Equals, "[table:1735]Unknown partition 'p4' in table 'th'")
 	err = tk.ExecToErr("select b from tr partition (r1,r4)")
 	c.Assert(err.Error(), Equals, "[table:1735]Unknown partition 'r4' in table 'tr'")
+
+	// test select partition table in transaction.
+	tk.MustExec("begin")
+	tk.MustExec("insert into th values (10,10),(11,11)")
+	tk.MustQuery("select a, b from th where b>10").Check(testkit.Rows("11 11"))
+	tk.MustExec("commit")
+	tk.MustQuery("select a, b from th where b>10").Check(testkit.Rows("11 11"))
 }
 
 func (s *testSuite) TestSelectView(c *C) {

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -60,9 +60,10 @@ func (s *partitionProcessor) rewriteDataSource(lp LogicalPlan) (LogicalPlan, err
 			// Union->(UnionScan->DataSource1), (UnionScan->DataSource2)
 			children := make([]LogicalPlan, 0, len(ua.Children()))
 			for _, child := range ua.Children() {
-				us := LogicalUnionScan{}.Init(ua.ctx)
-				us.SetChildren(child)
-				children = append(children, us)
+				usChild := LogicalUnionScan{}.Init(ua.ctx)
+				usChild.conditions = us.conditions
+				usChild.SetChildren(child)
+				children = append(children, usChild)
 			}
 			ua.SetChildren(children...)
 			return ua, nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix union scan on partition table bug
```sql
create table t (a int) partition by hash(a) partitions 4;
begin
insert into t values (0),(1);
select * from t where a>0; 
+---+
| a |
+---+
| 1 |
| 0 | --bug: filter is a>0
+---+
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch
