### PR TITLE
expression: implement vectorized evaluation for `builtinJSONQuoteSig`

### DIFF
--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -93,11 +93,29 @@ func (b *builtinJSONContainsSig) vecEvalInt(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinJSONQuoteSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinJSONQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETJson, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(buf.GetJSON(i).Quote())
+	}
+	return nil
 }
 
 func (b *builtinJSONSearchSig) vectorized() bool {

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -42,7 +42,9 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	ast.JSONRemove:       {},
 	ast.JSONMerge:        {},
 	ast.JSONInsert:       {},
-	ast.JSONQuote:        {},
+	ast.JSONQuote: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETJson}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinJSONFunc(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinJSONQuoteSig` in https://github.com/pingcap/tidb/issues/12104

### What is changed and how it works?
about 20% faster
```
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONQuoteSig-VecBuiltinFunc-12                   13716             87653 ns/op           12704 B/op       2382 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONQuoteSig-NonVecBuiltinFunc-12                 9867            104861 ns/op           12704 B/op       2382 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test