### PR TITLE
executor: add reserve methods to `Column` for var-length types

### DIFF
--- a/expression/vectorized.go
+++ b/expression/vectorized.go
@@ -25,12 +25,13 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 	tp := expr.GetType()
 	switch tp.EvalType() {
 	case types.ETInt:
-		result.PreAllocInt64(n)
+		result.ResizeInt64(n)
 		v, isNull, err := expr.EvalInt(ctx, chunk.Row{})
 		if err != nil {
 			return err
 		}
-		if isNull { // all slots are set to null by PreAlloc()
+		if isNull {
+			result.SetNulls(0, n, true)
 			return nil
 		}
 		i64s := result.Int64s()
@@ -39,12 +40,13 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 		}
 		result.SetNulls(0, n, false)
 	case types.ETReal:
-		result.PreAllocFloat64(n)
+		result.ResizeFloat64(n)
 		v, isNull, err := expr.EvalReal(ctx, chunk.Row{})
 		if err != nil {
 			return err
 		}
-		if isNull { // all slots are set to null by PreAlloc()
+		if isNull {
+			result.SetNulls(0, n, true)
 			return nil
 		}
 		f64s := result.Float64s()
@@ -53,12 +55,13 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 		}
 		result.SetNulls(0, n, false)
 	case types.ETDecimal:
-		result.PreAllocDecimal(n)
+		result.ResizeDecimal(n)
 		v, isNull, err := expr.EvalDecimal(ctx, chunk.Row{})
 		if err != nil {
 			return err
 		}
-		if isNull { // all slots are set to null by PreAlloc()
+		if isNull {
+			result.SetNulls(0, n, true)
 			return nil
 		}
 		ds := result.Decimals()
@@ -82,7 +85,7 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			}
 		}
 	case types.ETDuration:
-		result.Reset()
+		result.ResizeDuration(n)
 		v, isNull, err := expr.EvalDuration(ctx, chunk.Row{})
 		if err != nil {
 			return err
@@ -97,7 +100,7 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			}
 		}
 	case types.ETJson:
-		result.Reset()
+		result.ReserveJSON(n)
 		v, isNull, err := expr.EvalJSON(ctx, chunk.Row{})
 		if err != nil {
 			return err
@@ -112,7 +115,7 @@ func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.C
 			}
 		}
 	case types.ETString:
