### PR TITLE
fix the STR_TO_DATE incompatible between MySQL and TiDB

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3997,6 +3997,8 @@ func (s *testSuite4) TearDownTest(c *C) {
 
 func (s *testSuiteP1) TestStrToDateBuiltin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustQuery(`select str_to_date('20190101','%Y%m%d%f') from dual`).Check(testkit.Rows("2019-01-01 00:00:00.000000"))
+	tk.MustQuery(`select str_to_date('20190101','%Y%m%d%H%i%s') from dual`).Check(testkit.Rows("2019-01-01 00:00:00"))
 	tk.MustQuery(`select str_to_date('18/10/22','%y/%m/%d') from dual`).Check(testkit.Rows("2018-10-22"))
 	tk.MustQuery(`select str_to_date('a18/10/22','%y/%m/%d') from dual`).Check(testkit.Rows("<nil>"))
 	tk.MustQuery(`select str_to_date('69/10/22','%y/%m/%d') from dual`).Check(testkit.Rows("2069-10-22"))

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3997,6 +3997,7 @@ func (s *testSuite4) TearDownTest(c *C) {
 
 func (s *testSuiteP1) TestStrToDateBuiltin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustQuery(`select str_to_date('20190101','%Y%m%d%!') from dual`).Check(testkit.Rows("2019-01-01"))
 	tk.MustQuery(`select str_to_date('20190101','%Y%m%d%f') from dual`).Check(testkit.Rows("2019-01-01 00:00:00.000000"))
 	tk.MustQuery(`select str_to_date('20190101','%Y%m%d%H%i%s') from dual`).Check(testkit.Rows("2019-01-01 00:00:00"))
 	tk.MustQuery(`select str_to_date('18/10/22','%y/%m/%d') from dual`).Check(testkit.Rows("2018-10-22"))

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1789,17 +1789,14 @@ func (c *strToDateFunctionClass) getRetTp(ctx sessionctx.Context, arg Expression
 		return
 	}
 
-	if strings.Contains(format, "%f") {
-		tp = mysql.TypeDatetime
-		fsp = types.MaxFsp
-		return
-	}
-
 	isDuration, isDate := types.GetFormatType(format)
 	if isDuration && !isDate {
 		tp = mysql.TypeDuration
 	} else if !isDuration && isDate {
 		tp = mysql.TypeDate
+	}
+	if strings.Contains(format, "%f") {
+		fsp = types.MaxFsp
 	}
 	return
 }

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1788,14 +1788,18 @@ func (c *strToDateFunctionClass) getRetTp(ctx sessionctx.Context, arg Expression
 	if err != nil || isNull {
 		return
 	}
+
+	if strings.Contains(format, "%f") {
+		tp = mysql.TypeDatetime
+		fsp = types.MaxFsp
+		return
+	}
+
 	isDuration, isDate := types.GetFormatType(format)
 	if isDuration && !isDate {
 		tp = mysql.TypeDuration
 	} else if !isDuration && isDate {
 		tp = mysql.TypeDate
-	}
-	if strings.Contains(format, "%f") {
-		fsp = types.MaxFsp
 	}
 	return
 }

--- a/types/time.go
+++ b/types/time.go
@@ -2321,20 +2321,13 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 			isDuration, isDate = false, false
 			break
 		}
-		var durationTokens bool
-		var dateTokens bool
 		if len(token) >= 2 && token[0] == '%' {
 			switch token[1] {
-			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l':
-				durationTokens = true
+			case 'h', 'H', 'i', 'I', 's', 'S', 'k', 'l', 'f':
+				isDuration = true
 			case 'y', 'Y', 'm', 'M', 'c', 'b', 'D', 'd', 'e':
-				dateTokens = true
+				isDate = true
 			}
-		}
-		if durationTokens {
-			isDuration = true
-		} else if dateTokens {
-			isDate = true
 		}
 		if isDuration && isDate {
 			break

--- a/types/time.go
+++ b/types/time.go
@@ -2199,6 +2199,11 @@ func strToDate(t *MysqlTime, date string, format string, ctx map[string]int) boo
 		return true
 	}
 
+	if len(date) == 0 {
+		ctx[token] = 0
+		return true
+	}
+
 	dateRemain, succ := matchDateWithToken(t, date, token, ctx)
 	if !succ {
 		return false


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The result of `select str_to_date('20190101','%Y%m%d%H%i%s')` is incompitable between MySQL and TiDB.

MySQL
```
mysql> select str_to_date('20190101','%Y%m%d%H%i%s');
+----------------------------------------+
| str_to_date('20190101','%Y%m%d%H%i%s') |
+----------------------------------------+
| 2019-01-01 00:00:00                    |
+----------------------------------------+
1 row in set (0.01 sec)
```

TiDB
```
mysql> select str_to_date('20190101','%Y%m%d%H%i%s');
+----------------------------------------+
| str_to_date('20190101','%Y%m%d%H%i%s') |
+----------------------------------------+
| NULL                                   |
+----------------------------------------+
1 row in set (0.01 sec)
```

### What is changed and how it works?

Fix it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - fix the STR_TO_DATE incompatible between MySQL and TiDB
