### PR TITLE
*: replace pessimistic default config option with global variable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -401,6 +401,7 @@ var defaultConf = Config{
 		Strategy:     "range",
 	},
 	PessimisticTxn: PessimisticTxn{
+		Enable:        true,
 		MaxRetryCount: 256,
 		TTL:           "40s",
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -306,8 +306,6 @@ type Plugin struct {
 type PessimisticTxn struct {
 	// Enable must be true for 'begin lock' or session variable to start a pessimistic transaction.
 	Enable bool `toml:"enable" json:"enable"`
-	// Starts a pessimistic transaction by default when Enable is true.
-	Default bool `toml:"default" json:"default"`
 	// The max count of retry for a single statement in a pessimistic transaction.
 	MaxRetryCount uint `toml:"max-retry-count" json:"max-retry-count"`
 	// The pessimistic lock ttl.
@@ -403,8 +401,6 @@ var defaultConf = Config{
 		Strategy:     "range",
 	},
 	PessimisticTxn: PessimisticTxn{
-		Enable:        false,
-		Default:       false,
 		MaxRetryCount: 256,
 		TTL:           "40s",
 	},

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -306,9 +306,6 @@ strategy = "range"
 # enable pessimistic transaction.
 enable = false
 
-# start pessimistic transaction by default.
-default = false
-
 # max retry count for a statement in a pessimistic transaction.
 max-retry-count = 256
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -304,7 +304,7 @@ strategy = "range"
 
 [pessimistic-txn]
 # enable pessimistic transaction.
-enable = false
+enable = true
 
 # max retry count for a statement in a pessimistic transaction.
 max-retry-count = 256

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -144,15 +144,7 @@ func (s *baseTestSuite) TearDownSuite(c *C) {
 	s.store.Close()
 }
 
-func enablePessimisticTxn(enable bool) {
-	newConf := config.NewConfig()
-	newConf.PessimisticTxn.Enable = enable
-	config.StoreGlobalConfig(newConf)
-}
-
 func (s *testSuiteP1) TestPessimisticSelectForUpdate(c *C) {
-	defer func() { enablePessimisticTxn(false) }()
-	enablePessimisticTxn(true)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -518,9 +518,6 @@ func (e *SimpleExec) executeBegin(ctx context.Context, s *ast.BeginStmt) error {
 		txnMode := s.Mode
 		if txnMode == "" {
 			txnMode = e.ctx.GetSessionVars().TxnMode
-			if txnMode == "" && pTxnConf.Default {
-				txnMode = ast.Pessimistic
-			}
 		}
 		if txnMode == ast.Pessimistic {
 			e.ctx.GetSessionVars().TxnCtx.IsPessimistic = true

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
@@ -45,7 +44,6 @@ type testPessimisticSuite struct {
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	config.GetGlobalConfig().PessimisticTxn.Enable = true
 	// Set it to 300ms for testing lock resolve.
 	tikv.PessimisticLockTTL = 300
 	s.cluster = mocktikv.NewCluster()
@@ -67,7 +65,6 @@ func (s *testPessimisticSuite) SetUpSuite(c *C) {
 func (s *testPessimisticSuite) TearDownSuite(c *C) {
 	s.dom.Close()
 	s.store.Close()
-	config.GetGlobalConfig().PessimisticTxn.Enable = false
 	testleak.AfterTest(c)()
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -1709,6 +1709,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBExpensiveQueryTimeThreshold,
 	variable.TiDBEnableNoopFuncs,
 	variable.TiDBEnableIndexMerge,
+	variable.TiDBTxnMode,
 }
 
 var (
@@ -1795,11 +1796,7 @@ func (s *session) PrepareTxnCtx(ctx context.Context) {
 	if !s.sessionVars.IsAutocommit() {
 		pessTxnConf := config.GetGlobalConfig().PessimisticTxn
 		if pessTxnConf.Enable {
-			txnMode := s.sessionVars.TxnMode
-			if txnMode == "" && pessTxnConf.Default {
-				txnMode = ast.Pessimistic
-			}
-			if txnMode == ast.Pessimistic {
+			if s.sessionVars.TxnMode == ast.Pessimistic {
 				s.sessionVars.TxnCtx.IsPessimistic = true
 			}
 		}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -844,9 +844,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	case TiDBExpensiveQueryTimeThreshold:
 		atomic.StoreUint64(&ExpensiveQueryTimeThreshold, uint64(tidbOptPositiveInt32(val, DefTiDBExpensiveQueryTimeThreshold)))
 	case TiDBTxnMode:
-		if err := s.setTxnMode(val); err != nil {
-			return err
-		}
+		s.TxnMode = strings.ToUpper(val)
 	case TiDBLowResolutionTSO:
 		s.LowResolutionTSO = TiDBOptOn(val)
 	case TiDBEnableIndexMerge:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -678,7 +678,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeGlobal | ScopeSession, TiDBDisableTxnAutoRetry, BoolToIntStr(DefTiDBDisableTxnAutoRetry)},
 	{ScopeGlobal | ScopeSession, TiDBConstraintCheckInPlace, BoolToIntStr(DefTiDBConstraintCheckInPlace)},
-	{ScopeSession, TiDBTxnMode, DefTiDBTxnMode},
+	{ScopeGlobal | ScopeSession, TiDBTxnMode, DefTiDBTxnMode},
 	{ScopeSession, TiDBOptimizerSelectivityLevel, strconv.Itoa(DefTiDBOptimizerSelectivityLevel)},
 	{ScopeGlobal | ScopeSession, TiDBEnableWindowFunction, BoolToIntStr(DefEnableWindowFunction)},
 	{ScopeGlobal | ScopeSession, TiDBEnableVectorizedExpression, BoolToIntStr(DefEnableVectorizedExpression)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -29,7 +29,8 @@ import (
 	5. Update the `NewSessionVars` function to set the field to its default value.
 	6. Update the `variable.SetSessionSystemVar` function to use the new value when SET statement is executed.
 	7. If it is a global variable, add it in `session.loadCommonGlobalVarsSQL`.
-	8. Use this variable to control the behavior in code.
+	8. Update ValidateSetSystemVar if the variable's value need to be validated.
+	9. Use this variable to control the behavior in code.
 */
 
 // TiDB system variable names that only in session scope.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/types"
@@ -567,6 +568,12 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "leader", nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
+	case TiDBTxnMode:
+		switch strings.ToUpper(value) {
+		case ast.Pessimistic, ast.Optimistic, "":
+		default:
+			return value, ErrWrongValueForVar.GenWithStackByArgs(TiDBTxnMode, value)
+		}
 	}
 	return value, nil
 }

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -375,6 +375,10 @@ func (s *testVarsutilSuite) TestValidate(c *C) {
 		{TiDBOptJoinReorderThreshold, "a", true},
 		{TiDBOptJoinReorderThreshold, "-1", true},
 		{TiDBReplicaRead, "invalid", true},
+		{TiDBTxnMode, "invalid", true},
+		{TiDBTxnMode, "pessimistic", false},
+		{TiDBTxnMode, "optimistic", false},
+		{TiDBTxnMode, "", false},
 	}
 
 	for _, t := range tests {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The 'PessimisticTxn.Default' option in the `Config` requires a server restart to change.
It can be inconsistent for multiple servers.

### What is changed and how it works?
- Add global scope for `tidb_txn_mode` system variable.
- Remove `PessimisticTxn.Default` option in the config.
- Change the default value of `PessimisticTxn.Enable` to true.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported variable/fields change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Add global scope for `tidb_txn_mode` system variable, set `enable` option to 'true' and remove `default` option in the `[pessimistic-txn]` section of the config file.
