### PR TITLE
expression: implement vectorized evaluation for `builtinRealIsFalseSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -270,11 +270,31 @@ func (b *builtinBitAndSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinRealIsFalseSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinRealIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) || buf.GetInt64(i) != 0 {
+			i64s[i] = 0
+		} else {
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinUnaryMinusIntSig) vectorized() bool {

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -286,9 +286,9 @@ func (b *builtinRealIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 
 	result.ResizeInt64(numRows, false)
 	i64s := result.Int64s()
-
+	bufI64s := buf.Int64s()
 	for i := 0; i < numRows; i++ {
-		if buf.IsNull(i) || buf.GetInt64(i) != 0 {
+		if buf.IsNull(i) || bufI64s[i] != 0 {
 			i64s[i] = 0
 		} else {
 			i64s[i] = 1

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-	ast.IsTruth:   {},
-	ast.IsFalsity: {},
+	ast.IsTruth: {},
+	ast.IsFalsity: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
+	},
 	ast.LogicOr: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Implement vectorized evaluation for builtinRealIsFalseSig. #12103

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinOpFunc/builtinRealIsFalseSig-VecBuiltinFunc-4                   304029              3581 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinRealIsFalseSig-NonVecBuiltinFunc-4                 46515             25656 ns/op               0 B/op          0 allocs/op
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test