### PR TITLE
planner, expression: fix simplify outer join with cast (#12701)

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -276,7 +276,7 @@ func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 		for i, arg := range x.GetArgs() {
 			args[i] = EvaluateExprWithNull(ctx, schema, arg)
 		}
-		return NewFunctionInternal(ctx, x.FuncName.L, types.NewFieldType(mysql.TypeTiny), args...)
+		return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
 	case *Column:
 		if !schema.Contains(x) {
 			return x

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -105,3 +105,25 @@ func (s *testIntegrationSuite) runTestsWithTestData(caseName string, tk *testkit
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func (s *testIntegrationSuite) TestSimplifyOuterJoinWithCast(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int not null, b datetime default null)")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -4,12 +4,12 @@
     "cases": [
       // Limit should be pushed down into IndexLookUpReader, row count of IndexLookUpReader and TableScan should be 1.00.
       "explain select * from tbl use index(idx_b_c) where b > 1 limit 2,1",
-	  // Projection atop IndexLookUpReader, Limit should be pushed down into IndexLookUpReader, and Projection should have row count 1.00 as well.
+      // Projection atop IndexLookUpReader, Limit should be pushed down into IndexLookUpReader, and Projection should have row count 1.00 as well.
       "explain select * from tbl use index(idx_b_c) where b > 1 order by b desc limit 2,1",
-	  // Limit should be pushed down into IndexLookUpReader when Selection on top of IndexScan.
-	  "explain select * from tbl use index(idx_b_c) where b > 1 and c > 1 limit 2,1",
-	  // Limit should NOT be pushed down into IndexLookUpReader when Selection on top of TableScan.
-	  "explain select * from tbl use index(idx_b_c) where b > 1 and a > 1 limit 2,1"
+      // Limit should be pushed down into IndexLookUpReader when Selection on top of IndexScan.
+      "explain select * from tbl use index(idx_b_c) where b > 1 and c > 1 limit 2,1",
+      // Limit should NOT be pushed down into IndexLookUpReader when Selection on top of TableScan.
+      "explain select * from tbl use index(idx_b_c) where b > 1 and a > 1 limit 2,1"
     ]
   },
   {
@@ -17,6 +17,13 @@
     "cases": [
       // fix #12385
       "explain select * from t t1 left join t t2 on t1.a=t2.a where from_unixtime(t2.b);"
+    ]
+  },
+  {
+    "name": "TestSimplifyOuterJoinWithCast",
+    "cases": [
+      // LeftOuterJoin should no be simplified to InnerJoin.
+      "explain select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.b as date) >= '2019-01-01'"
     ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -18,5 +18,21 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestSimplifyOuterJoinWithCast",
+    "Cases": [
+      {
+        "SQL": "explain select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.b as date) >= '2019-01-01'",
+        "Plan": [
+          "HashLeftJoin_8 10000.00 root left outer join, inner:TableReader_13, equal:[eq(test.t1.a, test.t2.a)]",
+          "├─Selection_9 8000.00 root ge(cast(test.t1.b), 2019-01-01 00:00:00.000000)",
+          "│ └─TableReader_11 10000.00 root data:TableScan_10",
+          "│   └─TableScan_10 10000.00 cop table:t1, range:[-inf,+inf], keep order:false, stats:pseudo",
+          "└─TableReader_13 10000.00 root data:TableScan_12",
+          "  └─TableScan_12 10000.00 cop table:t2, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/12701 and https://github.com/pingcap/tidb/pull/12782

Conflicts:
	planner/core/integration_test.go