### PR TITLE
session: remove the mockFail field from txnFuture

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3731,8 +3731,9 @@ func (s *testSuite3) TestTSOFail(c *C) {
 	tk.MustExec(`drop table if exists t`)
 	tk.MustExec(`create table t(a int)`)
 
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, "mockGetTSFail", struct{}{})
+	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
+		return fpname == "mockGetTSFail"
+	})
 	_, err := tk.Se.Execute(ctx, `select * from t`)
 	c.Assert(err, NotNil)
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3731,11 +3731,13 @@ func (s *testSuite3) TestTSOFail(c *C) {
 	tk.MustExec(`drop table if exists t`)
 	tk.MustExec(`create table t(a int)`)
 
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/session/mockGetTSFail", "return"), IsNil)
 	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
-		return fpname == "mockGetTSFail"
+		return fpname == "github.com/pingcap/tidb/session/mockGetTSFail"
 	})
 	_, err := tk.Se.Execute(ctx, `select * from t`)
 	c.Assert(err, NotNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/mockGetTSFail"), IsNil)
 }
 
 func (s *testSuite3) TestSelectHashPartitionTable(c *C) {

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -82,8 +82,9 @@ func (s *testSessionSuite) TestGetTSFailDirtyState(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
 
-	ctx := context.Background()
-	ctx = context.WithValue(ctx, "mockGetTSFail", struct{}{})
+	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
+		return fpname == "mockGetTSFail"
+	})
 	tk.Se.Execute(ctx, "select * from t")
 
 	// Fix a bug that active txn fail set TxnState.fail to error, and then the following write

--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -82,15 +82,18 @@ func (s *testSessionSuite) TestGetTSFailDirtyState(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
 
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/session/mockGetTSFail", "return"), IsNil)
 	ctx := failpoint.WithHook(context.Background(), func(ctx context.Context, fpname string) bool {
-		return fpname == "mockGetTSFail"
+		return fpname == "github.com/pingcap/tidb/session/mockGetTSFail"
 	})
-	tk.Se.Execute(ctx, "select * from t")
+	_, err := tk.Se.Execute(ctx, "select * from t")
+	c.Assert(err, NotNil)
 
 	// Fix a bug that active txn fail set TxnState.fail to error, and then the following write
 	// affected by this fail flag.
 	tk.MustExec("insert into t values (1)")
 	tk.MustQuery(`select * from t`).Check(testkit.Rows("1"))
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/mockGetTSFail"), IsNil)
 }
 
 func (s *testSessionSuite) TestGetTSFailDirtyStateInretry(c *C) {

--- a/session/txn.go
+++ b/session/txn.go
@@ -372,22 +372,24 @@ func mergeToDirtyDB(dirtyDB *executor.DirtyDB, op dirtyTableOperation) {
 	}
 }
 
+type txnFailFuture struct{}
+
+func (txnFailFuture) Wait() (uint64, error) {
+	return 0, errors.New("mock get timestamp fail")
+}
+
 // txnFuture is a promise, which promises to return a txn in future.
 type txnFuture struct {
 	future oracle.Future
 	store  kv.Storage
-
-	mockFail bool
 }
 
 func (tf *txnFuture) wait() (kv.Transaction, error) {
-	if tf.mockFail {
-		return nil, errors.New("mock get timestamp fail")
-	}
-
 	startTS, err := tf.future.Wait()
 	if err == nil {
 		return tf.store.BeginWithStartTS(startTS)
+	} else if _, ok := tf.future.(txnFailFuture); ok {
+		return nil, err
 	}
 
 	// It would retry get timestamp.
@@ -410,7 +412,7 @@ func (s *session) getTxnFuture(ctx context.Context) *txnFuture {
 	}
 	ret := &txnFuture{future: tsFuture, store: s.store}
 	if x := ctx.Value("mockGetTSFail"); x != nil {
-		ret.mockFail = true
+		ret.future = txnFailFuture{}
 	}
 	return ret
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -411,9 +411,9 @@ func (s *session) getTxnFuture(ctx context.Context) *txnFuture {
 		tsFuture = oracleStore.GetTimestampAsync(ctx)
 	}
 	ret := &txnFuture{future: tsFuture, store: s.store}
-	if x := ctx.Value("mockGetTSFail"); x != nil {
+	failpoint.InjectContext(ctx, "mockGetTSFail", func() {
 		ret.future = txnFailFuture{}
-	}
+	})
 	return ret
 }
 


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. The `txnFuture` contains a field `mockFail` that is very weird. And we will check that field at every `txnFuture.wait()` call.
2. The `session.getTxnFuture` will check whether does the context contains `mockGetTSFail` in normal scenario, it not efficiency.

### What is changed and how it works?

1. Remove `mockFail` from `txnFuture` struct definition.
2. Returns the error if the error is produced by `txnFailFuture` (type assertion is very fast, see: https://godbolt.org/z/CF1Hcw).
3. Use `failpoint` to reduce the cost of checking `ctx.Value("mockGetTsFail")`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - No need to add to release note.
