### PR TITLE
tikv: invalidate store's regions when store be removed in kv

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -49,6 +49,7 @@ var (
 	tikvRegionCacheCounterWithScanRegionsError            = metrics.TiKVRegionCacheCounter.WithLabelValues("scan_regions", "err")
 	tikvRegionCacheCounterWithGetStoreOK                  = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "ok")
 	tikvRegionCacheCounterWithGetStoreError               = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "err")
+	tikvRegionCacheCounterWithInvalidateStoreRegionsOK    = metrics.TiKVRegionCacheCounter.WithLabelValues("invalidate_store_regions", "ok")
 )
 
 const (
@@ -967,6 +968,7 @@ func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
 		epoch := rs.storeFails[rs.workStoreIdx]
 		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
 			logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
+			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
 		}
 	}
 
@@ -1099,6 +1101,11 @@ func (s *Store) reResolve(c *RegionCache) {
 		return
 	}
 	if store == nil {
+		// store has be removed in PD, we should invalidate all regions using those store.
+		logutil.BgLogger().Info("invalidate regions in removed store",
+			zap.Uint64("store", s.storeID), zap.String("add", s.addr))
+		atomic.AddUint32(&s.fail, 1)
+		tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

this question can be reproduced by `TestReplaceAddrWithNewStore` testcase:

1. access A store using region1, then region1 will be put into region-cache
2. remove A store(store_id=1) in ip1:port2 from kv-cluster
3. then add B store(store_id=2) in the same ip1:port2 into kv-cluster 
4. access region1 again via region cache(make sure TTL isn't expired)

make sure 2-3 no any request hit region1, then 4 will be fail in infline loop

the root reason is: region-cache will try async fetch store A's new address but got nil, region request will [keep retry](https://github.com/pingcap/tidb/blob/eae30ebbcb8464d4644598db459337998ab1d43b/store/tikv/region_request.go#L244) and wait "new addr", this also will make cache TTL have no chance to invalidate cached info.

### What is changed and how it works?

invalidate regions in removed store, to let request have the chance to reload new region's store info from pd.

after this modification, `TestReplaceAddrWithNewStore` can works

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - invalidate code

Side effects

 -  N/A

Related changes

 - Need to cherry-pick to the release  3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11567)
<!-- Reviewable:end -->
