### PR TITLE
executor: fix unordered trace events in row format

### DIFF
--- a/executor/trace.go
+++ b/executor/trace.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/opentracing/basictracer-go"
@@ -198,6 +199,18 @@ func dfsTree(t *appdash.Trace, prefix string, isLast bool, chk *chunk.Chunk) {
 	chk.AppendString(0, prefix+suffix+t.Span.Name())
 	chk.AppendString(1, start.Format("15:04:05.000000"))
 	chk.AppendString(2, duration.String())
+
+	// Sort events by their start time
+	sort.Slice(t.Sub, func(i, j int) bool {
+		var istart, jstart time.Time
+		if ievent, err := t.Sub[i].TimespanEvent(); err == nil {
+			istart = ievent.Start()
+		}
+		if jevent, err := t.Sub[j].TimespanEvent(); err == nil {
+			jstart = jevent.Start()
+		}
+		return istart.Before(jstart)
+	})
 
 	for i, sp := range t.Sub {
 		dfsTree(sp, newPrefix, i == (len(t.Sub))-1 /*last element of array*/, chk)

--- a/executor/trace_test.go
+++ b/executor/trace_test.go
@@ -40,11 +40,28 @@ func (s *testSuite1) TestTraceExec(c *C) {
 	// +---------------------------+-----------------+------------+
 	rows = tk.MustQuery("trace format='row' select * from trace where id = 0;").Rows()
 	c.Assert(len(rows) > 1, IsTrue)
+	c.Assert(rowsOrdered(rows), IsTrue)
 
 	rows = tk.MustQuery("trace format='row' delete from trace where id = 0").Rows()
 	c.Assert(len(rows) > 1, IsTrue)
+	c.Assert(rowsOrdered(rows), IsTrue)
 
 	tk.MustExec("trace format='log' insert into trace (c1, c2, c3) values (1, 2, 3)")
 	rows = tk.MustQuery("trace format='log' select * from trace where id = 0;").Rows()
 	c.Assert(len(rows), GreaterEqual, 1)
+}
+
+func rowsOrdered(rows [][]interface{}) bool {
+	for idx := range rows {
+		if _, ok := rows[idx][1].(string); !ok {
+			return false
+		}
+		if idx == 0 {
+			continue
+		}
+		if rows[idx-1][1].(string) > rows[idx][1].(string) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
The trace statement can print out a trace tree, however, in row
format, the tree is unordered, where earlier events may be placed
behind.

Signed-off-by: lucklove <gnu.crazier@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The trace statement may result unordered events tree, for example:
```
 MySQL  localhost:4000  SQL > trace format='row' select * from mysql.user limit 1;
+------------------------------------------+-----------------+-----------+
| operation                                | startTS         | duration  |
+------------------------------------------+-----------------+-----------+
| trace                                    | 16:22:29.456361 | 763.741µs |
|   ├─*executor.LimitExec.Next             | 16:22:29.456875 | 226.354µs |
|   │ └─*executor.TableReaderExecutor.Next | 16:22:29.456877 | 209.508µs |
|   ├─*executor.LimitExec.Next             | 16:22:29.457109 | 904ns     |
|   └─session.Execute                      | 16:22:29.456371 | 487.914µs |
|     ├─executor.Compile                   | 16:22:29.456448 | 265.957µs |
|     │ └─session.getTxnFuture             | 16:22:29.456455 | 1.173µs   |
|     ├─session.runStmt                    | 16:22:29.456725 | 101.817µs |
|     │ ├─TableReaderExecutor.Open         | 16:22:29.456750 | 37.667µs  |
|     │ │ └─distsql.Select                 | 16:22:29.456765 | 15.333µs  |
|     │ └─session.CommitTxn                | 16:22:29.456813 | 10.098µs  |
|     │   └─session.doCommitWitRetry       | 16:22:29.456815 | 1.873µs   |
|     └─session.ParseSQL                   | 16:22:29.456377 | 12.654µs  |
+------------------------------------------+-----------------+-----------+
```
`session.ParseSQL` is behind `session.Compile`, it's not correct.

### What is changed and how it works?
Sort sub events before appending them into chunk.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Manual test
```
trace select * from mysql.user limit 1;
```

Code changes

Side effects

Related changes
 - Need to cherry-pick to the release branch

Release note
 - fix unordered trace events in row format.
