### PR TITLE
expression: implement vectorized evaluation for builtinLogicAndSig

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -1,0 +1,62 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinLogicAndSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	i64s := result.Int64s()
+	arg1s := buf.Int64s()
+
+	for i := 0; i < n; i++ {
+		isNull0 := result.IsNull(i)
+		isNull1 := buf.IsNull(i)
+		// Because buf is used to store the conversion of args[0] in place,
+		// it could be that args[0] is null, yet args[1] is 0, in which case
+		// the result is 0. In this case we need to reset the null bit mask
+		// of the corresponding row in result.
+		// See https://dev.mysql.com/doc/refman/5.7/en/logical-operators.html#operator_and
+		isNull := false
+		if (!isNull0 && i64s[i] == 0) || (!isNull1 && arg1s[i] == 0) {
+			i64s[i] = 0
+		} else if isNull0 || isNull1 {
+			isNull = true
+		} else {
+			i64s[i] = 1
+		}
+		result.SetNull(i, isNull)
+	}
+	return nil
+}
+
+func (b *builtinLogicAndSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -1,0 +1,102 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/types"
+)
+
+// givenValsGener returns the items sequentially from the slice given at
+// the construction time. If this slice is exhausted, it falls back to
+// the fallback generator.
+type givenValsGener struct {
+	given    []interface{}
+	idx      int
+	fallback dataGenerator
+}
+
+func (g *givenValsGener) gen() interface{} {
+	if g.idx >= len(g.given) {
+		return g.fallback.gen()
+	}
+	v := g.given[g.idx]
+	g.idx++
+	return v
+}
+
+func makeGivenValsOrDefaultGener(vals []interface{}, eType types.EvalType) *givenValsGener {
+	g := &givenValsGener{}
+	g.given = vals
+	g.fallback = &defaultGener{0.2, eType}
+	return g
+}
+
+func makeLogicAndDataGens() []dataGenerator {
+	pairs := [][]interface{}{
+		{nil, nil},
+		{0, nil},
+		{nil, 0},
+		{1, nil},
+		{nil, 1},
+		{0, 0},
+		{0, 1},
+		{1, 0},
+		{1, 1},
+		{-1, 1},
+	}
+
+	maybeToInt64 := func(v interface{}) interface{} {
+		if v == nil {
+			return nil
+		}
+		return int64(v.(int))
+	}
+
+	n := len(pairs)
+	vals0 := make([]interface{}, n)
+	vals1 := make([]interface{}, n)
+	for i, p := range pairs {
+		vals0[i] = maybeToInt64(p[0])
+		vals1[i] = maybeToInt64(p[1])
+	}
+	return []dataGenerator{
+		makeGivenValsOrDefaultGener(vals0, types.ETInt),
+		makeGivenValsOrDefaultGener(vals1, types.ETInt)}
+}
+
+var vecBuiltinOpCases = map[string][]vecExprBenchCase{
+	ast.LogicAnd: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeLogicAndDataGens()},
+	},
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinOpEvalOneVec(c *C) {
+	testVectorizedEvalOneVec(c, vecBuiltinOpCases)
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinOpCases)
+}
+
+func BenchmarkVectorizedBuiltinOpEvalOneVec(b *testing.B) {
+	benchmarkVectorizedEvalOneVec(b, vecBuiltinOpCases)
+}
+
+func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOpCases)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implement vectorized evaluation for `builtinLogicAndSig` for #12103.

### What is changed and how it works?

According to benchmark, about 4 times faster than before:

```
BenchmarkVectorizedBuiltinOpFunc/builtinLogicAndSig-VecBuiltinFunc-4         	  200000	      9100 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinLogicAndSig-NonVecBuiltinFunc-4      	   30000	     38651 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test