### PR TITLE
ddl: allow multiple `unique` attributes in a column (#12165)

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -923,3 +923,17 @@ func (s *testIntegrationSuite) TestDropAutoIncrement(c *C) {
 	tk.MustExec("alter table t1 modify column a int")
 	tk.MustExec("set @@tidb_allow_remove_auto_inc = off")
 }
+
+func (s *testIntegrationSuite) TestMultipleUnique(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create database if not exists test")
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists multi_unique")
+	tk.MustExec("create table multi_unique (a int unique unique)")
+	tk.MustExec("drop table multi_unique")
+	tk.MustExec("create table multi_unique (a int key primary key unique unique)")
+	tk.MustExec("drop table multi_unique")
+	tk.MustExec("create table multi_unique (a int key unique unique key unique)")
+	tk.MustExec("drop table multi_unique")
+}


### PR DESCRIPTION
Cherry-pick #12165 to release 2.1.
