### PR TITLE
expression: implement vectorized evaluation for 'builtinArithmeticMultiplyIntSig' 

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -270,11 +270,43 @@ func (b *builtinArithmeticIntDivideDecimalSig) vecEvalInt(input *chunk.Chunk, re
 }
 
 func (b *builtinArithmeticMultiplyIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinArithmeticMultiplyIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	x := result.Int64s()
+	y := buf.Int64s()
+	result.MergeNulls(buf)
+	var tmp int64
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		tmp = x[i] * y[i]
+		if x[i] != 0 && tmp/x[i] != y[i] {
+			result.SetNull(i, true)
+			return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+		}
+
+		x[i] = tmp
+	}
+
+	return nil
 }
 
 func (b *builtinArithmeticDivideRealSig) vectorized() bool {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -40,6 +40,7 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.Mul: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{&rangeInt64Gener{-10000, 10000}, &rangeInt64Gener{-10000, 10000}}},
 	},
 	ast.Round: {},
 	ast.And:   {},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for 'builtinArithmeticMultiplyIntSig' mentioned here https://github.com/pingcap/tidb/issues/12103

### What is changed and how it works?
about three times faster
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMultiplyIntSig-VecBuiltinFunc-4                  70140             15791 ns/op               0 B/op           0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticMultiplyIntSig-NonVecBuiltinFunc-4               24840             46757 ns/op               0 B/op           0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
