### PR TITLE
domain: increase TTL to reduce the occurrence of reporting min startTS errors

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -421,7 +421,7 @@ func (do *Domain) topNSlowQueryLoop() {
 func (do *Domain) infoSyncerKeeper() {
 	defer do.wg.Done()
 	defer recoverInDomain("infoSyncerKeeper", false)
-	ticker := time.NewTicker(time.Second * time.Duration(infosync.InfoSessionTTL) / 2)
+	ticker := time.NewTicker(time.Second * time.Duration(infosync.InfoSessionTTL) / 20)
 	defer ticker.Stop()
 	for {
 		select {

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -421,7 +421,7 @@ func (do *Domain) topNSlowQueryLoop() {
 func (do *Domain) infoSyncerKeeper() {
 	defer do.wg.Done()
 	defer recoverInDomain("infoSyncerKeeper", false)
-	ticker := time.NewTicker(time.Second * time.Duration(infosync.InfoSessionTTL) / 20)
+	ticker := time.NewTicker(infosync.ReportInterval)
 	defer ticker.Stop()
 	for {
 		select {

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -46,10 +46,11 @@ const (
 	keyOpDefaultRetryCnt = 5
 	// keyOpDefaultTimeout is the default time out for etcd store.
 	keyOpDefaultTimeout = 1 * time.Second
+	// InfoSessionTTL is the ETCD session's TTL in seconds.
+	InfoSessionTTL = 10 * 60
+	// ReportInterval is interval of infoSyncerKeeper reporting min startTS.
+	ReportInterval = 30 * time.Second
 )
-
-// InfoSessionTTL is the etcd session's TTL in seconds. It's exported for testing.
-var InfoSessionTTL = 10 * 60
 
 // InfoSyncer stores server info to etcd when the tidb-server starts and delete when tidb-server shuts down.
 type InfoSyncer struct {

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -43,13 +43,13 @@ const (
 	// ServerMinStartTSPath store the server min start timestamp.
 	ServerMinStartTSPath = "/tidb/server/minstartts"
 	// keyOpDefaultRetryCnt is the default retry count for etcd store.
-	keyOpDefaultRetryCnt = 2
+	keyOpDefaultRetryCnt = 5
 	// keyOpDefaultTimeout is the default time out for etcd store.
 	keyOpDefaultTimeout = 1 * time.Second
 )
 
 // InfoSessionTTL is the etcd session's TTL in seconds. It's exported for testing.
-var InfoSessionTTL = 1 * 60
+var InfoSessionTTL = 10 * 60
 
 // InfoSyncer stores server info to etcd when the tidb-server starts and delete when tidb-server shuts down.
 type InfoSyncer struct {


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the reported minimum startTS fails consecutively, the ETCD key may be cleaned up, which may cause some old transactions to be killed by the GC.

### What is changed and how it works?
increase TTL of info syncer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. start a TiDB cluster, and wait for 30 seconds.
1. kill -9 a TiDB server
1. wait for 5 mins to check the minstartts key in PD, it should exist.
1. wait for 5 mins to check the minstartts key in PD, it should not exist.

Code changes

 - Has exported variable/fields change