### PR TITLE
session, executor: support setting tidb_enable_stmt_summary in session scope

### DIFF
--- a/domain/global_vars_cache.go
+++ b/domain/global_vars_cache.go
@@ -83,7 +83,7 @@ func checkEnableStmtSummary(rows []chunk.Row, fields []*ast.ResultField) {
 				}
 			}
 
-			stmtsummary.OnEnableStmtSummaryModified(sVal)
+			stmtsummary.StmtSummaryByDigestMap.SetEnabled(variable.TiDBOptOn(sVal), false)
 			break
 		}
 	}

--- a/domain/global_vars_cache.go
+++ b/domain/global_vars_cache.go
@@ -83,7 +83,7 @@ func checkEnableStmtSummary(rows []chunk.Row, fields []*ast.ResultField) {
 				}
 			}
 
-			stmtsummary.StmtSummaryByDigestMap.SetEnabled(variable.TiDBOptOn(sVal), false)
+			stmtsummary.StmtSummaryByDigestMap.SetEnabled(sVal, false)
 			break
 		}
 	}

--- a/domain/global_vars_cache_test.go
+++ b/domain/global_vars_cache_test.go
@@ -127,7 +127,7 @@ func (gvcSuite *testGVCSuite) TestCheckEnableStmtSummary(c *C) {
 		Collate: charset.CollationBin,
 	}
 
-	stmtsummary.StmtSummaryByDigestMap.SetEnabled(false, false)
+	stmtsummary.StmtSummaryByDigestMap.SetEnabled("0", false)
 	ck := chunk.NewChunkWithCapacity([]*types.FieldType{ft, ft1}, 1024)
 	ck.AppendString(0, variable.TiDBEnableStmtSummary)
 	ck.AppendString(1, "1")

--- a/domain/global_vars_cache_test.go
+++ b/domain/global_vars_cache_test.go
@@ -14,7 +14,7 @@
 package domain
 
 import (
-	"sync/atomic"
+	"github.com/pingcap/tidb/util/stmtsummary"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -127,18 +127,18 @@ func (gvcSuite *testGVCSuite) TestCheckEnableStmtSummary(c *C) {
 		Collate: charset.CollationBin,
 	}
 
-	atomic.StoreInt32(&variable.EnableStmtSummary, 0)
+	stmtsummary.StmtSummaryByDigestMap.SetEnabled(false, false)
 	ck := chunk.NewChunkWithCapacity([]*types.FieldType{ft, ft1}, 1024)
 	ck.AppendString(0, variable.TiDBEnableStmtSummary)
 	ck.AppendString(1, "1")
 	row := ck.GetRow(0)
 	gvc.Update([]chunk.Row{row}, []*ast.ResultField{rf, rf1})
-	c.Assert(atomic.LoadInt32(&variable.EnableStmtSummary), Equals, int32(1))
+	c.Assert(stmtsummary.StmtSummaryByDigestMap.Enabled(), Equals, true)
 
 	ck = chunk.NewChunkWithCapacity([]*types.FieldType{ft, ft1}, 1024)
 	ck.AppendString(0, variable.TiDBEnableStmtSummary)
 	ck.AppendString(1, "0")
 	row = ck.GetRow(0)
 	gvc.Update([]chunk.Row{row}, []*ast.ResultField{rf, rf1})
-	c.Assert(atomic.LoadInt32(&variable.EnableStmtSummary), Equals, int32(0))
+	c.Assert(stmtsummary.StmtSummaryByDigestMap.Enabled(), Equals, false)
 }

