### PR TITLE
expression: implement vectorized evaluation for `builtinAbsRealSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -365,3 +365,21 @@ func (b *builtinPowSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) er
 func (b *builtinPowSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinAbsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		f64s[i] = math.Abs(f64s[i])
+	}
+	return nil
+}
+
+func (b *builtinAbsRealSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -415,9 +415,6 @@ func (b *builtinAbsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column
 	}
 	f64s := result.Float64s()
 	for i := 0; i < len(f64s); i++ {
-		if result.IsNull(i) {
-			continue
-		}
 		f64s[i] = math.Abs(f64s[i])
 	}
 	return nil

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -60,6 +60,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 	ast.Round: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinAbsRealSig` , for #12105 

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMathFunc/builtinAbsRealSig-VecBuiltinFunc-8         	  500000	      3174 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinAbsRealSig-NonVecBuiltinFunc-8      	  100000	     21304 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test