### PR TITLE
*: replace `context.WithValue` string key to typed `struct{}` key

### DIFF
--- a/kv/txn.go
+++ b/kv/txn.go
@@ -25,9 +25,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// ContextKey is the type of context's key
-type ContextKey string
-
 // RunInNewTxn will run the f in a new transaction environment.
 func RunInNewTxn(store Storage, retryable bool, f func(txn Transaction) error) error {
 	var (

--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -85,7 +85,7 @@ type AuditManifest struct {
 	OnParseEvent func(ctx context.Context, sctx *variable.SessionVars, event ParseEvent) error
 }
 
-const (
-	// ExecStartTimeCtxKey indicates stmt start execution time.
-	ExecStartTimeCtxKey = "ExecStartTime"
-)
+type execStartTimeCtxKeyType struct{}
+
+// ExecStartTimeCtxKey indicates stmt start execution time.
+var ExecStartTimeCtxKey = execStartTimeCtxKeyType{}

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -124,8 +124,10 @@ const (
 	LastExecuteDDL basicCtxType = 3
 )
 
+type connIDCtxKeyType struct{}
+
 // ConnID is the key in context.
-const ConnID kv.ContextKey = "conn ID"
+var ConnID = connIDCtxKeyType{}
 
 // SetCommitCtx sets the variables for context before commit a transaction.
 func SetCommitCtx(ctx context.Context, sessCtx Context) context.Context {

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -233,8 +233,10 @@ type Backoffer struct {
 	vars       *kv.Variables
 }
 
+type txnStartCtxKeyType struct{}
+
 // txnStartKey is a key for transaction start_ts info in context.Context.
-const txnStartKey = "_txn_start_key"
+var txnStartKey = txnStartCtxKeyType{}
 
 // NewBackoffer creates a Backoffer with maximum sleep time(in ms).
 func NewBackoffer(ctx context.Context, maxSleep int) *Backoffer {

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -26,8 +26,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type commitDetailCtxKeyType struct{}
+
 // CommitDetailCtxKey presents CommitDetail info key in context.
-const CommitDetailCtxKey = "commitDetail"
+var CommitDetailCtxKey = commitDetailCtxKeyType{}
 
 // ExecDetails contains execution detail information.
 type ExecDetails struct {

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -317,9 +317,9 @@ func SetLevel(level string) error {
 	return nil
 }
 
-type ctxKeyType int
+type ctxLogKeyType struct{}
 
-const ctxLogKey ctxKeyType = iota
+var ctxLogKey = ctxLogKeyType{}
 
 // Logger gets a contextual logger from current context.
 // contextual logger will output common fields from context.

--- a/util/testkit/ctestkit.go
+++ b/util/testkit/ctestkit.go
@@ -29,9 +29,9 @@ import (
 	"github.com/pingcap/tidb/util/sqlexec"
 )
 
-type contextKeyType int
+type sessionCtxKeyType struct{}
 
-const sessionKey contextKeyType = iota
+var sessionKey = sessionCtxKeyType{}
 
 func getSession(ctx context.Context) session.Session {
 	s := ctx.Value(sessionKey)


### PR DESCRIPTION
Improve performance

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixes #11634

### What is changed and how it works?
replace `context.WithValue` string key and int key to typed `struct{}` key

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - Has exported variable/fields change

Side effects

 - None
 
Related changes

 - None
