### PR TITLE
expression: implement vectorized evaluation for `builtinTimeIsNullSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -20,11 +20,31 @@ import (
 )
 
 func (b *builtinTimeIsNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTimeIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDatetime, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(numRows, false)
+	i64s := result.Int64s()
+	for i := 0; i < numRows; i++ {
+		if buf.IsNull(i) {
+			i64s[i] = 1
+		} else {
+			i64s[i] = 0
+		}
+	}
+	return nil
 }
 
 func (b *builtinLogicOrSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -52,6 +52,7 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 }
 


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinTimeIsNullSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinTimeIsNullSig-VecBuiltinFunc-4            453280              2418 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinTimeIsNullSig-NonVecBuiltinFunc-4          50761             23587 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test