### PR TITLE
executor,session: display the tree-like format of the trace statement

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -398,6 +398,7 @@ func (a *ExecStmt) handleNoDelayExecutor(ctx context.Context, e Executor) (sqlex
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("executor.handleNoDelayExecutor", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	// Check if "tidb_snapshot" is set for the write executors.

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -64,6 +64,7 @@ func (c *Compiler) compile(ctx context.Context, stmtNode ast.StmtNode, skipBind 
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("executor.Compile", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	if !skipBind {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -195,6 +195,7 @@ func Next(ctx context.Context, e Executor, req *chunk.Chunk) error {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan(fmt.Sprintf("%T.Next", e), opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 	return e.Next(ctx, req)
 }
@@ -907,6 +908,7 @@ func init() {
 		if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 			span1 := span.Tracer().StartSpan("executor.EvalSubQuery", opentracing.ChildOf(span.Context()))
 			defer span1.Finish()
+			ctx = opentracing.ContextWithSpan(ctx, span1)
 		}
 
 		e := &executorBuilder{is: is, ctx: sctx}

--- a/executor/update.go
+++ b/executor/update.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -129,11 +128,6 @@ func (e *UpdateExec) canNotUpdate(handle types.Datum) bool {
 
 // Next implements the Executor Next interface.
 func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
-	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
-		span1 := span.Tracer().StartSpan("update.Next", opentracing.ChildOf(span.Context()))
-		defer span1.Finish()
-	}
-
 	req.Reset()
 	if !e.fetched {
 		err := e.fetchChunkRows(ctx)

--- a/session/session.go
+++ b/session/session.go
@@ -524,7 +524,6 @@ func (s *session) RollbackTxn(ctx context.Context) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.RollbackTxn", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
-		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	if s.txn.Valid() {

--- a/session/session.go
+++ b/session/session.go
@@ -499,6 +499,7 @@ func (s *session) CommitTxn(ctx context.Context) error {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.CommitTxn", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	var commitDetail *execdetails.CommitDetails
@@ -523,6 +524,7 @@ func (s *session) RollbackTxn(ctx context.Context) {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.RollbackTxn", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	if s.txn.Valid() {
@@ -1027,6 +1029,7 @@ func (s *session) Execute(ctx context.Context, sql string) (recordSets []sqlexec
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.Execute", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 	if recordSets, err = s.execute(ctx, sql); err != nil {
 		s.sessionVars.StmtCtx.AppendError(err)

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -207,6 +207,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 		span1 := span.Tracer().StartSpan("session.runStmt", opentracing.ChildOf(span.Context()))
 		span1.LogKV("sql", s.OriginText())
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 	se := sctx.(*session)
 	defer func() {

--- a/session/txn.go
+++ b/session/txn.go
@@ -399,6 +399,7 @@ func (s *session) getTxnFuture(ctx context.Context) *txnFuture {
 	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("session.getTxnFuture", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
+		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
 	oracleStore := s.store.GetOracle()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the `trace format = 'row' ...` output.

Before:

```
mysql> trace format='row'  select 1, (select sleep(1));
+---------------------------------------+-----------------+--------------+
| operation                             | startTS         | duration     |
+---------------------------------------+-----------------+--------------+
| session.getTxnFuture                  | 13:07:52.726034 | 26.435µs     |
|   ├─session.Execute                   | 13:07:52.726027 | 1.00091883s  |
|   ├─session.ParseSQL                  | 13:07:52.726153 | 87.241µs     |
|   ├─executor.Compile                  | 13:07:52.726311 | 1.00057122s  |
|   ├─executor.EvalSubQuery             | 13:07:52.726621 | 1.000212522s |
|   ├─*executor.MaxOneRowExec.Next      | 13:07:52.726651 | 1.000170599s |
|   ├─*executor.ProjectionExec.Next     | 13:07:52.726657 | 1.000110148s |
|   ├─*executor.TableDualExec.Next      | 13:07:52.726663 | 2.632µs      |
|   ├─*executor.ProjectionExec.Next     | 13:07:53.726801 | 8.778µs      |
|   ├─*executor.TableDualExec.Next      | 13:07:53.726804 | 545ns        |
|   ├─*executor.MaxOneRowExec.Next      | 13:07:53.726829 | 492ns        |
|   ├─session.runStmt                   | 13:07:53.726892 | 25.862µs     |
|   ├─session.CommitTxn                 | 13:07:53.726910 | 3.252µs      |
|   ├─*executor.ProjectionExec.Next     | 13:07:53.726954 | 8.484µs      |
|   ├─*executor.TableDualExec.Next      | 13:07:53.726955 | 458ns        |
|   ├─*executor.ProjectionExec.Next     | 13:07:53.726967 | 4.26µs       |
|   └─*executor.TableDualExec.Next      | 13:07:53.726968 | 327ns        |
+---------------------------------------+-----------------+--------------+
17 rows in set (1.02 sec)
```

After:

```
mysql> trace format='row'  select 1, (select sleep(1));
+----------------------------------------------------+-----------------+--------------+
| operation                                          | startTS         | duration     |
+----------------------------------------------------+-----------------+--------------+
| session.Execute                                    | 13:01:01.350899 | 1.001122606s |
|   ├─session.ParseSQL                               | 13:01:01.351012 | 62.718µs     |
|   ├─executor.Compile                               | 13:01:01.351327 | 1.000635173s |
|   │ └─executor.EvalSubQuery                        | 13:01:01.351675 | 1.000236307s |
|   │   ├─*executor.MaxOneRowExec.Next               | 13:01:01.351717 | 1.000183409s |
|   │   │ ├─*executor.ProjectionExec.Next            | 13:01:01.351725 | 1.000117021s |
|   │   │ │ └─*executor.TableDualExec.Next           | 13:01:01.351732 | 3.911µs      |
|   │   │ └─*executor.ProjectionExec.Next            | 13:01:02.351886 | 10.062µs     |
|   │   │   └─*executor.TableDualExec.Next           | 13:01:02.351891 | 606ns        |
|   │   └─*executor.MaxOneRowExec.Next               | 13:01:02.351907 | 578ns        |
|   ├─session.runStmt                                | 13:01:02.351972 | 21.68µs      |
|   │ └─session.CommitTxn                            | 13:01:02.351987 | 2.941µs      |
|   ├─session.getTxnFuture                           | 13:01:01.350914 | 25.686µs     |
|   ├─*executor.ProjectionExec.Next                  | 13:01:02.352029 | 9.203µs      |
|   │ └─*executor.TableDualExec.Next                 | 13:01:02.352030 | 477ns        |
|   └─*executor.ProjectionExec.Next                  | 13:01:02.352045 | 4.33µs       |
|     └─*executor.TableDualExec.Next                 | 13:01:02.352046 | 349ns        |
+----------------------------------------------------+-----------------+--------------+
17 rows in set (1.01 sec)
```

### What is changed and how it works?

1. Add `ctx = opentracing.ContextWithSpan(ctx, span1)` 

```
f(ctx) {
   // span for tracing f
   // should create a ctx for g, otherwise, f's parent span and g's parent span is the same one!
   g(ctx)
}
```

2. Remove the sort trace result by the start time

The `dfsTree` print the trace result according to the parent-children relationship, sort by start time is useless.

3. Remove the trace code in `UpdateExec` because of the `executor.Executor` has already added it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

