### PR TITLE
executor,sessionctx: add correctness for system variables

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -520,6 +520,19 @@ func (s *testSuite2) TestValidateSetVar(c *C) {
 	_, err = tk.Exec("set @@global.thread_pool_size='hello'")
 	c.Assert(terror.ErrorEqual(err, variable.ErrWrongTypeForVar), IsTrue)
 
+	tk.MustExec("set @@global.tidb_optimizer_dynamic_sampling=12")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect tidb_optimizer_dynamic_sampling value: '12'"))
+	result = tk.MustQuery("select @@global.tidb_optimizer_dynamic_sampling;")
+	result.Check(testkit.Rows("11"))
+
+	tk.MustExec("set @@global.tidb_optimizer_dynamic_sampling=-1")
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect tidb_optimizer_dynamic_sampling value: '-1'"))
+	result = tk.MustQuery("select @@global.tidb_optimizer_dynamic_sampling;")
+	result.Check(testkit.Rows("0"))
+
+	_, err = tk.Exec("set @@global.tidb_optimizer_dynamic_sampling='hello'")
+	c.Assert(terror.ErrorEqual(err, variable.ErrWrongTypeForVar), IsTrue)
+
 	tk.MustExec("set @@global.max_allowed_packet=-1")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect max_allowed_packet value: '-1'"))
 	result = tk.MustQuery("select @@global.max_allowed_packet;")

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -692,6 +692,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBHashAggFinalConcurrency, strconv.Itoa(DefTiDBHashAggFinalConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBBackoffLockFast, strconv.Itoa(kv.DefBackoffLockFast)},
 	{ScopeGlobal | ScopeSession, TiDBBackOffWeight, strconv.Itoa(kv.DefBackOffWeight)},
+	{ScopeGlobal | ScopeSession, TiDBOptimizerDynamicSampling, strconv.Itoa(DefTiDBOptimizerDynamicSampling)},
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeGlobal | ScopeSession, TiDBDisableTxnAutoRetry, BoolToIntStr(DefTiDBDisableTxnAutoRetry)},
 	{ScopeGlobal | ScopeSession, TiDBConstraintCheckInPlace, BoolToIntStr(DefTiDBConstraintCheckInPlace)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -260,6 +260,9 @@ const (
 	// Only positive integers can be accepted, which means that the maximum back off time can only grow.
 	TiDBBackOffWeight = "tidb_backoff_weight"
 
+	// tidb_optimizer_dynamic_sampling defines the level of dynamic sampling.
+	TiDBOptimizerDynamicSampling = "tidb_optimizer_dynamic_sampling"
+
 	// tidb_ddl_reorg_worker_cnt defines the count of ddl reorg workers.
 	TiDBDDLReorgWorkerCount = "tidb_ddl_reorg_worker_cnt"
 
@@ -390,6 +393,7 @@ const (
 	DefTiDBDDLErrorCountLimit          = 512
 	DefTiDBMaxDeltaSchemaCount         = 1024
 	DefTiDBHashAggPartialConcurrency   = 4
+	DefTiDBOptimizerDynamicSampling    = 0
 	DefTiDBHashAggFinalConcurrency     = 4
 	DefTiDBForcePriority               = mysql.NoPriority
 	DefTiDBUseRadixJoin                = false

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -458,6 +458,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		return checkUInt64SystemVar(name, value, uint64(0), math.MaxInt64, vars)
 	case TiDBExpensiveQueryTimeThreshold:
 		return checkUInt64SystemVar(name, value, MinExpensiveQueryTimeThreshold, math.MaxInt64, vars)
+	case TiDBOptimizerDynamicSampling:
+		return checkUInt64SystemVar(name, value, 0, 11, vars)
 	case TiDBIndexLookupConcurrency, TiDBIndexLookupJoinConcurrency, TiDBIndexJoinBatchSize,
 		TiDBIndexLookupSize,
 		TiDBHashJoinConcurrency,


### PR DESCRIPTION
### What problem does this PR solve?

The optimizer will use pseudo statistic values if a column has not been analyzed. Oracle use dynamic sampling to get a quick estimate. For Oracle, [optimizer_dynamic_sampling](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/refrn/OPTIMIZER_DYNAMIC_SAMPLING.html#GUID-43655FC3-3C32-486B-8B11-8C20C152618D) defines the level of [dynamic sampling](https://blogs.oracle.com/oraclemagazine/on-dynamic-sampling).

Since TiDB is planning to support dynamic sampling in future, this commit is to add global/sesson variable `tidb_optimizer_dynamic_sampling` for TiDB as a feature flag.

### What is changed and how it works?

The default value of tidb_optimizer_dynamic_sampling is 0, which means dynamic sampling is disabled by default. The restriction includes:

- the value must be equal or greater than 0
- the value must be equal or less than 11

### Check List

Tests

 - Unit test

Code changes

 - Has exported variable/fields change

Side effects

 - Possible performance regression
 - Increased code complexity

