### PR TITLE
expression: implement vectorized evaluation for 'builtinBinSig'

### DIFF
--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -35,9 +35,6 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 			}},
 		},
 	},
-	ast.Bin: {
-		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
-	},
 }
 
 type dateTimeGenerWithFsp struct {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -35,6 +35,9 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 			}},
 		},
 	},
+	ast.Bin: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 }
 
 type dateTimeGenerWithFsp struct {

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"fmt"
 	"math"
 	"strings"
 	"unicode/utf8"
@@ -714,11 +715,30 @@ func (b *builtinCharLengthBinarySig) vecEvalInt(input *chunk.Chunk, result *chun
 }
 
 func (b *builtinBinSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinBinSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	nums := buf.Int64s()
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(fmt.Sprintf("%b", uint64(nums[i])))
+	}
+	return nil
 }
 
 func (b *builtinFormatSig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -44,10 +44,12 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Oct:            {},
 	ast.Ord:            {},
 	ast.Quote:          {},
-	ast.Bin:            {},
-	ast.ToBase64:       {},
-	ast.FromBase64:     {},
-	ast.ExportSet:      {},
+	ast.Bin: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
+	},
+	ast.ToBase64:   {},
+	ast.FromBase64: {},
+	ast.ExportSet:  {},
 	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinBinSig, for #12106

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinStringFunc/builtinBinSig-VecBuiltinFunc-8         	   10000	    158827 ns/op	   59789 B/op	    1660 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinBinSig-NonVecBuiltinFunc-8      	   10000	    174385 ns/op	   59789 B/op	    1660 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 