### PR TITLE
expression: generate `vecEval` methods for all functions to avoid further conflicts

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -12,3 +12,144 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinArithmeticMultiplyRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticDivideDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticModIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticModIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMinusRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMinusRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMinusDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMinusIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMinusIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticModRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticModRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticModDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticModDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticPlusRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticPlusRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMultiplyDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticIntDivideDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMultiplyIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticDivideRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticDivideRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticIntDivideIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticIntDivideIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticPlusIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticPlusIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticPlusDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinArithmeticMultiplyIntUnsignedSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinArithmeticMultiplyIntUnsignedSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -29,30 +29,21 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	},
 	ast.IntDiv: {
 	},
-	ast.Field: {
-	},
 	ast.Mod: {
 	},
 	ast.Or: {
 	},
 	ast.Mul: {
 	},
-	ast.Length: {
-	},
-	ast.Bin: {
-	},
-	ast.Sign: {
-	},
 	ast.Round: {
 	},
 	ast.And: {
 	},
-	ast.Truncate: {
-	},
 	ast.Plus: {
 	},
 	ast.NE: {
-	},}
+	},
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinArithmeticFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinArithmeticCases)

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -21,28 +21,17 @@ import (
 )
 
 var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
-	ast.LE: {
-	},
-	ast.Minus: {
-	},
-	ast.Div: {
-	},
-	ast.IntDiv: {
-	},
-	ast.Mod: {
-	},
-	ast.Or: {
-	},
-	ast.Mul: {
-	},
-	ast.Round: {
-	},
-	ast.And: {
-	},
-	ast.Plus: {
-	},
-	ast.NE: {
-	},
+	ast.LE:     {},
+	ast.Minus:  {},
+	ast.Div:    {},
+	ast.IntDiv: {},
+	ast.Mod:    {},
+	ast.Or:     {},
+	ast.Mul:    {},
+	ast.Round:  {},
+	ast.And:    {},
+	ast.Plus:   {},
+	ast.NE:     {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinArithmeticFunc(c *C) {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -17,10 +17,42 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
-}
+	ast.LE: {
+	},
+	ast.Minus: {
+	},
+	ast.Div: {
+	},
+	ast.IntDiv: {
+	},
+	ast.Field: {
+	},
+	ast.Mod: {
+	},
+	ast.Or: {
+	},
+	ast.Mul: {
+	},
+	ast.Length: {
+	},
+	ast.Bin: {
+	},
+	ast.Sign: {
+	},
+	ast.Round: {
+	},
+	ast.And: {
+	},
+	ast.Truncate: {
+	},
+	ast.Plus: {
+	},
+	ast.NE: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinArithmeticFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinArithmeticCases)

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -12,3 +12,20 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinArithmeticFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinArithmeticCases)
+}
+
+func BenchmarkVectorizedBuiltinArithmeticFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinArithmeticCases)
+}

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -142,4 +143,363 @@ func (b *builtinCastRealAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk
 
 func (b *builtinCastRealAsRealSig) vectorized() bool {
 	return true
+}
+func (b *builtinCastTimeAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastIntAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastIntAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastIntAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastIntAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastIntAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastIntAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastIntAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastIntAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastRealAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastRealAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastTimeAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastTimeAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastStringAsStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastStringAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastJSONAsDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastJSONAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDecimalAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDecimalAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCastDurationAsJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCastDurationAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -22,64 +22,7 @@ import (
 )
 
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
-	ast.Year: {
-	},
-	ast.Truncate: {
-	},
-	ast.Conv: {
-	},
-	ast.Format: {
-	},
-	ast.Trim: {
-	},
-	ast.LE: {
-	},
-	ast.Day: {
-	},
-	ast.DayName: {
-	},
-	ast.Time: {
-	},
-	ast.Sin: {
-	},
-	ast.Charset: {
-	},
-	ast.Field: {
-	},
-	ast.Lower: {
-	},
-	ast.Mod: {
-	},
-	ast.Convert: {
-	},
-	ast.Month: {
-	},
-	ast.Bin: {
-	},
-	ast.Length: {
-	},
-	ast.Sign: {
-	},
-	ast.Collation: {
-	},
-	ast.If: {
-	},
-	ast.Log: {
-	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
-	},
-	ast.GE: {
-	},
-	ast.Round: {
-	},
-	ast.Space: {
-	},
-	ast.Upper: {
-	},
-	ast.And: {
-	}, ast.Cast: {
+	ast.Cast: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{new(randDurInt)}},

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -22,7 +22,64 @@ import (
 )
 
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
-	ast.Cast: {
+	ast.Year: {
+	},
+	ast.Truncate: {
+	},
+	ast.Conv: {
+	},
+	ast.Format: {
+	},
+	ast.Trim: {
+	},
+	ast.LE: {
+	},
+	ast.Day: {
+	},
+	ast.DayName: {
+	},
+	ast.Time: {
+	},
+	ast.Sin: {
+	},
+	ast.Charset: {
+	},
+	ast.Field: {
+	},
+	ast.Lower: {
+	},
+	ast.Mod: {
+	},
+	ast.Convert: {
+	},
+	ast.Month: {
+	},
+	ast.Bin: {
+	},
+	ast.Length: {
+	},
+	ast.Sign: {
+	},
+	ast.Collation: {
+	},
+	ast.If: {
+	},
+	ast.Log: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.GE: {
+	},
+	ast.Round: {
+	},
+	ast.Space: {
+	},
+	ast.Upper: {
+	},
+	ast.And: {
+	}, ast.Cast: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{new(randDurInt)}},

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -159,4 +160,515 @@ func (b *builtinGreatestIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 
 func (b *builtinGreatestIntSig) vectorized() bool {
 	return true
+}
+func (b *builtinLTStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGEIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGEIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLeastRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLeastRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLeastStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLeastStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNEDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNEDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNEIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNEIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLERealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLERealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNETimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNETimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNEDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNEDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntervalIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntervalIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntervalRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntervalRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGEStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGEStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLEIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLEIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLEDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLEDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGEDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGEDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLEJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLEJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGEJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGEJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLETimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLETimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGETimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGETimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNEStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNEStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGreatestTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGreatestTimeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNEJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNEJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLEStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLEStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLEDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLEDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCoalesceJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCoalesceJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGEDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGEDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGreatestRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGreatestRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGTStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGTStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLeastTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLeastTimeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNERealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNERealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGERealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGERealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEQDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullEQDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullEQDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGreatestStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGreatestStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -22,26 +22,16 @@ import (
 )
 
 var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
-	ast.NE: {
-	},
-	ast.IsNull: {
-	},
-	ast.LE: {
-	},
-	ast.LT: {
-	},
-	ast.Coalesce: {
-	},
-	ast.NullEQ: {
-	},
-	ast.GT: {
-	},
-	ast.EQ: {
-	},
-	ast.GE: {
-	},
-	ast.Date: {
-	},
+	ast.NE:       {},
+	ast.IsNull:   {},
+	ast.LE:       {},
+	ast.LT:       {},
+	ast.Coalesce: {},
+	ast.NullEQ:   {},
+	ast.GT:       {},
+	ast.EQ:       {},
+	ast.GE:       {},
+	ast.Date:     {},
 	ast.Greatest: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -22,7 +22,50 @@ import (
 )
 
 var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
-	ast.Greatest: {
+	ast.Conv: {
+	},
+	ast.Interval: {
+	},
+	ast.NE: {
+	},
+	ast.IsNull: {
+	},
+	ast.LE: {
+	},
+	ast.LT: {
+	},
+	ast.Time: {
+	},
+	ast.Field: {
+	},
+	ast.Or: {
+	},
+	ast.Coalesce: {
+	},
+	ast.NullEQ: {
+	},
+	ast.Convert: {
+	},
+	ast.Floor: {
+	},
+	ast.GT: {
+	},
+	ast.Length: {
+	},
+	ast.Bin: {
+	},
+	ast.Ceil: {
+	},
+	ast.If: {
+	},
+	ast.EQ: {
+	},
+	ast.Timestamp: {
+	},
+	ast.GE: {
+	},
+	ast.Date: {
+	},	ast.Greatest: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
 	},

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -22,10 +22,6 @@ import (
 )
 
 var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
-	ast.Conv: {
-	},
-	ast.Interval: {
-	},
 	ast.NE: {
 	},
 	ast.IsNull: {
@@ -34,33 +30,13 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	},
 	ast.LT: {
 	},
-	ast.Time: {
-	},
-	ast.Field: {
-	},
-	ast.Or: {
-	},
 	ast.Coalesce: {
 	},
 	ast.NullEQ: {
 	},
-	ast.Convert: {
-	},
-	ast.Floor: {
-	},
 	ast.GT: {
 	},
-	ast.Length: {
-	},
-	ast.Bin: {
-	},
-	ast.Ceil: {
-	},
-	ast.If: {
-	},
 	ast.EQ: {
-	},
-	ast.Timestamp: {
 	},
 	ast.GE: {
 	},

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -41,7 +41,8 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.GE: {
 	},
 	ast.Date: {
-	},	ast.Greatest: {
+	},
+	ast.Greatest: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
 	},

--- a/expression/builtin_encryption_vec.go
+++ b/expression/builtin_encryption_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_encryption_vec.go
+++ b/expression/builtin_encryption_vec.go
@@ -12,3 +12,120 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinAesDecryptSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAesDecryptSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAesEncryptIVSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAesEncryptIVSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDecodeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDecodeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEncodeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEncodeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAesDecryptIVSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAesDecryptIVSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRandomBytesSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRandomBytesSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMD5Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMD5Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSHA2Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSHA2Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCompressSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCompressSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAesEncryptSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAesEncryptSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinPasswordSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinPasswordSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSHA1Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSHA1Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUncompressSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUncompressSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUncompressedLengthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUncompressedLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_encryption_vec.go
+++ b/expression/builtin_encryption_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -21,28 +21,17 @@ import (
 )
 
 var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
-	ast.AesEncrypt: {
-	},
-	ast.Uncompress: {
-	},
-	ast.AesDecrypt: {
-	},
-	ast.Compress: {
-	},
-	ast.MD5: {
-	},
-	ast.SHA: {
-	},
-	ast.RandomBytes: {
-	},
-	ast.UncompressedLength: {
-	},
-	ast.SHA1: {
-	},
-	ast.PasswordFunc: {
-	},
-	ast.SHA2: {
-	},
+	ast.AesEncrypt:         {},
+	ast.Uncompress:         {},
+	ast.AesDecrypt:         {},
+	ast.Compress:           {},
+	ast.MD5:                {},
+	ast.SHA:                {},
+	ast.RandomBytes:        {},
+	ast.UncompressedLength: {},
+	ast.SHA1:               {},
+	ast.PasswordFunc:       {},
+	ast.SHA2:               {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -21,21 +21,9 @@ import (
 )
 
 var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
-	ast.GT: {
-	},
-	ast.Bin: {
-	},
-	ast.Length: {
-	},
-	ast.Decode: {
-	},
 	ast.AesEncrypt: {
 	},
-	ast.Replace: {
-	},
 	ast.Uncompress: {
-	},
-	ast.If: {
 	},
 	ast.AesDecrypt: {
 	},
@@ -43,19 +31,11 @@ var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
 	},
 	ast.MD5: {
 	},
-	ast.LE: {
-	},
 	ast.SHA: {
 	},
 	ast.RandomBytes: {
 	},
-	ast.Encode: {
-	},
-	ast.Mod: {
-	},
 	ast.UncompressedLength: {
-	},
-	ast.Lower: {
 	},
 	ast.SHA1: {
 	},
@@ -63,8 +43,7 @@ var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
 	},
 	ast.SHA2: {
 	},
-	ast.Rand: {
-	},}
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinEncryptionCases)

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -17,10 +17,54 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
-}
+	ast.GT: {
+	},
+	ast.Bin: {
+	},
+	ast.Length: {
+	},
+	ast.Decode: {
+	},
+	ast.AesEncrypt: {
+	},
+	ast.Replace: {
+	},
+	ast.Uncompress: {
+	},
+	ast.If: {
+	},
+	ast.AesDecrypt: {
+	},
+	ast.Compress: {
+	},
+	ast.MD5: {
+	},
+	ast.LE: {
+	},
+	ast.SHA: {
+	},
+	ast.RandomBytes: {
+	},
+	ast.Encode: {
+	},
+	ast.Mod: {
+	},
+	ast.UncompressedLength: {
+	},
+	ast.Lower: {
+	},
+	ast.SHA1: {
+	},
+	ast.PasswordFunc: {
+	},
+	ast.SHA2: {
+	},
+	ast.Rand: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinEncryptionCases)

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -12,3 +12,20 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinEncryptionCases)
+}
+
+func BenchmarkVectorizedBuiltinEncryptionFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinEncryptionCases)
+}

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -12,3 +12,120 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinDatabaseSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDatabaseSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinConnectionIDSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConnectionIDSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTiDBVersionSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTiDBVersionSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRowCountSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRowCountSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCurrentUserSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCurrentUserSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCurrentRoleSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCurrentRoleSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUserSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUserSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTiDBIsDDLOwnerSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTiDBIsDDLOwnerSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFoundRowsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFoundRowsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBenchmarkSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBenchmarkSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLastInsertIDSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLastInsertIDSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLastInsertIDWithIDSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLastInsertIDWithIDSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinVersionSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinVersionSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTiDBDecodeKeySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTiDBDecodeKeySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -12,3 +12,21 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinInfoFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinInfoCases)
+}
+
+func BenchmarkVectorizedBuiltinInfoFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinInfoCases)
+}
+

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -17,10 +17,40 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
-}
+	ast.Decode: {
+	},
+	ast.TiDBVersion: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.CurrentUser: {
+	},
+	ast.FoundRows: {
+	},
+	ast.Database: {
+	},
+	ast.Format: {
+	},
+	ast.User: {
+	},
+	ast.TiDBDecodeKey: {
+	},
+	ast.RowCount: {
+	},
+	ast.CurrentRole: {
+	},
+	ast.Time: {
+	},
+	ast.TiDBIsDDLOwner: {
+	},
+	ast.ConnectionID: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinInfoFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinInfoCases)
@@ -29,4 +59,3 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinInfoFunc(c *C) {
 func BenchmarkVectorizedBuiltinInfoFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinInfoCases)
 }
