### PR TITLE
expression: implement vectorized evaluation for builtinAsinSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -64,6 +64,28 @@ func (b *builtinSqrtSig) vectorized() bool {
 	return true
 }
 
+func (b *builtinAsinSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] < -1 || f64s[i] > 1 {
+			result.SetNull(i, true)
+		} else {
+			f64s[i] = math.Asin(f64s[i])
+		}
+	}
+	return nil
+}
+
+func (b *builtinAsinSig) vectorized() bool {
+	return true
+}
+
 func (b *builtinAbsDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -28,10 +28,10 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sqrt: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-	ast.Asin: {
+	ast.Acos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-	ast.Acos: {
+	ast.Asin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Abs: {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -28,6 +28,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sqrt: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Asin: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinAsinSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinAsinSig-VecBuiltinFunc-8                100000             16326 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinAsinSig-NonVecBuiltinFunc-8              50000             32405 ns/op            0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test