### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticMinusRealSig`

### DIFF
--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -18,11 +18,14 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/types"
 )
 
 var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
-	ast.LE:     {},
-	ast.Minus:  {},
+	ast.LE: {},
+	ast.Minus: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+	},
 	ast.Div:    {},
 	ast.IntDiv: {},
 	ast.Mod:    {},


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticMinusRealSig.#12105

### What is changed and how it works?
```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusRealSig-VecBuiltinFunc-4                   256300              5510 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusRealSig-NonVecBuiltinFunc-4                 31702             40009 ns/op            0 B/op           0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.957s
```

### Check List

Tests
- Unit test