### PR TITLE
expression: set null conditionally in 'builtinLogicOrSig'

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -85,7 +85,9 @@ func (b *builtinLogicOrSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column)
 		} else {
 			i64s[i] = 0
 		}
-		result.SetNull(i, isNull)
+		if isNull != isNull0 {
+			result.SetNull(i, isNull)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Resolve comments in #12365 

### What is changed and how it works?

A tiny optimization to call `isNull()` conditionally.

No regression according to BM

```
BenchmarkVectorizedBuiltinOpFunc/builtinLogicOrSig-VecBuiltinFunc-4                  	  300000	      5521 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinLogicOrSig-NonVecBuiltinFunc-4               	   50000	     25758 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
