### PR TITLE
expression: implement vectorized evaluation for 'builtinBitAndSig'

### DIFF
--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -46,6 +46,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
+	ast.And: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},
+	},
 	ast.UnaryMinus: {},
 	ast.IsNull: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
PR implements vectorized `builtinBitAndSig` from #12103 

### What is changed and how it works?
`vecEvalInt` of `builtinBitAndSig` has been implemented and `vectorized()` has been enabled

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

```
BenchmarkVectorizedBuiltinOpFunc/builtinBitAndSig-VecBuiltinFunc-8              	  501752	      2385 ns/op
BenchmarkVectorizedBuiltinOpFunc/builtinBitAndSig-NonVecBuiltinFunc-8           	   23228	     51440 ns/op
```