### PR TITLE
expression: implement vectorized evaluation for `builtinTruncateRealSig`

### DIFF
--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -889,9 +889,11 @@ func (b *builtinTruncateDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *c
 		if result.IsNull(i) {
 			continue
 		}
-		if err := ds[i].Round(&ds[i], mathutil.Min(int(i64s[i]), ft), types.ModeTruncate); err != nil {
+		result := new(types.MyDecimal)
+		if err := ds[i].Round(result, mathutil.Min(int(i64s[i]), ft), types.ModeTruncate); err != nil {
 			return err
 		}
+		ds[i] = *result
 	}
 	return nil
 }

--- a/expression/builtin_math_vec.go
+++ b/expression/builtin_math_vec.go
@@ -865,11 +865,35 @@ func (b *builtinFloorDecToDecSig) vecEvalDecimal(input *chunk.Chunk, result *chu
 }
 
 func (b *builtinTruncateDecimalSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTruncateDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	if err := b.args[0].VecEvalDecimal(b.ctx, input, result); err != nil {
+		return err
+	}
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.MergeNulls(buf)
+	ds := result.Decimals()
+	i64s := buf.Int64s()
+	ft := b.getRetTp().Decimal
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		if err := ds[i].Round(&ds[i], mathutil.Min(int(i64s[i]), ft), types.ModeTruncate); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (b *builtinRoundWithFracDecSig) vectorized() bool {

--- a/expression/builtin_math_vec_test.go
+++ b/expression/builtin_math_vec_test.go
@@ -109,6 +109,7 @@ var vecBuiltinMathCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeInt24, Flag: mysql.UnsignedFlag}}, geners: []dataGenerator{nil, &rangeInt64Gener{-10, 10}}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal, types.ETInt}},
 	},
 	ast.Rand: {
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETInt}, geners: []dataGenerator{&defaultGener{0, types.ETInt}}},


### PR DESCRIPTION
PCP #12102 

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

#12102 

### What is changed and how it works?

```
BenchmarkVectorizedBuiltinMathFunc/builtinTruncateRealSig-VecBuiltinFunc-8         	  122958	     13975 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinMathFunc/builtinTruncateRealSig-NonVecBuiltinFunc-8      	   27172	     46372 ns/op	       0 B/op	       0 allocs/op
PASS
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes


Side effects



Related changes



Release note

 - vectorize `builtinTruncateRealSig`