--- a/domain/global_vars_cache_test.go
+++ b/domain/global_vars_cache_test.go
@@ -14,7 +14,6 @@
 package domain
 
 import (
-	"github.com/pingcap/tidb/util/stmtsummary"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/stmtsummary"
 	"github.com/pingcap/tidb/util/testleak"
 )
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -785,7 +785,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 // SummaryStmt collects statements for performance_schema.events_statements_summary_by_digest
 func (a *ExecStmt) SummaryStmt() {
 	sessVars := a.Ctx.GetSessionVars()
-	if sessVars.InRestrictedSQL || atomic.LoadInt32(&variable.EnableStmtSummary) == 0 {
+	if sessVars.InRestrictedSQL || !stmtsummary.StmtSummaryByDigestMap.Enabled() {
 		return
 	}
 	stmtCtx := sessVars.StmtCtx

--- a/executor/set.go
+++ b/executor/set.go
@@ -192,7 +192,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 	}
 
 	if name == variable.TiDBEnableStmtSummary {
-		stmtsummary.StmtSummaryByDigestMap.SetEnabled(variable.TiDBOptOn(valStr), !v.IsGlobal)
+		stmtsummary.StmtSummaryByDigestMap.SetEnabled(valStr, !v.IsGlobal)
 	}
 
 	return nil

--- a/executor/set.go
+++ b/executor/set.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/stmtsummary"
 	"go.uber.org/zap"
 )
 
@@ -119,6 +120,7 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 	if sysVar.Scope == variable.ScopeNone {
 		return errors.Errorf("Variable '%s' is a read only variable", name)
 	}
+	var valStr string
 	if v.IsGlobal {
 		// Set global scope system variable.
 		if sysVar.Scope&variable.ScopeGlobal == 0 {
@@ -131,18 +133,18 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 		if value.IsNull() {
 			value.SetString("")
 		}
-		svalue, err := value.ToString()
+		valStr, err = value.ToString()
 		if err != nil {
 			return err
 		}
-		err = sessionVars.GlobalVarsAccessor.SetGlobalSysVar(name, svalue)
+		err = sessionVars.GlobalVarsAccessor.SetGlobalSysVar(name, valStr)
 		if err != nil {
 			return err
 		}
 		err = plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
 			auditPlugin := plugin.DeclareAuditManifest(p.Manifest)
 			if auditPlugin.OnGlobalVariableEvent != nil {
-				auditPlugin.OnGlobalVariableEvent(context.Background(), e.ctx.GetSessionVars(), name, svalue)
+				auditPlugin.OnGlobalVariableEvent(context.Background(), e.ctx.GetSessionVars(), name, valStr)
 			}
 			return nil
 		})
@@ -179,7 +181,6 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 			sessionVars.SnapshotTS = oldSnapshotTS
 			return err
 		}
-		var valStr string
 		if value.IsNull() {
 			valStr = "NULL"
 		} else {
@@ -188,6 +189,10 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 			terror.Log(err)
 		}
 		logutil.BgLogger().Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+	}
+
+	if name == variable.TiDBEnableStmtSummary {
+		stmtsummary.StmtSummaryByDigestMap.SetEnabled(variable.TiDBOptOn(valStr), !v.IsGlobal)
 	}
 
 	return nil

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -145,4 +145,13 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("test 2 0 select * from t where a=2"))
+
+	// Unset session variable
+	tk.MustExec("set session tidb_enable_stmt_summary = ''")
+	tk.MustQuery("select * from t where a=2")
+
+	// Statement summary is disabled
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest`,
+	).Check(testkit.Rows())
 }

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -122,4 +122,27 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
 		from performance_schema.events_statements_summary_by_digest`,
 	).Check(testkit.Rows())
+
+	// Enable it in session scope
+	tk.MustExec("set session tidb_enable_stmt_summary = 1")
+	// It should work immediately
+	tk.MustQuery("select * from t where a=2")
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest
+		where digest_text like 'select * from t%'`,
+	).Check(testkit.Rows("test 1 0 select * from t where a=2"))
+
+	// Disable it in global scope
+	tk.MustExec("set global tidb_enable_stmt_summary = 0")
+
+	// Create a new session to test
+	tk = testkit.NewTestKitWithInit(c, s.store)
+
+	tk.MustQuery("select * from t where a=2")
+
+	// Statement summary is still enabled
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest
+		where digest_text like 'select * from t%'`,
+	).Check(testkit.Rows("test 2 0 select * from t where a=2"))
 }

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -109,7 +109,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	).Check(testkit.Rows("test 4 4 insert into t values(1, 'a')"))
 
 	// Disable it again
