### PR TITLE
expression: implement  vectorized evaluation for builtinLeastRealSig

### DIFF
--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -40,6 +40,7 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Least: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal, types.ETReal}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for ```builtinLeastRealSig```, for issue [#12105](https://github.com/pingcap/tidb/issues/12105)

### What is changed and how it works?
- Implement vectorized evaluation.

Here is the benchmark , almost 8x faster than before:
```
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastRealSig-VecBuiltinFunc-4               	  244906	      4751 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinLeastRealSig-NonVecBuiltinFunc-4            	   33703	     35600 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test