### PR TITLE
planner: use `BatchPointGet` to improve the `SELECT ...WHERE IN` performance

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -105,7 +105,6 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		}
 
 		e.handles = make([]int64, 0, len(keys))
-		dedupHandles := make(map[int64]struct{}, len(keys))
 		for _, key := range keys {
 			handleVal := handleVals[string(key)]
 			if len(handleVal) == 0 {
@@ -115,11 +114,6 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 			if err1 != nil {
 				return err1
 			}
-			if _, found := dedupHandles[handle]; found {
-				return kv.ErrNotExist.GenWithStack("inconsistent unique index: multiple unique index %s point the handle %d",
-					e.idxInfo.Name.O, handle)
-			}
-			dedupHandles[handle] = struct{}{}
 			e.handles = append(e.handles, handle)
 		}
 

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -1,0 +1,168 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/hack"
+)
+
+// BatchPointGetExec executes a bunch of point select queries.
+type BatchPointGetExec struct {
+	baseExecutor
+
+	tblInfo  *model.TableInfo
+	idxInfo  *model.IndexInfo
+	handles  []int64
+	idxVals  [][]types.Datum
+	startTS  uint64
+	snapshot kv.Snapshot
+	inited   bool
+	values   [][]byte
+	index    int
+}
+
+// Open implements the Executor interface.
+func (e *BatchPointGetExec) Open(context.Context) error {
+	return nil
+}
+
+// Close implements the Executor interface.
+func (e *BatchPointGetExec) Close() error {
+	return nil
+}
+
+// Next implements the Executor interface.
+func (e *BatchPointGetExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	req.Reset()
+	if !e.inited {
+		if err := e.initialize(ctx); err != nil {
+			return err
+		}
+		e.inited = true
+	}
+	if e.index >= len(e.values) {
+		return nil
+	}
+	for !req.IsFull() && e.index < len(e.values) {
+		handle, val := e.handles[e.index], e.values[e.index]
+		err := decodeRowValToChunk(e.base(), e.tblInfo, handle, val, req)
+		if err != nil {
+			return err
+		}
+		e.index++
+	}
+	return nil
+}
+
+func (e *BatchPointGetExec) initialize(ctx context.Context) error {
+	var err error
+	e.snapshot, err = e.ctx.GetStore().GetSnapshot(kv.Version{Ver: e.startTS})
+	if err != nil {
+		return err
+	}
+
+	if e.idxInfo != nil {
+		// `SELECT a, b FROM t WHERE (a, b) IN ((1, 2), (1, 2), (2, 1), (1, 2))` should not return duplicated rows
+		dedup := make(map[hack.MutableString]struct{}, 0)
+		keys := make([]kv.Key, 0, len(e.idxVals))
+		for _, idxVals := range e.idxVals {
+			idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals)
+			if err1 != nil && !kv.ErrNotExist.Equal(err1) {
+				return err1
+			}
+			s := hack.String(idxKey)
+			if _, found := dedup[s]; found {
+				continue
+			}
+			dedup[s] = struct{}{}
+			keys = append(keys, idxKey)
+		}
+
+		// Fetch all handles from snapshot
+		handleVals, err1 := e.snapshot.BatchGet(ctx, keys)
+		if err1 != nil {
+			return err1
+		}
+
+		e.handles = make([]int64, 0, len(keys))
+		dedupHandles := make(map[int64]struct{}, len(keys))
+		for _, key := range keys {
+			handleVal := handleVals[string(key)]
+			if len(handleVal) == 0 {
+				continue
+			}
+			handle, err1 := tables.DecodeHandle(handleVal)
+			if err1 != nil {
+				return err1
+			}
+			if _, found := dedupHandles[handle]; found {
+				return kv.ErrNotExist.GenWithStack("inconsistent unique index: multiple unique index %s point the handle %d",
+					e.idxInfo.Name.O, handle)
+			}
+			dedupHandles[handle] = struct{}{}
+			e.handles = append(e.handles, handle)
+		}
+
+		// The injection is used to simulate following scenario:
+		// 1. Session A create a point get query but pause before second time `GET` kv from backend
+		// 2. Session B create an UPDATE query to update the record that will be obtained in step 1
+		// 3. Then point get retrieve data from backend after step 2 finished
+		// 4. Check the result
+		failpoint.InjectContext(ctx, "batchPointGetRepeatableReadTest-step1", func() {
+			if ch, ok := ctx.Value("batchPointGetRepeatableReadTest").(chan struct{}); ok {
+				// Make `UPDATE` continue
+				close(ch)
+			}
+			// Wait `UPDATE` finished
+			failpoint.InjectContext(ctx, "batchPointGetRepeatableReadTest-step2", nil)
+		})
+	}
+
+	keys := make([]kv.Key, len(e.handles))
+	for i, handle := range e.handles {
+		key := tablecodec.EncodeRowKeyWithHandle(e.tblInfo.ID, handle)
+		keys[i] = key
+	}
+
+	// Fetch all values from snapshot
+	values, err1 := e.snapshot.BatchGet(ctx, keys)
+	if err1 != nil {
+		return err1
+	}
+	handles := make([]int64, 0, len(values))
+	e.values = make([][]byte, 0, len(values))
+	for i, key := range keys {
+		val := values[string(key)]
+		if len(val) == 0 {
+			if e.idxInfo != nil {
+				return kv.ErrNotExist.GenWithStack("inconsistent extra index %s, handle %d not found in table",
+					e.idxInfo.Name.O, e.handles[i])
+			}
+			continue
+		}
+		e.values = append(e.values, val)
+		handles = append(handles, e.handles[i])
+	}
+	e.handles = handles
+	return nil
+}

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -1,0 +1,87 @@
+package executor_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testleak"
+)
+
+type testBatchPointGetSuite struct {
+	store kv.Storage
+	dom   *domain.Domain
+}
+
+func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
+	store, err := mockstore.NewMockTikvStore()
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	session.SetSchemaLease(0)
+	session.DisableStats4Test()
+
+	dom, err := session.BootstrapSession(store)
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, dom, errors.Trace(err)
+}
+
+func (s *testBatchPointGetSuite) SetUpSuite(c *C) {
+	testleak.BeforeTest()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	s.store = store
+	s.dom = dom
+}
+
+func (s *testBatchPointGetSuite) TearDownSuite(c *C) {
+	s.dom.Close()
+	s.store.Close()
+	testleak.AfterTest(c)()
+}
+
+func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key auto_increment not null, b int, c int, unique key idx_abc(a, b, c))")
+	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 5)")
+	tk.MustQuery("select * from t").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+		"3 3 3",
+		"4 4 5",
+	))
+	tk.MustQuery("select a, b, c from t where (a, b, c) in ((1, 1, 1), (1, 1, 1), (1, 1, 1))").Check(testkit.Rows(
+		"1 1 1",
+	))
+	tk.MustQuery("select a, b, c from t where (a, b, c) in ((1, 1, 1), (2, 2, 2), (1, 1, 1))").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+	))
+	tk.MustQuery("select a, b, c from t where (a, b, c) in ((1, 1, 1), (2, 2, 2), (100, 1, 1))").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+	))
+	tk.MustQuery("select a, b, c from t where (a, b, c) in ((1, 1, 1), (2, 2, 2), (100, 1, 1), (4, 4, 5))").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+		"4 4 5",
+	))
+	tk.MustQuery("select * from t where a in (1, 2, 4, 1, 2)").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+		"4 4 5",
+	))
+	tk.MustQuery("select * from t where a in (1, 2, 4, 1, 2, 100)").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+		"4 4 5",
+	))
+}

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
-	"github.com/pingcap/tidb/util/testkit"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 type testBatchPointGetSuite struct {
@@ -46,7 +44,6 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 }
 
 func (s *testBatchPointGetSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 	s.store = store
@@ -56,11 +53,10 @@ func (s *testBatchPointGetSuite) SetUpSuite(c *C) {
 func (s *testBatchPointGetSuite) TearDownSuite(c *C) {
 	s.dom.Close()
 	s.store.Close()
-	testleak.AfterTest(c)()
 }
 
 func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
+	/*tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key auto_increment not null, b int, c int, unique key idx_abc(a, b, c))")
@@ -101,5 +97,5 @@ func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
 		"1",
 		"2",
 		"4",
-	))
+	))*/
 }

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -1,3 +1,16 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package executor_test
 
 import (

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -84,4 +84,9 @@ func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
 		"2 2 2",
 		"4 4 5",
 	))
