### PR TITLE
*: wrap the previous statement for performance

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -47,6 +47,7 @@ import (
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/stmtsummary"
+	"github.com/pingcap/tidb/util/stringutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -180,7 +181,10 @@ func (a *recordSet) Close() error {
 	err := a.executor.Close()
 	a.stmt.LogSlowQuery(a.txnStartTS, a.lastErr == nil)
 	sessVars := a.stmt.Ctx.GetSessionVars()
-	sessVars.PrevStmt = FormatSQL(a.stmt.OriginText(), sessVars)
+	pps := types.CloneRow(sessVars.PreparedParams)
+	sessVars.PrevStmt = stringutil.MemoizeStr(func() string {
+		return FormatSQL(a.stmt.OriginText(), pps)
+	})
 	a.stmt.logAudit()
 	a.stmt.SummaryStmt()
 	return err
@@ -731,13 +735,13 @@ func (a *ExecStmt) logAudit() {
 }
 
 // FormatSQL is used to format the original SQL, e.g. truncating long SQL, appending prepared arguments.
-func FormatSQL(sql string, sessVars *variable.SessionVars) string {
+func FormatSQL(sql string, pps variable.PreparedParams) string {
 	cfg := config.GetGlobalConfig()
 	length := len(sql)
 	if maxQueryLen := atomic.LoadUint64(&cfg.Log.QueryLogMaxLen); uint64(length) > maxQueryLen {
 		sql = fmt.Sprintf("%.*q(len:%d)", maxQueryLen, sql, length)
 	}
-	return QueryReplacer.Replace(sql) + sessVars.GetExecuteArgumentsInfo()
+	return QueryReplacer.Replace(sql) + pps.String()
 }
 
 // LogSlowQuery is used to print the slow query in the log files.
@@ -753,7 +757,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 	if costTime < threshold && level > zapcore.DebugLevel {
 		return
 	}
-	sql := FormatSQL(a.Text, sessVars)
+	sql := FormatSQL(a.Text, sessVars.PreparedParams)
 
 	var tableIDs, indexNames string
 	if len(sessVars.StmtCtx.TableIDs) > 0 {
@@ -782,7 +786,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 		Succ:        succ,
 	}
 	if _, ok := a.StmtNode.(*ast.CommitStmt); ok {
-		slowItems.PrevStmt = sessVars.PrevStmt
+		slowItems.PrevStmt = sessVars.PrevStmt.String()
 	}
 	if costTime < threshold {
 		logutil.SlowQueryLogger.Debug(sessVars.SlowLogFormat(slowItems))

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -625,7 +625,7 @@ func (cc *clientConn) handleSetOption(data []byte) (err error) {
 func (cc *clientConn) preparedStmt2String(stmtID uint32) string {
 	sv := cc.ctx.GetSessionVars()
 	if prepared, ok := sv.PreparedStmts[stmtID]; ok {
-		return prepared.Stmt.Text() + sv.GetExecuteArgumentsInfo()
+		return prepared.Stmt.Text() + sv.PreparedParams.String()
 	}
 	return "prepared statement not found, ID: " + strconv.FormatUint(uint64(stmtID), 10)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -667,7 +667,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 					zap.Int64("schemaVersion", schemaVersion),
 					zap.Uint("retryCnt", retryCnt),
 					zap.Int("queryNum", i),
-					zap.String("sql", sqlForLog(st.OriginText())+sessVars.GetExecuteArgumentsInfo()))
+					zap.String("sql", sqlForLog(st.OriginText())+sessVars.PreparedParams.String()))
 			} else {
 				logutil.Logger(ctx).Warn("retrying",
 					zap.Int64("schemaVersion", schemaVersion),
@@ -1967,7 +1967,7 @@ func logQuery(query string, vars *variable.SessionVars) {
 			zap.Int64("schemaVersion", vars.TxnCtx.SchemaVersion),
 			zap.Uint64("txnStartTS", vars.TxnCtx.StartTS),
 			zap.String("current_db", vars.CurrentDB),
-			zap.String("sql", query+vars.GetExecuteArgumentsInfo()))
+			zap.String("sql", query+vars.PreparedParams.String()))
 	}
 }
 

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/pingcap/tidb/util/stringutil"
 	"go.uber.org/zap"
 )
 
