### PR TITLE
WIP: isolate testing code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,14 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
 
 GO        := GO111MODULE=on go
-GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG)
+GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG) -tags codes
 GOTEST    := CGO_ENABLED=1 $(GO) test -p 4
 OVERALLS  := CGO_ENABLED=1 GO111MODULE=on overalls
 
 ARCH      := "`uname -s`"
 LINUX     := "Linux"
 MAC       := "Darwin"
-PACKAGE_LIST  := go list ./...| grep -vE "cmd"
+PACKAGE_LIST  := go list ./...| grep -vE "cmd" | grep -vE "test"
 PACKAGES  := $$($(PACKAGE_LIST))
 PACKAGE_DIRECTORIES := $(PACKAGE_LIST) | sed 's|github.com/pingcap/$(PROJECT)/||'
 FILES     := $$(find $$($(PACKAGE_DIRECTORIES)) -name "*.go")
@@ -140,7 +140,7 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 else
 	@echo "Running in native mode."
 	@export log_level=error; \
-	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) || { $(FAILPOINT_DISABLE); exit 1; }
+	$(GOTEST) -tags testing -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) || { $(FAILPOINT_DISABLE); exit 1; }
 endif
 	@$(FAILPOINT_DISABLE)
 

--- a/server/sql_info_fetcher.go
+++ b/server/sql_info_fetcher.go
@@ -34,7 +34,6 @@ import (
 	"github.com/pingcap/tidb/statistics/handle"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/pingcap/tidb/util/testkit"
 )
 
 type sqlInfoFetcher struct {
@@ -171,7 +170,7 @@ func (sh *sqlInfoFetcher) zipInfoForSQL(w http.ResponseWriter, r *http.Request) 
 			terror.Log(err)
 			return
 		}
-		sRows, err := testkit.ResultSetToStringSlice(reqCtx, sh.s, recordSets[0])
+		sRows, err := session.ResultSetToStringSlice(reqCtx, sh.s, recordSets[0])
 		if err != nil {
 			err = sh.writeErrFile(zw, "explain.err.txt", err)
 			terror.Log(err)
@@ -248,7 +247,7 @@ func (sh *sqlInfoFetcher) getExplainAnalyze(ctx context.Context, sql string, res
 		resultChan <- &explainAnalyzeResult{err: err}
 		return
 	}
-	rows, err := testkit.ResultSetToStringSlice(ctx, sh.s, recordSets[0])
+	rows, err := session.ResultSetToStringSlice(ctx, sh.s, recordSets[0])
 	if err != nil {
 		terror.Log(err)
 		rows = nil
@@ -292,7 +291,7 @@ func (sh *sqlInfoFetcher) getShowCreateTable(pair tableNamePair, zw *zip.Writer)
 	if err != nil {
 		return err
 	}
-	sRows, err := testkit.ResultSetToStringSlice(context.Background(), sh.s, recordSets[0])
+	sRows, err := session.ResultSetToStringSlice(context.Background(), sh.s, recordSets[0])
 	if err != nil {
 		terror.Log(err)
 		return nil

--- a/util/testkit/ctestkit.go
+++ b/util/testkit/ctestkit.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !codes
+
 package testkit
 
 import (

--- a/util/testkit/fake.go
+++ b/util/testkit/fake.go
@@ -1,0 +1,3 @@
+// +build codes
+
+package testkit

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !codes
+
 package testkit
 
 import (
@@ -241,39 +243,9 @@ func (tk *TestKit) ResultSetToResult(rs sqlexec.RecordSet, comment check.Comment
 	return tk.ResultSetToResultWithCtx(context.Background(), rs, comment)
 }
 
-// ResultSetToStringSlice changes the RecordSet to [][]string.
-func ResultSetToStringSlice(ctx context.Context, s session.Session, rs sqlexec.RecordSet) ([][]string, error) {
-	rows, err := session.GetRows4Test(ctx, s, rs)
-	if err != nil {
-		return nil, err
-	}
-	err = rs.Close()
-	if err != nil {
-		return nil, err
-	}
-	sRows := make([][]string, len(rows))
-	for i := range rows {
-		row := rows[i]
-		iRow := make([]string, row.Len())
-		for j := 0; j < row.Len(); j++ {
-			if row.IsNull(j) {
-				iRow[j] = "<nil>"
-			} else {
-				d := row.GetDatum(j, &rs.Fields()[j].Column.FieldType)
-				iRow[j], err = d.ToString()
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		sRows[i] = iRow
-	}
-	return sRows, nil
-}
-
 // ResultSetToResultWithCtx converts sqlexec.RecordSet to testkit.Result.
 func (tk *TestKit) ResultSetToResultWithCtx(ctx context.Context, rs sqlexec.RecordSet, comment check.CommentInterface) *Result {
-	sRows, err := ResultSetToStringSlice(ctx, tk.Se, rs)
+	sRows, err := session.ResultSetToStringSlice(ctx, tk.Se, rs)
 	tk.c.Check(err, check.IsNil, comment)
 	return &Result{rows: sRows, c: tk.c, comment: comment}
 }

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build !codes
+
 package testutil
 
 import (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`tidb-server -h` output test flags 
https://github.com/pingcap/tidb/issues/10975
### What is changed and how it works?

adjust testing code dependency, add build tags 'codes' to code and makefile.
these code would not build into tidb binary file

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
➜  tidb git:(tptpp/test-flags) ./bin/tidb-server -h
Usage of ./bin/tidb-server:
  -L string
    	log level: info, debug, warn, error, fatal (default "info")
  -P string
    	tidb server port (default "4000")
  -V	print version information and exit (default false)
  -advertise-address string
    	tidb server advertise IP
  -affinity-cpus string
    	affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)
  -config string
    	config file path
  -config-check
    	check config file validity and exit (default false)
  -config-strict
    	enforce config file validity (default false)
  -cors string
    	tidb server allow cors origin
  -enable-binlog
    	enable generate binlog (default false)
  -host string
    	tidb server host (default "0.0.0.0")
  -lease string
    	schema lease duration, very dangerous to change only if you know what you do (default "45s")
  -log-file string
    	log file path
  -log-slow-query string
    	slow query file path
  -metrics-addr string
    	prometheus pushgateway address, leaves it empty will disable prometheus push.
  -metrics-interval uint
    	prometheus client push interval in second, set "0" to disable prometheus push. (default 15)
  -path string
    	tidb storage path (default "/tmp/tidb")
  -plugin-dir string
    	the folder that hold plugin (default "/data/deploy/plugin")
  -plugin-load string
    	wait load plugin name(separated by comma)
  -proxy-protocol-header-timeout uint
    	proxy protocol header read timeout, unit is second. (default 5)
  -proxy-protocol-networks string
    	proxy protocol networks allowed IP or *, empty mean disable proxy protocol support
  -report-status
    	If enable status report HTTP service. (default true)
  -run-ddl
    	run ddl worker on this tidb-server (default true)
  -socket string
    	The socket file to use for connection.
  -status string
    	tidb server status port (default "10080")
  -status-host string
    	tidb server status host (default "0.0.0.0")
  -store string
    	registered store name, [tikv, mocktikv] (default "mocktikv")
  -token-limit int
    	the limit of concurrent executed sessions (default 1000)
```

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change


