### PR TITLE
implement vectorized evaluation for builtinDayOfMonthSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -676,14 +676,6 @@ func (b *builtinTimeToSecSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 	return errors.Errorf("not implemented")
 }
 
-func (b *builtinDayOfMonthSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinDayOfMonthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinStrToDateDatetimeSig) vectorized() bool {
 	return false
 }
@@ -1241,5 +1233,43 @@ func (b *builtinTimestamp2ArgsSig) vecEvalTime(input *chunk.Chunk, result *chunk
 }
 
 func (b *builtinTimestamp2ArgsSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinDayOfMonthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, false)
+	result.MergeNulls(buf)
+	i64s := result.Int64s()
+	ds := buf.Times()
+	for i := 0; i < input.NumRows(); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if ds[i].IsZero() {
+			if b.ctx.GetSessionVars().SQLMode.HasNoZeroDateMode() {
+				if err := handleInvalidTimeError(b.ctx, types.ErrIncorrectDatetimeValue.GenWithStackByArgs(ds[i].String())); err != nil {
+					return err
+				}
+				result.SetNull(i, true)
+				continue
+			}
+			i64s[i] = 0
+			continue
+		}
+		i64s[i] = int64(ds[i].Time.Day())
+	}
+	return nil
+}
+
+func (b *builtinDayOfMonthSig) vectorized() bool {
 	return true
 }

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -34,7 +34,6 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.Second:           {},
 	ast.MicroSecond:      {},
 	ast.Now:              {},
-	ast.DayOfMonth:       {},
 	ast.DayOfWeek:        {},
 	ast.DayOfYear:        {},
 	ast.Day:              {},
@@ -77,6 +76,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.MonthName: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDatetime}},
+	},
+	ast.DayOfMonth: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinDayOfMonthSig
#12103 

### What is changed and how it works?

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFunc/builtinDayOfMonthSig-VecBuiltinFunc-4                  100000             18583 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinDayOfMonthSig-NonVecBuiltinFunc-4                30000             43965 ns/op               0 B/op          0 allocs/op
```

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test