### PR TITLE
build: fix macos compatibility of check_testSuite.sh

### DIFF
--- a/tools/check/check_testSuite.sh
+++ b/tools/check/check_testSuite.sh
@@ -3,12 +3,12 @@
 set -euo pipefail
 
 exitCode=0
-for testSuite in $(find . -name "*_test.go" -print0 | xargs -0 grep -P "type test(.*)Suite" | awk '{print $2}'); do
+for testSuite in $(find . -name "*_test.go" -print0 | xargs -0 grep -E "type test(.*)Suite" | awk '{print $2}'); do
   # TODO: ugly regex
   # TODO: check code comment
-  if ! find . -name "*_test.go" -print0 | xargs -0 grep -P "_ = (check\.)?(Suite|SerialSuites)\((&?${testSuite}{|new\(${testSuite}\))" > /dev/null
+  if ! find . -name "*_test.go" -print0 | xargs -0 grep -E "_ = (check\.)?(Suite|SerialSuites)\((&?${testSuite}{|new\(${testSuite}\))" > /dev/null
   then
-    if find . -name "*_test.go" -print0 | xargs -0 grep -P "func \((.* )?\*?${testSuite}\) Test" > /dev/null
+    if find . -name "*_test.go" -print0 | xargs -0 grep -E "func \((.* )?\*?${testSuite}\) Test" > /dev/null
     then
       echo "${testSuite} is not enabled" && exitCode=1
     fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

grep of macos dose not suppot `-P` option.
```
usage: grep [-abcDEFGHhIiJLlmnOoqRSsUVvwxZ] [-A num] [-B num] [-C[num]]
    [-e pattern] [-f file] [--binary-files=value] [--color=when]
    [--context[=num]] [--directories=action] [--label] [--line-buffered]
    [--null] [pattern] [file ...]
```

### What is changed and how it works?

Use `grep -E` for compatibility.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - None

Side effects

 - None

Related changes

 - None