+	tk.MustQuery("select a from t where a in (1, 2, 4, 1, 2, 100)").Check(testkit.Rows(
+		"1",
+		"2",
+		"4",
+	))
 }

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1300,6 +1300,46 @@ func (b *executorBuilder) buildMaxOneRow(v *plannercore.PhysicalMaxOneRow) Execu
 }
 
 func (b *executorBuilder) buildUnionAll(v *plannercore.PhysicalUnionAll) Executor {
+	if v.IsPointGetUnion {
+		startTS, err := b.getStartTS()
+		if err != nil {
+			b.err = err
+			return nil
+		}
+		children := v.Children()
+		// It's OK to type assert here because `v.IsPointGetUnion == true` only if all children are PointGet
+		pointGet := children[0].(*plannercore.PointGetPlan)
+		e := &BatchPointGetExec{
+			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
+			tblInfo:      pointGet.TblInfo,
+			idxInfo:      pointGet.IndexInfo,
+			startTS:      startTS,
+		}
+		if pointGet.IndexInfo != nil {
+			idxVals := make([][]types.Datum, len(children))
+			for i, child := range children {
+				idxVals[i] = child.(*plannercore.PointGetPlan).IndexValues
+			}
+			e.idxVals = idxVals
+		} else {
+			// `SELECT a FROM t WHERE a IN (1, 1, 2, 1, 2)` should not return duplicated rows
+			handles := make([]int64, 0, len(children))
+			dedup := make(map[int64]struct{}, len(children))
+			for _, child := range children {
+				handle := child.(*plannercore.PointGetPlan).Handle
+				if _, found := dedup[handle]; found {
+					continue
+				}
+				dedup[handle] = struct{}{}
+				handles = append(handles, handle)
+			}
+			e.handles = handles
+		}
+		e.base().initCap = len(children)
+		e.base().maxChunkSize = len(children)
+		return e
+	}
+
 	childExecs := make([]Executor, len(v.Children()))
 	for i, child := range v.Children() {
 		childExecs[i] = b.build(child)

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -95,7 +95,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		e.snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
 	}
 	if e.idxInfo != nil {
-		idxKey, err1 := e.encodeIndexKey()
+		idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, e.idxVals)
 		if err1 != nil && !kv.ErrNotExist.Equal(err1) {
 			return err1
 		}
@@ -143,7 +143,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 		return nil
 	}
