### PR TITLE
planner: support predicate pushdown for Window 

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -722,3 +722,14 @@ id	count	task	operator info
 IndexReader_12	10.00	root	index:IndexScan_11
 └─IndexScan_11	10.00	cop	table:t, index:a, b, range:[1,1], keep order:true, stats:pseudo
 drop table if exists t;
+create table t(a int, b int);
+explain select a, b from (select a, b, avg(b) over (partition by a)as avg_b from t) as tt where a > 10 and b < 10 and a > avg_b;
+id	count	task	operator info
+Projection_8	2666.67	root	test.t.a, test.t.b
+└─Selection_9	2666.67	root	gt(cast(test.t.a), avg_b), lt(test.t.b, 10)
+  └─Window_10	3333.33	root	avg(cast(test.t.b)) over(partition by test.t.a)
+    └─Sort_14	3333.33	root	test.t.a:asc
+      └─TableReader_13	3333.33	root	data:Selection_12
+        └─Selection_12	3333.33	cop	gt(test.t.a, 10)
+          └─TableScan_11	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table if exists t;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -173,3 +173,8 @@ create table t(a int, b int, index idx_ab(a, b));
 explain select a, b from t where a in (1) order by b;
 explain select a, b from t where a = 1 order by b;
 drop table if exists t;
+
+# https://github.com/pingcap/tidb/issues/11903
+create table t(a int, b int);
+explain select a, b from (select a, b, avg(b) over (partition by a)as avg_b from t) as tt where a > 10 and b < 10 and a > avg_b;
+drop table if exists t;

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -547,17 +547,9 @@ func (p *LogicalWindow) PredicatePushDown(predicates []expression.Expression) ([
 	canNotBePushed := make([]expression.Expression, 0, len(predicates))
 	partitionCols := expression.NewSchema(p.getPartitionByCols()...)
 	for _, cond := range predicates {
-		canPush := true
-		extractedCols := expression.ExtractColumns(cond)
 		// We can push predicate beneath Window, only if all of the
 		// extractedCols are part of partitionBy columns.
-		for _, col := range extractedCols {
-			if !partitionCols.Contains(col) {
-				canPush = false
-				break
-			}
-		}
-		if canPush {
+		if expression.ExprFromSchema(cond, partitionCols) {
 			canBePushed = append(canBePushed, cond)
 		} else {
 			canNotBePushed = append(canNotBePushed, cond)

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -532,11 +532,39 @@ func (p *LogicalJoin) outerJoinPropConst(predicates []expression.Expression) []e
 	return predicates
 }
 
+// getPartitionByCols extracts 'partition by' columns from the Window.
+func (p *LogicalWindow) getPartitionByCols() []*expression.Column {
+	partitionCols := make([]*expression.Column, 0, len(p.PartitionBy))
+	for _, partitionItem := range p.PartitionBy {
+		partitionCols = append(partitionCols, partitionItem.Col)
+	}
+	return partitionCols
+}
+
 // PredicatePushDown implements LogicalPlan PredicatePushDown interface.
 func (p *LogicalWindow) PredicatePushDown(predicates []expression.Expression) ([]expression.Expression, LogicalPlan) {
-	// Window function forbids any condition to push down.
-	p.baseLogicalPlan.PredicatePushDown(nil)
-	return predicates, p
+	canBePushed := make([]expression.Expression, 0, len(predicates))
+	canNotBePushed := make([]expression.Expression, 0, len(predicates))
+	partitionCols := expression.NewSchema(p.getPartitionByCols() ...)
+	for _, cond := range predicates {
+		canPush := true
+		extractedCols := expression.ExtractColumns(cond)
+		// We can push predicate beneath Window, only if all of the
+		// extractedCols are part of partitionBy columns.
+		for _, col := range extractedCols {
+			if !partitionCols.Contains(col) {
+				canPush = false
+				break
+			}
+		}
+		if canPush {
+			canBePushed = append(canBePushed, cond)
+		} else {
+			canNotBePushed = append(canNotBePushed, cond)
+		}
+	}
+	p.baseLogicalPlan.PredicatePushDown(canBePushed)
+	return canNotBePushed, p
 }
 
 func (*ppdSolver) name() string {

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -545,7 +545,7 @@ func (p *LogicalWindow) getPartitionByCols() []*expression.Column {
 func (p *LogicalWindow) PredicatePushDown(predicates []expression.Expression) ([]expression.Expression, LogicalPlan) {
 	canBePushed := make([]expression.Expression, 0, len(predicates))
 	canNotBePushed := make([]expression.Expression, 0, len(predicates))
-	partitionCols := expression.NewSchema(p.getPartitionByCols() ...)
+	partitionCols := expression.NewSchema(p.getPartitionByCols()...)
 	for _, cond := range predicates {
 		canPush := true
 		extractedCols := expression.ExtractColumns(cond)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements predicate pushdown for window functions.
fix https://github.com/pingcap/tidb/issues/11903.

After this PR:
```
mysql> explain select a, b from (select avg(a) over (partition by b) as avg_a, a, b from t) as tt where b > 10 and avg_a < b;
+------------------------------+----------+------+------------------------------------------------------------+
| id                           | count    | task | operator info                                              |
+------------------------------+----------+------+------------------------------------------------------------+
| Projection_8                 | 2666.67  | root | test.t.a, test.t.b                                         |
| └─Selection_9                | 2666.67  | root | lt(avg_a, cast(test.t.b))                                  |
|   └─Window_10                | 3333.33  | root | avg(cast(test.t.a)) over(partition by test.t.b)            |
|     └─Sort_14                | 3333.33  | root | test.t.b:asc                                               |
|       └─TableReader_13       | 3333.33  | root | data:Selection_12                                          |
|         └─Selection_12       | 3333.33  | cop  | gt(test.t.b, 10)                                           |
|           └─TableScan_11     | 10000.00 | cop  | table:t, range:[-inf,+inf], keep order:false, stats:pseudo |
+------------------------------+----------+------+------------------------------------------------------------+
7 rows in set (0.00 sec)
```

### What is changed and how it works?
We can push down the prediacte, only if all of its extracted columns are part of `partition by` columns of the Window.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Add an explain test.

