### PR TITLE
docker: update go version to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Builder image
-FROM golang:1.12-alpine as builder
+FROM golang:1.13-alpine as builder
 
 RUN apk add --no-cache \
     wget \


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists--> 

fix build tidb image issue
```
go: finding golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
go: error loading module requirements
The command '/bin/sh -c GO111MODULE=on go mod download' returned a non-zero code: 1
```

### What is changed and how it works?
update go version  to 1.13 

```
docker build -t hub.pingcap.net/cwen/tidb:latest . 
...
Successfully built 532658314be8
Successfully tagged hub.pingcap.net/cwen/tidb:latest
```

