### PR TITLE
expression: make `baseBuiltinFunc` support converting between row-based evaluation and vectorized evaluation

### DIFF
--- a/expression/vectorized_test.go
+++ b/expression/vectorized_test.go
@@ -1,0 +1,299 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+)
+
+type mockVecBuiltinDoubleInt struct {
+	baseBuiltinFunc
+}
+
+func (p *mockVecBuiltinDoubleInt) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+	col1 := p.args[0]
+	if err := col1.VecEval(p.ctx, input, result); err != nil {
+		return err
+	}
+	sel := input.Sel()
+	v1 := result.Int64s()
+	if sel == nil {
+		for i := range v1 {
+			// ignore checking null to get a better performance
+			v1[i] += v1[i]
+		}
+	} else {
+		for _, i := range sel {
+			v1[i] += v1[i]
+		}
+	}
+	return nil
+}
+
+type mockRowBuiltinDoubleInt struct {
+	baseBuiltinFunc
+}
+
+func (p *mockRowBuiltinDoubleInt) evalInt(row chunk.Row) (int64, bool, error) {
+	v, isNull, err := p.args[0].EvalInt(p.ctx, row)
+	if err != nil {
+		return 0, false, err
+	}
+	return v * 2, isNull, nil
+}
+
+type mockVecBuiltinDoubleStr struct {
+	baseBuiltinFunc
+	buf *chunk.Column
+}
+
+func (p *mockVecBuiltinDoubleStr) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumEffectiveRows()
+	if p.buf == nil {
+		p.buf = chunk.NewColumn(p.getRetTp(), n)
+	}
+
+	col1 := p.args[0]
+	if err := col1.VecEval(p.ctx, input, p.buf); err != nil {
+		return err
+	}
+	sel := input.Sel()
+	strBuf := bytes.Buffer{}
+	if sel == nil {
+		result.Reset()
+		for i := 0; i < n; i++ {
+			if p.buf.IsNull(i) {
+				result.AppendNull()
+				continue
+			}
+			strBuf.Reset()
+			strBuf.WriteString(p.buf.GetString(i))
+			strBuf.WriteString(p.buf.GetString(i))
+			result.AppendString(strBuf.String())
+		}
+	} else if len(sel) == 0 {
+		result.Reset()
+	} else {
+		pos := result.Length()
+		if pos > sel[0] {
+			result.Reset()
+			pos = 0
+		}
+		for _, i := range sel {
+			for pos < i {
+				result.AppendNull()
+				pos++
+			}
+			if p.buf.IsNull(i) {
+				result.AppendNull()
+			} else {
+				strBuf.Reset()
+				strBuf.WriteString(p.buf.GetString(i))
+				strBuf.WriteString(p.buf.GetString(i))
+				result.AppendString(strBuf.String())
+			}
+			pos++
+		}
+	}
+	return nil
+}
+
+type mockRowBuiltinDoubleStr struct {
+	baseBuiltinFunc
+}
+
+func (p *mockRowBuiltinDoubleInt) evalString(row chunk.Row) (string, bool, error) {
+	v, isNull, err := p.args[0].EvalString(p.ctx, row)
+	if err != nil {
+		return "", false, err
+	}
+	return v + v, isNull, nil
+}
+
+func genMockRowDoubleInt() (*mockRowBuiltinDoubleInt, *chunk.Chunk) {
+	col1 := newColumn(1)
+	col1.Index = 0
+	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, types.ETInt, types.ETInt)
+	rowDouble := &mockRowBuiltinDoubleInt{bf}
+	rowDouble.baseBuiltinFunc.self = rowDouble
+	rowDouble.baseBuiltinFunc.vec = false
+	tpll := types.NewFieldType(mysql.TypeLonglong)
+	input := chunk.New([]*types.FieldType{tpll}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendInt64(0, int64(i))
+	}
+	return rowDouble, input
+}
+
+func genMockVecDoubleInt() (*mockVecBuiltinDoubleInt, *chunk.Chunk) {
+	col1 := newColumn(1)
+	col1.Index = 0
+	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, types.ETInt, types.ETInt)
+	vecDouble := &mockVecBuiltinDoubleInt{bf}
+	vecDouble.baseBuiltinFunc.self = vecDouble
+	vecDouble.baseBuiltinFunc.vec = true
+	tpll := types.NewFieldType(mysql.TypeLonglong)
+	input := chunk.New([]*types.FieldType{tpll}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendInt64(0, int64(i))
+	}
+	return vecDouble, input
+}
+
+func genMockRowDoubleStr() (*mockRowBuiltinDoubleStr, *chunk.Chunk) {
+	tpstr := types.NewFieldType(mysql.TypeVarString)
+	col1 := newColumn(1)
+	col1.Index = 0
+	col1.RetType = tpstr
+	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, types.ETString, types.ETString)
+	rowDouble := &mockRowBuiltinDoubleStr{bf}
+	rowDouble.baseBuiltinFunc.self = rowDouble
+	rowDouble.baseBuiltinFunc.vec = false
+	input := chunk.New([]*types.FieldType{tpstr}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendString(0, fmt.Sprintf("%v", i))
+	}
+	return rowDouble, input
+}
+
+func genMockVecDoubleStr() (*mockVecBuiltinDoubleStr, *chunk.Chunk) {
+	tpstr := types.NewFieldType(mysql.TypeVarString)
+	col1 := newColumn(1)
+	col1.Index = 0
+	col1.RetType = tpstr
+	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, types.ETString, types.ETString)
+	vecDouble := &mockVecBuiltinDoubleStr{bf, nil}
+	vecDouble.baseBuiltinFunc.self = vecDouble
+	vecDouble.baseBuiltinFunc.vec = true
+	input := chunk.New([]*types.FieldType{tpstr}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendString(0, fmt.Sprintf("%v", i))
+	}
+	return vecDouble, input
+}
+
+func BenchmarkMockDoubleIntVec(b *testing.B) {
+	vecDouble, input := genMockVecDoubleInt()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vecDouble.vecEval(input, result)
+	}
+}
+
+func BenchmarkMockDoubleIntRow(b *testing.B) {
+	rowDouble, input := genMockRowDoubleInt()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result.Reset()
+		it := chunk.NewIterator4Chunk(input)
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, isNull, _ := rowDouble.evalInt(row)
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendInt64(v)
+			}
+		}
+	}
+}
+
+func BenchmarkMockDoubleIntVec2Row(b *testing.B) {
+	vecDouble, input := genMockVecDoubleInt()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result.Reset()
+		it := chunk.NewIterator4Chunk(input)
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, isNull, _ := vecDouble.evalInt(row)
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendInt64(v)
+			}
+		}
+	}
+}
+
+func BenchmarkMockDoubleIntRow2Vec(b *testing.B) {
+	rowDouble, input := genMockRowDoubleInt()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rowDouble.vecEval(input, result)
+	}
+}
+
+func BenchmarkMockDoubleStrVec(b *testing.B) {
+	vecDouble, input := genMockVecDoubleStr()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		vecDouble.vecEval(input, result)
+	}
+}
+
+func BenchmarkMockDoubleStrRow(b *testing.B) {
+	rowDouble, input := genMockRowDoubleStr()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result.Reset()
+		it := chunk.NewIterator4Chunk(input)
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, isNull, _ := rowDouble.evalString(row)
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendString(v)
+			}
+		}
+	}
+}
+
+func BenchmarkMockDoubleStrVec2Row(b *testing.B) {
+	vecDouble, input := genMockVecDoubleStr()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result.Reset()
+		it := chunk.NewIterator4Chunk(input)
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, isNull, _ := vecDouble.evalString(row)
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendString(v)
+			}
+		}
+	}
+}
+
+func BenchmarkMockDoubleStrRow2Vec(b *testing.B) {
+	rowDouble, input := genMockRowDoubleInt()
+	result := chunk.NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rowDouble.vecEval(input, result)
+	}
+}

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -529,3 +529,8 @@ func (c *Column) CopyReconstruct(sel []int, dst *Column) *Column {
 	}
 	return dst
 }
