### PR TITLE
expression: implement vectorized evaluation for `builtinDecimalIsFalseSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -79,11 +79,33 @@ func (b *builtinBitOrSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 }
 
 func (b *builtinDecimalIsFalseSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinDecimalIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+
+	buf, err := b.bufAllocator.get(types.ETDecimal, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	desc := buf.Decimals()
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) || !desc[i].IsZero() {
+			i64s[i] = 0
+		} else {
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinIntIsFalseSig) vectorized() bool {

--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -94,12 +94,12 @@ func (b *builtinDecimalIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.
 		return err
 	}
 
-	desc := buf.Decimals()
+	decs := buf.Decimals()
 	result.ResizeInt64(numRows, false)
 	i64s := result.Int64s()
 
 	for i := 0; i < numRows; i++ {
-		if buf.IsNull(i) || !desc[i].IsZero() {
+		if buf.IsNull(i) || !decs[i].IsZero() {
 			i64s[i] = 0
 		} else {
 			i64s[i] = 1

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -22,8 +22,10 @@ import (
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{
-	ast.IsTruth:   {},
-	ast.IsFalsity: {},
+	ast.IsTruth: {},
+	ast.IsFalsity: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
+	},
 	ast.LogicOr: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Implement vectorized evaluation for builtinDecimalIsFalseSig. #12103
### What problem does this PR solve? <!--add issue link with summary if exists-->
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinOpFunc/builtinDecimalIsFalseSig-VecBuiltinFunc-4                135334              8808 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinDecimalIsFalseSig-NonVecBuiltinFunc-4              44178             27624 ns/op               0 B/op          0 allocs/op
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
