### PR TITLE
executor: fix data race of "admin check table"

### DIFF
--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -91,10 +91,10 @@ func (s *testSuite2) TestAdminRecoverIndex(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
 	c.Assert(executor.ErrAdminCheckTable.Equal(err), IsTrue)
-	_, err = tk.Exec("admin check index admin_test c2")
+	err = tk.ExecToErr("admin check index admin_test c2")
 	c.Assert(err, NotNil)
 
 	r = tk.MustQuery("SELECT COUNT(*) FROM admin_test USE INDEX(c2)")
@@ -115,7 +115,7 @@ func (s *testSuite2) TestAdminRecoverIndex(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	_, err = tk.Exec("admin check index admin_test c2")
+	err = tk.ExecToErr("admin check index admin_test c2")
 	c.Assert(err, NotNil)
 	r = tk.MustQuery("admin recover index admin_test c2")
 	r.Check(testkit.Rows("1 5"))
@@ -137,9 +137,9 @@ func (s *testSuite2) TestAdminRecoverIndex(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test c2")
+	err = tk.ExecToErr("admin check index admin_test c2")
 	c.Assert(err, NotNil)
 
 	r = tk.MustQuery("SELECT COUNT(*) FROM admin_test USE INDEX(c2)")
@@ -261,9 +261,9 @@ func (s *testSuite2) TestAdminCleanupIndex(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test c2")
+	err = tk.ExecToErr("admin check index admin_test c2")
 	c.Assert(err, NotNil)
 	r = tk.MustQuery("SELECT COUNT(*) FROM admin_test USE INDEX(c2)")
 	r.Check(testkit.Rows("11"))
@@ -273,9 +273,9 @@ func (s *testSuite2) TestAdminCleanupIndex(c *C) {
 	r.Check(testkit.Rows("6"))
 	tk.MustExec("admin check index admin_test c2")
 
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test c3")
+	err = tk.ExecToErr("admin check index admin_test c3")
 	c.Assert(err, NotNil)
 	r = tk.MustQuery("SELECT COUNT(*) FROM admin_test USE INDEX(c3)")
 	r.Check(testkit.Rows("9"))
@@ -322,9 +322,9 @@ func (s *testSuite2) TestAdminCleanupIndexPKNotHandle(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test `primary`")
+	err = tk.ExecToErr("admin check index admin_test `primary`")
 	c.Assert(err, NotNil)
 	r = tk.MustQuery("SELECT COUNT(*) FROM admin_test USE INDEX(`primary`)")
 	r.Check(testkit.Rows("6"))
@@ -374,11 +374,11 @@ func (s *testSuite2) TestAdminCleanupIndexMore(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test c1")
+	err = tk.ExecToErr("admin check index admin_test c1")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_test c2")
+	err = tk.ExecToErr("admin check index admin_test c2")
 	c.Assert(err, NotNil)
 	r := tk.MustQuery("SELECT COUNT(*) FROM admin_test")
 	r.Check(testkit.Rows("3"))
@@ -430,7 +430,7 @@ func (s *testSuite2) TestAdminCheckTableFailed(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err.Error(), Equals,
 		"[executor:8003]admin_test err:[admin:1]index:<nil> != record:&admin.RecordData{Handle:-1, Values:[]types.Datum{types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:-10, b:[]uint8(nil), x:interface {}(nil)}}}")
 	c.Assert(executor.ErrAdminCheckTable.Equal(err), IsTrue)
@@ -447,7 +447,7 @@ func (s *testSuite2) TestAdminCheckTableFailed(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err.Error(), Equals, "handle 0, index:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:0, b:[]uint8(nil), x:interface {}(nil)} != record:<nil>")
 
 	// Add one row of index.
@@ -464,7 +464,7 @@ func (s *testSuite2) TestAdminCheckTableFailed(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err.Error(), Equals, "col c2, handle 2, index:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:13, b:[]uint8(nil), x:interface {}(nil)} != record:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:12, b:[]uint8(nil), x:interface {}(nil)}")
 
 	// Table count = index count.
@@ -477,7 +477,7 @@ func (s *testSuite2) TestAdminCheckTableFailed(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err.Error(), Equals, "col c2, handle 10, index:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:19, b:[]uint8(nil), x:interface {}(nil)} != record:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:20, b:[]uint8(nil), x:interface {}(nil)}")
 
 	// Table count = index count.
@@ -490,7 +490,7 @@ func (s *testSuite2) TestAdminCheckTableFailed(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_test")
+	err = tk.ExecToErr("admin check table admin_test")
 	c.Assert(err.Error(), Equals, "col c2, handle 10, index:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:19, b:[]uint8(nil), x:interface {}(nil)} != record:types.Datum{k:0x1, collation:0x0, decimal:0x0, length:0x0, i:20, b:[]uint8(nil), x:interface {}(nil)}")
 
 	// Recover records.
@@ -576,7 +576,7 @@ func (s *testSuite1) TestAdminCheckTable(c *C) {
 
 	tk.MustExec("use mysql")
 	tk.MustExec(`admin check table test.t;`)
-	_, err := tk.Exec("admin check table t")
+	err := tk.ExecToErr("admin check table t")
 	c.Assert(err, NotNil)
 
 	// test add index on time type column which have default value
@@ -616,7 +616,7 @@ func (s *testSuite1) TestAdminCheckTable(c *C) {
 	tk.MustExec(`drop table if exists t1`)
 	tk.MustExec(`create table t1 (a decimal(2,1), index(a))`)
 	tk.MustExec(`insert into t1 set a='1.9'`)
-	_, err = tk.Exec(`alter table t1 modify column a decimal(3,2);`)
+	err = tk.ExecToErr(`alter table t1 modify column a decimal(3,2);`)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify decimal column precision")
 	tk.MustExec(`delete from t1;`)
@@ -659,9 +659,9 @@ func (s *testSuite2) TestAdminCheckWithSnapshot(c *C) {
 	c.Assert(err, IsNil)
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
-	_, err = tk.Exec("admin check table admin_t_s")
+	err = tk.ExecToErr("admin check table admin_t_s")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_t_s a")
+	err = tk.ExecToErr("admin check index admin_t_s a")
 	c.Assert(err, NotNil)
 
 	// For mocktikv, safe point is not initialized, we manually insert it for snapshot to use.
@@ -678,9 +678,9 @@ func (s *testSuite2) TestAdminCheckWithSnapshot(c *C) {
 	tk.MustExec("admin check index admin_t_s a;")
 
 	tk.MustExec("set @@tidb_snapshot = ''")
-	_, err = tk.Exec("admin check table admin_t_s")
+	err = tk.ExecToErr("admin check table admin_t_s")
 	c.Assert(err, NotNil)
-	_, err = tk.Exec("admin check index admin_t_s a")
+	err = tk.ExecToErr("admin check index admin_t_s a")
 	c.Assert(err, NotNil)
 
 	r := tk.MustQuery("admin cleanup index admin_t_s a")

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -480,6 +480,17 @@ func (e *CheckTableExec) Open(ctx context.Context) error {
 	return nil
 }
 
+// Close implements the Executor Close interface.
+func (e *CheckTableExec) Close() error {
+	var firstErr error
+	for _, src := range e.srcs {
+		if err := src.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
 func (e *CheckTableExec) checkIndexHandle(ctx context.Context, num int, src *IndexLookUpExecutor) error {
 	cols := src.schema.Columns
 	retFieldTypes := make([]*types.FieldType, len(cols))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the data race as follows:
```
[2019-08-01T03:20:55.984Z] WARNING: DATA RACE
[2019-08-01T03:20:55.984Z] Write at 0x00c011f4b740 by goroutine 375:
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/sessionctx/stmtctx.(*StatementContext).MergeExecDetails()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/stmtctx/stmtctx.go:431 +0x8b
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/distsql.(*selectResult).getSelectResp()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/distsql/select_result.go:197 +0x408
...
/home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/table_reader.go:139 +0x7b
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/executor.(*tableWorker).compareData()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/distsql.go:804 +0x13d8
[2019-08-01T03:20:55.984Z]
[2019-08-01T03:20:55.984Z] Previous write at 0x00c011f4b740 by goroutine 241:
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/executor.ResetContextOfStmt()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:1336 +0x2d2
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/session.(*session).execute()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1073 +0x7d5
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/session.(*session).Execute()
...
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/executor_test.(*testSuite2).TestAdminCleanupIndexMore()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/admin_test.go:379 +0xed0
[2019-08-01T03:20:55.984Z]   github.com/pingcap/tidb/executor_test.(*testSuite2).TestAdminCleanupIndexMore()
[2019-08-01T03:20:55.984Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/admin_test.go:343 +0x16f
```

### What is changed and how it works?
- Add a `Close` for `CheckTableExec` to close all `srcs`.

- Use `ExecToErr` instead of `Exec`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch