### PR TITLE
executor: change the way to use `Sel` in `Constant` and `Column`

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -188,7 +188,7 @@ func (col *Column) Equal(_ sessionctx.Context, expr Expression) bool {
 
 // VecEval evaluates this expression in a vectorized manner.
 func (col *Column) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	input.Column(col.Index).CopyConstruct(result)
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
 	return nil
 }
 

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -447,7 +447,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		chk.SetSel(sel)
 		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
 		i64s = col.Int64s()
-		for _, i := range sel {
+		for i := range sel {
 			c.Assert(i64s[i], Equals, int64(2333))
 		}
 	}
@@ -473,7 +473,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		sel := []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
 		chk.SetSel(sel)
 		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
-		for _, i := range sel {
+		for i := range sel {
 			c.Assert(col.GetString(i), Equals, "hello")
 		}
 	}

--- a/expression/vectorized.go
+++ b/expression/vectorized.go
@@ -21,8 +21,7 @@ import (
 )
 
 func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, result *chunk.Column) error {
-	n := input.NumEffectiveRows()
-	sel := input.Sel()
+	n := input.NumRows()
 	tp := expr.GetType()
 	switch tp.EvalType() {
 	case types.ETInt:
@@ -35,17 +34,10 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			return nil
 		}
 		i64s := result.Int64s()
-		if sel == nil {
-			for i := range i64s {
-				i64s[i] = v
-			}
-			result.SetNulls(0, n, false)
-		} else {
-			for _, i := range sel {
-				i64s[i] = v
-				result.SetNull(i, false)
-			}
+		for i := range i64s {
+			i64s[i] = v
 		}
+		result.SetNulls(0, n, false)
 	case types.ETReal:
 		result.PreAllocFloat64(n)
 		v, isNull, err := expr.EvalReal(ctx, chunk.Row{})
@@ -56,17 +48,10 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			return nil
 		}
 		f64s := result.Float64s()
-		if sel == nil {
-			for i := range f64s {
-				f64s[i] = v
-			}
-			result.SetNulls(0, n, false)
-		} else {
-			for _, i := range sel {
-				f64s[i] = v
-				result.SetNull(i, false)
-			}
+		for i := range f64s {
+			f64s[i] = v
 		}
+		result.SetNulls(0, n, false)
 	case types.ETDecimal:
 		result.PreAllocDecimal(n)
 		v, isNull, err := expr.EvalDecimal(ctx, chunk.Row{})
@@ -77,17 +62,10 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			return nil
 		}
 		ds := result.Decimals()
-		if sel == nil {
-			for i := range ds {
-				ds[i] = *v
-			}
-			result.SetNulls(0, n, false)
-		} else {
-			for _, i := range sel {
-				ds[i] = *v
-				result.SetNull(i, false)
-			}
+		for i := range ds {
+			ds[i] = *v
 		}
+		result.SetNulls(0, n, false)
 	case types.ETDatetime, types.ETTimestamp:
 		result.Reset()
 		v, isNull, err := expr.EvalTime(ctx, chunk.Row{})
@@ -99,20 +77,8 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 				result.AppendNull()
 			}
 		} else {
-			if sel == nil {
-				for i := 0; i < n; i++ {
-					result.AppendTime(v)
-				}
-			} else {
-				pos := 0
-				for _, i := range sel {
-					for pos < i {
-						result.AppendNull()
-						pos++
-					}
-					result.AppendTime(v)
-					pos++
-				}
+			for i := 0; i < n; i++ {
+				result.AppendTime(v)
 			}
 		}
 	case types.ETDuration:
@@ -126,20 +92,8 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 				result.AppendNull()
 			}
 		} else {
-			if sel == nil {
-				for i := 0; i < n; i++ {
-					result.AppendDuration(v)
-				}
-			} else {
-				pos := 0
-				for _, i := range sel {
-					for pos < i {
-						result.AppendNull()
-						pos++
-					}
-					result.AppendDuration(v)
-					pos++
-				}
+			for i := 0; i < n; i++ {
+				result.AppendDuration(v)
 			}
 		}
 	case types.ETJson:
@@ -153,20 +107,8 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 				result.AppendNull()
 			}
 		} else {
-			if sel == nil {
-				for i := 0; i < n; i++ {
-					result.AppendJSON(v)
-				}
-			} else {
-				pos := 0
-				for _, i := range sel {
-					for pos < i {
-						result.AppendNull()
-						pos++
-					}
-					result.AppendJSON(v)
-					pos++
-				}
+			for i := 0; i < n; i++ {
+				result.AppendJSON(v)
 			}
 		}
 	case types.ETString:
@@ -180,20 +122,8 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 				result.AppendNull()
 			}
 		} else {
-			if sel == nil {
-				for i := 0; i < n; i++ {
-					result.AppendString(v)
-				}
-			} else {
-				pos := 0
-				for _, i := range sel {
-					for pos < i {
-						result.AppendNull()
-						pos++
-					}
-					result.AppendString(v)
-					pos++
-				}
+			for i := 0; i < n; i++ {
+				result.AppendString(v)
 			}
 		}
 	default:

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -311,21 +311,6 @@ func (c *Chunk) NumRows() int {
 	return c.columns[0].length
 }
 
-// NumEffectiveRows returns the effective number of rows physically stored in this Chunk.
-// It is different with NumRows when sel is not nil.
-// For example: if sel is [2, 3, 5, 7, 9], then
-//   NumRow() returns 5 to indicate that 5 rows are selected logically in this Chunk, while
-//   NumEffectiveRows() returns 10(9+1) to indicate that at least 10 rows are stored in this Chunk physically.
-func (c *Chunk) NumEffectiveRows() int {
-	if c.sel == nil {
-		return c.NumRows()
-	}
-	if len(c.sel) == 0 {
-		return 0
-	}
-	return c.sel[len(c.sel)-1] + 1
-}
-
 // GetRow gets the Row in the chunk with the row index.
 func (c *Chunk) GetRow(idx int) Row {
 	if c.sel != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this PR, our results returned in `Constant` and `Column` are sparsely aligned to the `Sel`.

For example, if a `Sel` is `[1, 4, 5]`, the result now is `[null, v1, null, null, v2, v3]`.

After this PR, we make the result dense so now it is `[v1, v2, v3]`.

Advantages of this change are:
1. avoid maintaining unnecessary data;
2. save some memory;
3. it's a better code style to make `Sel` transparent to branch nodes in an expression tree;

### What is changed and how it works?
Modify `VecEval` method of `Constant` and `Column`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
