### PR TITLE
Makefile: add `-trim-path` flag for build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH)))
 export PATH := $(path_to_add):$(PATH)
 
 GO        := GO111MODULE=on go
-GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG)
+GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG) -trimpath
 GOTEST    := CGO_ENABLED=1 $(GO) test -p 3
 OVERALLS  := CGO_ENABLED=1 overalls
 GOVERALLS := goveralls


### PR DESCRIPTION
cherry pick #12639
> <!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
There is lengthy filesystem path with the binary built by  `go build` ,which made traceback seems messy,like:
```
[session:8002][16524] can not retry select for update statement
github.com/pingcap/errors.AddStack
 /home/jenkins/workspace/build_tidb_master/go/pkg/mod/github.com/pingcap/errors@v0.11.0/errors.go:174
github.com/pingcap/parser/terror.(*Error).GenWithStackByArgs
    /home/jenkins/workspace/build_tidb_master/go/pkg/mod/github.com/pingcap/parser@v0.0.0-20181122084134-815d2f65fd25/terror/terror.go:231
github.com/pingcap/tidb/session.(*session).retry
    /home/jenkins/workspace/build_tidb_master/go/src/github.com/pingcap/tidb/session/session.go:463
```

### What is changed and how it works?
In golang 1.13 see `go help build`:
```
	-trimpath
		remove all file system paths from the resulting executable.
		Instead of absolute file system paths, the recorded file names
		will begin with either "go" (for the standard library),
		or a module path@version (when using modules),
		or a plain import path (when using GOPATH).
```
which would trim ` /home/jenkins/workspace/build_tidb_master/go/pkg/mod/github.com/pingcap/parser` 
to 
`github.com/pingcap/parser`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - No code
