### PR TITLE
store/tikv: do not backoff when PessimisticLock return locked error

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -719,15 +719,12 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			}
 			locks = append(locks, lock)
 		}
-		var expire int64
-		expire, err = c.store.lockResolver.ResolveLocks(bo, c.startTS, locks)
+		// Because we already waited on tikv, no need to Backoff here.
+		_, err = c.store.lockResolver.ResolveLocks(bo, c.startTS, locks)
 		if err != nil {
 			return errors.Trace(err)
 		}
 
-		if err1 := bo.BackoffWithMaxSleep(BoTxnLock, int(expire), errors.New(locks[0].String())); err1 != nil {
-			return err1
-		}
 		// Handle the killed flag when waiting for the pessimistic lock.
 		// When a txn runs into LockKeys() and backoff here, it has no chance to call
 		// executor.Next() and check the killed flag.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When PessimisticLock gets a locked error, TiKV has already back off before returning the response, so it's unnecessary to back off again in TiDB.

### What is changed and how it works?

Reset the change here:

https://github.com/pingcap/tidb/pull/12852/files#diff-499c236856cd9ce3300d3f5ccde41a23R721


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
