### PR TITLE
perfschema: support query cpu/memory/mutex/block/allocs/goroutines flamegraph by SQL (#12986)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/golang/protobuf v1.2.0
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
+	github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
@@ -73,5 +74,7 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
+
+replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d h1:rQ
 github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d/go.mod h1:VKt7CNAQxpFpSDz3sXyj9hY/GbVsQCr0sB3w59nE7lU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -102,6 +103,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.5.1 h1:3scN4iuXkNOyP98jF55Lv8a9j1o/Iwv
 github.com/grpc-ecosystem/grpc-gateway v1.5.1/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -120,6 +123,8 @@ github.com/kr/pty v1.0.0/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d h1:6Ike9EBxOFsCMMih14rQJmb7WPWdgRu4C0OLl6oRHwE=
+github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d/go.mod h1:0vjxLpmyJvBwQbIQuxhHxmogQFpJvB9doVHvxFFfyoY=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -280,6 +285,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190909082730-f460065e899a h1:mIzbOulag9/gXacgxKlFVwpCOWSfBT3/pDyyCwGA9as=
 golang.org/x/sys v0.0.0-20190909082730-f460065e899a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2IVY3KZs6p9mix0ziNYJM=

--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -37,6 +37,12 @@ var perfSchemaTables = []string{
 	tableStagesHistory,
 	tableStagesHistoryLong,
 	tableEventsStatementsSummaryByDigest,
+	tableTiDBProfileCPU,
+	tableTiDBProfileMemory,
+	tableTiDBProfileMutex,
+	tableTiDBAllocsProfile,
+	tableTiDBProfileBlock,
+	tableTiDBGoroutine,
 }
 
 // tableGlobalStatus contains the column name definitions for table global_status, same as MySQL.
@@ -388,3 +394,55 @@ const tableEventsStatementsSummaryByDigest = "CREATE TABLE if not exists events_
 	"FIRST_SEEN TIMESTAMP(6) NOT NULL," +
 	"LAST_SEEN TIMESTAMP(6) NOT NULL," +
 	"QUERY_SAMPLE_TEXT LONGTEXT DEFAULT NULL);"
+
+// tableTiDBProfileCPU contains the columns name definitions for table events_cpu_profile_graph
+const tableTiDBProfileCPU = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileCPU + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tableTiDBProfileMemory contains the columns name definitions for table events_memory_profile_graph
+const tableTiDBProfileMemory = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileMemory + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tableTiDBProfileMutex contains the columns name definitions for table events_mutex_profile_graph
+const tableTiDBProfileMutex = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileMutex + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tableTiDBAllocsProfile contains the columns name definitions for table events_allocs_profile_graph
+const tableTiDBAllocsProfile = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileAllocs + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tableTiDBProfileBlock contains the columns name definitions for table events_block_profile_graph
+const tableTiDBProfileBlock = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileBlock + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tableTiDBGoroutine contains the columns name definitions for table events_goroutine
+const tableTiDBGoroutine = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBGoroutines + " (" +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"ID INT(8) NOT NULL," +
+	"STATE VARCHAR(16) NOT NULL," +
+	"LOCATION VARCHAR(512));"

--- a/infoschema/perfschema/tables.go
+++ b/infoschema/perfschema/tables.go
@@ -21,11 +21,18 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/profile"
 	"github.com/pingcap/tidb/util/stmtsummary"
 )
 
 const (
 	tableNameEventsStatementsSummaryByDigest = "events_statements_summary_by_digest"
+	tableNameTiDBProfileCPU                  = "tidb_profile_cpu"
+	tableNameTiDBProfileMemory               = "tidb_profile_memory"
+	tableNameTiDBProfileMutex                = "tidb_profile_mutex"
+	tableNameTiDBProfileAllocs               = "tidb_profile_allocs"
+	tableNameTiDBProfileBlock                = "tidb_profile_block"
+	tableNameTiDBGoroutines                  = "tidb_goroutines"
 )
 
 // perfSchemaTable stands for the fake table all its data is in the memory.
