### PR TITLE
executor: support converting from vectorized evaluation to row-based evaluation

### DIFF
--- a/expression/builtin_vectorized.go
+++ b/expression/builtin_vectorized.go
@@ -102,6 +102,7 @@ func (r *localSliceBuffer) put(buf *chunk.Column) {
 	r.Unlock()
 }
 
+// vecRowConverter is used to convert the underlying builtin function between row-based evaluation and vectorized evaluation.
 type vecRowConverter struct {
 	builtinFunc
 
@@ -114,6 +115,7 @@ func newVecRowConverter(underlying builtinFunc) *vecRowConverter {
 	return &vecRowConverter{underlying, nil, nil}
 }
 
+// vecEvalRow evaluates this single row in a vectorized manner.
 func (c *vecRowConverter) vecEvalRow(evalType types.EvalType, row chunk.Row) (err error) {
 	if c.sel == nil {
 		c.sel = make([]int, 1)
@@ -203,6 +205,8 @@ func (c *vecRowConverter) evalJSON(row chunk.Row) (val json.BinaryJSON, isNull b
 	return c.buf.GetJSON(0), c.buf.IsNull(0), nil
 }
 
+// vecEval evaluates this builtin function in a vectorized manner.
+// If the underlying builtin function is row-based, it will be converted to vectorized.
 func (c *vecRowConverter) vecEval(input *chunk.Chunk, result *chunk.Column) error {
 	if c.builtinFunc.vectorized() {
 		return c.builtinFunc.vecEval(input, result)

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -535,6 +535,116 @@ func (s *testEvaluatorSuite) TestDoubleVec2Row(c *C) {
 	}
 }
 
+func evalRows(b *testing.B, it *chunk.Iterator4Chunk, eType types.EvalType, result *chunk.Column, rowDouble builtinFunc) {
+	switch eType {
+	case types.ETInt:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalInt(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendInt64(v)
+				}
+			}
+		}
+	case types.ETReal:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalReal(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendFloat64(v)
+				}
+			}
+		}
+	case types.ETDecimal:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalDecimal(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendMyDecimal(v)
+				}
+			}
+		}
+	case types.ETDuration:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalDuration(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendDuration(v)
+				}
+			}
+		}
+	case types.ETString:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalString(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendString(v)
+				}
+			}
+		}
+	case types.ETDatetime:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalTime(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendTime(v)
+				}
+			}
+		}
+	case types.ETJson:
+		for i := 0; i < b.N; i++ {
+			result.Reset()
+			for r := it.Begin(); r != it.End(); r = it.Next() {
+				v, isNull, err := rowDouble.evalJSON(r)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if isNull {
+					result.AppendNull()
+				} else {
+					result.AppendJSON(v)
+				}
+			}
+		}
+	}
+}
+
 func BenchmarkMockDoubleRow(b *testing.B) {
 	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
@@ -543,113 +653,7 @@ func BenchmarkMockDoubleRow(b *testing.B) {
 			rowDouble, input, result, _ := genMockRowDouble(eType, false)
 			it := chunk.NewIterator4Chunk(input)
 			b.ResetTimer()
-			switch eType {
-			case types.ETInt:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalInt(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendInt64(v)
-						}
-					}
-				}
-			case types.ETReal:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalReal(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendFloat64(v)
-						}
-					}
-				}
-			case types.ETDecimal:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalDecimal(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendMyDecimal(v)
-						}
-					}
-				}
-			case types.ETDuration:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalDuration(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendDuration(v)
-						}
-					}
-				}
-			case types.ETString:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalString(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendString(v)
-						}
-					}
-				}
-			case types.ETDatetime:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalTime(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendTime(v)
-						}
-					}
-				}
-			case types.ETJson:
-				for i := 0; i < b.N; i++ {
-					result.Reset()
-					for r := it.Begin(); r != it.End(); r = it.Next() {
-						v, isNull, err := rowDouble.evalJSON(r)
-						if err != nil {
-							b.Fatal(err)
-						}
-						if isNull {
-							result.AppendNull()
-						} else {
-							result.AppendJSON(v)
-						}
-					}
-				}
-			}
+			evalRows(b, it, eType, result, rowDouble)
 		})
 	}
 }
@@ -679,15 +683,7 @@ func BenchmarkMockDoubleVec2Row(b *testing.B) {
 			rowDouble, input, result, _ := genMockRowDouble(eType, true)
 			it := chunk.NewIterator4Chunk(input)
 			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				result.Reset()
-				for r := it.Begin(); r != it.End(); r = it.Next() {
-					_, _, err := rowDouble.evalInt(r)
-					if err != nil {
-						b.Fatal(err)
-					}
-				}
-			}
+			evalRows(b, it, eType, result, rowDouble)
 		})
 	}
 }

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -658,6 +658,23 @@ func BenchmarkMockDoubleRow(b *testing.B) {
 	}
 }
 
