### PR TITLE
expression: implement vectorized evaluation for `builtinRoundIntSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -431,3 +431,11 @@ func (b *builtinAbsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 func (b *builtinAbsIntSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinRoundIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return b.args[0].VecEvalInt(b.ctx, input, result)
+}
+
+func (b *builtinRoundIntSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -70,6 +70,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.Round: {
 		{types.ETDecimal, []types.EvalType{types.ETDecimal}, nil},
+		{types.ETInt, []types.EvalType{types.ETInt}, nil},
 	},
 	ast.Pow: {
 		{types.ETReal, []types.EvalType{types.ETReal, types.ETReal}, []dataGenerator{&rangeRealGener{0, 10, 0.5}, &rangeRealGener{0, 100, 0.5}}},


### PR DESCRIPTION
### What problem does this PR solve?
Implement vectorized evaluation for builtinRoundIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinRoundIntSig-VecBuiltinFunc-4          20000000               107 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinRoundIntSig-NonVecBuiltinFunc-4         100000             19785 ns/op               0 B/op          0 allocs/op
```

### Check List 

Tests 

 - Unit test
