### PR TITLE
ddl: fix bug that range columns partition table add partitions failed(#12348)

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -171,6 +171,19 @@ func (s *testIntegrationSuite9) TestCreateTableWithPartition(c *C) {
 	assertErrorCode(c, tk, sql9, tmysql.ErrPartitionFunctionIsNotAllowed)
 
 	assertErrorCode(c, tk, `create TABLE t10 (c1 int,c2 int) partition by range(c1 / c2 ) (partition p0 values less than (2));`, tmysql.ErrPartitionFunctionIsNotAllowed)
+	_, err = tk.Exec(`CREATE TABLE t9 (
+		a INT NOT NULL,
+		b INT NOT NULL,
+		c INT NOT NULL
+	)
+	partition by range columns(a) (
+	partition p0 values less than (10),
+	partition p2 values less than (20),
+	partition p3 values less than (20)
+	);`)
+	c.Assert(ddl.ErrRangeNotIncreasing.Equal(err), IsTrue)
+
+	assertErrorCode(c, tk, `create TABLE t10 (c1 int,c2 int) partition by range(c1 / c2 ) (partition p0 values less than (2));`, tmysql.ErrPartitionFunctionIsNotAllowed)
 
 	tk.MustExec(`create TABLE t11 (c1 int,c2 int) partition by range(c1 div c2 ) (partition p0 values less than (2));`)
 	tk.MustExec(`create TABLE t12 (c1 int,c2 int) partition by range(c1 + c2 ) (partition p0 values less than (2));`)
@@ -525,6 +538,13 @@ func (s *testIntegrationSuite5) TestAlterTableAddPartition(c *C) {
 	);`)
 	tk.MustExec(`ALTER TABLE tt5 add partition ( partition p2 values less than (-1) );`)
 	tk.MustExec(`ALTER TABLE tt5 add partition ( partition p3 values less than (5-1) );`)
+
+	// Test add partition for the table partition by range columns.
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a datetime) partition by range columns (a) (partition p1 values less than ('2019-06-01'), partition p2 values less than ('2019-07-01'));")
+	sql := "alter table t add partition ( partition p3 values less than ('2019-07-01'));"
+	assertErrorCode(c, tk, sql, tmysql.ErrRangeNotIncreasing)
+	tk.MustExec("alter table t add partition ( partition p3 values less than ('2019-08-01'));")
 }
 
 func (s *testIntegrationSuite6) TestAlterTableDropPartition(c *C) {

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -161,7 +161,19 @@ func buildRangePartitionDefinitions(ctx sessionctx.Context, d *ddl, s *ast.Creat
 	return nil
 }
 
-func checkPartitionNameUnique(tbInfo *model.TableInfo, pi *model.PartitionInfo) error {
+func checkPartitionNameUnique(pi *model.PartitionInfo) error {
+	partNames := make(map[string]struct{})
+	newPars := pi.Definitions
+	for _, newPar := range newPars {
+		if _, ok := partNames[newPar.Name.L]; ok {
+			return ErrSameNamePartition.GenWithStackByArgs(newPar.Name)
+		}
+		partNames[newPar.Name.L] = struct{}{}
+	}
+	return nil
+}
+
+func checkAddPartitionNameUnique(tbInfo *model.TableInfo, pi *model.PartitionInfo) error {
 	partNames := make(map[string]struct{})
 	if tbInfo.Partition != nil {
 		oldPars := tbInfo.Partition.Definitions

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -772,7 +772,7 @@ func onAddTablePartition(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		return ver, errors.Trace(err)
 	}
 
-	err = checkPartitionNameUnique(tblInfo, partInfo)
+	err = checkAddPartitionNameUnique(tblInfo, partInfo)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Trace(err)


### PR DESCRIPTION
This PR backports #12348(by cherry-picking #12815 without conflicts).

----------------------------------

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```sql
create table t (a datetime) partition by range columns (a) (partition p1 values less than ('2019-06-01'), partition p2 values less than ('2019-07-01'));
alter table t add partition ( partition p3 values less than ('2019-08-01'));  -- should execute succeful.
(1659, u'Field \'"2019-06-01"\' is of a not allowed type for this type of partitioning')
```

### What is changed and how it works?
* Fix Add partition bug.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects


Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the issue that range columns partition table add partitions failed. 
