### PR TITLE
ddl: Fix generated column can refer only to generated columns defined prior to it.

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -595,7 +595,7 @@ func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn
 		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
 		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
-	// should check unknown column first, then the prior
+	// should check unknown column first, then the prior ones.
 	sql := "alter table t add column d int as (c + f + 1) first"
 	assertErrorCode(c, tk, sql, mysql.ErrBadField)
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -604,12 +604,10 @@ func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn
 	assertErrorCode(c, tk, sql, mysql.ErrGeneratedColumnNonPrior)
 
 	// correct case
-	_, err := tk.Exec("alter table t add column d int as (c+1) after c")
-	c.Assert(err, IsNil)
+	tk.MustExec("alter table t add column d int as (c+1) after c")
 
-	// check position nil
-	_, err = tk.Exec("alter table t add column(e int as (c+1))")
-	c.Assert(err, IsNil)
+	// check position nil case
+	tk.MustExec("alter table t add column(e int as (c+1))")
 }
 
 func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -586,6 +586,37 @@ func (s *testIntegrationSuite2) TestNullGeneratedColumn(c *C) {
 	tk.MustExec("drop table t")
 }
 
+func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`a` int(11) DEFAULT NULL," +
+		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
+		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	// should check unknown column first, then the prior
+	rs, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
+	if rs != nil {
+		rs.Close()
+	}
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
+	// depended generated column should be prior to generated column self
+	rs, err = tk.Exec("alter table t add column d int as (c+1) first")
+	if rs != nil {
+		rs.Close()
+	}
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
+	// correct case
+	rs, err = tk.Exec("alter table t add column d int as (c+1) after c")
+	if rs != nil {
+		rs.Close()
+	}
+	c.Assert(err, IsNil)
+}
+
 func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -586,43 +586,6 @@ func (s *testIntegrationSuite2) TestNullGeneratedColumn(c *C) {
 	tk.MustExec("drop table t")
 }
 
-func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("CREATE TABLE `t` (" +
-		"`a` int(11) DEFAULT NULL," +
-		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
-		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
-	// should check unknown column first, then the prior
-	rs, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
-	if rs != nil {
-		rs.Close()
-	}
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
-	// depended generated column should be prior to generated column self
-	rs, err = tk.Exec("alter table t add column d int as (c+1) first")
-	if rs != nil {
-		rs.Close()
-	}
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
-	// correct case
-	rs, err = tk.Exec("alter table t add column d int as (c+1) after c")
-	if rs != nil {
-		rs.Close()
-	}
-	c.Assert(err, IsNil)
-	// in this sql pattern, position will be nil, so default pos is len(cols)
-	rs, err = tk.Exec("alter table t add column(e int as (c+1))")
-	if rs != nil {
-		rs.Close()
-	}
-	c.Assert(err, IsNil)
-}
-
 func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -586,6 +586,32 @@ func (s *testIntegrationSuite2) TestNullGeneratedColumn(c *C) {
 	tk.MustExec("drop table t")
 }
 
+func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`a` int(11) DEFAULT NULL," +
+		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
+		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	// should check unknown column first, then the prior
+	sql := "alter table t add column d int as (c + f + 1) first"
+	assertErrorCode(c, tk, sql, mysql.ErrBadField)
+
+	// depended generated column should be prior to generated column self
+	sql = "alter table t add column d int as (c+1) first"
+	assertErrorCode(c, tk, sql, mysql.ErrGeneratedColumnNonPrior)
+
+	// correct case
+	_, err := tk.Exec("alter table t add column d int as (c+1) after c")
+	c.Assert(err, IsNil)
+
+	// check position nil
+	_, err = tk.Exec("alter table t add column(e int as (c+1))")
+	c.Assert(err, IsNil)
+}
+
 func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -615,6 +615,12 @@ func (s *testIntegrationSuite2) TestDependedGeneratedColumnPrior2GeneratedColumn
 		rs.Close()
 	}
 	c.Assert(err, IsNil)
+	// in this sql pattern, position will be nil, so default pos is len(cols)
+	rs, err = tk.Exec("alter table t add column(e int as (c+1))")
+	if rs != nil {
+		rs.Close()
+	}
+	c.Assert(err, IsNil)
 }
 
 func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2109,7 +2109,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 			if err = checkAutoIncrementRef(specNewColumn.Name.Name.L, dependColNames, t.Meta()); err != nil {
 				return errors.Trace(err)
 			}
-			duplicateColNames := make(map[string]struct{})
+			duplicateColNames := make(map[string]struct{}, len(dependColNames))
 			for k := range dependColNames {
 				duplicateColNames[k] = struct{}{}
 			}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2109,7 +2109,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 			if err = checkAutoIncrementRef(specNewColumn.Name.Name.L, dependColNames, t.Meta()); err != nil {
 				return errors.Trace(err)
 			}
