### PR TITLE
executor: expose `chunk.Column` to prepare for vectorized expression evaluation

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -28,8 +28,8 @@ import (
 // Values are appended in compact format and can be directly accessed without decoding.
 // When the chunk is done processing, we can reuse the allocated memory by resetting it.
 type Chunk struct {
-	columns []*column
-	// numVirtualRows indicates the number of virtual rows, which have zero column.
+	columns []*Column
+	// numVirtualRows indicates the number of virtual rows, which have zero Column.
 	// It is used only when this Chunk doesn't hold any data, i.e. "len(columns)==0".
 	numVirtualRows int
 	// capacity indicates the max number of rows this chunk can hold.
@@ -56,7 +56,7 @@ func NewChunkWithCapacity(fields []*types.FieldType, cap int) *Chunk {
 //  maxChunkSize: the max limit for the number of rows.
 func New(fields []*types.FieldType, cap, maxChunkSize int) *Chunk {
 	chk := &Chunk{
-		columns:  make([]*column, 0, len(fields)),
+		columns:  make([]*Column, 0, len(fields)),
 		capacity: mathutil.Min(cap, maxChunkSize),
 		// set the default value of requiredRows to maxChunkSize to let chk.IsFull() behave
 		// like how we judge whether a chunk is full now, then the statement
@@ -97,8 +97,8 @@ func Renew(chk *Chunk, maxChunkSize int) *Chunk {
 
 // renewColumns creates the columns of a Chunk. The capacity of the newly
 // created columns is equal to cap.
-func renewColumns(oldCol []*column, cap int) []*column {
-	columns := make([]*column, 0, len(oldCol))
+func renewColumns(oldCol []*Column, cap int) []*Column {
+	columns := make([]*Column, 0, len(oldCol))
 	for _, col := range oldCol {
 		if col.isFixed() {
 			columns = append(columns, newFixedLenColumn(len(col.elemBuf), cap))
@@ -110,7 +110,7 @@ func renewColumns(oldCol []*column, cap int) []*column {
 }
 
 // MemoryUsage returns the total memory usage of a Chunk in B.
-// We ignore the size of column.length and column.nullCount
+// We ignore the size of Column.length and Column.nullCount
 // since they have little effect of the total memory usage.
 func (c *Chunk) MemoryUsage() (sum int64) {
 	for _, col := range c.columns {
@@ -120,17 +120,17 @@ func (c *Chunk) MemoryUsage() (sum int64) {
 	return
 }
 
-// newFixedLenColumn creates a fixed length column with elemLen and initial data capacity.
-func newFixedLenColumn(elemLen, cap int) *column {
-	return &column{
+// newFixedLenColumn creates a fixed length Column with elemLen and initial data capacity.
+func newFixedLenColumn(elemLen, cap int) *Column {
+	return &Column{
 		elemBuf:    make([]byte, elemLen),
 		data:       make([]byte, 0, cap*elemLen),
 		nullBitmap: make([]byte, 0, cap>>3),
 	}
 }
 
-// newVarLenColumn creates a variable length column with initial data capacity.
-func newVarLenColumn(cap int, old *column) *column {
+// newVarLenColumn creates a variable length Column with initial data capacity.
+func newVarLenColumn(cap int, old *Column) *Column {
 	estimatedElemLen := 8
 	// For varLenColumn (e.g. varchar), the accurate length of an element is unknown.
 	// Therefore, in the first executor.Next we use an experience value -- 8 (so it may make runtime.growslice)
@@ -138,7 +138,7 @@ func newVarLenColumn(cap int, old *column) *column {
 	if old != nil && old.length != 0 {
 		estimatedElemLen = (len(old.data) + len(old.data)/8) / old.length
 	}
-	return &column{
+	return &Column{
 		offsets:    make([]int64, 1, cap+1),
 		data:       make([]byte, 0, cap*estimatedElemLen),
 		nullBitmap: make([]byte, 0, cap>>3),
@@ -164,7 +164,7 @@ func (c *Chunk) IsFull() bool {
 	return c.NumRows() >= c.requiredRows
 }
 
-// MakeRef makes column in "dstColIdx" reference to column in "srcColIdx".
+// MakeRef makes Column in "dstColIdx" reference to Column in "srcColIdx".
 func (c *Chunk) MakeRef(srcColIdx, dstColIdx int) {
 	c.columns[dstColIdx] = c.columns[srcColIdx]
 }
@@ -174,11 +174,11 @@ func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
 	c.columns[dstColIdx] = src.columns[srcColIdx]
 }
 
-// SwapColumn swaps column "c.columns[colIdx]" with column
-// "other.columns[otherIdx]". If there exists columns refer to the column to be
+// SwapColumn swaps Column "c.columns[colIdx]" with Column
+// "other.columns[otherIdx]". If there exists columns refer to the Column to be
 // swapped, we need to re-build the reference.
 func (c *Chunk) SwapColumn(colIdx int, other *Chunk, otherIdx int) {
-	// Find the leftmost column of the reference which is the actual column to
+	// Find the leftmost Column of the reference which is the actual Column to
 	// be swapped.
 	for i := 0; i < colIdx; i++ {
 		if c.columns[i] == c.columns[colIdx] {
@@ -191,7 +191,7 @@ func (c *Chunk) SwapColumn(colIdx int, other *Chunk, otherIdx int) {
 		}
 	}
 
-	// Find the columns which refer to the actual column to be swapped.
+	// Find the columns which refer to the actual Column to be swapped.
 	refColsIdx := make([]int, 0, len(c.columns)-colIdx)
 	for i := colIdx; i < len(c.columns); i++ {
 		if c.columns[i] == c.columns[colIdx] {
@@ -224,7 +224,7 @@ func (c *Chunk) SwapColumns(other *Chunk) {
 }
 
 // SetNumVirtualRows sets the virtual row number for a Chunk.
-// It should only be used when there exists no column in the Chunk.
+// It should only be used when there exists no Column in the Chunk.
 func (c *Chunk) SetNumVirtualRows(numVirtualRows int) {
 	c.numVirtualRows = numVirtualRows
 }
@@ -243,7 +243,7 @@ func (c *Chunk) Reset() {
 
 // CopyConstruct creates a new chunk and copies this chunk's data into it.
 func (c *Chunk) CopyConstruct() *Chunk {
-	newChk := &Chunk{numVirtualRows: c.numVirtualRows, capacity: c.capacity, columns: make([]*column, len(c.columns))}
+	newChk := &Chunk{numVirtualRows: c.numVirtualRows, capacity: c.capacity, columns: make([]*Column, len(c.columns))}
 	for i := range c.columns {
 		newChk.columns[i] = c.columns[i].copyConstruct()
 	}

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -236,7 +236,7 @@ func (c *Chunk) Reset() {
 		return
 	}
 	for _, col := range c.columns {
-		col.reset()
+		col.Reset()
 	}
 	c.numVirtualRows = 0
 }
@@ -461,17 +461,17 @@ func (c *Chunk) TruncateTo(numRows int) {
 
 // AppendNull appends a null value to the chunk.
 func (c *Chunk) AppendNull(colIdx int) {
-	c.columns[colIdx].appendNull()
+	c.columns[colIdx].AppendNull()
 }
 
 // AppendInt64 appends a int64 value to the chunk.
 func (c *Chunk) AppendInt64(colIdx int, i int64) {
-	c.columns[colIdx].appendInt64(i)
+	c.columns[colIdx].AppendInt64(i)
 }
 
 // AppendUint64 appends a uint64 value to the chunk.
 func (c *Chunk) AppendUint64(colIdx int, u uint64) {
-	c.columns[colIdx].appendUint64(u)
+	c.columns[colIdx].AppendUint64(u)
 }
 
 // AppendFloat32 appends a float32 value to the chunk.
@@ -481,33 +481,33 @@ func (c *Chunk) AppendFloat32(colIdx int, f float32) {
 
 // AppendFloat64 appends a float64 value to the chunk.
 func (c *Chunk) AppendFloat64(colIdx int, f float64) {
-	c.columns[colIdx].appendFloat64(f)
+	c.columns[colIdx].AppendFloat64(f)
 }
 
 // AppendString appends a string value to the chunk.
 func (c *Chunk) AppendString(colIdx int, str string) {
-	c.columns[colIdx].appendString(str)
+	c.columns[colIdx].AppendString(str)
 }
 
 // AppendBytes appends a bytes value to the chunk.
 func (c *Chunk) AppendBytes(colIdx int, b []byte) {
-	c.columns[colIdx].appendBytes(b)
+	c.columns[colIdx].AppendBytes(b)
 }
 
 // AppendTime appends a Time value to the chunk.
 // TODO: change the time structure so it can be directly written to memory.
 func (c *Chunk) AppendTime(colIdx int, t types.Time) {
-	c.columns[colIdx].appendTime(t)
+	c.columns[colIdx].AppendTime(t)
 }
 
 // AppendDuration appends a Duration value to the chunk.
 func (c *Chunk) AppendDuration(colIdx int, dur types.Duration) {
-	c.columns[colIdx].appendDuration(dur)
+	c.columns[colIdx].AppendDuration(dur)
 }
 
 // AppendMyDecimal appends a MyDecimal value to the chunk.
 func (c *Chunk) AppendMyDecimal(colIdx int, dec *types.MyDecimal) {
-	c.columns[colIdx].appendMyDecimal(dec)
+	c.columns[colIdx].AppendMyDecimal(dec)
 }
 
 // AppendEnum appends an Enum value to the chunk.
@@ -522,7 +522,7 @@ func (c *Chunk) AppendSet(colIdx int, set types.Set) {
 
 // AppendJSON appends a JSON value to the chunk.
 func (c *Chunk) AppendJSON(colIdx int, j json.BinaryJSON) {
-	c.columns[colIdx].appendJSON(j)
+	c.columns[colIdx].AppendJSON(j)
 }
 
 // AppendDatum appends a datum into the chunk.

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -300,7 +300,7 @@ func (s *testChunkSuite) TestChunkSizeControl(c *check.C) {
 }
 
 // newChunk creates a new chunk and initialize columns with element length.
-// 0 adds an varlen column, positive len add a fixed length column, negative len adds a interface column.
+// 0 adds an varlen Column, positive len add a fixed length Column, negative len adds a interface Column.
 func newChunk(elemLen ...int) *Chunk {
 	chk := &Chunk{}
 	for _, l := range elemLen {

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -964,7 +964,7 @@ func (b *benchChunkGrowCase) String() string {
 	if b.reuse {
 		buff.WriteString("renew,")
 	} else {
-		buff.WriteString("Reset,")
+		buff.WriteString("reset,")
 	}
 	buff.WriteString("cntPerCall:" + strconv.Itoa(b.cntPerCall) + ",")
 	buff.WriteString("cap from:" + strconv.Itoa(b.initCap) + " to " + strconv.Itoa(b.maxCap) + ",")

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -964,7 +964,7 @@ func (b *benchChunkGrowCase) String() string {
 	if b.reuse {
 		buff.WriteString("renew,")
 	} else {
-		buff.WriteString("reset,")
+		buff.WriteString("Reset,")
 	}
 	buff.WriteString("cntPerCall:" + strconv.Itoa(b.cntPerCall) + ",")
 	buff.WriteString("cap from:" + strconv.Itoa(b.initCap) + " to " + strconv.Itoa(b.maxCap) + ",")

--- a/util/chunk/chunk_util.go
+++ b/util/chunk/chunk_util.go
@@ -34,7 +34,7 @@ func CopySelectedJoinRows(src *Chunk, innerColOffset, outerColOffset int, select
 // return the number of rows which is selected.
 func copySelectedInnerRows(innerColOffset, outerColOffset int, src *Chunk, selected []bool, dst *Chunk) int {
 	oldLen := dst.columns[innerColOffset].length
-	var srcCols []*column
+	var srcCols []*Column
 	if innerColOffset == 0 {
 		srcCols = src.columns[:outerColOffset]
 	} else {
@@ -78,7 +78,7 @@ func copyOuterRows(innerColOffset, outerColOffset int, src *Chunk, numRows int, 
 		return
 	}
 	row := src.GetRow(0)
-	var srcCols []*column
+	var srcCols []*Column
 	if innerColOffset == 0 {
 		srcCols = src.columns[outerColOffset:]
 	} else {

--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -27,7 +27,7 @@ import (
 // 1. encode a Chunk to a byte slice.
 // 2. decode a Chunk from a byte slice.
 type Codec struct {
-	// colTypes is used to check whether a column is fixed sized and what the
+	// colTypes is used to check whether a Column is fixed sized and what the
 	// fixed size for every element.
 	// NOTE: It's only used for decoding.
 	colTypes []*types.FieldType
@@ -47,7 +47,7 @@ func (c *Codec) Encode(chk *Chunk) []byte {
 	return buffer
 }
 
-func (c *Codec) encodeColumn(buffer []byte, col *column) []byte {
+func (c *Codec) encodeColumn(buffer []byte, col *Column) []byte {
 	var lenBuffer [4]byte
 	// encode length.
 	binary.LittleEndian.PutUint32(lenBuffer[:], uint32(col.length))
@@ -90,7 +90,7 @@ func (c *Codec) i64SliceToBytes(i64s []int64) (b []byte) {
 func (c *Codec) Decode(buffer []byte) (*Chunk, []byte) {
 	chk := &Chunk{}
 	for ordinal := 0; len(buffer) > 0; ordinal++ {
-		col := &column{}
+		col := &Column{}
 		buffer = c.decodeColumn(buffer, col, ordinal)
 		chk.columns = append(chk.columns, col)
 	}
@@ -105,7 +105,7 @@ func (c *Codec) DecodeToChunk(buffer []byte, chk *Chunk) (remained []byte) {
 	return buffer
 }
 
-func (c *Codec) decodeColumn(buffer []byte, col *column, ordinal int) (remained []byte) {
+func (c *Codec) decodeColumn(buffer []byte, col *Column, ordinal int) (remained []byte) {
 	// decode length.
 	col.length = int(binary.LittleEndian.Uint32(buffer))
 	buffer = buffer[4:]
@@ -142,7 +142,7 @@ func (c *Codec) decodeColumn(buffer []byte, col *column, ordinal int) (remained 
 
 var allNotNullBitmap [128]byte
 
-func (c *Codec) setAllNotNull(col *column) {
+func (c *Codec) setAllNotNull(col *Column) {
 	numNullBitmapBytes := (col.length + 7) / 8
 	col.nullBitmap = col.nullBitmap[:0]
 	for i := 0; i < numNullBitmapBytes; {
@@ -163,7 +163,7 @@ func (c *Codec) bytesToI64Slice(b []byte) (i64s []int64) {
 	return i64s
 }
 
-// varElemLen indicates this column is a variable length column.
+// varElemLen indicates this Column is a variable length Column.
 const varElemLen = -1
 
 func getFixedLen(colType *types.FieldType) int {

--- a/util/chunk/codec_test.go
+++ b/util/chunk/codec_test.go
@@ -81,9 +81,9 @@ func BenchmarkEncodeChunk(b *testing.B) {
 	numCols := 4
 	numRows := 1024
 
-	chk := &Chunk{columns: make([]*column, numCols)}
+	chk := &Chunk{columns: make([]*Column, numCols)}
 	for i := 0; i < numCols; i++ {
-		chk.columns[i] = &column{
+		chk.columns[i] = &Column{
 			length:     numRows,
 			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),
@@ -104,9 +104,9 @@ func BenchmarkDecode(b *testing.B) {
 	numRows := 1024
 
 	colTypes := make([]*types.FieldType, numCols)
-	chk := &Chunk{columns: make([]*column, numCols)}
+	chk := &Chunk{columns: make([]*Column, numCols)}
 	for i := 0; i < numCols; i++ {
-		chk.columns[i] = &column{
+		chk.columns[i] = &Column{
 			length:     numRows,
 			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),
@@ -131,10 +131,10 @@ func BenchmarkDecodeToChunk(b *testing.B) {
 
 	colTypes := make([]*types.FieldType, numCols)
 	chk := &Chunk{
-		columns: make([]*column, numCols),
+		columns: make([]*Column, numCols),
 	}
 	for i := 0; i < numCols; i++ {
-		chk.columns[i] = &column{
+		chk.columns[i] = &Column{
 			length:     numRows,
 			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -149,7 +149,7 @@ func (c *Column) AppendInt64(i int64) {
 	c.finishAppendFixed()
 }
 
-// AppendUint64 appends an uint64 value into this Column.
+// AppendUint64 appends a uint64 value into this Column.
 func (c *Column) AppendUint64(u uint64) {
 	*(*uint64)(unsafe.Pointer(&c.elemBuf[0])) = u
 	c.finishAppendFixed()

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -20,11 +20,11 @@ import (
 	"github.com/pingcap/tidb/types/json"
 )
 
-func (c *Column) appendDuration(dur types.Duration) {
-	c.appendInt64(int64(dur.Duration))
+func (c *Column) AppendDuration(dur types.Duration) {
+	c.AppendInt64(int64(dur.Duration))
 }
 
-func (c *Column) appendMyDecimal(dec *types.MyDecimal) {
+func (c *Column) AppendMyDecimal(dec *types.MyDecimal) {
 	*(*types.MyDecimal)(unsafe.Pointer(&c.elemBuf[0])) = *dec
 	c.finishAppendFixed()
 }
@@ -37,7 +37,7 @@ func (c *Column) appendNameValue(name string, val uint64) {
 	c.finishAppendVar()
 }
 
-func (c *Column) appendJSON(j json.BinaryJSON) {
+func (c *Column) AppendJSON(j json.BinaryJSON) {
 	c.data = append(c.data, j.TypeCode)
 	c.data = append(c.data, j.Value...)
 	c.finishAppendVar()
@@ -56,7 +56,7 @@ func (c *Column) isFixed() bool {
 	return c.elemBuf != nil
 }
 
-func (c *Column) reset() {
+func (c *Column) Reset() {
 	c.length = 0
 	c.nullCount = 0
 	c.nullBitmap = c.nullBitmap[:0]
@@ -120,7 +120,7 @@ func (c *Column) appendMultiSameNullBitmap(notNull bool, num int) {
 	c.nullBitmap[len(c.nullBitmap)-1] &= bitMask
 }
 
-func (c *Column) appendNull() {
+func (c *Column) AppendNull() {
 	c.appendNullBitmap(false)
 	if c.isFixed() {
 		c.data = append(c.data, c.elemBuf...)
@@ -136,12 +136,12 @@ func (c *Column) finishAppendFixed() {
 	c.length++
 }
 
-func (c *Column) appendInt64(i int64) {
+func (c *Column) AppendInt64(i int64) {
 	*(*int64)(unsafe.Pointer(&c.elemBuf[0])) = i
 	c.finishAppendFixed()
 }
 
-func (c *Column) appendUint64(u uint64) {
+func (c *Column) AppendUint64(u uint64) {
 	*(*uint64)(unsafe.Pointer(&c.elemBuf[0])) = u
 	c.finishAppendFixed()
 }
@@ -151,7 +151,7 @@ func (c *Column) appendFloat32(f float32) {
 	c.finishAppendFixed()
 }
 
-func (c *Column) appendFloat64(f float64) {
+func (c *Column) AppendFloat64(f float64) {
 	*(*float64)(unsafe.Pointer(&c.elemBuf[0])) = f
 	c.finishAppendFixed()
 }
@@ -162,17 +162,17 @@ func (c *Column) finishAppendVar() {
 	c.length++
 }
 
-func (c *Column) appendString(str string) {
+func (c *Column) AppendString(str string) {
 	c.data = append(c.data, str...)
 	c.finishAppendVar()
 }
 
-func (c *Column) appendBytes(b []byte) {
+func (c *Column) AppendBytes(b []byte) {
 	c.data = append(c.data, b...)
 	c.finishAppendVar()
 }
 
-func (c *Column) appendTime(t types.Time) {
+func (c *Column) AppendTime(t types.Time) {
 	writeTime(c.elemBuf, t)
 	c.finishAppendFixed()
 }

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -20,10 +20,12 @@ import (
 	"github.com/pingcap/tidb/types/json"
 )
 
+// AppendDuration appends a duration value into this Column.
 func (c *Column) AppendDuration(dur types.Duration) {
 	c.AppendInt64(int64(dur.Duration))
 }
 
+// AppendMyDecimal appends a MyDecimal value into this Column.
 func (c *Column) AppendMyDecimal(dec *types.MyDecimal) {
 	*(*types.MyDecimal)(unsafe.Pointer(&c.elemBuf[0])) = *dec
 	c.finishAppendFixed()
@@ -37,12 +39,15 @@ func (c *Column) appendNameValue(name string, val uint64) {
 	c.finishAppendVar()
 }
 
+// AppendJSON appends a BinaryJSON value into this Column.
 func (c *Column) AppendJSON(j json.BinaryJSON) {
 	c.data = append(c.data, j.TypeCode)
 	c.data = append(c.data, j.Value...)
 	c.finishAppendVar()
 }
 
+// Column stores one column of data in Apache Arrow format.
+// See https://arrow.apache.org/docs/memory_layout.html
 type Column struct {
 	length     int
 	nullCount  int
@@ -56,6 +61,7 @@ func (c *Column) isFixed() bool {
 	return c.elemBuf != nil
 }
 
+// Reset resets this Column.
 func (c *Column) Reset() {
 	c.length = 0
 	c.nullCount = 0
@@ -120,6 +126,7 @@ func (c *Column) appendMultiSameNullBitmap(notNull bool, num int) {
 	c.nullBitmap[len(c.nullBitmap)-1] &= bitMask
 }
 
+// AppendNull appends a null value into this Column.
 func (c *Column) AppendNull() {
 	c.appendNullBitmap(false)
 	if c.isFixed() {
@@ -136,21 +143,25 @@ func (c *Column) finishAppendFixed() {
 	c.length++
 }
 
+// AppendInt64 appends a int64 value into this Column.
 func (c *Column) AppendInt64(i int64) {
 	*(*int64)(unsafe.Pointer(&c.elemBuf[0])) = i
 	c.finishAppendFixed()
 }
 
+// AppendUint64 appends a uint64 value into this Column.
 func (c *Column) AppendUint64(u uint64) {
 	*(*uint64)(unsafe.Pointer(&c.elemBuf[0])) = u
 	c.finishAppendFixed()
 }
 
+// appendFloat32 appends a float32 value into this Column.
 func (c *Column) appendFloat32(f float32) {
 	*(*float32)(unsafe.Pointer(&c.elemBuf[0])) = f
 	c.finishAppendFixed()
 }
 
+// AppendFloat64 appends a float64 value into this Column.
 func (c *Column) AppendFloat64(f float64) {
 	*(*float64)(unsafe.Pointer(&c.elemBuf[0])) = f
 	c.finishAppendFixed()
@@ -162,16 +173,19 @@ func (c *Column) finishAppendVar() {
 	c.length++
 }
 
+// AppendString appends a string value into this Column.
 func (c *Column) AppendString(str string) {
 	c.data = append(c.data, str...)
 	c.finishAppendVar()
 }
 
+// AppendBytes appends a byte slice into this Column.
 func (c *Column) AppendBytes(b []byte) {
 	c.data = append(c.data, b...)
 	c.finishAppendVar()
 }
 
+// AppendTime appends a time value into this Column.
 func (c *Column) AppendTime(t types.Time) {
 	writeTime(c.elemBuf, t)
 	c.finishAppendFixed()

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -143,13 +143,13 @@ func (c *Column) finishAppendFixed() {
 	c.length++
 }
 
-// AppendInt64 appends a int64 value into this Column.
+// AppendInt64 appends an int64 value into this Column.
 func (c *Column) AppendInt64(i int64) {
 	*(*int64)(unsafe.Pointer(&c.elemBuf[0])) = i
 	c.finishAppendFixed()
 }
 
-// AppendUint64 appends a uint64 value into this Column.
+// AppendUint64 appends an uint64 value into this Column.
 func (c *Column) AppendUint64(u uint64) {
 	*(*uint64)(unsafe.Pointer(&c.elemBuf[0])) = u
 	c.finishAppendFixed()

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pingcap/check"
 )
 
-func equalColumn(c1, c2 *column) bool {
+func equalColumn(c1, c2 *Column) bool {
 	if c1.length != c2.length ||
 		c1.nullCount != c2.nullCount {
 		return false

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -54,7 +54,7 @@ func equalColumn(c1, c2 *Column) bool {
 func (s *testChunkSuite) TestColumnCopy(c *check.C) {
 	col := newFixedLenColumn(8, 10)
 	for i := 0; i < 10; i++ {
-		col.appendInt64(int64(i))
+		col.AppendInt64(int64(i))
 	}
 
 	c1 := col.copyConstruct()

--- a/util/chunk/compare.go
+++ b/util/chunk/compare.go
@@ -209,7 +209,7 @@ func Compare(row Row, colIdx int, ad *types.Datum) int {
 	}
 }
 
-// LowerBound searches on the non-decreasing column colIdx,
+// LowerBound searches on the non-decreasing Column colIdx,
 // returns the smallest index i such that the value at row i is not less than `d`.
 func (c *Chunk) LowerBound(colIdx int, d *types.Datum) (index int, match bool) {
 	index = sort.Search(c.NumRows(), func(i int) bool {
@@ -222,7 +222,7 @@ func (c *Chunk) LowerBound(colIdx int, d *types.Datum) (index int, match bool) {
 	return
 }
 
-// UpperBound searches on the non-decreasing column colIdx,
+// UpperBound searches on the non-decreasing Column colIdx,
 // returns the smallest index i such that the value at row i is larger than `d`.
 func (c *Chunk) UpperBound(colIdx int, d *types.Datum) int {
 	return sort.Search(c.NumRows(), func(i int) bool {

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -40,7 +40,7 @@ func (mr MutRow) Len() int {
 
 // MutRowFromValues creates a MutRow from a interface slice.
 func MutRowFromValues(vals ...interface{}) MutRow {
-	c := &Chunk{columns: make([]*column, 0, len(vals))}
+	c := &Chunk{columns: make([]*Column, 0, len(vals))}
 	for _, val := range vals {
 		col := makeMutRowColumn(val)
 		c.columns = append(c.columns, col)
@@ -50,7 +50,7 @@ func MutRowFromValues(vals ...interface{}) MutRow {
 
 // MutRowFromDatums creates a MutRow from a datum slice.
 func MutRowFromDatums(datums []types.Datum) MutRow {
-	c := &Chunk{columns: make([]*column, 0, len(datums))}
+	c := &Chunk{columns: make([]*Column, 0, len(datums))}
 	for _, d := range datums {
 		col := makeMutRowColumn(d.GetValue())
 		c.columns = append(c.columns, col)
@@ -58,9 +58,9 @@ func MutRowFromDatums(datums []types.Datum) MutRow {
 	return MutRow{c: c, idx: 0}
 }
 
-// MutRowFromTypes creates a MutRow from a FieldType slice, each column is initialized to zero value.
+// MutRowFromTypes creates a MutRow from a FieldType slice, each Column is initialized to zero value.
 func MutRowFromTypes(types []*types.FieldType) MutRow {
-	c := &Chunk{columns: make([]*column, 0, len(types))}
+	c := &Chunk{columns: make([]*Column, 0, len(types))}
 	for _, tp := range types {
 		col := makeMutRowColumn(zeroValForType(tp))
 		c.columns = append(c.columns, col)
@@ -106,7 +106,7 @@ func zeroValForType(tp *types.FieldType) interface{} {
 	}
 }
 
-func makeMutRowColumn(in interface{}) *column {
+func makeMutRowColumn(in interface{}) *Column {
 	switch x := in.(type) {
 	case nil:
 		col := makeMutRowUint64Column(uint64(0))
@@ -162,9 +162,9 @@ func makeMutRowColumn(in interface{}) *column {
 	}
 }
 
-func newMutRowFixedLenColumn(elemSize int) *column {
+func newMutRowFixedLenColumn(elemSize int) *Column {
 	buf := make([]byte, elemSize+1)
-	col := &column{
+	col := &Column{
 		length:     1,
 		elemBuf:    buf[:elemSize],
 		data:       buf[:elemSize],
@@ -174,9 +174,9 @@ func newMutRowFixedLenColumn(elemSize int) *column {
 	return col
 }
 
-func newMutRowVarLenColumn(valSize int) *column {
+func newMutRowVarLenColumn(valSize int) *Column {
 	buf := make([]byte, valSize+1)
-	col := &column{
+	col := &Column{
 		length:     1,
 		offsets:    []int64{0, int64(valSize)},
 		data:       buf[:valSize],
@@ -186,13 +186,13 @@ func newMutRowVarLenColumn(valSize int) *column {
 	return col
 }
 
-func makeMutRowUint64Column(val uint64) *column {
+func makeMutRowUint64Column(val uint64) *Column {
 	col := newMutRowFixedLenColumn(8)
 	*(*uint64)(unsafe.Pointer(&col.data[0])) = val
 	return col
 }
 
-func makeMutRowBytesColumn(bin []byte) *column {
+func makeMutRowBytesColumn(bin []byte) *Column {
 	col := newMutRowVarLenColumn(len(bin))
 	copy(col.data, bin)
 	col.nullBitmap[0] = 1
@@ -305,7 +305,7 @@ func (mr MutRow) SetDatum(colIdx int, d types.Datum) {
 	col.nullBitmap[0] = 1
 }
 
-func setMutRowBytes(col *column, bin []byte) {
+func setMutRowBytes(col *Column, bin []byte) {
 	if len(col.data) >= len(bin) {
 		col.data = col.data[:len(bin)]
 	} else {
@@ -317,7 +317,7 @@ func setMutRowBytes(col *column, bin []byte) {
 	col.offsets[1] = int64(len(bin))
 }
 
-func setMutRowNameValue(col *column, name string, val uint64) {
+func setMutRowNameValue(col *Column, name string, val uint64) {
 	dataLen := len(name) + 8
 	if len(col.data) >= dataLen {
 		col.data = col.data[:dataLen]
@@ -331,12 +331,12 @@ func setMutRowNameValue(col *column, name string, val uint64) {
 	col.offsets[1] = int64(dataLen)
 }
 
-func setMutRowJSON(col *column, j json.BinaryJSON) {
+func setMutRowJSON(col *Column, j json.BinaryJSON) {
 	dataLen := len(j.Value) + 1
 	if len(col.data) >= dataLen {
 		col.data = col.data[:dataLen]
 	} else {
-		// In MutRow, there always exists 1 data in every column,
+		// In MutRow, there always exists 1 data in every Column,
 		// we should allocate one more byte for null bitmap.
 		buf := make([]byte, dataLen+1)
 		col.data = buf[:dataLen]

--- a/util/chunk/pool.go
+++ b/util/chunk/pool.go
@@ -19,7 +19,7 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
-// Pool is the column pool.
+// Pool is the Column pool.
 // NOTE: Pool is non-copyable.
 type Pool struct {
 	initCap int
@@ -47,19 +47,19 @@ func NewPool(initCap int) *Pool {
 func (p *Pool) GetChunk(fields []*types.FieldType) *Chunk {
 	chk := new(Chunk)
 	chk.capacity = p.initCap
-	chk.columns = make([]*column, len(fields))
+	chk.columns = make([]*Column, len(fields))
 	for i, f := range fields {
 		switch elemLen := getFixedLen(f); elemLen {
 		case varElemLen:
-			chk.columns[i] = p.varLenColPool.Get().(*column)
+			chk.columns[i] = p.varLenColPool.Get().(*Column)
 		case 4:
-			chk.columns[i] = p.fixLenColPool4.Get().(*column)
+			chk.columns[i] = p.fixLenColPool4.Get().(*Column)
 		case 8:
-			chk.columns[i] = p.fixLenColPool8.Get().(*column)
+			chk.columns[i] = p.fixLenColPool8.Get().(*Column)
 		case 16:
-			chk.columns[i] = p.fixLenColPool16.Get().(*column)
+			chk.columns[i] = p.fixLenColPool16.Get().(*Column)
 		case 40:
-			chk.columns[i] = p.fixLenColPool40.Get().(*column)
+			chk.columns[i] = p.fixLenColPool40.Get().(*Column)
 		}
 	}
 	return chk
@@ -81,5 +81,5 @@ func (p *Pool) PutChunk(fields []*types.FieldType, chk *Chunk) {
 			p.fixLenColPool40.Put(chk.columns[i])
 		}
 	}
-	chk.columns = nil // release the column references.
+	chk.columns = nil // release the Column references.
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Expose `chunk.Column` and some methods of it to let `Expression` can access data directly by it instead of using `Row` and `RowIter`, which is prepared for vectorized expression evaluation.

### What is changed and how it works?
Just expose `chunk.Column` and some methods of it.
**No logical changes.**
