### PR TITLE
fix some bugs in `builtinCastIntAsRealSig` and `builtinCastIntAsDecimalSig` that treat unsigned val  as signed val

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -463,7 +463,7 @@ func (b *builtinCastIntAsRealSig) evalReal(row chunk.Row) (res float64, isNull b
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = float64(val)
-	} else if b.inUnion && val < 0 {
+	} else if b.inUnion && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) && val < 0 {
 		res = 0
 	} else {
 		// recall that, int to float is different from uint to float
@@ -489,7 +489,7 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 	}
 	if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		res = types.NewDecFromInt(val)
-	} else if b.inUnion && val < 0 {
+	} else if b.inUnion && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) && val < 0 {
 		res = &types.MyDecimal{}
 	} else {
 		res = types.NewDecFromUint(uint64(val))

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2238,7 +2238,7 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	tk.MustExec(`drop table if exists tb5`)
 	tk.MustExec(`create table tb5 (a bigint(64) unsigned, b double(64, 10));`)
 	tk.MustExec(`insert into tb5 (a, b) values (9223372036854775808, 9223372036854775808);`)
-	result = tk.MustQuery(`select a from nb1 where a = b union all select b from nb1;`)
+	result = tk.MustQuery(`select a from tb5 where a = b union all select b from tb5;`)
 	result.Check(testkit.Rows("9223372036854776000", "9223372036854776000"))
 	tk.MustExec(`drop table tb5`)
 

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2226,6 +2226,22 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("9223372036854775808 9223372036854775808", "9223372036854775808 9223372036854775808"))
 	tk.MustExec(`drop table tb5;`)
 
+	// test builtinCastIntAsDecimalSig
+	tk.MustExec(`drop table if exists tb5`)
+	tk.MustExec(`create table tb5 (a decimal(65), b bigint(64) unsigned);`)
+	tk.MustExec(`insert into tb5 (a, b) values (9223372036854775808, 9223372036854775808);`)
+	result = tk.MustQuery(`select cast(b as decimal(64)) from tb5 union all select b from tb5;`)
+	result.Check(testkit.Rows("9223372036854775808", "9223372036854775808"))
+	tk.MustExec(`drop table tb5`)
+
+	// test builtinCastIntAsRealSig
+	tk.MustExec(`drop table if exists tb5`)
+	tk.MustExec(`create table tb5 (a bigint(64) unsigned, b double(64, 10));`)
+	tk.MustExec(`insert into tb5 (a, b) values (9223372036854775808, 9223372036854775808);`)
+	result = tk.MustQuery(`select a from nb1 where a = b union all select b from nb1;`)
+	result.Check(testkit.Rows("9223372036854776000", "9223372036854776000"))
+	tk.MustExec(`drop table tb5`)
+
 	// Test corner cases of cast string as datetime
 	result = tk.MustQuery(`select cast("170102034" as datetime);`)
 	result.Check(testkit.Rows("2017-01-02 03:04:00"))


### PR DESCRIPTION
Signed-off-by: H-ZeX <hzx20112012@gmail.com>


### What problem does this PR solve? <!--add issue link with summary if exists-->

in the original version, it will check `inUnion && val<0` no matter whether the val is unsigned(the val is always int64, but in sql, it may be unsigned), so in some case, it will dirrerent from mysql5.7

### What is changed and how it works?

add check of whether unsigned

### Check List <!--REMOVE the items that are not applicable-->

 - Integration test

Code changes

no.

Side effects

no.

Related changes

 - Need to cherry-pick to the release branch
