### PR TITLE
implement vectorized evaluation for builtinCastIntAsRealSig

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -58,6 +58,7 @@ func (b *builtinCastIntAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.
 
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
+			result.SetNull(i, true)
 			continue
 		}
 		if !mysql.HasUnsignedFlag(b.tp.Flag) && !mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -24,6 +24,7 @@ import (
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 	ast.Cast: {
 		{types.ETInt, []types.EvalType{types.ETInt}, nil},
+		{types.ETReal, []types.EvalType{types.ETInt}, nil},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinCastIntAsRealSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 3 times faster than before:
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastIntAsRealSig-VecBuiltinFunc-8               300000              5726 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastIntAsRealSig-NonVecBuiltinFunc-8            100000             15876 ns/op            0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test