### PR TITLE
expression: implement vectorized evaluation for `builtinPI` and make testing framework support functions without input arguments

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -657,6 +657,9 @@ func genVecBuiltinFuncBenchCase(ctx sessionctx.Context, funcName string, testCas
 		fillColumn(eType, input, i, testCase)
 		cols[i] = &Column{Index: i, RetType: fts[i]}
 	}
+	if len(cols) == 0 {
+		input.SetNumVirtualRows(1024)
+	}
 
 	var err error
 	if funcName == ast.Cast {

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -665,11 +665,17 @@ func (b *builtinCRC32Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 }
 
 func (b *builtinPISig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinPISig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	result.ResizeFloat64(n, false)
+	f64s := result.Float64s()
+	for i := range f64s {
+		f64s[i] = math.Pi
+	}
+	return nil
 }
 
 func (b *builtinRandSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -99,6 +99,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24}}, geners: nil},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}, geners: nil},
 	},
+	ast.PI: {
+		{retEvalType: types.ETReal},
+	},
 	ast.Truncate: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinPI` and make testing framework support functions without input arguments.

### What is changed and how it works?
If some function has no input argument, we set a virtual row number for its input data chunk.
Here is the benchmark:
```
BenchmarkVectorizedBuiltinMathFunc/builtinPISig-VecBuiltinFunc-12                5000000               316 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinPISig-NonVecBuiltinFunc-12              200000              7692 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
