### PR TITLE
executor: fix a bug of 'insert on duplicate update' statement on partitioned table (#11204)

### DIFF
--- a/executor/insert.go
+++ b/executor/insert.go
@@ -169,7 +169,7 @@ func (e *InsertExec) Open(ctx context.Context) error {
 
 // updateDupRow updates a duplicate row to a new row.
 func (e *InsertExec) updateDupRow(row toBeCheckedRow, handle int64, onDuplicate []*expression.Assignment) error {
-	oldRow, err := e.getOldRow(e.ctx, e.Table, handle, e.GenExprs)
+	oldRow, err := e.getOldRow(e.ctx, row.t, handle, e.GenExprs)
 	if err != nil {
 		logutil.Logger(context.Background()).Error("get old row failed when insert on dup", zap.Int64("handle", handle), zap.String("toBeInsertedRow", types.DatumsToStrNoErr(row.row)))
 		return err

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -286,3 +286,17 @@ func (s *testSuite3) TestAllowInvalidDates(c *C) {
 	runWithMode("STRICT_TRANS_TABLES,ALLOW_INVALID_DATES")
 	runWithMode("ALLOW_INVALID_DATES")
 }
+
+func (s *testSuite3) TestPartitionInsertOnDuplicate(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table t1 (a int,b int,primary key(a,b)) partition by range(a) (partition p0 values less than (100),partition p1 values less than (1000))`)
+	tk.MustExec(`insert into t1 set a=1, b=1`)
+	tk.MustExec(`insert into t1 set a=1,b=1 on duplicate key update a=1,b=1`)
+	tk.MustQuery(`select * from t1`).Check(testkit.Rows("1 1"))
+
+	tk.MustExec(`create table t2 (a int,b int,primary key(a,b)) partition by hash(a) partitions 4`)
+	tk.MustExec(`insert into t2 set a=1,b=1;`)
+	tk.MustExec(`insert into t2 set a=1,b=1 on duplicate key update a=1,b=1`)
+	tk.MustQuery(`select * from t2`).Check(testkit.Rows("1 1"))
+}

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -405,14 +405,19 @@ func (s *testFlushSuite) TestFlushPrivilegesPanic(c *C) {
 	c.Assert(err, IsNil)
 	defer store.Close()
 
-	config.GetGlobalConfig().Security.SkipGrantTable = true
+	saveConf := config.GetGlobalConfig()
+	conf := config.NewConfig()
+	conf.Security.SkipGrantTable = true
+	config.StoreGlobalConfig(conf)
+
 	dom, err := session.BootstrapSession(store)
 	c.Assert(err, IsNil)
 	defer dom.Close()
 
 	tk := testkit.NewTestKit(c, store)
 	tk.MustExec("FLUSH PRIVILEGES")
-	config.GetGlobalConfig().Security.SkipGrantTable = false
+
+	config.StoreGlobalConfig(saveConf)
 }
 
 func (s *testSuite3) TestDropStats(c *C) {


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/11204