### PR TITLE
expression: implement vectorized evaluation for builtinCastRealAsRealSig

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -118,3 +118,25 @@ func (b *builtinCastIntAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.
 func (b *builtinCastIntAsRealSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinCastRealAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	f64s := result.Float64s()
+	o := b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag)
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if o && f64s[i] < 0 {
+			f64s[i] = 0
+		}
+	}
+	return nil
+}
+
+func (b *builtinCastRealAsRealSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -125,12 +125,12 @@ func (b *builtinCastRealAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk
 	}
 	n := input.NumRows()
 	f64s := result.Float64s()
-	o := b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag)
+	conditionUnionAndUnsigned := b.inUnion && mysql.HasUnsignedFlag(b.tp.Flag)
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		if o && f64s[i] < 0 {
+		if conditionUnionAndUnsigned && f64s[i] < 0 {
 			f64s[i] = 0
 		}
 	}

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -26,6 +26,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		{types.ETInt, []types.EvalType{types.ETInt}, nil},
 		{types.ETReal, []types.EvalType{types.ETInt}, nil},
 		{types.ETDuration, []types.EvalType{types.ETInt}, []dataGenerator{new(randDurInt)}},
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinCastRealAsRealSig, for #12105


### What is changed and how it works?
according to benchmark, about 10 times faster than before:
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsRealSig-VecBuiltinFunc-8       	 1000000	      1826 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsRealSig-NonVecBuiltinFunc-8    	  100000	     20722 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
