### PR TITLE
expression: implement vectorized evaluation for `builtinOrdSig`

### DIFF
--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -2647,10 +2647,13 @@ func (b *builtinOrdSig) evalInt(row chunk.Row) (int64, bool, error) {
 	if isNull || err != nil {
 		return 0, isNull, err
 	}
-	if len(str) == 0 {
-		return 0, false, nil
-	}
+	return ord(str), false, nil
+}
 
+func ord(str string) int64 {
+	if len(str) == 0 {
+		return 0
+	}
 	_, size := utf8.DecodeRuneInString(str)
 	leftMost := str[:size]
 	var result int64
@@ -2659,8 +2662,7 @@ func (b *builtinOrdSig) evalInt(row chunk.Row) (int64, bool, error) {
 		result += int64(leftMost[i]) * factor
 		factor *= 256
 	}
-
-	return result, false, nil
+	return result
 }
 
 type quoteFunctionClass struct {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -151,7 +151,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&numStrGener{rangeInt64Gener{-10, 10}}}},
 	},
-	ast.Ord:   {},
+	ast.Ord: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
+	},
 	ast.Quote: {},
 	ast.Bin: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},


### PR DESCRIPTION
PCP #12103

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#12103 

### What is changed and how it works?

vectorize `builtinOrdSig`

```
BenchmarkVectorizedBuiltinStringFunc/builtinOrdSig-VecBuiltinFunc-8         	   59324	     36593 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinOrdSig-NonVecBuiltinFunc-8      	   20340	     59391 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	5.406s
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

Release note

 - vectorize builtinOrdSig
