### PR TITLE
server/conn: log more detailed errors

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -632,6 +632,7 @@ func (cc *clientConn) Run(ctx context.Context) {
 					logutil.Logger(ctx).Info("read packet timeout, close this connection",
 						zap.Duration("idle", idleTime),
 						zap.Uint64("waitTimeout", waitTimeout),
+						zap.Error(err),
 					)
 				} else {
 					errStack := errors.ErrorStack(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Print more message to help investigate an bug: when executed some long-time-costing SQL and encountered timeout error, `idleTime` is relatively small to `waitTimeout`, e.g.

```
[2019/08/12 07:43:00.259 +00:00] [INFO] [conn.go:631] ["read packet timeout, close this connection"] [conn=12] [idle=2h11m42.271040483s] [waitTimeout=28800]
```

### What is changed and how it works?
Print original error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes
