### PR TITLE
expression: implement vectorized evaluation for `builtinTruncateUintSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -732,11 +732,38 @@ func (b *builtinTruncateIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinTruncateUintSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTruncateUintSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.MergeNulls(buf)
+	i64s := result.Int64s()
+	buf64s := buf.Int64s()
+
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if buf64s[i] < 0 {
+			shift := uint64(math.Pow10(int(-buf64s[i])))
+			i64s[i] = int64(uint64(i64s[i]) / shift * shift)
+		}
+	}
+	return nil
 }
 
 func (b *builtinCeilDecToDecSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -98,6 +98,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Truncate: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24, Flag: mysql.UnsignedFlag}}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 	},
 }
 


### PR DESCRIPTION
### What problem does this PR solve?
Implement vectorized evaluation for builtinTruncateUintSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinTruncateUintSig-VecBuiltinFunc-4                        200000              6417 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinTruncateUintSig-NonVecBuiltinFunc-4                      50000             33907 ns/op               0 B/op            0 allocs/op

```

### Check List 

Tests 

 - Unit test
 - Integration test
