### PR TITLE
expression: implement vectorized evaluation for builtinCastTimeAsDecimalSig

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -170,11 +170,35 @@ func (b *builtinCastDecimalAsStringSig) vecEvalString(input *chunk.Chunk, result
 }
 
 func (b *builtinCastTimeAsDecimalSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastTimeAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeDecimal(n, false)
+	result.MergeNulls(buf)
+	times := buf.Times()
+	decs := result.Decimals()
+	sc := b.ctx.GetSessionVars().StmtCtx
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		decimalValue, err := types.ProduceDecWithSpecifiedTp(times[i].ToNumber(), b.tp, sc)
+		if err != nil {
+			return err
+		}
+		decs[i] = *decimalValue
+	}
+	return nil
 }
 
 func (b *builtinCastDurationAsIntSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -34,6 +34,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 				fsp:          1,
 			}},
 		},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implement vectorized evaluation for `builtinCastTimeAsRealSig`, as listed in #12105.

### What is changed and how it works?

According to benchmark, this change improves the performance, but not too much.

```bash
$ go test -v -benchmem -bench=BenchmarkVectorizedBuiltinCastFunc -run=BenchmarkVectorizedBuiltinCastFunc
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
...
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsDecimalSig-VecBuiltinFunc-8             	    3000	    494479 ns/op	  155393 B/op	    8829 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsDecimalSig-NonVecBuiltinFunc-8          	    3000	    545625 ns/op	  155393 B/op	    8829 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
