### PR TITLE
executor: fix update self-duplicate detect

### DIFF
--- a/executor/write.go
+++ b/executor/write.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -157,22 +156,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h int64, oldData
 		if sc.DupKeyAsWarning {
 			newHandle, err = t.AddRecord(sctx, newData, table.IsUpdate, table.SkipHandleCheck, table.WithCtx(ctx))
 		} else {
-			txn, err1 := sctx.Txn(true)
-			if err1 != nil {
-				return false, false, 0, err1
-			}
-			// If there are primary keys or unique indices, we have to check TiKV to ensure their uniqueness.
-			// The PresumeKeyNotExists option could delay the check to improve performance.
-			sessVars := sctx.GetSessionVars()
-			if !sessVars.ConstraintCheckInPlace {
-				// The purpose of adding the Autocommit and InTxn conditions here is for compatibility (older version TiDB behaviour).
-				// Remove the check should not affect correctness.
-				if sessVars.IsAutocommit() && !sessVars.InTxn() {
-					txn.SetOption(kv.PresumeKeyNotExists, nil)
-				}
-			}
 			newHandle, err = t.AddRecord(sctx, newData, table.IsUpdate, table.WithCtx(ctx))
-			txn.DelOption(kv.PresumeKeyNotExists)
 		}
 
 		if err != nil {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2451,11 +2451,17 @@ func (s *testSuite4) TestRebaseIfNeeded(c *C) {
 func (s *testSuite4) TestDeferConstraintCheckForInsert(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
+
+	tk.MustExec(`drop table if exists t;create table t (a int primary key, b int);`)
+	tk.MustExec(`insert into t values (1,2),(2,2)`)
+	_, err := tk.Exec("update t set a=a+1 where b=2")
+	c.Assert(err, NotNil)
+
 	tk.MustExec(`drop table if exists t;create table t (i int key);`)
 	tk.MustExec(`insert t values (1);`)
 	tk.MustExec(`set tidb_constraint_check_in_place = 1;`)
 	tk.MustExec(`begin;`)
-	_, err := tk.Exec(`insert t values (1);`)
+	_, err = tk.Exec(`insert t values (1);`)
 	c.Assert(err, NotNil)
 	tk.MustExec(`update t set i = 2 where i = 1;`)
 	tk.MustExec(`commit;`)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #12245

when multiple keys be changed in one update stmt, the new keys may be duplicate with others in storage, but duplicated one maybe change in current stmt too, for mysql this will report a error.

for that issue we update two rows, and let first column + 1

(1, 2), (2, 2)  

mysql will detect duplicate after first row became (2,2),(2, 2)

but in TiDB after #11720, we will lazy check this in commit phase, so in memory buffer can be change as 

(1, 2),(2, 2) => (2, 2) => (3, 2)

and in commit phase, the kv commands push to tikv also be valid to tikv, so we meet the problem described by issue

### What is changed and how it works?

simple fix is keeping check duplicate from tikv for each add index operation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - n/a

Release note

 - executor: keep pre duplicate check for update stmt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/12249)
<!-- Reviewable:end -->
