### PR TITLE
expression: implement vectorized evaluation for `builtinAbsIntSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -365,3 +365,26 @@ func (b *builtinPowSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) er
 func (b *builtinPowSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinAbsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	i64s := result.Int64s()
+	for i := 0; i < len(i64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if i64s[i] == math.MinInt64 {
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("abs(%d)", i64s[i]))
+		}
+		if i64s[i] < 0 {
+			i64s[i] = -i64s[i]
+		}
+	}
+	return nil
+}
+
+func (b *builtinAbsIntSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -60,6 +60,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.Abs: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
+		{types.ETInt, []types.EvalType{types.ETInt}, nil},
 	},
 	ast.Round: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinAbsIntSig.
Issue #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinAbsIntSig-VecBuiltinFunc-4              300000              5640 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinAbsIntSig-NonVecBuiltinFunc-4           100000             23146 ns/op               0 B/op          0 allocs/op

```

### Check List 
Tests 

 - Unit test
 - Integration test