### PR TITLE
executor: make insert dup on subquery return more than one row behavior compatible with MySQL

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -644,6 +644,11 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
 		InsertValues: ivs,
 		OnDuplicate:  append(v.OnDuplicate, v.GenCols.OnDuplicates...),
 	}
+	if v.OnDupExprErr != nil {
+		insert.OnDupExprErr = v.OnDupExprErr
+	} else if v.GenCols.OnDupExprErr != nil {
+		insert.OnDupExprErr = v.GenCols.OnDupExprErr
+	}
 	return insert
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1100,7 +1100,7 @@ func (e *MaxOneRowExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 		return nil
 	} else if num != 1 {
-		return errors.New("subquery returns more than 1 row")
+		return plannercore.ErrSubqueryNo1Row
 	}
 
 	childChunk := newFirstChunk(e.children[0])
@@ -1109,7 +1109,7 @@ func (e *MaxOneRowExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return err
 	}
 	if childChunk.NumRows() != 0 {
-		return errors.New("subquery returns more than 1 row")
+		return plannercore.ErrSubqueryNo1Row
 	}
 
 	return nil

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3556,7 +3556,7 @@ func (s *testSuite3) TestMaxOneRow(c *C) {
 	c.Assert(err, IsNil)
 
 	err = rs.Next(context.TODO(), rs.NewChunk())
-	c.Assert(err.Error(), Equals, "subquery returns more than 1 row")
+	c.Assert(err.Error(), Equals, "[planner:1242]Subquery returns more than 1 row")
 
 	err = rs.Close()
 	c.Assert(err, IsNil)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -416,6 +416,7 @@ type InsertGeneratedColumns struct {
 	Columns      []*ast.ColumnName
 	Exprs        []expression.Expression
 	OnDuplicates []*expression.Assignment
+	OnDupExprErr error
 }
 
 // Insert represents an insert plan.
@@ -429,6 +430,7 @@ type Insert struct {
 	SetList     []*expression.Assignment
 
 	OnDuplicate        []*expression.Assignment
+	OnDupExprErr       error
 	Schema4OnDuplicate *expression.Schema
 
 	IsReplace bool

--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -142,7 +142,8 @@ var (
 	ErrUnsupportedOnGeneratedColumn    = terror.ClassOptimizer.New(codeUnsupportedOnGeneratedColumn, mysql.MySQLErrName[mysql.ErrUnsupportedOnGeneratedColumn])
 	ErrNoSuchThread                    = terror.ClassOptimizer.New(mysql.ErrNoSuchThread, mysql.MySQLErrName[mysql.ErrNoSuchThread])
 	// Since we cannot know if user loggined with a password, use message of ErrAccessDeniedNoPassword instead
-	ErrAccessDenied = terror.ClassOptimizer.New(mysql.ErrAccessDenied, mysql.MySQLErrName[mysql.ErrAccessDeniedNoPassword])
+	ErrAccessDenied   = terror.ClassOptimizer.New(mysql.ErrAccessDenied, mysql.MySQLErrName[mysql.ErrAccessDeniedNoPassword])
+	ErrSubqueryNo1Row = terror.ClassOptimizer.New(mysql.ErrSubqueryNo1Row, mysql.MySQLErrName[mysql.ErrSubqueryNo1Row])
 )
 
 func init() {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1292,6 +1292,10 @@ func (b *PlanBuilder) resolveGeneratedColumns(columns []*table.Column, onDups ma
 
 		expr, _, err := b.rewrite(column.GeneratedExpr, mockPlan, nil, true)
 		if err != nil {
+			if ErrSubqueryNo1Row.Equal(err) {
+				igc.OnDupExprErr = err
+				break
+			}
 			return igc, err
 		}
 		expr = expression.BuildCastFunction(b.ctx, expr, colExpr.GetType())
@@ -1399,6 +1403,10 @@ func (b *PlanBuilder) buildInsert(insert *ast.InsertStmt) (Plan, error) {
 		// Construct the function which calculates the assign value of the column.
 		expr, err1 := b.rewriteInsertOnDuplicateUpdate(assign.Expr, mockTablePlan, insertPlan)
 		if err1 != nil {
+			if ErrSubqueryNo1Row.Equal(err1) {
+				insertPlan.OnDupExprErr = err1
+				break
+			}
 			return nil, err1
 		}
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB insert on dup execution,  expressions will be calculated during expression_rewrite phase before stmt actual execution, different from MySQL behaviors.  MySQL will try to insert ,   if there's conflictions "on dup update" then error will be reported, so if the insertion succeed, MySQL does not care whether update expressions is ok, subquery expression is one that we've met.

here's some different behaviors
```
If possible, provide a recipe for reproducing the error.
CREATE TABLE t1(a INTEGER);
CREATE TABLE t11(a INTEGER primary key);
CREATE TABLE t2(b INTEGER);
INSERT INTO t2 VALUES (1),(1);

INSERT INTO t1(a) VALUES (1)
ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);

INSERT INTO t11(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);

DROP TABLE t1, t2;
What did you expect to see
MySQL behavior:
for inserting into t1

INSERT INTO t1(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
Query OK, 1 row affected (0.01 sec)
INSERT INTO t1(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
Query OK, 1 row affected (0.01 sec)

for inserting into t11
INSERT INTO t11(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
Query OK, 1 row affected (0.02 sec)

INSERT INTO t11(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
ERROR 1105 (HY000): subquery returns more than 1 row

TiDB behvaior:
for inserting into t1
mysql> INSERT INTO t1(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
ERROR 1105 (HY000): subquery returns more than 1 row
mysql> INSERT INTO t1(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
ERROR 1105 (HY000): subquery returns more than 1 row

for inserting into t11
mysql> INSERT INTO t11(a) VALUES (1) ON DUPLICATE KEY UPDATE a= (SELECT b FROM t2);
ERROR 1105 (HY000): subquery returns more than 1 row  
```

I'm not quite sure if it's better to make this compatible
 PTAL

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Increased code complexity
 - Breaking backward compatibility

Related changes
