### PR TITLE
tikv: forbid to try to get a connection forever

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -408,14 +408,25 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 
 func (a *batchConn) getClientAndSend(entries []*batchCommandsEntry, requests []*tikvpb.BatchCommandsRequest_Request, requestIDs []uint64) {
 	// Choose a connection by round-robbin.
-	var cli *batchCommandsClient
-	for {
+	var cli *batchCommandsClient = nil
+	var target string = ""
+	for i := 0; i < len(a.batchCommandsClients); i++ {
 		a.index = (a.index + 1) % uint32(len(a.batchCommandsClients))
-		cli = a.batchCommandsClients[a.index]
+		target = a.batchCommandsClients[a.index].target
 		// The lock protects the batchCommandsClient from been closed while it's inuse.
-		if cli.tryLockForSend() {
+		if a.batchCommandsClients[a.index].tryLockForSend() {
+			cli = a.batchCommandsClients[a.index]
 			break
 		}
+	}
+	if cli == nil {
+		logutil.BgLogger().Warn("no available connections", zap.String("target", target))
+		for _, entry := range entries {
+			// Please ensure the error is handled in region cache correctly.
+			entry.err = errors.New("no available connections")
+			close(entry.res)
+		}
+		return
 	}
 	defer cli.unlockForSend()
 

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -15,6 +15,7 @@ package tikv
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -23,8 +24,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
-
-	"fmt"
 )
 
 func TestT(t *testing.T) {

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+
+	"fmt"
 )
 
 func TestT(t *testing.T) {
@@ -97,4 +100,25 @@ func (s *testClientSuite) TestCancelTimeoutRetErr(c *C) {
 
 	_, err = sendBatchRequest(context.Background(), "", a, req, 0)
 	c.Assert(errors.Cause(err), Equals, context.DeadlineExceeded)
+}
+
+func (s *testClientSuite) TestSendWhenReconnect(c *C) {
+	server, port := startMockTikvService()
+	c.Assert(port > 0, IsTrue)
+
+	rpcClient := newRPCClient(config.Security{})
+	addr := fmt.Sprintf("%s:%d", "127.0.0.1", port)
+	conn, err := rpcClient.getConnArray(addr)
+	c.Assert(err, IsNil)
+
+	// Suppose all connections are re-establishing.
+	for _, client := range conn.batchConn.batchCommandsClients {
+		client.lockForRecreate()
+	}
+
+	req := tikvrpc.NewRequest(tikvrpc.CmdEmpty, &tikvpb.BatchCommandsEmptyRequest{})
+	_, err = rpcClient.SendRequest(context.Background(), addr, req, 100*time.Second)
+	c.Assert(err.Error() == "no available connections", IsTrue)
+	conn.Close()
+	server.Stop()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`SendRequest` could be block forever if all connectons are broken.

### What is changed and how it works?

Forbid to try to get a connection forever so that `SendRequest` can return immediately and try an another target peer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - unit tests

Related changes

 - Need to cherry-pick to the release branch