### PR TITLE
tikv: fix wasted sleep and return error in last backoff (#11788)

### DIFF
--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -49,7 +49,7 @@ func (s *testRegionRequestSuite) SetUpTest(c *C) {
 	s.store, s.peer, s.region = mocktikv.BootstrapWithSingleStore(s.cluster)
 	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
 	s.cache = NewRegionCache(pdCli)
-	s.bo = NewBackoffer(context.Background(), 1)
+	s.bo = NewNoopBackoff(context.Background())
 	s.mvccStore = mocktikv.MustNewMVCCStore()
 	client := mocktikv.NewRPCClient(s.cluster, s.mvccStore)
 	s.regionRequestSender = NewRegionRequestSender(s.cache, client)


### PR DESCRIPTION

cherry-pick #11788 to 3.0

```
# Conflicts:
#	store/tikv/backoff.go
```
avoid last sleep but do nothing backoff

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11806)
<!-- Reviewable:end -->
