### PR TITLE
expression: implement vectorized evaluation for builtinUTCDateSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -14,6 +14,8 @@
 package expression
 
 import (
+	"time"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
@@ -660,11 +662,27 @@ func (b *builtinStrToDateDatetimeSig) vecEvalTime(input *chunk.Chunk, result *ch
 }
 
 func (b *builtinUTCDateSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinUTCDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return err
+	}
+	year, month, day := nowTs.UTC().Date()
+	utcDate := types.Time{
+		Time: types.FromGoTime(time.Date(year, month, day, 0, 0, 0, 0, time.UTC)),
+		Type: mysql.TypeDate,
+		Fsp:  types.UnspecifiedFsp}
+
+	n := input.NumRows()
+	result.ResizeTime(n, false)
+	times := result.Times()
+	for i := 0; i < n; i++ {
+		times[i] = utcDate
+	}
+	return nil
 }
 
 func (b *builtinWeekWithoutModeSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -99,6 +99,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.DayOfMonth: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
+	ast.UTCDate: {
+		{retEvalType: types.ETDatetime},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinTimeEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinUTCDateSig`. See #12101

### What is changed and how it works?

```
➜ go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args "builtinUTCDateSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.00817 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinUTCDateSig-VecBuiltinFunc-12         	  970830	      1061 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinUTCDateSig-NonVecBuiltinFunc-12      	    5869	    200764 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	2.308s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test