### PR TITLE
expression: implement vectorization for builtinGreatestRealSig

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -602,11 +602,38 @@ func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinGreatestRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinGreatestRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	f64s := result.Float64s()
+	for j := 1; j < len(b.args); j++ {
+		if err := b.args[j].VecEvalReal(b.ctx, input, buf); err != nil {
+			return err
+		}
+
+		result.MergeNulls(buf)
+		v := buf.Float64s()
+		for i := 0; i < n; i++ {
+			if result.IsNull(i) {
+				continue
+			}
+			if v[i] > f64s[i] {
+				f64s[i] = v[i]
+			}
+		}
+	}
+	return nil
 }
 
 func (b *builtinGTStringSig) vectorized() bool {

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -35,6 +35,7 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Greatest: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal, types.ETReal}},
 	},
 	ast.Least: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for ```builtinGreatestRealSig```, for issues [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
- Implement vectorized evaluation.

According to benchmark in may MAC, almost 6.9x faster than before:
```
BenchmarkVectorizedBuiltinCompareFunc/builtinGreatestRealSig-VecBuiltinFunc-4         	  229953	      5074 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinGreatestRealSig-NonVecBuiltinFunc-4      	   33604	     35460 ns/op	       0 B/op	       0 allocs/op

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test