### PR TITLE
planner: rewrite `in` as `eq` when the rhs list has only one item

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -704,3 +704,13 @@ TableReader_7	0.00	root	data:Selection_6
 └─Selection_6	0.00	cop	ge(test.t.a, 3), le(test.t.a, 8)
   └─TableScan_5	8.00	cop	table:t, range:[-inf,+inf], keep order:false
 drop table t;
+create table t(a int, b int, index idx_ab(a, b));
+explain select a, b from t where a in (1) order by b;
+id	count	task	operator info
+IndexReader_12	10.00	root	index:IndexScan_11
+└─IndexScan_11	10.00	cop	table:t, index:a, b, range:[1,1], keep order:true, stats:pseudo
+explain select a, b from t where a = 1 order by b;
+id	count	task	operator info
+IndexReader_12	10.00	root	index:IndexScan_11
+└─IndexScan_11	10.00	cop	table:t, index:a, b, range:[1,1], keep order:true, stats:pseudo
+drop table if exists t;

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -173,7 +173,7 @@ Projection_13	0.00	root	test.te.expect_time
     ├─TopN_95	0.00	root	test.te.expect_time:asc, offset:0, count:5
     │ └─IndexJoin_36	0.00	root	inner join, inner:IndexLookUp_35, outer key:test.tr.id, inner key:test.te.trade_id
     │   ├─IndexLookUp_74	0.00	root	
-    │   │ ├─Selection_72	0.00	cop	eq(test.tr.business_type, 18), in(test.tr.trade_type, 1)
+    │   │ ├─Selection_72	0.00	cop	eq(test.tr.business_type, 18), eq(test.tr.trade_type, 1)
     │   │ │ └─IndexScan_70	10.00	cop	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false, stats:pseudo
     │   │ └─Selection_73	0.00	cop	eq(test.tr.brand_identy, 32314), eq(test.tr.domain_type, 2)
     │   │   └─TableScan_71	0.00	cop	table:tr, keep order:false, stats:pseudo

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -167,3 +167,9 @@ insert into t values (1),(2),(2),(2),(9),(9),(9),(10);
 analyze table t with 1 buckets;
 explain select * from t where a >= 3 and a <= 8;
 drop table t;
+
+# https://github.com/pingcap/tidb/issues/10626
+create table t(a int, b int, index idx_ab(a, b));
+explain select a, b from t where a in (1) order by b;
+explain select a, b from t where a = 1 order by b;
+drop table if exists t;

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1157,7 +1157,7 @@ func (er *expressionRewriter) inToExpression(lLen int, not bool, tp *types.Field
 		}
 	}
 	var function expression.Expression
-	if allSameType && l == 1 {
+	if allSameType && l == 1 && lLen > 1 {
 		function = er.notToExpression(not, ast.In, tp, er.ctxStack[stkLen-lLen-1:]...)
 	} else {
 		eqFunctions := make([]expression.Expression, 0, lLen)

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -1110,7 +1110,7 @@ func (s *testPlanSuite) TestRefine(c *C) {
 		},
 		{
 			sql:  "select a from t where c not in (1)",
-			best: "IndexReader(Index(t.c_d_e)[(NULL,1) (1,+inf]])->Projection",
+			best: "IndexReader(Index(t.c_d_e)[[-inf,1) (1,+inf]])->Projection",
 		},
 		// test like
 		{

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -424,7 +424,7 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     `a in ('a') and b in ('1', 2.0, NULL)`,
-			accessConds: "[in(test.t.a, a) in(test.t.b, 1, 2, <nil>)]",
+			accessConds: "[eq(test.t.a, a) in(test.t.b, 1, 2, <nil>)]",
 			filterConds: "[]",
 			resultStr:   `[["a" 1,"a" 1] ["a" 2,"a" 2]]`,
 		},
@@ -466,7 +466,7 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     "a in (NULL)",
-			accessConds: "[in(test.t.a, <nil>)]",
+			accessConds: "[eq(test.t.a, <nil>)]",
 			filterConds: "[]",
 			resultStr:   "[]",
 		},
@@ -487,14 +487,14 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     "not (a not in (NULL) and a > '2')",
-			accessConds: "[or(in(test.t.a, <nil>), le(test.t.a, 2))]",
+			accessConds: "[or(eq(test.t.a, <nil>), le(test.t.a, 2))]",
 			filterConds: "[]",
 			resultStr:   "[[-inf,\"2\"]]",
 		},
 		{
 			indexPos:    0,
 			exprStr:     "not (a not in (NULL) or a > '2')",
-			accessConds: "[and(in(test.t.a, <nil>), le(test.t.a, 2))]",
+			accessConds: "[and(eq(test.t.a, <nil>), le(test.t.a, 2))]",
 			filterConds: "[]",
 			resultStr:   "[]",
 		},
