### PR TITLE
expression: implement vectorized evaluation for 'builtinIntAnyValueSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -169,11 +169,11 @@ func (b *builtinDurationAnyValueSig) vecEvalDuration(input *chunk.Chunk, result 
 }
 
 func (b *builtinIntAnyValueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinIntAnyValueSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[0].VecEvalInt(b.ctx, input, result)
 }
 
 func (b *builtinIsIPv4CompatSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -38,6 +38,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	},
 	ast.AnyValue: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

PR implements vectorized `builtinIntAnyValueSig` from #12103 

### What is changed and how it works?

`vecEvalInt` of `builtinIntAnyValueSig` has been implemented and `vectorized()` has been enabled

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinIntAnyValueSig-VecBuiltinFunc-8               	 5747052	       209 ns/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinIntAnyValueSig-NonVecBuiltinFunc-8            	   31389	     38370 ns/op
```