### PR TITLE
expression: don't use names when do patition pruning

### DIFF
--- a/expression/constraint_propagation.go
+++ b/expression/constraint_propagation.go
@@ -256,17 +256,7 @@ func ruleColumnOPConst(ctx sessionctx.Context, i, j int, exprs *exprSet) {
 	// Make sure col1 and col2 are the same column.
 	// Can't use col1.Equal(ctx, col2) here, because they are not generated in one
 	// expression and their UniqueID are not the same.
-	if col1.ColName.L != col2.ColName.L {
-		return
-	}
-	if col1.OrigColName.L != "" &&
-		col2.OrigColName.L != "" &&
-		col1.OrigColName.L != col2.OrigColName.L {
-		return
-	}
-	if col1.OrigTblName.L != "" &&
-		col2.OrigTblName.L != "" &&
-		col1.OrigColName.L != col2.OrigColName.L {
+	if col1.ID != col2.ID {
 		return
 	}
 	v, isNull, err := compareConstant(ctx, negOP(OP2), fc1, con2)

--- a/expression/constraint_propagation.go
+++ b/expression/constraint_propagation.go
@@ -256,6 +256,9 @@ func ruleColumnOPConst(ctx sessionctx.Context, i, j int, exprs *exprSet) {
 	// Make sure col1 and col2 are the same column.
 	// Can't use col1.Equal(ctx, col2) here, because they are not generated in one
 	// expression and their UniqueID are not the same.
+	// NOTE: We can use this way to compare this two column since this method is only called for partition pruning,
+	//       where all columns come from the same DataSource.
+	//       If we want to use this method in more places. We need to first change the comparing way.
 	if col1.ID != col2.ID {
 		return
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Use `expression.Column.ID` should be enough.

### What is changed and how it works?

When going into here, colums should be from the same DataSource. So the ID set from `TableInfo` can distinguish columns from each other.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Exsiting Unit test
