### PR TITLE
expression: implement vectorized evaluation for builtinYearSig

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -28,6 +28,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.Month: {
 		{types.ETInt, []types.EvalType{types.ETDatetime}, nil},
 	},
+	ast.Year: {
+		{types.ETInt, []types.EvalType{types.ETDatetime}, nil},
+	},
 	ast.Date: {
 		{types.ETDatetime, []types.EvalType{types.ETDatetime}, nil},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinYearSig

### What is changed and how it works?
go test -v -benchmem -bench=TestVectorizedBuiltinTimeFunc -run=TestVectorizedBuiltinTimeFunc
PASS
ok      github.com/pingcap/tidb/expression      0.564s


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test