### PR TITLE
*: fix panic when check null rejection for `from_unixtime` (#12413)

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1571,26 +1571,30 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	_, isArg0Con := args[0].(*Constant)
 	isArg0Str := args[0].GetType().EvalType() == types.ETString
 	bf := newBaseBuiltinFuncWithTp(ctx, args, retTp, argTps...)
-	if len(args) == 1 {
-		if isArg0Str {
-			bf.tp.Decimal = types.MaxFsp
-		} else if isArg0Con {
-			arg0, _, err1 := args[0].EvalDecimal(ctx, chunk.Row{})
-			if err1 != nil {
-				return sig, errors.Trace(err1)
-			}
-			fsp := int(arg0.GetDigitsFrac())
-			if fsp > types.MaxFsp {
-				fsp = types.MaxFsp
-			}
-			bf.tp.Decimal = fsp
-		}
-		sig = &builtinFromUnixTime1ArgSig{bf}
-	} else {
+
+	if len(args) > 1 {
 		bf.tp.Flen = args[1].GetType().Flen
-		sig = &builtinFromUnixTime2ArgSig{bf}
+		return &builtinFromUnixTime2ArgSig{bf}, nil
 	}
-	return sig, nil
+
+	// Calculate the time fsp.
+	switch {
+	case isArg0Str:
+		bf.tp.Decimal = int(types.MaxFsp)
+	case isArg0Con:
+		arg0, arg0IsNull, err0 := args[0].EvalDecimal(ctx, chunk.Row{})
+		if err0 != nil {
+			return nil, err0
+		}
+
+		bf.tp.Decimal = int(types.MaxFsp)
+		if !arg0IsNull {
+			fsp := int(arg0.GetDigitsFrac())
+			bf.tp.Decimal = mathutil.Min(fsp, int(types.MaxFsp))
+		}
+	}
+
+	return &builtinFromUnixTime1ArgSig{bf}, nil
 }
 
 func evalFromUnixTime(ctx sessionctx.Context, fsp int, row chunk.Row, arg Expression) (res types.Time, isNull bool, err error) {

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "TestPushLimitDownIndexLookUpReader",
+    "cases": [
+      // Limit should be pushed down into IndexLookUpReader, row count of IndexLookUpReader and TableScan should be 1.00.
+      "explain select * from tbl use index(idx_b_c) where b > 1 limit 2,1",
+	  // Projection atop IndexLookUpReader, Limit should be pushed down into IndexLookUpReader, and Projection should have row count 1.00 as well.
+      "explain select * from tbl use index(idx_b_c) where b > 1 order by b desc limit 2,1",
+	  // Limit should be pushed down into IndexLookUpReader when Selection on top of IndexScan.
+	  "explain select * from tbl use index(idx_b_c) where b > 1 and c > 1 limit 2,1",
+	  // Limit should NOT be pushed down into IndexLookUpReader when Selection on top of TableScan.
+	  "explain select * from tbl use index(idx_b_c) where b > 1 and a > 1 limit 2,1"
+    ]
+  },
+  {
+    "name": "TestIsFromUnixtimeNullRejective",
+    "cases": [
+      // fix #12385
+      "explain select * from t t1 left join t t2 on t1.a=t2.a where from_unixtime(t2.b);"
+    ]
+  }
+]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -1,0 +1,22 @@
+[
+  {
+    "Name": "TestPushLimitDownIndexLookUpReader",
+    "Cases": null
+  },
+  {
+    "Name": "TestIsFromUnixtimeNullRejective",
+    "Cases": [
+      {
+        "SQL": "explain select * from t t1 left join t t2 on t1.a=t2.a where from_unixtime(t2.b);",
+        "Plan": [
+          "HashLeftJoin_8 10000.00 root inner join, inner:Selection_12, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─TableReader_11 10000.00 root data:TableScan_10",
+          "│ └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
+          "└─Selection_12 8000.00 root from_unixtime(cast(test.t2.b))",
+          "  └─TableReader_14 10000.00 root data:TableScan_13",
+          "    └─TableScan_13 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -193,6 +193,26 @@ func loadTestSuiteCases(filePath string) (res []testCases, err error) {
 	return res, err
 }
 
+// GetTestCasesByName gets the test cases for a test function by its name.
+func (t *TestData) GetTestCasesByName(caseName string, c *check.C, in interface{}, out interface{}) {
+	casesIdx, ok := t.funcMap[caseName]
+	c.Assert(ok, check.IsTrue, check.Commentf("Must get test %s", caseName))
+	err := json.Unmarshal(*t.input[casesIdx].Cases, in)
+	c.Assert(err, check.IsNil)
+	if !record {
+		err = json.Unmarshal(*t.output[casesIdx].Cases, out)
+		c.Assert(err, check.IsNil)
+	} else {
+		// Init for generate output file.
+		inputLen := reflect.ValueOf(in).Elem().Len()
+		v := reflect.ValueOf(out).Elem()
+		if v.Kind() == reflect.Slice {
+			v.Set(reflect.MakeSlice(v.Type(), inputLen, inputLen))
+		}
+	}
+	t.output[casesIdx].decodedOut = out
+}
+
 // GetTestCases gets the test cases for a test function.
 func (t *TestData) GetTestCases(c *check.C, in interface{}, out interface{}) {
 	// Extract caller's name.


### PR DESCRIPTION
Cherry pick #12413 to release-2.1. Original PR description:

> Signed-off-by: Zhang Jian <zjsariel@gmail.com>
>
> ### What problem does this PR solve? <!--add issue link with summary if exists-->
>
> fix #12385
>
> ### What is changed and how it works?
>
> check whether the argument is NULL before using the value pointer.
>
> ### Check List <!--REMOVE the items that are not applicable-->
>
> Tests <!-- At least one of them must be included. -->
>
>  - Unit test
>  - Integration test
>
> Code changes
>
>  - Has exported function/method change
>  - Has exported variable/fields change
>
> Related changes
>
>  - Need to cherry-pick to the release branch
>
> Release note
>
> ```
> fix the panic when check null rejection for `from_unixtime`.
> ```