### PR TITLE
ddl: don't rely on `expression.Column.ColName`

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/ddl/util"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/sessionctx"
@@ -593,9 +592,9 @@ func generateOriginDefaultValue(col *model.ColumnInfo) (interface{}, error) {
 	return odValue, nil
 }
 
-func findColumnInIndexCols(c *expression.Column, cols []*ast.IndexColName) bool {
+func findColumnInIndexCols(c *model.ColumnInfo, cols []*ast.IndexColName) bool {
 	for _, c1 := range cols {
-		if c.ColName.L == c1.Column.Name.L {
+		if c.Name.L == c1.Column.Name.L {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Clean the dependencies of `expression.Column`.

### What is changed and how it works?

Directly extract the columns. Don't build expression and use `expression.Column.ColName`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Existing Unit test
