### PR TITLE
main: rename `tidb-coverage-server` to `tidb-server-coverage`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,9 +189,9 @@ else
 	$(GOBUILD) $(RACE_FLAG) -ldflags '$(CHECK_LDFLAGS)' -o '$(TARGET)' tidb-server/main.go
 endif
 
-coverage_server:
+server_coverage:
 ifeq ($(TARGET), "")
-	$(GOBUILDCOVERAGE) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(COVERAGE_SERVER_LDFLAGS) $(CHECK_FLAG)' -o ../bin/tidb-coverage-server
+	$(GOBUILDCOVERAGE) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(COVERAGE_SERVER_LDFLAGS) $(CHECK_FLAG)' -o ../bin/tidb-server-coverage
 else
 	$(GOBUILDCOVERAGE) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(COVERAGE_SERVER_LDFLAGS) $(CHECK_FLAG)' -o '$(TARGET)'
 endif


### PR DESCRIPTION
### What is changed and how it works?
- rename `make coverage_server` to `make server_coverage`
- rename the binary from `tidb-coverage-server` to `tidb-server-coverage`

This change is to keep consistency with other `make` output like
`tidb-server-race`/`tikv-server-failpoint`.

