### PR TITLE
expression: implement vectorized evaluation for builtinCosSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -108,6 +108,24 @@ func (b *builtinAsinSig) vectorized() bool {
 	return true
 }
 
+func (b *builtinCosSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		f64s[i] = math.Cos(f64s[i])
+	}
+	return nil
+}
+
+func (b *builtinCosSig) vectorized() bool {
+	return true
+}
+
 func (b *builtinAbsDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -34,6 +34,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Asin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Cos: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
 	},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -40,7 +40,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Atan2: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},
 	},
-  ast.Cos: {
+    ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Abs: {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -40,7 +40,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Atan2: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},
 	},
-    ast.Cos: {
+	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Abs: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinCosSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinCosSig-VecBuiltinFunc-8                 100000             14001 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinCosSig-NonVecBuiltinFunc-8               50000             29255 ns/op            0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test