### PR TITLE
main : check --config-check should has --config flag specified first. (#11855)

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -316,6 +316,12 @@ func loadConfig() string {
 			return err.Error()
 		}
 		terror.MustNil(err)
+	} else {
+		// configCheck should have the config file specified.
+		if *configCheck {
+			fmt.Fprintln(os.Stderr, "config check failed", errors.New("no config file specified for config-check"))
+			os.Exit(1)
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick to release3.0 #11855 

Release note

 - check --config-check should have --config flag specified first.
