### PR TITLE
planner/core: the order by with default field not parsed (#11210)

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4846,3 +4846,19 @@ func (s *testIntegrationSuite) TestIssue11309And11319(c *C) {
 	tk.MustQuery(`SELECT DATE_ADD('2007-03-28 22:08:28',INTERVAL 2.2 DAY_HOUR)`).Check(testkit.Rows("2007-03-31 00:08:28"))
 	tk.MustQuery(`SELECT DATE_ADD('2007-03-28 22:08:28',INTERVAL 2.2 YEAR_MONTH)`).Check(testkit.Rows("2009-05-28 22:08:28"))
 }
+
+func (s *testIntegrationSuite) TestOrderbyWithDefaultFunc(c *C) {
+	defer s.cleanEnv(c)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int default null, b int default null)")
+	tk.MustExec("insert into t values(1, 2), (3, 4)")
+	tk.MustQuery("select a from t order by default(a)").Check(testkit.Rows("1", "3"))
+	tk.MustQuery("select a from t order by default(b)").Check(testkit.Rows("1", "3"))
+	tk.MustQuery("select a, b from t order by default(a)").Check(testkit.Rows("1,2", "3,4"))
+	tk.MustQuery("select a from t order by length(b)").Check(testkit.Rows("1", "3"))
+	_, err := tk.Exec("select a, b from t order by default(c)")
+	c.Assert(err, NotNil)
+	c.Assert(terror.ErrorEqual(err, plannercore.ErrUnknownColumn.GenWithStackByArgs("c", "order clause")), IsTrue)
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1200,8 +1200,8 @@ func (a *havingWindowAndOrderbyExprResolver) Enter(n ast.Node) (node ast.Node, s
 	return n, false
 }
 
-func (a *havingWindowAndOrderbyExprResolver) resolveFromSchema(v *ast.ColumnNameExpr, schema *expression.Schema) (int, error) {
-	col, err := schema.FindColumn(v.Name)
+func (a *havingWindowAndOrderbyExprResolver) resolveFromSchema(colName *ast.ColumnName, schema *expression.Schema) (int, error) {
+	col, err := schema.FindColumn(colName)
 	if err != nil {
 		return -1, err
 	}
@@ -1253,6 +1253,16 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 		}
 	case *ast.WindowSpec:
 		a.inWindowSpec = false
+	case *ast.ColumnName:
+		index, err := a.resolveFromSchema(v, a.p.Schema())
+		if err != nil {
+			a.err = err
+			return node, false
+		}
+		if index == -1 {
+			a.err = ErrUnknownColumn.GenWithStackByArgs(v.OrigColName(), clauseMsg[a.curClause])
+			return node, false
+		}
 	case *ast.ColumnNameExpr:
 		resolveFieldsFirst := true
 		if a.inAggFunc || a.inWindowFunc || a.inWindowSpec || (a.orderBy && a.inExpr) {
@@ -1279,7 +1289,7 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 			}
 			if index == -1 {
 				if a.orderBy {
-					index, a.err = a.resolveFromSchema(v, a.p.Schema())
+					index, a.err = a.resolveFromSchema(v.Name, a.p.Schema())
 				} else {
 					index, a.err = resolveFromSelectFields(v, a.selectFields, true)
 				}
@@ -1288,7 +1298,7 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 			// We should ignore the err when resolving from schema. Because we could resolve successfully
 			// when considering select fields.
 			var err error
-			index, err = a.resolveFromSchema(v, a.p.Schema())
+			index, err = a.resolveFromSchema(v.Name, a.p.Schema())
 			_ = err
 			if index == -1 && a.curClause != windowClause {
 				index, a.err = resolveFromSelectFields(v, a.selectFields, false)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/11210
when order by with `default(colName)` is not resolved and got unknown column

### What is changed and how it works?
parse the column name expr in the order by resolver.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test  -- added and passed



