### PR TITLE
expression: implement vectorized evaluation for `builtinEncodeSig`

### DIFF
--- a/expression/builtin_encryption_vec.go
+++ b/expression/builtin_encryption_vec.go
@@ -15,7 +15,9 @@ package expression
 
 import (
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/encrypt"
 )
 
 func (b *builtinAesDecryptSig) vectorized() bool {
@@ -43,11 +45,42 @@ func (b *builtinDecodeSig) vecEvalString(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinEncodeSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinEncodeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+	buf1, err1 := b.bufAllocator.get(types.ETString, n)
+	if err1 != nil {
+		return err1
+	}
+	defer b.bufAllocator.put(buf1)
+	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+		return err
+	}
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) || buf1.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		decodeStr := buf.GetString(i)
+		passwordStr := buf1.GetString(i)
+		dataStr, err := encrypt.SQLEncode(decodeStr, passwordStr)
+		if err != nil {
+			return err
+		}
+		result.AppendString(dataStr)
+	}
+	return nil
 }
 
 func (b *builtinAesDecryptIVSig) vectorized() bool {

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/types"
 )
 
 var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
@@ -32,6 +33,9 @@ var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
 	ast.SHA1:               {},
 	ast.PasswordFunc:       {},
 	ast.SHA2:               {},
+	ast.Encode: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinEncodeSig, for #12106

### What is changed and how it works?
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinEncryptionFunc -run=BenchmarkVectorizedBuiltinEncryptionFunc -args 'builtinEncodeSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinEncryptionFunc/builtinEncodeSig-VecBuiltinFunc-4                   373           3206752 ns/op           14200 B/op       672 allocs/op
BenchmarkVectorizedBuiltinEncryptionFunc/builtinEncodeSig-NonVecBuiltinFunc-4                366           3279789 ns/op           14192 B/op       672 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.073s

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test