-			var pos int = -1
+			var pos int
 			if pos, err = findPositionRelativeColumn(t.Cols(), spec.Position); err != nil {
 				return errors.Trace(err)
 			}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2109,12 +2109,16 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 			if err = checkAutoIncrementRef(specNewColumn.Name.Name.L, dependColNames, t.Meta()); err != nil {
 				return errors.Trace(err)
 			}
-			var pos int
-			if pos, err = findPositionRelativeColumn(t.Cols(), spec.Position); err != nil {
+			duplicateColNames := make(map[string]struct{})
+			for k := range dependColNames {
+				duplicateColNames[k] = struct{}{}
+			}
+
+			if err = checkDependedColExist(dependColNames, t.Cols()); err != nil {
 				return errors.Trace(err)
 			}
 
-			if err = checkDependedColValid(dependColNames, t.Cols(), pos); err != nil {
+			if err = verifyColumnGenerationSingle(duplicateColNames, t.Cols(), spec.Position); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2113,12 +2113,13 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 			for k := range dependColNames {
 				duplicateColNames[k] = struct{}{}
 			}
+			cols := t.Cols()
 
-			if err = checkDependedColExist(dependColNames, t.Cols()); err != nil {
+			if err = checkDependedColExist(dependColNames, cols); err != nil {
 				return errors.Trace(err)
 			}
 
-			if err = verifyColumnGenerationSingle(duplicateColNames, t.Cols(), spec.Position); err != nil {
+			if err = verifyColumnGenerationSingle(duplicateColNames, cols, spec.Position); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2094,7 +2094,7 @@ func (d *ddl) AddColumn(ctx sessionctx.Context, ti ast.Ident, spec *ast.AlterTab
 
 	// If new column is a generated column, do validation.
 	// NOTE: we do check whether the column refers other generated
-	// columns occurring later in table. but not handle the col offset.
+	// columns occurring later in a table, but we don't handle the col offset.
 	for _, option := range specNewColumn.Options {
 		if option.Tp == ast.ColumnOptionGenerated {
 			if err := checkIllegalFn4GeneratedColumn(specNewColumn.Name.Name.L, option.Expr); err != nil {

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -77,7 +77,7 @@ func checkDependedColValid(dependCols map[string]struct{}, cols []*table.Column,
 	return nil
 }
 
-// findPositionRelativeColumn return a column relative to Adding column position
+// findPositionRelativeColumn return a pos relative to added generated column position
 func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (int, error) {
 	position := len(cols)
 	// Get column position.
@@ -120,7 +120,7 @@ func findDependedColumnNames(colDef *ast.ColumnDef) (generated bool, colsMap map
 // findColumnNamesInExpr returns a slice of ast.ColumnName which is referred in expr.
 func findColumnNamesInExpr(expr ast.ExprNode) []*ast.ColumnName {
 	var c generatedColumnChecker
-	expr.Accept(&c) //会递归遍历左右还在，找到其中的Column表达式，将ColumnName进行记录
+	expr.Accept(&c)
 	return c.cols
 }
 

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -72,7 +72,6 @@ func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*ta
 // checkDependedColExist ensure all depended columns exist.
 // NOTE: this will MODIFY parameter `dependCols`.
 func checkDependedColExist(dependCols map[string]struct{}, cols []*table.Column) error {
-	// Checks all depended columns exist.
 	for _, col := range cols {
 		delete(dependCols, col.Name.L)
 	}

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -51,7 +51,7 @@ func verifyColumnGeneration(colName2Generation map[string]columnGenerationInDDL,
 }
 
 // verifyColumnGenerationSingle is for ADD GENERATED COLUMN, we just need verify one column itself.
-func verifyColumnGenerationSingle(dependCols map[string]struct{}, cols []*table.Column, position *ast.ColumnPosition) error {
+func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*table.Column, position *ast.ColumnPosition) error {
 	// cause the added column hasn't existed, should derive it's offset from ColumnPosition
 	pos, err := findPositionRelativeColumn(cols, position)
 	if err != nil {
@@ -59,7 +59,7 @@ func verifyColumnGenerationSingle(dependCols map[string]struct{}, cols []*table.
 	}
 	// mysql then will check relative generated column should be prior to it, so it should be in one loop
 	for _, col := range cols {
-		if _, ok := dependCols[col.Name.L]; ok {
+		if _, ok := dependColNames[col.Name.L]; ok {
 			if col.IsGenerated() && col.Offset >= pos {
 				// Generated column can refer only to generated columns defined prior to it.
 				return errGeneratedColumnNonPrior.GenWithStackByArgs()

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -80,7 +80,12 @@ func checkDependedColValid(dependCols map[string]struct{}, cols []*table.Column,
 // findPositionRelativeColumn return a pos relative to added generated column position
 func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (int, error) {
 	position := len(cols)
-	// Get column position.
+	// get column position default is append behind
+	// For "alter table ... add column(...)", the position will be nil.
+	// For "alter table ... add column ... ", the position will be default one.
+	if pos == nil {
+		return position, nil
+	}
 	if pos.Tp == ast.ColumnPositionFirst {
 		position = 0
 	} else if pos.Tp == ast.ColumnPositionAfter {

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -87,7 +87,7 @@ func checkDependedColExist(dependCols map[string]struct{}, cols []*table.Column)
 // findPositionRelativeColumn return a pos relative to added generated column position
 func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (int, error) {
 	position := len(cols)
-	// get column position default is append behind
+	// Get the column position, default is cols's length means appending.
 	// For "alter table ... add column(...)", the position will be nil.
 	// For "alter table ... add column ... ", the position will be default one.
 	if pos == nil {
@@ -106,7 +106,7 @@ func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (
 		if col == nil {
 			return -1, ErrBadField.GenWithStackByArgs(pos.RelativeColumn, "generated column function")
 		}
-		// Insert position is after the mentioned column.
+		// Inserted position is after the mentioned column.
 		position = col.Offset + 1
 	}
 	return position, nil

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -52,12 +52,12 @@ func verifyColumnGeneration(colName2Generation map[string]columnGenerationInDDL,
 
 // verifyColumnGenerationSingle is for ADD GENERATED COLUMN, we just need verify one column itself.
 func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*table.Column, position *ast.ColumnPosition) error {
-	// cause the added column hasn't existed, should derive it's offset from ColumnPosition
+	// Since the added column does not exist yet, we should derive it's offset from ColumnPosition.
 	pos, err := findPositionRelativeColumn(cols, position)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// mysql then will check relative generated column should be prior to it, so it should be in one loop
+	// check if all relative generated columns are prior to it.
 	for _, col := range cols {
 		if _, ok := dependColNames[col.Name.L]; ok {
 			if col.IsGenerated() && col.Offset >= pos {
@@ -72,7 +72,7 @@ func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*ta
 // checkDependedColExist ensure all depended columns exist.
 // NOTE: this will MODIFY parameter `dependCols`.
 func checkDependedColExist(dependCols map[string]struct{}, cols []*table.Column) error {
-	// mysql will first check all depended column exist
+	// Checks all depended columns exist.
 	for _, col := range cols {
 		delete(dependCols, col.Name.L)
 	}
@@ -84,7 +84,7 @@ func checkDependedColExist(dependCols map[string]struct{}, cols []*table.Column)
 	return nil
 }
 
-// findPositionRelativeColumn return a pos relative to added generated column position
+// findPositionRelativeColumn returns a pos relative to added generated column position.
 func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (int, error) {
 	position := len(cols)
 	// Get the column position, default is cols's length means appending.

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -57,7 +57,7 @@ func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*ta
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// check if all relative generated columns are prior to it.
+	// should check unknown column first, then the prior ones.
 	for _, col := range cols {
 		if _, ok := dependColNames[col.Name.L]; ok {
 			if col.IsGenerated() && col.Offset >= pos {

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -59,10 +59,11 @@ func verifyColumnGenerationSingle(dependCols map[string]struct{}, cols []*table.
 	}
 	// mysql then will check relative generated column should be prior to it, so it should be in one loop
 	for _, col := range cols {
-		_, ok := dependCols[col.Name.L]
-		if col.Offset >= pos && ok && col.IsGenerated() {
-			// Generated column can refer only to generated columns defined prior to it.
-			return errGeneratedColumnNonPrior.GenWithStackByArgs()
+		if _, ok := dependCols[col.Name.L]; ok {
+			if col.IsGenerated() && col.Offset >= pos {
+				// Generated column can refer only to generated columns defined prior to it.
+				return errGeneratedColumnNonPrior.GenWithStackByArgs()
+			}
 		}
 	}
 	return nil

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -74,7 +74,6 @@ func checkDependedColValid(dependCols map[string]struct{}, cols []*table.Column,
 			return errGeneratedColumnNonPrior.GenWithStackByArgs()
 		}
 	}
-	duplicateMap = nil
 	return nil
 }
 

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -861,6 +861,28 @@ func (s *testSuite3) TestGeneratedColumnRelatedDDL(c *C) {
 	tk.MustExec("drop table t1;")
 }
 
+func (s *testSuite3) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`a` int(11) DEFAULT NULL," +
+		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
+		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	// should check unknown column first, then the prior
+	_, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
+	// depended generated column should be prior to generated column self
+	_, err = tk.Exec("alter table t add column d int as (c+1) first")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
+	// correct case
+	_, err = tk.Exec("alter table t add column d int as (c+1) after c")
+	c.Assert(err, IsNil)
+}
+
 func (s *testSuite3) TestSetDDLErrorCountLimit(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -861,31 +861,6 @@ func (s *testSuite3) TestGeneratedColumnRelatedDDL(c *C) {
 	tk.MustExec("drop table t1;")
 }
 
-func (s *testSuite3) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("CREATE TABLE `t` (" +
-		"`a` int(11) DEFAULT NULL," +
-		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
-		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
-	// should check unknown column first, then the prior
-	_, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
-	// depended generated column should be prior to generated column self
-	_, err = tk.Exec("alter table t add column d int as (c+1) first")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
-	// correct case
-	_, err = tk.Exec("alter table t add column d int as (c+1) after c")
-	c.Assert(err, IsNil)
-	// check position nil
-	_, err = tk.Exec("alter table t add column(e int as (c+1))")
-	c.Assert(err, IsNil)
-}
-
 func (s *testSuite3) TestSetDDLErrorCountLimit(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -861,6 +861,31 @@ func (s *testSuite3) TestGeneratedColumnRelatedDDL(c *C) {
 	tk.MustExec("drop table t1;")
 }
 
+func (s *testSuite3) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`a` int(11) DEFAULT NULL," +
+		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
+		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	// should check unknown column first, then the prior
+	_, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
+	// depended generated column should be prior to generated column self
+	_, err = tk.Exec("alter table t add column d int as (c+1) first")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
+	// correct case
+	_, err = tk.Exec("alter table t add column d int as (c+1) after c")
+	c.Assert(err, IsNil)
+	// check position nil
+	_, err = tk.Exec("alter table t add column(e int as (c+1))")
+	c.Assert(err, IsNil)
+}
+
 func (s *testSuite3) TestSetDDLErrorCountLimit(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -861,28 +861,6 @@ func (s *testSuite3) TestGeneratedColumnRelatedDDL(c *C) {
 	tk.MustExec("drop table t1;")
 }
 
-func (s *testSuite3) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("CREATE TABLE `t` (" +
-		"`a` int(11) DEFAULT NULL," +
-		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
-		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
-	// should check unknown column first, then the prior
-	_, err := tk.Exec("alter table t add column d int as (c + f + 1) first")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:1054]Unknown column 'f' in 'generated column function'")
-	// depended generated column should be prior to generated column self
-	_, err = tk.Exec("alter table t add column d int as (c+1) first")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:3107]Generated column can refer only to generated columns defined prior to it.")
-	// correct case
-	_, err = tk.Exec("alter table t add column d int as (c+1) after c")
-	c.Assert(err, IsNil)
-}
-
 func (s *testSuite3) TestSetDDLErrorCountLimit(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to solve the following bug that caused by the order of generated columns and non-generated columns:

TiDB master:
```
tidb> create table t (a int, b int as (a + 1), c int as (b + 1))
Query OK, 0 rows affected (0.16 sec)

tidb> insert into t set a=1;
Query OK, 1 rows affected (0.0 sec)

tidb>alter table t add column e int as (c + 1) first;
Query OK, 0 rows affected (0.16 sec)

tidb> select * from t
+--------+---+---+---+
| e      | a | b | c |
+--------+---+---+---+
| <null> | 1 | 2 | 3 |                      
+--------+---+---+---+
1 row in set

tidb> desc select * from t;
+-----------------+----------+------+-------------------------------------------------------------------------------------------------------------------+
| id              | count    | task | operator info                                                                                                     |
+-----------------+----------+------+-------------------------------------------------------------------------------------------------------------------+
| Projection_5    | 10000.00 | root | cast(plus(cast(plus(test.t.b, 1)), 1)), test.t.a, cast(plus(test.t.a, 1)), cast(plus(cast(plus(test.t.a, 1)), 1)) |
| └─TableReader_7 | 10000.00 | root | data:TableScan_6                                                                                                  |
|   └─TableScan_6 | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo                                                        |
+-----------------+----------+------+-------------------------------------------------------------------------------------------------------------------+
```

In MySQL 5.7 & 8.0:
```
mysql> create table t (a int, b int as (a + 1), c int as (b + 1))
Query OK, 0 rows affected (0.16 sec)

mysql> insert into t set a=1;
Query OK, 1 rows affected (0.0 sec)

mysql>alter table t add column e int as (c + 1) first;
(3107, u'Generated column can refer only to generated columns defined prior to it.')
```
Before putting add generated column to ddl job, computing the generated column offset itself and judging the relation with depended generated column offset as well.

### What is changed and how it works?
Find the generated column offset itself in func `findPositionRelativeColumn`
judge the relation with depended  generated column offset in func `checkDependedColValid`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

