### PR TITLE
fix the STR_TO_DATE incompatible between MySQL and TiDB (#12623)

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -1788,6 +1788,7 @@ func (c *strToDateFunctionClass) getRetTp(ctx sessionctx.Context, arg Expression
 	if err != nil || isNull {
 		return
 	}
+
 	isDuration, isDate := types.GetFormatType(format)
 	if isDuration && !isDate {
 		tp = mysql.TypeDuration

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1715,6 +1715,8 @@ func (s *testIntegrationSuite) TestTimeBuiltin(c *C) {
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Incorrect datetime value: '0000-00-00 00:00:00'"))
 	result = tk.MustQuery("select str_to_date('2018-6-1', '%Y-%m-%d'), str_to_date('2018-6-1', '%Y-%c-%d'), str_to_date('59:20:1', '%s:%i:%k'), str_to_date('59:20:1', '%s:%i:%l')")
 	result.Check(testkit.Rows("2018-06-01 2018-06-01 01:20:59 01:20:59"))
+	result = tk.MustQuery("select str_to_date('20190101','%Y%m%d%!'), str_to_date('20190101','%Y%m%d%f'), str_to_date('20190101','%Y%m%d%H%i%s')")
+	result.Check(testkit.Rows("2019-01-01 2019-01-01 00:00:00.000000 2019-01-01 00:00:00"))
 
 	// for maketime
 	tk.MustExec(`drop table if exists t`)

--- a/types/time.go
+++ b/types/time.go
@@ -2175,6 +2175,11 @@ func strToDate(t *MysqlTime, date string, format string, ctx map[string]int) boo
 		return true
 	}
 
+	if len(date) == 0 {
+		ctx[token] = 0
+		return true
+	}
+
 	dateRemain, succ := matchDateWithToken(t, date, token, ctx)
 	if !succ {
 		return false
@@ -2289,6 +2294,7 @@ func GetFormatType(format string) (isDuration, isDate bool) {
 		"%S": {},
 		"%k": {},
 		"%l": {},
+		"%f": {},
 	}
 	dateTokens := map[string]struct{}{
 		"%y": {},


### PR DESCRIPTION
cherry-pick #12623 to release-2.1

---

Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The result of `select str_to_date('20190101','%Y%m%d%H%i%s')` is incompitable between MySQL and TiDB.

MySQL
```
mysql> select str_to_date('20190101','%Y%m%d%H%i%s');
+----------------------------------------+
| str_to_date('20190101','%Y%m%d%H%i%s') |
+----------------------------------------+
| 2019-01-01 00:00:00                    |
+----------------------------------------+
1 row in set (0.01 sec)
```

TiDB
```
mysql> select str_to_date('20190101','%Y%m%d%H%i%s');
+----------------------------------------+
| str_to_date('20190101','%Y%m%d%H%i%s') |
+----------------------------------------+
| NULL                                   |
+----------------------------------------+
1 row in set (0.01 sec)
```

### What is changed and how it works?

Fix it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - fix the STR_TO_DATE incompatible between MySQL and TiDB
