### PR TITLE
builtin: logic op not compatibility with float

### DIFF
--- a/expression/builtin_op_test.go
+++ b/expression/builtin_op_test.go
@@ -91,6 +91,10 @@ func (s *testEvaluatorSuite) TestLogicAnd(c *C) {
 		{[]interface{}{0, nil}, 0, false, false},
 		{[]interface{}{nil, 0}, 0, false, false},
 		{[]interface{}{nil, 1}, 0, true, false},
+		{[]interface{}{0.1, 0.1}, 1, false, false},
+		{[]interface{}{0.1, 0}, 0, false, false},
+		{[]interface{}{0, 0.1}, 0, false, false},
+		{[]interface{}{nil, 0.1}, 0, true, false},
 
 		{[]interface{}{errors.New("must error"), 1}, 0, false, true},
 	}
@@ -305,6 +309,10 @@ func (s *testEvaluatorSuite) TestLogicOr(c *C) {
 		{[]interface{}{1, nil}, 1, false, false},
 		{[]interface{}{nil, 1}, 1, false, false},
 		{[]interface{}{nil, 0}, 0, true, false},
+		{[]interface{}{0.1, 0.1}, 1, false, false},
+		{[]interface{}{0.1, 0}, 1, false, false},
+		{[]interface{}{0, 0.1}, 1, false, false},
+		{[]interface{}{nil, 0.1}, 1, false, false},
 
 		{[]interface{}{errors.New("must error"), 1}, 0, false, true},
 	}