-

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -21,21 +21,13 @@ import (
 )
 
 var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
-	ast.Decode: {
-	},
 	ast.TiDBVersion: {
-	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
 	},
 	ast.CurrentUser: {
 	},
 	ast.FoundRows: {
 	},
 	ast.Database: {
-	},
-	ast.Format: {
 	},
 	ast.User: {
 	},
@@ -45,12 +37,11 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	},
 	ast.CurrentRole: {
 	},
-	ast.Time: {
-	},
 	ast.TiDBIsDDLOwner: {
 	},
 	ast.ConnectionID: {
-	},}
+	},
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinInfoFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinInfoCases)

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -21,26 +21,16 @@ import (
 )
 
 var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
-	ast.TiDBVersion: {
-	},
-	ast.CurrentUser: {
-	},
-	ast.FoundRows: {
-	},
-	ast.Database: {
-	},
-	ast.User: {
-	},
-	ast.TiDBDecodeKey: {
-	},
-	ast.RowCount: {
-	},
-	ast.CurrentRole: {
-	},
-	ast.TiDBIsDDLOwner: {
-	},
-	ast.ConnectionID: {
-	},
+	ast.TiDBVersion:    {},
+	ast.CurrentUser:    {},
+	ast.FoundRows:      {},
+	ast.Database:       {},
+	ast.User:           {},
+	ast.TiDBDecodeKey:  {},
+	ast.RowCount:       {},
+	ast.CurrentRole:    {},
+	ast.TiDBIsDDLOwner: {},
+	ast.ConnectionID:   {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinInfoFunc(c *C) {

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -12,3 +12,168 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinJSONDepthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONDepthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONKeysSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONKeysSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONInsertSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONInsertSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONReplaceSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONReplaceSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONArraySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONArraySig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONContainsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONContainsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONQuoteSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONSearchSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONSearchSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONSetSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONSetSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONObjectSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONObjectSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONArrayInsertSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONArrayInsertSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONKeys2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONKeys2ArgsSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONLengthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONTypeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONTypeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONExtractSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONExtractSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONRemoveSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONRemoveSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONMergeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONMergeSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONContainsPathSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONContainsPathSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONArrayAppendSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONArrayAppendSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinJSONUnquoteSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONUnquoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -12,3 +12,21 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinJSONCases)
+}
+
+func BenchmarkVectorizedBuiltinJSONFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinJSONCases)
+}
+

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
-	ast.Extract: {
-	},
 	ast.JSONKeys: {
 	},
 	ast.JSONArrayAppend: {
@@ -33,8 +31,6 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	},
 	ast.JSONLength: {
 	},
