### PR TITLE
expression: implement vectorized evaluation for `builtinRepeatSig` 

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -195,11 +195,12 @@ func BenchmarkScalarFunctionClone(b *testing.B) {
 	b.ReportAllocs()
 }
 
-// gener is used to generate data for test.
-type gener interface {
+// dataGenerator is used to generate data for test.
+type dataGenerator interface {
 	gen() interface{}
 }
 
+// rangeInt64Gener is used to generate int64 items in [begin, end).
 type rangeInt64Gener struct {
 	begin int
 	end   int
@@ -209,6 +210,7 @@ func (rig *rangeInt64Gener) gen() interface{} {
 	return int64(rand.Intn(rig.end-rig.begin) + rig.begin)
 }
 
+// randLenStrGener is used to generate strings whose lengths are in [lenBegin, lenEnd).
 type randLenStrGener struct {
 	lenBegin int
 	lenEnd   int
@@ -233,7 +235,11 @@ func (g *randLenStrGener) gen() interface{} {
 type vecExprBenchCase struct {
 	retEvalType   types.EvalType
 	childrenTypes []types.EvalType
-	geners        []gener // used to generate data for children
+	// geners are used to generate data for children and geners[i] generates data for children[i].
+	// if geners[i] is nil, the default dataGenerator will be used for its corresponding child.
+	// the geners slice can be shorter than the children slice, if it has 3 children, then
+	// geners[gen1, gen2] will be regarded as geners[gen1, gen2, nil].
+	geners []dataGenerator
 }
 
 var vecExprBenchCases = map[string][]vecExprBenchCase{
@@ -241,7 +247,7 @@ var vecExprBenchCases = map[string][]vecExprBenchCase{
 		{types.ETInt, []types.EvalType{types.ETInt}, nil},
 	},
 	ast.Repeat: {
-		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, []gener{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
+		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},
 }
 

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -236,8 +236,8 @@ type vecExprBenchCase struct {
 	retEvalType   types.EvalType
 	childrenTypes []types.EvalType
 	// geners are used to generate data for children and geners[i] generates data for children[i].
-	// if geners[i] is nil, the default dataGenerator will be used for its corresponding child.
-	// the geners slice can be shorter than the children slice, if it has 3 children, then
+	// If geners[i] is nil, the default dataGenerator will be used for its corresponding child.
+	// The geners slice can be shorter than the children slice, if it has 3 children, then
 	// geners[gen1, gen2] will be regarded as geners[gen1, gen2, nil].
 	geners []dataGenerator
 }

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -250,7 +250,7 @@ var vecExprBenchCases = map[string][]vecExprBenchCase{
 		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},
 	ast.Log10: {
-		{types.ETReal, []types.EvalType{types.ETReal}},
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 }
 

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -241,7 +241,7 @@ var vecExprBenchCases = map[string][]vecExprBenchCase{
 		{types.ETInt, []types.EvalType{types.ETInt}, nil},
 	},
 	ast.Repeat: {
-		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, []gener{&randLenStrGener{10, 50}, &rangeInt64Gener{10, 50}}},
+		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, []gener{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},
 }
 

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -15,7 +15,7 @@ func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 		return err
 	}
 	defer b.put(buf)
-	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
 		return err
 	}
 
@@ -24,7 +24,7 @@ func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 		return err
 	}
 	defer b.put(buf2)
-	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
 		return err
 	}
 

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -31,6 +31,7 @@ func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 	result.ReserveString(n)
 	nums := buf2.Int64s()
 	for i := 0; i < n; i++ {
+		// TODO: introduce vectorized null-bitmap to speed it up.
 		if buf.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
 			continue

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -42,6 +42,7 @@ func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 			continue
 		}
 		if num > math.MaxInt32 {
+			// to avoid overflow when calculating uint64(byteLength)*uint64(num) later
 			num = math.MaxInt32
 		}
 

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -30,7 +30,7 @@ func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 
 	result.ReserveString(n)
 	nums := buf2.Int64s()