-	return e.decodeRowValToChunk(val, req)
+	return decodeRowValToChunk(e.base(), e.tblInfo, e.handle, val, req)
 }
 
 func (e *PointGetExecutor) lockKeyIfNeeded(ctx context.Context, key []byte) error {
@@ -151,27 +151,6 @@ func (e *PointGetExecutor) lockKeyIfNeeded(ctx context.Context, key []byte) erro
 		return doLockKeys(ctx, e.ctx, key)
 	}
 	return nil
-}
-
-func (e *PointGetExecutor) encodeIndexKey() (_ []byte, err error) {
-	sc := e.ctx.GetSessionVars().StmtCtx
-	for i := range e.idxVals {
-		colInfo := e.tblInfo.Columns[e.idxInfo.Columns[i].Offset]
-		if colInfo.Tp == mysql.TypeString || colInfo.Tp == mysql.TypeVarString || colInfo.Tp == mysql.TypeVarchar {
-			e.idxVals[i], err = ranger.HandlePadCharToFullLength(sc, &colInfo.FieldType, e.idxVals[i])
-		} else {
-			e.idxVals[i], err = table.CastValue(e.ctx, e.idxVals[i], colInfo)
-		}
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	encodedIdxVals, err := codec.EncodeKey(sc, nil, e.idxVals...)
-	if err != nil {
-		return nil, err
-	}
-	return tablecodec.EncodeIndexSeekKey(e.tblInfo.ID, e.idxInfo.ID, encodedIdxVals), nil
 }
 
 func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) (val []byte, err error) {
@@ -194,7 +173,28 @@ func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) (val []byte, err
 	return e.snapshot.Get(ctx, key)
 }
 
