### PR TITLE
ddl : Fix generated column can refer only to generated columns defined prior to it. (#11549)

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -119,6 +119,15 @@ func (s *testDBSuite) TearDownSuite(c *C) {
 	autoid.SetStep(s.autoIDStep)
 }
 
+func assertErrorCode(c *C, tk *testkit.TestKit, sql string, errCode int) {
+	_, err := tk.Exec(sql)
+	c.Assert(err, NotNil)
+	originErr := errors.Cause(err)
+	tErr, ok := originErr.(*terror.Error)
+	c.Assert(ok, IsTrue, Commentf("err: %T", originErr))
+	c.Assert(tErr.ToSQLError().Code, DeepEquals, uint16(errCode), Commentf("MySQL code:%v", tErr.ToSQLError()))
+}
+
 func (s *testDBSuite) testErrorCode(c *C, sql string, errCode int) {
 	_, err := s.tk.Exec(sql)
 	c.Assert(err, NotNil)

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -47,6 +47,25 @@ func verifyColumnGeneration(colName2Generation map[string]columnGenerationInDDL,
 	return nil
 }
 
+// verifyColumnGenerationSingle is for ADD GENERATED COLUMN, we just need verify one column itself.
+func verifyColumnGenerationSingle(dependColNames map[string]struct{}, cols []*table.Column, position *ast.ColumnPosition) error {
+	// Since the added column does not exist yet, we should derive it's offset from ColumnPosition.
+	pos, err := findPositionRelativeColumn(cols, position)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	// should check unknown column first, then the prior ones.
+	for _, col := range cols {
+		if _, ok := dependColNames[col.Name.L]; ok {
+			if col.IsGenerated() && col.Offset >= pos {
+				// Generated column can refer only to generated columns defined prior to it.
+				return errGeneratedColumnNonPrior.GenWithStackByArgs()
+			}
+		}
+	}
+	return nil
+}
+
 // columnNamesCover checks whether dependColNames is covered by normalColNames or not.
 // it's only for alter table add column because before alter, we can make sure that all
 // columns in table are verified already.
@@ -57,6 +76,34 @@ func columnNamesCover(normalColNames map[string]struct{}, dependColNames map[str
 		}
 	}
 	return nil
+}
+
+// findPositionRelativeColumn returns a pos relative to added generated column position.
+func findPositionRelativeColumn(cols []*table.Column, pos *ast.ColumnPosition) (int, error) {
+	position := len(cols)
+	// Get the column position, default is cols's length means appending.
+	// For "alter table ... add column(...)", the position will be nil.
+	// For "alter table ... add column ... ", the position will be default one.
+	if pos == nil {
+		return position, nil
+	}
+	if pos.Tp == ast.ColumnPositionFirst {
+		position = 0
+	} else if pos.Tp == ast.ColumnPositionAfter {
+		var col *table.Column
+		for _, c := range cols {
+			if c.Name.L == pos.RelativeColumn.Name.L {
+				col = c
+				break
+			}
+		}
+		if col == nil {
+			return -1, errBadField.GenWithStackByArgs(pos.RelativeColumn.Name, "generated column function")
+		}
+		// Inserted position is after the mentioned column.
+		position = col.Offset + 1
+	}
+	return position, nil
 }
 
 // findDependedColumnNames returns a set of string, which indicates


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick to release2.1 [#11549](https://github.com/pingcap/tidb/pull/11549)

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->
keep using the old function, made a slight modification to origin PR. 

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
