### PR TITLE
planner: fix wrong request data type when pushing down avg aggfuncs

### DIFF
--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -434,15 +434,19 @@ func splitCopAvg2CountAndSum(p PhysicalPlan) {
 	if baseAgg == nil {
 		return
 	}
+
+	schemaCursor := len(baseAgg.Schema().Columns) - len(baseAgg.GroupByItems)
 	for i := len(baseAgg.AggFuncs) - 1; i >= 0; i-- {
 		f := baseAgg.AggFuncs[i]
+		schemaCursor--
 		if f.Name == ast.AggFuncAvg {
+			schemaCursor--
 			sumAgg := *f
 			sumAgg.Name = ast.AggFuncSum
-			sumAgg.RetTp = baseAgg.Schema().Columns[i+1].RetType
+			sumAgg.RetTp = baseAgg.Schema().Columns[schemaCursor+1].RetType
 			cntAgg := *f
 			cntAgg.Name = ast.AggFuncCount
-			cntAgg.RetTp = baseAgg.Schema().Columns[i].RetType
+			cntAgg.RetTp = baseAgg.Schema().Columns[schemaCursor].RetType
 			cntAgg.RetTp.Flag = f.RetTp.Flag
 			baseAgg.AggFuncs = append(baseAgg.AggFuncs[:i], append([]*aggregation.AggFuncDesc{&cntAgg, &sumAgg}, baseAgg.AggFuncs[i+1:]...)...)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When runing two `avg()` in one sql, the request types of aggfuncs in DAGRequest maybe wrong. (Now tikv can work well, because of it has type deduction and ignore the wrong infomation.)

### What is changed and how it works?

Add a  cursor to choose the right schema column.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