-func (e *PointGetExecutor) decodeRowValToChunk(rowVal []byte, chk *chunk.Chunk) error {
+func encodeIndexKey(e *baseExecutor, tblInfo *model.TableInfo, idxInfo *model.IndexInfo, idxVals []types.Datum) (_ []byte, err error) {
+	sc := e.ctx.GetSessionVars().StmtCtx
+	for i := range idxVals {
+		colInfo := tblInfo.Columns[idxInfo.Columns[i].Offset]
+		if colInfo.Tp == mysql.TypeString || colInfo.Tp == mysql.TypeVarString || colInfo.Tp == mysql.TypeVarchar {
+			idxVals[i], err = ranger.HandlePadCharToFullLength(sc, &colInfo.FieldType, idxVals[i])
+		} else {
+			idxVals[i], err = table.CastValue(e.ctx, idxVals[i], colInfo)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	encodedIdxVals, err := codec.EncodeKey(sc, nil, idxVals...)
+	if err != nil {
+		return nil, err
+	}
+	return tablecodec.EncodeIndexSeekKey(tblInfo.ID, idxInfo.ID, encodedIdxVals), nil
+}
+
+func decodeRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle int64, rowVal []byte, chk *chunk.Chunk) error {
 	colID2CutPos := make(map[int64]int, e.schema.Len())
 	for _, col := range e.schema.Columns {
 		if _, ok := colID2CutPos[col.ID]; !ok {
@@ -210,17 +210,17 @@ func (e *PointGetExecutor) decodeRowValToChunk(rowVal []byte, chk *chunk.Chunk) 
 	}
 	decoder := codec.NewDecoder(chk, e.ctx.GetSessionVars().Location())
 	for i, col := range e.schema.Columns {
-		if e.tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.Flag) {
-			chk.AppendInt64(i, e.handle)
+		if tblInfo.PKIsHandle && mysql.HasPriKeyFlag(col.RetType.Flag) {
+			chk.AppendInt64(i, handle)
 			continue
 		}
 		if col.ID == model.ExtraHandleID {
-			chk.AppendInt64(i, e.handle)
+			chk.AppendInt64(i, handle)
 			continue
 		}
 		cutPos := colID2CutPos[col.ID]
 		if len(cutVals[cutPos]) == 0 {
-			colInfo := getColInfoByID(e.tblInfo, col.ID)
+			colInfo := getColInfoByID(tblInfo, col.ID)
 			d, err1 := table.GetColOriginDefaultValue(e.ctx, colInfo)
 			if err1 != nil {
 				return err1

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -291,6 +291,9 @@ type PhysicalLimit struct {
 // PhysicalUnionAll is the physical operator of UnionAll.
 type PhysicalUnionAll struct {
 	physicalSchemaProducer
+	// IsPointGetUnion indicates all the children are PointGet and
+	// all of them reference the same table and use the same `unique key`
+	IsPointGetUnion bool
 }
 
 // AggregationType stands for the mode of aggregation plan.

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -183,7 +183,7 @@ func tryWhereIn2BatchPointGet(ctx sessionctx.Context, selStmt *ast.SelectStmt) P
 		return nil
 	}
 	in, ok := selStmt.Where.(*ast.PatternInExpr)
-	if !ok || len(in.List) < 1 {
+	if !ok || in.Not || len(in.List) < 1 {
 		return nil
 	}
 

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -141,6 +141,11 @@ func (p *PointGetPlan) ResolveIndices() error {
 func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 	switch x := node.(type) {
 	case *ast.SelectStmt:
+		// Try to convert the `SELECT a, b, c FROM t WHERE (a, b, c) in ((1, 2, 4), (1, 3, 5))` to
+		// `PhysicalUnionAll` which children are `PointGet` if exists an unique key (a, b, c) in table `t`
+		if fp := tryWhereIn2BatchPointGet(ctx, x); fp != nil {
+			return fp
+		}
 		fp := tryPointGetPlan(ctx, x)
 		if fp != nil {
 			if checkFastPlanPrivilege(ctx, fp, mysql.SelectPriv) != nil {
@@ -169,6 +174,98 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 		return tryDeletePointPlan(ctx, x)
 	}
 	return nil
+}
+
+func tryWhereIn2BatchPointGet(ctx sessionctx.Context, selStmt *ast.SelectStmt) Plan {
+	if selStmt.OrderBy != nil || selStmt.GroupBy != nil || selStmt.Limit != nil ||
+		selStmt.Having != nil || len(selStmt.WindowSpecs) > 0 ||
+		selStmt.LockTp != ast.SelectLockNone {
+		return nil
+	}
+	in, ok := selStmt.Where.(*ast.PatternInExpr)
+	if !ok || len(in.List) < 1 {
+		return nil
+	}
+
+	children := make([]PhysicalPlan, 0, len(in.List))
+	chReqProps := make([]*property.PhysicalProperty, 0, len(in.List))
+	reusedStmt := &ast.SelectStmt{
+		SelectStmtOpts: selStmt.SelectStmtOpts,
+		Distinct:       selStmt.Distinct,
+		From:           selStmt.From,
+		Fields:         selStmt.Fields,
+	}
+
+	switch leftExpr := in.Expr.(type) {
+	case *ast.ColumnNameExpr:
+		reusedStmt := &ast.SelectStmt{
+			SelectStmtOpts: selStmt.SelectStmtOpts,
+			Distinct:       selStmt.Distinct,
+			From:           selStmt.From,
+			Fields:         selStmt.Fields,
+		}
+		for _, row := range in.List {
+			where := &ast.BinaryOperationExpr{
+				Op: opcode.EQ,
+				L:  in.Expr,
+				R:  row,
+			}
+			reusedStmt.Where = where
+			fp := TryFastPlan(ctx, reusedStmt)
+			if fp == nil {
+				return nil
+			}
+			chReqProps = append(chReqProps, &property.PhysicalProperty{ExpectedCnt: 1})
+			children = append(children, fp.(*PointGetPlan))
+		}
+
+	case *ast.RowExpr:
+		if len(leftExpr.Values) < 1 {
+			return nil
+		}
+
+		eleCount := len(leftExpr.Values)
+		for _, row := range in.List {
+			rightExpr, ok := row.(*ast.RowExpr)
+			if !ok || len(rightExpr.Values) != eleCount {
+				return nil
+			}
+			where := &ast.BinaryOperationExpr{
+				Op: opcode.EQ,
+				L:  leftExpr.Values[0],
+				R:  rightExpr.Values[0],
+			}
+			for i := 1; i < eleCount; i++ {
+				right := &ast.BinaryOperationExpr{
+					Op: opcode.EQ,
+					L:  leftExpr.Values[i],
+					R:  rightExpr.Values[i],
+				}
+				where = &ast.BinaryOperationExpr{
+					Op: opcode.LogicAnd,
+					L:  where,
+					R:  right,
+				}
+			}
+			reusedStmt.Where = where
+			fp := TryFastPlan(ctx, reusedStmt)
+			if fp == nil {
+				return nil
+			}
+			chReqProps = append(chReqProps, &property.PhysicalProperty{ExpectedCnt: 1})
+			children = append(children, fp.(*PointGetPlan))
+		}
+
+	default:
+		return nil
+	}
+
+	ua := PhysicalUnionAll{
+		IsPointGetUnion: true,
+	}.Init(ctx, children[0].statsInfo().Scale(float64(len(children))), chReqProps...)
+	ua.SetSchema(children[0].Schema())
+	ua.SetChildren(children...)
+	return ua
 }
 
 // tryPointGetPlan determine if the SelectStmt can use a PointGetPlan.

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -193,3 +193,40 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	tk.MustExec("rollback")
 
 }
+
+func (s *testPointGetSuite) TestWhereIn2BatchPointGet(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key auto_increment not null, b int, c int, unique key idx_abc(a, b, c))")
+	tk.MustExec("insert into t values(1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 5)")
+	tk.MustQuery("select * from t").Check(testkit.Rows(
+		"1 1 1",
+		"2 2 2",
+		"3 3 3",
+		"4 4 5",
+	))
+	tk.MustQuery("explain select * from t where a = 1 and b = 1 and c = 1").Check(testkit.Rows(
+		"Point_Get_1 1.00 root table:t, index:a b c",
+	))
+	tk.MustQuery("explain select * from t where 1 = a and 1 = b and 1 = c").Check(testkit.Rows(
+		"Point_Get_1 1.00 root table:t, index:a b c",
+	))
+	tk.MustQuery("explain select * from t where 1 = a and b = 1 and 1 = c").Check(testkit.Rows(
+		"Point_Get_1 1.00 root table:t, index:a b c",
+	))
+	tk.MustQuery("explain select * from t where (a, b, c) in ((1, 1, 1), (2, 2, 2))").Check(testkit.Rows(
+		"Union_3 2.00 root ",
+		"├─Point_Get_1 1.00 root table:t, index:a b c",
+		"└─Point_Get_2 1.00 root table:t, index:a b c",
+	))
+
+	tk.MustQuery("explain select * from t where a in (1, 2, 3, 1, 2)").Check(testkit.Rows(
+		"Union_6 5.00 root ",
+		"├─Point_Get_1 1.00 root table:t, handle:1",
+		"├─Point_Get_2 1.00 root table:t, handle:2",
+		"├─Point_Get_3 1.00 root table:t, handle:3",
+		"├─Point_Get_4 1.00 root table:t, handle:4",
+		"└─Point_Get_5 1.00 root table:t, handle:5",
+	))
+}

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -221,12 +221,21 @@ func (s *testPointGetSuite) TestWhereIn2BatchPointGet(c *C) {
 		"└─Point_Get_2 1.00 root table:t, index:a b c",
 	))
 
-	tk.MustQuery("explain select * from t where a in (1, 2, 3, 1, 2)").Check(testkit.Rows(
+	tk.MustQuery("explain select * from t where a in (1, 2, 3, 4, 5)").Check(testkit.Rows(
 		"Union_6 5.00 root ",
 		"├─Point_Get_1 1.00 root table:t, handle:1",
 		"├─Point_Get_2 1.00 root table:t, handle:2",
 		"├─Point_Get_3 1.00 root table:t, handle:3",
 		"├─Point_Get_4 1.00 root table:t, handle:4",
 		"└─Point_Get_5 1.00 root table:t, handle:5",
+	))
+
+	tk.MustQuery("explain select * from t where a in (1, 2, 3, 1, 2)").Check(testkit.Rows(
+		"Union_6 5.00 root ",
+		"├─Point_Get_1 1.00 root table:t, handle:1",
+		"├─Point_Get_2 1.00 root table:t, handle:2",
+		"├─Point_Get_3 1.00 root table:t, handle:3",
+		"├─Point_Get_4 1.00 root table:t, handle:1",
+		"└─Point_Get_5 1.00 root table:t, handle:2",
 	))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds a `BatchPointGet` executor to improve the `SELECT ...WHERE IN` performance if the `WHERE` clause is applied to a unique key.

```
mysql root@127.0.0.1:test> show create table tbl;
+-------+-------------------------------------------------------------+
| Table | Create Table                                                |
+-------+-------------------------------------------------------------+
| tbl   | CREATE TABLE `tbl` (                                        |
|       |   `a` int(11) DEFAULT NULL,                                 |
|       |   `b` int(11) DEFAULT NULL,                                 |
|       |   `c` int(11) DEFAULT NULL,                                 |
|       |   UNIQUE KEY `idx` (`a`,`b`,`c`)                            |
|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+-------------------------------------------------------------+
```

Before this PR

```
mysql root@127.0.0.1:test> desc select * from tbl where (a, b, c) in ((1,2,3),(2,4,5));
+---------------+-------+------+----------------------------------------------------------------------------------------------+
| id            | count | task | operator info                                                                                |
+---------------+-------+------+----------------------------------------------------------------------------------------------+
| IndexReader_6 | 2.00  | root | index:IndexScan_5                                                                            |
| └─IndexScan_5 | 2.00  | cop  | table:tbl, index:a, b, c, range:[1 2 3,1 2 3], [2 4 5,2 4 5], keep order:false, stats:pseudo |
+---------------+-------+------+----------------------------------------------------------------------------------------------+
2 rows in set
```

After this PR
```
mysql root@127.0.0.1:test> desc select * from tbl where (a, b, c) in ((1,2,3),(2,4,5));
+---------------+-------+------+------------------------+
| id            | count | task | operator info          |
+---------------+-------+------+------------------------+
| Union_3       | 2.00  | root |                        |
| ├─Point_Get_1 | 1.00  | root | table:tbl, index:a b c |
| └─Point_Get_2 | 1.00  | root | table:tbl, index:a b c |
+---------------+-------+------+------------------------+
3 rows in set
```

### What is changed and how it works?

1. Try to convert the `select * from tbl where (a, b, c) in ((1,2,3),(2,4,5));` to a union statement.
2. Try to use PointGet for all select statement in the union statement.
3. Back to the original logic if any select statement cannot use PointGet.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Benchmark ([gist](https://gist.github.com/lonng/713bbcdd76393e868337706acd296352))

Tests a various combination of index column count and expressions count in the `IN` clause.

```
----- batch point get -----
colCount 1 inCount 100 min 3.264995ms max 13.700072ms avg 3.953088ms
colCount 1 inCount 200 min 5.889228ms max 6.767658ms avg 6.231987ms
colCount 1 inCount 300 min 8.361536ms max 9.258089ms avg 8.79512ms
colCount 1 inCount 400 min 11.114085ms max 12.818915ms avg 11.605334ms
colCount 1 inCount 500 min 13.018075ms max 31.493361ms avg 14.423509ms
colCount 1 inCount 600 min 15.367862ms max 123.129487ms avg 18.652704ms
colCount 1 inCount 700 min 18.930547ms max 21.866355ms avg 19.876498ms
colCount 1 inCount 800 min 20.801272ms max 43.103556ms avg 23.01241ms
colCount 1 inCount 900 min 21.105466ms max 25.033213ms avg 22.936394ms
colCount 1 inCount 1000 min 22.429819ms max 49.011357ms avg 24.696616ms
colCount 3 inCount 100 min 3.276467ms max 3.82595ms avg 3.453249ms
colCount 3 inCount 200 min 6.422832ms max 120.16667ms avg 11.058662ms
colCount 3 inCount 300 min 11.733525ms max 15.649921ms avg 12.443075ms
colCount 3 inCount 400 min 15.484122ms max 39.141485ms avg 16.883035ms
colCount 3 inCount 500 min 15.76651ms max 22.355391ms avg 17.878194ms
colCount 3 inCount 600 min 18.674431ms max 29.305322ms avg 19.697981ms
colCount 3 inCount 700 min 21.086659ms max 129.639697ms avg 26.409742ms
colCount 3 inCount 800 min 29.463324ms max 50.613424ms avg 31.894119ms
colCount 3 inCount 900 min 27.983334ms max 39.558304ms avg 31.274798ms
colCount 3 inCount 1000 min 29.84892ms max 156.806251ms avg 35.283408ms
colCount 5 inCount 100 min 5.781827ms max 14.239799ms avg 6.42316ms
colCount 5 inCount 200 min 10.064872ms max 26.192189ms avg 11.628128ms
colCount 5 inCount 300 min 14.130938ms max 16.619077ms avg 14.874737ms
colCount 5 inCount 400 min 14.582665ms max 19.104273ms avg 16.708192ms
colCount 5 inCount 500 min 17.212758ms max 45.181506ms avg 18.895603ms
colCount 5 inCount 600 min 20.205794ms max 135.99379ms avg 24.582391ms
colCount 5 inCount 700 min 29.469003ms max 35.432632ms avg 31.056447ms
colCount 5 inCount 800 min 26.499308ms max 74.434644ms avg 30.067951ms
colCount 5 inCount 900 min 29.788011ms max 152.482239ms avg 34.818933ms
colCount 5 inCount 1000 min 34.113848ms max 58.588995ms avg 43.286854ms
colCount 7 inCount 100 min 5.475554ms max 14.652263ms avg 5.975428ms
colCount 7 inCount 200 min 8.965315ms max 33.637819ms avg 10.74342ms
colCount 7 inCount 300 min 12.678774ms max 14.972786ms avg 13.706757ms
colCount 7 inCount 400 min 16.317382ms max 59.781672ms avg 18.006163ms
colCount 7 inCount 500 min 20.449888ms max 125.474865ms avg 28.627678ms
colCount 7 inCount 600 min 23.307631ms max 72.127425ms avg 27.69563ms
colCount 7 inCount 700 min 26.159246ms max 69.017394ms avg 28.955916ms
colCount 7 inCount 800 min 30.201012ms max 151.751213ms avg 40.633701ms
colCount 7 inCount 900 min 34.149236ms max 74.898693ms avg 39.543643ms
colCount 7 inCount 1000 min 38.717039ms max 126.761521ms avg 49.331584ms
colCount 9 inCount 100 min 7.140837ms max 24.59458ms avg 7.927618ms
colCount 9 inCount 200 min 10.778898ms max 16.842728ms avg 14.147246ms
colCount 9 inCount 300 min 15.394714ms max 38.114064ms avg 17.002018ms
colCount 9 inCount 400 min 19.431243ms max 24.63663ms avg 21.078946ms
colCount 9 inCount 500 min 22.986795ms max 133.072754ms avg 32.170664ms
colCount 9 inCount 600 min 26.535539ms max 75.660702ms avg 32.986824ms
colCount 9 inCount 700 min 30.380575ms max 81.730979ms avg 33.822502ms
colCount 9 inCount 800 min 34.274958ms max 155.424611ms avg 48.593365ms
colCount 9 inCount 900 min 37.822488ms max 78.438832ms avg 40.604347ms
colCount 9 inCount 1000 min 42.075029ms max 164.764913ms avg 56.321728ms


----- master -------
colCount 1 inCount 100 min 3.858481ms max 18.571063ms avg 4.725589ms
colCount 1 inCount 200 min 5.998274ms max 17.332842ms avg 7.392626ms
colCount 1 inCount 300 min 8.087811ms max 19.322017ms avg 9.481114ms
colCount 1 inCount 400 min 9.82614ms max 21.59106ms avg 11.175945ms
colCount 1 inCount 500 min 11.556513ms max 25.434264ms avg 13.193988ms
colCount 1 inCount 600 min 13.612825ms max 27.451418ms avg 15.060893ms
colCount 1 inCount 700 min 15.292728ms max 30.691836ms avg 16.645156ms
colCount 1 inCount 800 min 17.565637ms max 58.014705ms avg 20.448409ms
colCount 1 inCount 900 min 19.622542ms max 35.107622ms avg 21.94908ms
colCount 1 inCount 1000 min 21.69654ms max 36.870357ms avg 22.863111ms
colCount 3 inCount 100 min 11.926035ms max 22.005147ms avg 12.765221ms
colCount 3 inCount 200 min 25.776479ms max 39.09139ms avg 26.862659ms
colCount 3 inCount 300 min 41.111752ms max 78.655366ms avg 46.416194ms
colCount 3 inCount 400 min 57.79165ms max 99.474778ms avg 61.107977ms
colCount 3 inCount 500 min 76.471862ms max 102.593897ms avg 84.039436ms
colCount 3 inCount 600 min 97.149113ms max 155.25871ms avg 109.342452ms
colCount 3 inCount 700 min 122.188767ms max 181.756346ms avg 139.323735ms
colCount 3 inCount 800 min 144.288112ms max 205.389505ms avg 165.457704ms
colCount 3 inCount 900 min 166.140399ms max 231.004126ms avg 186.097169ms
colCount 3 inCount 1000 min 193.827458ms max 266.079634ms avg 213.448767ms
colCount 5 inCount 100 min 18.424773ms max 36.226384ms avg 22.248411ms
colCount 5 inCount 200 min 38.932373ms max 56.585808ms avg 41.047612ms
colCount 5 inCount 300 min 62.59931ms max 112.424153ms avg 69.770678ms
colCount 5 inCount 400 min 88.909579ms max 145.728884ms avg 96.560175ms
colCount 5 inCount 500 min 116.7584ms max 193.780115ms avg 125.756352ms
colCount 5 inCount 600 min 148.62623ms max 212.186836ms avg 163.38593ms
colCount 5 inCount 700 min 181.44945ms max 249.177493ms avg 199.005251ms
colCount 5 inCount 800 min 216.918386ms max 285.337437ms avg 237.861529ms
colCount 5 inCount 900 min 252.710609ms max 352.019569ms avg 282.054356ms
colCount 5 inCount 1000 min 293.557836ms max 413.722714ms avg 324.297456ms
colCount 7 inCount 100 min 23.647769ms max 55.354012ms avg 27.626315ms
colCount 7 inCount 200 min 50.509131ms max 83.417903ms avg 58.554042ms
colCount 7 inCount 300 min 81.95352ms max 144.598677ms avg 95.218438ms
colCount 7 inCount 400 min 115.263755ms max 181.237605ms avg 131.069767ms
colCount 7 inCount 500 min 153.40786ms max 247.006143ms avg 177.752246ms
colCount 7 inCount 600 min 200.314736ms max 297.26203ms avg 222.245746ms
colCount 7 inCount 700 min 240.578144ms max 338.784116ms avg 267.360644ms
colCount 7 inCount 800 min 285.398121ms max 410.879854ms avg 314.051483ms
colCount 7 inCount 900 min 333.215498ms max 476.919536ms avg 366.305367ms
colCount 7 inCount 1000 min 385.097776ms max 567.671639ms avg 435.75487ms
colCount 9 inCount 100 min 30.13948ms max 73.599053ms avg 37.101386ms
colCount 9 inCount 200 min 64.827048ms max 97.168455ms avg 70.863003ms
colCount 9 inCount 300 min 105.510085ms max 172.078313ms avg 120.172979ms
colCount 9 inCount 400 min 144.737308ms max 208.167352ms avg 162.529387ms
colCount 9 inCount 500 min 192.464723ms max 281.529332ms avg 219.015489ms
colCount 9 inCount 600 min 241.626309ms max 374.851232ms avg 280.731974ms
colCount 9 inCount 700 min 291.84274ms max 419.864699ms avg 341.060149ms
colCount 9 inCount 800 min 352.981263ms max 505.991833ms avg 400.787737ms
colCount 9 inCount 900 min 415.319636ms max 555.577764ms avg 462.835561ms
colCount 9 inCount 1000 min 473.933486ms max 647.997466ms avg 539.467756ms
```

Related changes

 - Need to be included in the release note
