### PR TITLE
expression: implement vectorized evaluation for `builtinCurrentTime0ArgSig` and `builtinCurrentTime1ArgSig` 

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -971,7 +971,7 @@ func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 	if err != nil {
 		return err
 	}
-	result.ResizeInt64(n, false)
+	result.ResizeGoDuration(n, false)
 	durations := result.Uint64s()
 	for i := 0; i < n; i++ {
 		durations[i] = uint64(res.Duration)
@@ -1136,7 +1136,7 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	i64s := buf.Int64s()
-	result.ResizeInt64(n, false)
+	result.ResizeGoDuration(n, false)
 	durations := result.Uint64s()
 	for i := 0; i < n; i++ {
 		res, err := types.ParseDuration(stmtCtx, dur, int8(i64s[i]))

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -962,11 +962,11 @@ func (b *builtinCurrentTime0ArgSig) vectorized() bool {
 func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	result.ResizeDecimal(n, true)
-	tz := b.ctx.GetSessionVars().Location()
 	nowTs, err := getStmtTimestamp(b.ctx)
 	if err != nil {
 		return err
 	}
+	tz := b.ctx.GetSessionVars().Location()
 	dur := nowTs.In(tz).Format(types.TimeFormat)
 	res, err := types.ParseDuration(b.ctx.GetSessionVars().StmtCtx, dur, types.MinFsp)
 	if err != nil {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1119,10 +1119,6 @@ func (b *builtinCurrentTime1ArgSig) vectorized() bool {
 
 func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	nowTs, err := getStmtTimestamp(b.ctx)
-	if err != nil {
-		return err
-	}
 	buf, err := b.bufAllocator.get(types.ETInt, n)
 	if err != nil {
 		return err
@@ -1132,6 +1128,10 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 		return err
 	}
 
+	nowTs, err := getStmtTimestamp(b.ctx)
+	if err != nil {
+		return err
+	}
 	tz := b.ctx.GetSessionVars().Location()
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -961,7 +961,6 @@ func (b *builtinCurrentTime0ArgSig) vectorized() bool {
 
 func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	result.ResizeDecimal(n, true)
 	nowTs, err := getStmtTimestamp(b.ctx)
 	if err != nil {
 		return err
@@ -972,7 +971,7 @@ func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 	if err != nil {
 		return err
 	}
-	result.SetNulls(0, n, false)
+	result.ResizeInt64(n, false)
 	durations := result.Uint64s()
 	for i := 0; i < n; i++ {
 		durations[i] = uint64(res.Duration)
@@ -1120,7 +1119,6 @@ func (b *builtinCurrentTime1ArgSig) vectorized() bool {
 
 func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-	result.ResizeDecimal(n, true)
 	nowTs, err := getStmtTimestamp(b.ctx)
 	if err != nil {
 		return err
@@ -1136,16 +1134,16 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 
 	tz := b.ctx.GetSessionVars().Location()
 	dur := nowTs.In(tz).Format(types.TimeFSPFormat)
-	durations := result.Uint64s()
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	i64s := buf.Int64s()
+	result.ResizeInt64(n, false)
+	durations := result.Uint64s()
 	for i := 0; i < n; i++ {
 		res, err := types.ParseDuration(stmtCtx, dur, int8(i64s[i]))
 		if err != nil {
 			return err
 		}
 		durations[i] = uint64(res.Duration)
-		result.SetNull(i, false)
 	}
 	return nil
 }

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -972,9 +972,9 @@ func (b *builtinCurrentTime0ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 		return err
 	}
 	result.ResizeGoDuration(n, false)
-	durations := result.Uint64s()
+	durations := result.GoDurations()
 	for i := 0; i < n; i++ {
-		durations[i] = uint64(res.Duration)
+		durations[i] = res.Duration
 	}
 	return nil
 }
@@ -1137,13 +1137,13 @@ func (b *builtinCurrentTime1ArgSig) vecEvalDuration(input *chunk.Chunk, result *
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	i64s := buf.Int64s()
 	result.ResizeGoDuration(n, false)
-	durations := result.Uint64s()
+	durations := result.GoDurations()
 	for i := 0; i < n; i++ {
 		res, err := types.ParseDuration(stmtCtx, dur, int8(i64s[i]))
 		if err != nil {
 			return err
 		}
-		durations[i] = uint64(res.Duration)
+		durations[i] = res.Duration
 	}
 	return nil
 }

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -39,7 +39,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.DayOfWeek:   {},
 	ast.DayOfYear:   {},
 	ast.Day:         {},
-	ast.CurrentTime: {},
+	ast.CurrentTime: {
+		{retEvalType: types.ETDuration},
+	},
 	ast.CurrentDate: {
 		{retEvalType: types.ETDatetime},
 	},

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -41,6 +41,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.Day:         {},
 	ast.CurrentTime: {
 		{retEvalType: types.ETDuration},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{&rangeInt64Gener{0, 7}}}, // fsp must be in the range 0 to 6.
 	},
 	ast.CurrentDate: {
 		{retEvalType: types.ETDatetime},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinCurrentTime0ArgSig, for #12176
implement vectorized evaluation for builtinCurrentTime1ArgSig, for #12176
### What is changed and how it works?
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args 'builtinCurrentTime0ArgSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-4   	1000000000	         0.00765 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinCurrentTime0ArgSig-VecBuiltinFunc-4         	  518395	      2350 ns/op	     224 B/op	      11 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinCurrentTime0ArgSig-NonVecBuiltinFunc-4      	     637	   1828290 ns/op	  229430 B/op	   11264 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	2.672s
```
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args 'builtinCurrentTime1ArgSig'
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-4   	1000000000	         0.00787 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinCurrentTime1ArgSig-VecBuiltinFunc-4         	     841	   1379328 ns/op	  196686 B/op	   10241 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinCurrentTime1ArgSig-NonVecBuiltinFunc-4      	     632	   1901938 ns/op	  229433 B/op	   11264 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	2.776s
```
### Check List <!--REMOVE the items that are not applicable-->
Tests <!-- At least one of them must be included. -->
- Unit test
