### PR TITLE
planner/cascades: support parameterized transformation/implementation rules

### DIFF
--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -29,14 +29,14 @@ type ImplementationRule interface {
 	OnImplement(expr *memo.GroupExpr, reqProp *property.PhysicalProperty) (memo.Implementation, error)
 }
 
-// GetImplementationRules gets all the candidate implementation rules for the
-// logical plan node.
-func GetImplementationRules(node plannercore.LogicalPlan) []ImplementationRule {
+// GetImplementationRules gets all the candidate implementation rules of the optimizer
+// for the logical plan node.
+func (opt *Optimizer) GetImplementationRules(node plannercore.LogicalPlan) []ImplementationRule {
 	operand := memo.GetOperand(node)
-	return implementationMap[operand]
+	return opt.implementationRuleMap[operand]
 }
 
-var implementationMap = map[memo.Operand][]ImplementationRule{
+var defaultImplementationMap = map[memo.Operand][]ImplementationRule{
 	memo.OperandTableDual: {
 		&ImplTableDual{},
 	},

--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -29,13 +29,6 @@ type ImplementationRule interface {
 	OnImplement(expr *memo.GroupExpr, reqProp *property.PhysicalProperty) (memo.Implementation, error)
 }
 
-// GetImplementationRules gets all the candidate implementation rules of the optimizer
-// for the logical plan node.
-func (opt *Optimizer) GetImplementationRules(node plannercore.LogicalPlan) []ImplementationRule {
-	operand := memo.GetOperand(node)
-	return opt.implementationRuleMap[operand]
-}
-
 var defaultImplementationMap = map[memo.Operand][]ImplementationRule{
 	memo.OperandTableDual: {
 		&ImplTableDual{},

--- a/planner/cascades/optimize.go
+++ b/planner/cascades/optimize.go
@@ -23,6 +23,10 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 )
 
+// DefaultOptimizer is the optimizer which contains all of the default
+// transformation and implementation rules.
+var DefaultOptimizer = NewOptimizer()
+
 // Optimizer is the struct for cascades optimizer.
 type Optimizer struct {
 	transformationRuleMap map[memo.Operand][]Transformation

--- a/planner/cascades/optimize.go
+++ b/planner/cascades/optimize.go
@@ -29,22 +29,38 @@ type Optimizer struct {
 	implementationRuleMap map[memo.Operand][]ImplementationRule
 }
 
-// NewDefaultOptimizer returns a cascades optimizer with default transformation
+// NewOptimizer returns a cascades optimizer with default transformation
 // rules and implementation rules.
-func NewDefaultOptimizer() *Optimizer {
+func NewOptimizer() *Optimizer {
 	return &Optimizer{
 		transformationRuleMap: defaultTransformationMap,
 		implementationRuleMap: defaultImplementationMap,
 	}
 }
 
-// NewOptimizerWithTrans returns a cascades optimizer which uses user defined
-// transformation rule map. This will be frequently used in unit tests.
-func NewOptimizerWithTrans(trans map[memo.Operand][]Transformation) *Optimizer {
-	return &Optimizer{
-		transformationRuleMap: trans,
-		implementationRuleMap: defaultImplementationMap,
-	}
+// ResetTransformationRules resets the transformationRuleMap of the optimizer, and returns the optimizer.
+func (opt *Optimizer) ResetTransformationRules(rules map[memo.Operand][]Transformation) *Optimizer {
+	opt.transformationRuleMap = rules
+	return opt
+}
+
+// ResetImplementationRules resets the implementationRuleMap of the optimizer, and returns the optimizer.
+func (opt *Optimizer) ResetImplementationRules(rules map[memo.Operand][]ImplementationRule) *Optimizer {
+	opt.implementationRuleMap = rules
+	return opt
+}
+
+// GetTransformationRules gets the all the candidate transformation rules of the optimizer
+// based on the logical plan node.
+func (opt *Optimizer) GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
+	return opt.transformationRuleMap[memo.GetOperand(node)]
+}
+
+// GetImplementationRules gets all the candidate implementation rules of the optimizer
+// for the logical plan node.
+func (opt *Optimizer) GetImplementationRules(node plannercore.LogicalPlan) []ImplementationRule {
+	operand := memo.GetOperand(node)
+	return opt.implementationRuleMap[operand]
 }
 
 // FindBestPlan is the optimization entrance of the cascades planner. The

--- a/planner/cascades/optimize.go
+++ b/planner/cascades/optimize.go
@@ -59,8 +59,7 @@ func (opt *Optimizer) GetTransformationRules(node plannercore.LogicalPlan) []Tra
 // GetImplementationRules gets all the candidate implementation rules of the optimizer
 // for the logical plan node.
 func (opt *Optimizer) GetImplementationRules(node plannercore.LogicalPlan) []ImplementationRule {
-	operand := memo.GetOperand(node)
-	return opt.implementationRuleMap[operand]
+	return opt.implementationRuleMap[memo.GetOperand(node)]
 }
 
 // FindBestPlan is the optimization entrance of the cascades planner. The

--- a/planner/cascades/optimize_test.go
+++ b/planner/cascades/optimize_test.go
@@ -47,7 +47,7 @@ func (s *testCascadesSuite) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
 	s.sctx = plannercore.MockContext()
 	s.Parser = parser.New()
-	s.optimizer = NewDefaultOptimizer()
+	s.optimizer = NewOptimizer()
 }
 
 func (s *testCascadesSuite) TearDownSuite(c *C) {

--- a/planner/cascades/optimize_test.go
+++ b/planner/cascades/optimize_test.go
@@ -37,8 +37,9 @@ var _ = Suite(&testCascadesSuite{})
 
 type testCascadesSuite struct {
 	*parser.Parser
-	is   infoschema.InfoSchema
-	sctx sessionctx.Context
+	is        infoschema.InfoSchema
+	sctx      sessionctx.Context
+	optimizer *Optimizer
 }
 
 func (s *testCascadesSuite) SetUpSuite(c *C) {
@@ -46,6 +47,7 @@ func (s *testCascadesSuite) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
 	s.sctx = plannercore.MockContext()
 	s.Parser = parser.New()
+	s.optimizer = NewDefaultOptimizer()
 }
 
 func (s *testCascadesSuite) TearDownSuite(c *C) {
@@ -63,7 +65,7 @@ func (s *testCascadesSuite) TestImplGroupZeroCost(c *C) {
 	prop := &property.PhysicalProperty{
 		ExpectedCnt: math.MaxFloat64,
 	}
-	impl, err := implGroup(rootGroup, prop, 0.0)
+	impl, err := s.optimizer.implGroup(rootGroup, prop, 0.0)
 	c.Assert(impl, IsNil)
 	c.Assert(err, IsNil)
 }
@@ -90,7 +92,7 @@ func (s *testCascadesSuite) TestFillGroupStats(c *C) {
 	logic, ok := p.(plannercore.LogicalPlan)
 	c.Assert(ok, IsTrue)
 	rootGroup := convert2Group(logic)
-	err = fillGroupStats(rootGroup)
+	err = s.optimizer.fillGroupStats(rootGroup)
 	c.Assert(err, IsNil)
 	c.Assert(rootGroup.Prop.Stats, NotNil)
 }

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -40,12 +40,6 @@ type Transformation interface {
 	OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error)
 }
 
-// GetTransformationRules gets the all the candidate transformation rules of the optimizer
-// based on the logical plan node.
-func (opt *Optimizer) GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
-	return opt.transformationRuleMap[memo.GetOperand(node)]
-}
-
 var defaultTransformationMap = map[memo.Operand][]Transformation{
 	memo.OperandSelection: {
 		&PushSelDownTableScan{},

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -40,13 +40,13 @@ type Transformation interface {
 	OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error)
 }
 
-// GetTransformationRules gets the all the candidate transformation rules based
-// on the logical plan node.
-func GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
-	return transformationMap[memo.GetOperand(node)]
+// GetTransformationRules gets the all the candidate transformation rules of the optimizer
+// based on the logical plan node.
+func (opt *Optimizer) GetTransformationRules(node plannercore.LogicalPlan) []Transformation {
+	return opt.transformationRuleMap[memo.GetOperand(node)]
 }
 
-var transformationMap = map[memo.Operand][]Transformation{
+var defaultTransformationMap = map[memo.Operand][]Transformation{
 	memo.OperandSelection: {
 		&PushSelDownTableScan{},
 		&PushSelDownTableGather{},

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -105,7 +105,7 @@ func optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 
 	// Handle the logical plan statement, use cascades planner if enabled.
 	if sctx.GetSessionVars().EnableCascadesPlanner {
-		return cascades.FindBestPlan(sctx, logic)
+		return cascades.NewDefaultOptimizer().FindBestPlan(sctx, logic)
 	}
 	return plannercore.DoOptimize(ctx, builder.GetOptFlag(), logic)
 }

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -105,7 +105,7 @@ func optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 
 	// Handle the logical plan statement, use cascades planner if enabled.
 	if sctx.GetSessionVars().EnableCascadesPlanner {
-		return cascades.NewDefaultOptimizer().FindBestPlan(sctx, logic)
+		return cascades.NewOptimizer().FindBestPlan(sctx, logic)
 	}
 	return plannercore.DoOptimize(ctx, builder.GetOptFlag(), logic)
 }

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -105,7 +105,7 @@ func optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 
 	// Handle the logical plan statement, use cascades planner if enabled.
 	if sctx.GetSessionVars().EnableCascadesPlanner {
-		return cascades.NewOptimizer().FindBestPlan(sctx, logic)
+		return cascades.DefaultOptimizer.FindBestPlan(sctx, logic)
 	}
 	return plannercore.DoOptimize(ctx, builder.GetOptFlag(), logic)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before this PR, cascades optimizer uses all of the transformation/implementation rules. This is not friendly to unit tests. Since we usually only want to check the specific transformation rule, and we don't want the unit tests affected by the new added rules, we must be able to choose the transformation rule map for a specific unit test.

Furthermore, if we want to support multi-level optimization, we also have to choose different transformation rule map for different optmization level.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

No tests. But will change the unit tests after other PRs of cascades merged.

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

