### PR TITLE
tikvclient: add metrics for gRPC connection transient failure (#12084)

### DIFF
--- a/metrics/gprc.go
+++ b/metrics/gprc.go
@@ -1,0 +1,27 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Metrics to monitor gRPC service
+var (
+	GRPCConnTransientFailureCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "grpc",
+			Name:      "connection_transient_failure_count",
+			Help:      "Counter of gRPC connection transient failure",
+		}, []string{LblAddress, LblStore})
+)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -131,4 +131,5 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TotalQueryProcHistogram)
 	prometheus.MustRegister(TotalCopProcHistogram)
 	prometheus.MustRegister(TotalCopWaitHistogram)
+	prometheus.MustRegister(GRPCConnTransientFailureCounter)
 }

--- a/metrics/session.go
+++ b/metrics/session.go
@@ -111,4 +111,6 @@ const (
 	LblSQLType     = "sql_type"
 	LblGeneral     = "general"
 	LblInternal    = "internal"
+	LblStore       = "store"
+	LblAddress     = "address"
 )

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -74,7 +74,7 @@ var (
 			Name:      "request_seconds",
 			Help:      "Bucketed histogram of sending request duration.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 20), // 0.5ms ~ 524s
-		}, []string{LblType, "store"})
+		}, []string{LblType, LblStore})
 
 	TiKVCoprocessorHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

Cherry-pick https://github.com/pingcap/tidb/pull/12084 for release-2.1

---

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

TiDB access to TiKV through gRPC requests. If the underlying socket is disconnected, gRPC will try to reconnect to the underlying socket, which may cause the request delay to jitter. We need to way to monitor the low-level socket state change.

### What is changed and how it works?

This PR adds a metric to monitor the gRPC connection state, the metric will record the connection state before sending the request to TiKV. We can diagnose the delay jitter by `rate(tidb_grpc_connection_state)` after this PR merged.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
 - Manual test
    ![image](https://user-images.githubusercontent.com/1638682/64512950-11a2c080-d31a-11e9-8a13-e4b47e8f61a8.png)

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
