### PR TITLE
fix ConvertJSONToInt unsigned bug (#11483)

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2062,6 +2062,7 @@ func (s *testIntegrationSuite) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("2017-01-01 00:00:00.00"))
 	result = tk.MustQuery(`select cast(20170118.999 as datetime);`)
 	result.Check(testkit.Rows("2017-01-18 00:00:00"))
+	tk.MustQuery(`select convert(a2.a, unsigned int) from (select cast('"9223372036854775808"' as json) as a) as a2;`)
 
 	tk.MustExec(`create table tb5(a bigint(64) unsigned, b double);`)
 	tk.MustExec(`insert into tb5 (a, b) values (9223372036854776000, 9223372036854776000);`)

--- a/types/convert.go
+++ b/types/convert.go
@@ -537,7 +537,12 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 		u, err := ConvertFloatToUint(sc, f, bound, mysql.TypeLonglong)
 		return int64(u), errors.Trace(err)
 	case json.TypeCodeString:
-		return StrToInt(sc, hack.String(j.GetString()))
+		str := string(hack.String(j.GetString()))
+		if !unsigned {
+			return StrToInt(sc, str)
+		}
+		u, err := StrToUint(sc, str)
+		return int64(u), errors.Trace(err)
 	}
 	return 0, errors.New("Unknown type code in JSON")
 }


### PR DESCRIPTION
cherry-pick  #11483 to release 2.1

-------------
Signed-off-by: H-ZeX <hzx20112012@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

The origin `ConvertJSONToInt` will fail in this sql `select convert(a2.a, unsigned int) from (select cast('"9223372036854775808"' as json) as a) as a2;`


### What is changed and how it works?

call `StrToInt` or `StrToUint` according to the param `unsigned`. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

No

Side effects

No.

Related changes

No.