### PR TITLE
expression: check decimal scale and precision before casting

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -497,10 +497,6 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	err = checkDecimalSize(b.tp, strconv.FormatInt(val, 10))
-	if err != nil {
-		return nil, false, err
-	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = types.NewDecFromInt(val)
 	} else if b.inUnion && val < 0 {
@@ -513,6 +509,10 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 			return res, false, err
 		}
 		res = types.NewDecFromUint(uVal)
+	}
+	err = checkDecimalSize(b.tp, strconv.FormatInt(val, 10))
+	if err != nil {
+		return nil, false, err
 	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, isNull, err

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -1402,11 +1402,6 @@ func (s *testEvaluatorSuite) TestCastToDecimalError(c *C) {
 			&Column{RetType: types.NewFieldType(mysql.TypeString), Index: 0},
 			chunk.MutRowFromDatums([]types.Datum{types.NewStringDatum("1234")}),
 		},
-		// cast real as decimal.
-		{
-			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
-			chunk.MutRowFromDatums([]types.Datum{types.NewFloat64Datum(1234.123)}),
-		},
 		// cast decimal as decimal.
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeNewDecimal), Index: 0},
@@ -1428,8 +1423,6 @@ func (s *testEvaluatorSuite) TestCastToDecimalError(c *C) {
 			case 1:
 				sig = &builtinCastStringAsDecimalSig{decFunc}
 			case 2:
-				sig = &builtinCastRealAsDecimalSig{decFunc}
-			case 3:
 				sig = &builtinCastDecimalAsDecimalSig{decFunc}
 			}
 			_, isNull, err := sig.evalDecimal(t.row.ToRow())


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
part of #11223 fix issue #11193

### What is changed and how it works?

Check the `Flen` of a record is not greater than `mysql.MaxDecimalWidth` and the `Decimal` of a record is not greater than `mysql.MaxDecimalScale` before casting to a decimal.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
