### PR TITLE
infoschema,store: fix the inconsistent definition of StoreStatus between TiDB/PD

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -594,8 +594,8 @@ var tableTiKVStoreStatusCols = []columnInfo{
 	{"LEADER_SCORE", mysql.TypeLonglong, 21, 0, nil, nil},
 	{"LEADER_SIZE", mysql.TypeLonglong, 21, 0, nil, nil},
 	{"REGION_COUNT", mysql.TypeLonglong, 21, 0, nil, nil},
-	{"REGION_WEIGHT", mysql.TypeLonglong, 21, 0, nil, nil},
-	{"REGION_SCORE", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"REGION_WEIGHT", mysql.TypeDouble, 22, 0, nil, nil},
+	{"REGION_SCORE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"REGION_SIZE", mysql.TypeLonglong, 21, 0, nil, nil},
 	{"START_TS", mysql.TypeDatetime, 0, 0, nil, nil},
 	{"LAST_HEARTBEAT_TS", mysql.TypeDatetime, 0, 0, nil, nil},
@@ -822,8 +822,8 @@ func dataForTiKVStoreStatus(ctx sessionctx.Context) (records [][]types.Datum, er
 		row[10].SetInt64(storeStat.Status.LeaderScore)
 		row[11].SetInt64(storeStat.Status.LeaderSize)
 		row[12].SetInt64(storeStat.Status.RegionCount)
-		row[13].SetInt64(storeStat.Status.RegionWeight)
-		row[14].SetInt64(storeStat.Status.RegionScore)
+		row[13].SetFloat64(storeStat.Status.RegionWeight)
+		row[14].SetFloat64(storeStat.Status.RegionScore)
 		row[15].SetInt64(storeStat.Status.RegionSize)
 		startTs := types.Time{
 			Time: types.FromGoTime(storeStat.Status.StartTs),

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -661,8 +661,8 @@ type StoreDetailStat struct {
 	LeaderScore     int64     `json:"leader_score"`
 	LeaderSize      int64     `json:"leader_size"`
 	RegionCount     int64     `json:"region_count"`
-	RegionWeight    int64     `json:"region_weight"`
-	RegionScore     int64     `json:"region_score"`
+	RegionWeight    float64   `json:"region_weight"`
+	RegionScore     float64   `json:"region_score"`
 	RegionSize      int64     `json:"region_size"`
 	StartTs         time.Time `json:"start_ts"`
 	LastHeartbeatTs time.Time `json:"last_heartbeat_ts"`


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Protocol incompatible with PD-Server, introduced in #10248.
Fix https://github.com/pingcap/tidb/issues/11960, https://github.com/pingcap/tidb/issues/11294

### What is changed and how it works?

This PR change the type of `RegionScore` and `RegionWeight` to `float64`.
See: https://github.com/pingcap/pd/blob/561d00414f9e43b3ba6da9a34d82c6d7acd16ae2/server/api/store.go#L42

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
    ```
    mysql> select * from INFORMATION_SCHEMA.TIKV_STORE_STATUS\G
    *************************** 1. row ***************************
            STORE_ID: 1
            ADDRESS: 127.0.0.1:20160
        STORE_STATE: 0
    STORE_STATE_NAME: Up
                LABEL: null
            VERSION: 4.0.0-alpha
            CAPACITY: 466 GiB
            AVAILABLE: 199 GiB
        LEADER_COUNT: 20
        LEADER_WEIGHT: 1
        LEADER_SCORE: 20
        LEADER_SIZE: 20
        REGION_COUNT: 20
        REGION_WEIGHT: 1
        REGION_SCORE: 20
        REGION_SIZE: 20
            START_TS: 2019-09-02 10:42:29
    LAST_HEARTBEAT_TS: 2019-09-02 10:43:29
            UPTIME: 1m0.808967s
    1 row in set (0.00 sec)
    ```

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the inconsistent definition of StoreStatus between TiDB/PD
