### PR TITLE
*: record and print the plan in slow log. (#12179)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,10 +104,11 @@ type Log struct {
 	// File log config.
 	File logutil.FileLogConfig `toml:"file" json:"file"`
 
-	SlowQueryFile      string `toml:"slow-query-file" json:"slow-query-file"`
-	SlowThreshold      uint64 `toml:"slow-threshold" json:"slow-threshold"`
-	ExpensiveThreshold uint   `toml:"expensive-threshold" json:"expensive-threshold"`
-	QueryLogMaxLen     uint64 `toml:"query-log-max-len" json:"query-log-max-len"`
+	SlowQueryFile       string `toml:"slow-query-file" json:"slow-query-file"`
+	SlowThreshold       uint64 `toml:"slow-threshold" json:"slow-threshold"`
+	ExpensiveThreshold  uint   `toml:"expensive-threshold" json:"expensive-threshold"`
+	QueryLogMaxLen      uint64 `toml:"query-log-max-len" json:"query-log-max-len"`
+	RecordPlanInSlowLog uint32 `toml:"record-plan-in-slow-log" json:"record-plan-in-slow-log"`
 }
 
 // Security is the security section of the config.
@@ -342,13 +343,14 @@ var defaultConf = Config{
 	},
 	LowerCaseTableNames: 2,
 	Log: Log{
-		Level:              "info",
-		Format:             "text",
-		File:               logutil.NewFileLogConfig(true, logutil.DefaultLogMaxSize),
-		SlowQueryFile:      "tidb-slow.log",
-		SlowThreshold:      logutil.DefaultSlowThreshold,
-		ExpensiveThreshold: 10000,
-		QueryLogMaxLen:     logutil.DefaultQueryLogMaxLen,
+		Level:               "info",
+		Format:              "text",
+		File:                logutil.NewFileLogConfig(true, logutil.DefaultLogMaxSize),
+		SlowQueryFile:       "tidb-slow.log",
+		SlowThreshold:       logutil.DefaultSlowThreshold,
+		ExpensiveThreshold:  10000,
+		QueryLogMaxLen:      logutil.DefaultQueryLogMaxLen,
+		RecordPlanInSlowLog: logutil.DefaultRecordPlanInSlowLog,
 	},
 	Status: Status{
 		ReportStatus:    true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -73,6 +73,10 @@ slow-query-file = "tidb-slow.log"
 # Queries with execution time greater than this value will be logged. (Milliseconds)
 slow-threshold = 300
 
+# record-plan-in-slow-log is used to enable record query plan in slow log.
+# 0 is disable. 1 is enable.
+record-plan-in-slow-log = 1
+
 # Queries with internal result greater than this value will be logged.
 expensive-threshold = 10000
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -674,6 +674,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 		ExecDetail:     execDetail,
 		MemMax:         memMax,
 		Succ:           succ,
+		Plan:           getPlanTree(a.Plan),
 		Prepared:       a.isPreparedStmt,
 		HasMoreResults: hasMoreResults,
 	}
@@ -707,6 +708,35 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 			Internal:   sessVars.InRestrictedSQL,
 		})
 	}
