### PR TITLE
expression: handle builtin add_date/sub_date func overflow

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2795,10 +2795,6 @@ func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, int
 		return types.Time{}, true, err
 	}
 
-	if goTime.Year() < 0 || goTime.Year() > (1<<16-1) {
-		return types.Time{}, true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
-	}
-
 	duration := time.Duration(nano)
 	goTime = goTime.Add(duration)
 	goTime = types.AddDate(year, month, day, goTime)
@@ -2807,6 +2803,10 @@ func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, int
 		date.Fsp = 0
 	} else {
 		date.Fsp = 6
+	}
+
+	if goTime.Year() < 0 || goTime.Year() > (1<<16-1) {
+		return types.Time{}, true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
 	}
 
 	date.Time = types.FromGoTime(goTime)

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2744,6 +2744,10 @@ func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, int
 		date.Fsp = 6
 	}
 
+	if goTime.Year() < 0 || goTime.Year() > (1<<16-1) {
+		return types.Time{}, true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
+	}
+
 	date.Time = types.FromGoTime(goTime)
 	overflow, err := types.DateTimeIsOverflow(ctx.GetSessionVars().StmtCtx, date)
 	if err := handleInvalidTimeError(ctx, err); err != nil {
@@ -2789,6 +2793,10 @@ func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, int
 	goTime, err := date.Time.GoTime(time.Local)
 	if err := handleInvalidTimeError(ctx, err); err != nil {
 		return types.Time{}, true, err
+	}
+
+	if goTime.Year() < 0 || goTime.Year() > (1<<16-1) {
+		return types.Time{}, true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
 	}
 
 	duration := time.Duration(nano)

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1826,6 +1826,25 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(v.GetMysqlTime().String(), Equals, test.expected)
 	}
+
+	testOverflowYears := []struct {
+		input string
+		year  int
+	}{
+		{"2008-11-23", -1465647104},
+		{"2008-11-23", 1465647104},
+	}
+
+	for _, test := range testOverflowYears {
+		args = types.MakeDatums(test.input, test.year, "YEAR")
+		f, err = fcAdd.getFunction(s.ctx, s.datumsToConstants(args))
+		c.Assert(err, IsNil)
+		c.Assert(f, NotNil)
+		v, err = evalBuiltinFunc(f, chunk.Row{})
+		c.Assert(err, IsNil)
+		c.Assert(v.IsNull(), IsTrue)
+	}
+
 	testDurations := []struct {
 		fc       functionClass
 		dur      string

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1845,6 +1845,16 @@ func (s *testEvaluatorSuite) TestDateArithFuncs(c *C) {
 		c.Assert(v.IsNull(), IsTrue)
 	}
 
+	for _, test := range testOverflowYears {
+		args = types.MakeDatums(test.input, test.year, "YEAR")
+		f, err = fcSub.getFunction(s.ctx, s.datumsToConstants(args))
+		c.Assert(err, IsNil)
+		c.Assert(f, NotNil)
+		v, err = evalBuiltinFunc(f, chunk.Row{})
+		c.Assert(err, IsNil)
+		c.Assert(v.IsNull(), IsTrue)
+	}
+
 	testDurations := []struct {
 		fc       functionClass
 		dur      string

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2103,6 +2103,12 @@ func (s *testIntegrationSuite) TestDatetimeOverflow(c *C) {
 		rows = append(rows, "<nil>")
 	}
 	tk.MustQuery("select * from t1").Check(testkit.Rows(rows...))
+
+	//Fix ISSUE 11256
+	tk.MustQuery(`select DATE_ADD('2000-04-13 07:17:02',INTERVAL -1465647104 YEAR);`).Check(testkit.Rows("<nil>"))
+	tk.MustQuery(`select DATE_ADD('2008-11-23 22:47:31',INTERVAL 266076160 QUARTER);`).Check(testkit.Rows("<nil>"))
+	tk.MustQuery(`select DATE_SUB('2000-04-13 07:17:02',INTERVAL 1465647104 YEAR);`).Check(testkit.Rows("<nil>"))
+	tk.MustQuery(`select DATE_SUB('2008-11-23 22:47:31',INTERVAL -266076160 QUARTER);`).Check(testkit.Rows("<nil>"))
 }
 
 func (s *testIntegrationSuite) TestBuiltin(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Part of issue #11223, fix issue #11256 

### What is changed and how it works?
if Year less then 0 or greater then max uint16
    then return null value
```golang
if goTime.Year() < 0 || goTime.Year() > (1<<16-1) {
	return types.Time{}, true, nil
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

