### PR TITLE
tikv: invalidate store's regions when send store fail

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -970,7 +970,6 @@ func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
 		s := rs.stores[rs.workStoreIdx]
 		epoch := rs.storeFails[rs.workStoreIdx]
 		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
-			rs.storeFails[rs.workStoreIdx] = epoch + 1
 			logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
 		}
 	}

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -282,10 +282,6 @@ func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID) (*RPCContext,
 
 	storeFailEpoch := atomic.LoadUint32(&store.fail)
 	if storeFailEpoch != regionStore.storeFails[regionStore.workStoreIdx] {
-		newRegionStore := regionStore.clone()
-		newRegionStore.workStoreIdx = regionStore.workStoreIdx
-		newRegionStore.storeFails[newRegionStore.workStoreIdx] = storeFailEpoch
-		cachedRegion.compareAndSwapStore(regionStore, newRegionStore)
 		cachedRegion.invalidate()
 		logutil.BgLogger().Info("invalidate current region, because others failed on same store",
 			zap.Uint64("region", id.GetID()),

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -287,6 +288,31 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
+}
+
+func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
+	// key range: ['' - 'm' - 'z']
+	region2 := s.cluster.AllocID()
+	newPeers := s.cluster.AllocIDs(2)
+	s.cluster.Split(s.region1, region2, []byte("m"), newPeers, newPeers[0])
+
+	// Check the two regions.
+	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
+	c.Assert(err, IsNil)
+	c.Assert(loc1.Region.id, Equals, s.region1)
+	loc2, err := s.cache.LocateKey(s.bo, []byte("x"))
+	c.Assert(err, IsNil)
+	c.Assert(loc2.Region.id, Equals, region2)
+
+	// Send fail on region1
+	ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
+	s.checkCache(c, 2)
+	s.cache.OnSendFail(s.bo, ctx, false, errors.New("test error"))
+
+	// Get region2 cache will get nil then reload.
+	ctx2, err := s.cache.GetRPCContext(s.bo, loc2.Region)
+	c.Assert(ctx2, IsNil)
+	c.Assert(err, IsNil)
 }
 
 func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
@@ -639,7 +665,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
 			if r == nil {
-				cache.switchNextPeer(r, rpcCtx.PeerIdx)
+				cache.switchNextPeer(r, rpcCtx.PeerIdx, nil)
 			}
 		}
 	})

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -112,7 +112,10 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOn
 
 	// send to failed store
 	resp, err = s.regionRequestSender.SendReq(NewBackoffer(context.Background(), 100), req, region.Region, time.Second)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
+	regionErr, err := resp.GetRegionError()
+	c.Assert(err, IsNil)
+	c.Assert(regionErr, NotNil)
 
 	// retry to send store by old region info
 	region, err = s.cache.LocateRegionByID(s.bo, s.region)
@@ -121,7 +124,10 @@ func (s *testRegionRequestSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOn
 
 	// retry again, reload region info and send to new store.
 	resp, err = s.regionRequestSender.SendReq(NewBackoffer(context.Background(), 100), req, region.Region, time.Second)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
+	regionErr, err = resp.GetRegionError()
+	c.Assert(err, IsNil)
+	c.Assert(regionErr, NotNil)
 }
 
 func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When many regions in one tikv store, and those store down, next query need wait "dial error: no route to host" for each region, if following query need region many region (e.g. `select count(*) from table`) will be every slow.

### What is changed and how it works?

make store's all region be invalid by introduce `storeFail` to store to invalidate store's region and keep region cache's lock-free feeling- -

- store' storeFail +1 when send store fail
- each region has its `snapshot failEpochs` for each region's peers
- when region's storeFails[i] != store.fail will let query refill region cache

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - Schrodinger  WIP

Code changes

 - Impl

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11344)
<!-- Reviewable:end -->
