### PR TITLE
expression: implement vectorized evaluation for `builtinUpperSig`

### DIFF
--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -32,6 +32,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{types.ETInt, []types.EvalType{types.ETString}, []dataGenerator{&randLenStrGener{10, 20}}},
 		{types.ETInt, []types.EvalType{types.ETString}, []dataGenerator{&defaultGener{0.2, types.ETString}}},
 	},
+	ast.Upper: {
+		{types.ETString, []types.EvalType{types.ETString}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinStringEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinUpperSig.
[12106](https://github.com/pingcap/tidb/issues/12106)

### What is changed and how it works?

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinUpperSig-VecBuiltinFunc-4        14036         80311 ns/op           0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinUpperSig-NonVecBuiltinFunc-4      7332        192043 ns/op       16944 B/op        833 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
