### PR TITLE
expression: implement vectorized evaluation for builtinQuoteSig 

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -478,14 +478,12 @@ func (b *builtinQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
-			result.AppendNull()
+			result.AppendString("NULL")
 			continue
 		}
-
 		str := buf.GetString(i)
 		result.AppendString(Quote(str))
 	}
-
 	return nil
 }
 

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -461,11 +461,32 @@ func (b *builtinFieldStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinQuoteSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinQuoteSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+
+		str := buf.GetString(i)
+		result.AppendString(Quote(str))
+	}
+
+	return nil
 }
 
 func (b *builtinInsertBinarySig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -151,8 +151,10 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&numStrGener{rangeInt64Gener{-10, 10}}}},
 	},
-	ast.Ord:   {},
-	ast.Quote: {},
+	ast.Ord: {},
+	ast.Quote: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
+	},
 	ast.Bin: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinAesEncryptSig in #12106

### What is changed and how it works?
```
goos: windows
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinQuoteSig-VecBuiltinFunc-8               8020            155946 ns/op           20176 B/op        835 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinQuoteSig-NonVecBuiltinFunc-8            7502            173490 ns/op           20176 B/op        835 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      2.723s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
