### PR TITLE
expression: implement vectorized evaluation for `builtinFloorIntToIntSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -820,11 +820,11 @@ func (b *builtinCeilIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinFloorIntToIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinFloorIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[0].VecEvalInt(b.ctx, input, result)
 }
 
 func (b *builtinFloorDecToIntSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -89,6 +89,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.Floor: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24}}, geners: nil},
 	},
 	ast.Ceil: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinFloorIntToIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinFloorIntToIntSig-VecBuiltinFunc-4             20000000               106 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinFloorIntToIntSig-NonVecBuiltinFunc-4            100000             19709 ns/op               0 B/op            0 allocs/op

```

### Check List 
Tests 

 - Unit test
