### PR TITLE
perfschema: rename TIDB_GOROUTINES to TIDB_PROFILE_GOROUTINES

### DIFF
--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -45,7 +45,7 @@ var perfSchemaTables = []string{
 	tableTiDBProfileMutex,
 	tableTiDBAllocsProfile,
 	tableTiDBProfileBlock,
-	tableTiDBGoroutine,
+	tableTiDBProfileGoroutines,
 }
 
 // tableGlobalStatus contains the column name definitions for table global_status, same as MySQL.
@@ -443,8 +443,8 @@ const tableTiDBProfileBlock = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfi
 	"DEPTH INT(8) NOT NULL," +
 	"FILE VARCHAR(512) NOT NULL);"
 
-// tableTiDBGoroutine contains the columns name definitions for table events_goroutine
-const tableTiDBGoroutine = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBGoroutines + " (" +
+// tableTiDBProfileGoroutines contains the columns name definitions for table events_goroutine
+const tableTiDBProfileGoroutines = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileGoroutines + " (" +
 	"FUNCTION VARCHAR(512) NOT NULL," +
 	"ID INT(8) NOT NULL," +
 	"STATE VARCHAR(16) NOT NULL," +

--- a/infoschema/perfschema/tables.go
+++ b/infoschema/perfschema/tables.go
@@ -32,7 +32,7 @@ const (
 	tableNameTiDBProfileMutex                = "tidb_profile_mutex"
 	tableNameTiDBProfileAllocs               = "tidb_profile_allocs"
 	tableNameTiDBProfileBlock                = "tidb_profile_block"
-	tableNameTiDBGoroutines                  = "tidb_goroutines"
+	tableNameTiDBProfileGoroutines           = "tidb_profile_goroutines"
 )
 
 // perfSchemaTable stands for the fake table all its data is in the memory.
@@ -107,7 +107,7 @@ func (vt *perfSchemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows, err = (&profile.Collector{}).ProfileGraph("allocs")
 	case tableNameTiDBProfileBlock:
 		fullRows, err = (&profile.Collector{}).ProfileGraph("block")
-	case tableNameTiDBGoroutines:
+	case tableNameTiDBProfileGoroutines:
 		fullRows, err = (&profile.Collector{}).Goroutines()
 	}
 	if err != nil {

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -63,5 +63,5 @@ func (s *profileSuite) TestProfiles(c *C) {
 	tk.MustExec("select * from performance_schema.tidb_profile_allocs")
 	tk.MustExec("select * from performance_schema.tidb_profile_mutex")
 	tk.MustExec("select * from performance_schema.tidb_profile_block")
-	tk.MustExec("select * from performance_schema.tidb_goroutines")
+	tk.MustExec("select * from performance_schema.tidb_profile_goroutines")
 }


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR renames performance_schema.TIDB_GOROUTINES to performance_schema.TIDB_PROFILE_GOROUTINES and unify the name convention.

### What is changed and how it works?

Rename performance_schema.TIDB_GOROUTINES to performance_schema.TIDB_PROFILE_GOROUTINES

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - No need (related release note https://github.com/pingcap/tidb/pull/12986)
