### PR TITLE
util: Simplify non-copy string-[]byte conversion

### DIFF
--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -24,15 +24,8 @@ type MutableString string
 // String converts slice to MutableString without copy.
 // The MutableString can be converts to string without copy.
 // Use it at your own risk.
-func String(b []byte) (s MutableString) {
-	if len(b) == 0 {
-		return ""
-	}
-	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	pstring.Data = pbytes.Data
-	pstring.Len = pbytes.Len
-	return
+func String(b []byte) MutableString {
+	return *(*MutableString)(unsafe.Pointer(&b))
 }
 
 // Slice converts string to slice without copy.

--- a/util/hack/hack_test.go
+++ b/util/hack/hack_test.go
@@ -19,6 +19,10 @@ import (
 )
 
 func TestString(t *testing.T) {
+	if String([]byte{}) != "" {
+		t.Fatal("Empty byte slice is not converted to empty string.")
+	}
+
 	b := []byte("hello world")
 	a := String(b)
 
@@ -39,6 +43,10 @@ func TestString(t *testing.T) {
 }
 
 func TestByte(t *testing.T) {
+	if !bytes.Equal(Slice(""), []byte{}) {
+		t.Fatal("Empty string is not converted to empty byte slice")
+	}
+
 	a := "hello world"
 
 	b := Slice(a)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In recent versions of Go, we can convert an `unsafe.Pointer` to a string
pointer directly.

As demonstrated in the source code of
[`strings.Builder`](https://golang.org/src/strings/builder.go#L45).


### What is changed and how it works?

Use the easier way to implement the non-copy conversion.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects


Related changes