### PR TITLE
types: invalid year should be 0

### DIFF
--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -654,12 +654,26 @@ func (s *testTypeConvertSuite) TestConvert(c *C) {
 	signedAccept(c, mysql.TypeDouble, "1e+1", "10")
 
 	// year
-	signedDeny(c, mysql.TypeYear, 123, "<nil>")
-	signedDeny(c, mysql.TypeYear, 3000, "<nil>")
+	signedDeny(c, mysql.TypeYear, 123, "0")
+	signedDeny(c, mysql.TypeYear, 3000, "0")
 	signedAccept(c, mysql.TypeYear, "2000", "2000")
 	signedAccept(c, mysql.TypeYear, "abc", "0")
 	signedAccept(c, mysql.TypeYear, "00abc", "2000")
 	signedAccept(c, mysql.TypeYear, "0019", "2019")
+	signedAccept(c, mysql.TypeYear, 2155, "2155")
+	signedAccept(c, mysql.TypeYear, 2155.123, "2155")
+	signedDeny(c, mysql.TypeYear, 2156, "0")
+	signedDeny(c, mysql.TypeYear, 123.123, "0")
+	signedDeny(c, mysql.TypeYear, 1900, "0")
+	signedAccept(c, mysql.TypeYear, 1901, "1901")
+	signedAccept(c, mysql.TypeYear, 1900.567, "1901")
+	signedDeny(c, mysql.TypeYear, 1900.456, "0")
+	signedAccept(c, mysql.TypeYear, 1, "2001")
+	signedAccept(c, mysql.TypeYear, 69, "2069")
+	signedAccept(c, mysql.TypeYear, 70, "1970")
+	signedAccept(c, mysql.TypeYear, 99, "1999")
+	signedDeny(c, mysql.TypeYear, 100, "0")
+	signedDeny(c, mysql.TypeYear, "99999999999999999999999999999999999", "0")
 
 	// time from string
 	signedAccept(c, mysql.TypeDate, "2012-08-23", "2012-08-23")

--- a/types/datum.go
+++ b/types/datum.go
@@ -1227,6 +1227,7 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 		s := d.GetString()
 		y, err = StrToInt(sc, s)
 		if err != nil {
+			ret.SetInt64(0)
 			return ret, errors.Trace(err)
 		}
 		if len(s) != 4 && len(s) > 0 && s[0:1] == "0" {
@@ -1239,16 +1240,18 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	default:
 		ret, err = d.convertToInt(sc, NewFieldType(mysql.TypeLonglong))
 		if err != nil {
-			return invalidConv(d, target.Tp)
+			_, err = invalidConv(d, target.Tp)
+			ret.SetInt64(0)
+			return ret, err
 		}
 		y = ret.GetInt64()
 	}
 	y, err = AdjustYear(y, adjust)
 	if err != nil {
-		return invalidConv(d, target.Tp)
+		_, err = invalidConv(d, target.Tp)
 	}
 	ret.SetInt64(y)
-	return ret, nil
+	return ret, err
 }
 
 func (d *Datum) convertToMysqlBit(sc *stmtctx.StatementContext, target *FieldType) (Datum, error) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Invalid year should be "0000". Fix https://github.com/pingcap/tidb/issues/12615

### What is changed and how it works?

Return 0 with error in convertToMysqlYear

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

```
mysql> create table t (y year);
Query OK, 0 rows affected (0.01 sec)

mysql> insert ignore into t values(2156);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> insert ignore into t values(999999999999999999999999999);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> insert ignore into t values(1900);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> insert ignore into t values(1900.5);
Query OK, 1 row affected (0.00 sec)

mysql> select * from t;
+------+
| y    |
+------+
| 0000 |
| 0000 |
| 0000 |
| 1901 |
+------+
4 rows in set (0.00 sec)
```

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix YEAR compatibility, inserting invalid year value will be "0000"