### PR TITLE
executor: update the memory usage format in the slow log

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1271,7 +1271,7 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 		}
 	}
 	if logItems.MemMax > 0 {
-		writeSlowLogItem(&buf, SlowLogMemMax, strconv.FormatInt(logItems.MemMax, 10))
+		writeSlowLogItem(&buf, SlowLogMemMax, fmt.Sprintf("%d bytes (%s)", logItems.MemMax, formatMemoryUsage(logItems.MemMax)))
 	}
 
 	writeSlowLogItem(&buf, SlowLogPrepared, strconv.FormatBool(logItems.Prepared))
@@ -1287,6 +1287,17 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 		buf.WriteString(";")
 	}
 	return buf.String()
+}
+
+func formatMemoryUsage(bytes int64) string {
+	if bytes >= (1 << 30) {
+		return fmt.Sprintf("%.2f GB", float64(bytes)/(1<<30))
+	} else if bytes >= (1 << 20) {
+		return fmt.Sprintf("%.2f MB", float64(bytes)/(1<<20))
+	} else if bytes >= (1 << 10) {
+		return fmt.Sprintf("%.2f KB", float64(bytes)/(1<<10))
+	}
+	return fmt.Sprintf("%d bytes", bytes)
 }
 
 // writeSlowLogItem writes a slow log item in the form of: "# ${key}:${value}"

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1271,7 +1271,7 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 		}
 	}
 	if logItems.MemMax > 0 {
-		writeSlowLogItem(&buf, SlowLogMemMax, fmt.Sprintf("%d bytes (%s)", logItems.MemMax, formatMemoryUsage(logItems.MemMax)))
+		writeSlowLogItem(&buf, SlowLogMemMax, fmt.Sprintf("%d bytes (%s)", logItems.MemMax, FormatMemoryUsage(logItems.MemMax)))
 	}
 
 	writeSlowLogItem(&buf, SlowLogPrepared, strconv.FormatBool(logItems.Prepared))
@@ -1289,7 +1289,8 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	return buf.String()
 }
 
-func formatMemoryUsage(bytes int64) string {
+// FormatMemoryUsage formats the number of bytes to a string with unit suffixes which is easy to read.
+func FormatMemoryUsage(bytes int64) string {
 	if bytes >= (1 << 30) {
 		return fmt.Sprintf("%.2f GB", float64(bytes)/(1<<30))
 	} else if bytes >= (1 << 20) {

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -14,6 +14,7 @@
 package variable_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -192,4 +193,16 @@ select * from t;`
 		Succ:           true,
 	})
 	c.Assert(logString, Equals, resultString)
+}
+
+func (*testSessionSuite) TestFormatMemoryUsage(c *C) {
+	bytes := (1 << 30) * 1.23
+	c.Assert(variable.FormatMemoryUsage(int64(bytes)), Equals, "1.23 GB")
+	fmt.Println(variable.FormatMemoryUsage(int64(bytes)))
+	bytes = (1 << 20) * 2.34
+	c.Assert(variable.FormatMemoryUsage(int64(bytes)), Equals, "2.34 MB")
+	bytes = (1 << 10) * 3.45
+	c.Assert(variable.FormatMemoryUsage(int64(bytes)), Equals, "3.45 KB")
+	bytes = 456
+	c.Assert(variable.FormatMemoryUsage(int64(bytes)), Equals, "456 bytes")
 }

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -168,7 +168,7 @@ func (*testSessionSuite) TestSlowLogFormat(c *C) {
 # Num_cop_tasks: 10
 # Cop_proc_avg: 1 Cop_proc_p90: 2 Cop_proc_max: 3 Cop_proc_addr: 10.6.131.78
 # Cop_wait_avg: 0.01 Cop_wait_p90: 0.02 Cop_wait_max: 0.03 Cop_wait_addr: 10.6.131.79
-# Mem_max: 2333
+# Mem_max: 2333 bytes (2.28 KB)
 # Prepared: true
 # Has_more_results: true
 # Succ: true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Update the memory usage format in the slow log to let it easier to read for users.

### What is changed and how it works?
Using unit suffixes like `GB`, `MB` in the result to make it easier to read.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test