### PR TITLE
expression: implement vectorized evaluation for `builtinRightSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -164,3 +164,49 @@ Loop:
 func (b *builtinUpperSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinRightSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	buf2, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf2)
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf2); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	nums := buf2.Int64s()
+	for i :=0; i < n; i++ {
+		if buf.IsNull(i) || buf2.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		str := buf.GetString(i)
+		runes := []rune(str)
+		strLength, rightLength := len(runes), int(nums[i])
+		if rightLength > strLength {
+			rightLength = strLength
+		} else if rightLength < 0 {
+			rightLength = 0
+		}
+
+		result.AppendString(string(runes[strLength-rightLength:]))
+	}
+	return nil
+}
+
+func (b *builtinRightSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -187,7 +187,7 @@ func (b *builtinRightSig) vecEvalString(input *chunk.Chunk, result *chunk.Column
 
 	result.ReserveString(n)
 	nums := buf2.Int64s()
-	for i :=0; i < n; i++ {
+	for i := 0; i < n; i++ {
 		if buf.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
 			continue

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -35,6 +35,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Upper: {
 		{types.ETString, []types.EvalType{types.ETString}, nil},
 	},
+	ast.Right: {
+		{types.ETString, []types.EvalType{types.ETString, types.ETInt}, nil},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinStringEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinRightSig , for #12106

### What is changed and how it works?

    $go test -v -benchmem -bench=BenchmarkVectorizedBuiltinStringFunc -run=BenchmarkVectorizedBuiltinStringFunc -args "builtinRightSig"
	goos: darwin
	goarch: amd64
	pkg: github.com/pingcap/tidb/expression
	BenchmarkVectorizedBuiltinStringFunc/builtinRightSig-VecBuiltinFunc-4         	   17068	     71850 ns/op	       0 B/op	       0 allocs/op
	BenchmarkVectorizedBuiltinStringFunc/builtinRightSig-NonVecBuiltinFunc-4      	   10000	    104396 ns/op	    9152 B/op	     664 allocs/op
	PASS
	ok  	github.com/pingcap/tidb/expression	3.024s

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test