### PR TITLE
planner/cascades: inject Projection below and above Sort

### DIFF
--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -22,7 +22,11 @@
       "explain select a from t order by a",
       "select a from t order by a",
       "explain select b from t order by b",
-      "select b from t order by b"
+      "select b from t order by b",
+      "explain select b from t order by a+b",
+      "select b from t order by a+b",
+      "explain select b from t order by b, a+b, a",
+      "select b from t order by b, a+b, a"
     ]
   }
 ]

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -114,6 +114,48 @@
           "33",
           "44"
         ]
+      },
+      {
+        "SQL": "explain select b from t order by a+b",
+        "Result": [
+          "Projection_7 10000.00 root Column#3",
+          "└─Projection_12 10000.00 root Column#3, Column#4",
+          "  └─Sort_8 10000.00 root Column#6:asc",
+          "    └─Projection_13 10000.00 root Column#3, Column#4, plus(Column#4, Column#3)",
+          "      └─Projection_9 10000.00 root Column#2, Column#1",
+          "        └─TableReader_10 10000.00 root data:TableScan_11",
+          "          └─TableScan_11 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select b from t order by a+b",
+        "Result": [
+          "11",
+          "22",
+          "33",
+          "44"
+        ]
+      },
+      {
+        "SQL": "explain select b from t order by b, a+b, a",
+        "Result": [
+          "Projection_7 10000.00 root Column#3",
+          "└─Projection_12 10000.00 root Column#3, Column#4",
+          "  └─Sort_8 10000.00 root Column#3:asc, Column#6:asc, Column#4:asc",
+          "    └─Projection_13 10000.00 root Column#3, Column#4, plus(Column#4, Column#3)",
+          "      └─Projection_9 10000.00 root Column#2, Column#1",
+          "        └─TableReader_10 10000.00 root data:TableScan_11",
+          "          └─TableScan_11 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select b from t order by b, a+b, a",
+        "Result": [
+          "11",
+          "22",
+          "33",
+          "44"
+        ]
       }
     ]
   }

--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -49,9 +49,9 @@ func (pe *projInjector) inject(plan PhysicalPlan) PhysicalPlan {
 	case *PhysicalStreamAgg:
 		plan = injectProjBelowAgg(plan, p.AggFuncs, p.GroupByItems)
 	case *PhysicalSort:
-		plan = injectProjBelowSort(p, p.ByItems)
+		plan = InjectProjBelowSort(p, p.ByItems)
 	case *PhysicalTopN:
-		plan = injectProjBelowSort(p, p.ByItems)
+		plan = InjectProjBelowSort(p, p.ByItems)
 	}
 	return plan
 }
@@ -139,14 +139,14 @@ func injectProjBelowAgg(aggPlan PhysicalPlan, aggFuncs []*aggregation.AggFuncDes
 	return aggPlan
 }
 
-// injectProjBelowSort extracts the ScalarFunctions of `orderByItems` into a
+// InjectProjBelowSort extracts the ScalarFunctions of `orderByItems` into a
 // PhysicalProjection and injects it below PhysicalTopN/PhysicalSort. The schema
 // of PhysicalSort and PhysicalTopN are the same as the schema of their
 // children. When a projection is injected as the child of PhysicalSort and
 // PhysicalTopN, some extra columns will be added into the schema of the
 // Projection, thus we need to add another Projection upon them to prune the
 // redundant columns.
-func injectProjBelowSort(p PhysicalPlan, orderByItems []*ByItems) PhysicalPlan {
+func InjectProjBelowSort(p PhysicalPlan, orderByItems []*ByItems) PhysicalPlan {
 	hasScalarFunc, numOrderByItems := false, len(orderByItems)
 	for i := 0; !hasScalarFunc && i < numOrderByItems; i++ {
 		_, isScalarFunc := orderByItems[i].Expr.(*expression.ScalarFunction)

--- a/planner/implementation/sort.go
+++ b/planner/implementation/sort.go
@@ -38,6 +38,16 @@ func (impl *SortImpl) CalcCost(outCount float64, children ...memo.Implementation
 	return impl.cost
 }
 
+// AttachChildren implements Implementation AttachChildren interface.
+func (impl *SortImpl) AttachChildren(children ...memo.Implementation) memo.Implementation {
+	sort := impl.plan.(*plannercore.PhysicalSort)
+	sort.SetChildren(children[0].GetPlan())
+	// When the Sort orderByItems contain ScalarFunction, we need
+	// to inject two Projections below and above the Sort.
+	impl.plan = plannercore.InjectProjBelowSort(sort, sort.ByItems)
+	return impl
+}
+
 // NominalSortImpl is the implementation of NominalSort.
 type NominalSortImpl struct {
 	baseImpl


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the Sort orderByColumns contain ScalarFunctions, we need to inject two Projections below and above Sort.

### What is changed and how it works?

Port some codes from `postOptimize` in planner/core to cascades planner.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit Tests

Code changes

 - Has exported function/method change
