### PR TITLE
infoschema: use BucketMap to reduce cost of table/database creation

### DIFF
--- a/infoschema/bucket_map.go
+++ b/infoschema/bucket_map.go
@@ -1,0 +1,101 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoschema
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+type bucketMap struct {
+	s []map[string]interface{}
+}
+
+func (bm *bucketMap) Spawn() *bucketMap {
+	newBM := NewBucketMap()
+	copy(newBM.s, bm.s)
+	return newBM
+}
+
+// NewBucketMap initialize a new bucketMap
+func NewBucketMap() *bucketMap {
+	s := make([]map[string]interface{}, bucketCount)
+	return &bucketMap{s}
+}
+
+func (bm *bucketMap) Set(key string, value interface{}) {
+	idx := bucketIndex(key)
+	if bm.s[idx] == nil {
+		bm.s[idx] = make(map[string]interface{})
+	} else {
+		newMap := make(map[string]interface{}, len(bm.s[idx])+1)
+		for k, v := range bm.s[idx] {
+			newMap[k] = v
+		}
+		bm.s[idx] = newMap
+	}
+	bm.s[idx][key] = value
+}
+
+func (bm *bucketMap) Get(key string) (interface{}, bool) {
+	idx := bucketIndex(key)
+	if bm.s[idx] == nil {
+		return nil, false
+	}
+	v, ok := bm.s[idx][key]
+	return v, ok
+}
+
+func (bm *bucketMap) Delete(key string) {
+	idx := bucketIndex(key)
+	if bm.s[idx] == nil {
+		return
+	}
+	size := len(bm.s[idx])
+	if _, ok := bm.s[idx][key]; !ok {
+		return
+	}
+	if size == 1 {
+		bm.s[idx] = nil
+		return
+	}
+	newMap := make(map[string]interface{}, len(bm.s[idx])-1)
+	for k, v := range bm.s[idx] {
+		if k != key {
+			newMap[k] = v
+		}
+	}
+	bm.s[idx] = newMap
+}
+
+func (bm bucketMap) String() string {
+	var s []string
+	for idx, m := range bm.s {
+		for k, v := range m {
+			s = append(s, fmt.Sprintf("|%v|%v -> %v", idx, k, v))
+		}
+	}
+	return "[" + strings.Join(s, ", ") + "]"
+}
+
+func bucketIndex(s string) uint32 {
+	return hashcode(s) % bucketCount
+}
+
+func hashcode(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}

--- a/infoschema/bucket_map_test.go
+++ b/infoschema/bucket_map_test.go
@@ -1,0 +1,123 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infoschema
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testBucketMapSuite{})
+
+type testBucketMapSuite struct{}
+
+func (s *testBucketMapSuite) Test1(c *C) {
+	bm := NewBucketMap()
+
+	_, ok := bm.Get("K1")
+	c.Assert(ok, Equals, false)
+
+	bm.Set("K1", "V1")
+
+	v, ok := bm.Get("K1")
+	c.Assert(ok, Equals, true)
+	c.Assert(v.(string), Equals, "V1")
+
+	bm.Set("K1", "V2")
+
+	v, ok = bm.Get("K1")
+	c.Assert(ok, Equals, true)
+	c.Assert(v.(string), Equals, "V2")
+
+	bm.Delete("K1")
+	bm.Delete("K2")
+	_, ok = bm.Get("K1")
+	c.Assert(ok, Equals, false)
+}
+
+func (s *testBucketMapSuite) TestSpawn(c *C) {
+	bm := NewBucketMap()
+	bm.Set("K1", "V1")
+
+	bm1 := bm.Spawn()
+	bm1.Set("K1", "V2")
+
+	v, ok := bm.Get("K1")
+	c.Assert(ok, Equals, true)
+	c.Assert(v.(string), Equals, "V1")
+
+	v, ok = bm1.Get("K1")
+	c.Assert(ok, Equals, true)
+	c.Assert(v.(string), Equals, "V2")
+
+	bm1.Delete("K1")
+	_, ok = bm1.Get("K1")
+	c.Assert(ok, Equals, false)
+
+	bm.Set("K0", "V0")
+	bm.Delete("K0")
+	_, ok = bm.Get("K0")
+	c.Assert(ok, Equals, false)
+
+	v, ok = bm.Get("K1")
+	c.Assert(ok, Equals, true)
+	c.Assert(v.(string), Equals, "V1")
+
+	bm1.Set("K2", "V2")
+	_, ok = bm.Get("K2")
+	c.Assert(ok, Equals, false)
+
+	bm1.Set("K3", "V3")
+	bm1.Delete("K2")
+	v, ok = bm1.Get("K3")
+	c.Assert(ok, Equals, true)
+	c.Assert(v, Equals, "V3")
+
+	_, ok = bm1.Get("K2")
+	c.Assert(ok, Equals, false)
+}
+
+func (s *testBucketMapSuite) TestConcurrent(c *C) {
+	bm := NewBucketMap()
+
+	ch := make(chan int, 2)
+
+	go func() {
+		for i := 0; i < 5; i++ {
+			k1 := fmt.Sprintf("K%d", i)
+			v1 := fmt.Sprintf("V%d", i)
+			bm.Set(k1, v1)
+		}
+		ch <- 1
+	}()
+
+	go func() {
+		for i := 5; i < 10; i++ {
+			k1 := fmt.Sprintf("K%d", i)
+			v1 := fmt.Sprintf("V%d", i)
+			bm.Set(k1, v1)
+		}
+		ch <- 1
+	}()
+
+	<-ch
+	<-ch
+
+	for i := 0; i < 10; i++ {
+		k1 := fmt.Sprintf("K%d", i)
+		_, ok := bm.Get(k1)
+		c.Assert(ok, Equals, true)
+	}
+}


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
use BucketMap to reduce the time duration of table/database creation

### What is changed and how it works?
a `BucketMap` is added to replace current `map` in `InfoSchema`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Increased code complexity

Related changes

NA

Release note

NA
