### PR TITLE
expression: implement vectorized evaluation for `builtinCastDecimalAsIntSig`

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -776,11 +776,56 @@ func (b *builtinCastStringAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chu
 }
 
 func (b *builtinCastDecimalAsIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastDecimalAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(n, false)
+	result.MergeNulls(buf)
+	i64s := result.Int64s()
+	d64s := buf.Decimals()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		var to types.MyDecimal
+		err = d64s[i].Round(&to, 0, types.ModeHalfEven)
+		if err != nil {
+			result.SetNull(i, true)
+			continue
+		}
+
+		if !mysql.HasUnsignedFlag(b.tp.Flag) {
+			i64s[i], err = to.ToInt()
+		} else if b.inUnion && to.IsNegative() {
+			i64s[i] = 0
+		} else {
+			var uintRes uint64
+			uintRes, err = to.ToUint()
+			i64s[i] = int64(uintRes)
+		}
+
+		if types.ErrOverflow.Equal(err) {
+			warnErr := types.ErrTruncatedWrongVal.GenWithStackByArgs("DECIMAL", d64s[i])
+			err = b.ctx.GetSessionVars().StmtCtx.HandleOverflow(err, warnErr)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (b *builtinCastDecimalAsDurationSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -24,6 +24,7 @@ import (
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 	ast.Cast: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{new(randDurInt)}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinCastDecimalAsIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsIntSig-VecBuiltinFunc-4             50000             37249 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsIntSig-NonVecBuiltinFunc-4          30000             53486 ns/op               0 B/op            0 allocs/op

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test