### PR TITLE
server: remove the error stack in logs when the connection is reset by the client

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -636,7 +636,8 @@ func (cc *clientConn) Run(ctx context.Context) {
 				} else {
 					errStack := errors.ErrorStack(err)
 					if !strings.Contains(errStack, "use of closed network connection") {
-						logutil.Logger(ctx).Error("read packet failed, close this connection", zap.Error(err))
+						logutil.Logger(ctx).Warn("read packet failed, close this connection",
+							zap.Error(errors.SuspendStack(err)))
 					}
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to fix https://github.com/pingcap/tidb/issues/11540 . The error stack is a bit useless when the connection is reset by the client.

### What is changed and how it works?
Clear the stack and then change the log level to the warning, because the error level will always print the stack either.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

1. start some clients and send requests
1. shut down all the clients
1. see the server logs

```text
[2019/07/31 15:51:53.591 +08:00] [WARN] [conn.go:639] ["read packet failed, close this connection"] [conn=2] [error="read tcp 127.0.0.1:4000->127.0.0.1:58207: read: connection reset by peer"]
[2019/07/31 15:51:53.591 +08:00] [WARN] [conn.go:639] ["read packet failed, close this connection"] [conn=3] [error="read tcp 127.0.0.1:4000->127.0.0.1:58205: read: connection reset by peer"]
[2019/07/31 15:51:53.592 +08:00] [WARN] [conn.go:639] ["read packet failed, close this connection"] [conn=4] [error="read tcp 127.0.0.1:4000->127.0.0.1:58208: read: connection reset by peer"]
[2019/07/31 15:51:53.593 +08:00] [WARN] [conn.go:639] ["read packet failed, close this connection"] [conn=1] [error="read tcp 127.0.0.1:4000->127.0.0.1:58206: read: connection reset by peer"]
```

Related changes

 - Need to cherry-pick to the release branch

