### PR TITLE
stats: fix panic when dump pseudo columns

### DIFF
--- a/statistics/table.go
+++ b/statistics/table.go
@@ -454,12 +454,15 @@ func PseudoTable(tblInfo *model.TableInfo) *Table {
 				PhysicalID: fakePhysicalID,
 				Info:       col,
 				IsHandle:   tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag),
+				Histogram:  *NewHistogram(col.ID, 0, 0, 0, &col.FieldType, 0, 0),
 			}
 		}
 	}
 	for _, idx := range tblInfo.Indices {
 		if idx.State == model.StatePublic {
-			t.Indices[idx.ID] = &Index{Info: idx}
+			t.Indices[idx.ID] = &Index{
+				Info:      idx,
+				Histogram: *NewHistogram(idx.ID, 0, 0, 0, types.NewFieldType(mysql.TypeBlob), 0, 0)}
 		}
 	}
 	return t


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
runtime error: invalid memory address or nil pointer dereference
goroutine 25913493 [running]:
net/http.(*conn).serve.func1(0xc30491c000)
	/usr/local/go/src/net/http/server.go:1769 +0xc9
panic(0x1a4f380, 0x2c1a650)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
github.com/pingcap/tidb/util/chunk.(*Chunk).NumCols(...)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/util/chunk/chunk.go:272
github.com/pingcap/tidb/util/chunk.(*Chunk).NumRows(...)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/util/chunk/chunk.go:277
github.com/pingcap/tidb/util/chunk.(*Iterator4Chunk).Begin(...)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/util/chunk/iterator.go:115
github.com/pingcap/tidb/statistics.(*Histogram).ConvertTo(0xc0076fbb80, 0xc4279c9200, 0xc04faf9c20, 0xc04fca1f50, 0xc4ace6a0c0, 0x0)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/statistics/histogram.go:160 +0xa9
github.com/pingcap/tidb/statistics.(*Handle).tableStatsToJSON(0xc0022b0630, 0xc316905570, 0x6, 0xc004182480, 0xc2e7, 0x160, 0x3, 0x1e247b8)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/statistics/dump.go:103 +0x27e
github.com/pingcap/tidb/statistics.(*Handle).DumpStatsToJSON(0xc0022b0630, 0xc316905570, 0x6, 0xc004182480, 0xc856fe8088, 0xc316905577, 0xb)
	/home/jenkins/workspace/release_tidb_2.1-ga/go/src/github.com/pingcap/tidb/statistics/dump.go:64 +0x33f
```
### What is changed and how it works?

The histograms of the pseudo table are not initialized properly, the `bounds` of them may be nil, so it will panic when we try to dump the stats.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None
