### PR TITLE
expression: implement vectorized evaluation for `builtinFloorDecToIntSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -855,9 +855,38 @@ func (b *builtinFloorIntToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinFloorDecToIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinFloorDecToIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, false)
+	result.MergeNulls(buf)
+
+	d := buf.Decimals()
+	i64s := result.Int64s()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		i64s[i], err = d[i].ToInt()
+		if err == types.ErrTruncated {
+			err = nil
+			if d[i].IsNegative() {
+				i64s[i]--
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -90,6 +90,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Floor: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24}}, geners: nil},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}, geners: nil},
 	},
 	ast.Ceil: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinFloorDecToIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinFloorDecToIntSig-VecBuiltinFunc-4               200000              9368 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinFloorDecToIntSig-NonVecBuiltinFunc-4            100000             23327 ns/op               0 B/op            0 allocs/op

```

### Check List 

Tests 

 - Unit test