@@ -549,17 +549,17 @@ func (s *testRangerSuite) TestIndexRange(c *C) {
 		},
 		{
 			indexPos:    2,
-			exprStr:     `d in ("你好啊")`,
-			accessConds: "[in(test.t.d, 你好啊)]",
-			filterConds: "[in(test.t.d, 你好啊)]",
-			resultStr:   "[[\"你好\",\"你好\"]]",
+			exprStr:     `d in ("你好啊", "再见")`,
+			accessConds: "[in(test.t.d, 你好啊, 再见)]",
+			filterConds: "[in(test.t.d, 你好啊, 再见)]",
+			resultStr:   "[[\"你好\",\"你好\"] [\"再见\",\"再见\"]]",
 		},
 		{
 			indexPos:    2,
 			exprStr:     `d not in ("你好啊")`,
-			accessConds: "[not(in(test.t.d, 你好啊))]",
-			filterConds: "[not(in(test.t.d, 你好啊))]",
-			resultStr:   "[(NULL,+inf]]",
+			accessConds: "[]",
+			filterConds: "[ne(test.t.d, 你好啊)]",
+			resultStr:   "[[NULL,+inf]]",
 		},
 		{
 			indexPos:    2,
@@ -652,9 +652,9 @@ func (s *testRangerSuite) TestIndexRangeForUnsignedInt(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     `a not in (111)`,
-			accessConds: "[not(in(test.t.a, 111))]",
+			accessConds: "[ne(test.t.a, 111)]",
 			filterConds: "[]",
-			resultStr:   `[(NULL,111) (111,+inf]]`,
+			resultStr:   `[[-inf,111) (111,+inf]]`,
 		},
 		{
 			indexPos:    0,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tidb/issues/10626

```
create table t (a int, b int, index idx_ab(a, b));
explain select a, b from t where a = 1 order by b;
+--------------------+-------+------+-----------------------------------------------------------------+
| id                 | count | task | operator info                                                   |
+--------------------+-------+------+-----------------------------------------------------------------+
| IndexReader_12     | 10.00 | root | index:IndexScan_11                                              |
| └─IndexScan_11     | 10.00 | cop  | table:t, index:a, b, range:[1,1], keep order:true, stats:pseudo |
+--------------------+-------+------+-----------------------------------------------------------------+
explain select a, b from t where a in (1) order by b;
+---------------------+-------+------+------------------------------------------------------------------+
| id                  | count | task | operator info                                                    |
+---------------------+-------+------+------------------------------------------------------------------+
| Sort_5              | 10.00 | root | test.t.b:asc                                                     |
| └─IndexReader_9     | 10.00 | root | index:IndexScan_8                                                |
|   └─IndexScan_8     | 10.00 | cop  | table:t, index:a, b, range:[1,1], keep order:false, stats:pseudo |
+---------------------+-------+------+------------------------------------------------------------------+

```
SQL `select a, b from t where a in (1) order by b` should have the same plan with `select a, b from t where a = 1 order by b`, but it has an unnecessary `Sort`.

### What is changed and how it works?
This PR rewrite `in` as `eq` when the `in`'s rhs list has only one item, e.g. `a in (3) => a = 3`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

