### PR TITLE
planner/cascades: make DeriveStats usable in cascades planner

### DIFF
--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -104,7 +104,9 @@ type LogicalPlan interface {
 	recursiveDeriveStats() (*property.StatsInfo, error)
 
 	// DeriveStats derives statistic info for current plan node given child stats.
-	DeriveStats(childStats []*property.StatsInfo) (*property.StatsInfo, error)
+	// We need selfSchema, childSchema here because it makes this method can be used in
+	// cascades planner, where LogicalPlan might not record its children or schema.
+	DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error)
 
 	// preparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR changes the LogicalPlan interface `DeriveStats` to be used in cascades planner.

### What is changed and how it works?

`DeriveStats` may use the plan's `children` and `Schema`. But in cascades planner, LogicalPlan might not have these.

This PR changes the `DeriveStats(childStats []*property.StatsInfo) (*property.StatsInfo, error)` interface to `DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error)`. And replace `p.Schema()` with `selfSchema`, `p.children[0].Schema()` with `p.childSchema[0]`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code, difficult to build a test case, will be testes in the future development of cascades planner.

Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity

