### PR TITLE
expression: implement vectorized evaluation for 'builtinBitAndSig'

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -375,9 +375,6 @@ func (b *builtinBitAndSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 	args0 := result.Int64s()
 	args1 := buf.Int64s()
 	for i := 0; i < n; i++ {
-		if result.IsNull(i) {
-			continue
-		}
 		args0[i] &= args1[i]
 	}
 	return nil

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -55,6 +55,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
+	ast.And: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
+	},
 }
 
 // givenValsGener returns the items sequentially from the slice given at


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinBitAndSig, for #12103


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinBitAndSig-VecBuiltinFunc-8         	  500000	      2670 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinBitAndSig-NonVecBuiltinFunc-8      	   50000	     29332 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
