### PR TITLE
tikv: retry region request when tiflash store not found

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -359,9 +359,8 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 
 	regionStore := cachedRegion.getStore()
 
-	// tikvCnt is to check whether the TiFlash store exist.
 	// sIdx is for load balance of TiFlash store.
-	tikvCnt, sIdx := 0, int(atomic.AddInt32(&regionStore.workTiFlashIdx, 1))
+	sIdx := int(atomic.AddInt32(&regionStore.workTiFlashIdx, 1))
 	for i := range regionStore.stores {
 		storeIdx := (sIdx + i) % len(regionStore.stores)
 		store := regionStore.stores[storeIdx]
@@ -377,7 +376,6 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 			store.reResolve(c)
 		}
 		if store.storeType != kv.TiFlash {
-			tikvCnt++
 			continue
 		}
 		atomic.StoreInt32(&regionStore.workTiFlashIdx, int32(storeIdx))
@@ -400,9 +398,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 		}, nil
 	}
 
-	if tikvCnt == len(regionStore.stores) {
-		return nil, errors.Errorf("Can not find the TiFlash store address, region version id:%v", id)
-	}
+	cachedRegion.invalidate()
 	return nil, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The region request for TiFlash returns an error when none TiFlash store found in the region cache. But sometimes the region has the TiFlash replica, the region cache will not update.

### What is changed and how it works?
Make region cache invalid instead of returning the error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Possible performance regression
