### PR TITLE
planner: add AGG_TO_COP hint

### DIFF
--- a/cmd/explaintest/r/access_path_selection.result
+++ b/cmd/explaintest/r/access_path_selection.result
@@ -31,8 +31,8 @@ Projection_6	3333.33	root	test.access_path_selection.a, test.access_path_selecti
     └─TableScan_11	10000.00	cop	table:access_path_selection, range:[-inf,+inf], keep order:true, stats:pseudo
 explain select max(_tidb_rowid) from access_path_selection;
 id	count	task	operator info
-StreamAgg_13	1.00	root	funcs:max(test.access_path_selection._tidb_rowid)
-└─Limit_17	1.00	root	offset:0, count:1
-  └─TableReader_27	1.00	root	data:Limit_26
-    └─Limit_26	1.00	cop	offset:0, count:1
-      └─TableScan_25	1.25	cop	table:access_path_selection, range:[-inf,+inf], keep order:true, desc, stats:pseudo
+StreamAgg_10	1.00	root	funcs:max(test.access_path_selection._tidb_rowid)
+└─Limit_14	1.00	root	offset:0, count:1
+  └─TableReader_24	1.00	root	data:Limit_23
+    └─Limit_23	1.00	cop	offset:0, count:1
+      └─TableScan_22	1.25	cop	table:access_path_selection, range:[-inf,+inf], keep order:true, desc, stats:pseudo

--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -107,26 +107,26 @@ explain SELECT `ds`, `p1`, `p2`, `p3`, `p4`, `p5`, `p6_md5`, `p7_md5`, count(dic
 id	count	task	operator info
 Projection_7	53.00	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device
 └─Sort_8	53.00	root	test.dt.ds2:desc
-  └─HashAgg_16	53.00	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_10), firstrow(col_2), firstrow(col_11), firstrow(col_12), firstrow(col_13), firstrow(col_14), firstrow(col_15), firstrow(col_16), firstrow(col_17)
-    └─IndexLookUp_17	53.00	root	
-      ├─IndexScan_13	2650.00	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false, stats:pseudo
-      └─HashAgg_11	53.00	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds2)
-        └─Selection_15	66.25	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)
-          └─TableScan_14	2650.00	cop	table:dt, keep order:false, stats:pseudo
+  └─HashAgg_20	53.00	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_10), firstrow(col_2), firstrow(col_11), firstrow(col_12), firstrow(col_13), firstrow(col_14), firstrow(col_15), firstrow(col_16), firstrow(col_17)
+    └─IndexLookUp_21	53.00	root	
+      ├─IndexScan_17	2650.00	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false, stats:pseudo
+      └─HashAgg_12	53.00	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds2)
+        └─Selection_19	66.25	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)
+          └─TableScan_18	2650.00	cop	table:dt, keep order:false, stats:pseudo
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
 id	count	task	operator info
 Projection_13	1.00	root	test.gad.id, test.dd.id, test.gad.aid, test.gad.cm, test.dd.dic, test.dd.ip, test.dd.t, test.gad.p1, test.gad.p2, test.gad.p3, test.gad.p4, test.gad.p5, test.gad.p6_md5, test.gad.p7_md5, test.gad.ext, test.gad.t
 └─Limit_16	1.00	root	offset:0, count:2500
-  └─HashAgg_19	1.00	root	group by:test.dd.dic, test.gad.aid, funcs:firstrow(test.gad.id), firstrow(test.gad.aid), firstrow(test.gad.cm), firstrow(test.gad.p1), firstrow(test.gad.p2), firstrow(test.gad.p3), firstrow(test.gad.p4), firstrow(test.gad.p5), firstrow(test.gad.p6_md5), firstrow(test.gad.p7_md5), firstrow(test.gad.ext), firstrow(test.gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)
-    └─IndexMergeJoin_30	0.00	root	inner join, inner:IndexLookUp_28, outer key:test.gad.aid, inner key:test.dd.aid, other cond:eq(test.dd.ip, test.gad.ip), gt(test.dd.t, test.gad.t)
-      ├─IndexLookUp_28	0.00	root	
-      │ ├─IndexScan_25	10.00	cop	table:dd, index:aid, dic, range: decided by [eq(test.dd.aid, test.gad.aid)], keep order:true, stats:pseudo
-      │ └─Selection_27	0.00	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
-      │   └─TableScan_26	10.00	cop	table:dd, keep order:false, stats:pseudo
-      └─IndexLookUp_39	3.33	root	
-        ├─IndexScan_36	3333.33	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false, stats:pseudo
-        └─Selection_38	3.33	cop	eq(test.gad.pt, "android"), not(isnull(test.gad.ip))
-          └─TableScan_37	3333.33	cop	table:gad, keep order:false, stats:pseudo
+  └─HashAgg_17	1.00	root	group by:test.dd.dic, test.gad.aid, funcs:firstrow(test.gad.id), firstrow(test.gad.aid), firstrow(test.gad.cm), firstrow(test.gad.p1), firstrow(test.gad.p2), firstrow(test.gad.p3), firstrow(test.gad.p4), firstrow(test.gad.p5), firstrow(test.gad.p6_md5), firstrow(test.gad.p7_md5), firstrow(test.gad.ext), firstrow(test.gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)
+    └─IndexMergeJoin_28	0.00	root	inner join, inner:IndexLookUp_26, outer key:test.gad.aid, inner key:test.dd.aid, other cond:eq(test.dd.ip, test.gad.ip), gt(test.dd.t, test.gad.t)
+      ├─IndexLookUp_26	0.00	root	
+      │ ├─IndexScan_23	10.00	cop	table:dd, index:aid, dic, range: decided by [eq(test.dd.aid, test.gad.aid)], keep order:true, stats:pseudo
+      │ └─Selection_25	0.00	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
+      │   └─TableScan_24	10.00	cop	table:dd, keep order:false, stats:pseudo
+      └─IndexLookUp_37	3.33	root	
+        ├─IndexScan_34	3333.33	cop	table:gad, index:t, range:(1478143908,+inf], keep order:false, stats:pseudo
+        └─Selection_36	3.33	cop	eq(test.gad.pt, "android"), not(isnull(test.gad.ip))
+          └─TableScan_35	3333.33	cop	table:gad, keep order:false, stats:pseudo
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	count	task	operator info
 Projection_10	0.00	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, test.sdk.dic, test.sdk.ip, test.sdk.t, test.gad.p1, test.gad.p2, test.gad.p3, test.gad.p4, test.gad.p5, test.gad.p6_md5, test.gad.p7_md5, test.gad.ext
@@ -143,7 +143,7 @@ Projection_10	0.00	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, tes
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	count	task	operator info
 Projection_5	1.00	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1
-└─HashAgg_7	1.00	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)
+└─HashAgg_6	1.00	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)
   └─IndexLookUp_15	0.00	root	
     ├─IndexScan_12	250.00	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false, stats:pseudo
     └─Selection_14	0.00	cop	eq(test.st.aid, "cn.sbkcq"), eq(test.st.pt, "android")
@@ -163,11 +163,11 @@ Projection_10	0.00	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test.d
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	count	task	operator info
 Projection_5	1.00	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2
-└─HashAgg_7	1.00	root	group by:test.pp.cr, test.pp.pc, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)
-  └─IndexLookUp_21	0.00	root	
-    ├─IndexScan_18	0.40	cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false, stats:pseudo
-    └─Selection_20	0.00	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)
-      └─TableScan_19	0.40	cop	table:pp, keep order:false, stats:pseudo
+└─HashAgg_6	1.00	root	group by:test.pp.cr, test.pp.pc, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)
+  └─IndexLookUp_23	0.00	root	
+    ├─IndexScan_20	0.40	cop	table:pp, index:uid, pi, range:[18089709 510017,18089709 510017], [18089709 520017,18089709 520017], [18090780 510017,18090780 510017], [18090780 520017,18090780 520017], keep order:false, stats:pseudo
+    └─Selection_22	0.00	cop	eq(test.pp.ps, 2), ge(test.pp.ppt, 1478188800), lt(test.pp.ppt, 1478275200)
+      └─TableScan_21	0.40	cop	table:pp, keep order:false, stats:pseudo
 CREATE TABLE `tbl_001` (`a` int, `b` int);
 CREATE TABLE `tbl_002` (`a` int, `b` int);
 CREATE TABLE `tbl_003` (`a` int, `b` int);
@@ -179,27 +179,27 @@ CREATE TABLE `tbl_008` (`a` int, `b` int);
 CREATE TABLE `tbl_009` (`a` int, `b` int);
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	count	task	operator info
-HashAgg_34	72000.00	root	group by:col_1, funcs:sum(col_0)
-└─Projection_63	90000.00	root	cast(x.a), x.b
-  └─Union_35	90000.00	root	
-    ├─TableReader_38	10000.00	root	data:TableScan_37
-    │ └─TableScan_37	10000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_41	10000.00	root	data:TableScan_40
-    │ └─TableScan_40	10000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_44	10000.00	root	data:TableScan_43
-    │ └─TableScan_43	10000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_47	10000.00	root	data:TableScan_46
-    │ └─TableScan_46	10000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_50	10000.00	root	data:TableScan_49
-    │ └─TableScan_49	10000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_53	10000.00	root	data:TableScan_52
-    │ └─TableScan_52	10000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_56	10000.00	root	data:TableScan_55
-    │ └─TableScan_55	10000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false, stats:pseudo
-    ├─TableReader_59	10000.00	root	data:TableScan_58
-    │ └─TableScan_58	10000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false, stats:pseudo
-    └─TableReader_62	10000.00	root	data:TableScan_61
-      └─TableScan_61	10000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false, stats:pseudo
+HashAgg_32	72000.00	root	group by:col_1, funcs:sum(col_0)
+└─Projection_61	90000.00	root	cast(x.a), x.b
+  └─Union_33	90000.00	root	
+    ├─TableReader_36	10000.00	root	data:TableScan_35
+    │ └─TableScan_35	10000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_39	10000.00	root	data:TableScan_38
+    │ └─TableScan_38	10000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_42	10000.00	root	data:TableScan_41
+    │ └─TableScan_41	10000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_45	10000.00	root	data:TableScan_44
+    │ └─TableScan_44	10000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_48	10000.00	root	data:TableScan_47
+    │ └─TableScan_47	10000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_51	10000.00	root	data:TableScan_50
+    │ └─TableScan_50	10000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_54	10000.00	root	data:TableScan_53
+    │ └─TableScan_53	10000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false, stats:pseudo
+    ├─TableReader_57	10000.00	root	data:TableScan_56
+    │ └─TableScan_56	10000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_60	10000.00	root	data:TableScan_59
+      └─TableScan_59	10000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false, stats:pseudo
 CREATE TABLE org_department (
 id int(11) NOT NULL AUTO_INCREMENT,
 ctx int(11) DEFAULT '0' COMMENT 'organization id',
@@ -243,19 +243,19 @@ UNIQUE KEY org_employee_position_pk (hotel_id,user_id,position_id)
 explain SELECT d.id, d.ctx, d.name, d.left_value, d.right_value, d.depth, d.leader_id, d.status, d.created_on, d.updated_on FROM org_department AS d LEFT JOIN org_position AS p ON p.department_id = d.id AND p.status = 1000 LEFT JOIN org_employee_position AS ep ON ep.position_id = p.id AND ep.status = 1000 WHERE (d.ctx = 1 AND (ep.user_id = 62 OR d.id = 20 OR d.id = 20) AND d.status = 1000) GROUP BY d.id ORDER BY d.left_value;
 id	count	task	operator info
 Sort_10	1.00	root	test.d.left_value:asc
-└─HashAgg_15	1.00	root	group by:test.d.id, funcs:firstrow(test.d.id), firstrow(test.d.ctx), firstrow(test.d.name), firstrow(test.d.left_value), firstrow(test.d.right_value), firstrow(test.d.depth), firstrow(test.d.leader_id), firstrow(test.d.status), firstrow(test.d.created_on), firstrow(test.d.updated_on)
-  └─Selection_22	0.01	root	or(eq(test.ep.user_id, 62), or(eq(test.d.id, 20), eq(test.d.id, 20)))
-    └─HashLeftJoin_23	0.02	root	left outer join, inner:TableReader_64, equal:[eq(test.p.id, test.ep.position_id)]
-      ├─IndexMergeJoin_39	0.01	root	left outer join, inner:IndexLookUp_37, outer key:test.d.id, inner key:test.p.department_id
-      │ ├─IndexLookUp_54	0.01	root	
-      │ │ ├─IndexScan_51	10.00	cop	table:d, index:ctx, range:[1,1], keep order:false, stats:pseudo
-      │ │ └─Selection_53	0.01	cop	eq(test.d.status, 1000)
-      │ │   └─TableScan_52	10.00	cop	table:d, keep order:false, stats:pseudo
-      │ └─IndexLookUp_37	0.01	root	
-      │   ├─Selection_35	9.99	cop	not(isnull(test.p.department_id))
-      │   │ └─IndexScan_33	10.00	cop	table:p, index:department_id, range: decided by [eq(test.p.department_id, test.d.id)], keep order:true, stats:pseudo
-      │   └─Selection_36	0.01	cop	eq(test.p.status, 1000)
-      │     └─TableScan_34	9.99	cop	table:p, keep order:false, stats:pseudo
-      └─TableReader_64	9.99	root	data:Selection_63
-        └─Selection_63	9.99	cop	eq(test.ep.status, 1000), not(isnull(test.ep.position_id))
-          └─TableScan_62	10000.00	cop	table:ep, range:[-inf,+inf], keep order:false, stats:pseudo
+└─HashAgg_13	1.00	root	group by:test.d.id, funcs:firstrow(test.d.id), firstrow(test.d.ctx), firstrow(test.d.name), firstrow(test.d.left_value), firstrow(test.d.right_value), firstrow(test.d.depth), firstrow(test.d.leader_id), firstrow(test.d.status), firstrow(test.d.created_on), firstrow(test.d.updated_on)
+  └─Selection_17	0.01	root	or(eq(test.ep.user_id, 62), or(eq(test.d.id, 20), eq(test.d.id, 20)))
+    └─HashLeftJoin_18	0.02	root	left outer join, inner:TableReader_59, equal:[eq(test.p.id, test.ep.position_id)]
+      ├─IndexMergeJoin_34	0.01	root	left outer join, inner:IndexLookUp_32, outer key:test.d.id, inner key:test.p.department_id
+      │ ├─IndexLookUp_49	0.01	root	
+      │ │ ├─IndexScan_46	10.00	cop	table:d, index:ctx, range:[1,1], keep order:false, stats:pseudo
+      │ │ └─Selection_48	0.01	cop	eq(test.d.status, 1000)
+      │ │   └─TableScan_47	10.00	cop	table:d, keep order:false, stats:pseudo
+      │ └─IndexLookUp_32	0.01	root	
+      │   ├─Selection_30	9.99	cop	not(isnull(test.p.department_id))
+      │   │ └─IndexScan_28	10.00	cop	table:p, index:department_id, range: decided by [eq(test.p.department_id, test.d.id)], keep order:true, stats:pseudo
+      │   └─Selection_31	0.01	cop	eq(test.p.status, 1000)
+      │     └─TableScan_29	9.99	cop	table:p, keep order:false, stats:pseudo
+      └─TableReader_59	9.99	root	data:Selection_58
+        └─Selection_58	9.99	cop	eq(test.ep.status, 1000), not(isnull(test.ep.position_id))
+          └─TableScan_57	10000.00	cop	table:ep, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -117,25 +117,25 @@ explain SELECT ds, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(dic) as install_dev
 id	count	task	operator info
 Projection_7	21.53	root	test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, install_device
 └─Sort_8	21.53	root	test.dt.ds2:desc
-  └─HashAgg_16	21.53	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_10), firstrow(col_2), firstrow(col_11), firstrow(col_12), firstrow(col_13), firstrow(col_14), firstrow(col_15), firstrow(col_16), firstrow(col_17)
-    └─IndexLookUp_17	21.53	root	
-      ├─IndexScan_13	128.32	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false
-      └─HashAgg_11	21.53	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds2)
-        └─Selection_15	21.56	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)
-          └─TableScan_14	128.32	cop	table:dt, keep order:false
+  └─HashAgg_20	21.53	root	group by:col_10, col_11, col_12, col_13, col_14, col_15, col_16, col_17, funcs:count(col_0), firstrow(col_10), firstrow(col_2), firstrow(col_11), firstrow(col_12), firstrow(col_13), firstrow(col_14), firstrow(col_15), firstrow(col_16), firstrow(col_17)
+    └─IndexLookUp_21	21.53	root	
+      ├─IndexScan_17	128.32	cop	table:dt, index:cm, range:[1062,1062], [1086,1086], [1423,1423], [1424,1424], [1425,1425], [1426,1426], [1427,1427], [1428,1428], [1429,1429], [1430,1430], [1431,1431], [1432,1432], [1433,1433], [1434,1434], [1435,1435], [1436,1436], [1437,1437], [1438,1438], [1439,1439], [1440,1440], [1441,1441], [1442,1442], [1443,1443], [1444,1444], [1445,1445], [1446,1446], [1447,1447], [1448,1448], [1449,1449], [1450,1450], [1451,1451], [1452,1452], [1488,1488], [1489,1489], [1490,1490], [1491,1491], [1492,1492], [1493,1493], [1494,1494], [1495,1495], [1496,1496], [1497,1497], [1550,1550], [1551,1551], [1552,1552], [1553,1553], [1554,1554], [1555,1555], [1556,1556], [1557,1557], [1558,1558], [1559,1559], [1597,1597], [1598,1598], [1599,1599], [1600,1600], [1601,1601], [1602,1602], [1603,1603], [1604,1604], [1605,1605], [1606,1606], [1607,1607], [1608,1608], [1609,1609], [1610,1610], [1611,1611], [1612,1612], [1613,1613], [1614,1614], [1615,1615], [1616,1616], [1623,1623], [1624,1624], [1625,1625], [1626,1626], [1627,1627], [1628,1628], [1629,1629], [1630,1630], [1631,1631], [1632,1632], [1709,1709], [1719,1719], [1720,1720], [1843,1843], [2813,2813], [2814,2814], [2815,2815], [2816,2816], [2817,2817], [2818,2818], [2819,2819], [2820,2820], [2821,2821], [2822,2822], [2823,2823], [2824,2824], [2825,2825], [2826,2826], [2827,2827], [2828,2828], [2829,2829], [2830,2830], [2831,2831], [2832,2832], [2833,2833], [2834,2834], [2835,2835], [2836,2836], [2837,2837], [2838,2838], [2839,2839], [2840,2840], [2841,2841], [2842,2842], [2843,2843], [2844,2844], [2845,2845], [2846,2846], [2847,2847], [2848,2848], [2849,2849], [2850,2850], [2851,2851], [2852,2852], [2853,2853], [2854,2854], [2855,2855], [2856,2856], [2857,2857], [2858,2858], [2859,2859], [2860,2860], [2861,2861], [2862,2862], [2863,2863], [2864,2864], [2865,2865], [2866,2866], [2867,2867], [2868,2868], [2869,2869], [2870,2870], [2871,2871], [2872,2872], [3139,3139], [3140,3140], [3141,3141], [3142,3142], [3143,3143], [3144,3144], [3145,3145], [3146,3146], [3147,3147], [3148,3148], [3149,3149], [3150,3150], [3151,3151], [3152,3152], [3153,3153], [3154,3154], [3155,3155], [3156,3156], [3157,3157], [3158,3158], [3386,3386], [3387,3387], [3388,3388], [3389,3389], [3390,3390], [3391,3391], [3392,3392], [3393,3393], [3394,3394], [3395,3395], [3664,3664], [3665,3665], [3666,3666], [3667,3667], [3668,3668], [3670,3670], [3671,3671], [3672,3672], [3673,3673], [3674,3674], [3676,3676], [3677,3677], [3678,3678], [3679,3679], [3680,3680], [3681,3681], [3682,3682], [3683,3683], [3684,3684], [3685,3685], [3686,3686], [3687,3687], [3688,3688], [3689,3689], [3690,3690], [3691,3691], [3692,3692], [3693,3693], [3694,3694], [3695,3695], [3696,3696], [3697,3697], [3698,3698], [3699,3699], [3700,3700], [3701,3701], [3702,3702], [3703,3703], [3704,3704], [3705,3705], [3706,3706], [3707,3707], [3708,3708], [3709,3709], [3710,3710], [3711,3711], [3712,3712], [3713,3713], [3714,3714], [3715,3715], [3960,3960], [3961,3961], [3962,3962], [3963,3963], [3964,3964], [3965,3965], [3966,3966], [3967,3967], [3968,3968], [3978,3978], [3979,3979], [3980,3980], [3981,3981], [3982,3982], [3983,3983], [3984,3984], [3985,3985], [3986,3986], [3987,3987], [4208,4208], [4209,4209], [4210,4210], [4211,4211], [4212,4212], [4304,4304], [4305,4305], [4306,4306], [4307,4307], [4308,4308], [4866,4866], [4867,4867], [4868,4868], [4869,4869], [4870,4870], [4871,4871], [4872,4872], [4873,4873], [4874,4874], [4875,4875], keep order:false
+      └─HashAgg_12	21.53	cop	group by:test.dt.ds, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5, funcs:count(test.dt.dic), firstrow(test.dt.ds2)
+        └─Selection_19	21.56	cop	ge(test.dt.ds, 2016-09-01 00:00:00.000000), le(test.dt.ds, 2016-11-03 00:00:00.000000)
+          └─TableScan_18	128.32	cop	table:dt, keep order:false
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext, gad.t as gtime from st gad join (select id, aid, pt, dic, ip, t from dd where pt = 'android' and bm = 0 and t > 1478143908) sdk on  gad.aid = sdk.aid and gad.ip = sdk.ip and sdk.t > gad.t where gad.t > 1478143908 and gad.bm = 0 and gad.pt = 'android' group by gad.aid, sdk.dic limit 2500;
 id	count	task	operator info
 Projection_13	424.00	root	test.gad.id, test.dd.id, test.gad.aid, test.gad.cm, test.dd.dic, test.dd.ip, test.dd.t, test.gad.p1, test.gad.p2, test.gad.p3, test.gad.p4, test.gad.p5, test.gad.p6_md5, test.gad.p7_md5, test.gad.ext, test.gad.t
 └─Limit_16	424.00	root	offset:0, count:2500
