### PR TITLE
planner: "for update" should not work in a single autocommit statement

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -458,7 +458,7 @@ Projection_3	10000.00	root	or(NULL, gt(test.t.a, 1))
   └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select * from t where a = 1 for update;
 id	count	task	operator info
-Point_Get_1	1.00	root	table:t, handle:1
+Point_Get_1	1.00	root	table:t, handle:1, lock
 drop table if exists ta, tb;
 create table ta (a varchar(20));
 create table tb (a varchar(20));


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
mysql> show create table t;
+-------+------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                 |
+-------+------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `id` int(11) NOT NULL,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)

mysql> select * from t where id = 9 for update;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

### What is changed and how it works?

The bug is introduced in this PR https://github.com/pingcap/tidb/pull/10972

```
github.com/pingcap/tidb/server.(*clientConn).Run.func1
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:600
runtime.gopanic
	/media/genius/OS/project/go/src/runtime/panic.go:522
github.com/pingcap/tidb/server.(*clientConn).writeResultset.func1
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:1268
runtime.gopanic
	/media/genius/OS/project/go/src/runtime/panic.go:522
runtime.panicmem
	/media/genius/OS/project/go/src/runtime/panic.go:82
runtime.sigpanic
	/media/genius/OS/project/go/src/runtime/signal_unix.go:390
github.com/pingcap/tidb/session.(*TxnState).LockKeys
	<autogenerated>:1
github.com/pingcap/tidb/executor.(*PointGetExecutor).lockKeyIfNeeded
	/media/genius/OS/project/src/github.com/pingcap/tidb/executor/point_get.go:152
github.com/pingcap/tidb/executor.(*PointGetExecutor).Next
	/media/genius/OS/project/src/github.com/pingcap/tidb/executor/point_get.go:132
github.com/pingcap/tidb/executor.Next
	/media/genius/OS/project/src/github.com/pingcap/tidb/executor/executor.go:200
github.com/pingcap/tidb/executor.(*recordSet).Next
	/media/genius/OS/project/src/github.com/pingcap/tidb/executor/adapter.go:113
github.com/pingcap/tidb/server.(*tidbResultSet).Next
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/driver_tidb.go:365
github.com/pingcap/tidb/server.(*clientConn).writeChunks
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:1315
github.com/pingcap/tidb/server.(*clientConn).writeResultset
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:1281
github.com/pingcap/tidb/server.(*clientConn).handleQuery
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:1198
github.com/pingcap/tidb/server.(*clientConn).dispatch
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:897
github.com/pingcap/tidb/server.(*clientConn).Run
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/conn.go:652
github.com/pingcap/tidb/server.(*Server).onConn
	/media/genius/OS/project/src/github.com/pingcap/tidb/server/server.go:438
```

The root cause of the panic is the mismatch of the life span between statement and executor.
We close the statement (or Txn in the auto-commit case) after `Execute` returns a `RecordSet`.
However, `RecordSet.Next` is still using the Txn, so the panic occurs.

This fix is actually a workaround: change `select ... for update` statement to normal `select ...` statement in the auto-commit case.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch

