### PR TITLE
expression: implement vectorized evaluation for `builtinIntIsTrueSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -538,22 +538,15 @@ func (b *builtinIntIsTrueSig) vectorized() bool {
 
 func (b *builtinIntIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	numRows := input.NumRows()
-	buf, err := b.bufAllocator.get(types.ETInt, numRows)
-	if err != nil {
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf)
-
-	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
-		return err
-	}
-
-	result.ResizeInt64(numRows, false)
 	i64s := result.Int64s()
 	for i := 0; i < numRows; i++ {
-		if buf.IsNull(i) || buf.GetInt64(i) == 0 {
+		if result.IsNull(i) {
 			i64s[i] = 0
-		} else {
+			result.SetNull(i, false)
+		} else if i64s[i] != 0 {
 			i64s[i] = 1
 		}
 	}

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -533,11 +533,31 @@ func (b *builtinDecimalIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinIntIsTrueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinIntIsTrueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) || buf.GetInt64(i) == 0 {
+			i64s[i] = 0
+		} else {
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinDurationIsNullSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -23,8 +23,9 @@ import (
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.IsTruth: {
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}, geners: []dataGenerator{&defaultGener{0.2, types.ETReal}}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}, geners: []dataGenerator{&defaultGener{0.2, types.ETDecimal}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.IsFalsity: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinIntIsTrueSig. #12103

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsTrueSig-VecBuiltinFunc-4             339927              3433 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsTrueSig-NonVecBuiltinFunc-4           47221             25373 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
