### PR TITLE
expression: implement vectorized evaluation for `builtinCastRealAsJSONSig`

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -310,6 +310,7 @@ func (b *builtinCastRealAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk
 	f64s := buf.Float64s()
 	result.ReserveJSON(n)
 	for i := 0; i < n; i++ {
+		// FIXME: `select json_type(cast(1111.11 as json))` should return `DECIMAL`, we return `DOUBLE` now.```
 		if buf.IsNull(i) {
 			result.AppendNull()
 		} else {

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -293,11 +294,29 @@ func (b *builtinCastIntAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 }
 
 func (b *builtinCastRealAsJSONSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastRealAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalReal(b.ctx, input, buf); err != nil {
+		return err
+	}
+	f64s := buf.Float64s()
+	result.ReserveJSON(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+		} else {
+			result.AppendJSON(json.CreateBinary(f64s[i]))
+		}
+	}
+	return nil
 }
 
 func (b *builtinCastJSONAsRealSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -45,6 +45,8 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETJson}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal}},
+
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETReal}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinCastRealAsJSONSig` mentioned at https://github.com/pingcap/tidb/issues/12104

### What is changed and how it works?
about 35% faster

```
BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsJSONSig-VecBuiltinFunc-4                       14770             79028 ns/op           13296 B/op       1662 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsJSONSig-NonVecBuiltinFunc-4                    10993            107003 ns/op           14840 B/op       1855 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
