### PR TITLE
http: fix scatter table

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -823,8 +823,8 @@ func (h tableHandler) addScatterSchedule(startKey, endKey []byte, name string) e
 	}
 	input := map[string]string{
 		"name":       "scatter-range",
-		"start_key":  string(startKey),
-		"end_key":    string(endKey),
+		"start_key":  url.QueryEscape(string(startKey)),
+		"end_key":    url.QueryEscape(string(endKey)),
 		"range_name": name,
 	}
 	v, err := json.Marshal(input)


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, the scatter table API cannot work well because the key in the HTTP request for the scatter table is not escaped. This PR is also related to pingcap/pd#1642.

### What is changed and how it works?
This PR fixes it by escaping the key.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (by using an existed cluster to verify it)

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
