### PR TITLE
expression: fix last_day incompatible with mysql

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -6416,14 +6416,13 @@ func (b *builtinLastDaySig) evalTime(row chunk.Row) (types.Time, bool, error) {
 		return types.Time{}, true, handleInvalidTimeError(b.ctx, err)
 	}
 	tm := arg.Time
-	var day int
-	year, month := tm.Year(), tm.Month()
-	if month == 0 {
+	year, month, day := tm.Year(), tm.Month(), tm.Day()
+	if month == 0 || day == 0 {
 		return types.Time{}, true, handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(arg.String()))
 	}
-	day = types.GetLastDay(year, month)
+	lastDay := types.GetLastDay(year, month)
 	ret := types.Time{
-		Time: types.FromDate(year, month, day, 0, 0, 0, 0),
+		Time: types.FromDate(year, month, lastDay, 0, 0, 0, 0),
 		Type: mysql.TypeDate,
 		Fsp:  types.DefaultFsp,
 	}

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -2676,6 +2676,7 @@ func (s *testEvaluatorSuite) TestLastDay(c *C) {
 		"2007-10-07 23:59:61",
 		"2005-00-00",
 		"2005-00-01",
+		"2243-01 00:00:00",
 		123456789}
 
 	for _, i := range testsNull {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #11695 

### What is changed and how it works?

Changed is described in issue.

Assert day is not 0 before calculate last_da

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

 - Breaking backward compatibility

Related changes
