### PR TITLE
Fix forever hanging when HashAgg is called by apply

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -207,7 +207,6 @@ func (e *HashAggExec) Close() error {
 		}
 		close(e.finalOutputCh)
 	}
-	e.executed = false
 	close(e.finishCh)
 	for _, ch := range e.partialOutputChs {
 		for range ch {
@@ -215,6 +214,7 @@ func (e *HashAggExec) Close() error {
 	}
 	for range e.finalOutputCh {
 	}
+	e.executed = false
 	return e.baseExecutor.Close()
 }
 

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -160,6 +160,7 @@ type HashAggExec struct {
 	// we can remove this attribute.
 	isUnparallelExec bool
 	prepared         bool
+	executed         bool
 }
 
 // HashAggInput indicates the input of hash agg exec.
@@ -603,10 +604,14 @@ func (e *HashAggExec) parallelExec(ctx context.Context, chk *chunk.Chunk) error 
 		}
 	})
 
+	if e.executed {
+		return nil
+	}
 	for !chk.IsFull() {
 		e.finalInputCh <- chk
 		result, ok := <-e.finalOutputCh
 		if !ok { // all finalWorkers exited
+			e.executed = true
 			if chk.NumRows() > 0 { // but there are some data left
 				return nil
 			}

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -207,6 +207,7 @@ func (e *HashAggExec) Close() error {
 		}
 		close(e.finalOutputCh)
 	}
+	e.executed = false
 	close(e.finishCh)
 	for _, ch := range e.partialOutputChs {
 		for range ch {

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -731,7 +731,8 @@ func (s *testSuite1) TestIssue10608(c *C) {
 	tk.MustExec("create table s(a int, b int)")
 	tk.MustExec("insert into s values(100292, 508931), (120002, 508932)")
 	tk.MustExec("insert into t values(508931), (508932)")
-	tk.MustQuery("select (select group_concat(concat(123,'-')) from t where t.a = s.b group by t.a) as t from s;").Check(testkit.Rows("123-", "123-"))
+	tk.MustQuery("select (select  /*+ stream_agg() */ group_concat(concat(123,'-')) from t where t.a = s.b group by t.a) as t from s;").Check(testkit.Rows("123-", "123-"))
+	tk.MustQuery("select (select  /*+ hash_agg() */ group_concat(concat(123,'-')) from t where t.a = s.b group by t.a) as t from s;").Check(testkit.Rows("123-", "123-"))
 
 }
 

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -734,3 +734,46 @@ func (s *testSuite1) TestIssue10608(c *C) {
 	tk.MustQuery("select (select group_concat(concat(123,'-')) from t where t.a = s.b group by t.a) as t from s;").Check(testkit.Rows("123-", "123-"))
 
 }
+
+func (s *testSuite1) TestIssue12759HashAggCalledByApply(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.Se.GetSessionVars().HashAggFinalConcurrency = 4
+	tk.MustExec(`insert into mysql.opt_rule_blacklist value("decorrelate");`)
+	defer func() {
+		tk.MustExec(`delete from mysql.opt_rule_blacklist where name = "decorrelate";`)
+		tk.MustExec(`admin reload opt_rule_blacklist;`)
+	}()
+	tk.MustExec(`drop table if exists test;`)
+	tk.MustExec("create table test (a int);")
+	tk.MustExec("insert into test value(1);")
+	tk.MustQuery("select /*+ hash_agg() */ sum(a), (select NULL from test where tt.a = test.a limit 1),(select NULL from test where tt.a = test.a limit 1),(select NULL from test where tt.a = test.a limit 1) from test tt;").Check(testkit.Rows("1 <nil> <nil> <nil>"))
+
+	// make sure the plan is Apply -> Apply -> Apply -> HashAgg, and the count of Apply is equal to HashAggFinalConcurrency-1.
+	tk.MustQuery("explain select /*+ hash_agg() */ sum(a), (select NULL from test where tt.a = test.a limit 1),(select NULL from test where tt.a = test.a limit 1),(select NULL from test where tt.a = test.a limit 1) from test tt;").Check(testkit.Rows("" +
+		"Projection_28 1.00 root Column#3, Column#7, Column#11, Column#15]\n" +
+		"[└─Apply_30 1.00 root CARTESIAN left outer join, inner:Projection_65]\n" +
+		"[  ├─Apply_32 1.00 root CARTESIAN left outer join, inner:Projection_54]\n" +
+		"[  │ ├─Apply_34 1.00 root CARTESIAN left outer join, inner:Projection_43]\n" +
+		"[  │ │ ├─HashAgg_39 1.00 root funcs:sum(Column#26), firstrow(Column#27)]\n" +
+		"[  │ │ │ └─TableReader_40 1.00 root data:HashAgg_35]\n" +
+		"[  │ │ │   └─HashAgg_35 1.00 cop[tikv] funcs:sum(Column#1), firstrow(Column#1)]\n" +
+		"[  │ │ │     └─TableScan_38 10000.00 cop[tikv] table:tt, range:[-inf,+inf], keep order:false, stats:pseudo]\n" +
+		"[  │ │ └─Projection_43 1.00 root NULL]\n" +
+		"[  │ │   └─Limit_44 1.00 root offset:0, count:1]\n" +
+		"[  │ │     └─TableReader_50 1.00 root data:Limit_49]\n" +
+		"[  │ │       └─Limit_49 1.00 cop[tikv] offset:0, count:1]\n" +
+		"[  │ │         └─Selection_48 1.00 cop[tikv] eq(Column#1, Column#5)]\n" +
+		"[  │ │           └─TableScan_47 1000.00 cop[tikv] table:test, range:[-inf,+inf], keep order:false, stats:pseudo]\n" +
+		"[  │ └─Projection_54 1.00 root NULL]\n" +
+		"[  │   └─Limit_55 1.00 root offset:0, count:1]\n" +
+		"[  │     └─TableReader_61 1.00 root data:Limit_60]\n" +
+		"[  │       └─Limit_60 1.00 cop[tikv] offset:0, count:1]\n" +
+		"[  │         └─Selection_59 1.00 cop[tikv] eq(Column#1, Column#9)]\n" +
+		"[  │           └─TableScan_58 1000.00 cop[tikv] table:test, range:[-inf,+inf], keep order:false, stats:pseudo]\n" +
+		"[  └─Projection_65 1.00 root NULL]\n" +
+		"[    └─Limit_66 1.00 root offset:0, count:1]\n" +
+		"[      └─TableReader_72 1.00 root data:Limit_71]\n" +
+		"[        └─Limit_71 1.00 cop[tikv] offset:0, count:1]\n" +
+		"[          └─Selection_70 1.00 cop[tikv] eq(Column#1, Column#13)]\n" +
+		"[            └─TableScan_69 1000.00 cop[tikv] table:test, range:[-inf,+inf], keep order:false, stats:pseudo"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #12759 

### What is changed and how it works?

The parent executors(apply) of HashAgg may [call `HashAgg.Next` once more](https://github.com/pingcap/tidb/blob/2f7a66f2da241765c7a732c6b03b7ec363f861ac/executor/join.go#L596-L598) to make sure the returned size of chunk is 0.
`HashAgg.Next` handle these calls incorrectly after its all `finalWorks` exits. 

On each call of `HashAgg.Next` after the job done, it returns a chunk with 0 size, but [put a chk into `finalInputCh`](https://github.com/pingcap/tidb/blob/2f7a66f2da241765c7a732c6b03b7ec363f861ac/executor/aggregate.go#L607). Each apply executor will call a `HashAgg.Next` once more, when the number of parent executors exceeds the channel buffer, the query will hang forever.

Explain the example in #12759,
1. The size of the channel buffer is 4, 
2. The first call of `HashAgg.Next` which returns a one-row chunk to its parent, sends the chunk into the buffer (This is valid).
3. Three times calls of `HashAgg.Next` called by each of the three apply, which returns a zero-row chunk to its parent, sends the chunk into the buffer (This should not happen).
4. Now the channel is full.
4. One more call of `HashAgg.Next` called by the session of tidb, which returns a zero-row chunk to its parent, sends the chunk into the buffer and hangs forever.

 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - Fix forever hanging when HashAgg is called by apply.
