### PR TITLE
executor, expression: fix current_timestamp/now not consistent in one stmt like MySQL (#11342)

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2337,3 +2337,15 @@ func (s *testSuite) TestBatchDML(c *C) {
 	tk.MustExec("commit")
 	tk.MustQuery("select * from t order by i").Check(testkit.Rows("1 d", "2 e", "3 e"))
 }
+
+func (s *testSuite) TestSetWithCurrentTimestampAndNow(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists tbl;`)
+	tk.MustExec(`create table t1(c1 timestamp default current_timestamp, c2 int, c3 timestamp default current_timestamp);`)
+	//c1 insert using now() function result, c3 using default value calculation, should be same
+	tk.MustExec(`insert into t1 set c1 = current_timestamp, c2 = sleep(2);`)
+	tk.MustQuery("select c1 = c3 from t1").Check(testkit.Rows("1"))
+	tk.MustExec(`insert into t1 set c1 = current_timestamp, c2 = sleep(1);`)
+	tk.MustQuery("select c1 = c3 from t1").Check(testkit.Rows("1", "1"))
+}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2028,7 +2028,11 @@ func (b *builtinCurrentDateSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_curdate
 func (b *builtinCurrentDateSig) evalTime(row chunk.Row) (d types.Time, isNull bool, err error) {
 	tz := b.ctx.GetSessionVars().Location()
-	year, month, day := time.Now().In(tz).Date()
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Time{}, true, err
+	}
+	year, month, day := nowTs.In(tz).Date()
 	result := types.Time{
 		Time: types.FromDate(year, int(month), day, 0, 0, 0, 0),
 		Type: mysql.TypeDate,
@@ -2083,7 +2087,11 @@ func (b *builtinCurrentTime0ArgSig) Clone() builtinFunc {
 
 func (b *builtinCurrentTime0ArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	tz := b.ctx.GetSessionVars().Location()
-	dur := time.Now().In(tz).Format(types.TimeFormat)
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Duration{}, true, err
+	}
+	dur := nowTs.In(tz).Format(types.TimeFormat)
 	res, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, dur, types.MinFsp)
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
@@ -2107,7 +2115,11 @@ func (b *builtinCurrentTime1ArgSig) evalDuration(row chunk.Row) (types.Duration,
 		return types.Duration{}, true, errors.Trace(err)
 	}
 	tz := b.ctx.GetSessionVars().Location()
-	dur := time.Now().In(tz).Format(types.TimeFSPFormat)
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Duration{}, true, err
+	}
+	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
 	res, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, dur, int(fsp))
 	if err != nil {
 		return types.Duration{}, true, errors.Trace(err)
@@ -2245,7 +2257,11 @@ func (b *builtinUTCDateSig) Clone() builtinFunc {
 // evalTime evals UTC_DATE, UTC_DATE().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-date
 func (b *builtinUTCDateSig) evalTime(row chunk.Row) (types.Time, bool, error) {
-	year, month, day := time.Now().UTC().Date()
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Time{}, true, err
+	}
+	year, month, day := nowTs.UTC().Date()
 	result := types.Time{
 		Time: types.FromGoTime(time.Date(year, month, day, 0, 0, 0, 0, time.UTC)),
 		Type: mysql.TypeDate,
@@ -2302,7 +2318,7 @@ func (c *utcTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []E
 }
 
 func evalUTCTimestampWithFsp(ctx sessionctx.Context, fsp int) (types.Time, bool, error) {
-	nowTs, err := getSystemTimestamp(ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
 		return types.Time{}, true, err
 	}
@@ -2389,9 +2405,9 @@ func (c *nowFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 }
 
 func evalNowWithFsp(ctx sessionctx.Context, fsp int) (types.Time, bool, error) {
-	sysTs, err := getSystemTimestamp(ctx)
+	nowTs, err := getStmtTimestamp(ctx)
 	if err != nil {
-		return types.Time{}, true, errors.Trace(err)
+		return types.Time{}, true, err
 	}
 
 	// In MySQL's implementation, now() will truncate the result instead of rounding it.
@@ -2402,7 +2418,7 @@ func evalNowWithFsp(ctx sessionctx.Context, fsp int) (types.Time, bool, error) {
 	//	+----------------------------+-------------------------+---------------------+
 	//	| 2019-03-25 15:57:56.612966 | 2019-03-25 15:57:56.612 | 2019-03-25 15:57:56 |
 	//	+----------------------------+-------------------------+---------------------+
-	result, err := convertTimeToMysqlTime(sysTs, fsp, types.ModeTruncate)
+	result, err := convertTimeToMysqlTime(nowTs, fsp, types.ModeTruncate)
 	if err != nil {
 		return types.Time{}, true, errors.Trace(err)
 	}
@@ -4023,7 +4039,11 @@ func (b *builtinUnixTimestampCurrentSig) Clone() builtinFunc {
 // evalInt evals a UNIX_TIMESTAMP().
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_unix-timestamp
 func (b *builtinUnixTimestampCurrentSig) evalInt(row chunk.Row) (int64, bool, error) {
-	dec, err := goTimeToMysqlUnixTimestamp(time.Now(), 1)
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return 0, true, err
+	}
+	dec, err := goTimeToMysqlUnixTimestamp(nowTs, 1)
 	if err != nil {
 		return 0, true, errors.Trace(err)
 	}
@@ -6022,7 +6042,11 @@ func (b *builtinUTCTimeWithoutArgSig) Clone() builtinFunc {
 // evalDuration evals a builtinUTCTimeWithoutArgSig.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_utc-time
 func (b *builtinUTCTimeWithoutArgSig) evalDuration(row chunk.Row) (types.Duration, bool, error) {
-	v, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, time.Now().UTC().Format(types.TimeFormat), 0)
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Duration{}, true, err
+	}
+	v, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, nowTs.UTC().Format(types.TimeFormat), 0)
 	return v, false, err
 }
 
@@ -6049,7 +6073,11 @@ func (b *builtinUTCTimeWithArgSig) evalDuration(row chunk.Row) (types.Duration, 
 	if fsp < int64(types.MinFsp) {
 		return types.Duration{}, true, errors.Errorf("Invalid negative %d specified, must in [0, 6].", fsp)
 	}
-	v, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, time.Now().UTC().Format(types.TimeFSPFormat), int(fsp))
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return types.Duration{}, true, err
+	}
+	v, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, nowTs.UTC().Format(types.TimeFSPFormat), int(fsp))
 	return v, false, err
 }
 

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -762,6 +762,10 @@ func (s *testEvaluatorSuite) TestTime(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func resetStmtContext(ctx sessionctx.Context) {
+	ctx.GetSessionVars().StmtCtx.ResetNowTs()
+}
+
 func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 	defer testleak.AfterTest(c)()
 

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -800,7 +800,7 @@ func (s *testEvaluatorSuite) TestNowAndUTCTimestamp(c *C) {
 		c.Assert(err, IsNil)
 		t = v.GetMysqlTime()
 		c.Assert(strings.Contains(t.String(), "."), IsTrue)
-		c.Assert(ts.Sub(gotime(t, ts.Location())), LessEqual, time.Millisecond)
+		c.Assert(ts.Sub(gotime(t, ts.Location())), LessEqual, time.Second)
 
 		f, err = x.fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(8)))
 		c.Assert(err, IsNil)

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -94,6 +94,8 @@ type StatementContext struct {
 	RuntimeStatsColl *execdetails.RuntimeStatsColl
 	TableIDs         []int64
 	IndexIDs         []int64
+	nowTs            time.Time // use this variable for now/current_timestamp calculation/cache for one stmt
+	stmtTimeCached   bool
 	StmtType         string
 	Tables           []TableEntry
 	OriginalSQL      string
@@ -102,6 +104,21 @@ type StatementContext struct {
 		normalized string
 		digest     string
 	}
+}
+
+// GetNowTsCached getter for nowTs, if not set get now time and cache it
+func (sc *StatementContext) GetNowTsCached() time.Time {
+	if !sc.stmtTimeCached {
+		now := time.Now()
+		sc.nowTs = now
+		sc.stmtTimeCached = true
+	}
+	return sc.nowTs
+}
+
+// ResetNowTs resetter for nowTs, clear cached time flag
+func (sc *StatementContext) ResetNowTs() {
+	sc.stmtTimeCached = false
 }
 
 // SQLDigest gets normalized and digest for provided sql.


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick for #11342.

MySQL will set time to “”time_cache“ structure before doing one command(COM_XXX)
later expresission calculation will use this timestamp as time value

TiDB logic different and default column calculation and now expr calculation will try to get timestamp twice.

more details see jira issue#4391
eg:
TiDB

CREATE TABLE `tt4` (
  `c1` timestamp DEFAULT CURRENT_TIMESTAMP,
  `c2` int(11) DEFAULT NULL,
  `c3` timestamp DEFAULT CURRENT_TIMESTAMP
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin

insert into tt4 set c1 = current_timestamp, c2 = sleep(2);
mysql> select c1 = c3 from tt4;
+---------+
| c1 = c3 |
+---------+
|       0 |
+---------+
1 row in set (0.00 sec)

MySQL

insert into tt4 set c1 = current_timestamp, c2 = sleep(2);
select c1 = c3 from tt4;
+---------+
| c1 = c3 |
+---------+
|       1 |
+---------+
1 row in set (0.00 sec)

remove stmtCtx.sysTs unused variable
cache time value once in stmtCtx.nowTs
refactor nowTs usage, offer Unified function interface for get and reset nowTS. Generally, accessing variable directly is not a good way for further maintenance, refactor these usage code

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change


Side effects


