### PR TITLE
sessionctx/binloginfo: fix uncomment pre_split_regions ddl-querys in binlog

### DIFF
--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -190,7 +190,11 @@ func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string 
 		if query[len(query)-1] != ' ' {
 			query += " "
 		}
-		return query + "*/ " + ddlQuery[minIdx:]
+		query += "*/"
+		if len(ddlQuery[minIdx:]) > 0 {
+			return query + " " + ddlQuery[minIdx:]
+		}
+		return query
 	}
 	return ddlQuery
 }

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -161,6 +161,7 @@ func AddSpecialComment(ddlQuery string) string {
 	return addSpecialCommentByRegexps(ddlQuery, shardPat, preSplitPat)
 }
 
+// addSpecialCommentByRegexps uses to add special comment for the worlds in the ddlQuery with match the regexps.
 func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string {
 	upperQuery := strings.ToUpper(ddlQuery)
 	var specialComments []string

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -135,7 +135,6 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) error {
 
 // SetDDLBinlog sets DDL binlog in the kv.Transaction.
 func SetDDLBinlog(client *pumpcli.PumpsClient, txn kv.Transaction, jobID int64, ddlQuery string) {
-	ddlQuery = AddSpecialComment(ddlQuery)
 	if client == nil {
 		return
 	}
@@ -167,9 +166,11 @@ func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string 
 	upperQuery := strings.ToUpper(ddlQuery)
 	var specialComments []string
 	minIdx := math.MaxInt64
-	for _, reg := range regs {
+	for i := 0; i < len(regs); {
+		reg := regs[i]
 		loc := reg.FindStringIndex(upperQuery)
 		if len(loc) < 2 {
+			i++
 			continue
 		}
 		specialComments = append(specialComments, ddlQuery[loc[0]:loc[1]])

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -44,7 +44,6 @@ var pumpsClient *pumpcli.PumpsClient
 var pumpsClientLock sync.RWMutex
 var shardPat = regexp.MustCompile(`SHARD_ROW_ID_BITS\s*=\s*\d+\s*`)
 var preSplitPat = regexp.MustCompile(`PRE_SPLIT_REGIONS\s*=\s*\d+\s*`)
-var redundantCommentPat = regexp.MustCompile(` \*\/\s*\/\*!90000`)
 
 // BinlogInfo contains binlog data and binlog client.
 type BinlogInfo struct {

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -165,17 +165,14 @@ func AddSpecialComment(ddlQuery string) string {
 
 func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string {
 	upperQuery := strings.ToUpper(ddlQuery)
-	specialComment := specialPrefix
+	var specialComments []string
 	minIdx := math.MaxInt64
 	for _, reg := range regs {
 		loc := reg.FindStringIndex(upperQuery)
 		if len(loc) < 2 {
 			continue
 		}
-		specialComment += ddlQuery[loc[0]:loc[1]]
-		if specialComment[len(specialComment)-1] != ' ' {
-			specialComment += " "
-		}
+		specialComments = append(specialComments, ddlQuery[loc[0]:loc[1]])
 		if loc[0] < minIdx {
 			minIdx = loc[0]
 		}
@@ -183,7 +180,17 @@ func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string 
 		upperQuery = upperQuery[:loc[0]] + upperQuery[loc[1]:]
 	}
 	if minIdx != math.MaxInt64 {
-		return ddlQuery[:minIdx] + specialComment + "*/ " + ddlQuery[minIdx:]
+		query := ddlQuery[:minIdx] + specialPrefix
+		for _, comment := range specialComments {
+			if query[len(query)-1] != ' ' {
+				query += " "
+			}
+			query += comment
+		}
+		if query[len(query)-1] != ' ' {
+			query += " "
+		}
+		return query + "*/ " + ddlQuery[minIdx:]
 	}
 	return ddlQuery
 }

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -195,16 +195,6 @@ func addSpecialCommentByRegexps(ddlQuery string, regs ...*regexp.Regexp) string 
 	return ddlQuery
 }
 
-// removeRedundantComment uses to remove redundant comment.
-// eg: /*!90000 a=1 */ /*!90000 b=1 */ => /*!90000 a=1 b=1 */
-func removeRedundantComment(ddlQuery string) string {
-	loc := redundantCommentPat.FindStringIndex(ddlQuery)
-	if len(loc) < 2 {
-		return ddlQuery
-	}
-	return ddlQuery[:loc[0]] + ddlQuery[loc[1]:]
-}
-
 // MockPumpsClient creates a PumpsClient, used for test.
 func MockPumpsClient(client binlog.PumpClient) *pumpcli.PumpsClient {
 	nodeID := "pump-1"

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -431,3 +431,32 @@ func (s *testBinlogSuite) TestDeleteSchema(c *C) {
 	tk.MustExec("delete from b1 where job_id in (select job_id from b2 where batch_class = 'TEST') or split_job_id in (select job_id from b2 where batch_class = 'TEST');")
 	tk.MustExec("delete b1 from b2 right join b1 on b1.job_id = b2.job_id and batch_class = 'TEST';")
 }
+
+func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
+	testCase := []struct {
+		input  string
+		result string
+	}{
+		{
+			"create table t1 (id int ) shard_row_id_bits=2;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 */;",
+		},
+		{
+			"create table t1 (id int ) shard_row_id_bits=2 pre_split_regions=2;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */;",
+		},
+		{
+			"create table t1 (id int ) shard_row_id_bits=2     pre_split_regions=2;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */;",
+		},
+
+		{
+			"create table t1 (id int ) shard_row_id_bits=2 engine=innodb pre_split_regions=2;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 */ engine=innodb /*!90000 pre_split_regions=2 */;",
+		},
+	}
+	for _, ca := range testCase {
+		re := binloginfo.AddSpecialComment(ca.input)
+		c.Assert(re, Equals, ca.result)
+	}
+}

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -458,6 +458,10 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int ) pre_split_regions=2 shard_row_id_bits=2;",
 			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */ ;",
 		},
+		{
+			"create table t6 (id int ) shard_row_id_bits=2 shard_row_id_bits=3 pre_split_regions=2;",
+			"create table t6 (id int ) /*!90000 shard_row_id_bits=2 shard_row_id_bits=3 pre_split_regions=2 */ ;",
+		},
 	}
 	for _, ca := range testCase {
 		re := binloginfo.AddSpecialComment(ca.input)

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -439,20 +439,24 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 	}{
 		{
 			"create table t1 (id int ) shard_row_id_bits=2;",
-			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 */;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 */ ;",
 		},
 		{
 			"create table t1 (id int ) shard_row_id_bits=2 pre_split_regions=2;",
-			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */ ;",
 		},
 		{
 			"create table t1 (id int ) shard_row_id_bits=2     pre_split_regions=2;",
-			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2     pre_split_regions=2 */ ;",
 		},
 
 		{
 			"create table t1 (id int ) shard_row_id_bits=2 engine=innodb pre_split_regions=2;",
-			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 */ engine=innodb /*!90000 pre_split_regions=2 */;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */ engine=innodb ;",
+		},
+		{
+			"create table t1 (id int ) pre_split_regions=2 shard_row_id_bits=2;",
+			"create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */ ;",
 		},
 	}
 	for _, ca := range testCase {


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When tidb write binlog query, TiDB should comment some special syntax for compatibility. eg:
`SHARD_ROW_ID_BITS`, `PRE_SPLIT_REGIONS`.

But before this PR, TiDB won't comment `PRE_SPLIT_REGIONS`, This PR use to fix this problem.

Before :
```sql
create table t1 (id int ) shard_row_id_bits=2 pre_split_regions=2;

// the write binlog query is, and mysql execute below sql will got error.
create table t1 (id int ) /*!90000 shard_row_id_bits=2 */ pre_split_regions=2 ;
```

This PR
```sql
create table t1 (id int ) shard_row_id_bits=2 pre_split_regions=2;
// the write binlog query is:
create table t1 (id int ) /*!90000 shard_row_id_bits=2 pre_split_regions=2 */;
```



### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes

 - Need to cherry-pick to the release branch

Release note

- Fix the issue that the TiDB special syntax `pre_split_regions`  was uncommented in `create table` statement when write binlog query. This may be cause downstream database error.