### PR TITLE
ddl: fix the parallel problem of "set default value" and other DDL

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -324,7 +324,7 @@ func onSetDefaultValue(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		return ver, errors.Trace(err)
 	}
 
-	return updateColumn(t, job, newCol, &newCol.Name)
+	return updateColumnDefaultValue(t, job, newCol, &newCol.Name)
 }
 
 func (w *worker) onModifyColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
@@ -489,7 +489,7 @@ func checkForNullValue(ctx sessionctx.Context, isDataTruncated bool, schema, tab
 	return nil
 }
 
-func updateColumn(t *meta.Meta, job *model.Job, newCol *model.ColumnInfo, oldColName *model.CIStr) (ver int64, _ error) {
+func updateColumnDefaultValue(t *meta.Meta, job *model.Job, newCol *model.ColumnInfo, oldColName *model.CIStr) (ver int64, _ error) {
 	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, job.SchemaID)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -499,7 +499,10 @@ func updateColumn(t *meta.Meta, job *model.Job, newCol *model.ColumnInfo, oldCol
 		job.State = model.JobStateCancelled
 		return ver, infoschema.ErrColumnNotExists.GenWithStackByArgs(newCol.Name, tblInfo.Name)
 	}
-	*oldCol = *newCol
+	// The newCol's offset may be the value of the old schema version, so we can't use its "offset" directly.
+	oldCol.DefaultValue = newCol.DefaultValue
+	oldCol.DefaultValueBit = newCol.DefaultValueBit
+	oldCol.Flag = newCol.Flag
 
 	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 	if err != nil {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -499,7 +499,7 @@ func updateColumnDefaultValue(t *meta.Meta, job *model.Job, newCol *model.Column
 		job.State = model.JobStateCancelled
 		return ver, infoschema.ErrColumnNotExists.GenWithStackByArgs(newCol.Name, tblInfo.Name)
 	}
-	// The newCol's offset may be the value of the old schema version, so we can't use its "offset" directly.
+	// The newCol's offset may be the value of the old schema version, so we can't use newCol directly.
 	oldCol.DefaultValue = newCol.DefaultValue
 	oldCol.DefaultValueBit = newCol.DefaultValueBit
 	oldCol.Flag = newCol.Flag


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The problem occurs as follows:
```
create table tx (c1 varchar(64), c2 enum('N','Y') not null default 'N', primary key idx2 (c2, c1));
insert into tx values('a', 'N');
```
Then execute the following DDL statements in parallel:
```
alter table tx add column cx int after c1
alter table tx alter c2 set default 'N'
```
Finally execute the following statement:
```
delete from tx where c1='a'
```
We will get the error as follows:
```
value *errors.withStack = [table:2]Index column c2 offset out of bound, offset: 2, row: [{6 0 0 0 0 [97] <nil>} {10 0 0 0 1 [78] <nil>}] ("[table:2]Index column c2 offset out of bound, offset: 2, row: [{6 0 0 0 0 [97] <nil>} {10 0 0 0 1 [78] <nil>}]")
```

### What is changed and how it works?
We don't change the offset when executing the DDL of `alter table .. set default`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
