### PR TITLE
dml : fix last insert id when autoid specified by user in first row. (#11973)

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -503,8 +503,9 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 		if e.filterErr(err) != nil {
 			return types.Datum{}, err
 		}
-		// It's compatible with mysql. So it sets last insert id to the first row.
-		if e.rowCount == 1 {
+		// It's compatible with mysql setting the first allocated autoID to lastInsertID.
+		// Cause autoID may be specified by user, judge only the first row is not suitable.
+		if e.lastInsertID == 0 {
 			e.lastInsertID = uint64(recordID)
 		}
 	}

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -367,6 +367,22 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 			`select * from t1 where id = 9`,
 			testkit.Rows(`9 9`),
 		},
+		// test last insert id
+		{
+			`insert into t1 values(3000, -1), (null, -2)`,
+			`select * from t1 where id = 3000`,
+			testkit.Rows(`3000 -1`),
+		},
+		{
+			`;`,
+			`select * from t1 where id = 3001`,
+			testkit.Rows(`3001 -2`),
+		},
+		{
+			`;`,
+			`select last_insert_id()`,
+			testkit.Rows(`3001`),
+		},
 		{
 			`insert into t2(id, n) values(1, 1)`,
 			`select * from t2 where id = 1`,


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #11973 to release-3.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - fix last insert id when autoid specified by user in first row.
