### PR TITLE
tikv: reduce backoff when region cache missed in 2nd lookup phase

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -497,9 +497,11 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			err = c.prewriteKeys(bo, batch.keys)
 			return errors.Trace(err)
@@ -584,9 +586,11 @@ func (c *twoPhaseCommitter) pessimisticLockSingleBatch(bo *Backoffer, batch batc
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			err = c.pessimisticLockKeys(bo, batch.keys)
 			return errors.Trace(err)
@@ -645,9 +649,11 @@ func (c *twoPhaseCommitter) pessimisticRollbackSingleBatch(bo *Backoffer, batch 
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			err = c.pessimisticRollbackKeys(bo, batch.keys)
 			return errors.Trace(err)
@@ -720,9 +726,11 @@ func (c *twoPhaseCommitter) commitSingleBatch(bo *Backoffer, batch batchKeys) er
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-		if err != nil {
-			return errors.Trace(err)
+		if !regionErr.RegionCacheMiss {
+			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 		// re-split keys and commit again.
 		err = c.commitKeys(bo, batch.keys)
@@ -778,9 +786,11 @@ func (c *twoPhaseCommitter) cleanupSingleBatch(bo *Backoffer, batch batchKeys) e
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-		if err != nil {
-			return errors.Trace(err)
+		if !regionErr.RegionCacheMiss {
+			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+			if err != nil {
+				return errors.Trace(err)
+			}
 		}
 		err = c.cleanupKeys(bo, batch.keys)
 		return errors.Trace(err)

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -640,6 +640,10 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 		return worker.handleCopStreamResult(bo, rpcCtx, resp.Resp.(*tikvrpc.CopStreamResponse), task, ch)
 	}
 
+	if resp.CacheMiss {
+		return buildCopTasks(bo, worker.store.regionCache, task.ranges, worker.req.Desc, worker.req.Streaming)
+	}
+
 	// Handles the response for non-streaming copTask.
 	return worker.handleCopResponse(bo, rpcCtx, &copResponse{pbResp: resp.Resp.(*coprocessor.Response)}, task, ch, nil)
 }

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -119,9 +119,11 @@ func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (Ra
 			return stat, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return stat, errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return stat, errors.Trace(err)
+				}
 			}
 			continue
 		}

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"
@@ -319,7 +318,7 @@ func (s *testGCWorkerSuite) TestDoGCForOneRegion(c *C) {
 	bo := tikv.NewBackoffer(ctx, tikv.GcOneRegionMaxBackoff)
 	loc, err := s.store.GetRegionCache().LocateKey(bo, []byte(""))
 	c.Assert(err, IsNil)
-	var regionErr *errorpb.Error
+	var regionErr *tikvrpc.RegionError
 
 	p := s.createGCProbe(c, "k1")
 	regionErr, err = s.gcWorker.doGCForRegion(bo, s.mustAllocTs(c), loc.Region)

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -233,9 +233,11 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 	}
 
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-		if err != nil {
-			return false, errors.Trace(err)
+		if !regionErr.RegionCacheMiss {
+			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+			if err != nil {
+				return false, errors.Trace(err)
+			}
 		}
 		return false, nil
 	}
@@ -354,9 +356,11 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 			return status, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return status, errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return status, errors.Trace(err)
+				}
 			}
 			continue
 		}
@@ -413,9 +417,11 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, cl
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			continue
 		}

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -142,6 +142,12 @@ func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp.Resp, NotNil)
 	c.Assert(ctx, NotNil)
+
+	s.cache.InvalidateCachedRegion(region.Region)
+	resp, ctx, err = s.regionRequestSender.SendReqCtx(s.bo, req, region.Region, time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(resp.CacheMiss, IsTrue)
+	c.Assert(ctx, IsNil)
 }
 
 func (s *testRegionRequestSuite) TestOnSendFailedWithCancelled(c *C) {

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -210,11 +210,13 @@ func (s *Scanner) getData(bo *Backoffer) error {
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			logutil.BgLogger().Debug("scanner getData failed",
-				zap.Stringer("regionErr", regionErr))
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				logutil.BgLogger().Debug("scanner getData failed",
+					zap.Stringer("regionErr", regionErr))
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			continue
 		}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -170,9 +170,11 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return errors.Trace(err)
+				}
 			}
 			err = s.batchGetKeysByRegions(bo, pending, collectF)
 			return errors.Trace(err)
@@ -254,9 +256,11 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 			return nil, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return nil, errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
 			}
 			continue
 		}

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -57,9 +57,11 @@ func (s *tikvStore) SplitRegion(splitKey kv.Key, scatter bool) (regionID uint64,
 			return 0, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err := bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return 0, errors.Trace(err)
+			if !regionErr.RegionCacheMiss {
+				err := bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+				if err != nil {
+					return 0, errors.Trace(err)
+				}
 			}
 			continue
 		}

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -358,7 +358,8 @@ func (req *Request) IsDebugReq() bool {
 
 // Response wraps all kv/coprocessor responses.
 type Response struct {
-	Resp interface{}
+	Resp      interface{}
+	CacheMiss bool
 }
 
 // FromBatchCommandsResponse converts a BatchCommands response to Response.
@@ -623,7 +624,7 @@ type getRegionError interface {
 }
 
 // GetRegionError returns the RegionError of the underlying concrete response.
-func (resp *Response) GetRegionError() (*errorpb.Error, error) {
+func (resp *Response) GetRegionError() (*RegionError, error) {
 	if resp.Resp == nil {
 		return nil, nil
 	}
@@ -634,7 +635,17 @@ func (resp *Response) GetRegionError() (*errorpb.Error, error) {
 		}
 		return nil, fmt.Errorf("invalid response type %v", resp)
 	}
-	return err.GetRegionError(), nil
+	rErr := err.GetRegionError()
+	if rErr == nil && !resp.CacheMiss {
+		return nil, nil
+	}
+	return &RegionError{Error: rErr, RegionCacheMiss: resp.CacheMiss}, nil
+}
+
+// RegionError extends kv Error with region cache error info.
+type RegionError struct {
+	*errorpb.Error
+	RegionCacheMiss bool
 }
 
 // CallRPC launches a rpc call.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes old age TODO in code: https://github.com/pingcap/tidb/blob/eae30ebbcb8464d4644598db459337998ab1d43b/store/tikv/region_request.go#L107

when we using region cache, in current impl need two-step:

- lookup KeyLocation by key in btree
- lookup region info by using KeyLocation.RegionID to find real region info

(...emm..maybe those steps have some space to improve)

In the first step when we meet cache-miss will get region info from pd right now.
but in the second step if we meet cache-miss(normally by invalidate or TTL timeout), current impl will return a fake response with `EpochNotMatch error` to make caller retry as a `RegionMiss`.

so the question here is: we mix regionMiss and cacheMiss in retry logic..

when we meet a cache-miss we should get region from pd directly instead of do a backoff sleep.

for region miss will sleep:

```
2.273153ms
4.176395ms
8.292427ms
16.168811ms
32.407544ms
64.177735ms
128.221769ms
256.29749ms
500.510278ms
500.393504ms
```

### What is changed and how it works?

separate cache-miss from region-miss, and do not backoff for cache-miss

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (WIP)

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11464)
<!-- Reviewable:end -->
