### PR TITLE
planner: use ExtraHandleColumn as PK when generating TablePath (#11959)

### DIFF
--- a/cmd/explaintest/r/access_path_selection.result
+++ b/cmd/explaintest/r/access_path_selection.result
@@ -44,3 +44,15 @@ IndexLookUp_11	0.00	root
 ├─IndexScan_8	1.00	cop	table:outdated_statistics, index:a, b, range:[1 1,1 1], keep order:false
 └─Selection_10	0.00	cop	eq(test.outdated_statistics.c, 1)
   └─TableScan_9	1.00	cop	table:outdated_statistics, keep order:false
+explain select a, b from access_path_selection order by _tidb_rowid;
+id	count	task	operator info
+Projection_5	10000.00	root	test.access_path_selection.a, test.access_path_selection.b
+└─TableReader_11	10000.00	root	data:TableScan_10
+  └─TableScan_10	10000.00	cop	table:access_path_selection, range:[-inf,+inf], keep order:true, stats:pseudo
+explain select max(_tidb_rowid) from access_path_selection;
+id	count	task	operator info
+StreamAgg_13	1.00	root	funcs:max(test.access_path_selection._tidb_rowid)
+└─Limit_17	1.00	root	offset:0, count:1
+  └─TableReader_42	1.00	root	data:Limit_41
+    └─Limit_41	1.00	cop	offset:0, count:1
+      └─TableScan_40	1.25	cop	table:access_path_selection, range:[-inf,+inf], keep order:true, desc, stats:pseudo

--- a/cmd/explaintest/t/access_path_selection.test
+++ b/cmd/explaintest/t/access_path_selection.test
@@ -35,3 +35,6 @@ insert into outdated_statistics values (1, 3, 3);
 # result after Skyline Pruning is introduced.
 analyze table outdated_statistics index idx_ab;
 explain select * from outdated_statistics where a=1 and b=1 and c=1;
+# _tidb_rowid should also be considered as PK.
+explain select a, b from access_path_selection order by _tidb_rowid;
+explain select max(_tidb_rowid) from access_path_selection;

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -613,6 +613,12 @@ func isColEqCorColOrConstant(filter expression.Expression, col *expression.Colum
 
 func (ds *DataSource) getPKIsHandleCol() *expression.Column {
 	if !ds.tableInfo.PKIsHandle {
+		// If the PKIsHandle is false, return the ExtraHandleColumn.
+		for i, col := range ds.Columns {
+			if col.ID == model.ExtraHandleID {
+				return ds.schema.Columns[i]
+			}
+		}
 		return nil
 	}
 	for i, col := range ds.Columns {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Cherry pick #11959 to branch release-3.0


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

Release note

When the table uses `_tidb_rowid` as Handle, we can correctly generate a TableScan that keeps the order of `_tidb_rowid`.  For example, `select max(_tidb_rowid) from t` won't require a `Sort` anymore.
