### PR TITLE
expression: implement vectorized evaluation for 'builtinLeftShiftSig'

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -516,11 +516,29 @@ func (b *builtinDecimalIsNullSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinLeftShiftSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinLeftShiftSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	numRows := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, numRows)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+	arg0s := result.Int64s()
+	arg1s := buf.Int64s()
+	result.MergeNulls(buf)
+	for i := 0; i < numRows; i++ {
+		arg0s[i] = int64(uint64(arg0s[i]) << uint64(arg1s[i]))
+	}
+	return nil
 }
 
 func (b *builtinRightShiftSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -53,6 +53,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.And: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},
 	},
+	ast.LeftShift: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
+	},
 	ast.UnaryMinus: {},
 	ast.IsNull: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

PR implements vectorized `builtinLeftShiftSig` from #12103 

### What is changed and how it works?

`vecEvalInt` of `builtinLeftShiftSig` has been implemented and `vectorized()` has been enabled

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


```
BenchmarkVectorizedBuiltinOpFunc/builtinLeftShiftSig-VecBuiltinFunc-8         	  319771	      3730 ns/op
BenchmarkVectorizedBuiltinOpFunc/builtinLeftShiftSig-NonVecBuiltinFunc-8      	   23181	     51198 ns/op
```