### PR TITLE
expression: let `testEvaluatorSuite` run serially to avoid affect other unit tests since it uses `failpoint` (#11310)

### DIFF
--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = Suite(&testEvaluatorSuite{})
+var _ = SerialSuites(&testEvaluatorSuite{})
 
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true


### PR DESCRIPTION
cherry-pick for #11310.