### PR TITLE
executor: uncomment the BatchPointGet unit tests

### DIFF
--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/testkit"
 )
 
 type testBatchPointGetSuite struct {
@@ -56,7 +57,7 @@ func (s *testBatchPointGetSuite) TearDownSuite(c *C) {
 }
 
 func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
-	/*tk := testkit.NewTestKit(c, s.store)
+	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int primary key auto_increment not null, b int, c int, unique key idx_abc(a, b, c))")
@@ -97,5 +98,5 @@ func (s *testBatchPointGetSuite) TestBatchPointGetExec(c *C) {
 		"1",
 		"2",
 		"4",
-	))*/
+	))
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `BatchPointGet` unit tests are commented unexpectedly.

### What is changed and how it works?

This PR uncomment related unit tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - **DO NOT NEED**
