### PR TITLE
metric, tikv: record duration for each backoff type

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -111,7 +111,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(DbStmtNodeCounter)
 	prometheus.MustRegister(StoreQueryFeedbackCounter)
 	prometheus.MustRegister(TiKVBackoffCounter)
-	prometheus.MustRegister(TiKVBackoffHistogram)
+	prometheus.MustRegister(TiKVBackoffDuration)
 	prometheus.MustRegister(TiKVCoprocessorHistogram)
 	prometheus.MustRegister(TiKVLoadSafepointCounter)
 	prometheus.MustRegister(TiKVLockResolverCounter)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -111,7 +111,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(DbStmtNodeCounter)
 	prometheus.MustRegister(StoreQueryFeedbackCounter)
 	prometheus.MustRegister(TiKVBackoffCounter)
-	prometheus.MustRegister(TiKVBackoffDuration)
+	prometheus.MustRegister(TiKVBackoffHistogram)
 	prometheus.MustRegister(TiKVCoprocessorHistogram)
 	prometheus.MustRegister(TiKVLoadSafepointCounter)
 	prometheus.MustRegister(TiKVLockResolverCounter)

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -58,14 +58,14 @@ var (
 			Help:      "Counter of backoff.",
 		}, []string{LblType})
 
-	TiKVBackoffHistogram = prometheus.NewHistogram(
+	TiKVBackoffDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",
 			Subsystem: "tikvclient",
 			Name:      "backoff_seconds",
 			Help:      "total backoff seconds of a single backoffer.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 20), // 0.5ms ~ 524s
-		})
+		}, []string{LblType})
 
 	TiKVSendReqHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -58,7 +58,7 @@ var (
 			Help:      "Counter of backoff.",
 		}, []string{LblType})
 
-	TiKVBackoffDuration = prometheus.NewHistogramVec(
+	TiKVBackoffHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",
 			Subsystem: "tikvclient",

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -45,42 +45,42 @@ const (
 )
 
 var (
-	tikvBackoffCounterRPC           = metrics.TiKVBackoffCounter.WithLabelValues("tikvRPC")
-	tikvBackoffCounterLock          = metrics.TiKVBackoffCounter.WithLabelValues("txnLock")
-	tikvBackoffCounterLockFast      = metrics.TiKVBackoffCounter.WithLabelValues("tikvLockFast")
-	tikvBackoffCounterPD            = metrics.TiKVBackoffCounter.WithLabelValues("pdRPC")
-	tikvBackoffCounterRegionMiss    = metrics.TiKVBackoffCounter.WithLabelValues("regionMiss")
-	tikvBackoffCounterUpdateLeader  = metrics.TiKVBackoffCounter.WithLabelValues("updateLeader")
-	tikvBackoffCounterServerBusy    = metrics.TiKVBackoffCounter.WithLabelValues("serverBusy")
-	tikvBackoffCounterEmpty         = metrics.TiKVBackoffCounter.WithLabelValues("")
-	tikvBackoffDurationRPC          = metrics.TiKVBackoffDuration.WithLabelValues("tikvRPC")
-	tikvBackoffDurationLock         = metrics.TiKVBackoffDuration.WithLabelValues("txnLock")
-	tikvBackoffDurationLockFast     = metrics.TiKVBackoffDuration.WithLabelValues("tikvLockFast")
-	tikvBackoffDurationPD           = metrics.TiKVBackoffDuration.WithLabelValues("pdRPC")
-	tikvBackoffDurationRegionMiss   = metrics.TiKVBackoffDuration.WithLabelValues("regionMiss")
-	tikvBackoffDurationUpdateLeader = metrics.TiKVBackoffDuration.WithLabelValues("updateLeader")
-	tikvBackoffDurationServerBusy   = metrics.TiKVBackoffDuration.WithLabelValues("serverBusy")
-	tikvBackoffDurationEmpty        = metrics.TiKVBackoffDuration.WithLabelValues("")
+	tikvBackoffCounterRPC            = metrics.TiKVBackoffCounter.WithLabelValues("tikvRPC")
+	tikvBackoffCounterLock           = metrics.TiKVBackoffCounter.WithLabelValues("txnLock")
+	tikvBackoffCounterLockFast       = metrics.TiKVBackoffCounter.WithLabelValues("tikvLockFast")
+	tikvBackoffCounterPD             = metrics.TiKVBackoffCounter.WithLabelValues("pdRPC")
+	tikvBackoffCounterRegionMiss     = metrics.TiKVBackoffCounter.WithLabelValues("regionMiss")
+	tikvBackoffCounterUpdateLeader   = metrics.TiKVBackoffCounter.WithLabelValues("updateLeader")
+	tikvBackoffCounterServerBusy     = metrics.TiKVBackoffCounter.WithLabelValues("serverBusy")
+	tikvBackoffCounterEmpty          = metrics.TiKVBackoffCounter.WithLabelValues("")
+	tikvBackoffHistogramRPC          = metrics.TiKVBackoffHistogram.WithLabelValues("tikvRPC")
+	tikvBackoffHistogramLock         = metrics.TiKVBackoffHistogram.WithLabelValues("txnLock")
+	tikvBackoffHistogramLockFast     = metrics.TiKVBackoffHistogram.WithLabelValues("tikvLockFast")
+	tikvBackoffHistogramPD           = metrics.TiKVBackoffHistogram.WithLabelValues("pdRPC")
+	tikvBackoffHistogramRegionMiss   = metrics.TiKVBackoffHistogram.WithLabelValues("regionMiss")
+	tikvBackoffHistogramUpdateLeader = metrics.TiKVBackoffHistogram.WithLabelValues("updateLeader")
+	tikvBackoffHistogramServerBusy   = metrics.TiKVBackoffHistogram.WithLabelValues("serverBusy")
+	tikvBackoffHistogramEmpty        = metrics.TiKVBackoffHistogram.WithLabelValues("")
 )
 
 func (t backoffType) metric() (prometheus.Counter, prometheus.Observer) {
 	switch t {
 	case boTiKVRPC:
-		return tikvBackoffCounterRPC, tikvBackoffDurationRPC
+		return tikvBackoffCounterRPC, tikvBackoffHistogramRPC
 	case BoTxnLock:
-		return tikvBackoffCounterLock, tikvBackoffDurationLock
+		return tikvBackoffCounterLock, tikvBackoffHistogramLock
 	case boTxnLockFast:
-		return tikvBackoffCounterLockFast, tikvBackoffDurationLockFast
+		return tikvBackoffCounterLockFast, tikvBackoffHistogramLockFast
 	case BoPDRPC:
-		return tikvBackoffCounterPD, tikvBackoffDurationPD
+		return tikvBackoffCounterPD, tikvBackoffHistogramPD
 	case BoRegionMiss:
-		return tikvBackoffCounterRegionMiss, tikvBackoffDurationRegionMiss
+		return tikvBackoffCounterRegionMiss, tikvBackoffHistogramRegionMiss
 	case BoUpdateLeader:
-		return tikvBackoffCounterUpdateLeader, tikvBackoffDurationUpdateLeader
+		return tikvBackoffCounterUpdateLeader, tikvBackoffHistogramUpdateLeader
 	case boServerBusy:
-		return tikvBackoffCounterServerBusy, tikvBackoffDurationServerBusy
+		return tikvBackoffCounterServerBusy, tikvBackoffHistogramServerBusy
 	}
-	return tikvBackoffCounterEmpty, tikvBackoffDurationEmpty
+	return tikvBackoffCounterEmpty, tikvBackoffHistogramEmpty
 }
 
 // NewBackoffFn creates a backoff func which implements exponential backoff with
@@ -286,8 +286,8 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 	default:
 	}
 
