### PR TITLE
expression: implement vectorized evaluation for `builtinToBase64Sig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -843,11 +844,51 @@ func (b *builtinOctIntSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinToBase64Sig) vectorized() bool {
-	return false
+	return true
 }
 
+// vecEvalString evals a builtinToBase64Sig.
+// See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_to-base64
 func (b *builtinToBase64Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		str := buf.GetString(i)
+		needEncodeLen := base64NeededEncodedLength(len(str))
+		if needEncodeLen == -1 {
+			result.AppendNull()
+			continue
+		} else if needEncodeLen > int(b.maxAllowedPacket) {
+			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnAllowedPacketOverflowed.GenWithStackByArgs("to_base64", b.maxAllowedPacket))
+			result.AppendNull()
+			continue
+		} else if b.tp.Flen == -1 || b.tp.Flen > mysql.MaxBlobWidth {
+			result.AppendNull()
+			continue
+		}
+
+		newStr := base64.StdEncoding.EncodeToString([]byte(str))
+		//A newline is added after each 76 characters of encoded output to divide long output into multiple lines.
+		count := len(newStr)
+		if count > 76 {
+			newStr = strings.Join(splitToSubN(newStr, 76), "\n")
+		}
+		result.AppendString(newStr)
+	}
+	return nil
 }
 
 func (b *builtinTrim1ArgSig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -51,7 +51,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Bin: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
-	ast.ToBase64:   {},
+	ast.ToBase64: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 10}}},
+	},
 	ast.FromBase64: {},
 	ast.ExportSet:  {},
 	ast.Repeat: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinToBase64Sig`.
[12106](https://github.com/pingcap/tidb/issues/12106)

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinToBase64Sig-VecBuiltinFunc-4     13584   90976 ns/op  17568 B/op  1860 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinToBase64Sig-NonVecBuiltinFunc-4  10000  105381 ns/op  17568 B/op  1860 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
