### PR TITLE
planner: do not convert filter to range for table scan with tiflash

### DIFF
--- a/cmd/explaintest/r/access_tiflash.result
+++ b/cmd/explaintest/r/access_tiflash.result
@@ -30,3 +30,13 @@ StreamAgg_16	1.00	root	funcs:sum(Column#7)
 └─TableReader_17	1.00	root	data:StreamAgg_8
   └─StreamAgg_8	1.00	cop[tiflash]	funcs:sum(isnull(Column#1))
     └─TableScan_15	10000.00	cop[tiflash]	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+create table tt(a int, b int, primary key(a));
+desc select * from tt where (tt.a > 1 and tt.a < 20) or (tt.a >= 30 and tt.a < 55);
+id	count	task	operator info
+TableReader_6	44.00	root	data:TableScan_5
+└─TableScan_5	44.00	cop[tikv]	table:tt, range:(1,20), [30,55), keep order:false, stats:pseudo
+desc select /*+ read_from_storage(tiflash[tt]) */ * from tt where (tt.a > 1 and tt.a < 20) or (tt.a >= 30 and tt.a < 55);
+id	count	task	operator info
+TableReader_7	44.00	root	data:Selection_6
+└─Selection_6	44.00	cop[tiflash]	or(and(gt(Column#1, 1), lt(Column#1, 20)), and(ge(Column#1, 30), lt(Column#1, 55)))
+  └─TableScan_5	44.00	cop[tiflash]	table:tt, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/access_tiflash.test
+++ b/cmd/explaintest/t/access_tiflash.test
@@ -11,3 +11,8 @@ desc select /*+ read_from_storage(tiflash[t]) */ sum(a) from t;
 desc select /*+ read_from_storage(tiflash[t]) */ sum(a+1) from t;
 
 desc select /*+ read_from_storage(tiflash[t]) */ sum(isnull(a)) from t;
+
+create table tt(a int, b int, primary key(a));
+
+desc select * from tt where (tt.a > 1 and tt.a < 20) or (tt.a >= 30 and tt.a < 55);
+desc select /*+ read_from_storage(tiflash[tt]) */ * from tt where (tt.a > 1 and tt.a < 20) or (tt.a >= 30 and tt.a < 55);

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1023,6 +1023,8 @@ func (ds *DataSource) getOriginalPhysicalTableScan(prop *property.PhysicalProper
 	}.Init(ds.ctx, ds.blockOffset)
 	if ds.preferStoreType&preferTiFlash != 0 {
 		ts.StoreType = kv.TiFlash
+		ts.filterCondition = append(ts.filterCondition, ts.AccessCondition...)
+		ts.AccessCondition = nil
 	} else {
 		ts.StoreType = kv.TiKV
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1025,6 +1025,7 @@ func (ds *DataSource) getOriginalPhysicalTableScan(prop *property.PhysicalProper
 		ts.StoreType = kv.TiFlash
 		ts.filterCondition = append(ts.filterCondition, ts.AccessCondition...)
 		ts.AccessCondition = nil
+		ts.Ranges = ranger.FullNotNullRange()
 	} else {
 		ts.StoreType = kv.TiKV
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
As the title says.

### What is changed and how it works?
Change the range and the filter conditions in `DataSource.getOriginalPhysicalTableScan`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Increased code complexity
 - Breaking backward compatibility

