### PR TITLE
executor: add benchmark for sortExec

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -770,7 +770,7 @@ func BenchmarkSortExec(b *testing.B) {
 		benchmarkSortExec(b, cas)
 	})
 
-	cas.ndvs = []int{4450, 0} // values of the first column are similar
+	cas.ndvs = []int{4450, 0} // values of the first column are mostly equal
 	b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 		benchmarkSortExec(b, cas)
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

add benchmark for `sortExec`

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None