### PR TITLE
expression: implement vectorized evaluation for `builtinNameConstIntSig`

### DIFF
--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -255,11 +255,11 @@ func (b *builtinIsIPv4CompatSig) vecEvalInt(input *chunk.Chunk, result *chunk.Co
 }
 
 func (b *builtinNameConstIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNameConstIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	return b.args[1].VecEvalInt(b.ctx, input, result)
 }
 
 func (b *builtinNameConstTimeSig) vectorized() bool {

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -61,6 +61,7 @@ var vecBuiltinMiscellaneousCases = map[string][]vecExprBenchCase{
 	ast.NameConst: {
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETInt}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETString, types.ETReal}},
 		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETString, types.ETTimestamp}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Expression: implement vectorized evaluation for 'builtinNameConstIntSig' #12102

### What is changed and how it works?
```
goos: windows
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstIntSig-VecBuiltinFunc-4             6779660           173 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinMiscellaneousCasesFunc/builtinNameConstIntSig-NonVecBuiltinFunc-4            36697         32455 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.084s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test