### PR TITLE
executor: add `Sel` to `Chunk` to indicate which rows are selected

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -635,6 +635,16 @@ func (c *Chunk) Column(colIdx int) *Column {
 	return c.columns[colIdx]
 }
 
+// Sel returns Sel of this Chunk.
+func (c *Chunk) Sel() Sel {
+	return c.sel
+}
+
+// SetSel sets a Sel for this Chunk.
+func (c *Chunk) SetSel(sel Sel) {
+	c.sel = sel
+}
+
 func writeTime(buf []byte, t types.Time) {
 	binary.BigEndian.PutUint16(buf, uint16(t.Time.Year()))
 	buf[2] = uint8(t.Time.Month())

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -23,11 +23,18 @@ import (
 	"github.com/pingcap/tidb/types/json"
 )
 
+// Sel indicates which rows are selected in a Chunk.
+type Sel []uint16
+
 // Chunk stores multiple rows of data in Apache Arrow format.
 // See https://arrow.apache.org/docs/memory_layout.html
 // Values are appended in compact format and can be directly accessed without decoding.
 // When the chunk is done processing, we can reuse the allocated memory by resetting it.
 type Chunk struct {
+	// sel indicates which rows are selected.
+	// if it is nil, all rows are selected.
+	sel Sel
+
 	columns []*Column
 	// numVirtualRows indicates the number of virtual rows, which have zero Column.
 	// It is used only when this Chunk doesn't hold any data, i.e. "len(columns)==0".
@@ -145,6 +152,7 @@ func (c *Chunk) RequiredRows() int {
 	return c.requiredRows
 }
 
+
 // SetRequiredRows sets the number of required rows.
 func (c *Chunk) SetRequiredRows(requiredRows, maxChunkSize int) *Chunk {
 	if requiredRows <= 0 || requiredRows > maxChunkSize {
@@ -165,6 +173,7 @@ func (c *Chunk) MakeRef(srcColIdx, dstColIdx int) {
 }
 
 // MakeRefTo copies columns `src.columns[srcColIdx]` to `c.columns[dstColIdx]`.
+// NOTICE: it doesn't reference Sel.
 func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
 	c.columns[dstColIdx] = src.columns[srcColIdx]
 }
@@ -214,6 +223,7 @@ func (c *Chunk) SwapColumn(colIdx int, other *Chunk, otherIdx int) {
 
 // SwapColumns swaps columns with another Chunk.
 func (c *Chunk) SwapColumns(other *Chunk) {
+	c.sel, other.sel = other.sel, c.sel
 	c.columns, other.columns = other.columns, c.columns
 	c.numVirtualRows, other.numVirtualRows = other.numVirtualRows, c.numVirtualRows
 }
@@ -227,6 +237,7 @@ func (c *Chunk) SetNumVirtualRows(numVirtualRows int) {
 // Reset resets the chunk, so the memory it allocated can be reused.
 // Make sure all the data in the chunk is not used anymore before you reuse this chunk.
 func (c *Chunk) Reset() {
+	c.sel = nil
 	if c.columns == nil {
 		return
 	}
@@ -242,6 +253,10 @@ func (c *Chunk) CopyConstruct() *Chunk {
 	for i := range c.columns {
 		newChk.columns[i] = c.columns[i].copyConstruct()
 	}
+	if c.sel != nil {
+		newChk.sel = make([]uint16, len(c.sel))
+		copy(newChk.sel, c.sel)
+	}
 	return newChk
 }
 
@@ -249,6 +264,7 @@ func (c *Chunk) CopyConstruct() *Chunk {
 // The doubled capacity should not be larger than maxChunkSize.
 // TODO: this method will be used in following PR.
 func (c *Chunk) GrowAndReset(maxChunkSize int) {
+	c.sel = nil
 	if c.columns == nil {
 		return
 	}
@@ -284,6 +300,9 @@ func (c *Chunk) NumCols() int {
 
 // NumRows returns the number of rows in the chunk.
 func (c *Chunk) NumRows() int {
+	if c.sel != nil {
+		return len(c.sel)
+	}
 	if c.NumCols() == 0 {
 		return c.numVirtualRows
 	}
@@ -292,6 +311,10 @@ func (c *Chunk) NumRows() int {
 
 // GetRow gets the Row in the chunk with the row index.
 func (c *Chunk) GetRow(idx int) Row {
+	if c.sel != nil {
+		// consistent with NumRows: for i := 0; i < c.NumRows(); i++ { r := c.GetRow(i) }
+		return Row{c: c, idx: int(c.sel[idx])}
+	}
 	return Row{c: c, idx: idx}
 }
 
@@ -303,6 +326,9 @@ func (c *Chunk) AppendRow(row Row) {
 
 // AppendPartialRow appends a row to the chunk.
 func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	for i, rowCol := range row.c.columns {
 		chkCol := c.columns[colIdx+i]
 		chkCol.appendNullBitmap(!rowCol.IsNull(row.idx))
@@ -404,6 +430,10 @@ func (c *Chunk) Insert(rowIdx int, row Row) {
 // Append appends rows in [begin, end) in another Chunk to a Chunk.
 func (c *Chunk) Append(other *Chunk, begin, end int) {
 	for colID, src := range other.columns {
+		if colID == 0 && c.sel != nil { // use column 0 as standard
+			c.sel = append(c.sel, uint16(c.columns[0].length))
+		}
+
 		dst := c.columns[colID]
 		if src.isFixed() {
 			elemLen := len(src.elemBuf)
@@ -456,72 +486,114 @@ func (c *Chunk) TruncateTo(numRows int) {
 
 // AppendNull appends a null value to the chunk.
 func (c *Chunk) AppendNull(colIdx int) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendNull()
 }
 
 // AppendInt64 appends a int64 value to the chunk.
 func (c *Chunk) AppendInt64(colIdx int, i int64) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendInt64(i)
 }
 
 // AppendUint64 appends a uint64 value to the chunk.
 func (c *Chunk) AppendUint64(colIdx int, u uint64) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendUint64(u)
 }
 
 // AppendFloat32 appends a float32 value to the chunk.
 func (c *Chunk) AppendFloat32(colIdx int, f float32) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendFloat32(f)
 }
 
 // AppendFloat64 appends a float64 value to the chunk.
 func (c *Chunk) AppendFloat64(colIdx int, f float64) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendFloat64(f)
 }
 
 // AppendString appends a string value to the chunk.
 func (c *Chunk) AppendString(colIdx int, str string) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendString(str)
 }
 
 // AppendBytes appends a bytes value to the chunk.
 func (c *Chunk) AppendBytes(colIdx int, b []byte) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendBytes(b)
 }
 
 // AppendTime appends a Time value to the chunk.
 // TODO: change the time structure so it can be directly written to memory.
 func (c *Chunk) AppendTime(colIdx int, t types.Time) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendTime(t)
 }
 
 // AppendDuration appends a Duration value to the chunk.
 func (c *Chunk) AppendDuration(colIdx int, dur types.Duration) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendDuration(dur)
 }
 
 // AppendMyDecimal appends a MyDecimal value to the chunk.
 func (c *Chunk) AppendMyDecimal(colIdx int, dec *types.MyDecimal) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendMyDecimal(dec)
 }
 
 // AppendEnum appends an Enum value to the chunk.
 func (c *Chunk) AppendEnum(colIdx int, enum types.Enum) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].appendNameValue(enum.Name, enum.Value)
 }
 
 // AppendSet appends a Set value to the chunk.
 func (c *Chunk) AppendSet(colIdx int, set types.Set) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].appendNameValue(set.Name, set.Value)
 }
 
 // AppendJSON appends a JSON value to the chunk.
 func (c *Chunk) AppendJSON(colIdx int, j json.BinaryJSON) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	c.columns[colIdx].AppendJSON(j)
 }
 
 // AppendDatum appends a datum into the chunk.
 func (c *Chunk) AppendDatum(colIdx int, d *types.Datum) {
+	if colIdx == 0 && c.sel != nil { // use column 0 as standard
+		c.sel = append(c.sel, uint16(c.columns[0].length))
+	}
 	switch d.Kind() {
 	case types.KindNull:
 		c.AppendNull(colIdx)

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -178,9 +178,8 @@ func (c *Chunk) MakeRef(srcColIdx, dstColIdx int) {
 }
 
 // MakeRefTo copies columns `src.columns[srcColIdx]` to `c.columns[dstColIdx]`.
-// NOTICE: it doesn't reference Sel.
 func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
-	c.assertNilSel()
+	c.assertNilSel() // it doesn't reference Sel.
 	c.columns[dstColIdx] = src.columns[srcColIdx]
 }
 
@@ -188,7 +187,7 @@ func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
 // "other.columns[otherIdx]". If there exists columns refer to the Column to be
 // swapped, we need to re-build the reference.
 func (c *Chunk) SwapColumn(colIdx int, other *Chunk, otherIdx int) {
-	c.assertNilSel()
+	c.assertNilSel() // undefined operation to swap columns have Sel
 	// Find the leftmost Column of the reference which is the actual Column to
 	// be swapped.
 	for i := 0; i < colIdx; i++ {
@@ -464,7 +463,7 @@ func (c *Chunk) Append(other *Chunk, begin, end int) {
 
 // TruncateTo truncates rows from tail to head in a Chunk to "numRows" rows.
 func (c *Chunk) TruncateTo(numRows int) {
-	c.assertNilSel()
+	c.assertNilSel() // undefined operation to truncate a chunk with Sel
 	for _, col := range c.columns {
 		if col.isFixed() {
 			elemLen := len(col.elemBuf)

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -646,6 +646,17 @@ func (c *Chunk) SetSel(sel Sel) {
 	c.sel = sel
 }
 
+// Reconstruct removes all unselected rows according to Sel.
+func (c *Chunk) Reconstruct() {
+	if c.sel == nil {
+		return
+	}
+	for _, col := range c.columns {
+		col.reconstruct(c.sel)
+	}
+	c.sel = nil
+}
+
 func writeTime(buf []byte, t types.Time) {
 	binary.BigEndian.PutUint16(buf, uint16(t.Time.Year()))
 	buf[2] = uint8(t.Time.Month())

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -152,6 +152,11 @@ func (c *Chunk) RequiredRows() int {
 	return c.requiredRows
 }
 
+func (c *Chunk) assertNilSel() {
+	if c.sel != nil {
+		panic("assert(Sel == nil)")
+	}
+}
 
 // SetRequiredRows sets the number of required rows.
 func (c *Chunk) SetRequiredRows(requiredRows, maxChunkSize int) *Chunk {
@@ -175,6 +180,7 @@ func (c *Chunk) MakeRef(srcColIdx, dstColIdx int) {
 // MakeRefTo copies columns `src.columns[srcColIdx]` to `c.columns[dstColIdx]`.
 // NOTICE: it doesn't reference Sel.
 func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
+	c.assertNilSel()
 	c.columns[dstColIdx] = src.columns[srcColIdx]
 }
 
@@ -182,6 +188,7 @@ func (c *Chunk) MakeRefTo(dstColIdx int, src *Chunk, srcColIdx int) {
 // "other.columns[otherIdx]". If there exists columns refer to the Column to be
 // swapped, we need to re-build the reference.
 func (c *Chunk) SwapColumn(colIdx int, other *Chunk, otherIdx int) {
+	c.assertNilSel()
 	// Find the leftmost Column of the reference which is the actual Column to
 	// be swapped.
 	for i := 0; i < colIdx; i++ {
@@ -455,6 +462,7 @@ func (c *Chunk) Append(other *Chunk, begin, end int) {
 
 // TruncateTo truncates rows from tail to head in a Chunk to "numRows" rows.
 func (c *Chunk) TruncateTo(numRows int) {
+	c.assertNilSel()
 	for _, col := range c.columns {
 		if col.isFixed() {
 			elemLen := len(col.elemBuf)

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -352,7 +352,7 @@ func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
 	}
 }
 
-// PreAlloc pre-allocates the memory space in a Chunk to store the Row.
+// preAlloc pre-allocates the memory space in a Chunk to store the Row.
 // NOTE:
 // 1. The Chunk must be empty or holds no useful data.
 // 2. The schema of the Row must be the same with the Chunk.
@@ -362,7 +362,8 @@ func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
 //    when the Insert() function is called parallelly, the data race on a byte
 //    can not be avoided although the manipulated bits are different inside a
 //    byte.
-func (c *Chunk) PreAlloc(row Row) (rowIdx uint32) {
+func (c *Chunk) preAlloc(row Row) (rowIdx uint32) {
+	c.assertNilSel()
 	rowIdx = uint32(c.NumRows())
 	for i, srcCol := range row.c.columns {
 		dstCol := c.columns[i]
@@ -412,10 +413,11 @@ func (c *Chunk) PreAlloc(row Row) (rowIdx uint32) {
 	return
 }
 
-// Insert inserts `row` on the position specified by `rowIdx`.
+// insert inserts `row` on the position specified by `rowIdx`.
 // Note: Insert will cover the origin data, it should be called after
 // PreAlloc.
-func (c *Chunk) Insert(rowIdx int, row Row) {
+func (c *Chunk) insert(rowIdx int, row Row) {
+	c.assertNilSel()
 	for i, srcCol := range row.c.columns {
 		if row.IsNull(i) {
 			continue

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -463,7 +463,7 @@ func (c *Chunk) Append(other *Chunk, begin, end int) {
 
 // TruncateTo truncates rows from tail to head in a Chunk to "numRows" rows.
 func (c *Chunk) TruncateTo(numRows int) {
-	c.assertNilSel() // undefined operation to truncate a chunk with Sel
+	c.Reconstruct()
 	for _, col := range c.columns {
 		if col.isFixed() {
 			elemLen := len(col.elemBuf)

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -626,6 +626,24 @@ func (s *testChunkSuite) TestSwapColumn(c *check.C) {
 	checkRef()
 }
 
+func (s *testChunkSuite) TestAppendSel(c *check.C) {
+	tll := &types.FieldType{Tp: mysql.TypeLonglong}
+	chk := NewChunkWithCapacity([]*types.FieldType{tll}, 1024)
+	sel := make(Sel, 0, 1024/2)
+	for i := 0; i < 1024/2; i++ {
+		chk.AppendInt64(0, int64(i))
+		if i%2 == 0 {
+			sel = append(sel, uint16(i))
+		}
+	}
+	chk.SetSel(sel)
+	c.Assert(chk.NumRows(), check.Equals, 1024/2/2)
+	chk.AppendInt64(0, int64(1))
+	c.Assert(chk.NumRows(), check.Equals, 1024/2/2+1)
+	sel = chk.Sel()
+	c.Assert(sel[len(sel)-1], check.Equals, uint16(1024/2))
+}
+
 func (s *testChunkSuite) TestPreAlloc4RowAndInsert(c *check.C) {
 	fieldTypes := make([]*types.FieldType, 0, 4)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -664,7 +664,7 @@ func (s *testChunkSuite) TestPreAlloc4RowAndInsert(c *check.C) {
 	// Test Chunk.PreAlloc.
 	for i := 0; i < srcChk.NumRows(); i++ {
 		c.Assert(destChk.NumRows(), check.Equals, i)
-		destChk.PreAlloc(srcChk.GetRow(i))
+		destChk.preAlloc(srcChk.GetRow(i))
 	}
 	for i, srcCol := range srcChk.columns {
 		destCol := destChk.columns[i]
@@ -691,7 +691,7 @@ func (s *testChunkSuite) TestPreAlloc4RowAndInsert(c *check.C) {
 
 	// Test Chunk.Insert.
 	for i := srcChk.NumRows() - 1; i >= 0; i-- {
-		destChk.Insert(i, srcChk.GetRow(i))
+		destChk.insert(i, srcChk.GetRow(i))
 	}
 	for i, srcCol := range srcChk.columns {
 		destCol := destChk.columns[i]
@@ -715,14 +715,14 @@ func (s *testChunkSuite) TestPreAlloc4RowAndInsert(c *check.C) {
 	startWg, endWg := &sync.WaitGroup{}, &sync.WaitGroup{}
 	startWg.Add(1)
 	for i := 0; i < srcChk.NumRows(); i++ {
-		destChk.PreAlloc(srcChk.GetRow(i))
+		destChk.preAlloc(srcChk.GetRow(i))
 		endWg.Add(1)
 		go func(rowIdx int) {
 			defer func() {
 				endWg.Done()
 			}()
 			startWg.Wait()
-			destChk.Insert(rowIdx, srcChk.GetRow(rowIdx))
+			destChk.insert(rowIdx, srcChk.GetRow(rowIdx))
 		}(i)
 	}
 	startWg.Done()

--- a/util/chunk/chunk_util.go
+++ b/util/chunk/chunk_util.go
@@ -22,6 +22,8 @@ func CopySelectedJoinRows(src *Chunk, innerColOffset, outerColOffset int, select
 	if src.NumRows() == 0 {
 		return false
 	}
+	src.assertNilSel()
+	dst.assertNilSel()
 
 	numSelected := copySelectedInnerRows(innerColOffset, outerColOffset, src, selected, dst)
 	copyOuterRows(innerColOffset, outerColOffset, src, numSelected, dst)

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -346,7 +346,7 @@ func (c *Column) reconstruct(sel Sel) {
 			idx := dst >> 3
 			pos := uint16(dst & 7)
 			if c.IsNull(int(src)) {
-				nullCnt ++
+				nullCnt++
 				c.nullBitmap[idx] &= ^byte(1 << pos)
 			} else {
 				copy(c.data[int(dst)*elemLen:int(dst)*elemLen+elemLen], c.data[int(src)*elemLen:int(src)*elemLen+elemLen])
@@ -360,7 +360,7 @@ func (c *Column) reconstruct(sel Sel) {
 			idx := dst >> 3
 			pos := uint16(dst & 7)
 			if c.IsNull(int(src)) {
-				nullCnt ++
+				nullCnt++
 				c.nullBitmap[idx] &= ^byte(1 << pos)
 				c.offsets[dst+1] = int64(tail)
 			} else {

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -263,6 +263,31 @@ func (c *Column) Decimals() []types.MyDecimal {
 	return res
 }
 
+// GetInt64 returns the int64 in the specific row.
+func (c *Column) GetInt64(rowID int) int64 {
+	return *(*int64)(unsafe.Pointer(&c.data[rowID*8]))
+}
+
+// GetUint64 returns the uint64 in the specific row.
+func (c *Column) GetUint64(rowID int) uint64 {
+	return *(*uint64)(unsafe.Pointer(&c.data[rowID*8]))
+}
+
+// GetFloat32 returns the float32 in the specific row.
+func (c *Column) GetFloat32(rowID int) float32 {
+	return *(*float32)(unsafe.Pointer(&c.data[rowID*4]))
+}
+
+// GetFloat64 returns the float64 in the specific row.
+func (c *Column) GetFloat64(rowID int) float64 {
+	return *(*float64)(unsafe.Pointer(&c.data[rowID*8]))
+}
+
+// GetDecimal returns the decimal in the specific row.
+func (c *Column) GetDecimal(rowID int) types.MyDecimal {
+	return *(*types.MyDecimal)(unsafe.Pointer(&c.data[rowID*types.MyDecimalStructSize]))
+}
+
 // GetString returns the string in the specific row.
 func (c *Column) GetString(rowID int) string {
 	return string(hack.String(c.data[c.offsets[rowID]:c.offsets[rowID+1]]))

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -353,7 +353,7 @@ func (c *Column) reconstruct(sel Sel) {
 				c.nullBitmap[idx] |= byte(1 << pos)
 			}
 		}
-		c.data = c.data[:c.length*elemLen]
+		c.data = c.data[:len(sel)*elemLen]
 	} else {
 		tail := 0
 		for dst, src := range sel {
@@ -362,6 +362,7 @@ func (c *Column) reconstruct(sel Sel) {
 			if c.IsNull(int(src)) {
 				nullCnt ++
 				c.nullBitmap[idx] &= ^byte(1 << pos)
+				c.offsets[dst+1] = int64(tail)
 			} else {
 				start, end := c.offsets[src], c.offsets[src+1]
 				copy(c.data[tail:], c.data[start:end])
@@ -371,7 +372,7 @@ func (c *Column) reconstruct(sel Sel) {
 			}
 		}
 		c.data = c.data[:tail]
-		c.offsets = c.offsets[:c.length+1]
+		c.offsets = c.offsets[:len(sel)+1]
 	}
 	c.length = len(sel)
 	c.nullCount = nullCnt

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -15,6 +15,7 @@ package chunk
 
 import (
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/pingcap/check"
@@ -319,5 +320,60 @@ func (s *testChunkSuite) TestNullsColumn(c *check.C) {
 			c.Assert(row.GetInt64(0), check.Equals, int64(i))
 		}
 		i++
+	}
+}
+
+func (s *testChunkSuite) TestReconstruct(c *check.C) {
+	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
+	results := make([]int64, 0, 1024)
+	nulls := make([]bool, 0, 1024)
+	sel := make(Sel, 0, 1024)
+	for i := 0; i < 1024; i++ {
+		if rand.Intn(10) < 6 {
+			sel = append(sel, uint16(i))
+		}
+
+		if rand.Intn(10) < 2 {
+			col.AppendNull()
+			nulls = append(nulls, true)
+			results = append(results, 0)
+			continue
+		}
+
+		v := rand.Int63()
+		col.AppendInt64(v)
+		results = append(results, v)
+		nulls = append(nulls, false)
+	}
+
+	col.reconstruct(sel)
+	nullCnt := 0
+	for n, i := range sel {
+		if nulls[i] {
+			nullCnt++
+			c.Assert(col.IsNull(n), check.Equals, true)
+		} else {
+			c.Assert(col.GetInt64(n), check.Equals, results[i])
+		}
+	}
+	c.Assert(nullCnt, check.Equals, col.nullCount)
+	c.Assert(col.length, check.Equals, len(sel))
+
+	for i := 0; i < 128; i++ {
+		if i%2 == 0 {
+			col.AppendNull()
+		} else {
+			col.AppendInt64(int64(i))
+		}
+	}
+
+	c.Assert(col.length, check.Equals, len(sel)+128)
+	c.Assert(col.nullCount, check.Equals, nullCnt+128/2)
+	for i := 0; i < 128; i++ {
+		if i%2 == 0 {
+			c.Assert(col.IsNull(len(sel)+i), check.Equals, true)
+		} else {
+			c.Assert(col.IsNull(len(sel)+i), check.Equals, false)
+		}
 	}
 }

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -323,7 +323,7 @@ func (s *testChunkSuite) TestNullsColumn(c *check.C) {
 	}
 }
 
-func (s *testChunkSuite) TestReconstruct(c *check.C) {
+func (s *testChunkSuite) TestReconstructFixedLen(c *check.C) {
 	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
 	results := make([]int64, 0, 1024)
 	nulls := make([]bool, 0, 1024)
@@ -363,7 +363,7 @@ func (s *testChunkSuite) TestReconstruct(c *check.C) {
 		if i%2 == 0 {
 			col.AppendNull()
 		} else {
-			col.AppendInt64(int64(i))
+			col.AppendInt64(int64(i * i * i))
 		}
 	}
 
@@ -373,6 +373,63 @@ func (s *testChunkSuite) TestReconstruct(c *check.C) {
 		if i%2 == 0 {
 			c.Assert(col.IsNull(len(sel)+i), check.Equals, true)
 		} else {
+			c.Assert(col.GetInt64(len(sel)+i), check.Equals, int64(i*i*i))
+			c.Assert(col.IsNull(len(sel)+i), check.Equals, false)
+		}
+	}
+}
+
+func (s *testChunkSuite) TestReconstructVarLen(c *check.C) {
+	col := NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	results := make([]string, 0, 1024)
+	nulls := make([]bool, 0, 1024)
+	sel := make(Sel, 0, 1024)
+	for i := 0; i < 1024; i++ {
+		if rand.Intn(10) < 6 {
+			sel = append(sel, uint16(i))
+		}
+
+		if rand.Intn(10) < 2 {
+			col.AppendNull()
+			nulls = append(nulls, true)
+			results = append(results, "")
+			continue
+		}
+
+		v := fmt.Sprintf("%v", rand.Int63())
+		col.AppendString(v)
+		results = append(results, v)
+		nulls = append(nulls, false)
+	}
+
+	col.reconstruct(sel)
+	nullCnt := 0
+	for n, i := range sel {
+		if nulls[i] {
+			nullCnt++
+			c.Assert(col.IsNull(n), check.Equals, true)
+		} else {
+			c.Assert(col.GetString(n), check.Equals, results[i])
+		}
+	}
+	c.Assert(nullCnt, check.Equals, col.nullCount)
+	c.Assert(col.length, check.Equals, len(sel))
+
+	for i := 0; i < 128; i++ {
+		if i%2 == 0 {
+			col.AppendNull()
+		} else {
+			col.AppendString(fmt.Sprintf("%v", i*i*i))
+		}
+	}
+
+	c.Assert(col.length, check.Equals, len(sel)+128)
+	c.Assert(col.nullCount, check.Equals, nullCnt+128/2)
+	for i := 0; i < 128; i++ {
+		if i%2 == 0 {
+			c.Assert(col.IsNull(len(sel)+i), check.Equals, true)
+		} else {
+			c.Assert(col.GetString(len(sel)+i), check.Equals, fmt.Sprintf("%v", i*i*i))
 			c.Assert(col.IsNull(len(sel)+i), check.Equals, false)
 		}
 	}

--- a/util/chunk/iterator_test.go
+++ b/util/chunk/iterator_test.go
@@ -19,6 +19,26 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
+func (s *testChunkSuite) TestIteratorOnSel(c *check.C) {
+	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
+	chk := New(fields, 32, 1024)
+	sel := make(Sel, 0, 1024)
+	for i := 0; i < 1024; i++ {
+		chk.AppendInt64(0, int64(i))
+		if i%2 == 0 {
+			sel = append(sel, uint16(i))
+		}
+	}
+	chk.SetSel(sel)
+	it := NewIterator4Chunk(chk)
+	cnt := 0
+	for row := it.Begin(); row != it.End(); row = it.Next() {
+		c.Assert(row.GetInt64(0)%2, check.Equals, int64(0))
+		cnt++
+	}
+	c.Assert(cnt, check.Equals, 1024/2)
+}
+
 func (s *testChunkSuite) TestIterator(c *check.C) {
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	chk := New(fields, 32, 1024)

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -145,13 +145,13 @@ func (l *List) Reset() {
 	l.consumedIdx = -1
 }
 
-// PreAlloc4Row pre-allocates the storage memory for a Row.
+// preAlloc4Row pre-allocates the storage memory for a Row.
 // NOTE:
 // 1. The List must be empty or holds no useful data.
 // 2. The schema of the Row must be the same with the List.
 // 3. This API is paired with the `Insert()` function, which inserts all the
 //    rows data into the List after the pre-allocation.
-func (l *List) PreAlloc4Row(row Row) (ptr RowPtr) {
+func (l *List) preAlloc4Row(row Row) (ptr RowPtr) {
 	chkIdx := len(l.chunks) - 1
 	if chkIdx == -1 || l.chunks[chkIdx].NumRows() >= l.chunks[chkIdx].Capacity() {
 		newChk := l.allocChunk()
@@ -163,16 +163,16 @@ func (l *List) PreAlloc4Row(row Row) (ptr RowPtr) {
 		chkIdx++
 	}
 	chk := l.chunks[chkIdx]
-	rowIdx := chk.PreAlloc(row)
+	rowIdx := chk.preAlloc(row)
 	l.length++
 	return RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)}
 }
 
-// Insert inserts `row` on the position specified by `ptr`.
+// insert inserts `row` on the position specified by `ptr`.
 // Note: Insert will cover the origin data, it should be called after
 // PreAlloc.
-func (l *List) Insert(ptr RowPtr, row Row) {
-	l.chunks[ptr.ChkIdx].Insert(int(ptr.RowIdx), row)
+func (l *List) insert(ptr RowPtr, row Row) {
+	l.chunks[ptr.ChkIdx].insert(int(ptr.RowIdx), row)
 }
 
 // ListWalkFunc is used to walk the list.

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -136,7 +136,7 @@ func (s *testChunkSuite) TestListPrePreAlloc4RowAndInsert(c *check.C) {
 	destRowPtr := make([]RowPtr, srcChk.NumRows())
 	for i := 0; i < srcChk.NumRows(); i++ {
 		srcList.AppendRow(srcChk.GetRow(i))
-		destRowPtr[i] = destList.PreAlloc4Row(srcChk.GetRow(i))
+		destRowPtr[i] = destList.preAlloc4Row(srcChk.GetRow(i))
 	}
 
 	c.Assert(srcList.NumChunks(), check.Equals, 4)
@@ -144,7 +144,7 @@ func (s *testChunkSuite) TestListPrePreAlloc4RowAndInsert(c *check.C) {
 
 	iter4Src := NewIterator4List(srcList)
 	for row, i := iter4Src.Begin(), 0; row != iter4Src.End(); row, i = iter4Src.Next(), i+1 {
-		destList.Insert(destRowPtr[i], row)
+		destList.insert(destRowPtr[i], row)
 	}
 
 	iter4Dest := NewIterator4List(destList)
@@ -197,7 +197,7 @@ func BenchmarkPreAllocList(b *testing.B) {
 		list.Reset()
 		// 32768 indicates the number of int64 rows to fill 256KB L2 cache.
 		for j := 0; j < 32768; j++ {
-			list.PreAlloc4Row(row)
+			list.preAlloc4Row(row)
 		}
 	}
 }
@@ -214,7 +214,7 @@ func BenchmarkPreAllocChunk(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		finalChk.Reset()
 		for j := 0; j < 32768; j++ {
-			finalChk.PreAlloc(row)
+			finalChk.preAlloc(row)
 		}
 	}
 }

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -14,7 +14,6 @@
 package chunk
 
 import (
-	"time"
 	"unsafe"
 
 	"github.com/pingcap/parser/mysql"
@@ -46,55 +45,43 @@ func (r Row) Len() int {
 
 // GetInt64 returns the int64 value with the colIdx.
 func (r Row) GetInt64(colIdx int) int64 {
-	col := r.c.columns[colIdx]
-	return *(*int64)(unsafe.Pointer(&col.data[r.idx*8]))
+	return r.c.columns[colIdx].GetInt64(r.idx)
 }
 
 // GetUint64 returns the uint64 value with the colIdx.
 func (r Row) GetUint64(colIdx int) uint64 {
-	col := r.c.columns[colIdx]
-	return *(*uint64)(unsafe.Pointer(&col.data[r.idx*8]))
+	return r.c.columns[colIdx].GetUint64(r.idx)
 }
 
 // GetFloat32 returns the float32 value with the colIdx.
 func (r Row) GetFloat32(colIdx int) float32 {
-	col := r.c.columns[colIdx]
-	return *(*float32)(unsafe.Pointer(&col.data[r.idx*4]))
+	return r.c.columns[colIdx].GetFloat32(r.idx)
 }
 
 // GetFloat64 returns the float64 value with the colIdx.
 func (r Row) GetFloat64(colIdx int) float64 {
-	col := r.c.columns[colIdx]
-	return *(*float64)(unsafe.Pointer(&col.data[r.idx*8]))
+	return r.c.columns[colIdx].GetFloat64(r.idx)
 }
 
 // GetString returns the string value with the colIdx.
 func (r Row) GetString(colIdx int) string {
-	col := r.c.columns[colIdx]
-	start, end := col.offsets[r.idx], col.offsets[r.idx+1]
-	str := string(hack.String(col.data[start:end]))
-	return str
+	return r.c.columns[colIdx].GetString(r.idx)
 }
 
 // GetBytes returns the bytes value with the colIdx.
 func (r Row) GetBytes(colIdx int) []byte {
-	col := r.c.columns[colIdx]
-	start, end := col.offsets[r.idx], col.offsets[r.idx+1]
-	return col.data[start:end]
+	return r.c.columns[colIdx].GetBytes(r.idx)
 }
 
 // GetTime returns the Time value with the colIdx.
 // TODO: use Time structure directly.
 func (r Row) GetTime(colIdx int) types.Time {
-	col := r.c.columns[colIdx]
-	return readTime(col.data[r.idx*16:])
+	return r.c.columns[colIdx].GetTime(r.idx)
 }
 
 // GetDuration returns the Duration value with the colIdx.
 func (r Row) GetDuration(colIdx int, fillFsp int) types.Duration {
-	col := r.c.columns[colIdx]
-	dur := *(*int64)(unsafe.Pointer(&col.data[r.idx*8]))
-	return types.Duration{Duration: time.Duration(dur), Fsp: fillFsp}
+	return r.c.columns[colIdx].GetDuration(r.idx, fillFsp)
 }
 
 func (r Row) getNameValue(colIdx int) (string, uint64) {
@@ -110,27 +97,23 @@ func (r Row) getNameValue(colIdx int) (string, uint64) {
 
 // GetEnum returns the Enum value with the colIdx.
 func (r Row) GetEnum(colIdx int) types.Enum {
-	name, val := r.getNameValue(colIdx)
-	return types.Enum{Name: name, Value: val}
+	return r.c.columns[colIdx].GetEnum(r.idx)
 }
 
 // GetSet returns the Set value with the colIdx.
 func (r Row) GetSet(colIdx int) types.Set {
-	name, val := r.getNameValue(colIdx)
-	return types.Set{Name: name, Value: val}
+	return r.c.columns[colIdx].GetSet(r.idx)
 }
 
 // GetMyDecimal returns the MyDecimal value with the colIdx.
 func (r Row) GetMyDecimal(colIdx int) *types.MyDecimal {
-	col := r.c.columns[colIdx]
-	return (*types.MyDecimal)(unsafe.Pointer(&col.data[r.idx*types.MyDecimalStructSize]))
+	v := r.c.columns[colIdx].GetDecimal(r.idx)
+	return &v
 }
 
 // GetJSON returns the JSON value with the colIdx.
 func (r Row) GetJSON(colIdx int) json.BinaryJSON {
-	col := r.c.columns[colIdx]
-	start, end := col.offsets[r.idx], col.offsets[r.idx+1]
-	return json.BinaryJSON{TypeCode: col.data[start], Value: col.data[start+1 : end]}
+	return r.c.columns[colIdx].GetJSON(r.idx)
 }
 
 // GetDatumRow converts chunk.Row to types.DatumRow.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduce `Sel` to indicate which rows are selected.
`Sel` can accelerate iteration on `Chunk` and reduce the size of materialized data when evaluating expressions.

### What is changed and how it works?
1. Add a new field `sel` to `Chunk;
2. Refactor some methods of `Row` and `Chunk`;
3. Add some unit tests to ensure that it's safe to iterate on a `Chunk` with `Sel`;

Most of these changes are unit tests and new methods;

Some existed functions are not easy to be compatible with `Sel`, so I use `assertNilSel` to ensure that there is no `Sel` when they are called.

I will make all functions be compatible with `Sel` when refactoring executors in the next few PRs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
