### PR TITLE
expression: implement vectorized evaluation for builtinRandSig

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -698,11 +698,17 @@ func (b *builtinPISig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) err
 }
 
 func (b *builtinRandSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinRandSig) vecEvalReal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	f64s := result.Float64s()
+	for i := range f64s {
+		b.mu.Lock()
+		f64s[i] = b.randGen.Float64()
+		b.mu.Unlock()
+	}
+	return nil
 }
 
 func (b *builtinRandWithSeedSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -105,6 +105,9 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 	ast.PI: {
 		{retEvalType: types.ETReal},
 	},
+	ast.Rand: {
+		{retEvalType: types.ETReal},
+	},
 	ast.Truncate: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
expression: implement vectorized evaluation for builtinRandSig

### What is changed and how it works?
    BenchmarkVectorizedBuiltinMathFunc/builtinRandSig-VecBuiltinFunc-4              50145840                23.7 ns/op             0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinMathFunc/builtinRandSig-NonVecBuiltinFunc-4              41485             28897 ns/op               0 B/op          0 allocs/op


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
