### PR TITLE
expression: implement vectorized evaluation for builtinLog1ArgSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
-unc (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+func (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
 		return err
 	}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -22,6 +22,28 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
+unc (b *builtinLog1ArgSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	f64s := result.Float64s()
+	for i := 0; i < len(f64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if f64s[i] <= 0 {
+			result.SetNull(i, true)
+		} else {
+			f64s[i] = math.Log(f64s[i])
+		}
+	}
+	return nil
+}
+
+func (b *builtinLog1ArgSig) vectorized() bool {
+	return true
+}
+
 func (b *builtinLog2Sig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
 	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
 		return err

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -22,6 +22,9 @@ import (
 )
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
+	ast.Log: {
+		{types.ETReal, []types.EvalType{types.ETReal}, nil},
+	},
 	ast.Log10: {
 		{types.ETReal, []types.EvalType{types.ETReal}, nil},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinLog1ArgSig, for [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinLog1ArgSig-VecBuiltinFunc-8                     200000              8206 ns/op            0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinLog1ArgSig-NonVecBuiltinFunc-8                  100000             22445 ns/op            0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 