-	tk.MustExec("set global tidb_enable_stmt_summary = 0")
+	tk.MustExec("set global tidb_enable_stmt_summary = false")
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
 
 	// Create a new session to test
@@ -124,7 +124,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	).Check(testkit.Rows())
 
 	// Enable it in session scope
-	tk.MustExec("set session tidb_enable_stmt_summary = 1")
+	tk.MustExec("set session tidb_enable_stmt_summary = on")
 	// It should work immediately
 	tk.MustQuery("select * from t where a=2")
 	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
@@ -133,7 +133,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	).Check(testkit.Rows("test 1 0 select * from t where a=2"))
 
 	// Disable it in global scope
-	tk.MustExec("set global tidb_enable_stmt_summary = 0")
+	tk.MustExec("set global tidb_enable_stmt_summary = off")
 
 	// Create a new session to test
 	tk = testkit.NewTestKitWithInit(c, s.store)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -109,7 +109,7 @@ func init() {
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassVariable] = mySQLErrCodes
 
-	stmtsummary.StmtSummaryByDigestMap.SetEnabled(DefTiDBEnableStmtSummary, false)
+	stmtsummary.StmtSummaryByDigestMap.SetDefaultEnabled(DefTiDBEnableStmtSummary)
 }
 
 // BoolToIntStr converts bool to int string, for example "0" or "1".

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/stmtsummary"
 )
 
 // ScopeFlag is for system variable whether can be changed in global/session dynamically or not.
@@ -108,8 +107,6 @@ func init() {
 		CodeMaxPreparedStmtCountReached: mysql.ErrMaxPreparedStmtCountReached,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassVariable] = mySQLErrCodes
-
-	stmtsummary.StmtSummaryByDigestMap.SetDefaultEnabled(DefTiDBEnableStmtSummary)
 }
 
 // BoolToIntStr converts bool to int string, for example "0" or "1".
@@ -718,7 +715,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBEnableNoopFuncs, BoolToIntStr(DefTiDBEnableNoopFuncs)},
 	{ScopeSession, TiDBReplicaRead, "leader"},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
-	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, BoolToIntStr(DefTiDBEnableStmtSummary)},
+	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/stmtsummary"
 )
 
 // ScopeFlag is for system variable whether can be changed in global/session dynamically or not.
@@ -107,6 +108,8 @@ func init() {
 		CodeMaxPreparedStmtCountReached: mysql.ErrMaxPreparedStmtCountReached,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassVariable] = mySQLErrCodes
+
+	stmtsummary.StmtSummaryByDigestMap.SetEnabled(DefTiDBEnableStmtSummary, false)
 }
 
 // BoolToIntStr converts bool to int string, for example "0" or "1".
@@ -715,7 +718,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBEnableNoopFuncs, BoolToIntStr(DefTiDBEnableNoopFuncs)},
 	{ScopeSession, TiDBReplicaRead, "leader"},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
