### PR TITLE
expression: implement vectorized evaluation for `builtinCoalesceStringSig`

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -435,7 +435,11 @@ func (b *builtinCoalesceStringSig) vecEvalString(input *chunk.Chunk, result *chu
 			return err
 		}
 		for j := 0; j < n; j++ {
-			if src.IsNull(j) && !arg.IsNull(j) {
+			if !src.IsNull(j) {
+				dst.AppendString(src.GetString(j))
+				continue
+			}
+			if !arg.IsNull(j) {
 				dst.AppendString(arg.GetString(j))
 				continue
 			}

--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -22,11 +22,15 @@ import (
 )
 
 var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
-	ast.NE:       {},
-	ast.IsNull:   {},
-	ast.LE:       {},
-	ast.LT:       {},
-	ast.Coalesce: {},
+	ast.NE:     {},
+	ast.IsNull: {},
+	ast.LE:     {},
+	ast.LT:     {},
+	ast.Coalesce: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString}},
+	},
 	ast.NullEQ: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 20}, &randLenStrGener{0, 20}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinCoalesceStringSig, for #12106
### What is changed and how it works?
```
 go test -v -benchmem -bench=BenchmarkVectorizedBuiltinCompareFunc -run=BenchmarkVectorizedBuiltinCompareFunc -args 'builtinCoalesceStringSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-VecBuiltinFunc-4         	 2308677	       515 ns/op	       0 B/op       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-NonVecBuiltinFunc-4      	   47698	     25309 ns/op	       0 B/op       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-VecBuiltinFunc#01-4      	   88285	     13372 ns/op	       0 B/op       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-NonVecBuiltinFunc#01-4   	   41358	     28975 ns/op	       0 B/op       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-VecBuiltinFunc#02-4      	   42958	     27560 ns/op	       0 B/op       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceStringSig-NonVecBuiltinFunc#02-4   	   40330	     29633 ns/op	       0 B/op       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	8.991s
```
### Check List <!--REMOVE the items that are not applicable-->
Tests <!-- At least one of them must be included. -->
- Unit test
