### PR TITLE
build: fix make tidy when using symlink

### DIFF
--- a/tools/check/check-tidy.sh
+++ b/tools/check/check-tidy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# go mod tidy do not support symlink
+cd -P .
+
 GO111MODULE=on go mod tidy
 git diff --quiet


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

If current dir is a symlink of tidb, `go mod tidy` will fail and corrupt go.sum and go.mod.

### What is changed and how it works?

add `cd -P .` before `go mod tidy`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes


 - None

Side effects


 - None

Related changes

 - None


Release note


 - None
