### PR TITLE
expression: implement vectorized evaluation for `builtinLeastDecimalSig`

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -72,11 +72,10 @@ func (b *builtinLeastDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chun
 		if err := b.args[j].VecEvalDecimal(b.ctx, input, buf); err != nil {
 			return err
 		}
+
+		result.MergeNulls(buf)
 		for i := 0; i < n; i++ {
 			if result.IsNull(i) {
-				continue
-			} else if buf.IsNull(i) {
-				result.SetNull(i, true)
 				continue
 			}
 			v := buf.GetDecimal(i)

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -25,6 +25,9 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Greatest: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}, nil},
 	},
+	ast.Least: {
+		{types.ETDecimal, []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinCompareEvalOneVec(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinLeastDecimalSig.

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastDecimalSig-VecBuiltinFunc-4                      50000             37267 ns/op               0 B/op         0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastDecimalSig-NonVecBuiltinFunc-4                   30000             51133 ns/op               0 B/op         0 allocs/op
```

### Check List

Tests
- Unit test