### PR TITLE
planner: extract basePhysicalJoin for several physical joins

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -942,8 +942,8 @@ func (b *executorBuilder) buildMergeJoin(v *plannercore.PhysicalMergeJoin) Execu
 		isOuterJoin: v.JoinType.IsOuterJoin(),
 	}
 
-	leftKeys := v.LeftKeys
-	rightKeys := v.RightKeys
+	leftKeys := v.LeftJoinKeys
+	rightKeys := v.RightJoinKeys
 
 	e.outerIdx = 0
 	innerFilter := v.RightConditions
@@ -1733,12 +1733,12 @@ func (b *executorBuilder) corColInAccess(p plannercore.PhysicalPlan) bool {
 }
 
 func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin) Executor {
-	outerExec := b.build(v.Children()[v.OuterIndex])
+	outerExec := b.build(v.Children()[1-v.InnerChildIdx])
 	if b.err != nil {
 		return nil
 	}
 	outerTypes := retTypes(outerExec)
-	innerPlan := v.Children()[1-v.OuterIndex]
+	innerPlan := v.Children()[v.InnerChildIdx]
 	innerTypes := make([]*types.FieldType, innerPlan.Schema().Len())
 	for i, col := range innerPlan.Schema().Columns {
 		innerTypes[i] = col.RetType
@@ -1749,7 +1749,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 		leftTypes, rightTypes []*types.FieldType
 	)
 
-	if v.OuterIndex == 1 {
+	if v.InnerChildIdx == 0 {
 		leftTypes, rightTypes = innerTypes, outerTypes
 		outerFilter = v.RightConditions
 		if len(v.LeftConditions) > 0 {
@@ -1788,7 +1788,7 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 			hasPrefixCol:  hasPrefixCol,
 		},
 		workerWg:      new(sync.WaitGroup),
-		joiner:        newJoiner(b.ctx, v.JoinType, v.OuterIndex == 1, defaultValues, v.OtherConditions, leftTypes, rightTypes),
+		joiner:        newJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes),
 		isOuterJoin:   v.JoinType.IsOuterJoin(),
 		indexRanges:   v.Ranges,
 		keyOff2IdxOff: v.KeyOff2IdxOff,

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -207,7 +207,7 @@ func (p *basePhysicalAgg) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalIndexJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
-	fmt.Fprintf(buffer, ", inner:%s", p.Children()[1-p.OuterIndex].ExplainID())
+	fmt.Fprintf(buffer, ", inner:%s", p.Children()[p.InnerChildIdx].ExplainID())
 	if len(p.OuterJoinKeys) > 0 {
 		fmt.Fprintf(buffer, ", outer key:%s",
 			expression.ExplainColumnList(p.OuterJoinKeys))
@@ -261,13 +261,13 @@ func (p *PhysicalHashJoin) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalMergeJoin) ExplainInfo() string {
 	buffer := bytes.NewBufferString(p.JoinType.String())
-	if len(p.LeftKeys) > 0 {
+	if len(p.LeftJoinKeys) > 0 {
 		fmt.Fprintf(buffer, ", left key:%s",
-			expression.ExplainColumnList(p.LeftKeys))
+			expression.ExplainColumnList(p.LeftJoinKeys))
 	}
-	if len(p.RightKeys) > 0 {
+	if len(p.RightJoinKeys) > 0 {
 		fmt.Fprintf(buffer, ", right key:%s",
-			expression.ExplainColumnList(p.RightKeys))
+			expression.ExplainColumnList(p.RightJoinKeys))
 	}
 	if len(p.LeftConditions) > 0 {
 		fmt.Fprintf(buffer, ", left cond:%s", p.LeftConditions)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -133,6 +133,9 @@ type LogicalJoin struct {
 	// redundantSchema contains columns which are eliminated in join.
 	// For select * from a join b using (c); a.c will in output schema, and b.c will in redundantSchema.
 	redundantSchema *expression.Schema
+
+	// equalCondOutCnt indicates the estimated count of joined rows after evaluating `EqualConditions`.
+	equalCondOutCnt float64
 }
 
 func (p *LogicalJoin) columnSubstitute(schema *expression.Schema, exprs []expression.Expression) {

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -121,19 +121,19 @@ func (p *PhysicalMergeJoin) ResolveIndices() (err error) {
 	}
 	lSchema := p.children[0].Schema()
 	rSchema := p.children[1].Schema()
-	for i, col := range p.LeftKeys {
+	for i, col := range p.LeftJoinKeys {
 		newKey, err := col.ResolveIndices(lSchema)
 		if err != nil {
 			return err
 		}
-		p.LeftKeys[i] = newKey.(*expression.Column)
+		p.LeftJoinKeys[i] = newKey.(*expression.Column)
 	}
-	for i, col := range p.RightKeys {
+	for i, col := range p.RightJoinKeys {
 		newKey, err := col.ResolveIndices(rSchema)
 		if err != nil {
 			return err
 		}
-		p.RightKeys[i] = newKey.(*expression.Column)
+		p.RightJoinKeys[i] = newKey.(*expression.Column)
 	}
 	for i, expr := range p.LeftConditions {
 		p.LeftConditions[i], err = expr.ResolveIndices(lSchema)
@@ -165,12 +165,12 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 	lSchema := p.children[0].Schema()
 	rSchema := p.children[1].Schema()
 	for i := range p.InnerJoinKeys {
-		newOuterKey, err := p.OuterJoinKeys[i].ResolveIndices(p.children[p.OuterIndex].Schema())
+		newOuterKey, err := p.OuterJoinKeys[i].ResolveIndices(p.children[1-p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
 		p.OuterJoinKeys[i] = newOuterKey.(*expression.Column)
-		newInnerKey, err := p.InnerJoinKeys[i].ResolveIndices(p.children[1-p.OuterIndex].Schema())
+		newInnerKey, err := p.InnerJoinKeys[i].ResolveIndices(p.children[p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
@@ -196,12 +196,12 @@ func (p *PhysicalIndexJoin) ResolveIndices() (err error) {
 		}
 	}
 	if p.CompareFilters != nil {
-		err = p.CompareFilters.resolveIndices(p.children[p.OuterIndex].Schema())
+		err = p.CompareFilters.resolveIndices(p.children[1-p.InnerChildIdx].Schema())
 		if err != nil {
 			return err
 		}
 		for i := range p.CompareFilters.affectedColSchema.Columns {
-			resolvedCol, err1 := p.CompareFilters.affectedColSchema.Columns[i].ResolveIndices(p.children[p.OuterIndex].Schema())
+			resolvedCol, err1 := p.CompareFilters.affectedColSchema.Columns[i].ResolveIndices(p.children[1-p.InnerChildIdx].Schema())
 			if err1 != nil {
 				return err1
 			}

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -93,9 +93,9 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 			id = "MergeInnerJoin"
 		}
 		str = id + "{" + strings.Join(children, "->") + "}"
-		for i := range x.LeftKeys {
-			l := x.LeftKeys[i].String()
-			r := x.RightKeys[i].String()
+		for i := range x.LeftJoinKeys {
+			l := x.LeftJoinKeys[i].String()
+			r := x.RightJoinKeys[i].String()
 			str += fmt.Sprintf("(%s,%s)", l, r)
 		}
 	case *LogicalApply, *PhysicalApply:

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -164,8 +164,8 @@ func (p *PhysicalApply) attach2Task(tasks ...task) task {
 
 func (p *PhysicalIndexMergeJoin) attach2Task(tasks ...task) task {
 	innerTask := p.innerTask
-	outerTask := finishCopTask(p.ctx, tasks[p.OuterIndex].copy())
-	if p.OuterIndex == 0 {
+	outerTask := finishCopTask(p.ctx, tasks[1-p.InnerChildIdx].copy())
+	if p.InnerChildIdx == 1 {
 		p.SetChildren(outerTask.plan(), innerTask.plan())
 	} else {
 		p.SetChildren(innerTask.plan(), outerTask.plan())
@@ -241,8 +241,8 @@ func (p *PhysicalIndexMergeJoin) GetCost(outerTask, innerTask task) float64 {
 
 func (p *PhysicalIndexJoin) attach2Task(tasks ...task) task {
 	innerTask := p.innerTask
-	outerTask := finishCopTask(p.ctx, tasks[p.OuterIndex].copy())
-	if p.OuterIndex == 0 {
+	outerTask := finishCopTask(p.ctx, tasks[1-p.InnerChildIdx].copy())
+	if p.InnerChildIdx == 1 {
 		p.SetChildren(outerTask.plan(), innerTask.plan())
 	} else {
 		p.SetChildren(innerTask.plan(), outerTask.plan())
@@ -368,12 +368,12 @@ func (p *PhysicalHashJoin) attach2Task(tasks ...task) task {
 // GetCost computes cost of merge join operator itself.
 func (p *PhysicalMergeJoin) GetCost(lCnt, rCnt float64) float64 {
 	outerCnt := lCnt
-	innerKeys := p.RightKeys
+	innerKeys := p.RightJoinKeys
 	innerSchema := p.children[1].Schema()
 	innerStats := p.children[1].statsInfo()
 	if p.JoinType == RightOuterJoin {
 		outerCnt = rCnt
-		innerKeys = p.LeftKeys
+		innerKeys = p.LeftJoinKeys
 		innerSchema = p.children[0].Schema()
 		innerStats = p.children[0].statsInfo()
 	}
@@ -381,8 +381,8 @@ func (p *PhysicalMergeJoin) GetCost(lCnt, rCnt float64) float64 {
 		cartesian:     false,
 		leftProfile:   p.children[0].statsInfo(),
 		rightProfile:  p.children[1].statsInfo(),
-		leftJoinKeys:  p.LeftKeys,
-		rightJoinKeys: p.RightKeys,
+		leftJoinKeys:  p.LeftJoinKeys,
+		rightJoinKeys: p.RightJoinKeys,
 		leftSchema:    p.children[0].Schema(),
 		rightSchema:   p.children[1].Schema(),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`PhysicalHashJoin`, `PhysicalIndexJoin` and `PhysicalMergeJoin` shares a lot of common fields, which is not graceful; and if we want to add a common field of these physical joins, we have to modify all those structures.

### What is changed and how it works?

Extract common fields of those 3 joins to a separate struct `basePhysicalJoin`, and modify related codes.

Also, add a field `equalCondOutCnt` to `LogicalJoin`, which stores the estimated row count of join results after applying the `EqualConditions`. This field would be used by sub-sequent PR which aims to improve row count estimation of index join's inner child.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code logic change

Code changes

 - Has exported variable/fields change

Side effects

N/A

Related changes

N/A

Release note

N/A
