### PR TITLE
Display a physical plan with IndexMergePath using the Explain [format="dot"] command

### DIFF
--- a/cmd/explaintest/r/explain_indexmerge.result
+++ b/cmd/explaintest/r/explain_indexmerge.result
@@ -48,3 +48,36 @@ IndexMerge_17	0.00	root
 ├─IndexScan_14	9.00	cop	table:t, index:d, range:[-inf,10), keep order:false
 └─Selection_16	0.00	cop	lt(Column#6, 10), or(lt(Column#2, 10000), lt(Column#3, 10000))
   └─TableScan_15	18.00	cop	table:t, keep order:false
+explain format="dot" select * from t where (a < 50 or b < 50) and f > 100;
+dot contents
+
+digraph IndexMerge_12 {
+subgraph cluster12{
+node [style=filled, color=lightgrey]
+color=black
+label = "root"
+"IndexMerge_12"
+}
+subgraph cluster8{
+node [style=filled, color=lightgrey]
+color=black
+label = "cop"
+"TableScan_8"
+}
+subgraph cluster9{
+node [style=filled, color=lightgrey]
+color=black
+label = "cop"
+"IndexScan_9"
+}
+subgraph cluster11{
+node [style=filled, color=lightgrey]
+color=black
+label = "cop"
+"Selection_11" -> "TableScan_10"
+}
+"IndexMerge_12" -> "TableScan_8"
+"IndexMerge_12" -> "IndexScan_9"
+"IndexMerge_12" -> "Selection_11"
+}
+

--- a/cmd/explaintest/t/explain_indexmerge.test
+++ b/cmd/explaintest/t/explain_indexmerge.test
@@ -12,3 +12,4 @@ explain select * from t where b < 50 or c < 50;
 explain select * from t where b < 50 or c < 5000000;
 explain select * from t where a < 50 or b < 50 or c < 50;
 explain select * from t where (b < 10000 or c < 10000) and (a < 10 or d < 10) and f < 10;
+explain format="dot" select * from t where (a < 50 or b < 50) and f > 100;


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
(1) After a physical plan with IndexMergePath generated, it's time to use `explain` command to display the plan.
(2) Fix bug in `explain format="dot"`. 

Tests <!-- At least one of them must be included. -->
 - Unit test
