### PR TITLE
planner: fix bug cost model for tiflash do not work

### DIFF
--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pingcap/parser/model"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -1017,4 +1018,38 @@ func (s *testAnalyzeSuite) TestUpdateProjEliminate(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int)")
 	tk.MustExec("explain update t t1, (select distinct b from t) t2 set t1.b = t2.b")
+}
+
+func (s *testAnalyzeSuite) TestTiFlashCostModel(c *C) {
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int, b int, c int, primary key(a))")
+	tk.MustExec("insert into t values(1,1,1), (2,2,2), (3,3,3)")
+
+	tbl, err := dom.InfoSchema().TableByName(model.CIStr{"test", "test"}, model.CIStr{"t", "t"})
+	c.Assert(err, IsNil)
+	// Set the hacked TiFlash replica for explain tests.
+	tbl.Meta().TiFlashReplica = &model.TiFlashReplicaInfo{Count: 1, Available: true}
+
+	tk.MustQuery("desc select * from t").Check(testkit.Rows(
+		"TableReader_7 10000.00 root data:TableScan_6",
+		"└─TableScan_6 10000.00 cop[tiflash] table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
+	))
+	tk.MustQuery("desc select * from t where t.a = 1 or t.a = 2").Check(testkit.Rows(
+		"TableReader_6 2.00 root data:TableScan_5",
+		"└─TableScan_5 2.00 cop[tikv] table:t, range:[1,1], [2,2], keep order:false, stats:pseudo",
+	))
+	tk.MustExec("set @@session.tidb_isolation_read_engines='tiflash'")
+	tk.MustQuery("desc select * from t where t.a = 1 or t.a = 2").Check(testkit.Rows(
+		"TableReader_7 2.00 root data:Selection_6",
+		"└─Selection_6 2.00 cop[tiflash] or(eq(Column#1, 1), eq(Column#1, 2))",
+		"  └─TableScan_5 2.00 cop[tiflash] table:t, range:[-inf,+inf], keep order:false, stats:pseudo",
+	))
 }

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/parser/model"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -25,6 +24,7 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -1033,7 +1033,7 @@ func (s *testAnalyzeSuite) TestTiFlashCostModel(c *C) {
 	tk.MustExec("create table t (a int, b int, c int, primary key(a))")
 	tk.MustExec("insert into t values(1,1,1), (2,2,2), (3,3,3)")
 
-	tbl, err := dom.InfoSchema().TableByName(model.CIStr{"test", "test"}, model.CIStr{"t", "t"})
+	tbl, err := dom.InfoSchema().TableByName(model.CIStr{O: "test", L: "test"}, model.CIStr{O: "t", L: "t"})
 	c.Assert(err, IsNil)
 	// Set the hacked TiFlash replica for explain tests.
 	tbl.Meta().TiFlashReplica = &model.TiFlashReplicaInfo{Count: 1, Available: true}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -985,12 +985,6 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 		return invalidTask, nil
 	}
 	ts, cost, _ := ds.getOriginalPhysicalTableScan(prop, candidate.path, candidate.isMatchProp)
-	if ds.preferStoreType&preferTiFlash != 0 && ts.StoreType == kv.TiKV {
-		return invalidTask, nil
-	}
-	if ds.preferStoreType&preferTiKV != 0 && ts.StoreType == kv.TiFlash {
-		return invalidTask, nil
-	}
 	copTask := &copTask{
 		tablePlan:         ts,
 		indexPlanFinished: true,
@@ -1034,6 +1028,12 @@ func (ds *DataSource) getOriginalPhysicalTableScan(prop *property.PhysicalProper
 		filterCondition: path.tableFilters,
 		StoreType:       path.storeType,
 	}.Init(ds.ctx, ds.blockOffset)
+	if ds.preferStoreType&preferTiFlash != 0 {
+		ts.StoreType = kv.TiFlash
+	}
+	if ds.preferStoreType&preferTiKV != 0 {
+		ts.StoreType = kv.TiKV
+	}
 	if ts.StoreType == kv.TiFlash {
 		ts.filterCondition = append(ts.filterCondition, ts.AccessCondition...)
 		ts.AccessCondition = nil


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
As the title says.

### What is changed and how it works?
Decouple the logic with hint `read_from_storage`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

A simple test for after the PR:
```sql
tidb(localhost:4001) > create table t (a int, b int, c int, primary key(a));
Query OK, 0 rows affected (1.04 sec)

tidb(localhost:4001) > insert into t values(1,1,1),(2,2,2),(3,3,4);
Query OK, 3 rows affected (0.02 sec)
Records: 3  Duplicates: 0  Warnings: 0

tidb(localhost:4001) > alter table t set tiflash replica 1 location labels 'rack', 'host', 'abc';
Query OK, 0 rows affected (1.03 sec)

tidb(localhost:4001) > desc select * from t;
+-------------------+-------+--------------+----------------------------------------------+
| id                | count | task         | operator info                                |
+-------------------+-------+--------------+----------------------------------------------+
| TableReader_7     | 3.00  | root         | data:TableScan_6                             |
| └─TableScan_6     | 3.00  | cop[tiflash] | table:t, range:[-inf,+inf], keep order:false |
+-------------------+-------+--------------+----------------------------------------------+
2 rows in set (0.00 sec)

tidb(localhost:4001) > desc select * from t where t.a = 1 or t.a = 2;
+-------------------+-------+-----------+-----------------------------------------------+
| id                | count | task      | operator info                                 |
+-------------------+-------+-----------+-----------------------------------------------+
| TableReader_6     | 1.50  | root      | data:TableScan_5                              |
| └─TableScan_5     | 1.50  | cop[tikv] | table:t, range:[1,1], [2,2], keep order:false |
+-------------------+-------+-----------+-----------------------------------------------+
2 rows in set (0.00 sec)

tidb(localhost:4001) > set @@session.tidb_isolation_read_engines="tiflash";
Query OK, 0 rows affected (0.00 sec)

tidb(localhost:4001) > desc select * from t where t.a = 1 or t.a = 2;
+---------------------+-------+--------------+----------------------------------------------+
| id                  | count | task         | operator info                                |
+---------------------+-------+--------------+----------------------------------------------+
| TableReader_7       | 1.50  | root         | data:Selection_6                             |
| └─Selection_6       | 1.50  | cop[tiflash] | or(eq(Column#1, 1), eq(Column#1, 2))         |
|   └─TableScan_5     | 1.50  | cop[tiflash] | table:t, range:[-inf,+inf], keep order:false |
+---------------------+-------+--------------+----------------------------------------------+
3 rows in set (0.00 sec)
```