### PR TITLE
tikv: non-blocking establish superbatch connection with timeout (#12733)

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -145,23 +145,16 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 		a.v[i] = conn
 
 		if allowBatch {
-			// Initialize batch streaming clients.
-			tikvClient := tikvpb.NewTikvClient(conn)
-			streamClient, err := tikvClient.BatchCommands(context.TODO())
-			if err != nil {
-				a.Close()
-				return errors.Trace(err)
-			}
 			batchClient := &batchCommandsClient{
-				target:  a.target,
-				conn:    conn,
-				client:  streamClient,
-				batched: sync.Map{},
-				idAlloc: 0,
-				closed:  0,
+				target:        a.target,
+				conn:          conn,
+				batched:       sync.Map{},
+				idAlloc:       0,
+				closed:        0,
+				tikvClientCfg: cfg.TiKVClient,
+				tikvLoad:      &a.tikvTransportLayerLoad,
 			}
 			a.batchCommandsClients = append(a.batchCommandsClients, batchClient)
-			go batchClient.batchRecvLoop(cfg.TiKVClient, &a.tikvTransportLayerLoad)
 		}
 	}
 	go tikvrpc.CheckStreamTimeoutLoop(a.streamTimeout)

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -446,7 +446,7 @@ func (a *batchConn) getClientAndSend(entries []*batchCommandsEntry, requests []*
 	}
 
 	if err := cli.initBatchClient(); err != nil {
-		logutil.BgLogger().Warn(
+		logutil.Logger(context.Background()).Warn(
 			"init create streaming fail",
 			zap.String("target", cli.target),
 			zap.Error(err),

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -192,6 +192,9 @@ type batchCommandsClient struct {
 	batched sync.Map
 	idAlloc uint64
 
+	tikvClientCfg config.TiKVClient
+	tikvLoad      *uint64
+
 	// closed indicates the batch client is closed explicitly or not.
 	closed int32
 	// tryLock protects client when re-create the streaming.
@@ -239,7 +242,6 @@ func (c *batchCommandsClient) failPendingRequests(err error) {
 
 func (c *batchCommandsClient) reCreateStreamingClientOnce(err error) error {
 	c.failPendingRequests(err) // fail all pending requests.
-
 	// Re-establish a application layer stream. TCP layer is handled by gRPC.
 	tikvClient := tikvpb.NewTikvClient(c.conn)
 	streamClient, err := tikvClient.BatchCommands(context.TODO())
@@ -443,8 +445,32 @@ func (a *batchConn) getClientAndSend(entries []*batchCommandsEntry, requests []*
 		RequestIds: requestIDs,
 	}
 
+	if err := cli.initBatchClient(); err != nil {
+		logutil.BgLogger().Warn(
+			"init create streaming fail",
+			zap.String("target", cli.target),
+			zap.Error(err),
+		)
+		return
+	}
+
 	cli.send(req, entries)
 	return
+}
+
+func (c *batchCommandsClient) initBatchClient() error {
+	if c.client != nil {
+		return nil
+	}
+	// Initialize batch streaming clients.
+	tikvClient := tikvpb.NewTikvClient(c.conn)
+	streamClient, err := tikvClient.BatchCommands(context.TODO())
+	if err != nil {
+		return errors.Trace(err)
+	}
+	c.client = streamClient
+	go c.batchRecvLoop(c.tikvClientCfg, c.tikvLoad)
+	return nil
 }
 
 func (a *batchConn) Close() {


### PR DESCRIPTION
cherry-pick #12733 to 3.0

without any conflict just fix logger compile error 
9f30108

```
What problem does this PR solve?
fix the potential problem that slow establishes the connection make other kv requests be slow

5 min dial timeout doesn't work in superbatch
createConnArray will block wait conn establish on create tikvClient.BatchCommands
long time hold lock in createConnArray will block getConnArray
What is changed and how it works?
make establish grpc client in other goroutine which is blocking process
check estDone before send request, send directly if done
wait estReady channel if it's not done(only need select channel for first time)
set right dialTimeout for batch client creation
more words:

current impl is using connectivity state API, to wait non-blocking dial result with context timeout.
new but not released grpc, we maybe can use grpc/grpc-go#2960 to simplify impl
also take care grpc/grpc-go#1786 if upgrade to new grpc in future
Check List
Tests

Unit test
Integration test
Code changes

impl
Side effects

n/a
Related changes

Need to cherry-pick to the release branch
Release note

fix the potential problem that slow establishes the connection make other kv requests be slow 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/12814)
<!-- Reviewable:end -->
