### PR TITLE
expression: implement vectorized evaluation for 'builtinCastDurationAsStringSig'

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -563,6 +563,8 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(input *chunk.Chunk, resul
 		return err
 	}
 
+	var res string
+	var isNull bool
 	sc := b.ctx.GetSessionVars().StmtCtx
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
@@ -570,19 +572,19 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(input *chunk.Chunk, resul
 			result.AppendNull()
 			continue
 		}
-		res, e := types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, 0).String(), b.tp, sc, false)
-		if e != nil {
-			return e
+		res, err = types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, 0).String(), b.tp, sc, false)
+		if err != nil {
+			return err
 		}
-		str, b, e1 := padZeroForBinaryType(res, b.tp, b.ctx)
-		if e1 != nil {
-			return e1
+		res, isNull, err = padZeroForBinaryType(res, b.tp, b.ctx)
+		if err != nil {
+			return err
 		}
-		if b {
+		if isNull {
 			result.AppendNull()
 			continue
 		}
-		result.AppendString(str)
+		result.AppendString(res)
 	}
 	return nil
 }

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -37,6 +37,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDuration}},
 	},
 }
 


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinCastDurationAsStringSig, for #12106

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastDurationAsStringSig-VecBuiltinFunc-8         	    5000	    352306 ns/op	  102205 B/op	    2917 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastDurationAsStringSig-NonVecBuiltinFunc-8      	    5000	    367838 ns/op	  102206 B/op	    2917 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 