-		result.Reset()
+		result.ReserveString(n)
 		v, isNull, err := expr.EvalString(ctx, chunk.Row{})
 		if err != nil {
 			return err

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -242,33 +242,57 @@ const (
 	sizeGoDuration = int(unsafe.Sizeof(time.Duration(0)))
 )
 
-// preAlloc allocates space for a fixed-length-type slice and resets all slots to null.
-func (c *Column) preAlloc(length, typeSize int) {
-	nData := length * typeSize
-	if len(c.data) >= nData {
-		c.data = c.data[:nData]
+// resize resizes the column so that it contains n elements, only valid for fixed-length types.
+func (c *Column) resize(n, typeSize int) {
+	sizeData := n * typeSize
+	if cap(c.data) >= sizeData {
+		(*reflect.SliceHeader)(unsafe.Pointer(&c.data)).Len = sizeData
 	} else {
-		c.data = make([]byte, nData)
+		c.data = make([]byte, sizeData)
 	}
 
-	nBitmap := (length + 7) >> 3
-	if len(c.nullBitmap) >= nBitmap {
-		c.nullBitmap = c.nullBitmap[:nBitmap]
-		for i := range c.nullBitmap {
-			// resets all slots to null.
-			c.nullBitmap[i] = 0
-		}
+	sizeNulls := (n + 7) >> 3
+	if cap(c.nullBitmap) >= sizeNulls {
+		(*reflect.SliceHeader)(unsafe.Pointer(&c.nullBitmap)).Len = sizeNulls
 	} else {
-		c.nullBitmap = make([]byte, nBitmap)
+		c.nullBitmap = make([]byte, sizeNulls)
 	}
 
-	if c.elemBuf != nil && len(c.elemBuf) >= typeSize {
-		c.elemBuf = c.elemBuf[:typeSize]
+	if cap(c.elemBuf) >= typeSize {
+		(*reflect.SliceHeader)(unsafe.Pointer(&c.elemBuf)).Len = typeSize
 	} else {
 		c.elemBuf = make([]byte, typeSize)
 	}
 
-	c.length = length
+	c.length = n
+}
+
+// reserve makes the column capacity be at least enough to contain n elements.
+// this method is only valid for var-length types and estElemSize is the estimated size of this type.
+func (c *Column) reserve(n, estElemSize int) {
+	sizeData := n * estElemSize
+	if cap(c.data) >= sizeData {
+		c.data = c.data[:0]
+	} else {
+		c.data = make([]byte, 0, sizeData)
+	}
+
+	sizeNulls := (n + 7) >> 3
+	if cap(c.nullBitmap) >= sizeNulls {
+		c.nullBitmap = c.nullBitmap[:0]
+	} else {
+		c.nullBitmap = make([]byte, 0, sizeNulls)
+	}
+
+	sizeOffs := n + 1
+	if cap(c.offsets) >= sizeOffs {
+		c.offsets = c.offsets[:1]
+	} else {
+		c.offsets = make([]int64, 1, sizeOffs)
+	}
+
+	c.elemBuf = nil
+	c.length = 0
 }
 
 // SetNull sets the rowIdx to null.
@@ -313,38 +337,63 @@ func (c *Column) nullCount() int {
 	return cnt
 }
 
-// PreAllocInt64 allocates space for an int64 slice and resets all slots to null.
-func (c *Column) PreAllocInt64(length int) {
-	c.preAlloc(length, sizeInt64)
+// ResizeInt64 resizes the column so that it contains n int64 elements.
+func (c *Column) ResizeInt64(n int) {
+	c.resize(n, sizeInt64)
 }
 
-// PreAllocUint64 allocates space for a uint64 slice and resets all slots to null.
-func (c *Column) PreAllocUint64(length int) {
-	c.preAlloc(length, sizeUint64)
+// ResizeUint64 resizes the column so that it contains n uint64 elements.
+func (c *Column) ResizeUint64(n int) {
+	c.resize(n, sizeUint64)
 }
 
-// PreAllocFloat32 allocates space for a float32 slice and resets all slots to null.
-func (c *Column) PreAllocFloat32(length int) {
-	c.preAlloc(length, sizeFloat32)
+// ResizeFloat32 resizes the column so that it contains n float32 elements.
+func (c *Column) ResizeFloat32(n int) {
+	c.resize(n, sizeFloat32)
 }
 
-// PreAllocFloat64 allocates space for a float64 slice and resets all slots to null.
-func (c *Column) PreAllocFloat64(length int) {
-	c.preAlloc(length, sizeFloat64)
+// ResizeFloat64 resizes the column so that it contains n float64 elements.
+func (c *Column) ResizeFloat64(n int) {
+	c.resize(n, sizeFloat64)
 }
 
-// PreAllocDecimal allocates space for a decimal slice and resets all slots to null.
-func (c *Column) PreAllocDecimal(length int) {
-	c.preAlloc(length, sizeMyDecimal)
+// ResizeDecimal resizes the column so that it contains n decimal elements.
+func (c *Column) ResizeDecimal(n int) {
+	c.resize(n, sizeMyDecimal)
 }
 
-// PreAllocDuration allocates space for a duration slice and resets all slots to null.
-func (c *Column) PreAllocDuration(length int) {
-	c.preAlloc(length, sizeGoDuration)
+// ResizeDuration resizes the column so that it contains n duration elements.
+func (c *Column) ResizeDuration(n int) {
+	c.resize(n, sizeGoDuration)
+}
+
+// ReserveString changes the column capacity to store n string elements and set the length to zero.
+func (c *Column) ReserveString(n int) {
+	c.reserve(n, 8)
+}
+
+// ReserveBytes changes the column capacity to store n bytes elements and set the length to zero.
+func (c *Column) ReserveBytes(n int) {
+	c.reserve(n, 8)
+}
+
+// ReserveJSON changes the column capacity to store n JSON elements and set the length to zero.
+func (c *Column) ReserveJSON(n int) {
+	c.reserve(n, 8)
+}
+
+// ReserveSet changes the column capacity to store n set elements and set the length to zero.
+func (c *Column) ReserveSet(n int) {
+	c.reserve(n, 8)
+}
+
+// ReserveEnum changes the column capacity to store n enum elements and set the length to zero.
+func (c *Column) ReserveEnum(n int) {
+	c.reserve(n, 8)
 }
 
 func (c *Column) castSliceHeader(header *reflect.SliceHeader, typeSize int) {
-	header.Data = uintptr(unsafe.Pointer(&c.data[0]))
+	header.Data = (*reflect.SliceHeader)(unsafe.Pointer(&c.data)).Data
 	header.Len = c.length
 	header.Cap = cap(c.data) / typeSize
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add reserve methods to `Column` for var-length types to reserve memory before using a `Column`.
And rename methods `PreAllocXXX` to `ResizeXXX`.

### What is changed and how it works?
1. Add reserve methods for `JSON`, `Enum`, `Bytes`, `Set` and `String`;
2. Rename all `PreAllocXXX` methods.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
