### PR TITLE
expression: implement vectorized evaluation for `builtinLengthSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -748,8 +748,8 @@ func (b *builtinLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		if result.IsNull(i) {
 			continue
 		}
-		str := buf.GetString(i)
-		i64s[i] = int64(len([]byte(str)))
+		str := buf.GetBytes(i)
+		i64s[i] = int64(len(str))
 	}
 	return nil
 }

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -22,7 +22,9 @@ import (
 )
 
 var vecBuiltinStringCases = map[string][]vecExprBenchCase{
-	ast.Length:         {},
+	ast.Length: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 10}}},
+	},
 	ast.ASCII:          {},
 	ast.Concat:         {},
 	ast.ConcatWS:       {},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -23,7 +23,7 @@ import (
 
 var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Length: {
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 10}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&defaultGener{0.2, types.ETString}}},
 	},
 	ast.ASCII:          {},
 	ast.Concat:         {},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinLengthSig`.
[12103](https://github.com/pingcap/tidb/issues/12103)

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinLengthSig-VecBuiltinFunc-4     75441  15770 ns/op  0 B/op  0 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinLengthSig-NonVecBuiltinFunc-4  29632  40072 ns/op  0 B/op  0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
