### PR TITLE
*: record query start time to session variables

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -192,7 +192,7 @@ func (a *ExecStmt) IsReadOnly(vars *variable.SessionVars) bool {
 func (a *ExecStmt) RebuildPlan(ctx context.Context) (int64, error) {
 	startTime := time.Now()
 	defer func() {
-		a.Ctx.GetSessionVars().StmtCtx.DurationCompile = time.Since(startTime)
+		a.Ctx.GetSessionVars().DurationCompile = time.Since(startTime)
 	}()
 
 	is := GetInfoSchema(a.Ctx)
@@ -522,6 +522,9 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 	// Rollback the statement change before retry it.
 	a.Ctx.StmtRollback()
 	a.Ctx.GetSessionVars().StmtCtx.ResetForRetry()
+	a.Ctx.GetSessionVars().StartTime = time.Now()
+	a.Ctx.GetSessionVars().DurationCompile = time.Duration(0)
+	a.Ctx.GetSessionVars().DurationParse = time.Duration(0)
 
 	if err = e.Open(ctx); err != nil {
 		return nil, err
@@ -624,7 +627,7 @@ func (a *ExecStmt) logAudit() {
 		audit := plugin.DeclareAuditManifest(p.Manifest)
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
-			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StmtCtx.StartTime)
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
 			audit.OnGeneralEvent(ctx, sessVars, plugin.Log, cmd)
 		}
 		return nil
@@ -642,7 +645,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 		return
 	}
 	cfg := config.GetGlobalConfig()
-	costTime := time.Since(a.Ctx.GetSessionVars().StmtCtx.StartTime)
+	costTime := time.Since(a.Ctx.GetSessionVars().StartTime)
 	threshold := time.Duration(atomic.LoadUint64(&cfg.Log.SlowThreshold)) * time.Millisecond
 	if costTime < threshold && level > zapcore.DebugLevel {
 		return
@@ -671,8 +674,8 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 			SQL:         sql,
 			Digest:      digest,
 			TimeTotal:   costTime,
-			TimeParse:   a.Ctx.GetSessionVars().StmtCtx.DurationParse,
-			TimeCompile: a.Ctx.GetSessionVars().StmtCtx.DurationCompile,
+			TimeParse:   a.Ctx.GetSessionVars().DurationParse,
+			TimeCompile: a.Ctx.GetSessionVars().DurationCompile,
 			IndexIDs:    indexIDs,
 			StatsInfos:  statsInfos,
 			CopTasks:    copTaskInfo,
@@ -687,8 +690,8 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 			SQL:         sql,
 			Digest:      digest,
 			TimeTotal:   costTime,
-			TimeParse:   a.Ctx.GetSessionVars().StmtCtx.DurationParse,
-			TimeCompile: a.Ctx.GetSessionVars().StmtCtx.DurationCompile,
+			TimeParse:   a.Ctx.GetSessionVars().DurationParse,
+			TimeCompile: a.Ctx.GetSessionVars().DurationCompile,
 			IndexIDs:    indexIDs,
 			StatsInfos:  statsInfos,
 			CopTasks:    copTaskInfo,
@@ -706,7 +709,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
 			SQL:      sql,
 			Digest:   digest,
-			Start:    a.Ctx.GetSessionVars().StmtCtx.StartTime,
+			Start:    a.Ctx.GetSessionVars().StartTime,
 			Duration: costTime,
 			Detail:   sessVars.StmtCtx.GetExecDetails(),
 			Succ:     succ,

--- a/executor/adapter_test.go
+++ b/executor/adapter_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+func (s *testSuiteP1) TestQueryTime(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	costTime := time.Since(tk.Se.GetSessionVars().StartTime)
+	c.Assert(costTime < 1*time.Second, IsTrue)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values(1), (1), (1), (1), (1)")
+	tk.MustExec("select * from t t1 join t t2 on t1.a = t2.a")
+
+	costTime = time.Since(tk.Se.GetSessionVars().StartTime)
+	c.Assert(costTime < 1*time.Second, IsTrue)
+}

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -271,7 +271,7 @@ func (e *DeallocateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 func CompileExecutePreparedStmt(ctx context.Context, sctx sessionctx.Context, ID uint32, args []types.Datum) (sqlexec.Statement, error) {
 	startTime := time.Now()
 	defer func() {
-		sctx.GetSessionVars().StmtCtx.DurationCompile = time.Since(startTime)
+		sctx.GetSessionVars().DurationCompile = time.Since(startTime)
 	}()
 	execStmt := &ast.ExecuteStmt{ExecID: ID}
 	if err := ResetContextOfStmt(sctx, execStmt); err != nil {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -76,13 +76,6 @@ type StatementContext struct {
 	// prefix in a strict way, only extract 0-9 and (+ or - in first bit).
 	CastStrToIntStrict bool
 
-	// StartTime is the query start time.
-	StartTime time.Time
-	// DurationParse is the duration of pasing SQL string to AST.
-	DurationParse time.Duration
-	// DurationCompile is the duration of compiling AST to execution plan.
-	DurationCompile time.Duration
-
 	// mu struct holds variables that change during execution.
 	mu struct {
 		sync.Mutex
@@ -420,9 +413,6 @@ func (sc *StatementContext) ResetForRetry() {
 	sc.mu.Unlock()
 	sc.TableIDs = sc.TableIDs[:0]
 	sc.IndexIDs = sc.IndexIDs[:0]
-	sc.StartTime = time.Now()
-	sc.DurationCompile = time.Duration(0)
-	sc.DurationParse = time.Duration(0)
 }
 
 // MergeExecDetails merges a single region execution details into self, used to print

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -403,13 +403,13 @@ type SessionVars struct {
 	// ReplicaRead is used for reading data from replicas, only follower is supported at this time.
 	ReplicaRead kv.ReplicaReadType
 
-	// StartTime is the query start time.
+	// StartTime is the start time of the last query.
 	StartTime time.Time
 
-	// DurationParse is the duration of pasing SQL string to AST.
+	// DurationParse is the duration of pasing SQL string to AST of the last query.
 	DurationParse time.Duration
 
-	// DurationCompile is the duration of compiling AST to execution plan.
+	// DurationCompile is the duration of compiling AST to execution plan of the last query.
 	DurationCompile time.Duration
 }
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -402,6 +402,15 @@ type SessionVars struct {
 
 	// ReplicaRead is used for reading data from replicas, only follower is supported at this time.
 	ReplicaRead kv.ReplicaReadType
+
+	// StartTime is the query start time.
+	StartTime time.Time
+
+	// DurationParse is the duration of pasing SQL string to AST.
+	DurationParse time.Duration
+
+	// DurationCompile is the duration of compiling AST to execution plan.
+	DurationCompile time.Duration
 }
 
 // ConnectionInfo present connection used by audit.


### PR DESCRIPTION
Signed-off-by: Zhang Jian <zjsariel@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

move the following 3 metrics from `StatementContext` to `SessionVars`:
* StartTime time.Time
* DurationParse time.Duration
* DurationCompile time.Duration

`StatementContext` will be reset when the physical plan is executed. All the metrics are reset.

### What is changed and how it works?

As described above.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit Test 
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
