### PR TITLE
expression: implement vectorized evaluation for builtinSinSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -177,6 +177,24 @@ func (b *builtinCosSig) vectorized() bool {
 	return true
 }
 
+func (b *builtinSinSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		f64s[i] = math.Sin(f64s[i])
+	}
+	return nil
+}
+
+func (b *builtinSinSig) vectorized() bool {
+	return true
+}
+
 func (b *builtinAbsDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -43,6 +43,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
+	ast.Sin: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
 	},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -46,7 +46,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  	ast.Sin: {
+	ast.Sin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Tan: {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -46,7 +46,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Cos: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
-  ast.Sin: {
+  	ast.Sin: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Tan: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinSinSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinSinSig-VecBuiltinFunc-8                 100000             12472 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinSinSig-NonVecBuiltinFunc-8               50000             29138 ns/op            0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test