### PR TITLE
expression: fix 2.1 testCurrentTime CI

### DIFF
--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1168,6 +1168,7 @@ func (s *testEvaluatorSuite) TestCurrentTime(c *C) {
 	tfStr := "15:04:05"
 
 	last := time.Now()
+	resetStmtContext(s.ctx)
 	fc := funcs[ast.CurrentTime]
 	f, err := fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(nil)))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

2.1 CI failed with:

```
[2019-07-29T09:09:23.536Z] FAIL: builtin_time_test.go:1166: testEvaluatorSuite.TestCurrentTime
[2019-07-29T09:09:23.536Z] 
[2019-07-29T09:09:23.536Z] builtin_time_test.go:1186:
[2019-07-29T09:09:23.536Z]     c.Assert(n.String(), GreaterEqual, last.Format(tfStr))
[2019-07-29T09:09:23.536Z] ... compare_one string = "17:08:18.911"
[2019-07-29T09:09:23.536Z] ... compare_two string = "17:08:19"
```

### What is changed and how it works?

reset stmt NowCacheTs

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - test

Side effects

 - N/A

Related changes

 - N/A

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11514)
<!-- Reviewable:end -->
