### PR TITLE
expression: implement vectorized evaluation for `builtinIntIsFalseSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -109,11 +109,26 @@ func (b *builtinDecimalIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.
 }
 
 func (b *builtinIntIsFalseSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinIntIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if result.IsNull(i) {
+			i64s[i] = 0
+			result.SetNull(i, false)
+		} else if i64s[i] != 0 {
+			i64s[i] = 0
+		} else {
+			i64s[i] = 1
+		}
+	}
+	return nil
 }
 
 func (b *builtinUnaryMinusRealSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -29,6 +29,7 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.IsFalsity: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.LogicOr: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

Implement vectorized evaluation for builtinIntIsTrueSig. #12103

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsFalseSig-VecBuiltinFunc-4            403776              3342 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinIntIsFalseSig-NonVecBuiltinFunc-4          39795             32692 ns/op               0 B/op          0 allocs/op
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 