### PR TITLE
planner: add table info into context in fast plan case

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2473,3 +2473,45 @@ func (s *testPlanSuite) TestSkylinePruning(c *C) {
 		c.Assert(pathsName(paths), Equals, tt.result)
 	}
 }
+
+func (s *testPlanSuite) TestFastPlanContextTables(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []struct {
+		sql      string
+		fastPlan bool
+	}{
+		{
+			"select * from t where a=1",
+			true,
+		},
+		{
+
+			"update t set f=0 where a=43215",
+			true,
+		},
+		{
+			"delete from t where a =43215",
+			true,
+		},
+		{
+			"select * from t where a>1",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		stmt, err := s.ParseOneStmt(tt.sql, "", "")
+		c.Assert(err, IsNil)
+		Preprocess(s.ctx, stmt, s.is)
+		s.ctx.GetSessionVars().StmtCtx.Tables = nil
+		p := TryFastPlan(s.ctx, stmt)
+		if tt.fastPlan {
+			c.Assert(p, NotNil)
+			c.Assert(len(s.ctx.GetSessionVars().StmtCtx.Tables), Equals, 1)
+			c.Assert(s.ctx.GetSessionVars().StmtCtx.Tables[0].Table, Equals, "t")
+			c.Assert(s.ctx.GetSessionVars().StmtCtx.Tables[0].DB, Equals, "test")
+		} else {
+			c.Assert(p, IsNil)
+			c.Assert(len(s.ctx.GetSessionVars().StmtCtx.Tables), Equals, 0)
+		}
+	}
+}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tipb/go-tipb"
@@ -264,6 +265,7 @@ func newPointGetPlan(ctx sessionctx.Context, schema *expression.Schema, tbl *mod
 		schema:   schema,
 		TblInfo:  tbl,
 	}
+	ctx.GetSessionVars().StmtCtx.Tables = []stmtctx.TableEntry{{DB: ctx.GetSessionVars().CurrentDB,  Table:tbl.Name.L}}
 	return p
 }
 

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -265,7 +265,7 @@ func newPointGetPlan(ctx sessionctx.Context, schema *expression.Schema, tbl *mod
 		schema:   schema,
 		TblInfo:  tbl,
 	}
-	ctx.GetSessionVars().StmtCtx.Tables = []stmtctx.TableEntry{{DB: ctx.GetSessionVars().CurrentDB,  Table:tbl.Name.L}}
+	ctx.GetSessionVars().StmtCtx.Tables = []stmtctx.TableEntry{{DB: ctx.GetSessionVars().CurrentDB, Table: tbl.Name.L}}
 	return p
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We forgot to add table info into session context in fast-plan case, so the audit log plugin can know which tabled is affected by the user.

### What is changed and how it works?
Add table info when building PointGetPlan

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

step1: build and run tidb with audit plugin enabled.
step2: config the audit plugin 
```bash
insert into tidb_audit_table_access(user,db, tbl, access_type) values ("","","","");
```
step 4: run point get, point update, point delete query.
step 3: check if the audit log containers the table info
```bash
[2019/07/25 16:29:18.987 +08:00] [INFO] [logger.go:72] [ID="2019-07-25 16:29:18.987597 +0800 CST m=+77.675152289 0"] [TIMESTAMP=2019/07/25 16:29:18.987 +08:00] [EVENT_CLASS=TABLE_ACCESS] [EVENT_SUBCLASS=Delete] [STATUS_CODE=0] [COST_TIME=202.192] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[tidb]"] [SQL_TEXT="delete from tidb where variable_name = ?"] [ROWS=1] [CONNECTION_ID=1] [CLIENT_PORT=53306] [PID=38271] [COMMAND=Query] [SQL_STATEMENTS=Delete]
[2019/07/25 16:30:09.478 +08:00] [INFO] [logger.go:72] [ID="2019-07-25 16:30:09.478366 +0800 CST m=+128.166084074 0"] [TIMESTAMP=2019/07/25 16:30:09.478 +08:00] [EVENT_CLASS=TABLE_ACCESS] [EVENT_SUBCLASS=Update] [STATUS_CODE=0] [COST_TIME=176.159] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[tidb]"] [SQL_TEXT="update tidb set variable_value = ? where variable_name = ?"] [ROWS=0] [CONNECTION_ID=1] [CLIENT_PORT=53306] [PID=38271] [COMMAND=Query] [SQL_STATEMENTS=Update]
[2019/07/25 16:30:25.376 +08:00] [INFO] [logger.go:72] [ID="2019-07-25 16:30:25.376784 +0800 CST m=+144.064068460 0"] [TIMESTAMP=2019/07/25 16:30:25.376 +08:00] [EVENT_CLASS=TABLE_ACCESS] [EVENT_SUBCLASS=Select] [STATUS_CODE=0] [COST_TIME=181.647] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[tidb]"] [SQL_TEXT="select * from tidb where variable_name = ?"] [ROWS=0] [CONNECTION_ID=1] [CLIENT_PORT=53306] [PID=38271] [COMMAND=Query] [SQL_STATEMENTS=Select]
```

Code changes

 - Has exported function/method change
no
 - Has exported variable/fields change
no
 - Has interface methods change
no
 - Has persistent data change
no


Related changes

 - Need to cherry-pick to the release branch
cherry-pick to release 2.1

