### PR TITLE
server: fix `TestTLS` when use RSA-PSS (#10274)

### DIFF
--- a/model/model_test.go
+++ b/model/model_test.go
@@ -101,7 +101,7 @@ func (*testModelSuite) TestModelBasic(c *C) {
 	c.Assert(tp.String(), Equals, "BTREE")
 	tp = IndexTypeHash
 	c.Assert(tp.String(), Equals, "HASH")
-	tp = 1E5
+	tp = 1e5
 	c.Assert(tp.String(), Equals, "")
 	has := index.HasPrefixIndex()
 	c.Assert(has, Equals, true)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -184,7 +184,7 @@ func (ts *TidbTestSuite) TestSocket(c *C) {
 // If parentCert and parentCertKey is specified, the new certificate will be signed by the parentCert.
 // Otherwise, the new certificate will be self-signed and is a CA.
 func generateCert(sn int, commonName string, parentCert *x509.Certificate, parentCertKey *rsa.PrivateKey, outKeyFile string, outCertFile string) (*x509.Certificate, *rsa.PrivateKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 512)
+	privateKey, err := rsa.GenerateKey(rand.Reader, 528)
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}


### PR DESCRIPTION
Cherry-pick #10274 to v2.1