### PR TITLE
planner/core: give the full schema information when group by fields not exists

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1769,7 +1769,7 @@ func (b *PlanBuilder) checkOnlyFullGroupByWithGroupClause(p LogicalPlan, sel *as
 		}
 		switch errExprLoc.Loc {
 		case ErrExprInSelect:
-			return ErrFieldNotInGroupBy.GenWithStackByArgs(errExprLoc.Offset+1, errExprLoc.Loc, sel.Fields.Fields[errExprLoc.Offset].Text())
+			return ErrFieldNotInGroupBy.GenWithStackByArgs(errExprLoc.Offset+1, errExprLoc.Loc, col.DBName.O+"."+col.TblName.O+"."+col.OrigColName.O)
 		case ErrExprInOrderBy:
 			return ErrFieldNotInGroupBy.GenWithStackByArgs(errExprLoc.Offset+1, errExprLoc.Loc, sel.OrderBy.Items[errExprLoc.Offset].Expr.Text())
 		}

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
@@ -571,6 +572,71 @@ func (s *testPlanSuite) TestDeriveNotNullConds(c *C) {
 		rightConds := fmt.Sprintf("%s", right.pushedDownConds)
 		c.Assert(leftConds, Equals, ca.left, comment)
 		c.Assert(rightConds, Equals, ca.right, comment)
+	}
+}
+
+func buildLogicPlan4GroupBy(s *testPlanSuite, c *C, sql string) (Plan, error) {
+	sqlMode := s.ctx.GetSessionVars().SQLMode
+	mockedTableInfo := MockSignedTable()
+	// mock the table info here for later use
+	// enable only full group by
+	s.ctx.GetSessionVars().SQLMode = sqlMode | mysql.ModeOnlyFullGroupBy
+	defer func() { s.ctx.GetSessionVars().SQLMode = sqlMode }() // restore it
+	comment := Commentf("for %s", sql)
+	stmt, err := s.ParseOneStmt(sql, "", "")
+	c.Assert(err, IsNil, comment)
+
+	stmt.(*ast.SelectStmt).From.TableRefs.Left.(*ast.TableSource).Source.(*ast.TableName).TableInfo = mockedTableInfo
+
+	return BuildLogicalPlan(context.Background(), s.ctx, stmt, s.is)
+}
+
+func (s *testPlanSuite) TestGroupByWhenNotExistCols(c *C) {
+	sqlTests := []struct {
+		sql              string
+		expectedErrMatch string
+	}{
+		{
+			sql:              "select a from t group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+		{
+			// has an as column alias
+			sql:              "select a as tempField from t group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+		{
+			// has as table alias
+			sql:              "select tempTable.a from t as tempTable group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.tempTable\\.a'.*",
+		},
+		{
+			// has a func call
+			sql:              "select length(a) from t  group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+		{
+			// has a func call with two cols
+			sql:              "select length(b + a) from t  group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+		{
+			// has a func call with two cols
+			sql:              "select length(a + b) from t  group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+		{
+			// has a func call with two cols
+			sql:              "select length(a + b) as tempField from t  group by b",
+			expectedErrMatch: ".*contains nonaggregated column 'test\\.t\\.a'.*",
+		},
+	}
+	for _, test := range sqlTests {
+		sql := test.sql
+		p, err := buildLogicPlan4GroupBy(s, c, sql)
+		c.Assert(err, NotNil)
+		c.Assert(p, IsNil)
+		c.Assert(err, ErrorMatches, test.expectedErrMatch)
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Closes https://github.com/pingcap/tidb/issues/11145
the error message didn't contains a valid column name when group by failed.

### What is changed and how it works?
when generating the error message compose it to dbName.tableName.colName format

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test   - Passed and Added 2 new test cases