@@ -90,6 +97,21 @@ func (vt *perfSchemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 	switch vt.meta.Name.O {
 	case tableNameEventsStatementsSummaryByDigest:
 		fullRows = stmtsummary.StmtSummaryByDigestMap.ToDatum()
+	case tableNameTiDBProfileCPU:
+		fullRows, err = (&profile.Collector{}).ProfileGraph("cpu")
+	case tableNameTiDBProfileMemory:
+		fullRows, err = (&profile.Collector{}).ProfileGraph("heap")
+	case tableNameTiDBProfileMutex:
+		fullRows, err = (&profile.Collector{}).ProfileGraph("mutex")
+	case tableNameTiDBProfileAllocs:
+		fullRows, err = (&profile.Collector{}).ProfileGraph("allocs")
+	case tableNameTiDBProfileBlock:
+		fullRows, err = (&profile.Collector{}).ProfileGraph("block")
+	case tableNameTiDBGoroutines:
+		fullRows, err = (&profile.Collector{}).Goroutines()
+	}
+	if err != nil {
+		return
 	}
 	if len(cols) == len(vt.cols) {
 		return

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -1,0 +1,215 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"runtime/pprof"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/pprof/graph"
+	"github.com/google/pprof/measurement"
+	"github.com/google/pprof/profile"
+	"github.com/google/pprof/report"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/texttree"
+)
+
+// CPUProfileInterval represents the duration of sampling CPU
+var CPUProfileInterval = 30 * time.Second
+
+// Collector is used to collect the profile results
+type Collector struct {
+	Rows [][]types.Datum
+}
+
+type perfNode struct {
+	Name      string
+	Location  string
+	Cum       int64
+	CumFormat string
+	Percent   string
+	Children  []*perfNode
+}
+
+func (c *Collector) collect(node *perfNode, depth int64, indent string, rootChild int, parentCur int64, isLastChild bool) {
+	row := types.MakeDatums(
+		texttree.PrettyIdentifier(node.Name, indent, isLastChild),
+		node.Percent,
+		strings.TrimSpace(measurement.Percentage(node.Cum, parentCur)),
+		rootChild,
+		depth,
+		node.Location,
+	)
+	c.Rows = append(c.Rows, row)
+
+	indent4Child := texttree.Indent4Child(indent, isLastChild)
+	for i, child := range node.Children {
+		rc := rootChild
+		if depth == 0 {
+			rc = i + 1
+		}
+		c.collect(child, depth+1, indent4Child, rc, node.Cum, i == len(node.Children)-1)
+	}
+}
+
+func (c *Collector) profileReaderToDatums(f io.Reader) ([][]types.Datum, error) {
+	p, err := profile.Parse(f)
+	if err != nil {
+		return nil, err
+	}
+	return c.profileToDatums(p)
+}
+
+func (c *Collector) profileToDatums(p *profile.Profile) ([][]types.Datum, error) {
+	err := p.Aggregate(true, true, true, true, true)
+	if err != nil {
+		return nil, err
+	}
+	rpt := report.NewDefault(p, report.Options{
+		OutputFormat: report.Dot,
+		CallTree:     true,
+	})
+	g, config := report.GetDOT(rpt)
+	var nodes []*perfNode
+	nroots := 0
+	rootValue := int64(0)
+	nodeArr := []string{}
+	nodeMap := map[*graph.Node]*perfNode{}
+	// Make all nodes and the map, collect the roots.
+	for _, n := range g.Nodes {
+		v := n.CumValue()
+		node := &perfNode{
+			Name:      n.Info.Name,
+			Location:  fmt.Sprintf("%s:%d", n.Info.File, n.Info.Lineno),
+			Cum:       v,
+			CumFormat: config.FormatValue(v),
+			Percent:   strings.TrimSpace(measurement.Percentage(v, config.Total)),
+		}
+		nodes = append(nodes, node)
+		if len(n.In) == 0 {
+			nodes[nroots], nodes[len(nodes)-1] = nodes[len(nodes)-1], nodes[nroots]
+			nroots++
+			rootValue += v
+		}
+		nodeMap[n] = node
+		// Get all node names into an array.
+		nodeArr = append(nodeArr, n.Info.Name)
+	}
+	// Populate the child links.
+	for _, n := range g.Nodes {
+		node := nodeMap[n]
+		for child := range n.Out {
+			node.Children = append(node.Children, nodeMap[child])
+		}
+	}
+
+	rootNode := &perfNode{
+		Name:      "root",
+		Location:  "root",
+		Cum:       rootValue,
+		CumFormat: config.FormatValue(rootValue),
+		Percent:   strings.TrimSpace(measurement.Percentage(rootValue, config.Total)),
+		Children:  nodes[0:nroots],
+	}
+
+	c.collect(rootNode, 0, "", 0, config.Total, len(rootNode.Children) == 0)
+	return c.Rows, nil
+}
+
+// cpuProfileGraph returns the CPU profile flamegraph which is organized by tree form
+func (c *Collector) cpuProfileGraph() ([][]types.Datum, error) {
+	buffer := &bytes.Buffer{}
+	if err := pprof.StartCPUProfile(buffer); err != nil {
+		panic(err)
+	}
+	time.Sleep(CPUProfileInterval)
+	pprof.StopCPUProfile()
+	return c.profileReaderToDatums(buffer)
+}
+
+// ProfileGraph returns the CPU/memory/mutex/allocs/block profile flamegraph which is organized by tree form
+func (c *Collector) ProfileGraph(name string) ([][]types.Datum, error) {
+	if strings.ToLower(strings.TrimSpace(name)) == "cpu" {
+		return c.cpuProfileGraph()
+	}
+
+	p := pprof.Lookup(name)
+	if p == nil {
+		return nil, errors.Errorf("cannot retrieve %s profile", name)
+	}
+	buffer := &bytes.Buffer{}
+	if err := p.WriteTo(buffer, 0); err != nil {
+		return nil, err
+	}
+	return c.profileReaderToDatums(buffer)
+}
+
+// Goroutines returns the groutine list which alive in runtime
+func (c *Collector) Goroutines() ([][]types.Datum, error) {
+	p := pprof.Lookup("goroutine")
+	if p == nil {
+		return nil, errors.Errorf("cannot retrieve goroutine profile")
+	}
+
+	buffer := bytes.Buffer{}
+	err := p.WriteTo(&buffer, 2)
+	if err != nil {
+		return nil, err
+	}
+
+	goroutines := strings.Split(buffer.String(), "\n\n")
+	var rows [][]types.Datum
+	for _, goroutine := range goroutines {
+		colIndex := strings.Index(goroutine, ":")
+		if colIndex < 0 {
+			return nil, errors.New("goroutine incompatible with current go version")
+		}
+
+		headers := strings.SplitN(strings.TrimSpace(goroutine[len("goroutine")+1:colIndex]), " ", 2)
+		if len(headers) != 2 {
+			return nil, errors.Errorf("incompatible goroutine headers: %s", goroutine[len("goroutine")+1:colIndex])
+		}
+		id, err := strconv.Atoi(strings.TrimSpace(headers[0]))
+		if err != nil {
+			return nil, errors.Annotatef(err, "invalid goroutine id: %s", headers[0])
+		}
+		state := strings.Trim(headers[1], "[]")
+		stack := strings.Split(strings.TrimSpace(goroutine[colIndex+1:]), "\n")
+		for i := 0; i < len(stack)/2; i++ {
+			fn := stack[i*2]
+			loc := stack[i*2+1]
+			var identifier string
+			if i == 0 {
+				identifier = fn
+			} else if i == len(stack)/2-1 {
+				identifier = string(texttree.TreeLastNode) + string(texttree.TreeNodeIdentifier) + fn
+			} else {
+				identifier = string(texttree.TreeMiddleNode) + string(texttree.TreeNodeIdentifier) + fn
+			}
+			rows = append(rows, types.MakeDatums(
+				identifier,
+				id,
+				state,
+				strings.TrimSpace(loc),
+			))
+		}
+	}
+	return rows, nil
+}

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -1,0 +1,67 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/profile"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+type profileSuite struct {
+	store kv.Storage
+	dom   *domain.Domain
+}
+
+var _ = Suite(&profileSuite{})
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+func (s *profileSuite) SetUpSuite(c *C) {
+	var err error
+	s.store, err = mockstore.NewMockTikvStore()
+	c.Assert(err, IsNil)
+	session.DisableStats4Test()
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+}
+
+func (s *profileSuite) TearDownSuite(c *C) {
+	s.dom.Close()
+	s.store.Close()
+}
+
+func (s *profileSuite) TestProfiles(c *C) {
+	oldValue := profile.CPUProfileInterval
+	profile.CPUProfileInterval = 2 * time.Second
+	defer func() {
+		profile.CPUProfileInterval = oldValue
+	}()
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("select * from performance_schema.tidb_profile_cpu")
+	tk.MustExec("select * from performance_schema.tidb_profile_memory")
+	tk.MustExec("select * from performance_schema.tidb_profile_allocs")
+	tk.MustExec("select * from performance_schema.tidb_profile_mutex")
+	tk.MustExec("select * from performance_schema.tidb_profile_block")
+	tk.MustExec("select * from performance_schema.tidb_goroutines")
+}

