### PR TITLE
ddl: add pre_split_region_count option for create table statement

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1795,13 +1795,21 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) err
 			tbInfo.MaxShardRowIDBits = tbInfo.ShardRowIDBits
 		case ast.TableOptionPreSplitRegion:
 			tbInfo.PreSplitRegions = op.UintValue
+		case ast.TableOptionPreSplitRegionCount:
+			tbInfo.PreSplitRegionCount = op.UintValue
 		}
 	}
 	if tbInfo.PreSplitRegions > tbInfo.ShardRowIDBits {
 		tbInfo.PreSplitRegions = tbInfo.ShardRowIDBits
 	}
-
+	if tbInfo.PreSplitRegionCount > 0 && !isPowerOf2(tbInfo.PreSplitRegionCount) || tbInfo.PreSplitRegionCount > (1<<tbInfo.ShardRowIDBits) {
+		return errors.Errorf("pre_split_region_count=%v is invalid, it should be 2^N and less than or equal to 2^shard_row_id_bits", tbInfo.PreSplitRegionCount)
+	}
 	return nil
+}
+
+func isPowerOf2(i uint64) bool {
+	return i > 0 && ((i & (i - 1)) == 0)
 }
 
 // isIgnorableSpec checks if the spec type is ignorable.

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -171,6 +171,14 @@ func (s *testSuite3) TestCreateTable(c *C) {
 	tk.MustExec("insert into create_auto_increment_test (name) values ('aa')")
 	r = tk.MustQuery("select * from create_auto_increment_test;")
 	r.Check(testkit.Rows("1000 aa"))
+
+	// test for table option pre_split_region_count
+	_, err = tk.Exec("create table t_pre_split_region_count (a int, b int) shard_row_id_bits = 4 pre_split_region_count=3")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "pre_split_region_count=3 is invalid, it should be 2^N and less than or equal to 2^shard_row_id_bits")
+	_, err = tk.Exec("create table t_pre_split_region_count (a int, b int) shard_row_id_bits = 4 pre_split_region_count=64")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "pre_split_region_count=64 is invalid, it should be 2^N and less than or equal to 2^shard_row_id_bits")
 }
 
 func (s *testSuite3) TestCreateView(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4259,6 +4259,18 @@ func (s *testSuite) TestShowTableRegion(c *C) {
 	c.Assert(rows[1][1], Equals, fmt.Sprintf("t_%d_r_2305843009213693952", tbl.Meta().ID))
 	c.Assert(rows[2][1], Equals, fmt.Sprintf("t_%d_r_4611686018427387904", tbl.Meta().ID))
 	c.Assert(rows[3][1], Equals, fmt.Sprintf("t_%d_r_6917529027641081856", tbl.Meta().ID))
+
+	// Test pre_split_region_count table region when create table.
+	tk.MustExec("drop table if exists t_pre")
+	tk.MustExec("create table t_pre (a int, b int) shard_row_id_bits = 2 pre_split_region_count=4;")
+	re = tk.MustQuery("show table t_pre regions")
+	rows = re.Rows()
+	// Table t_regions should have 4 regions now.
+	c.Assert(len(rows), Equals, 4)
+	tbl = testGetTableByName(c, tk.Se, "test", "t_pre")
+	c.Assert(rows[1][1], Equals, fmt.Sprintf("t_%d_r_2305843009213693952", tbl.Meta().ID))
+	c.Assert(rows[2][1], Equals, fmt.Sprintf("t_%d_r_4611686018427387904", tbl.Meta().ID))
+	c.Assert(rows[3][1], Equals, fmt.Sprintf("t_%d_r_6917529027641081856", tbl.Meta().ID))
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -816,6 +816,9 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		if tb.Meta().PreSplitRegions > 0 {
 			fmt.Fprintf(&buf, "PRE_SPLIT_REGIONS=%d ", tb.Meta().PreSplitRegions)
 		}
+		if tb.Meta().PreSplitRegionCount > 0 {
+			fmt.Fprintf(&buf, "PRE_SPLIT_REGION_COUNT=%d ", tb.Meta().PreSplitRegionCount)
+		}
 		buf.WriteString("*/")
 	}
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -529,6 +529,16 @@ func (s *testSuite2) TestShowCreateTable(c *C) {
 	))
 	tk.MustExec("drop table t")
 
+	tk.MustExec("create table t (a int, b int) shard_row_id_bits = 4 pre_split_region_count=8;")
+	tk.MustQuery("show create table `t`").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `a` int(11) DEFAULT NULL,\n"+
+			"  `b` int(11) DEFAULT NULL\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin/*!90000 SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGION_COUNT=8 */",
+	))
+	tk.MustExec("drop table t")
+
 	tk.MustExec("CREATE TABLE `log` (" +
 		"`LOG_ID` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT," +
 		"`ROUND_ID` bigint(20) UNSIGNED NOT NULL," +

--- a/go.mod
+++ b/go.mod
@@ -78,3 +78,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20191014051226-aff311c0003d

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/crazycs520/parser v0.0.0-20191014051226-aff311c0003d h1:T9Das+dkipyf8KPhPBOU0rqKbq3NLkRHNii0PW9+GFU=
+github.com/crazycs520/parser v0.0.0-20191014051226-aff311c0003d/go.mod h1:xLjI+gnWYexq011WPMEvCNS8rFM9qe1vdojIEzSKPuc=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 h1:iwZdTE0PVqJCos1vaoKsclOGD3ADKpshg3SRtYBbwso=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/cznic/sortutil v0.0.0-20150617083342-4c7342852e65 h1:hxuZop6tSoOi0sxFzoGGYdRqNrPubyaIf9KoBG9tPiE=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
*  Add `pre_split_region_count` table option for create table statement. 

Related Parser PR: https://github.com/pingcap/parser/pull/578

Since DBA said `pre_split_regions` option is too hard to use, then add `pre_split_region_count` table option for create table statement.

Example: 
```sql
-- pre-split 4 regions when create table.
create table t (a int, b int)shard_row_id_bits=2, pre_split_region_count=4; 
show table t regions;
+-----------+----------------------------+----------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+
| REGION_ID | START_KEY                  | END_KEY                    | LEADER_ID | LEADER_STORE_ID | PEERS | SCATTERING | WRITTEN_BYTES | READ_BYTES | APPROXIMATE_SIZE(MB) | APPROXIMATE_KEYS |
+-----------+----------------------------+----------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+
| 52        | t_54_5f72e000000000000000  | t_58_r_2305843009213693952 | 53        | 1               | 53    | 0          | 0             | 0          | 1                    | 0                |
| 54        | t_58_r_2305843009213693952 | t_58_r_4611686018427387904 | 55        | 1               | 55    | 0          | 0             | 0          | 1                    | 0                |
| 56        | t_58_r_4611686018427387904 | t_58_r_6917529027641081856 | 57        | 1               | 57    | 0          | 0             | 0          | 1                    | 0                |
| 58        | t_58_r_6917529027641081856 | t_60_5f72a000000000000000  | 59        | 1               | 59    | 0          | 76548         | 0          | 1                    | 0                |
+-----------+----------------------------+----------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+

```

### What is changed and how it works?
* `pre_split_region_count` should be 2^N
* `pre_split_region_count` should less than or equal to `2^shard_row_id_bits`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch

Release note

 - Add `pre_split_region_count` table option for create table statement. 
