### PR TITLE
expression: reduce the time of running the unit-test in expression package

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1157,8 +1157,8 @@ func generateRandomSel() []int {
 func (s *testEvaluatorSuite) TestVecEvalBool(c *C) {
 	ctx := mock.NewContext()
 	eTypes := []types.EvalType{types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
-	for numCols := 1; numCols <= 10; numCols++ {
-		for round := 0; round < 64; round++ {
+	for numCols := 1; numCols <= 5; numCols++ {
+		for round := 0; round < 16; round++ {
 			exprs, input := genVecEvalBool(numCols, nil, eTypes)
 			selected, nulls, err := VecEvalBool(ctx, exprs, input, nil, nil)
 			c.Assert(err, IsNil)
@@ -1181,7 +1181,7 @@ func BenchmarkVecEvalBool(b *testing.B) {
 	nulls := make([]bool, 0, 1024)
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
 	tNames := []string{"int", "real", "decimal", "string", "timestamp", "datetime", "duration"}
-	for numCols := 1; numCols <= 3; numCols++ {
+	for numCols := 1; numCols <= 2; numCols++ {
 		typeCombination := make([]types.EvalType, numCols)
 		var combFunc func(nCols int)
 		combFunc = func(nCols int) {
@@ -1231,8 +1231,8 @@ func BenchmarkVecEvalBool(b *testing.B) {
 func (s *testEvaluatorSuite) TestRowBasedFilterAndVectorizedFilter(c *C) {
 	ctx := mock.NewContext()
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
-	for numCols := 1; numCols <= 10; numCols++ {
-		for round := 0; round < 64; round++ {
+	for numCols := 1; numCols <= 5; numCols++ {
+		for round := 0; round < 16; round++ {
 			exprs, input := genVecEvalBool(numCols, nil, eTypes)
 			it := chunk.NewIterator4Chunk(input)
 			isNull := make([]bool, it.Len())
@@ -1329,8 +1329,8 @@ func (s *testEvaluatorSuite) TestVectorizedFilterConsiderNull(c *C) {
 	ctx := mock.NewContext()
 	dafaultEnableVectorizedExpressionVar := ctx.GetSessionVars().EnableVectorizedExpression
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
-	for numCols := 1; numCols <= 10; numCols++ {
-		for round := 0; round < 64; round++ {
+	for numCols := 1; numCols <= 5; numCols++ {
+		for round := 0; round < 16; round++ {
 			exprs, input := genVecEvalBool(numCols, nil, eTypes)
 			it := chunk.NewIterator4Chunk(input)
 			isNull := make([]bool, it.Len())

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -32,7 +32,8 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = SerialSuites(&testEvaluatorSuite{})
+var _ = SerialSuites(&testEvaluatorSerialSuites{})
+var _ = Suite(&testEvaluatorSuite{})
 
 func TestT(t *testing.T) {
 	CustomVerboseFlag = true
@@ -40,6 +41,11 @@ func TestT(t *testing.T) {
 }
 
 type testEvaluatorSuite struct {
+	*parser.Parser
+	ctx sessionctx.Context
+}
+
+type testEvaluatorSerialSuites struct {
 	*parser.Parser
 	ctx sessionctx.Context
 }

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -419,7 +419,7 @@ func (s *testEvaluatorSuite) TestBitwiseFunc2Pb(c *C) {
 	}
 }
 
-func (s *testEvaluatorSuite) TestPushDownSwitcher(c *C) {
+func (s *testEvaluatorSerialSuites) TestPushDownSwitcher(c *C) {
 	var funcs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -595,7 +595,7 @@ func (s *testEvaluatorSuite) TestSortByItem2Pb(c *C) {
 	c.Assert(string(js), Equals, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":46,\"charset\":\"\"}},\"desc\":true}")
 }
 
-func (s *testEvaluatorSuite) TestImplicitArgs(c *C) {
+func (s *testEvaluatorSerialSuites) TestImplicitArgs(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Reduce the time of running the unit-test in expression package

### What is changed and how it works?
Reduce the number of rounds of some time-consuming unit tests

In the old version
```
PASS: bench_test.go:1157: testEvaluatorSuite.TestVecEvalBool    26.551s
PASS: bench_test.go_1231_ testEvaluatorSuite.TestRowBasedFilterAndVectorizedFilter      18.848s
PASS: bench_test.go:1328: testEvaluatorSuite.TestVectorizedFilterConsiderNull   24.689s
```

In the new version
```
PASS: bench_test.go:1157: testEvaluatorSuite.TestVecEvalBool    2.335s
PASS: bench_test.go:1231: testEvaluatorSuite.TestRowBasedFilterAndVectorizedFilter      1.404s
PASS: bench_test.go:1328: testEvaluatorSuite.TestVectorizedFilterConsiderNull   2.367s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test