### PR TITLE
expression: implement vectorized evaluation for builtinNullEQRealSig

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -341,11 +341,49 @@ func (b *builtinNullEQIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinNullEQRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNullEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf0, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf0)
+
+	buf1, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf1)
+
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+		return err
+	}
+	arg0 := buf0.Float64s()
+
+	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+		return err
+	}
+	arg1 := buf1.Float64s()
+
+	result.ResizeInt64(n, false)
+	i64s := result.Int64s()
+
+	for i := 0; i < n; i++ {
+		isNull0 := buf0.IsNull(i)
+		isNull1 := buf1.IsNull(i)
+		switch {
+		case isNull0 && isNull1:
+			i64s[i] = 1
+		case isNull0 != isNull1:
+			break
+		case types.CompareFloat64(arg0[i], arg1[i]) == 0:
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinNullEQTimeSig) vectorized() bool {

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -27,11 +27,13 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.LE:       {},
 	ast.LT:       {},
 	ast.Coalesce: {},
-	ast.NullEQ:   {},
-	ast.GT:       {},
-	ast.EQ:       {},
-	ast.GE:       {},
-	ast.Date:     {},
+	ast.NullEQ: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+	},
+	ast.GT:   {},
+	ast.EQ:   {},
+	ast.GE:   {},
+	ast.Date: {},
 	ast.Greatest: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal, types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for ```builtinNullEQRealSig```, for issue #12103 

### What is changed and how it works?
- Implement vectorized evaluation.

Here is the benchmark , almost 7x faster than before:
```
BenchmarkVectorizedBuiltinCompareFunc/builtinNullEQRealSig-VecBuiltinFunc-4         	  284035	      3989 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinNullEQRealSig-NonVecBuiltinFunc-4      	   39982	     29278 ns/op	       0 B/op	       0 allocs/op

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
