### PR TITLE
expression: implement vectorized evaluation for builtinDurationIsNullSig

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -390,9 +390,29 @@ func (b *builtinIntIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinDurationIsNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinDurationIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDuration, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) {
+			i64s[i] = 1
+		} else {
+			i64s[i] = 0
+		}
+	}
+	return nil
 }

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -40,7 +40,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.UnaryMinus: {},
-	ast.IsNull:     {},
+	ast.IsNull: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}},
+	},
 }
 
 // givenValsGener returns the items sequentially from the slice given at


### PR DESCRIPTION
# What problem does this PR solve? 
Implement vectorized evaluation for builtinDurationIsNullSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinDurationIsNullSig-VecBuiltinFunc-4                516579              2092 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinDurationIsNullSig-NonVecBuiltinFunc-4              61326             19578 ns/op               0 B/op            0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test