### PR TITLE
expression: implement vectorized evaluation for `builtinIntIsNullSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -123,22 +123,15 @@ func (b *builtinIntIsNullSig) vectorized() bool {
 }
 
 func (b *builtinIntIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get(types.ETInt, numRows)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(buf)
-
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
 		return err
 	}
 
-	result.ResizeInt64(numRows, false)
 	i64s := result.Int64s()
-	for i := 0; i < numRows; i++ {
-		if buf.IsNull(i) {
+	for i := 0; i < len(i64s); i++ {
+		if result.IsNull(i) {
 			i64s[i] = 1
+			result.SetNull(i, false)
 		} else {
 			i64s[i] = 0
 		}

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -130,7 +130,7 @@ func (b *builtinIntIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 	}
 	defer b.bufAllocator.put(buf)
 
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
 		return err
 	}
 

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -119,11 +119,31 @@ func (b *builtinUnaryMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, result 
 }
 
 func (b *builtinIntIsNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinIntIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) {
+			i64s[i] = 1
+		} else {
+			i64s[i] = 0
+		}
+	}
+	return nil
 }
 
 func (b *builtinRealIsNullSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -40,7 +40,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.UnaryMinus: {},
-	ast.IsNull:     {},
+	ast.IsNull: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 }
 
 // givenValsGener returns the items sequentially from the slice given at


### PR DESCRIPTION
### What problem does this PR solve? 
Implement vectorized evaluation for builtinIntIsNullSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsNullSig-VecBuiltinFunc-4             540609              2086 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsNullSig-NonVecBuiltinFunc-4           60596             19653 ns/op               0 B/op          0 allocs/op

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test