### PR TITLE
store/mockstore/mocktikv: fix DATA RACE to make unit test stable

### DIFF
--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -611,7 +611,9 @@ func (h *rpcHandler) handleSplitRegion(req *kvrpcpb.SplitRegionRequest) *kvrpcpb
 	}
 	newRegionID, newPeerIDs := h.cluster.AllocID(), h.cluster.AllocIDs(len(region.Peers))
 	newRegion := h.cluster.SplitRaw(region.GetId(), newRegionID, key, newPeerIDs, newPeerIDs[0])
-	return &kvrpcpb.SplitRegionResponse{Left: newRegion.Meta}
+	// The mocktikv should return a deep copy of meta info to avoid data race
+	metaCloned := proto.Clone(newRegion.Meta)
+	return &kvrpcpb.SplitRegionResponse{Left: metaCloned.(*metapb.Region)}
 }
 
 // RPCClient sends kv RPC calls to mock cluster. RPCClient mocks the behavior of


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR  fixes the DATA RACE in mocktikv to make unit test stable. The mocktikv should return a copy of meta info to avoid data race instead of share the same pointer with the client.

### What is changed and how it works?

Deep clone the meta info before returning the response.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - N/A
