### PR TITLE
expression: implement vectorized builtinEQRealSig

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -798,12 +798,12 @@ func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		isNull1 := buf1.IsNull(i)
 		if isNull0 || isNull1 {
 			i64s[i] = compareNull(isNull0, isNull1)
+			continue
+		}
+		if types.CompareFloat64(x[i], y[i]) == 0 {
+			i64s[i] = 1
 		} else {
-			if x[i] == y[i] {
-				i64s[i] = 1
-			} else {
-				i64s[i] = 0
-			}
+			i64s[i] = 0
 		}
 	}
 	return nil

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -777,7 +777,7 @@ func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		return err
 	}
 	defer b.bufAllocator.put(buf0)
-	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+	if err = b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
 		return err
 	}
 	buf1, err := b.bufAllocator.get(types.ETReal, n)
@@ -785,7 +785,7 @@ func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		return err
 	}
 	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+	if err = b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
 		return err
 	}
 	result.ResizeInt64(n, false)

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -767,11 +767,46 @@ func (b *builtinGEDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinEQRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinEQRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf0, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf0)
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
+		return err
+	}
+	buf1, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf1)
+	if err := b.args[1].VecEvalReal(b.ctx, input, buf1); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, false)
+	result.MergeNulls(buf0, buf1)
+	i64s := result.Int64s()
+	x := buf0.Float64s()
+	y := buf1.Float64s()
+	for i := 0; i < n; i++ {
+		isNull0 := buf0.IsNull(i)
+		isNull1 := buf1.IsNull(i)
+		if isNull0 || isNull1 {
+			i64s[i] = compareNull(isNull0, isNull1)
+		} else {
+			if x[i] == y[i] {
+				i64s[i] = 1
+			} else {
+				i64s[i] = 0
+			}
+		}
+	}
+	return nil
 }
 
 func (b *builtinGreatestRealSig) vectorized() bool {

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -36,7 +36,7 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 		}},
 	},
 	ast.GT:   {},
-	ast.EQ:   {},
+	ast.EQ:   {{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}}},
 	ast.GE:   {},
 	ast.Date: {},
 	ast.Greatest: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized builtinEQRealSig. Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCompareFunc/builtinEQRealSig-VecBuiltinFunc-12         	  295028	      4013 ns/op	       0 B/op	       0 allocs/op

BenchmarkVectorizedBuiltinCompareFunc/builtinEQRealSig-NonVecBuiltinFunc-12      	   38734	     30172 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
