### PR TITLE
expression: implement vectorized evaluation for `builtinTiDBIsDDLOwnerSig`

### DIFF
--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -98,11 +98,21 @@ func (b *builtinUserSig) vecEvalString(input *chunk.Chunk, result *chunk.Column)
 }
 
 func (b *builtinTiDBIsDDLOwnerSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTiDBIsDDLOwnerSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	var res int64
+	if b.ctx.DDLOwnerChecker().IsOwner() {
+		res = 1
+	}
+	result.ResizeInt64(n, false)
+	i64s := result.Int64s()
+	for i := 0; i < n; i++ {
+		i64s[i] = res
+	}
+	return nil
 }
 
 func (b *builtinFoundRowsSig) vectorized() bool {

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -103,8 +103,9 @@ func (b *builtinTiDBIsDDLOwnerSig) vectorized() bool {
 
 func (b *builtinTiDBIsDDLOwnerSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
+	ddlOwnerChecker := b.ctx.DDLOwnerChecker()
 	var res int64
-	if b.ctx.DDLOwnerChecker().IsOwner() {
+	if ddlOwnerChecker.IsOwner() {
 		res = 1
 	}
 	result.ResizeInt64(n, false)

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -37,7 +37,9 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	ast.TiDBDecodeKey:  {},
 	ast.RowCount:       {},
 	ast.CurrentRole:    {},
-	ast.TiDBIsDDLOwner: {},
+	ast.TiDBIsDDLOwner: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
+	},
 	ast.ConnectionID:   {},
 	ast.LastInsertId: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -33,14 +33,14 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	ast.Database: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{}},
 	},
-	ast.User:           {},
-	ast.TiDBDecodeKey:  {},
-	ast.RowCount:       {},
-	ast.CurrentRole:    {},
+	ast.User:          {},
+	ast.TiDBDecodeKey: {},
+	ast.RowCount:      {},
+	ast.CurrentRole:   {},
 	ast.TiDBIsDDLOwner: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
 	},
-	ast.ConnectionID:   {},
+	ast.ConnectionID: {},
 	ast.LastInsertId: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -63,9 +63,13 @@ func (c *Context) Execute(ctx context.Context, sql string) ([]sqlexec.RecordSet,
 	return nil, errors.Errorf("Not Support.")
 }
 
+type mockDDLOwnerChecker struct{}
+
+func (c *mockDDLOwnerChecker) IsOwner() bool { return true }
+
 // DDLOwnerChecker returns owner.DDLOwnerChecker.
 func (c *Context) DDLOwnerChecker() owner.DDLOwnerChecker {
-	return nil
+	return &mockDDLOwnerChecker{}
 }
 
 // SetValue implements sessionctx.Context SetValue interface.


### PR DESCRIPTION
PCP #12103 

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#12103 

### What is changed and how it works?

vectorize `builtinTiDBIsDDLOwnerSig`

add `mockDDLOwnerChecker` for test.

```
make vectorized-bench VB_FILE=Info VB_FUNC=builtinTiDBIsDDLOwnerSig
cd ./expression && \
		go test -v -benchmem \
			-bench=BenchmarkVectorizedBuiltinInfoFunc \
			-run=BenchmarkVectorizedBuiltinInfoFunc \
			-args "builtinTiDBIsDDLOwnerSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinInfoFunc/builtinTiDBIsDDLOwnerSig-VecBuiltinFunc-4         	 2487384	       467 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinInfoFunc/builtinTiDBIsDDLOwnerSig-NonVecBuiltinFunc-4      	   88786	     13441 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.016s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes


Release note

 - vectorize `builtinTiDBIsDDLOwnerSig`
