### PR TITLE
Update builtin_time_vec.go

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -589,15 +589,34 @@ func (b *builtinMinuteSig) vectorized() bool {
 }
 
 func (b *builtinMinuteSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+    	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSecondSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinSecondSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+    buf, err := b.bufAllocator.get(types.ETDuration, n)
+    if err != nil {
+    	return err
+    }
+    defer b.bufAllocator.put(buf)
+    if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+    	return err
+    }
+    result.ResizeInt64(n, false)
+    result.MergeNulls(buf)
+    i64s := result.Int64s()
+    for i := 0; i < n; i++ {
+    	if result.IsNull(i) {
+    		continue
+    	}
+    	i64s[i] = int64(buf.GetDuration(i, int(types.UnspecifiedFsp)).Second())
+    }
+    return nil
+
 }
 
 func (b *builtinNowWithoutArgSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -33,7 +33,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}, geners: []dataGenerator{&rangeDurationGener{0.2}}},
 	},
 	ast.Minute:      {},
-	ast.Second:      {},
+	ast.Second:      {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}, geners: []dataGenerator{&rangeDurationGener{0.2}}},
+	},
 	ast.MicroSecond: {},
 	ast.Now:         {},
 	ast.DayOfWeek:   {},


### PR DESCRIPTION
Implement builtinSecondSig

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement builtinSecondSig

### What is changed and how it works?
BenchmarkVectorizedBuiltinTimeFunc/builtinSecondSig-VecBuiltinFunc-4                                      120044             10199 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinSecondSig-NonVecBuiltinFunc-4                                    31761             39806 ns/op               0 B/op              0 allocs/op

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Write release note for bug-fix or new feature.
