### PR TITLE
executor: fix data race of fast analyze

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -43,6 +43,7 @@ import (
 )
 
 var _ = Suite(&testFastAnalyze{})
+var _ = SerialSuites(&testFastAnalyzeSerial{testSuite1: testSuite1{}})
 
 func (s *testSuite1) TestAnalyzePartition(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
@@ -178,7 +179,23 @@ func (s *testSuite1) TestAnalyzeTooLongColumns(c *C) {
 	c.Assert(tbl.Columns[1].TotColSize, Equals, int64(65559))
 }
 
-func (s *testSuite1) TestAnalyzeFastSample(c *C) {
+type testFastAnalyzeSerial struct {
+	testSuite1 testSuite1
+}
+
+func (s *testFastAnalyzeSerial) SetUpSuite(c *C) {
+	s.testSuite1.SetUpSuite(c)
+}
+
+func (s *testFastAnalyzeSerial) TearDownSuite(c *C) {
+	s.testSuite1.TearDownSuite(c)
+}
+
+func (s *testFastAnalyzeSerial) TearDownTest(c *C) {
+	s.testSuite1.TearDownTest(c)
+}
+
+func (s *testFastAnalyzeSerial) TestAnalyzeFastSample(c *C) {
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	store, err := mockstore.NewMockTikvStore(
@@ -251,7 +268,7 @@ func (s *testSuite1) TestAnalyzeFastSample(c *C) {
 	c.Assert(fmt.Sprintln(vals), Equals, "[[0 4 6 9 10 11 12 14 17 24 25 29 30 34 35 44 52 54 57 58] [0 4 6 9 10 11 12 14 17 24 25 29 30 34 35 44 52 54 57 58]]\n")
 }
 
-func (s *testSuite1) TestFastAnalyze(c *C) {
+func (s *testFastAnalyzeSerial) TestFastAnalyze(c *C) {
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	store, err := mockstore.NewMockTikvStore(


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the data race of fast analyze
```
[2019-10-18T07:42:21.560Z] ==================
[2019-10-18T07:42:21.560Z] WARNING: DATA RACE
[2019-10-18T07:42:21.560Z] Write at 0x000004018d58 by goroutine 248:
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor_test.(*testSuite1).TestAnalyzeFastSample()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/analyze_test.go:171 +0x3cb
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:920 +0x37f
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:918 +0x352
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:916 +0x325
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:914 +0x2f8
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:912 +0x2cb
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:910 +0x29e
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:908 +0x271
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:906 +0x244
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:904 +0x217
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:902 +0x1ea
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:900 +0x1bd
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:898 +0x190
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:897 +0x163
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:896 +0x136
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:894 +0x109
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:892 +0xdc
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.doDDLWorks()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:890 +0x5b
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.bootstrap()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:294 +0x1a1
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.runInBootstrapSession()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1566 +0xe2
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.BootstrapSession()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1480 +0xa00
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor_test.(*testSuite1).TestAnalyzeFastSample()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/analyze_test.go:168 +0x2bb
[2019-10-18T07:42:21.560Z]   runtime.call32()
[2019-10-18T07:42:21.560Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-10-18T07:42:21.560Z]   reflect.Value.Call()
[2019-10-18T07:42:21.560Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-10-18T07:42:21.560Z] 
[2019-10-18T07:42:21.560Z] Previous read at 0x000004018d58 by goroutine 384:
[2019-10-18T07:42:21.560Z]   [failed to restore the stack]
[2019-10-18T07:42:21.560Z] 
[2019-10-18T07:42:21.560Z] Goroutine 248 (running) created at:
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkCall()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a3
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkTest()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).doRun()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x13a
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:643 +0xae
[2019-10-18T07:42:21.560Z] 
[2019-10-18T07:42:21.560Z] Goroutine 384 (running) created at:
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor.(*AnalyzeExec).Next()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/analyze.go:89 +0x1b0
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor.Next()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:191 +0x10f
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:408 +0x36e
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor.(*ExecStmt).Exec()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:272 +0x3af
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.runStmt()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:228 +0x215
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.(*session).executeStatement()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:964 +0x203
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.(*session).execute()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1079 +0xcfa
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/session.(*session).Execute()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1002 +0xeb
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:140 +0x100
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:174 +0x91
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor_test.(*testSuite3).TestDropStats()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/simple_test.go:458 +0x6b8
[2019-10-18T07:42:21.560Z]   github.com/pingcap/tidb/executor_test.(*testSuite3).TestDropStats()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/simple_test.go:441 +0x12f
[2019-10-18T07:42:21.560Z]   runtime.call32()
[2019-10-18T07:42:21.560Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-10-18T07:42:21.560Z]   reflect.Value.Call()
[2019-10-18T07:42:21.560Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-10-18T07:42:21.560Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-10-18T07:42:21.560Z]       /home/jenkins/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-10-18T07:42:21.560Z] ==================
```

### What is changed and how it works?

Run the tests fast analyze unparallel.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
