### PR TITLE
infoschema, session: support for events_statements_summary_by_digest #12017

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,8 +88,9 @@ type Config struct {
 	CheckMb4ValueInUTF8 bool              `toml:"check-mb4-value-in-utf8" json:"check-mb4-value-in-utf8"`
 	// TreatOldVersionUTF8AsUTF8MB4 is use to treat old version table/column UTF8 charset as UTF8MB4. This is for compatibility.
 	// Currently not support dynamic modify, because this need to reload all old version schema.
-	TreatOldVersionUTF8AsUTF8MB4 bool   `toml:"treat-old-version-utf8-as-utf8mb4" json:"treat-old-version-utf8-as-utf8mb4"`
-	SplitRegionMaxNum            uint64 `toml:"split-region-max-num" json:"split-region-max-num"`
+	TreatOldVersionUTF8AsUTF8MB4 bool        `toml:"treat-old-version-utf8-as-utf8mb4" json:"treat-old-version-utf8-as-utf8mb4"`
+	SplitRegionMaxNum            uint64      `toml:"split-region-max-num" json:"split-region-max-num"`
+	StmtSummary                  StmtSummary `toml:"stmt-summary" json:"stmt-summary"`
 }
 
 // Log is the log section of config.
@@ -306,6 +307,14 @@ type PessimisticTxn struct {
 	TTL string `toml:"ttl" json:"ttl"`
 }
 
+// StmtSummary is the config for statement summary.
+type StmtSummary struct {
+	// The maximum number of statements kept in memory.
+	MaxStmtCount uint `toml:"max-stmt-count" json:"max-stmt-count"`
+	// The maximum length of displayed normalized SQL and sample SQL.
+	MaxSQLLength uint `toml:"max-sql-length" json:"max-sql-length"`
+}
+
 var defaultConf = Config{
 	Host:                         "0.0.0.0",
 	AdvertiseAddress:             "",
@@ -395,6 +404,10 @@ var defaultConf = Config{
 		Enable:        true,
 		MaxRetryCount: 256,
 		TTL:           "40s",
+	},
+	StmtSummary: StmtSummary{
+		MaxStmtCount: 100,
+		MaxSQLLength: 4096,
 	},
 }
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -300,3 +300,10 @@ max-retry-count = 256
 # default TTL in milliseconds for pessimistic lock.
 # The value must between "15s" and "120s".
 ttl = "40s"
+
+[stmt-summary]
+# max number of statements kept in memory.
+max-stmt-count = 100
+
+# max length of displayed normalized sql and sample sql.
+max-sql-length = 4096

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -65,6 +65,9 @@ split-region-max-num=10000
 [tikv-client]
 commit-timeout="41s"
 max-batch-size=128
