### PR TITLE
planner, expression: fix simplify outer join with cast

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -542,10 +542,7 @@ func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 		for i, arg := range x.GetArgs() {
 			args[i] = EvaluateExprWithNull(ctx, schema, arg)
 		}
-		if x.FuncName.L == ast.Cast {
-			return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
-		}
-		return NewFunctionInternal(ctx, x.FuncName.L, types.NewFieldType(mysql.TypeTiny), args...)
+		return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
 	case *Column:
 		if !schema.Contains(x) {
 			return x

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -542,6 +542,9 @@ func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 		for i, arg := range x.GetArgs() {
 			args[i] = EvaluateExprWithNull(ctx, schema, arg)
 		}
+		if x.FuncName.L == ast.Cast {
+			return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
+		}
 		return NewFunctionInternal(ctx, x.FuncName.L, types.NewFieldType(mysql.TypeTiny), args...)
 	case *Column:
 		if !schema.Contains(x) {

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -1073,3 +1073,40 @@ func testDAGPlanBuilderSplitAvg(c *C, root core.PhysicalPlan) {
 		testDAGPlanBuilderSplitAvg(c, son)
 	}
 }
+
+func (s *testPlanSuite) TestSimplifyOuterJoinWithCast(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	se, err := session.CreateSession4Test(store)
+	c.Assert(err, IsNil)
+	_, err = se.Execute(context.Background(), "use test")
+	c.Assert(err, IsNil)
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Best string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, test := range input {
+		comment := Commentf("case:%v sql:%s", i, test)
+		stmt, err := s.ParseOneStmt(test, "", "")
+		c.Assert(err, IsNil, comment)
+
+		p, err := planner.Optimize(context.Background(), se, stmt, s.is)
+		c.Assert(err, IsNil)
+		s.testData.OnRecord(func() {
+			output[i].SQL = test
+			output[i].Best = core.ToString(p)
+		})
+		c.Assert(core.ToString(p), Equals, output[i].Best)
+
+		warnings := se.GetSessionVars().StmtCtx.GetWarnings()
+		c.Assert(warnings, HasLen, 0, comment)
+	}
+}

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -481,5 +481,11 @@
     "cases": [
       "select t1.a, (select count(t2.a) from t t2 where t2.g in (select t3.d from t t3 where t3.c = t1.a)) as agg_col from t t1;"
     ]
+  },
+  {
+    "name": "TestSimplifyOuterJoinWithCast",
+    "cases": [
+      "select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.c_str as float) = '2.3'"
+    ]
   }
 ]

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -1241,5 +1241,14 @@
         "Best": "Apply{IndexReader(Index(t.f)[[NULL,+inf]])->IndexMergeJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]]->HashAgg)->HashAgg->IndexReader(Index(t.g)[[NULL,+inf]])}(Column#29,Column#23)}->HashAgg"
       }
     ]
+  },
+  {
+    "Name": "TestSimplifyOuterJoinWithCast",
+    "Cases": [
+      {
+        "SQL": "select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.c_str as float) = '2.3'",
+        "Best": "MergeLeftOuterJoin{TableReader(Table(t))->Sel([eq(cast(Column#6), 2.3)])->TableReader(Table(t))}(Column#1,Column#13)"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Before this PR, left outer join was incorrectly simplified into inner join:

``` mysql
mysql> explain select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.c_str as char) = '2.3';
+--------------------------+----------+-----------+------------------------------------------------------------+
| id                       | count    | task      | operator info                                              |
+--------------------------+----------+-----------+------------------------------------------------------------+
| MergeJoin_8              | 10000.00 | root      | inner join, left key:Column#1, right key:Column#11         |
| ├─Selection_20           | 8000.00  | root      | eq(cast(Column#6), "2.3")                                  |
| │ └─TableReader_22       | 10000.00 | root      | data:TableScan_21                                          |
| │   └─TableScan_21       | 10000.00 | cop[tikv] | table:t1, range:[-inf,+inf], keep order:true, stats:pseudo |
| └─TableReader_24         | 10000.00 | root      | data:TableScan_23                                          |
|   └─TableScan_23         | 10000.00 | cop[tikv] | table:t2, range:[-inf,+inf], keep order:true, stats:pseudo |
+--------------------------+----------+-----------+------------------------------------------------------------+
6 rows in set, 1 warning (0.00 sec)
```

After this PR:

``` mysql
mysql> explain select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.c_str as char) = '2.3';
+--------------------------+----------+-----------+------------------------------------------------------------+
| id                       | count    | task      | operator info                                              |
+--------------------------+----------+-----------+------------------------------------------------------------+
| MergeJoin_8              | 10000.00 | root      | left outer join, left key:Column#1, right key:Column#11    |
| ├─Selection_19           | 8000.00  | root      | eq(cast(Column#6), "2.3")                                  |
| │ └─TableReader_21       | 10000.00 | root      | data:TableScan_20                                          |
| │   └─TableScan_20       | 10000.00 | cop[tikv] | table:t1, range:[-inf,+inf], keep order:true, stats:pseudo |
| └─TableReader_23         | 10000.00 | root      | data:TableScan_22                                          |
|   └─TableScan_22         | 10000.00 | cop[tikv] | table:t2, range:[-inf,+inf], keep order:true, stats:pseudo |
+--------------------------+----------+-----------+------------------------------------------------------------+
6 rows in set (0.00 sec)
```

### What is changed and how it works?

Handle ScalarFunction Cast in a different logic in `EvaluateExprWithNull`.

Before this PR, the following code is part of how `EvaluateExprWithNull` handles ScalarFunction.

``` golang
NewFunctionInternal(ctx, x.FuncName.L, types.NewFieldType(mysql.TypeTiny), args...)
```
This line will set the default RetType of ScarlarFunction into mysql.TypeTiny. For those ScalarFunctions other than Cast, RetType can be determined correctly as it will be recalcuated in `NewFunctionImpl`. However, when handling Cast, `newFunctionImpl` simply pass RetType to `BuildCastFunction` without any other processing, which may lead a wrong RetType. 

In the example, the Cast is `CastStringToIntSig` before this PR instead of `CastStringToStringSig`, which it supposed to be.

``` golang
// newFunctionImpl creates a new scalar function or constant.
func newFunctionImpl(ctx sessionctx.Context, fold bool, funcName string, retType *types.FieldType, args ...Expression) (Expression, error) {
	if retType == nil {
		return nil, errors.Errorf("RetType cannot be nil for ScalarFunction.")
	}
	if funcName == ast.Cast {
		return BuildCastFunction(ctx, args[0], retType), nil
	}
	fc, ok := funcs[funcName]
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - Change some execute plan

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix bug that simplify outer join get wrong result with cast in where clause.
