### PR TITLE
ddl: fix incorrect origin default bit value in ColumnInfo (#12168)

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -923,3 +923,16 @@ func (s *testIntegrationSuite) TestDropAutoIncrement(c *C) {
 	tk.MustExec("alter table t1 modify column a int")
 	tk.MustExec("set @@tidb_allow_remove_auto_inc = off")
 }
+
+func (s *testIntegrationSuite) TestBitDefaultValue(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create database if not exists test")
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t_bit (a int)")
+	tk.MustExec("insert into t_bit value (1)")
+	tk.MustExec("alter table t_bit add column c bit(16) null default b'1100110111001'")
+	tk.MustQuery("select c from t_bit").Check(testkit.Rows("\x19\xb9"))
+	tk.MustExec("update t_bit set c = b'11100000000111'")
+	tk.MustQuery("select c from t_bit").Check(testkit.Rows("\x38\x07"))
+}

--- a/table/column.go
+++ b/table/column.go
@@ -362,6 +362,12 @@ func CheckNotNull(cols []*Column, row []types.Datum) error {
 
 // GetColOriginDefaultValue gets default value of the column from original default value.
 func GetColOriginDefaultValue(ctx sessionctx.Context, col *model.ColumnInfo) (types.Datum, error) {
+	// If the column type is BIT, both `OriginDefaultValue` and `DefaultValue` of ColumnInfo are corrupted, because
+	// after JSON marshaling and unmarshaling against the field with type `interface{}`, the content with actual type `[]byte` is changed.
+	// We need `DefaultValueBit` to restore OriginDefaultValue before reading it.
+	if col.Tp == mysql.TypeBit && col.DefaultValueBit != nil && col.OriginDefaultValue != nil {
+		col.OriginDefaultValue = col.DefaultValueBit
+	}
 	return getColDefaultValue(ctx, col, col.OriginDefaultValue)
 }
 


### PR DESCRIPTION
Cherry-pick #12168 to release 2.1.