### PR TITLE
store/tikv: reduce the lock contend between sending message and re-creating streaming client

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -152,16 +152,15 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 				return errors.Trace(err)
 			}
 			batchClient := &batchCommandsClient{
-				target:                 a.target,
-				conn:                   conn,
-				client:                 streamClient,
-				batched:                sync.Map{},
-				idAlloc:                0,
-				tikvTransportLayerLoad: &a.tikvTransportLayerLoad,
-				closed:                 0,
+				target:  a.target,
+				conn:    conn,
+				client:  streamClient,
+				batched: sync.Map{},
+				idAlloc: 0,
+				closed:  0,
 			}
 			a.batchCommandsClients = append(a.batchCommandsClients, batchClient)
-			go batchClient.batchRecvLoop(cfg.TiKVClient)
+			go batchClient.batchRecvLoop(cfg.TiKVClient, &a.tikvTransportLayerLoad)
 		}
 	}
 	go tikvrpc.CheckStreamTimeoutLoop(a.streamTimeout)

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -311,9 +311,9 @@ func (c *batchCommandsClient) reCreateStreamingClient(err error) (stopped bool) 
 	// Forbids the batchSendLoop using the old client.
 	c.lockForRecreate()
 	defer c.unlockForRecreate()
+
 	for { // try to re-create the streaming in the loop.
 		if c.isStopped() {
-			c.unlockForRecreate()
 			return true
 		}
 		logutil.BgLogger().Error(

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -76,8 +76,8 @@ func (s *testClientSuite) TestRemoveCanceledRequests(c *C) {
 	for i := range entries {
 		requests[i] = entries[i].req
 	}
-	length := removeCanceledRequests(&entries, &requests)
-	c.Assert(length, Equals, 2)
+	entries, requests = removeCanceledRequests(entries, requests)
+	c.Assert(len(entries), Equals, 2)
 	for _, e := range entries {
 		c.Assert(e.isCanceled(), IsFalse)
 	}


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Tiny code refactor

### What is changed and how it works?

We use a lock here
https://github.com/pingcap/tidb/compare/master...tiancaiamao:batch-client-lock?expand=1#diff-db62a1f8315185d693e2a911ce0d5b49L176
and here 
https://github.com/pingcap/tidb/compare/master...tiancaiamao:batch-client-lock?expand=1#diff-db62a1f8315185d693e2a911ce0d5b49L214

Two write-write locks to protect the send and re-create operation.
The caller of the send operation is from the `batchSendLoop`, that means the whole send loop will be blocked during the streaming client re-creating.

In this commit, I provide a `tryLockForSend` function to try the lock first, if the `batchCommandsClient` is re-creating, we can try another one, instead of blocking the `batchSendLoop`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch

