### PR TITLE
expression: implement vectorized evaluation for builtinLog2Sig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -20,6 +20,28 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
+func (b *builtinLog2Sig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] <= 0 {
+			result.SetNull(i, true)
+		} else {
+			f64s[i] = math.Log2(f64s[i])
+		}
+	}
+	return nil
+}
+
+func (b *builtinLog2Sig) vectorized() bool {
+	return true
+}
+
 func (b *builtinLog10Sig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -25,6 +25,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Log10: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Log2: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Sqrt: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinLog2Sig, for #12105

### What is changed and how it works?
according to benchmark, about 2 times faster than before

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMathFunc/builtinLog2Sig-VecBuiltinFunc-8                100000             14679 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinLog2Sig-NonVecBuiltinFunc-8              50000             29524 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      14.005s

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


