### PR TITLE
expression: implement vectorized evaluation for builtinRoundDecSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -88,3 +88,25 @@ func (b *builtinAbsDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Colu
 func (b *builtinAbsDecSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinRoundDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+		return err
+	}
+	d64s := result.Decimals()
+	buf := new(types.MyDecimal)
+	for i := 0; i < len(d64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if err := d64s[i].Round(buf, 0, types.ModeHalfEven); err != nil {
+			return err
+		}
+		d64s[i] = *buf
+	}
+	return nil
+}
+
+func (b *builtinRoundDecSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -31,6 +31,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
 	},
+	ast.Round: {
+		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMathEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinRoundDecSig, for #12102

### What is changed and how it works?
over 2 times faster than before.
```
BenchmarkVectorizedBuiltinMathFunc/builtinRoundDecSig-VecBuiltinFunc-8      	  100000	     23671 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinRoundDecSig-NonVecBuiltinFunc-8   	   30000	     50865 ns/op	   39552 B/op	     824 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 Unit test
