### PR TITLE
planner/core: fix resolve rule for group by expression

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1462,16 +1462,25 @@ type gbyResolver struct {
 	err     error
 	inExpr  bool
 	isParam bool
+
+	exprDepth int // exprDepth is the depth of current expression in expression tree.
 }
 
 func (g *gbyResolver) Enter(inNode ast.Node) (ast.Node, bool) {
+	g.exprDepth++
 	switch n := inNode.(type) {
 	case *ast.SubqueryExpr, *ast.CompareSubqueryExpr, *ast.ExistsSubqueryExpr:
 		return inNode, true
 	case *driver.ParamMarkerExpr:
-		newNode := expression.ConstructPositionExpr(n)
 		g.isParam = true
-		return newNode, true
+		if g.exprDepth == 1 {
+			_, isNull, isExpectedType := getUintFromNode(g.ctx, n)
+			// For constant uint expression in top level, it should be treated as position expression.
+			if !isNull && isExpectedType {
+				return expression.ConstructPositionExpr(n), true
+			}
+		}
+		return n, true
 	case *driver.ValueExpr, *ast.ColumnNameExpr, *ast.ParenthesesExpr, *ast.ColumnName:
 	default:
 		g.inExpr = true

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -345,3 +345,28 @@ func (s *testPrepareSuite) TestPrepareWithWindowFunction(c *C) {
 	tk.MustExec("set @a=0, @b=1;")
 	tk.MustQuery("execute stmt2 using @a, @b").Check(testkit.Rows("0", "0"))
 }
+
+func (s *testPrepareSuite) TestPrepareForGroupByItems(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int, v int)")
+	tk.MustExec("insert into t(id, v) values(1, 2),(1, 2),(2, 3);")
+	tk.MustExec("prepare s1 from 'select max(v) from t group by floor(id/?)';")
+	tk.MustExec("set @a=2;")
+	tk.MustQuery("execute s1 using @a;").Check(testkit.Rows("3", "2"))
+
+	tk.MustExec("prepare s1 from 'select max(v) from t group by ?';")
+	tk.MustExec("set @a=2;")
+	err = tk.ExecToErr("execute s1 using @a;")
+	c.Assert(err.Error(), Equals, "Unknown column '2' in 'group statement'")
+	tk.MustExec("set @a=2.0;")
+	tk.MustQuery("execute s1 using @a;").Check(testkit.Rows("3"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When there is paramemter markers in group by, it should be only treated as position expression when it is in top level and it is a constant uint.

### What is changed and how it works?

Change the resolve rule for group by expressions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix wrong resolve rule for `GroupBy` expressions in prepare statemet.