+}
+
+// getPlanTree will try to get the select plan tree if the plan is select or the select plan of delete/update/insert statement.
+func getPlanTree(p plannercore.Plan) string {
+	cfg := config.GetGlobalConfig()
+	if atomic.LoadUint32(&cfg.Log.RecordPlanInSlowLog) == 0 {
+		return ""
+	}
+	var selectPlan plannercore.PhysicalPlan
+	if physicalPlan, ok := p.(plannercore.PhysicalPlan); ok {
+		selectPlan = physicalPlan
+	} else {
+		switch x := p.(type) {
+		case *plannercore.Delete:
+			selectPlan = x.SelectPlan
+		case *plannercore.Update:
+			selectPlan = x.SelectPlan
+		case *plannercore.Insert:
+			selectPlan = x.SelectPlan
+		}
+	}
+	if selectPlan == nil {
+		return ""
+	}
+	planTree := plannercore.EncodePlan(selectPlan)
+	if len(planTree) == 0 {
+		return planTree
+	}
+	return variable.SlowLogPlanPrefix + planTree + variable.SlowLogPlanSuffix
 }
 
 // SummaryStmt collects statements for performance_schema.events_statements_summary_by_digest

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -381,6 +381,11 @@ func (s *testSuite2) TestSetVar(c *C) {
 
 	tk.MustExec("set @@tidb_expensive_query_time_threshold=70")
 	tk.MustQuery("select @@tidb_expensive_query_time_threshold;").Check(testkit.Rows("70"))
+
+	tk.MustExec("set @@tidb_record_plan_in_slow_log = 1")
+	tk.MustQuery("select @@tidb_record_plan_in_slow_log;").Check(testkit.Rows("1"))
+	tk.MustExec("set @@tidb_record_plan_in_slow_log = 0")
+	tk.MustQuery("select @@tidb_record_plan_in_slow_log;").Check(testkit.Rows("0"))
 }
 
 func (s *testSuite2) TestSetCharset(c *C) {

--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -415,7 +415,6 @@ var funcs = map[string]functionClass{
 	ast.Year:             &yearFunctionClass{baseFunctionClass{ast.Year, 1, 1}},
 	ast.YearWeek:         &yearWeekFunctionClass{baseFunctionClass{ast.YearWeek, 1, 2}},
 	ast.LastDay:          &lastDayFunctionClass{baseFunctionClass{ast.LastDay, 1, 1}},
-	ast.TiDBParseTso:     &tidbParseTsoFunctionClass{baseFunctionClass{ast.TiDBParseTso, 1, 1}},
 
 	// string functions
 	ast.ASCII:           &asciiFunctionClass{baseFunctionClass{ast.ASCII, 1, 1}},
@@ -486,9 +485,6 @@ var funcs = map[string]functionClass{
 	ast.RowCount:     &rowCountFunctionClass{baseFunctionClass{ast.RowCount, 0, 0}},
 	ast.SessionUser:  &userFunctionClass{baseFunctionClass{ast.SessionUser, 0, 0}},
 	ast.SystemUser:   &userFunctionClass{baseFunctionClass{ast.SystemUser, 0, 0}},
-	// This function is used to show tidb-server version info.
-	ast.TiDBVersion:    &tidbVersionFunctionClass{baseFunctionClass{ast.TiDBVersion, 0, 0}},
-	ast.TiDBIsDDLOwner: &tidbIsDDLOwnerFunctionClass{baseFunctionClass{ast.TiDBIsDDLOwner, 0, 0}},
 
 	// control functions
 	ast.If:     &ifFunctionClass{baseFunctionClass{ast.If, 3, 3}},
@@ -600,4 +596,11 @@ var funcs = map[string]functionClass{
 	ast.JSONDepth:         &jsonDepthFunctionClass{baseFunctionClass{ast.JSONDepth, 1, 1}},
 	ast.JSONKeys:          &jsonKeysFunctionClass{baseFunctionClass{ast.JSONKeys, 1, 2}},
 	ast.JSONLength:        &jsonLengthFunctionClass{baseFunctionClass{ast.JSONLength, 1, 2}},
+
+	// TiDB internal function.
+	// This function is used to show tidb-server version info.
+	ast.TiDBVersion:    &tidbVersionFunctionClass{baseFunctionClass{ast.TiDBVersion, 0, 0}},
+	ast.TiDBIsDDLOwner: &tidbIsDDLOwnerFunctionClass{baseFunctionClass{ast.TiDBIsDDLOwner, 0, 0}},
+	ast.TiDBParseTso:   &tidbParseTsoFunctionClass{baseFunctionClass{ast.TiDBParseTso, 1, 1}},
+	ast.TiDBDecodePlan: &tidbDecodePlanFunctionClass{baseFunctionClass{ast.TiDBDecodePlan, 1, 1}},
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4043,6 +4043,25 @@ func (s *testIntegrationSuite) testTiDBIsOwnerFunc(c *C) {
 	result.Check(testkit.Rows(fmt.Sprintf("%v", ret)))
 }
 
+func (s *testIntegrationSuite) TestTiDBDecodePlanFunc(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	defer s.cleanEnv(c)
+	tk.MustQuery("select tidb_decode_plan('')").Check(testkit.Rows(""))
+	tk.MustQuery("select tidb_decode_plan('7APIMAk1XzEzCTAJMQlmdW5jczpjb3VudCgxKQoxCTE3XzE0CTAJMAlpbm5lciBqb2luLCBp" +
+		"AQyQOlRhYmxlUmVhZGVyXzIxLCBlcXVhbDpbZXEoQ29sdW1uIzEsIA0KCDkpIBkXADIVFywxMCldCjIJMzJfMTgFZXhkYXRhOlNlbGVjdGlvbl" +
+		"8xNwozCTFfMTcJMQkwCWx0HVlATlVMTCksIG5vdChpc251bGwVHAApUhcAUDIpKQo0CTEwXzE2CTEJMTAwMDAJdAHB2Dp0MSwgcmFuZ2U6Wy1p" +
+		"bmYsK2luZl0sIGtlZXAgb3JkZXI6ZmFsc2UsIHN0YXRzOnBzZXVkbwoFtgAyAZcEMAk6tgAEMjAFtgQyMDq2AAg5LCBmtgAAMFa3AAA5FbcAO" +
+		"T63AAAyzrcA')").Check(testkit.Rows("" +
+		"\tStreamAgg_13        \troot\t1    \tfuncs:count(1)\n" +
+		"\t└─HashLeftJoin_14   \troot\t0    \tinner join, inner:TableReader_21, equal:[eq(Column#1, Column#9) eq(Column#2, Column#10)]\n" +
+		"\t  ├─TableReader_18  \troot\t0    \tdata:Selection_17\n" +
+		"\t  │ └─Selection_17  \tcop \t0    \tlt(Column#1, NULL), not(isnull(Column#1)), not(isnull(Column#2))\n" +
+		"\t  │   └─TableScan_16\tcop \t10000\ttable:t1, range:[-inf,+inf], keep order:false, stats:pseudo\n" +
+		"\t  └─TableReader_21  \troot\t0    \tdata:Selection_20\n" +
+		"\t    └─Selection_20  \tcop \t0    \tlt(Column#9, NULL), not(isnull(Column#10)), not(isnull(Column#9))\n" +
+		"\t      └─TableScan_19\tcop \t10000\ttable:t2, range:[-inf,+inf], keep order:false, stats:pseudo"))
+}
+
 func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	store, err := mockstore.NewMockTikvStore()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-sql-driver/mysql v0.0.0-20170715192408-3955978caca4
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.2
-	github.com/golang/snappy v0.0.1 // indirect
+	github.com/golang/snappy v0.0.1
 	github.com/google/btree v1.0.0
 	github.com/google/pprof v0.0.0-20190930153522-6ce02741cba3
 	github.com/google/uuid v1.1.1
@@ -68,3 +68,5 @@ require (
 replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20191018025622-fbf07f9804da
 	github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd
-	github.com/pingcap/parser v0.0.0-20191011160321-0c4055ef2c1d
+	github.com/pingcap/parser v0.0.0-20191108104421-a8f0a51789f3
 	github.com/pingcap/pd v1.1.0-beta.0.20191018040858-0d9d9d67d029
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible
 	github.com/pingcap/tipb v0.0.0-20191101114505-cbd0e985c780
@@ -68,5 +68,3 @@ require (
 replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d
 
 go 1.13
-
-replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrU
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565 h1:3L8WLzL3zT4fDTOyD2yMz/UTEELS7AJU0ZNlevDGnFQ=
-github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -190,6 +188,8 @@ github.com/pingcap/kvproto v0.0.0-20191018025622-fbf07f9804da h1:dLmHmFq44tIq7yW
 github.com/pingcap/kvproto v0.0.0-20191018025622-fbf07f9804da/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
+github.com/pingcap/parser v0.0.0-20191108104421-a8f0a51789f3 h1:igazArQuuuyXhR6T27JB7mfynBkEnnczL1A0kun9s4k=
+github.com/pingcap/parser v0.0.0-20191108104421-a8f0a51789f3/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191018040858-0d9d9d67d029 h1:nJp6nnW70cGtmOiRnjvoU8fSxhb5QwGNgYr/AtyPCgo=
 github.com/pingcap/pd v1.1.0-beta.0.20191018040858-0d9d9d67d029/go.mod h1:+F+Zp4BoMM7TbDKCeosXO+X9A+IWaw/T3/gRBo1sr6Q=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible h1:H1jg0aDWz2SLRh3hNBo2HFtnuHtudIUvBumU7syRkic=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrU
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565 h1:3L8WLzL3zT4fDTOyD2yMz/UTEELS7AJU0ZNlevDGnFQ=
+github.com/bb7133/parser v0.0.0-20191108085541-3e1f36599565/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -188,8 +190,6 @@ github.com/pingcap/kvproto v0.0.0-20191018025622-fbf07f9804da h1:dLmHmFq44tIq7yW
 github.com/pingcap/kvproto v0.0.0-20191018025622-fbf07f9804da/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20191011160321-0c4055ef2c1d h1:d66fiFmhd0FhwgwwKxi+4mvoy8v7KLts/BsZ9Qlg5XU=
-github.com/pingcap/parser v0.0.0-20191011160321-0c4055ef2c1d/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191018040858-0d9d9d67d029 h1:nJp6nnW70cGtmOiRnjvoU8fSxhb5QwGNgYr/AtyPCgo=
 github.com/pingcap/pd v1.1.0-beta.0.20191018040858-0d9d9d67d029/go.mod h1:+F+Zp4BoMM7TbDKCeosXO+X9A+IWaw/T3/gRBo1sr6Q=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible h1:H1jg0aDWz2SLRh3hNBo2HFtnuHtudIUvBumU7syRkic=

--- a/infoschema/slow_log.go
+++ b/infoschema/slow_log.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/plancodec"
 	"go.uber.org/zap"
 )
 
@@ -61,6 +62,7 @@ var slowQueryCols = []columnInfo{
 	{variable.SlowLogCopWaitAddr, mysql.TypeVarchar, 64, 0, nil, nil},
 	{variable.SlowLogMemMax, mysql.TypeLonglong, 20, 0, nil, nil},
 	{variable.SlowLogSucc, mysql.TypeTiny, 1, 0, nil, nil},
+	{variable.SlowLogPlan, mysql.TypeLongBlob, types.UnspecifiedLength, 0, nil, nil},
 	{variable.SlowLogPrevStmt, mysql.TypeLongBlob, types.UnspecifiedLength, 0, nil, nil},
 	{variable.SlowLogQuerySQLStr, mysql.TypeLongBlob, types.UnspecifiedLength, 0, nil, nil},
 }
@@ -205,6 +207,7 @@ type slowQueryTuple struct {
 	sql               string
 	isInternal        bool
 	succ              bool
+	plan              string
 }
 
 func (st *slowQueryTuple) setFieldValue(tz *time.Location, field, value string) error {
@@ -274,6 +277,8 @@ func (st *slowQueryTuple) setFieldValue(tz *time.Location, field, value string) 
 		st.memMax, err = strconv.ParseInt(value, 10, 64)
 	case variable.SlowLogSucc:
 		st.succ, err = strconv.ParseBool(value)
+	case variable.SlowLogPlan:
+		st.plan = value
 	case variable.SlowLogQuerySQLStr:
 		st.sql = value
 	}
@@ -320,9 +325,24 @@ func (st *slowQueryTuple) convertToDatumRow() []types.Datum {
 	} else {
 		record = append(record, types.NewIntDatum(0))
 	}
+	record = append(record, types.NewStringDatum(parsePlan(st.plan)))
 	record = append(record, types.NewStringDatum(st.prevStmt))
 	record = append(record, types.NewStringDatum(st.sql))
 	return record
+}
+
+func parsePlan(planString string) string {
+	if len(planString) <= len(variable.SlowLogPlanPrefix)+len(variable.SlowLogPlanSuffix) {
+		return planString
+	}
+	planString = planString[len(variable.SlowLogPlanPrefix) : len(planString)-len(variable.SlowLogPlanSuffix)]
+	decodePlanString, err := plancodec.DecodePlan(planString)
+	if err == nil {
+		planString = decodePlanString
+	} else {
+		logutil.Logger(context.Background()).Error("decode plan in slow log failed", zap.String("plan", planString), zap.Error(err))
+	}
+	return planString
 }
 
 // ParseTime exports for testing.

--- a/infoschema/slow_log_test.go
+++ b/infoschema/slow_log_test.go
@@ -55,7 +55,7 @@ select * from t;`)
 		}
 		recordString += str
 	}
-	expectRecordString := "2019-04-28 15:24:04.309074,405888132465033227,,,0,0.216905,0.021,0,0,1,637,0,,,1,42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772,t1:1,t2:2,0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,0,update t set i = 1;,select * from t;"
+	expectRecordString := "2019-04-28 15:24:04.309074,405888132465033227,,,0,0.216905,0.021,0,0,1,637,0,,,1,42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772,t1:1,t2:2,0.1,0.2,0.03,127.0.0.1:20160,0.05,0.6,0.8,0.0.0.0:20160,70724,0,,update t set i = 1;,select * from t;"
 	c.Assert(expectRecordString, Equals, recordString)
 
 	// fix sql contain '# ' bug

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -475,6 +475,7 @@ func (s *testTableSuite) TestSlowQuery(c *C) {
 # Cop_wait_avg: 0.05 Cop_wait_p90: 0.6 Cop_wait_max: 0.8 Cop_wait_addr: 0.0.0.0:20160
 # Mem_max: 70724
 # Succ: true
+# Plan: abcd
 # Prev_stmt: update t set i = 2;
 select * from t_slim;`))
 	c.Assert(f.Sync(), IsNil)
@@ -484,10 +485,10 @@ select * from t_slim;`))
 	tk.MustExec("set time_zone = '+08:00';")
 	re := tk.MustQuery("select * from information_schema.slow_query")
 	re.Check(testutil.RowsWithSep("|",
-		"2019-02-12 19:33:56.571953|406315658548871171|root|127.0.0.1|6|4.895492|0.161|0.101|0.092|1|100001|100000|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|1|update t set i = 2;|select * from t_slim;"))
+		"2019-02-12 19:33:56.571953|406315658548871171|root|127.0.0.1|6|4.895492|0.161|0.101|0.092|1|100001|100000|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|1|abcd|update t set i = 2;|select * from t_slim;"))
 	tk.MustExec("set time_zone = '+00:00';")
 	re = tk.MustQuery("select * from information_schema.slow_query")
-	re.Check(testutil.RowsWithSep("|", "2019-02-12 11:33:56.571953|406315658548871171|root|127.0.0.1|6|4.895492|0.161|0.101|0.092|1|100001|100000|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|1|update t set i = 2;|select * from t_slim;"))
+	re.Check(testutil.RowsWithSep("|", "2019-02-12 11:33:56.571953|406315658548871171|root|127.0.0.1|6|4.895492|0.161|0.101|0.092|1|100001|100000|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|1|abcd|update t set i = 2;|select * from t_slim;"))
 
 	// Test for long query.
 	_, err = f.Write([]byte(`

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -1,0 +1,68 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"bytes"
+	"sync"
+
+	"github.com/pingcap/tidb/util/plancodec"
+)
+
+var encoderPool = sync.Pool{
+	New: func() interface{} {
+		return &planEncoder{}
+	},
+}
+
+type planEncoder struct {
+	buf          bytes.Buffer
+	encodedPlans map[int]bool
+}
+
+// EncodePlan is used to encodePlan the plan to the plan tree with compressing.
+func EncodePlan(p PhysicalPlan) string {
+	pn := encoderPool.Get().(*planEncoder)
+	defer encoderPool.Put(pn)
+	return pn.encodePlanTree(p)
+}
+
+func (pn *planEncoder) encodePlanTree(p PhysicalPlan) string {
+	pn.encodedPlans = make(map[int]bool)
+	pn.buf.Reset()
+	pn.encodePlan(p, true, 0)
+	return plancodec.Compress(pn.buf.Bytes())
+}
+
+func (pn *planEncoder) encodePlan(p PhysicalPlan, isRoot bool, depth int) {
+	plancodec.EncodePlanNode(depth, p.ID(), p.TP(), isRoot, p.statsInfo().RowCount, p.ExplainInfo(), &pn.buf)
+	pn.encodedPlans[p.ID()] = true
+
+	depth++
+	for _, child := range p.Children() {
+		if pn.encodedPlans[child.ID()] {
+			continue
+		}
+		pn.encodePlan(child.(PhysicalPlan), isRoot, depth)
+	}
+	switch copPlan := p.(type) {
+	case *PhysicalTableReader:
+		pn.encodePlan(copPlan.tablePlan, false, depth)
+	case *PhysicalIndexReader:
+		pn.encodePlan(copPlan.indexPlan, false, depth)
+	case *PhysicalIndexLookUpReader:
+		pn.encodePlan(copPlan.indexPlan, false, depth)
+		pn.encodePlan(copPlan.tablePlan, false, depth)
+	}
+}

--- a/planner/core/initialize.go
+++ b/planner/core/initialize.go
@@ -16,108 +16,42 @@ package core
 import (
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/sessionctx"
-)
-
-const (
-	// TypeSel is the type of Selection.
-	TypeSel = "Selection"
-	// TypeSet is the type of Set.
-	TypeSet = "Set"
-	// TypeProj is the type of Projection.
-	TypeProj = "Projection"
-	// TypeAgg is the type of Aggregation.
-	TypeAgg = "Aggregation"
-	// TypeStreamAgg is the type of StreamAgg.
-	TypeStreamAgg = "StreamAgg"
-	// TypeHashAgg is the type of HashAgg.
-	TypeHashAgg = "HashAgg"
-	// TypeShow is the type of show.
-	TypeShow = "Show"
-	// TypeJoin is the type of Join.
-	TypeJoin = "Join"
-	// TypeUnion is the type of Union.
-	TypeUnion = "Union"
-	// TypeTableScan is the type of TableScan.
-	TypeTableScan = "TableScan"
-	// TypeMemTableScan is the type of TableScan.
-	TypeMemTableScan = "MemTableScan"
-	// TypeUnionScan is the type of UnionScan.
-	TypeUnionScan = "UnionScan"
-	// TypeIdxScan is the type of IndexScan.
-	TypeIdxScan = "IndexScan"
-	// TypeSort is the type of Sort.
-	TypeSort = "Sort"
-	// TypeTopN is the type of TopN.
-	TypeTopN = "TopN"
-	// TypeLimit is the type of Limit.
-	TypeLimit = "Limit"
-	// TypeHashLeftJoin is the type of left hash join.
-	TypeHashLeftJoin = "HashLeftJoin"
-	// TypeHashRightJoin is the type of right hash join.
-	TypeHashRightJoin = "HashRightJoin"
-	// TypeMergeJoin is the type of merge join.
-	TypeMergeJoin = "MergeJoin"
-	// TypeIndexJoin is the type of index look up join.
-	TypeIndexJoin = "IndexJoin"
-	// TypeApply is the type of Apply.
-	TypeApply = "Apply"
-	// TypeMaxOneRow is the type of MaxOneRow.
-	TypeMaxOneRow = "MaxOneRow"
-	// TypeExists is the type of Exists.
-	TypeExists = "Exists"
-	// TypeDual is the type of TableDual.
-	TypeDual = "TableDual"
-	// TypeLock is the type of SelectLock.
-	TypeLock = "SelectLock"
-	// TypeInsert is the type of Insert
-	TypeInsert = "Insert"
-	// TypeUpdate is the type of Update.
-	TypeUpdate = "Update"
-	// TypeDelete is the type of Delete.
-	TypeDelete = "Delete"
-	// TypeIndexLookUp is the type of IndexLookUp.
-	TypeIndexLookUp = "IndexLookUp"
-	// TypeTableReader is the type of TableReader.
-	TypeTableReader = "TableReader"
-	// TypeIndexReader is the type of IndexReader.
-	TypeIndexReader = "IndexReader"
-	// TypeWindow is the type of Window.
-	TypeWindow = "Window"
+	"github.com/pingcap/tidb/util/plancodec"
 )
 
 // Init initializes LogicalAggregation.
 func (la LogicalAggregation) Init(ctx sessionctx.Context) *LogicalAggregation {
-	la.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeAgg, &la)
+	la.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeAgg, &la)
 	return &la
 }
 
 // Init initializes LogicalJoin.
 func (p LogicalJoin) Init(ctx sessionctx.Context) *LogicalJoin {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeJoin, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeJoin, &p)
 	return &p
 }
 
 // Init initializes DataSource.
 func (ds DataSource) Init(ctx sessionctx.Context) *DataSource {
-	ds.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeTableScan, &ds)
+	ds.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeTableScan, &ds)
 	return &ds
 }
 
 // Init initializes LogicalApply.
 func (la LogicalApply) Init(ctx sessionctx.Context) *LogicalApply {
-	la.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeApply, &la)
+	la.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeApply, &la)
 	return &la
 }
 
 // Init initializes LogicalSelection.
 func (p LogicalSelection) Init(ctx sessionctx.Context) *LogicalSelection {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeSel, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeSel, &p)
 	return &p
 }
 
 // Init initializes PhysicalSelection.
 func (p PhysicalSelection) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalSelection {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeSel, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeSel, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -125,19 +59,19 @@ func (p PhysicalSelection) Init(ctx sessionctx.Context, stats *property.StatsInf
 
 // Init initializes LogicalUnionScan.
 func (p LogicalUnionScan) Init(ctx sessionctx.Context) *LogicalUnionScan {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeUnionScan, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeUnionScan, &p)
 	return &p
 }
 
 // Init initializes LogicalProjection.
 func (p LogicalProjection) Init(ctx sessionctx.Context) *LogicalProjection {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeProj, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeProj, &p)
 	return &p
 }
 
 // Init initializes PhysicalProjection.
 func (p PhysicalProjection) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalProjection {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeProj, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeProj, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -145,13 +79,13 @@ func (p PhysicalProjection) Init(ctx sessionctx.Context, stats *property.StatsIn
 
 // Init initializes LogicalUnionAll.
 func (p LogicalUnionAll) Init(ctx sessionctx.Context) *LogicalUnionAll {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeUnion, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeUnion, &p)
 	return &p
 }
 
 // Init initializes PhysicalUnionAll.
 func (p PhysicalUnionAll) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalUnionAll {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeUnion, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeUnion, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -159,13 +93,13 @@ func (p PhysicalUnionAll) Init(ctx sessionctx.Context, stats *property.StatsInfo
 
 // Init initializes LogicalSort.
 func (ls LogicalSort) Init(ctx sessionctx.Context) *LogicalSort {
-	ls.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeSort, &ls)
+	ls.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeSort, &ls)
 	return &ls
 }
 
 // Init initializes PhysicalSort.
 func (p PhysicalSort) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalSort {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeSort, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeSort, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -173,20 +107,20 @@ func (p PhysicalSort) Init(ctx sessionctx.Context, stats *property.StatsInfo, pr
 
 // Init initializes NominalSort.
 func (p NominalSort) Init(ctx sessionctx.Context, props ...*property.PhysicalProperty) *NominalSort {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeSort, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeSort, &p)
 	p.childrenReqProps = props
 	return &p
 }
 
 // Init initializes LogicalTopN.
 func (lt LogicalTopN) Init(ctx sessionctx.Context) *LogicalTopN {
-	lt.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeTopN, &lt)
+	lt.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeTopN, &lt)
 	return &lt
 }
 
 // Init initializes PhysicalTopN.
 func (p PhysicalTopN) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalTopN {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeTopN, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeTopN, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -194,13 +128,13 @@ func (p PhysicalTopN) Init(ctx sessionctx.Context, stats *property.StatsInfo, pr
 
 // Init initializes LogicalLimit.
 func (p LogicalLimit) Init(ctx sessionctx.Context) *LogicalLimit {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeLimit, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeLimit, &p)
 	return &p
 }
 
 // Init initializes PhysicalLimit.
 func (p PhysicalLimit) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalLimit {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeLimit, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeLimit, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -208,26 +142,26 @@ func (p PhysicalLimit) Init(ctx sessionctx.Context, stats *property.StatsInfo, p
 
 // Init initializes LogicalTableDual.
 func (p LogicalTableDual) Init(ctx sessionctx.Context) *LogicalTableDual {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeDual, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeDual, &p)
 	return &p
 }
 
 // Init initializes PhysicalTableDual.
 func (p PhysicalTableDual) Init(ctx sessionctx.Context, stats *property.StatsInfo) *PhysicalTableDual {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeDual, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeDual, &p)
 	p.stats = stats
 	return &p
 }
 
 // Init initializes LogicalMaxOneRow.
 func (p LogicalMaxOneRow) Init(ctx sessionctx.Context) *LogicalMaxOneRow {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeMaxOneRow, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeMaxOneRow, &p)
 	return &p
 }
 
 // Init initializes PhysicalMaxOneRow.
 func (p PhysicalMaxOneRow) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalMaxOneRow {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeMaxOneRow, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeMaxOneRow, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -235,13 +169,13 @@ func (p PhysicalMaxOneRow) Init(ctx sessionctx.Context, stats *property.StatsInf
 
 // Init initializes LogicalWindow.
 func (p LogicalWindow) Init(ctx sessionctx.Context) *LogicalWindow {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeWindow, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeWindow, &p)
 	return &p
 }
 
 // Init initializes PhysicalWindow.
 func (p PhysicalWindow) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalWindow {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeWindow, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeWindow, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -249,25 +183,25 @@ func (p PhysicalWindow) Init(ctx sessionctx.Context, stats *property.StatsInfo, 
 
 // Init initializes Update.
 func (p Update) Init(ctx sessionctx.Context) *Update {
-	p.basePlan = newBasePlan(ctx, TypeUpdate)
+	p.basePlan = newBasePlan(ctx, plancodec.TypeUpdate)
 	return &p
 }
 
 // Init initializes Delete.
 func (p Delete) Init(ctx sessionctx.Context) *Delete {
-	p.basePlan = newBasePlan(ctx, TypeDelete)
+	p.basePlan = newBasePlan(ctx, plancodec.TypeDelete)
 	return &p
 }
 
 // Init initializes Insert.
 func (p Insert) Init(ctx sessionctx.Context) *Insert {
-	p.basePlan = newBasePlan(ctx, TypeInsert)
+	p.basePlan = newBasePlan(ctx, plancodec.TypeInsert)
 	return &p
 }
 
 // Init initializes Show.
 func (p Show) Init(ctx sessionctx.Context) *Show {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeShow, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeShow, &p)
 	// Just use pseudo stats to avoid panic.
 	p.stats = &property.StatsInfo{RowCount: 1}
 	return &p
@@ -275,13 +209,13 @@ func (p Show) Init(ctx sessionctx.Context) *Show {
 
 // Init initializes LogicalLock.
 func (p LogicalLock) Init(ctx sessionctx.Context) *LogicalLock {
-	p.baseLogicalPlan = newBaseLogicalPlan(ctx, TypeLock, &p)
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeLock, &p)
 	return &p
 }
 
 // Init initializes PhysicalLock.
 func (p PhysicalLock) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalLock {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeLock, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeLock, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -289,28 +223,28 @@ func (p PhysicalLock) Init(ctx sessionctx.Context, stats *property.StatsInfo, pr
 
 // Init initializes PhysicalTableScan.
 func (p PhysicalTableScan) Init(ctx sessionctx.Context) *PhysicalTableScan {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeTableScan, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeTableScan, &p)
 	return &p
 }
 
 // Init initializes PhysicalIndexScan.
 func (p PhysicalIndexScan) Init(ctx sessionctx.Context) *PhysicalIndexScan {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeIdxScan, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeIdxScan, &p)
 	return &p
 }
 
 // Init initializes PhysicalMemTable.
 func (p PhysicalMemTable) Init(ctx sessionctx.Context, stats *property.StatsInfo) *PhysicalMemTable {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeMemTableScan, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeMemTableScan, &p)
 	p.stats = stats
 	return &p
 }
 
 // Init initializes PhysicalHashJoin.
 func (p PhysicalHashJoin) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalHashJoin {
-	tp := TypeHashRightJoin
+	tp := plancodec.TypeHashRightJoin
 	if p.InnerChildIdx == 1 {
-		tp = TypeHashLeftJoin
+		tp = plancodec.TypeHashLeftJoin
 	}
 	p.basePhysicalPlan = newBasePhysicalPlan(ctx, tp, &p)
 	p.childrenReqProps = props
@@ -320,21 +254,21 @@ func (p PhysicalHashJoin) Init(ctx sessionctx.Context, stats *property.StatsInfo
 
 // Init initializes PhysicalMergeJoin.
 func (p PhysicalMergeJoin) Init(ctx sessionctx.Context, stats *property.StatsInfo) *PhysicalMergeJoin {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeMergeJoin, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeMergeJoin, &p)
 	p.stats = stats
 	return &p
 }
 
 // Init initializes basePhysicalAgg.
 func (base basePhysicalAgg) Init(ctx sessionctx.Context, stats *property.StatsInfo) *basePhysicalAgg {
-	base.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeHashAgg, &base)
+	base.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeHashAgg, &base)
 	base.stats = stats
 	return &base
 }
 
 func (base basePhysicalAgg) initForHash(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalHashAgg {
 	p := &PhysicalHashAgg{base}
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeHashAgg, p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeHashAgg, p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return p
@@ -342,7 +276,7 @@ func (base basePhysicalAgg) initForHash(ctx sessionctx.Context, stats *property.
 
 func (base basePhysicalAgg) initForStream(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalStreamAgg {
 	p := &PhysicalStreamAgg{base}
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeStreamAgg, p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeStreamAgg, p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return p
@@ -350,7 +284,7 @@ func (base basePhysicalAgg) initForStream(ctx sessionctx.Context, stats *propert
 
 // Init initializes PhysicalApply.
 func (p PhysicalApply) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalApply {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeApply, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeApply, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -358,7 +292,7 @@ func (p PhysicalApply) Init(ctx sessionctx.Context, stats *property.StatsInfo, p
 
 // Init initializes PhysicalUnionScan.
 func (p PhysicalUnionScan) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalUnionScan {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeUnionScan, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeUnionScan, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p
@@ -366,7 +300,7 @@ func (p PhysicalUnionScan) Init(ctx sessionctx.Context, stats *property.StatsInf
 
 // Init initializes PhysicalIndexLookUpReader.
 func (p PhysicalIndexLookUpReader) Init(ctx sessionctx.Context) *PhysicalIndexLookUpReader {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeIndexLookUp, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeIndexLookUp, &p)
 	p.TablePlans = flattenPushDownPlan(p.tablePlan)
 	p.IndexPlans = flattenPushDownPlan(p.indexPlan)
 	p.schema = p.tablePlan.Schema()
@@ -375,7 +309,7 @@ func (p PhysicalIndexLookUpReader) Init(ctx sessionctx.Context) *PhysicalIndexLo
 
 // Init initializes PhysicalTableReader.
 func (p PhysicalTableReader) Init(ctx sessionctx.Context) *PhysicalTableReader {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeTableReader, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeTableReader, &p)
 	p.TablePlans = flattenPushDownPlan(p.tablePlan)
 	p.schema = p.tablePlan.Schema()
 	return &p
@@ -383,7 +317,7 @@ func (p PhysicalTableReader) Init(ctx sessionctx.Context) *PhysicalTableReader {
 
 // Init initializes PhysicalIndexReader.
 func (p PhysicalIndexReader) Init(ctx sessionctx.Context) *PhysicalIndexReader {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeIndexReader, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeIndexReader, &p)
 	p.IndexPlans = flattenPushDownPlan(p.indexPlan)
 	switch p.indexPlan.(type) {
 	case *PhysicalHashAgg, *PhysicalStreamAgg:
@@ -398,7 +332,7 @@ func (p PhysicalIndexReader) Init(ctx sessionctx.Context) *PhysicalIndexReader {
 
 // Init initializes PhysicalIndexJoin.
 func (p PhysicalIndexJoin) Init(ctx sessionctx.Context, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalIndexJoin {
-	p.basePhysicalPlan = newBasePhysicalPlan(ctx, TypeIndexJoin, &p)
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeIndexJoin, &p)
 	p.childrenReqProps = props
 	p.stats = stats
 	return &p

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/plancodec"
 )
 
 const (
@@ -2569,7 +2570,7 @@ func (b *PlanBuilder) buildSemiApply(outerPlan, innerPlan LogicalPlan, condition
 	}
 
 	ap := &LogicalApply{LogicalJoin: *join}
-	ap.tp = TypeApply
+	ap.tp = plancodec.TypeApply
 	ap.self = ap
 	return ap, nil
 }

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -35,6 +35,10 @@ type Plan interface {
 	Schema() *expression.Schema
 	// Get the ID.
 	ID() int
+
+	// TP get the plan type.
+	TP() string
+
 	// Get the ID in explain statement
 	ExplainID() fmt.Stringer
 	// replaceExprColumns replace all the column reference in the plan's expression node.
@@ -270,6 +274,11 @@ func (p *basePlan) ExplainID() fmt.Stringer {
 	return stringutil.MemoizeStr(func() string {
 		return p.tp + "_" + strconv.Itoa(p.id)
 	})
+}
+
+// TP implements Plan interface.
+func (p *basePlan) TP() string {
+	return p.tp
 }
 
 // Schema implements Plan Schema interface.

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/parser_driver"
+	"github.com/pingcap/tidb/util/plancodec"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -283,7 +284,7 @@ func tryPointGetPlan(ctx sessionctx.Context, selStmt *ast.SelectStmt) *PointGetP
 
 func newPointGetPlan(ctx sessionctx.Context, dbName string, schema *expression.Schema, tbl *model.TableInfo) *PointGetPlan {
 	p := &PointGetPlan{
-		basePlan: newBasePlan(ctx, "Point_Get"),
+		basePlan: newBasePlan(ctx, plancodec.TypePointGet),
 		dbName:   dbName,
 		schema:   schema,
 		TblInfo:  tbl,

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/plancodec"
 	"github.com/pingcap/tidb/util/ranger"
 )
 
@@ -130,7 +131,7 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 
 		// Not a deep copy.
 		newDataSource := *ds
-		newDataSource.baseLogicalPlan = newBaseLogicalPlan(ds.context(), TypeTableScan, &newDataSource)
+		newDataSource.baseLogicalPlan = newBaseLogicalPlan(ds.context(), plancodec.TypeTableScan, &newDataSource)
 		newDataSource.isPartition = true
 		newDataSource.physicalTableID = pi.Definitions[i].ID
 		// There are many expression nodes in the plan tree use the original datasource

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/plancodec"
 )
 
 // task is a new version of `PhysicalPlanInfo`. It stores cost information for a task.
@@ -488,7 +489,7 @@ func (p *basePhysicalAgg) newPartialAggregate() (partial, final PhysicalPlan) {
 	}
 
 	// Create physical "final" aggregation.
-	if p.tp == TypeStreamAgg {
+	if p.tp == plancodec.TypeStreamAgg {
 		finalAgg := basePhysicalAgg{
 			AggFuncs:     finalAggFuncs,
 			GroupByItems: groupByItems,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -789,6 +789,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		atomic.StoreUint32(&ProcessGeneralLog, uint32(tidbOptPositiveInt32(val, DefTiDBGeneralLog)))
 	case TiDBSlowLogThreshold:
 		atomic.StoreUint64(&config.GetGlobalConfig().Log.SlowThreshold, uint64(tidbOptInt64(val, logutil.DefaultSlowThreshold)))
+	case TiDBRecordPlanInSlowLog:
+		atomic.StoreUint32(&config.GetGlobalConfig().Log.RecordPlanInSlowLog, uint32(tidbOptInt64(val, logutil.DefaultRecordPlanInSlowLog)))
 	case TiDBDDLSlowOprThreshold:
 		atomic.StoreUint32(&DDLSlowOprThreshold, uint32(tidbOptPositiveInt32(val, DefTiDBDDLSlowOprThreshold)))
 	case TiDBQueryLogMaxLen:
@@ -1040,6 +1042,12 @@ const (
 	SlowLogSucc = "Succ"
 	// SlowLogPrevStmt is used to show the previous executed statement.
 	SlowLogPrevStmt = "Prev_stmt"
+	// SlowLogPlan is used to record the query plan.
+	SlowLogPlan = "Plan"
+	// SlowLogPlanPrefix is the prefix of the plan value.
+	SlowLogPlanPrefix = ast.TiDBDecodePlan + "('"
+	// SlowLogPlanSuffix is the suffix of the plan value.
+	SlowLogPlanSuffix = "')"
 	// SlowLogPrevStmtPrefix is the prefix of Prev_stmt in slow log file.
 	SlowLogPrevStmtPrefix = SlowLogPrevStmt + SlowLogSpaceMarkStr
 )
@@ -1060,6 +1068,7 @@ type SlowQueryLogItems struct {
 	MemMax         int64
 	Succ           bool
 	Prepared       bool
+	Plan           string
 	HasMoreResults bool
 	PrevStmt       string
 }
@@ -1153,6 +1162,9 @@ func (s *SessionVars) SlowLogFormat(logItems *SlowQueryLogItems) string {
 	writeSlowLogItem(&buf, SlowLogPrepared, strconv.FormatBool(logItems.Prepared))
 	writeSlowLogItem(&buf, SlowLogHasMoreResults, strconv.FormatBool(logItems.HasMoreResults))
 	writeSlowLogItem(&buf, SlowLogSucc, strconv.FormatBool(logItems.Succ))
+	if len(logItems.Plan) != 0 {
+		writeSlowLogItem(&buf, SlowLogPlan, logItems.Plan)
+	}
 
 	if logItems.PrevStmt != "" {
 		writeSlowLogItem(&buf, SlowLogPrevStmt, logItems.PrevStmt)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -693,6 +693,7 @@ var defaultSysVars = []*SysVar{
 	/* The following variable is defined as session scope but is actually server scope. */
 	{ScopeSession, TiDBGeneralLog, strconv.Itoa(DefTiDBGeneralLog)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},
+	{ScopeSession, TiDBRecordPlanInSlowLog, strconv.Itoa(logutil.DefaultRecordPlanInSlowLog)},
 	{ScopeSession, TiDBDDLSlowOprThreshold, strconv.Itoa(DefTiDBDDLSlowOprThreshold)},
 	{ScopeSession, TiDBQueryLogMaxLen, strconv.Itoa(logutil.DefaultQueryLogMaxLen)},
 	{ScopeSession, TiDBConfig, ""},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -108,6 +108,9 @@ const (
 	// tidb_slow_log_threshold is used to set the slow log threshold in the server.
 	TiDBSlowLogThreshold = "tidb_slow_log_threshold"
 
+	// tidb_record_plan_in_slow_log is used to log the plan of the slow query.
+	TiDBRecordPlanInSlowLog = "tidb_record_plan_in_slow_log"
+
 	// tidb_query_log_max_len is used to set the max length of the query in the log.
 	TiDBQueryLogMaxLen = "tidb_query_log_max_len"
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -127,6 +127,8 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 		return mysql.Priority2Str[mysql.PriorityEnum(atomic.LoadInt32(&ForcePriority))], true, nil
 	case TiDBSlowLogThreshold:
 		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.SlowThreshold), 10), true, nil
+	case TiDBRecordPlanInSlowLog:
+		return strconv.FormatUint(uint64(atomic.LoadUint32(&config.GetGlobalConfig().Log.RecordPlanInSlowLog)), 10), true, nil
 	case TiDBDDLSlowOprThreshold:
 		return strconv.FormatUint(uint64(atomic.LoadUint32(&DDLSlowOprThreshold)), 10), true, nil
 	case TiDBQueryLogMaxLen:
@@ -394,7 +396,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		SQLWarnings, UniqueChecks, OldAlterTable, LogBinTrustFunctionCreators, SQLBigSelects,
 		BinlogDirectNonTransactionalUpdates, SQLQuoteShowCreate, AutomaticSpPrivileges,
 		RelayLogPurge, SQLAutoIsNull, QueryCacheWlockInvalidate, ValidatePasswordCheckUserName,
-		SuperReadOnly, BinlogOrderCommits, MasterVerifyChecksum, BinlogRowQueryLogEvents, LogSlowSlaveStatements,
+		SuperReadOnly, BinlogOrderCommits, MasterVerifyChecksum, BinlogRowQueryLogEvents, LogSlowSlaveStatements, TiDBRecordPlanInSlowLog,
 		LogSlowAdminStatements, LogQueriesNotUsingIndexes, Profiling:
 		if strings.EqualFold(value, "ON") {
 			return "1", nil

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -42,6 +42,8 @@ const (
 	DefaultSlowThreshold = 300
 	// DefaultQueryLogMaxLen is the default max length of the query in the log.
 	DefaultQueryLogMaxLen = 2048
+	// DefaultRecordPlanInSlowLog is the default value for whether enable log query plan in the slow log.
+	DefaultRecordPlanInSlowLog = 1
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/plancodec/codec.go
+++ b/util/plancodec/codec.go
@@ -1,0 +1,297 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plancodec
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/golang/snappy"
+	"github.com/pingcap/errors"
+)
+
+const (
+	// TreeBody indicates the current operator sub-tree is not finished, still
+	// has child operators to be attached on.
+	TreeBody = '│'
+	// TreeMiddleNode indicates this operator is not the last child of the
+	// current sub-tree rooted by its parent.
+	TreeMiddleNode = '├'
+	// TreeLastNode indicates this operator is the last child of the current
+	// sub-tree rooted by its parent.
+	TreeLastNode = '└'
+	// TreeGap is used to represent the gap between the branches of the tree.
+	TreeGap = ' '
+	// TreeNodeIdentifier is used to replace the TreeGap once we need to attach
+	// a node to a sub-tree.
+	TreeNodeIdentifier = '─'
+)
+
+const (
+	rootTaskType = "0"
+	copTaskType  = "1"
+)
+
+const (
+	idSeparator    = "_"
+	lineBreaker    = '\n'
+	lineBreakerStr = "\n"
+	separator      = '\t'
+	separatorStr   = "\t"
+)
+
+var decoderPool = sync.Pool{
+	New: func() interface{} {
+		return &planDecoder{}
+	},
+}
+
+// DecodePlan use to decode the string to plan tree.
+func DecodePlan(planString string) (string, error) {
+	if len(planString) == 0 {
+		return "", nil
+	}
+	pd := decoderPool.Get().(*planDecoder)
+	defer decoderPool.Put(pd)
+	pd.buf.Reset()
+	return pd.decode(planString)
+}
+
+type planDecoder struct {
+	buf       bytes.Buffer
+	depths    []int
+	indents   [][]rune
+	planInfos []*planInfo
+}
+
+type planInfo struct {
+	depth  int
+	fields []string
+}
+
+func (pd *planDecoder) decode(planString string) (string, error) {
+	str, err := decompress(planString)
+	if err != nil {
+		return "", err
+	}
+
+	nodes := strings.Split(str, lineBreakerStr)
+	if len(pd.depths) < len(nodes) {
+		pd.depths = make([]int, 0, len(nodes))
+		pd.planInfos = make([]*planInfo, 0, len(nodes))
+		pd.indents = make([][]rune, 0, len(nodes))
+	}
+	pd.depths = pd.depths[:0]
+	pd.planInfos = pd.planInfos[:0]
+	planInfos := pd.planInfos
+	for _, node := range nodes {
+		p, err := decodePlanInfo(node)
+		if err != nil {
+			return "", err
+		}
+		if p == nil {
+			continue
+		}
+		planInfos = append(planInfos, p)
+		pd.depths = append(pd.depths, p.depth)
+	}
+
+	// Calculated indentation of plans.
+	pd.initPlanTreeIndents()
+	for i := 1; i < len(pd.depths); i++ {
+		parentIndex := pd.findParentIndex(i)
+		pd.fillIndent(parentIndex, i)
+	}
+	// Align the value of plan fields.
+	pd.alignFields(planInfos)
+
+	for i, p := range planInfos {
+		if i > 0 {
+			pd.buf.WriteByte(lineBreaker)
+		}
+		// This is for alignment.
+		pd.buf.WriteByte(separator)
+		pd.buf.WriteString(string(pd.indents[i]))
+		for j := 0; j < len(p.fields); j++ {
+			if j > 0 {
+				pd.buf.WriteByte(separator)
+			}
+			pd.buf.WriteString(p.fields[j])
+		}
+	}
+	return pd.buf.String(), nil
+}
+
+func (pd *planDecoder) initPlanTreeIndents() {
+	pd.indents = pd.indents[:0]
+	for i := 0; i < len(pd.depths); i++ {
+		indent := make([]rune, 2*pd.depths[i])
+		pd.indents = append(pd.indents, indent)
+		if len(indent) == 0 {
+			continue
+		}
+		for i := 0; i < len(indent)-2; i++ {
+			indent[i] = ' '
+		}
+		indent[len(indent)-2] = TreeLastNode
+		indent[len(indent)-1] = TreeNodeIdentifier
+	}
+}
+
+func (pd *planDecoder) findParentIndex(childIndex int) int {
+	for i := childIndex - 1; i > 0; i-- {
+		if pd.depths[i]+1 == pd.depths[childIndex] {
+			return i
+		}
+	}
+	return 0
+}
+func (pd *planDecoder) fillIndent(parentIndex, childIndex int) {
+	depth := pd.depths[childIndex]
+	if depth == 0 {
+		return
+	}
+	idx := depth*2 - 2
+	for i := childIndex - 1; i > parentIndex; i-- {
+		if pd.indents[i][idx] == TreeLastNode {
+			pd.indents[i][idx] = TreeMiddleNode
+			break
+		}
+		pd.indents[i][idx] = TreeBody
+	}
+}
+
+func (pd *planDecoder) alignFields(planInfos []*planInfo) {
+	if len(planInfos) == 0 {
+		return
+	}
+	fieldsLen := len(planInfos[0].fields)
+	// Last field no need to align.
+	fieldsLen--
+	for colIdx := 0; colIdx < fieldsLen; colIdx++ {
+		maxFieldLen := pd.getMaxFieldLength(colIdx, planInfos)
+		for rowIdx, p := range planInfos {
+			fillLen := maxFieldLen - pd.getPlanFieldLen(rowIdx, colIdx, p)
+			for i := 0; i < fillLen; i++ {
+				p.fields[colIdx] += " "
+			}
+		}
+	}
+}
+
+func (pd *planDecoder) getMaxFieldLength(idx int, planInfos []*planInfo) int {
+	maxLength := -1
+	for rowIdx, p := range planInfos {
+		l := pd.getPlanFieldLen(rowIdx, idx, p)
+		if l > maxLength {
+			maxLength = l
+		}
+	}
+	return maxLength
+}
+
+func (pd *planDecoder) getPlanFieldLen(rowIdx, colIdx int, p *planInfo) int {
+	if colIdx == 0 {
+		return len(p.fields[0]) + len(pd.indents[rowIdx])
+	}
+	return len(p.fields[colIdx])
+}
+
+func decodePlanInfo(str string) (*planInfo, error) {
+	values := strings.Split(str, separatorStr)
+	if len(values) < 2 {
+		return nil, nil
+	}
+
+	p := &planInfo{
+		fields: make([]string, 0, len(values)-1),
+	}
+	for i, v := range values {
+		switch i {
+		// depth
+		case 0:
+			depth, err := strconv.Atoi(v)
+			if err != nil {
+				return nil, errors.Errorf("decode plan: %v, depth: %v, error: %v", str, v, err)
+			}
+			p.depth = depth
+		// plan ID
+		case 1:
+			ids := strings.Split(v, idSeparator)
+			if len(ids) != 2 {
+				return nil, errors.Errorf("decode plan: %v error, invalid plan id: %v", str, v)
+			}
+			planID, err := strconv.Atoi(ids[0])
+			if err != err {
+				return nil, errors.Errorf("decode plan: %v, plan id: %v, error: %v", str, v, err)
+			}
+			p.fields = append(p.fields, PhysicalIDToTypeString(planID)+idSeparator+ids[1])
+		// task type
+		case 2:
+			if v == rootTaskType {
+				p.fields = append(p.fields, "root")
+			} else {
+				p.fields = append(p.fields, "cop")
+			}
+		default:
+			p.fields = append(p.fields, v)
+		}
+	}
+	return p, nil
+}
+
+// EncodePlanNode is used to encode the plan to a string.
+func EncodePlanNode(depth, pid int, planType string, isRoot bool, rowCount float64, explainInfo string, buf *bytes.Buffer) {
+	buf.WriteString(strconv.Itoa(depth))
+	buf.WriteByte(separator)
+	buf.WriteString(encodeID(planType, pid))
+	buf.WriteByte(separator)
+	if isRoot {
+		buf.WriteString(rootTaskType)
+	} else {
+		buf.WriteString(copTaskType)
+	}
+	buf.WriteByte(separator)
+	buf.WriteString(strconv.FormatFloat(rowCount, 'f', -1, 64))
+	buf.WriteByte(separator)
+	buf.WriteString(explainInfo)
+	buf.WriteByte(lineBreaker)
+}
+
+func encodeID(planType string, id int) string {
+	planID := TypeStringToPhysicalID(planType)
+	return strconv.Itoa(planID) + idSeparator + strconv.Itoa(id)
+}
+
+// Compress is used to compress the input with zlib.
+func Compress(input []byte) string {
+	compressBytes := snappy.Encode(nil, input)
+	return base64.StdEncoding.EncodeToString(compressBytes)
+}
+
+func decompress(str string) (string, error) {
+	decodeBytes, err := base64.StdEncoding.DecodeString(str)
+	if err != nil {
+		return "", err
+	}
+
+	bs, err := snappy.Decode(nil, decodeBytes)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
+}

--- a/util/plancodec/id.go
+++ b/util/plancodec/id.go
@@ -1,0 +1,313 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plancodec
+
+import "strconv"
+
+const (
+	// TypeSel is the type of Selection.
+	TypeSel = "Selection"
+	// TypeSet is the type of Set.
+	TypeSet = "Set"
+	// TypeProj is the type of Projection.
+	TypeProj = "Projection"
+	// TypeAgg is the type of Aggregation.
+	TypeAgg = "Aggregation"
+	// TypeStreamAgg is the type of StreamAgg.
+	TypeStreamAgg = "StreamAgg"
+	// TypeHashAgg is the type of HashAgg.
+	TypeHashAgg = "HashAgg"
+	// TypeShow is the type of show.
+	TypeShow = "Show"
+	// TypeJoin is the type of Join.
+	TypeJoin = "Join"
+	// TypeUnion is the type of Union.
+	TypeUnion = "Union"
+	// TypeTableScan is the type of TableScan.
+	TypeTableScan = "TableScan"
+	// TypeMemTableScan is the type of TableScan.
+	TypeMemTableScan = "MemTableScan"
+	// TypeUnionScan is the type of UnionScan.
+	TypeUnionScan = "UnionScan"
+	// TypeIdxScan is the type of IndexScan.
+	TypeIdxScan = "IndexScan"
+	// TypeSort is the type of Sort.
+	TypeSort = "Sort"
+	// TypeTopN is the type of TopN.
+	TypeTopN = "TopN"
+	// TypeLimit is the type of Limit.
+	TypeLimit = "Limit"
+	// TypeHashLeftJoin is the type of left hash join.
+	TypeHashLeftJoin = "HashLeftJoin"
+	// TypeHashRightJoin is the type of right hash join.
+	TypeHashRightJoin = "HashRightJoin"
+	// TypeMergeJoin is the type of merge join.
+	TypeMergeJoin = "MergeJoin"
+	// TypeIndexJoin is the type of index look up join.
+	TypeIndexJoin = "IndexJoin"
+	// TypeIndexMergeJoin is the type of index look up merge join.
+	TypeIndexMergeJoin = "IndexMergeJoin"
+	// TypeIndexHashJoin is the type of index nested loop hash join.
+	TypeIndexHashJoin = "IndexHashJoin"
+	// TypeApply is the type of Apply.
+	TypeApply = "Apply"
+	// TypeMaxOneRow is the type of MaxOneRow.
+	TypeMaxOneRow = "MaxOneRow"
+	// TypeExists is the type of Exists.
+	TypeExists = "Exists"
+	// TypeDual is the type of TableDual.
+	TypeDual = "TableDual"
+	// TypeLock is the type of SelectLock.
+	TypeLock = "SelectLock"
+	// TypeInsert is the type of Insert
+	TypeInsert = "Insert"
+	// TypeUpdate is the type of Update.
+	TypeUpdate = "Update"
+	// TypeDelete is the type of Delete.
+	TypeDelete = "Delete"
+	// TypeIndexLookUp is the type of IndexLookUp.
+	TypeIndexLookUp = "IndexLookUp"
+	// TypeTableReader is the type of TableReader.
+	TypeTableReader = "TableReader"
+	// TypeIndexReader is the type of IndexReader.
+	TypeIndexReader = "IndexReader"
+	// TypeWindow is the type of Window.
+	TypeWindow = "Window"
+	// TypeTableGather is the type of TableGather.
+	TypeTableGather = "TableGather"
+	// TypeIndexMerge is the type of IndexMergeReader
+	TypeIndexMerge = "IndexMerge"
+	// TypePointGet is the type of PointGetPlan.
+	TypePointGet = "Point_Get"
+	// TypeShowDDLJobs is the type of show ddl jobs.
+	TypeShowDDLJobs = "ShowDDLJobs"
+	// TypeBatchPointGet is the type of BatchPointGetPlan.
+	TypeBatchPointGet = "Batch_Point_Get"
+)
+
+// plan id.
+const (
+	typeSelID int = iota + 1
+	typeSetID
+	typeProjID
+	typeAggID
+	typeStreamAggID
+	typeHashAggID
+	typeShowID
+	typeJoinID
+	typeUnionID
+	typeTableScanID
+	typeMemTableScanID
+	typeUnionScanID
+	typeIdxScanID
+	typeSortID
+	typeTopNID
+	typeLimitID
+	typeHashLeftJoinID
+	typeHashRightJoinID
+	typeMergeJoinID
+	typeIndexJoinID
+	typeIndexMergeJoinID
+	typeIndexHashJoinID
+	typeApplyID
+	typeMaxOneRowID
+	typeExistsID
+	typeDualID
+	typeLockID
+	typeInsertID
+	typeUpdateID
+	typeDeleteID
+	typeIndexLookUpID
+	typeTableReaderID
+	typeIndexReaderID
+	typeWindowID
+	typeTableGatherID
+	typeIndexMergeID
+	typePointGet
+	typeShowDDLJobs
+	typeBatchPointGet
+)
+
+// TypeStringToPhysicalID converts the plan type string to plan id.
+func TypeStringToPhysicalID(tp string) int {
+	switch tp {
+	case TypeSel:
+		return typeSelID
+	case TypeSet:
+		return typeSetID
+	case TypeProj:
+		return typeProjID
+	case TypeAgg:
+		return typeAggID
+	case TypeStreamAgg:
+		return typeStreamAggID
+	case TypeHashAgg:
+		return typeHashAggID
+	case TypeShow:
+		return typeShowID
+	case TypeJoin:
+		return typeJoinID
+	case TypeUnion:
+		return typeUnionID
+	case TypeTableScan:
+		return typeTableScanID
+	case TypeMemTableScan:
+		return typeMemTableScanID
+	case TypeUnionScan:
+		return typeUnionScanID
+	case TypeIdxScan:
+		return typeIdxScanID
+	case TypeSort:
+		return typeSortID
+	case TypeTopN:
+		return typeTopNID
+	case TypeLimit:
+		return typeLimitID
+	case TypeHashLeftJoin:
+		return typeHashLeftJoinID
+	case TypeHashRightJoin:
+		return typeHashRightJoinID
+	case TypeMergeJoin:
+		return typeMergeJoinID
+	case TypeIndexJoin:
+		return typeIndexJoinID
+	case TypeIndexMergeJoin:
+		return typeIndexMergeJoinID
+	case TypeIndexHashJoin:
+		return typeIndexHashJoinID
+	case TypeApply:
+		return typeApplyID
+	case TypeMaxOneRow:
+		return typeMaxOneRowID
+	case TypeExists:
+		return typeExistsID
+	case TypeDual:
+		return typeDualID
+	case TypeLock:
+		return typeLockID
+	case TypeInsert:
+		return typeInsertID
+	case TypeUpdate:
+		return typeUpdateID
+	case TypeDelete:
+		return typeDeleteID
+	case TypeIndexLookUp:
+		return typeIndexLookUpID
+	case TypeTableReader:
+		return typeTableReaderID
+	case TypeIndexReader:
+		return typeIndexReaderID
+	case TypeWindow:
+		return typeWindowID
+	case TypeTableGather:
+		return typeTableGatherID
+	case TypeIndexMerge:
+		return typeIndexMergeID
+	case TypePointGet:
+		return typePointGet
+	case TypeShowDDLJobs:
+		return typeShowDDLJobs
+	case TypeBatchPointGet:
+		return typeBatchPointGet
+	}
+	// Should never reach here.
+	return 0
+}
+
+// PhysicalIDToTypeString converts the plan id to plan type string.
+func PhysicalIDToTypeString(id int) string {
+	switch id {
+	case typeSelID:
+		return TypeSel
+	case typeSetID:
+		return TypeSet
+	case typeProjID:
+		return TypeProj
+	case typeAggID:
+		return TypeAgg
+	case typeStreamAggID:
+		return TypeStreamAgg
+	case typeHashAggID:
+		return TypeHashAgg
+	case typeShowID:
+		return TypeShow
+	case typeJoinID:
+		return TypeJoin
+	case typeUnionID:
+		return TypeUnion
+	case typeTableScanID:
+		return TypeTableScan
+	case typeMemTableScanID:
+		return TypeMemTableScan
+	case typeUnionScanID:
+		return TypeUnionScan
+	case typeIdxScanID:
+		return TypeIdxScan
+	case typeSortID:
+		return TypeSort
+	case typeTopNID:
+		return TypeTopN
+	case typeLimitID:
+		return TypeLimit
+	case typeHashLeftJoinID:
+		return TypeHashLeftJoin
+	case typeHashRightJoinID:
+		return TypeHashRightJoin
+	case typeMergeJoinID:
+		return TypeMergeJoin
+	case typeIndexJoinID:
+		return TypeIndexJoin
+	case typeIndexMergeJoinID:
+		return TypeIndexMergeJoin
+	case typeIndexHashJoinID:
+		return TypeIndexHashJoin
+	case typeApplyID:
+		return TypeApply
+	case typeMaxOneRowID:
+		return TypeMaxOneRow
+	case typeExistsID:
+		return TypeExists
+	case typeDualID:
+		return TypeDual
+	case typeLockID:
+		return TypeLock
+	case typeInsertID:
+		return TypeInsert
+	case typeUpdateID:
+		return TypeUpdate
+	case typeDeleteID:
+		return TypeDelete
+	case typeIndexLookUpID:
+		return TypeIndexLookUp
+	case typeTableReaderID:
+		return TypeTableReader
+	case typeIndexReaderID:
+		return TypeIndexReader
+	case typeWindowID:
+		return TypeWindow
+	case typeTableGatherID:
+		return TypeTableGather
+	case typeIndexMergeID:
+		return TypeIndexMerge
+	case typePointGet:
+		return TypePointGet
+	case typeShowDDLJobs:
+		return TypeShowDDLJobs
+	case typeBatchPointGet:
+		return TypeBatchPointGet
+	}
+
+	// Should never reach here.
+	return "UnknownPlanID" + strconv.Itoa(id)
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Backport #12179 by cherry-picking #12808 

Conflict files(from #12808):
```
        both modified:   executor/adapter.go
        both modified:   planner/core/common_plans.go
        both modified:   sessionctx/variable/session.go
```

Related Parser PR: https://github.com/pingcap/parser/pull/629

---------------------------------------------
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Print the plan in slow log.
2. Add `slow-log-plan` config item and system variable to control enable.
3. Add plan encode and plan decoder function.
4. Add `tidb_decode_plan` function to decode the ecoded plan string.
5. Add `Plan` column to `Slow_query` table.

Related PR: https://github.com/pingcap/parser/pull/557

**Example**

Enable `tidb_record_plan_in_slow_log` first.

```sql
set @@tidb_record_plan_in_slow_log=1;
select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select sleep(1);
```

**In slow log**

As is seen, `Plan` is the string of the encoded query plan.

```
# Time: 2019-09-12T19:36:50.003062+08:00
# Txn_start_ts: 411117344255639553
# User: root@127.0.0.1
# Conn_ID: 1
# Query_time: 1.002325096
# Request_count: 6 Total_keys: 36 Process_keys: 30
# DB: test
# Index_names: [t1:a,t1:b,t1:a,t1:b,t1:a,t1:b]
# Is_internal: false
# Digest: 35476665610eec1a5dff15ef68287edc48fa6b924d650f8dc26c4754b2293322
# Stats: t1:pseudo
# Num_cop_tasks: 6
# Cop_proc_avg: 0 Cop_proc_p90: 0 Cop_proc_max: 0 Cop_proc_addr: 127.0.0.1:20164
# Cop_wait_avg: 0 Cop_wait_p90: 0 Cop_wait_max: 0 Cop_wait_addr: 127.0.0.1:20164
# Mem_max: 2232
# Succ: true
# Plan: tidb_decode_plan('eNq0lM1uqzAQRtfDU3iZ3EsRY2MT+w267rKqLCAmpYkMso3SvH3FnxpVIouKbljMN8xhjkakIDSjkEIGJ9f2HSlvqmp7G3b/9jGpe1t5VTfOB9ded0uwjxCkZmx8LaLANMsgBYSq8OGuiwHXTI7JNGmKcB9lgFKLIRIJzVjOobHWOPLRNjYmF1MHcjY3FYwPScCkiIlrTu/3RZqUEQdGtRi/PpFymHE0n+p5eL5UhdUCIwHItEDAuSUU5cWogDGZmofJhT0Z9frU2Dr+39j6LSZnYzrSuqNxKrjexMSHInjVedMf2xmbrWPZjGU/sXTBlr/ADp5luuZZ8lXPSPkWohEPqysj5tPOiPn2rpGmD8hyIcvNdWMm1nwjx3XhB9xEeL5+Y5jPR4Y5+wPhuXhA5guZby6cpvRb+CB6KLGx5C/GdJNiyjVNpz+Oa69eYfQVAAD//z6BX5c=')
select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select sleep(1);
```

**query the `slow_query` table**

```sql
mysql>select plan,query from slow_query where plan != "" order by query_time  limit 1;
+-------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| plan                                                                                                        | query                                                                                                                                                                                          |
+-------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|       HashAgg_32                      root    4       group by:Column#32, funcs:firstrow(Column#32)                      | select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select count(*) from t1  join t1 t2 where t1.a=t2.b union select sleep(1); |
|       └─Union_33                      root    4                                                                          |                                                                                                                                                                                                |
|         ├─Projection_34               root    1       cast(Column#30)                                                    |                                                                                                                                                                                                |
|         │ └─HashAgg_37                root    1       funcs:count(1)                                                     |                                                                                                                                                                                                |
|         │   └─HashLeftJoin_40         root    12487.5 inner join, inner:TableReader_47, equal:[eq(Column#22, Column#27)] |                                                                                                                                                                                                |
|         │     ├─TableReader_44        root    9990    data:Selection_43                                                  |                                                                                                                                                                                                |
|         │     │ └─Selection_43        cop     9990    not(isnull(Column#22))                                             |                                                                                                                                                                                                |
|         │     │   └─TableScan_42      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         │     └─TableReader_47        root    9990    data:Selection_46                                                  |                                                                                                                                                                                                |
|         │       └─Selection_46        cop     9990    not(isnull(Column#27))                                             |                                                                                                                                                                                                |
|         │         └─TableScan_45      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         ├─Projection_50               root    1       cast(Column#20)                                                    |                                                                                                                                                                                                |
|         │ └─HashAgg_53                root    1       funcs:count(1)                                                     |                                                                                                                                                                                                |
|         │   └─HashLeftJoin_56         root    12487.5 inner join, inner:TableReader_63, equal:[eq(Column#12, Column#17)] |                                                                                                                                                                                                |
|         │     ├─TableReader_60        root    9990    data:Selection_59                                                  |                                                                                                                                                                                                |
|         │     │ └─Selection_59        cop     9990    not(isnull(Column#12))                                             |                                                                                                                                                                                                |
|         │     │   └─TableScan_58      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         │     └─TableReader_63        root    9990    data:Selection_62                                                  |                                                                                                                                                                                                |
|         │       └─Selection_62        cop     9990    not(isnull(Column#17))                                             |                                                                                                                                                                                                |
|         │         └─TableScan_61      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         ├─Projection_66               root    1       cast(Column#10)                                                    |                                                                                                                                                                                                |
|         │ └─HashAgg_69                root    1       funcs:count(1)                                                     |                                                                                                                                                                                                |
|         │   └─HashLeftJoin_72         root    12487.5 inner join, inner:TableReader_79, equal:[eq(Column#2, Column#7)]   |                                                                                                                                                                                                |
|         │     ├─TableReader_76        root    9990    data:Selection_75                                                  |                                                                                                                                                                                                |
|         │     │ └─Selection_75        cop     9990    not(isnull(Column#2))                                              |                                                                                                                                                                                                |
|         │     │   └─TableScan_74      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         │     └─TableReader_79        root    9990    data:Selection_78                                                  |                                                                                                                                                                                                |
|         │       └─Selection_78        cop     9990    not(isnull(Column#7))                                              |                                                                                                                                                                                                |
|         │         └─TableScan_77      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo        |                                                                                                                                                                                                |
|         └─Projection_82               root    1       cast(Column#1)                                                     |                                                                                                                                                                                                |
|           └─Projection_83             root    1       sleep(1)                                                           |                                                                                                                                                                                                |
|             └─TableDual_84            root    1       rows:1                                                             |                                                                                                                                                                                                |
+-------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

**Use `tidb_decode_plan` function to decode the encoded plan string.**

```sql
mysql>select tidb_decode_plan('jAu4MAk2XzMyCTAJNAlncm91cCBieTpDb2x1bW4jMzIsIGZ1bmNzOmZpcnN0cm93KEMRGhwpCjEJOV8zMwU5PAoyCTNfMzQJMAkxCWNhc3QVJwwwKQozAWAANwUbCUw8Y291bnQoMSkKNAkxN180MAEbSDI0ODcuNQlpbm5lciBqb2luLCAFDGQ6VGFibGVSZWFkZXJfNDcsIGVxdWFsOltlcRFjDDIyLCANrygyNyldCjUJMzJfNAGLeDk5OTAJZGF0YTpTZWxlY3Rpb25fNDMKNgkxXzQzCTEJICRub3QoaXNudWxsGVFMKSkKNwkxMF80MgkxCTEwMDAwCXQBh9g6dDEsIHJhbmdlOlstaW5mLCtpbmZdLCBrZWVwIG9yZGVyOmZhbHNlLCBzdGF0czpwc2V1ZG8KCZIhAlKSAAA2CZIANmqSAAA3FZIANT6SAAAyzpIAIa4ANSV4Mq4BADItrgA1IdUAMVKuAQQ1NqKuAQQ2M0quAQAxOa4AMTWuADYBi04cAQQ1OSUcCDU5CWKuAQAxNa4ENTg+HAHmrgEANiECTpIABDYyBZIANkEaBSBGQAIAMTWuBDYxPpIA4q4BADYleDKuAQAxLa4ENjkhk1KuAQA3YdeWXAMENzlKrgE5rTWsADcBiQX6OloDCDc1CmFaADdBogUgRhoBNasENzQ+GQHmqwEANwH/BXE+kQAAOAmRQRcFIEaRADWqBDc3PpEA4qoBADgldDaqAaEFCDNfOEFVGDEJc2xlZXCJ/0AyNl84NAkwCTEJcm93czoxCg==');
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_decode_plan('jAu4MAk2XzMyCTAJNAlncm91cCBieTpDb2x1bW4jMzIsIGZ1bmNzOmZpcnN0cm93KEMRGhwpCjEJOV8zMwU5PAoyCTNfMzQJMAkxCWNhc3QVJwwwKQozAWAANwUbCUw8Y291bnQoMSkKNAkxN180MAEbSDI0ODcuNQlpbm5lciBqb2luLCAFDGQ6VGFibGVSZWFkZXJfNDcsIGVxdWFsOltlcRFjDDIyLCANrygyNyldCj |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|       HashAgg_32                      root    4       group by:Column#32, funcs:firstrow(Column#32)                                                                                                                                                                           |
|       └─Union_33                      root    4                                                                                                                                                                                                                               |
|         ├─Projection_34               root    1       cast(Column#30)                                                                                                                                                                                                         |
|         │ └─HashAgg_37                root    1       funcs:count(1)                                                                                                                                                                                                          |
|         │   └─HashLeftJoin_40         root    12487.5 inner join, inner:TableReader_47, equal:[eq(Column#22, Column#27)]                                                                                                                                                      |
|         │     ├─TableReader_44        root    9990    data:Selection_43                                                                                                                                                                                                       |
|         │     │ └─Selection_43        cop     9990    not(isnull(Column#22))                                                                                                                                                                                                  |
|         │     │   └─TableScan_42      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         │     └─TableReader_47        root    9990    data:Selection_46                                                                                                                                                                                                       |
|         │       └─Selection_46        cop     9990    not(isnull(Column#27))                                                                                                                                                                                                  |
|         │         └─TableScan_45      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         ├─Projection_50               root    1       cast(Column#20)                                                                                                                                                                                                         |
|         │ └─HashAgg_53                root    1       funcs:count(1)                                                                                                                                                                                                          |
|         │   └─HashLeftJoin_56         root    12487.5 inner join, inner:TableReader_63, equal:[eq(Column#12, Column#17)]                                                                                                                                                      |
|         │     ├─TableReader_60        root    9990    data:Selection_59                                                                                                                                                                                                       |
|         │     │ └─Selection_59        cop     9990    not(isnull(Column#12))                                                                                                                                                                                                  |
|         │     │   └─TableScan_58      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         │     └─TableReader_63        root    9990    data:Selection_62                                                                                                                                                                                                       |
|         │       └─Selection_62        cop     9990    not(isnull(Column#17))                                                                                                                                                                                                  |
|         │         └─TableScan_61      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         ├─Projection_66               root    1       cast(Column#10)                                                                                                                                                                                                         |
|         │ └─HashAgg_69                root    1       funcs:count(1)                                                                                                                                                                                                          |
|         │   └─HashLeftJoin_72         root    12487.5 inner join, inner:TableReader_79, equal:[eq(Column#2, Column#7)]                                                                                                                                                        |
|         │     ├─TableReader_76        root    9990    data:Selection_75                                                                                                                                                                                                       |
|         │     │ └─Selection_75        cop     9990    not(isnull(Column#2))                                                                                                                                                                                                   |
|         │     │   └─TableScan_74      cop     10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         │     └─TableReader_79        root    9990    data:Selection_78                                                                                                                                                                                                       |
|         │       └─Selection_78        cop     9990    not(isnull(Column#7))                                                                                                                                                                                                   |
|         │         └─TableScan_77      cop     10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo                                                                                                                                                             |
|         └─Projection_82               root    1       cast(Column#1)                                                                                                                                                                                                          |
|           └─Projection_83             root    1       sleep(1)                                                                                                                                                                                                                |
|             └─TableDual_84            root    1       rows:1                                                                                                                                                                                                                  |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

```


### What is changed and how it works?

* Add `planEncoder` and `planDecoder`.
* The encode logic is:
    1.  first convert the plan to the string of plan tree.
    2.  use `snappy` to compress the string.
    3. use `base64` encode.

The performance of `snappy` is good than `zlib`.
```go
var input = []byte(`0       5_13    0       1       funcs:count(1)
1       17_14   0       0       inner join, inner:TableReader_21, equal:[eq(Column#1, Column#9) eq(Column#2, Column#10)]
2       32_18   0       0       data:Selection_17
3       1_17    1       0       lt(Column#1, NULL), not(isnull(Column#1)), not(isnull(Column#2))
4       10_16   1       10000   table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
2       32_21   0       0       data:Selection_20
3       1_20    1       0       lt(Column#9, NULL), not(isnull(Column#10)), not(isnull(Column#9))
4       10_19   1       10000   table:t2, range:[-inf,+inf], keep order:false, stats:pseudo`)

func BenchmarkSnappy(b *testing.B) {
	for i := 0; i < b.N; i++ {
		snappyCompress(input)
	}
}

func BenchmarkZlib(b *testing.B) {
	for i := 0; i < b.N; i++ {
		zlibCompress(input)
	}
}

func snappyCompress(input []byte) (string, error) {
	var buf bytes.Buffer
	bs := snappy.Encode(buf.Bytes(), input)
	return string(bs), nil
}

func zlibCompress(input []byte) (string, error) {
	var buf bytes.Buffer
	w := zlib.NewWriter(&buf)
	_, err := w.Write(input)
	if err != nil {
		return "", err
	}
	err = w.Close()
	if err != nil {
		return "", err
	}
	return buf.String(), nil
}
```

```shell
▶ go test -run '^$' -bench .
goos: darwin
goarch: amd64
pkg: github.com/crazycs520/test2
BenchmarkSnappy-12       2000000               714 ns/op
BenchmarkZlib-12           10000            102693 ns/op
```

## Benchmark test
Related PR: 
* https://github.com/pingcap/tidb/pull/12393
* https://github.com/pingcap/tidb/pull/12435

Set `tidb_slow_threshold` to 0 then do benchmark test.

As you can see, It only has a minimal impact on performance when record plan in the slow log.

**Before**
```shell
@@                               Benchmark Diff                               @@
================================================================================
--- tidb: 7c776be85d4445edd894052cc7585c310be6fca6
+++ tidb: 6c55a0e89b1fb24e6cd2e038dd3bcd00f7a35b36
tikv: 00b0234fecbe97f53700b125ce1f5793ba88531b
pd: 913cd8114b372eff5f037ec0e7f59e73ce2bbf70
================================================================================
test-1: < oltp_point_select >
    * QPS : 33061.64 ± 1.8422% (std=401.69) delta: -57.99% (p=0.000)
    * AvgMs : 7.74 ± 1.8853% (std=0.10) delta: 138.28%
    * PercentileMs99 : 21.50 ± 0.0000% (std=0.00) delta: 224.68%
            
test-2: < oltp_read_write >
    * QPS : 22465.13 ± 0.2941% (std=42.06) delta: -41.21% (p=0.000)
    * AvgMs : 228.86 ± 0.2960% (std=0.44) delta: 70.19%
    * PercentileMs99 : 317.88 ± 1.0796% (std=2.80) delta: 23.23%
            
test-3: < oltp_insert >
    * QPS : 20803.03 ± 0.1548% (std=21.93) delta: -5.83% (p=0.000)
    * AvgMs : 12.30 ± 0.1423% (std=0.01) delta: 6.18%
    * PercentileMs99 : 24.83 ± 0.0000% (std=0.00) delta: 5.57%
            
test-4: < oltp_update_index >
    * QPS : 16808.84 ± 0.3569% (std=43.98) delta: -5.00% (p=0.000)
    * AvgMs : 15.07 ± 0.6369% (std=0.06) delta: 4.17%
    * PercentileMs99 : 32.53 ± 0.0000% (std=0.00) delta: 2.95%
            
test-5: < oltp_update_non_index >
    * QPS : 26969.38 ± 0.2304% (std=37.26) delta: -9.58% (p=0.000)
    * AvgMs : 9.48 ± 0.1318% (std=0.01) delta: 10.52%
    * PercentileMs99 : 23.10 ± 0.0000% (std=0.00) delta: 9.43%

come from https://github.com/pingcap/tidb/pull/12435#issuecomment-539500714
```

**This PR**

```shell
@@                               Benchmark Diff                               @@
================================================================================
--- tidb: 5754d2db48c379805dc6637e53f4aaac88a08d03
+++ tidb: aa290fbcd0446bd2f9a8d92d4b8f18dba11fdd03
tikv: 00b0234fecbe97f53700b125ce1f5793ba88531b
pd: 913cd8114b372eff5f037ec0e7f59e73ce2bbf70
================================================================================
test-1: < oltp_point_select >
    * QPS : 32083.60 ± 1.5136% (std=322.89) delta: -59.05% (p=0.000)
    * AvgMs : 7.98 ± 1.4791% (std=0.08) delta: 144.35%
    * PercentileMs99 : 21.66 ± 1.0805% (std=0.19) delta: 227.62%
            
test-2: < oltp_read_write >
    * QPS : 22274.50 ± 0.6003% (std=100.29) delta: -41.72% (p=0.000)
    * AvgMs : 230.84 ± 0.6169% (std=1.05) delta: 71.63%
    * PercentileMs99 : 320.17 ± 0.0000% (std=0.00) delta: 24.12%
            
test-3: < oltp_insert >
    * QPS : 20822.39 ± 0.4590% (std=76.27) delta: -5.89% (p=0.000)
    * AvgMs : 12.29 ± 0.5046% (std=0.05) delta: 6.28%
    * PercentileMs99 : 24.83 ± 0.0000% (std=0.00) delta: 5.57%
            
test-4: < oltp_update_index >
    * QPS : 16716.31 ± 0.9649% (std=114.22) delta: -5.34% (p=0.000)
    * AvgMs : 15.17 ± 0.4614% (std=0.04) delta: 4.55%
    * PercentileMs99 : 33.36 ± 1.0791% (std=0.29) delta: 5.20%
            
test-5: < oltp_update_non_index >
    * QPS : 26569.69 ± 0.0832% (std=18.42) delta: -11.11% (p=0.000)
    * AvgMs : 9.63 ± 0.1038% (std=0.01) delta: 12.47%
    * PercentileMs99 : 24.38 ± 0.0000% (std=0.00) delta: 15.49%

come from  https://github.com/pingcap/tidb/pull/12393#issuecomment-539534879
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has exported function/method change
 - Has exported variable/fields change


