### PR TITLE
expression: implement vectorized evaluation for `builtinLog10Sig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -204,6 +204,9 @@ var vecExprBenchCases = map[string][]vecExprBenchCase{
 	ast.Cast: {
 		{types.ETInt, []types.EvalType{types.ETInt}},
 	},
+	ast.Log10: {
+		{types.ETReal, []types.EvalType{types.ETReal}},
+	},
 }
 
 func fillColumn(eType types.EvalType, chk *chunk.Chunk, colIdx int) {

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -14,6 +14,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package expression
 
 import (

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -1,0 +1,45 @@
+// Copyright 2013 The ql Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSES/QL-LICENSE file.
+
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package expression
+
+import (
+	"math"
+
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinLog10Sig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] <= 0 {
+			result.SetNull(i, true)
+		} else {
+			f64s[i] = math.Log10(f64s[i])
+		}
+	}
+	return nil
+}
+
+func (b *builtinLog10Sig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -1,7 +1,3 @@
-// Copyright 2013 The ql Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSES/QL-LICENSE file.
-
 // Copyright 2019 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinLog10Sig`

### What is changed and how it works?
Here is the benchmark, almost 2.5x fater than before:
```
BenchmarkVectorizedBuiltinFunc/builtinLog10Sig-VecBuiltinFunc-12                          200000              8148 ns/op
BenchmarkVectorizedBuiltinFunc/builtinLog10Sig-NonVecBuiltinFunc-12                       100000             20654 ns/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test