### PR TITLE
executor: refine an error log message

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -475,7 +475,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		logutil.Logger(ctx).Info("single statement deadlock, retry statement",
 			zap.Uint64("txn", txnCtx.StartTS),
 			zap.Uint64("lockTS", deadlock.LockTs),
-			zap.Binary("lockKey", (deadlock.LockKey)),
+			zap.Binary("lockKey", deadlock.LockKey),
 			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, err) {
 		errStr := err.Error()

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -475,9 +475,8 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		logutil.Logger(ctx).Info("single statement deadlock, retry statement",
 			zap.Uint64("txn", txnCtx.StartTS),
 			zap.Uint64("lockTS", deadlock.LockTs),
-			zap.Binary("lockKey", deadlock.LockKey),
-			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash),
-			zap.String("err", err.Error()))
+			zap.Binary("lockKey", (deadlock.LockKey)),
+			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, err) {
 		errStr := err.Error()
 		conflictCommitTS := extractConflictCommitTS(errStr)
@@ -488,7 +487,6 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		logutil.Logger(ctx).Info("pessimistic write conflict, retry statement",
 			zap.Uint64("txn", txnCtx.StartTS),
 			zap.Uint64("forUpdateTS", forUpdateTS),
-			zap.Uint64("conflictCommitTS", conflictCommitTS),
 			zap.String("err", errStr))
 		if conflictCommitTS > forUpdateTS {
 			newForUpdateTS = conflictCommitTS


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Display conflict keys for the pessimistic lock conflict in the log.

Before:
```
 [2019/08/15 15:38:05.626 +08:00] [INFO] [adapter.go:464] [“pessimistic write conflict, retry statement”] [conn=46396] [txn=410479410413568034] [forUpdateTS=410479410675712001] [conflictCommitTS=410479410701926401]
```

After:

```
[2019/08/16 14:46:17.322 +08:00] [INFO] [adapter.go:475] ["single statement deadlock, retry statement"] [txn=410501245124214785] [lockTS=410501245124214784] [lockKey="dIAAAAAAAAA8X3KAAAAAAAAAAw=="] [deadlockKeyHash=1804423900836245255] [err="lock_ts:410501245124214784 lock_key:\"t\\200\\000\\000\\000\\000\\000\\000<_r\\200\\000\\000\\000\\000\\000\\000\\003\" deadlock_key_hash:1804423900836245255 "]
[2019/08/16 14:46:17.377 +08:00] [INFO] [adapter.go:488] ["pessimistic write conflict, retry statement"] [txn=410501245124214785] [forUpdateTS=410501245127098368] [conflictCommitTS=0] [err="[kv:9007]Write conflict, txnStartTS=410501245127098368, conflictStartTS=410501245127360512, conflictCommitTS=0, key={tableID=60, handle=3} primary=[]byte(nil) [try again later]"]
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code