### PR TITLE
executor: show operators' memory consumption in results of `EXPLAIN ANALYZE`

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -42,6 +43,8 @@ func (s *testSuite) createSelectNormal(batch, totalRows int, c *C, planIDs []str
 		SetDesc(false).
 		SetKeepOrder(false).
 		SetFromSessionVars(variable.NewSessionVars()).
+		SetMemTracker(memory.NewTracker(stringutil.StringerStr("testSuite.createSelectNormal"),
+			s.sctx.GetSessionVars().MemQuotaDistSQL)).
 		Build()
 	c.Assert(err, IsNil)
 

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -42,7 +42,6 @@ func (s *testSuite) createSelectNormal(batch, totalRows int, c *C, planIDs []str
 		SetDesc(false).
 		SetKeepOrder(false).
 		SetFromSessionVars(variable.NewSessionVars()).
-		SetMemTracker(s.sctx, stringutil.StringerStr("testSuite.createSelectNormal")).
 		Build()
 	c.Assert(err, IsNil)
 

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -14,12 +14,10 @@
 package distsql
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
@@ -44,10 +42,8 @@ func (builder *RequestBuilder) Build() (*kv.Request, error) {
 }
 
 // SetMemTracker sets a memTracker for this request.
-func (builder *RequestBuilder) SetMemTracker(sctx sessionctx.Context, label fmt.Stringer) *RequestBuilder {
-	t := memory.NewTracker(label, sctx.GetSessionVars().MemQuotaDistSQL)
-	t.AttachTo(sctx.GetSessionVars().StmtCtx.MemTracker)
-	builder.Request.MemTracker = t
+func (builder *RequestBuilder) SetMemTracker(tracker *memory.Tracker) *RequestBuilder {
+	builder.Request.MemTracker = tracker
 	return builder
 }
 

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -527,7 +527,6 @@ func (e *IndexLookUpExecutor) Close() error {
 	e.tblWorkerWg.Wait()
 	e.finished = nil
 	e.workerStarted = false
-	e.memTracker.Detach()
 	e.memTracker = nil
 	if e.runtimeStats != nil {
 		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.idxPlans[0].ExplainID().String())

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -278,6 +278,7 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 	}
 
 	e.memTracker = memory.NewTracker(e.id, e.ctx.GetSessionVars().MemQuotaDistSQL)
+	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
 	var builder distsql.RequestBuilder
 	kvReq, err := builder.SetKeyRanges(kvRanges).
 		SetDAGRequest(e.dagPB).

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -417,7 +417,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		e.dagPB.CollectExecutionSummaries = &collExec
 	}
 
-	tracker := memory.NewTracker(stringutil.StringerStr("InnerWorker"), e.ctx.GetSessionVars().MemQuotaDistSQL)
+	tracker := memory.NewTracker(stringutil.StringerStr("InnerWorker"), e.ctx.GetSessionVars().MemQuotaIndexLookupReader)
 	tracker.AttachTo(e.memTracker)
 	var builder distsql.RequestBuilder
 	kvReq, err := builder.SetKeyRanges(kvRanges).
@@ -488,7 +488,8 @@ func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-cha
 			keepOrder:      e.keepOrder,
 			handleIdx:      e.handleIdx,
 			isCheckOp:      e.isCheckOp,
-			memTracker:     memory.NewTracker(stringutil.StringerStr(fmt.Sprintf("worker_%v", i)), -1),
+			memTracker: memory.NewTracker(stringutil.StringerStr(fmt.Sprintf("worker_%v", i)),
+				e.ctx.GetSessionVars().MemQuotaIndexLookupReader),
 		}
 		worker.memTracker.AttachTo(e.memTracker)
 		ctx1, cancel := context.WithCancel(ctx)

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"runtime"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -488,7 +489,7 @@ func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-cha
 			keepOrder:      e.keepOrder,
 			handleIdx:      e.handleIdx,
 			isCheckOp:      e.isCheckOp,
-			memTracker: memory.NewTracker(stringutil.StringerStr(fmt.Sprintf("TableWorker_%v", i)),
+			memTracker: memory.NewTracker(stringutil.MemoizeStr(func() string { return "TableWorker_" + strconv.Itoa(i) }),
 				e.ctx.GetSessionVars().MemQuotaIndexLookupReader),
 		}
 		worker.memTracker.AttachTo(e.memTracker)

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -417,7 +417,7 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 		e.dagPB.CollectExecutionSummaries = &collExec
 	}
 
