### PR TITLE
planner: support a hint to force using a IndexMerge path

### DIFF
--- a/cmd/explaintest/r/explain_indexmerge.result
+++ b/cmd/explaintest/r/explain_indexmerge.result
@@ -81,3 +81,33 @@ label = "cop"
 "IndexMerge_12" -> "Selection_11"
 }
 
+set session tidb_enable_index_merge = off;
+explain select /*+ use_index_merge(t, tb, tc) */ * from t where b < 50 or c < 5000000;
+id	count	task	operator info
+IndexMerge_8	5000000.00	root	
+├─IndexScan_5	49.00	cop[tikv]	table:t, index:b, range:[-inf,50), keep order:false
+├─IndexScan_6	4999999.00	cop[tikv]	table:t, index:c, range:[-inf,5000000), keep order:false
+└─TableScan_7	5000000.00	cop[tikv]	table:t, keep order:false
+explain select /*+ use_index_merge(t, tb, tc) */ * from t where (b < 10000 or c < 10000) and (a < 10 or d < 10) and f < 10;
+id	count	task	operator info
+IndexMerge_9	0.00	root	
+├─IndexScan_5	9999.00	cop[tikv]	table:t, index:b, range:[-inf,10000), keep order:false
+├─IndexScan_6	9999.00	cop[tikv]	table:t, index:c, range:[-inf,10000), keep order:false
+└─Selection_8	0.00	cop[tikv]	lt(Column#6, 10), or(lt(Column#1, 10), lt(Column#4, 10))
+  └─TableScan_7	19998.00	cop[tikv]	table:t, keep order:false
+explain select /*+ use_index_merge(t, tb) */ * from t where b < 50 or c < 5000000;
+id	count	task	operator info
+TableReader_7	4000000.00	root	data:Selection_6
+└─Selection_6	4000000.00	cop[tikv]	or(lt(Column#2, 50), lt(Column#3, 5000000))
+  └─TableScan_5	5000000.00	cop[tikv]	table:t, range:[-inf,+inf], keep order:false
+explain select /*+ no_index_merge(), use_index_merge(t, tb, tc) */ * from t where b < 50 or c < 5000000;
+id	count	task	operator info
+TableReader_7	4000000.00	root	data:Selection_6
+└─Selection_6	4000000.00	cop[tikv]	or(lt(Column#2, 50), lt(Column#3, 5000000))
+  └─TableScan_5	5000000.00	cop[tikv]	table:t, range:[-inf,+inf], keep order:false
+explain select /*+ use_index_merge(t, primary, tb) */ * from t where a < 50 or b < 5000000;
+id	count	task	operator info
+IndexMerge_8	5000000.00	root	
+├─TableScan_5	49.00	cop[tikv]	table:t, range:[-inf,50), keep order:false
+├─IndexScan_6	4999999.00	cop[tikv]	table:t, index:b, range:[-inf,5000000), keep order:false
+└─TableScan_7	5000000.00	cop[tikv]	table:t, keep order:false

--- a/cmd/explaintest/t/explain_indexmerge.test
+++ b/cmd/explaintest/t/explain_indexmerge.test
@@ -3,8 +3,10 @@ create table t (a int primary key, b int, c int, d int, e int, f int);
 create index tb on t (b);
 create index tc on t (c);
 create index td on t (d);
+# generate a, b, c, d, e, f from 0 to 5000000 and a = b = c = d = e = f
 load stats 's/explain_indexmerge_stats_t.json';
 set session tidb_enable_index_merge = on;
+# choose the best plan based on cost
 explain select * from t where a < 50 or b < 50;
 explain select * from t where (a < 50 or b < 50) and f > 100;
 explain select * from t where a < 50 or b < 5000000;
@@ -13,3 +15,12 @@ explain select * from t where b < 50 or c < 5000000;
 explain select * from t where a < 50 or b < 50 or c < 50;
 explain select * from t where (b < 10000 or c < 10000) and (a < 10 or d < 10) and f < 10;
 explain format="dot" select * from t where (a < 50 or b < 50) and f > 100;
+set session tidb_enable_index_merge = off;
+# be forced to use IndexMerge
+explain select /*+ use_index_merge(t, tb, tc) */ * from t where b < 50 or c < 5000000;
+explain select /*+ use_index_merge(t, tb, tc) */ * from t where (b < 10000 or c < 10000) and (a < 10 or d < 10) and f < 10;
+explain select /*+ use_index_merge(t, tb) */ * from t where b < 50 or c < 5000000;
+# no_index_merge hint
+explain select /*+ no_index_merge(), use_index_merge(t, tb, tc) */ * from t where b < 50 or c < 5000000;
+# tableScan can be a partial path to fetch handle
+explain select /*+ use_index_merge(t, primary, tb) */ * from t where a < 50 or b < 5000000;

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1468,8 +1468,7 @@ func handleStmtHints(hints []*ast.TableOptimizerHint) (stmtHints stmtctx.StmtHin
 			warn := errors.New("There are multiple NO_INDEX_MERGE hints, only the last one will take effect")
 			warns = append(warns, warn)
 		}
-		stmtHints.HasEnableIndexMergeHint = true
-		stmtHints.EnableIndexMerge = false
+		stmtHints.NoIndexMergeHint = true
 	}
 	// Handle READ_CONSISTENT_REPLICA
 	if readReplicaHintCnt != 0 {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -408,6 +408,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 
 	t = invalidTask
 	candidates := ds.skylinePruning(prop)
+
 	for _, candidate := range candidates {
 		path := candidate.path
 		if path.partialIndexPaths != nil {
@@ -450,6 +451,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 			t = idxTask
 		}
 	}
+
 	return
 }
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -81,6 +81,8 @@ const (
 	HintTiFlash = "tiflash"
 	// HintTiKV is a label represents the tikv storage type.
 	HintTiKV = "tikv"
+	// HintIndexMerge is a hint to enforce using some indexes at the same time.
+	HintIndexMerge = "use_index_merge"
 )
 
 const (
@@ -2127,7 +2129,7 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType n
 	hints = b.hintProcessor.getCurrentStmtHints(hints, nodeType, currentLevel)
 	var (
 		sortMergeTables, INLJTables, INLHJTables, INLMJTables, hashJoinTables []hintTableInfo
-		indexHintList                                                         []indexHintInfo
+		indexHintList, indexMergeHintList                                     []indexHintInfo
 		tiflashTables, tikvTables                                             []hintTableInfo
 		aggHints                                                              aggHintInfo
 	)
@@ -2188,6 +2190,17 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType n
 			if hint.StoreType.L == HintTiKV {
 				tikvTables = tableNames2HintTableInfo(b.ctx, hint.Tables, b.hintProcessor, nodeType, currentLevel)
 			}
+		case HintIndexMerge:
+			if len(hint.Tables) != 0 {
+				indexMergeHintList = append(indexMergeHintList, indexHintInfo{
+					tblName: hint.Tables[0].TableName,
+					indexHint: &ast.IndexHint{
+						IndexNames: hint.Indexes,
+						HintType:   ast.HintUse,
+						HintScope:  ast.HintForScan,
+					},
+				})
+			}
 		default:
 			// ignore hints that not implemented
 		}
@@ -2200,6 +2213,7 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType n
 		tiflashTables:             tiflashTables,
 		tikvTables:                tikvTables,
 		aggHints:                  aggHints,
+		indexMergeHintList:        indexMergeHintList,
 	})
 }
 
@@ -2529,6 +2543,15 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		statisticTable = getStatsTable(b.ctx, tbl.Meta(), tbl.Meta().ID)
 	}
 