-	{ScopeGlobal, TiDBEnableStmtSummary, BoolToIntStr(DefTiDBEnableStmtSummary)},
+	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, BoolToIntStr(DefTiDBEnableStmtSummary)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -385,5 +385,4 @@ var (
 	MaxOfMaxAllowedPacket          uint64 = 1073741824
 	ExpensiveQueryTimeThreshold    uint64 = DefTiDBExpensiveQueryTimeThreshold
 	MinExpensiveQueryTimeThreshold uint64 = 10 //10s
-	EnableStmtSummary              int32  = BoolToInt32(DefTiDBEnableStmtSummary)
 )

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -365,7 +365,6 @@ const (
 	DefWaitSplitRegionTimeout          = 300 // 300s
 	DefTiDBEnableNoopFuncs             = false
 	DefTiDBAllowRemoveAutoInc          = false
-	DefTiDBEnableStmtSummary           = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -380,8 +380,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
 		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction,
 		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBEnableIndexMerge, TiDBEnableNoopFuncs,
-		TiDBScatterRegion, TiDBGeneralLog, TiDBConstraintCheckInPlace, TiDBEnableVectorizedExpression,
-		TiDBEnableStmtSummary:
+		TiDBScatterRegion, TiDBGeneralLog, TiDBConstraintCheckInPlace, TiDBEnableVectorizedExpression:
 		fallthrough
 	case GeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
 		CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode, PseudoSlaveMode, LowPriorityUpdates,
@@ -581,6 +580,16 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "on", nil
 		case strings.EqualFold(value, "OFF") || value == "0":
 			return "off", nil
+		}
+		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
+	case TiDBEnableStmtSummary:
+		switch {
+		case strings.EqualFold(value, "ON") || value == "1":
+			return "1", nil
+		case strings.EqualFold(value, "OFF") || value == "0":
+			return "0", nil
+		case value == "":
+			return "", nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
 	}

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -231,14 +231,14 @@ func (ssMap *stmtSummaryByDigestMap) ToDatum() [][]types.Datum {
 }
 
 // SetEnabled enables or disables statement summary in global(cluster) or session(server) scope.
