### PR TITLE
expression: support vectorized bitmap operations for `nulls` in `Column`

### DIFF
--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -630,7 +630,8 @@ func (c *Column) CopyReconstruct(sel []int, dst *Column) *Column {
 }
 
 // OrNulls does the OR operation with all columns in the arguments.
-// The user should ensure that all these columns have the same length.
+// The user should ensure that all these columns have the same length, and
+// data stored in these columns are fixed-length type.
 func (c *Column) OrNulls(cols ...*Column) {
 	for _, col := range cols {
 		for i := range c.nullBitmap {

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -629,13 +629,16 @@ func (c *Column) CopyReconstruct(sel []int, dst *Column) *Column {
 	return dst
 }
 
-// OrNulls does the OR operation with all columns in the arguments.
+// MergeNulls merges these columns' null bitmaps.
+// For a row, if any column of it is null, the result is null.
+// It works like: if col1.IsNull || col2.IsNull || col3.IsNull.
 // The user should ensure that all these columns have the same length, and
 // data stored in these columns are fixed-length type.
-func (c *Column) OrNulls(cols ...*Column) {
+func (c *Column) MergeNulls(cols ...*Column) {
 	for _, col := range cols {
 		for i := range c.nullBitmap {
-			c.nullBitmap[i] |= col.nullBitmap[i]
+			// 1 is null while 0 is not null, so do AND operations here.
+			c.nullBitmap[i] &= col.nullBitmap[i]
 		}
 	}
 }

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -628,3 +628,13 @@ func (c *Column) CopyReconstruct(sel []int, dst *Column) *Column {
 	}
 	return dst
 }
+
+// OrNulls does the OR operation with all columns in the arguments.
+// The user should ensure that all these columns have the same length.
+func (c *Column) OrNulls(cols ...*Column) {
+	for _, col := range cols {
+		for i := range c.nullBitmap {
+			c.nullBitmap[i] |= col.nullBitmap[i]
+		}
+	}
+}

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -637,7 +637,7 @@ func (c *Column) CopyReconstruct(sel []int, dst *Column) *Column {
 func (c *Column) MergeNulls(cols ...*Column) {
 	for _, col := range cols {
 		for i := range c.nullBitmap {
-			// 1 is null while 0 is not null, so do AND operations here.
+			// bit 0 is null, 1 is not null, so do AND operations here.
 			c.nullBitmap[i] &= col.nullBitmap[i]
 		}
 	}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -918,7 +918,7 @@ func (s *testChunkSuite) TestVectorizedNulls(c *check.C) {
 	}
 }
 
-func BenchmarkOrNullsVectorized(b *testing.B) {
+func BenchmarkMergeNullsVectorized(b *testing.B) {
 	cols := genNullCols(3)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -912,7 +912,7 @@ func (s *testChunkSuite) TestVectorizedNulls(c *check.C) {
 			rowResult.SetNull(i, lCol.IsNull(i) || rCol.IsNull(i))
 		}
 
-		for i := 0; i < 1024; i ++ {
+		for i := 0; i < 1024; i++ {
 			c.Assert(rowResult.IsNull(i), check.Equals, vecResult.IsNull(i))
 		}
 	}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -926,7 +926,7 @@ func BenchmarkOrNullsVectorized(b *testing.B) {
 	}
 }
 
-func BenchmarkOrNullsNonVectorized(b *testing.B) {
+func BenchmarkMergeNullsNonVectorized(b *testing.B) {
 	cols := genNullCols(3)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Introduce a new method `MergeNulls` for `Column`.

### What is changed and how it works?
```
BenchmarkMergeNullsVectorized-12         5000000               265 ns/op               0 B/op          0 allocs/op
BenchmarkMergeNullsNonVectorized-12       500000              3068 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
