### PR TITLE
expression: implement vectorized evaluation for 'builtinIfNullRealSig'

### DIFF
--- a/expression/builtin_control_vec_generated_test.go
+++ b/expression/builtin_control_vec_generated_test.go
@@ -40,6 +40,9 @@ var vecBuiltinControlCases = map[string][]vecExprBenchCase{
 
 		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETInt, types.ETJson, types.ETJson}},
 	},
+	ast.Ifnull: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinControlEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinIfNullRealSig, for #12105

### What is changed and how it works?
BenchmarkVectorizedBuiltinControlFunc/builtinIfNullRealSig-VecBuiltinFunc-8         	  500000	      2361 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinControlFunc/builtinIfNullRealSig-NonVecBuiltinFunc-8      	   50000	     25116 ns/op	       0 B/op	       0 allocs/op

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
