### PR TITLE
expression: implement vectorized evaluation for 'builtinIntervalIntSig'

### DIFF
--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -44,6 +44,11 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal, types.ETReal}},
 	},
+	ast.Interval: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt, types.ETInt}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinCompareEvalOneVec(c *C) {

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -47,7 +47,9 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 	ast.Interval: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{0, 10}, &rangeInt64Gener{10, 20}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt, types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{0, 10}, &rangeInt64Gener{10, 20}, &rangeInt64Gener{20, 30}}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinIntervalIntSig, for #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-VecBuiltinFunc-8         	  100000	     23080 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-NonVecBuiltinFunc-8      	   30000	     44643 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-VecBuiltinFunc#01-8      	   50000	     29442 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-NonVecBuiltinFunc#01-8   	   30000	     49938 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-VecBuiltinFunc#02-8      	   50000	     38824 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinIntervalIntSig-NonVecBuiltinFunc#02-8   	   30000	     59479 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
