### PR TITLE
session,store/tikv: make CI more stable

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -151,7 +151,7 @@ func (s *testSessionSuite) TestErrorRollback(c *C) {
 	var wg sync.WaitGroup
 	cnt := 4
 	wg.Add(cnt)
-	num := 100
+	num := 20
 
 	for i := 0; i < cnt; i++ {
 		go func() {


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

make `TestBatchResolveLocks` more stable
make `TestErrorRollback` faster

Fix https://github.com/pingcap/tidb/issues/13281

### What is changed and how it works?


After https://github.com/pingcap/tidb/pull/13123, TestErrorRollback runs slower than before in the race test.

Increase TTL for `TestBatchResolveLocks` to make it more stable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
