### PR TITLE
planner/core: fix the 'for update' condition for the point get query

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -156,7 +156,8 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
 				// is disabled (either by beginning transaction with START TRANSACTION or by setting
 				// autocommit to 0. If autocommit is enabled, the rows matching the specification are not locked.
 				// See https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
-				if ctx.GetSessionVars().InTxn() {
+				sessVars := ctx.GetSessionVars()
+				if !sessVars.IsAutocommit() || sessVars.InTxn() {
 					fp.Lock = true
 					fp.IsForUpdate = true
 				}

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -182,7 +182,7 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	selectLock := strings.Contains(fmt.Sprintf("%s", opInfo), "lock")
 	c.Assert(selectLock, IsFalse)
 
-	checkUseForUpdate := func() {
+	checkUseForUpdate := func(tk *testkit.TestKit, c *C) {
 		res = tk.MustQuery("explain select * from fu where id = 6 for update")
 		// Point_Get_1	1.00	root	table:fu, handle:6
 		opInfo = res.Rows()[0][3]
@@ -193,10 +193,10 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	}
 
 	tk.MustExec("begin")
-	checkUseForUpdate()
+	checkUseForUpdate(tk, c)
 	tk.MustExec("rollback")
 
 	tk.MustExec("set @@session.autocommit = 0")
-	checkUseForUpdate()
+	checkUseForUpdate(tk, c)
 	tk.MustExec("rollback")
 }

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -171,9 +171,9 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("create table fu (id int primary key)")
-	tk.MustExec("insert into fu values (6)")
-	tk.MustQuery("select * from fu where id = 6 for update").Check(testkit.Rows("6"))
+	tk.MustExec("create table fu (id int primary key, val int)")
+	tk.MustExec("insert into fu values (6, 6)")
+	tk.MustQuery("select val from fu where id = 6 for update").Check(testkit.Rows("6"))
 
 	// In autocommit mode, outside a transaction, "for update" doesn't take effect.
 	res := tk.MustQuery("explain select * from fu where id = 6 for update")
@@ -182,14 +182,21 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	selectLock := strings.Contains(fmt.Sprintf("%s", opInfo), "lock")
 	c.Assert(selectLock, IsFalse)
 
-	tk.MustExec("begin")
-	tk.MustQuery("select * from fu where id = 6 for update").Check(testkit.Rows("6"))
-	res = tk.MustQuery("explain select * from fu where id = 6 for update")
-	// Point_Get_1	1.00	root	table:fu, handle:6
-	opInfo = res.Rows()[0][3]
-	selectLock = strings.Contains(fmt.Sprintf("%s", opInfo), "lock")
-	c.Assert(selectLock, IsTrue)
+	checkUseForUpdate := func() {
+		res = tk.MustQuery("explain select * from fu where id = 6 for update")
+		// Point_Get_1	1.00	root	table:fu, handle:6
+		opInfo = res.Rows()[0][3]
+		selectLock = strings.Contains(fmt.Sprintf("%s", opInfo), "lock")
+		c.Assert(selectLock, IsTrue)
 
+		tk.MustQuery("select * from fu where id = 6 for update").Check(testkit.Rows("6 6"))
+	}
+
+	tk.MustExec("begin")
+	checkUseForUpdate()
 	tk.MustExec("rollback")
 
+	tk.MustExec("set @@session.autocommit = 0")
+	checkUseForUpdate()
+	tk.MustExec("rollback")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix bug introduced in https://github.com/pingcap/tidb/pull/11715

Sometimes, `InTxn()` is not precise, so we should check both `InTxn()` and `autocommit`

```
// We should set the 'for update' flag in this case.
set @@auto_commit = 0;
select * from t where id = 6 for update;  // This is not InTxn() when the planner run here, because it's still in the plan phase.
```

### What is changed and how it works?

The check condition is changed from `InTxn()` to `IsAutocommit() || InTxn()`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

