### PR TITLE
bump the Go compiler version to 1.13 for circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.12
+      - image: golang:1.13
     working_directory: /go/src/github.com/pingcap/tidb
     steps:
       - checkout


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I find the go.mod file is already Go1.13, while the circle.yml is still 1.12

### What is changed and how it works?

Update circle.yml

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

