### PR TITLE
expression: implement vectorized evaluation for `builtinSignSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -819,11 +819,9 @@ func (b *builtinSignSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) er
 		if result.IsNull(i) {
 			continue
 		}
-		if i64s[i] == 0 {
-			result.SetNull(i, true)
-		} else if i64s[i] > 0 {
+		if i64s[i] > 0 {
 			i64s[i] = 1
-		} else {
+		} else if i64s[i] < 0 {
 			i64s[i] = -1
 		}
 	}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -807,11 +807,27 @@ func (b *builtinFloorIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chu
 }
 
 func (b *builtinSignSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinSignSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	i64s := result.Int64s()
+	for i := 0; i < len(i64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if i64s[i] == 0 {
+			result.SetNull(i, true)
+		} else if i64s[i] > 0 {
+			i64s[i] = 1
+		} else {
+			i64s[i] = -1
+		}
+	}
+	return nil
 }
 
 func (b *builtinConvSig) vectorized() bool {

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -820,7 +820,7 @@ func (b *builtinSignSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) er
 	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
 		return err
 	}
-	args := buf.Int64s()
+	args := buf.Float64s()
 	result.ResizeInt64(n, false)
 	result.MergeNulls(buf)
 	i64s := result.Int64s()
@@ -832,6 +832,8 @@ func (b *builtinSignSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) er
 			i64s[i] = 1
 		} else if args[i] < 0 {
 			i64s[i] = -1
+		} else {
+			i64s[i] = 0
 		}
 	}
 	return nil

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -25,7 +25,6 @@ import (
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sign: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{nil, nil}},
 	},
 	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -23,7 +23,9 @@ import (
 )
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
-	ast.Sign: {},
+	ast.Sign: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{nil, nil}},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -24,7 +24,7 @@ import (
 
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sign: {
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
 	},
 	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -25,6 +25,7 @@ import (
 var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.Sign: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{nil, nil}},
 	},
 	ast.Log: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinSignSig`, as listed in #12103 .

### What is changed and how it works?
Here is the benchmark, almost 7.3x faster than before:
```
BenchmarkVectorizedBuiltinMathFunc/builtinSignSig-VecBuiltinFunc-12                  	  262920	      4431 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinSignSig-NonVecBuiltinFunc-12               	   36554	     32638 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test