### PR TITLE
planner: handle single partition in IndexJoin correctly (#12581)

### DIFF
--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -106,3 +106,11 @@ func (s *testSuite) TestBatchIndexJoinUnionScan(c *C) {
 	))
 	tk.MustExec("rollback")
 }
+
+func (s *testSuite) TestIndexJoinPartitionTable(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int not null, c int, key idx(c)) partition by hash(b) partitions 30")
+	tk.MustExec("insert into t values(1, 27, 2)")
+	tk.MustQuery("SELECT /*+ TIDB_INLJ(t1) */ count(1) FROM t t1 INNER JOIN (SELECT a, max(c) AS c FROM t WHERE b = 27 AND a = 1 GROUP BY a) t2 ON t1.a = t2.a AND t1.c = t2.c WHERE t1.b = 27").Check(testkit.Rows("1"))
+}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -531,6 +531,8 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 		KeepOrder:        false,
 		Ranges:           ranger.FullRange(),
 		rangeDecidedBy:   outerJoinKeys,
+		isPartition:      ds.isPartition,
+		physicalTableID:  ds.physicalTableID,
 	}.init(ds.ctx)
 	is.filterCondition = remainedConds
 
@@ -552,7 +554,12 @@ func (p *LogicalJoin) constructInnerIndexScan(ds *DataSource, idx *model.IndexIn
 	}
 	if !isCoveringIndex(ds.schema.Columns, is.Index.Columns, is.Table.PKIsHandle) {
 		// On this way, it's double read case.
-		ts := PhysicalTableScan{Columns: ds.Columns, Table: is.Table}.init(ds.ctx)
+		ts := PhysicalTableScan{
+			Columns:         ds.Columns,
+			Table:           is.Table,
+			isPartition:     ds.isPartition,
+			physicalTableID: ds.physicalTableID,
+		}.init(ds.ctx)
 		ts.SetSchema(is.dataSourceSchema)
 		cop.tablePlan = ts
 	}


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/12581

Conflicts:
	executor/index_lookup_join_test.go
	planner/core/exhaust_physical_plans.go