### PR TITLE
metric, tikv: record duration for each backoff type (#11710)

### DIFF
--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -58,14 +58,14 @@ var (
 			Help:      "Counter of backoff.",
 		}, []string{LblType})
 
-	TiKVBackoffHistogram = prometheus.NewHistogram(
+	TiKVBackoffHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",
 			Subsystem: "tikvclient",
 			Name:      "backoff_seconds",
 			Help:      "total backoff seconds of a single backoffer.",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 20), // 0.5ms ~ 524s
-		})
+		}, []string{LblType})
 
 	TiKVSendReqHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -43,6 +43,45 @@ const (
 	DecorrJitter
 )
 
+var (
+	tikvBackoffCounterRPC            = metrics.TiKVBackoffCounter.WithLabelValues("tikvRPC")
+	tikvBackoffCounterLock           = metrics.TiKVBackoffCounter.WithLabelValues("txnLock")
+	tikvBackoffCounterLockFast       = metrics.TiKVBackoffCounter.WithLabelValues("tikvLockFast")
+	tikvBackoffCounterPD             = metrics.TiKVBackoffCounter.WithLabelValues("pdRPC")
+	tikvBackoffCounterRegionMiss     = metrics.TiKVBackoffCounter.WithLabelValues("regionMiss")
+	tikvBackoffCounterUpdateLeader   = metrics.TiKVBackoffCounter.WithLabelValues("updateLeader")
+	tikvBackoffCounterServerBusy     = metrics.TiKVBackoffCounter.WithLabelValues("serverBusy")
+	tikvBackoffCounterEmpty          = metrics.TiKVBackoffCounter.WithLabelValues("")
+	tikvBackoffHistogramRPC          = metrics.TiKVBackoffHistogram.WithLabelValues("tikvRPC")
+	tikvBackoffHistogramLock         = metrics.TiKVBackoffHistogram.WithLabelValues("txnLock")
+	tikvBackoffHistogramLockFast     = metrics.TiKVBackoffHistogram.WithLabelValues("tikvLockFast")
+	tikvBackoffHistogramPD           = metrics.TiKVBackoffHistogram.WithLabelValues("pdRPC")
+	tikvBackoffHistogramRegionMiss   = metrics.TiKVBackoffHistogram.WithLabelValues("regionMiss")
+	tikvBackoffHistogramUpdateLeader = metrics.TiKVBackoffHistogram.WithLabelValues("updateLeader")
+	tikvBackoffHistogramServerBusy   = metrics.TiKVBackoffHistogram.WithLabelValues("serverBusy")
+	tikvBackoffHistogramEmpty        = metrics.TiKVBackoffHistogram.WithLabelValues("")
+)
+
+func (t backoffType) metric() (prometheus.Counter, prometheus.Observer) {
+	switch t {
+	case boTiKVRPC:
+		return tikvBackoffCounterRPC, tikvBackoffHistogramRPC
+	case BoTxnLock:
+		return tikvBackoffCounterLock, tikvBackoffHistogramLock
+	case boTxnLockFast:
+		return tikvBackoffCounterLockFast, tikvBackoffHistogramLockFast
+	case BoPDRPC:
+		return tikvBackoffCounterPD, tikvBackoffHistogramPD
+	case BoRegionMiss:
+		return tikvBackoffCounterRegionMiss, tikvBackoffHistogramRegionMiss
+	case BoUpdateLeader:
+		return tikvBackoffCounterUpdateLeader, tikvBackoffHistogramUpdateLeader
+	case boServerBusy:
+		return tikvBackoffCounterServerBusy, tikvBackoffHistogramServerBusy
+	}
+	return tikvBackoffCounterEmpty, tikvBackoffHistogramEmpty
+}
+
 // NewBackoffFn creates a backoff func which implements exponential backoff with
 // optional jitters.
 // See http://www.awsarchitectureblog.com/2015/03/backoff.html
@@ -221,7 +260,8 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 	default:
 	}
 
-	metrics.TiKVBackoffCounter.WithLabelValues(typ.String()).Inc()
+	backoffCounter, backoffDuration := typ.metric()
+	backoffCounter.Inc()
 	// Lazy initialize.
 	if b.fn == nil {
 		b.fn = make(map[backoffType]func(context.Context) int)
@@ -232,7 +272,9 @@ func (b *Backoffer) Backoff(typ backoffType, err error) error {
 		b.fn[typ] = f
 	}
 
-	b.totalSleep += f(b.ctx)
+	realSleep := f(b.ctx)
+	backoffDuration.Observe(float64(realSleep) / 1000)
+	b.totalSleep += realSleep
 	b.types = append(b.types, typ)
 
 	var startTs interface{} = ""

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/net/context"
@@ -62,7 +63,7 @@ var (
 	tikvBackoffHistogramEmpty        = metrics.TiKVBackoffHistogram.WithLabelValues("")
 )
 
-func (t backoffType) metric() (prometheus.Counter, prometheus.Observer) {
+func (t backoffType) metric() (prometheus.Counter, prometheus.Histogram) {
 	switch t {
 	case boTiKVRPC:
 		return tikvBackoffCounterRPC, tikvBackoffHistogramRPC
@@ -70,7 +71,7 @@ func (t backoffType) metric() (prometheus.Counter, prometheus.Observer) {
 		return tikvBackoffCounterLock, tikvBackoffHistogramLock
 	case boTxnLockFast:
 		return tikvBackoffCounterLockFast, tikvBackoffHistogramLockFast
-	case BoPDRPC:
+	case boPDRPC:
 		return tikvBackoffCounterPD, tikvBackoffHistogramPD
 	case BoRegionMiss:
 		return tikvBackoffCounterRegionMiss, tikvBackoffHistogramRegionMiss

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -470,9 +470,6 @@ func (worker *copIteratorWorker) run(ctx context.Context) {
 
 		bo := NewBackoffer(ctx, copNextMaxBackoff).WithVars(worker.vars)
 		worker.handleTask(bo, task, respCh)
-		if bo.totalSleep > 0 {
-			metrics.TiKVBackoffHistogram.Observe(float64(bo.totalSleep) / 1000)
-		}
 		close(task.respChan)
 		select {
 		case <-worker.finishCh:


### PR DESCRIPTION
cherry-pick #11710 to 2.1


backoff.go have conflict

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/12326)
<!-- Reviewable:end -->
