### PR TITLE
planner: don't prune sleep function in LogicalProjection （#11927）

### DIFF
--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -443,3 +443,8 @@ Projection_8	10000.00	root	minus(4_window_3, test.t.x)
   └─Sort_12	10000.00	root	test.t.i:asc
     └─TableReader_11	10000.00	root	data:TableScan_10
       └─TableScan_10	10000.00	cop	table:t, range:[0,+inf], keep order:false, stats:pseudo
+explain select 1 from (select sleep(1)) t;
+id	count	task	operator info
+Projection_4	1.00	root	1
+└─Projection_5	1.00	root	sleep(1)
+  └─TableDual_6	1.00	root	rows:1

--- a/cmd/explaintest/t/select.test
+++ b/cmd/explaintest/t/select.test
@@ -210,3 +210,5 @@ CREATE TABLE t (id int(10) unsigned NOT NULL AUTO_INCREMENT,
     PRIMARY KEY (`id`)
 );
 explain select row_number() over( partition by i ) - x as rnk from t;
+
+explain select 1 from (select sleep(1)) t;


### PR DESCRIPTION
cherry-pick #11927 to release-3.1

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #11905 

### What is changed and how it works?
Don't prune sleep function in LogicalProjection

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- explain test

Code changes



Side effects



Related changes



Release note
