### PR TITLE
executor: update exeuctor cache for point update prepare statements

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1377,6 +1377,7 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {
 		tblID2table:               tblID2table,
 		tblColPosInfos:            v.TblColPosInfos,
 	}
+	updateExec.Init(v)
 	return updateExec
 }
 

--- a/executor/update.go
+++ b/executor/update.go
@@ -52,6 +52,24 @@ type UpdateExec struct {
 	allAssignmentsAreConstant bool
 }
 
+// Init do reset on some fields based input update plan, this is ONLY used for point update
+// with prepare statement cached execution
+func (e *UpdateExec) Init(v *plannercore.Update) {
+	e.OrderedList = v.OrderedList
+
+	e.updatedRowKeys = nil
+
+	e.rows = nil
+	e.newRowsData = nil
+
+	e.fetched = false
+	e.cursor = 0
+	e.matched = 0
+
+	e.tblColPosInfos = v.TblColPosInfos
+	e.allAssignmentsAreConstant = v.AllAssignmentsAreConstant
+}
+
 func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema) ([]types.Datum, error) {
 	assignFlag, err := e.getUpdateColumns(e.ctx, schema.Len())
 	if err != nil {

--- a/executor/update.go
+++ b/executor/update.go
@@ -56,16 +56,12 @@ type UpdateExec struct {
 // with prepare statement cached execution
 func (e *UpdateExec) Init(v *plannercore.Update) {
 	e.OrderedList = v.OrderedList
-
 	e.updatedRowKeys = nil
-
 	e.rows = nil
 	e.newRowsData = nil
-
 	e.fetched = false
 	e.cursor = 0
 	e.matched = 0
-
 	e.tblColPosInfos = v.TblColPosInfos
 	e.allAssignmentsAreConstant = v.AllAssignmentsAreConstant
 }

--- a/session/session.go
+++ b/session/session.go
@@ -1217,6 +1217,7 @@ func (s *session) CachedPlanExec(ctx context.Context,
 	case *plannercore.Update:
 		s.PrepareTxnFuture(ctx)
 		s.GetSessionVars().StmtCtx.Priority = kv.PriorityHigh
+		stmt.CachedPointUpdate = true
 		resultSet, err = runStmt(ctx, s, stmt)
 	default:
 		prepared.CachedPlan = nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

try to increase update index/non index like scenario reusing executor for prepared cached execution

### What is changed and how it works?

Like point select, store point update executor for prepare statement cached  execution.
This does not take effect that much like point select, besides the change will increase the complexity.

@jackysp @coocood PTAL do we refactor this like point select?

common
```
Total:       280ms      9.63s (flat, cum)  2.01%
 637         20ms       20ms           func (a *ExecStmt) buildExecutor() (Executor, error) { 
...
    672         10ms       80ms           	b := newExecutorBuilder(ctx, a.InfoSchema) 
    673         40ms      9.02s           	e := b.build(a.Plan) 
    674         60ms       60ms           	if b.err != nil { 
    675            .          .           		return nil, errors.Trace(b.err) 
...

```

dev
```
Total:       130ms      5.96s (flat, cum)  1.22%
    682            .          .           func (a *ExecStmt) buildExecutor() (Executor, error) {
...
     719         10ms       10ms           	if a.PsStmt != nil && a.PsStmt.Executor != nil { 
    720         20ms      5.61s           		e, err = a.TryReuseUpdateExecutor() 
    721            .          .           		if err != nil { 
    722            .          .           			return nil, err 
    723            .          .           		} 
    724            .          .           		if e != nil { 
    725         40ms       40ms           			return e, nil 
    726            .          .           		} 
    727            .          .           	}
... 
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects
- increase the code complexity

Related changes



Release note


