### PR TITLE
expression: implement vectorized evaluation for `builtinVersionSig`

### DIFF
--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -143,10 +143,10 @@ func (b *builtinVersionSig) vectorized() bool {
 
 func (b *builtinVersionSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
+	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		result.AppendString(mysql.ServerVersion)
 	}
-
 	return nil
 }
 

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -137,11 +138,16 @@ func (b *builtinLastInsertIDWithIDSig) vecEvalInt(input *chunk.Chunk, result *ch
 }
 
 func (b *builtinVersionSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinVersionSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	for i := 0; i < n; i++ {
+		result.AppendString(mysql.ServerVersion)
+	}
+
+	return nil
 }
 
 func (b *builtinTiDBDecodeKeySig) vectorized() bool {

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -22,7 +22,9 @@ import (
 )
 
 var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
-	ast.Version:     {},
+	ast.Version: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{}},
+	},
 	ast.TiDBVersion: {},
 	ast.CurrentUser: {},
 	ast.FoundRows:   {},

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
+	ast.Version:     {},
 	ast.TiDBVersion: {},
 	ast.CurrentUser: {},
 	ast.FoundRows:   {},


### PR DESCRIPTION
PCP #12106

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#12106

### What is changed and how it works?

vectorize `builtinVersionSig`

```
BenchmarkVectorizedBuiltinInfoFunc/builtinVersionSig-VecBuiltinFunc-4         	  126724	      9617 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinInfoFunc/builtinVersionSig-NonVecBuiltinFunc-4      	   59805	     18713 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	2.691s
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

Release note

vectorize `builtinVersionSIg`