### PR TITLE
expression: implement vectorized evaluation for `builtinStringAnyValueSig`

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -105,11 +105,11 @@ func (b *builtinRealAnyValueSig) vecEvalReal(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinStringAnyValueSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinStringAnyValueSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[0].VecEvalString(b.ctx, input, result)
 }
 
 func (b *builtinIsIPv6Sig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -41,6 +41,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETTimestamp}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
 	},
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinRightSig , for #12106

### What is changed and how it works?
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinMiscellaneousCasesFunc -run=BenchmarkVectorizedBuiltinMiscellaneousCasesFunc -args 'builtinStringAnyValueSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinStringAnyValueSig-VecBuiltinFunc-4               2138010               536 ns/op              0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinStringAnyValueSig-NonVecBuiltinFunc-4              22028             54741 ns/op              0 B/op           0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.513s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

