### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticMultiplyRealSig`

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -23,11 +23,36 @@ import (
 )
 
 func (b *builtinArithmeticMultiplyRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.MergeNulls(buf)
+	x := result.Float64s()
+	y := buf.Float64s()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		x[i] = x[i] * y[i]
+		if math.IsInf(x[i], 0) {
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+		}
+	}
+	return nil
 }
 
 func (b *builtinArithmeticDivideDecimalSig) vectorized() bool {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -30,9 +30,11 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.IntDiv: {},
 	ast.Mod:    {},
 	ast.Or:     {},
-	ast.Mul:    {},
-	ast.Round:  {},
-	ast.And:    {},
+	ast.Mul: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+	},
+	ast.Round: {},
+	ast.And:   {},
 	ast.Plus: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 	},


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticMultiplyRealSig.#12105

### What is changed and how it works?
```
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMultiplyRealSig-VecBuiltinFunc-4                384745              3277 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMultiplyRealSig-NonVecBuiltinFunc-4              39608             29081 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticPlusRealSig-VecBuiltinFunc-4                    270891              3777 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticPlusRealSig-NonVecBuiltinFunc-4                  40618             28557 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusRealSig-VecBuiltinFunc-4                   299098              3472 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusRealSig-NonVecBuiltinFunc-4                 37515             31396 ns/op            0 B/op           0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      8.894s
```

### Check List

Tests
- Unit test