+[stmt-summary]
+max-stmt-count=1000
+max-sql-length=1024
 `)
 
 	c.Assert(err, IsNil)
@@ -80,6 +83,8 @@ max-batch-size=128
 	c.Assert(conf.TiKVClient.MaxBatchSize, Equals, uint(128))
 	c.Assert(conf.TokenLimit, Equals, uint(1000))
 	c.Assert(conf.SplitRegionMaxNum, Equals, uint64(10000))
+	c.Assert(conf.StmtSummary.MaxStmtCount, Equals, uint(1000))
+	c.Assert(conf.StmtSummary.MaxSQLLength, Equals, uint(1024))
 	c.Assert(f.Close(), IsNil)
 	c.Assert(os.Remove(configFile), IsNil)
 

--- a/domain/global_vars_cache.go
+++ b/domain/global_vars_cache.go
@@ -18,7 +18,9 @@ import (
 	"time"
 
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/stmtsummary"
 )
 
 // GlobalVariableCache caches global variables.
@@ -41,6 +43,8 @@ func (gvc *GlobalVariableCache) Update(rows []chunk.Row, fields []*ast.ResultFie
 	gvc.rows = rows
 	gvc.fields = fields
 	gvc.Unlock()
+
+	checkEnableStmtSummary(rows, fields)
 }
 
 // Get gets the global variables from cache.
@@ -61,6 +65,28 @@ func (gvc *GlobalVariableCache) Disable() {
 	defer gvc.Unlock()
 	gvc.disable = true
 	return
+}
+
+// checkEnableStmtSummary looks for TiDBEnableStmtSummary and notifies StmtSummary
+func checkEnableStmtSummary(rows []chunk.Row, fields []*ast.ResultField) {
+	for _, row := range rows {
+		varName := row.GetString(0)
+		if varName == variable.TiDBEnableStmtSummary {
+			varVal := row.GetDatum(1, &fields[1].Column.FieldType)
+
+			sVal := ""
+			if !varVal.IsNull() {
+				var err error
+				sVal, err = varVal.ToString()
+				if err != nil {
+					return
+				}
+			}
+
+			stmtsummary.OnEnableStmtSummaryModified(sVal)
+			break
+		}
+	}
 }
 
 // GetGlobalVarsCache gets the global variable cache.

--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -36,6 +36,7 @@ var perfSchemaTables = []string{
 	tableStagesCurrent,
 	tableStagesHistory,
 	tableStagesHistoryLong,
+	tableEventsStatementsSummaryByDigest,
 }
 
 // tableGlobalStatus contains the column name definitions for table global_status, same as MySQL.
@@ -371,3 +372,19 @@ const tableStagesHistoryLong = "CREATE TABLE if not exists performance_schema.ev
 	"WORK_ESTIMATED	BIGINT(20) UNSIGNED," +
 	"NESTING_EVENT_ID		BIGINT(20) UNSIGNED," +
 	"NESTING_EVENT_TYPE		ENUM('TRANSACTION','STATEMENT','STAGE'));"
+
+// tableEventsStatementsSummaryByDigest contains the column name definitions for table
+// events_statements_summary_by_digest, same as MySQL.
+const tableEventsStatementsSummaryByDigest = "CREATE TABLE if not exists events_statements_summary_by_digest (" +
+	"SCHEMA_NAME VARCHAR(64) DEFAULT NULL," +
+	"DIGEST VARCHAR(64) DEFAULT NULL," +
+	"DIGEST_TEXT LONGTEXT DEFAULT NULL," +
+	"EXEC_COUNT BIGINT(20) UNSIGNED NOT NULL," +
+	"SUM_LATENCY BIGINT(20) UNSIGNED NOT NULL," +
+	"MAX_LATENCY BIGINT(20) UNSIGNED NOT NULL," +
+	"MIN_LATENCY BIGINT(20) UNSIGNED NOT NULL," +
+	"AVG_LATENCY BIGINT(20) UNSIGNED NOT NULL," +
+	"SUM_ROWS_AFFECTED BIGINT(20) UNSIGNED NOT NULL," +
+	"FIRST_SEEN TIMESTAMP(6) NOT NULL," +
+	"LAST_SEEN TIMESTAMP(6) NOT NULL," +
+	"QUERY_SAMPLE_TEXT LONGTEXT DEFAULT NULL);"

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/util/testkit"
@@ -28,26 +30,96 @@ func TestT(t *testing.T) {
 	TestingT(t)
 }
 
-var _ = Suite(&testSuite{})
+var _ = Suite(&testTableSuite{})
 
-type testSuite struct {
+type testTableSuite struct {
+	store kv.Storage
+	dom   *domain.Domain
 }
 
-func (s *testSuite) TestPerfSchemaTables(c *C) {
+func (s *testTableSuite) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	defer testleak.AfterTest(c)()
-	store, err := mockstore.NewMockTikvStore()
-	c.Assert(err, IsNil)
-	defer store.Close()
-	do, err := session.BootstrapSession(store)
-	c.Assert(err, IsNil)
-	defer do.Close()
 
-	tk := testkit.NewTestKit(c, store)
+	var err error
+	s.store, err = mockstore.NewMockTikvStore()
+	c.Assert(err, IsNil)
+	session.DisableStats4Test()
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+}
+
+func (s *testTableSuite) TearDownSuite(c *C) {
+	defer testleak.AfterTest(c)()
+	s.dom.Close()
+	s.store.Close()
+}
+
+func (s *testTableSuite) TestPerfSchemaTables(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("use performance_schema")
 	tk.MustQuery("select * from global_status where variable_name = 'Ssl_verify_mode'").Check(testkit.Rows())
 	tk.MustQuery("select * from session_status where variable_name = 'Ssl_verify_mode'").Check(testkit.Rows())
 	tk.MustQuery("select * from setup_actors").Check(testkit.Rows())
 	tk.MustQuery("select * from events_stages_history_long").Check(testkit.Rows())
+}
+
+// Test events_statements_summary_by_digest
+func (s *testTableSuite) TestStmtSummaryTable(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b varchar(10))")
+
+	// Statement summary is disabled by default
+	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
+	tk.MustExec("insert into t values(1, 'a')")
+	tk.MustQuery("select * from performance_schema.events_statements_summary_by_digest").Check(testkit.Rows())
+
+	tk.MustExec("set global tidb_enable_stmt_summary = 1")
+	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("1"))
+
+	// Invalidate the cache manually so that tidb_enable_stmt_summary works immediately.
+	s.dom.GetGlobalVarsCache().Disable()
+
+	// Create a new session to test
+	tk = testkit.NewTestKitWithInit(c, s.store)
+
+	// Test INSERT
+	tk.MustExec("insert into t values(1, 'a')")
+	tk.MustExec("insert into t    values(2, 'b')")
+	tk.MustExec("insert into t VALUES(3, 'c')")
+	tk.MustExec("/**/insert into t values(4, 'd')")
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest
+		where digest_text like 'insert into t%'`,
+	).Check(testkit.Rows("test 4 4 insert into t values(1, 'a')"))
+
+	// Test SELECT
+	tk.MustQuery("select * from t where a=2")
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest
+		where digest_text like 'select * from t%'`,
+	).Check(testkit.Rows("test 1 0 select * from t where a=2"))
+
+	// select ... order by
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest
+		order by exec_count desc limit 1`,
+	).Check(testkit.Rows("test 4 4 insert into t values(1, 'a')"))
+
+	// Disable it again
+	tk.MustExec("set global tidb_enable_stmt_summary = 0")
+	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
+
+	// Create a new session to test
+	tk = testkit.NewTestKitWithInit(c, s.store)
+
+	// This statement shouldn't be summarized
+	tk.MustQuery("select * from t where a=2")
+
+	// The table should be cleared
+	tk.MustQuery(`select schema_name, exec_count, sum_rows_affected, query_sample_text 
+		from performance_schema.events_statements_summary_by_digest`,
+	).Check(testkit.Rows())
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1701,6 +1701,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBEnableFastAnalyze,
 	variable.TiDBExpensiveQueryTimeThreshold,
 	variable.TiDBTxnMode,
