### PR TITLE
expression: implement vectorized evaluation for 'builtinCastDecimalAsStringSig'

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -164,11 +164,43 @@ func (b *builtinCastRealAsStringSig) vecEvalString(input *chunk.Chunk, result *c
 }
 
 func (b *builtinCastDecimalAsStringSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastDecimalAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	sc := b.ctx.GetSessionVars().StmtCtx
+	vas := buf.Decimals()
+	result.ReserveString(n)
+	for i, v := range vas {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		res, e := types.ProduceStrWithSpecifiedTp(string(v.ToString()), b.tp, sc, false)
+		if e != nil {
+			return e
+		}
+		str, b, e1 := padZeroForBinaryType(res, b.tp, b.ctx)
+		if e1 != nil {
+			return e1
+		}
+		if b {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(str)
+	}
+	return nil
 }
 
 func (b *builtinCastTimeAsDecimalSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -37,6 +37,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal}},
 	},
 }
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinCastDecimalAsStringSig, for #12106

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsStringSig-VecBuiltinFunc-8         	   20000	     99873 ns/op	   26272 B/op	     821 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsStringSig-NonVecBuiltinFunc-8      	   10000	    126724 ns/op	   51184 B/op	    1642 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 