### PR TITLE
expression: implement vectorized evaluation for `builtinLeastIntSig`

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -90,3 +90,38 @@ func (b *builtinLeastDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chun
 func (b *builtinLeastDecimalSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinLeastIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	i64s := result.Int64s()
+	for j := 1; j < len(b.args); j++ {
+		if err := b.args[j].VecEvalInt(b.ctx, input, buf); err != nil {
+			return err
+		}
+
+		result.MergeNulls(buf)
+		for i := 0; i < n; i++ {
+			if result.IsNull(i) {
+				continue
+			}
+			v := buf.GetInt64(i)
+			if v < i64s[i] {
+				i64s[i] = v
+			}
+		}
+	}
+	return nil
+}
+
+func (b *builtinLeastIntSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -27,6 +27,7 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	},
 	ast.Least: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}, nil},
+		{types.ETInt, []types.EvalType{types.ETInt, types.ETInt, types.ETInt}, nil},
 	},
 }
 


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinLeastIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastIntSig-VecBuiltinFunc-4             	  300000	      5311 ns/op
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastIntSig-NonVecBuiltinFunc-4          	   50000	     33817 ns/op

```


### Check List

Tests

 - Unit test
 - Integration test
