### PR TITLE
store/helper: remove timeout for fetch diagnose from info pd

### DIFF
--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -413,9 +413,7 @@ func (h *Helper) GetRegionsInfo() (*RegionsInfo, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	timeout, cancelFunc := context.WithTimeout(context.Background(), 5*time.Second)
-	resp, err := http.DefaultClient.Do(req.WithContext(timeout))
-	defer cancelFunc()
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -492,9 +490,7 @@ func (h *Helper) GetStoresStat() (*StoresStat, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	timeout, cancelFunc := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	resp, err := http.DefaultClient.Do(req.WithContext(timeout))
-	defer cancelFunc()
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

current timeout for fetch diagnose info from pd is too short for cluster that have many regions.

### What is changed and how it works?

remove timeout when we need to get diagnose info even if it's slow 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release 3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11352)
<!-- Reviewable:end -->
