### PR TITLE
expression: implement vectorized evalutaion for `builtinCharLengthSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -1666,9 +1666,27 @@ func (b *builtinFromBase64Sig) vecEvalString(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinCharLengthSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCharLengthSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, true)
+	i64s := result.Int64s()
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			continue
+		}
+		result.SetNull(i, false)
+		i64s[i] = int64(len([]rune(buf.GetString(i))))
+	}
+	return nil
 }

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -157,6 +157,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.FromBase64: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 100}}},
 	},
+	ast.CharLength: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randLenStrGener{10, 100}}},
+	},
 	ast.ExportSet: {},
 	ast.Repeat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETInt}, geners: []dataGenerator{&randLenStrGener{10, 20}, &rangeInt64Gener{-10, 10}}},


### PR DESCRIPTION
PCP #12103
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#12103

### What is changed and how it works?

```
		go test -v -benchmem \
			-bench=BenchmarkVectorizedBuiltinStringFunc \
			-run=BenchmarkVectorizedBuiltinStringFunc \
			-args "builtinCharLengthSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinCharLengthSig-VecBuiltinFunc-4         	   25234	     48450 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinCharLengthSig-NonVecBuiltinFunc-4      	   19014	     63037 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.781s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

Release note

 - vectorize `builtinCharLengthSig`
