### PR TITLE
expression: implement vectorized evaluation for `builtinCeilIntToDecSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -716,7 +716,7 @@ func (b *builtinCeilIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chun
 	i64s := buf.Int64s()
 	d := result.Decimals()
 	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
-	for i := 0; i < len(i64s); i++ {
+	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -722,6 +722,7 @@ func (b *builtinCeilIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chun
 		}
 		if isUnsigned || i64s[i] >= 0 {
 			d[i] = *types.NewDecFromUint(uint64(i64s[i]))
+			continue
 		}
 		d[i] = *types.NewDecFromInt(i64s[i])
 	}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
@@ -695,11 +696,36 @@ func (b *builtinRandWithSeedSig) vecEvalReal(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinCeilIntToDecSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCeilIntToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeDecimal(n, false)
+	result.MergeNulls(buf)
+
+	i64s := buf.Int64s()
+	d := result.Decimals()
+	isUnsigned := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
+	for i := 0; i < len(i64s); i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if isUnsigned || i64s[i] >= 0 {
+			d[i] = *types.NewDecFromUint(uint64(i64s[i]))
+		}
+		d[i] = *types.NewDecFromInt(i64s[i])
+	}
+	return nil
 }
 
 func (b *builtinTruncateIntSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -98,6 +98,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}, geners: nil},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24}}, geners: nil},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}, geners: nil},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETInt}, geners: nil},
 	},
 	ast.PI: {
 		{retEvalType: types.ETReal},


### PR DESCRIPTION
### What problem does this PR solve?

Implement vectorized evaluation for builtinCeilIntToDecSig.#12102

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinMathFunc/builtinCeilIntToDecSig-VecBuiltinFunc-4         59418             20651 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinCeilIntToDecSig-NonVecBuiltinFunc-4      16982             67640 ns/op           39264 B/op        818 allocs/op
```

### Check List

Tests
- Unit test