### PR TITLE
expression: implement vectorized evaluation for `builtinCRC32Sig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -674,11 +674,9 @@ func (b *builtinCRC32Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 	}
 	result.ResizeInt64(n, false)
 	i64s := result.Int64s()
+	result.MergeNulls(buf)
 	for i := range i64s {
-		if buf.IsNull(i) {
-			i64s[i] = 0
-			result.SetNull(i, true)
-		} else {
+		if !buf.IsNull(i) {
 			i64s[i] = int64(crc32.ChecksumIEEE(buf.GetBytes(i)))
 		}
 	}

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"fmt"
+	"hash/crc32"
 	"math"
 	"strconv"
 
@@ -658,11 +659,29 @@ func (b *builtinRoundWithFracIntSig) vectorized() bool {
 	return true
 }
 func (b *builtinCRC32Sig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCRC32Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, false)
+	i64s := result.Int64s()
+	for i := range i64s {
+		if buf.IsNull(i) {
+			i64s[i] = 0
+		} else {
+			i64s[i] = int64(crc32.ChecksumIEEE(buf.GetBytes(i)))
+		}
+	}
+	return nil
 }
 
 func (b *builtinPISig) vectorized() bool {

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -677,6 +677,7 @@ func (b *builtinCRC32Sig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 	for i := range i64s {
 		if buf.IsNull(i) {
 			i64s[i] = 0
+			result.SetNull(i, true)
 		} else {
 			i64s[i] = int64(crc32.ChecksumIEEE(buf.GetBytes(i)))
 		}

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -112,7 +112,6 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	},
 	ast.CRC32: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&defaultGener{1.0, types.ETString}}},
 	},
 }
 

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -110,6 +110,10 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24, Flag: mysql.UnsignedFlag}}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 	},
+	ast.CRC32: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&defaultGener{1.0, types.ETString}}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinMathEvalOneVec(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinIsIPv4MappedSig , for #12103 

### What is changed and how it works?
```
go test -v -benchmem -bench=BenchmarkVectorizedBuiltinMathFunc -run=BenchmarkVectorizedBuiltinMathFunc -args "builtinCRC32Sig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMathFunc/builtinCRC32Sig-VecBuiltinFunc-12               47541             26448 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinCRC32Sig-NonVecBuiltinFunc-12            15898             81080 ns/op           16736 B/op        804 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.581s
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