-  └─HashAgg_19	424.00	root	group by:test.dd.dic, test.gad.aid, funcs:firstrow(test.gad.id), firstrow(test.gad.aid), firstrow(test.gad.cm), firstrow(test.gad.p1), firstrow(test.gad.p2), firstrow(test.gad.p3), firstrow(test.gad.p4), firstrow(test.gad.p5), firstrow(test.gad.p6_md5), firstrow(test.gad.p7_md5), firstrow(test.gad.ext), firstrow(test.gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)
-    └─IndexMergeJoin_30	424.00	root	inner join, inner:IndexLookUp_28, outer key:test.gad.aid, inner key:test.dd.aid, other cond:eq(test.gad.ip, test.dd.ip), gt(test.dd.t, test.gad.t)
-      ├─TableReader_35	424.00	root	data:Selection_34
-      │ └─Selection_34	424.00	cop	eq(test.gad.bm, 0), eq(test.gad.pt, "android"), gt(test.gad.t, 1478143908), not(isnull(test.gad.ip))
-      │   └─TableScan_33	1999.00	cop	table:gad, range:[0,+inf], keep order:false
-      └─IndexLookUp_28	0.23	root	
-        ├─IndexScan_25	1.00	cop	table:dd, index:aid, dic, range: decided by [eq(test.dd.aid, test.gad.aid)], keep order:true
-        └─Selection_27	0.23	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
-          └─TableScan_26	1.00	cop	table:dd, keep order:false
+  └─HashAgg_17	424.00	root	group by:test.dd.dic, test.gad.aid, funcs:firstrow(test.gad.id), firstrow(test.gad.aid), firstrow(test.gad.cm), firstrow(test.gad.p1), firstrow(test.gad.p2), firstrow(test.gad.p3), firstrow(test.gad.p4), firstrow(test.gad.p5), firstrow(test.gad.p6_md5), firstrow(test.gad.p7_md5), firstrow(test.gad.ext), firstrow(test.gad.t), firstrow(test.dd.id), firstrow(test.dd.dic), firstrow(test.dd.ip), firstrow(test.dd.t)
+    └─IndexMergeJoin_28	424.00	root	inner join, inner:IndexLookUp_26, outer key:test.gad.aid, inner key:test.dd.aid, other cond:eq(test.gad.ip, test.dd.ip), gt(test.dd.t, test.gad.t)
+      ├─TableReader_33	424.00	root	data:Selection_32
+      │ └─Selection_32	424.00	cop	eq(test.gad.bm, 0), eq(test.gad.pt, "android"), gt(test.gad.t, 1478143908), not(isnull(test.gad.ip))
+      │   └─TableScan_31	1999.00	cop	table:gad, range:[0,+inf], keep order:false
+      └─IndexLookUp_26	0.23	root	
+        ├─IndexScan_23	1.00	cop	table:dd, index:aid, dic, range: decided by [eq(test.dd.aid, test.gad.aid)], keep order:true
+        └─Selection_25	0.23	cop	eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
+          └─TableScan_24	1.00	cop	table:dd, keep order:false
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	count	task	operator info
 Projection_10	170.34	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, test.sdk.dic, test.sdk.ip, test.sdk.t, test.gad.p1, test.gad.p2, test.gad.p3, test.gad.p4, test.gad.p5, test.gad.p6_md5, test.gad.p7_md5, test.gad.ext
@@ -151,7 +151,7 @@ Projection_10	170.34	root	test.gad.id, test.sdk.id, test.gad.aid, test.gad.cm, t
 explain SELECT cm, p1, p2, p3, p4, p5, p6_md5, p7_md5, count(1) as click_pv, count(DISTINCT ip) as click_ip FROM st WHERE (t between 1478188800 and 1478275200) and aid='cn.sbkcq' and pt='android' GROUP BY cm, p1, p2, p3, p4, p5, p6_md5, p7_md5;
 id	count	task	operator info
 Projection_5	39.28	root	test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, 3_col_0, 3_col_1
-└─HashAgg_7	39.28	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)
+└─HashAgg_6	39.28	root	group by:test.st.cm, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, funcs:count(1), count(distinct test.st.ip), firstrow(test.st.cm), firstrow(test.st.p1), firstrow(test.st.p2), firstrow(test.st.p3), firstrow(test.st.p4), firstrow(test.st.p5), firstrow(test.st.p6_md5), firstrow(test.st.p7_md5)
   └─IndexLookUp_15	39.38	root	
     ├─IndexScan_12	160.23	cop	table:st, index:t, range:[1478188800,1478275200], keep order:false
     └─Selection_14	39.38	cop	eq(test.st.aid, "cn.sbkcq"), eq(test.st.pt, "android")
@@ -171,11 +171,11 @@ Projection_10	428.32	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	count	task	operator info
 Projection_5	207.86	root	test.pp.pc, test.pp.cr, 3_col_0, 3_col_1, 3_col_2
-└─HashAgg_7	207.86	root	group by:test.pp.cr, test.pp.pc, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)
-  └─IndexLookUp_21	207.86	root	
-    ├─IndexScan_15	627.00	cop	table:pp, index:ps, range:[2,2], keep order:false
-    └─Selection_17	207.86	cop	ge(test.pp.ppt, 1478188800), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780), lt(test.pp.ppt, 1478275200)
-      └─TableScan_16	627.00	cop	table:pp, keep order:false
+└─HashAgg_6	207.86	root	group by:test.pp.cr, test.pp.pc, funcs:count(distinct test.pp.uid), count(test.pp.oid), sum(test.pp.am), firstrow(test.pp.pc), firstrow(test.pp.cr)
+  └─IndexLookUp_19	207.86	root	
+    ├─IndexScan_16	627.00	cop	table:pp, index:ps, range:[2,2], keep order:false
+    └─Selection_18	207.86	cop	ge(test.pp.ppt, 1478188800), in(test.pp.pi, 510017, 520017), in(test.pp.uid, 18089709, 18090780), lt(test.pp.ppt, 1478275200)
+      └─TableScan_17	627.00	cop	table:pp, keep order:false
 drop table if exists tbl_001;
 CREATE TABLE tbl_001 (a int, b int);
 load stats 's/explain_complex_stats_tbl_001.json';
@@ -205,24 +205,24 @@ CREATE TABLE tbl_009 (a int, b int);
 load stats 's/explain_complex_stats_tbl_009.json';
 explain select sum(a) from (select * from tbl_001 union all select * from tbl_002 union all select * from tbl_003 union all select * from tbl_004 union all select * from tbl_005 union all select * from tbl_006 union all select * from tbl_007 union all select * from tbl_008 union all select * from tbl_009) x group by b;
 id	count	task	operator info
-HashAgg_34	18000.00	root	group by:col_1, funcs:sum(col_0)
-└─Projection_63	18000.00	root	cast(x.a), x.b
-  └─Union_35	18000.00	root	
-    ├─TableReader_38	2000.00	root	data:TableScan_37
-    │ └─TableScan_37	2000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false
-    ├─TableReader_41	2000.00	root	data:TableScan_40
-    │ └─TableScan_40	2000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false
-    ├─TableReader_44	2000.00	root	data:TableScan_43
-    │ └─TableScan_43	2000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false
-    ├─TableReader_47	2000.00	root	data:TableScan_46
-    │ └─TableScan_46	2000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false
-    ├─TableReader_50	2000.00	root	data:TableScan_49
-    │ └─TableScan_49	2000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false
-    ├─TableReader_53	2000.00	root	data:TableScan_52
-    │ └─TableScan_52	2000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false
-    ├─TableReader_56	2000.00	root	data:TableScan_55
-    │ └─TableScan_55	2000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false
-    ├─TableReader_59	2000.00	root	data:TableScan_58
-    │ └─TableScan_58	2000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false
-    └─TableReader_62	2000.00	root	data:TableScan_61
-      └─TableScan_61	2000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false
+HashAgg_32	18000.00	root	group by:col_1, funcs:sum(col_0)
+└─Projection_61	18000.00	root	cast(x.a), x.b
+  └─Union_33	18000.00	root	
+    ├─TableReader_36	2000.00	root	data:TableScan_35
+    │ └─TableScan_35	2000.00	cop	table:tbl_001, range:[-inf,+inf], keep order:false
+    ├─TableReader_39	2000.00	root	data:TableScan_38
+    │ └─TableScan_38	2000.00	cop	table:tbl_002, range:[-inf,+inf], keep order:false
+    ├─TableReader_42	2000.00	root	data:TableScan_41
+    │ └─TableScan_41	2000.00	cop	table:tbl_003, range:[-inf,+inf], keep order:false
+    ├─TableReader_45	2000.00	root	data:TableScan_44
+    │ └─TableScan_44	2000.00	cop	table:tbl_004, range:[-inf,+inf], keep order:false
+    ├─TableReader_48	2000.00	root	data:TableScan_47
+    │ └─TableScan_47	2000.00	cop	table:tbl_005, range:[-inf,+inf], keep order:false
+    ├─TableReader_51	2000.00	root	data:TableScan_50
+    │ └─TableScan_50	2000.00	cop	table:tbl_006, range:[-inf,+inf], keep order:false
+    ├─TableReader_54	2000.00	root	data:TableScan_53
+    │ └─TableScan_53	2000.00	cop	table:tbl_007, range:[-inf,+inf], keep order:false
+    ├─TableReader_57	2000.00	root	data:TableScan_56
+    │ └─TableScan_56	2000.00	cop	table:tbl_008, range:[-inf,+inf], keep order:false
+    └─TableReader_60	2000.00	root	data:TableScan_59
+      └─TableScan_59	2000.00	cop	table:tbl_009, range:[-inf,+inf], keep order:false

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -12,14 +12,14 @@ set @@session.tidb_hashagg_final_concurrency = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
 id	count	task	operator info
 Projection_11	8000.00	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d
-└─HashLeftJoin_12	8000.00	root	semi join, inner:StreamAgg_27, equal:[eq(cast(test.t3.a), sel_agg_1)]
+└─HashLeftJoin_12	8000.00	root	semi join, inner:StreamAgg_29, equal:[eq(cast(test.t3.a), sel_agg_1)]
   ├─Projection_13	10000.00	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)
   │ └─TableReader_15	10000.00	root	data:TableScan_14
   │   └─TableScan_14	10000.00	cop	table:t3, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_27	1.00	root	funcs:sum(col_0)
-    └─TableReader_28	1.00	root	data:StreamAgg_19
-      └─StreamAgg_19	1.00	cop	funcs:sum(test.s.a)
-        └─TableScan_26	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─StreamAgg_29	1.00	root	funcs:sum(col_0)
+    └─TableReader_30	1.00	root	data:StreamAgg_20
+      └─StreamAgg_20	1.00	cop	funcs:sum(test.s.a)
+        └─TableScan_28	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select * from t1;
 id	count	task	operator info
 TableReader_5	10000.00	root	data:TableScan_4
@@ -61,14 +61,14 @@ IndexLookUp_9	10.00	root
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	count	task	operator info
 Projection_11	9990.00	root	cast(join_agg_0)
-└─HashLeftJoin_19	9990.00	root	inner join, inner:HashAgg_26, equal:[eq(test.a.c1, test.b.c2)]
+└─HashLeftJoin_19	9990.00	root	inner join, inner:HashAgg_29, equal:[eq(test.a.c1, test.b.c2)]
   ├─TableReader_32	10000.00	root	data:TableScan_31
   │ └─TableScan_31	10000.00	cop	table:a, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─HashAgg_26	7992.00	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
-    └─TableReader_27	7992.00	root	data:HashAgg_21
-      └─HashAgg_21	7992.00	cop	group by:test.b.c2, funcs:count(test.b.c2)
-        └─Selection_25	9990.00	cop	not(isnull(test.b.c2))
-          └─TableScan_24	10000.00	cop	table:b, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_29	7992.00	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
+    └─TableReader_30	7992.00	root	data:HashAgg_22
+      └─HashAgg_22	7992.00	cop	group by:test.b.c2, funcs:count(test.b.c2)
+        └─Selection_28	9990.00	cop	not(isnull(test.b.c2))
+          └─TableScan_27	10000.00	cop	table:b, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	count	task	operator info
 TopN_7	1.00	root	test.t2.c2:asc, offset:0, count:1
@@ -88,24 +88,24 @@ TableReader_7	0.33	root	data:Selection_6
   └─TableScan_5	1.00	cop	table:t1, range:[1,1], keep order:false, stats:pseudo
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(col_0)
-└─Projection_19	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_18	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
-    ├─TableReader_15	10000.00	root	data:TableScan_14
-    │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-    └─TableReader_17	10000.00	root	data:TableScan_16
-      └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_9	1.00	root	funcs:sum(col_0)
+└─Projection_16	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_15	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_14, other cond:eq(test.t1.c1, test.t2.c1)
+    ├─TableReader_12	10000.00	root	data:TableScan_11
+    │ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_14	10000.00	root	data:TableScan_13
+      └─TableScan_13	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	count	task	operator info
 Projection_9	9990.00	root	test.t1.c1
-└─HashLeftJoin_17	9990.00	root	inner join, inner:HashAgg_24, equal:[eq(test.t1.c1, test.t2.c2)]
+└─HashLeftJoin_17	9990.00	root	inner join, inner:HashAgg_27, equal:[eq(test.t1.c1, test.t2.c2)]
   ├─TableReader_30	10000.00	root	data:TableScan_29
   │ └─TableScan_29	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─HashAgg_24	7992.00	root	group by:col_1, funcs:firstrow(col_1)
-    └─TableReader_25	7992.00	root	data:HashAgg_19
-      └─HashAgg_19	7992.00	cop	group by:test.t2.c2, 
-        └─Selection_23	9990.00	cop	not(isnull(test.t2.c2))
-          └─TableScan_22	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_27	7992.00	root	group by:col_1, funcs:firstrow(col_1)
+    └─TableReader_28	7992.00	root	data:HashAgg_20
+      └─HashAgg_20	7992.00	cop	group by:test.t2.c2, 
+        └─Selection_26	9990.00	cop	not(isnull(test.t2.c2))
+          └─TableScan_25	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select (select count(1) k from t1 s where s.c1 = t1.c1 having k != 0) from t1;
 id	count	task	operator info
 Projection_12	10000.00	root	ifnull(5_col_0, 0)
@@ -163,73 +163,73 @@ TableReader_5	10000.00	root	data:TableScan_4
 explain select c1 from t2 union select c1 from t2 union all select c1 from t2;
 id	count	task	operator info
 Union_17	26000.00	root	
-├─HashAgg_21	16000.00	root	group by:c1, funcs:firstrow(join_agg_0)
-│ └─Union_22	16000.00	root	
+├─HashAgg_19	16000.00	root	group by:c1, funcs:firstrow(join_agg_0)
+│ └─Union_20	16000.00	root	
 │   ├─StreamAgg_34	8000.00	root	group by:col_2, funcs:firstrow(col_2), firstrow(col_2)
-│   │ └─IndexReader_35	8000.00	root	index:StreamAgg_26
-│   │   └─StreamAgg_26	8000.00	cop	group by:test.t2.c1, 
+│   │ └─IndexReader_35	8000.00	root	index:StreamAgg_25
+│   │   └─StreamAgg_25	8000.00	cop	group by:test.t2.c1, 
 │   │     └─IndexScan_33	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
 │   └─StreamAgg_49	8000.00	root	group by:col_2, funcs:firstrow(col_2), firstrow(col_2)
-│     └─IndexReader_50	8000.00	root	index:StreamAgg_41
-│       └─StreamAgg_41	8000.00	cop	group by:test.t2.c1, 
+│     └─IndexReader_50	8000.00	root	index:StreamAgg_40
+│       └─StreamAgg_40	8000.00	cop	group by:test.t2.c1, 
 │         └─IndexScan_48	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
-└─TableReader_55	10000.00	root	data:TableScan_54
-  └─TableScan_54	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+└─TableReader_53	10000.00	root	data:TableScan_52
+  └─TableScan_52	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select c1 from t2 union all select c1 from t2 union select c1 from t2;
 id	count	task	operator info
-HashAgg_18	24000.00	root	group by:c1, funcs:firstrow(join_agg_0)
-└─Union_19	24000.00	root	
+HashAgg_16	24000.00	root	group by:c1, funcs:firstrow(join_agg_0)
+└─Union_17	24000.00	root	
   ├─StreamAgg_31	8000.00	root	group by:col_2, funcs:firstrow(col_2), firstrow(col_2)
