### PR TITLE
expression: improve the compatibility with mysql when datatime is invalid.

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3562,11 +3562,18 @@ func (s *testIntegrationSuite) TestTimeLiteral(c *C) {
 	_, err = tk.Exec("select time '20171231235959.999999';")
 	c.Assert(err, NotNil)
 	c.Assert(terror.ErrorEqual(err, types.ErrIncorrectDatetimeValue.GenWithStackByArgs("20171231235959.999999")), IsTrue)
+
+	_, err = tk.Exec("select ADDDATE('2008-01-34', -1);")
+	c.Assert(err, NotNil)
+
+	c.Assert(terror.ErrorEqual(err, types.ErrIncorrectDatetimeValue.GenWithStackByArgs("2008-01-34")), IsTrue)
 }
 
 func (s *testIntegrationSuite) TestTimestampLiteral(c *C) {
 	defer s.cleanEnv(c)
+	
 	tk := testkit.NewTestKit(c, s.store)
+
 
 	r := tk.MustQuery("select timestamp '2017-01-01 00:00:00';")
 	r.Check(testkit.Rows("2017-01-01 00:00:00"))

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3564,6 +3564,7 @@ func (s *testIntegrationSuite) TestTimeLiteral(c *C) {
 	c.Assert(terror.ErrorEqual(err, types.ErrIncorrectDatetimeValue.GenWithStackByArgs("20171231235959.999999")), IsTrue)
 
 	_, err = tk.Exec("select ADDDATE('2008-01-34', -1);")
+	c.Assert(err, IsNil)
 	tk.MustQuery("Show warnings;").Check(testutil.RowsWithSep("|",
 		"Warning|1292|Incorrect datetime value: '2008-1-34'"))
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3571,9 +3571,8 @@ func (s *testIntegrationSuite) TestTimeLiteral(c *C) {
 
 func (s *testIntegrationSuite) TestTimestampLiteral(c *C) {
 	defer s.cleanEnv(c)
-	
-	tk := testkit.NewTestKit(c, s.store)
 
+	tk := testkit.NewTestKit(c, s.store)
 
 	r := tk.MustQuery("select timestamp '2017-01-01 00:00:00';")
 	r.Check(testkit.Rows("2017-01-01 00:00:00"))

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3564,14 +3564,12 @@ func (s *testIntegrationSuite) TestTimeLiteral(c *C) {
 	c.Assert(terror.ErrorEqual(err, types.ErrIncorrectDatetimeValue.GenWithStackByArgs("20171231235959.999999")), IsTrue)
 
 	_, err = tk.Exec("select ADDDATE('2008-01-34', -1);")
-	c.Assert(err, NotNil)
-
-	c.Assert(terror.ErrorEqual(err, types.ErrIncorrectDatetimeValue.GenWithStackByArgs("2008-01-34")), IsTrue)
+	tk.MustQuery("Show warnings;").Check(testutil.RowsWithSep("|",
+		"Warning|1292|Incorrect datetime value: '2008-1-34'"))
 }
 
 func (s *testIntegrationSuite) TestTimestampLiteral(c *C) {
 	defer s.cleanEnv(c)
-
 	tk := testkit.NewTestKit(c, s.store)
 
 	r := tk.MustQuery("select timestamp '2017-01-01 00:00:00';")

--- a/types/time.go
+++ b/types/time.go
@@ -1468,9 +1468,8 @@ func checkDateRange(t MysqlTime) error {
 }
 
 func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
-	dateTimeInStr := fmt.Sprintf("%d-%d-%d", year, month, day)
 	if month < 0 || month > 12 {
-		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(dateTimeInStr))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(fmt.Sprintf("%d-%d-%d", year, month, day)))
 	}
 
 	maxDay := 31
@@ -1484,7 +1483,7 @@ func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
 	}
 
 	if day < 0 || day > maxDay {
-		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(dateTimeInStr))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(fmt.Sprintf("%d-%d-%d", year, month, day)))
 	}
 	return nil
 }

--- a/types/time.go
+++ b/types/time.go
@@ -1468,8 +1468,9 @@ func checkDateRange(t MysqlTime) error {
 }
 
 func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
+	dateTimeInStr := fmt.Sprintf("%d-%d-%d", year, month, day)
 	if month < 0 || month > 12 {
-		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(month))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(dateTimeInStr))
 	}
 
 	maxDay := 31
@@ -1483,7 +1484,7 @@ func checkMonthDay(year, month, day int, allowInvalidDate bool) error {
 	}
 
 	if day < 0 || day > maxDay {
-		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(day))
+		return errors.Trace(ErrIncorrectDatetimeValue.GenWithStackByArgs(dateTimeInStr))
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->


### What is changed and how it works?
It is rather easy fix, just preparing a correct string and pass it into ErrorDataTimeFormat error. 
In this way, the wanting message looks correct.  

This PR closes https://github.com/pingcap/tidb/issues/11304

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

Code changes

Side effects
No side effects

Related changes
 - Need to cherry-pick to the release branch