### PR TITLE
implement vectorized evaluation for builtinSqrtSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -40,3 +40,25 @@ func (b *builtinLog10Sig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) 
 func (b *builtinLog10Sig) vectorized() bool {
 	return true
 }
+
+func (b *builtinSqrtSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] < 0 {
+			result.SetNull(i, true)
+		} else {
+			f64s[i] = math.Sqrt(f64s[i])
+		}
+	}
+	return nil
+}
+
+func (b *builtinSqrtSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -25,6 +25,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Log10: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Sqrt: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMathEvalOneVec(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?
implement vectorized evaluation for builtinSqrtSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 5 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinSqrtSig-VecBuiltinFunc-8                500000              2444 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinSqrtSig-NonVecBuiltinFunc-8             100000             13055 ns/op            0 B/op          0 allocs/op
```

ps:if we don't check ```result.IsNull(i)```in the loop,the method is only 3 times faster than before, so it's better to add those check nulls codes:
```
BenchmarkVectorizedBuiltinMathFunc/builtinSqrtSig-VecBuiltinFunc-8                300000              4281 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinSqrtSig-NonVecBuiltinFunc-8             100000             14611 ns/op            0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test