### PR TITLE
planner: use HistColl containing all columns for row width estimation

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -536,12 +536,12 @@ func (p *LogicalJoin) constructInnerTableScanTask(ds *DataSource, pk *expression
 	for i := range ds.stats.Cardinality {
 		ds.stats.Cardinality[i] = 1
 	}
-	rowSize := ds.tableStats.HistColl.GetAvgRowSize(ds.tableCols, false)
+	rowSize := ds.tblColHists.GetAvgRowSize(ds.tblCols, false)
 	copTask := &copTask{
 		tablePlan:         ts,
 		indexPlanFinished: true,
 		cst:               scanFactor * rowSize * ts.stats.RowCount,
-		tableStats:        ds.tableStats,
+		tblColHists:       ds.tblColHists,
 	}
 	selStats := ts.stats.Scale(selectionFactor)
 	ts.addPushedDownSelection(copTask, selStats)
@@ -594,9 +594,9 @@ func (p *LogicalJoin) constructInnerIndexScanTask(ds *DataSource, idx *model.Ind
 	}
 	is.stats = ds.tableStats.ScaleByExpectCnt(rowCount)
 	cop := &copTask{
-		indexPlan:  is,
-		tableStats: ds.tableStats,
-		tableCols:  ds.tableCols,
+		indexPlan:   is,
+		tblColHists: ds.tblColHists,
+		tblCols:     ds.tblCols,
 	}
 	if !isCoveringIndex(ds.schema.Columns, is.Index.Columns, is.Table.PKIsHandle) {
 		// On this way, it's double read case.

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -489,9 +489,9 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 	}
 	rowCount := path.countAfterAccess
 	cop := &copTask{
-		indexPlan:  is,
-		tableStats: ds.tableStats,
-		tableCols:  ds.tableCols,
+		indexPlan:   is,
+		tblColHists: ds.tblColHists,
+		tblCols:     ds.tblCols,
 	}
 	if !candidate.isSingleScan {
 		// On this way, it's double read case.
@@ -552,7 +552,7 @@ func (is *PhysicalIndexScan) indexScanRowSize(idx *model.IndexInfo, ds *DataSour
 	} else {
 		scanCols = is.schema.Columns
 	}
-	return ds.tableStats.HistColl.GetAvgRowSize(scanCols, true)
+	return ds.tblColHists.GetAvgRowSize(scanCols, true)
 }
 
 // TODO: refactor this part, we should not call Clone in fact.
@@ -818,7 +818,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 	copTask := &copTask{
 		tablePlan:         ts,
 		indexPlanFinished: true,
-		tableStats:        ds.tableStats,
+		tblColHists:       ds.tblColHists,
 	}
 	task = copTask
 	// Adjust number of rows we actually need to scan if prop.ExpectedCnt is smaller than the count we calculated.
@@ -845,7 +845,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 	// we still need to assume values are uniformly distributed. For simplicity, we use uniform-assumption
 	// for all columns now, as we do in `deriveStatsByFilter`.
 	ts.stats = ds.tableStats.ScaleByExpectCnt(rowCount)
-	rowSize := ds.tableStats.HistColl.GetAvgRowSize(ds.tableCols, false)
+	rowSize := ds.tblColHists.GetAvgRowSize(ds.tblCols, false)
 	copTask.cst = rowCount * rowSize * scanFactor
 	if candidate.isMatchProp {
 		if prop.Items[0].Desc {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2267,7 +2267,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 		possibleAccessPaths: possiblePaths,
 		Columns:             make([]*model.ColumnInfo, 0, len(columns)),
 		partitionNames:      tn.PartitionNames,
-		tableCols:           make([]*expression.Column, 0, len(columns)),
+		tblCols:             make([]*expression.Column, 0, len(columns)),
 	}.Init(b.ctx)
 
 	var handleCol *expression.Column
@@ -2288,7 +2288,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 			handleCol = newCol
 		}
 		schema.Append(newCol)
-		ds.tableCols = append(ds.tableCols, newCol)
+		ds.tblCols = append(ds.tblCols, newCol)
 	}
 	// We append an extra handle column to the schema when "ds" is not a memory
 	// table e.g. table in the "INFORMATION_SCHEMA" database, and the handle
@@ -2298,7 +2298,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 		ds.Columns = append(ds.Columns, model.NewExtraHandleColInfo())
 		handleCol = ds.newExtraHandleSchemaCol()
 		schema.Append(handleCol)
-		ds.tableCols = append(ds.tableCols, handleCol)
+		ds.tblCols = append(ds.tblCols, handleCol)
 	}
 	if handleCol != nil {
 		schema.TblID2Handle[tableInfo.ID] = []*expression.Column{handleCol}

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -358,9 +358,12 @@ type DataSource struct {
 	// handleCol represents the handle column for the datasource, either the
 	// int primary key column or extra handle column.
 	handleCol *expression.Column
-	// tableCols contains the original columns of table before being pruned, and it
+	// tblCols contains the original columns of table before being pruned, and it
 	// is used for estimating table scan cost.
-	tableCols []*expression.Column
+	tblCols []*expression.Column
+	// tblColHists contains the Histogram of all original table columns,
+	// it is converted from statisticTable, and used for IO/network cost estimating.
+	tblColHists *statistics.HistColl
 }
 
 // accessPath indicates the way we access a table: by using single index, or by using multiple indexes,

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -789,9 +789,9 @@ func (b *PlanBuilder) buildPhysicalIndexLookUpReader(ctx context.Context, dbName
 	ts := PhysicalTableScan{Columns: tblReaderCols, Table: is.Table}.Init(b.ctx)
 	ts.SetSchema(tblSchema)
 	cop := &copTask{
-		indexPlan:  is,
-		tablePlan:  ts,
-		tableStats: is.stats,
+		indexPlan:   is,
+		tablePlan:   ts,
+		tblColHists: is.stats.HistColl,
 	}
 	ts.HandleIdx = pkOffset
 	is.initSchema(id, idx, true)

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -104,6 +104,7 @@ func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs) {
 		tableStats.Cardinality[i] = ds.getColumnNDV(col.ID)
 	}
 	ds.tableStats = tableStats
+	ds.tblColHists = ds.statisticTable.ID2UniqueID(ds.tblCols)
 	selectivity, nodes, err := tableStats.HistColl.Selectivity(ds.ctx, conds)
 	if err != nil {
 		logutil.BgLogger().Debug("an error happened, use the default selectivity", zap.Error(err))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, we are using `tableStats` to estimate row width, while `tableStats` only contains the columns remained after applying column pruning rule, it does not include all columns of the table, so when calling its method `GetAvgRowSize`, some columns cannot be found and hence we use `pesudoColSize` for them.

### What is changed and how it works?

This PR build `tblColHists` from `DataSource::statisticTable` and save it in `DataSource`, and then use it for row width estimation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test: I did't figure out a simple way to add unit test for this PR.
 - Manual test (add detailed scripts or steps below)
```
create table tbl(a int primary key, b int, c int)
insert into tbl values(1,1,1),(2,2,2);
analyze table tbl;

explain select a from tbl;
-- observe the behavior of GetAvgRowSize by adding debug log or using debugger
```

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

N/A
