### PR TITLE
binloginfo: add default charset and collate in binlog output [ DNM ]

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -419,7 +419,7 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 				return errors.Trace(err)
 			}
 			if job.IsDone() || job.IsRollbackDone() {
-				binloginfo.SetDDLBinlog(d.binlogCli, txn, job.ID, job.Query)
+				binloginfo.SetDDLBinlog(d.binlogCli, txn, job, job.Query)
 			}
 			return nil
 		})


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
fix  [TIDB-4108](https://internal.pingcap.net/jira/browse/TIDB-4108) binlog output without default charset and collate


### What is changed and how it works?

- There is  a func `SetDDLBinlog` in binloginfo.go which puts the orgin ddl string from user into binlog info. 
- So I append the ddl string with the default charset and collate before it's put into binlog info.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - add two sub func `reverseString` and `appendDefaultCharsetAndCollate` to reverse string and append string.
- add append logic in `SetDDLBinlog`.