### PR TITLE
executor: add vectorized data access methods to `Column`

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -551,8 +551,8 @@ func (c *Chunk) AppendDatum(colIdx int, d *types.Datum) {
 }
 
 // Column returns the specific column.
-func (c *Chunk) Column(colID int) *Column {
-	return c.columns[colID]
+func (c *Chunk) Column(colIdx int) *Column {
+	return c.columns[colIdx]
 }
 
 func writeTime(buf []byte, t types.Time) {

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -471,7 +471,7 @@ func (c *Chunk) AppendUint64(colIdx int, u uint64) {
 
 // AppendFloat32 appends a float32 value to the chunk.
 func (c *Chunk) AppendFloat32(colIdx int, f float32) {
-	c.columns[colIdx].appendFloat32(f)
+	c.columns[colIdx].AppendFloat32(f)
 }
 
 // AppendFloat64 appends a float64 value to the chunk.

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -305,7 +305,7 @@ func (c *Chunk) AppendRow(row Row) {
 func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
 	for i, rowCol := range row.c.columns {
 		chkCol := c.columns[colIdx+i]
-		chkCol.appendNullBitmap(!rowCol.isNull(row.idx))
+		chkCol.appendNullBitmap(!rowCol.IsNull(row.idx))
 		if rowCol.isFixed() {
 			elemLen := len(rowCol.elemBuf)
 			offset := row.idx * elemLen
@@ -333,7 +333,7 @@ func (c *Chunk) PreAlloc(row Row) (rowIdx uint32) {
 	rowIdx = uint32(c.NumRows())
 	for i, srcCol := range row.c.columns {
 		dstCol := c.columns[i]
-		dstCol.appendNullBitmap(!srcCol.isNull(row.idx))
+		dstCol.appendNullBitmap(!srcCol.IsNull(row.idx))
 		elemLen := len(srcCol.elemBuf)
 		if !srcCol.isFixed() {
 			elemLen = int(srcCol.offsets[row.idx+1] - srcCol.offsets[row.idx])
@@ -416,7 +416,7 @@ func (c *Chunk) Append(other *Chunk, begin, end int) {
 			}
 		}
 		for i := begin; i < end; i++ {
-			dst.appendNullBitmap(!src.isNull(i))
+			dst.appendNullBitmap(!src.IsNull(i))
 			dst.length++
 		}
 	}
@@ -434,7 +434,7 @@ func (c *Chunk) TruncateTo(numRows int) {
 			col.offsets = col.offsets[:numRows+1]
 		}
 		for i := numRows; i < col.length; i++ {
-			if col.isNull(i) {
+			if col.IsNull(i) {
 				col.nullCount--
 			}
 		}

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -66,12 +66,7 @@ func New(fields []*types.FieldType, cap, maxChunkSize int) *Chunk {
 	}
 
 	for _, f := range fields {
-		elemLen := getFixedLen(f)
-		if elemLen == varElemLen {
-			chk.columns = append(chk.columns, newVarLenColumn(chk.capacity, nil))
-		} else {
-			chk.columns = append(chk.columns, newFixedLenColumn(elemLen, chk.capacity))
-		}
+		chk.columns = append(chk.columns, NewColumn(f, chk.capacity))
 	}
 
 	return chk
@@ -553,6 +548,11 @@ func (c *Chunk) AppendDatum(colIdx int, d *types.Datum) {
 	case types.KindMysqlJSON:
 		c.AppendJSON(colIdx, d.GetMysqlJSON())
 	}
+}
+
+// Column returns the specific column.
+func (c *Chunk) Column(colID int) *Column {
+	return c.columns[colID]
 }
 
 func writeTime(buf []byte, t types.Time) {

--- a/util/chunk/chunk_util.go
+++ b/util/chunk/chunk_util.go
@@ -47,7 +47,7 @@ func copySelectedInnerRows(innerColOffset, outerColOffset int, src *Chunk, selec
 				if !selected[i] {
 					continue
 				}
-				dstCol.appendNullBitmap(!srcCol.isNull(i))
+				dstCol.appendNullBitmap(!srcCol.IsNull(i))
 				dstCol.length++
 
 				elemLen := len(srcCol.elemBuf)
@@ -59,7 +59,7 @@ func copySelectedInnerRows(innerColOffset, outerColOffset int, src *Chunk, selec
 				if !selected[i] {
 					continue
 				}
-				dstCol.appendNullBitmap(!srcCol.isNull(i))
+				dstCol.appendNullBitmap(!srcCol.IsNull(i))
 				dstCol.length++
 
 				start, end := srcCol.offsets[i], srcCol.offsets[i+1]
@@ -86,7 +86,7 @@ func copyOuterRows(innerColOffset, outerColOffset int, src *Chunk, numRows int, 
 	}
 	for i, srcCol := range srcCols {
 		dstCol := dst.columns[outerColOffset+i]
-		dstCol.appendMultiSameNullBitmap(!srcCol.isNull(row.idx), numRows)
+		dstCol.appendMultiSameNullBitmap(!srcCol.IsNull(row.idx), numRows)
 		dstCol.length += numRows
 		if srcCol.isFixed() {
 			elemLen := len(srcCol.elemBuf)

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -64,9 +64,9 @@ type Column struct {
 func NewColumn(ft *types.FieldType, cap int) *Column {
 	typeSize := getFixedLen(ft)
 	if typeSize == varElemLen {
-		return newFixedLenColumn(typeSize, cap)
-	} else {
 		return newVarLenColumn(cap, nil)
+	} else {
+		return newFixedLenColumn(typeSize, cap)
 	}
 }
 

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -49,7 +49,7 @@ func (c *Column) AppendJSON(j json.BinaryJSON) {
 	c.finishAppendVar()
 }
 
-// AppendJSON appends a Set value into this Column.
+// AppendSet appends a Set value into this Column.
 func (c *Column) AppendSet(set types.Set) {
 	c.appendNameValue(set.Name, set.Value)
 }
@@ -70,9 +70,8 @@ func NewColumn(ft *types.FieldType, cap int) *Column {
 	typeSize := getFixedLen(ft)
 	if typeSize == varElemLen {
 		return newVarLenColumn(cap, nil)
-	} else {
-		return newFixedLenColumn(typeSize, cap)
 	}
+	return newFixedLenColumn(typeSize, cap)
 }
 
 func (c *Column) isFixed() bool {
@@ -283,7 +282,7 @@ func (c *Column) GetString(rowID int) string {
 	return string(hack.String(c.data[c.offsets[rowID]:c.offsets[rowID+1]]))
 }
 
-// GetString returns the JSON in the specific row.
+// GetJSON returns the JSON in the specific row.
 func (c *Column) GetJSON(rowID int) json.BinaryJSON {
 	start := c.offsets[rowID]
 	return json.BinaryJSON{TypeCode: c.data[start], Value: c.data[start+1 : c.offsets[rowID+1]]}
@@ -317,7 +316,6 @@ func (c *Column) GetDuration(rowID int, fillFsp int) types.Duration {
 	return types.Duration{Duration: time.Duration(dur), Fsp: fillFsp}
 }
 
-// GetString returns the byte slice in the specific row.
 func (c *Column) getNameValue(rowID int) (string, uint64) {
 	start, end := c.offsets[rowID], c.offsets[rowID+1]
 	if start == end {

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -209,6 +209,11 @@ func (c *Column) AppendTime(t types.Time) {
 	c.finishAppendFixed()
 }
 
+// AppendEnum appends a Enum value into this Column.
+func (c *Column) AppendEnum(enum types.Enum) {
+	c.appendNameValue(enum.Name, enum.Value)
+}
+
 const (
 	sizeInt64     = int(unsafe.Sizeof(int64(0)))
 	sizeUint64    = int(unsafe.Sizeof(uint64(0)))

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -49,6 +49,11 @@ func (c *Column) AppendJSON(j json.BinaryJSON) {
 	c.finishAppendVar()
 }
 
+// AppendJSON appends a Set value into this Column.
+func (c *Column) AppendSet(set types.Set) {
+	c.appendNameValue(set.Name, set.Value)
+}
+
 // Column stores one column of data in Apache Arrow format.
 // See https://arrow.apache.org/docs/memory_layout.html
 type Column struct {

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -91,7 +91,8 @@ func (c *Column) Reset() {
 	c.data = c.data[:0]
 }
 
-func (c *Column) isNull(rowIdx int) bool {
+// IsNull returns if this row is null.
+func (c *Column) IsNull(rowIdx int) bool {
 	nullByte := c.nullBitmap[rowIdx/8]
 	return nullByte&(1<<(uint(rowIdx)&7)) == 0
 }

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -222,58 +222,45 @@ const (
 	sizeMyDecimal = int(unsafe.Sizeof(types.MyDecimal{}))
 )
 
+func (c *Column) castSliceHeader(header *reflect.SliceHeader, typeSize int) {
+	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
+	header.Data = h.Data
+	header.Len = c.length
+	header.Cap = h.Cap / typeSize
+}
+
 // Int64s returns an int64 slice stored in this Column.
 func (c *Column) Int64s() []int64 {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
 	var res []int64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = c.length
-	s.Cap = h.Cap / sizeInt64
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeInt64)
 	return res
 }
 
 // Uint64s returns a uint64 slice stored in this Column.
 func (c *Column) Uint64s() []uint64 {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
 	var res []uint64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = c.length
-	s.Cap = h.Cap / sizeUint64
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeUint64)
 	return res
 }
 
 // Float32s returns a float32 slice stored in this Column.
 func (c *Column) Float32s() []float32 {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
 	var res []float32
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = c.length
-	s.Cap = h.Cap / sizeFloat32
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeFloat32)
 	return res
 }
 
 // Float64s returns a float64 slice stored in this Column.
 func (c *Column) Float64s() []float64 {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
 	var res []float64
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = c.length
-	s.Cap = h.Cap / sizeFloat64
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeFloat64)
 	return res
 }
 
 // MyDecimals returns a MyDecimal slice stored in this Column.
 func (c *Column) MyDecimals() []types.MyDecimal {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
 	var res []types.MyDecimal
-	s := (*reflect.SliceHeader)(unsafe.Pointer(&res))
-	s.Data = h.Data
-	s.Len = c.length
-	s.Cap = h.Cap / sizeMyDecimal
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeMyDecimal)
 	return res
 }
 

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -214,8 +214,6 @@ const (
 	sizeUint64    = int(unsafe.Sizeof(uint64(0)))
 	sizeFloat32   = int(unsafe.Sizeof(float32(0)))
 	sizeFloat64   = int(unsafe.Sizeof(float64(0)))
-	sizeTime      = int(unsafe.Sizeof(types.Time{}))
-	sizeDuration  = int(unsafe.Sizeof(types.Duration{}))
 	sizeMyDecimal = int(unsafe.Sizeof(types.MyDecimal{}))
 )
 

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -223,10 +223,9 @@ const (
 )
 
 func (c *Column) castSliceHeader(header *reflect.SliceHeader, typeSize int) {
-	h := (*reflect.SliceHeader)(unsafe.Pointer(&c.data))
-	header.Data = h.Data
+	header.Data = uintptr(unsafe.Pointer(&c.data[0]))
 	header.Len = c.length
-	header.Cap = h.Cap / typeSize
+	header.Cap = cap(c.data) / typeSize
 }
 
 // Int64s returns an int64 slice stored in this Column.
@@ -257,8 +256,8 @@ func (c *Column) Float64s() []float64 {
 	return res
 }
 
-// MyDecimals returns a MyDecimal slice stored in this Column.
-func (c *Column) MyDecimals() []types.MyDecimal {
+// Decimals returns a MyDecimal slice stored in this Column.
+func (c *Column) Decimals() []types.MyDecimal {
 	var res []types.MyDecimal
 	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeMyDecimal)
 	return res

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
+	"time"
 )
 
 func equalColumn(c1, c2 *Column) bool {
@@ -237,6 +238,24 @@ func (s *testChunkSuite) TestJSONColumn(c *check.C) {
 		j1 := col.GetJSON(i)
 		j2 := row.GetJSON(0)
 		c.Assert(j1.String(), check.Equals, j2.String())
+		i++
+	}
+}
+
+func (s *testChunkSuite) TestTimeColumn(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDatetime)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendTime(types.CurrentTime(mysql.TypeDatetime))
+		time.Sleep(time.Millisecond / 10)
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		j1 := col.GetTime(i)
+		j2 := row.GetTime(0)
+		c.Assert(j1.Compare(j2), check.Equals, 0)
 		i++
 	}
 }

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -296,3 +296,27 @@ func (s *testChunkSuite) TestEnumColumn(c *check.C) {
 		i++
 	}
 }
+
+func (s *testChunkSuite) TestNullsColumn(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		if i%2 == 0 {
+			col.AppendNull()
+			continue
+		}
+		col.AppendInt64(int64(i))
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		if i%2 == 0 {
+			c.Assert(row.IsNull(0), check.Equals, true)
+			c.Assert(col.IsNull(i), check.Equals, true)
+		} else {
+			c.Assert(row.GetInt64(0), check.Equals, int64(i))
+		}
+		i++
+	}
+}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -15,11 +15,12 @@ package chunk
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
-	"time"
 )
 
 func equalColumn(c1, c2 *Column) bool {

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -198,3 +198,23 @@ func (s *testChunkSuite) TestStringColumn(c *check.C) {
 		i++
 	}
 }
+
+func (s *testChunkSuite) TestSetColumn(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeSet)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendSet(types.Set{Name: fmt.Sprintf("%v", i), Value: uint64(i)})
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		s1 := col.GetSet(i)
+		s2 := row.GetSet(0)
+		c.Assert(s1.Name, check.Equals, s2.Name)
+		c.Assert(s1.Value, check.Equals, s2.Value)
+		c.Assert(s1.Name, check.Equals, fmt.Sprintf("%v", i))
+		c.Assert(s1.Value, check.Equals, uint64(i))
+		i++
+	}
+}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -276,3 +276,23 @@ func (s *testChunkSuite) TestDurationColumn(c *check.C) {
 		i++
 	}
 }
+
+func (s *testChunkSuite) TestEnumColumn(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeEnum)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendEnum(types.Enum{Name: fmt.Sprintf("%v", i), Value: uint64(i)})
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		s1 := col.GetEnum(i)
+		s2 := row.GetEnum(0)
+		c.Assert(s1.Name, check.Equals, s2.Name)
+		c.Assert(s1.Value, check.Equals, s2.Value)
+		c.Assert(s1.Name, check.Equals, fmt.Sprintf("%v", i))
+		c.Assert(s1.Value, check.Equals, uint64(i))
+		i++
+	}
+}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -259,3 +259,20 @@ func (s *testChunkSuite) TestTimeColumn(c *check.C) {
 		i++
 	}
 }
+
+func (s *testChunkSuite) TestDurationColumn(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDuration)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendDuration(types.Duration{Duration: time.Second * time.Duration(i)})
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		j1 := col.GetDuration(i, 0)
+		j2 := row.GetDuration(0, 0)
+		c.Assert(j1.Compare(j2), check.Equals, 0)
+		i++
+	}
+}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -84,7 +84,7 @@ func (s *testChunkSuite) TestI64Column(c *check.C) {
 	i64s := col.Int64s()
 	for i := 0; i < 1024; i++ {
 		c.Assert(i64s[i], check.Equals, int64(i))
-		i64s[i] ++
+		i64s[i]++
 	}
 
 	it := NewIterator4Chunk(chk)

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -92,6 +92,48 @@ func (s *testChunkSuite) TestI64Column(c *check.C) {
 	}
 }
 
+func (s *testChunkSuite) TestF64Column(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDouble)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendFloat64(float64(i))
+	}
+
+	f64s := col.Float64s()
+	for i := 0; i < 1024; i++ {
+		c.Assert(f64s[i], check.Equals, float64(i))
+		f64s[i] /= 2
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int64
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		c.Assert(row.GetFloat64(0), check.Equals, float64(i)/2)
+		i++
+	}
+}
+
+func (s *testChunkSuite) TestF32Column(c *check.C) {
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeFloat)}, 1024)
+	col := chk.Column(0)
+	for i := 0; i < 1024; i++ {
+		col.AppendFloat32(float32(i))
+	}
+
+	f32s := col.Float32s()
+	for i := 0; i < 1024; i++ {
+		c.Assert(f32s[i], check.Equals, float32(i))
+		f32s[i] /= 2
+	}
+
+	it := NewIterator4Chunk(chk)
+	var i int64
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		c.Assert(row.GetFloat32(0), check.Equals, float32(i)/2)
+		i++
+	}
+}
+
 func (s *testChunkSuite) TestStringColumn(c *check.C) {
 	col := NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
 	for i := 0; i < 1024; i++ {

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -148,7 +148,7 @@ func (s *testChunkSuite) TestMyDecimal(c *check.C) {
 		col.AppendMyDecimal(d)
 	}
 
-	ds := col.MyDecimals()
+	ds := col.Decimals()
 	for i := 0; i < 1024; i++ {
 		d := new(types.MyDecimal)
 		if err := d.FromFloat64(float64(i) * 1.1); err != nil {

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -184,11 +184,17 @@ func (s *testChunkSuite) TestMyDecimal(c *check.C) {
 }
 
 func (s *testChunkSuite) TestStringColumn(c *check.C) {
-	col := NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeVarString)}, 1024)
+	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
-		col.AppendString(fmt.Sprintf("%v", i))
+		col.AppendString(fmt.Sprintf("%v", i*i))
 	}
-	for i := 0; i < 1024; i++ {
-		c.Assert(col.GetString(i), check.Equals, fmt.Sprintf("%v", i))
+
+	it := NewIterator4Chunk(chk)
+	var i int
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		c.Assert(row.GetString(0), check.Equals, fmt.Sprintf("%v", i*i))
+		c.Assert(col.GetString(i), check.Equals, fmt.Sprintf("%v", i*i))
+		i++
 	}
 }

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -203,7 +203,7 @@ func makeMutRowBytesColumn(bin []byte) *Column {
 func (mr MutRow) SetRow(row Row) {
 	for colIdx, rCol := range row.c.columns {
 		mrCol := mr.c.columns[colIdx]
-		if rCol.isNull(row.idx) {
+		if rCol.IsNull(row.idx) {
 			mrCol.nullBitmap[0] = 0
 			continue
 		}
@@ -351,7 +351,7 @@ func setMutRowJSON(col *Column, j json.BinaryJSON) {
 func (mr MutRow) ShallowCopyPartialRow(colIdx int, row Row) {
 	for i, srcCol := range row.c.columns {
 		dstCol := mr.c.columns[colIdx+i]
-		if !srcCol.isNull(row.idx) {
+		if !srcCol.IsNull(row.idx) {
 			// MutRow only contains one row, so we can directly set the whole byte.
 			dstCol.nullBitmap[0] = 1
 		} else {

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -220,5 +220,5 @@ func (r Row) GetDatum(colIdx int, tp *types.FieldType) types.Datum {
 
 // IsNull returns if the datum in the chunk.Row is null.
 func (r Row) IsNull(colIdx int) bool {
-	return r.c.columns[colIdx].isNull(r.idx)
+	return r.c.columns[colIdx].IsNull(r.idx)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add some vectorized data access methods to `Column` to let `Expression` can access its data directly instead of using `Row` and `RowIter`, which is prepared for vectorized expression evaluation.

### What is changed and how it works?
Two kinds of data access methods are added to `Column`:
1. **Types() []Type**: added for fixed-length types like `i64`, `f64`, `MyDecimal`;
2. **GetType(rowID) Type**: added for var-length types like `JSON`, `String`;

And `IsNull` is exposed.

**Most of these changes are new methods or unit tests, so it's easy for you to review although there are hundreds of lines changed.**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
