### PR TITLE
executor: reuse chunk row for insert on duplicate update

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -465,6 +465,16 @@ func (col *Column) Vectorized() bool {
 	return true
 }
 
+// ToInfo converts the expression.Column to model.ColumnInfo for casting values,
+// beware it doesn't fill all the fields of the model.ColumnInfo.
+func (col *Column) ToInfo() *model.ColumnInfo {
+	return &model.ColumnInfo{
+		ID:        col.ID,
+		Name:      col.ColName,
+		FieldType: *col.RetType,
+	}
+}
+
 // Column2Exprs will transfer column slice to expression slice.
 func Column2Exprs(cols []*Column) []Expression {
 	result := make([]Expression, 0, len(cols))

--- a/expression/explain.go
+++ b/expression/explain.go
@@ -37,8 +37,8 @@ func (expr *ScalarFunction) ExplainInfo() string {
 }
 
 // ExplainInfo implements the Expression interface.
-func (expr *Column) ExplainInfo() string {
-	return expr.String()
+func (col *Column) ExplainInfo() string {
+	return col.String()
 }
 
 // ExplainInfo implements the Expression interface.


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
`MutRowFromDatums` hurts the performance when there are many columns in the table when updating the duplicate keys.

### What is changed and how it works?
Reuse chunk row for insert on duplicate update.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. insert 100000 rows in a sysbench table
1. modify the insert lua script of sysbench, replace insert to insert on duplicate
1. run sysbench with 100 threads, and ignore all errors.
1. profile TiDB.

master:
![企业微信截图_20191021143810](https://user-images.githubusercontent.com/4352397/67182475-e5e32200-f411-11e9-8295-8e9772ee7bf1.png)
this PR:
![企业微信截图_20191021143836](https://user-images.githubusercontent.com/4352397/67182476-e67bb880-f411-11e9-8a50-f0b95a25b80b.png)

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch



