### PR TITLE
expression: implement vectorized evaluation for `builtinRealIsTrueSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -371,7 +371,7 @@ func (b *builtinRealIsTrueSig) vectorized() bool {
 
 func (b *builtinRealIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get(types.ETInt, numRows)
+	buf, err := b.bufAllocator.get(types.ETReal, numRows)
 	if err != nil {
 		return err
 	}

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -383,7 +383,7 @@ func (b *builtinRealIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 	result.ResizeInt64(numRows, false)
 	f64s := buf.Float64s()
 	i64s := result.Int64s()
-	for i := 0; i < numRows; i ++ {
+	for i := 0; i < numRows; i++ {
 		if buf.IsNull(i) || f64s[i] == 0 {
 			i64s[i] = 0
 		} else {

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -366,11 +366,31 @@ func (b *builtinRightShiftSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 }
 
 func (b *builtinRealIsTrueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinRealIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeInt64(numRows, false)
+	f64s := buf.Float64s()
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i ++ {
+		if buf.IsNull(i) || f64s[i] == 0 {
+			i64s[i] = 0
+		} else {
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinDecimalIsTrueSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -22,7 +22,9 @@ import (
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-	ast.IsTruth:   {},
+	ast.IsTruth: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}, geners: []dataGenerator{&defaultGener{0.2, types.ETReal}}},
+	},
 	ast.IsFalsity: {},
 	ast.LogicOr: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Implement vectorized evaluation for builtinRealIsTrueSig.
#12103

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinOpFunc/builtinRealIsTrueSig-VecBuiltinFunc-4            335839              3479 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinRealIsTrueSig-NonVecBuiltinFunc-4          47275             26093 ns/op               0 B/op          0 allocs/op
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test