### PR TITLE
expression: implement vectorized evaluation for builtinAbsDecSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -14,9 +14,9 @@
 package expression
 
 import (
-	"github.com/pingcap/tidb/types"
 	"math"
 
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
 

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -63,7 +63,7 @@ func (b *builtinSqrtSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) e
 func (b *builtinSqrtSig) vectorized() bool {
 	return true
 }
-			
+
 func (b *builtinAbsDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -28,6 +28,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sqrt: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Abs: {
+		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMathEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinAbsDecSig, for #12102

### What is changed and how it works?
according to benchmark, about 10 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinAbsDecSig-VecBuiltinFunc-8        	  500000	      2705 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinAbsDecSig-NonVecBuiltinFunc-8     	   50000	     32222 ns/op	   39936 B/op	     832 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
