### PR TITLE
expression: implement vectorized evaluation for `builtinArithmeticDivideDecimalSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -309,6 +309,30 @@ func (g *rangeRealGener) gen() interface{} {
 	return rand.Float64()*(g.end-g.begin) + g.begin
 }
 
+// rangeDecimalGener is used to generate decimal items in [begin, end].
+type rangeDecimalGener struct {
+	begin float64
+	end   float64
+
+	nullRation float64
+}
+
+func (g *rangeDecimalGener) gen() interface{} {
+	if rand.Float64() < g.nullRation {
+		return nil
+	}
+	if g.end < g.begin {
+		g.begin = -100000
+		g.end = 100000
+	}
+	d := new(types.MyDecimal)
+	f := rand.Float64()*(g.end-g.begin) + g.begin
+	if err := d.FromFloat64(f); err != nil {
+		panic(err)
+	}
+	return d
+}
+
 // rangeInt64Gener is used to generate int64 items in [begin, end).
 type rangeInt64Gener struct {
 	begin int

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -57,11 +57,52 @@ func (b *builtinArithmeticMultiplyRealSig) vecEvalReal(input *chunk.Chunk, resul
 }
 
 func (b *builtinArithmeticDivideDecimalSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.MergeNulls(buf)
+	x := result.Decimals()
+	y := buf.Decimals()
+	var to types.MyDecimal
+	var frac int
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		err = types.DecimalDiv(&x[i], &y[i], &to, types.DivFracIncr)
+		if err == types.ErrDivByZero {
+			if err = handleDivisionByZeroError(b.ctx); err != nil {
+				return err
+			}
+			result.SetNull(i, true)
+			continue
+		} else if err == nil {
+			_, frac = to.PrecisionAndFrac()
+			if frac < b.baseBuiltinFunc.tp.Decimal {
+				if err = to.Round(&to, b.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven); err != nil {
+					return err
+				}
+			}
+		} else {
+			return err
+		}
+		x[i] = to
+	}
+	return nil
 }
 
 func (b *builtinArithmeticModIntSig) vectorized() bool {

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -30,6 +30,8 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 	ast.Div: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{nil, &rangeRealGener{0, 0, 0}}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETDecimal}, geners: []dataGenerator{nil, &rangeDecimalGener{0, 0, 0.2}}},
 	},
 	ast.IntDiv: {},
 	ast.Mod: {


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinArithmeticDivideDecimalSig.#12102

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideDecimalSig-VecBuiltinFunc-4                 5462            216735 ns/op          30928 B/op         648 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticDivideDecimalSig-NonVecBuiltinFunc-4              4324            284299 ns/op          62032 B/op        1296 allocs/op
```

### Check List

Tests
- Unit test