-	ast.NE: {
-	},
 	ast.JSONType: {
 	},
 	ast.JSONArray: {
@@ -42,10 +38,6 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	ast.JSONArrayInsert: {
 	},
 	ast.JSONContains: {
-	},
-	ast.Lower: {
-	},
-	ast.Mod: {
 	},
 	ast.JSONObject: {
 	},
@@ -59,28 +51,15 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	},
 	ast.JSONUnquote: {
 	},
-	ast.Bin: {
-	},
-	ast.InsertFunc: {
-	},
-	ast.Length: {
-	},
 	ast.JSONRemove: {
 	},
 	ast.JSONMerge: {
 	},
-	ast.Replace: {
-	},
-	ast.Quote: {
-	},
-	ast.If: {
-	},
-	ast.GE: {
-	},
 	ast.JSONInsert: {
 	},
 	ast.JSONQuote: {
-	},}
+	},
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinJSONCases)

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -21,44 +21,25 @@ import (
 )
 
 var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
-	ast.JSONKeys: {
-	},
-	ast.JSONArrayAppend: {
-	},
-	ast.JSONContainsPath: {
-	},
-	ast.JSONExtract: {
-	},
-	ast.JSONLength: {
-	},
-	ast.JSONType: {
-	},
-	ast.JSONArray: {
-	},
-	ast.JSONArrayInsert: {
-	},
-	ast.JSONContains: {
-	},
-	ast.JSONObject: {
-	},
-	ast.JSONSet: {
-	},
-	ast.JSONSearch: {
-	},
-	ast.JSONReplace: {
-	},
-	ast.JSONDepth: {
-	},
-	ast.JSONUnquote: {
-	},
-	ast.JSONRemove: {
-	},
-	ast.JSONMerge: {
-	},
-	ast.JSONInsert: {
-	},
-	ast.JSONQuote: {
-	},
+	ast.JSONKeys:         {},
+	ast.JSONArrayAppend:  {},
+	ast.JSONContainsPath: {},
+	ast.JSONExtract:      {},
+	ast.JSONLength:       {},
+	ast.JSONType:         {},
+	ast.JSONArray:        {},
+	ast.JSONArrayInsert:  {},
+	ast.JSONContains:     {},
+	ast.JSONObject:       {},
+	ast.JSONSet:          {},
+	ast.JSONSearch:       {},
+	ast.JSONReplace:      {},
+	ast.JSONDepth:        {},
+	ast.JSONUnquote:      {},
+	ast.JSONRemove:       {},
+	ast.JSONMerge:        {},
+	ast.JSONInsert:       {},
+	ast.JSONQuote:        {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -17,10 +17,70 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
-}
+	ast.Extract: {
+	},
+	ast.JSONKeys: {
+	},
+	ast.JSONArrayAppend: {
+	},
+	ast.JSONContainsPath: {
+	},
+	ast.JSONExtract: {
+	},
+	ast.JSONLength: {
+	},
+	ast.NE: {
+	},
+	ast.JSONType: {
+	},
+	ast.JSONArray: {
+	},
+	ast.JSONArrayInsert: {
+	},
+	ast.JSONContains: {
+	},
+	ast.Lower: {
+	},
+	ast.Mod: {
+	},
+	ast.JSONObject: {
+	},
+	ast.JSONSet: {
+	},
+	ast.JSONSearch: {
+	},
+	ast.JSONReplace: {
+	},
+	ast.JSONDepth: {
+	},
+	ast.JSONUnquote: {
+	},
+	ast.Bin: {
+	},
+	ast.InsertFunc: {
+	},
+	ast.Length: {
+	},
+	ast.JSONRemove: {
+	},
+	ast.JSONMerge: {
+	},
+	ast.Replace: {
+	},
+	ast.Quote: {
+	},
+	ast.If: {
+	},
+	ast.GE: {
+	},
+	ast.JSONInsert: {
+	},
+	ast.JSONQuote: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinJSONCases)
@@ -29,4 +89,3 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {
 func BenchmarkVectorizedBuiltinJSONFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinJSONCases)
 }
