### PR TITLE
implement vectorized evaluation for builtinCastTimeAsTimeSig

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -1085,11 +1085,7 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		}
 		res, err = tm.RoundFrac(sc, int8(b.tp.Decimal))
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err != nil {
-				return err
-			}
-			result.SetNull(i, true)
-			continue
+			return err
 		}
 
 		if b.tp.Tp == mysql.TypeDate {

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -1077,7 +1077,7 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		res := buf.GetTime(i)
 		tm, err := res.Convert(sc, b.tp.Tp)
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err!= nil{
+			if err = handleInvalidTimeError(b.ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)
@@ -1085,7 +1085,7 @@ func (b *builtinCastTimeAsTimeSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		}
 		res, err = tm.RoundFrac(sc, int8(b.tp.Decimal))
 		if err != nil {
-			if err = handleInvalidTimeError(b.ctx, err); err!= nil{
+			if err = handleInvalidTimeError(b.ctx, err); err != nil {
 				return err
 			}
 			result.SetNull(i, true)

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -70,6 +70,8 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 				&timeStrGener{},
 				&dataStrGener{},
 			}},
+		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDatetime}},
+		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETTimestamp}},
 	},
 }
 


### PR DESCRIPTION
PCR #12101
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
expression: implement vectorized evaluation for builtinCastTimeAsTimeSig

### What is changed and how it works?
``` go
make vectorized-bench VB_FILE=Cast VB_FUNC=builtinCastTimeAsTimeSig
cd ./expression && \
		go test -v -benchmem \
			-bench=BenchmarkVectorizedBuiltinCastFunc \
			-run=BenchmarkVectorizedBuiltinCastFunc \
			-args "builtinCastTimeAsTimeSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsTimeSig-VecBuiltinFunc-4         	   19060	     63673 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsTimeSig-NonVecBuiltinFunc-4      	   12570	     96082 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsTimeSig-VecBuiltinFunc#01-4      	   12018	    102677 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastTimeAsTimeSig-NonVecBuiltinFunc#01-4   	    8736	    149057 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	7.656s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

