### PR TITLE
expression: implement vectorized evaluation for `builtinNullEQDecimalSig`

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -510,8 +510,8 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 		switch {
 		case isNull0 && isNull1:
 			i64s[i] = 1
-		case i64s[i] == 0:
-			break
+		case isNull0 != isNull1:
+			i64s[i] = 0
 		case args0[i].Compare(&args1[i]) == 0:
 			i64s[i] = 1
 		}

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -480,26 +480,22 @@ func (b *builtinNullEQDecimalSig) vectorized() bool {
 
 func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
 	buf0, err := b.bufAllocator.get(types.ETDecimal, n)
 	if err != nil {
 		return err
 	}
+	defer b.bufAllocator.put(buf0)
 	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf0)
-
 	buf1, err := b.bufAllocator.get(types.ETDecimal, n)
 	if err != nil {
 		return err
 	}
-
+	defer b.bufAllocator.put(buf1)
 	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf1); err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(buf1)
-
 	args0 := buf0.Decimals()
 	args1 := buf1.Decimals()
 	result.ResizeInt64(n, false)

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -502,7 +502,7 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 
 	args0 := buf0.Decimals()
 	args1 := buf1.Decimals()
-	result.ResizeDecimal(n, false)
+	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
 	for i := 0; i < len(i64s); i++ {
 		isNull0 := buf0.IsNull(i)
@@ -510,7 +510,7 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 		switch {
 		case isNull0 && isNull1:
 			i64s[i] = 1
-		case isNull0 != isNull1:
+		case i64s[i] == 0:
 			break
 		case args0[i].Compare(&args1[i]) == 0:
 			i64s[i] = 1

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -504,7 +504,7 @@ func (b *builtinNullEQDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 	args1 := buf1.Decimals()
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
-	for i := 0; i < len(i64s); i++ {
+	for i := 0; i < n; i++ {
 		isNull0 := buf0.IsNull(i)
 		isNull1 := buf1.IsNull(i)
 		switch {

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -29,6 +29,7 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Coalesce: {},
 	ast.NullEQ: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}},
 	},
 	ast.GT:   {},
 	ast.EQ:   {},

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -29,7 +29,10 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Coalesce: {},
 	ast.NullEQ: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}, geners: []dataGenerator{
+			gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+			gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+		}},
 	},
 	ast.GT:   {},
 	ast.EQ:   {},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinNullEQDecimalSig `.

### What is changed and how it works?

Almost 2.5x faster than before:
```
BenchmarkVectorizedBuiltinCompareFunc/builtinNullEQDecimalSig-VecBuiltinFunc-12      	   78765	     14868 ns/op
BenchmarkVectorizedBuiltinCompareFunc/builtinNullEQDecimalSig-NonVecBuiltinFunc-12   	   31239	     38043 ns/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

