### PR TITLE
util, expression: 1. add Column.SetXType() 2. remove Column.PrimitiveType()

### DIFF
--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -436,19 +436,16 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		col := chunk.NewColumn(newIntFieldType(), 1024)
 		ctx := mock.NewContext()
 		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
-		i64s := col.Int64s()
-		c.Assert(len(i64s), Equals, 1024)
-		for _, v := range i64s {
-			c.Assert(v, Equals, int64(2333))
+		for i := 0; i < 1024; i++ {
+			c.Assert(col.GetInt64(i), Equals, int64(2333))
 		}
 
 		// fixed-length type with Sel
 		sel := []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
 		chk.SetSel(sel)
 		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
-		i64s = col.Int64s()
 		for i := range sel {
-			c.Assert(i64s[i], Equals, int64(2333))
+			c.Assert(col.GetInt64(i), Equals, int64(2333))
 		}
 	}
 

--- a/expression/vectorized.go
+++ b/expression/vectorized.go
@@ -20,6 +20,8 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
+// genVecFromConstExpr generates a vector, all the elements of this vector are
+// filled with the value of `expr`.
 func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	switch expr.GetType().EvalType() {

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -534,6 +534,11 @@ func (c *Chunk) AppendTime(colIdx int, t types.Time) {
 	c.columns[colIdx].AppendTime(t)
 }
 
+func (c *Chunk) AppendTime2(colIdx int, t types.Time) {
+	c.appendSel(colIdx)
+	c.columns[colIdx].AppendTime2(t)
+}
+
 // AppendDuration appends a Duration value to the chunk.
 func (c *Chunk) AppendDuration(colIdx int, dur types.Duration) {
 	c.appendSel(colIdx)

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -124,6 +124,7 @@ func newFixedLenColumn(elemLen, cap int) *Column {
 		elemBuf:    make([]byte, elemLen),
 		data:       make([]byte, 0, cap*elemLen),
 		nullBitmap: make([]byte, 0, cap>>3),
+		IsNullx:    make([]bool, 0, cap),
 	}
 }
 

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -213,6 +213,11 @@ func (c *Column) AppendFloat64(f float64) {
 	c.finishAppendFixed()
 }
 
+func (c *Column) AppendTime2(t types.Time) {
+	*(*types.Time)(unsafe.Pointer(&c.elemBuf[0])) = t
+	c.finishAppendFixed()
+}
+
 func (c *Column) finishAppendVar() {
 	c.appendNullBitmap(true)
 	c.offsets = append(c.offsets, int64(len(c.data)))
@@ -279,6 +284,12 @@ func (c *Column) preAlloc(length, typeSize int) {
 	}
 
 	c.length = length
+}
+
+func (c *Column) Time2s() []types.Time {
+	var res []types.Time
+	c.castSliceHeader((*reflect.SliceHeader)(unsafe.Pointer(&res)), sizeTime)
+	return res
 }
 
 func (c *Column) Int64s() []int64 {
@@ -402,7 +413,7 @@ func (c *Column) SetDuration(rowID int, v types.Duration) {
 
 // SetTime sets a time value to the position specified by `rowID`.
 func (c *Column) SetTime(rowID int, v types.Time) {
-	writeTime(c.data[rowID*sizeTime:], v)
+	writeTime(c.data[rowID*16:], v)
 }
 
 // GetInt64 returns the int64 in the specific row.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To make the code more readable, this commit does two things.
1. For Add an interface SetFixedType() for chunk.column
2. Remove the interfaces like `column.Int64s`/ `column.Uint64s` ...

### What is changed and how it works?
This commit will cause performance regression:
``` shell
$ GO111MODULE=on go test -bench=BenchmarkVec -run=none
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/util/chunk
BenchmarkVecPrimitive-4          2000000               847 ns/op
BenchmarkVecSet-4                1000000              1712 ns/op
PASS
ok      github.com/pingcap/tidb/util/chunk      4.304s

```
``` go
func BenchmarkVecPrimitive(b *testing.B) {
	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1024)
	col1 := chk.Column(0)
	for i := 0; i < 1024; i++ {
		col1.AppendInt64(int64(i))
	}
	col2 := col1.CopyConstruct(nil)
	result := col1.CopyConstruct(nil)

	xs1 := col1.Int64s()
	xs2 := col2.Int64s()
	xs3 := result.Int64s()

	b.ResetTimer()
	for i := 0; i < b.N; i++{
		for j := 0; j < 1024; j++ {
			xs3[j] = xs2[j] + xs1[j]
		}
	}
}

func BenchmarkVecSet(b *testing.B) {
	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1024)
	col1 := chk.Column(0)
	for i := 0; i < 1024; i++ {
		col1.AppendInt64(int64(i))
	}
	col2 := col1.CopyConstruct(nil)
	result := col1.CopyConstruct(nil)

	b.ResetTimer()
	for i := 0; i < b.N; i++{
		for j := 0; j < 1024; j++ {
			result.SetInt64(j, col1.GetInt64(j) + col2.GetInt64(j))
		}
	}
}


```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change


Side effects

 - Possible performance regression

Related changes

N/A
