### PR TITLE
executor: fix wrong runtime stats record in index merge join

### DIFF
--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -16,6 +16,10 @@ package executor
 import (
 	"context"
 	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -25,9 +29,6 @@ import (
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/stringutil"
-	"sort"
-	"sync"
-	"sync/atomic"
 )
 
 // IndexLookUpMergeJoin realizes IndexLookUpJoin by merge join

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -16,11 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"sort"
-	"sync"
-	"sync/atomic"
-	"time"
-
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -30,6 +25,9 @@ import (
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/stringutil"
+	"sort"
+	"sync"
+	"sync/atomic"
 )
 
 // IndexLookUpMergeJoin realizes IndexLookUpJoin by merge join
@@ -241,12 +239,6 @@ func (e *IndexLookUpMergeJoin) newInnerMergeWorker(taskCh chan *lookUpMergeJoinT
 
 // Next implements the Executor interface
 func (e *IndexLookUpMergeJoin) Next(ctx context.Context, req *chunk.Chunk) error {
-	if e.runtimeStats != nil {
-		start := time.Now()
-		defer func() {
-			e.runtimeStats.Record(time.Since(start), req.NumRows())
-		}()
-	}
 	if e.isOuterJoin {
 		atomic.StoreInt64(&e.requiredRows, int64(req.RequiredRows()))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #12911 

### What is changed and how it works?
Remove the extra runtime stats record in `IndexMergeJoinExec.Next()`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
