### PR TITLE
planner: disable projection elimination for select plan of update (#10962)

### DIFF
--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -849,3 +849,18 @@ func BenchmarkOptimize(b *testing.B) {
 		})
 	}
 }
+
+func (s *testAnalyzeSuite) TestUpdateProjEliminate(c *C) {
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("explain update t t1, (select distinct b from t) t2 set t1.b = t2.b")
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2206,7 +2206,9 @@ func (b *planBuilder) buildUpdate(update *ast.UpdateStmt) (Plan, error) {
 
 	updt := Update{OrderedList: orderedList}.init(b.ctx)
 	updt.SetSchema(p.Schema())
-	updt.SelectPlan, err = doOptimize(b.optFlag, p)
+	// We cannot apply projection elimination when building the subplan, because
+	// columns in orderedList cannot be resolved.
+	updt.SelectPlan, err = doOptimize(b.optFlag&^flagEliminateProjection, p)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/10962

Conflicts:
	planner/core/cbo_test.go
	planner/core/logical_plan_builder.go