### PR TITLE
planner: fix incorrect table name in explain information

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -126,7 +126,7 @@ Projection_13	1.00	root	test.gad.id, test.dd.id, test.gad.aid, test.gad.cm, test
       └─IndexLookUp_33	3.33	root	
         ├─IndexScan_30	3333.33	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false, stats:pseudo
         └─Selection_32	3.33	cop	eq(test.gad.pt, "android"), not(isnull(test.gad.ip))
-          └─TableScan_31	3333.33	cop	table:st, keep order:false, stats:pseudo
+          └─TableScan_31	3333.33	cop	table:gad, keep order:false, stats:pseudo
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	count	task	operator info
 Projection_10	0.00	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, test.sdk.dic, test.sdk.ip, test.sdk.t, test.gad.p1, test.gad.p2, test.gad.p3, test.gad.p4, test.gad.p5, test.gad.p6_md5, test.gad.p7_md5, test.gad.ext
@@ -135,11 +135,11 @@ Projection_10	0.00	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, tes
     ├─IndexLookUp_27	0.00	root	
     │ ├─IndexScan_24	3333.33	cop	table:gad, index:t, range:(1477971479,+inf], keep order:false, stats:pseudo
     │ └─Selection_26	0.00	cop	eq(test.gad.bm, 0), eq(test.gad.dit, "mac"), eq(test.gad.pt, "ios"), not(isnull(test.gad.dic))
-    │   └─TableScan_25	3333.33	cop	table:st, keep order:false, stats:pseudo
+    │   └─TableScan_25	3333.33	cop	table:gad, keep order:false, stats:pseudo
     └─IndexLookUp_17	0.00	root	
       ├─IndexScan_14	10.00	cop	table:sdk, index:aid, dic, range: decided by [eq(test.sdk.aid, test.gad.aid)], keep order:false, stats:pseudo
       └─Selection_16	0.00	cop	eq(test.sdk.bm, 0), eq(test.sdk.pt, "ios"), gt(test.sdk.t, 1477971479), not(isnull(test.sdk.mac)), not(isnull(test.sdk.t))
-        └─TableScan_15	10.00	cop	table:dd, keep order:false, stats:pseudo
+        └─TableScan_15	10.00	cop	table:sdk, keep order:false, stats:pseudo
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	count	task	operator info
 Projection_5	1.00	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1
@@ -250,12 +250,12 @@ Sort_10	1.00	root	test.d.left_value:asc
       │ ├─IndexLookUp_47	0.01	root	
       │ │ ├─IndexScan_44	10.00	cop	table:d, index:ctx, range:[1,1], keep order:false, stats:pseudo
       │ │ └─Selection_46	0.01	cop	eq(test.d.status, 1000)
-      │ │   └─TableScan_45	10.00	cop	table:org_department, keep order:false, stats:pseudo
+      │ │   └─TableScan_45	10.00	cop	table:d, keep order:false, stats:pseudo
       │ └─IndexLookUp_31	0.01	root	
       │   ├─Selection_29	9.99	cop	not(isnull(test.p.department_id))
       │   │ └─IndexScan_27	10.00	cop	table:p, index:department_id, range: decided by [eq(test.p.department_id, test.d.id)], keep order:false, stats:pseudo
       │   └─Selection_30	0.01	cop	eq(test.p.status, 1000)
-      │     └─TableScan_28	9.99	cop	table:org_position, keep order:false, stats:pseudo
+      │     └─TableScan_28	9.99	cop	table:p, keep order:false, stats:pseudo
       └─TableReader_57	9.99	root	data:Selection_56
         └─Selection_56	9.99	cop	eq(test.ep.status, 1000), not(isnull(test.ep.position_id))
           └─TableScan_55	10000.00	cop	table:ep, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -146,7 +146,7 @@ Projection_10	170.34	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, t
     └─IndexLookUp_17	0.25	root	
       ├─IndexScan_14	1.00	cop	table:sdk, index:aid, dic, range: decided by [eq(test.sdk.aid, test.gad.aid)], keep order:false
       └─Selection_16	0.25	cop	eq(test.sdk.bm, 0), eq(test.sdk.pt, "ios"), gt(test.sdk.t, 1477971479), not(isnull(test.sdk.mac)), not(isnull(test.sdk.t))
-        └─TableScan_15	1.00	cop	table:dd, keep order:false
+        └─TableScan_15	1.00	cop	table:sdk, keep order:false
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	count	task	operator info
 Projection_5	39.28	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -339,7 +339,7 @@ Projection_11	10000.00	root	9_aux_0
       ├─IndexLookUp_29	9.99	root	
       │ ├─IndexScan_26	10.00	cop	table:s, index:b, range: decided by [eq(test.s.b, test.t.a)], keep order:false, stats:pseudo
       │ └─Selection_28	9.99	cop	not(isnull(test.s.c))