-  │ └─IndexReader_32	8000.00	root	index:StreamAgg_23
-  │   └─StreamAgg_23	8000.00	cop	group by:test.t2.c1, 
+  │ └─IndexReader_32	8000.00	root	index:StreamAgg_22
+  │   └─StreamAgg_22	8000.00	cop	group by:test.t2.c1, 
   │     └─IndexScan_30	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
   ├─StreamAgg_46	8000.00	root	group by:col_2, funcs:firstrow(col_2), firstrow(col_2)
-  │ └─IndexReader_47	8000.00	root	index:StreamAgg_38
-  │   └─StreamAgg_38	8000.00	cop	group by:test.t2.c1, 
+  │ └─IndexReader_47	8000.00	root	index:StreamAgg_37
+  │   └─StreamAgg_37	8000.00	cop	group by:test.t2.c1, 
   │     └─IndexScan_45	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
   └─StreamAgg_61	8000.00	root	group by:col_2, funcs:firstrow(col_2), firstrow(col_2)
-    └─IndexReader_62	8000.00	root	index:StreamAgg_53
-      └─StreamAgg_53	8000.00	cop	group by:test.t2.c1, 
+    └─IndexReader_62	8000.00	root	index:StreamAgg_52
+      └─StreamAgg_52	8000.00	cop	group by:test.t2.c1, 
         └─IndexScan_60	10000.00	cop	table:t2, index:c1, range:[NULL,+inf], keep order:true, stats:pseudo
 explain select count(1) from (select count(1) from (select * from t1 where c3 = 100) k) k2;
 id	count	task	operator info
-StreamAgg_13	1.00	root	funcs:count(1)
+StreamAgg_10	1.00	root	funcs:count(1)
 └─StreamAgg_28	1.00	root	funcs:firstrow(col_0)
-  └─TableReader_29	1.00	root	data:StreamAgg_17
-    └─StreamAgg_17	1.00	cop	funcs:firstrow(1)
+  └─TableReader_29	1.00	root	data:StreamAgg_15
+    └─StreamAgg_15	1.00	cop	funcs:firstrow(1)
       └─Selection_27	10.00	cop	eq(test.t1.c3, 100)
         └─TableScan_26	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select 1 from (select count(c2), count(c3) from t1) k;
 id	count	task	operator info
 Projection_5	1.00	root	1
-└─StreamAgg_17	1.00	root	funcs:firstrow(col_0)
-  └─TableReader_18	1.00	root	data:StreamAgg_9
-    └─StreamAgg_9	1.00	cop	funcs:firstrow(1)
-      └─TableScan_16	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─StreamAgg_19	1.00	root	funcs:firstrow(col_0)
+  └─TableReader_20	1.00	root	data:StreamAgg_10
+    └─StreamAgg_10	1.00	cop	funcs:firstrow(1)
+      └─TableScan_18	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select count(1) from (select max(c2), count(c3) as m from t1) k;
 id	count	task	operator info
-StreamAgg_11	1.00	root	funcs:count(1)
-└─StreamAgg_23	1.00	root	funcs:firstrow(col_0)
-  └─TableReader_24	1.00	root	data:StreamAgg_15
-    └─StreamAgg_15	1.00	cop	funcs:firstrow(1)
-      └─TableScan_22	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_8	1.00	root	funcs:count(1)
+└─StreamAgg_22	1.00	root	funcs:firstrow(col_0)
+  └─TableReader_23	1.00	root	data:StreamAgg_13
+    └─StreamAgg_13	1.00	cop	funcs:firstrow(1)
+      └─TableScan_21	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select count(1) from (select count(c2) from t1 group by c3) k;
 id	count	task	operator info
