### PR TITLE
expression: implement vectorized evaluation for 'builtinCastJSONAsStringSig'

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -424,11 +424,29 @@ func (b *builtinCastJSONAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk
 }
 
 func (b *builtinCastJSONAsStringSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastJSONAsStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETJson, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(buf.GetJSON(i).String())
+	}
+	return nil
 }
 
 func (b *builtinCastDurationAsRealSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -37,6 +37,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETJson}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinCastJSONAsStringSig, for #12106


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastJSONAsStringSig-VecBuiltinFunc-8         	   10000	    134676 ns/op	   64960 B/op	    1624 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastJSONAsStringSig-NonVecBuiltinFunc-8      	   10000	    145043 ns/op	   64960 B/op	    1624 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 