### PR TITLE
ddl: fix problem with modifying bit column

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1593,6 +1593,8 @@ func (s *testIntegrationSuite3) TestAlterAlgorithm(c *C) {
 	a int,
 	b varchar(100),
 	c int,
+	d bit(1),
+	e year,
 	INDEX idx_c(c)) PARTITION BY RANGE ( a ) (
 	PARTITION p0 VALUES LESS THAN (6),
 		PARTITION p1 VALUES LESS THAN (11),
@@ -1645,6 +1647,10 @@ func (s *testIntegrationSuite3) TestAlterAlgorithm(c *C) {
 	s.assertAlterWarnExec(c, "alter table t default charset = utf8mb4, ALGORITHM=COPY")
 	s.assertAlterErrorExec(c, "alter table t default charset = utf8mb4, ALGORITHM=INPLACE")
 	s.tk.MustExec("alter table t default charset = utf8mb4, ALGORITHM=INSTANT")
+
+	// Test FieldType flags
+	s.tk.MustExec("alter table t modify column d bit(20)")
+	s.tk.MustExec("alter table t modify column e year")
 }
 
 func (s *testIntegrationSuite3) TestAlterTableAddUniqueOnPartionRangeColumn(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Unexpected error:
```sql
create table t (a bit(1));
alter table t modify column a bit(20);
(1105, 'unsupported modify column unsigned false not match origin true')
```
Similarly,

```sql
create table t (a year);
alter table t modify column a year;
(1105, 'unsupported modify column unsigned false not match origin true')
```

When creating a `bit` column, the flag in the `fieldType` is set to `Unsigned`. However, when modifying it, the `Unsigned` flag of the new column is forgotten to be set, leading to the error above.

### What is changed and how it works?
- Extract the logic of setting flags as `setFlagByFieldType`.
- Add `setFlagByFiledType()` to `getModifiableColumnJob`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test

Code changes

Side effects


Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix problem with modifying bit column
