### PR TITLE
expression: implement vectorized evaluation for `builtinDecimalIsNullSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -342,11 +342,31 @@ func (b *builtinUnaryNotIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinDecimalIsNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinDecimalIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) {
+			i64s[i] = 1
+		} else {
+			i64s[i] = 0
+		}
+	}
+	return nil
 }
 
 func (b *builtinLeftShiftSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -40,7 +40,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.UnaryMinus: {},
-	ast.IsNull:     {},
+	ast.IsNull: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
+	},
 }
 
 // givenValsGener returns the items sequentially from the slice given at


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinDecimalIsNullSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinDecimalIsNullSig-VecBuiltinFunc-4                 359746              2949 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinDecimalIsNullSig-NonVecBuiltinFunc-4               61214             19323 ns/op               0 B/op            0 allocs/op

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test