### PR TITLE
executor: fix panic when fetching `processlist` table data in some cases

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -432,6 +432,7 @@ func (cc *clientConn) connectInfo() *variable.ConnectionInfo {
 // ShowProcessList implements the SessionManager interface.
 func (s *Server) ShowProcessList() map[uint64]*util.ProcessInfo {
 	s.rwlock.RLock()
+	defer s.rwlock.RUnlock()
 	rs := make(map[uint64]*util.ProcessInfo, len(s.clients))
 	for _, client := range s.clients {
 		if atomic.LoadInt32(&client.status) == connStatusWaitShutdown {
@@ -441,7 +442,6 @@ func (s *Server) ShowProcessList() map[uint64]*util.ProcessInfo {
 			rs[pi.ID] = pi
 		}
 	}
-	s.rwlock.RUnlock()
 	return rs
 }
 

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -48,6 +48,10 @@ func (pi *ProcessInfo) ToRowForShow(full bool) []interface{} {
 		}
 	}
 	t := uint64(time.Since(pi.Time) / time.Second)
+	bytesConsumed := int64(0)
+	if pi.StmtCtx.MemTracker != nil {
+		bytesConsumed = pi.StmtCtx.MemTracker.BytesConsumed()
+	}
 	return []interface{}{
 		pi.ID,
 		pi.User,
@@ -57,7 +61,7 @@ func (pi *ProcessInfo) ToRowForShow(full bool) []interface{} {
 		t,
 		fmt.Sprintf("%d", pi.State),
 		info,
-		pi.StmtCtx.MemTracker.BytesConsumed(),
+		bytesConsumed,
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When TiDB fetches data from `processlist` table, it will get each connection's memory consumption according to their `Ctx.Memtracker`.
But in some cases, `Ctx.Memtracker` is not initialized at that time, which results in a panic.

### What is changed and how it works?
Check if `Ctx.Memtracker` is `nil` before using it when fetching `processlist` table data.
