### PR TITLE
parser: support cast as double

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -458,7 +458,7 @@ func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull b
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	if !mysql.HasUnsignedFlag(b.tp.Flag) {
+	if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = float64(val)
 	} else if b.inUnion && val < 0 {
 		res = 0

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2330,6 +2330,29 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	result = tk.MustQuery("select cast(1 as signed int)")
 	result.Check(testkit.Rows("1"))
 
+	// test cast as double
+	result = tk.MustQuery("select cast(1 as double)")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(1.1 as double)")
+	result.Check(testkit.Rows("1.1"))
+	result = tk.MustQuery("select cast(1.1 as double)")
+	result.Check(testkit.Rows("1.1"))
+	result = tk.MustQuery("select cast('123.321' as double)")
+	result.Check(testkit.Rows("123.321"))
+	result = tk.MustQuery("select cast(-1 as double)")
+	result.Check(testkit.Rows("-1"))
+	result = tk.MustQuery("select cast(null as double)")
+	result.Check(testkit.Rows("<nil>"))
+	/*  There is something wrong in showing float number.
+	The testkit gets the format 'f' (-ddd.dddd, no exponent),
+	but we need the format 'e' (-d.dddde±dd, a decimal exponent).
+
+	result = tk.MustQuery("select cast(12345678901234567890 as double)")
+	result.Check(testkit.Rows("1.2345678901234567e19"))
+	result = tk.MustQuery("select cast(cast(-1 as unsigned) as double)")
+	result.Check(testkit.Rows("1.8446744073709552e19"))
+	*/
+
 	// test cast time as decimal overflow
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(s1 time);")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2333,25 +2333,30 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	// test cast as double
 	result = tk.MustQuery("select cast(1 as double)")
 	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(cast(12345 as unsigned) as double)")
+	result.Check(testkit.Rows("12345"))
 	result = tk.MustQuery("select cast(1.1 as double)")
 	result.Check(testkit.Rows("1.1"))
-	result = tk.MustQuery("select cast(1.1 as double)")
-	result.Check(testkit.Rows("1.1"))
+	result = tk.MustQuery("select cast(-1.1 as double)")
+	result.Check(testkit.Rows("-1.1"))
 	result = tk.MustQuery("select cast('123.321' as double)")
 	result.Check(testkit.Rows("123.321"))
+	result = tk.MustQuery("select cast('12345678901234567890' as double) = 1.2345678901234567e19")
+	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery("select cast(-1 as double)")
 	result.Check(testkit.Rows("-1"))
 	result = tk.MustQuery("select cast(null as double)")
 	result.Check(testkit.Rows("<nil>"))
-	/*  There is something wrong in showing float number.
-	The testkit gets the format 'f' (-ddd.dddd, no exponent),
-	but we need the format 'e' (-d.dddde±dd, a decimal exponent).
-
-	result = tk.MustQuery("select cast(12345678901234567890 as double)")
-	result.Check(testkit.Rows("1.2345678901234567e19"))
-	result = tk.MustQuery("select cast(cast(-1 as unsigned) as double)")
-	result.Check(testkit.Rows("1.8446744073709552e19"))
-	*/
+	result = tk.MustQuery("select cast(12345678901234567890 as double) = 1.2345678901234567e19")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(cast(-1 as unsigned) as double) = 1.8446744073709552e19")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(1e100 as double) = 1e100")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(123456789012345678901234567890 as double) = 1.2345678901234568e29")
+	result.Check(testkit.Rows("1"))
+	result = tk.MustQuery("select cast(0x12345678 as double)")
+	result.Check(testkit.Rows("305419896"))
 
 	// test cast time as decimal overflow
 	tk.MustExec("drop table if exists t1")

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/parser => github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
-	github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd
+	github.com/pingcap/parser v0.0.0-20190726045944-46d1b3d054b2
 	github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b
 	github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible
 	github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330
@@ -75,5 +75,3 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-
-replace github.com/pingcap/parser => github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628

--- a/go.sum
+++ b/go.sum
@@ -166,10 +166,15 @@ github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 <<<<<<< HEAD
+<<<<<<< HEAD
 github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd h1:vFLYlcLyvWrIN+3Y9uPExiisDjeRCPh1Vic0vnkxBMs=
 github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 =======
 >>>>>>> support cast as double
+=======
+github.com/pingcap/parser v0.0.0-20190726045944-46d1b3d054b2 h1:uPLL91Kf8Sh86ht/ijNj6iUWw7JBArTcJtyn8aR+uDs=
+github.com/pingcap/parser v0.0.0-20190726045944-46d1b3d054b2/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+>>>>>>> update mod
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB52tXhVLEP7Ng3Qqsd6Z18iY=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=
@@ -245,8 +250,6 @@ github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d h1:ggUgChAeyge4NZ4
 github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d/go.mod h1:tu82oB5W2ykJRVioYsB+IQKcft7ryBr7w12qMBUPyXg=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
-github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628 h1:+eaulIIwc79SbkFIDImWw8Pb0kZev+PxYeuowmYruxQ=
-github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628/go.mod h1:PX+0XiEMV4qQtuROaVe41sEOF/kmqSbDA1N/+rYHI5k=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=

--- a/go.sum
+++ b/go.sum
@@ -165,16 +165,8 @@ github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-<<<<<<< HEAD
-<<<<<<< HEAD
-github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd h1:vFLYlcLyvWrIN+3Y9uPExiisDjeRCPh1Vic0vnkxBMs=
-github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
-=======
->>>>>>> support cast as double
-=======
 github.com/pingcap/parser v0.0.0-20190726045944-46d1b3d054b2 h1:uPLL91Kf8Sh86ht/ijNj6iUWw7JBArTcJtyn8aR+uDs=
 github.com/pingcap/parser v0.0.0-20190726045944-46d1b3d054b2/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
->>>>>>> update mod
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB52tXhVLEP7Ng3Qqsd6Z18iY=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,11 @@ github.com/pingcap/kvproto v0.0.0-20190703131923-d9830856b531/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596 h1:t2OQTpPJnrPDGlvA+3FwJptMTt6MEPdzK1Wt99oaefQ=
 github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
+<<<<<<< HEAD
 github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd h1:vFLYlcLyvWrIN+3Y9uPExiisDjeRCPh1Vic0vnkxBMs=
 github.com/pingcap/parser v0.0.0-20190726023712-ca2f45b420fd/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+=======
+>>>>>>> support cast as double
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB52tXhVLEP7Ng3Qqsd6Z18iY=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=
@@ -242,6 +245,8 @@ github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d h1:ggUgChAeyge4NZ4
 github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d/go.mod h1:tu82oB5W2ykJRVioYsB+IQKcft7ryBr7w12qMBUPyXg=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v0.3.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628 h1:+eaulIIwc79SbkFIDImWw8Pb0kZev+PxYeuowmYruxQ=
+github.com/wshwsh12/parser v0.0.0-20190726042505-e79dc5516628/go.mod h1:PX+0XiEMV4qQtuROaVe41sEOF/kmqSbDA1N/+rYHI5k=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/yookoala/realpath v1.0.0/go.mod h1:gJJMA9wuX7AcqLy1+ffPatSCySA1FQ2S8Ya9AIoYBpE=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Support `cast(xxx as double)`.
Mysql support the parser in 8.0.17.
https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html


