### PR TITLE
expression: implement vectorized evaluation for builtinCotSig 

### DIFF
--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -34,6 +34,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Asin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Cot: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
 	},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -34,8 +34,8 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Asin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  	ast.Atan: {
-		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	ast.Atan: {
+		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},
 	},
 	ast.Atan2: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -43,7 +43,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  	ast.Cot: {
+	ast.Cot: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Abs: {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -35,7 +35,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Atan: {
-		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Atan2: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, nil},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -34,7 +34,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Asin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  ast.Atan: {
+  	ast.Atan: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Atan2: {
@@ -43,7 +43,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  ast.Cot: {
+  	ast.Cot: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Abs: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinCotSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinCotSig-VecBuiltinFunc-8                 100000             18590 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinCotSig-NonVecBuiltinFunc-8               50000             42268 ns/op            0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test