-func (ssMap *stmtSummaryByDigestMap) SetEnabled(enable string, inSession bool) {
-	enable = ssMap.normalizeEnableValue(enable)
+func (ssMap *stmtSummaryByDigestMap) SetEnabled(value string, inSession bool) {
+	value = ssMap.normalizeEnableValue(value)
 
 	ssMap.enabledWrapper.Lock()
 	if inSession {
-		ssMap.enabledWrapper.sessionEnabled = enable
+		ssMap.enabledWrapper.sessionEnabled = value
 	} else {
-		ssMap.enabledWrapper.globalEnabled = enable
+		ssMap.enabledWrapper.globalEnabled = value
 	}
 	sessionEnabled := ssMap.enabledWrapper.sessionEnabled
 	globalEnabled := ssMap.enabledWrapper.globalEnabled
@@ -270,24 +270,24 @@ func (ssMap *stmtSummaryByDigestMap) Enabled() bool {
 }
 
 // normalizeEnableValue converts 'ON' to '1' and 'OFF' to '0'
-func (ssMap *stmtSummaryByDigestMap) normalizeEnableValue(enable string) string {
+func (ssMap *stmtSummaryByDigestMap) normalizeEnableValue(value string) string {
 	switch {
-	case strings.EqualFold(enable, "ON"):
+	case strings.EqualFold(value, "ON"):
 		return "1"
-	case strings.EqualFold(enable, "OFF"):
+	case strings.EqualFold(value, "OFF"):
 		return "0"
 	default:
-		return enable
+		return value
 	}
 }
 
 // isEnabled converts a string value to bool.
 // 1 indicates true, 0 or '' indicates false.
-func (ssMap *stmtSummaryByDigestMap) isEnabled(enable string) bool {
-	return enable == "1"
+func (ssMap *stmtSummaryByDigestMap) isEnabled(value string) bool {
+	return value == "1"
 }
 
 // isSet judges whether the variable is set.
-func (ssMap *stmtSummaryByDigestMap) isSet(enable string) bool {
-	return enable != ""
+func (ssMap *stmtSummaryByDigestMap) isSet(value string) bool {
+	return value != ""
 }

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -60,8 +60,7 @@ type stmtSummaryByDigestMap struct {
 		// enabled indicates whether statement summary is enabled in current server.
 		sessionEnabled string
 		// setInSession indicates whether statement summary has been set in any session.
-		globalEnabled  string
-		defaultEnabled bool
+		globalEnabled string
 	}
 }
 
@@ -231,13 +230,6 @@ func (ssMap *stmtSummaryByDigestMap) ToDatum() [][]types.Datum {
 	return rows
 }
 
-// SetDefaultEnabled sets the enabling status by default.
-func (ssMap *stmtSummaryByDigestMap) SetDefaultEnabled(defaultEnabled bool) {
-	ssMap.enabledWrapper.Lock()
-	ssMap.enabledWrapper.defaultEnabled = defaultEnabled
-	ssMap.enabledWrapper.Unlock()
-}
-
 // SetEnabled enables or disables statement summary in global(cluster) or session(server) scope.
 func (ssMap *stmtSummaryByDigestMap) SetEnabled(enable string, inSession bool) {
 	enable = ssMap.normalizeEnableValue(enable)
@@ -291,15 +283,9 @@ func (ssMap *stmtSummaryByDigestMap) normalizeEnableValue(enable string) string 
 }
 
 // isEnabled converts a string value to bool.
+// 1 indicates true, 0 or '' indicates false.
 func (ssMap *stmtSummaryByDigestMap) isEnabled(enable string) bool {
-	switch enable {
-	case "1":
-		return true
-	case "0":
-		return false
-	default:
-		return ssMap.enabledWrapper.defaultEnabled
-	}
+	return enable == "1"
 }
 
 // isSet judges whether the variable is set.

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -235,23 +235,22 @@ func (ssMap *stmtSummaryByDigestMap) SetEnabled(enable string, inSession bool) {
 	enable = ssMap.normalizeEnableValue(enable)
 
 	ssMap.enabledWrapper.Lock()
-	needClear := false
 	if inSession {
 		ssMap.enabledWrapper.sessionEnabled = enable
-		if ssMap.isSet(enable) {
-			needClear = !ssMap.isEnabled(enable)
-		} else {
-			needClear = !ssMap.isEnabled(ssMap.enabledWrapper.globalEnabled)
-		}
 	} else {
 		ssMap.enabledWrapper.globalEnabled = enable
-		if !ssMap.isSet(ssMap.enabledWrapper.sessionEnabled) {
-			needClear = !ssMap.isEnabled(enable)
-		}
 	}
+	sessionEnabled := ssMap.enabledWrapper.sessionEnabled
+	globalEnabled := ssMap.enabledWrapper.globalEnabled
 	ssMap.enabledWrapper.Unlock()
 
 	// Clear all summaries once statement summary is disabled.
+	var needClear bool
+	if ssMap.isSet(sessionEnabled) {
+		needClear = !ssMap.isEnabled(sessionEnabled)
+	} else {
+		needClear = !ssMap.isEnabled(globalEnabled)
+	}
 	if needClear {
 		ssMap.Clear()
 	}

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -241,10 +241,14 @@ func (ssMap *stmtSummaryByDigestMap) SetDefaultEnabled(defaultEnabled bool) {
 // SetEnabled enables or disables statement summary in global(cluster) or session(server) scope.
 func (ssMap *stmtSummaryByDigestMap) SetEnabled(enable string, inSession bool) {
 	ssMap.enabledWrapper.Lock()
-	var needClear bool
+	needClear := false
 	if inSession {
 		ssMap.enabledWrapper.sessionEnabled = enable
-		needClear = !ssMap.isEnabled(enable)
+		if ssMap.isSet(enable) {
+			needClear = !ssMap.isEnabled(enable)
+		} else {
+			needClear = !ssMap.isEnabled(ssMap.enabledWrapper.globalEnabled)
+		}
 	} else {
 		ssMap.enabledWrapper.globalEnabled = enable
 		if !ssMap.isSet(ssMap.enabledWrapper.sessionEnabled) {

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -240,6 +240,8 @@ func (ssMap *stmtSummaryByDigestMap) SetDefaultEnabled(defaultEnabled bool) {
 
 // SetEnabled enables or disables statement summary in global(cluster) or session(server) scope.
 func (ssMap *stmtSummaryByDigestMap) SetEnabled(enable string, inSession bool) {
+	enable = ssMap.normalizeEnableValue(enable)
+
 	ssMap.enabledWrapper.Lock()
 	needClear := false
 	if inSession {
@@ -276,12 +278,24 @@ func (ssMap *stmtSummaryByDigestMap) Enabled() bool {
 	return enabled
 }
 
+// normalizeEnableValue converts 'ON' to '1' and 'OFF' to '0'
+func (ssMap *stmtSummaryByDigestMap) normalizeEnableValue(enable string) string {
+	switch {
+	case strings.EqualFold(enable, "ON"):
+		return "1"
+	case strings.EqualFold(enable, "OFF"):
+		return "0"
+	default:
+		return enable
+	}
+}
+
 // isEnabled converts a string value to bool.
 func (ssMap *stmtSummaryByDigestMap) isEnabled(enable string) bool {
-	switch {
-	case strings.EqualFold(enable, "ON") || enable == "1":
+	switch enable {
+	case "1":
 		return true
-	case strings.EqualFold(enable, "OFF") || enable == "0":
+	case "0":
 		return false
 	default:
 		return ssMap.enabledWrapper.defaultEnabled

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -17,14 +17,12 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
 )
 
@@ -36,7 +34,7 @@ type testStmtSummarySuite struct {
 
 func (s *testStmtSummarySuite) SetUpSuite(c *C) {
 	s.ssMap = newStmtSummaryByDigestMap()
-	atomic.StoreInt32(&variable.EnableStmtSummary, 1)
+	s.ssMap.SetEnabled(true, false)
 }
 
 func TestT(t *testing.T) {
@@ -321,7 +319,8 @@ func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 // Test setting EnableStmtSummary to 0
 func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 	s.ssMap.Clear()
-	OnEnableStmtSummaryModified("0")
+	// Set false in global scope, it should work.
+	s.ssMap.SetEnabled(false, false)
 
 	stmtExecInfo1 := &StmtExecInfo{
 		SchemaName:    "schema_name",
@@ -338,9 +337,27 @@ func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 	datums := s.ssMap.ToDatum()
 	c.Assert(len(datums), Equals, 0)
 
-	OnEnableStmtSummaryModified("1")
+	// Set true in session scope, it will overwrite global scope.
+	s.ssMap.SetEnabled(true, true)
 
 	s.ssMap.AddStatement(stmtExecInfo1)
+	datums = s.ssMap.ToDatum()
+	c.Assert(len(datums), Equals, 1)
+
+	// Set false in global scope, it shouldn't work.
+	s.ssMap.SetEnabled(false, false)
+
+	stmtExecInfo2 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql2",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  50000,
+		AffectedRows:  500,
+		SentRows:      500,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 20, 10, time.UTC),
+	}
+	s.ssMap.AddStatement(stmtExecInfo2)
 	datums = s.ssMap.ToDatum()
 	c.Assert(len(datums), Equals, 1)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support setting tidb_enable_stmt_summary in session scope. It was only supported in global scope. Actually, session scope here equals server scope, and global scope here equals cluster scope.

### What is changed and how it works?
When statement summary is enabled in global scope, it'll work immediately on the current server and work in 2 seconds on the other servers in the cluster.
When statement summary is enabled in session scope, it'll work immediately on the current server, and subsequent settings in the global scope won't work.
If tidb_enable_stmt_summary is set to '' in session scope, then tidb_enable_stmt_summary in global scope works in the current server.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

Release Note

 - Support system table performance_schema.events_statements_summary_by_digest. The table is used to summarize statements by digest of statements.