--- a/expression/distsql_builtin.go
+++ b/expression/distsql_builtin.go
@@ -305,10 +305,14 @@ func getSignatureByPB(ctx sessionctx.Context, sigCode tipb.ScalarFuncSig, tp *ti
 	case tipb.ScalarFuncSig_FloorReal:
 		f = &builtinFloorRealSig{base}
 
-	case tipb.ScalarFuncSig_LogicalAnd:
-		f = &builtinLogicAndSig{base}
-	case tipb.ScalarFuncSig_LogicalOr:
-		f = &builtinLogicOrSig{base}
+	case tipb.ScalarFuncSig_IntLogicalAnd:
+		f = &builtinIntLogicAndSig{base}
+	case tipb.ScalarFuncSig_RealLogicalAnd:
+		f = &builtinRealLogicAndSig{base}
+	case tipb.ScalarFuncSig_IntLogicalOr:
+		f = &builtinIntLogicOrSig{base}
+	case tipb.ScalarFuncSig_RealLogicalOr:
+		f = &builtinRealLogicOrSig{base}
 	case tipb.ScalarFuncSig_LogicalXor:
 		f = &builtinLogicXorSig{base}
 	case tipb.ScalarFuncSig_BitAndSig:

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -453,12 +453,12 @@ func (s *testEvalSuite) TestEval(c *C) {
 			types.NewDecimalDatum(newMyDecimal(c, "1.23")),
 		},
 		{
-			scalarFunctionExpr(tipb.ScalarFuncSig_LogicalAnd,
+			scalarFunctionExpr(tipb.ScalarFuncSig_IntLogicalAnd,
 				toPBFieldType(newIntFieldType()), datumExpr(c, types.NewIntDatum(1)), datumExpr(c, types.NewIntDatum(1))),
 			types.NewIntDatum(1),
 		},
 		{
-			scalarFunctionExpr(tipb.ScalarFuncSig_LogicalOr,
+			scalarFunctionExpr(tipb.ScalarFuncSig_IntLogicalOr,
 				toPBFieldType(newIntFieldType()), datumExpr(c, types.NewIntDatum(1)), datumExpr(c, types.NewIntDatum(0))),
 			types.NewIntDatum(1),
 		},

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -59,7 +59,7 @@ func ExpressionsToPB(sc *stmtctx.StatementContext, exprs []Expression, client kv
 		// Merge multiple converted pb expression into a CNF.
 		pbCNF = &tipb.Expr{
 			Tp:        tipb.ExprType_ScalarFunc,
-			Sig:       tipb.ScalarFuncSig_LogicalAnd,
+			Sig:       tipb.ScalarFuncSig_IntLogicalAnd,
 			Children:  []*tipb.Expr{pbCNF, pbExpr},
 			FieldType: ToPBFieldType(retTypeOfAnd),
 		}

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -117,7 +117,7 @@ func (s *testUtilSuite) TestClone(c *check.C) {
 		&builtinInetAtonSig{}, &builtinInetNtoaSig{}, &builtinInet6AtonSig{}, &builtinInet6NtoaSig{}, &builtinIsIPv4Sig{},
 		&builtinIsIPv4CompatSig{}, &builtinIsIPv4MappedSig{}, &builtinIsIPv6Sig{}, &builtinUUIDSig{}, &builtinNameConstIntSig{},
 		&builtinNameConstRealSig{}, &builtinNameConstDecimalSig{}, &builtinNameConstTimeSig{}, &builtinNameConstDurationSig{}, &builtinNameConstStringSig{},
-		&builtinNameConstJSONSig{}, &builtinLogicAndSig{}, &builtinLogicOrSig{}, &builtinLogicXorSig{}, &builtinRealIsTrueSig{},
+		&builtinNameConstJSONSig{}, &builtinIntLogicAndSig{}, &builtinRealLogicAndSig{}, &builtinIntLogicOrSig{}, &builtinRealLogicOrSig{}, &builtinLogicXorSig{}, &builtinRealIsTrueSig{},
 		&builtinDecimalIsTrueSig{}, &builtinIntIsTrueSig{}, &builtinRealIsFalseSig{}, &builtinDecimalIsFalseSig{}, &builtinIntIsFalseSig{},
 		&builtinUnaryMinusIntSig{}, &builtinDecimalIsNullSig{}, &builtinDurationIsNullSig{}, &builtinIntIsNullSig{}, &builtinRealIsNullSig{},
 		&builtinStringIsNullSig{}, &builtinTimeIsNullSig{}, &builtinUnaryNotRealSig{}, &builtinUnaryNotDecimalSig{}, &builtinUnaryNotIntSig{}, &builtinSleepSig{}, &builtinInIntSig{},

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,3 @@ require (
 )
 
 replace github.com/pingcap/tipb => github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f
-

--- a/go.mod
+++ b/go.mod
@@ -78,4 +78,3 @@ require (
 
 replace github.com/pingcap/tipb => github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f
 
-go 1.13

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,7 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/pingcap/tipb => github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jingyugao/tipb v0.0.0-20190806070524-16909e03435e h1:SgfzTAMEcs003GgjRX+iwP50/myD5xKUd/E6pAXvZhs=
-github.com/jingyugao/tipb v0.0.0-20190806070524-16909e03435e/go.mod h1:EBxLpOvivm5T+SDsuT+icoNOaQGLvz2kBmMfKzhmIJ4=
 github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f h1:mtQuOG0TM05qjRfmOAm5nMzo2igGZHW99faxOKfwFNw=
 github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f/go.mod h1:EBxLpOvivm5T+SDsuT+icoNOaQGLvz2kBmMfKzhmIJ4=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
@@ -177,8 +175,6 @@ github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tipb v0.0.0-20190806070524-16909e03435e h1:H7meq8QPmWGImOkHTQYAWw82zwIqndJaCDPVUknOHbM=
-github.com/pingcap/tipb v0.0.0-20190806070524-16909e03435e/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -101,6 +101,10 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpg
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/jingyugao/tipb v0.0.0-20190806070524-16909e03435e h1:SgfzTAMEcs003GgjRX+iwP50/myD5xKUd/E6pAXvZhs=
+github.com/jingyugao/tipb v0.0.0-20190806070524-16909e03435e/go.mod h1:EBxLpOvivm5T+SDsuT+icoNOaQGLvz2kBmMfKzhmIJ4=
+github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f h1:mtQuOG0TM05qjRfmOAm5nMzo2igGZHW99faxOKfwFNw=
+github.com/jingyugao/tipb v0.0.0-20190911070230-03bcdbb81a3f/go.mod h1:EBxLpOvivm5T+SDsuT+icoNOaQGLvz2kBmMfKzhmIJ4=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6 h1:MrUvLMLTMxbqFJ9kzlvat/rYZqZnW3u4wkLzWTaFwKs=


### PR DESCRIPTION
Signed-off-by: jingyugao <1121087373@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/11552
logic operate not compatibility with float.

### What is changed and how it works?
Make logic op cast args to real instead of int.
convert 0.1 to int will be 0, "0 or null" is null.
convert 0.1 to float will be 0.1, "0.1 or null" is 1.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
add unit test

Code changes
changed in function body

Side effects
no
Related changes
no