### PR TITLE
server: panic if status port is inuse

### DIFF
--- a/server/http_status.go
+++ b/server/http_status.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/pingcap/log"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
@@ -263,7 +264,7 @@ func (s *Server) startHTTPServer() {
 	}
 
 	if err != nil {
-		logutil.BgLogger().Info("listen failed", zap.Error(err))
+		log.Fatal("listen failed", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Panic when status ports conflict in multi-instances situation

### What is changed and how it works?
Let tidb exit(1) when status ports conflicts