-	counter, timer := typ.metric()
-	counter.Inc()
+	backoffCounter, backoffDuration := typ.metric()
+	backoffCounter.Inc()
 	// Lazy initialize.
 	if b.fn == nil {
 		b.fn = make(map[backoffType]func(context.Context, int) int)
@@ -299,7 +299,7 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 	}
 
 	realSleep := f(b.ctx, maxSleepMs)
-	timer.Observe(float64(realSleep) / 1000)
+	backoffDuration.Observe(float64(realSleep) / 1000)
 	b.totalSleep += realSleep
 	b.types = append(b.types, typ)
 

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -45,34 +45,42 @@ const (
 )
 
 var (
-	tikvBackoffCounterRPC          = metrics.TiKVBackoffCounter.WithLabelValues("tikvRPC")
-	tikvBackoffCounterLock         = metrics.TiKVBackoffCounter.WithLabelValues("txnLock")
-	tikvBackoffCounterLockFast     = metrics.TiKVBackoffCounter.WithLabelValues("tikvLockFast")
-	tikvBackoffCounterPD           = metrics.TiKVBackoffCounter.WithLabelValues("pdRPC")
-	tikvBackoffCounterRegionMiss   = metrics.TiKVBackoffCounter.WithLabelValues("regionMiss")
-	tikvBackoffCounterUpdateLeader = metrics.TiKVBackoffCounter.WithLabelValues("updateLeader")
-	tikvBackoffCounterServerBusy   = metrics.TiKVBackoffCounter.WithLabelValues("serverBusy")
-	tikvBackoffCounterEmpty        = metrics.TiKVBackoffCounter.WithLabelValues("")
+	tikvBackoffCounterRPC           = metrics.TiKVBackoffCounter.WithLabelValues("tikvRPC")
+	tikvBackoffCounterLock          = metrics.TiKVBackoffCounter.WithLabelValues("txnLock")
+	tikvBackoffCounterLockFast      = metrics.TiKVBackoffCounter.WithLabelValues("tikvLockFast")
+	tikvBackoffCounterPD            = metrics.TiKVBackoffCounter.WithLabelValues("pdRPC")
+	tikvBackoffCounterRegionMiss    = metrics.TiKVBackoffCounter.WithLabelValues("regionMiss")
+	tikvBackoffCounterUpdateLeader  = metrics.TiKVBackoffCounter.WithLabelValues("updateLeader")
+	tikvBackoffCounterServerBusy    = metrics.TiKVBackoffCounter.WithLabelValues("serverBusy")
+	tikvBackoffCounterEmpty         = metrics.TiKVBackoffCounter.WithLabelValues("")
+	tikvBackoffDurationRPC          = metrics.TiKVBackoffDuration.WithLabelValues("tikvRPC")
+	tikvBackoffDurationLock         = metrics.TiKVBackoffDuration.WithLabelValues("txnLock")
+	tikvBackoffDurationLockFast     = metrics.TiKVBackoffDuration.WithLabelValues("tikvLockFast")
+	tikvBackoffDurationPD           = metrics.TiKVBackoffDuration.WithLabelValues("pdRPC")
+	tikvBackoffDurationRegionMiss   = metrics.TiKVBackoffDuration.WithLabelValues("regionMiss")
+	tikvBackoffDurationUpdateLeader = metrics.TiKVBackoffDuration.WithLabelValues("updateLeader")
+	tikvBackoffDurationServerBusy   = metrics.TiKVBackoffDuration.WithLabelValues("serverBusy")
+	tikvBackoffDurationEmpty        = metrics.TiKVBackoffDuration.WithLabelValues("")
 )
 
