### PR TITLE
store/tikv: make test stable by running `TestPanicInRecvLoop` unparallel with others

### DIFF
--- a/store/tikv/client_fail_test.go
+++ b/store/tikv/client_fail_test.go
@@ -25,13 +25,26 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
 
+type testClientFailSuite struct {
+	OneByOneSuite
+}
+
+func (s *testClientFailSuite) SetUpSuite(c *C) {
+	// This lock make testClientFailSuite runs exclusively.
+	withTiKVGlobalLock.Lock()
+}
+
+func (s testClientFailSuite) TearDownSuite(c *C) {
+	withTiKVGlobalLock.Unlock()
+}
+
 func setGrpcConnectionCount(count uint) {
 	newConf := config.NewConfig()
 	newConf.TiKVClient.GrpcConnectionCount = count
 	config.StoreGlobalConfig(newConf)
 }
 
-func (s *testClientSuite) TestPanicInRecvLoop(c *C) {
+func (s *testClientFailSuite) TestPanicInRecvLoop(c *C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/panicInFailPendingRequests", `panic`), IsNil)
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/gotErrorInRecvLoop", `return("0")`), IsNil)
 

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -36,6 +36,7 @@ type testClientSuite struct {
 }
 
 var _ = Suite(&testClientSuite{})
+var _ = Suite(&testClientFailSuite{})
 
 func setMaxBatchSize(size uint) {
 	newConf := config.NewConfig()

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	withTiKVGlobalLock sync.Mutex
+	withTiKVGlobalLock sync.RWMutex
 	withTiKV           = flag.Bool("with-tikv", false, "run tests with TiKV cluster started. (not use the mock server)")
 	pdAddrs            = flag.String("pd-addrs", "127.0.0.1:2379", "pd addrs")
 )

--- a/store/tikv/tikv_test.go
+++ b/store/tikv/tikv_test.go
@@ -18,18 +18,21 @@ import (
 )
 
 // OneByOneSuite is a suite, When with-tikv flag is true, there is only one storage, so the test suite have to run one by one.
-type OneByOneSuite struct {
-}
+type OneByOneSuite struct{}
 
-func (s OneByOneSuite) SetUpSuite(c *C) {
+func (s *OneByOneSuite) SetUpSuite(c *C) {
 	if *withTiKV {
 		withTiKVGlobalLock.Lock()
+	} else {
+		withTiKVGlobalLock.RLock()
 	}
 }
 
-func (s OneByOneSuite) TearDownSuite(c *C) {
+func (s *OneByOneSuite) TearDownSuite(c *C) {
 	if *withTiKV {
 		withTiKVGlobalLock.Unlock()
+	} else {
+		withTiKVGlobalLock.RUnlock()
 	}
 }
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Make CI more stable

### What is changed and how it works?

The fail point injected by `TestPanicInRecvLoop` affect other tests.
Use a lock to make it run unparalleled with others

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



