### PR TITLE
executor: add `PreAlloc` and replace `nullCnt` field with `NullCount` method in `Column`

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -468,11 +468,6 @@ func (c *Chunk) TruncateTo(numRows int) {
 			col.data = col.data[:col.offsets[numRows]]
 			col.offsets = col.offsets[:numRows+1]
 		}
-		for i := numRows; i < col.length; i++ {
-			if col.IsNull(i) {
-				col.nullCount--
-			}
-		}
 		col.length = numRows
 		bitmapLen := (col.length + 7) / 8
 		col.nullBitmap = col.nullBitmap[:bitmapLen]

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -160,21 +160,21 @@ func (s *testChunkSuite) TestAppend(c *check.C) {
 	c.Assert(len(dst.columns), check.Equals, 3)
 
 	c.Assert(dst.columns[0].length, check.Equals, 12)
-	c.Assert(dst.columns[0].nullCount, check.Equals, 6)
+	c.Assert(dst.columns[0].nullCount(), check.Equals, 6)
 	c.Assert(string(dst.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(dst.columns[0].offsets), check.Equals, 0)
 	c.Assert(len(dst.columns[0].data), check.Equals, 4*12)
 	c.Assert(len(dst.columns[0].elemBuf), check.Equals, 4)
 
 	c.Assert(dst.columns[1].length, check.Equals, 12)
-	c.Assert(dst.columns[1].nullCount, check.Equals, 6)
+	c.Assert(dst.columns[1].nullCount(), check.Equals, 6)
 	c.Assert(string(dst.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(fmt.Sprintf("%v", dst.columns[1].offsets), check.Equals, fmt.Sprintf("%v", []int64{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
 	c.Assert(string(dst.columns[1].data), check.Equals, "abcabcabcabcabcabc")
 	c.Assert(len(dst.columns[1].elemBuf), check.Equals, 0)
 
 	c.Assert(dst.columns[2].length, check.Equals, 12)
-	c.Assert(dst.columns[2].nullCount, check.Equals, 6)
+	c.Assert(dst.columns[2].nullCount(), check.Equals, 6)
 	c.Assert(string(dst.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(dst.columns[2].offsets), check.Equals, 13)
 	c.Assert(len(dst.columns[2].data), check.Equals, 150)
@@ -213,21 +213,21 @@ func (s *testChunkSuite) TestTruncateTo(c *check.C) {
 	c.Assert(len(src.columns), check.Equals, 3)
 
 	c.Assert(src.columns[0].length, check.Equals, 12)
-	c.Assert(src.columns[0].nullCount, check.Equals, 6)
+	c.Assert(src.columns[0].nullCount(), check.Equals, 6)
 	c.Assert(string(src.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(src.columns[0].offsets), check.Equals, 0)
 	c.Assert(len(src.columns[0].data), check.Equals, 4*12)
 	c.Assert(len(src.columns[0].elemBuf), check.Equals, 4)
 
 	c.Assert(src.columns[1].length, check.Equals, 12)
-	c.Assert(src.columns[1].nullCount, check.Equals, 6)
+	c.Assert(src.columns[1].nullCount(), check.Equals, 6)
 	c.Assert(string(src.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(fmt.Sprintf("%v", src.columns[1].offsets), check.Equals, fmt.Sprintf("%v", []int64{0, 3, 3, 6, 6, 9, 9, 12, 12, 15, 15, 18, 18}))
 	c.Assert(string(src.columns[1].data), check.Equals, "abcabcabcabcabcabc")
 	c.Assert(len(src.columns[1].elemBuf), check.Equals, 0)
 
 	c.Assert(src.columns[2].length, check.Equals, 12)
-	c.Assert(src.columns[2].nullCount, check.Equals, 6)
+	c.Assert(src.columns[2].nullCount(), check.Equals, 6)
 	c.Assert(string(src.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(src.columns[2].offsets), check.Equals, 13)
 	c.Assert(len(src.columns[2].data), check.Equals, 150)
@@ -655,7 +655,7 @@ func (s *testChunkSuite) TestPreAlloc4RowAndInsert(c *check.C) {
 		c.Assert(len(srcCol.offsets), check.Equals, len(destCol.offsets))
 		c.Assert(len(srcCol.nullBitmap), check.Equals, len(destCol.nullBitmap))
 		c.Assert(srcCol.length, check.Equals, destCol.length)
-		c.Assert(srcCol.nullCount, check.Equals, destCol.nullCount)
+		c.Assert(srcCol.nullCount(), check.Equals, destCol.nullCount())
 
 		for _, val := range destCol.data {
 			c.Assert(val == 0, check.IsTrue)

--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -54,11 +54,11 @@ func (c *Codec) encodeColumn(buffer []byte, col *Column) []byte {
 	buffer = append(buffer, lenBuffer[:4]...)
 
 	// encode nullCount.
-	binary.LittleEndian.PutUint32(lenBuffer[:], uint32(col.nullCount))
+	binary.LittleEndian.PutUint32(lenBuffer[:], uint32(col.nullCount()))
 	buffer = append(buffer, lenBuffer[:4]...)
 
 	// encode nullBitmap.
-	if col.nullCount > 0 {
+	if col.nullCount() > 0 {
 		numNullBitmapBytes := (col.length + 7) / 8
 		buffer = append(buffer, col.nullBitmap[:numNullBitmapBytes]...)
 	}
@@ -111,11 +111,11 @@ func (c *Codec) decodeColumn(buffer []byte, col *Column, ordinal int) (remained 
 	buffer = buffer[4:]
 
 	// decode nullCount.
-	col.nullCount = int(binary.LittleEndian.Uint32(buffer))
+	nullCount := int(binary.LittleEndian.Uint32(buffer))
 	buffer = buffer[4:]
 
 	// decode nullBitmap.
-	if col.nullCount > 0 {
+	if nullCount > 0 {
 		numNullBitmapBytes := (col.length + 7) / 8
 		col.nullBitmap = append(col.nullBitmap[:0], buffer[:numNullBitmapBytes]...)
 		buffer = buffer[numNullBitmapBytes:]

--- a/util/chunk/codec_test.go
+++ b/util/chunk/codec_test.go
@@ -85,7 +85,6 @@ func BenchmarkEncodeChunk(b *testing.B) {
 	for i := 0; i < numCols; i++ {
 		chk.columns[i] = &Column{
 			length:     numRows,
-			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),
 			data:       make([]byte, numRows*8),
 		}
@@ -108,7 +107,6 @@ func BenchmarkDecode(b *testing.B) {
 	for i := 0; i < numCols; i++ {
 		chk.columns[i] = &Column{
 			length:     numRows,
-			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),
 			data:       make([]byte, numRows*8),
 		}
@@ -136,7 +134,6 @@ func BenchmarkDecodeToChunk(b *testing.B) {
 	for i := 0; i < numCols; i++ {
 		chk.columns[i] = &Column{
 			length:     numRows,
-			nullCount:  14,
 			nullBitmap: make([]byte, numRows/8+1),
 			data:       make([]byte, numRows*8),
 			elemBuf:    make([]byte, 8),

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -14,6 +14,7 @@
 package chunk
 
 import (
+	"math/bits"
 	"reflect"
 	"time"
 	"unsafe"
@@ -58,8 +59,7 @@ func (c *Column) AppendSet(set types.Set) {
 // See https://arrow.apache.org/docs/memory_layout.html
 type Column struct {
 	length     int
-	nullCount  int
-	nullBitmap []byte
+	nullBitmap []byte // bit 0 is null, 1 is not null
 	offsets    []int64
 	data       []byte
 	elemBuf    []byte
@@ -94,7 +94,6 @@ func (c *Column) isFixed() bool {
 // Reset resets this Column.
 func (c *Column) Reset() {
 	c.length = 0
-	c.nullCount = 0
 	c.nullBitmap = c.nullBitmap[:0]
 	if len(c.offsets) > 0 {
 		// The first offset is always 0, it makes slicing the data easier, we need to keep it.
@@ -114,14 +113,13 @@ func (c *Column) IsNull(rowIdx int) bool {
 func (c *Column) CopyConstruct(dst *Column) *Column {
 	if dst != nil {
 		dst.length = c.length
-		dst.nullCount = c.nullCount
 		dst.nullBitmap = append(dst.nullBitmap[:0], c.nullBitmap...)
 		dst.offsets = append(dst.offsets[:0], c.offsets...)
 		dst.data = append(dst.data[:0], c.data...)
 		dst.elemBuf = append(dst.elemBuf[:0], c.elemBuf...)
 		return dst
 	}
-	newCol := &Column{length: c.length, nullCount: c.nullCount}
+	newCol := &Column{length: c.length}
 	newCol.nullBitmap = append(newCol.nullBitmap, c.nullBitmap...)
 	newCol.offsets = append(newCol.offsets, c.offsets...)
 	newCol.data = append(newCol.data, c.data...)
@@ -137,8 +135,6 @@ func (c *Column) appendNullBitmap(notNull bool) {
 	if notNull {
 		pos := uint(c.length) & 7
 		c.nullBitmap[idx] |= byte(1 << pos)
-	} else {
-		c.nullCount++
 	}
 }
 
@@ -155,7 +151,6 @@ func (c *Column) appendMultiSameNullBitmap(notNull bool, num int) {
 		c.nullBitmap = append(c.nullBitmap, b)
 	}
 	if !notNull {
-		c.nullCount += num
 		return
 	}
 	// 1. Set all the remaining bits in the last slot of old c.numBitMap to 1.
@@ -245,6 +240,84 @@ const (
 	sizeFloat64   = int(unsafe.Sizeof(float64(0)))
 	sizeMyDecimal = int(unsafe.Sizeof(types.MyDecimal{}))
 )
+
+// preAlloc allocates space for a fixed-length-type slice and resets all slots to null.
+func (c *Column) preAlloc(length, typeSize int) {
+	nData := length * typeSize
+	if len(c.data) >= nData {
+		c.data = c.data[:nData]
+	} else {
+		c.data = make([]byte, nData)
+	}
+
+	nBitmap := (length + 7) >> 3
+	if len(c.nullBitmap) >= nBitmap {
+		c.nullBitmap = c.nullBitmap[:nBitmap]
+		for i := range c.nullBitmap {
+			// resets all slots to null.
+			c.nullBitmap[i] = 0
+		}
+	} else {
+		c.nullBitmap = make([]byte, nBitmap)
+	}
+
+	if c.elemBuf != nil && len(c.elemBuf) >= typeSize {
+		c.elemBuf = c.elemBuf[:typeSize]
+	} else {
+		c.elemBuf = make([]byte, typeSize)
+	}
+
+	c.length = length
+}
+
+// SetNull sets the rowIdx to null.
+func (c *Column) SetNull(rowIdx int, isNull bool) {
+	if isNull {
+		c.nullBitmap[rowIdx>>3] &= ^(1 << uint(rowIdx&7))
+	} else {
+		c.nullBitmap[rowIdx>>3] |= 1 << uint(rowIdx&7)
+	}
+}
+
+// nullCount returns the number of nulls in this Column.
+func (c *Column) nullCount() int {
+	var cnt, i int
+	for ; i+8 <= c.length; i += 8 {
+		// 0 is null and 1 is not null
+		cnt += 8 - bits.OnesCount8(uint8(c.nullBitmap[i>>3]))
+	}
+	for ; i < c.length; i++ {
+		if c.IsNull(i) {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+// PreAllocInt64 allocates space for an int64 slice and resets all slots to null.
+func (c *Column) PreAllocInt64(length int) {
+	c.preAlloc(length, sizeInt64)
+}
+
+// PreAllocUint64 allocates space for a uint64 slice and resets all slots to null.
+func (c *Column) PreAllocUint64(length int) {
+	c.preAlloc(length, sizeUint64)
+}
+
+// PreAllocFloat32 allocates space for a float32 slice and resets all slots to null.
+func (c *Column) PreAllocFloat32(length int) {
+	c.preAlloc(length, sizeFloat32)
+}
+
+// PreAllocFloat64 allocates space for a float64 slice and resets all slots to null.
+func (c *Column) PreAllocFloat64(length int) {
+	c.preAlloc(length, sizeFloat64)
+}
+
+// PreAllocDecimal allocates space for a decimal slice and resets all slots to null.
+func (c *Column) PreAllocDecimal(length int) {
+	c.preAlloc(length, sizeMyDecimal)
+}
 
 func (c *Column) castSliceHeader(header *reflect.SliceHeader, typeSize int) {
 	header.Data = uintptr(unsafe.Pointer(&c.data[0]))
@@ -364,14 +437,12 @@ func (c *Column) reconstruct(sel []int) {
 	if sel == nil {
 		return
 	}
-	nullCnt := 0
 	if c.isFixed() {
 		elemLen := len(c.elemBuf)
 		for dst, src := range sel {
 			idx := dst >> 3
 			pos := uint16(dst & 7)
 			if c.IsNull(src) {
-				nullCnt++
 				c.nullBitmap[idx] &= ^byte(1 << pos)
 			} else {
 				copy(c.data[dst*elemLen:dst*elemLen+elemLen], c.data[src*elemLen:src*elemLen+elemLen])
@@ -385,7 +456,6 @@ func (c *Column) reconstruct(sel []int) {
 			idx := dst >> 3
 			pos := uint(dst & 7)
 			if c.IsNull(src) {
-				nullCnt++
 				c.nullBitmap[idx] &= ^byte(1 << pos)
 				c.offsets[dst+1] = int64(tail)
 			} else {
@@ -400,7 +470,6 @@ func (c *Column) reconstruct(sel []int) {
 		c.offsets = c.offsets[:len(sel)+1]
 	}
 	c.length = len(sel)
-	c.nullCount = nullCnt
 
 	// clean nullBitmap
 	c.nullBitmap = c.nullBitmap[:(len(sel)+7)>>3]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add `PreAllocXXX` methods for `Column`, which are prepared for vectorized evaluation.

Remove `nullCnt` field in `Column` since it's hard to maintain after we have methods like `Int64s() []int64` which allow users to modify values of the column outside.
On the other hand, `nullCnt` is only used when we encode a column, so it is not worth maintaining it.
Therefore, I replaced it with a method `NullCount()`.

### What is changed and how it works?
Add `PreAllocXXX` methods for all fixed-length types.
Replace `nullCnt` field with `NullCount()` method.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test