+	variable.TiDBEnableStmtSummary,
 }
 
 var (

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -217,6 +217,7 @@ func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) 
 		// then it could include the transaction commit time.
 		if rs == nil {
 			s.(*executor.ExecStmt).LogSlowQuery(origTxnCtx.StartTS, err == nil)
+			s.(*executor.ExecStmt).SummaryStmt()
 			sessVars.PrevStmt = s.OriginText()
 		}
 	}()

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -117,6 +117,14 @@ func BoolToIntStr(b bool) string {
 	return "0"
 }
 
+// BoolToInt32 converts bool to int32
+func BoolToInt32(b bool) int32 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // we only support MySQL now
 var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "gtid_mode", "OFF"},
@@ -702,6 +710,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBLowResolutionTSO, "0"},
 	{ScopeSession, TiDBExpensiveQueryTimeThreshold, strconv.Itoa(DefTiDBExpensiveQueryTimeThreshold)},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
+	{ScopeGlobal, TiDBEnableStmtSummary, BoolToIntStr(DefTiDBEnableStmtSummary)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -61,3 +61,8 @@ func (*testSysVarSuite) TestTxnMode(c *C) {
 	err = seVar.setTxnMode("something else")
 	c.Assert(err, NotNil)
 }
+
+func (*testSysVarSuite) TestBoolToInt32(c *C) {
+	c.Assert(BoolToInt32(true), Equals, int32(1))
+	c.Assert(BoolToInt32(false), Equals, int32(0))
+}

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -284,6 +284,9 @@ const (
 
 	// TiDBExpensiveQueryTimeThreshold indicates the time threshold of expensive query.
 	TiDBExpensiveQueryTimeThreshold = "tidb_expensive_query_time_threshold"
+
+	// TiDBEnableStmtSummary indicates whether the statement summary is enabled.
+	TiDBEnableStmtSummary = "tidb_enable_stmt_summary"
 )
 
 // Default TiDB system variable values.
@@ -348,6 +351,7 @@ const (
 	DefTiDBExpensiveQueryTimeThreshold = 60  // 60s
 	DefWaitSplitRegionTimeout          = 300 // 300s
 	DefTiDBAllowRemoveAutoInc          = false
+	DefTiDBEnableStmtSummary           = false
 )
 
 // Process global variables.
@@ -367,4 +371,5 @@ var (
 	MaxOfMaxAllowedPacket          uint64 = 1073741824
 	ExpensiveQueryTimeThreshold    uint64 = DefTiDBExpensiveQueryTimeThreshold
 	MinExpensiveQueryTimeThreshold uint64 = 10 //10s
+	EnableStmtSummary              int32  = BoolToInt32(DefTiDBEnableStmtSummary)
 )

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -420,7 +420,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming,
 		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction,
-		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBScatterRegion:
+		TiDBCheckMb4ValueInUTF8, TiDBLowResolutionTSO, TiDBScatterRegion, TiDBEnableStmtSummary:
 		if strings.EqualFold(value, "ON") || value == "1" || strings.EqualFold(value, "OFF") || value == "0" {
 			return value, nil
 		}

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -329,7 +329,7 @@ func loadConfig() string {
 // hotReloadConfigItems lists all config items which support hot-reload.
 var hotReloadConfigItems = []string{"Performance.MaxProcs", "Performance.MaxMemory", "Performance.CrossJoin",
 	"Performance.FeedbackProbability", "Performance.QueryFeedbackLimit", "Performance.PseudoEstimateRatio",
-	"OOMAction", "MemQuotaQuery"}
+	"OOMAction", "MemQuotaQuery", "StmtSummary.MaxStmtCount", "StmtSummary.MaxSQLLength"}
 
 func reloadConfig(nc, c *config.Config) {
 	// Just a part of config items need to be reload explicitly.

--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -106,6 +106,22 @@ func (s *testLRUCacheSuite) TestPut(c *C) {
 	c.Assert(root, IsNil)
 }
 
+func (s *testLRUCacheSuite) TestZeroQuota(c *C) {
+	lru := NewSimpleLRUCache(100, 0, 0)
+	c.Assert(lru.capacity, Equals, uint(100))
+
+	keys := make([]*mockCacheKey, 100)
+	vals := make([]int64, 100)
+
+	for i := 0; i < 100; i++ {
+		keys[i] = newMockHashKey(int64(i))
+		vals[i] = int64(i)
+		lru.Put(keys[i], vals[i])
+	}
+	c.Assert(lru.size, Equals, lru.capacity)
+	c.Assert(lru.size, Equals, uint(100))
+}
+
 func (s *testLRUCacheSuite) TestOOMGuard(c *C) {
 	maxMem, err := memory.MemTotal()
 	c.Assert(err, IsNil)
@@ -226,5 +242,27 @@ func (s *testLRUCacheSuite) TestDeleteAll(c *C) {
 		c.Assert(exists, IsFalse)
 		c.Assert(value, IsNil)
 		c.Assert(int(lru.size), Equals, 0)
+	}
+}
+
+func (s *testLRUCacheSuite) TestValues(c *C) {
+	maxMem, err := memory.MemTotal()
+	c.Assert(err, IsNil)
+
+	lru := NewSimpleLRUCache(5, 0, maxMem)
+
+	keys := make([]*mockCacheKey, 5)
+	vals := make([]int64, 5)
+
+	for i := 0; i < 5; i++ {
+		keys[i] = newMockHashKey(int64(i))
+		vals[i] = int64(i)
+		lru.Put(keys[i], vals[i])
+	}
+
+	values := lru.Values()
+	c.Assert(len(values), Equals, 5)
+	for i := 0; i < 5; i++ {
+		c.Assert(values[i], Equals, int64(4-i))
 	}
 }

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -1,0 +1,230 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stmtsummary
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/hack"
+	"github.com/pingcap/tidb/util/kvcache"
+)
+
+// There're many types of statement summary tables in MySQL, but we have
+// only implemented events_statement_summary_by_digest for now.
+
+// stmtSummaryByDigestKey defines key for stmtSummaryByDigestMap.summaryMap
+type stmtSummaryByDigestKey struct {
+	// Same statements may appear in different schema, but they refer to different tables.
+	schemaName string
+	digest     string
+	// TODO: add plan digest
+	// `hash` is the hash value of this object
+	hash []byte
+}
+
+// Hash implements SimpleLRUCache.Key
+func (key *stmtSummaryByDigestKey) Hash() []byte {
+	if len(key.hash) == 0 {
+		key.hash = make([]byte, 0, len(key.schemaName)+len(key.digest))
+		key.hash = append(key.hash, hack.Slice(key.digest)...)
+		key.hash = append(key.hash, hack.Slice(strings.ToLower(key.schemaName))...)
+	}
+	return key.hash
+}
+
+// stmtSummaryByDigestMap is a LRU cache that stores statement summaries.
+type stmtSummaryByDigestMap struct {
+	// It's rare to read concurrently, so RWMutex is not needed.
+	sync.Mutex
+	summaryMap *kvcache.SimpleLRUCache
+}
+
+// StmtSummaryByDigestMap is a global map containing all statement summaries.
+var StmtSummaryByDigestMap = newStmtSummaryByDigestMap()
+
+// stmtSummaryByDigest is the summary for each type of statements.
+type stmtSummaryByDigest struct {
+	// It's rare to read concurrently, so RWMutex is not needed.
+	sync.Mutex
+	schemaName      string
+	digest          string
+	normalizedSQL   string
+	sampleSQL       string
+	execCount       uint64
+	sumLatency      uint64
+	maxLatency      uint64
+	minLatency      uint64
+	sumAffectedRows uint64
+	// Number of rows sent to client.
+	sumSentRows uint64
+	// The first time this type of SQL executes.
+	firstSeen time.Time
+	// The last time this type of SQL executes.
+	lastSeen time.Time
+}
+
+// StmtExecInfo records execution information of each statement.
+type StmtExecInfo struct {
+	SchemaName    string
+	OriginalSQL   string
+	NormalizedSQL string
+	Digest        string
+	TotalLatency  uint64
+	AffectedRows  uint64
+	// Number of rows sent to client.
+	SentRows  uint64
+	StartTime time.Time
+}
+
+// newStmtSummaryByDigestMap creates an empty stmtSummaryByDigestMap.
+func newStmtSummaryByDigestMap() *stmtSummaryByDigestMap {
+	maxStmtCount := config.GetGlobalConfig().StmtSummary.MaxStmtCount
+	return &stmtSummaryByDigestMap{
+		summaryMap: kvcache.NewSimpleLRUCache(maxStmtCount, 0, 0),
+	}
+}
+
+// newStmtSummaryByDigest creates a stmtSummaryByDigest from StmtExecInfo
+func newStmtSummaryByDigest(sei *StmtExecInfo) *stmtSummaryByDigest {
+	// Trim SQL to size MaxSQLLength
+	maxSQLLength := config.GetGlobalConfig().StmtSummary.MaxSQLLength
+	normalizedSQL := sei.NormalizedSQL
+	if len(normalizedSQL) > int(maxSQLLength) {
+		normalizedSQL = normalizedSQL[:maxSQLLength]
+	}
+	sampleSQL := sei.OriginalSQL
+	if len(sampleSQL) > int(maxSQLLength) {
+		sampleSQL = sampleSQL[:maxSQLLength]
+	}
+
+	return &stmtSummaryByDigest{
+		schemaName:      sei.SchemaName,
+		digest:          sei.Digest,
+		normalizedSQL:   normalizedSQL,
+		sampleSQL:       sampleSQL,
+		execCount:       1,
+		sumLatency:      sei.TotalLatency,
+		maxLatency:      sei.TotalLatency,
+		minLatency:      sei.TotalLatency,
+		sumAffectedRows: sei.AffectedRows,
+		sumSentRows:     sei.SentRows,
+		firstSeen:       sei.StartTime,
+		lastSeen:        sei.StartTime,
+	}
+}
+
+// Add a StmtExecInfo to stmtSummary
+func (ssbd *stmtSummaryByDigest) add(sei *StmtExecInfo) {
+	ssbd.Lock()
+
+	ssbd.sumLatency += sei.TotalLatency
+	ssbd.execCount++
+	if sei.TotalLatency > ssbd.maxLatency {
+		ssbd.maxLatency = sei.TotalLatency
+	}
+	if sei.TotalLatency < ssbd.minLatency {
+		ssbd.minLatency = sei.TotalLatency
+	}
+	ssbd.sumAffectedRows += sei.AffectedRows
+	ssbd.sumSentRows += sei.SentRows
+	if sei.StartTime.Before(ssbd.firstSeen) {
+		ssbd.firstSeen = sei.StartTime
+	}
+	if ssbd.lastSeen.Before(sei.StartTime) {
+		ssbd.lastSeen = sei.StartTime
+	}
+
+	ssbd.Unlock()
+}
+
+// AddStatement adds a statement to StmtSummaryByDigestMap.
+func (ssMap *stmtSummaryByDigestMap) AddStatement(sei *StmtExecInfo) {
+	key := &stmtSummaryByDigestKey{
+		schemaName: sei.SchemaName,
+		digest:     sei.Digest,
+	}
+
+	ssMap.Lock()
+	// Check again. Statements could be added before disabling the flag and after Clear()
+	if atomic.LoadInt32(&variable.EnableStmtSummary) == 0 {
+		ssMap.Unlock()
+		return
+	}
+	value, ok := ssMap.summaryMap.Get(key)
+	if !ok {
+		newSummary := newStmtSummaryByDigest(sei)
+		ssMap.summaryMap.Put(key, newSummary)
+	}
+	ssMap.Unlock()
+
+	// Lock a single entry, not the whole cache.
+	if ok {
+		value.(*stmtSummaryByDigest).add(sei)
+	}
+}
+
+// Clear removes all statement summaries.
+func (ssMap *stmtSummaryByDigestMap) Clear() {
+	ssMap.Lock()
+	ssMap.summaryMap.DeleteAll()
+	ssMap.Unlock()
+}
+
+// Convert statement summary to Datum
+func (ssMap *stmtSummaryByDigestMap) ToDatum() [][]types.Datum {
+	ssMap.Lock()
+	values := ssMap.summaryMap.Values()
+	ssMap.Unlock()
+
+	rows := make([][]types.Datum, 0, len(values))
+	for _, value := range values {
+		summary := value.(*stmtSummaryByDigest)
+		summary.Lock()
+		record := types.MakeDatums(
+			summary.schemaName,
+			summary.digest,
+			summary.normalizedSQL,
+			summary.execCount,
+			summary.sumLatency,
+			summary.maxLatency,
+			summary.minLatency,
+			summary.sumLatency/summary.execCount, // AVG_LATENCY
+			summary.sumAffectedRows,
+			types.Time{Time: types.FromGoTime(summary.firstSeen), Type: mysql.TypeTimestamp},
+			types.Time{Time: types.FromGoTime(summary.lastSeen), Type: mysql.TypeTimestamp},
+			summary.sampleSQL,
+		)
+		summary.Unlock()
+		rows = append(rows, record)
+	}
+
+	return rows
+}
+
+// OnEnableStmtSummaryModified is triggered once EnableStmtSummary is modified.
+func OnEnableStmtSummaryModified(newValue string) {
+	if variable.TiDBOptOn(newValue) {
+		atomic.StoreInt32(&variable.EnableStmtSummary, 1)
+	} else {
+		atomic.StoreInt32(&variable.EnableStmtSummary, 0)
+		StmtSummaryByDigestMap.Clear()
+	}
+}

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -1,0 +1,346 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stmtsummary
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/types"
+)
+
+var _ = Suite(&testStmtSummarySuite{})
+
+type testStmtSummarySuite struct {
+	ssMap *stmtSummaryByDigestMap
+}
+
+func (s *testStmtSummarySuite) SetUpSuite(c *C) {
+	s.ssMap = newStmtSummaryByDigestMap()
+	atomic.StoreInt32(&variable.EnableStmtSummary, 1)
+}
+
+func TestT(t *testing.T) {
+	CustomVerboseFlag = true
+	TestingT(t)
+}
+
+// Test stmtSummaryByDigest.AddStatement
+func (s *testStmtSummarySuite) TestAddStatement(c *C) {
+	s.ssMap.Clear()
+
+	// First statement
+	stmtExecInfo1 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  10000,
+		AffectedRows:  100,
+		SentRows:      100,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+	}
+	key := &stmtSummaryByDigestKey{
+		schemaName: stmtExecInfo1.SchemaName,
+		digest:     stmtExecInfo1.Digest,
+	}
+	expectedSummary := stmtSummaryByDigest{
+		schemaName:      stmtExecInfo1.SchemaName,
+		digest:          stmtExecInfo1.Digest,
+		normalizedSQL:   stmtExecInfo1.NormalizedSQL,
+		sampleSQL:       stmtExecInfo1.OriginalSQL,
+		execCount:       1,
+		sumLatency:      stmtExecInfo1.TotalLatency,
+		maxLatency:      stmtExecInfo1.TotalLatency,
+		minLatency:      stmtExecInfo1.TotalLatency,
+		sumAffectedRows: stmtExecInfo1.AffectedRows,
+		sumSentRows:     stmtExecInfo1.SentRows,
+		firstSeen:       stmtExecInfo1.StartTime,
+		lastSeen:        stmtExecInfo1.StartTime,
+	}
+
+	s.ssMap.AddStatement(stmtExecInfo1)
+	summary, ok := s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	c.Assert(*summary.(*stmtSummaryByDigest) == expectedSummary, IsTrue)
+
+	// Second statement
+	stmtExecInfo2 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql2",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  50000,
+		AffectedRows:  500,
+		SentRows:      500,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 20, 10, time.UTC),
+	}
+	expectedSummary.execCount++
+	expectedSummary.sumLatency += stmtExecInfo2.TotalLatency
+	expectedSummary.maxLatency = stmtExecInfo2.TotalLatency
+	expectedSummary.sumAffectedRows += stmtExecInfo2.AffectedRows
+	expectedSummary.sumSentRows += stmtExecInfo2.SentRows
+	expectedSummary.lastSeen = stmtExecInfo2.StartTime
+
+	s.ssMap.AddStatement(stmtExecInfo2)
+	summary, ok = s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	c.Assert(*summary.(*stmtSummaryByDigest) == expectedSummary, IsTrue)
+
+	// Third statement
+	stmtExecInfo3 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql3",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  1000,
+		AffectedRows:  10,
+		SentRows:      10,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 0, 10, time.UTC),
+	}
+	expectedSummary.execCount++
+	expectedSummary.sumLatency += stmtExecInfo3.TotalLatency
+	expectedSummary.minLatency = stmtExecInfo3.TotalLatency
+	expectedSummary.sumAffectedRows += stmtExecInfo3.AffectedRows
+	expectedSummary.sumSentRows += stmtExecInfo3.SentRows
+	expectedSummary.firstSeen = stmtExecInfo3.StartTime
+
+	s.ssMap.AddStatement(stmtExecInfo3)
+	summary, ok = s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	c.Assert(*summary.(*stmtSummaryByDigest) == expectedSummary, IsTrue)
+
+	// Fourth statement that in a different schema
+	stmtExecInfo4 := &StmtExecInfo{
+		SchemaName:    "schema_name2",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  1000,
+		AffectedRows:  10,
+		SentRows:      10,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 0, 10, time.UTC),
+	}
+	key = &stmtSummaryByDigestKey{
+		schemaName: stmtExecInfo4.SchemaName,
+		digest:     stmtExecInfo4.Digest,
+	}
+
+	s.ssMap.AddStatement(stmtExecInfo4)
+	c.Assert(s.ssMap.summaryMap.Size(), Equals, 2)
+	_, ok = s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+
+	// Fifth statement that has a different digest
+	stmtExecInfo5 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql2",
+		Digest:        "digest2",
+		TotalLatency:  1000,
+		AffectedRows:  10,
+		SentRows:      10,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 0, 10, time.UTC),
+	}
+	key = &stmtSummaryByDigestKey{
+		schemaName: stmtExecInfo5.SchemaName,
+		digest:     stmtExecInfo5.Digest,
+	}
+
+	s.ssMap.AddStatement(stmtExecInfo5)
+	c.Assert(s.ssMap.summaryMap.Size(), Equals, 3)
+	_, ok = s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+}
+
+func match(c *C, row []types.Datum, expected ...interface{}) {
+	c.Assert(len(row), Equals, len(expected))
+	for i := range row {
+		got := fmt.Sprintf("%v", row[i].GetValue())
+		need := fmt.Sprintf("%v", expected[i])
+		c.Assert(got, Equals, need)
+	}
+}
+
+// Test stmtSummaryByDigest.ToDatum
+func (s *testStmtSummarySuite) TestToDatum(c *C) {
+	s.ssMap.Clear()
+
+	stmtExecInfo1 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  10000,
+		AffectedRows:  100,
+		SentRows:      100,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+	}
+	s.ssMap.AddStatement(stmtExecInfo1)
+	datums := s.ssMap.ToDatum()
+	c.Assert(len(datums), Equals, 1)
+	t := types.Time{Time: types.FromGoTime(stmtExecInfo1.StartTime), Type: mysql.TypeTimestamp}
+	match(c, datums[0], stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, stmtExecInfo1.NormalizedSQL,
+		1, stmtExecInfo1.TotalLatency, stmtExecInfo1.TotalLatency, stmtExecInfo1.TotalLatency, stmtExecInfo1.TotalLatency,
+		stmtExecInfo1.AffectedRows, t, t, stmtExecInfo1.OriginalSQL)
+}
+
+// Test AddStatement and ToDatum parallel
+func (s *testStmtSummarySuite) TestAddStatementParallel(c *C) {
+	s.ssMap.Clear()
+
+	threads := 8
+	loops := 32
+	wg := sync.WaitGroup{}
+	wg.Add(threads)
+
+	addStmtFunc := func() {
+		defer wg.Done()
+		stmtExecInfo1 := &StmtExecInfo{
+			SchemaName:    "schema_name",
+			OriginalSQL:   "original_sql1",
+			NormalizedSQL: "normalized_sql",
+			Digest:        "digest",
+			TotalLatency:  10000,
+			AffectedRows:  100,
+			SentRows:      100,
+			StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+		}
+
+		// Add 32 times with different digest
+		for i := 0; i < loops; i++ {
+			stmtExecInfo1.Digest = fmt.Sprintf("digest%d", i)
+			s.ssMap.AddStatement(stmtExecInfo1)
+		}
+
+		// There would be 32 summaries
+		datums := s.ssMap.ToDatum()
+		c.Assert(len(datums), Equals, loops)
+	}
+
+	for i := 0; i < threads; i++ {
+		go addStmtFunc()
+	}
+	wg.Wait()
+
+	datums := s.ssMap.ToDatum()
+	c.Assert(len(datums), Equals, loops)
+}
+
+// Test max number of statement count.
+func (s *testStmtSummarySuite) TestMaxStmtCount(c *C) {
+	s.ssMap.Clear()
+
+	stmtExecInfo1 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  10000,
+		AffectedRows:  100,
+		SentRows:      100,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+	}
+
+	maxStmtCount := config.GetGlobalConfig().StmtSummary.MaxStmtCount
+
+	// 1000 digests
+	loops := int(maxStmtCount) * 10
+	for i := 0; i < loops; i++ {
+		stmtExecInfo1.Digest = fmt.Sprintf("digest%d", i)
+		s.ssMap.AddStatement(stmtExecInfo1)
+	}
+
+	// Summary count should be MaxStmtCount
+	sm := s.ssMap.summaryMap
+	c.Assert(sm.Size(), Equals, int(maxStmtCount))
+
+	// LRU cache should work
+	for i := loops - int(maxStmtCount); i < loops; i++ {
+		key := &stmtSummaryByDigestKey{
+			schemaName: stmtExecInfo1.SchemaName,
+			digest:     fmt.Sprintf("digest%d", i),
+		}
+		_, ok := sm.Get(key)
+		c.Assert(ok, IsTrue)
+	}
+}
+
+// Test max length of normalized and sample SQL.
+func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
+	s.ssMap.Clear()
+
+	// Create a long SQL
+	maxSQLLength := config.GetGlobalConfig().StmtSummary.MaxSQLLength
+	length := int(maxSQLLength) * 10
+	str := strings.Repeat("a", length)
+
+	stmtExecInfo1 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   str,
+		NormalizedSQL: str,
+		Digest:        "digest",
+		TotalLatency:  10000,
+		AffectedRows:  100,
+		SentRows:      100,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+	}
+
+	s.ssMap.AddStatement(stmtExecInfo1)
+	key := &stmtSummaryByDigestKey{
+		schemaName: stmtExecInfo1.SchemaName,
+		digest:     stmtExecInfo1.Digest,
+	}
+	value, ok := s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	// Length of normalizedSQL and sampleSQL should be maxSQLLength
+	summary := value.(*stmtSummaryByDigest)
+	c.Assert(len(summary.normalizedSQL), Equals, int(maxSQLLength))
+	c.Assert(len(summary.sampleSQL), Equals, int(maxSQLLength))
+}
+
+// Test setting EnableStmtSummary to 0
+func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
+	s.ssMap.Clear()
+	OnEnableStmtSummaryModified("0")
+
+	stmtExecInfo1 := &StmtExecInfo{
+		SchemaName:    "schema_name",
+		OriginalSQL:   "original_sql1",
+		NormalizedSQL: "normalized_sql",
+		Digest:        "digest",
+		TotalLatency:  10000,
+		AffectedRows:  100,
+		SentRows:      100,
+		StartTime:     time.Date(2019, 1, 1, 10, 10, 10, 10, time.UTC),
+	}
+
+	s.ssMap.AddStatement(stmtExecInfo1)
+	datums := s.ssMap.ToDatum()
+	c.Assert(len(datums), Equals, 0)
+
+	OnEnableStmtSummaryModified("1")
+
+	s.ssMap.AddStatement(stmtExecInfo1)
+	datums = s.ssMap.ToDatum()
+	c.Assert(len(datums), Equals, 1)
+}


### PR DESCRIPTION
cherry-pick #12017 to release-3.0, with little conflict-resolve
<hr>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support system table `events_statements_summary_by_digest`, which is used to summary statements by digest.

### What is changed and how it works?
 - Add methods to `perfSchemaTable`, and add a new table `events_statements_summary_by_digest`.
 - Add a system variable `tidb_enable_stmt_summary` and add configurations `max-stmt-count` & `max-sql-length`.
 - Summary the statement execution information and put it into `StmtSummary` after a SQL runs.
 - Get information from `StmtSummary` when the user queries `events_statements_summary_by_digest`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Support system table `performance_schema`.`events_statements_summary_by_digest`. The table is used to summarize statements by digest of statements.