-	tracker := memory.NewTracker(stringutil.StringerStr("InnerWorker"), e.ctx.GetSessionVars().MemQuotaIndexLookupReader)
+	tracker := memory.NewTracker(stringutil.StringerStr("IndexWorker"), e.ctx.GetSessionVars().MemQuotaIndexLookupReader)
 	tracker.AttachTo(e.memTracker)
 	var builder distsql.RequestBuilder
 	kvReq, err := builder.SetKeyRanges(kvRanges).
@@ -488,7 +488,7 @@ func (e *IndexLookUpExecutor) startTableWorker(ctx context.Context, workCh <-cha
 			keepOrder:      e.keepOrder,
 			handleIdx:      e.handleIdx,
 			isCheckOp:      e.isCheckOp,
-			memTracker: memory.NewTracker(stringutil.StringerStr(fmt.Sprintf("worker_%v", i)),
+			memTracker: memory.NewTracker(stringutil.StringerStr(fmt.Sprintf("TableWorker_%v", i)),
 				e.ctx.GetSessionVars().MemQuotaIndexLookupReader),
 		}
 		worker.memTracker.AttachTo(e.memTracker)

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -14,12 +14,13 @@
 package executor_test
 
 import (
+	"strings"
+	
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/testkit"
-	"strings"
 )
 
 func (s *testSuite1) TestExplainPriviliges(c *C) {

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -96,7 +96,7 @@ func (s *testSuite1) TestExplainAnalyzeMemory(c *C) {
 
 func (s *testSuite1) checkMemoryInfo(c *C, tk *testkit.TestKit, sql string) {
 	memCol := 5
-	ops := []string{"Join", "MergeAgg", "Reader", "Top", "Sort"}
+	ops := []string{"Join", "Reader", "Top", "Sort"}
 	rows := tk.MustQuery(sql).Rows()
 	for _, row := range rows {
 		strs := make([]string, len(row))

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -117,9 +117,9 @@ func (s *testSuite1) checkMemoryInfo(c *C, tk *testkit.TestKit, sql string) {
 		}
 
 		if shouldHasMem {
-			c.Assert(strs[memCol], Not(Equals), "-")
+			c.Assert(strs[memCol], Not(Equals), "N/A")
 		} else {
-			c.Assert(strs[memCol], Equals, "-")
+			c.Assert(strs[memCol], Equals, "N/A")
 		}
 	}
 }

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -19,6 +19,7 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/testkit"
+	"strings"
 )
 
 func (s *testSuite1) TestExplainPriviliges(c *C) {
@@ -73,4 +74,51 @@ func (s *testSuite1) TestExplainWrite(c *C) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
 	tk.MustExec("explain analyze insert into t select 1")
 	tk.MustQuery("select * from t order by a").Check(testkit.Rows("1", "2"))
+}
+
+func (s *testSuite1) TestExplainAnalyzeMemory(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (v int, k int, key(k))")
+	tk.MustExec("insert into t values (1, 1), (1, 1), (1, 1), (1, 1), (1, 1)")
+
+	s.checkMemoryInfo(c, tk, "explain analyze select * from t order by v")
+	s.checkMemoryInfo(c, tk, "explain analyze select * from t order by v limit 5")
+	s.checkMemoryInfo(c, tk, "explain analyze select /*+ TIDB_HJ(t1, t2) */ t1.k from t t1, t t2 where t1.v = t2.v+1")
+	s.checkMemoryInfo(c, tk, "explain analyze select /*+ TIDB_SMJ(t1, t2) */ t1.k from t t1, t t2 where t1.k = t2.k+1")
+	s.checkMemoryInfo(c, tk, "explain analyze select /*+ TIDB_INLJ(t1, t2) */ t1.k from t t1, t t2 where t1.k = t2.k and t1.v=1")
+	s.checkMemoryInfo(c, tk, "explain analyze select sum(k) from t group by v")
+	s.checkMemoryInfo(c, tk, "explain analyze select sum(v) from t group by k")
+	s.checkMemoryInfo(c, tk, "explain analyze select * from t")
+	s.checkMemoryInfo(c, tk, "explain analyze select k from t use index(k)")
+	s.checkMemoryInfo(c, tk, "explain analyze select * from t use index(k)")
+}
+
+func (s *testSuite1) checkMemoryInfo(c *C, tk *testkit.TestKit, sql string) {
+	memCol := 5
+	ops := []string{"Join", "MergeAgg", "Reader", "Top", "Sort"}
+	rows := tk.MustQuery(sql).Rows()
+	for _, row := range rows {
+		strs := make([]string, len(row))
+		for i, c := range row {
+			strs[i] = c.(string)
+		}
+		if strings.Contains(strs[2], "cop") {
+			continue
+		}
+
+		shouldHasMem := false
+		for _, op := range ops {
+			if strings.Contains(strs[0], op) {
+				shouldHasMem = true
+				break
+			}
+		}
+
+		if shouldHasMem {
+			c.Assert(strs[memCol], Not(Equals), "-")
+		} else {
+			c.Assert(strs[memCol], Equals, "-")
+		}
+	}
 }

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -15,7 +15,7 @@ package executor_test
 
 import (
 	"strings"
-	
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -97,7 +97,7 @@ func (s *testSuite1) TestExplainAnalyzeMemory(c *C) {
 
 func (s *testSuite1) checkMemoryInfo(c *C, tk *testkit.TestKit, sql string) {
 	memCol := 5
-	ops := []string{"Join", "Reader", "Top", "Sort"}
+	ops := []string{"Join", "Reader", "Top", "Sort", "LookUp"}
 	rows := tk.MustQuery(sql).Rows()
 	for _, row := range rows {
 		strs := make([]string, len(row))

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -295,9 +295,6 @@ func (e *IndexLookUpJoin) getFinishedTask(ctx context.Context) (*lookUpJoinTask,
 		return nil, nil
 	}
 
-	if e.task != nil {
-		e.task.memTracker.Detach()
-	}
 	e.task = task
 	return task, nil
 }

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -650,7 +650,6 @@ func (e *IndexLookUpJoin) Close() error {
 		e.cancelFunc()
 	}
 	e.workerWg.Wait()
-	e.memTracker.Detach()
 	e.memTracker = nil
 	return e.children[0].Close()
 }

--- a/executor/join.go
+++ b/executor/join.go
@@ -134,7 +134,6 @@ func (e *HashJoinExec) Close() error {
 		e.outerChkResourceCh = nil
 		e.joinChkResourceCh = nil
 	}
-	e.memTracker.Detach()
 	e.memTracker = nil
 
 	err := e.baseExecutor.Close()
@@ -633,7 +632,6 @@ type NestedLoopApplyExec struct {
 func (e *NestedLoopApplyExec) Close() error {
 	e.innerRows = nil
 
-	e.memTracker.Detach()
 	e.memTracker = nil
 	return e.outerExec.Close()
 }

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -200,7 +200,6 @@ func (t *mergeJoinInnerTable) reallocReaderResult() {
 
 // Close implements the Executor Close interface.
 func (e *MergeJoinExec) Close() error {
-	e.memTracker.Detach()
 	e.childrenResults = nil
 	e.memTracker = nil
 

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -54,7 +54,6 @@ type SortExec struct {
 
 // Close implements the Executor Close interface.
 func (e *SortExec) Close() error {
-	e.memTracker.Detach()
 	e.memTracker = nil
 	return e.children[0].Close()
 }

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/memory"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/distsql"
@@ -27,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 )

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/ranger"
-	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -148,8 +147,6 @@ func (e *TableReaderExecutor) Close() error {
 	return err
 }
 
-var tableReaderDistSQLTrackerLabel fmt.Stringer = stringutil.StringerStr("TableReaderDistSQLTracker")
-
 // buildResp first builds request and sends it to tikv using distsql.Select. It uses SelectResut returned by the callee
 // to fetch all results.
 func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Range) (distsql.SelectResult, error) {
@@ -160,7 +157,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		SetKeepOrder(e.keepOrder).
 		SetStreaming(e.streaming).
 		SetFromSessionVars(e.ctx.GetSessionVars()).
-		SetMemTracker(e.ctx, tableReaderDistSQLTrackerLabel).
+		SetMemTracker(e.ctx, e.id).
 		Build()
 	if err != nil {
 		return nil, err

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -80,7 +80,7 @@ func (s *testAnalyzeSuite) TestExplainAnalyze(c *C) {
 	rs := tk.MustQuery("explain analyze select t1.a, t1.b, sum(t1.c) from t1 join t2 on t1.a = t2.b where t1.a > 1")
 	c.Assert(len(rs.Rows()), Equals, 10)
 	for _, row := range rs.Rows() {
-		c.Assert(len(row), Equals, 5)
+		c.Assert(len(row), Equals, 6)
 		execInfo := row[4].(string)
 		c.Assert(strings.Contains(execInfo, "time"), Equals, true)
 		c.Assert(strings.Contains(execInfo, "loops"), Equals, true)
@@ -977,7 +977,7 @@ func (s *testAnalyzeSuite) TestIssue9805(c *C) {
 	c.Assert(rs.Rows(), HasLen, 10)
 	hasIndexLookUp12 := false
 	for _, row := range rs.Rows() {
-		c.Assert(row, HasLen, 5)
+		c.Assert(row, HasLen, 6)
 		if strings.HasSuffix(row[0].(string), "IndexLookUp_12") {
 			hasIndexLookUp12 = true
 			c.Assert(row[4], Equals, "time:0ns, loops:0, rows:0")

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -648,7 +648,7 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 		if tracker != nil {
 			row = append(row, tracker.BytesToString(tracker.MaxConsumed()))
 		} else {
-			row = append(row, "-")
+			row = append(row, "N/A")
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -563,7 +563,7 @@ func (e *Explain) prepareSchema() error {
 	case ast.ExplainFormatROW:
 		retFields := []string{"id", "count", "task", "operator info"}
 		if e.Analyze {
-			retFields = append(retFields, "execution info")
+			retFields = append(retFields, "execution info", "memory")
 		}
 		schema := expression.NewSchema(make([]*expression.Column, 0, len(retFields))...)
 		for _, fieldName := range retFields {
@@ -642,6 +642,13 @@ func (e *Explain) prepareOperatorInfo(p PhysicalPlan, taskType string, indent st
 			row = append(row, runtimeStatsColl.GetRootStats(explainID).String())
 		} else {
 			row = append(row, "time:0ns, loops:0, rows:0")
+		}
+
+		tracker := e.ctx.GetSessionVars().StmtCtx.MemTracker.SearchTracker(p.ExplainID().String())
+		if tracker != nil {
+			row = append(row, tracker.BytesToString(tracker.MaxConsumed()))
+		} else {
+			row = append(row, "-")
 		}
 	}
 	e.Rows = append(e.Rows, row)

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -196,7 +196,6 @@ func (t *Tracker) toString(indent string, buffer *bytes.Buffer) {
 		fmt.Fprintf(buffer, "%s  \"quota\": %s\n", indent, t.BytesToString(t.bytesLimit))
 	}
 	fmt.Fprintf(buffer, "%s  \"consumed\": %s\n", indent, t.BytesToString(t.BytesConsumed()))
-	fmt.Fprintf(buffer, "%s  \"max-consumed\": %s\n", indent, t.BytesToString(t.MaxConsumed()))
 
 	t.mu.Lock()
 	for i := range t.mu.children {

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -211,17 +211,17 @@ func (t *Tracker) toString(indent string, buffer *bytes.Buffer) {
 func (t *Tracker) BytesToString(numBytes int64) string {
 	GB := float64(numBytes) / float64(1<<30)
 	if GB > 1 {
-		return fmt.Sprintf("%.3f GB", GB)
+		return fmt.Sprintf("%v GB", GB)
 	}
 
 	MB := float64(numBytes) / float64(1<<20)
 	if MB > 1 {
-		return fmt.Sprintf("%.3f MB", MB)
+		return fmt.Sprintf("%v MB", MB)
 	}
 
 	KB := float64(numBytes) / float64(1<<10)
 	if KB > 1 {
-		return fmt.Sprintf("%.3f KB", KB)
+		return fmt.Sprintf("%v KB", KB)
 	}
 
 	return fmt.Sprintf("%v Bytes", numBytes)

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -212,17 +212,17 @@ func (t *Tracker) toString(indent string, buffer *bytes.Buffer) {
 func (t *Tracker) BytesToString(numBytes int64) string {
 	GB := float64(numBytes) / float64(1<<30)
 	if GB > 1 {
-		return fmt.Sprintf("%v GB", GB)
+		return fmt.Sprintf("%.3f GB", GB)
 	}
 
 	MB := float64(numBytes) / float64(1<<20)
 	if MB > 1 {
-		return fmt.Sprintf("%v MB", MB)
+		return fmt.Sprintf("%.3f MB", MB)
 	}
 
 	KB := float64(numBytes) / float64(1<<10)
 	if KB > 1 {
-		return fmt.Sprintf("%v KB", KB)
+		return fmt.Sprintf("%.3f KB", KB)
 	}
 
 	return fmt.Sprintf("%v Bytes", numBytes)

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -87,11 +87,6 @@ func (t *Tracker) AttachTo(parent *Tracker) {
 	t.parent.Consume(t.BytesConsumed())
 }
 
-// Detach detaches this Tracker from its parent.
-func (t *Tracker) Detach() {
-	t.parent.remove(t)
-}
-
 func (t *Tracker) remove(oldChild *Tracker) {
 	t.mu.Lock()
 	defer t.mu.Unlock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add a new column named `memory` in the results of `EXPLAIN ANALYZE` to display memory consumption of operators.

After this PR, you can see:
```
mysql> explain analyze select * from t order by v limit 5;
+----------------------+-------+------+------------------------------------------------------------+----------------------------------+-----------+
| id                   | count | task | operator info                                              | execution info                   | memory    |
+----------------------+-------+------+------------------------------------------------------------+----------------------------------+-----------+
| TopN_9               | 5.00  | root | test.t.v:asc, offset:0, count:5                            | time:0s, loops:0, rows:0         | 800 Bytes |
| └─TableReader_17     | 5.00  | root | data:TableScan_16                                          | time:261.366µs, loops:2, rows:5  | 131 Bytes |
|   └─TableScan_16     | 5.00  | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo | time:136.023µs, loops:6, rows:5  | N/A         |
+----------------------+-------+------+------------------------------------------------------------+----------------------------------+-----------+

mysql> explain analyze select /*+ TIDB_HJ(t1, t2) */ t1.k from t t1, t t2 where t1.v = t2.v+1;
+--------------------------+-------+------+----------------------------------------------------------------------------+----------------------------------+---------------+
| id                       | count | task | operator info                                                              | execution info                   | memory        |
+--------------------------+-------+------+----------------------------------------------------------------------------+----------------------------------+---------------+
| Projection_8             | 6.25  | root | test.t1.k                                                                  | time:0s, loops:0, rows:0         | N/A             |
| └─HashLeftJoin_9         | 6.25  | root | inner join, inner:Projection_14, equal:[eq(test.t1.v, plus(test.t2.v, 1))] | time:280.29µs, loops:1, rows:0   | 8.61328125 KB |
|   ├─TableReader_13       | 5.00  | root | data:TableScan_12                                                          | time:171.233µs, loops:2, rows:5  | 131 Bytes     |
|   │ └─TableScan_12       | 5.00  | cop  | table:t1, range:[-inf,+inf], keep order:false, stats:pseudo                | time:117.687µs, loops:6, rows:5  | N/A             |
|   └─Projection_14        | 5.00  | root | test.t2.v, plus(test.t2.v, 1)                                              | time:0s, loops:0, rows:0         | N/A             |
|     └─TableReader_16     | 5.00  | root | data:TableScan_15                                                          | time:149.443µs, loops:2, rows:5  | 121 Bytes     |
|       └─TableScan_15     | 5.00  | cop  | table:t2, range:[-inf,+inf], keep order:false, stats:pseudo                | time:92.487µs, loops:6, rows:5   | N/A             |
+--------------------------+-------+------+----------------------------------------------------------------------------+----------------------------------+---------------+
```

**Pipeliner operators** like `Selection` or `Projection` have no memory consumption.
Cop-tasks' memory consumption will be added by another PR.

### What is changed and how it works?
Main changes:
1. Don't detach trackers when closing executor otherwise we can't get their memory consumption Information and all trackers will be cleaned by `ResetContextOfStmt` when the next query comes;
2. Add a new column named `memory` in results of `EXPLAIN ANALYZE`;
3. Rename some trackers' labels;
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
