### PR TITLE
planner, server: fix execute statements twice after prepare a statement

### DIFF
--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -227,7 +227,7 @@ func isPointGetWithoutDoubleRead(ctx sessionctx.Context, p plannercore.Plan) boo
 func OptimizeExecStmt(ctx context.Context, sctx sessionctx.Context,
 	execAst *ast.ExecuteStmt, is infoschema.InfoSchema) (plannercore.Plan, error) {
 	var err error
-	builder := plannercore.NewPlanBuilder(sctx, is, nil)
+	builder := plannercore.NewPlanBuilder(sctx, is, &plannercore.BlockHintProcessor{})
 	p, err := builder.Build(ctx, execAst)
 	if err != nil {
 		return nil, err

--- a/server/conn.go
+++ b/server/conn.go
@@ -596,6 +596,12 @@ func (cc *clientConn) PeerHost(hasPassword string) (host string, err error) {
 func (cc *clientConn) Run(ctx context.Context) {
 	const size = 4096
 	defer func() {
+		failpoint.Inject("mockNoRecover", func(val failpoint.Value) {
+			if val.(bool) {
+				failpoint.Return()
+			}
+		})
+
 		r := recover()
 		if r != nil {
 			buf := make([]byte, size)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -238,15 +238,15 @@ func runTestRegression(c *C, overrider configOverrider, dbName string) {
 // runTestPrepare executes a statement twice after preparing a statement.
 func runTestPrepare(t *C) {
 	runTests(t, nil, func(dbt *DBTest) {
-		dbt.mustExec("create table t(id int, a int, primary key(id))")
-		dbt.mustExec("insert into t values(1, 2)")
+		dbt.mustExec("create table prepare_t(id int, a int, primary key(id))")
+		dbt.mustExec("insert into prepare_t values(1, 2)")
 
 		dbt.Assert(failpoint.Enable("github.com/pingcap/tidb/server/mockNoRecover", `return(true)`), IsNil)
 		defer func() {
 			dbt.Assert(failpoint.Disable("github.com/pingcap/tidb/server/mockNoRecover"), IsNil)
 		}()
 
-		stmt := dbt.mustPrepare("update t set a = a + 1 where id = ? ")
+		stmt := dbt.mustPrepare("update prepare_t set a = a + 1 where id = ? ")
 		dbt.mustExec("set @arg = 1")
 		defer stmt.Close()
 		res, err := stmt.Exec("1")

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -93,6 +93,10 @@ func (ts *TidbTestSuite) TestRegression(c *C) {
 	}
 }
 
+func (ts *TidbTestSuite) TestPrepareExec(c *C) {
+	runTestPrepare(c)
+}
+
 func (ts *TidbTestSuite) TestUint64(c *C) {
 	runTestPrepareResultFieldType(c)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When we run the sysbench's oltp_point_select tests, some connections panic. the stack as follows:
 ```
invalid memory address or nil pointer dereference\""] [stack="goroutine 42350688 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0x24b6b80, 0xc0038f8330, 0xc002492300)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/server/conn.go:598 +0xee
panic(0x1f9b5c0, 0x33b29c0)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/pingcap/tidb/planner/core.(*BlockHintProcessor).MaxSelectStmtOffset(...)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/planner/core/hints.go:40
github.com/pingcap/tidb/planner/core.NewPlanBuilder(0x24fa600, 0xc002d8a300, 0x24d6dc0, 0xc0042893b0, 0x0, 0xcbb0ad)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/planner/core/planbuilder.go:312 +0x44
github.com/pingcap/tidb/planner.OptimizeExecStmt(0x24b6b80, 0xc0038f8330, 0x24fa600, 0xc002d8a300, 0xc0011d1950, 0x24d6dc0, 0xc0042893b0, 0xc001293ef0, 0x37f5980, 0x24d6dc0, ...)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/planner/optimize.go:230 +0x5c
github.com/pingcap/tidb/session.(*session).CachedPlanExec(0xc002d8a300, 0x24b6b80, 0xc0038f8330, 0xc000000013, 0xc003fecca0, 0xc0018734c0, 0x1, 0x1, 0x203000, 0x203000, ...)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/session/session.go:1189 +0x185
github.com/pingcap/tidb/session.(*session).ExecutePreparedStmt(0xc002d8a300, 0x24b6b80, 0xc0038f8330, 0xc000000013, 0xc0018734c0, 0x1, 0x1, 0x18, 0xc00450d3f0, 0x1d08ba4, ...)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/session/session.go:1274 +0x335
github.com/pingcap/tidb/server.(*TiDBStatement).Execute(0xc003c87490, 0x24b6b80, 0xc0038f8330, 0xc0018734c0, 0x1, 0x1, 0x1, 0xc003b9ec6a, 0x1, 0xa)
/home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/server/driver_tidb.go:75 +0x85
...
```

### What is changed and how it works?
Use `&plannercore.BlockHintProcessor{}` instead of nil.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

