### PR TITLE
expression: implement vectorized evaluation for 'builtinNameConstRealSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -265,11 +265,11 @@ func (b *builtinInet6NtoaSig) vecEvalString(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinNameConstRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNameConstRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[1].VecEvalReal(b.ctx, input, result)
 }
 
 func (b *builtinReleaseLockSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -42,6 +42,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETString, types.ETReal}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinNameConstRealSig, for #12105


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstRealSig-VecBuiltinFunc-8         	20000000	       119 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstRealSig-NonVecBuiltinFunc-8      	  100000	     22142 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
