### PR TITLE
executor: wait all `fetchChildData` exiting in `HashAggExec.Close`

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -205,6 +205,9 @@ func (e *HashAggExec) Close() error {
 		for _, ch := range e.partialOutputChs {
 			close(ch)
 		}
+		for _, ch := range e.partialInputChs {
+			close(ch)
+		}
 		close(e.finalOutputCh)
 	}
 	close(e.finishCh)

--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -212,6 +212,10 @@ func (e *HashAggExec) Close() error {
 		for range ch {
 		}
 	}
+	for _, ch := range e.partialInputChs {
+		for range ch {
+		}
+	}
 	for range e.finalOutputCh {
 	}
 	e.executed = false


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #12929 

### What is changed and how it works?

Wait all `fetchChildData` exiting in `HashAggExec.Close`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - None

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
