### PR TITLE
expression: implement vectorized evaluation for `builtinMicroSecondSig`

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -509,11 +509,30 @@ func (b *builtinFromDaysSig) vecEvalTime(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinMicroSecondSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinMicroSecondSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err = b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ResizeInt64(n, false)
+	result.MergeNulls(buf)
+	i64s := result.Int64s()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		i64s[i] = int64(buf.GetDuration(i, int(types.UnspecifiedFsp)).Microseconds())
+	}
+	return nil
 }
 
 func (b *builtinSubDatetimeAndStringSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -62,7 +62,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.ToSeconds: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
-	ast.MicroSecond: {},
+	ast.MicroSecond: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDuration}, geners: []dataGenerator{&rangeDurationGener{0.2}}},
+	},
 	ast.Now:         {},
 	ast.DayOfWeek: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinQuarterSig

### What is changed and how it works?
goos: windows
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFunc/builtinMicroSecondSig-VecBuiltinFunc-4                    1000000000               0.0110 ns/op          0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinMicroSecondSig-NonVecBuiltinFunc-4                    1000000000               0.0130 ns/op          0 B/op          0 allocs/op

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test