### PR TITLE
expression: implement vectorized evaluation for `builtinJSONExtractSig`

### DIFF
--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -458,11 +458,70 @@ func (b *builtinJSONTypeSig) vecEvalString(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinJSONExtractSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinJSONExtractSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	var err error
+
+	nr := input.NumRows()
+	jsonBuf, err := b.bufAllocator.get(types.ETJson, nr)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(jsonBuf)
+	if err = b.args[0].VecEvalJSON(b.ctx, input, jsonBuf); err != nil {
+		return err
+	}
+
+	pathArgs := b.args[1:]
+	pathBuffers := make([]*chunk.Column, len(pathArgs))
+	for k := 0; k < len(pathArgs); k++ {
+		if pathBuffers[k], err = b.bufAllocator.get(types.ETString, nr); err != nil {
+			return err
+		}
+		defer func(buf *chunk.Column) {
+			b.bufAllocator.put(buf)
+		}(pathBuffers[k])
+
+		if err := pathArgs[k].VecEvalString(b.ctx, input, pathBuffers[k]); err != nil {
+			return err
+		}
+	}
+
+	result.ReserveJSON(nr)
+	for i := 0; i < nr; i++ {
+		if jsonBuf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		jsonItem := jsonBuf.GetJSON(i)
+
+		pathExprs := make([]json.PathExpression, len(pathBuffers))
+		hasNullPath := false
+		for k, pathBuf := range pathBuffers {
+			if pathBuf.IsNull(i) {
+				hasNullPath = true
+				break
+			}
+			if pathExprs[k], err = json.ParseJSONPathExpr(pathBuf.GetString(i)); err != nil {
+				return err
+			}
+		}
+		if hasNullPath {
+			result.AppendNull()
+			continue
+		}
+
+		var found bool
+		if jsonItem, found = jsonItem.Extract(pathExprs); !found {
+			result.AppendNull()
+			continue
+		}
+		result.AppendJSON(jsonItem)
+	}
+
+	return nil
 }
 
 func (b *builtinJSONRemoveSig) vectorized() bool {

--- a/expression/builtin_json_vec_test.go
+++ b/expression/builtin_json_vec_test.go
@@ -27,7 +27,10 @@ var vecBuiltinJSONCases = map[string][]vecExprBenchCase{
 	},
 	ast.JSONArrayAppend:  {},
 	ast.JSONContainsPath: {},
-	ast.JSONExtract:      {},
+	ast.JSONExtract: {
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson, types.ETString}, geners: []dataGenerator{nil, &constStrGener{"$.key"}}},
+		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETJson, types.ETString, types.ETString}, geners: []dataGenerator{nil, &constStrGener{"$.key"}, &constStrGener{"$[0]"}}},
+	},
 	ast.JSONLength: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETJson}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETJson, types.ETString}, geners: []dataGenerator{nil, &constStrGener{"$.key"}}},