--- a/util/texttree/texttree.go
+++ b/util/texttree/texttree.go
@@ -1,0 +1,80 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package texttree
+
+const (
+	// TreeBody indicates the current operator sub-tree is not finished, still
+	// has child operators to be attached on.
+	TreeBody = '│'
+	// TreeMiddleNode indicates this operator is not the last child of the
+	// current sub-tree rooted by its parent.
+	TreeMiddleNode = '├'
+	// TreeLastNode indicates this operator is the last child of the current
+	// sub-tree rooted by its parent.
+	TreeLastNode = '└'
+	// TreeGap is used to represent the gap between the branches of the tree.
+	TreeGap = ' '
+	// TreeNodeIdentifier is used to replace the treeGap once we need to attach
+	// a node to a sub-tree.
+	TreeNodeIdentifier = '─'
+)
+
+// Indent4Child appends more blank to the `indent` string
+func Indent4Child(indent string, isLastChild bool) string {
+	if !isLastChild {
+		return string(append([]rune(indent), TreeBody, TreeGap))
+	}
+
+	// If the current node is the last node of the current operator tree, we
+	// need to end this sub-tree by changing the closest treeBody to a treeGap.
+	indentBytes := []rune(indent)
+	for i := len(indentBytes) - 1; i >= 0; i-- {
+		if indentBytes[i] == TreeBody {
+			indentBytes[i] = TreeGap
+			break
+		}
+	}
+
+	return string(append(indentBytes, TreeBody, TreeGap))
+}
+
+// PrettyIdentifier returns a pretty identifier which contains indent and tree node hierarchy indicator
+func PrettyIdentifier(id, indent string, isLastChild bool) string {
+	if len(indent) == 0 {
+		return id
+	}
+
+	indentBytes := []rune(indent)
+	for i := len(indentBytes) - 1; i >= 0; i-- {
+		if indentBytes[i] != TreeBody {
+			continue
+		}
+
+		// Here we attach a new node to the current sub-tree by changing
+		// the closest treeBody to a:
+		// 1. treeLastNode, if this operator is the last child.
+		// 2. treeMiddleNode, if this operator is not the last child..
+		if isLastChild {
+			indentBytes[i] = TreeLastNode
+		} else {
+			indentBytes[i] = TreeMiddleNode
+		}
+		break
+	}
+
+	// Replace the treeGap between the treeBody and the node to a
+	// treeNodeIdentifier.
+	indentBytes[len(indentBytes)-1] = TreeNodeIdentifier
+	return string(indentBytes) + id
+}

