### PR TITLE
tikv: fix wasted sleep and return error in last backoff

### DIFF
--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -49,7 +49,7 @@ func (s *testRegionRequestSuite) SetUpTest(c *C) {
 	s.store, s.peer, s.region = mocktikv.BootstrapWithSingleStore(s.cluster)
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	s.cache = NewRegionCache(pdCli)
-	s.bo = NewBackoffer(context.Background(), 1)
+	s.bo = NewNoopBackoff(context.Background())
 	s.mvccStore = mocktikv.MustNewMVCCStore()
 	client := mocktikv.NewRPCClient(s.cluster, s.mvccStore)
 	s.regionRequestSender = NewRegionRequestSender(s.cache, client)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

current backoff will check `maxSleep` after sleep finish, so for example, we backoff 20s, for last backoff will sleep 3s, but the current version will return error after weakup, so last sleep is wasted?

### What is changed and how it works?

check `maxSleep` before sleep

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - Need to cherry-pick to the release branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11788)
<!-- Reviewable:end -->
