### PR TITLE
expression: implement vectorized evaluation for builtinFromUnixTime1ArgSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1326,11 +1326,39 @@ func (b *builtinDayOfYearSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 }
 
 func (b *builtinFromUnixTime1ArgSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinFromUnixTime1ArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeTime(n, false)
+	result.MergeNulls(buf)
+	ts := result.Times()
+	ds := buf.Decimals()
+	fsp := int8(b.tp.Decimal)
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		t, isNull, err := evalFromUnixTime(b.ctx, fsp, &ds[i])
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		ts[i] = t
+	}
+	return nil
 }
 
 func (b *builtinSubDateDurationIntSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -178,6 +178,11 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.FromDays: {
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETInt}},
 	},
+	ast.FromUnixTime: {
+		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDecimal},
+			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}},
+		},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinTimeEvalOneVec(c *C) {


### PR DESCRIPTION
PCP #12101

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinFromUnixTime1ArgSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=Time VB_FUNC=builtinFromUnixTime1ArgSig
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinTimeFunc \
		-run=BenchmarkVectorizedBuiltinTimeFunc \
		-args "builtinFromUnixTime1ArgSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.00811 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinFromUnixTime1ArgSig-VecBuiltinFunc-12         	   33603	     31449 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinFromUnixTime1ArgSig-NonVecBuiltinFunc-12      	   24670	     46619 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.134s

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
