### PR TITLE
expression: make `baseBuiltinFunc` support converting from row-based evaluation to vectorized evaluation

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -204,6 +204,10 @@ func (b *baseBuiltinFunc) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error)
 	return json.BinaryJSON{}, false, errors.Errorf("baseBuiltinFunc.evalJSON() should never be called, please contact the TiDB team for help")
 }
 
+func (b *baseBuiltinFunc) vectorized() bool {
+	return false
+}
+
 func (b *baseBuiltinFunc) getRetTp() *types.FieldType {
 	switch b.tp.EvalType() {
 	case types.ETString:
@@ -285,6 +289,8 @@ func newBaseBuiltinCastFunc(builtinFunc baseBuiltinFunc, inUnion bool) baseBuilt
 type vecBuiltinFunc interface {
 	// vecEval evaluates this builtin function in a vectorized manner.
 	vecEval(input *chunk.Chunk, result *chunk.Column) error
+	// vectorized returns if this builtin function supports vectorized evaluation.
+	vectorized() bool
 }
 
 // builtinFunc stands for a particular function signature.
@@ -344,6 +350,12 @@ func (b *baseFunctionClass) verifyArgs(args []Expression) error {
 type functionClass interface {
 	// getFunction gets a function signature by the types and the counts of given arguments.
 	getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error)
+}
+
+func init() {
+	for k, v := range funcs {
+		funcs[k] = &vecRowConvertFuncClass{v}
+	}
 }
 
 // funcs holds all registered builtin functions. When new function is added,

--- a/expression/builtin_arithmetic_test.go
+++ b/expression/builtin_arithmetic_test.go
@@ -96,7 +96,7 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	bf, err := funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	intSig, ok := bf.(*builtinArithmeticPlusIntSig)
+	intSig, ok := bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticPlusIntSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(intSig, NotNil)
 
@@ -111,7 +111,7 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	bf, err = funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok := bf.(*builtinArithmeticPlusRealSig)
+	realSig, ok := bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticPlusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -126,7 +126,7 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	bf, err = funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok = bf.(*builtinArithmeticPlusRealSig)
+	realSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticPlusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -141,7 +141,7 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	bf, err = funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok = bf.(*builtinArithmeticPlusRealSig)
+	realSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticPlusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -158,7 +158,7 @@ func (s *testEvaluatorSuite) TestArithmeticPlus(c *C) {
 	bf, err = funcs[ast.Plus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	intSig, ok = bf.(*builtinArithmeticPlusIntSig)
+	intSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticPlusIntSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(intSig, NotNil)
 
@@ -176,7 +176,7 @@ func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {
 	bf, err := funcs[ast.Minus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	intSig, ok := bf.(*builtinArithmeticMinusIntSig)
+	intSig, ok := bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticMinusIntSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(intSig, NotNil)
 
@@ -191,7 +191,7 @@ func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {
 	bf, err = funcs[ast.Minus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok := bf.(*builtinArithmeticMinusRealSig)
+	realSig, ok := bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticMinusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -206,7 +206,7 @@ func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {
 	bf, err = funcs[ast.Minus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok = bf.(*builtinArithmeticMinusRealSig)
+	realSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticMinusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -221,7 +221,7 @@ func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {
 	bf, err = funcs[ast.Minus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok = bf.(*builtinArithmeticMinusRealSig)
+	realSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticMinusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 
@@ -236,7 +236,7 @@ func (s *testEvaluatorSuite) TestArithmeticMinus(c *C) {
 	bf, err = funcs[ast.Minus].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(args...)))
 	c.Assert(err, IsNil)
 	c.Assert(bf, NotNil)
-	realSig, ok = bf.(*builtinArithmeticMinusRealSig)
+	realSig, ok = bf.(*vecRowConverter).builtinFunc.(*builtinArithmeticMinusRealSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(realSig, NotNil)
 

--- a/expression/builtin_info_test.go
+++ b/expression/builtin_info_test.go
@@ -213,7 +213,7 @@ func (s *testEvaluatorSuite) TestRowCount(c *C) {
 	f, err := funcs[ast.RowCount].getFunction(ctx, nil)
 	c.Assert(err, IsNil)
 	c.Assert(f, NotNil)
-	sig, ok := f.(*builtinRowCountSig)
+	sig, ok := f.(*vecRowConverter).builtinFunc.(*builtinRowCountSig)
 	c.Assert(ok, IsTrue)
 	c.Assert(sig, NotNil)
 	intResult, isNull, err := sig.evalInt(chunk.Row{})

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -821,7 +821,7 @@ func (s *testEvaluatorSuite) TestConvert(c *C) {
 	f, err := fc.getFunction(s.ctx, s.datumsToConstants(types.MakeDatums("haha", "utf8")))
 	c.Assert(err, IsNil)
 	c.Assert(f, NotNil)
-	wrongFunction := f.(*builtinConvertSig)
+	wrongFunction := f.(*vecRowConverter).builtinFunc.(*builtinConvertSig)
 	wrongFunction.tp.Charset = "wrongcharset"
 	_, err = evalBuiltinFunc(wrongFunction, chunk.Row{})
 	c.Assert(err.Error(), Equals, "[expression:1115]Unknown character set: 'wrongcharset'")

--- a/expression/builtin_vectorized.go
+++ b/expression/builtin_vectorized.go
@@ -1,0 +1,158 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+type vecRowConverter struct {
+	builtinFunc
+}
+
+func (c *vecRowConverter) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEval(input, result)
+	}
+
+	// convert from row-based evaluation to vectorized evaluation.
+	// evaluate each row in input according to its row-based evaluation methods and updates the result.
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	switch c.builtinFunc.getRetTp().EvalType() {
+	case types.ETInt:
+		result.ResizeInt64(input.NumRows())
+		i64s := result.Int64s()
+		for i := range i64s {
+			if i64s[i], isNull, err = c.builtinFunc.evalInt(row); err != nil {
+				return err
+			}
+			result.SetNull(i, isNull)
+			row = it.Next()
+		}
+	case types.ETReal:
+		result.ResizeFloat64(input.NumRows())
+		f64s := result.Float64s()
+		for i := range f64s {
+			if f64s[i], isNull, err = c.builtinFunc.evalReal(row); err != nil {
+				return err
+			}
+			result.SetNull(i, isNull)
+			row = it.Next()
+		}
+	case types.ETDecimal:
+		result.ResizeDecimal(input.NumRows())
+		ds := result.Decimals()
+		var v *types.MyDecimal
+		for i := range ds {
+			if v, isNull, err = c.builtinFunc.evalDecimal(row); err != nil {
+				return err
+			}
+			if isNull {
+				result.SetNull(i, true)
+			} else {
+				result.SetNull(i, false)
+				ds[i] = *v
+			}
+			row = it.Next()
+		}
+	case types.ETDuration:
+		result.ResizeDuration(input.NumRows())
+		ds := result.GoDurations()
+		var v types.Duration
+		for i := range ds {
+			if v, isNull, err = c.builtinFunc.evalDuration(row); err != nil {
+				return err
+			}
+			ds[i] = v.Duration
+			result.SetNull(i, isNull)
+			row = it.Next()
+		}
+	case types.ETJson:
+		result.ReserveJSON(input.NumRows())
+		var v json.BinaryJSON
+		for ; row != it.End(); row = it.Next() {
+			if v, isNull, err = c.builtinFunc.evalJSON(row); err != nil {
+				return err
+			}
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendJSON(v)
+			}
+		}
+	case types.ETString:
+		result.ReserveString(input.NumRows())
+		var v string
+		for ; row != it.End(); row = it.Next() {
+			if v, isNull, err = c.builtinFunc.evalString(row); err != nil {
+				return err
+			}
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendString(v)
+			}
+		}
+	case types.ETDatetime, types.ETTimestamp:
+		result.Reset()
+		var v types.Time
+		for ; row != it.End(); row = it.Next() {
+			if v, isNull, err = c.builtinFunc.evalTime(row); err != nil {
+				return err
+			}
+			if isNull {
+				result.AppendNull()
+			} else {
+				result.AppendTime(v)
+			}
+		}
+	default:
+		return errors.Errorf("unsupported type for converting from row-based to vectorized evaluation, please contact the TiDB team for help")
+	}
+	return nil
+}
+
+func (c *vecRowConverter) vectorized() bool {
+	return true
+}
+
+func (c *vecRowConverter) equal(bf builtinFunc) bool {
+	if converter, ok := bf.(*vecRowConverter); ok {
+		bf = converter.builtinFunc
+	}
+	return c.builtinFunc.equal(bf)
+}
+
+func (c *vecRowConverter) Clone() builtinFunc {
+	return &vecRowConverter{c.builtinFunc.Clone()}
+}
+
+type vecRowConvertFuncClass struct {
+	functionClass
+}
+
+func (c *vecRowConvertFuncClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
+	bf, err := c.functionClass.getFunction(ctx, args)
+	if err != nil {
+		return nil, err
+	}
+	return &vecRowConverter{bf}, nil
+}

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -1,0 +1,394 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+type mockRowBuiltinDouble struct {
+	baseBuiltinFunc
+}
+
+func (p *mockRowBuiltinDouble) evalInt(row chunk.Row) (int64, bool, error) {
+	v, isNull, err := p.args[0].EvalInt(p.ctx, row)
+	if err != nil {
+		return 0, false, err
+	}
+	return v * 2, isNull, nil
+}
+
+func (p *mockRowBuiltinDouble) evalReal(row chunk.Row) (float64, bool, error) {
+	v, isNull, err := p.args[0].EvalReal(p.ctx, row)
+	if err != nil {
+		return 0, false, err
+	}
+	return v * 2, isNull, nil
+}
+
+func (p *mockRowBuiltinDouble) evalString(row chunk.Row) (string, bool, error) {
+	v, isNull, err := p.args[0].EvalString(p.ctx, row)
+	if err != nil {
+		return "", false, err
+	}
+	return v + v, isNull, nil
+}
+
+func (p *mockRowBuiltinDouble) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
+	v, isNull, err := p.args[0].EvalDecimal(p.ctx, row)
+	if err != nil {
+		return nil, false, err
+	}
+	r := new(types.MyDecimal)
+	if err := types.DecimalAdd(v, v, r); err != nil {
+		return nil, false, err
+	}
+	return r, isNull, nil
+}
+
+func (p *mockRowBuiltinDouble) evalTime(row chunk.Row) (types.Time, bool, error) {
+	v, isNull, err := p.args[0].EvalTime(p.ctx, row)
+	if err != nil {
+		return types.Time{}, false, err
+	}
+	d, err := v.ConvertToDuration()
+	if err != nil {
+		return types.Time{}, false, err
+	}
+	v, err = v.Add(p.ctx.GetSessionVars().StmtCtx, d)
+	return v, isNull, err
+}
+
+func (p *mockRowBuiltinDouble) evalDuration(row chunk.Row) (types.Duration, bool, error) {
+	v, isNull, err := p.args[0].EvalDuration(p.ctx, row)
+	if err != nil {
+		return types.Duration{}, false, err
+	}
+	v, err = v.Add(v)
+	return v, isNull, err
+}
+
+func (p *mockRowBuiltinDouble) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error) {
+	j, isNull, err := p.args[0].EvalJSON(p.ctx, row)
+	if err != nil {
+		return json.BinaryJSON{}, false, err
+	}
+	if isNull {
+		return json.BinaryJSON{}, true, nil
+	}
+	path, err := json.ParseJSONPathExpr("$.key")
+	if err != nil {
+		return json.BinaryJSON{}, false, err
+	}
+	ret, ok := j.Extract([]json.PathExpression{path})
+	if !ok {
+		return json.BinaryJSON{}, true, err
+	}
+	if err := j.UnmarshalJSON([]byte(fmt.Sprintf(`{"key":%v}`, 2*ret.GetInt64()))); err != nil {
+		return json.BinaryJSON{}, false, err
+	}
+	return j, false, nil
+}
+
+func convertETType(eType types.EvalType) (mysqlType byte) {
+	switch eType {
+	case types.ETInt:
+		mysqlType = mysql.TypeLonglong
+	case types.ETReal:
+		mysqlType = mysql.TypeDouble
+	case types.ETDecimal:
+		mysqlType = mysql.TypeNewDecimal
+	case types.ETDuration:
+		mysqlType = mysql.TypeDuration
+	case types.ETJson:
+		mysqlType = mysql.TypeJSON
+	case types.ETString:
+		mysqlType = mysql.TypeVarString
+	case types.ETDatetime:
+		mysqlType = mysql.TypeDatetime
+	}
+	return
+}
+
+func genMockRowDouble(eType types.EvalType) (builtinFunc, *chunk.Chunk, *chunk.Column, error) {
+	mysqlType := convertETType(eType)
+	tp := types.NewFieldType(mysqlType)
+	col1 := newColumn(1)
+	col1.Index = 0
+	col1.RetType = tp
+	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, eType, eType)
+	rowDouble := &mockRowBuiltinDouble{bf}
+	input := chunk.New([]*types.FieldType{tp}, 1024, 1024)
+	buf := chunk.NewColumn(types.NewFieldType(convertETType(eType)), 1024)
+	for i := 0; i < 1024; i++ {
+		switch eType {
+		case types.ETInt:
+			input.AppendInt64(0, int64(i))
+		case types.ETReal:
+			input.AppendFloat64(0, float64(i))
+		case types.ETDecimal:
+			dec := new(types.MyDecimal)
+			if err := dec.FromFloat64(float64(i)); err != nil {
+				return nil, nil, nil, err
+			}
+			input.AppendMyDecimal(0, dec)
+		case types.ETDuration:
+			input.AppendDuration(0, types.Duration{Duration: time.Duration(i)})
+		case types.ETJson:
+			j := new(json.BinaryJSON)
+			if err := j.UnmarshalJSON([]byte(fmt.Sprintf(`{"key":%v}`, i))); err != nil {
+				return nil, nil, nil, err
+			}
+			input.AppendJSON(0, *j)
+		case types.ETString:
+			input.AppendString(0, fmt.Sprintf("%v", i))
+		case types.ETDatetime:
+			t := types.FromDate(i, 0, 0, 0, 0, 0, 0)
+			input.AppendTime(0, types.Time{Time: t, Type: mysqlType})
+		}
+	}
+	return &vecRowConverter{rowDouble}, input, buf, nil
+}
+
+func (s *testEvaluatorSuite) checkVecEval(c *C, eType types.EvalType, sel []int, result *chunk.Column) {
+	if sel == nil {
+		for i := 0; i < 1024; i++ {
+			sel = append(sel, i)
+		}
+	}
+	switch eType {
+	case types.ETInt:
+		i64s := result.Int64s()
+		c.Assert(len(i64s), Equals, len(sel))
+		for i, j := range sel {
+			c.Assert(i64s[i], Equals, int64(j*2))
+		}
+	case types.ETReal:
+		f64s := result.Float64s()
+		c.Assert(len(f64s), Equals, len(sel))
+		for i, j := range sel {
+			c.Assert(f64s[i], Equals, float64(j*2))
+		}
+	case types.ETDecimal:
+		ds := result.Decimals()
+		c.Assert(len(ds), Equals, len(sel))
+		for i, j := range sel {
+			dec := new(types.MyDecimal)
+			c.Assert(dec.FromFloat64(float64(j)), IsNil)
+			rst := new(types.MyDecimal)
+			c.Assert(types.DecimalAdd(dec, dec, rst), IsNil)
+			c.Assert(rst.Compare(&ds[i]), Equals, 0)
+		}
+	case types.ETDuration:
+		ds := result.GoDurations()
+		c.Assert(len(ds), Equals, len(sel))
+		for i, j := range sel {
+			c.Assert(ds[i], Equals, time.Duration(j+j))
+		}
+	case types.ETJson:
+		for i, j := range sel {
+			path, err := json.ParseJSONPathExpr("$.key")
+			c.Assert(err, IsNil)
+			ret, ok := result.GetJSON(i).Extract([]json.PathExpression{path})
+			c.Assert(ok, IsTrue)
+			c.Assert(ret.GetInt64(), Equals, int64(j*2))
+		}
+	case types.ETString:
+		for i, j := range sel {
+			c.Assert(result.GetString(i), Equals, fmt.Sprintf("%v%v", j, j))
+		}
+	case types.ETDatetime:
+		for i, j := range sel {
+			gt := types.FromDate(j, 0, 0, 0, 0, 0, 0)
+			t := types.Time{Time: gt, Type: convertETType(eType)}
+			d, err := t.ConvertToDuration()
+			c.Assert(err, IsNil)
+			v, err := t.Add(mock.NewContext().GetSessionVars().StmtCtx, d)
+			c.Assert(err, IsNil)
+			c.Assert(v.Compare(result.GetTime(i)), Equals, 0)
+		}
+	}
+}
+
+func (s *testEvaluatorSuite) TestDoubleRow2Vec(c *C) {
+	defer testleak.AfterTest(c)()
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for _, eType := range eTypes {
+		rowDouble, input, result, err := genMockRowDouble(eType)
+		c.Assert(err, IsNil)
+		c.Assert(rowDouble.vecEval(input, result), IsNil)
+		s.checkVecEval(c, eType, nil, result)
+
+		sel := []int{0}
+		for {
+			end := sel[len(sel)-1]
+			gap := 1024 - end
+			if gap < 10 {
+				break
+			}
+			sel = append(sel, end+rand.Intn(gap-1)+1)
+		}
+		input.SetSel(sel)
+		c.Assert(rowDouble.vecEval(input, result), IsNil)
+
+		s.checkVecEval(c, eType, sel, result)
+	}
+}
+
+func BenchmarkMockDoubleRow(b *testing.B) {
+	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for i, eType := range eTypes {
+		b.Run(typeNames[i], func(b *testing.B) {
+			rowDouble, input, result, _ := genMockRowDouble(eType)
+			it := chunk.NewIterator4Chunk(input)
+			b.ResetTimer()
+			switch eType {
+			case types.ETInt:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalInt(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendInt64(v)
+						}
+					}
+				}
+			case types.ETReal:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalReal(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendFloat64(v)
+						}
+					}
+				}
+			case types.ETDecimal:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalDecimal(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendMyDecimal(v)
+						}
+					}
+				}
+			case types.ETDuration:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalDuration(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendDuration(v)
+						}
+					}
+				}
+			case types.ETString:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalString(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendString(v)
+						}
+					}
+				}
+			case types.ETDatetime:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalTime(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendTime(v)
+						}
+					}
+				}
+			case types.ETJson:
+				for i := 0; i < b.N; i++ {
+					result.Reset()
+					for r := it.Begin(); r != it.End(); r = it.Next() {
+						v, isNull, err := rowDouble.evalJSON(r)
+						if err != nil {
+							b.Fatal(err)
+						}
+						if isNull {
+							result.AppendNull()
+						} else {
+							result.AppendJSON(v)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMockDoubleRow2Vec(b *testing.B) {
+	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for i, eType := range eTypes {
+		b.Run(typeNames[i], func(b *testing.B) {
+			rowDouble, input, result, _ := genMockRowDouble(eType)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err := rowDouble.vecEval(input, result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
We will implement the vectorized evaluation for all our builtin functions soon.
For each builtin function, we only keep one kind of implementation (row-based or vectorized) since it's hard and unnecessary to maintain these two.

Therefore, we need a converter to make all builtin function support row-based evaluation and vectorized evaluation both since these two kinds of evaluation are needed by users.

This PR makes `baseBuiltinFunc` support converting from row-based evaluation to vectorized evaluation.
### What is changed and how it works?
1. Make baseBuiltinFunc support this converting;
2. Add some unit tests;

#### All changes are new methods or unit tests, so it's easy to review.

After converting row-based evaluation to vectorized evaluation, we get some performance gain, and here is the benchmark:
```
BenchmarkMockDoubleRow/Int-12                     100000             15573 ns/op
BenchmarkMockDoubleRow/Real-12                    100000             15661 ns/op
BenchmarkMockDoubleRow/Decimal-12                  30000             56280 ns/op
BenchmarkMockDoubleRow/Duration-12                100000             18741 ns/op
BenchmarkMockDoubleRow/String-12                   30000             49367 ns/op
BenchmarkMockDoubleRow/Datetime-12                 10000            176552 ns/op
BenchmarkMockDoubleRow/JSON-12                      1000           2222229 ns/op

BenchmarkMockDoubleRow2Vec/Int-12                 200000             10135 ns/op
BenchmarkMockDoubleRow2Vec/Real-12                200000             10105 ns/op
BenchmarkMockDoubleRow2Vec/Decimal-12              30000             47783 ns/op
BenchmarkMockDoubleRow2Vec/Duration-12            100000             14568 ns/op
BenchmarkMockDoubleRow2Vec/String-12               30000             48718 ns/op
BenchmarkMockDoubleRow2Vec/Datetime-12             10000            186369 ns/op
BenchmarkMockDoubleRow2Vec/JSON-12                  1000           2226560 ns/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
