### PR TITLE
tikv: collapse load region requests during retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	go.uber.org/zap v1.9.1
 	golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7 // indirect
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -280,6 +280,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -137,6 +137,6 @@ func (s *testCommitterSuite) TestFailPrewriteRegionError(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := context.Background()
-	err = committer.prewriteKeys(NewBackoffer(ctx, 1000), committer.keys)
+	err = committer.prewriteKeys(NewBackoffer(ctx, 1000), committer.keys, nil)
 	c.Assert(err, NotNil)
 }

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -136,7 +136,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := newTwoPhaseCommitterWithInit(txn1, 0)
 	c.Assert(err, IsNil)
-	err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys)
+	err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys, nil)
 	c.Assert(err, IsNil)
 
 	txn2 := s.begin(c)
@@ -144,7 +144,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("a0"))
 
-	err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys)
+	err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys, nil)
 	if err != nil {
 		// Retry.
 		txn1 = s.begin(c)
@@ -154,12 +154,12 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 		c.Assert(err, IsNil)
 		committer, err = newTwoPhaseCommitterWithInit(txn1, 0)
 		c.Assert(err, IsNil)
-		err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys)
+		err = committer.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), committer.keys, nil)
 		c.Assert(err, IsNil)
 	}
 	committer.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 	c.Assert(err, IsNil)
-	err = committer.commitKeys(NewBackoffer(ctx, CommitMaxBackoff), [][]byte{[]byte("a")})
+	err = committer.commitKeys(NewBackoffer(ctx, CommitMaxBackoff), [][]byte{[]byte("a")}, nil)
 	c.Assert(err, IsNil)
 
 	txn3 := s.begin(c)
@@ -180,7 +180,7 @@ func (s *testCommitterSuite) TestContextCancel(c *C) {
 	bo := NewBackoffer(context.Background(), prewriteMaxBackoff)
 	backoffer, cancel := bo.Fork()
 	cancel() // cancel the context
-	err = committer.prewriteKeys(backoffer, committer.keys)
+	err = committer.prewriteKeys(backoffer, committer.keys, nil)
 	c.Assert(errors.Cause(err), Equals, context.Canceled)
 }
 
@@ -206,7 +206,7 @@ func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := newTwoPhaseCommitterWithInit(txn1, 0)
 	c.Assert(err, IsNil)
-	err = committer.prewriteKeys(NewBackoffer(context.Background(), prewriteMaxBackoff), committer.keys)
+	err = committer.prewriteKeys(NewBackoffer(context.Background(), prewriteMaxBackoff), committer.keys, nil)
 	c.Assert(err, IsNil)
 	// txn3 writes "c"
 	err = txn3.Set([]byte("c"), []byte("c3"))
@@ -342,9 +342,9 @@ func (s *testCommitterSuite) TestCommitBeforePrewrite(c *C) {
 	commiter, err := newTwoPhaseCommitterWithInit(txn, 0)
 	c.Assert(err, IsNil)
 	ctx := context.Background()
-	err = commiter.cleanupKeys(NewBackoffer(ctx, cleanupMaxBackoff), commiter.keys)
+	err = commiter.cleanupKeys(NewBackoffer(ctx, cleanupMaxBackoff), commiter.keys, nil)
 	c.Assert(err, IsNil)
-	err = commiter.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), commiter.keys)
+	err = commiter.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), commiter.keys, nil)
 	c.Assert(err, NotNil)
 	errMsgMustContain(c, err, "conflictCommitTS")
 }
