### PR TITLE
ddl : Fix generated column can refer only to generated columns defined prior to it. (#11549)

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -620,6 +620,7 @@ func (s *testIntegrationSuite7) TestDependedGeneratedColumnPrior2GeneratedColumn
 
 	// check position nil case
 	tk.MustExec("alter table t add column(e int as (c+1))")
+	tk.MustExec("drop table if exists t")
 }
 
 func (s *testIntegrationSuite9) TestChangingCharsetToUtf8(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -598,6 +598,30 @@ func (s *testIntegrationSuite7) TestNullGeneratedColumn(c *C) {
 	tk.MustExec("drop table t")
 }
 
+func (s *testIntegrationSuite7) TestDependedGeneratedColumnPrior2GeneratedColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`a` int(11) DEFAULT NULL," +
+		"`b` int(11) GENERATED ALWAYS AS (`a` + 1) VIRTUAL," +
+		"`c` int(11) GENERATED ALWAYS AS (`b` + 1) VIRTUAL" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin")
+	// should check unknown column first, then the prior ones.
+	sql := "alter table t add column d int as (c + f + 1) first"
+	assertErrorCode(c, tk, sql, mysql.ErrBadField)
+
+	// depended generated column should be prior to generated column self
+	sql = "alter table t add column d int as (c+1) first"
+	assertErrorCode(c, tk, sql, mysql.ErrGeneratedColumnNonPrior)
+
+	// correct case
+	tk.MustExec("alter table t add column d int as (c+1) after c")
+
+	// check position nil case
+	tk.MustExec("alter table t add column(e int as (c+1))")
+}
+
 func (s *testIntegrationSuite9) TestChangingCharsetToUtf8(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick to 3.0 [#11549](https://github.com/pingcap/tidb/pull/11549)

### What is changed and how it works?
resolve conflicts when cherry-pick.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 