### PR TITLE
*: support the TiFlash replica of table

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -250,6 +250,7 @@ type DDL interface {
 	LockTables(ctx sessionctx.Context, stmt *ast.LockTablesStmt) error
 	UnlockTables(ctx sessionctx.Context, lockedTables []model.TableLockTpInfo) error
 	CleanupTableLock(ctx sessionctx.Context, tables []*ast.TableName) error
+	UpdateTableReplicaInfo(ctx sessionctx.Context, tid int64, regionCount, flashRegionCount uint64) error
 
 	// GetLease returns current schema lease time.
 	GetLease() time.Duration

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -559,6 +559,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onUnlockTables(t, job)
 	case model.ActionSetFlashReplica:
 		ver, err = onSetTableFlashReplica(t, job)
+	case model.ActionUpdateFlashReplicaStatus:
+		ver, err = onUpdateFlashReplicaStatus(t, job)
 	default:
 		// Invalid job, cancel it.
 		job.State = model.JobStateCancelled

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -557,6 +557,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onLockTables(t, job)
 	case model.ActionUnlockTable:
 		ver, err = onUnlockTables(t, job)
+	case model.ActionSetFlashReplica:
+		ver, err = onSetTableFlashReplica(t, job)
 	default:
 		// Invalid job, cancel it.
 		job.State = model.JobStateCancelled

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
-	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514 // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
@@ -81,4 +80,4 @@ require (
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20190927113954-2a207934a58d

--- a/go.mod
+++ b/go.mod
@@ -81,4 +81,4 @@ require (
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20190911022129-16c5e0f7d110
+	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190905072037-92dd089d5514 // indirect
 	google.golang.org/grpc v1.23.0
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
@@ -79,3 +80,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,8 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f h1:lrikUiMIZLIdFgkDETl9VyOyaifpi1EObZLs8mH4tMA=
-github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
+github.com/crazycs520/parser v0.0.0-20190927113954-2a207934a58d h1:XwqYCIO4z0ncjB0dYTJX0ArGlwm1sibEWOtb6Pz1qA8=
+github.com/crazycs520/parser v0.0.0-20190927113954-2a207934a58d/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65 h1:hxuZop6tSoOi0sxFzoGGYdRqNrPubyaIf9KoBG9tPiE=

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,10 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/crazycs520/parser v0.0.0-20190927065716-9757ee294fb0 h1:vDrNavNiXjUkTWD3lmMkalmnaDrW+zha9xubsh4/Ycg=
+github.com/crazycs520/parser v0.0.0-20190927065716-9757ee294fb0/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
+github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d h1:pPBpXbtGYMAHvfixs6L3czzYIiPFN3egy+ck8ZtLvY8=
+github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65 h1:hxuZop6tSoOi0sxFzoGGYdRqNrPubyaIf9KoBG9tPiE=

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,8 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/crazycs520/parser v0.0.0-20190927065716-9757ee294fb0 h1:vDrNavNiXjUkTWD3lmMkalmnaDrW+zha9xubsh4/Ycg=
-github.com/crazycs520/parser v0.0.0-20190927065716-9757ee294fb0/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
-github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d h1:pPBpXbtGYMAHvfixs6L3czzYIiPFN3egy+ck8ZtLvY8=
-github.com/crazycs520/parser v0.0.0-20190927074402-68b2524ec09d/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
+github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f h1:lrikUiMIZLIdFgkDETl9VyOyaifpi1EObZLs8mH4tMA=
+github.com/crazycs520/parser v0.0.0-20190927082245-0ea8ace7bc5f/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65 h1:hxuZop6tSoOi0sxFzoGGYdRqNrPubyaIf9KoBG9tPiE=
@@ -170,8 +168,6 @@ github.com/pingcap/kvproto v0.0.0-20190910074005-0e61b6f435c1/go.mod h1:QMdbTAXC
 github.com/pingcap/log v0.0.0-20190214045112-b37da76f67a7/go.mod h1:xsfkWVaFVV5B8e1K9seWfyJWFrIhbtUTAD8NV1Pq3+w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20190923031704-33636bc5e5d6 h1:PyjsTUD8gJ6QGilbwiy/TTn89J84/69Pj9LixOd/fFE=
-github.com/pingcap/parser v0.0.0-20190923031704-33636bc5e5d6/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b h1:oS9PftxQqgcRouKhhdaB52tXhVLEP7Ng3Qqsd6Z18iY=
 github.com/pingcap/pd v0.0.0-20190712044914-75a1f9f3062b/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible h1:MkWCxgZpJBgY2f4HtwWMMFzSBb3+JPzeJgF3VrXE/bU=

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -421,3 +421,11 @@ func HasAutoIncrementColumn(tbInfo *model.TableInfo) (bool, string) {
 	}
 	return false, ""
 }
+
+// CheckTableFlashReplicaStatus uses to check the status of table flash replica.
+func CheckTableFlashReplicaStatus(tblInfo *model.TableInfo) bool {
+	if tblInfo == nil || tblInfo.FlashReplica == nil {
+		return false
+	}
+	return tblInfo.FlashReplica.RegionCount == tblInfo.FlashReplica.FlashRegionCount
+}

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -93,6 +93,8 @@ func (s *Server) startHTTPServer() {
 	router.Handle("/info/all", allServerInfoHandler{tikvHandlerTool}).Name("InfoALL")
 	// HTTP path for get db and table info that is related to the tableID.
 	router.Handle("/db-table/{tableID}", dbTableHandler{tikvHandlerTool})
+	// HTTP path for get table flash replica info.
+	router.Handle("/flash/replica", flashReplicaHandler{tikvHandlerTool})
 
 	if s.cfg.Store == "tikv" {
 		// HTTP path for tikv.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Related parser PR: 

* Add DDL syntax to support add table flash replica. 
```sql
ALTER TABLE [table_name] SET FLASH REPLICA [count] LOCATION LABELS [location_labels]
eg:
ALTER TABLE t SET FLASH REPLICA 3 LOCATION LABELS "rack", "host", "abc";
```
* Add `/flash/replica` http api to query the all table flash replica infos.

```shell
▶ curl "http://$IP:10080/flash/replica"
[
 {
  "id": 84,
  "replica_count": 3,
  "location_labels": [
   "rack",
   "host",
   "abc"
  ],
  "status": false
 }
]% 
``` 

* The `/flash/replica`HTTP API also use to let TiFlash to report the table replica status.
```shell
# update the replica status.
▶ curl -X POST -d '{"id":84,"region_count":3,"flash_region_count":3}' http://127.0.0.1:10080/flash/replica

▶ curl http://127.0.0.1:10080/flash/replica
[
 {
  "id": 84,
  "replica_count": 3,
  "location_labels": [
   "rack",
   "host",
   "abc"
  ],
  "status": true    # the status was true mean the flash replica is available now.
 }
]% 
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
Code changes

 - Has exported function/method change

Side effects

Related changes


Release note

