### PR TITLE
expression: implement vectorized evaluation for 'builtinNameConstStringSig'

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -121,11 +121,11 @@ func (b *builtinIsIPv6Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinNameConstStringSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNameConstStringSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[1].VecEvalString(b.ctx, input, result)
 }
 
 func (b *builtinDecimalAnyValueSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -42,6 +42,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinNameConstStringSig, for #12106


### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstStringSig-VecBuiltinFunc-8         	 2000000	       591 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstStringSig-NonVecBuiltinFunc-8      	   50000	     32330 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
