### PR TITLE
expression: introduce vectorized evaluating methods for each type individually

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -177,8 +177,32 @@ func (b *baseBuiltinFunc) getArgs() []Expression {
 	return b.args
 }
 
-func (b *baseBuiltinFunc) vecEval(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("baseBuiltinFunc.vecEval() should never be called, please contact the TiDB team for help")
+func (b *baseBuiltinFunc) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalInt() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalReal() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalString() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalDecimal() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalTime() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalDuration() should never be called, please contact the TiDB team for help")
+}
+
+func (b *baseBuiltinFunc) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("baseBuiltinFunc.vecEvalJSON() should never be called, please contact the TiDB team for help")
 }
 
 func (b *baseBuiltinFunc) evalInt(row chunk.Row) (int64, bool, error) {
@@ -294,10 +318,29 @@ func newBaseBuiltinCastFunc(builtinFunc baseBuiltinFunc, inUnion bool) baseBuilt
 type vecBuiltinFunc interface {
 	columnBufferAllocator
 
-	// vecEval evaluates this builtin function in a vectorized manner.
-	vecEval(input *chunk.Chunk, result *chunk.Column) error
 	// vectorized returns if this builtin function supports vectorized evaluation.
 	vectorized() bool
+
+	// vecEvalInt evaluates this builtin function in a vectorized manner.
+	vecEvalInt(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalReal evaluates this builtin function in a vectorized manner.
+	vecEvalReal(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalString evaluates this builtin function in a vectorized manner.
+	vecEvalString(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalDecimal evaluates this builtin function in a vectorized manner.
+	vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalTime evaluates this builtin function in a vectorized manner.
+	vecEvalTime(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalDuration evaluates this builtin function in a vectorized manner.
+	vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error
+
+	// vecEvalJSON evaluates this builtin function in a vectorized manner.
+	vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error
 }
 
 // builtinFunc stands for a particular function signature.

--- a/expression/builtin_vectorized.go
+++ b/expression/builtin_vectorized.go
@@ -105,208 +105,332 @@ func (r *localSliceBuffer) put(buf *chunk.Column) {
 // vecRowConverter is used to convert the underlying builtin function between row-based evaluation and vectorized evaluation.
 type vecRowConverter struct {
 	builtinFunc
-
-	// fields for converting vectorized evaluation to row-based evaluation.
-	buf *chunk.Column
-	sel []int
 }
 
 func newVecRowConverter(underlying builtinFunc) *vecRowConverter {
-	return &vecRowConverter{underlying, nil, nil}
-}
-
-// vecEvalRow evaluates this single row in a vectorized manner.
-func (c *vecRowConverter) vecEvalRow(evalType types.EvalType, row chunk.Row) (err error) {
-	if c.sel == nil {
-		c.sel = make([]int, 1)
-	}
-	c.sel[0] = row.Idx()
-	if c.buf == nil {
-		c.buf, err = c.builtinFunc.get(evalType, 1)
-		if err != nil {
-			return
-		}
-	}
-	input := row.Chunk()
-	sel := input.Sel()
-	input.SetSel(c.sel)
-	err = c.builtinFunc.vecEval(input, c.buf)
-	input.SetSel(sel)
-	return
+	return &vecRowConverter{underlying}
 }
 
 func (c *vecRowConverter) evalInt(row chunk.Row) (val int64, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalInt(row)
 	}
-	if err = c.vecEvalRow(types.ETInt, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetInt64(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalInt(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetInt64(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalReal(row chunk.Row) (val float64, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalReal(row)
 	}
-	if err = c.vecEvalRow(types.ETReal, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetFloat64(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalReal(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetFloat64(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalString(row chunk.Row) (val string, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalString(row)
 	}
-	if err = c.vecEvalRow(types.ETString, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetString(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalString(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetString(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalDecimal(row chunk.Row) (val *types.MyDecimal, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalDecimal(row)
 	}
-	if err = c.vecEvalRow(types.ETDecimal, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetDecimal(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalDecimal(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetDecimal(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalTime(row chunk.Row) (val types.Time, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalTime(row)
 	}
-	if err = c.vecEvalRow(types.ETDatetime, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetTime(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalTime(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetTime(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalDuration(row chunk.Row) (val types.Duration, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalDuration(row)
 	}
-	if err = c.vecEvalRow(types.ETReal, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetDuration(0, 0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalDuration(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetDuration(0, 0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
 func (c *vecRowConverter) evalJSON(row chunk.Row) (val json.BinaryJSON, isNull bool, err error) {
 	if !c.builtinFunc.vectorized() {
 		return c.builtinFunc.evalJSON(row)
 	}
-	if err = c.vecEvalRow(types.ETReal, row); err != nil {
+	var sel [1]int
+	sel[0] = row.Idx()
+	var buf *chunk.Column
+	if buf, err = c.builtinFunc.get(types.ETInt, 1); err != nil {
 		return
 	}
-	return c.buf.GetJSON(0), c.buf.IsNull(0), nil
+
+	input := row.Chunk()
+	oriSel := input.Sel()
+	input.SetSel(sel[:])
+	err = c.builtinFunc.vecEvalJSON(input, buf)
+	input.SetSel(oriSel)
+
+	val = buf.GetJSON(0)
+	isNull = buf.IsNull(0)
+	c.builtinFunc.put(buf)
+	return
 }
 
-// vecEval evaluates this builtin function in a vectorized manner.
-// If the underlying builtin function is row-based, it will be converted to vectorized.
-func (c *vecRowConverter) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+// vecEvalInt evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	if c.builtinFunc.vectorized() {
-		return c.builtinFunc.vecEval(input, result)
+		return c.builtinFunc.vecEvalInt(input, result)
 	}
-
-	// convert from row-based evaluation to vectorized evaluation.
-	// evaluate each row in input according to its row-based evaluation methods and updates the result.
 	it := chunk.NewIterator4Chunk(input)
 	row := it.Begin()
 	var isNull bool
 	var err error
-	switch c.builtinFunc.getRetTp().EvalType() {
-	case types.ETInt:
-		result.ResizeInt64(input.NumRows())
-		i64s := result.Int64s()
-		for i := range i64s {
-			if i64s[i], isNull, err = c.builtinFunc.evalInt(row); err != nil {
-				return err
-			}
-			result.SetNull(i, isNull)
-			row = it.Next()
+	result.ResizeInt64(input.NumRows())
+	i64s := result.Int64s()
+	for i := range i64s {
+		if i64s[i], isNull, err = c.builtinFunc.evalInt(row); err != nil {
+			return err
 		}
-	case types.ETReal:
-		result.ResizeFloat64(input.NumRows())
-		f64s := result.Float64s()
-		for i := range f64s {
-			if f64s[i], isNull, err = c.builtinFunc.evalReal(row); err != nil {
-				return err
-			}
-			result.SetNull(i, isNull)
-			row = it.Next()
+		result.SetNull(i, isNull)
+		row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalReal evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalReal(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ResizeFloat64(input.NumRows())
+	f64s := result.Float64s()
+	for i := range f64s {
+		if f64s[i], isNull, err = c.builtinFunc.evalReal(row); err != nil {
+			return err
 		}
-	case types.ETDecimal:
-		result.ResizeDecimal(input.NumRows())
-		ds := result.Decimals()
-		var v *types.MyDecimal
-		for i := range ds {
-			if v, isNull, err = c.builtinFunc.evalDecimal(row); err != nil {
-				return err
-			}
-			if isNull {
-				result.SetNull(i, true)
-			} else {
-				result.SetNull(i, false)
-				ds[i] = *v
-			}
-			row = it.Next()
+		result.SetNull(i, isNull)
+		row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalString evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalString(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ReserveString(input.NumRows())
+	var v string
+	for ; row != it.End(); row = it.Next() {
+		if v, isNull, err = c.builtinFunc.evalString(row); err != nil {
+			return err
 		}
-	case types.ETDuration:
-		result.ResizeDuration(input.NumRows())
-		ds := result.GoDurations()
-		var v types.Duration
-		for i := range ds {
-			if v, isNull, err = c.builtinFunc.evalDuration(row); err != nil {
-				return err
-			}
-			ds[i] = v.Duration
-			result.SetNull(i, isNull)
-			row = it.Next()
+		if isNull {
+			result.AppendNull()
+		} else {
+			result.AppendString(v)
 		}
-	case types.ETDatetime, types.ETTimestamp:
-		result.ResizeTime(input.NumRows())
-		ds := result.Times()
-		var v types.Time
-		for i := range ds {
-			if v, isNull, err = c.builtinFunc.evalTime(row); err != nil {
-				return err
-			}
-			ds[i] = v
-			result.SetNull(i, isNull)
-			row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalDecimal evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalDecimal(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ResizeDecimal(input.NumRows())
+	ds := result.Decimals()
+	var v *types.MyDecimal
+	for i := range ds {
+		if v, isNull, err = c.builtinFunc.evalDecimal(row); err != nil {
+			return err
 		}
-	case types.ETJson:
-		result.ReserveJSON(input.NumRows())
-		var v json.BinaryJSON
-		for ; row != it.End(); row = it.Next() {
-			if v, isNull, err = c.builtinFunc.evalJSON(row); err != nil {
-				return err
-			}
-			if isNull {
-				result.AppendNull()
-			} else {
-				result.AppendJSON(v)
-			}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			result.SetNull(i, false)
+			ds[i] = *v
 		}
-	case types.ETString:
-		result.ReserveString(input.NumRows())
-		var v string
-		for ; row != it.End(); row = it.Next() {
-			if v, isNull, err = c.builtinFunc.evalString(row); err != nil {
-				return err
-			}
-			if isNull {
-				result.AppendNull()
-			} else {
-				result.AppendString(v)
-			}
+		row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalTime evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalTime(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ResizeTime(input.NumRows())
+	ds := result.Times()
+	var v types.Time
+	for i := range ds {
+		if v, isNull, err = c.builtinFunc.evalTime(row); err != nil {
+			return err
 		}
-	default:
-		return errors.Errorf("unsupported type for converting from row-based to vectorized evaluation, please contact the TiDB team for help")
+		ds[i] = v
+		result.SetNull(i, isNull)
+		row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalDuration evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalDuration(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ResizeDuration(input.NumRows())
+	ds := result.GoDurations()
+	var v types.Duration
+	for i := range ds {
+		if v, isNull, err = c.builtinFunc.evalDuration(row); err != nil {
+			return err
+		}
+		ds[i] = v.Duration
+		result.SetNull(i, isNull)
+		row = it.Next()
+	}
+	return nil
+}
+
+// vecEvalJSON evaluates this builtin function in a vectorized manner.
+func (c *vecRowConverter) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	if c.builtinFunc.vectorized() {
+		return c.builtinFunc.vecEvalJSON(input, result)
+	}
+	it := chunk.NewIterator4Chunk(input)
+	row := it.Begin()
+	var isNull bool
+	var err error
+	result.ReserveJSON(input.NumRows())
+	var v json.BinaryJSON
+	for ; row != it.End(); row = it.Next() {
+		if v, isNull, err = c.builtinFunc.evalJSON(row); err != nil {
+			return err
+		}
+		if isNull {
+			result.AppendNull()
+		} else {
+			result.AppendJSON(v)
+		}
 	}
 	return nil
 }
@@ -323,7 +447,7 @@ func (c *vecRowConverter) equal(bf builtinFunc) bool {
 }
 
 func (c *vecRowConverter) Clone() builtinFunc {
-	return &vecRowConverter{c.builtinFunc.Clone(), nil, nil}
+	return &vecRowConverter{c.builtinFunc.Clone()}
 }
 
 type vecRowConvertFuncClass struct {

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -53,17 +53,17 @@ func (p *mockVecPlusIntBuiltinFunc) releaseBuf(buf *chunk.Column) {
 	}
 }
 
-func (p *mockVecPlusIntBuiltinFunc) vecEval(input *chunk.Chunk, result *chunk.Column) error {
+func (p *mockVecPlusIntBuiltinFunc) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := p.allocBuf(n)
 	if err != nil {
 		return err
 	}
 	defer p.releaseBuf(buf)
-	if err := p.args[0].VecEval(p.ctx, input, result); err != nil {
+	if err := p.args[0].VecEvalInt(p.ctx, input, result); err != nil {
 		return err
 	}
-	if err := p.args[1].VecEval(p.ctx, input, buf); err != nil {
+	if err := p.args[1].VecEvalInt(p.ctx, input, buf); err != nil {
 		return err
 	}
 	dst64s := result.Int64s()
@@ -99,14 +99,14 @@ func genMockVecPlusIntBuiltinFunc() (*mockVecPlusIntBuiltinFunc, *chunk.Chunk, *
 func (s *testEvaluatorSuite) TestMockVecPlusInt(c *C) {
 	plus, input, buf := genMockVecPlusIntBuiltinFunc()
 	plus.enableAlloc = false
-	c.Assert(plus.vecEval(input, buf), IsNil)
+	c.Assert(plus.vecEvalInt(input, buf), IsNil)
 	for i := 0; i < 1024; i++ {
 		c.Assert(buf.IsNull(i), IsFalse)
 		c.Assert(buf.GetInt64(i), Equals, int64(i*2))
 	}
 
 	plus.enableAlloc = true
-	c.Assert(plus.vecEval(input, buf), IsNil)
+	c.Assert(plus.vecEvalInt(input, buf), IsNil)
 	for i := 0; i < 1024; i++ {
 		c.Assert(buf.IsNull(i), IsFalse)
 		c.Assert(buf.GetInt64(i), Equals, int64(i*2))
@@ -122,7 +122,7 @@ func (s *testEvaluatorSuite) TestMockVecPlusIntParallel(c *C) {
 		go func() {
 			result := buf.CopyConstruct(nil)
 			for i := 0; i < 200; i++ {
-				c.Assert(plus.vecEval(input, result), IsNil)
+				c.Assert(plus.vecEvalInt(input, result), IsNil)
 				for i := 0; i < 1024; i++ {
 					c.Assert(result.IsNull(i), IsFalse)
 					c.Assert(result.GetInt64(i), Equals, int64(i*2))
@@ -163,7 +163,7 @@ func BenchmarkPlusIntBufAllocator(b *testing.B) {
 			plus.enableAlloc = enable[i]
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				if err := plus.vecEval(input, buf); err != nil {
+				if err := plus.vecEvalInt(input, buf); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -182,85 +182,115 @@ func (p *mockBuiltinDouble) vectorized() bool {
 	return p.enableVec
 }
 
-func (p *mockBuiltinDouble) vecEval(input *chunk.Chunk, result *chunk.Column) error {
-	var buf *chunk.Column
-	switch p.evalType {
-	case types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETDatetime:
-		if err := p.args[0].VecEval(p.ctx, input, result); err != nil {
-			return err
-		}
-	default:
-		var err error
-		if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
-			return err
-		}
-		if err := p.args[0].VecEval(p.ctx, input, buf); err != nil {
-			return err
-		}
+func (p *mockBuiltinDouble) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	if err := p.args[0].VecEvalInt(p.ctx, input, result); err != nil {
+		return err
 	}
+	i64s := result.Int64s()
+	for i := range i64s {
+		i64s[i] <<= 1
+	}
+	return nil
+}
 
-	switch p.evalType {
-	case types.ETInt:
-		i64s := result.Int64s()
-		for i := range i64s {
-			i64s[i] *= 2
-		}
-	case types.ETReal:
-		f64s := result.Float64s()
-		for i := range f64s {
-			f64s[i] *= 2
-		}
-	case types.ETDecimal:
-		ds := result.Decimals()
-		for i := range ds {
-			r := new(types.MyDecimal)
-			if err := types.DecimalAdd(&ds[i], &ds[i], r); err != nil {
-				return err
-			}
-			ds[i] = *r
-		}
-	case types.ETDuration:
-		ds := result.GoDurations()
-		for i := range ds {
-			ds[i] *= 2
-		}
-	case types.ETDatetime:
-		ts := result.Times()
-		for i := range ts {
-			d, err := ts[i].ConvertToDuration()
-			if err != nil {
-				return err
-			}
-			if ts[i], err = ts[i].Add(p.ctx.GetSessionVars().StmtCtx, d); err != nil {
-				return err
-			}
-		}
-	case types.ETJson:
-		result.ReserveString(input.NumRows())
-		for i := 0; i < input.NumRows(); i++ {
-			j := buf.GetJSON(i)
-			path, err := json.ParseJSONPathExpr("$.key")
-			if err != nil {
-				return err
-			}
-			ret, ok := j.Extract([]json.PathExpression{path})
-			if !ok {
-				return errors.Errorf("path not found")
-			}
-			if err := j.UnmarshalJSON([]byte(fmt.Sprintf(`{"key":%v}`, 2*ret.GetInt64()))); err != nil {
-				return err
-			}
-			result.AppendJSON(j)
-		}
-		p.baseBuiltinFunc.put(buf)
-	case types.ETString:
-		result.ReserveString(input.NumRows())
-		for i := 0; i < input.NumRows(); i++ {
-			str := buf.GetString(i)
-			result.AppendString(str + str)
-		}
-		p.baseBuiltinFunc.put(buf)
+func (p *mockBuiltinDouble) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := p.args[0].VecEvalReal(p.ctx, input, result); err != nil {
+		return err
 	}
+	f64s := result.Float64s()
+	for i := range f64s {
+		f64s[i] *= 2
+	}
+	return nil
+}
+
+func (p *mockBuiltinDouble) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	var buf *chunk.Column
+	var err error
+	if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
+		return err
+	}
+	if err := p.args[0].VecEvalString(p.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ReserveString(input.NumRows())
+	for i := 0; i < input.NumRows(); i++ {
+		str := buf.GetString(i)
+		result.AppendString(str + str)
+	}
+	p.baseBuiltinFunc.put(buf)
+	return nil
+}
+
+func (p *mockBuiltinDouble) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := p.args[0].VecEvalDecimal(p.ctx, input, result); err != nil {
+		return err
+	}
+	ds := result.Decimals()
+	for i := range ds {
+		r := new(types.MyDecimal)
+		if err := types.DecimalAdd(&ds[i], &ds[i], r); err != nil {
+			return err
+		}
+		ds[i] = *r
+	}
+	return nil
+}
+
+func (p *mockBuiltinDouble) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	if err := p.args[0].VecEvalTime(p.ctx, input, result); err != nil {
+		return err
+	}
+	ts := result.Times()
+	for i := range ts {
+		d, err := ts[i].ConvertToDuration()
+		if err != nil {
+			return err
+		}
+		if ts[i], err = ts[i].Add(p.ctx.GetSessionVars().StmtCtx, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *mockBuiltinDouble) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	if err := p.args[0].VecEvalDuration(p.ctx, input, result); err != nil {
+		return err
+	}
+	ds := result.GoDurations()
+	for i := range ds {
+		ds[i] *= 2
+	}
+	return nil
+}
+
+func (p *mockBuiltinDouble) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	var buf *chunk.Column
+	var err error
+	if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
+		return err
+	}
+	if err := p.args[0].VecEvalJSON(p.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ReserveString(input.NumRows())
+	for i := 0; i < input.NumRows(); i++ {
+		j := buf.GetJSON(i)
+		path, err := json.ParseJSONPathExpr("$.key")
+		if err != nil {
+			return err
+		}
+		ret, ok := j.Extract([]json.PathExpression{path})
+		if !ok {
+			return errors.Errorf("path not found")
+		}
+		if err := j.UnmarshalJSON([]byte(fmt.Sprintf(`{"key":%v}`, 2*ret.GetInt64()))); err != nil {
+			return err
+		}
+		result.AppendJSON(j)
+	}
+	p.baseBuiltinFunc.put(buf)
 	return nil
 }
 
@@ -466,13 +496,33 @@ func (s *testEvaluatorSuite) checkVecEval(c *C, eType types.EvalType, sel []int,
 	}
 }
 
+func vecEvalType(f builtinFunc, eType types.EvalType, input *chunk.Chunk, result *chunk.Column) error {
+	switch eType {
+	case types.ETInt:
+		return f.vecEvalInt(input, result)
+	case types.ETReal:
+		return f.vecEvalReal(input, result)
+	case types.ETDecimal:
+		return f.vecEvalDecimal(input, result)
+	case types.ETDuration:
+		return f.vecEvalDuration(input, result)
+	case types.ETString:
+		return f.vecEvalString(input, result)
+	case types.ETDatetime:
+		return f.vecEvalTime(input, result)
+	case types.ETJson:
+		return f.vecEvalJSON(input, result)
+	}
+	panic("not implement")
+}
+
 func (s *testEvaluatorSuite) TestDoubleRow2Vec(c *C) {
 	defer testleak.AfterTest(c)()
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETDuration, types.ETString, types.ETDatetime, types.ETJson}
 	for _, eType := range eTypes {
 		rowDouble, input, result, err := genMockRowDouble(eType, false)
 		c.Assert(err, IsNil)
-		c.Assert(rowDouble.vecEval(input, result), IsNil)
+		c.Assert(vecEvalType(rowDouble, eType, input, result), IsNil)
 		s.checkVecEval(c, eType, nil, result)
 
 		sel := []int{0}
@@ -485,7 +535,7 @@ func (s *testEvaluatorSuite) TestDoubleRow2Vec(c *C) {
 			sel = append(sel, end+rand.Intn(gap-1)+1)
 		}
 		input.SetSel(sel)
-		c.Assert(rowDouble.vecEval(input, result), IsNil)
+		c.Assert(vecEvalType(rowDouble, eType, input, result), IsNil)
 
 		s.checkVecEval(c, eType, sel, result)
 	}
@@ -666,8 +716,7 @@ func BenchmarkMockDoubleVec(b *testing.B) {
 			rowDouble, input, result, _ := genMockRowDouble(eType, true)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				err := rowDouble.vecEval(input, result)
-				if err != nil {
+				if err := vecEvalType(rowDouble, eType, input, result); err != nil {
 					b.Fatal(err)
 				}
 			}
@@ -683,8 +732,7 @@ func BenchmarkMockDoubleRow2Vec(b *testing.B) {
 			rowDouble, input, result, _ := genMockRowDouble(eType, false)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				err := rowDouble.vecEval(input, result)
-				if err != nil {
+				if err := vecEvalType(rowDouble, eType, input, result); err != nil {
 					b.Fatal(err)
 				}
 			}

--- a/expression/column.go
+++ b/expression/column.go
@@ -40,9 +40,39 @@ func (col *CorrelatedColumn) Clone() Expression {
 	return col
 }
 
-// VecEval evaluates this expression in a vectorized manner.
-func (col *CorrelatedColumn) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) (err error) {
-	return genVecFromConstExpr(ctx, col, input, result)
+// VecEvalInt evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETInt, input, result)
+}
+
+// VecEvalReal evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETReal, input, result)
+}
+
+// VecEvalString evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETString, input, result)
+}
+
+// VecEvalDecimal evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETDecimal, input, result)
+}
+
+// VecEvalTime evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETTimestamp, input, result)
+}
+
+// VecEvalDuration evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETDuration, input, result)
+}
+
+// VecEvalJSON evaluates this expression in a vectorized manner.
+func (col *CorrelatedColumn) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return genVecFromConstExpr(ctx, col, types.ETJson, input, result)
 }
 
 // Eval implements Expression interface.
@@ -186,13 +216,9 @@ func (col *Column) Equal(_ sessionctx.Context, expr Expression) bool {
 	return false
 }
 
-// VecEval evaluates this expression in a vectorized manner.
-func (col *Column) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	ft := col.RetType
-	// do evaluation in a row-based manner when it's hybrid type.
-	// TODO: optimize vectorized evaluation on hybrid types.
-	switch {
-	case ft.EvalType() == types.ETInt && ft.Hybrid():
+// VecEvalInt evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if col.RetType.Hybrid() {
 		it := chunk.NewIterator4Chunk(input)
 		result.Reset()
 		for row := it.Begin(); row != it.End(); row = it.Next() {
@@ -206,7 +232,21 @@ func (col *Column) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *c
 				result.AppendInt64(v)
 			}
 		}
-	case ft.EvalType() == types.ETString && ft.Hybrid():
+		return nil
+	}
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalReal evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalString evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if col.RetType.Hybrid() {
 		it := chunk.NewIterator4Chunk(input)
 		result.ReserveString(input.NumRows())
 		for row := it.Begin(); row != it.End(); row = it.Next() {
@@ -220,9 +260,33 @@ func (col *Column) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *c
 				result.AppendString(v)
 			}
 		}
-	default:
-		input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+		return nil
 	}
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalDecimal evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalTime evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalDuration evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
+	return nil
+}
+
+// VecEvalJSON evaluates this expression in a vectorized manner.
+func (col *Column) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	input.Column(col.Index).CopyReconstruct(input.Sel(), result)
 	return nil
 }
 

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -181,7 +181,7 @@ func (s *testEvaluatorSuite) TestColHybird(c *C) {
 	}
 	result, err := newBuffer(types.ETInt, 1024)
 	c.Assert(err, IsNil)
-	c.Assert(col.VecEval(ctx, input, result), IsNil)
+	c.Assert(col.VecEvalInt(ctx, input, result), IsNil)
 
 	it := chunk.NewIterator4Chunk(input)
 	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {
@@ -199,7 +199,7 @@ func (s *testEvaluatorSuite) TestColHybird(c *C) {
 	}
 	result, err = newBuffer(types.ETString, 1024)
 	c.Assert(err, IsNil)
-	c.Assert(col.VecEval(ctx, input, result), IsNil)
+	c.Assert(col.VecEvalString(ctx, input, result), IsNil)
 
 	it = chunk.NewIterator4Chunk(input)
 	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {
@@ -217,7 +217,7 @@ func (s *testEvaluatorSuite) TestColHybird(c *C) {
 	}
 	result, err = newBuffer(types.ETString, 1024)
 	c.Assert(err, IsNil)
-	c.Assert(col.VecEval(ctx, input, result), IsNil)
+	c.Assert(col.VecEvalString(ctx, input, result), IsNil)
 
 	it = chunk.NewIterator4Chunk(input)
 	for row, i := it.Begin(), 0; row != it.End(); row, i = it.Next(), i+1 {

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -88,12 +88,60 @@ func (c *Constant) GetType() *types.FieldType {
 	return c.RetType
 }
 
-// VecEval evaluates this expression in a vectorized manner.
-func (c *Constant) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+// VecEvalInt evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	if c.DeferredExpr == nil {
-		return genVecFromConstExpr(ctx, c, input, result)
+		return genVecFromConstExpr(ctx, c, types.ETInt, input, result)
 	}
-	return c.DeferredExpr.VecEval(ctx, input, result)
+	return c.DeferredExpr.VecEvalInt(ctx, input, result)
+}
+
+// VecEvalReal evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETReal, input, result)
+	}
+	return c.DeferredExpr.VecEvalReal(ctx, input, result)
+}
+
+// VecEvalString evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETString, input, result)
+	}
+	return c.DeferredExpr.VecEvalString(ctx, input, result)
+}
+
+// VecEvalDecimal evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETDecimal, input, result)
+	}
+	return c.DeferredExpr.VecEvalDecimal(ctx, input, result)
+}
+
+// VecEvalTime evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETTimestamp, input, result)
+	}
+	return c.DeferredExpr.VecEvalTime(ctx, input, result)
+}
+
+// VecEvalDuration evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETDecimal, input, result)
+	}
+	return c.DeferredExpr.VecEvalDuration(ctx, input, result)
+}
+
+// VecEvalJSON evaluates this expression in a vectorized manner.
+func (c *Constant) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	if c.DeferredExpr == nil {
+		return genVecFromConstExpr(ctx, c, types.ETJson, input, result)
+	}
+	return c.DeferredExpr.VecEvalJSON(ctx, input, result)
 }
 
 // Eval implements Expression interface.

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -435,7 +435,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		}
 		col := chunk.NewColumn(newIntFieldType(), 1024)
 		ctx := mock.NewContext()
-		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
+		c.Assert(cst.VecEvalInt(ctx, chk, col), IsNil)
 		i64s := col.Int64s()
 		c.Assert(len(i64s), Equals, 1024)
 		for _, v := range i64s {
@@ -445,7 +445,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		// fixed-length type with Sel
 		sel := []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
 		chk.SetSel(sel)
-		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
+		c.Assert(cst.VecEvalInt(ctx, chk, col), IsNil)
 		i64s = col.Int64s()
 		for i := range sel {
 			c.Assert(i64s[i], Equals, int64(2333))
@@ -464,7 +464,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		chk.SetSel(nil)
 		col := chunk.NewColumn(newStringFieldType(), 1024)
 		ctx := mock.NewContext()
-		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
+		c.Assert(cst.VecEvalString(ctx, chk, col), IsNil)
 		for i := 0; i < 1024; i++ {
 			c.Assert(col.GetString(i), Equals, "hello")
 		}
@@ -472,7 +472,7 @@ func (*testExpressionSuite) TestVectorizedConstant(c *C) {
 		// var-length type with Sel
 		sel := []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29}
 		chk.SetSel(sel)
-		c.Assert(cst.VecEval(ctx, chk, col), IsNil)
+		c.Assert(cst.VecEvalString(ctx, chk, col), IsNil)
 		for i := range sel {
 			c.Assert(col.GetString(i), Equals, "hello")
 		}

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -40,8 +40,26 @@ var EvalAstExpr func(sctx sessionctx.Context, expr ast.ExprNode) (types.Datum, e
 
 // VecExpr contains all vectorized evaluation methods.
 type VecExpr interface {
-	// VecEval evaluates this expression in a vectorized manner.
-	VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+	// VecEvalInt evaluates this expression in a vectorized manner.
+	VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalReal evaluates this expression in a vectorized manner.
+	VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalString evaluates this expression in a vectorized manner.
+	VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalDecimal evaluates this expression in a vectorized manner.
+	VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalTime evaluates this expression in a vectorized manner.
+	VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalDuration evaluates this expression in a vectorized manner.
+	VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
+
+	// VecEvalJSON evaluates this expression in a vectorized manner.
+	VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error
 }
 
 // Expression represents all scalar expression in SQL.

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -41,9 +41,39 @@ type ScalarFunction struct {
 	hashcode []byte
 }
 
-// VecEval evaluates this expression in a vectorized manner.
-func (sf *ScalarFunction) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
-	return sf.Function.vecEval(input, result)
+// VecEvalInt evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalInt(input, result)
+}
+
+// VecEvalReal evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalReal(input, result)
+}
+
+// VecEvalString evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalString(input, result)
+}
+
+// VecEvalDecimal evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalDecimal(input, result)
+}
+
+// VecEvalTime evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalTime(input, result)
+}
+
+// VecEvalDuration evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalDuration(input, result)
+}
+
+// VecEvalJSON evaluates this expression in a vectorized manner.
+func (sf *ScalarFunction) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return sf.Function.vecEvalJSON(input, result)
 }
 
 // GetArgs gets arguments of function.

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -385,7 +385,25 @@ type MockExpr struct {
 	i   interface{}
 }
 
-func (m *MockExpr) VecEval(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+func (m *MockExpr) VecEvalInt(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalReal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalString(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalDecimal(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalTime(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalDuration(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
+	return nil
+}
+func (m *MockExpr) VecEvalJSON(ctx sessionctx.Context, input *chunk.Chunk, result *chunk.Column) error {
 	return nil
 }
 

--- a/expression/vectorized.go
+++ b/expression/vectorized.go
@@ -20,10 +20,9 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
-func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, input *chunk.Chunk, result *chunk.Column) error {
+func genVecFromConstExpr(ctx sessionctx.Context, expr Expression, targetType types.EvalType, input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	tp := expr.GetType()
-	switch tp.EvalType() {
+	switch targetType {
 	case types.ETInt:
 		result.ResizeInt64(n)
 		v, isNull, err := expr.EvalInt(ctx, chunk.Row{})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When evaluating some hybrid types like `Enum`, we need to know what kind of type the user wants, but the vectorized evaluating method now doesn't include this information.
In this PR, we Introduce more vectorized evaluating methods for each type individually.

### What is changed and how it works?
1. Remove the old vectorized evaluating method `VecEval`;
2. Add more vectorized evaluating methods for each type like `VecEvalInt`, `VecEvalString`...

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