--- a/util/texttree/texttree_test.go
+++ b/util/texttree/texttree_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package texttree_test
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/texttree"
+)
+
+type texttreeSuite struct{}
+
+var _ = Suite(&texttreeSuite{})
+
+func TestT(t *testing.T) {
+	CustomVerboseFlag = true
+	TestingT(t)
+}
+
+func (s *texttreeSuite) TestPrettyIdentifier(c *C) {
+	c.Assert(texttree.PrettyIdentifier("test", "", false), Equals, "test")
+	c.Assert(texttree.PrettyIdentifier("test", "  │  ", false), Equals, "  ├ ─test")
+	c.Assert(texttree.PrettyIdentifier("test", "\t\t│\t\t", false), Equals, "\t\t├\t─test")
+	c.Assert(texttree.PrettyIdentifier("test", "  │  ", true), Equals, "  └ ─test")
+	c.Assert(texttree.PrettyIdentifier("test", "\t\t│\t\t", true), Equals, "\t\t└\t─test")
+}
+
+func (s *texttreeSuite) TestIndent4Child(c *C) {
+	c.Assert(texttree.Indent4Child("    ", false), Equals, "    │ ")
+	c.Assert(texttree.Indent4Child("    ", true), Equals, "    │ ")
+	c.Assert(texttree.Indent4Child("   │ ", true), Equals, "     │ ")
+}


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

Cherry-pick https://github.com/pingcap/tidb/pull/12986 for release-3.1

Conflicts:
- `util/plancodec/codec.go` this file does not exists in release-3.1 and changed in original PR, it's conflicted as expected.

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, we need to get the profile file through the HTTP interface, and then convert the profile file into a flame map through an external tool. This process is very inefficient and cumbersome.

### What is changed and how it works?

