### PR TITLE
planner: set windowClause only in WindowFuncExpr #(19956)

### DIFF
--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -430,3 +430,16 @@ Projection_7	10000.00	root	6_aux_0
   │ └─TableScan_9	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
   └─TableReader_12	10000.00	root	data:TableScan_11
     └─TableScan_11	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table t;
+CREATE TABLE t (id int(10) unsigned NOT NULL AUTO_INCREMENT,
+i int(10) unsigned DEFAULT NULL,
+x int(10) unsigned DEFAULT 0,
+PRIMARY KEY (`id`)
+);
+explain select row_number() over( partition by i ) - x as rnk from t;
+id	count	task	operator info
+Projection_8	10000.00	root	minus(4_window_3, test.t.x)
+└─Window_9	10000.00	root	row_number() over(partition by test.t.i)
+  └─Sort_12	10000.00	root	test.t.i:asc
+    └─TableReader_11	10000.00	root	data:TableScan_10
+      └─TableScan_10	10000.00	cop	table:t, range:[0,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -201,3 +201,12 @@ explain select a in (select a+b from t t2 where t2.b = t1.b) from t t1;
 drop table t;
 create table t(a int not null, b int);
 explain select a in (select a from t t2 where t2.b = t1.b) from t t1;
+
+# test fields with windows function
+drop table t;
+CREATE TABLE t (id int(10) unsigned NOT NULL AUTO_INCREMENT,
+    i int(10) unsigned DEFAULT NULL,
+    x int(10) unsigned DEFAULT 0,
+    PRIMARY KEY (`id`)
+);
+explain select row_number() over( partition by i ) - x as rnk from t;

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1272,7 +1272,7 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 		a.inWindowSpec = false
 	case *ast.ColumnNameExpr:
 		resolveFieldsFirst := true
-		if a.inAggFunc || a.inWindowFunc || a.inWindowSpec || (a.orderBy && a.inExpr) {
+		if a.inAggFunc || a.inWindowFunc || a.inWindowSpec || (a.orderBy && a.inExpr) || a.curClause == fieldList {
 			resolveFieldsFirst = false
 		}
 		if !a.inAggFunc && !a.orderBy {
@@ -1307,7 +1307,7 @@ func (a *havingWindowAndOrderbyExprResolver) Leave(n ast.Node) (node ast.Node, o
 			var err error
 			index, err = a.resolveFromSchema(v, a.p.Schema())
 			_ = err
-			if index == -1 && a.curClause != windowClause {
+			if index == -1 && a.curClause != fieldList {
 				index, a.err = resolveFromSelectFields(v, a.selectFields, false)
 				if index != -1 && a.curClause == havingClause && ast.HasWindowFlag(a.selectFields[index].Expr) {
 					a.err = ErrWindowInvalidWindowFuncAliasUse.GenWithStackByArgs(v.Name.Name.O)
@@ -1412,7 +1412,7 @@ func (b *PlanBuilder) resolveWindowFunction(sel *ast.SelectStmt, p LogicalPlan) 
 		colMapper:    b.colMapper,
 		outerSchemas: b.outerSchemas,
 	}
-	extractor.curClause = windowClause
+	extractor.curClause = fieldList
 	for _, field := range sel.Fields.Fields {
 		if !ast.HasWindowFlag(field.Expr) {
 			continue

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2486,6 +2486,11 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 			sql:    "SELECT NTH_VALUE(fieldA, -1) OVER (w1 PARTITION BY fieldB ORDER BY fieldB , fieldA ) AS 'ntile', fieldA, fieldB FROM ( SELECT a AS fieldA, b AS fieldB FROM t ) as temp WINDOW w1 AS ( ORDER BY fieldB ASC, fieldA DESC )",
 			result: "[planner:1210]Incorrect arguments to nth_value",
 		},
+		// Test issue 11943
+		{
+			sql:    "SELECT ROW_NUMBER() OVER (partition by b) + a FROM t",
+			result: "TableReader(Table(t))->Sort->Window(row_number() over(partition by test.t.b))->Projection->Projection",
+		},
 	}
 
 	s.Parser.EnableWindowFunc(true)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -157,7 +157,6 @@ const (
 	onClause
 	orderByClause
 	whereClause
-	windowClause
 	groupByClause
 	showStatement
 	globalOrderByClause
@@ -173,7 +172,6 @@ var clauseMsg = map[clauseCode]string{
 	groupByClause:       "group statement",
 	showStatement:       "show statement",
 	globalOrderByClause: "global ORDER clause",
-	windowClause:        "field list", // For window functions that in field list.
 }
 
 // PlanBuilder builds Plan from an ast.Node.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #11943 

### What is changed and how it works?
Presently, TiDB sets windowClause even if the expr is a binaryExpr. So
set windowClause only in WindowFuncExpr to fix it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Integration test


Code changes



Side effects



Related changes




Release note

 - Write release note for bug-fix or new feature.
