### PR TITLE
executor: vectorize hash calculation in hashJoin (#12048)

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"hash/fnv"
 	"sync"
 	"sync/atomic"
 
@@ -334,8 +333,6 @@ func (e *HashJoinExec) runJoinWorker(workerID uint, outerKeyColIdx []int) {
 	hCtx := &hashContext{
 		allTypes:  retTypes(e.outerExec),
 		keyColIdx: outerKeyColIdx,
-		h:         fnv.New64(),
-		buf:       make([]byte, 1),
 	}
 	for ok := true; ok; {
 		if e.finished.Load().(bool) {
@@ -506,8 +503,6 @@ func (e *HashJoinExec) buildHashTableForList(innerResultCh <-chan *chunk.Chunk) 
 	hCtx := &hashContext{
 		allTypes:  allTypes,
 		keyColIdx: innerKeyColIdx,
-		h:         fnv.New64(),
-		buf:       make([]byte, 1),
 	}
 	initList := chunk.NewList(allTypes, e.initCap, e.maxChunkSize)
 	e.rowContainer = newHashRowContainer(e.ctx, int(e.innerEstCount), hCtx, initList)

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -16,6 +16,7 @@ package codec
 import (
 	"bytes"
 	"encoding/binary"
+	"hash"
 	"io"
 	"time"
 	"unsafe"
@@ -43,6 +44,11 @@ const (
 	uvarintFlag      byte = 9
 	jsonFlag         byte = 10
 	maxFlag          byte = 250
+)
+
+const (
+	sizeUint64  = unsafe.Sizeof(uint64(0))
+	sizeFloat64 = unsafe.Sizeof(float64(0))
 )
 
 func preRealloc(b []byte, vals []types.Datum, comparable bool) []byte {
@@ -348,6 +354,215 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 		b = row.GetBytes(idx)
 	default:
 		return 0, nil, errors.Errorf("unsupport column type for encode %d", tp.Tp)
+	}
+	return
+}
+
+// HashChunkColumns writes the encoded value of each row's column, which of index `colIdx`, to h.
+func HashChunkColumns(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk.Chunk, tp *types.FieldType, colIdx int, buf []byte, isNull []bool) (err error) {
+	var b []byte
+	column := chk.Column(colIdx)
+	rows := chk.NumRows()
+	switch tp.Tp {
+	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
+		i64s := column.Int64s()
+		for i, v := range i64s {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = varintFlag
+				if mysql.HasUnsignedFlag(tp.Flag) && v < 0 {
+					buf[0] = uvarintFlag
+				}
+				b = column.GetRaw(i)
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeFloat:
+		f32s := column.Float32s()
+		for i, f := range f32s {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = floatFlag
+				d := float64(f)
+				b = (*[sizeFloat64]byte)(unsafe.Pointer(&d))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeDouble:
+		f64s := column.Float64s()
+		for i, f := range f64s {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = floatFlag
+				b = (*[sizeFloat64]byte)(unsafe.Pointer(&f))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeVarchar, mysql.TypeVarString, mysql.TypeString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = compactBytesFlag
+				b = column.GetBytes(i)
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
+		ts := column.Times()
+		for i, t := range ts {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = uintFlag
+				// Encoding timestamp need to consider timezone.
+				// If it's not in UTC, transform to UTC first.
+				if t.Type == mysql.TypeTimestamp && sc.TimeZone != time.UTC {
+					err = t.ConvertTimeZone(sc.TimeZone, time.UTC)
+					if err != nil {
+						return
+					}
+				}
+				var v uint64
+				v, err = t.ToPackedUint()
+				if err != nil {
+					return
+				}
+				b = (*[sizeUint64]byte)(unsafe.Pointer(&v))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeDuration:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = durationFlag
+				// duration may have negative value, so we cannot use String to encode directly.
+				b = column.GetRaw(i)
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeNewDecimal:
+		ds := column.Decimals()
+		for i, d := range ds {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = decimalFlag
+				// If hash is true, we only consider the original value of this decimal and ignore it's precision.
+				b, err = d.ToHashKey()
+				if err != nil {
+					return
+				}
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeEnum:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = uvarintFlag
+				v := uint64(column.GetEnum(i).ToNumber())
+				b = (*[sizeUint64]byte)(unsafe.Pointer(&v))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeSet:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = uvarintFlag
+				v := uint64(column.GetSet(i).ToNumber())
+				b = (*[sizeUint64]byte)(unsafe.Pointer(&v))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeBit:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				// We don't need to handle errors here since the literal is ensured to be able to store in uint64 in convertToMysqlBit.
+				buf[0] = uvarintFlag
+				v, err1 := types.BinaryLiteral(column.GetBytes(i)).ToInt(sc)
+				terror.Log(errors.Trace(err1))
+				b = (*[sizeUint64]byte)(unsafe.Pointer(&v))[:]
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error.
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	case mysql.TypeJSON:
+		for i := 0; i < rows; i++ {
+			if column.IsNull(i) {
+				buf[0], b = NilFlag, nil
+				isNull[i] = true
+			} else {
+				buf[0] = jsonFlag
+				b = column.GetBytes(i)
+			}
+
+			// As the golang doc described, `Hash.Write` never returns an error..
+			// See https://golang.org/pkg/hash/#Hash
+			_, _ = h[i].Write(buf)
+			_, _ = h[i].Write(b)
+		}
+	default:
+		return errors.Errorf("unsupport column type for encode %d", tp.Tp)
 	}
 	return
 }

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -15,7 +15,9 @@ package codec
 
 import (
 	"bytes"
+	"hash"
 	"hash/crc32"
+	"hash/fnv"
 	"math"
 	"testing"
 	"time"
@@ -1157,5 +1159,62 @@ func (s *testCodecSuite) TestValueSizeOfUnsignedInt(c *C) {
 
 		b = encodeUnsignedInt(b[:0], v+10, false)
 		c.Assert(len(b), Equals, valueSizeOfUnsignedInt(v+10))
+	}
+}
+
+func (s *testCodecSuite) TestHashChunkColumns(c *C) {
+	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	buf := make([]byte, 1)
+	datums, tps := datumsForTest(sc)
+	chk := chunkForTest(c, sc, datums, tps, 3)
+
+	colIdx := make([]int, len(tps))
+	for i := 0; i < len(tps); i++ {
+		colIdx[i] = i
+	}
+	hasNull := []bool{false, false, false}
+	vecHash := []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
+	rowHash := []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
+
+	// Test hash value of the first `Null` column
+	c.Assert(chk.GetRow(0).IsNull(0), Equals, true)
+	err1 := HashChunkColumns(sc, vecHash, chk, tps[0], 0, buf, hasNull)
+	err2 := HashChunkRow(sc, rowHash[0], chk.GetRow(0), tps, colIdx[0:1], buf)
+	err3 := HashChunkRow(sc, rowHash[1], chk.GetRow(1), tps, colIdx[0:1], buf)
+	err4 := HashChunkRow(sc, rowHash[2], chk.GetRow(2), tps, colIdx[0:1], buf)
+	c.Assert(err1, IsNil)
+	c.Assert(err2, IsNil)
+	c.Assert(err3, IsNil)
+	c.Assert(err4, IsNil)
+
+	c.Assert(hasNull[0], Equals, true)
+	c.Assert(hasNull[1], Equals, true)
+	c.Assert(hasNull[2], Equals, true)
+	c.Assert(vecHash[0].Sum64(), Equals, rowHash[0].Sum64())
+	c.Assert(vecHash[1].Sum64(), Equals, rowHash[1].Sum64())
+	c.Assert(vecHash[2].Sum64(), Equals, rowHash[2].Sum64())
+
+	// Test hash value of every single column that is not `Null`
+	for i := 1; i < len(tps); i++ {
+		hasNull = []bool{false, false, false}
+		vecHash = []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
+		rowHash = []hash.Hash64{fnv.New64(), fnv.New64(), fnv.New64()}
+
+		c.Assert(chk.GetRow(0).IsNull(i), Equals, false)
+		err1 = HashChunkColumns(sc, vecHash, chk, tps[i], i, buf, hasNull)
+		err2 = HashChunkRow(sc, rowHash[0], chk.GetRow(0), tps, colIdx[i:i+1], buf)
+		err3 = HashChunkRow(sc, rowHash[1], chk.GetRow(1), tps, colIdx[i:i+1], buf)
+		err4 = HashChunkRow(sc, rowHash[2], chk.GetRow(2), tps, colIdx[i:i+1], buf)
+		c.Assert(err1, IsNil)
+		c.Assert(err2, IsNil)
+		c.Assert(err3, IsNil)
+		c.Assert(err4, IsNil)
+
+		c.Assert(hasNull[0], Equals, false)
+		c.Assert(hasNull[1], Equals, false)
+		c.Assert(hasNull[2], Equals, false)
+		c.Assert(vecHash[0].Sum64(), Equals, rowHash[0].Sum64())
+		c.Assert(vecHash[1].Sum64(), Equals, rowHash[1].Sum64())
+		c.Assert(vecHash[2].Sum64(), Equals, rowHash[2].Sum64())
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix issue #12048 

### What is changed and how it works?

benchstat result

```
name                                                                    old time/op    new time/op    delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              810ms ± 1%     806ms ± 1%   -0.54%  (p=0.021 n=8+8)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                145ms ±16%     135ms ± 3%   -7.23%  (p=0.001 n=10+8)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     594ms ± 1%     587ms ± 0%   -1.18%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      13.3ms ± 1%    10.8ms ± 0%  -18.85%  (p=0.000 n=10+9)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          4.17µs ± 4%    4.23µs ± 3%     ~     (p=0.287 n=9+8)

name                                                                    old alloc/op   new alloc/op   delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=9+10)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4    7.11MB ± 0%    7.13MB ± 0%   +0.35%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      7.11MB ± 0%    7.14MB ± 0%   +0.36%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          2.00kB ± 0%    2.28kB ± 0%  +13.57%  (p=0.000 n=10+10)

name                                                                    old allocs/op  new allocs/op  delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4               306k ± 0%      307k ± 0%   +0.35%  (p=0.000 n=10+9)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                 306k ± 0%      307k ± 0%   +0.34%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     3.79k ± 1%     4.80k ± 2%  +26.63%  (p=0.000 n=8+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4       3.79k ± 0%     4.82k ± 0%  +27.04%  (p=0.000 n=10+9)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4            16.0 ± 0%      27.0 ± 0%  +68.75%  (p=0.000 n=10+10)
```

```
name                                                                    old time/op    new time/op    delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              817ms ± 2%     806ms ± 1%   -1.34%  (p=0.011 n=9+8)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                145ms ± 7%     135ms ± 3%   -6.92%  (p=0.000 n=10+8)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     592ms ± 0%     587ms ± 0%   -0.96%  (p=0.000 n=9+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      13.4ms ± 2%    10.8ms ± 0%  -19.19%  (p=0.000 n=9+9)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          4.16µs ± 5%    4.23µs ± 3%     ~     (p=0.173 n=10+8)

name                                                                    old alloc/op   new alloc/op   delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=10+10)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4    7.11MB ± 0%    7.13MB ± 0%   +0.34%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      7.11MB ± 0%    7.14MB ± 0%   +0.37%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          2.00kB ± 0%    2.28kB ± 0%  +13.57%  (p=0.000 n=10+10)

name                                                                    old allocs/op  new allocs/op  delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4               306k ± 0%      307k ± 0%   +0.35%  (p=0.000 n=10+9)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                 306k ± 0%      307k ± 0%   +0.34%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     3.78k ± 2%     4.80k ± 2%  +26.84%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4       3.79k ± 0%     4.82k ± 0%  +27.10%  (p=0.000 n=10+9)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4            16.0 ± 0%      27.0 ± 0%  +68.75%  (p=0.000 n=10+10)
```

```
name                                                                    old time/op    new time/op    delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              810ms ± 1%     811ms ± 1%     ~     (p=0.541 n=8+9)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                145ms ±16%     143ms ±14%     ~     (p=0.739 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     594ms ± 1%     588ms ± 0%   -1.01%  (p=0.000 n=10+9)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      13.3ms ± 1%    10.9ms ± 2%  -18.17%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          4.17µs ± 4%    4.44µs ±10%   +6.52%  (p=0.004 n=9+10)

name                                                                    old alloc/op   new alloc/op   delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4              304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=9+10)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                304MB ± 0%     304MB ± 0%   +0.01%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4    7.11MB ± 0%    7.14MB ± 0%   +0.41%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4      7.11MB ± 0%    7.14MB ± 0%   +0.35%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4          2.00kB ± 0%    2.28kB ± 0%  +13.57%  (p=0.000 n=10+10)

name                                                                    old allocs/op  new allocs/op  delta
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4               306k ± 0%      307k ± 0%   +0.34%  (p=0.000 n=10+10)
HashJoinExec/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4                 306k ± 0%      307k ± 0%   +0.34%  (p=0.000 n=10+9)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0_1])-4     3.79k ± 1%     4.82k ± 2%  +27.07%  (p=0.000 n=8+10)
BuildHashTableForList/(rows:100000,_concurency:4,_joinKeyIdx:_[0])-4       3.79k ± 0%     4.81k ± 0%  +26.95%  (p=0.000 n=10+10)
BuildHashTableForList/(rows:10,_concurency:4,_joinKeyIdx:_[0])-4            16.0 ± 0%      27.0 ± 0%  +68.75%  (p=0.000 n=10+10)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression

Related changes

<!--
 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
-->

Release note

