### PR TITLE
log: move autocommit varable value into connection info

### DIFF
--- a/executor/set.go
+++ b/executor/set.go
@@ -190,6 +190,10 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 		}
 		if name != variable.AutoCommit {
 			logutil.BgLogger().Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+		} else {
+			// Some applications will set `autocommit` variable before query.
+			// This will print too many unnecessary log info.
+			logutil.BgLogger().Debug("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
 		}
 	}
 

--- a/executor/set.go
+++ b/executor/set.go
@@ -188,7 +188,9 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 			valStr, err = value.ToString()
 			terror.Log(err)
 		}
-		logutil.BgLogger().Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+		if name != variable.AutoCommit {
+			logutil.BgLogger().Info("set session var", zap.Uint64("conn", sessionVars.ConnectionID), zap.String("name", name), zap.String("val", valStr))
+		}
 	}
 
 	if name == variable.TiDBEnableStmtSummary {

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514 // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514 // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/server/conn.go
+++ b/server/conn.go
@@ -160,7 +160,7 @@ type clientConn struct {
 
 func (cc *clientConn) String() string {
 	collationStr := mysql.Collations[cc.collation]
-	return fmt.Sprintf("id:%d, addr:%s status:%d, collation:%s, user:%s",
+	return fmt.Sprintf("id:%d, addr:%s status:%b, collation:%s, user:%s",
 		cc.connectionID, cc.bufReadConn.RemoteAddr(), cc.ctx.Status(), collationStr, cc.user,
 	)
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -160,8 +160,12 @@ type clientConn struct {
 
 func (cc *clientConn) String() string {
 	collationStr := mysql.Collations[cc.collation]
-	return fmt.Sprintf("id:%d, addr:%s status:%d, collation:%s, user:%s",
-		cc.connectionID, cc.bufReadConn.RemoteAddr(), cc.ctx.Status(), collationStr, cc.user,
+	autoCommit := 0
+	if cc.ctx.GetSessionVars().IsAutocommit() {
+		autoCommit = 1
+	}
+	return fmt.Sprintf("id:%d, addr:%s status:%d, collation:%s, user:%s autocommit:%d",
+		cc.connectionID, cc.bufReadConn.RemoteAddr(), cc.ctx.Status(), collationStr, cc.user, autoCommit,
 	)
 }
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -541,10 +541,10 @@ func (cc *clientConn) readOptionalSSLRequestAndHandshakeResponse(ctx context.Con
 func (cc *clientConn) SessionStatusToString() string {
 	status := cc.ctx.Status()
 	inTxn, autoCommit := 0, 0
-	if status & mysql.ServerStatusInTrans > 0 {
+	if status&mysql.ServerStatusInTrans > 0 {
 		inTxn = 1
 	}
-	if status & mysql.ServerStatusAutocommit > 0 {
+	if status&mysql.ServerStatusAutocommit > 0 {
 		autoCommit = 1
 	}
 	return fmt.Sprintf("inTxn:%d, autocommit:%d",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some applications will set `autocommit` variable every time when they execute queries. This action will make tidb log full of `set session var`. 

### What is changed and how it works?

I remove this log info for `autocommit` variable and add `autocommit` value when print connection information into log.
just like: `["command dispatched failed"] [conn=2] [connInfo="id:2, addr:127.0.0.1:52703 status:0, collation:utf8_general_ci, user:root autocommit:0"]`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - no

Side effects

 - no

Related changes

 - Need to cherry-pick to the release branch

Release note

