### PR TITLE
expression: implement vectorized evaluation for `builtinFromBase64Sig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -942,11 +943,50 @@ func (b *builtinFieldIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column
 }
 
 func (b *builtinFromBase64Sig) vectorized() bool {
-	return false
+	return true
 }
 
+// vecEvalString evals FROM_BASE64(str).
+// See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_from-base64
 func (b *builtinFromBase64Sig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		str := buf.GetString(i)
+		needDecodeLen := base64NeededDecodedLength(len(str))
+		if needDecodeLen == -1 {
+			result.AppendNull()
+			continue
+		} else if needDecodeLen > int(b.maxAllowedPacket) {
+			b.ctx.GetSessionVars().StmtCtx.AppendWarning(errWarnAllowedPacketOverflowed.GenWithStackByArgs("from_base64", b.maxAllowedPacket))
+			result.AppendNull()
+			continue
+		}
+
+		str = strings.Replace(str, "\t", "", -1)
+		str = strings.Replace(str, " ", "", -1)
+		newStr, err := base64.StdEncoding.DecodeString(str)
+		if err != nil {
+			// When error happens, take `from_base64("asc")` as an example, we should return NULL.
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(string(newStr))
+	}
+	return nil
 }
 
 func (b *builtinCharLengthSig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -52,8 +52,10 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.ToBase64:   {},
-	ast.FromBase64: {},
-	ast.ExportSet:  {},
+	ast.FromBase64: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 100}}},
+	},
+	ast.ExportSet: {},
 	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},
 	},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -51,7 +51,7 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Bin: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
-	ast.ToBase64:   {},
+	ast.ToBase64: {},
 	ast.FromBase64: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 100}}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinFromBase64Sig`.
[12106](https://github.com/pingcap/tidb/issues/12106)

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinFromBase64Sig-VecBuiltinFunc-4     6112  356812 ns/op  7504 B/op  1023 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinFromBase64Sig-NonVecBuiltinFunc-4  4002  295296 ns/op  8768 B/op  1252 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test