### PR TITLE
dml : fix last insert id when autoid specified by user in first row.

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -570,8 +570,9 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 		if e.filterErr(err) != nil {
 			return types.Datum{}, err
 		}
-		// It's compatible with mysql. So it sets last insert id to the first row.
-		if e.rowCount == 1 {
+		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
+		// Cause autoID may be specified by user, judge only the first row is not suitable.
+		if e.lastInsertID == 0 {
 			e.lastInsertID = uint64(recordID)
 		}
 	}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -15,7 +15,6 @@ package executor
 
 import (
 	"context"
-	"fmt"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -573,11 +572,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 		}
 		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
 		// Cause autoID may be specified by user, judge only the first row is not suitable.
-		//if e.lastInsertID == 0 {
-		//	e.lastInsertID = uint64(recordID)
-		//}
-		fmt.Println(e.rowCount, uint64(recordID), hasValue)
-		if e.rowCount == 1 {
+		if e.lastInsertID == 0 {
 			e.lastInsertID = uint64(recordID)
 		}
 	}

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -15,6 +15,7 @@ package executor
 
 import (
 	"context"
+	"fmt"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -572,7 +573,11 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 		}
 		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
 		// Cause autoID may be specified by user, judge only the first row is not suitable.
-		if e.lastInsertID == 0 {
+		//if e.lastInsertID == 0 {
+		//	e.lastInsertID = uint64(recordID)
+		//}
+		fmt.Println(e.rowCount, uint64(recordID), hasValue)
+		if e.rowCount == 1 {
 			e.lastInsertID = uint64(recordID)
 		}
 	}

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -356,7 +356,7 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 		// test last insert id
 		{
 			`insert into t1 values(3000, -1), (null, -2)`,
-			`select * from t1 where id = 3000git `,
+			`select * from t1 where id = 3000`,
 			testkit.Rows(`3000, -1`),
 		},
 		{

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -353,6 +353,22 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 			`select * from t1 where id = 9`,
 			testkit.Rows(`9 9`),
 		},
+		// test last insert id
+		{
+			`insert into t1 values(3000, -1), (null, -2)`,
+			`select * from t1 where id = 3001`,
+			testkit.Rows(`3000, -1`),
+		},
+		{
+			`insert into t1 values(3000, -1), (null, -2)`,
+			`select * from t1 where id = 3001`,
+			testkit.Rows(`3001, -2`),
+		},
+		{
+			``,
+			`select last_insert_id()`,
+			testkit.Rows(`3001`),
+		},
 		{
 			`insert into t2(id, n) values(1, 1)`,
 			`select * from t2 where id = 1`,

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -357,12 +357,12 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 		{
 			`insert into t1 values(3000, -1), (null, -2)`,
 			`select * from t1 where id = 3000`,
-			testkit.Rows(`3000, -1`),
+			testkit.Rows(`3000 -1`),
 		},
 		{
 			`;`,
 			`select * from t1 where id = 3001`,
-			testkit.Rows(`3001, -2`),
+			testkit.Rows(`3001 -2`),
 		},
 		{
 			`;`,

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -356,7 +356,7 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 		// test last insert id
 		{
 			`insert into t1 values(3000, -1), (null, -2)`,
-			`select * from t1 where id = 3001`,
+			`select * from t1 where id = 3000git `,
 			testkit.Rows(`3000, -1`),
 		},
 		{

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -360,12 +360,12 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 			testkit.Rows(`3000, -1`),
 		},
 		{
-			`insert into t1 values(3000, -1), (null, -2)`,
+			`;`,
 			`select * from t1 where id = 3001`,
 			testkit.Rows(`3001, -2`),
 		},
 		{
-			``,
+			`;`,
 			`select last_insert_id()`,
 			testkit.Rows(`3001`),
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix last insert id when autoid specified by user in first row.
Table
```
mysql> desc t;
+-------+---------+------+------+---------+----------------+
| Field | Type    | Null | Key  | Default | Extra          |
+-------+---------+------+------+---------+----------------+
| a     | int(11) | NO   | PRI  | NULL    | auto_increment |
| b     | int(11) | YES  |      | NULL    |                |
+-------+---------+------+------+---------+----------------+
2 rows in set (0.00 sec)

```
before this PR
```
mysql> insert into t values(300000, -1),(null, -1),(null, -1);
Query OK, 3 rows affected (0.00 sec)
Records: 3  Duplicates: 0  Warnings: 0

mysql> select last_insert_id();
+------------------+
| last_insert_id() |
+------------------+
|                0 |
+------------------+
1 row in set (0.00 sec)

```
After this PR = MySQL's behavior
```
mysql> insert into t values(300000, -1),(null, -1),(null, -1);
Query OK, 3 rows affected (0.00 sec)
Records: 3  Duplicates: 0  Warnings: 0

mysql> select last_insert_id();
+------------------+
| last_insert_id() |
+------------------+
|           300001 |
+------------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?
Last insert id is not strong lied with the first insert row.
More specifically, it does lie with the first row that without user specified autoID.

Change the judging logic, 0 is inited value meaning that last insert id hasn't be assigned. So do the assignment under the condition.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix last insert id when autoid specified by user in first row.