@@ -386,7 +386,7 @@ func (s *testCommitterSuite) TestPrewritePrimaryKeyFailed(c *C) {
 	ctx := context.Background()
 	commiter, err := newTwoPhaseCommitterWithInit(txn2, 0)
 	c.Assert(err, IsNil)
-	err = commiter.cleanupKeys(NewBackoffer(ctx, cleanupMaxBackoff), commiter.keys)
+	err = commiter.cleanupKeys(NewBackoffer(ctx, cleanupMaxBackoff), commiter.keys, nil)
 	c.Assert(err, IsNil)
 
 	// check the data after rollback twice.
@@ -457,7 +457,7 @@ func (s *testCommitterSuite) TestPrewriteTxnSize(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := context.Background()
-	err = commiter.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), commiter.keys)
+	err = commiter.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), commiter.keys, nil)
 	c.Assert(err, IsNil)
 
 	// Check the written locks in the first region (50 keys)

--- a/store/tikv/coprocessor_test.go
+++ b/store/tikv/coprocessor_test.go
@@ -39,28 +39,28 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 
 	bo := NewBackoffer(context.Background(), 3000)
 
-	tasks, err := buildCopTasks(bo, cache, buildCopRanges("a", "c"), false, false)
+	tasks, err := buildCopTasks(bo, cache, buildCopRanges("a", "c"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 1)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "c")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("g", "n"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("g", "n"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 1)
 	s.taskEqual(c, tasks[0], regionIDs[1], "g", "n")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("m", "n"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("m", "n"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 1)
 	s.taskEqual(c, tasks[0], regionIDs[1], "m", "n")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "k"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "k"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 2)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "g")
 	s.taskEqual(c, tasks[1], regionIDs[1], "g", "k")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "x"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "x"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 4)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "g")
@@ -68,23 +68,23 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 	s.taskEqual(c, tasks[2], regionIDs[2], "n", "t")
 	s.taskEqual(c, tasks[3], regionIDs[3], "t", "x")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "b", "b", "c"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "b", "b", "c"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 1)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "b", "b", "c")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "b", "e", "f"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "b", "e", "f"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 1)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "b", "e", "f")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("g", "n", "o", "p"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("g", "n", "o", "p"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 2)
 	s.taskEqual(c, tasks[0], regionIDs[1], "g", "n")
 	s.taskEqual(c, tasks[1], regionIDs[2], "o", "p")
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("h", "k", "m", "p"), false, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("h", "k", "m", "p"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 2)
 	s.taskEqual(c, tasks[0], regionIDs[1], "h", "k", "m", "n")
@@ -154,7 +154,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	defer cache.Close()
 	bo := NewBackoffer(context.Background(), 3000)
 
-	tasks, err := buildCopTasks(bo, cache, buildCopRanges("a", "z"), false, false)
+	tasks, err := buildCopTasks(bo, cache, buildCopRanges("a", "z"), false, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 2)
 	s.taskEqual(c, tasks[0], regionIDs[0], "a", "m")
@@ -167,7 +167,7 @@ func (s *testCoprocessorSuite) TestRebuild(c *C) {
 	cluster.Split(regionIDs[1], regionIDs[2], []byte("q"), []uint64{peerIDs[2]}, storeID)
 	cache.InvalidateCachedRegion(tasks[1].region)
 
-	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "z"), true, false)
+	tasks, err = buildCopTasks(bo, cache, buildCopRanges("a", "z"), true, false, nil)
 	c.Assert(err, IsNil)
 	c.Assert(tasks, HasLen, 3)
 	s.taskEqual(c, tasks[2], regionIDs[0], "a", "m")

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -65,13 +65,13 @@ func (s *testLockSuite) lockKey(c *C, key, value, primaryKey, primaryValue []byt
 	}
 
 	ctx := context.Background()
-	err = tpc.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), tpc.keys)
+	err = tpc.prewriteKeys(NewBackoffer(ctx, prewriteMaxBackoff), tpc.keys, nil)
 	c.Assert(err, IsNil)
 
 	if commitPrimary {
 		tpc.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 		c.Assert(err, IsNil)
-		err = tpc.commitKeys(NewBackoffer(ctx, CommitMaxBackoff), [][]byte{primaryKey})
+		err = tpc.commitKeys(NewBackoffer(ctx, CommitMaxBackoff), [][]byte{primaryKey}, nil)
 		c.Assert(err, IsNil)
 	}
 	return txn.startTS, tpc.commitTS
