### PR TITLE
executor,sessionctx: refine output format for tidb-specific variables of boolean type

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -429,9 +429,25 @@ func (s *testSuite2) TestValidateSetVar(c *C) {
 	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
 
 	tk.MustExec("set @@tidb_batch_delete='On';")
+	tk.MustQuery("select @@tidb_batch_delete;").Check(testkit.Rows("1"))
 	tk.MustExec("set @@tidb_batch_delete='oFf';")
+	tk.MustQuery("select @@tidb_batch_delete;").Check(testkit.Rows("0"))
 	tk.MustExec("set @@tidb_batch_delete=1;")
+	tk.MustQuery("select @@tidb_batch_delete;").Check(testkit.Rows("1"))
 	tk.MustExec("set @@tidb_batch_delete=0;")
+	tk.MustQuery("select @@tidb_batch_delete;").Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@tidb_opt_agg_push_down=off;")
+	tk.MustQuery("select @@tidb_opt_agg_push_down;").Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@tidb_constraint_check_in_place=on;")
+	tk.MustQuery("select @@tidb_constraint_check_in_place;").Check(testkit.Rows("1"))
+
+	tk.MustExec("set @@tidb_general_log=0;")
+	tk.MustQuery("select @@tidb_general_log;").Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@tidb_enable_streaming=1;")
+	tk.MustQuery("select @@tidb_enable_streaming;").Check(testkit.Rows("1"))
 
 	_, err = tk.Exec("set @@tidb_batch_delete=3;")
 	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue, Commentf("err %v", err))
@@ -789,9 +805,9 @@ func (s *testSuite2) TestEnableNoopFunctionsVar(c *C) {
 	_, err = tk.Exec(`set tidb_enable_noop_functions=11`)
 	c.Assert(err, NotNil)
 	tk.MustExec(`set tidb_enable_noop_functions="off";`)
-	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("off"))
+	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("0"))
 	tk.MustExec(`set tidb_enable_noop_functions="on";`)
-	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("on"))
+	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("1"))
 	tk.MustExec(`set tidb_enable_noop_functions=0;`)
 	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("0"))
 }

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -374,9 +374,16 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "1", nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
-	case GeneralLog, TiDBGeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
+	case TiDBSkipUTF8Check, TiDBOptAggPushDown,
+		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
+		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
+		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction,
+		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBEnableIndexMerge, TiDBEnableNoopFuncs,
+		TiDBScatterRegion, TiDBGeneralLog, TiDBConstraintCheckInPlace:
+		fallthrough
+	case GeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
 		CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode, PseudoSlaveMode, LowPriorityUpdates,
-		SkipNameResolve, SQLSafeUpdates, TiDBConstraintCheckInPlace, serverReadOnly, SlaveAllowBatching,
+		SkipNameResolve, SQLSafeUpdates, serverReadOnly, SlaveAllowBatching,
 		Flush, PerformanceSchema, LocalInFile, ShowOldTemporals, KeepFilesOnCreate, AutoCommit,
 		SQLWarnings, UniqueChecks, OldAlterTable, LogBinTrustFunctionCreators, SQLBigSelects,
 		BinlogDirectNonTransactionalUpdates, SQLQuoteShowCreate, AutomaticSpPrivileges,
@@ -413,16 +420,6 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			} else if val == 0 {
 				return "0", nil
 			}
-		}
-		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
-	case TiDBSkipUTF8Check, TiDBOptAggPushDown,
-		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
-		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
-		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction,
-		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBEnableIndexMerge, TiDBEnableNoopFuncs,
-		TiDBScatterRegion:
-		if strings.EqualFold(value, "ON") || value == "1" || strings.EqualFold(value, "OFF") || value == "0" {
-			return value, nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
 	case MaxExecutionTime:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, the result of selecting tidb-specific variables of boolean type is not well formatted. I think we'd better make it same style with MySQL. For example:
```sql
tidb> set @@tidb_batch_delete='On';
Query OK, 0 rows affected (0.00 sec)

tidb> select @@tidb_batch_delete;
+---------------------+
| @@tidb_batch_delete |
+---------------------+
| On                  |
+---------------------+
1 row in set (0.00 sec)

tidb> set @@tidb_enable_streaming='OfF'
    -> ;
Query OK, 0 rows affected (0.00 sec)

tidb> select @@tidb_enable_streaming;
+-------------------------+
| @@tidb_enable_streaming |
+-------------------------+
| OfF                     |
+-------------------------+
1 row in set (0.00 sec)

tidb> set @@tidb_disable_txn_auto_retry=on;
Query OK, 0 rows affected (0.00 sec)

tidb> select @@tidb_disable_txn_auto_retry;
+-------------------------------+
| @@tidb_disable_txn_auto_retry |
+-------------------------------+
| ON                            |
+-------------------------------+
1 row in set (0.00 sec)

tidb> set @@tidb_batch_insert=0;
Query OK, 0 rows affected (0.00 sec)

tidb> select @@tidb_batch_insert;
+---------------------+
| @@tidb_batch_insert |
+---------------------+
| 0                   |
+---------------------+
1 row in set (0.00 sec)

``` 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

N / A

Side effects

N / A

Related changes

N / A