### PR TITLE
tune grpc connection count between tidb and tikv

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -404,7 +404,7 @@ var defaultConf = Config{
 		Reporter: OpenTracingReporter{},
 	},
 	TiKVClient: TiKVClient{
-		GrpcConnectionCount:  16,
+		GrpcConnectionCount:  4,
 		GrpcKeepAliveTime:    10,
 		GrpcKeepAliveTimeout: 3,
 		CommitTimeout:        "41s",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -259,7 +259,7 @@ local-agent-host-port = ""
 
 [tikv-client]
 # Max gRPC connections that will be established with each tikv-server.
-grpc-connection-count = 16
+grpc-connection-count = 4
 
 # After a duration of this time in seconds if the client doesn't see any activity it pings
 # the server to see if the transport is still alive.


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Tune the gRPC connection between TiDB and TiKV to  make super batch works better. This is a prepare step of https://github.com/tikv/tikv/pull/5598, this pr will make https://github.com/tikv/tikv/pull/5598 works better.

### What is changed and how it works?
Tune the default gRPC connection between tidb and tikv.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

