### PR TITLE
*: record query start time to session variables (#11822)

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -189,7 +189,7 @@ func (a *ExecStmt) IsReadOnly(vars *variable.SessionVars) bool {
 func (a *ExecStmt) RebuildPlan(ctx context.Context) (int64, error) {
 	startTime := time.Now()
 	defer func() {
-		a.Ctx.GetSessionVars().StmtCtx.DurationCompile = time.Since(startTime)
+		a.Ctx.GetSessionVars().DurationCompile = time.Since(startTime)
 	}()
 
 	is := GetInfoSchema(a.Ctx)
@@ -500,6 +500,9 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 	// Rollback the statement change before retry it.
 	a.Ctx.StmtRollback()
 	a.Ctx.GetSessionVars().StmtCtx.ResetForRetry()
+	a.Ctx.GetSessionVars().StartTime = time.Now()
+	a.Ctx.GetSessionVars().DurationCompile = time.Duration(0)
+	a.Ctx.GetSessionVars().DurationParse = time.Duration(0)
 
 	if err = e.Open(ctx); err != nil {
 		return nil, err
@@ -602,7 +605,7 @@ func (a *ExecStmt) logAudit() {
 		audit := plugin.DeclareAuditManifest(p.Manifest)
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
-			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StmtCtx.StartTime)
+			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
 			audit.OnGeneralEvent(ctx, sessVars, plugin.Log, cmd)
 		}
 		return nil
@@ -617,7 +620,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 	sessVars := a.Ctx.GetSessionVars()
 	level := log.GetLevel()
 	cfg := config.GetGlobalConfig()
-	costTime := time.Since(a.Ctx.GetSessionVars().StmtCtx.StartTime)
+	costTime := time.Since(a.Ctx.GetSessionVars().StartTime)
 	threshold := time.Duration(atomic.LoadUint64(&cfg.Log.SlowThreshold)) * time.Millisecond
 	if costTime < threshold && level > zapcore.DebugLevel {
 		return
@@ -646,8 +649,8 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 			SQL:         sql,
 			Digest:      digest,
 			TimeTotal:   costTime,
-			TimeParse:   a.Ctx.GetSessionVars().StmtCtx.DurationParse,
-			TimeCompile: a.Ctx.GetSessionVars().StmtCtx.DurationCompile,
+			TimeParse:   a.Ctx.GetSessionVars().DurationParse,
+			TimeCompile: a.Ctx.GetSessionVars().DurationCompile,
 			IndexNames:  indexNames,
 			StatsInfos:  statsInfos,
 			CopTasks:    copTaskInfo,
@@ -662,8 +665,8 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 			SQL:         sql,
 			Digest:      digest,
 			TimeTotal:   costTime,
-			TimeParse:   a.Ctx.GetSessionVars().StmtCtx.DurationParse,
-			TimeCompile: a.Ctx.GetSessionVars().StmtCtx.DurationCompile,
+			TimeParse:   a.Ctx.GetSessionVars().DurationParse,
+			TimeCompile: a.Ctx.GetSessionVars().DurationCompile,
 			IndexNames:  indexNames,
 			StatsInfos:  statsInfos,
 			CopTasks:    copTaskInfo,
@@ -681,7 +684,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool) {
 		domain.GetDomain(a.Ctx).LogSlowQuery(&domain.SlowQueryInfo{
 			SQL:        sql,
 			Digest:     digest,
-			Start:      a.Ctx.GetSessionVars().StmtCtx.StartTime,
+			Start:      a.Ctx.GetSessionVars().StartTime,
 			Duration:   costTime,
 			Detail:     sessVars.StmtCtx.GetExecDetails(),
 			Succ:       succ,
@@ -704,7 +707,7 @@ func (a *ExecStmt) SummaryStmt() {
 	}
 	stmtCtx := sessVars.StmtCtx
 	normalizedSQL, digest := stmtCtx.SQLDigest()
-	costTime := time.Since(sessVars.StmtCtx.StartTime)
+	costTime := time.Since(sessVars.StartTime)
 	stmtsummary.StmtSummaryByDigestMap.AddStatement(&stmtsummary.StmtExecInfo{
 		SchemaName:    sessVars.CurrentDB,
 		OriginalSQL:   a.Text,
@@ -713,7 +716,7 @@ func (a *ExecStmt) SummaryStmt() {
 		TotalLatency:  uint64(costTime.Nanoseconds()),
 		AffectedRows:  stmtCtx.AffectedRows(),
 		SentRows:      0,
-		StartTime:     sessVars.StmtCtx.StartTime,
+		StartTime:     sessVars.StartTime,
 	})
 }
 

--- a/executor/adapter_test.go
+++ b/executor/adapter_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor_test
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+func (s *testSuite) TestQueryTime(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	costTime := time.Since(tk.Se.GetSessionVars().StartTime)
+	c.Assert(costTime < 1*time.Second, IsTrue)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("insert into t values(1), (1), (1), (1), (1)")
+	tk.MustExec("select * from t t1 join t t2 on t1.a = t2.a")
+
+	costTime = time.Since(tk.Se.GetSessionVars().StartTime)
+	c.Assert(costTime < 1*time.Second, IsTrue)
+}

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -270,7 +270,7 @@ func (e *DeallocateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 func CompileExecutePreparedStmt(ctx context.Context, sctx sessionctx.Context, ID uint32, args ...interface{}) (sqlexec.Statement, error) {
 	startTime := time.Now()
 	defer func() {
-		sctx.GetSessionVars().StmtCtx.DurationCompile = time.Since(startTime)
+		sctx.GetSessionVars().DurationCompile = time.Since(startTime)
 	}()
 	execStmt := &ast.ExecuteStmt{ExecID: ID}
 	if err := ResetContextOfStmt(sctx, execStmt); err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -598,6 +598,9 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 		for i, sr := range nh.history {
 			st := sr.st
 			s.sessionVars.StmtCtx = sr.stmtCtx
+			s.sessionVars.StartTime = time.Now()
+			s.sessionVars.DurationCompile = time.Duration(0)
+			s.sessionVars.DurationParse = time.Duration(0)
 			s.sessionVars.StmtCtx.ResetForRetry()
 			s.sessionVars.PreparedParams = s.sessionVars.PreparedParams[:0]
 			schemaVersion, err = st.RebuildPlan(ctx)
@@ -1014,7 +1017,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 
 	// Step1: Compile query string to abstract syntax trees(ASTs).
 	startTS := time.Now()
-	s.GetSessionVars().StmtCtx.StartTime = startTS
+	s.GetSessionVars().StartTime = startTS
 	stmtNodes, warns, err := s.ParseSQL(ctx, sql, charsetInfo, collation)
 	if err != nil {
 		s.rollbackOnError(ctx)
@@ -1024,7 +1027,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 		return nil, util.SyntaxError(err)
 	}
 	durParse := time.Since(startTS)
-	s.GetSessionVars().StmtCtx.DurationParse = durParse
+	s.GetSessionVars().DurationParse = durParse
 	isInternal := s.isInternal()
 	if isInternal {
 		sessionExecuteParseDurationInternal.Observe(durParse.Seconds())
@@ -1064,7 +1067,7 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 			s.handleInvalidBindRecord(ctx, stmtNode)
 		}
 		durCompile := time.Since(startTS)
-		s.GetSessionVars().StmtCtx.DurationCompile = durCompile
+		s.GetSessionVars().DurationCompile = durCompile
 		if isInternal {
 			sessionExecuteCompileDurationInternal.Observe(durCompile.Seconds())
 		} else {
@@ -1232,7 +1235,7 @@ func (s *session) ExecutePreparedStmt(ctx context.Context, stmtID uint32, args .
 	}
 
 	s.PrepareTxnCtx(ctx)
-	s.sessionVars.StmtCtx.StartTime = time.Now()
+	s.sessionVars.StartTime = time.Now()
 	st, err := executor.CompileExecutePreparedStmt(ctx, s, stmtID, args...)
 	if err != nil {
 		return nil, err

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -75,13 +75,6 @@ type StatementContext struct {
 	// prefix in a strict way, only extract 0-9 and (+ or - in first bit).
 	CastStrToIntStrict bool
 
-	// StartTime is the query start time.
-	StartTime time.Time
-	// DurationParse is the duration of pasing SQL string to AST.
-	DurationParse time.Duration
-	// DurationCompile is the duration of compiling AST to execution plan.
-	DurationCompile time.Duration
-
 	// mu struct holds variables that change during execution.
 	mu struct {
 		sync.Mutex
@@ -427,9 +420,6 @@ func (sc *StatementContext) ResetForRetry() {
 	sc.mu.Unlock()
 	sc.TableIDs = sc.TableIDs[:0]
 	sc.IndexNames = sc.IndexNames[:0]
-	sc.StartTime = time.Now()
-	sc.DurationCompile = time.Duration(0)
-	sc.DurationParse = time.Duration(0)
 }
 
 // MergeExecDetails merges a single region execution details into self, used to print

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -395,6 +395,15 @@ type SessionVars struct {
 
 	// ReplicaRead is used for reading data from replicas, only follower is supported at this time.
 	ReplicaRead kv.ReplicaReadType
+
+	// StartTime is the start time of the last query.
+	StartTime time.Time
+
+	// DurationParse is the duration of pasing SQL string to AST of the last query.
+	DurationParse time.Duration
+
+	// DurationCompile is the duration of compiling AST to execution plan of the last query.
+	DurationCompile time.Duration
 }
 
 // ConnectionInfo present connection used by audit.


### PR DESCRIPTION
cherry pick #11822 to release-3.1

```
# Conflicts:
#       session/session.go
```

original PR description:

> Signed-off-by: Zhang Jian <zjsariel@gmail.com>
>
> ### What problem does this PR solve? <!--add issue link with summary if exists-->
>
> move the following 3 metrics from `StatementContext` to `SessionVars`:
> * StartTime time.Time
> * DurationParse time.Duration
> * DurationCompile time.Duration
>
> `StatementContext` will be reset when the physical plan is executed. All the metrics are reset.
>
> ### What is changed and how it works?
>
> As described above.
>
> ### Check List <!--REMOVE the items that are not applicable-->
>
> Tests <!-- At least one of them must be included. -->
>
>  - Unit Test
>  - Manual test (add detailed scripts or steps below)
>
> Code changes
>
>  - Has exported function/method change
>  - Has exported variable/fields change
>
> Related changes
>
>  - Need to cherry-pick to the release branch
>  - Need to update the documentation
>  - Need to be included in the release note