### PR TITLE
tikv: fix out-of-index in split-region (#12265)

### DIFF
--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/stringutil"
 	"go.uber.org/zap"
 )
 
@@ -153,7 +154,12 @@ func (s *tikvStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bo
 	logutil.Logger(context.Background()).Info("batch split regions complete",
 		zap.Uint64("batch region ID", batch.regionID.id),
 		zap.Binary("first at", batch.keys[0]),
-		zap.Stringer("first new region left", spResp.Regions[0]),
+		zap.Stringer("first new region left", stringutil.MemoizeStr(func() string {
+			if len(spResp.Regions) == 0 {
+				return ""
+			}
+			return spResp.Regions[0].String()
+		})),
 		zap.Int("new region count", len(spResp.Regions)))
 
 	if !scatter {


### PR DESCRIPTION
cherry-pick #12265 to 3.0

```
# Conflicts:
#	store/tikv/split_region.go
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/13092)
<!-- Reviewable:end -->