-	for i := 0; i < n; i ++ {
+	for i := 0; i < n; i++ {
 		if buf.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
 			continue

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -1,0 +1,65 @@
+package expression
+
+import (
+	"math"
+	"strings"
+
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	buf2, err := b.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.put(buf2)
+	if err := b.args[1].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	nums := buf2.Int64s()
+	for i := 0; i < n; i ++ {
+		if buf.IsNull(i) || buf2.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		num := nums[i]
+		if num < 1 {
+			result.AppendString("")
+			continue
+		}
+		if num > math.MaxInt32 {
+			num = math.MaxInt32
+		}
+
+		str := buf.GetString(i)
+		byteLength := len(str)
+		if uint64(byteLength)*uint64(num) > b.maxAllowedPacket {
+			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnAllowedPacketOverflowed.GenWithStackByArgs("repeat", b.maxAllowedPacket))
+			result.AppendNull()
+			continue
+		}
+		if int64(byteLength) > int64(b.tp.Flen)/num {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(strings.Repeat(str, int(num)))
+	}
+	return nil
+}
+
+func (b *builtinRepeatSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -10,20 +10,20 @@ import (
 
 func (b *builtinRepeatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	buf, err := b.get(types.ETString, n)
+	buf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.put(buf)
+	defer b.bufAllocator.put(buf)
 	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
 		return err
 	}
 
-	buf2, err := b.get(types.ETInt, n)
+	buf2, err := b.bufAllocator.get(types.ETInt, n)
 	if err != nil {
 		return err
 	}
-	defer b.put(buf2)
+	defer b.bufAllocator.put(buf2)
 	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
 		return err
 	}

--- a/expression/builtin_vectorized_test.go
+++ b/expression/builtin_vectorized_test.go
@@ -39,7 +39,7 @@ type mockVecPlusIntBuiltinFunc struct {
 
 func (p *mockVecPlusIntBuiltinFunc) allocBuf(n int) (*chunk.Column, error) {
 	if p.enableAlloc {
-		return p.get(types.ETInt, n)
+		return p.bufAllocator.get(types.ETInt, n)
 	}
 	if p.buf == nil {
 		p.buf = chunk.NewColumn(types.NewFieldType(mysql.TypeLonglong), n)
@@ -49,7 +49,7 @@ func (p *mockVecPlusIntBuiltinFunc) allocBuf(n int) (*chunk.Column, error) {
 
 func (p *mockVecPlusIntBuiltinFunc) releaseBuf(buf *chunk.Column) {
 	if p.enableAlloc {
-		p.put(buf)
+		p.bufAllocator.put(buf)
 	}
 }
 
@@ -207,7 +207,7 @@ func (p *mockBuiltinDouble) vecEvalReal(input *chunk.Chunk, result *chunk.Column
 func (p *mockBuiltinDouble) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
 	var buf *chunk.Column
 	var err error
-	if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
+	if buf, err = p.baseBuiltinFunc.bufAllocator.get(p.evalType, input.NumRows()); err != nil {
 		return err
 	}
 	if err := p.args[0].VecEvalString(p.ctx, input, buf); err != nil {
@@ -218,7 +218,7 @@ func (p *mockBuiltinDouble) vecEvalString(input *chunk.Chunk, result *chunk.Colu
 		str := buf.GetString(i)
 		result.AppendString(str + str)
 	}
-	p.baseBuiltinFunc.put(buf)
+	p.baseBuiltinFunc.bufAllocator.put(buf)
 	return nil
 }
 
@@ -268,7 +268,7 @@ func (p *mockBuiltinDouble) vecEvalDuration(input *chunk.Chunk, result *chunk.Co
 func (p *mockBuiltinDouble) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
 	var buf *chunk.Column
 	var err error
-	if buf, err = p.baseBuiltinFunc.get(p.evalType, input.NumRows()); err != nil {
+	if buf, err = p.baseBuiltinFunc.bufAllocator.get(p.evalType, input.NumRows()); err != nil {
 		return err
 	}
 	if err := p.args[0].VecEvalJSON(p.ctx, input, buf); err != nil {
@@ -290,7 +290,7 @@ func (p *mockBuiltinDouble) vecEvalJSON(input *chunk.Chunk, result *chunk.Column
 		}
 		result.AppendJSON(j)
 	}
-	p.baseBuiltinFunc.put(buf)
+	p.baseBuiltinFunc.bufAllocator.put(buf)
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinRepeatSig`.

### What is changed and how it works?
Almost 1.5s faster than before:
```
BenchmarkVectorizedBuiltinFunc/builtinRepeatSig-VecBuiltinFunc-12                          50000             29567 ns/op
BenchmarkVectorizedBuiltinFunc/builtinRepeatSig-NonVecBuiltinFunc-12                       30000             45092 ns/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test