### PR TITLE
expression: implement vectorization for builtinCoalesceRealSig

### DIFF
--- a/expression/builtin_compare_vec_test.go
+++ b/expression/builtin_compare_vec_test.go
@@ -61,8 +61,10 @@ var vecBuiltinCompareCases = map[string][]vecExprBenchCase{
 			},
 		},
 	},
-	ast.Coalesce: {},
-	ast.NullEQ:   {},
+	ast.Coalesce: {
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETReal, types.ETReal}},
+	},
+	ast.NullEQ: {},
 	ast.GT: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt},

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -678,3 +678,21 @@ func (c *Column) MergeNulls(cols ...*Column) {
 		}
 	}
 }
+
+// LogicalORNulls merges these columns' null bitmaps
+// by using logical OR
+func (c *Column) LogicalORNulls(cols ...*Column) {
+	if !c.isFixed() {
+		panic("result column should be fixed-length type")
+	}
+	for _, col := range cols {
+		if c.length != col.length {
+			panic("should ensure all columns have the same length")
+		}
+	}
+	for _, col := range cols {
+		for i := range c.nullBitmap {
+			c.nullBitmap[i] |= col.nullBitmap[i]
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinCoalesceRealSig`, for issue [#12105](https://github.com/pingcap/tidb/issues/12105)


### What is changed and how it works?
- Implement vectorized evaluation.
- Add a `LogicalORNulls` func to merges columns' null bitmaps by using logical OR
```
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceRealSig-VecBuiltinFunc-4                     191886              5851 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinCompareFunc/builtinCoalesceRealSig-NonVecBuiltinFunc-4                   52080             22656 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


