### PR TITLE
executor: show `CARTESIAN Join` explicitly in the results of `Explain` (#11415)

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -90,7 +90,7 @@ explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:sum(col_0)
 └─Projection_19	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_18	10000.00	root	left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
+  └─HashLeftJoin_18	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
     ├─TableReader_15	10000.00	root	data:TableScan_14
     │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
     └─TableReader_17	10000.00	root	data:TableScan_16
@@ -122,7 +122,7 @@ MemTableScan_4	10000.00	root
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	count	task	operator info
 Projection_12	10000.00	root	eq(test.t1.c2, test.t2.c2)
-└─Apply_14	10000.00	root	left outer join, inner:Limit_21
+└─Apply_14	10000.00	root	CARTESIAN left outer join, inner:Limit_21
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
   └─Limit_21	1.00	root	offset:0, count:1
@@ -226,7 +226,7 @@ explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:sum(col_0)
 └─Projection_19	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_18	10000.00	root	left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
+  └─HashLeftJoin_18	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
     ├─TableReader_15	10000.00	root	data:TableScan_14
     │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
     └─TableReader_17	10000.00	root	data:TableScan_16
@@ -234,7 +234,7 @@ StreamAgg_12	1.00	root	funcs:sum(col_0)
 explain select 1 in (select c2 from t2) from t1;
 id	count	task	operator info
 Projection_6	10000.00	root	5_aux_0
-└─HashLeftJoin_7	10000.00	root	left outer semi join, inner:TableReader_12
+└─HashLeftJoin_7	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_12
   ├─TableReader_9	10000.00	root	data:TableScan_8
   │ └─TableScan_8	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
   └─TableReader_12	10.00	root	data:Selection_11
@@ -244,7 +244,7 @@ explain select sum(6 in (select c2 from t2)) from t1;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:sum(col_0)
 └─Projection_20	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_19	10000.00	root	left outer semi join, inner:TableReader_18
+  └─HashLeftJoin_19	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_18
     ├─TableReader_15	10000.00	root	data:TableScan_14
     │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
     └─TableReader_18	10.00	root	data:Selection_17
@@ -313,7 +313,7 @@ create table t(a int primary key, b int, c int, index idx(b));
 explain select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -326,7 +326,7 @@ Projection_11	10000.00	root	9_aux_0
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -338,7 +338,7 @@ Projection_11	10000.00	root	9_aux_0
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -354,7 +354,7 @@ analyze table t;
 explain select t.c in (select count(*) from t s, t t1 where s.b = t.a and s.b = 3 and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	5.00	root	9_aux_0
-└─Apply_13	5.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	5.00	root	data:TableScan_14
   │ └─TableScan_14	5.00	cop	table:t, range:[-inf,+inf], keep order:false
   └─StreamAgg_20	1.00	root	funcs:count(1)
@@ -368,7 +368,7 @@ Projection_11	5.00	root	9_aux_0
 explain select t.c in (select count(*) from t s left join t t1 on s.a = t1.a where 3 = t.a and s.b = 3) from t;
 id	count	task	operator info
 Projection_10	5.00	root	9_aux_0
-└─Apply_12	5.00	root	left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
+└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_14	5.00	root	data:TableScan_13
   │ └─TableScan_13	5.00	cop	table:t, range:[-inf,+inf], keep order:false
   └─StreamAgg_19	1.00	root	funcs:count(1)
@@ -382,7 +382,7 @@ Projection_10	5.00	root	9_aux_0
 explain select t.c in (select count(*) from t s right join t t1 on s.a = t1.a where 3 = t.a and t1.b = 3) from t;
 id	count	task	operator info
 Projection_10	5.00	root	9_aux_0
-└─Apply_12	5.00	root	left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
+└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_14	5.00	root	data:TableScan_13
   │ └─TableScan_13	5.00	cop	table:t, range:[-inf,+inf], keep order:false
   └─StreamAgg_19	1.00	root	funcs:count(1)
@@ -560,7 +560,7 @@ HashRightJoin_9	4166.67	root	inner join, inner:TableReader_12, equal:[eq(test.ta
 explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_12	10000.00	root	9_aux_0
-└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, other cond:eq(test.t.nc, 7_col_0)
+└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_19, other cond:eq(test.t.nc, 7_col_0)
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
@@ -593,7 +593,7 @@ HashRightJoin_7	8000.00	root	right outer join, inner:TableReader_10, equal:[eq(t
 explain select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_12	10000.00	root	9_aux_0
-└─Apply_14	10000.00	root	left outer semi join, inner:HashAgg_19, other cond:eq(ifnull(test.t.a, 1), 7_col_0)
+└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_19, other cond:eq(ifnull(test.t.a, 1), 7_col_0)
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
   └─HashAgg_19	1.00	root	funcs:count(join_agg_0)

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -108,7 +108,7 @@ MemTableScan_4	10000.00	root
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	count	task	operator info
 Projection_12	1999.00	root	eq(test.t1.c2, test.t2.c2)
-└─Apply_14	1999.00	root	left outer join, inner:Limit_21
+└─Apply_14	1999.00	root	CARTESIAN left outer join, inner:Limit_21
   ├─TableReader_16	1999.00	root	data:TableScan_15
   │ └─TableScan_15	1999.00	cop	table:t1, range:[-inf,+inf], keep order:false
   └─Limit_21	1.00	root	offset:0, count:1
@@ -127,7 +127,7 @@ set @@session.tidb_opt_insubq_to_join_and_agg=0;
 explain select 1 in (select c2 from t2) from t1;
 id	count	task	operator info
 Projection_6	1999.00	root	5_aux_0
-└─HashLeftJoin_7	1999.00	root	left outer semi join, inner:TableReader_12
+└─HashLeftJoin_7	1999.00	root	CARTESIAN left outer semi join, inner:TableReader_12
   ├─TableReader_9	1999.00	root	data:TableScan_8
   │ └─TableScan_8	1999.00	cop	table:t1, range:[-inf,+inf], keep order:false
   └─TableReader_12	0.00	root	data:Selection_11

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -325,7 +325,7 @@ drop table if exists t;
 create table t (id int primary key, a int, b int);
 explain select * from (t t1 left join t t2 on t1.a = t2.a) left join (t t3 left join t t4 on t3.a = t4.a) on t2.b = 1;
 id	count	task	operator info
-HashLeftJoin_10	155937656.25	root	left outer join, inner:HashLeftJoin_17, left cond:[eq(test.t2.b, 1)]
+HashLeftJoin_10	155937656.25	root	CARTESIAN left outer join, inner:HashLeftJoin_17, left cond:[eq(test.t2.b, 1)]
 ├─HashLeftJoin_11	12487.50	root	left outer join, inner:TableReader_16, equal:[eq(test.t1.a, test.t2.a)]
 │ ├─TableReader_13	10000.00	root	data:TableScan_12
 │ │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
@@ -381,7 +381,7 @@ create table t(a int, b int);
 explain select a != any (select a from t t2) from t t1;
 id	count	task	operator info
 Projection_9	10000.00	root	and(or(or(gt(col_count, 1), ne(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 0)), and(ne(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 1)))
-└─HashLeftJoin_10	10000.00	root	inner join, inner:StreamAgg_17
+└─HashLeftJoin_10	10000.00	root	CARTESIAN inner join, inner:StreamAgg_17
   ├─TableReader_13	10000.00	root	data:TableScan_12
   │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_17	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)
@@ -391,7 +391,7 @@ Projection_9	10000.00	root	and(or(or(gt(col_count, 1), ne(test.t1.a, col_firstro
 explain select a = all (select a from t t2) from t t1;
 id	count	task	operator info
 Projection_9	10000.00	root	or(and(and(le(col_count, 1), eq(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 1)), or(eq(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 0)))
-└─HashLeftJoin_10	10000.00	root	inner join, inner:StreamAgg_17
+└─HashLeftJoin_10	10000.00	root	CARTESIAN inner join, inner:StreamAgg_17
   ├─TableReader_13	10000.00	root	data:TableScan_12
   │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
   └─StreamAgg_17	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)

--- a/cmd/explaintest/r/subquery.result
+++ b/cmd/explaintest/r/subquery.result
@@ -4,7 +4,7 @@ create table t1(a bigint, b bigint);
 create table t2(a bigint, b bigint);
 explain select * from t1 where t1.a in (select t1.b + t2.b from t2);
 id	count	task	operator info
-HashLeftJoin_8	8000.00	root	semi join, inner:TableReader_12, other cond:eq(test.t1.a, plus(test.t1.b, test.t2.b))
+HashLeftJoin_8	8000.00	root	CARTESIAN semi join, inner:TableReader_12, other cond:eq(test.t1.a, plus(test.t1.b, test.t2.b))
 ├─TableReader_10	10000.00	root	data:TableScan_9
 │ └─TableScan_9	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 └─TableReader_12	10000.00	root	data:TableScan_11
@@ -16,7 +16,7 @@ analyze table t;
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c = 1 and s.d = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	5.00	root	9_aux_0
-└─Apply_13	5.00	root	left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	5.00	root	data:TableScan_14
   │ └─TableScan_14	5.00	cop	table:t, range:[-inf,+inf], keep order:false
   └─StreamAgg_20	1.00	root	funcs:count(1)

--- a/expression/constant_propagation_test.go
+++ b/expression/constant_propagation_test.go
@@ -66,7 +66,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 
 	// Positive tests.
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a > t2.a and t1.a = 1;").Check(testkit.Rows(
-		"HashLeftJoin_6 33233333.33 root left outer join, inner:TableReader_11, left cond:[eq(test.t1.a, 1)]",
+		"HashLeftJoin_6 33233333.33 root CARTESIAN left outer join, inner:TableReader_11, left cond:[eq(test.t1.a, 1)]",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_11 3323.33 root data:Selection_10",
@@ -74,7 +74,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"    └─TableScan_9 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a > t2.a where t1.a = 1;").Check(testkit.Rows(
-		"HashLeftJoin_7 33233.33 root left outer join, inner:TableReader_13",
+		"HashLeftJoin_7 33233.33 root CARTESIAN left outer join, inner:TableReader_13",
 		"├─TableReader_10 10.00 root data:Selection_9",
 		"│ └─Selection_9 10.00 cop eq(test.t1.a, 1)",
 		"│   └─TableScan_8 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -100,7 +100,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"    └─TableScan_11 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 right join t2 on t1.a > t2.a where t2.a = 1;").Check(testkit.Rows(
-		"HashRightJoin_7 33333.33 root right outer join, inner:TableReader_10",
+		"HashRightJoin_7 33333.33 root CARTESIAN right outer join, inner:TableReader_10",
 		"├─TableReader_10 3333.33 root data:Selection_9",
 		"│ └─Selection_9 3333.33 cop gt(test.t1.a, 1)",
 		"│   └─TableScan_8 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -126,7 +126,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"  └─TableScan_10 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 right join t2 on t1.a > t2.a and t2.a = 1;").Check(testkit.Rows(
-		"HashRightJoin_6 33333333.33 root right outer join, inner:TableReader_9, right cond:eq(test.t2.a, 1)",
+		"HashRightJoin_6 33333333.33 root CARTESIAN right outer join, inner:TableReader_9, right cond:eq(test.t2.a, 1)",
 		"├─TableReader_9 3333.33 root data:Selection_8",
 		"│ └─Selection_8 3333.33 cop gt(test.t1.a, 1)",
 		"│   └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -143,7 +143,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"    └─TableScan_9 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a > t2.a and t2.a = 1;").Check(testkit.Rows(
-		"HashLeftJoin_6 100000.00 root left outer join, inner:TableReader_11, other cond:gt(test.t1.a, test.t2.a)",
+		"HashLeftJoin_6 100000.00 root CARTESIAN left outer join, inner:TableReader_11, other cond:gt(test.t1.a, test.t2.a)",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_11 10.00 root data:Selection_10",
@@ -151,7 +151,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"    └─TableScan_9 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 right join t2 on t1.a > t2.a and t1.a = 1;").Check(testkit.Rows(
-		"HashRightJoin_6 100000.00 root right outer join, inner:TableReader_9, other cond:gt(test.t1.a, test.t2.a)",
+		"HashRightJoin_6 100000.00 root CARTESIAN right outer join, inner:TableReader_9, other cond:gt(test.t1.a, test.t2.a)",
 		"├─TableReader_9 10.00 root data:Selection_8",
 		"│ └─Selection_8 10.00 cop eq(test.t1.a, 1), not(isnull(test.t1.a))",
 		"│   └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -167,14 +167,14 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"  └─TableScan_10 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a = t1.b and t1.a > 1;").Check(testkit.Rows(
-		"HashLeftJoin_6 100000000.00 root left outer join, inner:TableReader_10, left cond:[eq(test.t1.a, test.t1.b) gt(test.t1.a, 1)]",
+		"HashLeftJoin_6 100000000.00 root CARTESIAN left outer join, inner:TableReader_10, left cond:[eq(test.t1.a, test.t1.b) gt(test.t1.a, 1)]",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_10 10000.00 root data:TableScan_9",
 		"  └─TableScan_9 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t2.a = t2.b and t2.a > 1;").Check(testkit.Rows(
-		"HashLeftJoin_6 26666666.67 root left outer join, inner:TableReader_11",
+		"HashLeftJoin_6 26666666.67 root CARTESIAN left outer join, inner:TableReader_11",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_11 2666.67 root data:Selection_10",
@@ -195,7 +195,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"TableDual_8 0.00 root rows:0",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on true where t1.a = 1 and t1.a = 1;").Check(testkit.Rows(
-		"HashLeftJoin_7 80000.00 root left outer join, inner:TableReader_12",
+		"HashLeftJoin_7 80000.00 root CARTESIAN left outer join, inner:TableReader_12",
 		"├─TableReader_10 10.00 root data:Selection_9",
 		"│ └─Selection_9 10.00 cop eq(test.t1.a, 1)",
 		"│   └─TableScan_8 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -203,32 +203,32 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 		"  └─TableScan_11 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on false;").Check(testkit.Rows(
-		"HashLeftJoin_6 80000000.00 root left outer join, inner:TableDual_9",
+		"HashLeftJoin_6 80000000.00 root CARTESIAN left outer join, inner:TableDual_9",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableDual_9 8000.00 root rows:0",
 	))
 	tk.MustQuery("explain select * from t1 right join t2 on false;").Check(testkit.Rows(
-		"HashRightJoin_6 80000000.00 root right outer join, inner:TableDual_7",
+		"HashRightJoin_6 80000000.00 root CARTESIAN right outer join, inner:TableDual_7",
 		"├─TableDual_7 8000.00 root rows:0",
 		"└─TableReader_9 10000.00 root data:TableScan_8",
 		"  └─TableScan_8 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a = 1 and t1.a = 2;").Check(testkit.Rows(
-		"HashLeftJoin_6 80000000.00 root left outer join, inner:TableDual_9",
+		"HashLeftJoin_6 80000000.00 root CARTESIAN left outer join, inner:TableDual_9",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableDual_9 8000.00 root rows:0",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a =1 where t1.a = 2;").Check(testkit.Rows(
-		"HashLeftJoin_7 80000.00 root left outer join, inner:TableDual_11",
+		"HashLeftJoin_7 80000.00 root CARTESIAN left outer join, inner:TableDual_11",
 		"├─TableReader_10 10.00 root data:Selection_9",
 		"│ └─Selection_9 10.00 cop eq(test.t1.a, 2)",
 		"│   └─TableScan_8 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableDual_11 8000.00 root rows:0",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on t2.a = 1 and t2.a = 2;").Check(testkit.Rows(
-		"HashLeftJoin_6 0.00 root left outer join, inner:TableReader_11",
+		"HashLeftJoin_6 0.00 root CARTESIAN left outer join, inner:TableReader_11",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_11 0.00 root data:Selection_10",
@@ -237,14 +237,14 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 	))
 	// Constant propagation for DNF in outer join.
 	tk.MustQuery("explain select * from t1 left join t2 on t1.a = 1 or (t1.a = 2 and t1.a = 3);").Check(testkit.Rows(
-		"HashLeftJoin_6 100000000.00 root left outer join, inner:TableReader_10, left cond:[or(eq(test.t1.a, 1), 0)]",
+		"HashLeftJoin_6 100000000.00 root CARTESIAN left outer join, inner:TableReader_10, left cond:[or(eq(test.t1.a, 1), 0)]",
 		"├─TableReader_8 10000.00 root data:TableScan_7",
 		"│ └─TableScan_7 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"└─TableReader_10 10000.00 root data:TableScan_9",
 		"  └─TableScan_9 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo",
 	))
 	tk.MustQuery("explain select * from t1 left join t2 on true where t1.a = 1 or (t1.a = 2 and t1.a = 3);").Check(testkit.Rows(
-		"HashLeftJoin_7 80000.00 root left outer join, inner:TableReader_12",
+		"HashLeftJoin_7 80000.00 root CARTESIAN left outer join, inner:TableReader_12",
 		"├─TableReader_10 10.00 root data:Selection_9",
 		"│ └─Selection_9 10.00 cop or(eq(test.t1.a, 1), 0)",
 		"│   └─TableScan_8 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -255,7 +255,7 @@ func (s *testSuite) TestOuterJoinPropConst(c *C) {
 	tk.MustQuery("explain select * from t1 where t1.b > 1 or t1.b in (select b from t2);").Check(testkit.Rows(
 		"Projection_7 8000.00 root test.t1.id, test.t1.a, test.t1.b",
 		"└─Selection_8 8000.00 root or(gt(test.t1.b, 1), 5_aux_0)",
-		"  └─HashLeftJoin_9 10000.00 root left outer semi join, inner:TableReader_13, other cond:eq(test.t1.b, test.t2.b)",
+		"  └─HashLeftJoin_9 10000.00 root CARTESIAN left outer semi join, inner:TableReader_13, other cond:eq(test.t1.b, test.t2.b)",
 		"    ├─TableReader_11 10000.00 root data:TableScan_10",
 		"    │ └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"    └─TableReader_13 10000.00 root data:TableScan_12",

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -136,9 +136,9 @@ func (s *testAnalyzeSuite) TestStraightJoin(c *C) {
 	}
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4").Check(testkit.Rows(
-		"HashLeftJoin_10 10000000000000000.00 root inner join, inner:TableReader_23",
-		"├─HashLeftJoin_12 1000000000000.00 root inner join, inner:TableReader_21",
-		"│ ├─HashLeftJoin_14 100000000.00 root inner join, inner:TableReader_19",
+		"HashLeftJoin_10 10000000000000000.00 root CARTESIAN inner join, inner:TableReader_23",
+		"├─HashLeftJoin_12 1000000000000.00 root CARTESIAN inner join, inner:TableReader_21",
+		"│ ├─HashLeftJoin_14 100000000.00 root CARTESIAN inner join, inner:TableReader_19",
 		"│ │ ├─TableReader_17 10000.00 root data:TableScan_16",
 		"│ │ │ └─TableScan_16 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"│ │ └─TableReader_19 10000.00 root data:TableScan_18",
@@ -150,9 +150,9 @@ func (s *testAnalyzeSuite) TestStraightJoin(c *C) {
 	))
 
 	testKit.MustQuery("explain select * from t1 straight_join t2 straight_join t3 straight_join t4").Check(testkit.Rows(
-		"HashLeftJoin_10 10000000000000000.00 root inner join, inner:TableReader_23",
-		"├─HashLeftJoin_12 1000000000000.00 root inner join, inner:TableReader_21",
-		"│ ├─HashLeftJoin_14 100000000.00 root inner join, inner:TableReader_19",
+		"HashLeftJoin_10 10000000000000000.00 root CARTESIAN inner join, inner:TableReader_23",
+		"├─HashLeftJoin_12 1000000000000.00 root CARTESIAN inner join, inner:TableReader_21",
+		"│ ├─HashLeftJoin_14 100000000.00 root CARTESIAN inner join, inner:TableReader_19",
 		"│ │ ├─TableReader_17 10000.00 root data:TableScan_16",
 		"│ │ │ └─TableScan_16 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
 		"│ │ └─TableReader_19 10000.00 root data:TableScan_18",
@@ -165,8 +165,8 @@ func (s *testAnalyzeSuite) TestStraightJoin(c *C) {
 
 	testKit.MustQuery("explain select straight_join * from t1, t2, t3, t4 where t1.a=t4.a;").Check(testkit.Rows(
 		"HashLeftJoin_11 1248750000000.00 root inner join, inner:TableReader_26, equal:[eq(test.t1.a, test.t4.a)]",
-		"├─HashLeftJoin_13 999000000000.00 root inner join, inner:TableReader_23",
-		"│ ├─HashRightJoin_16 99900000.00 root inner join, inner:TableReader_19",
+		"├─HashLeftJoin_13 999000000000.00 root CARTESIAN inner join, inner:TableReader_23",
+		"│ ├─HashRightJoin_16 99900000.00 root CARTESIAN inner join, inner:TableReader_19",
 		"│ │ ├─TableReader_19 9990.00 root data:Selection_18",
 		"│ │ │ └─Selection_18 9990.00 cop not(isnull(test.t1.a))",
 		"│ │ │   └─TableScan_17 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
@@ -688,7 +688,7 @@ func (s *testAnalyzeSuite) TestCorrelatedEstimation(c *C) {
 	tk.MustQuery("explain select t.c in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;").
 		Check(testkit.Rows(
 			"Projection_11 10.00 root 9_aux_0",
-			"└─Apply_13 10.00 root left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)",
+			"└─Apply_13 10.00 root CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)",
 			"  ├─TableReader_15 10.00 root data:TableScan_14",
 			"  │ └─TableScan_14 10.00 cop table:t, range:[-inf,+inf], keep order:false",
 			"  └─StreamAgg_20 1.00 root funcs:count(1)",
@@ -703,7 +703,7 @@ func (s *testAnalyzeSuite) TestCorrelatedEstimation(c *C) {
 	tk.MustQuery("explain select (select concat(t1.a, \",\", t1.b) from t t1 where t1.a=t.a and t1.c=t.c) from t").
 		Check(testkit.Rows(
 			"Projection_8 10.00 root concat(t1.a, \",\", t1.b)",
-			"└─Apply_10 10.00 root left outer join, inner:MaxOneRow_13",
+			"└─Apply_10 10.00 root CARTESIAN left outer join, inner:MaxOneRow_13",
 			"  ├─TableReader_12 10.00 root data:TableScan_11",
 			"  │ └─TableScan_11 10.00 cop table:t, range:[-inf,+inf], keep order:false",
 			"  └─MaxOneRow_13 1.00 root ",

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -233,7 +233,13 @@ func (p *PhysicalIndexJoin) ExplainInfo() string {
 
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalHashJoin) ExplainInfo() string {
-	buffer := bytes.NewBufferString(p.JoinType.String())
+	buffer := new(bytes.Buffer)
+
+	if len(p.EqualConditions) == 0 {
+		buffer.WriteString("CARTESIAN ")
+	}
+
+	buffer.WriteString(p.JoinType.String())
 	fmt.Fprintf(buffer, ", inner:%s", p.Children()[p.InnerChildIdx].ExplainID())
 	if len(p.EqualConditions) > 0 {
 		fmt.Fprintf(buffer, ", equal:%v", p.EqualConditions)

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1047,7 +1047,7 @@ func (s *testRangerSuite) TestCompIndexInExprCorrCol(c *C) {
 	testKit.MustExec("analyze table t")
 	testKit.MustQuery("explain select t.e in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c in (1, 2) and s.d = t.a and s.a = t1.a) from t").Check(testkit.Rows(
 		"Projection_11 2.00 root 9_aux_0",
-		"└─Apply_13 2.00 root left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.e, 7_col_0)",
+		"└─Apply_13 2.00 root CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.e, 7_col_0)",
 		"  ├─TableReader_15 2.00 root data:TableScan_14",
 		"  │ └─TableScan_14 2.00 cop table:t, range:[-inf,+inf], keep order:false",
 		"  └─StreamAgg_20 1.00 root funcs:count(1)",


### PR DESCRIPTION
cherry-pick for #11415 .
no conflict.