### PR TITLE
expression: implement vectorized evaluation for builtinFromUnixTime2ArgSig

### DIFF
--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -225,6 +225,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Elt: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString}, geners: []dataGenerator{&rangeInt64Gener{-1, 5}}},
 	},
+	ast.FromUnixTime: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETString}},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinStringEvalOneVec(c *C) {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -227,7 +227,12 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString}, geners: []dataGenerator{&rangeInt64Gener{-1, 5}}},
 	},
 	ast.FromUnixTime: {
-		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETString}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}},
+				&constStrGener{"%y-%m-%d"},
+			},
+		},
 	},
 }
 

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -155,11 +155,7 @@ func (b *builtinFromUnixTime2ArgSig) vecEvalString(input *chunk.Chunk, result *c
 	ds := buf1.Decimals()
 	fsp := int8(b.tp.Decimal)
 	for i := 0; i < n; i++ {
-		if buf1.IsNull(i) {
-			result.AppendNull()
-			continue
-		}
-		if buf2.IsNull(i) {
+		if buf1.IsNull(i) || buf2.IsNull(i) {
 			result.AppendNull()
 			continue
 		}

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -128,11 +128,56 @@ func (b *builtinDateSig) vectorized() bool {
 }
 
 func (b *builtinFromUnixTime2ArgSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinFromUnixTime2ArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf1, err := b.bufAllocator.get(types.ETDecimal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf1)
+	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf1); err != nil {
+		return err
+	}
+
+	buf2, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf2)
+	if err = b.args[1].VecEvalString(b.ctx, input, buf2); err != nil {
+		return err
+	}
+
+	result.ReserveString(n)
+	ds := buf1.Decimals()
+	fsp := int8(b.tp.Decimal)
+	for i := 0; i < n; i++ {
+		if buf1.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		if buf2.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		t, isNull, err := evalFromUnixTime(b.ctx, fsp, &ds[i])
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.AppendNull()
+			continue
+		}
+		res, err := t.DateFormat(buf2.GetString(i))
+		if err != nil {
+			return err
+		}
+		result.AppendString(res)
+	}
+	return nil
 }
 
 func (b *builtinSysDateWithoutFspSig) vectorized() bool {


### PR DESCRIPTION
PCP #12106

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinFromUnixTime2ArgSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=String VB_FUNC=builtinFromUnixTime2ArgSig
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinStringFunc \
		-run=BenchmarkVectorizedBuiltinStringFunc \
		-args "builtinFromUnixTime2ArgSig"
[2019/11/09 22:45:29.543 +03:00] [WARN] [builtin_string.go:268] ["unexpected `Flen` value(-1) in CONCAT's args"] ["arg's index"=0]
[2019/11/09 22:45:29.543 +03:00] [WARN] [builtin_string.go:268] ["unexpected `Flen` value(-1) in CONCAT's args"] ["arg's index"=1]
[2019/11/09 22:45:29.543 +03:00] [WARN] [builtin_string.go:268] ["unexpected `Flen` value(-1) in CONCAT's args"] ["arg's index"=2]
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinStringFunc/builtinFromUnixTime2ArgSig-VecBuiltinFunc-12         	    3189	   1356461 ns/op	   85537 B/op	    1941 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinFromUnixTime2ArgSig-NonVecBuiltinFunc-12      	     766	   1406440 ns/op	   85536 B/op	    1941 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	5.655s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
