### PR TITLE
executor: support projection as inner child of index join

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2028,6 +2028,8 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoin(ctx context.Context,
 		return builder.buildIndexLookUpReaderForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *plannercore.PhysicalUnionScan:
 		return builder.buildUnionScanForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
+	// If the index lookup reader need to keep order and the pk is not handle. Then the planner will generate a projection as its parent.
+	// Because the extra column row_id will be appended in this case.
 	case *plannercore.PhysicalProjection:
 		return builder.buildProjectionForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *mockPhysicalIndexReader:

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2033,7 +2033,7 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoin(ctx context.Context,
 		// 	2. PK is not handle
 		// 	3. The inner child needs to keep order
 		// In this case, an extra column tidb_rowid will be appended in the output result of IndexLookupReader(see copTask.doubleReadNeedProj).
-		// Then we need a Projection upon IndexLookupReaderto prune the redundant column.
+		// Then we need a Projection upon IndexLookupReader to prune the redundant column.
 	case *plannercore.PhysicalProjection:
 		return builder.buildProjectionForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *mockPhysicalIndexReader:

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2028,8 +2028,12 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoin(ctx context.Context,
 		return builder.buildIndexLookUpReaderForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *plannercore.PhysicalUnionScan:
 		return builder.buildUnionScanForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
-	// If the index lookup reader need to keep order and the pk is not handle. Then the planner will generate a projection as its parent.
-	// Because the extra column row_id will be appended in this case.
+		// The inner child of IndexJoin might be Projection when a combination of the following conditions is true:
+		// 	1. The inner child fetch data using indexLookupReader
+		// 	2. PK is not handle
+		// 	3. The inner child needs to keep order
+		// In this case, an extra column tidb_rowid will be appended in the output result of IndexLookupReader(see copTask.doubleReadNeedProj).
+		// Then we need a Projection upon IndexLookupReaderto prune the redundant column.
 	case *plannercore.PhysicalProjection:
 		return builder.buildProjectionForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *mockPhysicalIndexReader:

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2028,12 +2028,12 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoin(ctx context.Context,
 		return builder.buildIndexLookUpReaderForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *plannercore.PhysicalUnionScan:
 		return builder.buildUnionScanForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
-		// The inner child of IndexJoin might be Projection when a combination of the following conditions is true:
-		// 	1. The inner child fetch data using indexLookupReader
-		// 	2. PK is not handle
-		// 	3. The inner child needs to keep order
-		// In this case, an extra column tidb_rowid will be appended in the output result of IndexLookupReader(see copTask.doubleReadNeedProj).
-		// Then we need a Projection upon IndexLookupReader to prune the redundant column.
+	// The inner child of IndexJoin might be Projection when a combination of the following conditions is true:
+	// 	1. The inner child fetch data using indexLookupReader
+	// 	2. PK is not handle
+	// 	3. The inner child needs to keep order
+	// In this case, an extra column tidb_rowid will be appended in the output result of IndexLookupReader(see copTask.doubleReadNeedProj).
+	// Then we need a Projection upon IndexLookupReader to prune the redundant column.
 	case *plannercore.PhysicalProjection:
 		return builder.buildProjectionForIndexJoin(ctx, v, lookUpContents, IndexRanges, keyOff2IdxOff, cwc)
 	case *mockPhysicalIndexReader:

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2127,7 +2127,7 @@ func (builder *dataReaderBuilder) buildProjectionForIndexJoin(ctx context.Contex
 	lookUpContents []*indexJoinLookUpContent, indexRanges []*ranger.Range, keyOff2IdxOff []int, cwc *plannercore.ColWithCmpFuncManager) (Executor, error) {
 	physicalIndexLookUp, isDoubleRead := v.Children()[0].(*plannercore.PhysicalIndexLookUpReader)
 	if !isDoubleRead {
-		return nil, errors.Errorf("it's a invalid plan when the projection is the inner child of indexMergeJoin and its child is not indexLookUpReader")
+		return nil, errors.Errorf("inner child of Projection should be IndexLookupReader, but got %T", v)
 	}
 	childExec, err := builder.buildIndexLookUpReaderForIndexJoin(ctx, physicalIndexLookUp, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 	if err != nil {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2147,9 +2147,9 @@ func (builder *dataReaderBuilder) buildProjectionForIndexJoin(ctx context.Contex
 	if int64(v.StatsCount()) < int64(builder.ctx.GetSessionVars().MaxChunkSize) {
 		e.numWorkers = 0
 	}
-	e.Open(ctx)
+	err = e.Open(ctx)
 
-	return e, nil
+	return e, err
 }
 
 // buildKvRangesForIndexJoin builds kv ranges for index join when the inner plan is index scan plan.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix bug that the master branch can't execute the plan of TPCH Q10.

### What is changed and how it works?
support projection as the inner child of index join

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
 - Increased code complexity

