### PR TITLE
expression: remove unnecessary convertIntToUint. fix error in err msg(should be bigint but not double)(#11640)

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2055,6 +2055,30 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	msg := strings.Split(err.Error(), " ")
 	last := msg[len(msg)-1]
 	c.Assert(last, Equals, "bigint")
+	tk.MustExec(`drop table tb5;`)
+
+	// test builtinCastIntAsDecimalSig
+	tk.MustExec(`create table tb5(a bigint(64) unsigned, b decimal(64, 10));`)
+	tk.MustExec(`insert into tb5 (a, b) values (9223372036854775808, 9223372036854775808);`)
+	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
+	tk.MustExec(`drop table tb5;`)
+
+	// test builtinCastIntAsRealSig
+	tk.MustExec(`create table tb5(a bigint(64) unsigned, b float(64, 10));`)
+	tk.MustExec(`insert into tb5 (a, b) values (13835058000000000000, 13835058000000000000);`)
+	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
+	tk.MustExec(`drop table tb5;`)
+
+	tk.MustExec(`create table tb5 (a bigint(64) unsigned, b float(64, 10));`)
+	tk.MustExec(`insert into tb5 (a, b) values (13835058000000000000, 13835058000000000000);`)
+	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
+	tk.MustExec(`drop table tb5;`)
+
+	// test builtinCastIntAsStringSig
+	tk.MustExec(`create table tb5(a bigint(64) unsigned,b varchar(50));`)
+	tk.MustExec(`insert into tb5(a, b) values (9223372036854775808, '9223372036854775808');`)
+	tk.MustExec(`insert into tb5(select * from tb5 where a = b);`)
+	tk.MustExec(`drop table tb5;`)
 
 	// Test corner cases of cast string as datetime
 	result = tk.MustQuery(`select cast("170102034" as datetime);`)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2061,23 +2061,24 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	tk.MustExec(`create table tb5(a bigint(64) unsigned, b decimal(64, 10));`)
 	tk.MustExec(`insert into tb5 (a, b) values (9223372036854775808, 9223372036854775808);`)
 	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
+	result = tk.MustQuery(`select * from tb5;`)
+	result.Check(testkit.Rows("9223372036854775808 9223372036854775808.0000000000", "9223372036854775808 9223372036854775808.0000000000"))
 	tk.MustExec(`drop table tb5;`)
 
 	// test builtinCastIntAsRealSig
-	tk.MustExec(`create table tb5(a bigint(64) unsigned, b float(64, 10));`)
+	tk.MustExec(`create table tb5(a bigint(64) unsigned, b double(64, 10));`)
 	tk.MustExec(`insert into tb5 (a, b) values (13835058000000000000, 13835058000000000000);`)
 	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
-	tk.MustExec(`drop table tb5;`)
-
-	tk.MustExec(`create table tb5 (a bigint(64) unsigned, b float(64, 10));`)
-	tk.MustExec(`insert into tb5 (a, b) values (13835058000000000000, 13835058000000000000);`)
-	tk.MustExec(`insert into tb5 (select * from tb5 where a = b);`)
+	result = tk.MustQuery(`select * from tb5;`)
+	result.Check(testkit.Rows("13835058000000000000 13835058000000000000", "13835058000000000000 13835058000000000000"))
 	tk.MustExec(`drop table tb5;`)
 
 	// test builtinCastIntAsStringSig
 	tk.MustExec(`create table tb5(a bigint(64) unsigned,b varchar(50));`)
 	tk.MustExec(`insert into tb5(a, b) values (9223372036854775808, '9223372036854775808');`)
 	tk.MustExec(`insert into tb5(select * from tb5 where a = b);`)
+	result = tk.MustQuery(`select * from tb5;`)
+	result.Check(testkit.Rows("9223372036854775808 9223372036854775808", "9223372036854775808 9223372036854775808"))
 	tk.MustExec(`drop table tb5;`)
 
 	// Test corner cases of cast string as datetime

--- a/types/convert.go
+++ b/types/convert.go
@@ -68,7 +68,6 @@ var SignedLowerBound = map[byte]int64{
 }
 
 // ConvertFloatToInt converts a float64 value to a int value.
-//
 // `tp` is used in err msg, if there is overflow, this func will report err according to `tp`
 func ConvertFloatToInt(fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
 	val := RoundFloat(fval)

--- a/types/convert.go
+++ b/types/convert.go
@@ -68,6 +68,8 @@ var SignedLowerBound = map[byte]int64{
 }
 
 // ConvertFloatToInt converts a float64 value to a int value.
+//
+// `tp` is used in err msg, if there is overflow, this func will report err according to `tp`
 func ConvertFloatToInt(fval float64, lowerBound, upperBound int64, tp byte) (int64, error) {
 	val := RoundFloat(fval)
 	if val < float64(lowerBound) {

--- a/types/etc.go
+++ b/types/etc.go
@@ -83,10 +83,7 @@ func IsTemporalWithDate(tp byte) bool {
 // IsBinaryStr returns a boolean indicating
 // whether the field type is a binary string type.
 func IsBinaryStr(ft *FieldType) bool {
-	if ft.Collate == charset.CollationBin && IsString(ft.Tp) {
-		return true
-	}
-	return false
+	return ft.Collate == charset.CollationBin && IsString(ft.Tp)
 }
 
 // IsNonBinaryStr returns a boolean indicating


### PR DESCRIPTION
cherry-pick #11640 to release-2.1

---

Signed-off-by: H-ZeX <hzx20112012@gmail.com>


### What problem does this PR solve? <!--add issue link with summary if exists-->

In some of the code, we get a uint from the row which is stored in int, however, we needn't casting it from int to uint when it is uint, this will make some bugs.

In the origin `builtinCastStringAsDecimalSig::evalDecimal`, the res is always not neg, this is a bug.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

NO.

Side effects

NO.

Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note
