### PR TITLE
ddl: make `TestModifyColumnNullToNotNull` test stable

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2695,27 +2695,25 @@ func (s *testDBSuite1) TestModifyColumnNullToNotNull(c *C) {
 	times := 0
 	hook := &ddl.TestDDLCallback{}
 	s.tk.MustExec("delete from t1")
-	hook.OnJobUpdatedExported = func(job *model.Job) {
+	var checkErr error
+	hook.OnJobRunBeforeExported = func(job *model.Job) {
 		if tbl.Meta().ID != job.TableID {
 			return
 		}
-		if job.State != model.JobStateRunning {
-			return
-		}
 		if times == 0 {
-			tk2.MustExec("insert into t1 values ();")
+			_, checkErr = tk2.Exec("insert into t1 values ();")
 		}
 		times++
 	}
 	s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
 	_, err := s.tk.Exec("alter table t1 change c2 c2 int not null;")
+	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[ddl:1138]Invalid use of NULL value")
 	s.tk.MustQuery("select * from t1").Check(testkit.Rows("<nil> <nil>"))
 
 	// Check insert error when column has prevent null flag.
 	s.tk.MustExec("delete from t1")
-	hook.OnJobUpdatedExported = nil
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
 		if tbl.Meta().ID != job.TableID {
 			return
@@ -2725,18 +2723,18 @@ func (s *testDBSuite1) TestModifyColumnNullToNotNull(c *C) {
 		}
 		c2 := getModifyColumn()
 		if mysql.HasPreventNullInsertFlag(c2.Flag) {
-			_, err := tk2.Exec("insert into t1 values ();")
-			c.Assert(err.Error(), Equals, "[table:1048]Column 'c2' cannot be null")
+			_, checkErr = tk2.Exec("insert into t1 values ();")
 		}
 	}
-
 	s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
 	s.tk.MustExec("alter table t1 change c2 c2 bigint not null;")
+	c.Assert(checkErr.Error(), Equals, "[table:1048]Column 'c2' cannot be null")
 
 	c2 := getModifyColumn()
 	c.Assert(mysql.HasNotNullFlag(c2.Flag), IsTrue)
 	c.Assert(mysql.HasPreventNullInsertFlag(c2.Flag), IsFalse)
 	_, err = s.tk.Exec("insert into t1 values ();")
+	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[table:1364]Field 'c2' doesn't have a default value")
 }
 

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2712,7 +2712,7 @@ func (s *testDBSuite1) TestModifyColumnNullToNotNull(c *C) {
 	c.Assert(err.Error(), Equals, "[ddl:1138]Invalid use of NULL value")
 	s.tk.MustQuery("select * from t1").Check(testkit.Rows("<nil> <nil>"))
 
-	// Check insert error when column has prevent null flag.
+	// Check insert error when column has PreventNullInsertFlag.
 	s.tk.MustExec("delete from t1")
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
 		if tbl.Meta().ID != job.TableID {
@@ -2721,10 +2721,8 @@ func (s *testDBSuite1) TestModifyColumnNullToNotNull(c *C) {
 		if job.State != model.JobStateRunning {
 			return
 		}
-		c2 := getModifyColumn()
-		if mysql.HasPreventNullInsertFlag(c2.Flag) {
-			_, checkErr = tk2.Exec("insert into t1 values ();")
-		}
+		// now c2 has PreventNullInsertFlag, an error is expected.
+		_, checkErr = tk2.Exec("insert into t1 values ();")
 	}
 	s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
 	s.tk.MustExec("alter table t1 change c2 c2 bigint not null;")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to fix a potentially failed assertion that makes TiDB unit test keep hanging and failed because of timeout.

### What is changed and how it works?
The code：
https://github.com/pingcap/tidb/blob/1b72ce5987b3d3396390648cd80788b07b40e4e1/ddl/db_test.go#L2706
in `TestModifyColumnNullToNotNull` has following flaws:

1. Made a write during the schema change of `t1`, in which leads a potential `information schema is changed` error.
2. When the assertion `MustExec` failed, only ddl worker goroutine exits, which leaves ddl job never ends.

This PR removes `MustExec` and does the make outside of `hook`, while changing the time of hook called to avoid `information schema is changed` error.

PS: There are still some other codes that use assertion inside of `hook` in ddl tests, we should refine them all to avoid similar timeout failures, I plan to do the refinements later.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Unit test
 - Integration test

Code changes
 - NA

Side effects
 - NA

Related changes
 - NA
 
Release note
 - NA