+func BenchmarkMockDoubleVec(b *testing.B) {
+	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for i, eType := range eTypes {
+		b.Run(typeNames[i], func(b *testing.B) {
+			rowDouble, input, result, _ := genMockRowDouble(eType, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				err := rowDouble.vecEval(input, result)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkMockDoubleRow2Vec(b *testing.B) {
 	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -170,11 +171,100 @@ func BenchmarkPlusIntBufAllocator(b *testing.B) {
 	}
 }
 
-type mockRowBuiltinDouble struct {
+type mockBuiltinDouble struct {
 	baseBuiltinFunc
+
+	evalType  types.EvalType
+	enableVec bool
 }
 
-func (p *mockRowBuiltinDouble) evalInt(row chunk.Row) (int64, bool, error) {
+func (p *mockBuiltinDouble) vectorized() bool {
+	return p.enableVec
+}
+
+func (p *mockBuiltinDouble) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+	var buf *chunk.Column
+	switch p.evalType {
+	case types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETDatetime:
+		if err := p.args[0].VecEval(p.ctx, input, result); err != nil {
+			return err
+		}
+	default:
+		var err error
+		if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
+			return err
+		}
+		if err := p.args[0].VecEval(p.ctx, input, buf); err != nil {
+			return err
+		}
+	}
+
+	switch p.evalType {
+	case types.ETInt:
+		i64s := result.Int64s()
+		for i := range i64s {
+			i64s[i] *= 2
+		}
+	case types.ETReal:
+		f64s := result.Float64s()
+		for i := range f64s {
+			f64s[i] *= 2
+		}
+	case types.ETDecimal:
+		ds := result.Decimals()
+		for i := range ds {
+			r := new(types.MyDecimal)
+			if err := types.DecimalAdd(&ds[i], &ds[i], r); err != nil {
+				return err
+			}
+			ds[i] = *r
+		}
+	case types.ETDuration:
+		ds := result.GoDurations()
+		for i := range ds {
+			ds[i] *= 2
+		}
+	case types.ETDatetime:
+		ts := result.Times()
+		for i := range ts {
+			d, err := ts[i].ConvertToDuration()
+			if err != nil {
+				return err
+			}
+			if ts[i], err = ts[i].Add(p.ctx.GetSessionVars().StmtCtx, d); err != nil {
+				return err
+			}
+		}
+	case types.ETJson:
+		result.ReserveString(input.NumRows())
+		for i := 0; i < input.NumRows(); i++ {
+			j := buf.GetJSON(i)
+			path, err := json.ParseJSONPathExpr("$.key")
+			if err != nil {
+				return err
+			}
+			ret, ok := j.Extract([]json.PathExpression{path})
+			if !ok {
+				return errors.Errorf("path not found")
+			}
+			if err := j.UnmarshalJSON([]byte(fmt.Sprintf(`{"key":%v}`, 2*ret.GetInt64()))); err != nil {
+				return err
+			}
+			result.AppendJSON(j)
+		}
+		p.baseBuiltinFunc.put(buf)
+	case types.ETString:
+		result.ReserveString(input.NumRows())
+		for i := 0; i < input.NumRows(); i++ {
+			str := buf.GetString(i)
+			result.AppendString(str + str)
+		}
+		p.baseBuiltinFunc.put(buf)
+	}
+	return nil
+}
+
+func (p *mockBuiltinDouble) evalInt(row chunk.Row) (int64, bool, error) {
 	v, isNull, err := p.args[0].EvalInt(p.ctx, row)
 	if err != nil {
 		return 0, false, err
@@ -182,7 +272,7 @@ func (p *mockRowBuiltinDouble) evalInt(row chunk.Row) (int64, bool, error) {
 	return v * 2, isNull, nil
 }
 
-func (p *mockRowBuiltinDouble) evalReal(row chunk.Row) (float64, bool, error) {
+func (p *mockBuiltinDouble) evalReal(row chunk.Row) (float64, bool, error) {
 	v, isNull, err := p.args[0].EvalReal(p.ctx, row)
 	if err != nil {
 		return 0, false, err
@@ -190,7 +280,7 @@ func (p *mockRowBuiltinDouble) evalReal(row chunk.Row) (float64, bool, error) {
 	return v * 2, isNull, nil
 }
 
-func (p *mockRowBuiltinDouble) evalString(row chunk.Row) (string, bool, error) {
+func (p *mockBuiltinDouble) evalString(row chunk.Row) (string, bool, error) {
 	v, isNull, err := p.args[0].EvalString(p.ctx, row)
 	if err != nil {
 		return "", false, err
@@ -198,7 +288,7 @@ func (p *mockRowBuiltinDouble) evalString(row chunk.Row) (string, bool, error) {
 	return v + v, isNull, nil
 }
 
-func (p *mockRowBuiltinDouble) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
+func (p *mockBuiltinDouble) evalDecimal(row chunk.Row) (*types.MyDecimal, bool, error) {
 	v, isNull, err := p.args[0].EvalDecimal(p.ctx, row)
 	if err != nil {
 		return nil, false, err
@@ -210,7 +300,7 @@ func (p *mockRowBuiltinDouble) evalDecimal(row chunk.Row) (*types.MyDecimal, boo
 	return r, isNull, nil
 }
 
-func (p *mockRowBuiltinDouble) evalTime(row chunk.Row) (types.Time, bool, error) {
+func (p *mockBuiltinDouble) evalTime(row chunk.Row) (types.Time, bool, error) {
 	v, isNull, err := p.args[0].EvalTime(p.ctx, row)
 	if err != nil {
 		return types.Time{}, false, err
@@ -223,7 +313,7 @@ func (p *mockRowBuiltinDouble) evalTime(row chunk.Row) (types.Time, bool, error)
 	return v, isNull, err
 }
 
-func (p *mockRowBuiltinDouble) evalDuration(row chunk.Row) (types.Duration, bool, error) {
+func (p *mockBuiltinDouble) evalDuration(row chunk.Row) (types.Duration, bool, error) {
 	v, isNull, err := p.args[0].EvalDuration(p.ctx, row)
 	if err != nil {
 		return types.Duration{}, false, err
@@ -232,7 +322,7 @@ func (p *mockRowBuiltinDouble) evalDuration(row chunk.Row) (types.Duration, bool
 	return v, isNull, err
 }
 
-func (p *mockRowBuiltinDouble) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error) {
+func (p *mockBuiltinDouble) evalJSON(row chunk.Row) (json.BinaryJSON, bool, error) {
 	j, isNull, err := p.args[0].EvalJSON(p.ctx, row)
 	if err != nil {
 		return json.BinaryJSON{}, false, err
@@ -274,14 +364,14 @@ func convertETType(eType types.EvalType) (mysqlType byte) {
 	return
 }
 
-func genMockRowDouble(eType types.EvalType) (builtinFunc, *chunk.Chunk, *chunk.Column, error) {
+func genMockRowDouble(eType types.EvalType, enableVec bool) (builtinFunc, *chunk.Chunk, *chunk.Column, error) {
 	mysqlType := convertETType(eType)
 	tp := types.NewFieldType(mysqlType)
 	col1 := newColumn(1)
 	col1.Index = 0
 	col1.RetType = tp
 	bf := newBaseBuiltinFuncWithTp(mock.NewContext(), []Expression{col1}, eType, eType)
-	rowDouble := &mockRowBuiltinDouble{bf}
+	rowDouble := &mockBuiltinDouble{bf, eType, enableVec}
 	input := chunk.New([]*types.FieldType{tp}, 1024, 1024)
 	buf := chunk.NewColumn(types.NewFieldType(convertETType(eType)), 1024)
 	for i := 0; i < 1024; i++ {
@@ -311,7 +401,7 @@ func genMockRowDouble(eType types.EvalType) (builtinFunc, *chunk.Chunk, *chunk.C
 			input.AppendTime(0, types.Time{Time: t, Type: mysqlType})
 		}
 	}
-	return &vecRowConverter{rowDouble}, input, buf, nil
+	return newVecRowConverter(rowDouble), input, buf, nil
 }
 
 func (s *testEvaluatorSuite) checkVecEval(c *C, eType types.EvalType, sel []int, result *chunk.Column) {
@@ -380,7 +470,7 @@ func (s *testEvaluatorSuite) TestDoubleRow2Vec(c *C) {
 	defer testleak.AfterTest(c)()
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
 	for _, eType := range eTypes {
-		rowDouble, input, result, err := genMockRowDouble(eType)
+		rowDouble, input, result, err := genMockRowDouble(eType, false)
 		c.Assert(err, IsNil)
 		c.Assert(rowDouble.vecEval(input, result), IsNil)
 		s.checkVecEval(c, eType, nil, result)
@@ -401,12 +491,56 @@ func (s *testEvaluatorSuite) TestDoubleRow2Vec(c *C) {
 	}
 }
 
+func (s *testEvaluatorSuite) TestDoubleVec2Row(c *C) {
+	defer testleak.AfterTest(c)()
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for _, eType := range eTypes {
+		rowDouble, input, result, err := genMockRowDouble(eType, true)
+		result.Reset()
+		c.Assert(err, IsNil)
+		it := chunk.NewIterator4Chunk(input)
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			switch eType {
+			case types.ETInt:
+				v, _, err := rowDouble.evalInt(row)
+				c.Assert(err, IsNil)
+				result.AppendInt64(v)
+			case types.ETReal:
+				v, _, err := rowDouble.evalReal(row)
+				c.Assert(err, IsNil)
+				result.AppendFloat64(v)
+			case types.ETDecimal:
+				v, _, err := rowDouble.evalDecimal(row)
+				c.Assert(err, IsNil)
+				result.AppendMyDecimal(v)
+			case types.ETDuration:
+				v, _, err := rowDouble.evalDuration(row)
+				c.Assert(err, IsNil)
+				result.AppendDuration(v)
+			case types.ETString:
+				v, _, err := rowDouble.evalString(row)
+				c.Assert(err, IsNil)
+				result.AppendString(v)
+			case types.ETDatetime:
+				v, _, err := rowDouble.evalTime(row)
+				c.Assert(err, IsNil)
+				result.AppendTime(v)
+			case types.ETJson:
+				v, _, err := rowDouble.evalJSON(row)
+				c.Assert(err, IsNil)
+				result.AppendJSON(v)
+			}
+		}
+		s.checkVecEval(c, eType, nil, result)
+	}
+}
+
 func BenchmarkMockDoubleRow(b *testing.B) {
 	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
 	for i, eType := range eTypes {
 		b.Run(typeNames[i], func(b *testing.B) {
-			rowDouble, input, result, _ := genMockRowDouble(eType)
+			rowDouble, input, result, _ := genMockRowDouble(eType, false)
 			it := chunk.NewIterator4Chunk(input)
 			b.ResetTimer()
 			switch eType {
@@ -525,12 +659,33 @@ func BenchmarkMockDoubleRow2Vec(b *testing.B) {
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
 	for i, eType := range eTypes {
 		b.Run(typeNames[i], func(b *testing.B) {
-			rowDouble, input, result, _ := genMockRowDouble(eType)
+			rowDouble, input, result, _ := genMockRowDouble(eType, false)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				err := rowDouble.vecEval(input, result)
 				if err != nil {
 					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkMockDoubleVec2Row(b *testing.B) {
+	typeNames := []string{"Int", "Real", "Decimal", "Duration", "String", "Datetime", "JSON"}
+	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
+	for i, eType := range eTypes {
+		b.Run(typeNames[i], func(b *testing.B) {
+			rowDouble, input, result, _ := genMockRowDouble(eType, true)
+			it := chunk.NewIterator4Chunk(input)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				result.Reset()
+				for r := it.Begin(); r != it.End(); r = it.Next() {
+					_, _, err := rowDouble.evalInt(r)
+					if err != nil {
+						b.Fatal(err)
+					}
 				}
 			}
 		})

--- a/util/chunk/row.go
+++ b/util/chunk/row.go
@@ -28,6 +28,11 @@ type Row struct {
 	idx int
 }
 
+// Chunk returns the Chunk which the row belongs to.
+func (r Row) Chunk() *Chunk {
+	return r.c
+}
+
 // IsEmpty returns true if the Row is empty.
 func (r Row) IsEmpty() bool {
 	return r == Row{}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Following up #11630, support converting from vectorized evaluation to row-based evaluation.

### What is changed and how it works?
Here are all benchmarks:
```
BenchmarkMockDoubleRow/Int-12             100000             19420 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleRow/Real-12            100000             20694 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleRow/Decimal-12                  30000             58472 ns/op           49152 B/op       1024 allocs/op
BenchmarkMockDoubleRow/Duration-12                 50000             25042 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleRow/String-12                   30000             54641 ns/op            7777 B/op       1024 allocs/op
BenchmarkMockDoubleRow/Datetime-12                 10000            179747 ns/op               1 B/op          0 allocs/op
BenchmarkMockDoubleRow/JSON-12                      1000           2191484 ns/op         1960679 B/op      22537 allocs/op

BenchmarkMockDoubleVec2Row/Int-12                  50000             35709 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/Real-12                 50000             37853 ns/op               1 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/Decimal-12              30000             60536 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/Duration-12             50000             37666 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/String-12               20000             91115 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/Datetime-12              5000            227377 ns/op               3 B/op          0 allocs/op
BenchmarkMockDoubleVec2Row/JSON-12                  1000           2286588 ns/op         1959418 B/op      22536 allocs/op
```
There are some performance drawbacks, but it's ok since we will update all expression evaluations which are important to the performance from row-based evaluation to vectorized evaluation soon.

And when all expressions are vectorized, the performance will be much better than now.
Here is the benchmark about pure vectorized evaluation:
```
BenchmarkMockDoubleVec/Int-12            3000000               428 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/Real-12           3000000               416 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/Decimal-12                 100000             20071 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/Duration-12               3000000               605 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/String-12                   50000             24638 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/Datetime-12                 10000            126060 ns/op               0 B/op          0 allocs/op
BenchmarkMockDoubleVec/JSON-12                      1000           2247046 ns/op         1971854 B/op      22540 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