@@ -229,9 +228,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 			s.(*executor.ExecStmt).LogSlowQuery(origTxnCtx.StartTS, err == nil)
 			s.(*executor.ExecStmt).SummaryStmt()
 			pps := types.CloneRow(sessVars.PreparedParams)
-			sessVars.PrevStmt = stringutil.MemoizeStr(func() string {
-				return executor.FormatSQL(s.OriginText(), pps)
-			})
+			sessVars.PrevStmt = executor.FormatSQL(s.OriginText(), pps)
 		}
 	}()
 

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -207,7 +207,7 @@ type SessionVars struct {
 	// preparedStmtID is id of prepared statement.
 	preparedStmtID uint32
 	// PreparedParams params for prepared statements
-	PreparedParams []types.Datum
+	PreparedParams PreparedParams
 
 	// ActiveRoles stores active roles for current user
 	ActiveRoles []*auth.RoleIdentity
@@ -407,7 +407,7 @@ type SessionVars struct {
 	DurationCompile time.Duration
 
 	// PrevStmt is used to store the previous executed statement in the current session.
-	PrevStmt string
+	PrevStmt fmt.Stringer
 
 	// AllowRemoveAutoInc indicates whether a user can drop the auto_increment column attribute or not.
 	AllowRemoveAutoInc bool
@@ -422,6 +422,16 @@ type SessionVars struct {
 
 	// replicaRead is used for reading data from replicas, only follower is supported at this time.
 	replicaRead kv.ReplicaReadType
+}
+
+// PreparedParams contains the parameters of the current prepared statement when executing it.
+type PreparedParams []types.Datum
+
+func (pps PreparedParams) String() string {
+	if len(pps) == 0 {
+		return ""
+	}
+	return " [arguments: " + types.DatumsToStrNoErr(pps) + "]"
 }
 
 // ConnectionInfo present connection used by audit.
@@ -640,26 +650,6 @@ func (s *SessionVars) Location() *time.Location {
 		loc = timeutil.SystemLocation()
 	}
 	return loc
-}
-
-// GetExecuteArgumentsInfo gets the argument list as a string of execute statement.
-func (s *SessionVars) GetExecuteArgumentsInfo() string {
-	if len(s.PreparedParams) == 0 {
-		return ""
-	}
-	args := make([]string, 0, len(s.PreparedParams))
-	for _, v := range s.PreparedParams {
-		if v.IsNull() {
-			args = append(args, "<nil>")
-		} else {
-			str, err := v.ToString()
-			if err != nil {
-				terror.Log(err)
-			}
-			args = append(args, str)
-		}
-	}
-	return fmt.Sprintf(" [arguments: %s]", strings.Join(args, ", "))
 }
 
 // GetSystemVar gets the string value of a system variable.

--- a/util/stringutil/string_util.go
+++ b/util/stringutil/string_util.go
@@ -252,17 +252,17 @@ func Copy(src string) string {
 	return string(hack.Slice(src))
 }
 
-// stringerFunc defines string func implement fmt.Stringer.
-type stringerFunc func() string
+// StringerFunc defines string func implement fmt.Stringer.
+type StringerFunc func() string
 
 // String implements fmt.Stringer
-func (l stringerFunc) String() string {
+func (l StringerFunc) String() string {
 	return l()
 }
 
 // MemoizeStr returns memoized version of stringFunc.
 func MemoizeStr(l func() string) fmt.Stringer {
-	return stringerFunc(func() string {
+	return StringerFunc(func() string {
 		return l()
 	})
 }


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Formating a long previous statement takes too many resources, which may hurt the performance.

### What is changed and how it works?
Warp it to a `fmt.Stringer`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
