### PR TITLE
 implement vectorized evaluation for builtinArithmeticModIntSig

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -90,22 +90,36 @@ func (b *builtinArithmeticModIntSig) vecEvalInt(input *chunk.Chunk, result *chun
 	switch {
 	case xIsunsiged && yIsunsiged:
 		for i := 0; i < n; i++ {
+			if buf.IsNull(i) {
+				result.SetNull(i, true)
+				continue
+			}
 			if y[i] == 0 {
+				result.SetNull(i, true)
 				if err := handleDivisionByZeroError(b.ctx); err != nil {
 					return err
 				}
-				result.SetNull(i, true)
+				continue
+			}
+			if result.IsNull(i) {
 				continue
 			}
 			x[i] = x[i] % y[i]
 		}
 	case xIsunsiged && !yIsunsiged:
 		for i := 0; i < n; i++ {
+			if buf.IsNull(i) {
+				result.SetNull(i, true)
+				continue
+			}
 			if y[i] == 0 {
+				result.SetNull(i, true)
 				if err := handleDivisionByZeroError(b.ctx); err != nil {
 					return err
 				}
-				result.SetNull(i, true)
+				continue
+			}
+			if result.IsNull(i) {
 				continue
 			}
 			if y[i] < 0 {
@@ -116,6 +130,20 @@ func (b *builtinArithmeticModIntSig) vecEvalInt(input *chunk.Chunk, result *chun
 		}
 	case !xIsunsiged && yIsunsiged:
 		for i := 0; i < n; i++ {
+			if buf.IsNull(i) {
+				result.SetNull(i, true)
+				continue
+			}
+			if y[i] == 0 {
+				result.SetNull(i, true)
+				if err := handleDivisionByZeroError(b.ctx); err != nil {
+					return err
+				}
+				continue
+			}
+			if result.IsNull(i) {
+				continue
+			}
 			if x[i] < 0 {
 				x[i] = -int64(uint64(-x[i])) % y[i]
 			} else {
@@ -124,6 +152,20 @@ func (b *builtinArithmeticModIntSig) vecEvalInt(input *chunk.Chunk, result *chun
 		}
 	case !xIsunsiged && !yIsunsiged:
 		for i := 0; i < n; i++ {
+			if buf.IsNull(i) {
+				result.SetNull(i, true)
+				continue
+			}
+			if y[i] == 0 {
+				result.SetNull(i, true)
+				if err := handleDivisionByZeroError(b.ctx); err != nil {
+					return err
+				}
+				continue
+			}
+			if result.IsNull(i) {
+				continue
+			}
 			x[i] = x[i] % y[i]
 		}
 	}

--- a/expression/builtin_arithmetic_vec_test.go
+++ b/expression/builtin_arithmetic_vec_test.go
@@ -37,6 +37,8 @@ var vecBuiltinArithmeticCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{nil, &rangeRealGener{0, 0, 0}}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{&rangeRealGener{0, 0, 0}, nil}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}, geners: []dataGenerator{nil, &rangeRealGener{0, 0, 1}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{0, 1000}}},
 	},
 	ast.Or: {},
 	ast.Mul: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
 implement vectorized evaluation for builtinArithmeticModIntSig

### What is changed and how it works?
after change
almost accelerate 300%
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSig-VecBuiltinFunc-4                               72500             16676 ns/op              0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSig-NonVecBuiltinFunc-4                            21747             57987 ns/op              0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSig-VecBuiltinFunc#01-4                            59473             20724 ns/op              0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSig-NonVecBuiltinFunc#01-4                         19250             63244 ns/op              0 B/op          0 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

