### PR TITLE
executor: do update forUpdateTs for err path

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -600,20 +600,21 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		if conflictCommitTS > forUpdateTS {
 			newForUpdateTS = conflictCommitTS
 		}
-	} else if terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet) {
+	} else {
+		// this branch if err not nil, always update forUpdateTS to avoid problem described below
 		// for nowait, when ErrLock happened, ErrLockAcquireFailAndNoWaitSet will be returned, and in the same txn
 		// the select for updateTs must be updated, otherwise there maybe rollback problem.
 		// begin;  select for update key1(here ErrLocked or other errors(or max_execution_time like util),
 		//         key1 lock not get and async rollback key1 is raised)
 		//         select for update key1 again(this time lock succ(maybe lock released by others))
 		//         the async rollback operation rollbacked the lock just acquired
-		newForUpdateTS, tsErr := a.GetTimestampWithRetry(ctx)
-		if tsErr != nil {
-			return nil, tsErr
+		if err != nil {
+			newForUpdateTS, tsErr := a.GetTimestampWithRetry(ctx)
+			if tsErr != nil {
+				return nil, tsErr
+			}
+			txnCtx.SetForUpdateTS(newForUpdateTS)
 		}
-		txnCtx.SetForUpdateTS(newForUpdateTS)
-		return nil, err
-	} else {
 		return nil, err
 	}
 	if a.retryCount >= config.GetGlobalConfig().PessimisticTxn.MaxRetryCount {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -381,7 +381,7 @@ func (txn *tikvTxn) rollbackPessimisticLocks() error {
 	return txn.committer.pessimisticRollbackKeys(NewBackoffer(context.Background(), cleanupMaxBackoff), txn.lockKeys)
 }
 
-// lockWaitTime in ms, except that 0 means always wait lock, 1 means nowait lock
+// lockWaitTime in ms, except that kv.LockAlwaysWait(0) means always wait lock, kv.LockNowait(-1) means nowait lock
 func (txn *tikvTxn) LockKeys(ctx context.Context, killed *uint32, forUpdateTS uint64, lockWaitTime int64, keysInput ...kv.Key) error {
 	// Exclude keys that are already locked.
 	keys := make([][]byte, 0, len(keysInput))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Tries to update `forUpdateTs` when lock failed for pessimistic transaction, to avoid possible async rollback problem(like ErrLocked, ErrLockWaitTimeout  execution paths)

### What is changed and how it works?

- Update "forUpdateTs" if err not nil
- fix some comments

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes



Release note


