### PR TITLE
expression: implement vectorized evaluation for `builtinRowCountSig`

### DIFF
--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -66,11 +66,20 @@ func (b *builtinTiDBVersionSig) vecEvalString(input *chunk.Chunk, result *chunk.
 }
 
 func (b *builtinRowCountSig) vectorized() bool {
-	return false
+	return true
 }
 
+// evalInt evals ROW_COUNT().
+// See https://dev.mysql.com/doc/refman/5.7/en/information-functions.html#function_row-count
 func (b *builtinRowCountSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	result.ResizeInt64(n, false)
+	i64s := result.Int64s()
+	res := int64(b.ctx.GetSessionVars().StmtCtx.PrevAffectedRows)
+	for i := 0; i < n; i++ {
+		i64s[i] = res
+	}
+	return nil
 }
 
 func (b *builtinCurrentUserSig) vectorized() bool {

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -35,8 +35,10 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	},
 	ast.User:          {},
 	ast.TiDBDecodeKey: {},
-	ast.RowCount:      {},
-	ast.CurrentRole:   {},
+	ast.RowCount: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
+	},
+	ast.CurrentRole: {},
 	ast.TiDBIsDDLOwner: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinRowCountSig , for #12103 

### What is changed and how it works?

```
$ make vectorized-bench VB_FILE=Info VB_FUNC=builtinRowCountSig      
cd ./expression && \
                go test -v -benchmem \
                        -bench=BenchmarkVectorizedBuiltinInfoFunc \
                        -run=BenchmarkVectorizedBuiltinInfoFunc \
                        -args "builtinRowCountSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinInfoFunc/builtinRowCountSig-VecBuiltinFunc-8           2638152               453 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinInfoFunc/builtinRowCountSig-NonVecBuiltinFunc-8          89845             13156 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.004s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test