### PR TITLE
expression: implement vectorized evaluation for `builtinQuoteSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -443,11 +443,32 @@ func (b *builtinFieldStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinQuoteSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		str := buf.GetString(i)
+		result.AppendString(Quote(str))
+	}
+
+	return nil
 }
 
 func (b *builtinInsertBinarySig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -149,8 +149,10 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&numStrGener{rangeInt64Gener{-10, 10}}}},
 	},
-	ast.Ord:   {},
-	ast.Quote: {},
+	ast.Ord: {},
+	ast.Quote: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
+	},
 	ast.Bin: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},


### PR DESCRIPTION
### What problem does this PR solve?
implement vectorized evaluation for builtinQuoteSig, for #12106

### What is changed and how it works?
```
goos: windows
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinQuoteSig-VecBuiltinFunc-8               7522            155659 ns/op           19616 B/op         810 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinQuoteSig-NonVecBuiltinFunc-8            6672            171567 ns/op           19616 B/op         810 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      2.516s
```
### Check List
Tests

- Unit test