### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticDivideRealSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -302,7 +302,7 @@ func (g *rangeRealGener) gen() interface{} {
 	if rand.Float64() < g.nullRation {
 		return nil
 	}
-	if g.end <= g.begin {
+	if g.end < g.begin {
 		g.begin = -100
 		g.end = 100
 	}

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -194,11 +194,44 @@ func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(input *chunk.Chunk, result 
 }
 
 func (b *builtinArithmeticDivideRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinArithmeticDivideRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.MergeNulls(buf)
+	x := result.Float64s()
+	y := buf.Float64s()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if y[i] == 0 {
+			if err := handleDivisionByZeroError(b.ctx); err != nil {
+				return err
+			}
+			result.SetNull(i, true)
+			continue
+		}
+
+		x[i] = x[i] / y[i]
+		if math.IsInf(x[i], 0) {
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", fmt.Sprintf("(%s / %s)", b.args[0].String(), b.args[1].String()))
+		}
+	}
+	return nil
 }
 
 func (b *builtinArithmeticIntDivideIntSig) vectorized() bool {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -26,7 +26,10 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.Minus: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 	},
-	ast.Div:    {},
+	ast.Div: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{nil, &rangeRealGener{0, 0, 0}}},
+	},
 	ast.IntDiv: {},
 	ast.Mod:    {},
 	ast.Or:     {},


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticDivideRealSig.#12105

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideRealSig-VecBuiltinFunc-4                  287391              3930 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideRealSig-NonVecBuiltinFunc-4                37618             30057 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideRealSig-VecBuiltinFunc#01-4                62211             19411 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideRealSig-NonVecBuiltinFunc#01-4             31480             37321 ns/op            0 B/op           0 allocs/op
```

### Check List

Tests
- Unit test