-func (t backoffType) Counter() prometheus.Counter {
+func (t backoffType) metric() (prometheus.Counter, prometheus.Observer) {
 	switch t {
 	case boTiKVRPC:
-		return tikvBackoffCounterRPC
+		return tikvBackoffCounterRPC, tikvBackoffDurationRPC
 	case BoTxnLock:
-		return tikvBackoffCounterLock
+		return tikvBackoffCounterLock, tikvBackoffDurationLock
 	case boTxnLockFast:
-		return tikvBackoffCounterLockFast
+		return tikvBackoffCounterLockFast, tikvBackoffDurationLockFast
 	case BoPDRPC:
-		return tikvBackoffCounterPD
+		return tikvBackoffCounterPD, tikvBackoffDurationPD
 	case BoRegionMiss:
-		return tikvBackoffCounterRegionMiss
+		return tikvBackoffCounterRegionMiss, tikvBackoffDurationRegionMiss
 	case BoUpdateLeader:
-		return tikvBackoffCounterUpdateLeader
+		return tikvBackoffCounterUpdateLeader, tikvBackoffDurationUpdateLeader
 	case boServerBusy:
-		return tikvBackoffCounterServerBusy
+		return tikvBackoffCounterServerBusy, tikvBackoffDurationServerBusy
 	}
-	return tikvBackoffCounterEmpty
+	return tikvBackoffCounterEmpty, tikvBackoffDurationEmpty
 }
 
 // NewBackoffFn creates a backoff func which implements exponential backoff with
@@ -278,7 +286,8 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 	default:
 	}
 
-	typ.Counter().Inc()
+	counter, timer := typ.metric()
+	counter.Inc()
 	// Lazy initialize.
 	if b.fn == nil {
 		b.fn = make(map[backoffType]func(context.Context, int) int)
@@ -289,7 +298,9 @@ func (b *Backoffer) BackoffWithMaxSleep(typ backoffType, maxSleepMs int, err err
 		b.fn[typ] = f
 	}
 
-	b.totalSleep += f(b.ctx, maxSleepMs)
+	realSleep := f(b.ctx, maxSleepMs)
+	timer.Observe(float64(realSleep) / 1000)
+	b.totalSleep += realSleep
 	b.types = append(b.types, typ)
 
 	var startTs interface{}

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -436,9 +436,6 @@ func (worker *copIteratorWorker) run(ctx context.Context) {
 
 		bo := NewBackoffer(ctx, copNextMaxBackoff).WithVars(worker.vars)
 		worker.handleTask(bo, task, respCh)
-		if bo.totalSleep > 0 {
-			metrics.TiKVBackoffHistogram.Observe(float64(bo.totalSleep) / 1000)
-		}
 		close(task.respChan)
 		select {
 		case <-worker.finishCh:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

current "KV Errors" - "KV Retry Duration" metrics in grafana only record coprocessor's backoff time.

that miss:

- 2pc commit path's backoff
- kv get path's backoff

it also miss the fine-gain time for each backoff-type

### What is changed and how it works?

- record backoff duration in backoff
- remove duplicate cop duration recording

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - change metric record

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11710)
<!-- Reviewable:end -->
