### PR TITLE
ddl: add check against _tidb_rowid as column name

### DIFF
--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -977,18 +977,20 @@ func (s *testColumnSuite) colDefStrToFieldType(c *C, str string) *types.FieldTyp
 
 func (s *testColumnSuite) TestFieldCase(c *C) {
 	var fields = []string{"field", "Field"}
-	var colDefs = make([]*ast.ColumnDef, len(fields))
 	colNames := make([]model.CIStr, 0, len(fields))
-	for i, name := range fields {
-		colDefs[i] = &ast.ColumnDef{
-			Name: &ast.ColumnName{
-				Schema: model.NewCIStr("TestSchema"),
-				Table:  model.NewCIStr("TestTable"),
-				Name:   model.NewCIStr(name),
-			},
-		}
-		colNames = append(colNames, colDefs[i].Name.Name)
+	for _, name := range fields {
+		colNames = append(colNames, model.NewCIStr(name))
 	}
 	err := checkDuplicateColumn(colNames)
 	c.Assert(err.Error(), Equals, infoschema.ErrColumnExists.GenWithStackByArgs("Field").Error())
+}
+
+func (s *testColumnSuite) TestReservedColumnsCheck(c *C) {
+	var fields = []string{"a", "_tidb_rowid", "b"}
+	colNames := make([]model.CIStr, 0, len(fields))
+	for _, name := range fields {
+		colNames = append(colNames, model.NewCIStr(name))
+	}
+	err := checkColumnsReserved(colNames)
+	c.Assert(err.Error(), Equals, infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid").Error())
 }

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -978,7 +978,7 @@ func (s *testColumnSuite) colDefStrToFieldType(c *C, str string) *types.FieldTyp
 func (s *testColumnSuite) TestFieldCase(c *C) {
 	var fields = []string{"field", "Field"}
 	var colDefs = make([]*ast.ColumnDef, len(fields))
-	colObjects := make([]interface{}, 0, len(fields))
+	colNames := make([]model.CIStr, 0, len(fields))
 	for i, name := range fields {
 		colDefs[i] = &ast.ColumnDef{
 			Name: &ast.ColumnName{
@@ -987,8 +987,8 @@ func (s *testColumnSuite) TestFieldCase(c *C) {
 				Name:   model.NewCIStr(name),
 			},
 		}
-		colObjects = append(colObjects, colDefs[i])
+		colNames = append(colNames, colDefs[i].Name.Name)
 	}
-	err := checkDuplicateColumn(colObjects)
+	err := checkDuplicateColumn(colNames)
 	c.Assert(err.Error(), Equals, infoschema.ErrColumnExists.GenWithStackByArgs("Field").Error())
 }

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -992,5 +992,5 @@ func (s *testColumnSuite) TestReservedColumnsCheck(c *C) {
 		colNames = append(colNames, model.NewCIStr(name))
 	}
 	err := checkColumnsReserved(colNames)
-	c.Assert(err.Error(), Equals, infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid").Error())
+	c.Assert(err.Error(), Equals, ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid").Error())
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1280,6 +1280,39 @@ func (s *testDBSuite4) TestAddIndexWithDupCols(c *C) {
 	s.tk.MustExec("drop table test_add_index_with_dup")
 }
 
+func (s *testDBSuite4) TestCreateTableWithReservedCol(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use " + s.schemaName)
+	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+
+	_, err := s.tk.Exec("create table test_table_with_reserved_col (a int, _tidb_rowid int)")
+	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
+}
+
+func (s *testDBSuite4) TestAddColWithReservedName(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use " + s.schemaName)
+	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+
+	s.tk.MustExec("create table test_add_col_with_reserved_name (a int, b int)")
+	_, err := s.tk.Exec("alter table test_add_col_with_reserved_name add column _tidb_rowid int")
+	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
+
+	s.tk.MustExec("drop table test_add_col_with_reserved_name")
+}
+
+func (s *testDBSuite4) TestChangeColNameToReservedName(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use " + s.schemaName)
+	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+
+	s.tk.MustExec("create table test_change_col_name_to_reserved_name (a int, b int)")
+	_, err := s.tk.Exec("alter table test_change_col_name_to_reserved_name change a _tidb_rowid int")
+	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
+
+	s.tk.MustExec("drop table test_change_col_name_to_reserved_name")
+}
+
 func (s *testDBSuite) showColumns(c *C, tableName string) [][]interface{} {
 	return s.mustQuery(c, fmt.Sprintf("show columns from %s", tableName))
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1283,7 +1283,7 @@ func (s *testDBSuite4) TestAddIndexWithDupCols(c *C) {
 func (s *testDBSuite4) TestCreateTableWithReservedCol(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
-	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+	err1 := ddl.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
 
 	_, err := s.tk.Exec("create table test_table_with_reserved_col (a int, _tidb_rowid int)")
 	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
@@ -1292,7 +1292,7 @@ func (s *testDBSuite4) TestCreateTableWithReservedCol(c *C) {
 func (s *testDBSuite4) TestAddColWithReservedName(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
-	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+	err1 := ddl.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
 
 	s.tk.MustExec("create table test_add_col_with_reserved_name (a int, b int)")
 	_, err := s.tk.Exec("alter table test_add_col_with_reserved_name add column _tidb_rowid int")
@@ -1304,7 +1304,7 @@ func (s *testDBSuite4) TestAddColWithReservedName(c *C) {
 func (s *testDBSuite4) TestChangeColNameToReservedName(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
-	err1 := infoschema.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
+	err1 := ddl.ErrReservedColumnConflict.GenWithStackByArgs("_tidb_rowid")
 
 	s.tk.MustExec("create table test_change_col_name_to_reserved_name (a int, b int)")
 	_, err := s.tk.Exec("alter table test_change_col_name_to_reserved_name change a _tidb_rowid int")

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -141,6 +141,8 @@ var (
 		"unsupported partition by range columns")
 	errUnsupportedCreatePartition = terror.ClassDDL.New(codeUnsupportedCreatePartition, "unsupported partition type, treat as normal table")
 	errUnsupportedIndexType       = terror.ClassDDL.New(codeUnsupportedIndexType, "unsupported index type")
+	// ErrReservedColumnConflict returns for conflicting with the reserved column name.
+	ErrReservedColumnConflict = terror.ClassDDL.New(codeReservedColumnConflict, "Conflicting with a reserved column name '%s'")
 
 	// ErrDupKeyName returns for duplicated key name
 	ErrDupKeyName = terror.ClassDDL.New(codeDupKeyName, "duplicate key name")
@@ -689,6 +691,7 @@ const (
 	codeUnsupportedPartitionByRangeColumns = 211
 	codeUnsupportedCreatePartition         = 212
 	codeUnsupportedIndexType               = 213
+	codeReservedColumnConflict             = 214
 
 	codeFileNotFound                           = 1017
 	codeErrorOnRename                          = 1025

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -897,7 +897,7 @@ func checkColumnsReserved(colNames []model.CIStr) error {
 
 func checkColumnReserved(colName model.CIStr) error {
 	if colName.L == "_tidb_rowid" {
-		return infoschema.ErrReservedColumnConflict.GenWithStackByArgs(colName.O)
+		return ErrReservedColumnConflict.GenWithStackByArgs(colName.O)
 	}
 	return nil
 }

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -51,6 +51,8 @@ var (
 	ErrUserDropExists = terror.ClassSchema.New(codeBadUser, "User %s does not exist.")
 	// ErrColumnExists returns for column already exists.
 	ErrColumnExists = terror.ClassSchema.New(codeColumnExists, "Duplicate column name '%s'")
+	// ErrReservedColumnConflict returns for conflicting with reserved column name.
+	ErrReservedColumnConflict = terror.ClassSchema.New(codeReservedColumnConflict, "Conflicting with a reserved column name '%s'")
 	// ErrIndexExists returns for index already exists.
 	ErrIndexExists = terror.ClassSchema.New(codeIndexExists, "Duplicate Index")
 	// ErrKeyNameDuplicate returns for index duplicate when rename index.
@@ -328,16 +330,17 @@ const (
 	codeForeignKeyNotExists = 1091
 	codeWrongFkDef          = 1239
 
-	codeDatabaseExists   = 1007
-	codeTableExists      = 1050
-	codeBadTable         = 1051
-	codeBadUser          = 3162
-	codeColumnExists     = 1060
-	codeIndexExists      = 1831
-	codeMultiplePriKey   = 1068
-	codeTooManyKeyParts  = 1070
-	codeKeyNameDuplicate = 1061
-	codeKeyNotExists     = 1176
+	codeDatabaseExists         = 1007
+	codeTableExists            = 1050
+	codeBadTable               = 1051
+	codeBadUser                = 3162
+	codeColumnExists           = 1060
+	codeReservedColumnConflict = 1066
+	codeIndexExists            = 1831
+	codeMultiplePriKey         = 1068
+	codeTooManyKeyParts        = 1070
+	codeKeyNameDuplicate       = 1061
+	codeKeyNotExists           = 1176
 
 	codeErrTableNotLockedForWrite = mysql.ErrTableNotLockedForWrite
 	codeErrTableNotLocked         = mysql.ErrTableNotLocked

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -51,8 +51,6 @@ var (
 	ErrUserDropExists = terror.ClassSchema.New(codeBadUser, "User %s does not exist.")
 	// ErrColumnExists returns for column already exists.
 	ErrColumnExists = terror.ClassSchema.New(codeColumnExists, "Duplicate column name '%s'")
-	// ErrReservedColumnConflict returns for conflicting with the reserved column name.
-	ErrReservedColumnConflict = terror.ClassSchema.New(codeReservedColumnConflict, "Conflicting with a reserved column name '%s'")
 	// ErrIndexExists returns for index already exists.
 	ErrIndexExists = terror.ClassSchema.New(codeIndexExists, "Duplicate Index")
 	// ErrKeyNameDuplicate returns for index duplicate when rename index.
@@ -335,7 +333,6 @@ const (
 	codeBadTable               = 1051
 	codeBadUser                = 3162
 	codeColumnExists           = 1060
-	codeReservedColumnConflict = 215
 	codeIndexExists            = 1831
 	codeMultiplePriKey         = 1068
 	codeTooManyKeyParts        = 1070

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -51,7 +51,7 @@ var (
 	ErrUserDropExists = terror.ClassSchema.New(codeBadUser, "User %s does not exist.")
 	// ErrColumnExists returns for column already exists.
 	ErrColumnExists = terror.ClassSchema.New(codeColumnExists, "Duplicate column name '%s'")
-	// ErrReservedColumnConflict returns for conflicting with reserved column name.
+	// ErrReservedColumnConflict returns for conflicting with the reserved column name.
 	ErrReservedColumnConflict = terror.ClassSchema.New(codeReservedColumnConflict, "Conflicting with a reserved column name '%s'")
 	// ErrIndexExists returns for index already exists.
 	ErrIndexExists = terror.ClassSchema.New(codeIndexExists, "Duplicate Index")
@@ -335,7 +335,7 @@ const (
 	codeBadTable               = 1051
 	codeBadUser                = 3162
 	codeColumnExists           = 1060
-	codeReservedColumnConflict = 1066
+	codeReservedColumnConflict = 215
 	codeIndexExists            = 1831
 	codeMultiplePriKey         = 1068
 	codeTooManyKeyParts        = 1070


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #12835.

### What is changed and how it works?
Check column name when building table info. It forbids creating table contains column `_tidb_rowid`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes
N/A

Side effects
N/A

Related changes
N/A

Release note
N/A