### PR TITLE
expression: implement vectorized evaluation for 'builtinTimeAnyValueSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -241,11 +241,11 @@ func (b *builtinInet6AtonSig) vecEvalString(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinTimeAnyValueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTimeAnyValueSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[0].VecEvalTime(b.ctx, input, result)
 }
 
 func (b *builtinInetAtonSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -39,6 +39,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	ast.AnyValue: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETTimestamp}},
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinTimeAnyValueSig, for #12101


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinTimeAnyValueSig-VecBuiltinFunc-8         	 3000000	       550 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinTimeAnyValueSig-NonVecBuiltinFunc-8      	   30000	     46329 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
