### PR TITLE
expression, types: fix Mod(%), Multiple(*), Minus(-) operators meets inconsistent 0 results.

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2839,7 +2839,10 @@ func (s *testIntegrationSuite) TestArithmeticBuiltin(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[types:1690]BIGINT UNSIGNED value is out of range in '(18446744073709551615 - -1)'")
 	c.Assert(rs.Close(), IsNil)
+	tk.MustQuery(`select cast(-3 as unsigned) - cast(-1 as signed);`).Check(testkit.Rows("18446744073709551614"))
+	tk.MustQuery("select 1.11 - 1.11;").Check(testkit.Rows("0.00"))
 
+	// for multiply
 	tk.MustQuery("select 1234567890 * 1234567890").Check(testkit.Rows("1524157875019052100"))
 	rs, err = tk.Exec("select 1234567890 * 12345671890")
 	c.Assert(err, IsNil)
@@ -2866,8 +2869,7 @@ func (s *testIntegrationSuite) TestArithmeticBuiltin(c *C) {
 	_, err = session.GetRows4Test(ctx, tk.Se, rs)
 	c.Assert(terror.ErrorEqual(err, types.ErrOverflow), IsTrue)
 	c.Assert(rs.Close(), IsNil)
-	result = tk.MustQuery(`select cast(-3 as unsigned) - cast(-1 as signed);`)
-	result.Check(testkit.Rows("18446744073709551614"))
+	tk.MustQuery("select 0.0 * -1;").Check(testkit.Rows("0.0"))
 
 	tk.MustExec("DROP TABLE IF EXISTS t;")
 	tk.MustExec("CREATE TABLE t(a DECIMAL(4, 2), b DECIMAL(5, 3));")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2937,6 +2937,7 @@ func (s *testIntegrationSuite) TestArithmeticBuiltin(c *C) {
 	tk.MustExec("INSERT IGNORE INTO t VALUE(12 MOD 0);")
 	tk.MustQuery("show warnings;").Check(testkit.Rows("Warning 1365 Division by 0"))
 	tk.MustQuery("select v from t;").Check(testkit.Rows("<nil>"))
+	tk.MustQuery("select 0.000 % 0.11234500000000000000;").Check(testkit.Rows("0.00000000000000000000"))
 
 	_, err = tk.Exec("INSERT INTO t VALUE(12 MOD 0);")
 	c.Assert(terror.ErrorEqual(err, expression.ErrDivisionByZero), IsTrue)

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d/go.mo
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -191,6 +192,7 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d h1:GoAlyOgbOEIFd
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 h1:FUL3b97ZY2EPqg2NbXKuMHs5pXJB9hjj1fDHnF2vl28=
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -2010,7 +2010,9 @@ func doDivMod(from1, from2, to, mod *MyDecimal, fracIncr int) error {
 	}
 	if prec1 <= 0 {
 		/* short-circuit everything: from1 == 0 */
+		resultFrac := to.resultFrac
 		*to = zeroMyDecimal
+		to.resultFrac = resultFrac
 		return nil
 	}
 	prec1 -= countLeadingZeroes((prec1-1)%digitsPerWord, from1.wordBuf[idx1])

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -110,6 +110,7 @@ var (
 // get the zero of MyDecimal with the specified result fraction digits
 func zeroMyDecimalWithFrac(frac int8) MyDecimal {
 	zero := MyDecimal{}
+	zero.digitsFrac = frac
 	zero.resultFrac = frac
 	return zero
 }

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -107,6 +107,13 @@ var (
 	zeroMyDecimal = MyDecimal{}
 )
 
+// get the zero of MyDecimal with the specified result fraction digits
+func zeroMyDecimalWithFrac(frac int8) MyDecimal {
+	zero := MyDecimal{}
+	zero.resultFrac = frac
+	return zero
+}
+
 // add adds a and b and carry, returns the sum and new carry.
 func add(a, b, carry int32) (int32, int32) {
 	sum := a + b + carry
@@ -1556,7 +1563,7 @@ func doSub(from1, from2, to *MyDecimal) (cmp int, err error) {
 				if to == nil {
 					return 0, nil
 				}
-				*to = zeroMyDecimal
+				*to = zeroMyDecimalWithFrac(to.resultFrac)
 				return 0, nil
 			}
 		}
@@ -1911,7 +1918,7 @@ func DecimalMul(from1, from2, to *MyDecimal) error {
 			idx++
 			/* We got decimal zero */
 			if idx == end {
-				*to = zeroMyDecimal
+				*to = zeroMyDecimalWithFrac(to.resultFrac)
 				break
 			}
 		}
@@ -2010,9 +2017,7 @@ func doDivMod(from1, from2, to, mod *MyDecimal, fracIncr int) error {
 	}
 	if prec1 <= 0 {
 		/* short-circuit everything: from1 == 0 */
-		resultFrac := to.resultFrac
-		*to = zeroMyDecimal
-		to.resultFrac = resultFrac
+		*to = zeroMyDecimalWithFrac(to.resultFrac)
 		return nil
 	}
 	prec1 -= countLeadingZeroes((prec1-1)%digitsPerWord, from1.wordBuf[idx1])

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -718,7 +718,7 @@ func (s *testMyDecimalSuite) TestSub(c *C) {
 		{"1234500009876.5", ".00012345000098765", "1234500009876.49987654999901235", nil},
 		{"9999900000000.5", ".555", "9999899999999.945", nil},
 		{"1111.5551", "1111.555", "0.0001", nil},
-		{".555", ".555", "0", nil},
+		{".555", ".555", "0.000", nil},
 		{"10000000", "1", "9999999", nil},
 		{"1000001000", ".1", "1000000999.9", nil},
 		{"1000000000", ".1", "999999999.9", nil},
@@ -728,6 +728,7 @@ func (s *testMyDecimalSuite) TestSub(c *C) {
 		{"-123.45", "-12345", "12221.55", nil},
 		{"-12345", "123.45", "-12468.45", nil},
 		{"12345", "-123.45", "12468.45", nil},
+		{"12.12", "12.12", "0.00", nil},
 	}
 	for _, tt := range tests {
 		var a, b, sum MyDecimal
@@ -759,6 +760,7 @@ func (s *testMyDecimalSuite) TestMul(c *C) {
 		{"1" + strings.Repeat("0", 60), "1" + strings.Repeat("0", 60), "0", ErrOverflow},
 		{"0.5999991229316", "0.918755041726043", "0.5512522192246113614062276588", nil},
 		{"0.5999991229317", "0.918755041726042", "0.5512522192247026369112773314", nil},
+		{"0.000", "-1", "0.000", nil},
 	}
 	for _, tt := range tests {
 		var a, b, product MyDecimal
@@ -786,7 +788,7 @@ func (s *testMyDecimalSuite) TestDivMod(c *C) {
 		{"0", "0", "", ErrDivByZero},
 		{"-12193185.1853376", "98765.4321", "-123.456000000000000000", nil},
 		{"121931851853376", "987654321", "123456.000000000", nil},
-		{"0", "987", "0", nil},
+		{"0", "987", "0.00000", nil},
 		{"1", "3", "0.333333333", nil},
 		{"1.000000000000", "3", "0.333333333333333333", nil},
 		{"1", "1", "1.000000000", nil},
@@ -799,7 +801,7 @@ func (s *testMyDecimalSuite) TestDivMod(c *C) {
 		var a, b, to MyDecimal
 		a.FromString([]byte(tt.a))
 		b.FromString([]byte(tt.b))
-		err := doDivMod(&a, &b, &to, nil, 5)
+		err := DecimalDiv(&a, &b, &to, 5)
 		c.Check(err, Equals, tt.err)
 		if tt.err == ErrDivByZero {
 			continue
@@ -816,12 +818,13 @@ func (s *testMyDecimalSuite) TestDivMod(c *C) {
 		{"99999999999999999999999999999999999999", "3", "0", nil},
 		{"51", "0.003430", "0.002760", nil},
 		{"0.0000000001", "1.0", "0.0000000001", nil},
+		{"0.000", "0.1", "0.000", nil},
 	}
 	for _, tt := range tests {
 		var a, b, to MyDecimal
 		a.FromString([]byte(tt.a))
 		b.FromString([]byte(tt.b))
-		ec := doDivMod(&a, &b, nil, &to, 0)
+		ec := DecimalMod(&a, &b, &to)
 		c.Check(ec, Equals, tt.err)
 		if tt.err == ErrDivByZero {
 			continue

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -694,6 +694,7 @@ func (s *testMyDecimalSuite) TestAdd(c *C) {
 		{"-123.45", "12345", "12221.55", nil},
 		{"5", "-6.0", "-1.0", nil},
 		{"2" + strings.Repeat("1", 71), strings.Repeat("8", 81), "8888888890" + strings.Repeat("9", 71), nil},
+		{"-1234.1234", "1234.1234", "0.0000", nil},
 	}
 	for _, tt := range tests {
 		a := NewDecFromStringForTest(tt.a)
@@ -839,6 +840,7 @@ func (s *testMyDecimalSuite) TestDivMod(c *C) {
 		{"1", "1.000", "1.0000", nil},
 		{"2", "3", "0.6667", nil},
 		{"51", "0.003430", "14868.8047", nil},
+		{"0.000", "0.1", "0.0000000", nil},
 	}
 	for _, tt := range tests {
 		var a, b, to MyDecimal


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #11211

### What is changed and how it works?
Add a method `zeroMyDecimalWithFrac()` to get the zero of MyDecimal with the specified result fraction digits

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Integration test
 - Unit test

Code changes


Side effects


Related changes