+	// extract the IndexMergeHint
+	var indexMergeHints []*ast.IndexHint
+	if hints := b.TableHints(); hints != nil {
+		for _, hint := range hints.indexMergeHintList {
+			if hint.tblName.L == tblName.L {
+				indexMergeHints = append(indexMergeHints, hint.indexHint)
+			}
+		}
+	}
 	ds := DataSource{
 		DBName:              dbName,
 		TableAsName:         asName,
@@ -2536,6 +2559,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		tableInfo:           tableInfo,
 		statisticTable:      statisticTable,
 		indexHints:          tn.IndexHints,
+		indexMergeHints:     indexMergeHints,
 		possibleAccessPaths: possiblePaths,
 		Columns:             make([]*model.ColumnInfo, 0, len(columns)),
 		partitionNames:      tn.PartitionNames,

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -388,7 +388,8 @@ type DataSource struct {
 	DBName     model.CIStr
 
 	TableAsName *model.CIStr
-
+	// indexMergeHints are the hint for indexmerge.
+	indexMergeHints []*ast.IndexHint
 	// pushedDownConds are the conditions that will be pushed down to coprocessor.
 	pushedDownConds []expression.Expression
 	// allConds contains all the filters on this table. For now it's maintained

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -70,6 +70,7 @@ type tableHintInfo struct {
 	tiflashTables       []hintTableInfo
 	tikvTables          []hintTableInfo
 	aggHints            aggHintInfo
+	indexMergeHintList  []indexHintInfo
 }
 
 type hintTableInfo struct {

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -16,6 +16,7 @@ package core
 import (
 	"math"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -196,19 +197,40 @@ func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo, selfSchema *
 		}
 	}
 	// Consider the IndexMergePath. Now, we just generate `IndexMergePath` in DNF case.
-	if len(ds.pushedDownConds) > 0 && len(ds.possibleAccessPaths) > 1 && ds.ctx.GetSessionVars().GetEnableIndexMerge() {
-		needConsiderIndexMerge := true
-		for i := 1; i < len(ds.possibleAccessPaths); i++ {
-			if len(ds.possibleAccessPaths[i].accessConds) != 0 {
-				needConsiderIndexMerge = false
-				break
-			}
-		}
-		if needConsiderIndexMerge {
-			ds.generateIndexMergeOrPaths()
+	isPossibleIdxMerge := len(ds.pushedDownConds) > 0 && len(ds.possibleAccessPaths) > 1
+	sessionAndStmtPermission := (ds.ctx.GetSessionVars().GetEnableIndexMerge() || ds.indexMergeHints != nil) && !ds.ctx.GetSessionVars().StmtCtx.NoIndexMergeHint
+	// If there is an index path, we current do not consider `IndexMergePath`.
+	needConsiderIndexMerge := true
+	for i := 1; i < len(ds.possibleAccessPaths); i++ {
+		if len(ds.possibleAccessPaths[i].accessConds) != 0 {
+			needConsiderIndexMerge = false
+			break
 		}
 	}
+	if isPossibleIdxMerge && sessionAndStmtPermission && needConsiderIndexMerge {
+		ds.generateAndPruneIndexMergePath()
+	} else if ds.indexMergeHints != nil {
+		ds.indexMergeHints = nil
+		ds.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("IndexMerge is inapplicable or disabled"))
+	}
 	return ds.stats, nil
+}
+
+func (ds *DataSource) generateAndPruneIndexMergePath() {
+	regularPathCount := len(ds.possibleAccessPaths)
+	ds.generateIndexMergeOrPaths()
+	// If without hints, it means that `enableIndexMerge` is true
+	if ds.indexMergeHints == nil {
+		return
+	}
+	// With hints and without generated IndexMerge paths
+	if regularPathCount == len(ds.possibleAccessPaths) {
+		ds.indexMergeHints = nil
+		ds.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("IndexMerge is inapplicable or disabled"))
+		return
+	}
+	// Do not need to consider the regular paths in find_best_task().
+	ds.possibleAccessPaths = ds.possibleAccessPaths[regularPathCount:]
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
@@ -272,12 +294,31 @@ func (ds *DataSource) generateIndexMergeOrPaths() {
 	}
 }
 
+// isInIndexMergeHints checks whether current index or primary key is in IndexMerge hints.
+func (ds *DataSource) isInIndexMergeHints(name string) bool {
+	if ds.indexMergeHints == nil ||
+		(len(ds.indexMergeHints) == 1 && ds.indexMergeHints[0].IndexNames == nil) {
+		return true
+	}
+	for _, hint := range ds.indexMergeHints {
+		for _, index := range hint.IndexNames {
+			if name == index.L {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // accessPathsForConds generates all possible index paths for conditions.
 func (ds *DataSource) accessPathsForConds(conditions []expression.Expression, usedIndexCount int) []*accessPath {
 	var results = make([]*accessPath, 0, usedIndexCount)
 	for i := 0; i < usedIndexCount; i++ {
 		path := &accessPath{}
 		if ds.possibleAccessPaths[i].isTablePath {
+			if !ds.isInIndexMergeHints("primary") {
+				continue
+			}
 			path.isTablePath = true
 			noIntervalRanges, err := ds.deriveTablePathStats(path, conditions, true)
 			if err != nil {
@@ -292,6 +333,9 @@ func (ds *DataSource) accessPathsForConds(conditions []expression.Expression, us
 			}
 		} else {
 			path.index = ds.possibleAccessPaths[i].index
+			if !ds.isInIndexMergeHints(path.index.Name.L) {
+				continue
+			}
 			noIntervalRanges, err := ds.deriveIndexPathStats(path, conditions, true)
 			if err != nil {
 				logutil.BgLogger().Debug("can not derive statistics of a path", zap.Error(err))

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -179,6 +179,15 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 		str = fmt.Sprintf("IndexReader(%s)", ToString(x.indexPlan))
 	case *PhysicalIndexLookUpReader:
 		str = fmt.Sprintf("IndexLookUp(%s, %s)", ToString(x.indexPlan), ToString(x.tablePlan))
+	case *PhysicalIndexMergeReader:
+		str = "IndexMergeReader(PartialPlans->["
+		for i, paritalPlan := range x.partialPlans {
+			if i > 0 {
+				str += ", "
+			}
+			str += ToString(paritalPlan)
+		}
+		str += "], TablePlan->" + ToString(x.tablePlan) + ")"
 	case *PhysicalUnionScan:
 		str = fmt.Sprintf("UnionScan(%s)", x.Conditions)
 	case *PhysicalIndexJoin:

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -52,6 +52,15 @@
     ]
   },
   {
+    "name": "TestIndexMergeHint",
+    "cases": [
+      "select /*+ USE_INDEX_MERGE(t, c_d_e, f_g) */ * from t where c < 1 or f > 2",
+      "select /*+ USE_INDEX_MERGE(t, primary, f_g) */ * from t where a < 1 or f > 2",
+      "select /*+ USE_INDEX_MERGE(t, primary, f_g, c_d_e) */ * from t where a < 1 or f > 2",
+      "select /*+ NO_INDEX_MERGE(), USE_INDEX_MERGE(t, primary, f_g, c_d_e) */ * from t where a < 1 or f > 2"
+    ]
+  },
+  {
     "name": "TestDAGPlanBuilderSimpleCase",
     "cases":[
       // Test index hint.

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -186,6 +186,35 @@
     ]
   },
   {
+    "Name": "TestIndexMergeHint",
+    "Cases": [
+      {
+        "SQL": "select /*+ USE_INDEX_MERGE(t, c_d_e, f_g) */ * from t where c < 1 or f > 2",
+        "Best": "IndexMergeReader(PartialPlans->[Index(t.c_d_e)[[-inf,1)], Index(t.f_g)[(2,+inf]]], TablePlan->Table(t))",
+        "HasWarn": false,
+        "Hints": "USE_INDEX_MERGE(@`sel_1` `t` `c_d_e`, `f_g`)"
+      },
+      {
+        "SQL": "select /*+ USE_INDEX_MERGE(t, primary, f_g) */ * from t where a < 1 or f > 2",
+        "Best": "IndexMergeReader(PartialPlans->[Table(t), Index(t.f_g)[(2,+inf]]], TablePlan->Table(t))",
+        "HasWarn": false,
+        "Hints": "USE_INDEX_MERGE(@`sel_1` `t` `PRIMARY`, `f_g`)"
+      },
+      {
+        "SQL": "select /*+ USE_INDEX_MERGE(t, primary, f_g, c_d_e) */ * from t where a < 1 or f > 2",
+        "Best": "IndexMergeReader(PartialPlans->[Table(t), Index(t.f_g)[(2,+inf]]], TablePlan->Table(t))",
+        "HasWarn": false,
+        "Hints": "USE_INDEX_MERGE(@`sel_1` `t` `PRIMARY`, `f_g`)"
+      },
+      {
+        "SQL": "select /*+ NO_INDEX_MERGE(), USE_INDEX_MERGE(t, primary, f_g, c_d_e) */ * from t where a < 1 or f > 2",
+        "Best": "TableReader(Table(t)->Sel([or(lt(Column#1, 1), gt(Column#9, 2))]))",
+        "HasWarn": true,
+        "Hints": "USE_INDEX(@`sel_1` `test`.`t` )"
+      }
+    ]
+  },
+  {
     "Name": "TestDAGPlanBuilderSimpleCase",
     "Cases": [
       {

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2860,10 +2860,10 @@ func (s *testSessionSuite) TestStmtHints(c *C) {
 	// Test NO_INDEX_MERGE hint
 	tk.Se.GetSessionVars().SetEnableIndexMerge(true)
 	tk.MustExec("select /*+ NO_INDEX_MERGE() */ 1;")
-	c.Assert(tk.Se.GetSessionVars().GetEnableIndexMerge(), IsFalse)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.NoIndexMergeHint, IsTrue)
 	tk.MustExec("select /*+ NO_INDEX_MERGE(), NO_INDEX_MERGE() */ 1;")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
-	c.Assert(tk.Se.GetSessionVars().GetEnableIndexMerge(), IsFalse)
+	c.Assert(tk.Se.GetSessionVars().GetEnableIndexMerge(), IsTrue)
 
 	// Test USE_TOJA hint
 	tk.Se.GetSessionVars().SetAllowInSubqToJoinAndAgg(true)

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -146,13 +146,12 @@ type StatementContext struct {
 type StmtHints struct {
 	// Hint flags
 	HasAllowInSubqToJoinAndAggHint bool
-	HasEnableIndexMergeHint        bool
 	HasMemQuotaHint                bool
 	HasReplicaReadHint             bool
 
 	// Hint Information
 	AllowInSubqToJoinAndAgg bool
-	EnableIndexMerge        bool
+	NoIndexMergeHint        bool
 	MemQuotaQuery           int64
 	ReplicaRead             byte
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -594,11 +594,8 @@ func (s *SessionVars) SetAllowInSubqToJoinAndAgg(val bool) {
 	s.allowInSubqToJoinAndAgg = val
 }
 
-// GetEnableIndexMerge get EnableIndexMerge from sql hints and SessionVars.enableIndexMerge.
+// GetEnableIndexMerge get EnableIndexMerge from SessionVars.enableIndexMerge.
 func (s *SessionVars) GetEnableIndexMerge() bool {
-	if s.StmtCtx.HasEnableIndexMergeHint {
-		return s.StmtCtx.EnableIndexMerge
-	}
 	return s.enableIndexMerge
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Support a hint to access a table using IndexMerge way.

### What is changed and how it works?
It is just like the other hints. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
mainly change `func (ds *DataSource) accessPathsForConds` and `func (ds *DataSource) DeriveStats`
 - Has exported variable/fields change
`tableHintInfo` adds the `indexMergeHintList` field.
`Datasource` adds the `indexMergeHint` field.
Side effects

 - Possible performance regression
 - Breaking backward compatibility
