### PR TITLE
server: handle partitioned table in some http APIs

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -479,14 +479,32 @@ type RegionDetail struct {
 func (rt *RegionDetail) addTableInRange(dbName string, curTable *model.TableInfo, r *helper.RegionFrameRange) {
 	tName := curTable.Name.String()
 	tID := curTable.ID
-
+	pi := curTable.GetPartitionInfo()
 	for _, index := range curTable.Indices {
-		if f := r.GetIndexFrame(tID, index.ID, dbName, tName, index.Name.String()); f != nil {
+		if pi != nil {
+			for _, def := range pi.Definitions {
+				if f := r.GetIndexFrame(def.ID, index.ID, dbName, fmt.Sprintf("%s(%s)", tName, def.Name.O), index.Name.String()); f != nil {
+					rt.Frames = append(rt.Frames, f)
+				}
+			}
+		} else {
+			if f := r.GetIndexFrame(tID, index.ID, dbName, tName, index.Name.String()); f != nil {
+				rt.Frames = append(rt.Frames, f)
+			}
+		}
+
+	}
+
+	if pi != nil {
+		for _, def := range pi.Definitions {
+			if f := r.GetRecordFrame(def.ID, dbName, fmt.Sprintf("%s(%s)", tName, def.Name.O)); f != nil {
+				rt.Frames = append(rt.Frames, f)
+			}
+		}
+	} else {
+		if f := r.GetRecordFrame(tID, dbName, tName); f != nil {
 			rt.Frames = append(rt.Frames, f)
 		}
-	}
-	if f := r.GetRecordFrame(tID, dbName, tName); f != nil {
-		rt.Frames = append(rt.Frames, f)
 	}
 }
 
@@ -913,18 +931,43 @@ func (h tableHandler) handleStopScatterTableRequest(schema infoschema.InfoSchema
 }
 
 func (h tableHandler) handleRegionRequest(schema infoschema.InfoSchema, tbl table.Table, w http.ResponseWriter, req *http.Request) {
-	tableID := tbl.Meta().ID
-	// for record
-	startKey, endKey := tablecodec.GetTableHandleKeyRange(tableID)
-	recordRegionIDs, err := h.RegionCache.ListRegionIDsInKeyRange(tikv.NewBackoffer(context.Background(), 500), startKey, endKey)
+	pi := tbl.Meta().GetPartitionInfo()
+	if pi != nil {
+		// Partitioned table.
+		var data []*TableRegions
+		for _, def := range pi.Definitions {
+			tableRegions, err := h.getRegionsByID(tbl, def.ID, def.Name.O)
+			if err != nil {
+				writeError(w, err)
+				return
+			}
+
+			data = append(data, tableRegions)
+		}
+		writeData(w, data)
+		return
+	}
+
+	meta := tbl.Meta()
+	tableRegions, err := h.getRegionsByID(tbl, meta.ID, meta.Name.O)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
+
+	writeData(w, tableRegions)
+}
+
+func (h tableHandler) getRegionsByID(tbl table.Table, id int64, name string) (*TableRegions, error) {
+	// for record
+	startKey, endKey := tablecodec.GetTableHandleKeyRange(id)
+	recordRegionIDs, err := h.RegionCache.ListRegionIDsInKeyRange(tikv.NewBackoffer(context.Background(), 500), startKey, endKey)
+	if err != nil {
+		return nil, err
+	}
 	recordRegions, err := h.getRegionsMeta(recordRegionIDs)
 	if err != nil {
-		writeError(w, err)
-		return
+		return nil, err
 	}
 
 	// for indices
@@ -933,27 +976,23 @@ func (h tableHandler) handleRegionRequest(schema infoschema.InfoSchema, tbl tabl
 		indexID := index.Meta().ID
 		indices[i].Name = index.Meta().Name.String()
 		indices[i].ID = indexID
-		startKey, endKey := tablecodec.GetTableIndexKeyRange(tableID, indexID)
+		startKey, endKey := tablecodec.GetTableIndexKeyRange(id, indexID)
 		rIDs, err := h.RegionCache.ListRegionIDsInKeyRange(tikv.NewBackoffer(context.Background(), 500), startKey, endKey)
 		if err != nil {
-			writeError(w, err)
-			return
+			return nil, err
 		}
 		indices[i].Regions, err = h.getRegionsMeta(rIDs)
 		if err != nil {
-			writeError(w, err)
-			return
+			return nil, err
 		}
 	}
 
-	tableRegions := &TableRegions{
-		TableName:     tbl.Meta().Name.O,
-		TableID:       tableID,
+	return &TableRegions{
+		TableName:     name,
+		TableID:       id,
 		Indices:       indices,
 		RecordRegions: recordRegions,
-	}
-
-	writeData(w, tableRegions)
+	}, nil
 }
 
 // pdRegionStats is the json response from PD.

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -204,13 +204,28 @@ func regionContainsTable(c *C, regionID uint64, tableID int64) bool {
 	return false
 }
 
-func (ts *HTTPHandlerTestSuite) TestListTableRegionsWithError(c *C) {
+func (ts *HTTPHandlerTestSuite) TestListTableRegions(c *C) {
 	ts.startServer(c)
 	defer ts.stopServer(c)
+	ts.prepareData(c)
+	// Test list table regions with error
 	resp, err := http.Get("http://127.0.0.1:10090/tables/fdsfds/aaa/regions")
 	c.Assert(err, IsNil)
 	defer resp.Body.Close()
 	c.Assert(resp.StatusCode, Equals, http.StatusBadRequest)
+
+	resp, err = http.Get("http://127.0.0.1:10090/tables/tidb/pt/regions")
+	c.Assert(err, IsNil)
+	defer resp.Body.Close()
+
+	var data []*TableRegions
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&data)
+	c.Assert(err, IsNil)
+
+	region := data[1]
+	resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:10090/regions/%d", region.TableID))
+	c.Assert(err, IsNil)
 }
 
 func (ts *HTTPHandlerTestSuite) TestGetRegionByIDWithError(c *C) {
@@ -305,6 +320,11 @@ func (ts *HTTPHandlerTestSuite) prepareData(c *C) {
 	c.Assert(err, IsNil)
 	dbt.mustExec("alter table tidb.test add index idx1 (a, b);")
 	dbt.mustExec("alter table tidb.test add unique index idx2 (a, b);")
+
+	dbt.mustExec(`create table tidb.pt (a int) partition by range (a)
+(partition p0 values less than (256),
+ partition p1 values less than (512),
+ partition p2 values less than (1024))`)
 }
 
 func decodeKeyMvcc(closer io.ReadCloser, c *C, valid bool) {


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
mysql> create table xx (a int) partition by range (a) 
    -> (partition p0 values less than (255),
    -> partition p1 values less than (65535),
    -> partition p2 values less than (100000));
Query OK, 0 rows affected (0.16 sec)
```

Visit the HTTP API http://localhost:10080/tables/test/xx/regions

Before:

```
{
 "name": "xx",
 "id": 43,
 "record_regions": [
  {
   "region_id": 42,
   "leader": {
    "id": 43,
    "store_id": 1
   },
   "peers": [
    {
     "id": 43,
     "store_id": 1
    }
   ],
   "region_epoch": {
    "conf_ver": 1,
    "version": 21
   }
  }
 ],
 "indices": []
}
```

After:

```
[
 {
  "name": "p0",
  "id": 44,
  "record_regions": [
   {
    "region_id": 44,
    "leader": {
     "id": 45,
     "store_id": 1
    },
    "peers": [
     {
      "id": 45,
      "store_id": 1
     }
    ],
    "region_epoch": {
     "conf_ver": 1,
     "version": 22
    }
   }
  ],
  "indices": []
 },
 {
  "name": "p1",
  "id": 45,
  "record_regions": [
   {
    "region_id": 46,
    "leader": {
     "id": 47,
     "store_id": 1
    },
    "peers": [
     {
      "id": 47,
      "store_id": 1
     }
    ],
    "region_epoch": {
     "conf_ver": 1,
     "version": 23
    }
   }
  ],
  "indices": []
 },
 {
  "name": "p2",
  "id": 46,
  "record_regions": [
   {
    "region_id": 2,
    "leader": {
     "id": 3,
     "store_id": 1
    },
    "peers": [
     {
      "id": 3,
      "store_id": 1
     }
    ],
    "region_epoch": {
     "conf_ver": 1,
     "version": 23
    }
   }
  ],
  "indices": []
 }
]
```

And the HTTP API http://localhost:10080/regions/44

Before:

```
{
 "region_id": 44,
 "start_key": "dIAAAAAAAAAs",
 "end_key": "dIAAAAAAAAAt",
 "frames": null
}
```

After:

```
{
 "region_id": 44,
 "start_key": "dIAAAAAAAAAs",
 "end_key": "dIAAAAAAAAAt",
 "frames": [
  {
   "db_name": "test",
   "table_name": "xx(p0)",
   "table_id": 44,
   "is_record": true
  }
 ]
}
```


### What is changed and how it works?

Now the following two http endpoint supports partitioned table:
*   /tables/{db}/{table}/regions
*   /regions/{regionID}




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

