### PR TITLE
expression: implement vectorized evaluation for `builtinLog1ArgSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -442,7 +442,7 @@ func (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column
 		}
 		if f64s[i] <= 0 {
 			result.SetNull(i, true)
-      continue
+			continue
 		}
 		f64s[i] = math.Log(f64s[i])
 	}
@@ -450,7 +450,7 @@ func (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column
 }
 
 func (b *builtinLog1ArgSig) vectorized() bool {
-  	return true
+	return true
 }
 
 func (b *builtinAbsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -365,3 +365,24 @@ func (b *builtinPowSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) er
 func (b *builtinPowSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] <= 0 {
+			result.SetNull(i, true)
+		}
+		f64s[i] = math.Log(f64s[i])
+	}
+	return nil
+}
+
+func (b *builtinLog1ArgSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -67,6 +67,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Pow: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, []dataGenerator{&rangeRealGener{0, 10, 0.5}, &rangeRealGener{0, 100, 0.5}}},
 	},
+	ast.Log: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMathEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
expression: implement vectorized evaluation for `builtinLog1ArgSig`,for #12105

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMathFunc/builtinLog1ArgSig-VecBuiltinFunc-8         	  200000      9698 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinLog1ArgSig-NonVecBuiltinFunc-8      	   50000     33978 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 