### PR TITLE
expression: implement vectorized evaluation for `builtinDecodeSig`

### DIFF
--- a/expression/builtin_encryption_vec.go
+++ b/expression/builtin_encryption_vec.go
@@ -37,11 +37,42 @@ func (b *builtinAesEncryptIVSig) vecEvalString(input *chunk.Chunk, result *chunk
 }
 
 func (b *builtinDecodeSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinDecodeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+	buf1, err1 := b.bufAllocator.get(types.ETString, n)
+	if err1 != nil {
+		return err1
+	}
+	defer b.bufAllocator.put(buf1)
+	if err := b.args[1].VecEvalString(b.ctx, input, buf1); err != nil {
+		return err
+	}
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) || buf1.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		dataStr := buf.GetString(i)
+		passwordStr := buf1.GetString(i)
+		decodeStr, err := encrypt.SQLDecode(dataStr, passwordStr)
+		if err != nil {
+			return err
+		}
+		result.AppendString(decodeStr)
+	}
+	return nil
 }
 
 func (b *builtinEncodeSig) vectorized() bool {

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -37,7 +37,7 @@ var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
 	},
 	ast.Decode: {
-		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 20}}},
 	},
 }
 

--- a/expression/builtin_encryption_vec_test.go
+++ b/expression/builtin_encryption_vec_test.go
@@ -36,6 +36,9 @@ var vecBuiltinEncryptionCases = map[string][]vecExprBenchCase{
 	ast.Encode: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
 	},
+	ast.Decode: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinEncryptionFunc(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinDecodeSig, for #12106

### What is changed and how it works?
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinEncryptionFunc -run=BenchmarkVectorizedBuiltinEncryptionFunc -args 'builtinDecodeSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinEncryptionFunc/builtinDecodeSig-VecBuiltinFunc-4                   372           3236232 ns/op           13901 B/op       675 allocs/op
BenchmarkVectorizedBuiltinEncryptionFunc/builtinDecodeSig-NonVecBuiltinFunc-4                360           3251602 ns/op           13888 B/op       675 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.059s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test