### PR TITLE
expression: make Column support hybrid types when vectorized evaluation

### DIFF
--- a/expression/builtin_vectorized.go
+++ b/expression/builtin_vectorized.go
@@ -47,7 +47,7 @@ func newLocalSliceBuffer(initCap int) *localSliceBuffer {
 	return &localSliceBuffer{buffers: make([]*chunk.Column, initCap)}
 }
 
-func (r *localSliceBuffer) newBuffer(evalType types.EvalType, capacity int) (*chunk.Column, error) {
+func newBuffer(evalType types.EvalType, capacity int) (*chunk.Column, error) {
 	switch evalType {
 	case types.ETInt:
 		return chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), capacity), nil
@@ -80,7 +80,7 @@ func (r *localSliceBuffer) get(evalType types.EvalType, capacity int) (*chunk.Co
 		return buf, nil
 	}
 	r.Unlock()
-	return r.newBuffer(evalType, capacity)
+	return newBuffer(evalType, capacity)
 }
 
 func (r *localSliceBuffer) put(buf *chunk.Column) {

--- a/expression/column.go
+++ b/expression/column.go
@@ -188,7 +188,41 @@ func (col *Column) Equal(_ sessionctx.Context, expr Expression) bool {
 
 // VecEval evaluates this expression in a vectorized manner.
 func (col *Column) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	ft := col.RetType
+	// do evaluation in a row-based manner when it's hybrid type.
+	// TODO: optimize vectorized evaluation on hybrid types.
+	switch {
+	case ft.EvalType() == types.ETInt && ft.Hybrid():
+		it := chunk.NewIterator4Chunk(input)
+		result.Reset()
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, null, err := col.EvalInt(ctx, row)
+			if err != nil {
+				return err
+			}
+			if null {
+				result.AppendNull()
+			} else {
+				result.AppendInt64(v)
+			}
+		}
+	case ft.EvalType() == types.ETString && ft.Hybrid():
+		it := chunk.NewIterator4Chunk(input)
+		result.ReserveString(input.NumRows())
+		for row := it.Begin(); row != it.End(); row = it.Next() {
+			v, null, err := col.EvalString(ctx, row)
+			if err != nil {
+				return err
+			}
+			if null {
+				result.AppendNull()
+			} else {
+				result.AppendString(v)
+			}
+		}
+	default:
+		input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	}
 	return nil
 }
 

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -14,11 +14,14 @@
 package expression
 
 import (
+	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -161,4 +164,65 @@ func (s *testEvaluatorSuite) TestIndexInfo2Cols(c *C) {
 	c.Assert(len(lengths), Equals, 2)
 	c.Assert(resCols[0].Equal(nil, col0), IsTrue)
 	c.Assert(resCols[1].Equal(nil, col1), IsTrue)
+}
+
+func (s *testEvaluatorSuite) TestColHybird(c *C) {
+	defer testleak.AfterTest(c)()
+	ctx := mock.NewContext()
+
+	// bit
+	ft := types.NewFieldType(mysql.TypeBit)
+	col := &Column{RetType: ft, Index: 0}
+	input := chunk.New([]*types.FieldType{ft}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		num, err := types.ParseBitStr(fmt.Sprintf("0b%b", i))
+		c.Assert(err, IsNil)
+		input.AppendBytes(0, num)
+	}
+	result, err := newBuffer(types.ETInt, 1024)
+	c.Assert(err, IsNil)
+	c.Assert(col.VecEval(ctx, input, result), IsNil)
+
+	it := chunk.NewIterator4Chunk(input)
+	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {
+		v, _, err := col.EvalInt(ctx, row)
+		c.Assert(err, IsNil)
+		c.Assert(v, Equals, result.GetInt64(i))
+	}
+
+	// enum
+	ft = types.NewFieldType(mysql.TypeEnum)
+	col.RetType = ft
+	input = chunk.New([]*types.FieldType{ft}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendEnum(0, types.Enum{Name: fmt.Sprintf("%v", i), Value: uint64(i)})
+	}
+	result, err = newBuffer(types.ETString, 1024)
+	c.Assert(err, IsNil)
+	c.Assert(col.VecEval(ctx, input, result), IsNil)
+
+	it = chunk.NewIterator4Chunk(input)
+	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {
+		v, _, err := col.EvalString(ctx, row)
+		c.Assert(err, IsNil)
+		c.Assert(v, Equals, result.GetString(i))
+	}
+
+	// set
+	ft = types.NewFieldType(mysql.TypeSet)
+	col.RetType = ft
+	input = chunk.New([]*types.FieldType{ft}, 1024, 1024)
+	for i := 0; i < 1024; i++ {
+		input.AppendSet(0, types.Set{Name: fmt.Sprintf("%v", i), Value: uint64(i)})
+	}
+	result, err = newBuffer(types.ETString, 1024)
+	c.Assert(err, IsNil)
+	c.Assert(col.VecEval(ctx, input, result), IsNil)
+
+	it = chunk.NewIterator4Chunk(input)
+	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {
+		v, _, err := col.EvalString(ctx, row)
+		c.Assert(err, IsNil)
+		c.Assert(v, Equals, result.GetString(i))
+	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Vectorized Column doesn't support hybrid types now, and this PR make it support these types.

### What is changed and how it works?
When evaluating hybrid types, evaluate it in a row-based manner.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test