### PR TITLE
expression: let `testEvaluatorSuite` run serially to avoid affect other unit tests since it uses `failpoint`

### DIFF
--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = Suite(&testEvaluatorSuite{})
+var _ = SerialSuites(&testEvaluatorSuite{})
 
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some unit tests of `testEvaluatorSuite` use `failpoint` to control whether to push down some expressions.

Therefore, when it runs parallelly with other unit tests, all other tests will also be affected by this `failpoint`, which is undesired.


### What is changed and how it works?
Let it run serially to avoid affect other unit tests.
