### PR TITLE
planner, executor: push limit down into IndexLookUpReader executor (#12262)

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -122,15 +122,14 @@ MemTableScan_4	10000.00	root
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	count	task	operator info
 Projection_12	10000.00	root	eq(test.t1.c2, test.t2.c2)
-└─Apply_14	10000.00	root	CARTESIAN left outer join, inner:Limit_21
+└─Apply_14	10000.00	root	CARTESIAN left outer join, inner:Projection_41
   ├─IndexReader_16	10000.00	root	index:IndexScan_15
   │ └─IndexScan_15	10000.00	cop	table:t1, index:c2, range:[NULL,+inf], keep order:false, stats:pseudo
-  └─Limit_21	1.00	root	offset:0, count:1
-    └─Projection_41	1.00	root	test.t2.c1, test.t2.c2
-      └─IndexLookUp_40	1.00	root	
-        ├─Limit_39	1.00	cop	offset:0, count:1
-        │ └─IndexScan_37	1.00	cop	table:t2, index:c1, range: decided by [eq(test.t1.c1, test.t2.c1)], keep order:true, stats:pseudo
-        └─TableScan_38	1.00	cop	table:t2, keep order:false, stats:pseudo
+  └─Projection_41	1.00	root	test.t2.c1, test.t2.c2
+    └─IndexLookUp_40	1.00	root	limit embedded(offset:0, count:1)
+      ├─Limit_39	1.00	cop	offset:0, count:1
+      │ └─IndexScan_37	1.00	cop	table:t2, index:c1, range: decided by [eq(test.t1.c1, test.t2.c1)], keep order:true, stats:pseudo
+      └─TableScan_38	1.00	cop	table:t2, keep order:false, stats:pseudo
 explain select * from t1 order by c1 desc limit 1;
 id	count	task	operator info
 Limit_10	1.00	root	offset:0, count:1

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -108,15 +108,14 @@ MemTableScan_4	10000.00	root
 explain select c2 = (select c2 from t2 where t1.c1 = t2.c1 order by c1 limit 1) from t1;
 id	count	task	operator info
 Projection_12	1999.00	root	eq(test.t1.c2, test.t2.c2)
-└─Apply_14	1999.00	root	CARTESIAN left outer join, inner:Limit_21
+└─Apply_14	1999.00	root	CARTESIAN left outer join, inner:Projection_41
   ├─IndexReader_16	1999.00	root	index:IndexScan_15
   │ └─IndexScan_15	1999.00	cop	table:t1, index:c2, range:[NULL,+inf], keep order:false
-  └─Limit_21	1.00	root	offset:0, count:1
-    └─Projection_41	1.00	root	test.t2.c1, test.t2.c2
-      └─IndexLookUp_40	1.00	root	
-        ├─Limit_39	1.00	cop	offset:0, count:1
-        │ └─IndexScan_37	1.25	cop	table:t2, index:c1, range: decided by [eq(test.t1.c1, test.t2.c1)], keep order:true
-        └─TableScan_38	1.00	cop	table:t2, keep order:false, stats:pseudo
+  └─Projection_41	1.00	root	test.t2.c1, test.t2.c2
+    └─IndexLookUp_40	1.00	root	limit embedded(offset:0, count:1)
+      ├─Limit_39	1.00	cop	offset:0, count:1
+      │ └─IndexScan_37	1.25	cop	table:t2, index:c1, range: decided by [eq(test.t1.c1, test.t2.c1)], keep order:true
+      └─TableScan_38	1.00	cop	table:t2, keep order:false, stats:pseudo
 explain select * from t1 order by c1 desc limit 1;
 id	count	task	operator info
 Limit_10	1.00	root	offset:0, count:1
@@ -169,18 +168,16 @@ id	count	task	operator info
 TableDual_5	0.00	root	rows:0
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 1;
 id	count	task	operator info
-Limit_9	1.00	root	offset:1, count:1
-└─IndexLookUp_14	1.00	root	
-  ├─Limit_13	1.00	cop	offset:0, count:2
-  │ └─IndexScan_11	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
-  └─TableScan_12	1.00	cop	table:index_prune, keep order:false, stats:pseudo
+IndexLookUp_14	1.00	root	limit embedded(offset:1, count:1)
+├─Limit_13	1.00	cop	offset:0, count:2
+│ └─IndexScan_11	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
+└─TableScan_12	1.00	cop	table:index_prune, keep order:false, stats:pseudo
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 1, 0;
 id	count	task	operator info
-Limit_9	0.00	root	offset:1, count:0
-└─IndexLookUp_14	0.00	root	
-  ├─Limit_13	0.00	cop	offset:0, count:1
-  │ └─IndexScan_11	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
-  └─TableScan_12	0.00	cop	table:index_prune, keep order:false, stats:pseudo
+IndexLookUp_14	0.00	root	limit embedded(offset:1, count:0)
+├─Limit_13	0.00	cop	offset:0, count:1
+│ └─IndexScan_11	1.00	cop	table:index_prune, index:a, b, range:[1010010404050976781 26467085526790,1010010404050976781 26467085526790], keep order:false
+└─TableScan_12	0.00	cop	table:index_prune, keep order:false, stats:pseudo
 explain select * from index_prune WHERE a = 1010010404050976781 AND b = 26467085526790 LIMIT 0, 1;
 id	count	task	operator info
 Point_Get_1	1.00	root	table:index_prune, index:a b

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1998,6 +1998,7 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 		colLens:           is.IdxColLens,
 		idxPlans:          v.IndexPlans,
 		tblPlans:          v.TablePlans,
+		PushedLimit:       v.PushedLimit,
 	}
 
 	if containsLimit(indexReq.Executors) {

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -141,6 +141,9 @@ func (p *PhysicalIndexReader) ExplainInfo() string {
 // ExplainInfo implements PhysicalPlan interface.
 func (p *PhysicalIndexLookUpReader) ExplainInfo() string {
 	// The children can be inferred by the relation symbol.
+	if p.PushedLimit != nil {
+		return fmt.Sprintf("limit embedded(offset:%v, count:%v)", p.PushedLimit.Offset, p.PushedLimit.Count)
+	}
 	return ""
 }
 

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -106,7 +106,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 		// Test TopN to Limit in double read.
 		{
 			sql:  "select * from t where t.c = 1 and t.e = 1 order by t.d limit 1",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)])->Limit, Table(t))->Limit",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)])->Limit, Table(t))",
 		},
 		// Test TopN to Limit in index single read.
 		{
@@ -151,7 +151,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 		// Test Limit push down in double single read.
 		{
 			sql:  "select c, b from t where c = 1 limit 1",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Limit, Table(t))->Limit->Projection",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Limit, Table(t))->Projection",
 		},
 		// Test Selection + Limit push down in double single read.
 		{
@@ -182,7 +182,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderSimpleCase(c *C) {
 		// Test PK in index double read.
 		{
 			sql:  "select * from t where t.c = 1 and t.a > 1 order by t.d limit 1",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([gt(test.t.a, 1)])->Limit, Table(t))->Limit",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([gt(test.t.a, 1)])->Limit, Table(t))",
 		},
 		// Test index filter condition push down.
 		{
@@ -574,7 +574,7 @@ func (s *testPlanSuite) TestDAGPlanTopN(c *C) {
 		},
 		{
 			sql:  "select * from t where c = 1 order by c limit 1",
-			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Limit, Table(t))->Limit",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Limit, Table(t))",
 		},
 		{
 			sql:  "select * from t order by a limit 1",

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -72,6 +72,12 @@ type PhysicalIndexReader struct {
 	OutputColumns []*expression.Column
 }
 
+// PushedDownLimit is the limit operator pushed down into PhysicalIndexLookUpReader.
+type PushedDownLimit struct {
+	Offset uint64
+	Count  uint64
+}
+
 // PhysicalIndexLookUpReader is the index look up reader in tidb. It's used in case of double reading.
 type PhysicalIndexLookUpReader struct {
 	physicalSchemaProducer
@@ -82,6 +88,9 @@ type PhysicalIndexLookUpReader struct {
 	TablePlans []PhysicalPlan
 	indexPlan  PhysicalPlan
 	tablePlan  PhysicalPlan
+
+	// PushedLimit is used to avoid unnecessary table scan tasks of IndexLookUpReader.
+	PushedLimit *PushedDownLimit
 }
 
 // PhysicalIndexScan represents an index scan plan.

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -264,6 +264,7 @@ func (t *rootTask) plan() PhysicalPlan {
 
 func (p *PhysicalLimit) attach2Task(tasks ...task) task {
 	t := tasks[0].copy()
+	sunk := false
 	if cop, ok := t.(*copTask); ok {
 		// If the table/index scans data by order and applies a double read, the limit cannot be pushed to the table side.
 		if !cop.keepOrder || !cop.indexPlanFinished || cop.indexPlan == nil {
@@ -272,9 +273,42 @@ func (p *PhysicalLimit) attach2Task(tasks ...task) task {
 			cop = attachPlan2Task(pushedDownLimit, cop).(*copTask)
 		}
 		t = finishCopTask(p.ctx, cop)
+		sunk = p.sinkIntoIndexLookUp(t)
 	}
-	t = attachPlan2Task(p, t)
-	return t
+	if sunk {
+		return t
+	}
+	return attachPlan2Task(p, t)
+}
+
+func (p *PhysicalLimit) sinkIntoIndexLookUp(t task) bool {
+	root := t.(*rootTask)
+	reader, isDoubleRead := root.p.(*PhysicalIndexLookUpReader)
+	proj, isProj := root.p.(*PhysicalProjection)
+	if !isDoubleRead && !isProj {
+		return false
+	}
+	if isProj {
+		reader, isDoubleRead = proj.Children()[0].(*PhysicalIndexLookUpReader)
+		if !isDoubleRead {
+			return false
+		}
+	}
+	// We can sink Limit into IndexLookUpReader only if tablePlan contains no Selection.
+	ts, isTableScan := reader.tablePlan.(*PhysicalTableScan)
+	if !isTableScan {
+		return false
+	}
+	reader.PushedLimit = &PushedDownLimit{
+		Offset: p.Offset,
+		Count:  p.Count,
+	}
+	ts.stats = p.stats
+	reader.stats = p.stats
+	if isProj {
+		proj.stats = p.stats
+	}
+	return true
 }
 
 // GetCost computes the cost of in memory sort.


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/12262

Conflicts:
	cmd/explaintest/r/explain_easy.result
	cmd/explaintest/r/explain_easy_stats.result
	planner/core/integration_test.go
	planner/core/physical_plans.go
	planner/core/testdata/plan_suite_out.json
