### PR TITLE
executor, expression: fix current_timestamp/now not consistent in one stmt like MySQL

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2538,3 +2538,15 @@ func (s *testSuite4) TestSetWithRefGenCol(c *C) {
 	_, err = tk.Exec(`insert into t3 set j = i + 1`)
 	c.Assert(err, NotNil)
 }
+
+func (s *testSuite4) TestSetWithCurrentTimestampAndNow(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists tbl;`)
+	tk.MustExec(`create table t1(c1 timestamp default current_timestamp, c2 int, c3 timestamp default current_timestamp);`)
+	//c1 insert using now() function result, c3 using default value calculation, should be same
+	tk.MustExec(`insert into t1 set c1 = current_timestamp, c2 = sleep(2);`)
+	tk.MustQuery("select c1 = c3 from t1").Check(testkit.Rows("1"))
+	tk.MustExec(`insert into t1 set c1 = current_timestamp, c2 = sleep(1);`)
+	tk.MustQuery("select c1 = c3 from t1").Check(testkit.Rows("1", "1"))
+}

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -764,8 +764,7 @@ func (s *testEvaluatorSuite) TestTime(c *C) {
 }
 
 func resetStmtContext(ctx sessionctx.Context) {
-	ctx.GetSessionVars().StmtCtx.NowTs = time.Time{}
-	ctx.GetSessionVars().StmtCtx.SysTs = time.Time{}
+	ctx.GetSessionVars().StmtCtx.ResetNowTs()
 }
 
 func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -120,8 +120,8 @@ type StatementContext struct {
 	RuntimeStatsColl *execdetails.RuntimeStatsColl
 	TableIDs         []int64
 	IndexIDs         []int64
-	NowTs            time.Time
-	SysTs            time.Time
+	nowTs            time.Time // use this variable for now/current_timestamp calculation/cache for one stmt
+	stmtTimeCached   bool
 	StmtType         string
 	OriginalSQL      string
 	digestMemo       struct {
@@ -130,6 +130,21 @@ type StatementContext struct {
 		digest     string
 	}
 	Tables []TableEntry
+}
+
+// GetNowTsCached getter for nowTs, if not set get now time and cache it
+func (sc *StatementContext) GetNowTsCached() time.Time {
+	if !sc.stmtTimeCached {
+		now := time.Now()
+		sc.nowTs = now
+		sc.stmtTimeCached = true
+	}
+	return sc.nowTs
+}
+
+// ResetNowTs resetter for nowTs, clear cached time flag
+func (sc *StatementContext) ResetNowTs() {
+	sc.stmtTimeCached = false
 }
 
 // SQLDigest gets normalized and digest for provided sql.


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

MySQL will set time to “”time_cache“ structure before doing one command(COM_XXX)
later expresission calculation will use this timestamp as time value

TiDB logic different and default column calculation and now expr calculation will try to get timestamp twice.

more details see jira issue#4391
eg:
TiDB
```
CREATE TABLE `tt4` (
  `c1` timestamp DEFAULT CURRENT_TIMESTAMP,
  `c2` int(11) DEFAULT NULL,
  `c3` timestamp DEFAULT CURRENT_TIMESTAMP
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin

insert into tt4 set c1 = current_timestamp, c2 = sleep(2);
mysql> select c1 = c3 from tt4;
+---------+
| c1 = c3 |
+---------+
|       0 |
+---------+
1 row in set (0.00 sec)

```

MySQL
```
insert into tt4 set c1 = current_timestamp, c2 = sleep(2);
select c1 = c3 from tt4;
+---------+
| c1 = c3 |
+---------+
|       1 |
+---------+
1 row in set (0.00 sec)

```

- remove stmtCtx.sysTs unused variable
- cache time value once in stmtCtx.nowTs 
- refactor nowTs usage, offer Unified function interface for get and reset nowTS. Generally, accessing variable directly is not a good way for further maintenance, refactor these usage code

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change


Side effects




Related changes

 - Need to cherry-pick to the release branch

