### PR TITLE
expression: implement vectorized evaluation for 'builtinCoalesceJSONSig'

### DIFF
--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -22,11 +22,17 @@ import (
 )
 
 var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
-	ast.NE:       {},
-	ast.IsNull:   {},
-	ast.LE:       {},
-	ast.LT:       {},
-	ast.Coalesce: {},
+	ast.NE:     {},
+	ast.IsNull: {},
+	ast.LE:     {},
+	ast.LT:     {},
+	ast.Coalesce: {
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson}},
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson, types.ETJson}},
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson, types.ETJson, types.ETJson}},
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson, types.ETJson, types.ETJson},
+			geners: []dataGenerator{&defaultGener{1, types.ETJson}, &defaultGener{1, types.ETJson}, &defaultGener{1, types.ETJson}}},
+	},
 	ast.NullEQ: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal, types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 20}, &randLenStrGener{0, 20}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinCoalesceJSONSig, for #12104 



### What is changed and how it works?
```
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-VecBuiltinFunc-8         	   10000	    172660 ns/o   69806 B/op	     837 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-NonVecBuiltinFunc-8      	   50000	     28641 ns/o       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-VecBuiltinFunc#01-8      	    5000	    257775 ns/o  117342 B/op	    1034 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-NonVecBuiltinFunc#01-8   	   50000	     30344 ns/o       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-VecBuiltinFunc#02-8      	    5000	    276389 ns/o  117744 B/op	    1047 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-NonVecBuiltinFunc#02-8   	   50000	     30684 ns/o       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-VecBuiltinFunc#03-8      	  200000	     10548 ns/o       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceJSONSig-NonVecBuiltinFunc#03-8   	   50000	     31831 ns/o       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test