### PR TITLE
expression: deduce result type for multi-argument functions like `IF` wrongly in some cases

### DIFF
--- a/expression/builtin_control.go
+++ b/expression/builtin_control.go
@@ -67,9 +67,8 @@ func InferType4ControlFuncs(lhs, rhs *types.FieldType) *types.FieldType {
 	} else if rhs.Tp == mysql.TypeNull {
 		*resultFieldType = *lhs
 	} else {
-		var unsignedFlag uint
-		evalType := types.AggregateEvalType([]*types.FieldType{lhs, rhs}, &unsignedFlag)
 		resultFieldType = types.AggFieldType([]*types.FieldType{lhs, rhs})
+		evalType := types.AggregateEvalType([]*types.FieldType{lhs, rhs}, &resultFieldType.Flag)
 		if evalType == types.ETInt {
 			resultFieldType.Decimal = 0
 		} else {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4760,6 +4760,16 @@ func (s *testIntegrationSuite) TestFuncCaseWithLeftJoin(c *C) {
 	tk.MustQuery("select t1.id from kankan1 t1 left join kankan2 t2 on t1.id = t2.id where (case  when t1.name='b' then 'case2' when t1.name='a' then 'case1' else NULL end) = 'case1' order by t1.id").Check(testkit.Rows("1", "2"))
 }
 
+func (s *testIntegrationSuite) TestIssue11594(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec("CREATE TABLE t1 (v bigint(20) UNSIGNED NOT NULL);")
+	tk.MustExec("INSERT INTO t1 VALUES (1), (2);")
+	tk.MustQuery("SELECT SUM(IF(v > 1, v, -v)) FROM t1;").Check(testkit.Rows("1"))
+	tk.MustQuery("SELECT sum(IFNULL(cast(null+rand() as unsigned), -v)) FROM t1;").Check(testkit.Rows("-3"))
+}
+
 func (s *testIntegrationSuite) TestIssue11309And11319(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4768,6 +4768,8 @@ func (s *testIntegrationSuite) TestIssue11594(c *C) {
 	tk.MustExec("INSERT INTO t1 VALUES (1), (2);")
 	tk.MustQuery("SELECT SUM(IF(v > 1, v, -v)) FROM t1;").Check(testkit.Rows("1"))
 	tk.MustQuery("SELECT sum(IFNULL(cast(null+rand() as unsigned), -v)) FROM t1;").Check(testkit.Rows("-3"))
+	tk.MustQuery("SELECT sum(COALESCE(cast(null+rand() as unsigned), -v)) FROM t1;").Check(testkit.Rows("-3"))
+	tk.MustQuery("SELECT sum(COALESCE(cast(null+rand() as unsigned), v)) FROM t1;").Check(testkit.Rows("3"))
 }
 
 func (s *testIntegrationSuite) TestIssue11309And11319(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/11594;

When we deduce the result type for a multi-argument function like `IF`, we don't take `signed/unsigned` flag into account now;

### What is changed and how it works?
If anyone of these input arguments is not unsigned, we set the result type to signed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test