### PR TITLE
expression: the quote function should treat null expr as NULL literal string instead of NULL

### DIFF
--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -2698,7 +2698,7 @@ func (b *builtinQuoteSig) evalString(row chunk.Row) (string, bool, error) {
 	if err != nil {
 		return "", true, err
 	} else if isNull {
-		// If the argument is NULL, the return value is the word “NULL” without enclosing single quotation marks.
+		// If the argument is NULL, the return value is the word "NULL" without enclosing single quotation marks. see ref.
 		return "NULL", false, err
 	}
 

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -2695,9 +2695,14 @@ func (b *builtinQuoteSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_quote
 func (b *builtinQuoteSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
-	if isNull || err != nil {
+
+	if err != nil {
 		return "", true, err
+	} else if isNull {
+		// If the argument is NULL, the return value is the word “NULL” without enclosing single quotation marks.
+		return "NULL", false, err
 	}
+
 
 	runes := []rune(str)
 	buffer := bytes.NewBufferString("")

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -2695,14 +2695,12 @@ func (b *builtinQuoteSig) Clone() builtinFunc {
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_quote
 func (b *builtinQuoteSig) evalString(row chunk.Row) (string, bool, error) {
 	str, isNull, err := b.args[0].EvalString(b.ctx, row)
-
 	if err != nil {
 		return "", true, err
 	} else if isNull {
 		// If the argument is NULL, the return value is the word “NULL” without enclosing single quotation marks.
 		return "NULL", false, err
 	}
-
 
 	runes := []rune(str)
 	buffer := bytes.NewBufferString("")

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -2171,7 +2171,7 @@ func (s *testEvaluatorSuite) TestQuote(c *C) {
 		{`萌萌哒(๑•ᴗ•๑)😊`, `'萌萌哒(๑•ᴗ•๑)😊'`},
 		{`㍿㌍㍑㌫`, `'㍿㌍㍑㌫'`},
 		{string([]byte{0, 26}), `'\0\Z'`},
-		{nil, nil},
+		{nil, "NULL"},
 	}
 
 	for _, t := range tbl {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -901,7 +901,14 @@ func (s *testIntegrationSuite) TestStringBuiltin(c *C) {
 	result = tk.MustQuery(`select quote("aaaa"), quote(""), quote("\"\""), quote("\n\n");`)
 	result.Check(testkit.Rows("'aaaa' '' '\"\"' '\n\n'"))
 	result = tk.MustQuery(`select quote(0121), quote(0000), quote("中文"), quote(NULL);`)
-	result.Check(testkit.Rows("'121' '0' '中文' <nil>"))
+	result.Check(testkit.Rows("'121' '0' '中文' NULL"))
+	tk.MustQuery(`select quote(null) is NULL;`).Check(testkit.Rows(`0`))
+	tk.MustQuery(`select quote(null) is NOT NULL;`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select length(quote(null));`).Check(testkit.Rows(`4`))
+	tk.MustQuery(`select quote(null) REGEXP binary 'null'`).Check(testkit.Rows(`0`))
+	tk.MustQuery(`select quote(null) REGEXP binary 'NULL'`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select quote(null) REGEXP 'NULL'`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select quote(null) REGEXP 'null'`).Check(testkit.Rows(`1`))
 
 	// for convert
 	result = tk.MustQuery(`select convert("123" using "binary"), convert("中文" using "binary"), convert("中文" using "utf8"), convert("中文" using "utf8mb4"), convert(cast("中文" as binary) using "utf8");`)
@@ -4764,17 +4771,4 @@ func (s *testIntegrationSuite) TestIssue11309(c *C) {
 	tk.MustQuery(`SELECT DATE_ADD('2003-11-18 07:25:13',INTERVAL b MINUTE_SECOND) FROM t`).Check(testkit.Rows(`2004-03-13 03:14:52`, `2003-07-25 11:35:34`))
 	tk.MustQuery(`SELECT DATE_ADD('2003-11-18 07:25:13',INTERVAL c MINUTE_SECOND) FROM t`).Check(testkit.Rows(`2003-11-18 09:29:13`, `2003-11-18 05:21:13`))
 	tk.MustExec(`drop table if exists t;`)
-}
-
-
-func (s *testIntegrationSuite) TestQuote(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustQuery(`select quote(null) is NULL;`).Check(testkit.Rows(`0`))
-	tk.MustQuery(`select quote(null) is NOT NULL;`).Check(testkit.Rows(`1`))
-	tk.MustQuery(`select length(quote(null));`).Check(testkit.Rows(`4`))
-	tk.MustQuery(`select quote(null) REGEXP binary 'null'`).Check(testkit.Rows(`0`))
-	tk.MustQuery(`select quote(null) REGEXP binary 'NULL'`).Check(testkit.Rows(`1`))
-	tk.MustQuery(`select quote(null) REGEXP 'NULL'`).Check(testkit.Rows(`1`))
-	tk.MustQuery(`select quote(null) REGEXP 'null'`).Check(testkit.Rows(`1`))
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4765,3 +4765,16 @@ func (s *testIntegrationSuite) TestIssue11309(c *C) {
 	tk.MustQuery(`SELECT DATE_ADD('2003-11-18 07:25:13',INTERVAL c MINUTE_SECOND) FROM t`).Check(testkit.Rows(`2003-11-18 09:29:13`, `2003-11-18 05:21:13`))
 	tk.MustExec(`drop table if exists t;`)
 }
+
+
+func (s *testIntegrationSuite) TestQuote(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustQuery(`select quote(null) is NULL;`).Check(testkit.Rows(`0`))
+	tk.MustQuery(`select quote(null) is NOT NULL;`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select length(quote(null));`).Check(testkit.Rows(`4`))
+	tk.MustQuery(`select quote(null) REGEXP binary 'null'`).Check(testkit.Rows(`0`))
+	tk.MustQuery(`select quote(null) REGEXP binary 'NULL'`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select quote(null) REGEXP 'NULL'`).Check(testkit.Rows(`1`))
+	tk.MustQuery(`select quote(null) REGEXP 'null'`).Check(testkit.Rows(`1`))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/11556  QUOTE(null) should return 'NULL' string instead of NULL value
### What is changed and how it works?
if the expr is NULL, then the value for quote(expr) will be "NULL" instead of NULL.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test  - added more cases.

Side effects
 - Increased code complexity  -  maybe difficult to understand. but that's just what mysql does.
