### PR TITLE
executor,sessionctx: add correctness for system variables (#12311)

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -484,6 +484,19 @@ func (s *testSuite2) TestValidateSetVar(c *C) {
 	_, err = tk.Exec("set @@global.max_connections='hello'")
 	c.Assert(terror.ErrorEqual(err, variable.ErrWrongTypeForVar), IsTrue)
 
+	tk.MustExec("set @@global.thread_pool_size=65")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect thread_pool_size value: '65'"))
+	result = tk.MustQuery("select @@global.thread_pool_size;")
+	result.Check(testkit.Rows("64"))
+
+	tk.MustExec("set @@global.thread_pool_size=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect thread_pool_size value: '-1'"))
+	result = tk.MustQuery("select @@global.thread_pool_size;")
+	result.Check(testkit.Rows("1"))
+
+	_, err = tk.Exec("set @@global.thread_pool_size='hello'")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongTypeForVar), IsTrue)
+
 	tk.MustExec("set @@global.max_allowed_packet=-1")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect max_allowed_packet value: '-1'"))
 	result = tk.MustQuery("select @@global.max_allowed_packet;")

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -637,6 +637,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, "innodb_online_alter_log_max_size", "134217728"},
 	{ScopeSession, WarningCount, "0"},
 	{ScopeSession, ErrorCount, "0"},
+	{ScopeGlobal, "thread_pool_size", "16"},
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
 	{ScopeSession, TiDBOptAggPushDown, BoolToIntStr(DefOptAggPushDown)},
@@ -948,6 +949,8 @@ const (
 	InnodbTableLocks = "innodb_table_locks"
 	// InnodbStatusOutput is the name for 'innodb_status_output' system variable.
 	InnodbStatusOutput = "innodb_status_output"
+	// ThreadPoolSize is the name of 'thread_pool_size' variable.
+	ThreadPoolSize = "thread_pool_size"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -439,6 +439,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
 	case MaxExecutionTime:
 		return checkUInt64SystemVar(name, value, 0, math.MaxUint64, vars)
+	case ThreadPoolSize:
+		return checkUInt64SystemVar(name, value, 1, 64, vars)
 	case TiDBEnableTablePartition:
 		switch {
 		case strings.EqualFold(value, "ON") || value == "1":


### PR DESCRIPTION
### What problem does this PR solve? 

For MySQL, [thread_pool_size](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_thread_pool_size) is the number of thread groups, which determine how many queries can execute simultaneously.

This commit is to add constraints for global variable thread_pool_size for TiDB, which is a subtask of epic [Complete correctness for system](https://github.com/pingcap/tidb/issues/7195).

### What is changed and how it works?

Add restriction for global variable `thread_pool_size`, of which

- the value must be equal or greater than 1
- the value must be equal or less than 64

### Check List 

Tests

 - Unit test

Code changes

 - Has exported variable/fields change


Side effects

 - Possible performance regression
 - Increased code complexity