### PR TITLE
main : check --config-check should has --config flag specified first.

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -156,7 +156,10 @@ func main() {
 		fmt.Fprintln(os.Stderr, "invalid config", err)
 		os.Exit(1)
 	}
-	flagConfigCheck()
+	if *configCheck {
+		fmt.Println("config check successful")
+		os.Exit(0)
+	}
 	setGlobalVars()
 	setCPUAffinity()
 	setupLog()
@@ -342,6 +345,12 @@ func loadConfig() string {
 			return err.Error()
 		}
 		terror.MustNil(err)
+	} else {
+		// configCheck should have the config file specified
+		if *configCheck {
+			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
+			os.Exit(1)
+		}
 	}
 	return ""
 }
@@ -608,16 +617,4 @@ func cleanup() {
 	}
 	plugin.Shutdown(context.Background())
 	closeDomainAndStorage()
-}
-
-// the flag --config-check should have --config specified first
-func flagConfigCheck() {
-	if *configCheck {
-		if *configPath != "" {
-			fmt.Println("config check successful")
-		} else {
-			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
-		}
-		os.Exit(0)
-	}
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -156,10 +156,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "invalid config", err)
 		os.Exit(1)
 	}
-	if *configCheck {
-		fmt.Println("config check successful")
-		os.Exit(0)
-	}
+	flagConfigCheck()
 	setGlobalVars()
 	setCPUAffinity()
 	setupLog()
@@ -611,4 +608,17 @@ func cleanup() {
 	}
 	plugin.Shutdown(context.Background())
 	closeDomainAndStorage()
+}
+
+// the flag --config-check should have --config specified first
+func flagConfigCheck() {
+	if *configCheck {
+		if *configPath != "" {
+			fmt.Println("config check successful")
+			os.Exit(0)
+		} else {
+			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
+			os.Exit(1)
+		}
+	}
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -615,10 +615,9 @@ func flagConfigCheck() {
 	if *configCheck {
 		if *configPath != "" {
 			fmt.Println("config check successful")
-			os.Exit(0)
 		} else {
 			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
-			os.Exit(1)
 		}
+		os.Exit(0)
 	}
 }

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -346,7 +346,7 @@ func loadConfig() string {
 		}
 		terror.MustNil(err)
 	} else {
-		// configCheck should have the config file specified
+		// configCheck should have the config file specified.
 		if *configCheck {
 			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
 			os.Exit(1)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
when start tidb with flag: 
 --config-check & **without** --config specified
it will succeed in config check regardless of what content the config file has. 
```

### What is changed and how it works?

Make sure --config is specified first when it has --config-check flag, then talk about file validation.
Otherwise, return config check failed cause no config file specified.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

manual test

Code changes

modified in loadconfig.go

Side effects

no

Related changes

no

Release Note

check  --config-check should have --config flag specified first. 