### PR TITLE
expression: implement vectorized evaluation for `builtinCeilIntToIntSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -812,11 +812,11 @@ func (b *builtinCeilDecToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinCeilIntToIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCeilIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[0].VecEvalInt(b.ctx, input, result)
 }
 
 func (b *builtinFloorIntToIntSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -92,6 +92,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.Ceil: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24}}, geners: nil},
 	},
 	ast.Truncate: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinCeilIntToIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinCeilIntToIntSig-VecBuiltinFunc-4                      20000000               103 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinCeilIntToIntSig-NonVecBuiltinFunc-4                     100000             19115 ns/op               0 B/op            0 allocs/op

```

### Check List 

Tests 

 - Unit test
 - Integration test