### PR TITLE
executor: record prepared stmt in `handle_query_duration` (#11753)

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -250,7 +250,9 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		maxExecutionTime := getMaxExecutionTime(sctx, a.StmtNode)
 		// Update processinfo, ShowProcess() will use it.
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
-		a.Ctx.GetSessionVars().StmtCtx.StmtType = GetStmtLabel(a.StmtNode)
+		if a.Ctx.GetSessionVars().StmtCtx.StmtType == "" {
+			a.Ctx.GetSessionVars().StmtCtx.StmtType = GetStmtLabel(a.StmtNode)
+		}
 	}
 
 	// If the executor doesn't return any result to the client, we execute it without delay.

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -157,6 +157,7 @@ func (e *PrepareExec) Next(ctx context.Context, chk *chunk.Chunk) error {
 	}
 	prepared := &ast.Prepared{
 		Stmt:          stmt,
+		StmtType:      GetStmtLabel(stmt),
 		Params:        sorter.markers,
 		SchemaVersion: e.is.SchemaMetaVersion(),
 	}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -165,6 +165,7 @@ type Execute struct {
 	UsingVars []expression.Expression
 	ExecID    uint32
 	Stmt      ast.StmtNode
+	StmtType  string
 	Plan      Plan
 }
 
@@ -177,6 +178,7 @@ func (e *Execute) optimizePreparedPlan(ctx sessionctx.Context, is infoschema.Inf
 	if !ok {
 		return errors.Trace(ErrStmtNotFound)
 	}
+	vars.StmtCtx.StmtType = prepared.StmtType
 
 	if len(prepared.Params) != len(e.UsingVars) {
 		return errors.Trace(ErrWrongParamCount)


### PR DESCRIPTION
cherry-pick #11753 to 2.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/12329)
<!-- Reviewable:end -->
