### PR TITLE
executor: utilities for disk-based hash join

### DIFF
--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -66,7 +66,7 @@ func (c *Codec) encodeColumn(buffer []byte, col *Column) []byte {
 	// encode offsets.
 	if !col.isFixed() {
 		numOffsetBytes := (col.length + 1) * 8
-		offsetBytes := c.i64SliceToBytes(col.offsets)
+		offsetBytes := i64SliceToBytes(col.offsets)
 		buffer = append(buffer, offsetBytes[:numOffsetBytes]...)
 	}
 
@@ -75,7 +75,7 @@ func (c *Codec) encodeColumn(buffer []byte, col *Column) []byte {
 	return buffer
 }
 
-func (c *Codec) i64SliceToBytes(i64s []int64) (b []byte) {
+func i64SliceToBytes(i64s []int64) (b []byte) {
 	if len(i64s) == 0 {
 		return nil
 	}
@@ -128,7 +128,7 @@ func (c *Codec) decodeColumn(buffer []byte, col *Column, ordinal int) (remained 
 	numDataBytes := int64(numFixedBytes * col.length)
 	if numFixedBytes == -1 {
 		numOffsetBytes := (col.length + 1) * 8
-		col.offsets = append(col.offsets[:0], c.bytesToI64Slice(buffer[:numOffsetBytes])...)
+		col.offsets = append(col.offsets[:0], bytesToI64Slice(buffer[:numOffsetBytes])...)
 		buffer = buffer[numOffsetBytes:]
 		numDataBytes = col.offsets[col.length]
 	} else if cap(col.elemBuf) < numFixedBytes {
@@ -152,7 +152,7 @@ func (c *Codec) setAllNotNull(col *Column) {
 	}
 }
 
-func (c *Codec) bytesToI64Slice(b []byte) (i64s []int64) {
+func bytesToI64Slice(b []byte) (i64s []int64) {
 	if len(b) == 0 {
 		return nil
 	}

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -174,6 +174,18 @@ func (c *Column) AppendNull() {
 	c.length++
 }
 
+// AppendRaw appends the raw bytes into this Column.
+func (c *Column) AppendRaw(data []byte) {
+	c.appendNullBitmap(true)
+	if c.isFixed() {
+		c.data = append(c.data, data...)
+	} else {
+		c.data = append(c.data, data...)
+		c.offsets = append(c.offsets, int64(len(c.data)))
+	}
+	c.length++
+}
+
 func (c *Column) finishAppendFixed() {
 	c.data = append(c.data, c.elemBuf...)
 	c.appendNullBitmap(true)

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -174,18 +174,6 @@ func (c *Column) AppendNull() {
 	c.length++
 }
 
-// AppendRaw appends the raw bytes into this Column.
-func (c *Column) AppendRaw(data []byte) {
-	c.appendNullBitmap(true)
-	if c.isFixed() {
-		c.data = append(c.data, data...)
-	} else {
-		c.data = append(c.data, data...)
-		c.offsets = append(c.offsets, int64(len(c.data)))
-	}
-	c.length++
-}
-
 func (c *Column) finishAppendFixed() {
 	c.data = append(c.data, c.elemBuf...)
 	c.appendNullBitmap(true)

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -16,7 +16,6 @@ package chunk
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 	"testing"
 	"time"
 	"unsafe"
@@ -777,40 +776,6 @@ func (s *testChunkSuite) TestGetRaw(c *check.C) {
 	for row := it.Begin(); row != it.End(); row = it.Next() {
 		c.Assert(row.GetRaw(0), check.DeepEquals, []byte(fmt.Sprint(i)))
 		c.Assert(col.GetRaw(int(i)), check.DeepEquals, []byte(fmt.Sprint(i)))
-		i++
-	}
-}
-
-func (s *testChunkSuite) TestAppendRaw(c *check.C) {
-	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeFloat)}, 1024)
-	col := chk.Column(0)
-	for i := 0; i < 1024; i++ {
-		f := float32(i)
-		raw := (*[unsafe.Sizeof(f)]byte)(unsafe.Pointer(&f))[:]
-		col.AppendRaw(raw)
-	}
-	it := NewIterator4Chunk(chk)
-	var i int
-	for row := it.Begin(); row != it.End(); row = it.Next() {
-		f := float32(i)
-		c.Assert(row.GetFloat32(0), check.Equals, f)
-		c.Assert(col.GetFloat32(i), check.Equals, f)
-		i++
-	}
-
-	chk = NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeVarString)}, 1024)
-	col = chk.Column(0)
-	for i := 0; i < 1024; i++ {
-		str := strings.Repeat(fmt.Sprint(i), i)
-		raw := []byte(str)
-		col.AppendRaw(raw)
-	}
-	it = NewIterator4Chunk(chk)
-	i = 0
-	for row := it.Begin(); row != it.End(); row = it.Next() {
-		str := strings.Repeat(fmt.Sprint(i), i)
-		c.Assert(row.GetString(0), check.Equals, str)
-		c.Assert(col.GetString(i), check.Equals, str)
 		i++
 	}
 }

--- a/util/chunk/disk.go
+++ b/util/chunk/disk.go
@@ -1,0 +1,286 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/disk"
+	"github.com/pingcap/tidb/util/stringutil"
+)
+
+const (
+	writeBufSize = 128 * 1024
+	readBufSize  = 4 * 1024
+)
+
+var bufWriterPool = sync.Pool{
+	New: func() interface{} {
+		return bufio.NewWriterSize(nil, writeBufSize)
+	},
+}
+
+var bufReaderPool = sync.Pool{New: func() interface{} {
+	return bufio.NewReaderSize(nil, readBufSize)
+}}
+
+var tmpDir = path.Join(os.TempDir(), "tidb-server-hashJoin")
+
+func init() {
+	_ = os.RemoveAll(tmpDir)
+	_ = os.Mkdir(tmpDir, 0755)
+}
+
+// ListInDisk represents a slice of chunks storing in temporary disk.
+type ListInDisk struct {
+	fieldTypes []*types.FieldType
+	// offsets stores the offsets in disk of all RowPtr,
+	// the offset of one RowPtr is offsets[RowPtr.ChkIdx][RowPtr.RowIdx].
+	offsets [][]int64
+	// offWrite is the current offset for writing
+	offWrite int64
+
+	disk        *os.File
+	bufWriter   *bufio.Writer
+	diskTracker *disk.Tracker // track disk usage.
+}
+
+var chunkListInDiskLabel fmt.Stringer = stringutil.StringerStr("chunk.ListInDisk")
+
+// NewListInDisk creates a new ListInDisk with field types.
+func NewListInDisk(fieldTypes []*types.FieldType) *ListInDisk {
+	l := &ListInDisk{
+		fieldTypes: fieldTypes,
+		// TODO(fengliyuan): set the quota of disk usage.
+		diskTracker: disk.NewTracker(chunkListInDiskLabel, -1),
+	}
+	return l
+}
+
+// GetDiskTracker returns the memory tracker of this List.
+func (l *ListInDisk) GetDiskTracker() *disk.Tracker {
+	return l.diskTracker
+}
+
+// Add adds a chunk to the ListInDisk. Caller must make sure the input chk
+// is not empty and not used any more and has the same field types.
+func (l *ListInDisk) Add(chk *Chunk) (err error) {
+	if chk.NumRows() == 0 {
+		panic("chunk appended to List should have at least 1 row")
+	}
+	if l.disk == nil {
+		l.disk, err = ioutil.TempFile(tmpDir, "listInDisk")
+		if err != nil {
+			return
+		}
+		l.bufWriter = bufWriterPool.Get().(*bufio.Writer)
+		l.bufWriter.Reset(l.disk)
+	}
+	chk2 := chunkInDisk{Chunk: chk, off: l.offWrite}
+	n, err := chk2.WriteTo(l.bufWriter)
+	l.offWrite += n
+	if err != nil {
+		return
+	}
+	l.offsets = append(l.offsets, chk2.getOffsetsOfRows())
+	err = l.bufWriter.Flush()
+	if err == nil {
+		l.diskTracker.Consume(n)
+	}
+	return
+}
+
+// GetRow gets a Row from the ListInDisk by RowPtr.
+func (l *ListInDisk) GetRow(ptr RowPtr) (row Row, err error) {
+	off := l.offsets[ptr.ChkIdx][ptr.RowIdx]
+	r := io.NewSectionReader(l.disk, off, l.offWrite-off)
+	bufReader := bufReaderPool.Get().(*bufio.Reader)
+	bufReader.Reset(r)
+	defer bufReaderPool.Put(bufReader)
+
+	format := rowInDisk{numCol: len(l.fieldTypes)}
+	_, err = format.ReadFrom(bufReader)
+	if err != nil {
+		return
+	}
+	row = format.toRow(l.fieldTypes)
+	return row, err
+}
+
+// NumChunks returns the number of chunks in the ListInDisk.
+func (l *ListInDisk) NumChunks() int {
+	return len(l.offsets)
+}
+
+// Close releases the disk resource.
+func (l *ListInDisk) Close() error {
+	if l.disk != nil {
+		l.diskTracker.Consume(-l.diskTracker.BytesConsumed())
+		terror.Call(l.disk.Close)
+		bufWriterPool.Put(l.bufWriter)
+		return os.Remove(l.disk.Name())
+	}
+	return nil
+}
+
+// chunkInDisk represents a chunk in disk format. Each row of the chunk
+// is serialized and in sequence ordered. The format of each row is like
+// the struct diskFormatRow, put size of each column first, then the
+// data of each column.
+//
+// For example, a chunk has 2 rows and 3 columns, the disk format of the
+// chunk is as follow:
+//
+// [size of row0 column0], [size of row0 column1], [size of row0 column2]
+// [data of row0 column0], [data of row0 column1], [data of row0 column2]
+// [size of row1 column0], [size of row1 column1], [size of row1 column2]
+// [data of row1 column0], [data of row1 column1], [data of row1 column2]
+//
+// If a column of a row is null, the size of it is -1 and the data is empty.
+type chunkInDisk struct {
+	*Chunk
+	off int64
+	// offsetsOfRows stores the offset of each row.
+	offsetsOfRows []int64
+}
+
+// WriteTo serializes the chunk into the format of chunkInDisk, and
+// writes to w.
+func (chk *chunkInDisk) WriteTo(w io.Writer) (written int64, err error) {
+	var n int64
+	numRows := chk.NumRows()
+	chk.offsetsOfRows = make([]int64, 0, numRows)
+	var format *diskFormatRow
+	for rowIdx := 0; rowIdx < numRows; rowIdx++ {
+		format = convertFromRow(chk.GetRow(rowIdx), format)
+		chk.offsetsOfRows = append(chk.offsetsOfRows, chk.off+written)
+
+		n, err = chk.writeRowTo(w, format)
+		written += n
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// writeRowTo serializes a row of the chunk into the format of
+// diskFormatRow, and writes to w.
+func (chk *chunkInDisk) writeRowTo(w io.Writer, format *diskFormatRow) (written int64, err error) {
+	n, err := w.Write(i64SliceToBytes(format.sizesOfColumns))
+	written += int64(n)
+	if err != nil {
+		return
+	}
+	for _, data := range format.cells {
+		n, err = w.Write(data)
+		written += int64(n)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (chk *chunkInDisk) getOffsetsOfRows() []int64 { return chk.offsetsOfRows }
+
+// rowInDisk represents a Row in format of diskFormatRow.
+type rowInDisk struct {
+	numCol int
+	diskFormatRow
+}
+
+// ReadFrom reads data of r, deserializes it from the format of diskFormatRow
+// into Row.
+func (row *rowInDisk) ReadFrom(r io.Reader) (n int64, err error) {
+	b := make([]byte, 8*row.numCol)
+	var n1 int
+	n1, err = io.ReadFull(r, b)
+	n += int64(n1)
+	if err != nil {
+		return
+	}
+	row.sizesOfColumns = bytesToI64Slice(b)
+	row.cells = make([][]byte, 0, row.numCol)
+	for _, size := range row.sizesOfColumns {
+		if size == -1 {
+			continue
+		}
+		cell := make([]byte, size)
+		row.cells = append(row.cells, cell)
+		n1, err = io.ReadFull(r, cell)
+		n += int64(n1)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// diskFormatRow represents a row in a chunk in disk format. The disk format
+// of a row is described in the doc of chunkInDisk.
+type diskFormatRow struct {
+	// sizesOfColumns stores the size of each column in a row.
+	// -1 means the value of this column is null.
+	sizesOfColumns []int64 // -1 means null
+	cells          [][]byte
+}
+
+// convertFromRow serializes one row of chunk to diskFormatRow
+func convertFromRow(row Row, reuse *diskFormatRow) (format *diskFormatRow) {
+	numCols := row.Chunk().NumCols()
+	if reuse != nil {
+		format = reuse
+		format.sizesOfColumns = format.sizesOfColumns[:0]
+		format.cells = format.cells[:0]
+	} else {
+		format = &diskFormatRow{
+			sizesOfColumns: make([]int64, 0, numCols),
+			cells:          make([][]byte, 0, numCols),
+		}
+	}
+	for colIdx := 0; colIdx < numCols; colIdx++ {
+		if row.IsNull(colIdx) {
+			format.sizesOfColumns = append(format.sizesOfColumns, -1)
+		} else {
+			cell := row.GetRaw(colIdx)
+			format.sizesOfColumns = append(format.sizesOfColumns, int64(len(cell)))
+			format.cells = append(format.cells, cell)
+		}
+	}
+	return
+}
+
+// toRow deserializes diskFormatRow to Row.
+func (format *diskFormatRow) toRow(fields []*types.FieldType) Row {
+	chk := NewChunkWithCapacity(fields, 1)
+	var cellOff int
+	for colIdx, size := range format.sizesOfColumns {
+		if size == -1 {
+			chk.columns[colIdx].AppendNull()
+		} else {
+			chk.columns[colIdx].AppendRaw(format.cells[cellOff])
+			cellOff++
+		}
+	}
+	return chk.GetRow(0)
+}

--- a/util/chunk/disk.go
+++ b/util/chunk/disk.go
@@ -34,14 +34,12 @@ const (
 )
 
 var bufWriterPool = sync.Pool{
-	New: func() interface{} {
-		return bufio.NewWriterSize(nil, writeBufSize)
-	},
+	New: func() interface{} { return bufio.NewWriterSize(nil, writeBufSize) },
 }
 
-var bufReaderPool = sync.Pool{New: func() interface{} {
-	return bufio.NewReaderSize(nil, readBufSize)
-}}
+var bufReaderPool = sync.Pool{
+	New: func() interface{} { return bufio.NewReaderSize(nil, readBufSize) },
+}
 
 var tmpDir = path.Join(os.TempDir(), "tidb-server-hashJoin")
 

--- a/util/chunk/disk_test.go
+++ b/util/chunk/disk_test.go
@@ -1,0 +1,73 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chunk
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+)
+
+func (s *testChunkSuite) TestListInDisk(c *check.C) {
+	fields := []*types.FieldType{
+		types.NewFieldType(mysql.TypeVarString),
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeVarString),
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeJSON),
+	}
+	l := NewListInDisk(fields)
+	defer func() {
+		err := l.Close()
+		c.Check(err, check.IsNil)
+		_, err = os.Stat(l.disk.Name())
+		c.Check(os.IsNotExist(err), check.IsTrue)
+	}()
+
+	numChk, numRow := 2, 2
+	chks := make([]*Chunk, 0, numChk)
+	for chkIdx := 0; chkIdx < numChk; chkIdx++ {
+		chk := NewChunkWithCapacity(fields, 2)
+		for rowIdx := 0; rowIdx < numRow; rowIdx++ {
+			data := int64(chkIdx*numRow + rowIdx)
+			chk.AppendString(0, fmt.Sprint(data))
+			chk.AppendNull(1)
+			chk.AppendNull(2)
+			chk.AppendInt64(3, data)
+			if chkIdx == 0 {
+				chk.AppendJSON(4, json.CreateBinary(fmt.Sprint(data)))
+			} else {
+				chk.AppendNull(4)
+			}
+		}
+		chks = append(chks, chk)
+		err := l.Add(chk)
+		c.Check(err, check.IsNil)
+	}
+
+	c.Check(l.NumChunks(), check.Equals, 2)
+	c.Check(l.GetDiskTracker().BytesConsumed() > 0, check.IsTrue)
+
+	for chkIdx := 0; chkIdx < numChk; chkIdx++ {
+		for rowIdx := 0; rowIdx < numRow; rowIdx++ {
+			row, err := l.GetRow(RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)})
+			c.Check(err, check.IsNil)
+			c.Check(row.GetDatumRow(fields), check.DeepEquals, chks[chkIdx].GetRow(rowIdx).GetDatumRow(fields))
+		}
+	}
+}

--- a/util/chunk/disk_test.go
+++ b/util/chunk/disk_test.go
@@ -51,7 +51,7 @@ func (s *testChunkSuite) TestListInDisk(c *check.C) {
 		for rowIdx := 0; rowIdx < numRow; rowIdx++ {
 			row, err := l.GetRow(RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)})
 			c.Check(err, check.IsNil)
-			c.Check(row.ToRow().GetDatumRow(fields), check.DeepEquals, chks[chkIdx].GetRow(rowIdx).GetDatumRow(fields))
+			c.Check(row.GetDatumRow(fields), check.DeepEquals, chks[chkIdx].GetRow(rowIdx).GetDatumRow(fields))
 		}
 	}
 }