-

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_like_vec.go
+++ b/expression/builtin_like_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_like_vec.go
+++ b/expression/builtin_like_vec.go
@@ -12,3 +12,32 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinLikeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLikeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRegexpBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRegexpBinarySig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRegexpSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRegexpSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_like_vec.go
+++ b/expression/builtin_like_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -12,3 +12,21 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinLikeCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinLikeFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinLikeCases)
+}
+
+func BenchmarkVectorizedBuiltinLikeFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinLikeCases)
+}
+

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -21,10 +21,8 @@ import (
 )
 
 var vecBuiltinLikeCases = map[string][]vecExprBenchCase{
-	ast.Like: {
-	},
-	ast.Regexp: {
-	},
+	ast.Like:   {},
+	ast.Regexp: {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinLikeFunc(c *C) {

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -17,10 +17,16 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinLikeCases = map[string][]vecExprBenchCase{
-}
+	ast.Bin: {
+	},
+	ast.GE: {
+	},
+	ast.Regexp: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinLikeFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinLikeCases)
@@ -29,4 +35,3 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinLikeFunc(c *C) {
 func BenchmarkVectorizedBuiltinLikeFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinLikeCases)
 }
-

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -21,12 +21,11 @@ import (
 )
 
 var vecBuiltinLikeCases = map[string][]vecExprBenchCase{
-	ast.Bin: {
-	},
-	ast.GE: {
+	ast.Like: {
 	},
 	ast.Regexp: {
-	},}
+	},
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinLikeFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinLikeCases)

--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -602,4 +603,171 @@ func (b *builtinRoundWithFracIntSig) vecEvalInt(input *chunk.Chunk, result *chun
 
 func (b *builtinRoundWithFracIntSig) vectorized() bool {
 	return true
+}
+func (b *builtinCRC32Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCRC32Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinPISig) vectorized() bool {
+	return false
+}
+
+func (b *builtinPISig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRandSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRandSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRandWithSeedSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRandWithSeedSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCeilIntToDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCeilIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTruncateIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTruncateIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTruncateUintSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTruncateUintSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCeilDecToDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCeilDecToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFloorDecToDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFloorDecToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTruncateDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTruncateDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRoundWithFracDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRoundWithFracDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFloorIntToDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFloorIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSignSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSignSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFloorRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFloorRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLog2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLog2ArgsSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinConvSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConvSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAbsUIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAbsUIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCeilDecToIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCeilDecToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCeilIntToIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCeilIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFloorIntToIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFloorIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFloorDecToIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFloorDecToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
-	ast.Sign: {
-	},
+	ast.Sign: {},
 	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
 	},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -22,46 +22,6 @@ import (
 )
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
-	ast.CRC32: {
-	},
-	ast.If: {
-	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
-	},
-	ast.GE: {
-	},
-	ast.Space: {
-	},
-	ast.Upper: {
-	},
-	ast.And: {
-	},
-	ast.Conv: {
-	},
-	ast.Now: {
-	},
-	ast.Format: {
-	},
-	ast.Trim: {
-	},
-	ast.LE: {
-	},
-	ast.PI: {
-	},
-	ast.Time: {
-	},
-	ast.Field: {
-	},
-	ast.Mod: {
-	},
-	ast.Rand: {
-	},
-	ast.Floor: {
-	},
-	ast.Length: {
-	},
 	ast.Sign: {
 	}, ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -23,7 +23,8 @@ import (
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sign: {
-	}, ast.Log: {
+	},
+	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
 	},
 	ast.Log10: {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -22,7 +22,48 @@ import (
 )
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
-	ast.Log: {
+	ast.CRC32: {
+	},
+	ast.If: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.GE: {
+	},
+	ast.Space: {
+	},
+	ast.Upper: {
+	},
+	ast.And: {
+	},
+	ast.Conv: {
+	},
+	ast.Now: {
+	},
+	ast.Format: {
+	},
+	ast.Trim: {
+	},
+	ast.LE: {
+	},
+	ast.PI: {
+	},
+	ast.Time: {
+	},
+	ast.Field: {
+	},
+	ast.Mod: {
+	},
+	ast.Rand: {
+	},
+	ast.Floor: {
+	},
+	ast.Length: {
+	},
+	ast.Sign: {
+	}, ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
 	},
 	ast.Log10: {

--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -18,6 +18,7 @@ import (
 	"math"
 	"net"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -86,4 +87,195 @@ func (b *builtinIsIPv4Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 
 func (b *builtinIsIPv4Sig) vectorized() bool {
 	return true
+}
+func (b *builtinJSONAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinJSONAnyValueSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRealAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRealAnyValueSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStringAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStringAnyValueSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIsIPv6Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIsIPv6Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDecimalAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDecimalAnyValueSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUUIDSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUUIDSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLockSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLockSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDurationAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDurationAnyValueSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntAnyValueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIsIPv4CompatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIsIPv4CompatSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSleepSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSleepSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIsIPv4MappedSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIsIPv4MappedSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInet6AtonSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInet6AtonSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeAnyValueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeAnyValueSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInetAtonSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInetAtonSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInet6NtoaSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInet6NtoaSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNameConstRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNameConstRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinReleaseLockSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinReleaseLockSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -22,7 +22,54 @@ import (
 )
 
 var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
-	ast.InetNtoa: {
+	ast.NameConst: {
+	},
+	ast.LT: {
+	},
+	ast.Inet6Aton: {
+	},
+	ast.Time: {
+	},
+	ast.IsIPv6: {
+	},
+	ast.Charset: {
+	},
+	ast.Mod: {
+	},
+	ast.ReleaseLock: {
+	},
+	ast.Bin: {
+	},
+	ast.Length: {
+	},
+	ast.Collation: {
+	},
+	ast.Sleep: {
+	},
+	ast.UUID: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.Inet6Ntoa: {
+	},
+	ast.And: {
+	},
+	ast.InetAton: {
+	},
+	ast.AnyValue: {
+	},
+	ast.Second: {
+	},
+	ast.IsIPv4Mapped: {
+	},
+	ast.Now: {
+	},
+	ast.IsIPv4Compat: {
+	},
+	ast.LE: {
+	},	ast.InetNtoa: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.IsIPv4: {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -22,22 +22,14 @@ import (
 )
 
 var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
-	ast.Inet6Aton: {
-	},
-	ast.IsIPv6: {
-	},
-	ast.Sleep: {
-	},
-	ast.UUID: {
-	},
-	ast.Inet6Ntoa: {
-	},
-	ast.InetAton: {
-	},
-	ast.IsIPv4Mapped: {
-	},
-	ast.IsIPv4Compat: {
-	},
+	ast.Inet6Aton:    {},
+	ast.IsIPv6:       {},
+	ast.Sleep:        {},
+	ast.UUID:         {},
+	ast.Inet6Ntoa:    {},
+	ast.InetAton:     {},
+	ast.IsIPv4Mapped: {},
+	ast.IsIPv4Compat: {},
 	ast.InetNtoa: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -22,54 +22,23 @@ import (
 )
 
 var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
-	ast.NameConst: {
-	},
-	ast.LT: {
-	},
 	ast.Inet6Aton: {
 	},
-	ast.Time: {
-	},
 	ast.IsIPv6: {
-	},
-	ast.Charset: {
-	},
-	ast.Mod: {
-	},
-	ast.ReleaseLock: {
-	},
-	ast.Bin: {
-	},
-	ast.Length: {
-	},
-	ast.Collation: {
 	},
 	ast.Sleep: {
 	},
 	ast.UUID: {
 	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
-	},
 	ast.Inet6Ntoa: {
-	},
-	ast.And: {
 	},
 	ast.InetAton: {
 	},
-	ast.AnyValue: {
-	},
-	ast.Second: {
-	},
 	ast.IsIPv4Mapped: {
-	},
-	ast.Now: {
 	},
 	ast.IsIPv4Compat: {
 	},
-	ast.LE: {
-	},	ast.InetNtoa: {
+	ast.InetNtoa: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.IsIPv4: {

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -12,3 +12,216 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinTimeIsNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLogicOrSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLogicOrSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitOrSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitOrSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDecimalIsFalseSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDecimalIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntIsFalseSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryMinusRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryMinusRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitNegSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitNegSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryMinusDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntIsNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRealIsNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRealIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryNotRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryNotRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLogicAndSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLogicAndSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitXorSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitXorSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLogicXorSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLogicXorSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitAndSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitAndSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRealIsFalseSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRealIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryMinusIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryMinusIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryNotDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryNotDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnaryNotIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnaryNotIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDecimalIsNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDecimalIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLeftShiftSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLeftShiftSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRightShiftSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRightShiftSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRealIsTrueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRealIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDecimalIsTrueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDecimalIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinIntIsTrueSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinIntIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDurationIsNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDurationIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -17,10 +17,52 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-}
+	ast.Minus: {
+	},
+	ast.Time: {
+	},
+	ast.IsTruth: {
+	},
+	ast.Or: {
+	},
+	ast.BitNeg: {
+	},
+	ast.LeftShift: {
+	},
+	ast.IsFalsity: {
+	},
+	ast.Left: {
+	},
+	ast.LogicOr: {
+	},
+	ast.LogicXor: {
+	},
+	ast.Xor: {
+	},
+	ast.Right: {
+	},
+	ast.RightShift: {
+	},
+	ast.Log: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.And: {
+	},
+	ast.LogicAnd: {
+	},
+	ast.UnaryNot: {
+	},
+	ast.UnaryMinus: {
+	},
+	ast.IsNull: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinOpCases)
@@ -29,4 +71,3 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
 func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOpCases)
 }
-

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -12,3 +12,21 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinOpCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinOpCases)
+}
+
+func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOpCases)
+}
+

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -21,39 +21,15 @@ import (
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-	ast.Minus: {
-	},
-	ast.Time: {
-	},
 	ast.IsTruth: {
 	},
-	ast.Or: {
-	},
-	ast.BitNeg: {
-	},
-	ast.LeftShift: {
-	},
 	ast.IsFalsity: {
-	},
-	ast.Left: {
 	},
 	ast.LogicOr: {
 	},
 	ast.LogicXor: {
 	},
 	ast.Xor: {
-	},
-	ast.Right: {
-	},
-	ast.RightShift: {
-	},
-	ast.Log: {
-	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
-	},
-	ast.And: {
 	},
 	ast.LogicAnd: {
 	},
@@ -62,7 +38,8 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.UnaryMinus: {
 	},
 	ast.IsNull: {
-	},}
+	},
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinOpCases)

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -21,24 +21,15 @@ import (
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-	ast.IsTruth: {
-	},
-	ast.IsFalsity: {
-	},
-	ast.LogicOr: {
-	},
-	ast.LogicXor: {
-	},
-	ast.Xor: {
-	},
-	ast.LogicAnd: {
-	},
-	ast.UnaryNot: {
-	},
-	ast.UnaryMinus: {
-	},
-	ast.IsNull: {
-	},
+	ast.IsTruth:    {},
+	ast.IsFalsity:  {},
+	ast.LogicOr:    {},
+	ast.LogicXor:   {},
+	ast.Xor:        {},
+	ast.LogicAnd:   {},
+	ast.UnaryNot:   {},
+	ast.UnaryMinus: {},
+	ast.IsNull:     {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {

--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -12,3 +12,160 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+func (b *builtinValuesIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRowSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRowSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesJSONSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitCountSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitCountSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGetParamStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGetParamStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSetVarSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSetVarSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinValuesDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinValuesDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGetVarSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGetVarSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}

--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -1,0 +1,1 @@
+package expression

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -17,10 +17,42 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
 )
 
 var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
-}
+	ast.CharLength: {
+	},
+	ast.ReleaseLock: {
+	},
+	ast.Length: {
+	},
+	ast.Bin: {
+	},
+	ast.Sleep: {
+	},
+	ast.GetVar: {
+	},
+	ast.Timestamp: {
+	},
+	ast.Date: {
+	},
+	ast.BitCount: {
+	},
+	ast.SetVar: {
+	},
+	ast.IsNull: {
+	},
+	ast.User: {
+	},
+	ast.Time: {
+	},
+	ast.Field: {
+	},
+	ast.GetParam: {
+	},
+	ast.Lower: {
+	},}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOtherFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinOtherCases)
@@ -29,4 +61,3 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinOtherFunc(c *C) {
 func BenchmarkVectorizedBuiltinOtherFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOtherCases)
 }
