### PR TITLE
planner/cascades: add transformation rule TransformLimitToTopN

### DIFF
--- a/planner/cascades/testdata/transformation_rules_suite_in.json
+++ b/planner/cascades/testdata/transformation_rules_suite_in.json
@@ -10,5 +10,12 @@
       "select a, max(b) from t group by a having a > 1",
       "select a, avg(b) from t group by a having a > 1 and max(b) > 10"
     ]
+  },
+  {
+    "name": "TestTopNRules",
+    "cases": [
+      "select b from t order by a limit 2",
+      "select a+b from t order by a limit 1 offset 2"
+    ]
   }
 ]

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -110,5 +110,40 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestTopNRules",
+    "Cases": [
+      {
+        "SQL": "select b from t order by a limit 2",
+        "Result": [
+          "Group#0 Schema:[Column#15]",
+          "    Projection_5 input:[Group#1], Column#13",
+          "Group#1 Schema:[Column#13,Column#14], UniqueKey:[Column#14]",
+          "    TopN_8 input:[Group#2], Column#14:asc, offset:0, count:2",
+          "Group#2 Schema:[Column#13,Column#14], UniqueKey:[Column#14]",
+          "    Projection_2 input:[Group#3], Column#2, Column#1",
+          "Group#3 Schema:[Column#1,Column#2], UniqueKey:[Column#1]",
+          "    TableGather_7 input:[Group#4]",
+          "Group#4 Schema:[Column#1,Column#2], UniqueKey:[Column#1]",
+          "    TableScan_6 table:t, pk col:Column#1"
+        ]
+      },
+      {
+        "SQL": "select a+b from t order by a limit 1 offset 2",
+        "Result": [
+          "Group#0 Schema:[Column#15]",
+          "    Projection_5 input:[Group#1], Column#13",
+          "Group#1 Schema:[Column#13,Column#14], UniqueKey:[Column#14]",
+          "    TopN_8 input:[Group#2], Column#14:asc, offset:2, count:1",
+          "Group#2 Schema:[Column#13,Column#14], UniqueKey:[Column#14]",
+          "    Projection_2 input:[Group#3], plus(Column#1, Column#2), Column#1",
+          "Group#3 Schema:[Column#1,Column#2], UniqueKey:[Column#1]",
+          "    TableGather_7 input:[Group#4]",
+          "Group#4 Schema:[Column#1,Column#2], UniqueKey:[Column#1]",
+          "    TableScan_6 table:t, pk col:Column#1"
+        ]
+      }
+    ]
   }
 ]

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -96,24 +96,7 @@ func (s *testTransformationRuleSuite) TestPredicatePushDown(c *C) {
 		Result []string
 	}
 	s.testData.GetTestCases(c, &input, &output)
-	for i, sql := range input {
-		stmt, err := s.ParseOneStmt(sql, "", "")
-		c.Assert(err, IsNil)
-		p, _, err := plannercore.BuildLogicalPlan(context.Background(), s.sctx, stmt, s.is)
-		c.Assert(err, IsNil)
-		logic, ok := p.(plannercore.LogicalPlan)
-		c.Assert(ok, IsTrue)
-		logic, err = s.optimizer.onPhasePreprocessing(s.sctx, logic)
-		c.Assert(err, IsNil)
-		group := convert2Group(logic)
-		err = s.optimizer.onPhaseExploration(s.sctx, group)
-		c.Assert(err, IsNil)
-		s.testData.OnRecord(func() {
-			output[i].SQL = sql
-			output[i].Result = ToString(group)
-		})
-		c.Assert(ToString(group), DeepEquals, output[i].Result)
-	}
+	testGroupToString(input, output, s, c)
 }
 
 func (s *testTransformationRuleSuite) TestTopNRules(c *C) {

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -50,6 +50,30 @@ func (s *testTransformationRuleSuite) TearDownSuite(c *C) {
 	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
 }
 
+func testGroupToString(input []string, output []struct {
+	SQL    string
+	Result []string
+}, s *testTransformationRuleSuite, c *C) {
+	for i, sql := range input {
+		stmt, err := s.ParseOneStmt(sql, "", "")
+		c.Assert(err, IsNil)
+		p, _, err := plannercore.BuildLogicalPlan(context.Background(), s.sctx, stmt, s.is)
+		c.Assert(err, IsNil)
+		logic, ok := p.(plannercore.LogicalPlan)
+		c.Assert(ok, IsTrue)
+		logic, err = s.optimizer.onPhasePreprocessing(s.sctx, logic)
+		c.Assert(err, IsNil)
+		group := convert2Group(logic)
+		err = s.optimizer.onPhaseExploration(s.sctx, group)
+		c.Assert(err, IsNil)
+		s.testData.OnRecord(func() {
+			output[i].SQL = sql
+			output[i].Result = ToString(group)
+		})
+		c.Assert(ToString(group), DeepEquals, output[i].Result)
+	}
+}
+
 func (s *testTransformationRuleSuite) TestPredicatePushDown(c *C) {
 	s.optimizer.ResetTransformationRules(map[memo.Operand][]TransformationID{
 		memo.OperandSelection: {
@@ -90,4 +114,22 @@ func (s *testTransformationRuleSuite) TestPredicatePushDown(c *C) {
 		})
 		c.Assert(ToString(group), DeepEquals, output[i].Result)
 	}
+}
+
+func (s *testTransformationRuleSuite) TestTopNRules(c *C) {
+	s.optimizer.ResetTransformationRules(map[memo.Operand][]TransformationID{
+		memo.OperandLimit: {
+			ruleTransformLimitToTopN,
+		},
+		memo.OperandDataSource: {
+			ruleEnumeratePaths,
+		},
+	})
+	var input []string
+	var output []struct {
+		SQL    string
+		Result []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	testGroupToString(input, output, s, c)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds transformation rule TransformLimitToTopN, which transforms `Limit + Sort` to `TopN`.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

