### PR TITLE
util: Return empty string directly if the byte slice is empty

### DIFF
--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -16,6 +16,9 @@ package hack
 import (
 	"reflect"
 	"unsafe"
+
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 )
 
 // MutableString can be used as string via string(MutableString) without performance loss.
@@ -25,6 +28,7 @@ type MutableString string
 // The MutableString can be converts to string without copy.
 // Use it at your own risk.
 func String(b []byte) (s MutableString) {
+	logutil.BgLogger().Info("hack.String", zap.Binary("input", b))
 	if len(b) == 0 {
 		return ""
 	}

--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -25,6 +25,9 @@ type MutableString string
 // The MutableString can be converts to string without copy.
 // Use it at your own risk.
 func String(b []byte) MutableString {
+	if len(b) == 0 {
+		return ""
+	}
 	return *(*MutableString)(unsafe.Pointer(&b))
 }
 

--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -24,11 +24,15 @@ type MutableString string
 // String converts slice to MutableString without copy.
 // The MutableString can be converts to string without copy.
 // Use it at your own risk.
-func String(b []byte) MutableString {
+func String(b []byte) (s MutableString) {
 	if len(b) == 0 {
 		return ""
 	}
-	return *(*MutableString)(unsafe.Pointer(&b))
+	pbytes := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	pstring := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	pstring.Data = pbytes.Data
+	pstring.Len = pbytes.Len
+	return
 }
 
 // Slice converts string to slice without copy.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the input is empty, it's faster to just return an empty string.


### What is changed and how it works?

Return an empty string directly if the input is empty.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects


Related changes