### PR TITLE
types/json: fix an over-quoted bug in `BinaryJSON.Unquote` function #11934

### DIFF
--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -65,8 +65,10 @@ func (s *testEvaluatorSuite) TestJSONUnquote(c *C) {
 		{`{"a":     "b"}`, `{"a":     "b"}`},
 		{`"hello,\"quoted string\",world"`, `hello,"quoted string",world`},
 		{`"hello,\"宽字符\",world"`, `hello,"宽字符",world`},
-		{`Invalid Json string\tis OK`, `Invalid Json string	is OK`},
+		{`Invalid Json string\tis OK`, `Invalid Json string\tis OK`},
 		{`"1\\u2232\\u22322"`, `1\u2232\u22322`},
+		{`"[{\"x\":\"{\\\"y\\\":12}\"}]"`, `[{"x":"{\"y\":12}"}]`},
+		{`[{\"x\":\"{\\\"y\\\":12}\"}]`, `[{\"x\":\"{\\\"y\\\":12}\"}]`},
 	}
 	dtbl := tblToDtbl(tbl)
 	for _, t := range dtbl {

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -58,19 +58,18 @@ func (bj BinaryJSON) Type() string {
 func (bj BinaryJSON) Unquote() (string, error) {
 	switch bj.TypeCode {
 	case TypeCodeString:
-		s, err := unquoteString(hack.String(bj.GetString()))
-		if err != nil {
-			return "", errors.Trace(err)
+		tmp := string(hack.String(bj.GetString()))
+		tlen := len(tmp)
+		if tlen < 2 {
+			return tmp, nil
 		}
-		// Remove prefix and suffix '"'.
-		slen := len(s)
-		if slen > 1 {
-			head, tail := s[0], s[slen-1]
-			if head == '"' && tail == '"' {
-				return s[1 : slen-1], nil
-			}
+		head, tail := tmp[0], tmp[tlen-1]
+		if head == '"' && tail == '"' {
+			// Remove prefix and suffix '"' before unquoting
+			return unquoteString(tmp[1 : tlen-1])
 		}
-		return s, nil
+		// if value is not double quoted, do nothing
+		return tmp, nil
 	default:
 		return bj.String(), nil
 	}

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -111,6 +111,7 @@ func (s *testJSONSuite) TestBinaryJSONUnquote(c *C) {
 	}{
 		{j: `3`, unquoted: "3"},
 		{j: `"3"`, unquoted: "3"},
+		{j: `"[{\"x\":\"{\\\"y\\\":12}\"}]"`, unquoted: `[{"x":"{\"y\":12}"}]`},
 		{j: `"hello, \"escaped quotes\" world"`, unquoted: "hello, \"escaped quotes\" world"},
 		{j: "\"\\u4f60\"", unquoted: "你"},
 		{j: `true`, unquoted: "true"},


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/11934 to release-2.1, with little conflict-resolve

---

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
# What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to fix the following issue:

```
create table a(a json);
insert into a values ("{\"low_keywords\":\"[{\\\"x\\\":\\\"{\\\\\\\"y\\\\\\\":12}\\\"}]\"}");
```

In current TiDB(master/3.0/2.1):

```
tidb> select a->>"$.low_keywords" from a;
+----------------------+
| a->>"$.low_keywords" |
+----------------------+
| [{"x":"{"y":12}"}] |
+----------------------+
1 rows in set (0.02 sec)
```
In MySQL 5.7/8.0:

```
tidb> select a->>"$.low_keywords" from a;
+----------------------+
| a->>"$.low_keywords" |
+----------------------+
| [{"x":"{\"y\":12}"}] |
+----------------------+
1 rows in set (0.02 sec)
```

### What is changed and how it works?
The issue is caused by the over-unquote behaviors of `BinaryJSON.Unquote`: for a string literal of JSON, it should be unquoted only when enclosed by double quotes(`"`)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
```
tidb> select json_unquote("\"[{\\\"x\\\":\\\"{\\\\\\\"y\\\\\\\":12}\\\"}]\"");
+------------------------------------------------------------------+
| json_unquote("\"[{\\\"x\\\":\\\"{\\\\\\\"y\\\\\\\":12}\\\"}]\"") |
+------------------------------------------------------------------+
| [{"x":"{\"y\":12}"}]                                             |
+------------------------------------------------------------------+
1 row in set (0.00 sec)

tidb> select json_unquote("\\\\");
+----------------------+
| json_unquote("\\\\") |
+----------------------+
| \\                   |
+----------------------+
1 row in set (0.00 sec)
```


 - No code

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

Release note

Fix an over-quoted bug for `JSON_UNQUOTE` function: only values enclosed by the double quote marks(`"`) should be unquoted. For example, result of `SELECT JSON_UNQUOTE("\\\\")` should be `\\`(not changed).
