### PR TITLE
ddl: make ddl test more stable

### DIFF
--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -44,6 +44,7 @@ func (s *testDDLTableSplitSuite) TestTableSplit(c *C) {
 	c.Assert(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
 	tk.MustExec("use test")
+	tk.MustExec("set global tidb_scatter_region = 1")
 	tk.MustExec(`create table t_part (a int key) partition by range(a) (
 		partition p0 values less than (10),
 		partition p1 values less than (20)

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -14,10 +14,8 @@
 package ddl_test
 
 import (
-	"bytes"
 	"context"
 	"sync/atomic"
-	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
@@ -44,6 +42,7 @@ func (s *testDDLTableSplitSuite) TestTableSplit(c *C) {
 	c.Assert(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
 	tk.MustExec("use test")
+	// Synced split table region.
 	tk.MustExec("set global tidb_scatter_region = 1")
 	tk.MustExec(`create table t_part (a int key) partition by range(a) (
 		partition p0 values less than (10),
@@ -74,17 +73,10 @@ func checkRegionStartWithTableID(c *C, id int64, store kvStore) {
 	regionStartKey := tablecodec.EncodeTablePrefix(id)
 	var loc *tikv.KeyLocation
 	var err error
-	for i := 0; i < 10; i++ {
-		cache := store.GetRegionCache()
-		loc, err = cache.LocateKey(tikv.NewBackoffer(context.Background(), 5000), regionStartKey)
-		c.Assert(err, IsNil)
-
-		// Region cache may be out of date, so we need to drop this expired region and load it again.
-		cache.InvalidateCachedRegion(loc.Region)
-		if bytes.Equal(loc.StartKey, []byte(regionStartKey)) {
-			return
-		}
-		time.Sleep(3 * time.Millisecond)
-	}
-	c.Assert(loc.StartKey, BytesEquals, []byte(regionStartKey))
+	cache := store.GetRegionCache()
+	loc, err = cache.LocateKey(tikv.NewBackoffer(context.Background(), 5000), regionStartKey)
+	c.Assert(err, IsNil)
+	// Region cache may be out of date, so we need to drop this expired region and load it again.
+	cache.InvalidateCachedRegion(loc.Region)
+	c.Assert([]byte(loc.StartKey), BytesEquals, []byte(regionStartKey))
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

* Use synchronism split table region in test.

```go
----------------------------------------------------------------------
FAIL: table_split_test.go:36: testDDLTableSplitSuite.TestTableSplit

table_split_test.go:57:
    checkRegionStartWithTableID(c, t.Meta().ID, store.(kvStore))
table_split_test.go:88:
    c.Assert(loc.StartKey, BytesEquals, []byte(regionStartKey))
... bytes_one kv.Key = kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xd} ("74800000000000000d")
... bytes_two []uint8 = []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf}
... Arguments to BytesEqual must both be bytestrings

```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code