### PR TITLE
executor: fix panic when execute change pump state

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -232,7 +232,8 @@ func (b *executorBuilder) buildCancelDDLJobs(v *plannercore.CancelDDLJobs) Execu
 
 func (b *executorBuilder) buildChange(v *plannercore.Change) Executor {
 	return &ChangeExec{
-		ChangeStmt: v.ChangeStmt,
+		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
+		ChangeStmt:   v.ChangeStmt,
 	}
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4044,6 +4044,16 @@ func (s *testSuite) TestShowTableRegion(c *C) {
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
 }
 
+func (s *testSuite) TestChangePumpAndDrainer(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	// change pump or drainer's state need connect to etcd
+	// so will meet error "URL scheme must be http, https, unix, or unixs: /tmp/tidb"
+	err := tk.ExecToErr("change pump to node_state ='paused' for node_id 'pump1'")
+	c.Assert(err, ErrorMatches, "URL scheme must be http, https, unix, or unixs.*")
+	err = tk.ExecToErr("change drainer to node_state ='paused' for node_id 'drainer1'")
+	c.Assert(err, ErrorMatches, "URL scheme must be http, https, unix, or unixs.*")
+}
+
 func testGetTableByName(c *C, ctx sessionctx.Context, db, table string) table.Table {
 	dom := domain.GetDomain(ctx)
 	// Make sure the table schema is the new schema.


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
when execute sql like change pump to node_state ='paused' for node_id 'pump1', tidb will return error connection running loop panic

### What is changed and how it works?
fix it 
cherry pick from https://github.com/pingcap/tidb/pull/11730

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test