### PR TITLE
Makefile: gotest, froze TZ for unixtime test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 			|| { $(FAILPOINT_DISABLE); exit 1; }
 else
 	@echo "Running in native mode."
-	@export log_level=error; \
+	@export log_level=error; export TZ='Asia/Shanghai'; \
 	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) || { $(FAILPOINT_DISABLE); exit 1; }
 endif
 	@$(FAILPOINT_DISABLE)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Without this fix i could not run tests:

```bash
$ make gotest
...
----------------------------------------------------------------------
FAIL: simple_rewriter_test.go:22: testEvaluatorSuite.TestSimpleRewriter

simple_rewriter_test.go:172:
    c.Assert(num, Equals, int64(1209571200))
... obtained int64 = 1209585600
... expected int64 = 1209571200
...
```

It looks like the root of this fail is that my time zone is different from time zone where tests usually run.

### What is changed and how it works?

Time zone was hard coded before tests. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - No code