-

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -12,3 +12,21 @@
 // limitations under the License.
 
 package expression
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
+}
+
+func (s *testEvaluatorSuite) TestVectorizedBuiltinOtherFunc(c *C) {
+	testVectorizedBuiltinFunc(c, vecBuiltinOtherCases)
+}
+
+func BenchmarkVectorizedBuiltinOtherFunc(b *testing.B) {
+	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOtherCases)
+}
+

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -21,16 +21,11 @@ import (
 )
 
 var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
-	ast.In: {
-	},
-	ast.SetVar: {
-	},
-	ast.GetVar: {
-	},
-	ast.BitCount: {
-	},
-	ast.GetParam: {
-	},
+	ast.In:       {},
+	ast.SetVar:   {},
+	ast.GetVar:   {},
+	ast.BitCount: {},
+	ast.GetParam: {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOtherFunc(c *C) {

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -21,38 +21,17 @@ import (
 )
 
 var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
-	ast.CharLength: {
-	},
-	ast.ReleaseLock: {
-	},
-	ast.Length: {
-	},
-	ast.Bin: {
-	},
-	ast.Sleep: {
-	},
-	ast.GetVar: {
-	},
-	ast.Timestamp: {
-	},
-	ast.Date: {
-	},
-	ast.BitCount: {
+	ast.In: {
 	},
 	ast.SetVar: {
 	},
-	ast.IsNull: {
+	ast.GetVar: {
 	},
-	ast.User: {
-	},
-	ast.Time: {
-	},
-	ast.Field: {
+	ast.BitCount: {
 	},
 	ast.GetParam: {
 	},
-	ast.Lower: {
-	},}
+}
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinOtherFunc(c *C) {
 	testVectorizedBuiltinFunc(c, vecBuiltinOtherCases)

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -1,1 +1,14 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package expression

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -319,4 +320,459 @@ func (b *builtinReverseSig) vecEvalString(input *chunk.Chunk, result *chunk.Colu
 
 func (b *builtinReverseSig) vectorized() bool {
 	return true
+}
+func (b *builtinConcatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConcatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLocate3ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLocate3ArgsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinHexStrArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinHexStrArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLTrimSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLTrimSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFieldStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFieldStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinQuoteSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInsertBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInsertBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinConcatWSSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConcatWSSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinConvertSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConvertSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubstringIndexSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubstringIndexSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnHexSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnHexSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinExportSet3ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinExportSet3ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinASCIISig) vectorized() bool {
+	return false
+}
+
+func (b *builtinASCIISig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLpadBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLpadBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLpadSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLpadSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFindInSetSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLeftBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLeftBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinReverseBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinReverseBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRTrimSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRTrimSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStrcmpSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStrcmpSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLocateBinary2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLocateBinary2ArgsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLocateBinary3ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLocateBinary3ArgsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinExportSet4ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinExportSet4ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRpadBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRpadBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFormatWithLocaleSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFormatWithLocaleSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubstringBinary2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubstringBinary2ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubstring2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubstring2ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTrim2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTrim2ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInstrSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInstrSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFieldRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFieldRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinOctStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinOctStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinEltSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinEltSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInsertSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInsertSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinExportSet5ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinExportSet5ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubstring3ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubstring3ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTrim3ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTrim3ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinOrdSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinOrdSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinInstrBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinInstrBinarySig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLengthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLocate2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLocate2ArgsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBitLengthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBitLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCharSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCharSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinReplaceSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinReplaceSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMakeSetSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMakeSetSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinOctIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinOctIntSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinToBase64Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinToBase64Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTrim1ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTrim1ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRpadSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRpadSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCharLengthBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCharLengthBinarySig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinBinSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinBinSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFormatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFormatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinRightBinarySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinRightBinarySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubstringBinary3ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubstringBinary3ArgsSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinHexIntArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinHexIntArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFieldIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFieldIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFromBase64Sig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFromBase64Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCharLengthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCharLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -22,7 +22,102 @@ import (
 )
 
 var vecBuiltinStringCases = map[string][]vecExprBenchCase{
-	ast.Repeat: {
+	ast.Convert: {
+	},
+	ast.Bin: {
+	},
+	ast.Length: {
+	},
+	ast.MakeSet: {
+	},
+	ast.Decode: {
+	},
+	ast.ASCII: {
+	},
+	ast.Collation: {
+	},
+	ast.ToBase64: {
+	},
+	ast.Replace: {
+	},
+	ast.Quote: {
+	},
+	ast.BitLength: {
+	},
+	ast.If: {
+	},
+	ast.Oct: {
+	},
+	ast.Strcmp: {
+	},
+	ast.Log: {
+	},
+	ast.Date: {
+	},
+	ast.Timestamp: {
+	},
+	ast.RTrim: {
+	},
+	ast.Substr: {
+	},
+	ast.And: {
+	},
+	ast.FromBase64: {
+	},
+	ast.ConcatWS: {
+	},
+	ast.SubstringIndex: {
+	},
+	ast.Conv: {
+	},
+	ast.Ord: {
+	},
+	ast.Instr: {
+	},
+	ast.Rpad: {
+	},
+	ast.LE: {
+	},
+	ast.Format: {
+	},
+	ast.Trim: {
+	},
+	ast.Concat: {
+	},
+	ast.LT: {
+	},
+	ast.Locate: {
+	},
+	ast.Elt: {
+	},
+	ast.Hex: {
+	},
+	ast.Time: {
+	},
+	ast.Sin: {
+	},
+	ast.Charset: {
+	},
+	ast.Lpad: {
+	},
+	ast.Unhex: {
+	},
+	ast.Encode: {
+	},
+	ast.Field: {
+	},
+	ast.FindInSet: {
+	},
+	ast.Or: {
+	},
+	ast.LTrim: {
+	},
+	ast.Substring: {
+	},
+	ast.CharLength: {
+	},
+	ast.ExportSet: {
+	},	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},
 	ast.Lower: {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -22,58 +22,32 @@ import (
 )
 
 var vecBuiltinStringCases = map[string][]vecExprBenchCase{
-	ast.Length: {
-	},
-	ast.ASCII: {
-	},
-	ast.Concat: {
-	},
-	ast.ConcatWS: {
-	},
-	ast.Convert: {
-	},
-	ast.Substring: {
-	},
-	ast.SubstringIndex: {
-	},
-	ast.Locate: {
-	},
-	ast.Hex: {
-	},
-	ast.Unhex: {
-	},
-	ast.Trim: {
-	},
-	ast.LTrim: {
-	},
-	ast.RTrim: {
-	},
-	ast.Lpad: {
-	},
-	ast.Rpad: {
-	},
-	ast.BitLength: {
-	},
-	ast.FindInSet: {
-	},
-	ast.Field: {
-	},
-	ast.MakeSet: {
-	},
-	ast.Oct: {
-	},
-	ast.Ord: {
-	},
-	ast.Quote: {
-	},
-	ast.Bin: {
-	},
-	ast.ToBase64: {
-	},
-	ast.FromBase64: {
-	},
-	ast.ExportSet: {
-	},
+	ast.Length:         {},
+	ast.ASCII:          {},
+	ast.Concat:         {},
+	ast.ConcatWS:       {},
+	ast.Convert:        {},
+	ast.Substring:      {},
+	ast.SubstringIndex: {},
+	ast.Locate:         {},
+	ast.Hex:            {},
+	ast.Unhex:          {},
+	ast.Trim:           {},
+	ast.LTrim:          {},
+	ast.RTrim:          {},
+	ast.Lpad:           {},
+	ast.Rpad:           {},
+	ast.BitLength:      {},
+	ast.FindInSet:      {},
+	ast.Field:          {},
+	ast.MakeSet:        {},
+	ast.Oct:            {},
+	ast.Ord:            {},
+	ast.Quote:          {},
+	ast.Bin:            {},
+	ast.ToBase64:       {},
+	ast.FromBase64:     {},
+	ast.ExportSet:      {},
 	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -22,102 +22,59 @@ import (
 )
 
 var vecBuiltinStringCases = map[string][]vecExprBenchCase{
-	ast.Convert: {
-	},
-	ast.Bin: {
-	},
 	ast.Length: {
-	},
-	ast.MakeSet: {
-	},
-	ast.Decode: {
 	},
 	ast.ASCII: {
 	},
-	ast.Collation: {
-	},
-	ast.ToBase64: {
-	},
-	ast.Replace: {
-	},
-	ast.Quote: {
-	},
-	ast.BitLength: {
-	},
-	ast.If: {
-	},
-	ast.Oct: {
-	},
-	ast.Strcmp: {
-	},
-	ast.Log: {
-	},
-	ast.Date: {
-	},
-	ast.Timestamp: {
-	},
-	ast.RTrim: {
-	},
-	ast.Substr: {
-	},
-	ast.And: {
-	},
-	ast.FromBase64: {
+	ast.Concat: {
 	},
 	ast.ConcatWS: {
 	},
-	ast.SubstringIndex: {
-	},
-	ast.Conv: {
-	},
-	ast.Ord: {
-	},
-	ast.Instr: {
-	},
-	ast.Rpad: {
-	},
-	ast.LE: {
-	},
-	ast.Format: {
-	},
-	ast.Trim: {
-	},
-	ast.Concat: {
-	},
-	ast.LT: {
-	},
-	ast.Locate: {
-	},
-	ast.Elt: {
-	},
-	ast.Hex: {
-	},
-	ast.Time: {
-	},
-	ast.Sin: {
-	},
-	ast.Charset: {
-	},
-	ast.Lpad: {
-	},
-	ast.Unhex: {
-	},
-	ast.Encode: {
-	},
-	ast.Field: {
-	},
-	ast.FindInSet: {
-	},
-	ast.Or: {
-	},
-	ast.LTrim: {
+	ast.Convert: {
 	},
 	ast.Substring: {
 	},
-	ast.CharLength: {
+	ast.SubstringIndex: {
+	},
+	ast.Locate: {
+	},
+	ast.Hex: {
+	},
+	ast.Unhex: {
+	},
+	ast.Trim: {
+	},
+	ast.LTrim: {
+	},
+	ast.RTrim: {
+	},
+	ast.Lpad: {
+	},
+	ast.Rpad: {
+	},
+	ast.BitLength: {
+	},
+	ast.FindInSet: {
+	},
+	ast.Field: {
+	},
+	ast.MakeSet: {
+	},
+	ast.Oct: {
+	},
+	ast.Ord: {
+	},
+	ast.Quote: {
+	},
+	ast.Bin: {
+	},
+	ast.ToBase64: {
+	},
+	ast.FromBase64: {
 	},
 	ast.ExportSet: {
-	},	ast.Repeat: {
+	},
+	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},
 	ast.Lower: {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -121,4 +122,995 @@ func (b *builtinDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) e
 
 func (b *builtinDateSig) vectorized() bool {
 	return true
+}
+func (b *builtinFromUnixTime2ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFromUnixTime2ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSysDateWithoutFspSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSysDateWithoutFspSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinExtractDatetimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinExtractDatetimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateIntIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStringStringTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStringStringTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDayNameSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDayNameSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinWeekDaySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinWeekDaySig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeFormatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeFormatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUTCTimeWithArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUTCTimeWithArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateIntIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnixTimestampCurrentSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnixTimestampCurrentSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddTimeDateTimeNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddTimeDateTimeNullSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateIntRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinYearWeekWithoutModeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinYearWeekWithoutModeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateStringRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateStringDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinPeriodDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinPeriodDiffSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeTimeTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNowWithArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNowWithArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDurationAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDurationAndStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateStringRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDatetimeIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDurationDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateAndStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNullTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNullTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinGetFormatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinGetFormatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinLastDaySig) vectorized() bool {
+	return false
+}
+
+func (b *builtinLastDaySig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateStringDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDatetimeRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubTimeDurationNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubTimeDurationNullSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStrToDateDateSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStrToDateDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateStringIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSysDateWithFspSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSysDateWithFspSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDurationIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimestamp1ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimestamp1ArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateIntStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTidbParseTsoSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTidbParseTsoSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDurationStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateAndDurationSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubStringAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubStringAndDurationSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeStringTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeStringTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFromDaysSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFromDaysSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMicroSecondSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMicroSecondSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDatetimeAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDatetimeAndStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDurationDurationTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDurationDurationTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateStringStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinQuarterSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinQuarterSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinWeekWithModeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinWeekWithModeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinExtractDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinExtractDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStrToDateDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStrToDateDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubTimeDateTimeNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubTimeDateTimeNullSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinToSecondsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinToSecondsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDurationAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDurationAndStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateAndStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMinuteSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMinuteSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSecondSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSecondSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinNowWithoutArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinNowWithoutArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStringDurationTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStringDurationTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimestampLiteralSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimestampLiteralSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDatetimeAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDatetimeAndDurationSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddStringAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddStringAndDurationSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateIntDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMakeDateSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMakeDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinWeekOfYearSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinWeekOfYearSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUTCTimestampWithArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUTCTimestampWithArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateIntRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDurationAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDurationAndDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDurationAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDurationAndDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeToSecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeToSecSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDayOfMonthSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDayOfMonthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStrToDateDatetimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStrToDateDatetimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUTCDateSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUTCDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinWeekWithoutModeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinWeekWithoutModeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnixTimestampDecSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnixTimestampDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinPeriodAddSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinPeriodAddSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimestampAddSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimestampAddSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinToDaysSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinToDaysSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDateFormatSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDateFormatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinHourSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinHourSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDurationRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDatetimeAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDatetimeAndStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSecToTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSecToTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubStringAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubStringAndStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUTCTimeWithoutArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUTCTimeWithoutArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateIntDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDateDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDateDiffSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCurrentDateSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCurrentDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateStringStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDurationStringTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDurationStringTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateIntStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDatetimeStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMakeTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMakeTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateAndDurationSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDayOfYearSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDayOfYearSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinFromUnixTime1ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinFromUnixTime1ArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDurationIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimestamp2ArgsSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimestamp2ArgsSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinYearWeekWithModeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinYearWeekWithModeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimestampDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimestampDiffSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUnixTimestampIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUnixTimestampIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDurationDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDatetimeRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDurationRealSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCurrentTime0ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddDateDatetimeIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateStringIntSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddTimeStringNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddTimeStringNullSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDateLiteralSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDateLiteralSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinStringTimeTimeDiffSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinStringTimeTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinTimeLiteralSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinTimeLiteralSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDurationStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddTimeDurationNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddTimeDurationNullSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubTimeStringNullSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubTimeStringNullSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinMonthNameSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinMonthNameSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDatetimeStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDateDatetimeDecimalSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinSubDatetimeAndDurationSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinSubDatetimeAndDurationSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinDayOfWeekSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinDayOfWeekSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinCurrentTime1ArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinAddStringAndStringSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinAddStringAndStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinUTCTimestampWithoutArgSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinUTCTimestampWithoutArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
+}
+
+func (b *builtinConvertTzSig) vectorized() bool {
+	return false
+}
+
+func (b *builtinConvertTzSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	return errors.Errorf("not implemented")
 }

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -25,7 +25,146 @@ import (
 )
 
 var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
-	ast.Month: {
+	ast.CurrentTime: {
+	},
+	ast.Format: {
+	},
+	ast.DateDiff: {
+	},
+	ast.LT: {
+	},
+	ast.Day: {
+	},
+	ast.Week: {
+	},
+	ast.YearWeek: {
+	},
+	ast.DayName: {
+	},
+	ast.TimeToSec: {
+	},
+	ast.DayOfMonth: {
+	},
+	ast.Regexp: {
+	},
+	ast.SubDate: {
+	},
+	ast.MakeDate: {
+	},
+	ast.Lower: {
+	},
+	ast.DateLiteral: {
+	},
+	ast.UTCTime: {
+	},
+	ast.Quarter: {
+	},
+	ast.GetFormat: {
+	},
+	ast.StrToDate: {
+	},
+	ast.TimestampAdd: {
+	},
+	ast.FromUnixTime: {
+	},
+	ast.Mul: {
+	},
+	ast.UTCDate: {
+	},
+	ast.Convert: {
+	},
+	ast.SecToTime: {
+	},
+	ast.UTCTimestamp: {
+	},
+	ast.Abs: {
+	},
+	ast.SubTime: {
+	},
+	ast.Bin: {
+	},
+	ast.Length: {
+	},
+	ast.DayOfWeek: {
+	},
+	ast.MicroSecond: {
+	},
+	ast.PeriodAdd: {
+	},
+	ast.CurrentDate: {
+	},
+	ast.Replace: {
+	},
+	ast.UnixTimestamp: {
+	},
+	ast.If: {
+	},
+	ast.AddDate: {
+	},
+	ast.Hour: {
+	},
+	ast.Log: {
+	},
+	ast.Timestamp: {
+	},
+	ast.GE: {
+	},
+	ast.DayOfYear: {
+	},
+	ast.Round: {
+	},
+	ast.FromDays: {
+	},
+	ast.TimeDiff: {
+	},
+	ast.Upper: {
+	},
+	ast.AddTime: {
+	},
+	ast.MakeTime: {
+	},
+	ast.MonthName: {
+	},
+	ast.And: {
+	},
+	ast.TimeFormat: {
+	},
+	ast.TimestampLiteral: {
+	},
+	ast.ToSeconds: {
+	},
+	ast.TimestampDiff: {
+	},
+	ast.Extract: {
+	},
+	ast.ToDays: {
+	},
+	ast.LastDay: {
+	},
+	ast.ConvertTz: {
+	},
+	ast.Truncate: {
+	},
+	ast.Conv: {
+	},
+	ast.Minute: {
+	},
+	ast.Second: {
+	},
+	ast.TimeLiteral: {
+	},
+	ast.Interval: {
+	},
+	ast.Now: {
+	},
+	ast.WeekOfYear: {
+	},
+	ast.DateFormat: {
+	},
+	ast.PeriodDiff: {
+	},
+	ast.Weekday: {
+	}, ast.Month: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 	ast.Year: {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -25,146 +25,65 @@ import (
 )
 
 var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
-	ast.CurrentTime: {
-	},
-	ast.Format: {
+	ast.DateLiteral: {
 	},
 	ast.DateDiff: {
 	},
-	ast.LT: {
-	},
-	ast.Day: {
-	},
-	ast.Week: {
-	},
-	ast.YearWeek: {
-	},
-	ast.DayName: {
-	},
-	ast.TimeToSec: {
-	},
-	ast.DayOfMonth: {
-	},
-	ast.Regexp: {
-	},
-	ast.SubDate: {
-	},
-	ast.MakeDate: {
-	},
-	ast.Lower: {
-	},
-	ast.DateLiteral: {
-	},
-	ast.UTCTime: {
-	},
-	ast.Quarter: {
-	},
-	ast.GetFormat: {
-	},
-	ast.StrToDate: {
-	},
-	ast.TimestampAdd: {
-	},
-	ast.FromUnixTime: {
-	},
-	ast.Mul: {
-	},
-	ast.UTCDate: {
-	},
-	ast.Convert: {
-	},
-	ast.SecToTime: {
-	},
-	ast.UTCTimestamp: {
-	},
-	ast.Abs: {
-	},
-	ast.SubTime: {
-	},
-	ast.Bin: {
-	},
-	ast.Length: {
-	},
-	ast.DayOfWeek: {
-	},
-	ast.MicroSecond: {
-	},
-	ast.PeriodAdd: {
-	},
-	ast.CurrentDate: {
-	},
-	ast.Replace: {
-	},
-	ast.UnixTimestamp: {
-	},
-	ast.If: {
-	},
-	ast.AddDate: {
-	},
-	ast.Hour: {
-	},
-	ast.Log: {
-	},
-	ast.Timestamp: {
-	},
-	ast.GE: {
-	},
-	ast.DayOfYear: {
-	},
-	ast.Round: {
-	},
-	ast.FromDays: {
-	},
 	ast.TimeDiff: {
 	},
-	ast.Upper: {
+	ast.DateFormat: {
 	},
-	ast.AddTime: {
-	},
-	ast.MakeTime: {
-	},
-	ast.MonthName: {
-	},
-	ast.And: {
-	},
-	ast.TimeFormat: {
-	},
-	ast.TimestampLiteral: {
-	},
-	ast.ToSeconds: {
-	},
-	ast.TimestampDiff: {
-	},
-	ast.Extract: {
-	},
-	ast.ToDays: {
-	},
-	ast.LastDay: {
-	},
-	ast.ConvertTz: {
-	},
-	ast.Truncate: {
-	},
-	ast.Conv: {
+	ast.Hour: {
 	},
 	ast.Minute: {
 	},
 	ast.Second: {
 	},
-	ast.TimeLiteral: {
-	},
-	ast.Interval: {
+	ast.MicroSecond: {
 	},
 	ast.Now: {
 	},
-	ast.WeekOfYear: {
+	ast.DayOfMonth: {
 	},
-	ast.DateFormat: {
+	ast.DayOfWeek: {
+	},
+	ast.DayOfYear: {
+	},
+	ast.Day: {
+	},
+	ast.CurrentTime: {
+	},
+	ast.CurrentDate: {
+	},
+	ast.MakeDate: {
+	},
+	ast.MakeTime: {
+	},
+	ast.PeriodAdd: {
 	},
 	ast.PeriodDiff: {
 	},
-	ast.Weekday: {
-	}, ast.Month: {
+	ast.Quarter: {
+	},
+	ast.TimeFormat: {
+	},
+	ast.TimeToSec: {
+	},
+	ast.TimestampAdd: {
+	},
+	ast.TimestampDiff: {
+	},
+	ast.TimestampLiteral: {
+	},
+	ast.SubDate: {
+	},
+	ast.AddDate: {
+	},
+	ast.SubTime: {
+	},
+	ast.AddTime: {
+	},
+	ast.Month: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 	ast.Year: {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -25,64 +25,35 @@ import (
 )
 
 var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
-	ast.DateLiteral: {
-	},
-	ast.DateDiff: {
-	},
-	ast.TimeDiff: {
-	},
-	ast.DateFormat: {
-	},
-	ast.Hour: {
-	},
-	ast.Minute: {
-	},
-	ast.Second: {
-	},
-	ast.MicroSecond: {
-	},
-	ast.Now: {
-	},
-	ast.DayOfMonth: {
-	},
-	ast.DayOfWeek: {
-	},
-	ast.DayOfYear: {
-	},
-	ast.Day: {
-	},
-	ast.CurrentTime: {
-	},
-	ast.CurrentDate: {
-	},
-	ast.MakeDate: {
-	},
-	ast.MakeTime: {
-	},
-	ast.PeriodAdd: {
-	},
-	ast.PeriodDiff: {
-	},
-	ast.Quarter: {
-	},
-	ast.TimeFormat: {
-	},
-	ast.TimeToSec: {
-	},
-	ast.TimestampAdd: {
-	},
-	ast.TimestampDiff: {
-	},
-	ast.TimestampLiteral: {
-	},
-	ast.SubDate: {
-	},
-	ast.AddDate: {
-	},
-	ast.SubTime: {
-	},
-	ast.AddTime: {
-	},
+	ast.DateLiteral:      {},
+	ast.DateDiff:         {},
+	ast.TimeDiff:         {},
+	ast.DateFormat:       {},
+	ast.Hour:             {},
+	ast.Minute:           {},
+	ast.Second:           {},
+	ast.MicroSecond:      {},
+	ast.Now:              {},
+	ast.DayOfMonth:       {},
+	ast.DayOfWeek:        {},
+	ast.DayOfYear:        {},
+	ast.Day:              {},
+	ast.CurrentTime:      {},
+	ast.CurrentDate:      {},
+	ast.MakeDate:         {},
+	ast.MakeTime:         {},
+	ast.PeriodAdd:        {},
+	ast.PeriodDiff:       {},
+	ast.Quarter:          {},
+	ast.TimeFormat:       {},
+	ast.TimeToSec:        {},
+	ast.TimestampAdd:     {},
+	ast.TimestampDiff:    {},
+	ast.TimestampLiteral: {},
+	ast.SubDate:          {},
+	ast.AddDate:          {},
+	ast.SubTime:          {},
+	ast.AddTime:          {},
 	ast.Month: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Generate `vecEval` methods for all functions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
