### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticPlusRealSig`

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -16,7 +16,6 @@ package expression
 import (
 	"fmt"
 	"math"
-	"strconv"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/types"
@@ -113,7 +112,7 @@ func (b *builtinArithmeticPlusRealSig) vecEvalReal(input *chunk.Chunk, result *c
 			continue
 		}
 		if (x[i] > 0 && y[i] > math.MaxFloat64-x[i]) || (x[i] < 0 && y[i] < -math.MaxFloat64-x[i]) {
-			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", strconv.FormatFloat(x[i], 'f', -1, 64), strconv.FormatFloat(y[i], 'f', -1, 64)))
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
 		}
 		x[i] = x[i] + y[i]
 	}

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/types"
 )
 
 var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
@@ -30,7 +31,9 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.Mul:    {},
 	ast.Round:  {},
 	ast.And:    {},
-	ast.Plus:   {},
+	ast.Plus:   {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+	},
 	ast.NE:     {},
 }
 

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -31,10 +31,10 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.Mul:    {},
 	ast.Round:  {},
 	ast.And:    {},
-	ast.Plus:   {
+	ast.Plus: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 	},
-	ast.NE:     {},
+	ast.NE: {},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinArithmeticFunc(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticPlusRealSig.#12105

### What is changed and how it works?
```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticPlusRealSig-VecBuiltinFunc-4            280898              3963 ns/op               0 B/op        0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticPlusRealSig-NonVecBuiltinFunc-4          33783             35185 ns/op               0 B/op        0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      2.736s
```

### Check List

Tests
- Unit test