### PR TITLE
*: use bytes.Equal to check byte slice equivalent

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -687,7 +687,7 @@ func (e *AnalyzeFastExec) getNextSampleKey(bo *tikv.Backoffer, startKey kv.Key) 
 		if err != nil {
 			return nil, err
 		}
-		if bytes.Compare(loc.StartKey, e.sampTasks[prefixLen].Location.EndKey) == 0 {
+		if bytes.Equal(loc.StartKey, e.sampTasks[prefixLen].Location.EndKey) {
 			startKey = loc.StartKey
 			break
 		}

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -506,7 +506,7 @@ func (e *LoadDataInfo) getFieldsFromLine(line []byte) ([]field, error) {
 	for {
 		eol, f := reader.GetField()
 		f = f.escape()
-		if bytes.Compare(f.str, null) == 0 && !f.enclosed {
+		if bytes.Equal(f.str, null) && !f.enclosed {
 			f.str = []byte{'N'}
 			f.maybeNull = true
 		}

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -650,7 +650,7 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 		if len(meta.Peers) == 0 {
 			return nil, errors.New("receive Region with no peer")
 		}
-		if isEndKey && !searchPrev && bytes.Compare(meta.StartKey, key) == 0 && len(meta.StartKey) != 0 {
+		if isEndKey && !searchPrev && bytes.Equal(meta.StartKey, key) && len(meta.StartKey) != 0 {
 			searchPrev = true
 			continue
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`bytes.Equal` is faster than `bytes.Compare() == 0`

simple benchmark code snippet: https://play.golang.org/p/omqWdp4z0S9

```
➜  go test -bench=. bytes_bench_test.go -run=none
goos: linux
goarch: amd64
BenchmarkCompare-2      300000000                5.80 ns/op
BenchmarkEqual-2        300000000                4.83 ns/op
BenchmarkCompareNE-2    200000000                6.15 ns/op
BenchmarkEqualNE-2      500000000                3.04 ns/op
PASS
```

### What is changed and how it works?

change `bytes.Compare() == 0` with `bytes.Equal`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch
