### PR TITLE
executor: fix panic when fetching `processlist` table data in some cases

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -483,6 +483,7 @@ func (cc *clientConn) connectInfo() *variable.ConnectionInfo {
 // ShowProcessList implements the SessionManager interface.
 func (s *Server) ShowProcessList() map[uint64]*util.ProcessInfo {
 	s.rwlock.RLock()
+	defer s.rwlock.RUnlock()
 	rs := make(map[uint64]*util.ProcessInfo, len(s.clients))
 	for _, client := range s.clients {
 		if atomic.LoadInt32(&client.status) == connStatusWaitShutdown {
@@ -492,7 +493,6 @@ func (s *Server) ShowProcessList() map[uint64]*util.ProcessInfo {
 			rs[pi.ID] = pi
 		}
 	}
-	s.rwlock.RUnlock()
 	return rs
 }
 

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -80,7 +80,11 @@ func (pi *ProcessInfo) txnStartTs(tz *time.Location) (txnStart string) {
 // ToRow returns []interface{} for the row data of
 // "SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST".
 func (pi *ProcessInfo) ToRow(tz *time.Location) []interface{} {
-	return append(pi.ToRowForShow(true), pi.StmtCtx.MemTracker.BytesConsumed(), pi.txnStartTs(tz))
+	bytesConsumed := int64(0)
+	if pi.StmtCtx.MemTracker != nil {
+		bytesConsumed = pi.StmtCtx.MemTracker.BytesConsumed()
+	}
+	return append(pi.ToRowForShow(true), bytesConsumed, pi.txnStartTs(tz))
 }
 
 // SessionManager is an interface for session manage. Show processlist and


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When TiDB fetches data from `processlist` table, it will get each connection's memory consumption according to their `Ctx.Memtracker`.
But in some cases, `Ctx.Memtracker` is not initialized at that time, which results in a panic.

### What is changed and how it works?
Check if `Ctx.Memtracker` is `nil` before using it when fetching `processlist` table data.
