### PR TITLE
store: return empty response in `FromBatchCommandsResponse()`

### DIFF
--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -445,7 +445,7 @@ func FromBatchCommandsResponse(res *tikvpb.BatchCommandsResponse_Response) *Resp
 	case *tikvpb.BatchCommandsResponse_Response_CheckTxnStatus:
 		return &Response{Resp: res.CheckTxnStatus}
 	}
-	return nil
+	return &Response{}
 }
 
 // CopStreamResponse combinates tikvpb.Tikv_CoprocessorStreamClient and the first Recv() result together.


### PR DESCRIPTION
Fixes #13053

The new version SDK supports the large transaction and introduces the `CheckTxnStatus` command which is not supported on old TiKV versions. So TiKV can not reply with a proper response. The SDK returns a nil resp if it did not get the right response, and causes the panic.

From the design of go's error handling, we should use error to indicates something wrong, if the returned `err` is nil, the extra returned value should not be nil.

Signed-off-by: Shafreeck Sea <shafreeck@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix panic of TiKV SDK

### What is changed and how it works?

Return an empty object, not nil when receiving an unknown response.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
