### PR TITLE
session: remove backoff in transaction retry

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -716,7 +716,6 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 			zap.String("label", label),
 			zap.Error(err),
 			zap.String("txn", s.txn.GoString()))
-		kv.BackOff(retryCnt)
 		s.txn.changeToInvalid()
 		s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
 	}


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The reason for transaction retry now is that only some of the problems that have occurred and ended, for example, the writes have conflicted. Therefore, it is very likely that the commit will be successful if you try again immediately. In the past, the reason we added backoff might be that many of the errors that caused the retry were not recovered, such as the PD timeout error, and immediately retrying the PD may not recover, which would send a lot of useless requests.

### What is changed and how it works?
Remove the backoff in transaction retry.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. Sysbench update non-index test with small-size tables.
1. Observe the max commit latency in Grafana.
(I have not done this test yet.)

Or we can compare the Sysbench result between with the pessimistic transaction model.

Code changes

 - Has exported function/method change