### PR TITLE
expression: implement vectorized evaluation for 'builtinNameConstDurationSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -149,10 +149,7 @@ func (b *builtinNameConstDurationSig) vectorized() bool {
 }
 
 func (b *builtinNameConstDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	if err := b.args[1].VecEvalDuration(b.ctx, input, result); err != nil {
-		return err
-	}
-	return nil
+	return b.args[1].VecEvalDuration(b.ctx, input, result)
 }
 
 func (b *builtinLockSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -145,11 +145,14 @@ func (b *builtinUUIDSig) vecEvalString(input *chunk.Chunk, result *chunk.Column)
 }
 
 func (b *builtinNameConstDurationSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNameConstDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[1].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *builtinLockSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -36,6 +36,9 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	ast.IsIPv4: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},
+	ast.NameConst: {
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMiscellaneousCasesEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinNameConstDurationSig, for #12176


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstDurationSig-VecBuiltinFunc-8         	20000000	       115 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstDurationSig-NonVecBuiltinFunc-8      	  100000	     21252 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