@@ -268,7 +268,7 @@ func (s *testLockSuite) TestTxnHeartBeat(c *C) {
 func (s *testLockSuite) prewriteTxn(c *C, txn *tikvTxn) {
 	committer, err := newTwoPhaseCommitterWithInit(txn, 0)
 	c.Assert(err, IsNil)
-	err = committer.prewriteKeys(NewBackoffer(context.Background(), prewriteMaxBackoff), committer.keys)
+	err = committer.prewriteKeys(NewBackoffer(context.Background(), prewriteMaxBackoff), committer.keys, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -395,14 +395,14 @@ func (c *RawKVClient) sendReq(key []byte, req *tikvrpc.Request, reverse bool) (*
 }
 
 func (c *RawKVClient) sendBatchReq(bo *Backoffer, keys [][]byte, cmdType tikvrpc.CmdType) (*tikvrpc.Response, error) { // split the keys
-	groups, _, err := c.regionCache.GroupKeysByRegion(bo, keys, nil)
+	groups, _, err := c.regionCache.GroupKeysByRegion(bo, keys, nil, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	var batches []batch
 	for regionID, groupKeys := range groups {
-		batches = appendKeyBatches(batches, regionID, groupKeys, rawBatchPairCount)
+		batches = appendKeyBatches(batches, regionID, groupKeys.Keys, rawBatchPairCount)
 	}
 	bo, cancel := bo.Fork()
 	ches := make(chan singleBatchResp, len(batches))
@@ -544,14 +544,14 @@ func (c *RawKVClient) sendBatchPut(bo *Backoffer, keys, values [][]byte) error {
 	for i, key := range keys {
 		keyToValue[string(key)] = values[i]
 	}
-	groups, _, err := c.regionCache.GroupKeysByRegion(bo, keys, nil)
+	groups, _, err := c.regionCache.GroupKeysByRegion(bo, keys, nil, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	var batches []batch
 	// split the keys by size and RegionVerID
 	for regionID, groupKeys := range groups {
-		batches = appendBatches(batches, regionID, groupKeys, keyToValue, rawBatchPutSize)
+		batches = appendBatches(batches, regionID, groupKeys.Keys, keyToValue, rawBatchPutSize)
 	}
 	bo, cancel := bo.Fork()
 	ch := make(chan error, len(batches))

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -399,6 +399,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 
 // KeyLocation is the region and range that a key is located.
 type KeyLocation struct {
+	*RegionToken
 	Region   RegionVerID
 	StartKey kv.Key
 	EndKey   kv.Key
@@ -412,50 +413,53 @@ func (l *KeyLocation) Contains(key []byte) bool {
 
 // LocateKey searches for the region and range that the key is located.
 func (c *RegionCache) LocateKey(bo *Backoffer, key []byte) (*KeyLocation, error) {
-	r, err := c.findRegionByKey(bo, key, false)
+	return c.LocateKeyWithToken(bo, key, nil)
+}
+
+// LocateKeyWithToken searches for the region and range that the key is located with token.
+func (c *RegionCache) LocateKeyWithToken(bo *Backoffer, key []byte, token *RegionToken) (*KeyLocation, error) {
+	r, tok, err := c.findRegionByKey(bo, key, false, token)
 	if err != nil {
 		return nil, err
 	}
 	return &KeyLocation{
-		Region:   r.VerID(),
-		StartKey: r.StartKey(),
-		EndKey:   r.EndKey(),
+		RegionToken: tok,
+		Region:      r.VerID(),
+		StartKey:    r.StartKey(),
+		EndKey:      r.EndKey(),
 	}, nil
-}
-
-func (c *RegionCache) loadAndInsertRegion(bo *Backoffer, key []byte) (*Region, error) {
-	r, err := c.loadRegion(bo, key, false)
-	if err != nil {
-		return nil, err
-	}
-	c.mu.Lock()
-	c.insertRegionToCache(r)
-	c.mu.Unlock()
-	return r, nil
 }
 
 // LocateEndKey searches for the region and range that the key is located.
 // Unlike LocateKey, start key of a region is exclusive and end key is inclusive.
 func (c *RegionCache) LocateEndKey(bo *Backoffer, key []byte) (*KeyLocation, error) {
-	r, err := c.findRegionByKey(bo, key, true)
+	return c.LocateEndKeyWithToken(bo, key, nil)
+}
+
+// LocateEndKeyWithToken searches for the region and range that the key is located with token.
+// Unlike LocateKey, start key of a region is exclusive and end key is inclusive.
+func (c *RegionCache) LocateEndKeyWithToken(bo *Backoffer, key []byte, token *RegionToken) (*KeyLocation, error) {
+	r, tok, err := c.findRegionByKey(bo, key, true, token)
 	if err != nil {
 		return nil, err
 	}
 	return &KeyLocation{
-		Region:   r.VerID(),
-		StartKey: r.StartKey(),
-		EndKey:   r.EndKey(),
+		RegionToken: tok,
+		Region:      r.VerID(),
+		StartKey:    r.StartKey(),
+		EndKey:      r.EndKey(),
 	}, nil
 }
 
-func (c *RegionCache) findRegionByKey(bo *Backoffer, key []byte, isEndKey bool) (r *Region, err error) {
+func (c *RegionCache) findRegionByKey(bo *Backoffer, key []byte, isEndKey bool, token *RegionToken) (r *Region, tok *RegionToken, err error) {
+	var lr *Region
 	r = c.searchCachedRegion(key, isEndKey)
 	if r == nil {
 		// load region when it is not exists or expired.
-		lr, err := c.loadRegion(bo, key, isEndKey)
+		lr, tok, err = c.loadRegionWithToken(bo, key, isEndKey, token)
 		if err != nil {
 			// no region data, return error if failure.
-			return nil, err
+			return nil, tok, err
 		}
 		logutil.Eventf(bo.ctx, "load region %d from pd, due to cache-miss", lr.GetID())
 		r = lr
@@ -464,7 +468,7 @@ func (c *RegionCache) findRegionByKey(bo *Backoffer, key []byte, isEndKey bool) 
 		c.mu.Unlock()
 	} else if r.needReload() {
 		// load region when it be marked as need reload.
-		lr, err := c.loadRegion(bo, key, isEndKey)
+		lr, tok, err = c.loadRegionWithToken(bo, key, isEndKey, token)
 		if err != nil {
 			// ignore error and use old region info.
 			logutil.Logger(bo.ctx).Error("load region failure",
@@ -477,7 +481,7 @@ func (c *RegionCache) findRegionByKey(bo *Backoffer, key []byte, isEndKey bool) 
 			c.mu.Unlock()
 		}
 	}
-	return r, nil
+	return r, tok, nil
 }
 
 // OnSendFail handles send request fail logic.
@@ -542,18 +546,24 @@ func (c *RegionCache) LocateRegionByID(bo *Backoffer, regionID uint64) (*KeyLoca
 	}, nil
 }
 
+// GroupKeys holds group's region token and its keys.
+type GroupKeys struct {
+	Keys  [][]byte
+	Token *RegionToken
+}
+
 // GroupKeysByRegion separates keys into groups by their belonging Regions.
 // Specially it also returns the first key's region which may be used as the
 // 'PrimaryLockKey' and should be committed ahead of others.
 // filter is used to filter some unwanted keys.
-func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte, filter func(key, regionStartKey []byte) bool) (map[RegionVerID][][]byte, RegionVerID, error) {
-	groups := make(map[RegionVerID][][]byte)
+func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte, filter func(key, regionStartKey []byte) bool, tok *RegionToken) (map[RegionVerID]GroupKeys, RegionVerID, error) {
+	groups := make(map[RegionVerID]GroupKeys)
 	var first RegionVerID
 	var lastLoc *KeyLocation
 	for i, k := range keys {
 		if lastLoc == nil || !lastLoc.Contains(k) {
 			var err error
-			lastLoc, err = c.LocateKey(bo, k)
+			lastLoc, err = c.LocateKeyWithToken(bo, k, tok)
 			if err != nil {
 				return nil, first, errors.Trace(err)
 			}
@@ -565,7 +575,10 @@ func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte, filter fun
 		if i == 0 {
 			first = id
 		}
-		groups[id] = append(groups[id], k)
+		g := groups[id]
+		g.Keys = append(g.Keys, k)
+		g.Token = lastLoc.RegionToken
+		groups[id] = g
 	}
 	return groups, first, nil
 }
@@ -718,26 +731,32 @@ func (c *RegionCache) getRegionByIDFromCache(regionID uint64) *Region {
 	return nil
 }
 
-// loadRegion loads region from pd client, and picks the first peer as leader.
-// If the given key is the end key of the region that you want, you may set the second argument to true. This is useful
-// when processing in reverse order.
-func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Region, error) {
+func (c *RegionCache) loadRegionWithToken(bo *Backoffer, key []byte, isEndKey bool, token *RegionToken) (*Region, *RegionToken, error) {
+	findKey := key
+	if token != nil {
+		if isEndKey {
+			findKey = token.EndKey
+		} else {
+			findKey = token.StartKey
+		}
+	}
+
 	var backoffErr error
 	searchPrev := false
 	for {
 		if backoffErr != nil {
 			err := bo.Backoff(BoPDRPC, backoffErr)
 			if err != nil {
-				return nil, errors.Trace(err)
+				return nil, nil, errors.Trace(err)
 			}
 		}
 		var meta *metapb.Region
 		var leader *metapb.Peer
 		var err error
 		if searchPrev {
-			meta, leader, err = c.pdClient.GetPrevRegion(bo.ctx, key)
+			meta, leader, err = c.pdClient.GetPrevRegion(bo.ctx, findKey)
 		} else {
-			meta, leader, err = c.pdClient.GetRegion(bo.ctx, key)
+			meta, leader, err = c.pdClient.GetRegion(bo.ctx, findKey)
 		}
 		if err != nil {
 			tikvRegionCacheCounterWithGetRegionError.Inc()
@@ -745,18 +764,24 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 			tikvRegionCacheCounterWithGetRegionOK.Inc()
 		}
 		if err != nil {
-			backoffErr = errors.Errorf("loadRegion from PD failed, key: %q, err: %v", key, err)
+			backoffErr = errors.Errorf("loadRegion from PD failed, key: %q, err: %v", findKey, err)
 			continue
 		}
 		if meta == nil {
-			backoffErr = errors.Errorf("region not found for key %q", key)
+			backoffErr = errors.Errorf("region not found for key %q", findKey)
 			continue
 		}
 		if len(meta.Peers) == 0 {
-			return nil, errors.New("receive Region with no peer")
+			return nil, nil, errors.New("receive Region with no peer")
 		}
-		if isEndKey && !searchPrev && bytes.Equal(meta.StartKey, key) && len(meta.StartKey) != 0 {
+		if isEndKey && !searchPrev && bytes.Equal(meta.StartKey, findKey) && len(meta.StartKey) != 0 {
 			searchPrev = true
+			continue
+		}
+		if !containKey(meta, key) {
+			// using token find a region but that region didn't contains target key.
+			// retry with target key, this happens when region split, half of region need take retry.
+			findKey = key
 			continue
 		}
 		region := &Region{meta: meta}
@@ -764,8 +789,31 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 		if leader != nil {
 			c.switchToPeer(region, leader.StoreId)
 		}
-		return region, nil
+		return region, &RegionToken{StartKey: meta.StartKey, EndKey: meta.EndKey}, nil
 	}
+}
+
+// RegionToken holds previous region info.
+// this helps deduplicate pd request during retry operation.
+type RegionToken struct {
+	StartKey []byte
+	EndKey   []byte
+}
+
+func containKey(t *metapb.Region, key []byte) bool {
+	if t == nil {
+		return true
+	}
+	return bytes.Compare(t.GetStartKey(), key) <= 0 &&
+		(bytes.Compare(key, t.GetEndKey()) < 0 || len(t.GetEndKey()) == 0)
+}
+
+// loadRegion loads region from pd client, and picks the first peer as leader.
+// If the given key is the end key of the region that you want, you may set the second argument to true. This is useful
+// when processing in reverse order.
+func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Region, error) {
+	r, _, err := c.loadRegionWithToken(bo, key, isEndKey, nil)
+	return r, err
 }
 
 // loadRegionByID loads region from pd client, and picks the first peer as leader.

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -42,14 +42,14 @@ func equalRegionStartKey(key, regionStartKey []byte) bool {
 func (s *tikvStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter bool) (*tikvrpc.Response, error) {
 	// equalRegionStartKey is used to filter split keys.
 	// If the split key is equal to the start key of the region, then the key has been split, we need to skip the split key.
-	groups, _, err := s.regionCache.GroupKeysByRegion(bo, keys, equalRegionStartKey)
+	groups, _, err := s.regionCache.GroupKeysByRegion(bo, keys, equalRegionStartKey, nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
 	var batches []batch
 	for regionID, groupKeys := range groups {
-		batches = appendKeyBatches(batches, regionID, groupKeys, rawBatchPutSize)
+		batches = appendKeyBatches(batches, regionID, groupKeys.Keys, rawBatchPutSize)
 	}
 
 	if len(batches) == 0 {

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -61,7 +61,7 @@ func (s *testSplitSuite) TestSplitBatchGet(c *C) {
 	snapshot := newTiKVSnapshot(s.store, kv.Version{Ver: txn.StartTS()}, 0)
 
 	keys := [][]byte{{'a'}, {'b'}, {'c'}}
-	_, region, err := s.store.regionCache.GroupKeysByRegion(s.bo, keys, nil)
+	_, region, err := s.store.regionCache.GroupKeysByRegion(s.bo, keys, nil, nil)
 	c.Assert(err, IsNil)
 	batch := batchKeys{
 		region: region,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

mainly take care two problem:

#### 1) many regions in on one store and that store crashed with high concurrent client request

for example, store1 have 3 regions(r1-3) and it crashed.

TiDB receives 5 requests and all of them will go to `r1` like this

```
|----------------------------r1-----------------------------|----------------------r2----------------------|--------r3----------| 
      k1req  k2req  k3req    k4req  k5req
``` 

and all of them will find store cannot access and try load new region info from PD.

will send load region request for `k1req, k2req, k3req, k4req, k5req`, but in the cluster view, region 1 just "change a leader", all request `k1req, k2req, k3req, k4req, k5req` will got the same result but send N network requests to pd and lock contention on region-cache.

we'd better just collapse those request into one request  --- request the startKey of r1, because we known r1 in previous request.

#### 2) region split with high concurrent client request

for example, there a region1 have be split into two region21, region22

```
|-------------------------------------------------------r1--------------------------------------------------------------------|

     k1req          k2req                                                                           k3req
```
split into 
```
|-----------------------r21-------------------------------|----------------------------------r22----------------------------------|

     k1req          k2req                                                                           k3req
```

just like the previous k1req, k2req also can be collapse although k3req need retry to get right result.

#### the problem before doing duplicate

we need to get the previous region info during retry(to collapse request to old start key) then do deduplicate.

### What is changed and how it works?

- [x] maintain previous region info in region-token during retry
- [x] singleflight load region and fill back to region-cache

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Write release note for bug-fix or new feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/11898)
<!-- Reviewable:end -->
