### PR TITLE
CODEOWNERS: update codeowner of expression package to @pingcap/co-expression

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/expression @qw4990 @SunRunAway @XuHuaiyu @Reminiscent
+/expression @pingcap/co-expression


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Recently, I added a CODEOWNER rule for the expression package, which automatically request 4 people to review the expression-related PRs. It's really annoying:

1. some PRs are not necessary to be reviewed by more than 2 reviewers.
2. the review request list of these 4 person is quite long.

### What is changed and how it works?

1. installed the [pull assigner](https://github.com/apps/pull-assigner) app for the `pingcap/tidb` repo
2. created a team named `co-expression` in the `pingcap` account. `co` is short for `codeowner`.
3. change the codeowner rule for expression package, make the codeowner to be `co-expression`

After all these 3 steps, in which this PR is the last step, once a PR related to the `expression` package is filed:
1. github automatically request `co-expression` to review that PR
2. pull assigner automatically chose 2, which is configurable, person in that team to review that PR and remove the review request on that team.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code