### PR TITLE
tikv: fix out-of-index in split-region

### DIFF
--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -16,7 +16,6 @@ package tikv
 import (
 	"bytes"
 	"context"
-	"github.com/pingcap/tidb/util/stringutil"
 	"math"
 	"time"
 
@@ -29,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/stringutil"
 	"go.uber.org/zap"
 )
 

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"github.com/pingcap/tidb/util/stringutil"
 	"math"
 	"time"
 
@@ -154,7 +155,12 @@ func (s *tikvStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bo
 	logutil.BgLogger().Info("batch split regions complete",
 		zap.Uint64("batch region ID", batch.regionID.id),
 		zap.Stringer("first at", kv.Key(batch.keys[0])),
-		zap.Stringer("first new region left", logutil.Hex(spResp.Regions[0])),
+		zap.Stringer("first new region left", stringutil.MemoizeStr(func() string {
+			if len(spResp.Regions) == 0 {
+				return ""
+			}
+			return logutil.Hex(spResp.Regions[0]).String()
+		})),
 		zap.Int("new region count", len(spResp.Regions)))
 
 	if !scatter {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

simple fix "out of index" error when split reponse's region num be zero and want to write info log.

<img width="1618" alt="x1" src="https://user-images.githubusercontent.com/528332/65138546-b8cfd800-da3d-11e9-95bd-9aec5df6c5c1.png">


### What is changed and how it works?

check region num and avoid out of index error

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - n/a

Side effects

 - n/a

Related changes

 - n/a

Release note

 - n/a

/cc @breeswish

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/12265)
<!-- Reviewable:end -->
