### PR TITLE
Makefile:Revert "Makefile: add `-trim-path` flag for build command (#12653)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
 
 GO        := GO111MODULE=on go
-GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG) -trimpath
+GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG)
 GOTEST    := CGO_ENABLED=1 $(GO) test -p 4
 OVERALLS  := CGO_ENABLED=1 GO111MODULE=on overalls
 


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `trimpath` leads to  plugin loading failure 
see 
https://github.com/pingcap/tidb/issues/12927
https://github.com/golang/go/issues/31278#issuecomment-541106229
### What is changed and how it works?
revert the `-trimpath` flag


Code changes