### PR DESCRIPTION
PCP #12104 

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinJSONExtractSig` at #12104

### What is changed and how it works?
It gets faster about 4%.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
```
> GO111MODULE=on go test -check.f TestVectorizedBuiltinJSONFunc
PASS: builtin_json_vec_test.go:99: testEvaluatorSuite.TestVectorizedBuiltinJSONFunc	0.124s
OK: 1 passed
PASS
ok  	github.com/pingcap/tidb/expression	0.150s
```


 - Benchmark
```
> go test -v -benchmem -bench=BenchmarkVectorizedBuiltinJSONFunc -run=BenchmarkVectorizedBuiltinJSONFunc
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-VecBuiltinFunc-12         	    4389	    245424 ns/op	  171627 B/op	    6145 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-NonVecBuiltinFunc-12      	    4611	    257671 ns/op	  147049 B/op	    6144 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-VecBuiltinFunc#01-12      	    2901	    404341 ns/op	  363535 B/op	    9217 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-NonVecBuiltinFunc#01-12   	    2726	    429171 ns/op	  338947 B/op	    9216 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-VecBuiltinFunc#02-12      	    2389	    488518 ns/op	  448263 B/op	   10724 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONArraySig-NonVecBuiltinFunc#02-12   	    2200	    551271 ns/op	  423685 B/op	   10723 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONObjectSig-VecBuiltinFunc-12        	     290	   4010606 ns/op	 3677470 B/op	   29203 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONObjectSig-NonVecBuiltinFunc-12     	     278	   4286756 ns/op	 3668885 B/op	   29199 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONTypeSig-VecBuiltinFunc-12          	  116358	     10318 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONTypeSig-NonVecBuiltinFunc-12       	   60430	     19782 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-VecBuiltinFunc-12      	   15435	     74136 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-NonVecBuiltinFunc-12   	   12962	     95830 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-VecBuiltinFunc#01-12   	    2709	    440059 ns/op	  238676 B/op	    1911 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-NonVecBuiltinFunc#01-12         	    2421	    481896 ns/op	  238870 B/op	    1911 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-VecBuiltinFunc#02-12            	    2337	    519413 ns/op	  255835 B/op	    2046 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONContainsSig-NonVecBuiltinFunc#02-12         	    2102	    555384 ns/op	  256055 B/op	    2046 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-VecBuiltinFunc-12                 	  302348	      3769 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-NonVecBuiltinFunc-12              	   61208	     19493 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-VecBuiltinFunc#01-12              	    1884	    585823 ns/op	  313967 B/op	    2515 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-NonVecBuiltinFunc#01-12           	    1924	    621749 ns/op	  314418 B/op	    2515 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-VecBuiltinFunc#02-12              	    2097	    565734 ns/op	  309345 B/op	    2476 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONLengthSig-NonVecBuiltinFunc#02-12           	    2011	    589481 ns/op	  309233 B/op	    2476 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONExtractSig-VecBuiltinFunc-12                	    1912	    630398 ns/op	  337870 B/op	    3318 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONExtractSig-NonVecBuiltinFunc-12             	    1774	    658718 ns/op	  337953 B/op	    3317 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONExtractSig-VecBuiltinFunc#01-12             	     896	   1333639 ns/op	  780689 B/op	    7420 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONExtractSig-NonVecBuiltinFunc#01-12          	     840	   1383648 ns/op	  782900 B/op	    7419 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONDepthSig-VecBuiltinFunc-12                  	   79332	     14727 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONDepthSig-NonVecBuiltinFunc-12               	   37339	     33364 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONUnquoteSig-VecBuiltinFunc-12                	    7794	    158192 ns/op	   73728 B/op	    4096 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONUnquoteSig-NonVecBuiltinFunc-12             	    7244	    167338 ns/op	   73728 B/op	    4096 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONQuoteSig-VecBuiltinFunc-12                  	   19314	     62259 ns/op	   13248 B/op	    2484 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONQuoteSig-NonVecBuiltinFunc-12               	   16605	     73159 ns/op	   13248 B/op	    2484 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONKeysSig-VecBuiltinFunc-12                   	    7759	    159359 ns/op	   90048 B/op	    4824 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONKeysSig-NonVecBuiltinFunc-12                	    7203	    169511 ns/op	   90049 B/op	    4824 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONMergeSig-VecBuiltinFunc-12                  	     786	   1443204 ns/op	  962522 B/op	   14362 allocs/op
BenchmarkVectorizedBuiltinJSONFunc/builtinJSONMergeSig-NonVecBuiltinFunc-12               	     633	   1880462 ns/op	 1036929 B/op	   15025 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	50.270s
```


 - Manual test (add detailed scripts or steps below)
```sql
mysql> SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]');
+--------------------------------------------+
| JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]') |
+--------------------------------------------+
| 20                                         |
+--------------------------------------------+
1 row in set (0.00 sec)

mysql> SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]', '$[0]');
+----------------------------------------------------+
| JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]', '$[0]') |
+----------------------------------------------------+
| [20, 10]                                           |
+----------------------------------------------------+
1 row in set (0.00 sec)

mysql> SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[2][*]');
+-----------------------------------------------+
| JSON_EXTRACT('[10, 20, [30, 40]]', '$[2][*]') |
+-----------------------------------------------+
| [30, 40]                                      |
+-----------------------------------------------+
1 row in set (0.00 sec)

mysql> SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[2][*]', NULL);
+-----------------------------------------------------+
| JSON_EXTRACT('[10, 20, [30, 40]]', '$[2][*]', NULL) |
+-----------------------------------------------------+
| NULL                                                |
+-----------------------------------------------------+
1 row in set (0.00 sec)

mysql> 
```
