### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticMinusDecimalSig`

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -125,15 +125,15 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, re
 	result.MergeNulls(buf)
 	x := result.Decimals()
 	y := buf.Decimals()
-	to := new(types.MyDecimal)
+	var to types.MyDecimal
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		if err = types.DecimalSub(&x[i], &y[i], to); err != nil {
+		if err = types.DecimalSub(&x[i], &y[i], &to); err != nil {
 			return err
 		}
-		x[i] = *to
+		x[i] = to
 	}
 	return nil
 }

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -105,11 +105,37 @@ func (b *builtinArithmeticMinusRealSig) vecEvalReal(input *chunk.Chunk, result *
 }
 
 func (b *builtinArithmeticMinusDecimalSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.MergeNulls(buf)
+	x := result.Decimals()
+	y := buf.Decimals()
+	to := new(types.MyDecimal)
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if err = types.DecimalSub(&x[i], &y[i], to); err != nil {
+			return err
+		}
+		x[i] = *to
+	}
+	return nil
 }
 
 func (b *builtinArithmeticMinusIntSig) vectorized() bool {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -25,6 +25,7 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.LE: {},
 	ast.Minus: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}},
 	},
 	ast.Div: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticMinusDecimalSig.#12102

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusDecimalSig-VecBuiltinFunc-4                 40449             28477 ns/op            0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMinusDecimalSig-NonVecBuiltinFunc-4              14368             85609 ns/op        29424 B/op         613 allocs/op
```

### Check List

Tests
- Unit test
