### PR TITLE
expression: implement vectorized evaluation for 'builtinUnaryMinusRealSig'

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -170,11 +170,21 @@ func (b *builtinIntIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 }
 
 func (b *builtinUnaryMinusRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinUnaryMinusRealSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	var err error
+	if err = b.args[0].VecEvalReal(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	n := input.NumRows()
+	f64s := result.Float64s()
+	for i := 0; i < n; i++ {
+		f64s[i] = -f64s[i]
+	}
+	return nil
 }
 
 func (b *builtinBitNegSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -59,7 +59,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.LeftShift: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
 	},
-	ast.UnaryMinus: {},
+	ast.UnaryMinus: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
+	},
 	ast.IsNull: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinUnaryMinusRealSig, for #12105

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinUnaryMinusRealSig-VecBuiltinFunc-8         	 2000000	       769 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinUnaryMinusRealSig-NonVecBuiltinFunc-8      	   50000	     23754 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
