### PR TITLE
plugin: add "exec start-time" to GeneralEvent

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -608,7 +608,8 @@ func (a *ExecStmt) logAudit() {
 		audit := plugin.DeclareAuditManifest(p.Manifest)
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
-			audit.OnGeneralEvent(context.Background(), sessVars, plugin.Log, cmd)
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.StartTime)
+			audit.OnGeneralEvent(ctx, sessVars, plugin.Log, cmd)
 		}
 		return nil
 	})

--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -84,3 +84,8 @@ type AuditManifest struct {
 	// OnParseEvent will be called around parse logic.
 	OnParseEvent func(ctx context.Context, sctx *variable.SessionVars, event ParseEvent) error
 }
+
+const (
+	// ExecStartTimeCtxKey indicates stmt start execution time.
+	ExecStartTimeCtxKey = "ExecStartTime"
+)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

add "exec start-time" to GeneralEvent to support TEP requirement.

### What is changed and how it works?

for not break compatibility (old plugin can compile with new TiDB, vice versa) pass it though `context.Context`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11293)
<!-- Reviewable:end -->
