### PR TITLE
statistics: the overflow check is not correct in `0-Math.MinInt64` situation.

### DIFF
--- a/statistics/scalar.go
+++ b/statistics/scalar.go
@@ -196,7 +196,7 @@ func enumRangeValues(low, high types.Datum, lowExclude, highExclude bool) []type
 		// Overflow check.
 		lowVal, highVal := low.GetInt64(), high.GetInt64()
 		if lowVal <= 0 && highVal >= 0 {
-			if lowVal <= -maxNumStep || highVal >= maxNumStep {
+			if lowVal < -maxNumStep || highVal > maxNumStep {
 				return nil
 			}
 		}

--- a/statistics/scalar.go
+++ b/statistics/scalar.go
@@ -195,7 +195,7 @@ func enumRangeValues(low, high types.Datum, lowExclude, highExclude bool) []type
 	case types.KindInt64:
 		// Overflow check.
 		lowVal, highVal := low.GetInt64(), high.GetInt64()
-		if lowVal < 0 && highVal > 0 {
+		if lowVal <= 0 && highVal >= 0 {
 			if lowVal <= -maxNumStep || highVal >= maxNumStep {
 				return nil
 			}

--- a/statistics/scalar_test.go
+++ b/statistics/scalar_test.go
@@ -241,11 +241,19 @@ func (s *testStatisticsSuite) TestEnumRangeValues(c *C) {
 			highExclude: true,
 			res:         "(2017-01-01 00:00:00, 2017-01-01 00:00:01, 2017-01-01 00:00:02, 2017-01-01 00:00:03, 2017-01-01 00:00:04)",
 		},
+		// fix issue 11610
+		{
+			low:         types.NewIntDatum(math.MinInt64),
+			high:        types.NewIntDatum(0),
+			lowExclude:  false,
+			highExclude: false,
+			res:         "",
+		},
 	}
 	for _, t := range tests {
 		vals := enumRangeValues(t.low, t.high, t.lowExclude, t.highExclude)
 		str, err := types.DatumsToString(vals, true)
 		c.Assert(err, IsNil)
-		c.Assert(t.res, Equals, str)
+		c.Assert(str, Equals, t.res)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #11610.

### What is changed and how it works?
Change the check range.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - None

Side effects

 - None

Related changes

 - None
