### PR TITLE
executor: update auto_increment position when executing "show create table"

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -529,7 +529,7 @@ func (s *testSuite2) TestShowCreateTable(c *C) {
 		"KEY `IDX_EndTime` (`END_TIME`)," +
 		"KEY `IDX_RoundId` (`ROUND_ID`)," +
 		"KEY `IDX_UserId_EndTime` (`USER_ID`,`END_TIME`)" +
-		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=505488 " +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='comment_x' AUTO_INCREMENT=505488 " +
 		"PARTITION BY RANGE ( month(`end_time`) ) (" +
 		"PARTITION p1 VALUES LESS THAN (2)," +
 		"PARTITION p2 VALUES LESS THAN (3)," +
@@ -556,7 +556,7 @@ func (s *testSuite2) TestShowCreateTable(c *C) {
 			"  KEY `IDX_EndTime` (`END_TIME`),\n"+
 			"  KEY `IDX_RoundId` (`ROUND_ID`),\n"+
 			"  KEY `IDX_UserId_EndTime` (`USER_ID`,`END_TIME`)\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin AUTO_INCREMENT=505488\n"+
+			") ENGINE=InnoDB AUTO_INCREMENT=505488 DEFAULT CHARSET=utf8 COLLATE=utf8_bin COMMENT='comment_x'\n"+
 			"PARTITION BY RANGE ( month(`end_time`) ) (\n"+
 			"  PARTITION p1 VALUES LESS THAN (2),\n"+
 			"  PARTITION p2 VALUES LESS THAN (3),\n"+

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -95,7 +95,7 @@ func (s *testTableSuite) TestInfoschemaFieldValue(c *C) {
 			"  `c` int(11) NOT NULL AUTO_INCREMENT,\n" +
 			"  `d` int(11) DEFAULT NULL,\n" +
 			"  PRIMARY KEY (`c`)\n" +
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=30002"))
+			") ENGINE=InnoDB AUTO_INCREMENT=30002 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 
 	// Test auto_increment for table without auto_increment column
 	tk.MustExec("drop table if exists t")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
create table show_auto_increment (id int key auto_increment) comment 'xxx', auto_increment=4;
show create table show_auto_increment;
```
Before this PR:
```
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table               | Create Table                                                                                                                                                                                 |
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| show_auto_increment | CREATE TABLE `show_auto_increment` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=4 COMMENT='xxx' |
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

After this PR:
```
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table               | Create Table                                                                                                                                                                                 |
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| show_auto_increment | CREATE TABLE `show_auto_increment` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin COMMENT='xxx' |
+---------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

### What is changed and how it works?
Update `auto_increment` position in `ShowExec`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