-      │   └─TableScan_27	10.00	cop	table:t, keep order:false, stats:pseudo
+      │   └─TableScan_27	10.00	cop	table:s, keep order:false, stats:pseudo
       └─TableReader_33	1.00	root	data:TableScan_32
         └─TableScan_32	1.00	cop	table:t1, range: decided by [test.s.c], keep order:false, stats:pseudo
 insert into t values(1, 1, 1), (2, 2 ,2), (3, 3, 3), (4, 3, 4),(5,3,5);
@@ -678,7 +678,7 @@ Projection_8	8320.83	root	test.t.a, test.t1.a
   └─UnionScan_14	6656.67	root	not(and(ge(test.t1.a, 1), le(test.t1.a, 2))), not(isnull(test.t1.a))
     └─TableReader_17	6656.67	root	data:Selection_16
       └─Selection_16	6656.67	cop	not(isnull(test.t1.a)), or(lt(test.t1.a, 1), gt(test.t1.a, 2))
-        └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+        └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 rollback;
 drop table if exists t;
 create table t(a time, b date);

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -1240,11 +1240,11 @@ Projection_25	1.00	root	tpch.supplier.s_name, 17_col_0
       │ │     └─TableScan_59	1.00	cop	table:orders, range: decided by [tpch.l1.l_orderkey], keep order:false
       │ └─IndexLookUp_55	1.00	root	
       │   ├─IndexScan_53	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l2.l_orderkey, tpch.l1.l_orderkey)], keep order:false
-      │   └─TableScan_54	1.00	cop	table:lineitem, keep order:false
+      │   └─TableScan_54	1.00	cop	table:l2, keep order:false
       └─IndexLookUp_39	0.80	root	
         ├─IndexScan_36	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l3.l_orderkey, tpch.l1.l_orderkey)], keep order:false
         └─Selection_38	0.80	cop	gt(tpch.l3.l_receiptdate, tpch.l3.l_commitdate)
-          └─TableScan_37	1.00	cop	table:lineitem, keep order:false
+          └─TableScan_37	1.00	cop	table:l3, keep order:false
 /*
 Q22 Global Sales Opportunity Query
 The Global Sales Opportunity Query identifies geographies where there are customers who may be likely to make a

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -581,7 +581,7 @@ func (p *LogicalJoin) constructInnerIndexScanTask(ds *DataSource, idx *model.Ind
 	}
 	if !isCoveringIndex(ds.schema.Columns, is.Index.Columns, is.Table.PKIsHandle) {
 		// On this way, it's double read case.
-		ts := PhysicalTableScan{Columns: ds.Columns, Table: is.Table}.Init(ds.ctx)
+		ts := PhysicalTableScan{Columns: ds.Columns, Table: is.Table, TableAsName: ds.TableAsName}.Init(ds.ctx)
 		ts.SetSchema(is.dataSourceSchema)
 		cop.tablePlan = ts
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -498,6 +498,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 		ts := PhysicalTableScan{
 			Columns:         ds.Columns,
 			Table:           is.Table,
+			TableAsName:     ds.TableAsName,
 			isPartition:     ds.isPartition,
 			physicalTableID: ds.physicalTableID,
 		}.Init(ds.ctx)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -842,7 +842,7 @@ func (b *PlanBuilder) buildPhysicalIndexLookUpReader(ctx context.Context, dbName
 	// There is no alternative plan choices, so just use pseudo stats to avoid panic.
 	is.stats = &property.StatsInfo{HistColl: &(statistics.PseudoTable(tblInfo)).HistColl}
 	// It's double read case.
-	ts := PhysicalTableScan{Columns: tblReaderCols, Table: is.Table}.Init(b.ctx)
+	ts := PhysicalTableScan{Columns: tblReaderCols, Table: is.Table, TableAsName: &tblInfo.Name}.Init(b.ctx)
 	ts.SetSchema(tblSchema)
 	cop := &copTask{
 		indexPlan:   is,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/11782

### What is changed and how it works?

Add necessary `TableAsName` field into `PhysicalTableScan`. 
For case 1, add it in `constructInnerIndexScanTask`.
For case 2, add it in `convertToIndexScan`.

For case 3, this case happens because we set `TableAsName` after `buildDataSource`. In most cases it goes well, but when we need union scan, line 2348 will be triggered:
``` golang
if txn.Valid() && !txn.IsReadOnly() && !isMemDB {
	us := LogicalUnionScan{handleCol: handleCol}.Init(b.ctx)
	us.SetChildren(ds)
	result = us
}
```
The return value is `LogicalUnionScan` instead of `DataSource`, so `TableAsName` will not be set in these lines of `buildResultSetNode`:
``` golang
if v, ok := p.(*DataSource); ok {
	v.TableAsName = &x.AsName
}
```
So we can pass `&x.AsName` into `buildDataSource`, and set `TableAsName` in it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Explain test

Side effects

 - Change explain information in some cases.
