### PR TITLE
store/tikv: refine streaming client re-create log and use a smarter backoff strategy

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -226,8 +226,13 @@ func (c *batchCommandsClient) reCreateStreamingClient(err error) error {
 			zap.String("target", c.target),
 		)
 		c.client = streamClient
-		return err
+		return nil
 	}
+	logutil.BgLogger().Error(
+		"batchRecvLoop re-create streaming fail",
+		zap.String("target", c.target),
+		zap.Error(err),
+	)
 	return err
 }
 

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -276,7 +276,9 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 				if err1 == nil {
 					break
 				}
-				b.Backoff(boTiKVRPC, err1)
+				if err := b.Backoff(boTiKVRPC, err1); err != nil {
+					logutil.BgLogger().Error("backoff error", zap.Error(err))
+				}
 			}
 			metrics.TiKVBatchClientUnavailable.Observe(time.Since(now).Seconds())
 			continue

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
+	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -262,9 +263,10 @@ func (c *batchCommandsClient) batchRecvLoop(cfg config.TiKVClient) {
 				if err1 == nil {
 					break
 				}
-				if err2 := b.Backoff(boTiKVRPC, err1); err2 != nil {
-					logutil.BgLogger().Error("backoff error", zap.Error(err2))
-				}
+				err2 := b.Backoff(boTiKVRPC, err1)
+				// As timeout is set to math.MaxUint32, err2 should always be nil.
+				// This line is added to make the 'make errcheck' pass.
+				terror.Log(err2)
 			}
 			metrics.TiKVBatchClientUnavailable.Observe(time.Since(now).Seconds())
 			continue


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When TiKV is down, or restart and bind to another port, the re-create streaming client loop can't perceive the changes.
Although we use the recycle idle connections mechanism to handle that, **the error log is still boring and makes our users confusing**.

### What is changed and how it works?

* Print error log for 10 times, ignore more error logs.
* Use a smarter backoff strategy

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code


Related changes

 - Need to cherry-pick to the release branch

