### PR TITLE
executor: fix execution info of explain analyze

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"github.com/pingcap/errors"
@@ -566,10 +565,6 @@ func (e *IndexLookUpExecutor) Close() error {
 
 // Next implements Exec Next interface.
 func (e *IndexLookUpExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
-	if e.runtimeStats != nil {
-		start := time.Now()
-		defer func() { e.runtimeStats.Record(time.Since(start), req.NumRows()) }()
-	}
 	if !e.workerStarted {
 		if err := e.startWorkers(ctx, req.RequiredRows()); err != nil {
 			return err
@@ -801,7 +796,7 @@ func (w *tableWorker) compareData(ctx context.Context, task *lookupTableTask, ta
 	tblInfo := w.idxLookup.table.Meta()
 	vals := make([]types.Datum, 0, len(w.idxTblCols))
 	for {
-		err := tableReader.Next(ctx, chk)
+		err := Next(ctx, tableReader, chk)
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -878,7 +873,7 @@ func (w *tableWorker) executeTask(ctx context.Context, task *lookupTableTask) er
 	task.rows = make([]chunk.Row, 0, handleCnt)
 	for {
 		chk := newFirstChunk(tableReader)
-		err = tableReader.Next(ctx, chk)
+		err = Next(ctx, tableReader, chk)
 		if err != nil {
 			logutil.Logger(ctx).Error("table reader fetch next chunk failed", zap.Error(err))
 			return err

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -522,7 +522,7 @@ func (e *CheckTableExec) checkIndexHandle(ctx context.Context, num int, src *Ind
 
 	var err error
 	for {
-		err = src.Next(ctx, chk)
+		err = Next(ctx, src, chk)
 		if err != nil {
 			break
 		}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -74,7 +74,7 @@ func (e *ExplainExec) generateExplainInfo(ctx context.Context) ([][]string, erro
 	if e.analyzeExec != nil {
 		chk := newFirstChunk(e.analyzeExec)
 		for {
-			err := e.analyzeExec.Next(ctx, chk)
+			err := Next(ctx, e.analyzeExec, chk)
 			if err != nil {
 				return nil, err
 			}

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -169,6 +169,22 @@ func (s *testSuite1) TestExplainAnalyzeExecutionInfo(c *C) {
 	s.checkExecutionInfo(c, tk, "explain analyze select * from t")
 	s.checkExecutionInfo(c, tk, "explain analyze select k from t use index(k)")
 	s.checkExecutionInfo(c, tk, "explain analyze select * from t use index(k)")
+
+	tk.MustExec("CREATE TABLE IF NOT EXISTS nation  ( N_NATIONKEY  BIGINT NOT NULL,N_NAME       CHAR(25) NOT NULL,N_REGIONKEY  BIGINT NOT NULL,N_COMMENT    VARCHAR(152),PRIMARY KEY (N_NATIONKEY));")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS part  ( P_PARTKEY     BIGINT NOT NULL,P_NAME        VARCHAR(55) NOT NULL,P_MFGR        CHAR(25) NOT NULL,P_BRAND       CHAR(10) NOT NULL,P_TYPE        VARCHAR(25) NOT NULL,P_SIZE        BIGINT NOT NULL,P_CONTAINER   CHAR(10) NOT NULL,P_RETAILPRICE DECIMAL(15,2) NOT NULL,P_COMMENT     VARCHAR(23) NOT NULL,PRIMARY KEY (P_PARTKEY));")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS supplier  ( S_SUPPKEY     BIGINT NOT NULL,S_NAME        CHAR(25) NOT NULL,S_ADDRESS     VARCHAR(40) NOT NULL,S_NATIONKEY   BIGINT NOT NULL,S_PHONE       CHAR(15) NOT NULL,S_ACCTBAL     DECIMAL(15,2) NOT NULL,S_COMMENT     VARCHAR(101) NOT NULL,PRIMARY KEY (S_SUPPKEY),CONSTRAINT FOREIGN KEY SUPPLIER_FK1 (S_NATIONKEY) references nation(N_NATIONKEY));")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS partsupp ( PS_PARTKEY     BIGINT NOT NULL,PS_SUPPKEY     BIGINT NOT NULL,PS_AVAILQTY    BIGINT NOT NULL,PS_SUPPLYCOST  DECIMAL(15,2)  NOT NULL,PS_COMMENT     VARCHAR(199) NOT NULL,PRIMARY KEY (PS_PARTKEY,PS_SUPPKEY),CONSTRAINT FOREIGN KEY PARTSUPP_FK1 (PS_SUPPKEY) references supplier(S_SUPPKEY),CONSTRAINT FOREIGN KEY PARTSUPP_FK2 (PS_PARTKEY) references part(P_PARTKEY));")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS orders  ( O_ORDERKEY       BIGINT NOT NULL,O_CUSTKEY        BIGINT NOT NULL,O_ORDERSTATUS    CHAR(1) NOT NULL,O_TOTALPRICE     DECIMAL(15,2) NOT NULL,O_ORDERDATE      DATE NOT NULL,O_ORDERPRIORITY  CHAR(15) NOT NULL,O_CLERK          CHAR(15) NOT NULL,O_SHIPPRIORITY   BIGINT NOT NULL,O_COMMENT        VARCHAR(79) NOT NULL,PRIMARY KEY (O_ORDERKEY),CONSTRAINT FOREIGN KEY ORDERS_FK1 (O_CUSTKEY) references customer(C_CUSTKEY));")
+	tk.MustExec("CREATE TABLE IF NOT EXISTS lineitem ( L_ORDERKEY    BIGINT NOT NULL,L_PARTKEY     BIGINT NOT NULL,L_SUPPKEY     BIGINT NOT NULL,L_LINENUMBER  BIGINT NOT NULL,L_QUANTITY    DECIMAL(15,2) NOT NULL,L_EXTENDEDPRICE  DECIMAL(15,2) NOT NULL,L_DISCOUNT    DECIMAL(15,2) NOT NULL,L_TAX         DECIMAL(15,2) NOT NULL,L_RETURNFLAG  CHAR(1) NOT NULL,L_LINESTATUS  CHAR(1) NOT NULL,L_SHIPDATE    DATE NOT NULL,L_COMMITDATE  DATE NOT NULL,L_RECEIPTDATE DATE NOT NULL,L_SHIPINSTRUCT CHAR(25) NOT NULL,L_SHIPMODE     CHAR(10) NOT NULL,L_COMMENT      VARCHAR(44) NOT NULL,PRIMARY KEY (L_ORDERKEY,L_LINENUMBER),CONSTRAINT FOREIGN KEY LINEITEM_FK1 (L_ORDERKEY)  references orders(O_ORDERKEY),CONSTRAINT FOREIGN KEY LINEITEM_FK2 (L_PARTKEY,L_SUPPKEY) references partsupp(PS_PARTKEY, PS_SUPPKEY));")
+
+	s.checkExecutionInfo(c, tk, "select nation, o_year, sum(amount) as sum_profit from ( select n_name as nation, extract(year from o_orderdate) as o_year, l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity as amount from part, supplier, lineitem, partsupp, orders, nation where s_suppkey = l_suppkey and ps_suppkey = l_suppkey and ps_partkey = l_partkey and p_partkey = l_partkey and o_orderkey = l_orderkey and s_nationkey = n_nationkey and p_name like '%dim%' ) as profit group by nation, o_year order by nation, o_year desc;")
+
+	tk.MustExec("drop table if exists nation")
+	tk.MustExec("drop table if exists part")
+	tk.MustExec("drop table if exists supplier")
+	tk.MustExec("drop table if exists partsupp")
+	tk.MustExec("drop table if exists orders")
+	tk.MustExec("drop table if exists lineitem")
 }
 
 func (s *testSuite1) checkExecutionInfo(c *C, tk *testkit.TestKit, sql string) {

--- a/executor/join.go
+++ b/executor/join.go
@@ -266,7 +266,7 @@ func (e *HashJoinExec) fetchInnerRows(ctx context.Context, chkCh chan<- *chunk.C
 			return
 		}
 		chk := chunk.NewChunkWithCapacity(e.innerExec.base().retFieldTypes, e.ctx.GetSessionVars().MaxChunkSize)
-		err = e.innerExec.Next(ctx, chk)
+		err = Next(ctx, e.innerExec, chk)
 		if err != nil {
 			e.innerFinished <- errors.Trace(err)
 			return


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Closed issue: #11930  
The execution info is wrong.
In tpch query-9, there are three wrong rows in the column.
1）The first row's execution info is always `time:0s, loops:0, rows:0`
2)  Some hash join's execution info is `time:0s, loops:0, rows:0`
3)  Some TableReader's execution info is `time:0s, loops:0, rows:0`

Before the pr: 
```
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+-----------------------+
| id                                             | count        | task | operator info                                                                                                                                                                                                       | execution info                                                                         | memory                |
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+-----------------------+
| Sort_25                                        | 2406.00      | root | tpch10.profit.nation:asc, profit.o_year:desc                                                                                                                                                                        | time:0s, loops:0, rows:0                                                               | 15.9375 KB            |
| └─Projection_27                                | 2406.00      | root | tpch10.profit.nation, profit.o_year, 14_col_0                                                                                                                                                                       | time:1m31.354718463s, loops:2, rows:175                                                | N/A                   |
|   └─HashAgg_30                                 | 2406.00      | root | group by:profit.o_year, tpch10.profit.nation, funcs:sum(profit.amount), firstrow(tpch10.profit.nation), firstrow(profit.o_year)                                                                                     | time:1m31.354594763s, loops:2, rows:175                                                | N/A                   |
|     └─Projection_31                            | 193562456.32 | root | tpch10.nation.n_name, extract("YEAR", tpch10.orders.o_orderdate), minus(mul(tpch10.lineitem.l_extendedprice, minus(1, tpch10.lineitem.l_discount)), mul(tpch10.partsupp.ps_supplycost, tpch10.lineitem.l_quantity)) | time:1m31.337919122s, loops:3185, rows:3256948                                         | N/A                   |
|       └─HashLeftJoin_36                        | 193562456.32 | root | inner join, inner:TableReader_73, equal:[eq(tpch10.lineitem.l_suppkey, tpch10.partsupp.ps_suppkey) eq(tpch10.lineitem.l_partkey, tpch10.partsupp.ps_partkey)]                                                       | time:1m31.332897833s, loops:3185, rows:3256948                                         | 432.8766326904297 MB  |
|         ├─HashLeftJoin_42                      | 48189309.13  | root | inner join, inner:TableReader_71, equal:[eq(tpch10.lineitem.l_orderkey, tpch10.orders.o_orderkey)]                                                                                                                  | time:1m31.288088698s, loops:3185, rows:3256948                                         | 350.15348052978516 MB |
|         │ ├─HashLeftJoin_52                    | 48189309.13  | root | inner join, inner:TableReader_69, equal:[eq(tpch10.lineitem.l_partkey, tpch10.part.p_partkey)]                                                                                                                      | time:1m13.415965034s, loops:3185, rows:3256948                                         | 4.622791290283203 MB  |
|         │ │ ├─HashRightJoin_55                 | 59986052.00  | root | inner join, inner:HashRightJoin_60, equal:[eq(tpch10.supplier.s_suppkey, tpch10.lineitem.l_suppkey)]                                                                                                                | time:1m11.546198691s, loops:58582, rows:59986052                                       | 3.5566139221191406 MB |
|         │ │ │ ├─HashRightJoin_60               | 100000.00    | root | inner join, inner:TableReader_64, equal:[eq(tpch10.nation.n_nationkey, tpch10.supplier.s_nationkey)]                                                                                                                | time:0s, loops:0, rows:0                                                               | 20.46484375 KB        |
|         │ │ │ │ ├─TableReader_64               | 25.00        | root | data:TableScan_63                                                                                                                                                                                                   | time:0s, loops:0, rows:0                                                               | 640 Bytes             |
|         │ │ │ │ │ └─TableScan_63               | 25.00        | cop  | table:nation, range:[-inf,+inf], keep order:false                                                                                                                                                                   | time:1ms, loops:1, rows:25                                                             | N/A                   |
|         │ │ │ │ └─TableReader_62               | 100000.00    | root | data:TableScan_61                                                                                                                                                                                                   | time:257.91515ms, loops:99, rows:100000                                                | 1.0503253936767578 MB |
|         │ │ │ │   └─TableScan_61               | 100000.00    | cop  | table:supplier, range:[-inf,+inf], keep order:false                                                                                                                                                                 | time:195ms, loops:102, rows:100000                                                     | N/A                   |
|         │ │ │ └─TableReader_66                 | 59986052.00  | root | data:TableScan_65                                                                                                                                                                                                   | time:1m10.27179512s, loops:58582, rows:59986052                                        | 762.3230466842651 MB  |
|         │ │ │   └─TableScan_65                 | 59986052.00  | cop  | table:lineitem, range:[-inf,+inf], keep order:false                                                                                                                                                                 | proc max:954ms, min:53ms, p80:856ms, p95:923ms, rows:59986052, iters:59230, tasks:153  | N/A                   |
|         │ │ └─TableReader_69                   | 1600000.00   | root | data:Selection_68                                                                                                                                                                                                   | time:0s, loops:0, rows:0                                                               | 2.312417984008789 MB  |
|         │ │   └─Selection_68                   | 1600000.00   | cop  | like(tpch10.part.p_name, "%dim%", 92)                                                                                                                                                                               | proc max:1.339s, min:910ms, p80:1.339s, p95:1.339s, rows:108551, iters:1973, tasks:4   | N/A                   |
|         │ │     └─TableScan_67                 | 2000000.00   | cop  | table:part, range:[-inf,+inf], keep order:false                                                                                                                                                                     | proc max:1.215s, min:827ms, p80:1.215s, p95:1.215s, rows:2000000, iters:1973, tasks:4  | N/A                   |
|         │ └─TableReader_71                     | 15000000.00  | root | data:TableScan_70                                                                                                                                                                                                   | time:0s, loops:0, rows:0                                                               | 209.7378511428833 MB  |
|         │   └─TableScan_70                     | 15000000.00  | cop  | table:orders, range:[-inf,+inf], keep order:false                                                                                                                                                                   | proc max:1.072s, min:584ms, p80:991ms, p95:1.03s, rows:15000000, iters:14788, tasks:31 | N/A                   |
|         └─TableReader_73                       | 8000000.00   | root | data:TableScan_72                                                                                                                                                                                                   | time:0s, loops:0, rows:0                                                               | 85.15747451782227 MB  |
|           └─TableScan_72                       | 8000000.00   | cop  | table:partsupp, range:[-inf,+inf], keep order:false                                                                                                                                                                 | proc max:1.681s, min:93ms, p80:1.195s, p95:1.681s, rows:8000000, iters:7903, tasks:20  | N/A                   |
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------+-----------------------+
22 rows in set (1 min 31.37 sec)
```

This PR:
```
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+-----------------------+
| id                                             | count        | task | operator info                                                                                                                                                                                                       | execution info                                                                          | memory                |
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+-----------------------+
| Sort_25                                        | 2406.00      | root | tpch10.profit.nation:asc, profit.o_year:desc                                                                                                                                                                        | time:1m31.469960222s, loops:2, rows:175                                                 | 15.9375 KB            |
| └─Projection_27                                | 2406.00      | root | tpch10.profit.nation, profit.o_year, 14_col_0                                                                                                                                                                       | time:1m31.469636224s, loops:2, rows:175                                                 | N/A                   |
|   └─HashAgg_30                                 | 2406.00      | root | group by:profit.o_year, tpch10.profit.nation, funcs:sum(profit.amount), firstrow(tpch10.profit.nation), firstrow(profit.o_year)                                                                                     | time:1m31.469537724s, loops:2, rows:175                                                 | N/A                   |
|     └─Projection_31                            | 193562456.32 | root | tpch10.nation.n_name, extract("YEAR", tpch10.orders.o_orderdate), minus(mul(tpch10.lineitem.l_extendedprice, minus(1, tpch10.lineitem.l_discount)), mul(tpch10.partsupp.ps_supplycost, tpch10.lineitem.l_quantity)) | time:1m31.451166003s, loops:3184, rows:3256948                                          | N/A                   |
|       └─HashLeftJoin_36                        | 193562456.32 | root | inner join, inner:TableReader_73, equal:[eq(tpch10.lineitem.l_suppkey, tpch10.partsupp.ps_suppkey) eq(tpch10.lineitem.l_partkey, tpch10.partsupp.ps_partkey)]                                                       | time:1m31.449746406s, loops:3184, rows:3256948                                          | 432.8766326904297 MB  |
|         ├─HashLeftJoin_42                      | 48189309.13  | root | inner join, inner:TableReader_71, equal:[eq(tpch10.lineitem.l_orderkey, tpch10.orders.o_orderkey)]                                                                                                                  | time:1m31.395733381s, loops:3184, rows:3256948                                          | 407.4320182800293 MB  |
|         │ ├─HashLeftJoin_52                    | 48189309.13  | root | inner join, inner:TableReader_69, equal:[eq(tpch10.lineitem.l_partkey, tpch10.part.p_partkey)]                                                                                                                      | time:1m15.86744989s, loops:3184, rows:3256948                                           | 4.622791290283203 MB  |
|         │ │ ├─HashRightJoin_55                 | 59986052.00  | root | inner join, inner:HashRightJoin_60, equal:[eq(tpch10.supplier.s_suppkey, tpch10.lineitem.l_suppkey)]                                                                                                                | time:1m11.571157322s, loops:58582, rows:59986052                                        | 3.5566139221191406 MB |
|         │ │ │ ├─HashRightJoin_60               | 100000.00    | root | inner join, inner:TableReader_64, equal:[eq(tpch10.nation.n_nationkey, tpch10.supplier.s_nationkey)]                                                                                                                | time:146.8503ms, loops:99, rows:100000                                                  | 20.46484375 KB        |
|         │ │ │ │ ├─TableReader_64               | 25.00        | root | data:TableScan_63                                                                                                                                                                                                   | time:52.499µs, loops:2, rows:25                                                         | 640 Bytes             |
|         │ │ │ │ │ └─TableScan_63               | 25.00        | cop  | table:nation, range:[-inf,+inf], keep order:false                                                                                                                                                                   | time:1ms, loops:1, rows:25                                                              | N/A                   |
|         │ │ │ │ └─TableReader_62               | 100000.00    | root | data:TableScan_61                                                                                                                                                                                                   | time:148.667084ms, loops:99, rows:100000                                                | 1.0503253936767578 MB |
|         │ │ │ │   └─TableScan_61               | 100000.00    | cop  | table:supplier, range:[-inf,+inf], keep order:false                                                                                                                                                                 | time:203ms, loops:102, rows:100000                                                      | N/A                   |
|         │ │ │ └─TableReader_66                 | 59986052.00  | root | data:TableScan_65                                                                                                                                                                                                   | time:1m10.450959146s, loops:58582, rows:59986052                                        | 762.3230428695679 MB  |
|         │ │ │   └─TableScan_65                 | 59986052.00  | cop  | table:lineitem, range:[-inf,+inf], keep order:false                                                                                                                                                                 | proc max:1.021s, min:88ms, p80:905ms, p95:984ms, rows:59986052, iters:59230, tasks:153  | N/A                   |
|         │ │ └─TableReader_69                   | 1600000.00   | root | data:Selection_68                                                                                                                                                                                                   | time:4.276630636s, loops:108, rows:108551                                               | 2.308246612548828 MB  |
|         │ │   └─Selection_68                   | 1600000.00   | cop  | like(tpch10.part.p_name, "%dim%", 92)                                                                                                                                                                               | proc max:1.384s, min:938ms, p80:1.384s, p95:1.384s, rows:108551, iters:1973, tasks:4    | N/A                   |
|         │ │     └─TableScan_67                 | 2000000.00   | cop  | table:part, range:[-inf,+inf], keep order:false                                                                                                                                                                     | proc max:1.259s, min:848ms, p80:1.259s, p95:1.259s, rows:2000000, iters:1973, tasks:4   | N/A                   |
|         │ └─TableReader_71                     | 15000000.00  | root | data:TableScan_70                                                                                                                                                                                                   | time:5.462070178s, loops:14650, rows:15000000                                           | 183.09504795074463 MB |
|         │   └─TableScan_70                     | 15000000.00  | cop  | table:orders, range:[-inf,+inf], keep order:false                                                                                                                                                                   | proc max:1.26s, min:614ms, p80:1.048s, p95:1.133s, rows:15000000, iters:14788, tasks:31 | N/A                   |
|         └─TableReader_73                       | 8000000.00   | root | data:TableScan_72                                                                                                                                                                                                   | time:6.730286856s, loops:7814, rows:8000000                                             | 84.7912769317627 MB   |
|           └─TableScan_72                       | 8000000.00   | cop  | table:partsupp, range:[-inf,+inf], keep order:false                                                                                                                                                                 | proc max:1.472s, min:88ms, p80:918ms, p95:1.472s, rows:8000000, iters:7903, tasks:20    | N/A                   |
+------------------------------------------------+--------------+------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+-----------------------+
22 rows in set (1 min 31.65 sec)
```

### What is changed and how it works?

The root reason is that we should call function `Next(ctx context.Context, e Executor, req *chunk.Chunk)` instant of calling `e.Next(ctx context.Context, req *chunk.Chunk)` directly.

`Next` is a wrapper function on `e.Next()` , it records the infomation and call `e.Next()`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

Related changes