Use SQL to directly obtain flamegraph to help us improve diagnostic efficiency.
**Note**: This PR is part of [Hackathon 2019](https://pingcap.com/community-cn/hackathon2019/) TBSSQL2.0.

```sql
select * from performance_schema.tidb_profile_allocs;
select * from performance_schema.tidb_profile_block;
select * from performance_schema.tidb_profile_cpu;
select * from performance_schema.tidb_goroutines;
select * from performance_schema.tidb_profile_memory;
select * from performance_schema.tidb_profile_mutex;
```
eg:
```
mysql> select * from performance_schema.tidb_profile_memory;
+-------------------------------------------------------------------------------------------------------------------+-------------+-------------+------------+-------+------------------------------------------------------------------------------------------------------+
| FUNCTION                                                                                                          | PERCENT_ABS | PERCENT_REL | ROOT_CHILD | DEPTH | FILE                                                                                                 |
+-------------------------------------------------------------------------------------------------------------------+-------------+-------------+------------+-------+------------------------------------------------------------------------------------------------------+
| root                                                                                                              | 100%        | 100%        |          0 |     0 | root                                                                                                 |
| ├─runtime.main                                                                                                    | 66.66%      | 66.66%      |          1 |     1 | runtime/proc.go:203                                                                                  |
| │ ├─main.main                                                                                                     | 61.93%      | 92.91%      |          1 |     2 | github.com/pingcap/tidb@/tidb-server/main.go:176                                                     |
| │ │ ├─main.createStoreAndDomain                                                                                   | 19.51%      | 31.50%      |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:238                                                     |
| │ │ │ └─github.com/pingcap/tidb/session.BootstrapSession                                                          | 19.51%      | 100%        |          1 |     4 | github.com/pingcap/tidb@/session/session.go:1579                                                     |
| │ │ │   └─github.com/pingcap/tidb/session.createSession                                                           | 19.51%      | 100%        |          1 |     5 | github.com/pingcap/tidb@/session/session.go:1670                                                     |
| │ │ │     └─github.com/pingcap/tidb/session.(*domainMap).Get                                                      | 19.51%      | 100%        |          1 |     6 | github.com/pingcap/tidb@/session/tidb.go:70                                                          |
| │ │ │       └─github.com/pingcap/tidb/util.RunWithRetry                                                           | 19.51%      | 100%        |          1 |     7 | github.com/pingcap/tidb@/util/misc.go:46                                                             |
| │ │ │         └─github.com/pingcap/tidb/session.(*domainMap).Get.func1                                            | 19.51%      | 100%        |          1 |     8 | github.com/pingcap/tidb@/session/tidb.go:78                                                          |
| │ │ │           ├─github.com/pingcap/tidb/domain.(*Domain).Init                                                   | 4.69%       | 24.06%      |          1 |     9 | github.com/pingcap/tidb@/domain/domain.go:604                                                        |
| │ │ │           │ └─github.com/pingcap/tidb/infoschema/perfschema.Init                                            | 4.69%       | 100%        |          1 |    10 | github.com/pingcap/tidb@/infoschema/perfschema/init.go:69                                            |
| │ │ │           │   └─sync.(*Once).Do                                                                             | 4.69%       | 100%        |          1 |    11 | sync/once.go:57                                                                                      |
| │ │ │           │     └─sync.(*Once).doSlow                                                                       | 4.69%       | 100%        |          1 |    12 | sync/once.go:66                                                                                      |
| │ │ │           │       └─github.com/pingcap/tidb/infoschema/perfschema.Init.func1                                | 4.69%       | 100%        |          1 |    13 | github.com/pingcap/tidb@/infoschema/perfschema/init.go:49                                            |
| │ │ │           │         └─github.com/pingcap/tidb/ddl.BuildTableInfoFromAST                                     | 4.69%       | 100%        |          1 |    14 | github.com/pingcap/tidb@/ddl/ddl_api.go:1282                                                         |
| │ │ │           │           └─github.com/pingcap/tidb/ddl.buildTableInfoWithCheck                                 | 4.69%       | 100%        |          1 |    15 | github.com/pingcap/tidb@/ddl/ddl_api.go:1314                                                         |
| │ │ │           │             └─github.com/pingcap/tidb/ddl.buildColumnsAndConstraints                            | 4.69%       | 100%        |          1 |    16 | github.com/pingcap/tidb@/ddl/ddl_api.go:269                                                          |
| │ │ │           │               └─github.com/pingcap/tidb/ddl.buildColumnAndConstraint                            | 4.69%       | 100%        |          1 |    17 | github.com/pingcap/tidb@/ddl/ddl_api.go:404                                                          |
| │ │ │           │                 └─github.com/pingcap/tidb/ddl.columnDefToCol                                    | 4.69%       | 100%        |          1 |    18 | github.com/pingcap/tidb@/ddl/ddl_api.go:489                                                          |
| │ │ │           └─github.com/pingcap/tidb/domain.(*Domain).Init                                                   | 14.81%      | 75.94%      |          1 |     9 | github.com/pingcap/tidb@/domain/domain.go:642                                                        |
| │ │ │             └─github.com/pingcap/tidb/ddl.NewDDL                                                            | 14.81%      | 100%        |          1 |    10 | github.com/pingcap/tidb@/ddl/ddl.go:355                                                              |
| │ │ │               └─github.com/pingcap/tidb/ddl.newDDL                                                          | 14.81%      | 100%        |          1 |    11 | github.com/pingcap/tidb@/ddl/ddl.go:396                                                              |
| │ │ │                 └─github.com/pingcap/tidb/ddl.(*ddl).start                                                  | 14.81%      | 100%        |          1 |    12 | github.com/pingcap/tidb@/ddl/ddl.go:440                                                              |
| │ │ │                   └─github.com/pingcap/tidb/ddl.(*ddl).newDeleteRangeManager                                | 14.81%      | 100%        |          1 |    13 | github.com/pingcap/tidb@/ddl/ddl.go:416                                                              |
| │ │ │                     └─github.com/pingcap/tidb/ddl.newDelRangeManager                                        | 14.81%      | 100%        |          1 |    14 | github.com/pingcap/tidb@/ddl/delete_range.go:78                                                      |
| │ │ └─main.createStoreAndDomain                                                                                   | 42.43%      | 68.50%      |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:235                                                     |
| │ │   └─github.com/pingcap/tidb/store.New                                                                         | 42.43%      | 100%        |          1 |     4 | github.com/pingcap/tidb@/store/store.go:51                                                           |
| │ │     └─github.com/pingcap/tidb/store.newStoreWithRetry                                                         | 42.43%      | 100%        |          1 |     5 | github.com/pingcap/tidb@/store/store.go:67                                                           |
| │ │       └─github.com/pingcap/tidb/util.RunWithRetry                                                             | 42.43%      | 100%        |          1 |     6 | github.com/pingcap/tidb@/util/misc.go:46                                                             |
| │ │         └─github.com/pingcap/tidb/store.newStoreWithRetry.func1                                               | 42.43%      | 100%        |          1 |     7 | github.com/pingcap/tidb@/store/store.go:69                                                           |
| │ │           └─github.com/pingcap/tidb/store/mockstore.MockDriver.Open                                           | 42.43%      | 100%        |          1 |     8 | github.com/pingcap/tidb@/store/mockstore/tikv.go:47                                                  |
| │ │             └─github.com/pingcap/tidb/store/mockstore.NewMockTikvStore                                        | 42.43%      | 100%        |          1 |     9 | github.com/pingcap/tidb@/store/mockstore/tikv.go:106                                                 |
| │ │               └─github.com/pingcap/tidb/store/mockstore/mocktikv.NewTiKVAndPDClient                           | 42.43%      | 100%        |          1 |    10 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mock.go:30                                         |
| │ │                 └─github.com/pingcap/tidb/store/mockstore/mocktikv.NewMVCCLevelDB                             | 42.43%      | 100%        |          1 |    11 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mvcc_leveldb.go:124                                |
| │ │                   └─github.com/pingcap/goleveldb/leveldb.OpenFile                                             | 42.43%      | 100%        |          1 |    12 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db.go:216                    |
| │ │                     └─github.com/pingcap/goleveldb/leveldb.Open                                               | 42.43%      | 100%        |          1 |    13 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db.go:194                    |
| │ │                       └─github.com/pingcap/goleveldb/leveldb.openDB                                           | 42.43%      | 100%        |          1 |    14 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db.go:122                    |
| │ │                         ├─github.com/pingcap/goleveldb/leveldb.(*DB).recoverJournal                           | 4.88%       | 11.50%      |          1 |    15 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db.go:617                    |
| │ │                         │ └─github.com/pingcap/goleveldb/leveldb.(*session).commit                            | 4.88%       | 100%        |          1 |    16 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/session.go:199               |
| │ │                         │   └─github.com/pingcap/goleveldb/leveldb.(*session).newManifest                     | 4.88%       | 100%        |          1 |    17 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/session_util.go:198          |
| │ │                         │     └─github.com/pingcap/goleveldb/leveldb/journal.NewWriter                        | 4.88%       | 100%        |          1 |    18 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/journal/journal.go:370       |
| │ │                         └─github.com/pingcap/goleveldb/leveldb.(*DB).recoverJournal                           | 37.55%      | 88.50%      |          1 |    15 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db.go:610                    |
| │ │                           └─github.com/pingcap/goleveldb/leveldb.(*DB).newMem                                 | 37.55%      | 100%        |          1 |    16 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db_state.go:147              |
| │ │                             └─github.com/pingcap/goleveldb/leveldb.(*DB).mpoolGet                             | 37.55%      | 100%        |          1 |    17 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db_state.go:90               |
| │ │                               └─github.com/pingcap/goleveldb/leveldb/memdb.New                                | 37.55%      | 100%        |          1 |    18 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/memdb/memdb.go:519           |
| │ └─main.main                                                                                                     | 4.73%       | 7.09%       |          1 |     2 | github.com/pingcap/tidb@/tidb-server/main.go:177                                                     |
| │   └─main.createServer                                                                                           | 4.73%       | 100%        |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:555                                                     |
| │     └─github.com/pingcap/tidb/server.NewServer                                                                  | 4.73%       | 100%        |          1 |     4 | github.com/pingcap/tidb@/server/server.go:200                                                        |
| │       └─github.com/pingcap/tidb/server.NewTokenLimiter                                                          | 4.73%       | 100%        |          1 |     5 | github.com/pingcap/tidb@/server/tokenlimiter.go:38                                                   |
| ├─runtime.main                                                                                                    | 23.90%      | 23.90%      |          2 |     1 | runtime/proc.go:190                                                                                  |
| │ └─runtime.doInit                                                                                                | 23.90%      | 100%        |          2 |     2 | runtime/proc.go:5217                                                                                 |
| │   └─runtime.doInit                                                                                              | 23.90%      | 100%        |          2 |     3 | runtime/proc.go:5217                                                                                 |
| │     ├─runtime.doInit                                                                                            | 19.20%      | 80.36%      |          2 |     4 | runtime/proc.go:5217                                                                                 |
| │     │ └─runtime.doInit                                                                                          | 19.20%      | 100%        |          2 |     5 | runtime/proc.go:5217                                                                                 |
| │     │   └─runtime.doInit                                                                                        | 19.20%      | 100%        |          2 |     6 | runtime/proc.go:5222                                                                                 |
| │     │     ├─github.com/pingcap/parser.init.0                                                                    | 4.70%       | 24.49%      |          2 |     7 | github.com/pingcap/parser@v0.0.0-20191025082927-f8adf1670b97/misc.go:114                             |
| │     │     │ └─github.com/pingcap/parser.initTokenString                                                         | 4.70%       | 100%        |          2 |     8 | github.com/pingcap/parser@v0.0.0-20191025082927-f8adf1670b97/misc.go:61                              |
| │     │     ├─github.com/pingcap/parser.init                                                                      | 4.88%       | 25.40%      |          2 |     7 | github.com/pingcap/parser@v0.0.0-20191025082927-f8adf1670b97/parser.go:691                           |
| │     │     ├─github.com/pingcap/parser.init                                                                      | 4.82%       | 25.11%      |          2 |     7 | github.com/pingcap/parser@v0.0.0-20191025082927-f8adf1670b97/parser.go:136                           |
| │     │     └─github.com/pingcap/tipb/go-tipb.init                                                                | 4.80%       | 25.01%      |          2 |     7 | github.com/pingcap/tipb@v0.0.0-20191015023537-709b39e7f8bb/go-tipb/expression.pb.go:1166             |
| │     └─runtime.doInit                                                                                            | 4.69%       | 19.64%      |          2 |     4 | runtime/proc.go:5222                                                                                 |
| │       └─github.com/pingcap/tidb/infoschema.init.0                                                               | 4.69%       | 100%        |          2 |     5 | github.com/pingcap/tidb@/infoschema/infoschema.go:375                                                |
| │         └─github.com/pingcap/tidb/infoschema.initInfoSchemaDB                                                   | 4.69%       | 100%        |          2 |     6 | github.com/pingcap/tidb@/infoschema/infoschema.go:386                                                |
| │           └─github.com/pingcap/tidb/infoschema.buildTableMeta                                                   | 4.69%       | 100%        |          2 |     7 | github.com/pingcap/tidb@/infoschema/tables.go:124                                                    |
| │             └─github.com/pingcap/tidb/infoschema.buildColumnInfo                                                | 4.69%       | 100%        |          2 |     8 | github.com/pingcap/tidb@/infoschema/tables.go:117                                                    |
| ├─github.com/pingcap/tidb/server.(*Server).startHTTPServer                                                        | 4.75%       | 4.75%       |          3 |     1 | github.com/pingcap/tidb@/server/http_status.go:73                                                    |
| │ └─github.com/prometheus/client_golang/prometheus.Handler                                                        | 4.75%       | 100%        |          3 |     2 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:66                                     |
| │   └─github.com/prometheus/client_golang/prometheus.InstrumentHandler                                            | 4.75%       | 100%        |          3 |     3 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:162                                    |
| │     └─github.com/prometheus/client_golang/prometheus.InstrumentHandlerFunc                                      | 4.75%       | 100%        |          3 |     4 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:172                                    |
| │       └─github.com/prometheus/client_golang/prometheus.InstrumentHandlerFuncWithOpts                            | 4.75%       | 100%        |          3 |     5 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:242                                    |
| │         └─github.com/prometheus/client_golang/prometheus.NewSummary                                             | 4.75%       | 100%        |          3 |     6 | github.com/prometheus/client_golang@v0.9.0/prometheus/summary.go:171                                 |
| │           └─github.com/prometheus/client_golang/prometheus.newSummary                                           | 4.75%       | 100%        |          3 |     7 | github.com/prometheus/client_golang@v0.9.0/prometheus/summary.go:233                                 |
| │             └─github.com/prometheus/client_golang/prometheus.(*summary).newStream                               | 4.75%       | 100%        |          3 |     8 | github.com/prometheus/client_golang@v0.9.0/prometheus/summary.go:330                                 |
| │               └─github.com/beorn7/perks/quantile.NewTargeted                                                    | 4.75%       | 100%        |          3 |     9 | github.com/beorn7/perks@v0.0.0-20180321164747-3a771d992973/quantile/stream.go:101                    |
| │                 └─github.com/beorn7/perks/quantile.newStream                                                    | 4.75%       | 100%        |          3 |    10 | github.com/beorn7/perks@v0.0.0-20180321164747-3a771d992973/quantile/stream.go:133                    |
| └─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).run                                                     | 4.69%       | 4.69%       |          4 |     1 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:452                                               |
|   └─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTask                                            | 4.69%       | 100%        |          4 |     2 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:624                                               |
|     └─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTaskOnce                                      | 4.69%       | 100%        |          4 |     3 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:660                                               |
|       └─github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).SendReqCtx                                      | 4.69%       | 100%        |          4 |     4 | github.com/pingcap/tidb@/store/tikv/region_request.go:140                                            |
|         └─github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).sendReqToRegion                               | 4.69%       | 100%        |          4 |     5 | github.com/pingcap/tidb@/store/tikv/region_request.go:170                                            |
|           └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*RPCClient).SendRequest                             | 4.69%       | 100%        |          4 |     6 | github.com/pingcap/tidb@/store/mockstore/mocktikv/rpc.go:934                                         |
|             └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*rpcHandler).handleCopDAGRequest                  | 4.69%       | 100%        |          4 |     7 | github.com/pingcap/tidb@/store/mockstore/mocktikv/cop_handler_dag.go:70                              |
|               └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*indexScanExec).Next                            | 4.69%       | 100%        |          4 |     8 | github.com/pingcap/tidb@/store/mockstore/mocktikv/executor.go:341                                    |
|                 └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*indexScanExec).getRowFromRange               | 4.69%       | 100%        |          4 |     9 | github.com/pingcap/tidb@/store/mockstore/mocktikv/executor.go:385                                    |
|                   └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*MVCCLevelDB).Scan                          | 4.69%       | 100%        |          4 |    10 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mvcc_leveldb.go:352                                |
|                     └─github.com/pingcap/tidb/store/mockstore/mocktikv.getValue                                   | 4.69%       | 100%        |          4 |    11 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mvcc_leveldb.go:294                                |
|                       └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*valueDecoder).Decode                   | 4.69%       | 100%        |          4 |    12 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mvcc_leveldb.go:237                                |
|                         └─github.com/pingcap/tidb/store/mockstore/mocktikv.(*Iterator).Next                       | 4.69%       | 100%        |          4 |    13 | github.com/pingcap/tidb@/store/mockstore/mocktikv/mvcc_leveldb.go:138                                |
|                           └─github.com/pingcap/goleveldb/leveldb.(*dbIter).Next                                   | 4.69%       | 100%        |          4 |    14 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/db_iter.go:240               |
|                             └─github.com/pingcap/goleveldb/leveldb/iterator.(*mergedIterator).Next                | 4.69%       | 100%        |          4 |    15 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/iterator/merged_iter.go:169  |
|                               └─github.com/pingcap/goleveldb/leveldb/iterator.(*indexedIterator).Next             | 4.69%       | 100%        |          4 |    16 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/iterator/indexed_iter.go:149 |
|                                 └─github.com/pingcap/goleveldb/leveldb/iterator.(*indexedIterator).Next           | 4.69%       | 100%        |          4 |    17 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/iterator/indexed_iter.go:160 |
|                                   └─github.com/pingcap/goleveldb/leveldb/iterator.(*indexedIterator).setData      | 4.69%       | 100%        |          4 |    18 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/iterator/indexed_iter.go:39  |
|                                     └─github.com/pingcap/goleveldb/leveldb/table.(*indexIter).Get                 | 4.69%       | 100%        |          4 |    19 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/table/reader.go:507          |
|                                       └─github.com/pingcap/goleveldb/leveldb/table.(*Reader).getDataIterErr       | 4.69%       | 100%        |          4 |    20 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/table/reader.go:780          |
|                                         └─github.com/pingcap/goleveldb/leveldb/table.(*Reader).getDataIter        | 4.69%       | 100%        |          4 |    21 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/table/reader.go:769          |
|                                           └─github.com/pingcap/goleveldb/leveldb/table.(*Reader).newBlockIter     | 4.69%       | 100%        |          4 |    22 | github.com/pingcap/goleveldb@v0.0.0-20171020122428-b9ff6c35079e/leveldb/table/reader.go:736          |
+-------------------------------------------------------------------------------------------------------------------+-------------+-------------+------------+-------+------------------------------------------------------------------------------------------------------+
97 rows in set (0.09 sec)
```

And we can filter some leavies easily.
```
mysql> select * from performance_schema.tidb_profile_memory where depth < 5;
+------------------------------------------------------------------------------------+-------------+-------------+------------+-------+-------------------------------------------------------------------+
| FUNCTION                                                                           | PERCENT_ABS | PERCENT_REL | ROOT_CHILD | DEPTH | FILE                                                              |
+------------------------------------------------------------------------------------+-------------+-------------+------------+-------+-------------------------------------------------------------------+
| root                                                                               | 100%        | 100%        |          0 |     0 | root                                                              |
| ├─runtime.main                                                                     | 63.67%      | 63.67%      |          1 |     1 | runtime/proc.go:203                                               |
| │ ├─main.main                                                                      | 4.52%       | 7.09%       |          1 |     2 | github.com/pingcap/tidb@/tidb-server/main.go:177                  |
| │ │ └─main.createServer                                                            | 4.52%       | 100%        |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:555                  |
| │ │   └─github.com/pingcap/tidb/server.NewServer                                   | 4.52%       | 100%        |          1 |     4 | github.com/pingcap/tidb@/server/server.go:200                     |
| │ └─main.main                                                                      | 59.16%      | 92.91%      |          1 |     2 | github.com/pingcap/tidb@/tidb-server/main.go:176                  |
| │   ├─main.createStoreAndDomain                                                    | 40.53%      | 68.50%      |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:235                  |
| │   │ └─github.com/pingcap/tidb/store.New                                          | 40.53%      | 100%        |          1 |     4 | github.com/pingcap/tidb@/store/store.go:51                        |
| │   └─main.createStoreAndDomain                                                    | 18.63%      | 31.50%      |          1 |     3 | github.com/pingcap/tidb@/tidb-server/main.go:238                  |
| │     └─github.com/pingcap/tidb/session.BootstrapSession                           | 18.63%      | 100%        |          1 |     4 | github.com/pingcap/tidb@/session/session.go:1579                  |
| ├─runtime.main                                                                     | 22.83%      | 22.83%      |          2 |     1 | runtime/proc.go:190                                               |
| │ └─runtime.doInit                                                                 | 22.83%      | 100%        |          2 |     2 | runtime/proc.go:5217                                              |
| │   └─runtime.doInit                                                               | 22.83%      | 100%        |          2 |     3 | runtime/proc.go:5217                                              |
| │     ├─runtime.doInit                                                             | 4.48%       | 19.64%      |          2 |     4 | runtime/proc.go:5222                                              |
| │     └─runtime.doInit                                                             | 18.34%      | 80.36%      |          2 |     4 | runtime/proc.go:5217                                              |
| ├─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).run                      | 8.96%       | 8.96%       |          3 |     1 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:452            |
| │ └─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTask             | 8.96%       | 100%        |          3 |     2 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:624            |
| │   └─github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTaskOnce       | 8.96%       | 100%        |          3 |     3 | github.com/pingcap/tidb@/store/tikv/coprocessor.go:660            |
| │     └─github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).SendReqCtx       | 8.96%       | 100%        |          3 |     4 | github.com/pingcap/tidb@/store/tikv/region_request.go:140         |
| └─github.com/pingcap/tidb/server.(*Server).startHTTPServer                         | 4.53%       | 4.53%       |          4 |     1 | github.com/pingcap/tidb@/server/http_status.go:73                 |
|   └─github.com/prometheus/client_golang/prometheus.Handler                         | 4.53%       | 100%        |          4 |     2 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:66  |
|     └─github.com/prometheus/client_golang/prometheus.InstrumentHandler             | 4.53%       | 100%        |          4 |     3 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:162 |
|       └─github.com/prometheus/client_golang/prometheus.InstrumentHandlerFunc       | 4.53%       | 100%        |          4 |     4 | github.com/prometheus/client_golang@v0.9.0/prometheus/http.go:172 |
+------------------------------------------------------------------------------------+-------------+-------------+------------+-------+-------------------------------------------------------------------+
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change


Related changes

 - Need to update the documentation

Release note

 - [feature] Support query cpu/memory/mutex/block/allocs/goroutines flamegraph by SQL.