-StreamAgg_11	1.00	root	funcs:count(1)
-└─HashAgg_23	8000.00	root	group by:col_1, funcs:firstrow(col_0)
-  └─TableReader_24	8000.00	root	data:HashAgg_20
-    └─HashAgg_20	8000.00	cop	group by:test.t1.c3, funcs:firstrow(1)
-      └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_8	1.00	root	funcs:count(1)
+└─HashAgg_20	8000.00	root	group by:col_1, funcs:firstrow(col_0)
+  └─TableReader_21	8000.00	root	data:HashAgg_18
+    └─HashAgg_18	8000.00	cop	group by:test.t1.c3, funcs:firstrow(1)
+      └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 set @@session.tidb_opt_insubq_to_join_and_agg=0;
 explain select sum(t1.c1 in (select c1 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(col_0)
-└─Projection_19	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_18	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_17, other cond:eq(test.t1.c1, test.t2.c1)
-    ├─TableReader_15	10000.00	root	data:TableScan_14
-    │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-    └─TableReader_17	10000.00	root	data:TableScan_16
-      └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_9	1.00	root	funcs:sum(col_0)
+└─Projection_16	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_15	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_14, other cond:eq(test.t1.c1, test.t2.c1)
+    ├─TableReader_12	10000.00	root	data:TableScan_11
+    │ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_14	10000.00	root	data:TableScan_13
+      └─TableScan_13	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select 1 in (select c2 from t2) from t1;
 id	count	task	operator info
 Projection_6	10000.00	root	5_aux_0
@@ -241,41 +241,41 @@ Projection_6	10000.00	root	5_aux_0
       └─TableScan_10	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select sum(6 in (select c2 from t2)) from t1;
 id	count	task	operator info
-StreamAgg_12	1.00	root	funcs:sum(col_0)
-└─Projection_20	10000.00	root	cast(5_aux_0)
-  └─HashLeftJoin_19	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_18
-    ├─TableReader_15	10000.00	root	data:TableScan_14
-    │ └─TableScan_14	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-    └─TableReader_18	10.00	root	data:Selection_17
-      └─Selection_17	10.00	cop	eq(6, test.t2.c2)
-        └─TableScan_16	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_9	1.00	root	funcs:sum(col_0)
+└─Projection_17	10000.00	root	cast(5_aux_0)
+  └─HashLeftJoin_16	10000.00	root	CARTESIAN left outer semi join, inner:TableReader_15
+    ├─TableReader_12	10000.00	root	data:TableScan_11
+    │ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+    └─TableReader_15	10.00	root	data:Selection_14
+      └─Selection_14	10.00	cop	eq(6, test.t2.c2)
+        └─TableScan_13	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain format="dot" select sum(t1.c1 in (select c1 from t2)) from t1;
 dot contents
 
-digraph StreamAgg_12 {
-subgraph cluster12{
+digraph StreamAgg_9 {
+subgraph cluster9{
 node [style=filled, color=lightgrey]
 color=black
 label = "root"
-"StreamAgg_12" -> "Projection_19"
-"Projection_19" -> "HashLeftJoin_18"
-"HashLeftJoin_18" -> "TableReader_15"
-"HashLeftJoin_18" -> "TableReader_17"
+"StreamAgg_9" -> "Projection_16"
+"Projection_16" -> "HashLeftJoin_15"
+"HashLeftJoin_15" -> "TableReader_12"
+"HashLeftJoin_15" -> "TableReader_14"
 }
-subgraph cluster14{
+subgraph cluster11{
 node [style=filled, color=lightgrey]
 color=black
 label = "cop"
-"TableScan_14"
+"TableScan_11"
 }
-subgraph cluster16{
+subgraph cluster13{
 node [style=filled, color=lightgrey]
 color=black
 label = "cop"
-"TableScan_16"
+"TableScan_13"
 }
-"TableReader_15" -> "TableScan_14"
-"TableReader_17" -> "TableScan_16"
+"TableReader_12" -> "TableScan_11"
+"TableReader_14" -> "TableScan_13"
 }
 
 explain format="dot" select 1 in (select c2 from t2) from t1;
@@ -312,85 +312,85 @@ create table t(a int primary key, b int, c int, index idx(b));
 explain select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_17, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_20	1.00	root	funcs:count(1)
-    └─MergeJoin_50	12.50	root	inner join, left key:test.s.a, right key:test.t1.a
-      ├─TableReader_43	1.00	root	data:TableScan_42
-      │ └─TableScan_42	1.00	cop	table:s, range: decided by [eq(test.s.a, test.t.a)], keep order:true, stats:pseudo
-      └─TableReader_45	1.00	root	data:TableScan_44
-        └─TableScan_44	1.00	cop	table:t1, range: decided by [eq(test.t1.a, test.t.a)], keep order:true, stats:pseudo
+  └─StreamAgg_17	1.00	root	funcs:count(1)
+    └─MergeJoin_47	12.50	root	inner join, left key:test.s.a, right key:test.t1.a
+      ├─TableReader_40	1.00	root	data:TableScan_39
+      │ └─TableScan_39	1.00	cop	table:s, range: decided by [eq(test.s.a, test.t.a)], keep order:true, stats:pseudo
+      └─TableReader_42	1.00	root	data:TableScan_41
+        └─TableScan_41	1.00	cop	table:t1, range: decided by [eq(test.t1.a, test.t.a)], keep order:true, stats:pseudo
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_17, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_20	1.00	root	funcs:count(1)
-    └─IndexMergeJoin_40	12.50	root	inner join, inner:TableReader_38, outer key:test.s.a, inner key:test.t1.a
-      ├─IndexReader_31	10.00	root	index:IndexScan_30
-      │ └─IndexScan_30	10.00	cop	table:s, index:b, range: decided by [eq(test.s.b, test.t.a)], keep order:false, stats:pseudo
-      └─TableReader_38	1.00	root	data:TableScan_37
-        └─TableScan_37	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true, stats:pseudo
+  └─StreamAgg_17	1.00	root	funcs:count(1)
+    └─IndexMergeJoin_37	12.50	root	inner join, inner:TableReader_35, outer key:test.s.a, inner key:test.t1.a
+      ├─IndexReader_28	10.00	root	index:IndexScan_27
+      │ └─IndexScan_27	10.00	cop	table:s, index:b, range: decided by [eq(test.s.b, test.t.a)], keep order:false, stats:pseudo
+      └─TableReader_35	1.00	root	data:TableScan_34
+        └─TableScan_34	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true, stats:pseudo
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t;
 id	count	task	operator info
 Projection_11	10000.00	root	9_aux_0
-└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	10000.00	root	CARTESIAN left outer semi join, inner:StreamAgg_17, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	10000.00	root	data:TableScan_14
   │ └─TableScan_14	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_20	1.00	root	funcs:count(1)
-    └─IndexMergeJoin_42	12.49	root	inner join, inner:TableReader_40, outer key:test.s.c, inner key:test.t1.a
-      ├─IndexLookUp_33	9.99	root	
-      │ ├─IndexScan_30	10.00	cop	table:s, index:b, range: decided by [eq(test.s.b, test.t.a)], keep order:false, stats:pseudo
-      │ └─Selection_32	9.99	cop	not(isnull(test.s.c))
-      │   └─TableScan_31	10.00	cop	table:s, keep order:false, stats:pseudo
-      └─TableReader_40	1.00	root	data:TableScan_39
-        └─TableScan_39	1.00	cop	table:t1, range: decided by [test.s.c], keep order:true, stats:pseudo
+  └─StreamAgg_17	1.00	root	funcs:count(1)
+    └─IndexMergeJoin_39	12.49	root	inner join, inner:TableReader_37, outer key:test.s.c, inner key:test.t1.a
+      ├─IndexLookUp_30	9.99	root	
+      │ ├─IndexScan_27	10.00	cop	table:s, index:b, range: decided by [eq(test.s.b, test.t.a)], keep order:false, stats:pseudo
+      │ └─Selection_29	9.99	cop	not(isnull(test.s.c))
+      │   └─TableScan_28	10.00	cop	table:s, keep order:false, stats:pseudo
+      └─TableReader_37	1.00	root	data:TableScan_36
+        └─TableScan_36	1.00	cop	table:t1, range: decided by [test.s.c], keep order:true, stats:pseudo
 insert into t values(1, 1, 1), (2, 2 ,2), (3, 3, 3), (4, 3, 4),(5,3,5);
 analyze table t;
 explain select t.c in (select count(*) from t s, t t1 where s.b = t.a and s.b = 3 and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	5.00	root	9_aux_0
-└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_17, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	5.00	root	data:TableScan_14
   │ └─TableScan_14	5.00	cop	table:t, range:[-inf,+inf], keep order:false
-  └─StreamAgg_20	1.00	root	funcs:count(1)
-    └─IndexMergeJoin_65	2.40	root	inner join, inner:TableReader_63, outer key:test.s.a, inner key:test.t1.a
-      ├─IndexReader_51	2.40	root	index:Selection_50
-      │ └─Selection_50	2.40	cop	eq(3, test.t.a)
-      │   └─IndexScan_49	3.00	cop	table:s, index:b, range:[3,3], keep order:false
-      └─TableReader_63	0.80	root	data:Selection_62
-        └─Selection_62	0.80	cop	eq(3, test.t.a)
-          └─TableScan_61	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true
+  └─StreamAgg_17	1.00	root	funcs:count(1)
+    └─IndexMergeJoin_62	2.40	root	inner join, inner:TableReader_60, outer key:test.s.a, inner key:test.t1.a
+      ├─IndexReader_48	2.40	root	index:Selection_47
+      │ └─Selection_47	2.40	cop	eq(3, test.t.a)
+      │   └─IndexScan_46	3.00	cop	table:s, index:b, range:[3,3], keep order:false
+      └─TableReader_60	0.80	root	data:Selection_59
+        └─Selection_59	0.80	cop	eq(3, test.t.a)
+          └─TableScan_58	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true
 explain select t.c in (select count(*) from t s left join t t1 on s.a = t1.a where 3 = t.a and s.b = 3) from t;
 id	count	task	operator info
 Projection_10	5.00	root	9_aux_0
-└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
+└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_16, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_14	5.00	root	data:TableScan_13
   │ └─TableScan_13	5.00	cop	table:t, range:[-inf,+inf], keep order:false
-  └─StreamAgg_19	1.00	root	funcs:count(1)
-    └─MergeJoin_44	2.40	root	left outer join, left key:test.s.a, right key:test.t1.a
-      ├─TableReader_34	2.40	root	data:Selection_33
-      │ └─Selection_33	2.40	cop	eq(3, test.t.a), eq(test.s.b, 3)
-      │   └─TableScan_32	5.00	cop	table:s, range:[-inf,+inf], keep order:true
-      └─TableReader_37	4.00	root	data:Selection_36
-        └─Selection_36	4.00	cop	eq(3, test.t.a)
-          └─TableScan_35	5.00	cop	table:t1, range:[-inf,+inf], keep order:true
+  └─StreamAgg_16	1.00	root	funcs:count(1)
+    └─MergeJoin_41	2.40	root	left outer join, left key:test.s.a, right key:test.t1.a
+      ├─TableReader_31	2.40	root	data:Selection_30
+      │ └─Selection_30	2.40	cop	eq(3, test.t.a), eq(test.s.b, 3)
+      │   └─TableScan_29	5.00	cop	table:s, range:[-inf,+inf], keep order:true
+      └─TableReader_34	4.00	root	data:Selection_33
+        └─Selection_33	4.00	cop	eq(3, test.t.a)
+          └─TableScan_32	5.00	cop	table:t1, range:[-inf,+inf], keep order:true
 explain select t.c in (select count(*) from t s right join t t1 on s.a = t1.a where 3 = t.a and t1.b = 3) from t;
 id	count	task	operator info
 Projection_10	5.00	root	9_aux_0
-└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_19, other cond:eq(test.t.c, 7_col_0)
+└─Apply_12	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_16, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_14	5.00	root	data:TableScan_13
   │ └─TableScan_13	5.00	cop	table:t, range:[-inf,+inf], keep order:false
-  └─StreamAgg_19	1.00	root	funcs:count(1)
-    └─MergeJoin_43	2.40	root	right outer join, left key:test.s.a, right key:test.t1.a
-      ├─TableReader_33	4.00	root	data:Selection_32
-      │ └─Selection_32	4.00	cop	eq(3, test.t.a)
-      │   └─TableScan_31	5.00	cop	table:s, range:[-inf,+inf], keep order:true
-      └─TableReader_36	2.40	root	data:Selection_35
-        └─Selection_35	2.40	cop	eq(3, test.t.a), eq(test.t1.b, 3)
-          └─TableScan_34	5.00	cop	table:t1, range:[-inf,+inf], keep order:true
+  └─StreamAgg_16	1.00	root	funcs:count(1)
+    └─MergeJoin_40	2.40	root	right outer join, left key:test.s.a, right key:test.t1.a
+      ├─TableReader_30	4.00	root	data:Selection_29
+      │ └─Selection_29	4.00	cop	eq(3, test.t.a)
+      │   └─TableScan_28	5.00	cop	table:s, range:[-inf,+inf], keep order:true
+      └─TableReader_33	2.40	root	data:Selection_32
+        └─Selection_32	2.40	cop	eq(3, test.t.a), eq(test.t1.b, 3)
+          └─TableScan_31	5.00	cop	table:t1, range:[-inf,+inf], keep order:true
 drop table if exists t;
 create table t(a int unsigned);
 explain select t.a = '123455' from t;
@@ -558,19 +558,19 @@ HashRightJoin_9	4166.67	root	inner join, inner:TableReader_12, equal:[eq(test.ta
 explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_12	10000.00	root	9_aux_0
-└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_19, other cond:eq(test.t.nc, 7_col_0)
+└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_17, other cond:eq(test.t.nc, 7_col_0)
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
-    └─HashLeftJoin_20	9.99	root	inner join, inner:HashAgg_30, equal:[eq(test.s.a, test.t1.a)]
-      ├─TableReader_24	9.99	root	data:Selection_23
-      │ └─Selection_23	9.99	cop	eq(test.s.a, test.t.a), not(isnull(test.s.a))
-      │   └─TableScan_22	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
-      └─HashAgg_30	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
-        └─TableReader_31	7.99	root	data:HashAgg_25
-          └─HashAgg_25	7.99	cop	group by:test.t1.a, funcs:count(1)
-            └─Selection_29	9.99	cop	eq(test.t1.a, test.t.a), not(isnull(test.t1.a))
-              └─TableScan_28	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_17	1.00	root	funcs:count(join_agg_0)
+    └─HashLeftJoin_18	9.99	root	inner join, inner:HashAgg_31, equal:[eq(test.s.a, test.t1.a)]
+      ├─TableReader_22	9.99	root	data:Selection_21
+      │ └─Selection_21	9.99	cop	eq(test.s.a, test.t.a), not(isnull(test.s.a))
+      │   └─TableScan_20	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+      └─HashAgg_31	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
+        └─TableReader_32	7.99	root	data:HashAgg_24
+          └─HashAgg_24	7.99	cop	group by:test.t1.a, funcs:count(1)
+            └─Selection_30	9.99	cop	eq(test.t1.a, test.t.a), not(isnull(test.t1.a))
+              └─TableScan_29	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.a, 1) or tb.a is null;
 id	count	task	operator info
 Selection_7	10000.00	root	or(ifnull(test.tb.a, 1), isnull(test.tb.a))
@@ -591,19 +591,19 @@ HashRightJoin_7	8000.00	root	right outer join, inner:TableReader_10, equal:[eq(t
 explain select ifnull(t.a, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_12	10000.00	root	9_aux_0
-└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_19, other cond:eq(ifnull(test.t.a, 1), 7_col_0)
+└─Apply_14	10000.00	root	CARTESIAN left outer semi join, inner:HashAgg_17, other cond:eq(ifnull(test.t.a, 1), 7_col_0)
   ├─TableReader_16	10000.00	root	data:TableScan_15
   │ └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─HashAgg_19	1.00	root	funcs:count(join_agg_0)
-    └─HashLeftJoin_20	9.99	root	inner join, inner:HashAgg_30, equal:[eq(test.s.a, test.t1.a)]
-      ├─TableReader_24	9.99	root	data:Selection_23
-      │ └─Selection_23	9.99	cop	eq(test.s.a, test.t.a), not(isnull(test.s.a))
-      │   └─TableScan_22	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
-      └─HashAgg_30	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
-        └─TableReader_31	7.99	root	data:HashAgg_25
-          └─HashAgg_25	7.99	cop	group by:test.t1.a, funcs:count(1)
-            └─Selection_29	9.99	cop	eq(test.t1.a, test.t.a), not(isnull(test.t1.a))
-              └─TableScan_28	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─HashAgg_17	1.00	root	funcs:count(join_agg_0)
+    └─HashLeftJoin_18	9.99	root	inner join, inner:HashAgg_31, equal:[eq(test.s.a, test.t1.a)]
+      ├─TableReader_22	9.99	root	data:Selection_21
+      │ └─Selection_21	9.99	cop	eq(test.s.a, test.t.a), not(isnull(test.s.a))
+      │   └─TableScan_20	10000.00	cop	table:s, range:[-inf,+inf], keep order:false, stats:pseudo
+      └─HashAgg_31	7.99	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
+        └─TableReader_32	7.99	root	data:HashAgg_24
+          └─HashAgg_24	7.99	cop	group by:test.t1.a, funcs:count(1)
+            └─Selection_30	9.99	cop	eq(test.t1.a, test.t.a), not(isnull(test.t1.a))
+              └─TableScan_29	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;
@@ -645,21 +645,21 @@ set @@session.tidb_opt_insubq_to_join_and_agg=1;
 explain SELECT 0 AS a FROM dual UNION SELECT 1 AS a FROM dual ORDER BY a;
 id	count	task	operator info
 Sort_13	2.00	root	a:asc
-└─HashAgg_17	2.00	root	group by:a, funcs:firstrow(join_agg_0)
-  └─Union_18	2.00	root	
-    ├─HashAgg_19	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
-    │ └─TableDual_22	1.00	root	rows:1
-    └─HashAgg_25	1.00	root	group by:1, funcs:firstrow(1), firstrow(1)
-      └─TableDual_28	1.00	root	rows:1
+└─HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
+  └─Union_16	2.00	root	
+    ├─HashAgg_17	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
+    │ └─TableDual_18	1.00	root	rows:1
+    └─HashAgg_19	1.00	root	group by:1, funcs:firstrow(1), firstrow(1)
+      └─TableDual_20	1.00	root	rows:1
 explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a);
 id	count	task	operator info
-HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
-└─Union_16	2.00	root	
-  ├─HashAgg_17	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
-  │ └─TableDual_20	1.00	root	rows:1
-  └─StreamAgg_27	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
-    └─Projection_32	1.00	root	1
-      └─TableDual_33	1.00	root	rows:1
+HashAgg_13	2.00	root	group by:a, funcs:firstrow(join_agg_0)
+└─Union_14	2.00	root	
+  ├─HashAgg_15	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
+  │ └─TableDual_16	1.00	root	rows:1
+  └─StreamAgg_18	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+    └─Projection_23	1.00	root	1
+      └─TableDual_24	1.00	root	rows:1
 create table t (i int key, j int, unique key (i, j));
 begin;
 insert into t values (1, 1);

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -15,14 +15,14 @@ set @@session.tidb_hashagg_final_concurrency = 1;
 explain select * from t3 where exists (select s.a from t3 s having sum(s.a) = t3.a );
 id	count	task	operator info
 Projection_11	1600.00	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d
-└─HashLeftJoin_12	1600.00	root	semi join, inner:StreamAgg_27, equal:[eq(cast(test.t3.a), sel_agg_1)]
+└─HashLeftJoin_12	1600.00	root	semi join, inner:StreamAgg_29, equal:[eq(cast(test.t3.a), sel_agg_1)]
   ├─Projection_13	2000.00	root	test.t3.a, test.t3.b, test.t3.c, test.t3.d, cast(test.t3.a)
   │ └─TableReader_15	2000.00	root	data:TableScan_14
   │   └─TableScan_14	2000.00	cop	table:t3, range:[-inf,+inf], keep order:false
-  └─StreamAgg_27	1.00	root	funcs:sum(col_0)
-    └─TableReader_28	1.00	root	data:StreamAgg_19
-      └─StreamAgg_19	1.00	cop	funcs:sum(test.s.a)
-        └─TableScan_26	2000.00	cop	table:s, range:[-inf,+inf], keep order:false
+  └─StreamAgg_29	1.00	root	funcs:sum(col_0)
+    └─TableReader_30	1.00	root	data:StreamAgg_20
+      └─StreamAgg_20	1.00	cop	funcs:sum(test.s.a)
+        └─TableScan_28	2000.00	cop	table:s, range:[-inf,+inf], keep order:false
 explain select * from t1;
 id	count	task	operator info
 TableReader_5	1999.00	root	data:TableScan_4
@@ -64,14 +64,14 @@ IndexLookUp_9	0.00	root
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	count	task	operator info
 Projection_11	1985.00	root	cast(join_agg_0)
-└─HashLeftJoin_19	1985.00	root	inner join, inner:HashAgg_26, equal:[eq(test.a.c1, test.b.c2)]
+└─HashLeftJoin_19	1985.00	root	inner join, inner:HashAgg_29, equal:[eq(test.a.c1, test.b.c2)]
   ├─TableReader_32	1999.00	root	data:TableScan_31
   │ └─TableScan_31	1999.00	cop	table:a, range:[-inf,+inf], keep order:false
-  └─HashAgg_26	1985.00	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
-    └─TableReader_27	1985.00	root	data:HashAgg_21
-      └─HashAgg_21	1985.00	cop	group by:test.b.c2, funcs:count(test.b.c2)
-        └─Selection_25	1985.00	cop	not(isnull(test.b.c2))
-          └─TableScan_24	1985.00	cop	table:b, range:[-inf,+inf], keep order:false
+  └─HashAgg_29	1985.00	root	group by:col_2, funcs:count(col_0), firstrow(col_2)
+    └─TableReader_30	1985.00	root	data:HashAgg_22
+      └─HashAgg_22	1985.00	cop	group by:test.b.c2, funcs:count(test.b.c2)
+        └─Selection_28	1985.00	cop	not(isnull(test.b.c2))
+          └─TableScan_27	1985.00	cop	table:b, range:[-inf,+inf], keep order:false
 explain select * from t2 order by t2.c2 limit 0, 1;
 id	count	task	operator info
 TopN_7	1.00	root	test.t2.c2:asc, offset:0, count:1
@@ -92,13 +92,13 @@ TableReader_7	0.50	root	data:Selection_6
 explain select c1 from t1 where c1 in (select c2 from t2);
 id	count	task	operator info
 Projection_9	1985.00	root	test.t1.c1
-└─HashLeftJoin_17	1985.00	root	inner join, inner:HashAgg_21, equal:[eq(test.t1.c1, test.t2.c2)]
+└─HashLeftJoin_17	1985.00	root	inner join, inner:HashAgg_19, equal:[eq(test.t1.c1, test.t2.c2)]
   ├─TableReader_30	1999.00	root	data:TableScan_29
   │ └─TableScan_29	1999.00	cop	table:t1, range:[-inf,+inf], keep order:false
-  └─HashAgg_21	1985.00	root	group by:test.t2.c2, funcs:firstrow(test.t2.c2)
-    └─TableReader_28	1985.00	root	data:Selection_27
-      └─Selection_27	1985.00	cop	not(isnull(test.t2.c2))
-        └─TableScan_26	1985.00	cop	table:t2, range:[-inf,+inf], keep order:false
+  └─HashAgg_19	1985.00	root	group by:test.t2.c2, funcs:firstrow(test.t2.c2)
+    └─TableReader_24	1985.00	root	data:Selection_23
+      └─Selection_23	1985.00	cop	not(isnull(test.t2.c2))
+        └─TableScan_22	1985.00	cop	table:t2, range:[-inf,+inf], keep order:false
 explain select * from information_schema.columns;
 id	count	task	operator info
 MemTableScan_4	10000.00	root	

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -50,7 +50,7 @@ Projection_8	10000.00	root	test.t1.a, test.t1.b
   ├─IndexLookUp_11	10.00	root	
   │ ├─IndexScan_9	10.00	cop	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false, stats:pseudo
   │ └─TableScan_10	10.00	cop	table:t1, keep order:false, stats:pseudo
-  └─StreamAgg_29	8000.00	root	group by:col_1, funcs:firstrow(col_1)
-    └─IndexReader_30	8000.00	root	index:StreamAgg_21
-      └─StreamAgg_21	8000.00	cop	group by:test.t2.a, 
-        └─IndexScan_28	10000.00	cop	table:t2, index:a, range:[NULL,+inf], keep order:true, stats:pseudo
+  └─StreamAgg_31	8000.00	root	group by:col_1, funcs:firstrow(col_1)
+    └─IndexReader_32	8000.00	root	index:StreamAgg_22
+      └─StreamAgg_22	8000.00	cop	group by:test.t2.a, 
+        └─IndexScan_30	10000.00	cop	table:t2, index:a, range:[NULL,+inf], keep order:true, stats:pseudo

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -256,41 +256,41 @@ drop table if exists t;
 create table t (a int, b int, c int, key idx(a, b, c));
 explain select count(a) from t;
 id	count	task	operator info
-StreamAgg_16	1.00	root	funcs:count(col_0)
-└─TableReader_17	1.00	root	data:StreamAgg_8
-  └─StreamAgg_8	1.00	cop	funcs:count(test.t.a)
-    └─TableScan_15	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+StreamAgg_18	1.00	root	funcs:count(col_0)
+└─TableReader_19	1.00	root	data:StreamAgg_9
+  └─StreamAgg_9	1.00	cop	funcs:count(test.t.a)
+    └─TableScan_17	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
 select count(a) from t;
 count(a)
 0
 insert t values(0,0,0);
 explain select distinct b from t group by a;
 id	count	task	operator info
-HashAgg_7	8000.00	root	group by:test.t.b, funcs:firstrow(test.t.b)
+HashAgg_5	8000.00	root	group by:test.t.b, funcs:firstrow(test.t.b)
 └─StreamAgg_19	8000.00	root	group by:col_1, funcs:firstrow(col_0)
-  └─IndexReader_20	8000.00	root	index:StreamAgg_11
-    └─StreamAgg_11	8000.00	cop	group by:test.t.a, funcs:firstrow(test.t.b)
+  └─IndexReader_20	8000.00	root	index:StreamAgg_10
+    └─StreamAgg_10	8000.00	cop	group by:test.t.a, funcs:firstrow(test.t.b)
       └─IndexScan_18	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
 select distinct b from t group by a;
 b
 0
 explain select count(b) from t group by a;
 id	count	task	operator info
-StreamAgg_16	8000.00	root	group by:col_1, funcs:count(col_0)
-└─IndexReader_17	8000.00	root	index:StreamAgg_8
-  └─StreamAgg_8	8000.00	cop	group by:test.t.a, funcs:count(test.t.b)
-    └─IndexScan_15	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
+StreamAgg_18	8000.00	root	group by:col_1, funcs:count(col_0)
+└─IndexReader_19	8000.00	root	index:StreamAgg_9
+  └─StreamAgg_9	8000.00	cop	group by:test.t.a, funcs:count(test.t.b)
+    └─IndexScan_17	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
 select count(b) from t group by a;
 count(b)
 1
 insert t values(1,1,1),(3,3,6),(3,2,5),(2,1,4),(1,1,3),(1,1,2);
 explain select count(a) from t where b>0 group by a, b;
 id	count	task	operator info
-StreamAgg_20	2666.67	root	group by:col_1, col_2, funcs:count(col_0)
-└─IndexReader_21	2666.67	root	index:StreamAgg_9
-  └─StreamAgg_9	2666.67	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
-    └─Selection_19	3333.33	cop	gt(test.t.b, 0)
-      └─IndexScan_18	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
+StreamAgg_23	2666.67	root	group by:col_1, col_2, funcs:count(col_0)
+└─IndexReader_24	2666.67	root	index:StreamAgg_10
+  └─StreamAgg_10	2666.67	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
+    └─Selection_22	3333.33	cop	gt(test.t.b, 0)
+      └─IndexScan_21	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
 select count(a) from t where b>0 group by a, b;
 count(a)
 3
@@ -301,10 +301,10 @@ explain select count(a) from t where b>0 group by a, b order by a;
 id	count	task	operator info
 Projection_7	2666.67	root	count(a)
 └─StreamAgg_31	2666.67	root	group by:col_2, col_3, funcs:count(col_0), firstrow(col_2)
-  └─IndexReader_32	2666.67	root	index:StreamAgg_29
-    └─StreamAgg_29	2666.67	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
-      └─Selection_23	3333.33	cop	gt(test.t.b, 0)
-        └─IndexScan_22	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
+  └─IndexReader_32	2666.67	root	index:StreamAgg_30
+    └─StreamAgg_30	2666.67	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
+      └─Selection_26	3333.33	cop	gt(test.t.b, 0)
+        └─IndexScan_25	10000.00	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
 select count(a) from t where b>0 group by a, b order by a;
 count(a)
 3
@@ -315,11 +315,11 @@ explain select count(a) from t where b>0 group by a, b order by a limit 1;
 id	count	task	operator info
 Projection_9	1.00	root	count(a)
 └─Limit_15	1.00	root	offset:0, count:1
-  └─StreamAgg_39	1.00	root	group by:col_2, col_3, funcs:count(col_0), firstrow(col_2)
-    └─IndexReader_40	1.00	root	index:StreamAgg_35
-      └─StreamAgg_35	1.00	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
-        └─Selection_38	1.25	cop	gt(test.t.b, 0)
-          └─IndexScan_37	3.75	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
+  └─StreamAgg_42	1.00	root	group by:col_2, col_3, funcs:count(col_0), firstrow(col_2)
+    └─IndexReader_43	1.00	root	index:StreamAgg_36
+      └─StreamAgg_36	1.00	cop	group by:test.t.a, test.t.b, funcs:count(test.t.a)
+        └─Selection_41	1.25	cop	gt(test.t.b, 0)
+          └─IndexScan_40	3.75	cop	table:t, index:a, b, c, range:[NULL,+inf], keep order:true, stats:pseudo
 select count(a) from t where b>0 group by a, b order by a limit 1;
 count(a)
 3

--- a/cmd/explaintest/r/subquery.result
+++ b/cmd/explaintest/r/subquery.result
@@ -18,12 +18,12 @@ analyze table t;
 explain select t.c in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c = 1 and s.d = t.a and s.a = t1.a) from t;
 id	count	task	operator info
 Projection_11	5.00	root	9_aux_0
-└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_20, other cond:eq(test.t.c, 7_col_0)
+└─Apply_13	5.00	root	CARTESIAN left outer semi join, inner:StreamAgg_17, other cond:eq(test.t.c, 7_col_0)
   ├─TableReader_15	5.00	root	data:TableScan_14
   │ └─TableScan_14	5.00	cop	table:t, range:[-inf,+inf], keep order:false
-  └─StreamAgg_20	1.00	root	funcs:count(1)
-    └─IndexMergeJoin_27	0.50	root	inner join, inner:TableReader_25, outer key:test.s.a, inner key:test.t1.a
-      ├─IndexReader_31	1.00	root	index:IndexScan_30
-      │ └─IndexScan_30	1.00	cop	table:s, index:b, c, d, range: decided by [eq(test.s.b, 1) eq(test.s.c, 1) eq(test.s.d, test.t.a)], keep order:false
-      └─TableReader_25	1.00	root	data:TableScan_24
-        └─TableScan_24	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true
+  └─StreamAgg_17	1.00	root	funcs:count(1)
+    └─IndexMergeJoin_24	0.50	root	inner join, inner:TableReader_22, outer key:test.s.a, inner key:test.t1.a
+      ├─IndexReader_28	1.00	root	index:IndexScan_27
+      │ └─IndexScan_27	1.00	cop	table:s, index:b, c, d, range: decided by [eq(test.s.b, 1) eq(test.s.c, 1) eq(test.s.d, test.t.a)], keep order:false
+      └─TableReader_22	1.00	root	data:TableScan_21
+        └─TableScan_21	1.00	cop	table:t1, range: decided by [test.s.a], keep order:true

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -121,11 +121,11 @@ l_linestatus;
 id	count	task	operator info
 Sort_6	2.94	root	tpch.lineitem.l_returnflag:asc, tpch.lineitem.l_linestatus:asc
 └─Projection_8	2.94	root	tpch.lineitem.l_returnflag, tpch.lineitem.l_linestatus, 3_col_0, 3_col_1, 3_col_2, 3_col_3, 3_col_4, 3_col_5, 3_col_6, 3_col_7
-  └─HashAgg_14	2.94	root	group by:col_13, col_14, funcs:sum(col_0), sum(col_1), sum(col_2), sum(col_3), avg(col_4, col_5), avg(col_6, col_7), avg(col_8, col_9), count(col_10), firstrow(col_13), firstrow(col_14)
-    └─TableReader_15	2.94	root	data:HashAgg_9
-      └─HashAgg_9	2.94	cop	group by:tpch.lineitem.l_linestatus, tpch.lineitem.l_returnflag, funcs:sum(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_extendedprice), sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), sum(mul(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), plus(1, tpch.lineitem.l_tax))), count(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_quantity), count(tpch.lineitem.l_extendedprice), sum(tpch.lineitem.l_extendedprice), count(tpch.lineitem.l_discount), sum(tpch.lineitem.l_discount), count(1)
-        └─Selection_13	293795345.00	cop	le(tpch.lineitem.l_shipdate, 1998-08-15)
-          └─TableScan_12	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+  └─HashAgg_17	2.94	root	group by:col_13, col_14, funcs:sum(col_0), sum(col_1), sum(col_2), sum(col_3), avg(col_4, col_5), avg(col_6, col_7), avg(col_8, col_9), count(col_10), firstrow(col_13), firstrow(col_14)
+    └─TableReader_18	2.94	root	data:HashAgg_10
+      └─HashAgg_10	2.94	cop	group by:tpch.lineitem.l_linestatus, tpch.lineitem.l_returnflag, funcs:sum(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_extendedprice), sum(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))), sum(mul(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), plus(1, tpch.lineitem.l_tax))), count(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_quantity), count(tpch.lineitem.l_extendedprice), sum(tpch.lineitem.l_extendedprice), count(tpch.lineitem.l_discount), sum(tpch.lineitem.l_discount), count(1)
+        └─Selection_16	293795345.00	cop	le(tpch.lineitem.l_shipdate, 1998-08-15)
+          └─TableScan_15	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
 /*
 Q2 Minimum Cost Supplier Query
 This query finds which supplier should be selected to place an order for a given part in a given region.
@@ -202,19 +202,19 @@ Projection_37	100.00	root	tpch.supplier.s_acctbal, tpch.supplier.s_name, tpch.na
     │   └─Selection_83	155496.00	cop	eq(tpch.part.p_size, 30), like(tpch.part.p_type, "%STEEL", 92)
     │     └─TableScan_82	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
     └─Selection_85	6524008.35	root	not(isnull(min(ps_supplycost)))
-      └─HashAgg_88	8155010.44	root	group by:tpch.partsupp.ps_partkey, funcs:min(tpch.partsupp.ps_supplycost), firstrow(tpch.partsupp.ps_partkey)
-        └─HashRightJoin_92	8155010.44	root	inner join, inner:HashRightJoin_94, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
-          ├─HashRightJoin_94	100000.00	root	inner join, inner:HashRightJoin_105, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-          │ ├─HashRightJoin_105	5.00	root	inner join, inner:TableReader_110, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
-          │ │ ├─TableReader_110	1.00	root	data:Selection_109
-          │ │ │ └─Selection_109	1.00	cop	eq(tpch.region.r_name, "ASIA")
-          │ │ │   └─TableScan_108	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-          │ │ └─TableReader_107	25.00	root	data:TableScan_106
-          │ │   └─TableScan_106	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-          │ └─TableReader_112	500000.00	root	data:TableScan_111
-          │   └─TableScan_111	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-          └─TableReader_114	40000000.00	root	data:TableScan_113
-            └─TableScan_113	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+      └─HashAgg_86	8155010.44	root	group by:tpch.partsupp.ps_partkey, funcs:min(tpch.partsupp.ps_supplycost), firstrow(tpch.partsupp.ps_partkey)
+        └─HashRightJoin_89	8155010.44	root	inner join, inner:HashRightJoin_91, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
+          ├─HashRightJoin_91	100000.00	root	inner join, inner:HashRightJoin_102, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+          │ ├─HashRightJoin_102	5.00	root	inner join, inner:TableReader_107, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
+          │ │ ├─TableReader_107	1.00	root	data:Selection_106
+          │ │ │ └─Selection_106	1.00	cop	eq(tpch.region.r_name, "ASIA")
+          │ │ │   └─TableScan_105	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+          │ │ └─TableReader_104	25.00	root	data:TableScan_103
+          │ │   └─TableScan_103	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+          │ └─TableReader_109	500000.00	root	data:TableScan_108
+          │   └─TableScan_108	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+          └─TableReader_111	40000000.00	root	data:TableScan_110
+            └─TableScan_110	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
 /*
 Q3 Shipping Priority Query
 This query retrieves the 10 unshipped orders with the highest value.
@@ -251,20 +251,20 @@ limit 10;
 id	count	task	operator info
 Projection_14	10.00	root	tpch.lineitem.l_orderkey, 7_col_0, tpch.orders.o_orderdate, tpch.orders.o_shippriority
 └─TopN_17	10.00	root	7_col_0:desc, tpch.orders.o_orderdate:asc, offset:0, count:10
-  └─HashAgg_23	40252367.98	root	group by:col_4, col_5, col_6, funcs:sum(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3)
-    └─Projection_74	91515927.49	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.orders.o_orderdate, tpch.orders.o_shippriority, tpch.lineitem.l_orderkey, tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority
-      └─IndexMergeJoin_35	91515927.49	root	inner join, inner:IndexLookUp_33, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-        ├─HashRightJoin_64	22592975.51	root	inner join, inner:TableReader_70, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-        │ ├─TableReader_70	1498236.00	root	data:Selection_69
-        │ │ └─Selection_69	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
-        │ │   └─TableScan_68	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        │ └─TableReader_67	36870000.00	root	data:Selection_66
-        │   └─Selection_66	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
-        │     └─TableScan_65	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─IndexLookUp_33	0.54	root	
-          ├─IndexScan_30	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
-          └─Selection_32	0.54	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
-            └─TableScan_31	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_21	40252367.98	root	group by:col_4, col_5, col_6, funcs:sum(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3)
+    └─Projection_72	91515927.49	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.orders.o_orderdate, tpch.orders.o_shippriority, tpch.lineitem.l_orderkey, tpch.lineitem.l_orderkey, tpch.orders.o_orderdate, tpch.orders.o_shippriority
+      └─IndexMergeJoin_33	91515927.49	root	inner join, inner:IndexLookUp_31, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+        ├─HashRightJoin_62	22592975.51	root	inner join, inner:TableReader_68, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        │ ├─TableReader_68	1498236.00	root	data:Selection_67
+        │ │ └─Selection_67	1498236.00	cop	eq(tpch.customer.c_mktsegment, "AUTOMOBILE")
+        │ │   └─TableScan_66	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        │ └─TableReader_65	36870000.00	root	data:Selection_64
+        │   └─Selection_64	36870000.00	cop	lt(tpch.orders.o_orderdate, 1995-03-13 00:00:00.000000)
+        │     └─TableScan_63	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─IndexLookUp_31	0.54	root	
+          ├─IndexScan_28	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
+          └─Selection_30	0.54	cop	gt(tpch.lineitem.l_shipdate, 1995-03-13 00:00:00.000000)
+            └─TableScan_29	1.00	cop	table:lineitem, keep order:false
 /*
 Q4 Order Priority Checking Query
 This query determines how well the order priority system is working and gives an assessment of customer satisfaction.
@@ -297,15 +297,15 @@ o_orderpriority;
 id	count	task	operator info
 Sort_10	1.00	root	tpch.orders.o_orderpriority:asc
 └─Projection_12	1.00	root	tpch.orders.o_orderpriority, 7_col_0
-  └─HashAgg_15	1.00	root	group by:tpch.orders.o_orderpriority, funcs:count(1), firstrow(tpch.orders.o_orderpriority)
-    └─IndexMergeJoin_27	2340750.00	root	semi join, inner:IndexLookUp_25, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─TableReader_39	2925937.50	root	data:Selection_38
-      │ └─Selection_38	2925937.50	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-04-01)
-      │   └─TableScan_37	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_25	0.80	root	
-        ├─IndexScan_22	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
-        └─Selection_24	0.80	cop	lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate)
-          └─TableScan_23	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_13	1.00	root	group by:tpch.orders.o_orderpriority, funcs:count(1), firstrow(tpch.orders.o_orderpriority)
+    └─IndexMergeJoin_25	2340750.00	root	semi join, inner:IndexLookUp_23, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+      ├─TableReader_37	2925937.50	root	data:Selection_36
+      │ └─Selection_36	2925937.50	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-04-01)
+      │   └─TableScan_35	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+      └─IndexLookUp_23	0.80	root	
+        ├─IndexScan_20	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
+        └─Selection_22	0.80	cop	lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate)
+          └─TableScan_21	1.00	cop	table:lineitem, keep order:false
 /*
 Q5 Local Supplier Volume Query
 This query lists the revenue volume done through local suppliers.
@@ -345,27 +345,27 @@ revenue desc;
 id	count	task	operator info
 Sort_23	5.00	root	revenue:desc
 └─Projection_25	5.00	root	tpch.nation.n_name, 13_col_0
-  └─HashAgg_28	5.00	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
-    └─Projection_80	11822812.50	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.nation.n_name, tpch.nation.n_name
-      └─HashLeftJoin_36	11822812.50	root	inner join, inner:TableReader_78, equal:[eq(tpch.supplier.s_nationkey, tpch.customer.c_nationkey) eq(tpch.orders.o_custkey, tpch.customer.c_custkey)]
-        ├─HashLeftJoin_48	11822812.50	root	inner join, inner:TableReader_76, equal:[eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)]
-        │ ├─HashRightJoin_51	61163763.01	root	inner join, inner:HashRightJoin_53, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
-        │ │ ├─HashRightJoin_53	100000.00	root	inner join, inner:HashRightJoin_64, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-        │ │ │ ├─HashRightJoin_64	5.00	root	inner join, inner:TableReader_69, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
-        │ │ │ │ ├─TableReader_69	1.00	root	data:Selection_68
-        │ │ │ │ │ └─Selection_68	1.00	cop	eq(tpch.region.r_name, "MIDDLE EAST")
-        │ │ │ │ │   └─TableScan_67	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-        │ │ │ │ └─TableReader_66	25.00	root	data:TableScan_65
-        │ │ │ │   └─TableScan_65	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ │ │ └─TableReader_71	500000.00	root	data:TableScan_70
-        │ │ │   └─TableScan_70	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_73	300005811.00	root	data:TableScan_72
-        │ │   └─TableScan_72	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        │ └─TableReader_76	11822812.50	root	data:Selection_75
-        │   └─Selection_75	11822812.50	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
-        │     └─TableScan_74	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─TableReader_78	7500000.00	root	data:TableScan_77
-          └─TableScan_77	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+  └─HashAgg_26	5.00	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
+    └─Projection_78	11822812.50	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.nation.n_name, tpch.nation.n_name
+      └─HashLeftJoin_34	11822812.50	root	inner join, inner:TableReader_76, equal:[eq(tpch.supplier.s_nationkey, tpch.customer.c_nationkey) eq(tpch.orders.o_custkey, tpch.customer.c_custkey)]
+        ├─HashLeftJoin_46	11822812.50	root	inner join, inner:TableReader_74, equal:[eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)]
+        │ ├─HashRightJoin_49	61163763.01	root	inner join, inner:HashRightJoin_51, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
+        │ │ ├─HashRightJoin_51	100000.00	root	inner join, inner:HashRightJoin_62, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+        │ │ │ ├─HashRightJoin_62	5.00	root	inner join, inner:TableReader_67, equal:[eq(tpch.region.r_regionkey, tpch.nation.n_regionkey)]
+        │ │ │ │ ├─TableReader_67	1.00	root	data:Selection_66
+        │ │ │ │ │ └─Selection_66	1.00	cop	eq(tpch.region.r_name, "MIDDLE EAST")
+        │ │ │ │ │   └─TableScan_65	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+        │ │ │ │ └─TableReader_64	25.00	root	data:TableScan_63
+        │ │ │ │   └─TableScan_63	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ │ └─TableReader_69	500000.00	root	data:TableScan_68
+        │ │ │   └─TableScan_68	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_71	300005811.00	root	data:TableScan_70
+        │ │   └─TableScan_70	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        │ └─TableReader_74	11822812.50	root	data:Selection_73
+        │   └─Selection_73	11822812.50	cop	ge(tpch.orders.o_orderdate, 1994-01-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1995-01-01)
+        │     └─TableScan_72	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─TableReader_76	7500000.00	root	data:TableScan_75
+          └─TableScan_75	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
 /*
 Q6 Forecasting Revenue Change Query
 This query quantifies the amount of revenue increase that would have resulted from eliminating certain companywide
@@ -388,11 +388,11 @@ and l_shipdate < date_add('1994-01-01', interval '1' year)
 and l_discount between 0.06 - 0.01 and 0.06 + 0.01
 and l_quantity < 24;
 id	count	task	operator info
-StreamAgg_20	1.00	root	funcs:sum(col_0)
-└─TableReader_21	1.00	root	data:StreamAgg_9
-  └─StreamAgg_9	1.00	cop	funcs:sum(mul(tpch.lineitem.l_extendedprice, tpch.lineitem.l_discount))
-    └─Selection_19	3713857.91	cop	ge(tpch.lineitem.l_discount, 0.05), ge(tpch.lineitem.l_shipdate, 1994-01-01 00:00:00.000000), le(tpch.lineitem.l_discount, 0.07), lt(tpch.lineitem.l_quantity, 24), lt(tpch.lineitem.l_shipdate, 1995-01-01)
-      └─TableScan_18	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+StreamAgg_23	1.00	root	funcs:sum(col_0)
+└─TableReader_24	1.00	root	data:StreamAgg_10
+  └─StreamAgg_10	1.00	cop	funcs:sum(mul(tpch.lineitem.l_extendedprice, tpch.lineitem.l_discount))
+    └─Selection_22	3713857.91	cop	ge(tpch.lineitem.l_discount, 0.05), ge(tpch.lineitem.l_shipdate, 1994-01-01 00:00:00.000000), le(tpch.lineitem.l_discount, 0.07), lt(tpch.lineitem.l_quantity, 24), lt(tpch.lineitem.l_shipdate, 1995-01-01)
+      └─TableScan_21	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
 /*
 Q7 Volume Shipping Query
 This query determines the value of goods shipped between certain nations to help in the re-negotiation of shipping
@@ -446,28 +446,28 @@ l_year;
 id	count	task	operator info
 Sort_22	769.96	root	tpch.shipping.supp_nation:asc, tpch.shipping.cust_nation:asc, shipping.l_year:asc
 └─Projection_24	769.96	root	tpch.shipping.supp_nation, tpch.shipping.cust_nation, shipping.l_year, 14_col_0
-  └─HashAgg_27	769.96	root	group by:shipping.l_year, tpch.shipping.cust_nation, tpch.shipping.supp_nation, funcs:sum(shipping.volume), firstrow(tpch.shipping.supp_nation), firstrow(tpch.shipping.cust_nation), firstrow(shipping.l_year)
-    └─Projection_28	1957240.42	root	tpch.n1.n_name, tpch.n2.n_name, extract("YEAR", tpch.lineitem.l_shipdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
-      └─HashLeftJoin_38	1957240.42	root	inner join, inner:TableReader_86, equal:[eq(tpch.customer.c_nationkey, tpch.n2.n_nationkey)], other cond:or(and(eq(tpch.n1.n_name, "JAPAN"), eq(tpch.n2.n_name, "INDIA")), and(eq(tpch.n1.n_name, "INDIA"), eq(tpch.n2.n_name, "JAPAN")))
-        ├─HashLeftJoin_47	24465505.20	root	inner join, inner:TableReader_83, equal:[eq(tpch.orders.o_custkey, tpch.customer.c_custkey)]
-        │ ├─IndexMergeJoin_56	24465505.20	root	inner join, inner:TableReader_54, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-        │ │ ├─HashRightJoin_60	24465505.20	root	inner join, inner:HashRightJoin_71, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
-        │ │ │ ├─HashRightJoin_71	40000.00	root	inner join, inner:TableReader_76, equal:[eq(tpch.n1.n_nationkey, tpch.supplier.s_nationkey)]
-        │ │ │ │ ├─TableReader_76	2.00	root	data:Selection_75
-        │ │ │ │ │ └─Selection_75	2.00	cop	or(eq(tpch.n1.n_name, "JAPAN"), eq(tpch.n1.n_name, "INDIA"))
-        │ │ │ │ │   └─TableScan_74	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
-        │ │ │ │ └─TableReader_73	500000.00	root	data:TableScan_72
-        │ │ │ │   └─TableScan_72	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        │ │ │ └─TableReader_79	91446230.29	root	data:Selection_78
-        │ │ │   └─Selection_78	91446230.29	cop	ge(tpch.lineitem.l_shipdate, 1995-01-01 00:00:00.000000), le(tpch.lineitem.l_shipdate, 1996-12-31 00:00:00.000000)
-        │ │ │     └─TableScan_77	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_54	1.00	root	data:TableScan_53
-        │ │   └─TableScan_53	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:true
-        │ └─TableReader_83	7500000.00	root	data:TableScan_82
-        │   └─TableScan_82	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        └─TableReader_86	2.00	root	data:Selection_85
-          └─Selection_85	2.00	cop	or(eq(tpch.n2.n_name, "INDIA"), eq(tpch.n2.n_name, "JAPAN"))
-            └─TableScan_84	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
+  └─HashAgg_25	769.96	root	group by:shipping.l_year, tpch.shipping.cust_nation, tpch.shipping.supp_nation, funcs:sum(shipping.volume), firstrow(tpch.shipping.supp_nation), firstrow(tpch.shipping.cust_nation), firstrow(shipping.l_year)
+    └─Projection_26	1957240.42	root	tpch.n1.n_name, tpch.n2.n_name, extract("YEAR", tpch.lineitem.l_shipdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
+      └─HashLeftJoin_36	1957240.42	root	inner join, inner:TableReader_84, equal:[eq(tpch.customer.c_nationkey, tpch.n2.n_nationkey)], other cond:or(and(eq(tpch.n1.n_name, "JAPAN"), eq(tpch.n2.n_name, "INDIA")), and(eq(tpch.n1.n_name, "INDIA"), eq(tpch.n2.n_name, "JAPAN")))
+        ├─HashLeftJoin_45	24465505.20	root	inner join, inner:TableReader_81, equal:[eq(tpch.orders.o_custkey, tpch.customer.c_custkey)]
+        │ ├─IndexMergeJoin_54	24465505.20	root	inner join, inner:TableReader_52, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
+        │ │ ├─HashRightJoin_58	24465505.20	root	inner join, inner:HashRightJoin_69, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
+        │ │ │ ├─HashRightJoin_69	40000.00	root	inner join, inner:TableReader_74, equal:[eq(tpch.n1.n_nationkey, tpch.supplier.s_nationkey)]
+        │ │ │ │ ├─TableReader_74	2.00	root	data:Selection_73
+        │ │ │ │ │ └─Selection_73	2.00	cop	or(eq(tpch.n1.n_name, "JAPAN"), eq(tpch.n1.n_name, "INDIA"))
+        │ │ │ │ │   └─TableScan_72	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
+        │ │ │ │ └─TableReader_71	500000.00	root	data:TableScan_70
+        │ │ │ │   └─TableScan_70	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        │ │ │ └─TableReader_77	91446230.29	root	data:Selection_76
+        │ │ │   └─Selection_76	91446230.29	cop	ge(tpch.lineitem.l_shipdate, 1995-01-01 00:00:00.000000), le(tpch.lineitem.l_shipdate, 1996-12-31 00:00:00.000000)
+        │ │ │     └─TableScan_75	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_52	1.00	root	data:TableScan_51
+        │ │   └─TableScan_51	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:true
+        │ └─TableReader_81	7500000.00	root	data:TableScan_80
+        │   └─TableScan_80	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        └─TableReader_84	2.00	root	data:Selection_83
+          └─Selection_83	2.00	cop	or(eq(tpch.n2.n_name, "INDIA"), eq(tpch.n2.n_name, "JAPAN"))
+            └─TableScan_82	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
 /*
 Q8 National Market Share Query
 This query determines how the market share of a given nation within a given region has changed over two years for
@@ -518,36 +518,36 @@ o_year;
 id	count	task	operator info
 Sort_29	719.02	root	all_nations.o_year:asc
 └─Projection_31	719.02	root	all_nations.o_year, div(18_col_0, 18_col_1)
-  └─HashAgg_34	719.02	root	group by:col_3, funcs:sum(col_0), sum(col_1), firstrow(col_2)
-    └─Projection_112	563136.02	root	case(eq(tpch.all_nations.nation, "INDIA"), all_nations.volume, 0), all_nations.volume, all_nations.o_year, all_nations.o_year
-      └─Projection_35	563136.02	root	extract("YEAR", tpch.orders.o_orderdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.n2.n_name
-        └─HashLeftJoin_43	563136.02	root	inner join, inner:TableReader_110, equal:[eq(tpch.supplier.s_nationkey, tpch.n2.n_nationkey)]
-          ├─HashLeftJoin_52	563136.02	root	inner join, inner:TableReader_108, equal:[eq(tpch.lineitem.l_suppkey, tpch.supplier.s_suppkey)]
-          │ ├─HashLeftJoin_63	563136.02	root	inner join, inner:TableReader_106, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
-          │ │ ├─IndexMergeJoin_74	90788402.51	root	inner join, inner:IndexLookUp_72, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-          │ │ │ ├─HashRightJoin_78	22413367.93	root	inner join, inner:HashRightJoin_80, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-          │ │ │ │ ├─HashRightJoin_80	1500000.00	root	inner join, inner:HashRightJoin_91, equal:[eq(tpch.n1.n_nationkey, tpch.customer.c_nationkey)]
-          │ │ │ │ │ ├─HashRightJoin_91	5.00	root	inner join, inner:TableReader_96, equal:[eq(tpch.region.r_regionkey, tpch.n1.n_regionkey)]
-          │ │ │ │ │ │ ├─TableReader_96	1.00	root	data:Selection_95
-          │ │ │ │ │ │ │ └─Selection_95	1.00	cop	eq(tpch.region.r_name, "ASIA")
-          │ │ │ │ │ │ │   └─TableScan_94	5.00	cop	table:region, range:[-inf,+inf], keep order:false
-          │ │ │ │ │ │ └─TableReader_93	25.00	root	data:TableScan_92
-          │ │ │ │ │ │   └─TableScan_92	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
-          │ │ │ │ │ └─TableReader_98	7500000.00	root	data:TableScan_97
-          │ │ │ │ │   └─TableScan_97	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-          │ │ │ │ └─TableReader_101	22413367.93	root	data:Selection_100
-          │ │ │ │   └─Selection_100	22413367.93	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), le(tpch.orders.o_orderdate, 1996-12-31 00:00:00.000000)
-          │ │ │ │     └─TableScan_99	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-          │ │ │ └─IndexLookUp_72	1.00	root	
-          │ │ │   ├─IndexScan_70	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
-          │ │ │   └─TableScan_71	1.00	cop	table:lineitem, keep order:false
-          │ │ └─TableReader_106	61674.00	root	data:Selection_105
-          │ │   └─Selection_105	61674.00	cop	eq(tpch.part.p_type, "SMALL PLATED COPPER")
-          │ │     └─TableScan_104	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-          │ └─TableReader_108	500000.00	root	data:TableScan_107
-          │   └─TableScan_107	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-          └─TableReader_110	25.00	root	data:TableScan_109
-            └─TableScan_109	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
+  └─HashAgg_32	719.02	root	group by:col_3, funcs:sum(col_0), sum(col_1), firstrow(col_2)
+    └─Projection_110	563136.02	root	case(eq(tpch.all_nations.nation, "INDIA"), all_nations.volume, 0), all_nations.volume, all_nations.o_year, all_nations.o_year
+      └─Projection_33	563136.02	root	extract("YEAR", tpch.orders.o_orderdate), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.n2.n_name
+        └─HashLeftJoin_41	563136.02	root	inner join, inner:TableReader_108, equal:[eq(tpch.supplier.s_nationkey, tpch.n2.n_nationkey)]
+          ├─HashLeftJoin_50	563136.02	root	inner join, inner:TableReader_106, equal:[eq(tpch.lineitem.l_suppkey, tpch.supplier.s_suppkey)]
+          │ ├─HashLeftJoin_61	563136.02	root	inner join, inner:TableReader_104, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
+          │ │ ├─IndexMergeJoin_72	90788402.51	root	inner join, inner:IndexLookUp_70, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+          │ │ │ ├─HashRightJoin_76	22413367.93	root	inner join, inner:HashRightJoin_78, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+          │ │ │ │ ├─HashRightJoin_78	1500000.00	root	inner join, inner:HashRightJoin_89, equal:[eq(tpch.n1.n_nationkey, tpch.customer.c_nationkey)]
+          │ │ │ │ │ ├─HashRightJoin_89	5.00	root	inner join, inner:TableReader_94, equal:[eq(tpch.region.r_regionkey, tpch.n1.n_regionkey)]
+          │ │ │ │ │ │ ├─TableReader_94	1.00	root	data:Selection_93
+          │ │ │ │ │ │ │ └─Selection_93	1.00	cop	eq(tpch.region.r_name, "ASIA")
+          │ │ │ │ │ │ │   └─TableScan_92	5.00	cop	table:region, range:[-inf,+inf], keep order:false
+          │ │ │ │ │ │ └─TableReader_91	25.00	root	data:TableScan_90
+          │ │ │ │ │ │   └─TableScan_90	25.00	cop	table:n1, range:[-inf,+inf], keep order:false
+          │ │ │ │ │ └─TableReader_96	7500000.00	root	data:TableScan_95
+          │ │ │ │ │   └─TableScan_95	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+          │ │ │ │ └─TableReader_99	22413367.93	root	data:Selection_98
+          │ │ │ │   └─Selection_98	22413367.93	cop	ge(tpch.orders.o_orderdate, 1995-01-01 00:00:00.000000), le(tpch.orders.o_orderdate, 1996-12-31 00:00:00.000000)
+          │ │ │ │     └─TableScan_97	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+          │ │ │ └─IndexLookUp_70	1.00	root	
+          │ │ │   ├─IndexScan_68	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
+          │ │ │   └─TableScan_69	1.00	cop	table:lineitem, keep order:false
+          │ │ └─TableReader_104	61674.00	root	data:Selection_103
+          │ │   └─Selection_103	61674.00	cop	eq(tpch.part.p_type, "SMALL PLATED COPPER")
+          │ │     └─TableScan_102	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+          │ └─TableReader_106	500000.00	root	data:TableScan_105
+          │   └─TableScan_105	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+          └─TableReader_108	25.00	root	data:TableScan_107
+            └─TableScan_107	25.00	cop	table:n2, range:[-inf,+inf], keep order:false
 /*
 Q9 Product Type Profit Measure Query
 This query determines how much profit is made on a given line of parts, broken out by supplier nation and year.
@@ -594,26 +594,26 @@ o_year desc;
 id	count	task	operator info
 Sort_25	2406.00	root	tpch.profit.nation:asc, profit.o_year:desc
 └─Projection_27	2406.00	root	tpch.profit.nation, profit.o_year, 14_col_0
-  └─HashAgg_30	2406.00	root	group by:profit.o_year, tpch.profit.nation, funcs:sum(profit.amount), firstrow(tpch.profit.nation), firstrow(profit.o_year)
-    └─Projection_31	971049283.51	root	tpch.nation.n_name, extract("YEAR", tpch.orders.o_orderdate), minus(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), mul(tpch.partsupp.ps_supplycost, tpch.lineitem.l_quantity))
-      └─HashLeftJoin_41	971049283.51	root	inner join, inner:TableReader_95, equal:[eq(tpch.lineitem.l_suppkey, tpch.partsupp.ps_suppkey) eq(tpch.lineitem.l_partkey, tpch.partsupp.ps_partkey)]
-        ├─HashLeftJoin_51	241379546.70	root	inner join, inner:TableReader_93, equal:[eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)]
-        │ ├─HashLeftJoin_70	241379546.70	root	inner join, inner:TableReader_91, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
-        │ │ ├─HashRightJoin_73	300005811.00	root	inner join, inner:HashRightJoin_82, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
-        │ │ │ ├─HashRightJoin_82	500000.00	root	inner join, inner:TableReader_86, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-        │ │ │ │ ├─TableReader_86	25.00	root	data:TableScan_85
-        │ │ │ │ │ └─TableScan_85	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ │ │ │ └─TableReader_84	500000.00	root	data:TableScan_83
-        │ │ │ │   └─TableScan_83	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-        │ │ │ └─TableReader_88	300005811.00	root	data:TableScan_87
-        │ │ │   └─TableScan_87	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_91	8000000.00	root	data:Selection_90
-        │ │   └─Selection_90	8000000.00	cop	like(tpch.part.p_name, "%dim%", 92)
-        │ │     └─TableScan_89	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-        │ └─TableReader_93	75000000.00	root	data:TableScan_92
-        │   └─TableScan_92	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─TableReader_95	40000000.00	root	data:TableScan_94
-          └─TableScan_94	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+  └─HashAgg_28	2406.00	root	group by:profit.o_year, tpch.profit.nation, funcs:sum(profit.amount), firstrow(tpch.profit.nation), firstrow(profit.o_year)
+    └─Projection_29	971049283.51	root	tpch.nation.n_name, extract("YEAR", tpch.orders.o_orderdate), minus(mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), mul(tpch.partsupp.ps_supplycost, tpch.lineitem.l_quantity))
+      └─HashLeftJoin_39	971049283.51	root	inner join, inner:TableReader_93, equal:[eq(tpch.lineitem.l_suppkey, tpch.partsupp.ps_suppkey) eq(tpch.lineitem.l_partkey, tpch.partsupp.ps_partkey)]
+        ├─HashLeftJoin_49	241379546.70	root	inner join, inner:TableReader_91, equal:[eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)]
+        │ ├─HashLeftJoin_68	241379546.70	root	inner join, inner:TableReader_89, equal:[eq(tpch.lineitem.l_partkey, tpch.part.p_partkey)]
+        │ │ ├─HashRightJoin_71	300005811.00	root	inner join, inner:HashRightJoin_80, equal:[eq(tpch.supplier.s_suppkey, tpch.lineitem.l_suppkey)]
+        │ │ │ ├─HashRightJoin_80	500000.00	root	inner join, inner:TableReader_84, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+        │ │ │ │ ├─TableReader_84	25.00	root	data:TableScan_83
+        │ │ │ │ │ └─TableScan_83	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ │ │ └─TableReader_82	500000.00	root	data:TableScan_81
+        │ │ │ │   └─TableScan_81	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+        │ │ │ └─TableReader_86	300005811.00	root	data:TableScan_85
+        │ │ │   └─TableScan_85	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_89	8000000.00	root	data:Selection_88
+        │ │   └─Selection_88	8000000.00	cop	like(tpch.part.p_name, "%dim%", 92)
+        │ │     └─TableScan_87	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+        │ └─TableReader_91	75000000.00	root	data:TableScan_90
+        │   └─TableScan_90	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─TableReader_93	40000000.00	root	data:TableScan_92
+          └─TableScan_92	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
 /*
 Q10 Returned Item Reporting Query
 The query identifies customers who might be having problems with the parts that are shipped to them.
@@ -660,22 +660,22 @@ limit 20;
 id	count	task	operator info
 Projection_17	20.00	root	tpch.customer.c_custkey, tpch.customer.c_name, 9_col_0, tpch.customer.c_acctbal, tpch.nation.n_name, tpch.customer.c_address, tpch.customer.c_phone, tpch.customer.c_comment
 └─TopN_20	20.00	root	9_col_0:desc, offset:0, count:20
-  └─HashAgg_26	3017307.69	root	group by:col_10, col_11, col_12, col_13, col_14, col_8, col_9, funcs:sum(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7)
-    └─Projection_62	12222016.17	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_address, tpch.customer.c_phone, tpch.customer.c_acctbal, tpch.customer.c_comment, tpch.nation.n_name, tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_acctbal, tpch.customer.c_phone, tpch.nation.n_name, tpch.customer.c_address, tpch.customer.c_comment
-      └─IndexMergeJoin_38	12222016.17	root	inner join, inner:IndexLookUp_36, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-        ├─HashLeftJoin_41	3017307.69	root	inner join, inner:TableReader_58, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-        │ ├─HashRightJoin_51	7500000.00	root	inner join, inner:TableReader_55, equal:[eq(tpch.nation.n_nationkey, tpch.customer.c_nationkey)]
-        │ │ ├─TableReader_55	25.00	root	data:TableScan_54
-        │ │ │ └─TableScan_54	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-        │ │ └─TableReader_53	7500000.00	root	data:TableScan_52
-        │ │   └─TableScan_52	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        │ └─TableReader_58	3017307.69	root	data:Selection_57
-        │   └─Selection_57	3017307.69	cop	ge(tpch.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1993-11-01)
-        │     └─TableScan_56	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-        └─IndexLookUp_36	0.25	root	
-          ├─IndexScan_33	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
-          └─Selection_35	0.25	cop	eq(tpch.lineitem.l_returnflag, "R")
-            └─TableScan_34	1.00	cop	table:lineitem, keep order:false
+  └─HashAgg_24	3017307.69	root	group by:col_10, col_11, col_12, col_13, col_14, col_8, col_9, funcs:sum(col_0), firstrow(col_1), firstrow(col_2), firstrow(col_3), firstrow(col_4), firstrow(col_5), firstrow(col_6), firstrow(col_7)
+    └─Projection_60	12222016.17	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_address, tpch.customer.c_phone, tpch.customer.c_acctbal, tpch.customer.c_comment, tpch.nation.n_name, tpch.customer.c_custkey, tpch.customer.c_name, tpch.customer.c_acctbal, tpch.customer.c_phone, tpch.nation.n_name, tpch.customer.c_address, tpch.customer.c_comment
+      └─IndexMergeJoin_36	12222016.17	root	inner join, inner:IndexLookUp_34, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+        ├─HashLeftJoin_39	3017307.69	root	inner join, inner:TableReader_56, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        │ ├─HashRightJoin_49	7500000.00	root	inner join, inner:TableReader_53, equal:[eq(tpch.nation.n_nationkey, tpch.customer.c_nationkey)]
+        │ │ ├─TableReader_53	25.00	root	data:TableScan_52
+        │ │ │ └─TableScan_52	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+        │ │ └─TableReader_51	7500000.00	root	data:TableScan_50
+        │ │   └─TableScan_50	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        │ └─TableReader_56	3017307.69	root	data:Selection_55
+        │   └─Selection_55	3017307.69	cop	ge(tpch.orders.o_orderdate, 1993-08-01 00:00:00.000000), lt(tpch.orders.o_orderdate, 1993-11-01)
+        │     └─TableScan_54	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+        └─IndexLookUp_34	0.25	root	
+          ├─IndexScan_31	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
+          └─Selection_33	0.25	cop	eq(tpch.lineitem.l_returnflag, "R")
+            └─TableScan_32	1.00	cop	table:lineitem, keep order:false
 /*
 Q11 Important Stock Identification Query
 This query finds the most important subset of suppliers' stock in a given nation.
@@ -712,20 +712,20 @@ and n_name = 'MOZAMBIQUE'
 order by
 value desc;
 id	count	task	operator info
-Projection_55	1304801.67	root	tpch.partsupp.ps_partkey, value
-└─Sort_56	1304801.67	root	value:desc
-  └─Selection_58	1304801.67	root	gt(sel_agg_4, NULL)
-    └─HashAgg_61	1631002.09	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
-      └─Projection_85	1631002.09	root	mul(tpch.partsupp.ps_supplycost, cast(tpch.partsupp.ps_availqty)), tpch.partsupp.ps_partkey, tpch.partsupp.ps_partkey
-        └─HashRightJoin_65	1631002.09	root	inner join, inner:HashRightJoin_76, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
-          ├─HashRightJoin_76	20000.00	root	inner join, inner:TableReader_81, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-          │ ├─TableReader_81	1.00	root	data:Selection_80
-          │ │ └─Selection_80	1.00	cop	eq(tpch.nation.n_name, "MOZAMBIQUE")
-          │ │   └─TableScan_79	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-          │ └─TableReader_78	500000.00	root	data:TableScan_77
-          │   └─TableScan_77	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-          └─TableReader_83	40000000.00	root	data:TableScan_82
-            └─TableScan_82	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
+Projection_52	1304801.67	root	tpch.partsupp.ps_partkey, value
+└─Sort_53	1304801.67	root	value:desc
+  └─Selection_55	1304801.67	root	gt(sel_agg_4, NULL)
+    └─HashAgg_56	1631002.09	root	group by:col_2, funcs:sum(col_0), firstrow(col_1)
+      └─Projection_79	1631002.09	root	mul(tpch.partsupp.ps_supplycost, cast(tpch.partsupp.ps_availqty)), tpch.partsupp.ps_partkey, tpch.partsupp.ps_partkey
+        └─HashRightJoin_59	1631002.09	root	inner join, inner:HashRightJoin_70, equal:[eq(tpch.supplier.s_suppkey, tpch.partsupp.ps_suppkey)]
+          ├─HashRightJoin_70	20000.00	root	inner join, inner:TableReader_75, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+          │ ├─TableReader_75	1.00	root	data:Selection_74
+          │ │ └─Selection_74	1.00	cop	eq(tpch.nation.n_name, "MOZAMBIQUE")
+          │ │   └─TableScan_73	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+          │ └─TableReader_72	500000.00	root	data:TableScan_71
+          │   └─TableScan_71	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+          └─TableReader_77	40000000.00	root	data:TableScan_76
+            └─TableScan_76	40000000.00	cop	table:partsupp, range:[-inf,+inf], keep order:false
 /*
 Q12 Shipping Modes and Order Priority Query
 This query determines whether selecting less expensive modes of shipping is negatively affecting the critical-priority
@@ -768,14 +768,14 @@ l_shipmode;
 id	count	task	operator info
 Sort_9	1.00	root	tpch.lineitem.l_shipmode:asc
 └─Projection_11	1.00	root	tpch.lineitem.l_shipmode, 5_col_0, 5_col_1
-  └─HashAgg_14	1.00	root	group by:col_3, funcs:sum(col_0), sum(col_1), firstrow(col_2)
-    └─Projection_49	10023369.01	root	cast(case(or(eq(tpch.orders.o_orderpriority, "1-URGENT"), eq(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), cast(case(and(ne(tpch.orders.o_orderpriority, "1-URGENT"), ne(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), tpch.lineitem.l_shipmode, tpch.lineitem.l_shipmode
-      └─IndexMergeJoin_22	10023369.01	root	inner join, inner:TableReader_20, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-        ├─TableReader_45	10023369.01	root	data:Selection_44
-        │ └─Selection_44	10023369.01	cop	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
-        │   └─TableScan_43	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-        └─TableReader_20	1.00	root	data:TableScan_19
-          └─TableScan_19	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:true
+  └─HashAgg_12	1.00	root	group by:col_3, funcs:sum(col_0), sum(col_1), firstrow(col_2)
+    └─Projection_47	10023369.01	root	cast(case(or(eq(tpch.orders.o_orderpriority, "1-URGENT"), eq(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), cast(case(and(ne(tpch.orders.o_orderpriority, "1-URGENT"), ne(tpch.orders.o_orderpriority, "2-HIGH")), 1, 0)), tpch.lineitem.l_shipmode, tpch.lineitem.l_shipmode
+      └─IndexMergeJoin_20	10023369.01	root	inner join, inner:TableReader_18, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
+        ├─TableReader_43	10023369.01	root	data:Selection_42
+        │ └─Selection_42	10023369.01	cop	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
+        │   └─TableScan_41	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+        └─TableReader_18	1.00	root	data:TableScan_17
+          └─TableScan_17	1.00	cop	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:true
 /*
 Q13 Customer Distribution Query
 This query seeks relationships between customers and the size of their orders.
@@ -808,14 +808,14 @@ c_count desc;
 id	count	task	operator info
 Sort_9	7500000.00	root	custdist:desc, c_orders.c_count:desc
 └─Projection_11	7500000.00	root	c_count, 6_col_0
-  └─HashAgg_14	7500000.00	root	group by:c_count, funcs:count(1), firstrow(c_count)
-    └─HashAgg_17	7500000.00	root	group by:tpch.customer.c_custkey, funcs:count(tpch.orders.o_orderkey)
-      └─HashLeftJoin_20	60000000.00	root	left outer join, inner:TableReader_25, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-        ├─TableReader_22	7500000.00	root	data:TableScan_21
-        │ └─TableScan_21	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        └─TableReader_25	60000000.00	root	data:Selection_24
-          └─Selection_24	60000000.00	cop	not(like(tpch.orders.o_comment, "%pending%deposits%", 92))
-            └─TableScan_23	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+  └─HashAgg_12	7500000.00	root	group by:c_count, funcs:count(1), firstrow(c_count)
+    └─HashAgg_13	7500000.00	root	group by:tpch.customer.c_custkey, funcs:count(tpch.orders.o_orderkey)
+      └─HashLeftJoin_15	60000000.00	root	left outer join, inner:TableReader_20, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        ├─TableReader_17	7500000.00	root	data:TableScan_16
+        │ └─TableScan_16	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        └─TableReader_20	60000000.00	root	data:Selection_19
+          └─Selection_19	60000000.00	cop	not(like(tpch.orders.o_comment, "%pending%deposits%", 92))
+            └─TableScan_18	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
 /*
 Q14 Promotion Effect Query
 This query monitors the market response to a promotion such as TV advertisements or a special campaign.
@@ -839,14 +839,14 @@ and l_shipdate >= '1996-12-01'
 and l_shipdate < date_add('1996-12-01', interval '1' month);
 id	count	task	operator info
 Projection_8	1.00	root	div(mul(100.00, 5_col_0), 5_col_1)
-└─StreamAgg_13	1.00	root	funcs:sum(col_0), sum(col_1)
-  └─Projection_37	4121984.49	root	case(like(tpch.part.p_type, "PROMO%", 92), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), 0), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
-    └─IndexMergeJoin_34	4121984.49	root	inner join, inner:TableReader_32, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey
-      ├─TableReader_25	4121984.49	root	data:Selection_24
-      │ └─Selection_24	4121984.49	cop	ge(tpch.lineitem.l_shipdate, 1996-12-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1997-01-01)
-      │   └─TableScan_23	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      └─TableReader_32	1.00	root	data:TableScan_31
-        └─TableScan_31	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:true
+└─StreamAgg_10	1.00	root	funcs:sum(col_0), sum(col_1)
+  └─Projection_34	4121984.49	root	case(like(tpch.part.p_type, "PROMO%", 92), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount)), 0), mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
+    └─IndexMergeJoin_31	4121984.49	root	inner join, inner:TableReader_29, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey
+      ├─TableReader_22	4121984.49	root	data:Selection_21
+      │ └─Selection_21	4121984.49	cop	ge(tpch.lineitem.l_shipdate, 1996-12-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1997-01-01)
+      │   └─TableScan_20	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+      └─TableReader_29	1.00	root	data:TableScan_28
+        └─TableScan_28	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:true
 /*
 Q15 Top Supplier Query
 This query determines the top supplier so it can be rewarded, given more business, or identified for special recognition.
@@ -929,17 +929,17 @@ p_size;
 id	count	task	operator info
 Sort_13	3863988.24	root	supplier_cnt:desc, tpch.part.p_brand:asc, tpch.part.p_type:asc, tpch.part.p_size:asc
 └─Projection_15	3863988.24	root	tpch.part.p_brand, tpch.part.p_type, tpch.part.p_size, 9_col_0
-  └─HashAgg_18	3863988.24	root	group by:tpch.part.p_brand, tpch.part.p_size, tpch.part.p_type, funcs:count(distinct tpch.partsupp.ps_suppkey), firstrow(tpch.part.p_brand), firstrow(tpch.part.p_type), firstrow(tpch.part.p_size)
-    └─HashLeftJoin_28	3863988.24	root	anti semi join, inner:TableReader_60, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
-      ├─IndexMergeJoin_36	4829985.30	root	inner join, inner:IndexReader_34, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
-      │ ├─TableReader_55	1200618.43	root	data:Selection_54
-      │ │ └─Selection_54	1200618.43	cop	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
-      │ │   └─TableScan_53	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-      │ └─IndexReader_34	1.00	root	index:IndexScan_33
-      │   └─IndexScan_33	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:true
-      └─TableReader_60	400000.00	root	data:Selection_59
-        └─Selection_59	400000.00	cop	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
-          └─TableScan_58	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+  └─HashAgg_16	3863988.24	root	group by:tpch.part.p_brand, tpch.part.p_size, tpch.part.p_type, funcs:count(distinct tpch.partsupp.ps_suppkey), firstrow(tpch.part.p_brand), firstrow(tpch.part.p_type), firstrow(tpch.part.p_size)
+    └─HashLeftJoin_26	3863988.24	root	anti semi join, inner:TableReader_58, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
+      ├─IndexMergeJoin_34	4829985.30	root	inner join, inner:IndexReader_32, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
+      │ ├─TableReader_53	1200618.43	root	data:Selection_52
+      │ │ └─Selection_52	1200618.43	cop	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
+      │ │   └─TableScan_51	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+      │ └─IndexReader_32	1.00	root	index:IndexScan_31
+      │   └─IndexScan_31	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:true
+      └─TableReader_58	400000.00	root	data:Selection_57
+        └─Selection_57	400000.00	cop	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
+          └─TableScan_56	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
 /*
 Q17 Small-Quantity-Order Revenue Query
 This query determines how much average yearly revenue would be lost if orders were no longer filled for small
@@ -970,19 +970,19 @@ l_partkey = p_partkey
 );
 id	count	task	operator info
 Projection_16	1.00	root	div(11_col_0, 7.0)
-└─StreamAgg_21	1.00	root	funcs:sum(tpch.lineitem.l_extendedprice)
-  └─Projection_49	293773.83	root	tpch.lineitem.l_partkey, tpch.lineitem.l_quantity, tpch.lineitem.l_extendedprice, tpch.part.p_partkey, tpch.part.p_brand, tpch.part.p_container, mul(0.2, 7_col_0)
-    └─HashRightJoin_51	293773.83	root	inner join, inner:HashRightJoin_35, equal:[eq(tpch.part.p_partkey, tpch.lineitem.l_partkey)], other cond:lt(tpch.lineitem.l_quantity, mul(0.2, 7_col_0))
-      ├─HashRightJoin_35	293773.83	root	inner join, inner:TableReader_40, equal:[eq(tpch.part.p_partkey, tpch.lineitem.l_partkey)]
-      │ ├─TableReader_40	9736.49	root	data:Selection_39
-      │ │ └─Selection_39	9736.49	cop	eq(tpch.part.p_brand, "Brand#44"), eq(tpch.part.p_container, "WRAP PKG")
-      │ │   └─TableScan_38	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-      │ └─TableReader_37	300005811.00	root	data:TableScan_36
-      │   └─TableScan_36	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      └─HashAgg_45	9943040.00	root	group by:col_3, funcs:avg(col_0, col_1), firstrow(col_3)
-        └─TableReader_46	9943040.00	root	data:HashAgg_41
-          └─HashAgg_41	9943040.00	cop	group by:tpch.lineitem.l_partkey, funcs:count(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_quantity)
-            └─TableScan_44	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+└─StreamAgg_18	1.00	root	funcs:sum(tpch.lineitem.l_extendedprice)
+  └─Projection_46	293773.83	root	tpch.lineitem.l_partkey, tpch.lineitem.l_quantity, tpch.lineitem.l_extendedprice, tpch.part.p_partkey, tpch.part.p_brand, tpch.part.p_container, mul(0.2, 7_col_0)
+    └─HashRightJoin_48	293773.83	root	inner join, inner:HashRightJoin_32, equal:[eq(tpch.part.p_partkey, tpch.lineitem.l_partkey)], other cond:lt(tpch.lineitem.l_quantity, mul(0.2, 7_col_0))
+      ├─HashRightJoin_32	293773.83	root	inner join, inner:TableReader_37, equal:[eq(tpch.part.p_partkey, tpch.lineitem.l_partkey)]
+      │ ├─TableReader_37	9736.49	root	data:Selection_36
+      │ │ └─Selection_36	9736.49	cop	eq(tpch.part.p_brand, "Brand#44"), eq(tpch.part.p_container, "WRAP PKG")
+      │ │   └─TableScan_35	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+      │ └─TableReader_34	300005811.00	root	data:TableScan_33
+      │   └─TableScan_33	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+      └─HashAgg_44	9943040.00	root	group by:col_3, funcs:avg(col_0, col_1), firstrow(col_3)
+        └─TableReader_45	9943040.00	root	data:HashAgg_39
+          └─HashAgg_39	9943040.00	cop	group by:tpch.lineitem.l_partkey, funcs:count(tpch.lineitem.l_quantity), sum(tpch.lineitem.l_quantity)
+            └─TableScan_43	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
 /*
 Q18 Large Volume Customer Query
 The Large Volume Customer Query ranks customers based on their having placed a large quantity order. Large
@@ -1028,22 +1028,22 @@ limit 100;
 id	count	task	operator info
 Projection_24	100.00	root	tpch.customer.c_name, tpch.customer.c_custkey, tpch.orders.o_orderkey, tpch.orders.o_orderdate, tpch.orders.o_totalprice, 14_col_0
 └─TopN_27	100.00	root	tpch.orders.o_totalprice:desc, tpch.orders.o_orderdate:asc, offset:0, count:100
-  └─HashAgg_33	59251097.60	root	group by:tpch.customer.c_custkey, tpch.customer.c_name, tpch.orders.o_orderdate, tpch.orders.o_orderkey, tpch.orders.o_totalprice, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.customer.c_custkey), firstrow(tpch.customer.c_name), firstrow(tpch.orders.o_orderkey), firstrow(tpch.orders.o_totalprice), firstrow(tpch.orders.o_orderdate)
-    └─IndexMergeJoin_43	240004648.80	root	inner join, inner:IndexLookUp_41, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
-      ├─HashLeftJoin_46	59251097.60	root	inner join, inner:Selection_61, equal:[eq(tpch.orders.o_orderkey, tpch.lineitem.l_orderkey)]
-      │ ├─HashRightJoin_56	75000000.00	root	inner join, inner:TableReader_60, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-      │ │ ├─TableReader_60	7500000.00	root	data:TableScan_59
-      │ │ │ └─TableScan_59	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_58	75000000.00	root	data:TableScan_57
-      │ │   └─TableScan_57	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
-      │ └─Selection_61	59251097.60	root	gt(sel_agg_2, 314)
+  └─HashAgg_31	59251097.60	root	group by:tpch.customer.c_custkey, tpch.customer.c_name, tpch.orders.o_orderdate, tpch.orders.o_orderkey, tpch.orders.o_totalprice, funcs:sum(tpch.lineitem.l_quantity), firstrow(tpch.customer.c_custkey), firstrow(tpch.customer.c_name), firstrow(tpch.orders.o_orderkey), firstrow(tpch.orders.o_totalprice), firstrow(tpch.orders.o_orderdate)
+    └─IndexMergeJoin_41	240004648.80	root	inner join, inner:IndexLookUp_39, outer key:tpch.orders.o_orderkey, inner key:tpch.lineitem.l_orderkey
+      ├─HashLeftJoin_44	59251097.60	root	inner join, inner:Selection_59, equal:[eq(tpch.orders.o_orderkey, tpch.lineitem.l_orderkey)]
+      │ ├─HashRightJoin_54	75000000.00	root	inner join, inner:TableReader_58, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+      │ │ ├─TableReader_58	7500000.00	root	data:TableScan_57
+      │ │ │ └─TableScan_57	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+      │ │ └─TableReader_56	75000000.00	root	data:TableScan_55
+      │ │   └─TableScan_55	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+      │ └─Selection_59	59251097.60	root	gt(sel_agg_2, 314)
       │   └─HashAgg_68	74063872.00	root	group by:col_2, funcs:sum(col_0), firstrow(col_2)
-      │     └─TableReader_69	74063872.00	root	data:HashAgg_62
-      │       └─HashAgg_62	74063872.00	cop	group by:tpch.lineitem.l_orderkey, funcs:sum(tpch.lineitem.l_quantity)
+      │     └─TableReader_69	74063872.00	root	data:HashAgg_61
+      │       └─HashAgg_61	74063872.00	cop	group by:tpch.lineitem.l_orderkey, funcs:sum(tpch.lineitem.l_quantity)
       │         └─TableScan_67	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-      └─IndexLookUp_41	1.00	root	
-        ├─IndexScan_39	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
-        └─TableScan_40	1.00	cop	table:lineitem, keep order:false
+      └─IndexLookUp_39	1.00	root	
+        ├─IndexScan_37	1.00	cop	table:lineitem, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.lineitem.l_orderkey, tpch.orders.o_orderkey)], keep order:true
+        └─TableScan_38	1.00	cop	table:lineitem, keep order:false
 /*
 Q19 Discounted Revenue Query
 The Discounted Revenue Query reports the gross discounted revenue attributed to the sale of selected parts handled
@@ -1090,15 +1090,15 @@ and l_shipmode in ('AIR', 'AIR REG')
 and l_shipinstruct = 'DELIVER IN PERSON'
 );
 id	count	task	operator info
-StreamAgg_13	1.00	root	funcs:sum(col_0)
-└─Projection_42	6286493.79	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
-  └─IndexMergeJoin_39	6286493.79	root	inner join, inner:TableReader_37, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey, other cond:or(and(and(eq(tpch.part.p_brand, "Brand#52"), in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG")), and(ge(tpch.lineitem.l_quantity, 4), and(le(tpch.lineitem.l_quantity, 14), le(tpch.part.p_size, 5)))), or(and(and(eq(tpch.part.p_brand, "Brand#11"), in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")), and(ge(tpch.lineitem.l_quantity, 18), and(le(tpch.lineitem.l_quantity, 28), le(tpch.part.p_size, 10)))), and(and(eq(tpch.part.p_brand, "Brand#51"), in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG")), and(ge(tpch.lineitem.l_quantity, 29), and(le(tpch.lineitem.l_quantity, 39), le(tpch.part.p_size, 15))))))
-    ├─TableReader_27	6286493.79	root	data:Selection_26
-    │ └─Selection_26	6286493.79	cop	eq(tpch.lineitem.l_shipinstruct, "DELIVER IN PERSON"), in(tpch.lineitem.l_shipmode, "AIR", "AIR REG"), or(and(ge(tpch.lineitem.l_quantity, 4), le(tpch.lineitem.l_quantity, 14)), or(and(ge(tpch.lineitem.l_quantity, 18), le(tpch.lineitem.l_quantity, 28)), and(ge(tpch.lineitem.l_quantity, 29), le(tpch.lineitem.l_quantity, 39))))
-    │   └─TableScan_25	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
-    └─TableReader_37	0.80	root	data:Selection_36
-      └─Selection_36	0.80	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
-        └─TableScan_35	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:true
+StreamAgg_10	1.00	root	funcs:sum(col_0)
+└─Projection_39	6286493.79	root	mul(tpch.lineitem.l_extendedprice, minus(1, tpch.lineitem.l_discount))
+  └─IndexMergeJoin_36	6286493.79	root	inner join, inner:TableReader_34, outer key:tpch.lineitem.l_partkey, inner key:tpch.part.p_partkey, other cond:or(and(and(eq(tpch.part.p_brand, "Brand#52"), in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG")), and(ge(tpch.lineitem.l_quantity, 4), and(le(tpch.lineitem.l_quantity, 14), le(tpch.part.p_size, 5)))), or(and(and(eq(tpch.part.p_brand, "Brand#11"), in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK")), and(ge(tpch.lineitem.l_quantity, 18), and(le(tpch.lineitem.l_quantity, 28), le(tpch.part.p_size, 10)))), and(and(eq(tpch.part.p_brand, "Brand#51"), in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG")), and(ge(tpch.lineitem.l_quantity, 29), and(le(tpch.lineitem.l_quantity, 39), le(tpch.part.p_size, 15))))))
+    ├─TableReader_24	6286493.79	root	data:Selection_23
+    │ └─Selection_23	6286493.79	cop	eq(tpch.lineitem.l_shipinstruct, "DELIVER IN PERSON"), in(tpch.lineitem.l_shipmode, "AIR", "AIR REG"), or(and(ge(tpch.lineitem.l_quantity, 4), le(tpch.lineitem.l_quantity, 14)), or(and(ge(tpch.lineitem.l_quantity, 18), le(tpch.lineitem.l_quantity, 28)), and(ge(tpch.lineitem.l_quantity, 29), le(tpch.lineitem.l_quantity, 39))))
+    │   └─TableScan_22	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+    └─TableReader_34	0.80	root	data:Selection_33
+      └─Selection_33	0.80	cop	ge(tpch.part.p_size, 1), or(and(eq(tpch.part.p_brand, "Brand#52"), and(in(tpch.part.p_container, "SM CASE", "SM BOX", "SM PACK", "SM PKG"), le(tpch.part.p_size, 5))), or(and(eq(tpch.part.p_brand, "Brand#11"), and(in(tpch.part.p_container, "MED BAG", "MED BOX", "MED PKG", "MED PACK"), le(tpch.part.p_size, 10))), and(eq(tpch.part.p_brand, "Brand#51"), and(in(tpch.part.p_container, "LG CASE", "LG BOX", "LG PACK", "LG PKG"), le(tpch.part.p_size, 15)))))
+        └─TableScan_32	1.00	cop	table:part, range: decided by [tpch.lineitem.l_partkey], keep order:true
 /*
 Q20 Potential Part Promotion Query
 The Potential Part Promotion Query identifies suppliers in a particular nation having selected parts that may be candidates
@@ -1155,21 +1155,21 @@ Sort_28	20000.00	root	tpch.supplier.s_name:asc
     │ │   └─TableScan_46	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
     │ └─TableReader_45	500000.00	root	data:TableScan_44
     │   └─TableScan_44	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-    └─HashAgg_51	64006.34	root	group by:tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_suppkey)
-      └─Projection_52	64006.34	root	tpch.partsupp.ps_partkey, tpch.partsupp.ps_suppkey, tpch.partsupp.ps_availqty, tpch.part.p_partkey, mul(0.5, 14_col_0)
-        └─Selection_53	64006.34	root	gt(cast(tpch.partsupp.ps_availqty), mul(0.5, 14_col_0))
-          └─HashAgg_56	80007.93	root	group by:tpch.partsupp.ps_partkey, tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_partkey), firstrow(tpch.partsupp.ps_suppkey), firstrow(tpch.partsupp.ps_availqty), firstrow(tpch.part.p_partkey), sum(tpch.lineitem.l_quantity)
-            └─HashLeftJoin_59	9711455.06	root	left outer join, inner:TableReader_95, equal:[eq(tpch.partsupp.ps_partkey, tpch.lineitem.l_partkey) eq(tpch.partsupp.ps_suppkey, tpch.lineitem.l_suppkey)]
-              ├─IndexMergeJoin_69	321865.05	root	inner join, inner:IndexLookUp_67, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
-              │ ├─TableReader_90	80007.93	root	data:Selection_89
-              │ │ └─Selection_89	80007.93	cop	like(tpch.part.p_name, "green%", 92)
-              │ │   └─TableScan_88	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
-              │ └─IndexLookUp_67	1.00	root	
-              │   ├─IndexScan_65	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:true
-              │   └─TableScan_66	1.00	cop	table:partsupp, keep order:false
-              └─TableReader_95	44189356.65	root	data:Selection_94
-                └─Selection_94	44189356.65	cop	ge(tpch.lineitem.l_shipdate, 1993-01-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1994-01-01)
-                  └─TableScan_93	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
+    └─HashAgg_49	64006.34	root	group by:tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_suppkey)
+      └─Projection_50	64006.34	root	tpch.partsupp.ps_partkey, tpch.partsupp.ps_suppkey, tpch.partsupp.ps_availqty, tpch.part.p_partkey, mul(0.5, 14_col_0)
+        └─Selection_51	64006.34	root	gt(cast(tpch.partsupp.ps_availqty), mul(0.5, 14_col_0))
+          └─HashAgg_52	80007.93	root	group by:tpch.partsupp.ps_partkey, tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_partkey), firstrow(tpch.partsupp.ps_suppkey), firstrow(tpch.partsupp.ps_availqty), firstrow(tpch.part.p_partkey), sum(tpch.lineitem.l_quantity)
+            └─HashLeftJoin_54	9711455.06	root	left outer join, inner:TableReader_90, equal:[eq(tpch.partsupp.ps_partkey, tpch.lineitem.l_partkey) eq(tpch.partsupp.ps_suppkey, tpch.lineitem.l_suppkey)]
+              ├─IndexMergeJoin_64	321865.05	root	inner join, inner:IndexLookUp_62, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
+              │ ├─TableReader_85	80007.93	root	data:Selection_84
+              │ │ └─Selection_84	80007.93	cop	like(tpch.part.p_name, "green%", 92)
+              │ │   └─TableScan_83	10000000.00	cop	table:part, range:[-inf,+inf], keep order:false
+              │ └─IndexLookUp_62	1.00	root	
+              │   ├─IndexScan_60	1.00	cop	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:true
+              │   └─TableScan_61	1.00	cop	table:partsupp, keep order:false
+              └─TableReader_90	44189356.65	root	data:Selection_89
+                └─Selection_89	44189356.65	cop	ge(tpch.lineitem.l_shipdate, 1993-01-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1994-01-01)
+                  └─TableScan_88	300005811.00	cop	table:lineitem, range:[-inf,+inf], keep order:false
 /*
 Q21 Suppliers Who Kept Orders Waiting Query
 This query identifies certain suppliers who were not able to ship required parts in a timely manner.
@@ -1221,30 +1221,30 @@ limit 100;
 id	count	task	operator info
 Projection_25	1.00	root	tpch.supplier.s_name, 17_col_0
 └─TopN_28	1.00	root	17_col_0:desc, tpch.supplier.s_name:asc, offset:0, count:100
-  └─HashAgg_34	1.00	root	group by:tpch.supplier.s_name, funcs:count(1), firstrow(tpch.supplier.s_name)
-    └─IndexMergeJoin_46	7828961.66	root	anti semi join, inner:IndexLookUp_44, outer key:tpch.l1.l_orderkey, inner key:tpch.l3.l_orderkey, other cond:ne(tpch.l3.l_suppkey, tpch.l1.l_suppkey), ne(tpch.l3.l_suppkey, tpch.supplier.s_suppkey)
-      ├─IndexMergeJoin_77	9786202.08	root	semi join, inner:IndexLookUp_75, outer key:tpch.l1.l_orderkey, inner key:tpch.l2.l_orderkey, other cond:ne(tpch.l2.l_suppkey, tpch.l1.l_suppkey), ne(tpch.l2.l_suppkey, tpch.supplier.s_suppkey)
-      │ ├─IndexMergeJoin_88	12232752.60	root	inner join, inner:TableReader_86, outer key:tpch.l1.l_orderkey, inner key:tpch.orders.o_orderkey
-      │ │ ├─HashRightJoin_92	12232752.60	root	inner join, inner:HashRightJoin_103, equal:[eq(tpch.supplier.s_suppkey, tpch.l1.l_suppkey)]
-      │ │ │ ├─HashRightJoin_103	20000.00	root	inner join, inner:TableReader_108, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
-      │ │ │ │ ├─TableReader_108	1.00	root	data:Selection_107
-      │ │ │ │ │ └─Selection_107	1.00	cop	eq(tpch.nation.n_name, "EGYPT")
-      │ │ │ │ │   └─TableScan_106	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
-      │ │ │ │ └─TableReader_105	500000.00	root	data:TableScan_104
-      │ │ │ │   └─TableScan_104	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
-      │ │ │ └─TableReader_111	240004648.80	root	data:Selection_110
-      │ │ │   └─Selection_110	240004648.80	cop	gt(tpch.l1.l_receiptdate, tpch.l1.l_commitdate)
-      │ │ │     └─TableScan_109	300005811.00	cop	table:l1, range:[-inf,+inf], keep order:false
-      │ │ └─TableReader_86	0.80	root	data:Selection_85
-      │ │   └─Selection_85	0.80	cop	eq(tpch.orders.o_orderstatus, "F")
-      │ │     └─TableScan_84	1.00	cop	table:orders, range: decided by [tpch.l1.l_orderkey], keep order:true
-      │ └─IndexLookUp_75	1.00	root	
-      │   ├─IndexScan_73	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l2.l_orderkey, tpch.l1.l_orderkey)], keep order:true
-      │   └─TableScan_74	1.00	cop	table:l2, keep order:false
-      └─IndexLookUp_44	0.80	root	
-        ├─IndexScan_41	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l3.l_orderkey, tpch.l1.l_orderkey)], keep order:true
-        └─Selection_43	0.80	cop	gt(tpch.l3.l_receiptdate, tpch.l3.l_commitdate)
-          └─TableScan_42	1.00	cop	table:l3, keep order:false
+  └─HashAgg_32	1.00	root	group by:tpch.supplier.s_name, funcs:count(1), firstrow(tpch.supplier.s_name)
+    └─IndexMergeJoin_44	7828961.66	root	anti semi join, inner:IndexLookUp_42, outer key:tpch.l1.l_orderkey, inner key:tpch.l3.l_orderkey, other cond:ne(tpch.l3.l_suppkey, tpch.l1.l_suppkey), ne(tpch.l3.l_suppkey, tpch.supplier.s_suppkey)
+      ├─IndexMergeJoin_75	9786202.08	root	semi join, inner:IndexLookUp_73, outer key:tpch.l1.l_orderkey, inner key:tpch.l2.l_orderkey, other cond:ne(tpch.l2.l_suppkey, tpch.l1.l_suppkey), ne(tpch.l2.l_suppkey, tpch.supplier.s_suppkey)
+      │ ├─IndexMergeJoin_86	12232752.60	root	inner join, inner:TableReader_84, outer key:tpch.l1.l_orderkey, inner key:tpch.orders.o_orderkey
+      │ │ ├─HashRightJoin_90	12232752.60	root	inner join, inner:HashRightJoin_101, equal:[eq(tpch.supplier.s_suppkey, tpch.l1.l_suppkey)]
+      │ │ │ ├─HashRightJoin_101	20000.00	root	inner join, inner:TableReader_106, equal:[eq(tpch.nation.n_nationkey, tpch.supplier.s_nationkey)]
+      │ │ │ │ ├─TableReader_106	1.00	root	data:Selection_105
+      │ │ │ │ │ └─Selection_105	1.00	cop	eq(tpch.nation.n_name, "EGYPT")
+      │ │ │ │ │   └─TableScan_104	25.00	cop	table:nation, range:[-inf,+inf], keep order:false
+      │ │ │ │ └─TableReader_103	500000.00	root	data:TableScan_102
+      │ │ │ │   └─TableScan_102	500000.00	cop	table:supplier, range:[-inf,+inf], keep order:false
+      │ │ │ └─TableReader_109	240004648.80	root	data:Selection_108
+      │ │ │   └─Selection_108	240004648.80	cop	gt(tpch.l1.l_receiptdate, tpch.l1.l_commitdate)
+      │ │ │     └─TableScan_107	300005811.00	cop	table:l1, range:[-inf,+inf], keep order:false
+      │ │ └─TableReader_84	0.80	root	data:Selection_83
+      │ │   └─Selection_83	0.80	cop	eq(tpch.orders.o_orderstatus, "F")
+      │ │     └─TableScan_82	1.00	cop	table:orders, range: decided by [tpch.l1.l_orderkey], keep order:true
+      │ └─IndexLookUp_73	1.00	root	
+      │   ├─IndexScan_71	1.00	cop	table:l2, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l2.l_orderkey, tpch.l1.l_orderkey)], keep order:true
+      │   └─TableScan_72	1.00	cop	table:l2, keep order:false
+      └─IndexLookUp_42	0.80	root	
+        ├─IndexScan_39	1.00	cop	table:l3, index:L_ORDERKEY, L_LINENUMBER, range: decided by [eq(tpch.l3.l_orderkey, tpch.l1.l_orderkey)], keep order:true
+        └─Selection_41	0.80	cop	gt(tpch.l3.l_receiptdate, tpch.l3.l_commitdate)
+          └─TableScan_40	1.00	cop	table:l3, keep order:false
 /*
 Q22 Global Sales Opportunity Query
 The Global Sales Opportunity Query identifies geographies where there are customers who may be likely to make a
@@ -1292,14 +1292,14 @@ cntrycode
 order by
 cntrycode;
 id	count	task	operator info
-Sort_32	1.00	root	custsale.cntrycode:asc
-└─Projection_34	1.00	root	custsale.cntrycode, 28_col_0, 28_col_1
-  └─HashAgg_37	1.00	root	group by:custsale.cntrycode, funcs:count(1), sum(tpch.custsale.c_acctbal), firstrow(custsale.cntrycode)
-    └─Projection_38	0.00	root	substring(tpch.customer.c_phone, 1, 2), tpch.customer.c_acctbal
-      └─HashLeftJoin_39	0.00	root	anti semi join, inner:TableReader_45, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
-        ├─Selection_40	0.00	root	in(substring(tpch.customer.c_phone, 1, 2), "20", "40", "22", "30", "39", "42", "21")
-        │ └─TableReader_43	0.00	root	data:Selection_42
-        │   └─Selection_42	0.00	cop	gt(tpch.customer.c_acctbal, NULL)
-        │     └─TableScan_41	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
-        └─TableReader_45	75000000.00	root	data:TableScan_44
-          └─TableScan_44	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false
+Sort_29	1.00	root	custsale.cntrycode:asc
+└─Projection_31	1.00	root	custsale.cntrycode, 25_col_0, 25_col_1
+  └─HashAgg_32	1.00	root	group by:custsale.cntrycode, funcs:count(1), sum(tpch.custsale.c_acctbal), firstrow(custsale.cntrycode)
+    └─Projection_33	0.00	root	substring(tpch.customer.c_phone, 1, 2), tpch.customer.c_acctbal
+      └─HashLeftJoin_34	0.00	root	anti semi join, inner:TableReader_40, equal:[eq(tpch.customer.c_custkey, tpch.orders.o_custkey)]
+        ├─Selection_35	0.00	root	in(substring(tpch.customer.c_phone, 1, 2), "20", "40", "22", "30", "39", "42", "21")
+        │ └─TableReader_38	0.00	root	data:Selection_37
+        │   └─Selection_37	0.00	cop	gt(tpch.customer.c_acctbal, NULL)
+        │     └─TableScan_36	7500000.00	cop	table:customer, range:[-inf,+inf], keep order:false
+        └─TableReader_40	75000000.00	root	data:TableScan_39
+          └─TableScan_39	75000000.00	cop	table:orders, range:[-inf,+inf], keep order:false

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -442,7 +442,8 @@ func (er *expressionRewriter) handleCompareSubquery(ctx context.Context, v *ast.
 func (er *expressionRewriter) handleOtherComparableSubq(lexpr, rexpr expression.Expression, np LogicalPlan, useMin bool, cmpFunc string, all bool) {
 	plan4Agg := LogicalAggregation{}.Init(er.sctx)
 	if hint := er.b.TableHints(); hint != nil {
-		plan4Agg.preferAggType = hint.preferAggType
+		plan4Agg.preferAggType = hint.aggHints.preferAggType
+		plan4Agg.preferAggToCop = hint.aggHints.preferAggToCop
 	}
 	plan4Agg.SetChildren(np)
 
@@ -571,7 +572,8 @@ func (er *expressionRewriter) handleNEAny(lexpr, rexpr expression.Expression, np
 		AggFuncs: []*aggregation.AggFuncDesc{firstRowFunc, countFunc},
 	}.Init(er.sctx)
 	if hint := er.b.TableHints(); hint != nil {
-		plan4Agg.preferAggType = hint.preferAggType
+		plan4Agg.preferAggType = hint.aggHints.preferAggType
+		plan4Agg.preferAggToCop = hint.aggHints.preferAggToCop
 	}
 	plan4Agg.SetChildren(np)
 	firstRowResultCol := &expression.Column{
@@ -608,7 +610,8 @@ func (er *expressionRewriter) handleEQAll(lexpr, rexpr expression.Expression, np
 		AggFuncs: []*aggregation.AggFuncDesc{firstRowFunc, countFunc},
 	}.Init(er.sctx)
 	if hint := er.b.TableHints(); hint != nil {
-		plan4Agg.preferAggType = hint.preferAggType
+		plan4Agg.preferAggType = hint.aggHints.preferAggType
+		plan4Agg.preferAggToCop = hint.aggHints.preferAggToCop
 	}
 	plan4Agg.SetChildren(np)
 	firstRowResultCol := &expression.Column{

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -250,6 +250,8 @@ type LogicalAggregation struct {
 
 	// preferAggType stores preferred aggregation algorithm type.
 	preferAggType uint
+	// preferAggToCop indicates whether want it to be pushed to coprocessor.
+	preferAggToCop bool
 
 	possibleProperties [][]*expression.Column
 	inputCount         float64 // inputCount is the input count of this plan.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -60,8 +60,7 @@ type tableHintInfo struct {
 	sortMergeJoinTables       []hintTableInfo
 	hashJoinTables            []hintTableInfo
 	indexHintList             []indexHintInfo
-	preferAggType             uint
-	preferAggToCop            bool
+	aggHints                  aggHintInfo
 }
 
 type hintTableInfo struct {
@@ -72,6 +71,11 @@ type hintTableInfo struct {
 type indexHintInfo struct {
 	tblName   model.CIStr
 	indexHint *ast.IndexHint
+}
+
+type aggHintInfo struct {
+	preferAggType  uint
+	preferAggToCop bool
 }
 
 func tableNames2HintTableInfo(hintTables []ast.HintTable) []hintTableInfo {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -61,6 +61,7 @@ type tableHintInfo struct {
 	hashJoinTables            []hintTableInfo
 	indexHintList             []indexHintInfo
 	preferAggType             uint
+	preferAggToCop            bool
 }
 
 type hintTableInfo struct {

--- a/planner/core/rule_aggregation_push_down.go
+++ b/planner/core/rule_aggregation_push_down.go
@@ -189,7 +189,7 @@ func (a *aggregationPushDownSolver) decompose(ctx sessionctx.Context, aggFunc *a
 // tryToPushDownAgg tries to push down an aggregate function into a join path. If all aggFuncs are first row, we won't
 // process it temporarily. If not, We will add additional group by columns and first row functions. We make a new aggregation operator.
 // If the pushed aggregation is grouped by unique key, it's no need to push it down.
-func (a *aggregationPushDownSolver) tryToPushDownAgg(aggFuncs []*aggregation.AggFuncDesc, gbyCols []*expression.Column, join *LogicalJoin, childIdx int, preferAggType uint) (_ LogicalPlan, err error) {
+func (a *aggregationPushDownSolver) tryToPushDownAgg(aggFuncs []*aggregation.AggFuncDesc, gbyCols []*expression.Column, join *LogicalJoin, childIdx int, aggHints aggHintInfo) (_ LogicalPlan, err error) {
 	child := join.children[childIdx]
 	if aggregation.IsAllFirstRow(aggFuncs) {
 		return child, nil
@@ -204,7 +204,7 @@ func (a *aggregationPushDownSolver) tryToPushDownAgg(aggFuncs []*aggregation.Agg
 			return child, nil
 		}
 	}
-	agg, err := a.makeNewAgg(join.ctx, aggFuncs, gbyCols, preferAggType)
+	agg, err := a.makeNewAgg(join.ctx, aggFuncs, gbyCols, aggHints)
 	if err != nil {
 		return nil, err
 	}
@@ -247,11 +247,12 @@ func (a *aggregationPushDownSolver) checkAnyCountAndSum(aggFuncs []*aggregation.
 	return false
 }
 
-func (a *aggregationPushDownSolver) makeNewAgg(ctx sessionctx.Context, aggFuncs []*aggregation.AggFuncDesc, gbyCols []*expression.Column, preferAggType uint) (*LogicalAggregation, error) {
+func (a *aggregationPushDownSolver) makeNewAgg(ctx sessionctx.Context, aggFuncs []*aggregation.AggFuncDesc, gbyCols []*expression.Column, aggHints aggHintInfo) (*LogicalAggregation, error) {
 	agg := LogicalAggregation{
-		GroupByItems:  expression.Column2Exprs(gbyCols),
-		groupByCols:   gbyCols,
-		preferAggType: preferAggType,
+		GroupByItems:   expression.Column2Exprs(gbyCols),
+		groupByCols:    gbyCols,
+		preferAggType:  aggHints.preferAggType,
+		preferAggToCop: aggHints.preferAggToCop,
 	}.Init(ctx)
 	aggLen := len(aggFuncs) + len(gbyCols)
 	newAggFuncDescs := make([]*aggregation.AggFuncDesc, 0, aggLen)
@@ -283,9 +284,10 @@ func (a *aggregationPushDownSolver) makeNewAgg(ctx sessionctx.Context, aggFuncs 
 func (a *aggregationPushDownSolver) pushAggCrossUnion(agg *LogicalAggregation, unionSchema *expression.Schema, unionChild LogicalPlan) LogicalPlan {
 	ctx := agg.ctx
 	newAgg := LogicalAggregation{
-		AggFuncs:      make([]*aggregation.AggFuncDesc, 0, len(agg.AggFuncs)),
-		GroupByItems:  make([]expression.Expression, 0, len(agg.GroupByItems)),
-		preferAggType: agg.preferAggType,
+		AggFuncs:       make([]*aggregation.AggFuncDesc, 0, len(agg.AggFuncs)),
+		GroupByItems:   make([]expression.Expression, 0, len(agg.GroupByItems)),
+		preferAggType:  agg.preferAggType,
+		preferAggToCop: agg.preferAggToCop,
 	}.Init(ctx)
 	newAgg.SetSchema(agg.schema.Clone())
 	for _, aggFunc := range agg.AggFuncs {
@@ -342,7 +344,10 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan) (_ LogicalPlan, e
 					if rightInvalid {
 						rChild = join.children[1]
 					} else {
-						rChild, err = a.tryToPushDownAgg(rightAggFuncs, rightGbyCols, join, 1, agg.preferAggType)
+						rChild, err = a.tryToPushDownAgg(rightAggFuncs, rightGbyCols, join, 1, aggHintInfo{
+							preferAggType:  agg.preferAggType,
+							preferAggToCop: agg.preferAggToCop,
+						})
 						if err != nil {
 							return nil, err
 						}
@@ -350,7 +355,10 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan) (_ LogicalPlan, e
 					if leftInvalid {
 						lChild = join.children[0]
 					} else {
-						lChild, err = a.tryToPushDownAgg(leftAggFuncs, leftGbyCols, join, 0, agg.preferAggType)
+						lChild, err = a.tryToPushDownAgg(leftAggFuncs, leftGbyCols, join, 0, aggHintInfo{
+							preferAggType:  agg.preferAggType,
+							preferAggToCop: agg.preferAggToCop,
+						})
 						if err != nil {
 							return nil, err
 						}
@@ -382,7 +390,10 @@ func (a *aggregationPushDownSolver) aggPushDown(p LogicalPlan) (_ LogicalPlan, e
 			} else if union, ok1 := child.(*LogicalUnionAll); ok1 {
 				var gbyCols []*expression.Column
 				gbyCols = expression.ExtractColumnsFromExpressions(gbyCols, agg.GroupByItems, nil)
-				pushedAgg, err := a.makeNewAgg(agg.ctx, agg.AggFuncs, gbyCols, agg.preferAggType)
+				pushedAgg, err := a.makeNewAgg(agg.ctx, agg.AggFuncs, gbyCols, aggHintInfo{
+					preferAggType:  agg.preferAggType,
+					preferAggToCop: agg.preferAggToCop,
+				})
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add sql hint for enforcing push aggregation to coprocessor.

### What is changed and how it works?

Only cop task will be considered when enumerating task types with AGG_TO_COP hint.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None