+
+// Length returns the length of this column.
+func (c *Column) Length() int {
+	return c.length
+}

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -28,6 +28,11 @@ type Row struct {
 	idx int
 }
 
+// Chunk returns the chunk which contains this row.
+func (r Row) Chunk() *Chunk {
+	return r.c
+}
+
 // IsEmpty returns true if the Row is empty.
 func (r Row) IsEmpty() bool {
 	return r == Row{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We will implement the vectorized evaluation for all our builtin functions soon.
For each builtin function, we only keep one kind of implementation (row-based or vectorized) since it's hard and unnecessary to maintain these two.

Therefore, we need a converter to make all builtin function support row-based evaluation and vectorized evaluation both since these two kinds of evaluation are needed by users.

We decide to make `baseBuiltinFunc` support this feature so that all builtin functions which inherit it can support this converting too.

### What is changed and how it works?
1. Make `baseBuiltinFunc` support this converting;
2. Add some unit tests;

Here is the benchmark: 
```
BenchmarkMockDoubleIntVec-12             3000000               427 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleIntRow-12              100000             14554 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleIntVec2Row-12           50000             32872 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleIntRow2Vec-12          100000             12993 ns/op            8320 B/op          2 allocs/op
BenchmarkMockDoubleStrVec-12               50000             33466 ns/op              64 B/op          1 allocs/op
BenchmarkMockDoubleStrRow-12                2000            909000 ns/op          426348 B/op       4097 allocs/op
BenchmarkMockDoubleStrVec2Row-12           10000            105747 ns/op           65541 B/op       1024 allocs/op
BenchmarkMockDoubleStrRow2Vec-12          100000             13016 ns/op            8320 B/op          2 allocs/op
```
1. Vectorized evaluation is 30X than row-based evaluation;
2. Converting from Vec to Row has some performance drawback for fixed-length type like `Int`, but I think it's ok since we will finally change all places which is import for performance to vectorized evaluation;

**All changes are for this new feature and unit tests, so it's easy to review.**

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
