### PR TITLE
expression: implement vectorized evaluation for 'builtinDurationAnyValueSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -165,10 +165,7 @@ func (b *builtinDurationAnyValueSig) vectorized() bool {
 }
 
 func (b *builtinDurationAnyValueSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
-		return err
-	}
-	return nil
+	return b.args[0].VecEvalDuration(b.ctx, input, result)
 }
 
 func (b *builtinIntAnyValueSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -161,11 +161,14 @@ func (b *builtinLockSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) er
 }
 
 func (b *builtinDurationAnyValueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinDurationAnyValueSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *builtinIntAnyValueSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -36,6 +36,9 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	ast.IsIPv4: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},
+	ast.AnyValue: {
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMiscellaneousCasesEvalOneVec(c *C) {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -38,7 +38,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	},
 	ast.AnyValue: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration}},
-  },
+	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinDurationAnyValueSig, for #12176

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinDurationAnyValueSig-VecBuiltinFunc-8        20000000	       115 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinDurationAnyValueSig-NonVecBuiltinFunc-8       100000	     20525 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
