### PR TITLE
 *: convert key to hex for logs 

### DIFF
--- a/ddl/util/util.go
+++ b/ddl/util/util.go
@@ -40,11 +40,11 @@ const (
 // DelRangeTask is for run delete-range command in gc_worker.
 type DelRangeTask struct {
 	JobID, ElementID int64
-	StartKey, EndKey []byte
+	StartKey, EndKey kv.Key
 }
 
 // Range returns the range [start, end) to delete.
-func (t DelRangeTask) Range() ([]byte, []byte) {
+func (t DelRangeTask) Range() (kv.Key, kv.Key) {
 	return t.StartKey, t.EndKey
 }
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -475,7 +475,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		logutil.Logger(ctx).Info("single statement deadlock, retry statement",
 			zap.Uint64("txn", txnCtx.StartTS),
 			zap.Uint64("lockTS", deadlock.LockTs),
-			zap.Binary("lockKey", deadlock.LockKey),
+			zap.Stringer("lockKey", kv.Key(deadlock.LockKey)),
 			zap.Uint64("deadlockKeyHash", deadlock.DeadlockKeyHash))
 	} else if terror.ErrorEqual(kv.ErrWriteConflict, err) {
 		conflictCommitTS := extractConflictCommitTS(err.Error())

--- a/kv/key.go
+++ b/kv/key.go
@@ -13,7 +13,10 @@
 
 package kv
 
-import "bytes"
+import (
+	"bytes"
+	"encoding/hex"
+)
 
 // Key represents high-level Key type.
 type Key []byte
@@ -68,6 +71,11 @@ func (k Key) HasPrefix(prefix Key) bool {
 // Clone returns a copy of the Key.
 func (k Key) Clone() Key {
 	return append([]byte(nil), k...)
+}
+
+// String implements fmt.Stringer interface.
+func (k Key) String() string {
+	return hex.EncodeToString(k)
 }
 
 // KeyRange represents a range where StartKey <= key < EndKey.

--- a/kv/union_iter.go
+++ b/kv/union_iter.go
@@ -121,7 +121,7 @@ func (iter *UnionIter) updateCur() error {
 				// record from dirty comes first
 				if len(iter.dirtyIt.Value()) == 0 {
 					logutil.BgLogger().Warn("delete a record not exists?",
-						zap.Binary("key", iter.dirtyIt.Key()))
+						zap.Stringer("key", iter.dirtyIt.Key()))
 					// jump over this deletion
 					if err := iter.dirtyNext(); err != nil {
 						return err

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -158,12 +158,13 @@ func (t *tikvHandlerTool) getMvccByHandle(tableID, handle int64) (*mvccKV, error
 	return &mvccKV{Key: strings.ToUpper(hex.EncodeToString(encodedKey)), Value: data, RegionID: regionID}, err
 }
 
-func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []byte) (*mvccKV, error) {
+func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey kv.Key) (*mvccKV, error) {
 	bo := tikv.NewBackoffer(context.Background(), 5000)
 	for {
 		curRegion, err := t.RegionCache.LocateKey(bo, startKey)
 		if err != nil {
-			logutil.BgLogger().Error("get MVCC by startTS failed", zap.Uint64("txnStartTS", startTS), zap.Binary("startKey", startKey), zap.Error(err))
+			logutil.BgLogger().Error("get MVCC by startTS failed", zap.Uint64("txnStartTS", startTS),
+				zap.Stringer("startKey", startKey), zap.Error(err))
 			return nil, errors.Trace(err)
 		}
 
@@ -175,10 +176,10 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		if err != nil {
 			logutil.BgLogger().Error("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
-				zap.Binary("startKey", startKey),
+				zap.Stringer("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),
-				zap.Binary("curRegion startKey", curRegion.StartKey),
-				zap.Binary("curRegion endKey", curRegion.EndKey),
+				zap.Stringer("curRegion startKey", curRegion.StartKey),
+				zap.Stringer("curRegion endKey", curRegion.EndKey),
 				zap.Reflect("kvResp", kvResp),
 				zap.Error(err))
 			return nil, errors.Trace(err)
@@ -187,10 +188,10 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		if err := data.GetRegionError(); err != nil {
 			logutil.BgLogger().Warn("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
-				zap.Binary("startKey", startKey),
+				zap.Stringer("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),
-				zap.Binary("curRegion startKey", curRegion.StartKey),
-				zap.Binary("curRegion endKey", curRegion.EndKey),
+				zap.Stringer("curRegion startKey", curRegion.StartKey),
+				zap.Stringer("curRegion endKey", curRegion.EndKey),
 				zap.Reflect("kvResp", kvResp),
 				zap.Stringer("error", err))
 			continue
@@ -199,10 +200,10 @@ func (t *tikvHandlerTool) getMvccByStartTs(startTS uint64, startKey, endKey []by
 		if len(data.GetError()) > 0 {
 			logutil.BgLogger().Error("get MVCC by startTS failed",
 				zap.Uint64("txnStartTS", startTS),
-				zap.Binary("startKey", startKey),
+				zap.Stringer("startKey", startKey),
 				zap.Reflect("region", curRegion.Region),
-				zap.Binary("curRegion startKey", curRegion.StartKey),
-				zap.Binary("curRegion endKey", curRegion.EndKey),
+				zap.Stringer("curRegion startKey", curRegion.StartKey),
+				zap.Stringer("curRegion endKey", curRegion.EndKey),
 				zap.Reflect("kvResp", kvResp),
 				zap.String("error", data.GetError()))
 			return nil, errors.New(data.GetError())

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -67,10 +67,10 @@ func (h *Helper) GetMvccByEncodedKey(encodedKey kv.Key) (*kvrpcpb.MvccGetByKeyRe
 	kvResp, err := h.Store.SendReq(tikv.NewBackoffer(context.Background(), 500), tikvReq, keyLocation.Region, time.Minute)
 	if err != nil {
 		logutil.BgLogger().Info("get MVCC by encoded key failed",
-			zap.Binary("encodeKey", encodedKey),
+			zap.Stringer("encodeKey", encodedKey),
 			zap.Reflect("region", keyLocation.Region),
-			zap.Binary("startKey", keyLocation.StartKey),
-			zap.Binary("endKey", keyLocation.EndKey),
+			zap.Stringer("startKey", keyLocation.StartKey),
+			zap.Stringer("endKey", keyLocation.EndKey),
 			zap.Reflect("kvResp", kvResp),
 			zap.Error(err))
 		return nil, errors.Trace(err)

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -539,7 +539,7 @@ func (c *twoPhaseCommitter) prewriteSingleBatch(bo *Backoffer, batch batchKeys) 
 				}
 				logutil.BgLogger().Debug("key already exists",
 					zap.Uint64("conn", c.connID),
-					zap.Binary("key", key))
+					zap.Stringer("key", kv.Key(key)))
 				return errors.Trace(conditionPair.Err())
 			}
 

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -560,8 +560,8 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64, concurren
 		if err != nil {
 			logutil.Logger(ctx).Error("[gc worker] delete range failed on range",
 				zap.String("uuid", w.uuid),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Error(err))
 			continue
 		}
@@ -572,8 +572,8 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64, concurren
 		if err != nil {
 			logutil.Logger(ctx).Error("[gc worker] failed to mark delete range task done",
 				zap.String("uuid", w.uuid),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Error(err))
 			metrics.GCUnsafeDestroyRangeFailuresCounterVec.WithLabelValues("save").Inc()
 		}
@@ -612,8 +612,8 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64, concu
 		if err != nil {
 			logutil.Logger(ctx).Error("[gc worker] redo-delete range failed on range",
 				zap.String("uuid", w.uuid),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Error(err))
 			continue
 		}
@@ -624,8 +624,8 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64, concu
 		if err != nil {
 			logutil.Logger(ctx).Error("[gc worker] failed to remove delete_range_done record",
 				zap.String("uuid", w.uuid),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Error(err))
 			metrics.GCUnsafeDestroyRangeFailuresCounterVec.WithLabelValues("save_redo").Inc()
 		}

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -576,8 +576,10 @@ Loop:
 		for storeIndex := range expectedStores {
 			i := rangeIndex*len(expectedStores) + storeIndex
 			c.Assert(sentReq[i].addr, Equals, expectedStores[storeIndex].Address)
-			c.Assert(sentReq[i].req.UnsafeDestroyRange().GetStartKey(), DeepEquals, sortedRanges[rangeIndex].StartKey)
-			c.Assert(sentReq[i].req.UnsafeDestroyRange().GetEndKey(), DeepEquals, sortedRanges[rangeIndex].EndKey)
+			c.Assert(kv.Key(sentReq[i].req.UnsafeDestroyRange().GetStartKey()), DeepEquals,
+				sortedRanges[rangeIndex].StartKey)
+			c.Assert(kv.Key(sentReq[i].req.UnsafeDestroyRange().GetEndKey()), DeepEquals,
+				sortedRanges[rangeIndex].EndKey)
 		}
 	}
 }

--- a/store/tikv/range_task.go
+++ b/store/tikv/range_task.go
@@ -98,22 +98,22 @@ func (s *RangeTaskRunner) SetStatLogInterval(interval time.Duration) {
 
 // RunOnRange runs the task on the given range.
 // Empty startKey or endKey means unbounded.
-func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey []byte, endKey []byte) error {
+func (s *RangeTaskRunner) RunOnRange(ctx context.Context, startKey, endKey kv.Key) error {
 	s.completedRegions = 0
 	metrics.TiKVRangeTaskStats.WithLabelValues(s.name, lblCompletedRegions).Set(0)
 
 	if len(endKey) != 0 && bytes.Compare(startKey, endKey) >= 0 {
 		logutil.Logger(ctx).Info("empty range task executed. ignored",
 			zap.String("name", s.name),
-			zap.Binary("startKey", startKey),
-			zap.Binary("endKey", endKey))
+			zap.Stringer("startKey", startKey),
+			zap.Stringer("endKey", endKey))
 		return nil
 	}
 
 	logutil.Logger(ctx).Info("range task started",
 		zap.String("name", s.name),
-		zap.Binary("startKey", startKey),
-		zap.Binary("endKey", endKey),
+		zap.Stringer("startKey", startKey),
+		zap.Stringer("endKey", endKey),
 		zap.Int("concurrency", s.concurrency))
 
 	// Periodically log the progress
@@ -154,8 +154,8 @@ Loop:
 		case <-statLogTicker.C:
 			logutil.Logger(ctx).Info("range task in progress",
 				zap.String("name", s.name),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Int("concurrency", s.concurrency),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Int("completed regions", s.CompletedRegions()))
@@ -168,8 +168,8 @@ Loop:
 		if err != nil {
 			logutil.Logger(ctx).Info("range task failed",
 				zap.String("name", s.name),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Error(err))
 			return errors.Trace(err)
@@ -208,8 +208,8 @@ Loop:
 		if w.err != nil {
 			logutil.Logger(ctx).Info("range task failed",
 				zap.String("name", s.name),
-				zap.Binary("startKey", startKey),
-				zap.Binary("endKey", endKey),
+				zap.Stringer("startKey", startKey),
+				zap.Stringer("endKey", endKey),
 				zap.Duration("cost time", time.Since(startTime)),
 				zap.Error(w.err))
 			return errors.Trace(w.err)
@@ -218,8 +218,8 @@ Loop:
 
 	logutil.Logger(ctx).Info("range task finished",
 		zap.String("name", s.name),
-		zap.Binary("startKey", startKey),
-		zap.Binary("endKey", endKey),
+		zap.Stringer("startKey", startKey),
+		zap.Stringer("endKey", endKey),
 		zap.Duration("cost time", time.Since(startTime)),
 		zap.Int("completed regions", s.CompletedRegions()))
 
@@ -286,8 +286,8 @@ func (w *rangeTaskWorker) run(ctx context.Context, cancel context.CancelFunc) {
 		if err != nil {
 			logutil.Logger(ctx).Info("canceling range task because of error",
 				zap.String("name", w.name),
-				zap.Binary("failed startKey", r.StartKey),
-				zap.Binary("failed endKey", r.EndKey),
+				zap.Stringer("failed startKey", r.StartKey),
+				zap.Stringer("failed endKey", r.EndKey),
 				zap.Error(err))
 			w.err = err
 			cancel()

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -332,8 +332,8 @@ func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID, replicaRead k
 // KeyLocation is the region and range that a key is located.
 type KeyLocation struct {
 	Region   RegionVerID
-	StartKey []byte
-	EndKey   []byte
+	StartKey kv.Key
+	EndKey   kv.Key
 }
 
 // Contains checks if key is in [StartKey, EndKey).

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -31,11 +31,11 @@ type Scanner struct {
 	batchSize    int
 	cache        []*pb.KvPair
 	idx          int
-	nextStartKey []byte
-	endKey       []byte
+	nextStartKey kv.Key
+	endKey       kv.Key
 
 	// Use for reverse scan.
-	nextEndKey []byte
+	nextEndKey kv.Key
 	reverse    bool
 
 	valid bool
@@ -155,8 +155,8 @@ func (s *Scanner) resolveCurrentLock(bo *Backoffer, current *pb.KvPair) error {
 
 func (s *Scanner) getData(bo *Backoffer) error {
 	logutil.BgLogger().Debug("txn getData",
-		zap.Binary("nextStartKey", s.nextStartKey),
-		zap.Binary("nextEndKey", s.nextEndKey),
+		zap.Stringer("nextStartKey", s.nextStartKey),
+		zap.Stringer("nextEndKey", s.nextEndKey),
 		zap.Bool("reverse", s.reverse),
 		zap.Uint64("txnStartTS", s.startTS()))
 	sender := NewRegionRequestSender(s.snapshot.store.regionCache, s.snapshot.store.client)

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -31,7 +31,7 @@ import (
 // splitKey) and [splitKey, end).
 func (s *tikvStore) SplitRegion(splitKey kv.Key, scatter bool) (regionID uint64, err error) {
 	logutil.BgLogger().Info("start split region",
-		zap.Binary("at", splitKey))
+		zap.Stringer("at", splitKey))
 	bo := NewBackoffer(context.Background(), splitRegionBackoff)
 	sender := NewRegionRequestSender(s.regionCache, s.client)
 	req := tikvrpc.NewRequest(tikvrpc.CmdSplitRegion, &kvrpcpb.SplitRegionRequest{

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -16,7 +16,6 @@ package tikv
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -46,7 +45,7 @@ func (s *tikvStore) SplitRegion(splitKey kv.Key, scatter bool) (regionID uint64,
 		}
 		if bytes.Equal(splitKey, loc.StartKey) {
 			logutil.BgLogger().Info("skip split region",
-				zap.String("at", hex.EncodeToString(splitKey)))
+				zap.Stringer("at", splitKey))
 			return 0, nil
 		}
 		res, err := sender.SendReq(bo, req, loc.Region, readTimeoutShort)
@@ -66,7 +65,7 @@ func (s *tikvStore) SplitRegion(splitKey kv.Key, scatter bool) (regionID uint64,
 		}
 		splitRegion := res.Resp.(*kvrpcpb.SplitRegionResponse)
 		logutil.BgLogger().Info("split region complete",
-			zap.String("at", hex.EncodeToString(splitKey)),
+			zap.Stringer("at", splitKey),
 			zap.Stringer("new region left", logutil.Hex(splitRegion.GetLeft())),
 			zap.Stringer("new region right", logutil.Hex(splitRegion.GetRight())))
 		left := splitRegion.GetLeft()

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -703,8 +703,8 @@ func iterRecords(sessCtx sessionctx.Context, retriever kv.Retriever, t table.Tab
 	}
 
 	logutil.BgLogger().Debug("record",
-		zap.Binary("startKey", startKey),
-		zap.Binary("key", it.Key()),
+		zap.Stringer("startKey", startKey),
+		zap.Stringer("key", it.Key()),
 		zap.Binary("value", it.Value()))
 	rowDecoder := makeRowDecoder(t, cols, genExprs)
 	for it.Valid() && it.Key().HasPrefix(prefix) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It is not suitable to print the binary keys in logs.

### What is changed and how it works?
Change the keys to hex in logs, which is consistent with TiKV and make it easy to use.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
