### PR TITLE
expression: implement vectorized evaluation for `builtinJSONTypeSig`

### DIFF
--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -186,11 +186,29 @@ func (b *builtinJSONLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 }
 
 func (b *builtinJSONTypeSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinJSONTypeSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETJson, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalJSON(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(buf.GetJSON(i).Type())
+	}
+	return nil
 }
 
 func (b *builtinJSONExtractSig) vectorized() bool {

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -29,7 +29,7 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	ast.JSONContainsPath: {},
 	ast.JSONExtract:      {},
 	ast.JSONLength:       {},
-	ast.JSONType:         {},
+	ast.JSONType:         {{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETJson}}},
 	ast.JSONArray:        {},
 	ast.JSONArrayInsert:  {},
 	ast.JSONContains:     {},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinJSONTypeSig` mentioned at https://github.com/pingcap/tidb/issues/12104

### What is changed and how it works?
about 100% faster
```
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONTypeSig-VecBuiltinFunc-12                    76419             15707 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONTypeSig-NonVecBuiltinFunc-12                 39229             30186 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test