### PR TITLE
expression: implement vectorized evaluation for 'builtinNameConstTimeSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -193,11 +193,11 @@ func (b *builtinNameConstIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinNameConstTimeSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNameConstTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[1].VecEvalTime(b.ctx, input, result)
 }
 
 func (b *builtinSleepSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -42,6 +42,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
+		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETString, types.ETTimestamp}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinNameConstTimeSig, for #12101


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstTimeSig-VecBuiltinFunc-8         	 2000000	       605 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstTimeSig-NonVecBuiltinFunc-8      	   30000	     50750 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
