### PR TITLE
session: do not lock untouched unique key in pessimistic mode

### DIFF
--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -166,5 +167,32 @@ func match(c *C, row []types.Datum, expected ...interface{}) {
 		got := fmt.Sprintf("%v", row[i].GetValue())
 		need := fmt.Sprintf("%v", expected[i])
 		c.Assert(got, Equals, need)
+	}
+}
+
+func (s *testMainSuite) TestKeysNeedLock(c *C) {
+	rowKey := tablecodec.EncodeRowKeyWithHandle(1, 1)
+	indexKey := tablecodec.EncodeIndexSeekKey(1, 1, []byte{1})
+	uniqueValue := make([]byte, 8)
+	uniqueUntouched := append(uniqueValue, '1')
+	nonUniqueVal := []byte{'0'}
+	nonUniqueUntouched := []byte{'1'}
+	var deleteVal []byte
+	rowVal := []byte{'a', 'b', 'c'}
+	tests := []struct {
+		key  []byte
+		val  []byte
+		need bool
+	}{
+		{rowKey, rowVal, true},
+		{rowKey, deleteVal, true},
+		{indexKey, nonUniqueVal, false},
+		{indexKey, nonUniqueUntouched, false},
+		{indexKey, uniqueValue, true},
+		{indexKey, uniqueUntouched, false},
+		{indexKey, deleteVal, false},
+	}
+	for _, tt := range tests {
+		c.Assert(keyNeedToLock(tt.key, tt.val), Equals, tt.need)
 	}
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -333,6 +333,9 @@ func keyNeedToLock(k, v []byte) bool {
 		// only need to delete row key.
 		return k[10] == 'r'
 	}
+	if tablecodec.IsUntouchedIndexKValue(k, v) {
+		return false
+	}
 	isNonUniqueIndex := len(v) == 1
 	// Put row key and unique index need to lock.
 	return !isNonUniqueIndex


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In https://github.com/pingcap/tidb/pull/11702 We set untouched index in mem buffer for UnionScan optimization, but in pessimistic transaction mode, we didn't check if the key is untouched index before lock it, we unnecessarily locked unique keys.

### What is changed and how it works?
Check if the key is untouched index in `keysNeedToLock` function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