@@ -127,7 +127,6 @@ func BenchmarkListInDiskGetRow(b *testing.B) {
 		})
 	}
 	b.ResetTimer()
-	// fmt.Println(b.N)
 	for i := 0; i < b.N; i++ {
 		_, err = l.GetRow(ptrs[i])
 		if err != nil {

--- a/util/chunk/list.go
+++ b/util/chunk/list.go
@@ -100,6 +100,7 @@ func (l *List) AppendRow(row Row) RowPtr {
 func (l *List) Add(chk *Chunk) {
 	// FixMe: we should avoid add a Chunk that chk.NumRows() > list.maxChunkSize.
 	if chk.NumRows() == 0 {
+		// TODO: return error here.
 		panic("chunk appended to List should have at least 1 row")
 	}
 	if chkIdx := len(l.chunks) - 1; l.consumedIdx != chkIdx {

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cznic/mathutil"
 	"github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
@@ -222,10 +223,7 @@ func BenchmarkPreAllocChunk(b *testing.B) {
 
 func BenchmarkListAdd(b *testing.B) {
 	numChk, numRow := 1, 2
-	chks, fields, err := initChunks(numChk, numRow)
-	if err != nil {
-		b.Fatal(err)
-	}
+	chks, fields := initChunks(numChk, numRow)
 	chk := chks[0]
 	l := NewList(fields, numRow, numRow)
 
@@ -237,21 +235,21 @@ func BenchmarkListAdd(b *testing.B) {
 
 func BenchmarkListGetRow(b *testing.B) {
 	numChk, numRow := 10000, 2
-	chks, fields, err := initChunks(numChk, numRow)
-	if err != nil {
-		b.Fatal(err)
-	}
+	chks, fields := initChunks(numChk, numRow)
 	l := NewList(fields, numRow, numRow)
 	for _, chk := range chks {
 		l.Add(chk)
 	}
 	rand.Seed(0)
 	ptrs := make([]RowPtr, 0, b.N)
-	for i := 0; i < b.N; i++ {
+	for i := 0; i < mathutil.Min(b.N, 10000); i++ {
 		ptrs = append(ptrs, RowPtr{
 			ChkIdx: rand.Uint32() % uint32(numChk),
 			RowIdx: rand.Uint32() % uint32(numRow),
 		})
+	}
+	for i := 10000; i < cap(ptrs); i++ {
+		ptrs = append(ptrs, ptrs[i%10000])
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -15,6 +15,7 @@ package chunk
 
 import (
 	"math"
+	"math/rand"
 	"strconv"
 	"strings"
 	"testing"
@@ -216,5 +217,44 @@ func BenchmarkPreAllocChunk(b *testing.B) {
 		for j := 0; j < 32768; j++ {
 			finalChk.preAlloc(row)
 		}
+	}
+}
+
+func BenchmarkListAdd(b *testing.B) {
+	numChk, numRow := 1, 2
+	chks, fields, err := initChunks(numChk, numRow)
+	if err != nil {
+		b.Fatal(err)
+	}
+	chk := chks[0]
+	l := NewList(fields, numRow, numRow)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.Add(chk)
+	}
+}
+
+func BenchmarkListGetRow(b *testing.B) {
+	numChk, numRow := 10000, 2
+	chks, fields, err := initChunks(numChk, numRow)
+	if err != nil {
+		b.Fatal(err)
+	}
+	l := NewList(fields, numRow, numRow)
+	for _, chk := range chks {
+		l.Add(chk)
+	}
+	rand.Seed(0)
+	ptrs := make([]RowPtr, 0, b.N)
+	for i := 0; i < b.N; i++ {
+		ptrs = append(ptrs, RowPtr{
+			ChkIdx: rand.Uint32() % uint32(numChk),
+			RowIdx: rand.Uint32() % uint32(numRow),
+		})
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		l.GetRow(ptrs[i])
 	}
 }

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -195,7 +195,6 @@ func makeMutRowUint64Column(val uint64) *Column {
 func makeMutRowBytesColumn(bin []byte) *Column {
 	col := newMutRowVarLenColumn(len(bin))
 	copy(col.data, bin)
-	col.nullBitmap[0] = 1
 	return col
 }
 

--- a/util/disk/tracker.go
+++ b/util/disk/tracker.go
@@ -1,0 +1,26 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"github.com/pingcap/tidb/util/memory"
+)
+
+// Tracker is used to track the disk usage during query execution.
+type Tracker = memory.Tracker
+
+// NewTracker creates a disk tracker.
+//	1. "label" is the label used in the usage string.
+//	2. "bytesLimit <= 0" means no limit.
+var NewTracker = memory.NewTracker

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -35,7 +35,7 @@ import (
 //
 // NOTE: We only protect concurrent access to "bytesConsumed" and "children",
 // that is to say:
-// 1. Only "BytesConsumed()", "Consume()", "AttachTo()" and "Detach" are thread-safe.
+// 1. Only "BytesConsumed()", "Consume()" and "AttachTo()" are thread-safe.
 // 2. Other operations of a Tracker tree is not thread-safe.
 type Tracker struct {
 	mu struct {
@@ -53,7 +53,7 @@ type Tracker struct {
 
 // NewTracker creates a memory tracker.
 //	1. "label" is the label used in the usage string.
-//	2. "bytesLimit < 0" means no limit.
+//	2. "bytesLimit <= 0" means no limit.
 func NewTracker(label fmt.Stringer, bytesLimit int64) *Tracker {
 	return &Tracker{
 		label:          label,
@@ -62,7 +62,13 @@ func NewTracker(label fmt.Stringer, bytesLimit int64) *Tracker {
 	}
 }
 
-// SetActionOnExceed sets the action when memory usage is out of memory quota.
+// SetBytesLimit sets the bytes limit for this tracker.
+// "bytesLimit <= 0" means no limit.
+func (t *Tracker) SetBytesLimit(bytesLimit int64) {
+	t.bytesLimit = bytesLimit
+}
+
+// SetActionOnExceed sets the action when memory usage exceeds bytesLimit.
 func (t *Tracker) SetActionOnExceed(a ActionOnExceed) {
 	t.actionOnExceed = a
 }
@@ -131,12 +137,15 @@ func (t *Tracker) ReplaceChild(oldChild, newChild *Tracker) {
 }
 
 // Consume is used to consume a memory usage. "bytes" can be a negative value,
-// which means this is a memory release operation.
+// which means this is a memory release operation. When memory usage of a tracker
+// exceeds its bytesLimit, the tracker calls its action, so does each of its ancestors.
 func (t *Tracker) Consume(bytes int64) {
-	var rootExceed *Tracker
 	for tracker := t; tracker != nil; tracker = tracker.parent {
 		if atomic.AddInt64(&tracker.bytesConsumed, bytes) >= tracker.bytesLimit && tracker.bytesLimit > 0 {
-			rootExceed = tracker
+			// TODO(fengliyuan): try to find a way to avoid logging at each tracker in chain.
+			if tracker.actionOnExceed != nil {
+				tracker.actionOnExceed.Action(tracker)
+			}
 		}
 
 		for {
@@ -147,9 +156,6 @@ func (t *Tracker) Consume(bytes int64) {
 			}
 			break
 		}
-	}
-	if rootExceed != nil {
-		rootExceed.actionOnExceed.Action(rootExceed)
 	}
 }
 

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -78,6 +78,10 @@ func (t *Tracker) SetLabel(label fmt.Stringer) {
 	t.label = label
 }
 
+func (t *Tracker) Label() fmt.Stringer {
+	return t.label
+}
+
 // AttachTo attaches this memory tracker as a child to another Tracker. If it
 // already has a parent, this function will remove it from the old parent.
 // Its consumed memory usage is used to update all its ancestors.

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -78,6 +78,7 @@ func (t *Tracker) SetLabel(label fmt.Stringer) {
 	t.label = label
 }
 
+// Label gets the label of a Tracker.
 func (t *Tracker) Label() fmt.Stringer {
 	return t.label
 }

--- a/util/memory/tracker_test.go
+++ b/util/memory/tracker_test.go
@@ -86,6 +86,10 @@ func (s *testSuite) TestConsume(c *C) {
 
 func (s *testSuite) TestOOMAction(c *C) {
 	tracker := NewTracker(stringutil.StringerStr("oom tracker"), 100)
+	// make sure no panic here.
+	tracker.Consume(10000)
+
+	tracker = NewTracker(stringutil.StringerStr("oom tracker"), 100)
 	action := &mockAction{}
 	tracker.SetActionOnExceed(action)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

part of #11607
The utilities for disk-based hash join

### What is changed and how it works?

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/util/chunk
BenchmarkListInDiskAdd-12       	  300000	      4681 ns/op	     360 B/op	       4 allocs/op
BenchmarkListInDiskGetRow-12    	  500000	      2878 ns/op	     994 B/op	      21 allocs/op
BenchmarkListMemoryUsage-12     	2000000000	         0.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkListAdd-12             	20000000	       104 ns/op	      41 B/op	       0 allocs/op
BenchmarkListGetRow-12          	500000000	         4.13 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/util/chunk	31.892s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

Release note

 - None