### PR TITLE
server: improve the addMetrics method performance

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -108,21 +108,20 @@ var (
 		mysql.ComStmtReset:        metrics.QueryTotalCounter.WithLabelValues("StmtReset", "Error"),
 		mysql.ComSetOption:        metrics.QueryTotalCounter.WithLabelValues("SetOption", "Error"),
 	}
-	queryDurationHistogram = map[string]prometheus.Observer{
-		"Use":              metrics.QueryDurationHistogram.WithLabelValues("Use"),
-		"Show":             metrics.QueryDurationHistogram.WithLabelValues("Show"),
-		"Begin":            metrics.QueryDurationHistogram.WithLabelValues("Begin"),
-		"Commit":           metrics.QueryDurationHistogram.WithLabelValues("Commit"),
-		"Rollback":         metrics.QueryDurationHistogram.WithLabelValues("Rollback"),
-		"Insert":           metrics.QueryDurationHistogram.WithLabelValues("Insert"),
-		"Replace":          metrics.QueryDurationHistogram.WithLabelValues("Replace"),
-		"Delete":           metrics.QueryDurationHistogram.WithLabelValues("Delete"),
-		"Update":           metrics.QueryDurationHistogram.WithLabelValues("Update"),
-		"Select":           metrics.QueryDurationHistogram.WithLabelValues("Select"),
-		"Execute":          metrics.QueryDurationHistogram.WithLabelValues("Execute"),
-		"Set":              metrics.QueryDurationHistogram.WithLabelValues("Set"),
-		metrics.LblGeneral: metrics.QueryDurationHistogram.WithLabelValues(metrics.LblGeneral),
-	}
+
+	queryDurationHistogramUse      = metrics.QueryDurationHistogram.WithLabelValues("Use")
+	queryDurationHistogramShow     = metrics.QueryDurationHistogram.WithLabelValues("Show")
+	queryDurationHistogramBegin    = metrics.QueryDurationHistogram.WithLabelValues("Begin")
+	queryDurationHistogramCommit   = metrics.QueryDurationHistogram.WithLabelValues("Commit")
+	queryDurationHistogramRollback = metrics.QueryDurationHistogram.WithLabelValues("Rollback")
+	queryDurationHistogramInsert   = metrics.QueryDurationHistogram.WithLabelValues("Insert")
+	queryDurationHistogramReplace  = metrics.QueryDurationHistogram.WithLabelValues("Replace")
+	queryDurationHistogramDelete   = metrics.QueryDurationHistogram.WithLabelValues("Delete")
+	queryDurationHistogramUpdate   = metrics.QueryDurationHistogram.WithLabelValues("Update")
+	queryDurationHistogramSelect   = metrics.QueryDurationHistogram.WithLabelValues("Select")
+	queryDurationHistogramExecute  = metrics.QueryDurationHistogram.WithLabelValues("Execute")
+	queryDurationHistogramSet      = metrics.QueryDurationHistogram.WithLabelValues("Set")
+	queryDurationHistogramGeneral  = metrics.QueryDurationHistogram.WithLabelValues(metrics.LblGeneral)
 )
 
 // newClientConn creates a *clientConn object.
@@ -747,10 +746,34 @@ func (cc *clientConn) addMetrics(cmd byte, startTime time.Time, err error) {
 		sqlType = stmtType
 	}
 
-	observer, found := queryDurationHistogram[sqlType]
-	if found && observer != nil {
-		observer.Observe(time.Since(startTime).Seconds())
-	} else {
+	switch sqlType {
+	case "Use":
+		queryDurationHistogramUse.Observe(time.Since(startTime).Seconds())
+	case "Show":
+		queryDurationHistogramShow.Observe(time.Since(startTime).Seconds())
+	case "Begin":
+		queryDurationHistogramBegin.Observe(time.Since(startTime).Seconds())
+	case "Commit":
+		queryDurationHistogramCommit.Observe(time.Since(startTime).Seconds())
+	case "Rollback":
+		queryDurationHistogramRollback.Observe(time.Since(startTime).Seconds())
+	case "Insert":
+		queryDurationHistogramInsert.Observe(time.Since(startTime).Seconds())
+	case "Replace":
+		queryDurationHistogramReplace.Observe(time.Since(startTime).Seconds())
+	case "Delete":
+		queryDurationHistogramDelete.Observe(time.Since(startTime).Seconds())
+	case "Update":
+		queryDurationHistogramUpdate.Observe(time.Since(startTime).Seconds())
+	case "Select":
+		queryDurationHistogramSelect.Observe(time.Since(startTime).Seconds())
+	case "Execute":
+		queryDurationHistogramExecute.Observe(time.Since(startTime).Seconds())
+	case "Set":
+		queryDurationHistogramSet.Observe(time.Since(startTime).Seconds())
+	case metrics.LblGeneral:
+		queryDurationHistogramGeneral.Observe(time.Since(startTime).Seconds())
+	default:
 		metrics.QueryDurationHistogram.WithLabelValues(sqlType).Observe(time.Since(startTime).Seconds())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. The `addMetrics` method is a hot path in TiDB and will be executed in every query. It uses `switch .. case` to find the `Counter` and add metrics to monitor system. It's not an efficient way.
2. Every metric use two global variables  (ok/error), which is global variable abuse.

See: https://godbolt.org/z/czr__4

### What is changed and how it works?

This PR makes the following change.

1. Group related metrics into two global variables by status (ok/error) and save them in an array. It's fast to get `Counter` by `cmd` (index).
2. Use a hash map to save statement type related metrics. And find the `Observer` from map is fast than `switch .. case` in common case.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - No need to add to release note.
